### PR TITLE
[codex] Apply native graphite palette

### DIFF
--- a/.agents/DESIGN.md
+++ b/.agents/DESIGN.md
@@ -3,23 +3,23 @@ version: alpha
 name: MeterBar Native Utility
 description: Compact macOS utility UI for AI quota, usage, and local token spend.
 colors:
-  primary: "#F4F4F5"
-  secondary: "#B4B4BC"
-  muted: "#6B6B78"
-  background: "#050607"
-  surface: "#0C0D10"
-  surface-elevated: "#131518"
-  surface-hover: "#20232A"
+  primary: "#F2F2F7"
+  secondary: "#AEAEB2"
+  muted: "#8E8E93"
+  background: "#1C1C1E"
+  surface: "#242426"
+  surface-elevated: "#2C2C2E"
+  surface-hover: "#3A3A3C"
   border: "rgba(255,255,255,0.10)"
-  border-strong: "rgba(255,255,255,0.18)"
-  accent: "#38BDF8"
-  accent-foreground: "#050607"
-  codex: "#45D6F0"
-  claude: "#D97757"
-  cursor: "#35E66B"
-  success: "#10B981"
-  warning: "#EAB308"
-  danger: "#EF4444"
+  border-strong: "rgba(255,255,255,0.16)"
+  accent: "#006EDB"
+  accent-foreground: "#FFFFFF"
+  codex: "#64D2FF"
+  claude: "#D18665"
+  cursor: "#63D297"
+  success: "#30D158"
+  warning: "#FFD60A"
+  danger: "#FF453A"
 typography:
   title:
     fontFamily: "-apple-system, BlinkMacSystemFont, SF Pro Display, system-ui, sans-serif"
@@ -73,23 +73,63 @@ components:
     rounded: "{rounded.md}"
     padding: "8px 14px"
   sidebar-item-active:
-    backgroundColor: "{colors.accent}"
-    textColor: "{colors.accent-foreground}"
+    backgroundColor: "{colors.surface-elevated}"
+    textColor: "{colors.primary}"
     rounded: "{rounded.md}"
     padding: "8px 14px"
+  sidebar-active-indicator:
+    backgroundColor: "{colors.accent}"
+    rounded: "{rounded.sm}"
+    width: "3px"
+    height: "18px"
+  hairline-border:
+    backgroundColor: "{colors.border}"
+    height: "1px"
+  strong-hairline-border:
+    backgroundColor: "{colors.border-strong}"
+    height: "1px"
   usage-bar-track:
-    backgroundColor: "rgba(255,255,255,0.16)"
+    backgroundColor: "{colors.border-strong}"
+    rounded: "{rounded.sm}"
+    height: "7px"
+  usage-bar-fill-codex:
+    backgroundColor: "{colors.codex}"
+    rounded: "{rounded.sm}"
+    height: "7px"
+  usage-bar-fill-claude:
+    backgroundColor: "{colors.claude}"
+    rounded: "{rounded.sm}"
+    height: "7px"
+  usage-bar-fill-cursor:
+    backgroundColor: "{colors.cursor}"
     rounded: "{rounded.sm}"
     height: "7px"
   usage-bar-deficit:
     backgroundColor: "{colors.danger}"
     rounded: "{rounded.sm}"
     height: "7px"
+  status-success:
+    textColor: "{colors.success}"
+    backgroundColor: "transparent"
+    rounded: "{rounded.sm}"
+  status-warning:
+    textColor: "{colors.warning}"
+    backgroundColor: "transparent"
+    rounded: "{rounded.sm}"
   icon-button:
     backgroundColor: "{colors.surface-hover}"
     textColor: "{colors.primary}"
     rounded: "{rounded.md}"
     size: "32px"
+  accent-button:
+    backgroundColor: "{colors.accent}"
+    textColor: "{colors.accent-foreground}"
+    rounded: "{rounded.md}"
+    padding: "6px 10px"
+  helper-text:
+    textColor: "{colors.muted}"
+    backgroundColor: "transparent"
+    rounded: "{rounded.sm}"
 ---
 
 ## Overview
@@ -105,17 +145,17 @@ Both surfaces must stay lean. Avoid decorative hero layouts, big cards, nested p
 
 ## Colors
 
-Use Shipcode-style dark tokens as the default. Surfaces are near-black graphite with subtle elevation, not blue-purple gradients. Borders should remain quiet at 10-18% white.
+Use Apple-style dark graphite tokens as the default. Surfaces are charcoal graphite with subtle elevation, not blue-purple gradients or near-black voids. Borders should remain quiet at 10-16% white.
 
 Provider accents are semantic and stable:
 
 - Codex: cyan.
-- Claude: Anthropic orange `#d97757`.
-- Cursor: green.
+- Claude: muted Anthropic orange `#d18665`.
+- Cursor: softened green.
 - Deficit: red only where quota is missing versus expected pace.
 - Reserve: green only for positive pace state.
 
-Do not let provider colors take over the whole UI. They are indicators, not themes.
+Do not let provider colors take over the whole UI. They are indicators, not themes. Large percentage and cost metrics should use primary text unless the value is exhausted; color belongs on icons, bars, markers, and compact status labels.
 
 ## Typography
 

--- a/.agents/SESSIONS/2026-06-17.md
+++ b/.agents/SESSIONS/2026-06-17.md
@@ -1,6 +1,6 @@
 # Sessions: 2026-06-17
 
-**Summary:** Reset countdowns for quota windows
+**Summary:** Reset countdowns and Apple-friendly palette correction
 
 ---
 
@@ -39,3 +39,47 @@
 - `swift test` passed: 54 tests executed, 2 credential-dependent API tests skipped, 0 failures.
 - `git diff --check` passed.
 - `swiftformat` is not installed in this environment.
+
+---
+
+## Session 2: Native Graphite Palette Pass
+
+**Duration:** ~25 minutes
+**Status:** Complete
+
+### What was done
+
+- Replaced neon cyan/green/red UI accents with shared Apple-style graphite and semantic color tokens.
+- Updated the menu bar popover, usage bars, companion dashboard, and settings panels to use the shared palette.
+- Changed large quota and cost metrics to use primary text unless the quota is exhausted.
+- Kept provider color as a restrained indicator on icons, bars, markers, and compact status labels.
+- Updated the design contract to document the new palette and metric-coloring rule.
+- Fixed `ClaudeCodeCLIUsageParserTests` optional percentage assertions so the SwiftPM test suite can compile and run.
+
+### Files changed
+
+- `MeterBar/Views/MeterBarTheme.swift` - Added graphite surfaces, provider accents, semantic status colors, and helper functions.
+- `MeterBar/Views/MenuBarView.swift` - Applied the calmer palette to popover chrome, cards, status colors, and usage bars.
+- `MeterBar/Views/UsageDashboardView.swift` - Applied the same palette to dashboard background, sidebar, cards, charts, and metrics.
+- `MeterBar/Views/SettingsView.swift` - Replaced raw section/control colors with theme tokens.
+- `MeterBar/Models/UsageLimit.swift` - Routed status colors through the shared theme.
+- `MeterBarTests/ClaudeCodeCLIUsageParserTests.swift` - Unwrapped optional limits before percentage assertions.
+- `.agents/DESIGN.md` - Documented the updated Apple-friendly palette and component color roles.
+
+### Decisions
+
+- **Decision:** Use graphite surfaces `#1C1C1E`, `#242426`, and `#2C2C2E`.
+  - **Rationale:** These read closer to native macOS dark UI than the previous near-black/neon treatment.
+
+- **Decision:** Use `#006EDB` for the app/control accent instead of Apple dark blue `#0A84FF`.
+  - **Rationale:** It keeps the native blue feel while giving white button text WCAG AA contrast.
+
+- **Decision:** Keep big percentage metrics neutral except when exhausted.
+  - **Rationale:** Status remains visible without making healthy quota cards feel like a game HUD.
+
+### Verification
+
+- `git diff --check` passed.
+- `swift build` passed.
+- `npx @google/design.md lint .agents/DESIGN.md` passed with 0 errors and 0 warnings.
+- `swift test` passed: 53 tests executed, 2 skipped for missing Admin API keys, 0 failures.

--- a/MeterBar/Models/UsageLimit.swift
+++ b/MeterBar/Models/UsageLimit.swift
@@ -204,9 +204,9 @@ enum UsageStatus {
 
     var color: Color {
         switch self {
-        case .good: return .green
-        case .warning: return .orange
-        case .critical: return .red
+        case .good: return MeterBarTheme.success
+        case .warning: return MeterBarTheme.warning
+        case .critical: return MeterBarTheme.danger
         }
     }
 }

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -88,7 +88,7 @@ struct MenuBarView: View {
         .frame(width: popoverWidth, height: popoverHeight)
         .background {
             ZStack {
-                Color(red: 0.075, green: 0.080, blue: 0.080).opacity(0.74)
+                MeterBarTheme.graphiteBackground.opacity(0.86)
                 Rectangle().fill(.ultraThinMaterial)
             }
         }
@@ -122,7 +122,7 @@ struct MenuBarView: View {
             HStack(spacing: 9) {
                 Image(systemName: "chart.line.uptrend.xyaxis")
                     .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(.cyan)
+                    .foregroundColor(MeterBarTheme.appAccent)
                 Text("MeterBar")
                     .font(.headline)
                     .fontWeight(.semibold)
@@ -180,7 +180,7 @@ struct PopoverOverviewPanel: View {
             result.append(PopoverProviderSnapshot(
                 title: "Codex",
                 logoKind: .codex,
-                accentColor: .cyan,
+                accentColor: MeterBarTheme.codexAccent,
                 metrics: metrics[.codexCli],
                 emptyDetail: codexCliHasAccess ? "Waiting for refresh" : "Run codex login"
             ))
@@ -214,7 +214,7 @@ struct PopoverOverviewPanel: View {
             result.append(PopoverProviderSnapshot(
                 title: "Cursor",
                 logoKind: .cursor,
-                accentColor: .green,
+                accentColor: MeterBarTheme.cursorAccent,
                 metrics: metrics[.cursor],
                 emptyDetail: cursorHasAccess ? "Waiting for refresh" : "Log in to Cursor"
             ))
@@ -233,10 +233,7 @@ struct PopoverOverviewPanel: View {
 
     private var statusColor: Color {
         guard let tightestLimit else { return .secondary }
-        if tightestLimit.percentLeft <= 0 { return .red.opacity(0.72) }
-        if tightestLimit.percentLeft <= 10 { return .red }
-        if tightestLimit.percentLeft <= 25 { return MeterBarTheme.warning }
-        return .green
+        return MeterBarTheme.quotaStatusColor(percentLeft: tightestLimit.percentLeft)
     }
 
     private var statusTitle: String {
@@ -394,10 +391,7 @@ private struct PopoverProviderStatusCard: View {
 
     private var statusColor: Color {
         guard let primaryLimit else { return .secondary }
-        if primaryLimit.percentLeft <= 0 { return .red.opacity(0.72) }
-        if primaryLimit.percentLeft <= 10 { return .red }
-        if primaryLimit.percentLeft <= 25 { return MeterBarTheme.warning }
-        return .green
+        return MeterBarTheme.quotaStatusColor(percentLeft: primaryLimit.percentLeft)
     }
 
     private var statusText: String {
@@ -408,8 +402,9 @@ private struct PopoverProviderStatusCard: View {
         return "Healthy"
     }
 
-    private var isOut: Bool {
-        primaryLimit?.percentLeft ?? 100 <= 0
+    private var metricColor: Color {
+        guard let primaryLimit else { return .primary }
+        return MeterBarTheme.metricColor(percentLeft: primaryLimit.percentLeft)
     }
 
     var body: some View {
@@ -433,7 +428,7 @@ private struct PopoverProviderStatusCard: View {
                 HStack(alignment: .firstTextBaseline, spacing: 4) {
                     Text("\(primaryLimit.percentLeft)%")
                         .font(.system(size: 25, weight: .bold))
-                        .foregroundColor(statusColor)
+                        .foregroundColor(metricColor)
                     Text("left")
                         .font(.caption2)
                         .foregroundColor(.secondary)
@@ -484,7 +479,6 @@ private struct PopoverProviderStatusCard: View {
         }
         .padding(11)
         .frame(maxWidth: .infinity, minHeight: 142, alignment: .topLeading)
-        .opacity(isOut ? 0.72 : 1)
         .popoverGlassCard()
     }
 
@@ -680,17 +674,17 @@ struct UsageBar: View {
         GeometryReader { proxy in
             ZStack(alignment: .leading) {
                 RoundedRectangle(cornerRadius: 3)
-                    .fill(Color.gray.opacity(0.22))
+                    .fill(MeterBarTheme.barTrack)
                     .frame(height: 7)
                     .offset(y: 4)
 
                 if isExhausted {
                     RoundedRectangle(cornerRadius: 3)
-                        .fill(Color.red.opacity(0.26))
+                        .fill(MeterBarTheme.danger.opacity(0.16))
                         .frame(width: proxy.size.width, height: 7)
                         .offset(y: 4)
                     RoundedRectangle(cornerRadius: 1)
-                        .fill(Color.red.opacity(0.82))
+                        .fill(MeterBarTheme.danger)
                         .frame(width: 2, height: 13)
                         .offset(x: max(0, proxy.size.width - 2), y: 1)
                 } else if let pace, pace.stage != .onPace {
@@ -705,7 +699,7 @@ struct UsageBar: View {
 
                         if pace.stage == .deficit {
                             Rectangle()
-                                .fill(Color.red.opacity(0.82))
+                                .fill(MeterBarTheme.danger.opacity(0.86))
                                 .frame(width: max(0, expectedX - actualX), height: 7)
                                 .offset(x: actualX)
                         }
@@ -735,9 +729,9 @@ struct UsageBar: View {
         case .onPace:
             return .white.opacity(0.85)
         case .reserve:
-            return .green
+            return MeterBarTheme.success
         case .deficit:
-            return .red
+            return MeterBarTheme.danger
         }
     }
 }
@@ -745,10 +739,15 @@ struct UsageBar: View {
 private extension View {
     func popoverGlassCard() -> some View {
         self
-            .background(.thinMaterial)
+            .background {
+                ZStack {
+                    MeterBarTheme.graphiteSurface.opacity(0.78)
+                    Rectangle().fill(.thinMaterial).opacity(0.35)
+                }
+            }
             .overlay {
                 RoundedRectangle(cornerRadius: 8)
-                    .stroke(Color.white.opacity(0.10), lineWidth: 1)
+                    .stroke(MeterBarTheme.border, lineWidth: 1)
             }
             .clipShape(RoundedRectangle(cornerRadius: 8))
     }

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -3,11 +3,44 @@ import SwiftUI
 enum MeterBarTheme {
     static let anthropicDark = Color(red: 20 / 255, green: 20 / 255, blue: 19 / 255)
     static let anthropicLight = Color(red: 250 / 255, green: 249 / 255, blue: 245 / 255)
-    static let claudeAccent = Color(red: 217 / 255, green: 119 / 255, blue: 87 / 255)
-    static let warning = Color(red: 234 / 255, green: 179 / 255, blue: 8 / 255)
+    static let graphiteBackground = Color(red: 28 / 255, green: 28 / 255, blue: 30 / 255)
+    static let graphiteSurface = Color(red: 36 / 255, green: 36 / 255, blue: 38 / 255)
+    static let graphiteElevated = Color(red: 44 / 255, green: 44 / 255, blue: 46 / 255)
+    static let graphiteHover = Color(red: 58 / 255, green: 58 / 255, blue: 60 / 255)
+    static let appAccent = Color(red: 0 / 255, green: 110 / 255, blue: 219 / 255)
+    static let codexAccent = Color(red: 100 / 255, green: 210 / 255, blue: 255 / 255)
+    static let claudeAccent = Color(red: 209 / 255, green: 134 / 255, blue: 101 / 255)
+    static let cursorAccent = Color(red: 99 / 255, green: 210 / 255, blue: 151 / 255)
+    static let success = Color(red: 48 / 255, green: 209 / 255, blue: 88 / 255)
+    static let warning = Color(red: 255 / 255, green: 214 / 255, blue: 10 / 255)
+    static let danger = Color(red: 255 / 255, green: 69 / 255, blue: 58 / 255)
+    static let barTrack = Color.white.opacity(0.14)
+    static let border = Color.white.opacity(0.10)
+    static let borderStrong = Color.white.opacity(0.16)
     static let toolbarIconForeground = Color.white.opacity(0.92)
-    static let toolbarIconBackground = Color(red: 32 / 255, green: 35 / 255, blue: 42 / 255)
-    static let toolbarIconBorder = Color.white.opacity(0.14)
+    static let toolbarIconBackground = graphiteElevated
+    static let toolbarIconBorder = borderStrong
+
+    static func accent(for service: ServiceType) -> Color {
+        switch service {
+        case .claude, .claudeCode:
+            return claudeAccent
+        case .codexCli, .openai:
+            return codexAccent
+        case .cursor:
+            return cursorAccent
+        }
+    }
+
+    static func quotaStatusColor(percentLeft: Int) -> Color {
+        if percentLeft <= 10 { return danger }
+        if percentLeft <= 25 { return warning }
+        return success
+    }
+
+    static func metricColor(percentLeft: Int) -> Color {
+        percentLeft <= 0 ? danger : .primary
+    }
 }
 
 enum LucideSymbol {

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -67,7 +67,7 @@ struct SettingsView: View {
     }
 
     private var trackedProvidersSection: some View {
-        SettingsPanelSection(title: "Tracked Providers", systemImage: "switch.2", color: .cyan) {
+        SettingsPanelSection(title: "Tracked Providers", systemImage: "switch.2", color: MeterBarTheme.appAccent) {
             providerToggleRow(
                 title: "Claude Code",
                 detail: "Track Pro/Max quota via Claude CLI profiles.",
@@ -228,7 +228,7 @@ struct SettingsView: View {
     }
 
     private var openAISection: some View {
-        SettingsPanelSection(title: "OpenAI", logoKind: .codex, color: .cyan) {
+        SettingsPanelSection(title: "OpenAI", logoKind: .codex, color: MeterBarTheme.codexAccent) {
             SettingsRowView(title: "Connection") {
                 StatusPill(
                     title: authManager.isOpenAIAuthenticated ? "Connected" : "Not Connected",
@@ -267,7 +267,7 @@ struct SettingsView: View {
     }
 
     private var cursorSection: some View {
-        SettingsPanelSection(title: "Cursor", logoKind: .cursor, color: .green) {
+        SettingsPanelSection(title: "Cursor", logoKind: .cursor, color: MeterBarTheme.cursorAccent) {
             SettingsRowView(title: "Connection") {
                 HStack(spacing: 8) {
                     StatusPill(
@@ -301,7 +301,7 @@ struct SettingsView: View {
     }
 
     private var costTrackingSection: some View {
-        SettingsPanelSection(title: "Cost Tracking", systemImage: "chart.bar.xaxis", color: .green) {
+        SettingsPanelSection(title: "Cost Tracking", systemImage: "chart.bar.xaxis", color: MeterBarTheme.success) {
             if costTracker.isScanning {
                 SettingsRowView(title: "Status") {
                     HStack(spacing: 8) {
@@ -374,7 +374,7 @@ struct SettingsView: View {
     }
 
     private var refreshSection: some View {
-        SettingsPanelSection(title: "Refresh", systemImage: "arrow.clockwise", color: .cyan) {
+        SettingsPanelSection(title: "Refresh", systemImage: "arrow.clockwise", color: MeterBarTheme.appAccent) {
             SettingsRowView(title: "Auto-refresh interval") {
                 Picker("", selection: Binding(
                     get: { dataManager.refreshInterval },
@@ -463,11 +463,11 @@ struct SettingsView: View {
 }
 
 private enum SettingsDesign {
-    static let background = Color(red: 0.02, green: 0.024, blue: 0.028)
-    static let surface = Color(red: 0.075, green: 0.082, blue: 0.094)
-    static let row = Color.white.opacity(0.025)
-    static let border = Color.white.opacity(0.08)
-    static let borderStrong = Color.white.opacity(0.14)
+    static let background = MeterBarTheme.graphiteBackground
+    static let surface = MeterBarTheme.graphiteSurface
+    static let row = Color.white.opacity(0.035)
+    static let border = MeterBarTheme.border.opacity(0.82)
+    static let borderStrong = MeterBarTheme.borderStrong
 }
 
 private struct SettingsPanelSection<Content: View>: View {
@@ -616,7 +616,7 @@ private struct StatusPill: View {
     var body: some View {
         HStack(spacing: 6) {
             Circle()
-                .fill(isConnected ? Color.green : Color.secondary)
+                .fill(isConnected ? MeterBarTheme.success : Color.secondary)
                 .frame(width: 7, height: 7)
             Text(title)
                 .font(.caption)
@@ -624,11 +624,11 @@ private struct StatusPill: View {
         }
         .padding(.horizontal, 9)
         .padding(.vertical, 5)
-        .background((isConnected ? Color.green : Color.secondary).opacity(0.14))
+        .background((isConnected ? MeterBarTheme.success : Color.secondary).opacity(0.14))
         .clipShape(RoundedRectangle(cornerRadius: 6))
         .overlay {
             RoundedRectangle(cornerRadius: 6)
-                .stroke((isConnected ? Color.green : Color.secondary).opacity(0.18), lineWidth: 1)
+                .stroke((isConnected ? MeterBarTheme.success : Color.secondary).opacity(0.18), lineWidth: 1)
         }
     }
 }
@@ -699,32 +699,32 @@ private struct SettingsButtonStyle: ButtonStyle {
     }
 
     private var textColor: Color {
-        if prominent { return .black }
+        if prominent { return .white }
         switch role {
         case .normal:
             return .primary
         case .destructive:
-            return .red
+            return MeterBarTheme.danger
         }
     }
 
     private var backgroundColor: Color {
-        if prominent { return .cyan }
+        if prominent { return MeterBarTheme.appAccent }
         switch role {
         case .normal:
             return Color.white.opacity(0.06)
         case .destructive:
-            return Color.red.opacity(0.12)
+            return MeterBarTheme.danger.opacity(0.12)
         }
     }
 
     private var borderColor: Color {
-        if prominent { return Color.cyan.opacity(0.7) }
+        if prominent { return MeterBarTheme.appAccent.opacity(0.7) }
         switch role {
         case .normal:
             return SettingsDesign.borderStrong
         case .destructive:
-            return Color.red.opacity(0.22)
+            return MeterBarTheme.danger.opacity(0.22)
         }
     }
 }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -82,17 +82,17 @@ struct UsageDashboardView: View {
                 }
                 .padding(22)
             }
-            .background(Color.white.opacity(0.018))
+            .background(MeterBarTheme.graphiteSurface.opacity(0.48))
             .clipShape(RoundedRectangle(cornerRadius: 14))
             .overlay {
                 RoundedRectangle(cornerRadius: 14)
-                    .stroke(Color.white.opacity(0.055), lineWidth: 1)
+                    .stroke(MeterBarTheme.border.opacity(0.72), lineWidth: 1)
             }
         }
         .padding(10)
         .background {
             ZStack {
-                Color(red: 0.075, green: 0.080, blue: 0.080)
+                MeterBarTheme.graphiteBackground
                 Rectangle().fill(.ultraThinMaterial).opacity(0.42)
             }
         }
@@ -103,7 +103,7 @@ struct UsageDashboardView: View {
             HStack(spacing: 10) {
                 Image(systemName: "chart.line.uptrend.xyaxis")
                     .font(.system(size: 20, weight: .semibold))
-                    .foregroundColor(.cyan)
+                    .foregroundColor(MeterBarTheme.appAccent)
                 Text("MeterBar")
                     .font(.headline)
                     .fontWeight(.semibold)
@@ -127,12 +127,12 @@ struct UsageDashboardView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, 14)
                         .padding(.vertical, 8)
-                        .foregroundColor(selectedSection == section ? .white : .secondary)
-                        .background(selectedSection == section ? Color.white.opacity(0.10) : Color.clear)
+                        .foregroundColor(selectedSection == section ? .primary : .secondary)
+                        .background(selectedSection == section ? MeterBarTheme.graphiteElevated : Color.clear)
                         .overlay(alignment: .leading) {
                             if selectedSection == section {
                                 RoundedRectangle(cornerRadius: 2)
-                                    .fill(Color.cyan)
+                                    .fill(MeterBarTheme.appAccent)
                                     .frame(width: 3)
                                     .padding(.vertical, 7)
                             }
@@ -169,7 +169,7 @@ struct UsageDashboardView: View {
         .clipShape(RoundedRectangle(cornerRadius: 14))
         .overlay {
             RoundedRectangle(cornerRadius: 14)
-                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                .stroke(MeterBarTheme.border, lineWidth: 1)
         }
     }
 
@@ -386,10 +386,7 @@ struct UsageDashboardView: View {
         guard let limit = providerSnapshots.flatMap(\.limits).min(by: { $0.percentLeft < $1.percentLeft }) else {
             return .secondary
         }
-        if limit.percentLeft <= 0 { return .red.opacity(0.72) }
-        if limit.percentLeft <= 10 { return .red }
-        if limit.percentLeft <= 25 { return MeterBarTheme.warning }
-        return .green
+        return MeterBarTheme.quotaStatusColor(percentLeft: limit.percentLeft)
     }
 
     private var overviewStatusTitle: String {
@@ -438,14 +435,7 @@ struct UsageDashboardView: View {
     }
 
     private func color(for service: ServiceType) -> Color {
-        switch service {
-        case .claude, .claudeCode:
-            return MeterBarTheme.claudeAccent
-        case .codexCli, .openai:
-            return .cyan
-        case .cursor:
-            return .green
-        }
+        MeterBarTheme.accent(for: service)
     }
 
     private func relativeDate(_ date: Date) -> String {
@@ -579,14 +569,7 @@ private struct ProviderOverviewStatusCard: View {
     let snapshot: DashboardProviderSnapshot
 
     private var accentColor: Color {
-        switch snapshot.service {
-        case .claude, .claudeCode:
-            return MeterBarTheme.claudeAccent
-        case .codexCli, .openai:
-            return .cyan
-        case .cursor:
-            return .green
-        }
+        MeterBarTheme.accent(for: snapshot.service)
     }
 
     private var primaryLimit: DashboardLimit? {
@@ -601,8 +584,9 @@ private struct ProviderOverviewStatusCard: View {
         return "Healthy"
     }
 
-    private var isOut: Bool {
-        primaryLimit?.percentLeft ?? 100 <= 0
+    private var metricColor: Color {
+        guard let primaryLimit else { return .primary }
+        return MeterBarTheme.metricColor(percentLeft: primaryLimit.percentLeft)
     }
 
     var body: some View {
@@ -628,7 +612,7 @@ private struct ProviderOverviewStatusCard: View {
                 HStack(alignment: .firstTextBaseline) {
                     Text("\(primaryLimit.percentLeft)%")
                         .font(.system(size: 34, weight: .bold))
-                        .foregroundColor(statusColor)
+                        .foregroundColor(metricColor)
                     Text("left")
                         .font(.subheadline)
                         .foregroundColor(.secondary)
@@ -668,16 +652,12 @@ private struct ProviderOverviewStatusCard: View {
             }
         }
         .padding(14)
-        .opacity(isOut ? 0.72 : 1)
         .dashboardCardBackground()
     }
 
     private var statusColor: Color {
         guard let primaryLimit else { return .secondary }
-        if primaryLimit.percentLeft <= 0 { return .red.opacity(0.72) }
-        if primaryLimit.percentLeft <= 10 { return .red }
-        if primaryLimit.percentLeft <= 25 { return MeterBarTheme.warning }
-        return .green
+        return MeterBarTheme.quotaStatusColor(percentLeft: primaryLimit.percentLeft)
     }
 
     private func relativeDate(_ date: Date) -> String {
@@ -697,7 +677,7 @@ private struct CostOverviewStatusCard: View {
             HStack(alignment: .center, spacing: 9) {
                 Image(systemName: "dollarsign.circle.fill")
                     .font(.system(size: 20, weight: .semibold))
-                    .foregroundColor(.green)
+                    .foregroundColor(MeterBarTheme.success)
                 VStack(alignment: .leading, spacing: 2) {
                     Text("API-Rate Estimate")
                         .font(.headline)
@@ -715,14 +695,14 @@ private struct CostOverviewStatusCard: View {
                         .controlSize(.small)
                     Text("Scanning...")
                         .font(.system(size: 28, weight: .bold))
-                        .foregroundColor(.green)
+                        .foregroundColor(.primary)
                         .lineLimit(1)
                         .minimumScaleFactor(0.75)
                 }
             } else {
                 Text(summary?.formattedTotalCost ?? "Scan needed")
                     .font(.system(size: 34, weight: .bold))
-                    .foregroundColor(.green)
+                    .foregroundColor(.primary)
                     .lineLimit(1)
                     .minimumScaleFactor(0.75)
             }
@@ -822,6 +802,7 @@ private struct DashboardLimitRow: View {
                 Text(isOut ? "Out" : "\(limit.percentLeft)% left")
                     .font(.subheadline)
                     .bold()
+                    .foregroundColor(isOut ? MeterBarTheme.danger : .primary)
             }
 
             UsageBar(
@@ -852,16 +833,15 @@ private struct DashboardLimitRow: View {
                 }
             }
         }
-        .opacity(isOut ? 0.68 : 1)
     }
 
     private func paceLabelColor(_ pace: UsagePace) -> Color {
         if pace.isExhausted {
-            return .red.opacity(0.78)
+            return MeterBarTheme.danger
         }
         switch pace.stage {
         case .reserve:
-            return .green
+            return MeterBarTheme.success
         case .deficit:
             return MeterBarTheme.warning
         case .onPace:
@@ -911,8 +891,8 @@ private struct CostScanLoadingChart: View {
                                     .fill(
                                         LinearGradient(
                                             colors: [
-                                                Color.cyan.opacity(0.22 + wave * 0.18),
-                                                Color.green.opacity(0.18 + seed * 0.25)
+                                                MeterBarTheme.codexAccent.opacity(0.18 + wave * 0.16),
+                                                MeterBarTheme.cursorAccent.opacity(0.16 + seed * 0.20)
                                             ],
                                             startPoint: .bottom,
                                             endPoint: .top
@@ -1135,14 +1115,7 @@ private struct DailyUsageChart: View {
     }
 
     private func color(for provider: ServiceType) -> Color {
-        switch provider {
-        case .claude, .claudeCode:
-            return MeterBarTheme.claudeAccent
-        case .codexCli, .openai:
-            return .cyan
-        case .cursor:
-            return .green
-        }
+        MeterBarTheme.accent(for: provider)
     }
 
     private func fullDateLabel(_ date: Date) -> String {
@@ -1404,14 +1377,7 @@ private struct ProviderCostBreakdown: View {
     }
 
     private var logoColor: Color {
-        switch cost.provider {
-        case .codexCli, .openai:
-            return .cyan
-        case .claude, .claudeCode:
-            return MeterBarTheme.claudeAccent
-        case .cursor:
-            return .green
-        }
+        MeterBarTheme.accent(for: cost.provider)
     }
 
     var body: some View {
@@ -1568,23 +1534,21 @@ private func logoKind(for provider: ServiceType) -> ProviderLogoKind {
 }
 
 private func color(for provider: ServiceType) -> Color {
-    switch provider {
-    case .claude, .claudeCode:
-        return MeterBarTheme.claudeAccent
-    case .codexCli, .openai:
-        return .cyan
-    case .cursor:
-        return .green
-    }
+    MeterBarTheme.accent(for: provider)
 }
 
 private extension View {
     func dashboardCardBackground() -> some View {
         self
-            .background(.thinMaterial)
+            .background {
+                ZStack {
+                    MeterBarTheme.graphiteSurface.opacity(0.78)
+                    Rectangle().fill(.thinMaterial).opacity(0.30)
+                }
+            }
             .overlay {
                 RoundedRectangle(cornerRadius: 8)
-                    .stroke(Color.white.opacity(0.10), lineWidth: 1)
+                    .stroke(MeterBarTheme.border, lineWidth: 1)
             }
             .clipShape(RoundedRectangle(cornerRadius: 8))
     }

--- a/MeterBarTests/ClaudeCodeCLIUsageParserTests.swift
+++ b/MeterBarTests/ClaudeCodeCLIUsageParserTests.swift
@@ -15,12 +15,15 @@ final class ClaudeCodeCLIUsageParserTests: XCTestCase {
         let metrics = try ClaudeCodeCLIUsageParser.parseMetrics(from: output, now: now)
 
         XCTAssertEqual(metrics.service, .claudeCode)
-        XCTAssertEqual(try XCTUnwrap(metrics.sessionLimit).percentage, 36, accuracy: 0.01)
-        XCTAssertEqual(try XCTUnwrap(metrics.weeklyLimit).percentage, 100, accuracy: 0.01)
-        XCTAssertEqual(try XCTUnwrap(metrics.codeReviewLimit).percentage, 83, accuracy: 0.01)
-        XCTAssertNotNil(metrics.sessionLimit?.resetTime)
-        XCTAssertNotNil(metrics.weeklyLimit?.resetTime)
-        XCTAssertNotNil(metrics.codeReviewLimit?.resetTime)
+        let sessionLimit = try XCTUnwrap(metrics.sessionLimit)
+        let weeklyLimit = try XCTUnwrap(metrics.weeklyLimit)
+        let codeReviewLimit = try XCTUnwrap(metrics.codeReviewLimit)
+        XCTAssertEqual(sessionLimit.percentage, 36, accuracy: 0.01)
+        XCTAssertEqual(weeklyLimit.percentage, 100, accuracy: 0.01)
+        XCTAssertEqual(codeReviewLimit.percentage, 83, accuracy: 0.01)
+        XCTAssertNotNil(sessionLimit.resetTime)
+        XCTAssertNotNil(weeklyLimit.resetTime)
+        XCTAssertNotNil(codeReviewLimit.resetTime)
     }
 
     func testParsesRemainingPercentAsUsedPercent() throws {
@@ -33,8 +36,10 @@ final class ClaudeCodeCLIUsageParserTests: XCTestCase {
             from: output,
             now: Date(timeIntervalSince1970: 1_781_154_000))
 
-        XCTAssertEqual(try XCTUnwrap(metrics.sessionLimit).percentage, 36, accuracy: 0.01)
-        XCTAssertEqual(try XCTUnwrap(metrics.weeklyLimit).percentage, 75, accuracy: 0.01)
+        let sessionLimit = try XCTUnwrap(metrics.sessionLimit)
+        let weeklyLimit = try XCTUnwrap(metrics.weeklyLimit)
+        XCTAssertEqual(sessionLimit.percentage, 36, accuracy: 0.01)
+        XCTAssertEqual(weeklyLimit.percentage, 75, accuracy: 0.01)
     }
 
     func testThrowsWhenNoUsageWindowsArePresent() {


### PR DESCRIPTION
## Summary

- Replace the neon-leaning UI colors with shared Apple-style graphite, provider accent, and semantic status tokens.
- Apply the palette across the menu popover, companion dashboard, settings panels, usage bars, and design contract.
- Keep large quota/cost metrics neutral unless exhausted, with color reserved for indicators, bars, and compact status labels.
- Fix optional limit unwraps in Claude Code parser tests so the SwiftPM suite compiles and runs.

## Validation

- `git diff --check`
- `swift build`
- `npx @google/design.md lint .agents/DESIGN.md`
- `swift test` — 53 tests executed, 2 skipped for missing Admin API keys, 0 failures