### PR TITLE
Improve MeterBar provider status and Codex details

### DIFF
--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -1,17 +1,10 @@
+import Combine
 import SwiftUI
-import UserNotifications
 
 @main
 struct MeterBarApp: App {
-    @StateObject private var dataManager = UsageDataManager.shared
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    
-    init() {
-        print("═══════════════════════════════════════")
-        print("🎯 MeterBar: App Initializing")
-        print("═══════════════════════════════════════")
-    }
-    
+
     var body: some Scene {
         Settings {
             SettingsView()
@@ -22,129 +15,64 @@ struct MeterBarApp: App {
 class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem?
     private var popover: NSPopover?
-    
+    private var cancellables = Set<AnyCancellable>()
+
     func applicationDidFinishLaunching(_ notification: Notification) {
-        print("🚀 MeterBar: Application did finish launching")
-        
-        // Create menu bar item
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        
+
         guard let button = statusItem?.button else {
-            print("❌ Failed to create status item button")
             return
         }
-        
-        // Set up the menu bar icon with 3 progress bars
+
         let image = createMenuBarIcon()
         image.isTemplate = true
         button.image = image
-        
+
         button.action = #selector(togglePopover)
         button.target = self
         button.toolTip = "MeterBar"
-        
-        // Create popover
+
         popover = NSPopover()
-        popover?.contentSize = NSSize(width: 320, height: 500)
+        popover?.contentSize = NSSize(width: 432, height: 560)
         popover?.behavior = .transient
         popover?.contentViewController = NSHostingController(rootView: MenuBarView())
 
-        // Setup notifications (also handles initial data refresh)
-        setupNotifications()
+        configureObservers()
+        updateStatusItemAppearance()
+
+        Task { @MainActor in
+            await UsageDataManager.shared.refreshAll()
+        }
     }
-    
+
     @objc func togglePopover() {
         guard let button = statusItem?.button,
               let popover = popover else { return }
-        
+
         if popover.isShown {
             popover.performClose(nil)
         } else {
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         }
     }
-    
-    private func setupNotifications() {
-        // Check current authorization status first
-        UNUserNotificationCenter.current().getNotificationSettings { settings in
-            switch settings.authorizationStatus {
-            case .notDetermined:
-                // Request permission only if not yet determined
-                UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, error in
-                    if let error = error {
-                        print("Notification permission error: \(error)")
-                    } else if !granted {
-                        print("Notification permission denied by user")
-                    }
-                }
-            case .denied:
-                print("Notification permission was previously denied. User can enable in System Settings.")
-            case .authorized, .provisional, .ephemeral:
-                // Already authorized, no action needed
-                break
-            @unknown default:
-                break
-            }
-        }
-        
-        // Monitor usage and send notifications
-        Task {
-            await monitorUsage()
-        }
-    }
-    
-    @MainActor
-    private func monitorUsage() async {
-        // Initial refresh on app launch
-        await UsageDataManager.shared.refreshAll()
-
-        // Check for approaching limits periodically
-        // Note: UsageDataManager handles its own 15-minute auto-refresh
-        // This loop just checks metrics for notification purposes
-        while true {
-            for (_, metrics) in UsageDataManager.shared.metrics {
-                checkAndNotify(metrics: metrics)
-            }
-
-            // Wait 5 minutes before next notification check
-            try? await Task.sleep(nanoseconds: 5 * 60 * 1_000_000_000)
-        }
-    }
-    
-    private func checkAndNotify(metrics: UsageMetrics) {
-        let limits = [metrics.sessionLimit, metrics.weeklyLimit, metrics.codeReviewLimit].compactMap { $0 }
-        
-        for limit in limits {
-            if limit.percentage >= 90 && limit.percentage < 100 {
-                sendNotification(
-                    title: "\(metrics.service.displayName) Usage Warning",
-                    body: "You're at \(Int(limit.percentage))% of your limit"
-                )
-            } else if limit.percentage >= 100 {
-                sendNotification(
-                    title: "\(metrics.service.displayName) Limit Reached",
-                    body: "You've reached your usage limit"
-                )
-            }
-        }
-    }
-    
-    private func sendNotification(title: String, body: String) {
-        let content = UNMutableNotificationContent()
-        content.title = title
-        content.body = body
-        content.sound = .default
-
-        let request = UNNotificationRequest(
-            identifier: UUID().uuidString,
-            content: content,
-            trigger: nil
-        )
-
-        UNUserNotificationCenter.current().add(request)
-    }
 
     private func createMenuBarIcon() -> NSImage {
+        let snapshots = enabledStatusSnapshots()
+        let mode = UserDefaults.standard.string(forKey: "statusItemIconMode") ?? "usageBars"
+        let indicator = statusIndicatorState()
+
+        if mode == "providerDots" {
+            return createProviderDotsIcon(snapshots: snapshots, indicator: indicator)
+        }
+
+        if mode == "template" || snapshots.isEmpty {
+            return createTemplateMenuBarIcon(indicator: indicator)
+        }
+
+        return createUsageBarsIcon(snapshots: snapshots, indicator: indicator)
+    }
+
+    private func createTemplateMenuBarIcon(indicator: IconIndicatorState) -> NSImage {
         let size = NSSize(width: 18, height: 18)
         let image = NSImage(size: size, flipped: false) { rect in
             let barHeight: CGFloat = 3
@@ -165,10 +93,275 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 NSColor.black.setFill()
                 path.fill()
             }
+
+            drawIndicator(indicator, in: rect)
             return true
         }
         image.isTemplate = true
         return image
     }
+
+    private func createUsageBarsIcon(snapshots: [StatusIconSnapshot], indicator: IconIndicatorState) -> NSImage {
+        let size = NSSize(width: 18, height: 18)
+        let image = NSImage(size: size, flipped: false) { rect in
+            let rows = min(3, snapshots.count)
+            let barHeight: CGFloat = 3
+            let barSpacing: CGFloat = 2
+            let cornerRadius: CGFloat = 1.5
+            let totalBarsHeight = (barHeight * CGFloat(rows)) + (barSpacing * CGFloat(max(0, rows - 1)))
+            let startY = (rect.height - totalBarsHeight) / 2
+
+            for (index, snapshot) in snapshots.prefix(3).enumerated() {
+                let y = startY + CGFloat(index) * (barHeight + barSpacing)
+                let fillWidth = max(2, rect.width * snapshot.remainingFraction)
+                let backgroundRect = NSRect(x: 0, y: y, width: rect.width - 2, height: barHeight)
+                let fillRect = NSRect(x: 0, y: y, width: min(rect.width - 2, fillWidth), height: barHeight)
+
+                NSColor.labelColor.withAlphaComponent(0.18).setFill()
+                NSBezierPath(roundedRect: backgroundRect, xRadius: cornerRadius, yRadius: cornerRadius).fill()
+
+                snapshot.color.setFill()
+                NSBezierPath(roundedRect: fillRect, xRadius: cornerRadius, yRadius: cornerRadius).fill()
+            }
+
+            drawIndicator(indicator, in: rect)
+            return true
+        }
+        image.isTemplate = false
+        return image
+    }
+
+    private func createProviderDotsIcon(snapshots: [StatusIconSnapshot], indicator: IconIndicatorState) -> NSImage {
+        let size = NSSize(width: 18, height: 18)
+        let image = NSImage(size: size, flipped: false) { rect in
+            let dots = min(3, snapshots.count)
+            let diameter: CGFloat = 4
+            let spacing: CGFloat = 2
+            let totalWidth = (diameter * CGFloat(dots)) + (spacing * CGFloat(max(0, dots - 1)))
+            let startX = (rect.width - totalWidth) / 2
+            let y = (rect.height - diameter) / 2
+
+            for (index, snapshot) in snapshots.prefix(3).enumerated() {
+                let x = startX + CGFloat(index) * (diameter + spacing)
+                let dotRect = NSRect(x: x, y: y, width: diameter, height: diameter)
+                snapshot.color.setFill()
+                NSBezierPath(ovalIn: dotRect).fill()
+            }
+
+            drawIndicator(indicator, in: rect)
+            return true
+        }
+        image.isTemplate = false
+        return image
+    }
+
+    private func drawIndicator(_ indicator: IconIndicatorState, in rect: NSRect) {
+        guard indicator != .none else {
+            return
+        }
+
+        let badgeRect = NSRect(x: rect.maxX - 5.5, y: rect.maxY - 5.5, width: 4.5, height: 4.5)
+        indicator.color.setFill()
+        NSBezierPath(ovalIn: badgeRect).fill()
+    }
+
+    private func configureObservers() {
+        let metricsPublisher = UsageDataManager.shared.$metrics.map { _ in () }.eraseToAnyPublisher()
+        let errorPublisher = UsageDataManager.shared.$lastError.map { _ in () }.eraseToAnyPublisher()
+        let claudePublisher = Publishers.Merge(
+            ClaudeCodeLocalService.shared.$hasAccess.map { _ in () }.eraseToAnyPublisher(),
+            ClaudeCodeLocalService.shared.$lastError.map { _ in () }.eraseToAnyPublisher()
+        ).eraseToAnyPublisher()
+        let codexPublisher = Publishers.Merge(
+            CodexCliLocalService.shared.$hasAccess.map { _ in () }.eraseToAnyPublisher(),
+            CodexCliLocalService.shared.$lastError.map { _ in () }.eraseToAnyPublisher()
+        ).eraseToAnyPublisher()
+        let cursorPublisher = Publishers.Merge(
+            CursorLocalService.shared.$hasAccess.map { _ in () }.eraseToAnyPublisher(),
+            CursorLocalService.shared.$lastError.map { _ in () }.eraseToAnyPublisher()
+        ).eraseToAnyPublisher()
+        let defaultsPublisher = NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification).map { _ in () }.eraseToAnyPublisher()
+
+        Publishers.MergeMany([
+            metricsPublisher,
+            errorPublisher,
+            claudePublisher,
+            codexPublisher,
+            cursorPublisher,
+            defaultsPublisher,
+        ])
+        .receive(on: RunLoop.main)
+        .sink { [weak self] in
+            self?.updateStatusItemAppearance()
+        }
+        .store(in: &cancellables)
+    }
+
+    private func updateStatusItemAppearance() {
+        guard let button = statusItem?.button else {
+            return
+        }
+
+        let image = createMenuBarIcon()
+        image.isTemplate = UserDefaults.standard.string(forKey: "statusItemIconMode") == "template"
+        button.image = image
+        button.toolTip = buildTooltip()
+    }
+
+    private func enabledStatusSnapshots() -> [StatusIconSnapshot] {
+        var snapshots: [StatusIconSnapshot] = []
+        let summaries = enabledHealthSummaries()
+
+        if UserDefaults.standard.object(forKey: "showCodexProvider") as? Bool ?? true {
+            let summary = summaries.first(where: { $0.service == .codexCli })
+            snapshots.append(snapshot(for: summary, defaultColor: NSColor(calibratedRed: 0.45, green: 0.82, blue: 0.85, alpha: 1.0)))
+        }
+
+        if UserDefaults.standard.object(forKey: "showClaudeProvider") as? Bool ?? true {
+            let summary = summaries.first(where: { $0.service == .claudeCode })
+            snapshots.append(snapshot(for: summary, defaultColor: NSColor(calibratedRed: 0.92, green: 0.63, blue: 0.49, alpha: 1.0)))
+        }
+
+        if UserDefaults.standard.object(forKey: "showCursorProvider") as? Bool ?? true {
+            let summary = summaries.first(where: { $0.service == .cursor })
+            snapshots.append(snapshot(for: summary, defaultColor: NSColor(calibratedRed: 0.54, green: 0.68, blue: 1.00, alpha: 1.0)))
+        }
+
+        return snapshots
+    }
+
+    private func snapshot(for summary: ProviderHealthSummary?, defaultColor: NSColor) -> StatusIconSnapshot {
+        let metrics = summary?.metrics
+        let primaryLimit = metrics?.sessionLimit ?? metrics?.weeklyLimit ?? metrics?.codeReviewLimit
+        let remainingFraction = primaryLimit.map { max(0.08, min(1, $0.remaining / max($0.total, 1))) } ?? ((summary?.isConnected ?? false) ? 0.18 : 0.06)
+        let baseColor = (summary?.isConnected ?? false) ? defaultColor : NSColor.labelColor.withAlphaComponent(0.35)
+        let statusColor = (summary?.state).map { $0.menuBarColor(defaultColor: baseColor) } ?? baseColor
+
+        return StatusIconSnapshot(
+            title: summary?.title ?? "Provider",
+            remainingFraction: remainingFraction,
+            color: statusColor
+        )
+    }
+
+    private func statusIndicatorState() -> IconIndicatorState {
+        let summaries = enabledHealthSummaries()
+        if summaries.contains(where: { $0.state == .error || $0.state == .critical }) {
+            return .error
+        }
+
+        if summaries.contains(where: { $0.state == .warning }) {
+            return .warning
+        }
+
+        if summaries.contains(where: { $0.state == .stale }) {
+            return .stale
+        }
+
+        return .none
+    }
+
+    private func buildTooltip() -> String {
+        let summaries = enabledHealthSummaries()
+        var parts: [String] = []
+
+        for summary in summaries {
+            if let remaining = summary.remainingText {
+                parts.append("\(summary.title) \(remaining)")
+            } else if !summary.isConnected && summary.metrics == nil {
+                parts.append("\(summary.title) not connected")
+            } else if summary.state.isIssue {
+                parts.append("\(summary.title) \(summary.state.label.lowercased())")
+            } else {
+                parts.append("\(summary.title) ready")
+            }
+        }
+
+        if parts.isEmpty {
+            return "MeterBar"
+        }
+
+        return parts.joined(separator: " • ")
+    }
+
+    private func enabledHealthSummaries() -> [ProviderHealthSummary] {
+        var summaries: [ProviderHealthSummary] = []
+
+        if UserDefaults.standard.object(forKey: "showCodexProvider") as? Bool ?? true {
+            summaries.append(
+                ProviderHealthSummary(
+                    service: .codexCli,
+                    title: "Codex",
+                    metrics: UsageDataManager.shared.metrics[.codexCli],
+                    isConnected: CodexCliLocalService.shared.hasAccess,
+                    lastError: CodexCliLocalService.shared.lastError
+                )
+            )
+        }
+
+        if UserDefaults.standard.object(forKey: "showClaudeProvider") as? Bool ?? true {
+            summaries.append(
+                ProviderHealthSummary(
+                    service: .claudeCode,
+                    title: "Claude",
+                    metrics: UsageDataManager.shared.metrics[.claudeCode],
+                    isConnected: ClaudeCodeLocalService.shared.hasAccess,
+                    lastError: ClaudeCodeLocalService.shared.lastError
+                )
+            )
+        }
+
+        if UserDefaults.standard.object(forKey: "showCursorProvider") as? Bool ?? true {
+            summaries.append(
+                ProviderHealthSummary(
+                    service: .cursor,
+                    title: "Cursor",
+                    metrics: UsageDataManager.shared.metrics[.cursor],
+                    isConnected: CursorLocalService.shared.hasAccess,
+                    lastError: CursorLocalService.shared.lastError
+                )
+            )
+        }
+
+        return summaries
+    }
 }
 
+private struct StatusIconSnapshot {
+    let title: String
+    let remainingFraction: Double
+    let color: NSColor
+}
+
+private enum IconIndicatorState {
+    case none
+    case stale
+    case warning
+    case error
+
+    var color: NSColor {
+        switch self {
+        case .none:
+            return .clear
+        case .stale, .warning:
+            return .systemOrange
+        case .error:
+            return .systemRed
+        }
+    }
+}
+
+private extension ProviderHealthState {
+    func menuBarColor(defaultColor: NSColor) -> NSColor {
+        switch self {
+        case .disconnected:
+            return NSColor.labelColor.withAlphaComponent(0.35)
+        case .healthy:
+            return defaultColor
+        case .stale, .warning:
+            return .systemOrange
+        case .critical, .error:
+            return .systemRed
+        }
+    }
+}

--- a/MeterBar/Models/ProviderHealth.swift
+++ b/MeterBar/Models/ProviderHealth.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+enum ProviderHealthState: Int, Comparable {
+    case disconnected = 0
+    case healthy = 1
+    case stale = 2
+    case warning = 3
+    case critical = 4
+    case error = 5
+
+    static func < (lhs: ProviderHealthState, rhs: ProviderHealthState) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    var isIssue: Bool {
+        switch self {
+        case .stale, .warning, .critical, .error:
+            return true
+        case .disconnected, .healthy:
+            return false
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .disconnected:
+            return "Disconnected"
+        case .healthy:
+            return "Healthy"
+        case .stale:
+            return "Stale"
+        case .warning:
+            return "Low"
+        case .critical:
+            return "Limit Hit"
+        case .error:
+            return "Issue"
+        }
+    }
+}
+
+struct ProviderHealthSummary: Identifiable {
+    let service: ServiceType
+    let title: String
+    let state: ProviderHealthState
+    let message: String
+    let remainingText: String?
+    let metrics: UsageMetrics?
+    let isConnected: Bool
+
+    var id: ServiceType { service }
+
+    var shouldShowBanner: Bool {
+        state.isIssue
+    }
+
+    init(
+        service: ServiceType,
+        title: String,
+        metrics: UsageMetrics?,
+        isConnected: Bool,
+        lastError: Error?,
+        staleAfter: TimeInterval = 3600
+    ) {
+        self.service = service
+        self.title = title
+        self.metrics = metrics
+        self.isConnected = isConnected
+
+        let remainingText = Self.remainingText(from: metrics)
+        self.remainingText = remainingText
+
+        if let lastError {
+            self.state = .error
+            self.message = lastError.localizedDescription
+            return
+        }
+
+        guard let metrics else {
+            if isConnected {
+                self.state = .healthy
+                self.message = "Connected. Refresh to load the current quota windows."
+            } else {
+                self.state = .disconnected
+                self.message = "Local sign-in was not detected yet."
+            }
+            return
+        }
+
+        if Date().timeIntervalSince(metrics.lastUpdated) > staleAfter {
+            self.state = .stale
+            self.message = "Last updated \(Self.relativeTimestamp(metrics.lastUpdated)). Refresh to confirm current limits."
+            return
+        }
+
+        switch metrics.overallStatus {
+        case .critical:
+            self.state = .critical
+            self.message = remainingText.map { "A quota window is exhausted or nearly exhausted (\($0))." }
+                ?? "A quota window is exhausted or nearly exhausted."
+        case .warning:
+            self.state = .warning
+            self.message = remainingText.map { "A quota window is running low (\($0))." }
+                ?? "A quota window is running low."
+        case .good:
+            self.state = .healthy
+            self.message = remainingText.map { "Primary window has \($0)." }
+                ?? "Usage is healthy."
+        }
+    }
+
+    private static func remainingText(from metrics: UsageMetrics?) -> String? {
+        guard let limit = mostConstrainedLimit(from: metrics) else {
+            return nil
+        }
+        let remaining = Int(round(max(0, 100 - limit.percentage)))
+        return "\(remaining)% left"
+    }
+
+    private static func mostConstrainedLimit(from metrics: UsageMetrics?) -> UsageLimit? {
+        guard let metrics else {
+            return nil
+        }
+
+        return [metrics.sessionLimit, metrics.weeklyLimit, metrics.codeReviewLimit]
+            .compactMap { $0 }
+            .max(by: { $0.percentage < $1.percentage })
+    }
+
+    private static func relativeTimestamp(_ date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .short
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}

--- a/MeterBar/Models/ServiceType.swift
+++ b/MeterBar/Models/ServiceType.swift
@@ -13,8 +13,8 @@ enum ServiceType: String, Codable, CaseIterable, Identifiable {
         switch self {
         case .claude: return "Claude API"
         case .claudeCode: return "Claude Code"
-        case .openai: return "OpenAI"
-        case .codexCli: return "OpenAI Codex"
+        case .openai: return "OpenAI API"
+        case .codexCli: return "Codex"
         case .cursor: return "Cursor"
         }
     }

--- a/MeterBar/Models/TokenCost.swift
+++ b/MeterBar/Models/TokenCost.swift
@@ -47,3 +47,20 @@ struct CostSummary {
         String(format: "$%.2f/day", averageDailyCost)
     }
 }
+
+struct LocalUsageSummary {
+    let provider: ServiceType
+    let inputTokens: Int
+    let outputTokens: Int
+    let cachedInputTokens: Int
+    let reasoningTokens: Int
+    let totalTokens: Int
+    let sessionCount: Int
+    let periodDays: Int
+
+    var formattedTokens: String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter.string(from: NSNumber(value: totalTokens)) ?? "\(totalTokens)"
+    }
+}

--- a/MeterBar/Services/ClaudeCodeLocalService.swift
+++ b/MeterBar/Services/ClaudeCodeLocalService.swift
@@ -1,15 +1,13 @@
-import Foundation
-import AppKit
 import Combine
+import Foundation
 
 class ClaudeCodeLocalService: ObservableObject {
     static let shared = ClaudeCodeLocalService()
 
     // Working endpoint (discovered via testing)
     private let usageEndpoint = "https://api.anthropic.com/api/oauth/usage"
-
-    private let baseURL = "https://api.anthropic.com"
     private let keychainService = "Claude Code-credentials"
+    private let credentialCacheTTL: TimeInterval = 300
 
     // URLSession with timeout configuration
     private lazy var urlSession: URLSession = {
@@ -25,9 +23,11 @@ class ClaudeCodeLocalService: ObservableObject {
     @Published private(set) var rateLimitTier: String?
     @Published private(set) var lastError: ServiceError?
 
+    private var cachedCredentials: ClaudeCodeCredentials?
+    private var credentialsLoadedAt: Date?
+
     private init() {
-        // Check if we have Claude Code credentials on init
-        if let _ = getOAuthToken() {
+        if getOAuthToken() != nil {
             hasAccess = true
         }
     }
@@ -35,7 +35,15 @@ class ClaudeCodeLocalService: ObservableObject {
     // MARK: - Keychain Access
 
     /// Get OAuth token from Claude Code's keychain storage
-    func getOAuthToken() -> String? {
+    func getOAuthToken(forceRefresh: Bool = false) -> String? {
+        if !forceRefresh,
+           let credentials = cachedCredentials,
+           let loadedAt = credentialsLoadedAt,
+           Date().timeIntervalSince(loadedAt) < credentialCacheTTL {
+            apply(credentials: credentials)
+            return credentials.claudeAiOauth.accessToken
+        }
+
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: keychainService,
@@ -58,19 +66,16 @@ class ClaudeCodeLocalService: ObservableObject {
             return nil
         }
 
-        // Update subscription info
-        DispatchQueue.main.async {
-            self.subscriptionType = credentials.claudeAiOauth.subscriptionType
-            self.rateLimitTier = credentials.claudeAiOauth.rateLimitTier
-            self.hasAccess = true
-        }
+        cachedCredentials = credentials
+        credentialsLoadedAt = Date()
+        apply(credentials: credentials)
 
         return credentials.claudeAiOauth.accessToken
     }
 
     /// Check and update access status
-    func checkAccess() {
-        if let _ = getOAuthToken() {
+    func checkAccess(forceRefresh: Bool = false) {
+        if getOAuthToken(forceRefresh: forceRefresh) != nil {
             hasAccess = true
         } else {
             hasAccess = false
@@ -115,6 +120,8 @@ class ClaudeCodeLocalService: ObservableObject {
                     self.hasAccess = false
                     self.lastError = ServiceError.notAuthenticated
                 }
+                cachedCredentials = nil
+                credentialsLoadedAt = nil
                 throw ServiceError.notAuthenticated
             }
 
@@ -182,6 +189,14 @@ class ClaudeCodeLocalService: ObservableObject {
             let serviceError = ServiceError.parsingError
             await MainActor.run { self.lastError = serviceError }
             throw serviceError
+        }
+    }
+
+    private func apply(credentials: ClaudeCodeCredentials) {
+        DispatchQueue.main.async {
+            self.subscriptionType = credentials.claudeAiOauth.subscriptionType
+            self.rateLimitTier = credentials.claudeAiOauth.rateLimitTier
+            self.hasAccess = true
         }
     }
 }

--- a/MeterBar/Services/ClaudeService.swift
+++ b/MeterBar/Services/ClaudeService.swift
@@ -138,7 +138,7 @@ enum ServiceError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .notAuthenticated:
-            return "Not authenticated. Please set up your Admin API key in settings."
+            return "Not authenticated. Sign in with the CLI or configure an API key in Settings."
         case .invalidURL:
             return "Invalid URL"
         case .apiError(let message):

--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -49,6 +49,7 @@ class CodexCliLocalService: ObservableObject {
     @Published private(set) var hasAccess: Bool = false
     @Published private(set) var lastError: ServiceError?
     @Published private(set) var subscriptionType: String?
+    @Published private(set) var credits: Credits?
 
     private init() {
         // Check if we have Codex CLI credentials on init
@@ -61,40 +62,25 @@ class CodexCliLocalService: ObservableObject {
     /// This file is created and maintained by the Codex CLI when user logs in
     func getAuthToken() -> String? {
         let path = authFilePath
-        print("[CodexCliLocalService] Reading auth file: \(path)")
 
         let fileExists = FileManager.default.fileExists(atPath: path)
-        print("[CodexCliLocalService] File exists: \(fileExists)")
 
         if !fileExists {
-            print("[CodexCliLocalService] Auth file not found at \(path)")
             return nil
         }
 
         guard let data = FileManager.default.contents(atPath: path) else {
-            print("[CodexCliLocalService] Could not read file contents (permission issue?)")
             return nil
-        }
-
-        print("[CodexCliLocalService] Read \(data.count) bytes")
-
-        // Log raw JSON for debugging
-        if let rawJson = String(data: data, encoding: .utf8) {
-            print("[CodexCliLocalService] Raw JSON (first 200 chars): \(rawJson.prefix(200))")
         }
 
         do {
             let authData = try JSONDecoder().decode(CodexAuthFile.self, from: data)
-            print("[CodexCliLocalService] Decoded auth file - tokens: \(authData.tokens != nil), accessToken: \(authData.tokens?.accessToken != nil)")
             if let token = authData.tokens?.accessToken {
-                print("[CodexCliLocalService] Access token found (length: \(token.count))")
                 return token
             } else {
-                print("[CodexCliLocalService] No access token in auth file")
                 return nil
             }
         } catch {
-            print("[CodexCliLocalService] Failed to parse auth.json: \(error)")
             return nil
         }
     }
@@ -110,11 +96,7 @@ class CodexCliLocalService: ObservableObject {
 
         do {
             let authData = try JSONDecoder().decode(CodexAuthFile.self, from: data)
-            if let accountId = authData.tokens?.accountId {
-                print("[CodexCliLocalService] Account ID found: \(accountId)")
-                return accountId
-            }
-            return nil
+            return authData.tokens?.accountId
         } catch {
             return nil
         }
@@ -125,11 +107,12 @@ class CodexCliLocalService: ObservableObject {
     func checkAccess() {
         let token = getAuthToken()
         let hasToken = token != nil
-        print("[CodexCliLocalService] checkAccess: authFile=\(authFilePath), hasToken=\(hasToken)")
         if hasToken {
             hasAccess = true
+            lastError = nil
         } else {
             hasAccess = false
+            credits = nil
         }
     }
 
@@ -159,7 +142,6 @@ class CodexCliLocalService: ObservableObject {
         // Without this header, API returns free plan data even for team accounts
         if let accountId = getAccountId() {
             request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
-            print("[CodexCliLocalService] Using account ID: \(accountId)")
         }
 
         // Browser-like headers to avoid blocks
@@ -176,8 +158,6 @@ class CodexCliLocalService: ObservableObject {
                 throw ServiceError.apiError("Invalid response type")
             }
 
-            print("[CodexCliLocalService] Usage response status: \(httpResponse.statusCode)")
-
             if httpResponse.statusCode == 401 {
                 await MainActor.run {
                     self.hasAccess = false
@@ -188,13 +168,8 @@ class CodexCliLocalService: ObservableObject {
 
             guard (200...299).contains(httpResponse.statusCode) else {
                 let errorMessage = String(data: data, encoding: .utf8) ?? "Unknown error"
-                print("[CodexCliLocalService] Usage error: \(errorMessage.prefix(200))")
                 throw ServiceError.apiError("HTTP \(httpResponse.statusCode): \(errorMessage.prefix(100))")
             }
-
-            // Parse the response
-            let rawResponse = String(data: data, encoding: .utf8) ?? "{}"
-            print("[CodexCliLocalService] Raw response: \(rawResponse.prefix(500))")
 
             let decoder = JSONDecoder()
             // Note: Codex CLI API uses Unix timestamps (Int64), not ISO8601 dates
@@ -206,11 +181,11 @@ class CodexCliLocalService: ObservableObject {
                 self.lastError = nil
                 self.hasAccess = true
                 self.subscriptionType = usageResponse.planType
+                self.credits = usageResponse.credits
             }
 
             // Check if rate limits exist (free accounts have null rate_limit)
             guard let rateLimit = usageResponse.rateLimit else {
-                print("[CodexCliLocalService] No rate limit data (free account or no usage yet)")
                 // Return empty metrics for free accounts
                 return UsageMetrics(
                     service: .codexCli,
@@ -223,7 +198,6 @@ class CodexCliLocalService: ObservableObject {
             // Map the response to UsageMetrics
             // Primary window (5 hours = 18000 seconds) = session limit
             let primaryWindow = rateLimit.primaryWindow
-            print("[CodexCliLocalService] Primary window: usedPercent=\(primaryWindow.usedPercent), resetAt=\(primaryWindow.resetAt)")
             let sessionLimit = UsageLimit(
                 used: primaryWindow.usedPercent,
                 total: 100.0,
@@ -232,7 +206,6 @@ class CodexCliLocalService: ObservableObject {
 
             // Secondary window (7 days = 604800 seconds) = weekly limit
             let secondaryWindow = rateLimit.secondaryWindow
-            print("[CodexCliLocalService] Secondary window: usedPercent=\(secondaryWindow?.usedPercent ?? -1), resetAt=\(secondaryWindow?.resetAt ?? 0)")
             let weeklyLimit = UsageLimit(
                 used: secondaryWindow?.usedPercent ?? 0.0,
                 total: 100.0,
@@ -242,7 +215,6 @@ class CodexCliLocalService: ObservableObject {
             // Code review rate limit (7 days window) = code review limit
             var codeReviewLimit: UsageLimit? = nil
             if let codeReviewPrimary = usageResponse.codeReviewRateLimit?.primaryWindow {
-                print("[CodexCliLocalService] Code review: usedPercent=\(codeReviewPrimary.usedPercent), resetAt=\(codeReviewPrimary.resetAt)")
                 codeReviewLimit = UsageLimit(
                     used: codeReviewPrimary.usedPercent,
                     total: 100.0,
@@ -250,7 +222,6 @@ class CodexCliLocalService: ObservableObject {
                 )
             }
 
-            print("[CodexCliLocalService] Final metrics: session=\(sessionLimit.percentage)%, weekly=\(weeklyLimit.percentage)%, codeReview=\(codeReviewLimit?.percentage ?? -1)%")
             return UsageMetrics(
                 service: .codexCli,
                 sessionLimit: sessionLimit,
@@ -275,13 +246,7 @@ class CodexCliLocalService: ObservableObject {
         } catch let error as ServiceError {
             throw error
         } catch let decodingError as DecodingError {
-            print("[CodexCliLocalService] Decoding error: \(decodingError)")
-            // If decoding fails, the API structure might be different
-            // Log the raw response for debugging
-            if let data = try? Data(contentsOf: URL(string: usageEndpoint)!) {
-                let rawResponse = String(data: data, encoding: .utf8) ?? "{}"
-                print("[CodexCliLocalService] Failed to decode response. Raw JSON: \(rawResponse)")
-            }
+            _ = decodingError
             let serviceError = ServiceError.parsingError
             await MainActor.run { self.lastError = serviceError }
             throw serviceError

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -6,6 +6,7 @@ class CostTracker: ObservableObject {
     static let shared = CostTracker()
 
     @Published var costSummary: CostSummary?
+    @Published var codexUsageSummary: LocalUsageSummary?
     @Published var isScanning: Bool = false
     @Published var lastScanDate: Date?
 
@@ -30,6 +31,8 @@ class CostTracker: ObservableObject {
         if let claudeCost = await scanClaudeCodeSessions(since: cutoffDate) {
             allCosts.append(claudeCost)
         }
+
+        codexUsageSummary = scanCodexSessions(since: cutoffDate, days: days)
 
         // Calculate summary
         let totalCost = allCosts.reduce(0) { $0 + $1.estimatedCostUSD }
@@ -103,7 +106,6 @@ class CostTracker: ObservableObject {
                 }
             }
         } catch {
-            print("Error scanning Claude sessions: \(error)")
             return nil
         }
 
@@ -188,6 +190,114 @@ class CostTracker: ObservableObject {
         let cacheCreationCost = Double(cacheCreation) / 1_000_000 * pricing.cacheCreation
         let cacheReadCost = Double(cacheRead) / 1_000_000 * pricing.cacheRead
         return inputCost + outputCost + cacheCreationCost + cacheReadCost
+    }
+
+    private func scanCodexSessions(since cutoffDate: Date, days: Int) -> LocalUsageSummary? {
+        let homeDirectory = FileManager.default.homeDirectoryForCurrentUser
+        let baseDirectories = [
+            homeDirectory.appendingPathComponent(".codex/sessions"),
+            homeDirectory.appendingPathComponent(".codex/archived_sessions"),
+        ]
+
+        var totalInput = 0
+        var totalOutput = 0
+        var totalCachedInput = 0
+        var totalReasoning = 0
+        var totalTokens = 0
+        var sessionCount = 0
+
+        for baseDirectory in baseDirectories where FileManager.default.fileExists(atPath: baseDirectory.path) {
+            guard let enumerator = FileManager.default.enumerator(
+                at: baseDirectory,
+                includingPropertiesForKeys: [.contentModificationDateKey],
+                options: [.skipsHiddenFiles]
+            ) else {
+                continue
+            }
+
+            for case let fileURL as URL in enumerator {
+                guard ["jsonl", "json"].contains(fileURL.pathExtension) else {
+                    continue
+                }
+
+                guard let values = try? fileURL.resourceValues(forKeys: [.contentModificationDateKey]),
+                      let modifiedAt = values.contentModificationDate,
+                      modifiedAt >= cutoffDate else {
+                    continue
+                }
+
+                if let usage = parseCodexSessionFile(at: fileURL), usage.totalTokens > 0 {
+                    totalInput += usage.inputTokens
+                    totalOutput += usage.outputTokens
+                    totalCachedInput += usage.cachedInputTokens
+                    totalReasoning += usage.reasoningTokens
+                    totalTokens += usage.totalTokens
+                    sessionCount += 1
+                }
+            }
+        }
+
+        guard totalTokens > 0 else {
+            return nil
+        }
+
+        return LocalUsageSummary(
+            provider: .codexCli,
+            inputTokens: totalInput,
+            outputTokens: totalOutput,
+            cachedInputTokens: totalCachedInput,
+            reasoningTokens: totalReasoning,
+            totalTokens: totalTokens,
+            sessionCount: sessionCount,
+            periodDays: days
+        )
+    }
+
+    private func parseCodexSessionFile(at url: URL) -> LocalUsageSummary? {
+        guard url.pathExtension == "jsonl",
+              let data = try? Data(contentsOf: url),
+              let content = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        var latestTotals: (input: Int, output: Int, cached: Int, reasoning: Int, total: Int)?
+
+        for line in content.components(separatedBy: .newlines) where !line.isEmpty {
+            guard let lineData = line.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  let type = json["type"] as? String,
+                  type == "event_msg",
+                  let payload = json["payload"] as? [String: Any],
+                  let payloadType = payload["type"] as? String,
+                  payloadType == "token_count",
+                  let info = payload["info"] as? [String: Any],
+                  let totals = info["total_token_usage"] as? [String: Any] else {
+                continue
+            }
+
+            latestTotals = (
+                input: totals["input_tokens"] as? Int ?? 0,
+                output: totals["output_tokens"] as? Int ?? 0,
+                cached: totals["cached_input_tokens"] as? Int ?? 0,
+                reasoning: totals["reasoning_output_tokens"] as? Int ?? 0,
+                total: totals["total_tokens"] as? Int ?? 0
+            )
+        }
+
+        guard let latestTotals else {
+            return nil
+        }
+
+        return LocalUsageSummary(
+            provider: .codexCli,
+            inputTokens: latestTotals.input,
+            outputTokens: latestTotals.output,
+            cachedInputTokens: latestTotals.cached,
+            reasoningTokens: latestTotals.reasoning,
+            totalTokens: latestTotals.total,
+            sessionCount: 1,
+            periodDays: 0
+        )
     }
 }
 

--- a/MeterBar/Services/CursorLocalService.swift
+++ b/MeterBar/Services/CursorLocalService.swift
@@ -68,14 +68,12 @@ class CursorLocalService: ObservableObject {
         // Check each path
         for path in pathsToCheck {
             if fileManager.fileExists(atPath: path) {
-                print("[CursorLocalService] Found database at: \(path)")
                 return path
             }
         }
         
         // If not found and forceRescan is true, search recursively in Cursor directories
         if forceRescan {
-            print("[CursorLocalService] Primary paths not found, scanning Cursor directories...")
             let cursorBasePaths = [
                 "\(homeDir)/Library/Application Support/Cursor",
                 "\(homeDir)/.config/Cursor"
@@ -83,19 +81,11 @@ class CursorLocalService: ObservableObject {
             
             for basePath in cursorBasePaths {
                 if let foundPath = findDatabaseRecursively(in: basePath, filename: "state.vscdb") {
-                    print("[CursorLocalService] Found database via recursive search at: \(foundPath)")
                     return foundPath
                 }
             }
         }
-        
-        // Log all checked paths for debugging
-        print("[CursorLocalService] Database not found. Checked paths:")
-        for path in pathsToCheck {
-            let exists = fileManager.fileExists(atPath: path)
-            print("[CursorLocalService]   \(exists ? "✓" : "✗") \(path)")
-        }
-        
+
         return nil
     }
     
@@ -124,9 +114,6 @@ class CursorLocalService: ObservableObject {
     /// - Parameter forceRescan: If true, will recursively search for database if not found in primary paths
     func getAccessTokenFromDatabase(forceRescan: Bool = false) -> (userId: String, token: String)? {
         guard let dbPath = getCursorDatabasePath(forceRescan: forceRescan) else {
-            if forceRescan {
-                print("[CursorLocalService] Database not found after rescanning all paths")
-            }
             // Database not found - Cursor may not be installed, which is okay
             // Don't print error on init, only when actively trying to fetch
             return nil
@@ -135,14 +122,12 @@ class CursorLocalService: ObservableObject {
         // Verify file exists and is readable before attempting to open
         let isReadable = FileManager.default.isReadableFile(atPath: dbPath)
         if !isReadable {
-            print("[CursorLocalService] Database file not readable (sandbox blocking access)")
             return nil
         }
 
         var db: OpaquePointer?
         let result = sqlite3_open_v2(dbPath, &db, SQLITE_OPEN_READONLY, nil)
         guard result == SQLITE_OK else {
-            print("[CursorLocalService] SQLite open failed: \(result) - \(String(cString: sqlite3_errmsg(db)))")
             sqlite3_close(db)
             return nil
         }
@@ -152,18 +137,15 @@ class CursorLocalService: ObservableObject {
         var statement: OpaquePointer?
 
         guard sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK else {
-            print("[CursorLocalService] Failed to prepare query: \(String(cString: sqlite3_errmsg(db)))")
             return nil
         }
         defer { sqlite3_finalize(statement) }
 
         guard sqlite3_step(statement) == SQLITE_ROW else {
-            print("[CursorLocalService] No token found in database")
             return nil
         }
 
         guard let tokenCString = sqlite3_column_text(statement, 0) else {
-            print("[CursorLocalService] Failed to read token value")
             return nil
         }
 
@@ -171,11 +153,9 @@ class CursorLocalService: ObservableObject {
 
         // Decode JWT to extract userId from 'sub' claim
         guard let userId = extractUserIdFromJWT(token) else {
-            print("[CursorLocalService] Failed to extract userId from JWT")
             return nil
         }
 
-        print("[CursorLocalService] Successfully retrieved token for user: \(userId.prefix(8))...")
         return (userId: userId, token: token)
     }
 
@@ -224,6 +204,7 @@ class CursorLocalService: ObservableObject {
     func checkAccess(forceRescan: Bool = false) {
         if let _ = getAccessTokenFromDatabase(forceRescan: forceRescan) {
             hasAccess = true
+            lastError = nil
         } else {
             hasAccess = false
             subscriptionType = nil
@@ -240,15 +221,12 @@ class CursorLocalService: ObservableObject {
                 self.lastError = error
                 self.hasAccess = false
             }
-            print("[CursorLocalService] No access token found in database after full scan")
             throw error
         }
 
         await MainActor.run {
             self.hasAccess = true
         }
-
-        print("[CursorLocalService] Fetching usage data from Cursor API...")
 
         // Fetch usage summary data (uses /api/usage-summary endpoint)
         let summaryData = try await fetchUsageSummary(userId: userId, token: token)
@@ -277,10 +255,6 @@ class CursorLocalService: ObservableObject {
         let planUsed = Double(summaryData.individualUsage?.plan?.used ?? 0)
         let planTotal = Double(summaryData.individualUsage?.plan?.total ?? 500)
 
-        print("[CursorLocalService] Plan type: \(summaryData.membershipType ?? "unknown")")
-        print("[CursorLocalService] Plan usage: \(Int(planUsed)) / \(Int(planTotal))")
-        print("[CursorLocalService] Billing cycle end: \(summaryData.billingCycleEnd ?? "unknown")")
-
         // Create usage metrics using plan data
         let weeklyLimit = UsageLimit(
             used: planUsed,
@@ -301,8 +275,6 @@ class CursorLocalService: ObservableObject {
                 )
             }
         }
-
-        print("[CursorLocalService] Successfully fetched Cursor usage data")
 
         return UsageMetrics(
             service: .cursor,
@@ -341,15 +313,11 @@ class CursorLocalService: ObservableObject {
             request.setValue(value, forHTTPHeaderField: key)
         }
 
-        print("[CursorLocalService] Calling usage-summary endpoint")
-
         let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ServiceError.apiError("Invalid response type")
         }
-
-        print("[CursorLocalService] Usage summary response status: \(httpResponse.statusCode)")
 
         if httpResponse.statusCode == 401 {
             await MainActor.run {
@@ -361,23 +329,14 @@ class CursorLocalService: ObservableObject {
 
         guard (200...299).contains(httpResponse.statusCode) else {
             let errorMsg = String(data: data, encoding: .utf8) ?? "Unknown error"
-            print("[CursorLocalService] Usage summary error: \(errorMsg.prefix(200))")
             throw ServiceError.apiError("HTTP \(httpResponse.statusCode): \(errorMsg.prefix(100))")
-        }
-
-        // Debug: print raw response
-        if let rawResponse = String(data: data, encoding: .utf8) {
-            print("[CursorLocalService] Raw usage-summary response: \(rawResponse.prefix(500))")
         }
 
         // Parse the response
         let decoder = JSONDecoder()
         do {
-            let summaryResponse = try decoder.decode(CursorUsageSummaryResponse.self, from: data)
-            print("[CursorLocalService] Parsed usage summary: used=\(summaryResponse.individualUsage?.plan?.used ?? 0), total=\(summaryResponse.individualUsage?.plan?.total ?? 0)")
-            return summaryResponse
+            return try decoder.decode(CursorUsageSummaryResponse.self, from: data)
         } catch {
-            print("[CursorLocalService] JSON decode error: \(error)")
             throw ServiceError.parsingError
         }
     }

--- a/MeterBar/Services/SharedDataStore.swift
+++ b/MeterBar/Services/SharedDataStore.swift
@@ -15,11 +15,9 @@ class SharedDataStore {
     
     func saveMetrics(_ metrics: [ServiceType: UsageMetrics]) {
         guard let containerURL = containerURL else {
-            print("❌ [SharedDataStore] App Group container not available. Enable 'App Groups' capability in Xcode for both app and widget targets.")
             return
         }
 
-        print("✅ [SharedDataStore] Writing to App Group: \(containerURL.path)")
         let fileURL = containerURL.appendingPathComponent("\(metricsKey).json")
         
         let encoded = metrics.reduce(into: [String: UsageMetrics]()) { result, pair in
@@ -48,4 +46,3 @@ class SharedDataStore {
         }
     }
 }
-

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -49,7 +49,6 @@ class UsageDataManager: ObservableObject {
                 newMetrics[.claude] = metrics
             } catch {
                 lastError = error
-                print("Failed to fetch Claude metrics: \(error)")
             }
         }
 
@@ -74,7 +73,6 @@ class UsageDataManager: ObservableObject {
                 newMetrics[.openai] = metrics
             } catch {
                 lastError = error
-                print("Failed to fetch OpenAI metrics: \(error)")
             }
         }
 
@@ -85,7 +83,6 @@ class UsageDataManager: ObservableObject {
                 newMetrics[.codexCli] = metrics
             } catch {
                 lastError = error
-                print("Failed to fetch Codex CLI metrics: \(error)")
                 // Preserve cached data if available (graceful degradation)
                 if let cachedMetrics = self.metrics[.codexCli] {
                     newMetrics[.codexCli] = cachedMetrics
@@ -100,7 +97,6 @@ class UsageDataManager: ObservableObject {
                 newMetrics[.cursor] = metrics
             } catch {
                 lastError = error
-                print("Failed to fetch Cursor metrics: \(error)")
                 // Preserve cached data if available (graceful degradation)
                 if let cachedMetrics = self.metrics[.cursor] {
                     newMetrics[.cursor] = cachedMetrics

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -1,782 +1,1218 @@
-import SwiftUI
 import AppKit
+import SwiftUI
 
-// Which card is currently expanded (accordion behavior - only one at a time)
-enum ExpandedCard: Equatable {
-    case none
-    case claudeCode
-    case codexCli
+private enum MenuTab: String, Hashable {
+    case overview
+    case codex
+    case claude
     case cursor
+
+    var title: String {
+        switch self {
+        case .overview:
+            return "Overview"
+        case .codex:
+            return "Codex"
+        case .claude:
+            return "Claude"
+        case .cursor:
+            return "Cursor"
+        }
+    }
+}
+
+private struct ServiceSnapshot: Identifiable {
+    let service: ServiceType
+    let title: String
+    let subtitle: String
+    let accent: Color
+    let summary: String?
+    let metrics: UsageMetrics?
+    let isConnected: Bool
+    let actionLabel: String
+    let dashboardURL: URL?
+    let health: ProviderHealthSummary
+
+    var id: ServiceType { service }
 }
 
 struct MenuBarView: View {
     @StateObject private var dataManager = UsageDataManager.shared
-    @StateObject private var authManager = AuthenticationManager.shared
     @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
     @StateObject private var codexCliService = CodexCliLocalService.shared
     @StateObject private var cursorService = CursorLocalService.shared
+    @StateObject private var costTracker = CostTracker.shared
 
-    // Track which card is expanded (only one at a time)
-    @State private var expandedCard: ExpandedCard = .none
+    @AppStorage("showClaudeProvider") private var showClaudeProvider: Bool = true
+    @AppStorage("showCodexProvider") private var showCodexProvider: Bool = true
+    @AppStorage("showCursorProvider") private var showCursorProvider: Bool = true
+    @AppStorage("showOverviewTab") private var showOverviewTab: Bool = true
+    @AppStorage("selectedMenuTab") private var selectedTabRaw: String = MenuTab.overview.rawValue
 
-    var body: some View {
-        VStack(spacing: 0) {
-            // Header
-            HStack {
-                Text("MeterBar")
-                    .font(.headline)
-                Spacer()
-                Button(action: {
-                    Task {
-                        await dataManager.refreshAll()
-                    }
-                }) {
-                    Image(systemName: "arrow.clockwise")
-                }
-                .buttonStyle(.plain)
-            }
-            .padding()
-            .background(Color(NSColor.controlBackgroundColor))
+    @State private var selectedTab: MenuTab = .overview
 
-            Divider()
+    private let panelBackground = Color(nsColor: NSColor(calibratedRed: 0.10, green: 0.11, blue: 0.14, alpha: 0.98))
+    private let cardBackground = Color(nsColor: NSColor(calibratedRed: 0.15, green: 0.16, blue: 0.20, alpha: 1.0))
+    private let dividerColor = Color.white.opacity(0.08)
 
-            // Service Cards
-            ScrollView {
-                VStack(spacing: 12) {
-                    // Claude: Show Claude Code if available, otherwise Claude API
-                    // Priority: Claude Code (easier setup) > Claude API (requires admin key)
-                    if claudeCodeService.hasAccess {
-                        // User has Claude Code logged in - show that
-                        ClaudeCodeServiceRow(
-                            hasAccess: claudeCodeService.hasAccess,
-                            metrics: dataManager.metrics[.claudeCode],
-                            expandedCard: $expandedCard
-                        )
-                    } else if authManager.isClaudeAuthenticated {
-                        // User has Claude API key configured - show that
-                        ServiceRowView(
-                            service: .claude,
-                            isAuthenticated: authManager.isClaudeAuthenticated,
-                            metrics: dataManager.metrics[.claude]
-                        )
-                    } else {
-                        // Neither configured - show Claude Code with login prompt
-                        ClaudeCodeServiceRow(
-                            hasAccess: false,
-                            metrics: nil,
-                            expandedCard: $expandedCard
-                        )
-                    }
-
-                    // Codex CLI (local auth from ~/.codex/auth.json)
-                    CodexCliServiceRow(
-                        hasAccess: codexCliService.hasAccess,
-                        metrics: dataManager.metrics[.codexCli],
-                        expandedCard: $expandedCard
-                    )
-
-                    // Cursor (Local)
-                    CursorServiceRow(
-                        hasAccess: cursorService.hasAccess,
-                        metrics: dataManager.metrics[.cursor],
-                        expandedCard: $expandedCard
-                    )
-                }
-                .padding()
-            }
-
-            Divider()
-
-            // Footer Actions
-            HStack {
-                Button("Quit") {
-                    NSApplication.shared.terminate(nil)
-                }
-                .buttonStyle(.bordered)
-                .foregroundColor(.red)
-            }
-            .padding(.horizontal)
-            .padding(.vertical, 8)
-        }
-        .frame(width: 320, height: 500)
+    private var claudeSnapshot: ServiceSnapshot {
+        let plan = claudeCodeService.subscriptionType?.capitalized ?? "CLI account"
+        let metrics = dataManager.metrics[.claudeCode]
+        return ServiceSnapshot(
+            service: .claudeCode,
+            title: "Claude",
+            subtitle: plan,
+            accent: .meterClaudeAccent,
+            summary: claudeCodeService.rateLimitTier?.replacingOccurrences(of: "_", with: " ").capitalized,
+            metrics: metrics,
+            isConnected: claudeCodeService.hasAccess,
+            actionLabel: "Run `claude login`",
+            dashboardURL: URL(string: "https://claude.ai"),
+            health: ProviderHealthSummary(
+                service: .claudeCode,
+                title: "Claude",
+                metrics: metrics,
+                isConnected: claudeCodeService.hasAccess,
+                lastError: claudeCodeService.lastError
+            )
+        )
     }
-}
 
-// MARK: - Service Row View
+    private var codexSnapshot: ServiceSnapshot {
+        let plan = codexCliService.subscriptionType?.replacingOccurrences(of: "_", with: " ").capitalized ?? "CLI account"
+        let metrics = dataManager.metrics[.codexCli]
+        return ServiceSnapshot(
+            service: .codexCli,
+            title: "Codex",
+            subtitle: plan,
+            accent: .meterCodexAccent,
+            summary: nil,
+            metrics: metrics,
+            isConnected: codexCliService.hasAccess,
+            actionLabel: "Run `codex login`",
+            dashboardURL: URL(string: "https://chatgpt.com"),
+            health: ProviderHealthSummary(
+                service: .codexCli,
+                title: "Codex",
+                metrics: metrics,
+                isConnected: codexCliService.hasAccess,
+                lastError: codexCliService.lastError
+            )
+        )
+    }
 
-struct ServiceRowView: View {
-    let service: ServiceType
-    let isAuthenticated: Bool
-    let metrics: UsageMetrics?
+    private var cursorSnapshot: ServiceSnapshot {
+        let plan = cursorService.subscriptionType?.replacingOccurrences(of: "_", with: " ").capitalized ?? "Cursor account"
+        let metrics = dataManager.metrics[.cursor]
+        return ServiceSnapshot(
+            service: .cursor,
+            title: "Cursor",
+            subtitle: plan,
+            accent: .meterCursorAccent,
+            summary: "Local database sync",
+            metrics: metrics,
+            isConnected: cursorService.hasAccess,
+            actionLabel: "Open Cursor and sign in",
+            dashboardURL: URL(string: "https://cursor.com/dashboard"),
+            health: ProviderHealthSummary(
+                service: .cursor,
+                title: "Cursor",
+                metrics: metrics,
+                isConnected: cursorService.hasAccess,
+                lastError: cursorService.lastError
+            )
+        )
+    }
 
-    @StateObject private var authManager = AuthenticationManager.shared
-    @State private var isExpanded: Bool = false
-    @State private var apiKeyInput: String = ""
+    private var availableTabs: [MenuTab] {
+        var tabs: [MenuTab] = []
+        if showOverviewTab || (!showCodexProvider && !showClaudeProvider && !showCursorProvider) {
+            tabs.append(.overview)
+        }
+        if showCodexProvider {
+            tabs.append(.codex)
+        }
+        if showClaudeProvider {
+            tabs.append(.claude)
+        }
+        if showCursorProvider, (cursorSnapshot.isConnected || cursorSnapshot.metrics != nil) {
+            tabs.append(.cursor)
+        }
+        return tabs
+    }
+
+    private var issueSummaries: [ProviderHealthSummary] {
+        enabledSnapshots
+            .map(\.health)
+            .filter(\.shouldShowBanner)
+            .sorted { $0.state > $1.state }
+    }
+
+    private var enabledSnapshots: [ServiceSnapshot] {
+        var snapshots: [ServiceSnapshot] = []
+        if showCodexProvider {
+            snapshots.append(codexSnapshot)
+        }
+        if showClaudeProvider {
+            snapshots.append(claudeSnapshot)
+        }
+        if showCursorProvider {
+            snapshots.append(cursorSnapshot)
+        }
+        return snapshots
+    }
+
+    private var anyConnectedProvider: Bool {
+        enabledSnapshots.contains(where: \.isConnected)
+    }
+
+    private var lastUpdatedText: String {
+        let dates = [codexSnapshot.metrics?.lastUpdated, claudeSnapshot.metrics?.lastUpdated, cursorSnapshot.metrics?.lastUpdated].compactMap { $0 }
+        guard let latest = dates.max() else {
+            return "No data yet"
+        }
+        return relativeTimestamp(latest)
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            // Header
-            HStack {
-                Image(systemName: service.iconName)
-                    .foregroundColor(headerColor)
-                Text(service.displayName)
-                    .font(.headline)
-                Spacer()
+        ZStack {
+            panelBackground
+                .ignoresSafeArea()
 
-                if isAuthenticated {
-                    if let metrics = metrics {
-                        StatusIndicator(status: metrics.overallStatus)
-                    }
+            VStack(spacing: 0) {
+                header
+                tabBar
 
-                    // Show gear button to manage key when authenticated
-                    Button(action: { isExpanded.toggle() }) {
-                        Image(systemName: isExpanded ? "chevron.up" : "gearshape")
-                            .font(.caption)
-                            .frame(width: 24, height: 24)
-                            .contentShape(Rectangle())
+                Divider()
+                    .overlay(dividerColor)
+
+                content
+
+                Divider()
+                    .overlay(dividerColor)
+
+                footer
+            }
+        }
+        .frame(width: 432, height: 560)
+        .preferredColorScheme(.dark)
+        .onAppear {
+            selectedTab = MenuTab(rawValue: selectedTabRaw) ?? .overview
+            normalizeSelectedTab()
+            if dataManager.metrics.isEmpty {
+                Task {
+                    await dataManager.refreshAll()
+                }
+            }
+        }
+        .onChange(of: selectedTab) { newValue in
+            selectedTabRaw = newValue.rawValue
+        }
+        .task(id: availableTabs.map(\.rawValue).joined(separator: ",")) {
+            normalizeSelectedTab()
+        }
+        .task(id: selectedTab) {
+            if selectedTab == .claude || selectedTab == .codex {
+                guard costTracker.costSummary == nil, !costTracker.isScanning else {
+                    return
+                }
+                await costTracker.scanCosts(days: 30)
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("MeterBar")
+                    .font(.system(size: 19, weight: .semibold))
+                    .foregroundStyle(.white)
+                Text(lastUpdatedText)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button(action: refreshAll) {
+                Image(systemName: dataManager.isLoading ? "arrow.triangle.2.circlepath.circle.fill" : "arrow.clockwise")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.86))
+            }
+            .buttonStyle(.plain)
+            .disabled(dataManager.isLoading)
+            .help("Refresh usage")
+        }
+        .padding(.horizontal, 18)
+        .padding(.top, 16)
+        .padding(.bottom, 14)
+    }
+
+    private var tabBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 10) {
+                ForEach(availableTabs, id: \.self) { tab in
+                    Button(action: {
+                        selectedTab = tab
+                    }) {
+                        VStack(spacing: 6) {
+                            HStack(spacing: 6) {
+                                Image(systemName: iconName(for: tab))
+                                    .font(.system(size: 11, weight: .semibold))
+                                Text(tab.title)
+                                    .font(.system(size: 13, weight: .semibold))
+                            }
+                            .foregroundStyle(selectedTab == tab ? .white : Color.white.opacity(0.68))
+                            .padding(.horizontal, 14)
+                            .padding(.top, 9)
+
+                            Capsule()
+                                .fill(accentColor(for: tab))
+                                .frame(height: 3)
+                                .opacity(selectedTab == tab ? 1 : 0.65)
+                                .padding(.horizontal, 12)
+                        }
+                        .padding(.bottom, 6)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .fill(selectedTab == tab ? Color.white.opacity(0.08) : Color.clear)
+                        )
                     }
                     .buttonStyle(.plain)
-                    .foregroundColor(.secondary)
-                } else {
-                    Button(action: { isExpanded.toggle() }) {
-                        HStack(spacing: 4) {
-                            Image(systemName: isExpanded ? "chevron.up" : "gearshape")
-                            Text(isExpanded ? "Close" : "Configure")
-                        }
-                        .font(.caption)
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
                 }
             }
+            .padding(.horizontal, 14)
+            .padding(.bottom, 10)
+        }
+    }
 
-            if isAuthenticated, let metrics = metrics {
-                Divider()
-
-                // Show usage data
-                if let sessionLimit = metrics.sessionLimit {
-                    LimitRow(title: "Session", limit: sessionLimit)
-                }
-
-                if let weeklyLimit = metrics.weeklyLimit {
-                    LimitRow(title: "Weekly", limit: weeklyLimit)
-                }
-
-                if let codeReviewLimit = metrics.codeReviewLimit {
-                    LimitRow(title: "Code Review", limit: codeReviewLimit)
-                }
-
-                Text("Updated: \(formatDate(metrics.lastUpdated))")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            } else if !isAuthenticated && !isExpanded {
-                Text("Not configured")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-
-            // Inline settings section
-            if isExpanded {
-                Divider()
-
-                VStack(alignment: .leading, spacing: 8) {
-                    if isAuthenticated {
-                        // Show masked key and remove button
-                        HStack {
-                            Image(systemName: "checkmark.circle.fill")
-                                .foregroundColor(.green)
-                            Text("API Key configured")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-
-                        Button(action: {
-                            removeApiKey()
-                            isExpanded = false
-                        }) {
-                            HStack {
-                                Image(systemName: "trash")
-                                Text("Remove Key")
-                            }
-                            .font(.caption)
-                        }
-                        .buttonStyle(.bordered)
-                        .foregroundColor(.red)
-                    } else {
-                        // Show input field for new key
-                        Text(keyPlaceholder)
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-
-                        SecureField("Paste API key here...", text: $apiKeyInput)
-                            .textFieldStyle(.roundedBorder)
-                            .font(.caption)
-
-                        HStack {
-                            Button(action: {
-                                saveApiKey()
-                            }) {
-                                HStack {
-                                    Image(systemName: "checkmark")
-                                    Text("Save")
-                                }
-                                .font(.caption)
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .disabled(apiKeyInput.isEmpty)
-
-                            Button(action: {
-                                openHelpUrl()
-                            }) {
-                                HStack {
-                                    Image(systemName: "questionmark.circle")
-                                    Text("Help")
-                                }
-                                .font(.caption)
-                            }
-                            .buttonStyle(.bordered)
-                        }
-                    }
+    @ViewBuilder
+    private var content: some View {
+        ScrollView(showsIndicators: false) {
+            VStack(spacing: 14) {
+                switch selectedTab {
+                case .overview:
+                    overviewTab
+                case .codex:
+                    ServiceDetailView(
+                        snapshot: codexSnapshot,
+                        primaryAction: refreshCodex,
+                        secondaryAction: openDashboard(for: codexSnapshot),
+                        supplemental: AnyView(codexCreditsCard)
+                    )
+                case .claude:
+                    ServiceDetailView(
+                        snapshot: claudeSnapshot,
+                        primaryAction: refreshClaude,
+                        secondaryAction: openDashboard(for: claudeSnapshot),
+                        supplemental: AnyView(claudeCostCard)
+                    )
+                case .cursor:
+                    ServiceDetailView(
+                        snapshot: cursorSnapshot,
+                        primaryAction: refreshCursor,
+                        secondaryAction: openDashboard(for: cursorSnapshot)
+                    )
                 }
             }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 14)
         }
-        .padding()
-        .background(Color(NSColor.controlBackgroundColor))
-        .cornerRadius(8)
     }
 
-    private var headerColor: Color {
-        if isAuthenticated, let metrics = metrics {
-            return metrics.overallStatus.color
+    private var overviewTab: some View {
+        VStack(spacing: 14) {
+            if enabledSnapshots.isEmpty {
+                InlineMessageCard(
+                    title: "No providers enabled",
+                    message: "Turn providers back on in Settings to show them in the menu bar."
+                )
+            } else if !anyConnectedProvider {
+                onboardingCard
+            }
+
+            ForEach(issueSummaries) { summary in
+                ProviderIssueCard(summary: summary)
+            }
+
+            if showCodexProvider {
+                SummaryServiceCard(snapshot: codexSnapshot, action: refreshCodex)
+            }
+
+            if showClaudeProvider {
+                SummaryServiceCard(snapshot: claudeSnapshot, action: refreshClaude)
+            }
+
+            if showCursorProvider, (cursorSnapshot.isConnected || cursorSnapshot.metrics != nil || !anyConnectedProvider) {
+                SummaryServiceCard(snapshot: cursorSnapshot, action: refreshCursor)
+            }
+
+            if let error = dataManager.lastError {
+                InlineMessageCard(
+                    title: "Latest issue",
+                    message: error.localizedDescription
+                )
+            }
         }
-        return .gray
     }
 
-    private var keyPlaceholder: String {
-        switch service {
+    private var onboardingCard: some View {
+        InlineMessageCard(
+            title: "Connect your local tools",
+            message: "Run `codex login`, run `claude`, and sign into Cursor. MeterBar reads those local credentials directly and avoids browser-cookie import."
+        )
+    }
+
+    @ViewBuilder
+    private var claudeCostCard: some View {
+        if costTracker.isScanning {
+            InlineMessageCard(title: "Scanning local sessions", message: "Estimating Claude Code cost from `~/.claude/projects`.")
+        } else if let summary = costTracker.costSummary,
+                  let claudeCost = summary.costs.first(where: { $0.provider == .claudeCode }) {
+            CostSummaryCard(cost: claudeCost, total: summary)
+        }
+    }
+
+    @ViewBuilder
+    private var codexCreditsCard: some View {
+        if costTracker.isScanning, costTracker.codexUsageSummary == nil {
+            InlineMessageCard(title: "Scanning local sessions", message: "Reading recent Codex session files under `~/.codex`.")
+        }
+
+        if let credits = codexCliService.credits {
+            CodexCreditsCard(credits: credits)
+        }
+
+        if let usageSummary = costTracker.codexUsageSummary {
+            CodexLocalUsageCard(summary: usageSummary)
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 14) {
+            FooterButton(title: "Settings…", action: openSettings)
+            FooterButton(title: "About MeterBar", action: openAboutPanel)
+
+            Spacer()
+
+            Button("Quit", action: terminate)
+                .buttonStyle(.plain)
+                .foregroundStyle(Color.white.opacity(0.84))
+        }
+        .font(.system(size: 13, weight: .medium))
+        .padding(.horizontal, 18)
+        .padding(.vertical, 14)
+    }
+
+    private func iconName(for tab: MenuTab) -> String {
+        switch tab {
+        case .overview:
+            return "square.grid.2x2"
+        case .codex:
+            return "terminal"
         case .claude:
-            return "Admin API Key (sk-ant-admin...)"
-        case .claudeCode, .codexCli, .cursor:
-            return ""
-        case .openai:
-            return "Admin API Key"
+            return "sparkles"
+        case .cursor:
+            return "cursorarrow.click"
         }
     }
 
-    private func saveApiKey() {
-        switch service {
+    private func accentColor(for tab: MenuTab) -> Color {
+        switch tab {
+        case .overview:
+            return .meterOverviewAccent
+        case .codex:
+            return .meterCodexAccent
         case .claude:
-            _ = authManager.setClaudeAdminKey(apiKeyInput)
-        case .claudeCode, .codexCli, .cursor:
-            break // These use local auth, not API key
-        case .openai:
-            _ = authManager.setOpenAIAdminKey(apiKeyInput)
-        }
-        apiKeyInput = ""
-        isExpanded = false
-    }
-
-    private func removeApiKey() {
-        switch service {
-        case .claude:
-            authManager.removeClaudeAdminKey()
-        case .claudeCode, .codexCli, .cursor:
-            break // These use local auth
-        case .openai:
-            authManager.removeOpenAIAdminKey()
+            return .meterClaudeAccent
+        case .cursor:
+            return .meterCursorAccent
         }
     }
 
-    private func openHelpUrl() {
-        let urlString: String
-        switch service {
-        case .claude:
-            urlString = "https://console.anthropic.com/settings/admin-keys"
-        case .claudeCode, .codexCli, .cursor:
-            return // No help URL for local auth services
-        case .openai:
-            urlString = "https://platform.openai.com/settings/organization/admin-keys"
+    private func refreshAll() {
+        Task {
+            await dataManager.refreshAll()
         }
+    }
 
-        if let url = URL(string: urlString) {
+    private func refreshClaude() {
+        claudeCodeService.checkAccess(forceRefresh: true)
+        Task {
+            await dataManager.refresh(service: .claudeCode)
+            await costTracker.scanCosts(days: 30)
+        }
+    }
+
+    private func refreshCodex() {
+        codexCliService.checkAccess()
+        Task {
+            await dataManager.refresh(service: .codexCli)
+            await costTracker.scanCosts(days: 30)
+        }
+    }
+
+    private func refreshCursor() {
+        cursorService.checkAccess(forceRescan: true)
+        Task {
+            await dataManager.refresh(service: .cursor)
+        }
+    }
+
+    private func openDashboard(for snapshot: ServiceSnapshot) -> (() -> Void)? {
+        guard let url = snapshot.dashboardURL else {
+            return nil
+        }
+        return {
             NSWorkspace.shared.open(url)
         }
     }
 
-    private func formatDate(_ date: Date) -> String {
+    private func openSettings() {
+        let selector = NSSelectorFromString("showSettingsWindow:")
+        if NSApp.sendAction(selector, to: nil, from: nil) {
+            return
+        }
+        NSApp.sendAction(NSSelectorFromString("showPreferencesWindow:"), to: nil, from: nil)
+    }
+
+    private func openAboutPanel() {
+        NSApp.orderFrontStandardAboutPanel(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func terminate() {
+        NSApplication.shared.terminate(nil)
+    }
+
+    private func relativeTimestamp(_ date: Date) -> String {
         let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: date, relativeTo: Date())
+        formatter.unitsStyle = .short
+        return "Updated \(formatter.localizedString(for: date, relativeTo: Date()))"
+    }
+
+    private func normalizeSelectedTab() {
+        guard !availableTabs.isEmpty else {
+            selectedTab = .overview
+            return
+        }
+
+        if !availableTabs.contains(selectedTab) {
+            selectedTab = availableTabs.first ?? .overview
+        }
     }
 }
 
-// MARK: - Cursor Service Row (Local)
+private struct SummaryServiceCard: View {
+    let snapshot: ServiceSnapshot
+    let action: () -> Void
 
-struct CursorServiceRow: View {
-    let hasAccess: Bool
-    let metrics: UsageMetrics?
-    @Binding var expandedCard: ExpandedCard
-
-    @StateObject private var cursorService = CursorLocalService.shared
-    @StateObject private var dataManager = UsageDataManager.shared
-
-    private var isExpanded: Bool { expandedCard == .cursor }
+    private let cardBackground = Color(nsColor: NSColor(calibratedRed: 0.15, green: 0.16, blue: 0.20, alpha: 1.0))
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            // Header - entire row is tappable
-            Button(action: {
-                expandedCard = isExpanded ? .none : .cursor
-            }) {
-                HStack {
-                    Image(systemName: ServiceType.cursor.iconName)
-                        .foregroundColor(headerColor)
-                    Text(ServiceType.cursor.displayName)
-                        .font(.headline)
-                        .foregroundColor(.primary)
+        VStack(alignment: .leading, spacing: 14) {
+            header
 
-                    // Show compact progress bar when collapsed
-                    if !isExpanded, hasAccess, let metrics = metrics, let session = metrics.weeklyLimit {
-                        CompactProgressBar(percentage: session.percentage, color: session.statusColor.color)
-                    }
+            if snapshot.health.shouldShowBanner {
+                HealthBanner(summary: snapshot.health)
+            }
 
-                    Spacer()
-
-                    if hasAccess {
-                        if let metrics = metrics {
-                            StatusIndicator(status: metrics.overallStatus)
-                        }
-                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
+            if snapshot.isConnected, let metrics = snapshot.metrics {
+                VStack(spacing: 12) {
+                    ForEach(metricDescriptors(for: metrics)) { descriptor in
+                        UsageMeterRow(
+                            descriptor: descriptor,
+                            accent: snapshot.accent
+                        )
                     }
                 }
-                .contentShape(Rectangle())
+            } else {
+                disconnectedState
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(cardBackground)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color.white.opacity(0.06), lineWidth: 1)
+        )
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 10) {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    Text(snapshot.title)
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(.white)
+
+                    if snapshot.isConnected {
+                        Text(snapshot.subtitle)
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(Color.white.opacity(0.68))
+                    }
+
+                    StatusBadge(summary: snapshot.health)
+                }
+
+                if let metrics = snapshot.metrics {
+                    Text("Updated \(relativeTimestamp(metrics.lastUpdated))")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                } else if let summary = snapshot.summary {
+                    Text(summary)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            Button(action: action) {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.78))
+                    .frame(width: 28, height: 28)
+                    .background(Color.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
             }
             .buttonStyle(.plain)
-
-            if !hasAccess {
-                Text("Log in to Cursor IDE to enable")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-
-                Button(action: {
-                    cursorService.checkAccess()
-                    if cursorService.hasAccess {
-                        Task { await dataManager.refreshAll() }
-                    }
-                }) {
-                    HStack {
-                        Image(systemName: "arrow.clockwise")
-                        Text("Check Again")
-                    }
-                    .font(.caption)
-                }
-                .buttonStyle(.bordered)
-            }
-
-            // Expanded content
-            if isExpanded, hasAccess, let metrics = metrics {
-                Divider()
-
-                if let weeklyLimit = metrics.weeklyLimit {
-                    LimitRow(title: "Monthly", limit: weeklyLimit)
-                }
-
-                if let subscriptionType = cursorService.subscriptionType {
-                    HStack {
-                        Text(formatSubscriptionType(subscriptionType))
-                            .font(.caption)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(Color.blue.opacity(0.2))
-                            .cornerRadius(4)
-                        Spacer()
-                        Text("Updated: \(formatDate(metrics.lastUpdated))")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                } else {
-                    Text("Updated: \(formatDate(metrics.lastUpdated))")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-            }
         }
-        .padding()
-        .background(Color(NSColor.controlBackgroundColor))
-        .cornerRadius(8)
     }
 
-    private var headerColor: Color {
-        if hasAccess, let metrics = metrics {
-            return metrics.overallStatus.color
+    private var disconnectedState: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(snapshot.actionLabel)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(Color.white.opacity(0.78))
+
+            Text(snapshot.health.message)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
-        return .gray
     }
 
-    private func formatDate(_ date: Date) -> String {
+    private func metricDescriptors(for metrics: UsageMetrics) -> [MetricDescriptor] {
+        var descriptors: [MetricDescriptor] = []
+
+        if let session = metrics.sessionLimit {
+            descriptors.append(MetricDescriptor(title: sessionTitle(for: metrics.service), limit: session))
+        }
+
+        if let weekly = metrics.weeklyLimit {
+            descriptors.append(MetricDescriptor(title: weeklyTitle(for: metrics.service), limit: weekly))
+        }
+
+        if let codeReview = metrics.codeReviewLimit {
+            descriptors.append(MetricDescriptor(title: codeReviewTitle(for: metrics.service), limit: codeReview))
+        }
+
+        return descriptors
+    }
+
+    private func sessionTitle(for service: ServiceType) -> String {
+        switch service {
+        case .claudeCode:
+            return "Session"
+        case .codexCli:
+            return "Session"
+        case .cursor:
+            return "On-demand"
+        case .claude, .openai:
+            return "Current"
+        }
+    }
+
+    private func weeklyTitle(for service: ServiceType) -> String {
+        switch service {
+        case .claudeCode, .codexCli:
+            return "Weekly"
+        case .cursor:
+            return "Monthly"
+        case .claude, .openai:
+            return "Weekly"
+        }
+    }
+
+    private func codeReviewTitle(for service: ServiceType) -> String {
+        switch service {
+        case .claudeCode:
+            return "Sonnet"
+        case .codexCli:
+            return "Code Review"
+        case .cursor, .claude, .openai:
+            return "Extra"
+        }
+    }
+
+    private func relativeTimestamp(_ date: Date) -> String {
         let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
+        formatter.unitsStyle = .short
         return formatter.localizedString(for: date, relativeTo: Date())
-    }
-
-    private func formatSubscriptionType(_ type: String) -> String {
-        switch type.lowercased() {
-        case "pro_plus":
-            return "Pro+"
-        default:
-            return type.replacingOccurrences(of: "_", with: " ").capitalized
-        }
     }
 }
 
-// MARK: - Claude Code Service Row (Local Files)
+private struct ServiceDetailView: View {
+    let snapshot: ServiceSnapshot
+    let primaryAction: () -> Void
+    let secondaryAction: (() -> Void)?
+    var supplemental: AnyView? = nil
 
-struct ClaudeCodeServiceRow: View {
-    let hasAccess: Bool
-    let metrics: UsageMetrics?
-    @Binding var expandedCard: ExpandedCard
-
-    @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
-    @StateObject private var dataManager = UsageDataManager.shared
-
-    private var isExpanded: Bool { expandedCard == .claudeCode }
+    private let cardBackground = Color(nsColor: NSColor(calibratedRed: 0.15, green: 0.16, blue: 0.20, alpha: 1.0))
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            // Header - entire row is tappable
-            Button(action: {
-                expandedCard = isExpanded ? .none : .claudeCode
-            }) {
-                HStack {
-                    Image(systemName: ServiceType.claudeCode.iconName)
-                        .foregroundColor(headerColor)
-                    Text(ServiceType.claudeCode.displayName)
-                        .font(.headline)
-                        .foregroundColor(.primary)
+        VStack(alignment: .leading, spacing: 14) {
+            hero
 
-                    // Show compact progress bar when collapsed
-                    if !isExpanded, hasAccess, let metrics = metrics, let session = metrics.sessionLimit {
-                        CompactProgressBar(percentage: session.percentage, color: session.statusColor.color)
-                    }
-
-                    Spacer()
-
-                    if hasAccess {
-                        if let metrics = metrics {
-                            StatusIndicator(status: metrics.overallStatus)
-                        }
-                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-
-            if !hasAccess {
-                Text("Log in to Claude Code CLI to enable")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-
-                Button(action: {
-                    claudeCodeService.checkAccess()
-                    if claudeCodeService.hasAccess {
-                        Task { await dataManager.refreshAll() }
-                    }
-                }) {
-                    HStack {
-                        Image(systemName: "arrow.clockwise")
-                        Text("Check Again")
-                    }
-                    .font(.caption)
-                }
-                .buttonStyle(.bordered)
+            if snapshot.health.shouldShowBanner {
+                HealthBanner(summary: snapshot.health)
             }
 
-            // Expanded content
-            if isExpanded, hasAccess, let metrics = metrics {
-                Divider()
-
-                if let sessionLimit = metrics.sessionLimit {
-                    LimitRow(title: "Session (5h)", limit: sessionLimit)
-                }
-
-                if let weeklyLimit = metrics.weeklyLimit {
-                    LimitRow(title: "All Models (7d)", limit: weeklyLimit)
-                }
-
-                if let sonnetLimit = metrics.codeReviewLimit {
-                    LimitRow(title: "Sonnet (7d)", limit: sonnetLimit)
-                }
-
-                if let subscriptionType = claudeCodeService.subscriptionType {
-                    HStack {
-                        Text(subscriptionType.capitalized)
-                            .font(.caption)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(Color.purple.opacity(0.2))
-                            .cornerRadius(4)
-                        Spacer()
-                        Text("Updated: \(formatDate(metrics.lastUpdated))")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                } else {
-                    Text("Updated: \(formatDate(metrics.lastUpdated))")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
+            if snapshot.isConnected, let metrics = snapshot.metrics {
+                meterList(metrics: metrics)
+            } else {
+                InlineMessageCard(
+                    title: "Not connected",
+                    message: "\(snapshot.actionLabel). \(snapshot.health.message)"
+                )
             }
+
+            if let supplemental {
+                supplemental
+            }
+
+            actions
         }
-        .padding()
-        .background(Color(NSColor.controlBackgroundColor))
-        .cornerRadius(8)
+        .padding(18)
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(cardBackground)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .stroke(Color.white.opacity(0.06), lineWidth: 1)
+        )
     }
 
-    private var headerColor: Color {
-        if hasAccess, let metrics = metrics {
-            return metrics.overallStatus.color
+    private var hero: some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(snapshot.title)
+                    .font(.system(size: 24, weight: .semibold))
+                    .foregroundStyle(.white)
+
+                HStack(spacing: 8) {
+                    Text(snapshot.subtitle)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Color.white.opacity(0.68))
+
+                    if let summary = snapshot.summary, !summary.isEmpty {
+                        Text(summary)
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if let metrics = snapshot.metrics {
+                    Text("Updated \(relativeTimestamp(metrics.lastUpdated))")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            StatusBadge(summary: snapshot.health, prominent: true)
         }
-        return .gray
     }
 
-    private func formatDate(_ date: Date) -> String {
+    private func meterList(metrics: UsageMetrics) -> some View {
+        VStack(spacing: 14) {
+            ForEach(metricDescriptors(for: metrics)) { descriptor in
+                UsageMeterRow(
+                    descriptor: descriptor,
+                    accent: snapshot.accent,
+                    emphasized: true
+                )
+            }
+        }
+    }
+
+    private var actions: some View {
+        HStack(spacing: 10) {
+            ActionButton(title: "Refresh", icon: "arrow.clockwise", accent: snapshot.accent, action: primaryAction)
+
+            if let secondaryAction {
+                ActionButton(title: "Dashboard", icon: "globe", accent: Color.white.opacity(0.18), foreground: .white, action: secondaryAction)
+            }
+        }
+    }
+
+    private func metricDescriptors(for metrics: UsageMetrics) -> [MetricDescriptor] {
+        var descriptors: [MetricDescriptor] = []
+
+        if let session = metrics.sessionLimit {
+            descriptors.append(MetricDescriptor(title: sessionTitle(for: snapshot.service), limit: session))
+        }
+
+        if let weekly = metrics.weeklyLimit {
+            descriptors.append(MetricDescriptor(title: weeklyTitle(for: snapshot.service), limit: weekly))
+        }
+
+        if let codeReview = metrics.codeReviewLimit {
+            descriptors.append(MetricDescriptor(title: codeReviewTitle(for: snapshot.service), limit: codeReview))
+        }
+
+        return descriptors
+    }
+
+    private func sessionTitle(for service: ServiceType) -> String {
+        switch service {
+        case .claudeCode, .codexCli:
+            return "Session"
+        case .cursor:
+            return "On-demand"
+        case .claude, .openai:
+            return "Current"
+        }
+    }
+
+    private func weeklyTitle(for service: ServiceType) -> String {
+        switch service {
+        case .claudeCode, .codexCli:
+            return "Weekly"
+        case .cursor:
+            return "Monthly"
+        case .claude, .openai:
+            return "Weekly"
+        }
+    }
+
+    private func codeReviewTitle(for service: ServiceType) -> String {
+        switch service {
+        case .claudeCode:
+            return "Sonnet"
+        case .codexCli:
+            return "Code Review"
+        case .cursor, .claude, .openai:
+            return "Extra"
+        }
+    }
+
+    private func relativeTimestamp(_ date: Date) -> String {
         let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
+        formatter.unitsStyle = .short
         return formatter.localizedString(for: date, relativeTo: Date())
     }
 }
 
-// MARK: - Codex CLI Service Row (Local Files)
-
-struct CodexCliServiceRow: View {
-    let hasAccess: Bool
-    let metrics: UsageMetrics?
-    @Binding var expandedCard: ExpandedCard
-
-    @StateObject private var codexCliService = CodexCliLocalService.shared
-    @StateObject private var dataManager = UsageDataManager.shared
-
-    private var isExpanded: Bool { expandedCard == .codexCli }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            // Header - entire row is tappable
-            Button(action: {
-                expandedCard = isExpanded ? .none : .codexCli
-            }) {
-                HStack {
-                    Image(systemName: ServiceType.codexCli.iconName)
-                        .foregroundColor(headerColor)
-                    Text(ServiceType.codexCli.displayName)
-                        .font(.headline)
-                        .foregroundColor(.primary)
-
-                    // Show compact progress bar when collapsed
-                    if !isExpanded, hasAccess, let metrics = metrics, let session = metrics.sessionLimit {
-                        CompactProgressBar(percentage: session.percentage, color: session.statusColor.color)
-                    }
-
-                    Spacer()
-
-                    if hasAccess {
-                        if let metrics = metrics {
-                            StatusIndicator(status: metrics.overallStatus)
-                        }
-                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-
-            if !hasAccess {
-                Text("Log in to Codex CLI to enable")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-
-                Button(action: {
-                    codexCliService.checkAccess()
-                    if codexCliService.hasAccess {
-                        Task { await dataManager.refreshAll() }
-                    }
-                }) {
-                    HStack {
-                        Image(systemName: "arrow.clockwise")
-                        Text("Check Again")
-                    }
-                    .font(.caption)
-                }
-                .buttonStyle(.bordered)
-            }
-
-            // Expanded content
-            if isExpanded, hasAccess, let metrics = metrics {
-                Divider()
-
-                if let sessionLimit = metrics.sessionLimit {
-                    LimitRow(title: "5 Hour Limit", limit: sessionLimit)
-                }
-
-                if let weeklyLimit = metrics.weeklyLimit {
-                    LimitRow(title: "Weekly Limit", limit: weeklyLimit)
-                }
-
-                if let codeReviewLimit = metrics.codeReviewLimit {
-                    LimitRow(title: "Code Review", limit: codeReviewLimit)
-                }
-
-                if let subscriptionType = codexCliService.subscriptionType {
-                    HStack {
-                        Text(subscriptionType.replacingOccurrences(of: "_", with: " ").capitalized)
-                            .font(.caption)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(Color.green.opacity(0.2))
-                            .cornerRadius(4)
-                        Spacer()
-                        Text("Updated: \(formatDate(metrics.lastUpdated))")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                } else {
-                    Text("Updated: \(formatDate(metrics.lastUpdated))")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-            }
-        }
-        .padding()
-        .background(Color(NSColor.controlBackgroundColor))
-        .cornerRadius(8)
-    }
-
-    private var headerColor: Color {
-        if hasAccess, let metrics = metrics {
-            return metrics.overallStatus.color
-        }
-        return .gray
-    }
-
-    private func formatDate(_ date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: date, relativeTo: Date())
-    }
-}
-
-// MARK: - Reusable Components
-
-struct ServiceCard: View {
-    let metrics: UsageMetrics
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Image(systemName: metrics.service.iconName)
-                    .foregroundColor(metrics.overallStatus.color)
-                Text(metrics.service.displayName)
-                    .font(.headline)
-                Spacer()
-                StatusIndicator(status: metrics.overallStatus)
-            }
-
-            Divider()
-
-            if let sessionLimit = metrics.sessionLimit {
-                LimitRow(title: "Session", limit: sessionLimit)
-            }
-
-            if let weeklyLimit = metrics.weeklyLimit {
-                LimitRow(title: "Weekly", limit: weeklyLimit)
-            }
-
-            if let codeReviewLimit = metrics.codeReviewLimit {
-                LimitRow(title: "Code Review", limit: codeReviewLimit)
-            }
-
-            Text("Updated: \(formatDate(metrics.lastUpdated))")
-                .font(.caption)
-                .foregroundColor(.secondary)
-        }
-        .padding()
-        .background(Color(NSColor.controlBackgroundColor))
-        .cornerRadius(8)
-    }
-
-    private func formatDate(_ date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: date, relativeTo: Date())
-    }
-}
-
-struct LimitRow: View {
+private struct MetricDescriptor: Identifiable {
+    let id = UUID()
     let title: String
     let limit: UsageLimit
+}
+
+private struct UsageMeterRow: View {
+    let descriptor: MetricDescriptor
+    let accent: Color
+    var emphasized: Bool = false
+
+    private var remainingPercentage: Int {
+        Int(round(max(0, 100 - descriptor.limit.percentage)))
+    }
+
+    private var remainingFraction: Double {
+        max(0, min(1, descriptor.limit.remaining / max(descriptor.limit.total, 1)))
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack {
-                Text(title)
-                    .font(.subheadline)
+        VStack(alignment: .leading, spacing: emphasized ? 8 : 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(descriptor.title)
+                    .font(.system(size: emphasized ? 17 : 15, weight: .semibold))
+                    .foregroundStyle(.white)
+
                 Spacer()
-                Text("\(Int(limit.percentage))%")
-                    .font(.subheadline)
-                    .bold()
+
+                Text("\(remainingPercentage)% left")
+                    .font(.system(size: emphasized ? 15 : 13, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.86))
             }
 
-            ProgressView(value: min(max(limit.used, 0), limit.total), total: limit.total)
-                .tint(limit.statusColor.color)
+            GeometryReader { proxy in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Color.white.opacity(0.10))
+                        .frame(height: emphasized ? 8 : 6)
 
-            if let resetTime = limit.resetTime {
-                Text("Resets: \(formatResetTime(resetTime))")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+                    Capsule()
+                        .fill(accent)
+                        .frame(width: max(18, proxy.size.width * remainingFraction), height: emphasized ? 8 : 6)
+                }
             }
+            .frame(height: emphasized ? 8 : 6)
+
+            HStack(spacing: 8) {
+                if descriptor.limit.percentage > 0 {
+                    Text("\(Int(round(descriptor.limit.percentage)))% used")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                if let resetTime = descriptor.limit.resetTime {
+                    Text(countdownText(resetTime))
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, emphasized ? 2 : 0)
+    }
+
+    private func countdownText(_ date: Date) -> String {
+        guard date > Date() else {
+            return "Resetting now"
+        }
+
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = date.timeIntervalSinceNow > 86_400 ? [.day, .hour] : [.hour, .minute]
+        formatter.unitsStyle = .abbreviated
+        formatter.maximumUnitCount = 2
+
+        if let formatted = formatter.string(from: Date(), to: date) {
+            return "Resets in \(formatted)"
+        }
+
+        return "Resets soon"
+    }
+}
+
+private struct InlineMessageCard: View {
+    let title: String
+    let message: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.white)
+            Text(message)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.white.opacity(0.05))
+        )
+    }
+}
+
+private struct ProviderIssueCard: View {
+    let summary: ProviderHealthSummary
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: summary.state.iconName)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(summary.state.tintColor)
+                .frame(width: 18, height: 18)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    Text(summary.title)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.white)
+                    StatusBadge(summary: summary)
+                }
+
+                Text(summary.message)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.white.opacity(0.05))
+        )
+    }
+}
+
+private struct HealthBanner: View {
+    let summary: ProviderHealthSummary
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: summary.state.iconName)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(summary.state.tintColor)
+                .frame(width: 16, height: 16)
+
+            Text(summary.message)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer()
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(summary.state.tintColor.opacity(0.12))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(summary.state.tintColor.opacity(0.20), lineWidth: 1)
+        )
+    }
+}
+
+private struct CostSummaryCard: View {
+    let cost: TokenCost
+    let total: CostSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Local Cost Estimate")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.white)
+
+            HStack {
+                summaryItem(title: "30 days", value: cost.formattedCost)
+                Spacer()
+                summaryItem(title: "Tokens", value: cost.formattedTokens)
+                Spacer()
+                summaryItem(title: "Avg/day", value: total.formattedDailyCost)
+            }
+
+            Text("Based on Claude Code session files already on disk. No extra network requests.")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.white.opacity(0.05))
+        )
+    }
+
+    private func summaryItem(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.white)
+        }
+    }
+}
+
+private struct CodexCreditsCard: View {
+    let credits: Credits
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Codex Credits")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.white)
+
+            HStack {
+                creditItem(title: "Credits", value: credits.unlimited ? "Unlimited" : (credits.hasCredits ? "Available" : "None"))
+                Spacer()
+                if let balance = credits.balance {
+                    creditItem(title: "Balance", value: String(format: "%.0f", balance))
+                }
+                Spacer()
+                if let approxCloud = credits.approxCloudMessages {
+                    creditItem(title: "Cloud msgs", value: "\(approxCloud)")
+                }
+            }
+
+            if let approxLocal = credits.approxLocalMessages {
+                Text("Approx. local messages: \(approxLocal)")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.white.opacity(0.05))
+        )
+    }
+
+    private func creditItem(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.white)
+        }
+    }
+}
+
+private struct CodexLocalUsageCard: View {
+    let summary: LocalUsageSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Local Session Usage")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.white)
+
+            HStack {
+                summaryItem(title: "30 days", value: summary.formattedTokens)
+                Spacer()
+                summaryItem(title: "Sessions", value: "\(summary.sessionCount)")
+                Spacer()
+                summaryItem(title: "Cached input", value: formatted(summary.cachedInputTokens))
+            }
+
+            Text("Derived from the last token-count event in each Codex session file under `~/.codex`.")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.white.opacity(0.05))
+        )
+    }
+
+    private func summaryItem(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.white)
         }
     }
 
-    private func formatResetTime(_ date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: date, relativeTo: Date())
+    private func formatted(_ value: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
     }
 }
 
-struct StatusIndicator: View {
-    let status: UsageStatus
+private struct ActionButton: View {
+    let title: String
+    let icon: String
+    let accent: Color
+    var foreground: Color = .black
+    let action: () -> Void
 
     var body: some View {
-        Circle()
-            .fill(status.color)
-            .frame(width: 8, height: 8)
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .semibold))
+                Text(title)
+                    .font(.system(size: 13, weight: .semibold))
+            }
+            .foregroundStyle(foreground)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+            .background(accent, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        }
+        .buttonStyle(.plain)
     }
 }
 
-// MARK: - Compact Progress Bar (for collapsed headers)
-
-struct CompactProgressBar: View {
-    let percentage: Double
-    let color: Color
+private struct StatusBadge: View {
+    let summary: ProviderHealthSummary
+    var prominent: Bool = false
 
     var body: some View {
-        ZStack(alignment: .leading) {
-            // Background track
-            RoundedRectangle(cornerRadius: 2)
-                .fill(Color.gray.opacity(0.3))
-                .frame(width: 40, height: 4)
+        HStack(spacing: 5) {
+            Image(systemName: summary.state.iconName)
+                .font(.system(size: prominent ? 11 : 10, weight: .semibold))
+            Text(summary.state.label)
+                .font(.system(size: prominent ? 11 : 10, weight: .semibold))
+        }
+        .foregroundStyle(prominent ? .white : summary.state.tintColor)
+        .padding(.horizontal, prominent ? 10 : 8)
+        .padding(.vertical, prominent ? 6 : 4)
+        .background(
+            Capsule(style: .continuous)
+                .fill(prominent ? summary.state.tintColor.opacity(0.18) : summary.state.tintColor.opacity(0.12))
+        )
+        .overlay(
+            Capsule(style: .continuous)
+                .stroke(summary.state.tintColor.opacity(0.22), lineWidth: 1)
+        )
+    }
+}
 
-            // Progress fill
-            RoundedRectangle(cornerRadius: 2)
-                .fill(color)
-                .frame(width: 40 * min(max(percentage, 0), 100) / 100, height: 4)
+private struct FooterButton: View {
+    let title: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(title, action: action)
+            .buttonStyle(.plain)
+            .foregroundStyle(Color.white.opacity(0.84))
+    }
+}
+
+private extension Color {
+    static let meterOverviewAccent = Color(nsColor: NSColor(calibratedRed: 0.33, green: 0.58, blue: 1.00, alpha: 1.0))
+    static let meterCodexAccent = Color(nsColor: NSColor(calibratedRed: 0.45, green: 0.82, blue: 0.85, alpha: 1.0))
+    static let meterClaudeAccent = Color(nsColor: NSColor(calibratedRed: 0.92, green: 0.63, blue: 0.49, alpha: 1.0))
+    static let meterCursorAccent = Color(nsColor: NSColor(calibratedRed: 0.54, green: 0.68, blue: 1.00, alpha: 1.0))
+}
+
+private extension ProviderHealthState {
+    var tintColor: Color {
+        switch self {
+        case .disconnected:
+            return Color.white.opacity(0.45)
+        case .healthy:
+            return Color.meterCodexAccent
+        case .stale, .warning:
+            return .orange
+        case .critical, .error:
+            return .red
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .disconnected:
+            return "bolt.slash"
+        case .healthy:
+            return "checkmark.circle.fill"
+        case .stale:
+            return "clock.badge.exclamationmark"
+        case .warning:
+            return "exclamationmark.triangle.fill"
+        case .critical:
+            return "xmark.octagon.fill"
+        case .error:
+            return "exclamationmark.circle.fill"
         }
     }
 }

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -5,8 +5,15 @@ struct SettingsView: View {
     @StateObject private var authManager = AuthenticationManager.shared
     @StateObject private var dataManager = UsageDataManager.shared
     @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
+    @StateObject private var codexCliService = CodexCliLocalService.shared
     @StateObject private var cursorService = CursorLocalService.shared
     @StateObject private var costTracker = CostTracker.shared
+
+    @AppStorage("showClaudeProvider") private var showClaudeProvider: Bool = true
+    @AppStorage("showCodexProvider") private var showCodexProvider: Bool = true
+    @AppStorage("showCursorProvider") private var showCursorProvider: Bool = true
+    @AppStorage("showOverviewTab") private var showOverviewTab: Bool = true
+    @AppStorage("statusItemIconMode") private var statusItemIconMode: String = "usageBars"
 
     @State private var claudeAdminKey: String = ""
     @State private var openaiAdminKey: String = ""
@@ -16,7 +23,153 @@ struct SettingsView: View {
 
     var body: some View {
         Form {
-            Section("Claude (Anthropic)") {
+            Section("Recommended Setup") {
+                Text("MeterBar works best with your existing local sign-ins. Claude Code, Codex CLI, and Cursor are read from credentials those tools already manage on your Mac.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                Text("Admin API keys below are optional and only used for direct API-based usage endpoints.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Section("Menu Bar") {
+                Toggle("Show Overview tab", isOn: $showOverviewTab)
+                Toggle("Show Codex", isOn: $showCodexProvider)
+                Toggle("Show Claude", isOn: $showClaudeProvider)
+                Toggle("Show Cursor", isOn: $showCursorProvider)
+
+                Picker("Status item icon", selection: $statusItemIconMode) {
+                    Text("Usage bars").tag("usageBars")
+                    Text("Provider dots").tag("providerDots")
+                    Text("Template").tag("template")
+                }
+            }
+
+            Section("Claude Code (Recommended)") {
+                HStack {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(claudeCodeService.hasAccess ? .green : .gray)
+                    Text(claudeCodeService.hasAccess ? "Connected" : "Not Connected")
+                }
+
+                if claudeCodeService.hasAccess {
+                    if let subscriptionType = claudeCodeService.subscriptionType {
+                        HStack {
+                            Text("Plan:")
+                                .foregroundColor(.secondary)
+                            Text(subscriptionType.capitalized)
+                                .bold()
+                        }
+                        .font(.caption)
+                    }
+
+                    if let rateLimitTier = claudeCodeService.rateLimitTier {
+                        HStack {
+                            Text("Tier:")
+                                .foregroundColor(.secondary)
+                            Text(rateLimitTier.replacingOccurrences(of: "_", with: " ").capitalized)
+                        }
+                        .font(.caption)
+                    }
+
+                    Button("Refresh Status") {
+                        claudeCodeService.checkAccess(forceRefresh: true)
+                        Task {
+                            await dataManager.refreshAll()
+                        }
+                    }
+                } else {
+                    Text("Automatically reads Claude Code CLI credentials from macOS Keychain.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    Text("Log in to Claude Code CLI first: run 'claude' in Terminal")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+
+                    Button("Check Again") {
+                        claudeCodeService.checkAccess(forceRefresh: true)
+                        if claudeCodeService.hasAccess {
+                            Task {
+                                await dataManager.refreshAll()
+                            }
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+
+            Section("Codex CLI (Recommended)") {
+                HStack {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(codexCliService.hasAccess ? .green : .gray)
+                    Text(codexCliService.hasAccess ? "Connected" : "Not Connected")
+                }
+
+                Text("Automatically reads `~/.codex/auth.json`. No browser cookie import.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                Text("Log in first: run 'codex login' in Terminal")
+                    .font(.caption)
+                    .foregroundColor(.orange)
+
+                Button("Refresh Status") {
+                    codexCliService.checkAccess()
+                    Task {
+                        await dataManager.refreshAll()
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+            }
+
+            Section("Cursor (Recommended)") {
+                HStack {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(cursorService.hasAccess ? .green : .gray)
+                    Text(cursorService.hasAccess ? "Connected" : "Not Connected")
+                }
+
+                if cursorService.hasAccess {
+                    if let subscriptionType = cursorService.subscriptionType {
+                        HStack {
+                            Text("Plan:")
+                                .foregroundColor(.secondary)
+                            Text(subscriptionType.capitalized)
+                                .bold()
+                        }
+                        .font(.caption)
+                    }
+
+                    Button("Refresh Status") {
+                        cursorService.checkAccess()
+                        Task {
+                            await dataManager.refreshAll()
+                        }
+                    }
+                } else {
+                    Text("Automatically reads Cursor IDE credentials from Cursor's local database.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    Text("Log in to Cursor first, then refresh here")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+
+                    Button("Check Again") {
+                        cursorService.checkAccess(forceRescan: true)
+                        if cursorService.hasAccess {
+                            Task {
+                                await dataManager.refreshAll()
+                            }
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+
+            Section("Claude Admin API (Optional)") {
                 HStack {
                     Image(systemName: "checkmark.circle.fill")
                         .foregroundColor(authManager.isClaudeAuthenticated ? .green : .gray)
@@ -46,61 +199,7 @@ struct SettingsView: View {
                 .buttonStyle(.link)
             }
 
-            Section("Claude Code (Pro/Max)") {
-                HStack {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(claudeCodeService.hasAccess ? .green : .gray)
-                    Text(claudeCodeService.hasAccess ? "Connected" : "Not Connected")
-                }
-
-                if claudeCodeService.hasAccess {
-                    if let subscriptionType = claudeCodeService.subscriptionType {
-                        HStack {
-                            Text("Plan:")
-                                .foregroundColor(.secondary)
-                            Text(subscriptionType.capitalized)
-                                .bold()
-                        }
-                        .font(.caption)
-                    }
-
-                    if let rateLimitTier = claudeCodeService.rateLimitTier {
-                        HStack {
-                            Text("Tier:")
-                                .foregroundColor(.secondary)
-                            Text(rateLimitTier.replacingOccurrences(of: "_", with: " ").capitalized)
-                        }
-                        .font(.caption)
-                    }
-
-                    Button("Refresh Status") {
-                        claudeCodeService.checkAccess()
-                        Task {
-                            await dataManager.refreshAll()
-                        }
-                    }
-                } else {
-                    Text("Automatically reads Claude Code CLI credentials from macOS Keychain.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-
-                    Text("Log in to Claude Code CLI first: run 'claude' in terminal")
-                        .font(.caption)
-                        .foregroundColor(.orange)
-
-                    Button("Check Again") {
-                        claudeCodeService.checkAccess()
-                        if claudeCodeService.hasAccess {
-                            Task {
-                                await dataManager.refreshAll()
-                            }
-                        }
-                    }
-                    .buttonStyle(.borderedProminent)
-                }
-            }
-
-            Section("OpenAI") {
+            Section("OpenAI Admin API (Optional)") {
                 HStack {
                     Image(systemName: "checkmark.circle.fill")
                         .foregroundColor(authManager.isOpenAIAuthenticated ? .green : .gray)
@@ -128,52 +227,6 @@ struct SettingsView: View {
                     showingOpenAIHelp = true
                 }
                 .buttonStyle(.link)
-            }
-
-            Section("Cursor") {
-                HStack {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(cursorService.hasAccess ? .green : .gray)
-                    Text(cursorService.hasAccess ? "Connected" : "Not Connected")
-                }
-
-                if cursorService.hasAccess {
-                    if let subscriptionType = cursorService.subscriptionType {
-                        HStack {
-                            Text("Plan:")
-                                .foregroundColor(.secondary)
-                            Text(subscriptionType.capitalized)
-                                .bold()
-                        }
-                        .font(.caption)
-                    }
-
-                    Button("Refresh Status") {
-                        cursorService.checkAccess()
-                        Task {
-                            await dataManager.refreshAll()
-                        }
-                    }
-                } else {
-                    Text("Automatically reads Cursor IDE credentials from macOS Keychain.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-
-                    Text("Log in to Cursor IDE first: open Cursor and sign in to your account")
-                        .font(.caption)
-                        .foregroundColor(.orange)
-
-                    Button("Check Again") {
-                        // Force a rescan of all possible database paths
-                        cursorService.checkAccess(forceRescan: true)
-                        if cursorService.hasAccess {
-                            Task {
-                                await dataManager.refreshAll()
-                            }
-                        }
-                    }
-                    .buttonStyle(.borderedProminent)
-                }
             }
 
             Section("Cost Tracking (Last 30 Days)") {
@@ -223,6 +276,24 @@ struct SettingsView: View {
                             Text("Last scanned: \(lastScan, style: .relative) ago")
                                 .font(.caption2)
                                 .foregroundColor(.secondary)
+                        }
+
+                        if let codexUsage = costTracker.codexUsageSummary {
+                            Divider()
+
+                            HStack {
+                                Text("Codex local usage")
+                                Spacer()
+                                Text(codexUsage.formattedTokens)
+                                    .bold()
+                            }
+
+                            HStack {
+                                Text("Codex sessions")
+                                Spacer()
+                                Text("\(codexUsage.sessionCount)")
+                                    .foregroundColor(.secondary)
+                            }
                         }
                     }
                 } else {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,6 @@ let package = Package(
             dependencies: [],
             path: "MeterBar",
             exclude: [
-                "Widget",
                 "App/MeterBarApp.swift",
                 "Info.plist",
                 "MeterBar.entitlements",


### PR DESCRIPTION
## Summary
- rework the menu bar popover into a more complete CodexBar-style UI with persistent tabs, provider issue badges, and richer Codex/Claude detail cards
- add shared provider health modeling so the status item and popover can show stale, warning, critical, and error states consistently
- reduce noisy local-service logging, keep Codex local usage scanning in the UI/settings flow, and clean the package warning so `swift build` stays clean

## Verification
- `swift build`
- `swift test` *(fails in this environment: `MeterBarTests/APIIntegrationTests.swift:1` cannot resolve `XCTest`)*