### PR TITLE
feat(app): Dock visibility toggle + keep MeterBar in the menu bar

### DIFF
--- a/.agents/SESSIONS/2026-06-19.md
+++ b/.agents/SESSIONS/2026-06-19.md
@@ -1,0 +1,70 @@
+# Sessions: 2026-06-19
+
+**Summary:** Dock visibility toggle and stay-in-menu-bar lifecycle
+
+---
+
+## Session 1: Hide From Dock + Keep Running In Menu Bar
+
+**Duration:** ~1 hour
+**Status:** Complete
+
+### What was done
+
+- Added `DockVisibilityStore`, a UserDefaults-backed `ObservableObject` that persists
+  whether MeterBar shows a Dock icon (`ShowMeterBarInDock`, default = shown).
+- Wired the app delegate to apply the preference via `NSApp.setActivationPolicy`
+  (`.regular` = Dock shown, `.accessory` = menu bar only), applied as early as
+  `applicationWillFinishLaunching` to avoid a Dock-icon flash, and re-applied via a
+  Combine subscription whenever the preference changes.
+- Made the app stay alive in the menu bar when its window is closed:
+  `applicationShouldTerminateAfterLastWindowClosed` returns `false`, and
+  `applicationShouldHandleReopen` reopens the usage dashboard on Dock-icon click.
+- Added a "Show in Dock" toggle to Settings (new General section) and to the popover's
+  `⋯` options menu.
+- Added a native right-click / control-click menu on the menu bar status item
+  (Show in Dock, Open Usage Dashboard, Quit MeterBar) so Quit is always reachable even
+  when the Dock icon is hidden — independent of the transient popover.
+- Added `DockVisibilityStoreTests` covering default, persistence, and no-op publishing.
+
+### Files changed
+
+- `MeterBar/Services/DockVisibilityStore.swift` - New persisted Dock-visibility preference.
+- `MeterBar/App/MeterBarApp.swift` - Activation-policy switching, stay-in-menu-bar lifecycle, status-item right-click menu.
+- `MeterBar/Views/SettingsView.swift` - General section with "Show in Dock" toggle.
+- `MeterBar/Views/MenuBarView.swift` - Popover `⋯` options menu (Show in Dock, Quit).
+- `MeterBarTests/DockVisibilityStoreTests.swift` - Unit coverage for the store.
+
+### Decisions
+
+- **Decision:** Default to showing MeterBar in the Dock.
+  - **Context:** The shipped app target uses `GENERATE_INFOPLIST_FILE = YES` and never
+    references the hand-written `MeterBar/Info.plist`, so its `LSUIElement=true` is dead;
+    the built app already launches `.regular` with a Dock icon.
+  - **Rationale:** Defaulting to shown is non-destructive for existing installs; users opt
+    into hiding via the new toggle, matching the request to "hide from the dock."
+
+- **Decision:** Add a native status-item right-click menu for Quit rather than relying only
+  on the SwiftUI `Menu` inside the popover.
+  - **Rationale:** A SwiftUI `Menu` inside a `.transient` `NSPopover` can dismiss the
+    popover as it opens. Hiding the Dock removes the Dock's Quit and the app menu, so a
+    popover-independent Quit is required to avoid trapping the user.
+
+### Verification
+
+- `swift build` passed.
+- `swift test` passed: 58 tests, 2 credential-dependent API tests skipped, 0 failures
+  (includes 4 new `DockVisibilityStoreTests`).
+- `xcodebuild` of the `MeterBar` app target: BUILD SUCCEEDED.
+- Confirmed the built `.app` ships without `LSUIElement` (runtime activation policy is now
+  the source of truth).
+- `git diff --check` clean.
+
+### Next steps
+
+- [ ] Manual smoke test on device: toggle Show in Dock, confirm no flash on relaunch when
+      hidden, confirm right-click Quit works in both Dock-shown and Dock-hidden states.
+
+---
+
+**Total sessions today:** 1

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Combine
 import SwiftUI
 import UserNotifications
@@ -24,10 +25,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem?
     private var popover: NSPopover?
     private let providerVisibilityStore = ProviderVisibilityStore.shared
+    private let dockVisibilityStore = DockVisibilityStore.shared
     private var cancellables = Set<AnyCancellable>()
-    
+
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        // Apply the persisted Dock visibility as early as possible so users who
+        // hide MeterBar from the Dock don't see a brief Dock-icon flash.
+        applyActivationPolicy(showInDock: dockVisibilityStore.showInDock)
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         print("🚀 MeterBar: Application did finish launching")
+
+        // Keep Dock visibility in sync with the user's preference.
+        observeDockVisibility()
         
         // Create menu bar item
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -42,8 +53,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         image.isTemplate = true
         button.image = image
         
-        button.action = #selector(togglePopover)
+        button.action = #selector(handleStatusItemClick)
         button.target = self
+        button.sendAction(on: [.leftMouseUp, .rightMouseUp])
         button.toolTip = "MeterBar"
         button.imagePosition = .imageLeft
         button.font = .systemFont(ofSize: 14, weight: .semibold)
@@ -66,17 +78,128 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         setupNotifications()
     }
     
+    /// Left-click opens the popover; right-click (or control-click) opens a
+    /// native menu so Quit stays reachable even when the Dock icon is hidden.
+    @objc private func handleStatusItemClick() {
+        let event = NSApp.currentEvent
+        let isSecondaryClick = event?.type == .rightMouseUp
+            || (event?.modifierFlags.contains(.control) ?? false)
+
+        if isSecondaryClick {
+            showStatusMenu()
+        } else {
+            togglePopover()
+        }
+    }
+
     @objc func togglePopover() {
         guard let button = statusItem?.button,
               let popover = popover else { return }
-        
+
         if popover.isShown {
             popover.performClose(nil)
         } else {
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         }
     }
-    
+
+    /// Shows a native menu anchored to the menu bar icon. This is the always-on
+    /// escape hatch for Quit (and Dock visibility), independent of the popover.
+    private func showStatusMenu() {
+        guard let button = statusItem?.button else { return }
+
+        if popover?.isShown == true {
+            popover?.performClose(nil)
+        }
+
+        let menu = makeStatusMenu()
+        let location = NSPoint(x: 0, y: button.bounds.height + 4)
+        menu.popUp(positioning: nil, at: location, in: button)
+    }
+
+    private func makeStatusMenu() -> NSMenu {
+        let menu = NSMenu()
+
+        let dockItem = NSMenuItem(
+            title: "Show in Dock",
+            action: #selector(toggleShowInDock),
+            keyEquivalent: ""
+        )
+        dockItem.target = self
+        dockItem.state = dockVisibilityStore.showInDock ? .on : .off
+        menu.addItem(dockItem)
+
+        let dashboardItem = NSMenuItem(
+            title: "Open Usage Dashboard",
+            action: #selector(openDashboardFromStatusMenu),
+            keyEquivalent: ""
+        )
+        dashboardItem.target = self
+        menu.addItem(dashboardItem)
+
+        menu.addItem(.separator())
+
+        let quitItem = NSMenuItem(
+            title: "Quit MeterBar",
+            action: #selector(quitApp),
+            keyEquivalent: "q"
+        )
+        quitItem.target = self
+        menu.addItem(quitItem)
+
+        return menu
+    }
+
+    @objc private func toggleShowInDock() {
+        dockVisibilityStore.setShowInDock(!dockVisibilityStore.showInDock)
+    }
+
+    @objc private func openDashboardFromStatusMenu() {
+        UsageDashboardWindowController.shared.show()
+    }
+
+    @objc private func quitApp() {
+        NSApp.terminate(nil)
+    }
+
+    /// Closing the dashboard window (or any window) should never quit MeterBar —
+    /// it keeps running in the menu bar until the user explicitly quits.
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        false
+    }
+
+    /// Clicking the Dock icon (when shown) with no open windows reopens the
+    /// usage dashboard instead of doing nothing.
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if !flag {
+            UsageDashboardWindowController.shared.show()
+        }
+        return true
+    }
+
+    private func observeDockVisibility() {
+        dockVisibilityStore.$showInDock
+            .sink { [weak self] showInDock in
+                Task { @MainActor in
+                    self?.applyActivationPolicy(showInDock: showInDock)
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    /// Shows or hides the Dock icon by switching the app's activation policy.
+    /// The menu bar status item is unaffected and always remains visible.
+    private func applyActivationPolicy(showInDock: Bool) {
+        let policy: NSApplication.ActivationPolicy = showInDock ? .regular : .accessory
+        guard NSApp.activationPolicy() != policy else { return }
+        NSApp.setActivationPolicy(policy)
+        if showInDock {
+            // Reassert foreground status so menus/windows behave after the
+            // accessory -> regular transition.
+            NSApp.activate(ignoringOtherApps: false)
+        }
+    }
+
     private func setupNotifications() {
         // Check current authorization status first
         UNUserNotificationCenter.current().getNotificationSettings { settings in

--- a/MeterBar/Services/DockVisibilityStore.swift
+++ b/MeterBar/Services/DockVisibilityStore.swift
@@ -1,0 +1,35 @@
+import Combine
+import Foundation
+
+/// Persists whether MeterBar shows an icon in the Dock.
+///
+/// MeterBar always keeps its menu bar (status bar) item regardless of this
+/// setting. This flag only controls the Dock icon, which the app delegate
+/// applies by switching `NSApplication.ActivationPolicy` between `.regular`
+/// (Dock icon shown) and `.accessory` (menu bar only).
+final class DockVisibilityStore: ObservableObject {
+    static let shared = DockVisibilityStore()
+
+    /// `true` shows the Dock icon (`.regular`); `false` hides it (`.accessory`).
+    @Published private(set) var showInDock: Bool
+
+    private let userDefaults: UserDefaults
+    private let storageKey = "ShowMeterBarInDock"
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        if userDefaults.object(forKey: storageKey) == nil {
+            // Default to showing in the Dock so the change is non-destructive
+            // for existing installs; users opt into hiding it.
+            showInDock = true
+        } else {
+            showInDock = userDefaults.bool(forKey: storageKey)
+        }
+    }
+
+    func setShowInDock(_ show: Bool) {
+        guard show != showInDock else { return }
+        showInDock = show
+        userDefaults.set(show, forKey: storageKey)
+    }
+}

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -48,6 +48,7 @@ struct MenuBarView: View {
     @StateObject private var cursorService = CursorLocalService.shared
     @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
+    @StateObject private var dockVisibility = DockVisibilityStore.shared
 
     @State private var contentHeight: CGFloat = 320
 
@@ -150,10 +151,42 @@ struct MenuBarView: View {
                     await dataManager.refreshAll()
                 }
             }
+
+            optionsMenu
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
         .background(.ultraThinMaterial)
+    }
+
+    private var optionsMenu: some View {
+        Menu {
+            Toggle("Show in Dock", isOn: Binding(
+                get: { dockVisibility.showInDock },
+                set: { dockVisibility.setShowInDock($0) }
+            ))
+            Button("Open Usage Dashboard", action: openDashboard)
+            Divider()
+            Button("Quit MeterBar") {
+                NSApp.terminate(nil)
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 16, weight: .semibold))
+                .frame(width: 32, height: 32)
+                .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .frame(width: 32, height: 32)
+        .foregroundColor(MeterBarTheme.toolbarIconForeground)
+        .background(MeterBarTheme.toolbarIconBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(MeterBarTheme.toolbarIconBorder, lineWidth: 1)
+        }
+        .help("More options")
     }
 
     private func openDashboard() {

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -11,6 +11,7 @@ struct SettingsView: View {
     @StateObject private var cursorService = CursorLocalService.shared
     @StateObject private var costTracker = CostTracker.shared
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
+    @StateObject private var dockVisibility = DockVisibilityStore.shared
 
     @State private var claudeAdminKey: String = ""
     @State private var openaiAdminKey: String = ""
@@ -62,8 +63,25 @@ struct SettingsView: View {
             }
             costTrackingSection
             refreshSection
+            generalSection
         }
         .frame(maxWidth: 760, alignment: .leading)
+    }
+
+    private var generalSection: some View {
+        SettingsPanelSection(title: "General", systemImage: "dock.rectangle", color: MeterBarTheme.appAccent) {
+            SettingsRowView(
+                title: "Show in Dock",
+                detail: "Show MeterBar's icon in the Dock. MeterBar always stays in the menu bar."
+            ) {
+                Toggle("", isOn: Binding(
+                    get: { dockVisibility.showInDock },
+                    set: { dockVisibility.setShowInDock($0) }
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+            }
+        }
     }
 
     private var trackedProvidersSection: some View {

--- a/MeterBarTests/DockVisibilityStoreTests.swift
+++ b/MeterBarTests/DockVisibilityStoreTests.swift
@@ -1,0 +1,62 @@
+import Combine
+import XCTest
+@testable import MeterBar
+
+final class DockVisibilityStoreTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "DockVisibilityStoreTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testDefaultsToShowingInDock() {
+        let store = DockVisibilityStore(userDefaults: defaults)
+        XCTAssertTrue(store.showInDock, "A fresh install should show MeterBar in the Dock by default.")
+    }
+
+    func testHidingFromDockPersists() {
+        let store = DockVisibilityStore(userDefaults: defaults)
+
+        store.setShowInDock(false)
+        XCTAssertFalse(store.showInDock)
+
+        let reloaded = DockVisibilityStore(userDefaults: defaults)
+        XCTAssertFalse(reloaded.showInDock, "Hiding from the Dock should survive a relaunch.")
+    }
+
+    func testShowingInDockPersistsAfterHiding() {
+        defaults.set(false, forKey: "ShowMeterBarInDock")
+        let store = DockVisibilityStore(userDefaults: defaults)
+        XCTAssertFalse(store.showInDock)
+
+        store.setShowInDock(true)
+        XCTAssertTrue(store.showInDock)
+
+        let reloaded = DockVisibilityStore(userDefaults: defaults)
+        XCTAssertTrue(reloaded.showInDock, "Re-showing in the Dock should survive a relaunch.")
+    }
+
+    func testSettingSameValueDoesNotPublishRedundantly() {
+        let store = DockVisibilityStore(userDefaults: defaults)
+        var publishedCount = 0
+        let cancellable = store.$showInDock.dropFirst().sink { _ in publishedCount += 1 }
+
+        store.setShowInDock(true) // already the default — no change expected
+        XCTAssertEqual(publishedCount, 0)
+
+        store.setShowInDock(false) // genuine change
+        XCTAssertEqual(publishedCount, 1)
+
+        cancellable.cancel()
+    }
+}


### PR DESCRIPTION
## Description

Lets you **close MeterBar and keep it running in the menu bar**, and adds an **option to hide MeterBar from the Dock**.

Root cause found along the way: the app target uses `GENERATE_INFOPLIST_FILE = YES` and never references the hand-written `MeterBar/Info.plist`, so its `LSUIElement=true` is **dead** — the built app actually ships *without* `LSUIElement`, i.e. it launches with a Dock icon and quits like a normal app. This PR makes Dock visibility a runtime preference instead.

### What changed

- **`DockVisibilityStore`** (new): UserDefaults-backed `ObservableObject` persisting a `Show in Dock` preference (`ShowMeterBarInDock`, default **shown** — non-destructive for existing installs).
- **Activation policy** (`AppDelegate`): applies the preference via `NSApp.setActivationPolicy(.regular/.accessory)` — `.regular` shows the Dock icon, `.accessory` is menu-bar-only. Applied at `applicationWillFinishLaunching` (no Dock-icon flash) and re-applied via Combine whenever the toggle changes. The menu-bar status item is never affected.
- **Stay in the menu bar**: `applicationShouldTerminateAfterLastWindowClosed → false`, so closing the dashboard window keeps MeterBar alive in the menu bar. `applicationShouldHandleReopen` reopens the dashboard on Dock-icon click.
- **Controls**: a `Show in Dock` toggle in **Settings → General** and in the popover's `⋯` menu.
- **Always-reachable Quit**: a native **right-click / control-click menu on the menu-bar icon** (Show in Dock, Open Usage Dashboard, Quit MeterBar). This is independent of the Dock and the transient popover, so Quit is never stranded when the Dock icon is hidden.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] `swift build` — passes
- [x] `swift test` — 58 tests, 2 credential-dependent API tests skipped, **0 failures** (incl. 4 new `DockVisibilityStoreTests`: default, persistence, no-op publish)
- [x] `xcodebuild` app target — **BUILD SUCCEEDED**
- [x] Confirmed the built `.app` ships without `LSUIElement` (runtime policy is now the source of truth)
- [ ] Manual smoke test on macOS: toggle Show in Dock; confirm no flash on relaunch when hidden; confirm right-click Quit works in both Dock-shown and Dock-hidden states
- [ ] Verified menu bar functionality on device

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (session notes in `.agents/SESSIONS/2026-06-19.md`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

- **Default is "shown in Dock"** so existing users see no behavior change; hiding is opt-in (matching the "option to hide" request).
- The dead `MeterBar/Info.plist` (`LSUIElement=true`) was left untouched to keep the diff focused; it's a latent trap if someone later wires `INFOPLIST_FILE` to it (it would flip the default to hidden). Happy to remove/neutralize it in a follow-up.
- No new entitlements required; `setActivationPolicy` works under the existing App Sandbox.