### PR TITLE
[codex] Add reset countdowns

### DIFF
--- a/.agents/SESSIONS/2026-06-17.md
+++ b/.agents/SESSIONS/2026-06-17.md
@@ -1,0 +1,41 @@
+# Sessions: 2026-06-17
+
+**Summary:** Reset countdowns for quota windows
+
+---
+
+## Session 1: Claude and Codex Reset Counters
+
+**Duration:** ~25 minutes
+**Status:** Complete
+
+### What was done
+
+- Added shared reset countdown helpers to `UsageLimit`.
+- Added live reset countdown labels to Claude and Codex provider cards in the popover overview.
+- Added live reset countdown labels to the Usage Dashboard overview cards and quota rows.
+- Added reset countdown coverage in `UsageLimitTests`.
+- Updated Claude CLI parser tests to unwrap optional usage windows before percentage assertions so the suite compiles on this toolchain.
+
+### Files changed
+
+- `MeterBar/Models/UsageLimit.swift` - Added reset countdown helpers and shared short duration formatting.
+- `MeterBar/Views/MenuBarView.swift` - Added reusable countdown views and rendered next-reset counters in provider cards.
+- `MeterBar/Views/UsageDashboardView.swift` - Rendered next-reset counters in dashboard provider cards and quota rows.
+- `MeterBarTests/UsageLimitTests.swift` - Added reset countdown unit coverage.
+- `MeterBarTests/ClaudeCodeCLIUsageParserTests.swift` - Fixed optional percentage assertions with `XCTUnwrap`.
+
+### Decisions
+
+- **Decision:** Show the earliest upcoming reset per provider card.
+  - **Rationale:** The requested "next reset" should be the nearest future reset across session, weekly, and model-specific windows.
+
+- **Decision:** Use minute-level counters with existing `4h 12m`-style duration text.
+  - **Rationale:** It matches the existing quota pace language and avoids noisy second-by-second menu updates.
+
+### Verification
+
+- `swift build` passed.
+- `swift test` passed: 54 tests executed, 2 credential-dependent API tests skipped, 0 failures.
+- `git diff --check` passed.
+- `swiftformat` is not installed in this environment.

--- a/MeterBar/Models/UsageLimit.swift
+++ b/MeterBar/Models/UsageLimit.swift
@@ -45,6 +45,17 @@ struct UsageLimit: Codable, Equatable {
         }
     }
 
+    func secondsUntilReset(now: Date = Date()) -> TimeInterval? {
+        guard let resetTime else { return nil }
+        return resetTime.timeIntervalSince(now)
+    }
+
+    func resetCountdownText(now: Date = Date()) -> String? {
+        guard let secondsUntilReset = secondsUntilReset(now: now) else { return nil }
+        guard secondsUntilReset > 0 else { return "now" }
+        return UsageDurationText.short(seconds: secondsUntilReset)
+    }
+
     func pace(now: Date = Date()) -> UsagePace? {
         guard let resetTime,
               let windowSeconds,
@@ -145,10 +156,12 @@ struct UsagePace: Equatable {
             return context.emptyNowLabel
         }
 
-        return "\(context.emptyPrefix) \(Self.durationText(seconds: etaSeconds))"
+        return "\(context.emptyPrefix) \(UsageDurationText.short(seconds: etaSeconds))"
     }
+}
 
-    private static func durationText(seconds: TimeInterval) -> String {
+enum UsageDurationText {
+    static func short(seconds: TimeInterval) -> String {
         let wholeSeconds = max(0, Int(seconds.rounded()))
         let hours = wholeSeconds / 3600
         let minutes = (wholeSeconds % 3600) / 60

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -352,6 +352,16 @@ private struct PopoverProviderSnapshot: Identifiable {
     var primaryLimit: PopoverLimit? {
         limits.min { $0.percentLeft < $1.percentLeft }
     }
+
+    var resetWindows: [ResetCountdownWindow] {
+        limits.map {
+            ResetCountdownWindow(
+                id: "\(id)-\($0.title)",
+                title: $0.title,
+                limit: $0.usageLimit
+            )
+        }
+    }
 }
 
 private struct PopoverLimit: Identifiable {
@@ -440,6 +450,13 @@ private struct PopoverProviderStatusCard: View {
                     paceContext: primaryLimit.title.localizedCaseInsensitiveContains("weekly") ? .weekly : .session
                 )
 
+                NextResetCountdownLabel(
+                    windows: snapshot.resetWindows,
+                    font: .caption2,
+                    foregroundColor: .secondary,
+                    iconSize: 10
+                )
+
                 VStack(spacing: 5) {
                     ForEach(snapshot.limits.prefix(2)) { limit in
                         HStack {
@@ -476,6 +493,92 @@ private struct PopoverProviderStatusCard: View {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
         return "Updated \(formatter.localizedString(for: updatedAt, relativeTo: Date()))"
+    }
+}
+
+struct ResetCountdownWindow: Identifiable {
+    let id: String
+    let title: String
+    let limit: UsageLimit
+}
+
+struct ResetCountdownLabel: View {
+    let title: String?
+    let limit: UsageLimit
+    var font: Font = .caption
+    var foregroundColor: Color = .secondary
+    var iconSize: CGFloat = 10
+
+    var body: some View {
+        TimelineView(.periodic(from: Date(), by: 30)) { timeline in
+            Group {
+                if let text = Self.counterText(title: title, limit: limit, now: timeline.date) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "clock")
+                            .font(.system(size: iconSize, weight: .semibold))
+                        Text(text)
+                            .font(font)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.8)
+                    }
+                    .foregroundColor(foregroundColor)
+                    .help(text)
+                }
+            }
+        }
+    }
+
+    static func counterText(title: String?, limit: UsageLimit, now: Date) -> String? {
+        guard let countdown = limit.resetCountdownText(now: now) else { return nil }
+        if countdown == "now" {
+            return title.map { "\($0) reset due" } ?? "Reset due"
+        }
+        return title.map { "\($0) reset in \(countdown)" } ?? "Resets in \(countdown)"
+    }
+}
+
+struct NextResetCountdownLabel: View {
+    let windows: [ResetCountdownWindow]
+    var font: Font = .caption
+    var foregroundColor: Color = .secondary
+    var iconSize: CGFloat = 10
+
+    var body: some View {
+        TimelineView(.periodic(from: Date(), by: 30)) { timeline in
+            Group {
+                if let window = nextWindow(now: timeline.date),
+                   let text = ResetCountdownLabel.counterText(
+                       title: window.title,
+                       limit: window.limit,
+                       now: timeline.date
+                   ) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "clock")
+                            .font(.system(size: iconSize, weight: .semibold))
+                        Text(text)
+                            .font(font)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.8)
+                    }
+                    .foregroundColor(foregroundColor)
+                    .help(text)
+                }
+            }
+        }
+    }
+
+    private func nextWindow(now: Date) -> ResetCountdownWindow? {
+        let candidates = windows.compactMap { window -> (window: ResetCountdownWindow, seconds: TimeInterval)? in
+            guard let seconds = window.limit.secondsUntilReset(now: now) else { return nil }
+            return (window, seconds)
+        }
+
+        let futureCandidates = candidates.filter { $0.seconds > 0 }
+        if let next = futureCandidates.min(by: { $0.seconds < $1.seconds }) {
+            return next.window
+        }
+
+        return candidates.max(by: { $0.seconds < $1.seconds })?.window
     }
 }
 

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -489,6 +489,16 @@ private struct DashboardProviderSnapshot: Identifiable {
         ].compactMap { $0 }
     }
 
+    var resetWindows: [ResetCountdownWindow] {
+        limits.map {
+            ResetCountdownWindow(
+                id: "\(id)-\($0.title)",
+                title: $0.title,
+                limit: $0.usageLimit
+            )
+        }
+    }
+
     private static func logoKind(for service: ServiceType) -> ProviderLogoKind {
         switch service {
         case .codexCli, .openai:
@@ -633,6 +643,13 @@ private struct ProviderOverviewStatusCard: View {
                     accentColor: accentColor,
                     pace: primaryLimit.usageLimit.pace(),
                     paceContext: primaryLimit.title.localizedCaseInsensitiveContains("weekly") ? .weekly : .session
+                )
+
+                NextResetCountdownLabel(
+                    windows: snapshot.resetWindows,
+                    font: .caption,
+                    foregroundColor: .secondary,
+                    iconSize: 11
                 )
             }
 
@@ -824,10 +841,14 @@ private struct DashboardLimitRow: View {
                         .foregroundColor(paceLabelColor(pace))
                 }
                 Spacer()
-                if let resetTime = limit.usageLimit.resetTime {
-                    Text("Resets \(relativeDate(resetTime))")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+                if limit.usageLimit.resetTime != nil {
+                    ResetCountdownLabel(
+                        title: nil,
+                        limit: limit.usageLimit,
+                        font: .caption,
+                        foregroundColor: .secondary,
+                        iconSize: 10
+                    )
                 }
             }
         }
@@ -848,11 +869,6 @@ private struct DashboardLimitRow: View {
         }
     }
 
-    private func relativeDate(_ date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: date, relativeTo: Date())
-    }
 }
 
 private struct CostScanLoadingChart: View {

--- a/MeterBarTests/ClaudeCodeCLIUsageParserTests.swift
+++ b/MeterBarTests/ClaudeCodeCLIUsageParserTests.swift
@@ -15,9 +15,9 @@ final class ClaudeCodeCLIUsageParserTests: XCTestCase {
         let metrics = try ClaudeCodeCLIUsageParser.parseMetrics(from: output, now: now)
 
         XCTAssertEqual(metrics.service, .claudeCode)
-        XCTAssertEqual(metrics.sessionLimit?.percentage, 36, accuracy: 0.01)
-        XCTAssertEqual(metrics.weeklyLimit?.percentage, 100, accuracy: 0.01)
-        XCTAssertEqual(metrics.codeReviewLimit?.percentage, 83, accuracy: 0.01)
+        XCTAssertEqual(try XCTUnwrap(metrics.sessionLimit).percentage, 36, accuracy: 0.01)
+        XCTAssertEqual(try XCTUnwrap(metrics.weeklyLimit).percentage, 100, accuracy: 0.01)
+        XCTAssertEqual(try XCTUnwrap(metrics.codeReviewLimit).percentage, 83, accuracy: 0.01)
         XCTAssertNotNil(metrics.sessionLimit?.resetTime)
         XCTAssertNotNil(metrics.weeklyLimit?.resetTime)
         XCTAssertNotNil(metrics.codeReviewLimit?.resetTime)
@@ -33,8 +33,8 @@ final class ClaudeCodeCLIUsageParserTests: XCTestCase {
             from: output,
             now: Date(timeIntervalSince1970: 1_781_154_000))
 
-        XCTAssertEqual(metrics.sessionLimit?.percentage, 36, accuracy: 0.01)
-        XCTAssertEqual(metrics.weeklyLimit?.percentage, 75, accuracy: 0.01)
+        XCTAssertEqual(try XCTUnwrap(metrics.sessionLimit).percentage, 36, accuracy: 0.01)
+        XCTAssertEqual(try XCTUnwrap(metrics.weeklyLimit).percentage, 75, accuracy: 0.01)
     }
 
     func testThrowsWhenNoUsageWindowsArePresent() {

--- a/MeterBarTests/UsageLimitTests.swift
+++ b/MeterBarTests/UsageLimitTests.swift
@@ -63,4 +63,30 @@ final class UsageLimitTests: XCTestCase {
         XCTAssertEqual(deficitPace?.leftLabel, "25% in deficit")
         XCTAssertEqual(deficitPace?.rightLabel(), "Projected empty in 50m")
     }
+
+    func testResetCountdownText() throws {
+        let now = Date(timeIntervalSince1970: 0)
+        let futureReset = UsageLimit(
+            used: 25,
+            total: 100,
+            resetTime: now.addingTimeInterval(3_660)
+        )
+        let imminentReset = UsageLimit(
+            used: 25,
+            total: 100,
+            resetTime: now.addingTimeInterval(45)
+        )
+        let dueReset = UsageLimit(
+            used: 25,
+            total: 100,
+            resetTime: now.addingTimeInterval(-1)
+        )
+        let noReset = UsageLimit(used: 25, total: 100, resetTime: nil)
+
+        XCTAssertEqual(try XCTUnwrap(futureReset.secondsUntilReset(now: now)), 3_660, accuracy: 0.01)
+        XCTAssertEqual(futureReset.resetCountdownText(now: now), "1h 1m")
+        XCTAssertEqual(imminentReset.resetCountdownText(now: now), "1m")
+        XCTAssertEqual(dueReset.resetCountdownText(now: now), "now")
+        XCTAssertNil(noReset.resetCountdownText(now: now))
+    }
 }


### PR DESCRIPTION
## Summary

- Add shared reset countdown helpers for quota windows.
- Show live next-reset counters in the menu bar popover for Claude and Codex provider cards.
- Show live reset counters in the Usage Dashboard overview cards and quota rows.
- Add reset countdown unit coverage and clean up optional assertions in Claude CLI parser tests so the suite compiles cleanly.

## Validation

- `swift build`
- `swift test` (54 tests passed, 2 credential-dependent API tests skipped)
- `git diff --check`

## Notes

The provider cards choose the earliest upcoming reset across the available session, weekly, and Sonnet/Code Review windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added live quota reset countdowns showing when usage limits will reset
  * Provider cards now display next reset time with minute-level precision
  * "Reset due" indicator appears for overdue quotas
  * Countdown timers available in both menu bar and usage dashboard

<!-- end of auto-generated comment: release notes by coderabbit.ai -->