### PR TITLE
fix: reset-countdown, theme, and CI review findings

### DIFF
--- a/.agents/SESSIONS/2026-06-19.md
+++ b/.agents/SESSIONS/2026-06-19.md
@@ -1,0 +1,73 @@
+# Sessions: 2026-06-19
+
+**Summary:** Review of last 7 days of commits + fixes
+
+---
+
+## Session 1: Review recent commits and fix findings
+
+**Duration:** ~60 minutes
+**Status:** Complete
+
+### What was done
+
+- Reviewed the last 7 days of commits (range `ce017a6^..86a2aed`: reset-countdown feature,
+  native graphite palette, secret-scan gate, GitHub ownership migration) across five dimensions
+  (logic bugs, SwiftUI performance, theme regressions, CI/security, test coverage), with
+  adversarial verification of each finding. 18 issues confirmed, 1 rejected as out-of-scope.
+- Fixed the reset-countdown formatting: `UsageDurationText.short` now emits a day bucket
+  (`6d`, `1d 1h`, `7d`) so weekly windows no longer render as raw hours (e.g. `168h`), and
+  returns `<1m` for sub-minute remaining instead of overstating it as `1m`.
+- Fixed the stale `"reset due"` label: extracted the window-selection logic into a testable
+  static `NextResetCountdownLabel.selectNextWindow`, which now hides the label once the most
+  recent reset is past a 5-minute grace period (prevents a perpetual "reset due" when a
+  provider source goes offline and cached data ages out).
+- Aligned the quota color signal: `MeterBarTheme.metricColor` now turns the prominent "N%"
+  metric red across the whole critical band (`<= 10`), matching the adjacent status label,
+  instead of only at exactly 0%.
+- Changed the `warning` token from pure systemYellow to native systemOrange `(255,159,10)`
+  for clearer green/amber/red separation at caption sizes.
+- Reduced reset-countdown timer churn: both countdown labels now share a fixed-anchor,
+  60-second `TimelineView` schedule, so ticks land on real minute boundaries and stay in phase
+  instead of drifting per-view.
+- Hardened CI: secret-scan now runs `gitleaks git .` (scans commit history, not just the
+  working tree) and its `push` trigger is scoped to `master` to stop duplicate runs; pinned
+  `actions/checkout` to a commit SHA in ci/release/update-homebrew (matching secret-scan) and
+  pinned `softprops/action-gh-release` to `3bb1273…` (v2.6.2).
+- Backfilled unit tests (TDD per project policy) for `MeterBarTheme` color thresholds,
+  `UsageDurationText.short` edge cases, `ResetCountdownLabel.counterText`, and
+  `NextResetCountdownLabel.selectNextWindow`.
+
+### Files changed
+
+- `MeterBar/Models/UsageLimit.swift` - Day bucket + `<1m` in `UsageDurationText.short`.
+- `MeterBar/Views/MeterBarTheme.swift` - `metricColor` danger threshold to `<= 10`; warning → systemOrange.
+- `MeterBar/Views/MenuBarView.swift` - Shared 60s tick anchor; testable `selectNextWindow` with grace period.
+- `MeterBarTests/UsageLimitTests.swift` - Updated `<1m`/weekly `6d` assertions.
+- `MeterBarTests/MeterBarThemeTests.swift` - New: color threshold / accent coverage.
+- `MeterBarTests/ResetCountdownTests.swift` - New: duration / counter-text / window-selection coverage.
+- `.github/workflows/secret-scan.yml` - `gitleaks git`; `push` scoped to `master`.
+- `.github/workflows/ci.yml`, `release.yml`, `update-homebrew.yml` - Pinned actions to commit SHAs.
+
+### Decisions
+
+- For the timer-consolidation finding, applied the anchor + 60s-cadence fix (the real issue:
+  drift and redundant wakeups) rather than the larger "single hoisted TimelineView per tab"
+  refactor — verification showed the tab `switch` already prevents the labels from coexisting
+  and per-tick work is trivial, so the structural rewrite carried layout risk for marginal gain.
+- Kept `metricColor` neutral (`.primary`) above 10% to preserve the graphite redesign's calm
+  high-legibility numbers, only adding the danger color to match the existing status label.
+- Left the rejected finding (deficit bar red vs label color) untouched: pre-existing and not
+  worsened by these commits.
+
+### Verification
+
+- `swift test` passed (19 unit tests in the changed/added suites: MeterBarThemeTests,
+  ResetCountdownTests, UsageLimitTests; 0 failures). Full module compiles.
+- `swiftlint` reports no new violations from the changed lines (pre-existing warnings only).
+- All four workflow YAML files parse successfully; `softprops/action-gh-release` SHA resolved
+  via `gh api` (both `v2` and `v2.6.2` point at `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65`).
+
+### Next steps
+
+- [ ] Consider a CI gate that fails feature commits adding pure logic without a corresponding test.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
@@ -67,7 +67,7 @@ jobs:
         id: package
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: |
             MeterBar-${{ github.ref_name }}.zip

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -2,6 +2,7 @@ name: Secret Scan
 
 on:
   push:
+    branches: [master]
   pull_request:
   workflow_dispatch:
 
@@ -23,7 +24,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Run gitleaks (filesystem scan, pinned + checksum-verified, license-free)
+      - name: Run gitleaks (git history scan, pinned + checksum-verified, license-free)
         run: |
           set -euo pipefail
           TARBALL="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
@@ -35,4 +36,4 @@ jobs:
           echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum --check --strict
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
           chmod +x /tmp/gitleaks
-          /tmp/gitleaks dir . --redact --no-banner --exit-code 1
+          /tmp/gitleaks git . --redact --no-banner --exit-code 1

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -40,7 +40,7 @@ jobs:
         id: sha
 
       - name: Checkout homebrew-tap
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: VincentShipsIt/homebrew-tap
           token: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,8 @@
+# gitleaks false positives (fingerprint = commit:file:rule:startline).
+# Each entry is scoped to one historical finding, so real future secrets are
+# still caught.
+
+# Illustrative "BAD: hardcoded secret" example (sk-1234567890) inside the
+# .cursor/commands/security-audit.md command doc (since removed from the tree).
+# Not a real credential — it is documentation showing what NOT to do.
+0f6594991c17d6a479ee7adbf383983a83bf84db:.cursor/commands/security-audit.md:generic-api-key:179

--- a/MeterBar/Models/UsageLimit.swift
+++ b/MeterBar/Models/UsageLimit.swift
@@ -163,14 +163,20 @@ struct UsagePace: Equatable {
 enum UsageDurationText {
     static func short(seconds: TimeInterval) -> String {
         let wholeSeconds = max(0, Int(seconds.rounded()))
-        let hours = wholeSeconds / 3600
-        let minutes = (wholeSeconds % 3600) / 60
+        let days = wholeSeconds / 86_400
+        let hours = (wholeSeconds % 86_400) / 3_600
+        let minutes = (wholeSeconds % 3_600) / 60
 
+        if days > 0 {
+            return hours > 0 ? "\(days)d \(hours)h" : "\(days)d"
+        }
         if hours > 0 {
             return minutes > 0 ? "\(hours)h \(minutes)m" : "\(hours)h"
         }
-
-        return "\(max(1, minutes))m"
+        if wholeSeconds < 60 {
+            return "<1m"
+        }
+        return "\(minutes)m"
     }
 }
 

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -496,6 +496,15 @@ struct ResetCountdownWindow: Identifiable {
     let limit: UsageLimit
 }
 
+/// Shared tick schedule for all reset-countdown labels. Anchoring to a fixed
+/// reference date (a whole-minute boundary) keeps every label in phase so ticks
+/// land on real minute boundaries instead of drifting per-view. A 60s cadence is
+/// sufficient since the displayed granularity is minutes.
+private enum ResetCountdownSchedule {
+    static let anchor = Date(timeIntervalSinceReferenceDate: 0)
+    static let interval: TimeInterval = 60
+}
+
 struct ResetCountdownLabel: View {
     let title: String?
     let limit: UsageLimit
@@ -504,7 +513,7 @@ struct ResetCountdownLabel: View {
     var iconSize: CGFloat = 10
 
     var body: some View {
-        TimelineView(.periodic(from: Date(), by: 30)) { timeline in
+        TimelineView(.periodic(from: ResetCountdownSchedule.anchor, by: ResetCountdownSchedule.interval)) { timeline in
             Group {
                 if let text = Self.counterText(title: title, limit: limit, now: timeline.date) {
                     HStack(spacing: 4) {
@@ -537,10 +546,15 @@ struct NextResetCountdownLabel: View {
     var foregroundColor: Color = .secondary
     var iconSize: CGFloat = 10
 
+    /// How long after a window's reset time we keep showing "reset due" before
+    /// treating the data as stale and hiding the label (until a refresh repopulates
+    /// a future reset time). Prevents a perpetual "reset due" when a provider goes offline.
+    static let resetDueGracePeriod: TimeInterval = 5 * 60
+
     var body: some View {
-        TimelineView(.periodic(from: Date(), by: 30)) { timeline in
+        TimelineView(.periodic(from: ResetCountdownSchedule.anchor, by: ResetCountdownSchedule.interval)) { timeline in
             Group {
-                if let window = nextWindow(now: timeline.date),
+                if let window = Self.selectNextWindow(windows, now: timeline.date),
                    let text = ResetCountdownLabel.counterText(
                        title: window.title,
                        limit: window.limit,
@@ -561,7 +575,16 @@ struct NextResetCountdownLabel: View {
         }
     }
 
-    private func nextWindow(now: Date) -> ResetCountdownWindow? {
+    /// Picks the window each provider card should count down to: the soonest
+    /// upcoming reset, or — if every window has already passed — the most recently
+    /// due one, but only while it is within `gracePeriod` of now. Beyond that the
+    /// data is treated as stale and `nil` is returned so the label hides instead of
+    /// showing "reset due" indefinitely.
+    static func selectNextWindow(
+        _ windows: [ResetCountdownWindow],
+        now: Date,
+        gracePeriod: TimeInterval = resetDueGracePeriod
+    ) -> ResetCountdownWindow? {
         let candidates = windows.compactMap { window -> (window: ResetCountdownWindow, seconds: TimeInterval)? in
             guard let seconds = window.limit.secondsUntilReset(now: now) else { return nil }
             return (window, seconds)
@@ -572,7 +595,12 @@ struct NextResetCountdownLabel: View {
             return next.window
         }
 
-        return candidates.max(by: { $0.seconds < $1.seconds })?.window
+        if let mostRecent = candidates.max(by: { $0.seconds < $1.seconds }),
+           mostRecent.seconds >= -gracePeriod {
+            return mostRecent.window
+        }
+
+        return nil
     }
 }
 

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -12,7 +12,7 @@ enum MeterBarTheme {
     static let claudeAccent = Color(red: 209 / 255, green: 134 / 255, blue: 101 / 255)
     static let cursorAccent = Color(red: 99 / 255, green: 210 / 255, blue: 151 / 255)
     static let success = Color(red: 48 / 255, green: 209 / 255, blue: 88 / 255)
-    static let warning = Color(red: 255 / 255, green: 214 / 255, blue: 10 / 255)
+    static let warning = Color(red: 255 / 255, green: 159 / 255, blue: 10 / 255)
     static let danger = Color(red: 255 / 255, green: 69 / 255, blue: 58 / 255)
     static let barTrack = Color.white.opacity(0.14)
     static let border = Color.white.opacity(0.10)
@@ -39,7 +39,10 @@ enum MeterBarTheme {
     }
 
     static func metricColor(percentLeft: Int) -> Color {
-        percentLeft <= 0 ? danger : .primary
+        // Match the danger threshold of quotaStatusColor so the prominent "N%"
+        // metric turns red across the whole critical band, agreeing with the
+        // adjacent status label, while staying neutral for healthy quotas.
+        percentLeft <= 10 ? danger : .primary
     }
 }
 

--- a/MeterBarTests/MeterBarThemeTests.swift
+++ b/MeterBarTests/MeterBarThemeTests.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import XCTest
+@testable import MeterBar
+
+final class MeterBarThemeTests: XCTestCase {
+    func testQuotaStatusColorBuckets() {
+        // danger: percentLeft <= 10
+        XCTAssertEqual(MeterBarTheme.quotaStatusColor(percentLeft: 0), MeterBarTheme.danger)
+        XCTAssertEqual(MeterBarTheme.quotaStatusColor(percentLeft: 10), MeterBarTheme.danger)
+        // warning: 11...25
+        XCTAssertEqual(MeterBarTheme.quotaStatusColor(percentLeft: 11), MeterBarTheme.warning)
+        XCTAssertEqual(MeterBarTheme.quotaStatusColor(percentLeft: 25), MeterBarTheme.warning)
+        // success: > 25
+        XCTAssertEqual(MeterBarTheme.quotaStatusColor(percentLeft: 26), MeterBarTheme.success)
+        XCTAssertEqual(MeterBarTheme.quotaStatusColor(percentLeft: 100), MeterBarTheme.success)
+    }
+
+    func testMetricColorMatchesDangerThreshold() {
+        // Metric turns red across the whole critical band (<= 10), agreeing with
+        // the status label, and stays neutral above it.
+        XCTAssertEqual(MeterBarTheme.metricColor(percentLeft: -5), MeterBarTheme.danger)
+        XCTAssertEqual(MeterBarTheme.metricColor(percentLeft: 0), MeterBarTheme.danger)
+        XCTAssertEqual(MeterBarTheme.metricColor(percentLeft: 10), MeterBarTheme.danger)
+        XCTAssertEqual(MeterBarTheme.metricColor(percentLeft: 11), Color.primary)
+        XCTAssertEqual(MeterBarTheme.metricColor(percentLeft: 100), Color.primary)
+    }
+
+    func testAccentForEveryService() {
+        XCTAssertEqual(MeterBarTheme.accent(for: .claude), MeterBarTheme.claudeAccent)
+        XCTAssertEqual(MeterBarTheme.accent(for: .claudeCode), MeterBarTheme.claudeAccent)
+        XCTAssertEqual(MeterBarTheme.accent(for: .openai), MeterBarTheme.codexAccent)
+        XCTAssertEqual(MeterBarTheme.accent(for: .codexCli), MeterBarTheme.codexAccent)
+        XCTAssertEqual(MeterBarTheme.accent(for: .cursor), MeterBarTheme.cursorAccent)
+    }
+}

--- a/MeterBarTests/ResetCountdownTests.swift
+++ b/MeterBarTests/ResetCountdownTests.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+import XCTest
+@testable import MeterBar
+
+final class ResetCountdownTests: XCTestCase {
+    private let epoch = Date(timeIntervalSince1970: 0)
+
+    private func limit(resetIn seconds: TimeInterval?) -> UsageLimit {
+        UsageLimit(
+            used: 25,
+            total: 100,
+            resetTime: seconds.map { epoch.addingTimeInterval($0) }
+        )
+    }
+
+    private func window(_ id: String, _ title: String, resetIn seconds: TimeInterval?) -> ResetCountdownWindow {
+        ResetCountdownWindow(id: id, title: title, limit: limit(resetIn: seconds))
+    }
+
+    // MARK: - UsageDurationText.short
+
+    func testShortSubMinute() {
+        XCTAssertEqual(UsageDurationText.short(seconds: 45), "<1m")
+        XCTAssertEqual(UsageDurationText.short(seconds: 0), "<1m")
+        XCTAssertEqual(UsageDurationText.short(seconds: -5), "<1m")
+        XCTAssertEqual(UsageDurationText.short(seconds: 59), "<1m")
+    }
+
+    func testShortMinutesAndHours() {
+        XCTAssertEqual(UsageDurationText.short(seconds: 60), "1m")
+        XCTAssertEqual(UsageDurationText.short(seconds: 120), "2m")
+        XCTAssertEqual(UsageDurationText.short(seconds: 3_600), "1h")
+        XCTAssertEqual(UsageDurationText.short(seconds: 3_660), "1h 1m")
+        XCTAssertEqual(UsageDurationText.short(seconds: 7_200), "2h")
+    }
+
+    func testShortDays() {
+        XCTAssertEqual(UsageDurationText.short(seconds: 86_400), "1d")
+        XCTAssertEqual(UsageDurationText.short(seconds: 90_000), "1d 1h")
+        XCTAssertEqual(UsageDurationText.short(seconds: 6 * 86_400), "6d")
+        XCTAssertEqual(UsageDurationText.short(seconds: 7 * 86_400), "7d")
+    }
+
+    // MARK: - ResetCountdownLabel.counterText
+
+    func testCounterTextFutureWithAndWithoutTitle() {
+        XCTAssertEqual(
+            ResetCountdownLabel.counterText(title: "Weekly", limit: limit(resetIn: 3_660), now: epoch),
+            "Weekly reset in 1h 1m"
+        )
+        XCTAssertEqual(
+            ResetCountdownLabel.counterText(title: nil, limit: limit(resetIn: 3_660), now: epoch),
+            "Resets in 1h 1m"
+        )
+    }
+
+    func testCounterTextDueWithAndWithoutTitle() {
+        XCTAssertEqual(
+            ResetCountdownLabel.counterText(title: "Session", limit: limit(resetIn: -1), now: epoch),
+            "Session reset due"
+        )
+        XCTAssertEqual(
+            ResetCountdownLabel.counterText(title: nil, limit: limit(resetIn: -1), now: epoch),
+            "Reset due"
+        )
+    }
+
+    func testCounterTextNilWhenNoResetTime() {
+        XCTAssertNil(ResetCountdownLabel.counterText(title: "Weekly", limit: limit(resetIn: nil), now: epoch))
+    }
+
+    // MARK: - NextResetCountdownLabel.selectNextWindow
+
+    func testSelectNextWindowPicksSoonestFuture() {
+        let session = window("s", "Session", resetIn: 3_600)
+        let weekly = window("w", "Weekly", resetIn: 86_400)
+        XCTAssertEqual(NextResetCountdownLabel.selectNextWindow([weekly, session], now: epoch)?.id, "s")
+    }
+
+    func testSelectNextWindowPrefersFutureOverPast() {
+        let past = window("p", "Session", resetIn: -120)
+        let future = window("f", "Weekly", resetIn: 9_000)
+        XCTAssertEqual(NextResetCountdownLabel.selectNextWindow([past, future], now: epoch)?.id, "f")
+    }
+
+    func testSelectNextWindowFallsBackToMostRecentlyDueWithinGrace() {
+        let justPast = window("j", "Session", resetIn: -60)
+        let longPast = window("l", "Weekly", resetIn: -240)
+        // Both within the 5-minute grace period: pick the least-negative (most recently due).
+        XCTAssertEqual(NextResetCountdownLabel.selectNextWindow([longPast, justPast], now: epoch)?.id, "j")
+    }
+
+    func testSelectNextWindowHidesStaleWindowsBeyondGrace() {
+        let stale = window("x", "Session", resetIn: -10 * 60)
+        XCTAssertNil(NextResetCountdownLabel.selectNextWindow([stale], now: epoch))
+    }
+
+    func testSelectNextWindowReturnsNilWhenNoResetTimes() {
+        XCTAssertNil(NextResetCountdownLabel.selectNextWindow([window("n", "Session", resetIn: nil)], now: epoch))
+        XCTAssertNil(NextResetCountdownLabel.selectNextWindow([], now: epoch))
+    }
+}

--- a/MeterBarTests/UsageLimitTests.swift
+++ b/MeterBarTests/UsageLimitTests.swift
@@ -76,6 +76,11 @@ final class UsageLimitTests: XCTestCase {
             total: 100,
             resetTime: now.addingTimeInterval(45)
         )
+        let weeklyReset = UsageLimit(
+            used: 25,
+            total: 100,
+            resetTime: now.addingTimeInterval(6 * 86_400)
+        )
         let dueReset = UsageLimit(
             used: 25,
             total: 100,
@@ -85,7 +90,8 @@ final class UsageLimitTests: XCTestCase {
 
         XCTAssertEqual(try XCTUnwrap(futureReset.secondsUntilReset(now: now)), 3_660, accuracy: 0.01)
         XCTAssertEqual(futureReset.resetCountdownText(now: now), "1h 1m")
-        XCTAssertEqual(imminentReset.resetCountdownText(now: now), "1m")
+        XCTAssertEqual(imminentReset.resetCountdownText(now: now), "<1m")
+        XCTAssertEqual(weeklyReset.resetCountdownText(now: now), "6d")
         XCTAssertEqual(dueReset.resetCountdownText(now: now), "now")
         XCTAssertNil(noReset.resetCountdownText(now: now))
     }


### PR DESCRIPTION
## Overview

Multi-agent review of the last 7 days of commits (reset-countdown feature, native graphite palette, secret-scan gate, GitHub ownership migration) surfaced 18 confirmed issues. This PR fixes all of them, with tests added per the project's TDD policy.

## What changed

### Reset countdowns (`MeterBar/Models/UsageLimit.swift`, `MeterBar/Views/MenuBarView.swift`)
- **Day bucket** in `UsageDurationText.short` — weekly windows now read `6d` / `1d 1h` / `7d` instead of raw hours like `168h` (regression vs. the old `RelativeDateTimeFormatter`).
- **`<1m`** for sub-minute remaining instead of overstating it as `1m`.
- Extracted the window-selection logic into a testable static `NextResetCountdownLabel.selectNextWindow`, which now **hides the label past a 5-minute grace period** so a stale/offline provider no longer shows `reset due` forever.

### Theme (`MeterBar/Views/MeterBarTheme.swift`)
- `metricColor` turns the prominent "N%" metric red across the whole critical band (`<= 10`) to **match the adjacent status label**, instead of only at exactly 0%.
- `warning` token → native **systemOrange** `(255,159,10)` for clearer green/amber/red separation at caption sizes.

### Performance
- Both countdown labels now share a **fixed-anchor, 60-second `TimelineView`** schedule, so ticks land on real minute boundaries and stay in phase instead of drifting per-view.

### CI / supply chain (`.github/workflows/`)
- `secret-scan` runs **`gitleaks git .`** (scans commit history, not just the working tree) and scopes its `push` trigger to `master` to stop duplicate runs.
- Pinned `actions/checkout` to a commit SHA in `ci` / `release` / `update-homebrew` (matching `secret-scan`), and pinned `softprops/action-gh-release` to `3bb1273` (v2.6.2).

### Tests (TDD)
- New `MeterBarThemeTests` (color thresholds 0/10/11/25/26, `metricColor`, `accent(for:)` across all 5 services — locks the 4→3 bucket change).
- New `ResetCountdownTests` (`short` sub-minute/hours/days, `counterText` 4 strings + nil, `selectNextWindow` soonest-future / grace fallback / stale-hide / nil).
- Updated `UsageLimitTests` (`<1m` + weekly `6d`).

## Notes for reviewers
- **Timer consolidation:** applied the anchor + 60s-cadence fix (the real issue: drift + redundant wakeups) rather than the larger "single hoisted `TimelineView` per tab" refactor — the tab `switch` already prevents the labels from coexisting and per-tick work is trivial, so the structural rewrite carried layout risk for marginal gain.
- `metricColor` stays neutral (`.primary`) above 10% to preserve the graphite redesign's calm, high-legibility numbers.
- One review finding (deficit bar red vs. label color) was intentionally **not** changed: it's pre-existing and not worsened by these commits.

## Verification
- `swift test` → **19/19 pass** in the changed/added suites; full module compiles.
- `swiftlint` → no new violations from changed lines.
- All four workflow YAML files parse; `softprops/action-gh-release` SHA resolved via `gh api` (both `v2` and `v2.6.2` → `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)