### PR TITLE
Adopt native macOS Liquid Glass design across all surfaces

### DIFF
--- a/.agents/DESIGN.md
+++ b/.agents/DESIGN.md
@@ -1,224 +1,125 @@
 ---
-version: alpha
+version: beta
 name: MeterBar Native Utility
-description: Compact macOS utility UI for AI quota, usage, and local token spend.
+description: Native macOS menu-bar utility for AI quota, usage, and local token spend, built on Liquid Glass.
+platform:
+  minimum: "macOS 26 (Tahoe)"
+  appearance: "adaptive (light + dark); never force a color scheme"
+principles:
+  - "Glass is a system-owned chrome layer (menu bar, popover, toolbar, sidebar, floating controls). Never put glass in the content layer, never stack glass on glass, use it sparingly."
+  - "Adopt by subtraction: use standard SwiftUI/AppKit containers and REMOVE custom backgrounds/materials/tints so the system supplies Liquid Glass automatically."
+  - "Content uses semantic system colors and standard materials, not fixed hex. Foreground text/symbols on materials use vibrancy."
+  - "Tint sparingly — only the single most important action. Provider/quota colors are semantic indicators, never surface washes."
 colors:
-  primary: "#F2F2F7"
-  secondary: "#AEAEB2"
-  muted: "#8E8E93"
-  background: "#1C1C1E"
-  surface: "#242426"
-  surface-elevated: "#2C2C2E"
-  surface-hover: "#3A3A3C"
-  border: "rgba(255,255,255,0.10)"
-  border-strong: "rgba(255,255,255,0.16)"
-  accent: "#006EDB"
-  accent-foreground: "#FFFFFF"
-  codex: "#64D2FF"
-  claude: "#D18665"
-  cursor: "#63D297"
-  success: "#30D158"
-  warning: "#FFD60A"
-  danger: "#FF453A"
+  note: "Use semantic system colors so everything adapts to light/dark, accent, Increase Contrast, and Reduce Transparency. Do NOT define fixed graphite hex."
+  text-primary: "Color.primary / NSColor.labelColor"
+  text-secondary: "Color.secondary / NSColor.secondaryLabelColor"
+  text-tertiary: ".tertiary"
+  window-background: "Color(nsColor: .windowBackgroundColor)"
+  content-surface: "Color(nsColor: .controlBackgroundColor)  # for non-grouped card fills"
+  separator: "Color(nsColor: .separatorColor) / .quaternary"
+  fill-subtle: ".quaternary  # tracks, inactive chips, zebra rows"
+  accent: "Color.accentColor  # follows the user's system accent"
+  # Brand + status accents are the ONLY custom colors. Define in Assets.xcassets
+  # with Any/Dark + High-Contrast variants so they adapt.
+  codex: "asset 'AccentCodex'  (cyan)"
+  claude: "asset 'AccentClaude' (muted Anthropic orange)"
+  cursor: "asset 'AccentCursor' (green)"
+  success: ".green (asset 'StatusHealthy')"
+  warning: ".yellow (asset 'StatusWarning')"
+  danger: ".red (asset 'StatusDanger')"
 typography:
-  title:
-    fontFamily: "-apple-system, BlinkMacSystemFont, SF Pro Display, system-ui, sans-serif"
-    fontSize: "28px"
-    fontWeight: 650
-    lineHeight: 1.15
-    letterSpacing: "0px"
-  section-title:
-    fontFamily: "-apple-system, BlinkMacSystemFont, SF Pro Text, system-ui, sans-serif"
-    fontSize: "18px"
-    fontWeight: 650
-    lineHeight: 1.25
-    letterSpacing: "0px"
-  body:
-    fontFamily: "-apple-system, BlinkMacSystemFont, SF Pro Text, system-ui, sans-serif"
-    fontSize: "13px"
-    fontWeight: 400
-    lineHeight: 1.35
-    letterSpacing: "0px"
-  label:
-    fontFamily: "-apple-system, BlinkMacSystemFont, SF Pro Text, system-ui, sans-serif"
-    fontSize: "12px"
-    fontWeight: 600
-    lineHeight: 1.2
-    letterSpacing: "0px"
-  metric:
-    fontFamily: "-apple-system, BlinkMacSystemFont, SF Pro Display, system-ui, sans-serif"
-    fontSize: "24px"
-    fontWeight: 700
-    lineHeight: 1.1
-    letterSpacing: "0px"
+  family: "system (SF) via SwiftUI Font APIs — never hardcode font names"
+  title: ".title, semibold"
+  section-title: ".title3 / .headline, semibold"
+  body: ".body / .subheadline"
+  label: ".caption, secondary"
+  metric: ".system(size: ~24-26, weight: .bold) — primary text unless exhausted"
+  note: "On materials use Regular/Medium/Semibold/Bold weights; thin glyphs lose legibility. Letter spacing is zero. Never scale text with viewport width."
 rounded:
-  sm: "4px"
-  md: "8px"
-  lg: "10px"
+  note: "Prefer concentric / container-relative radii and Capsule over scattered fixed values. Native containers (List/GroupBox/Form) handle radii for you."
+  control: ".rect(cornerRadius: 8, style: .continuous)"
+  card: ".rect(cornerRadius: 12, style: .continuous) / GroupBox"
+  pill-or-bar: "Capsule()"
 spacing:
   xs: "4px"
   sm: "8px"
   md: "12px"
   lg: "16px"
   xl: "22px"
-components:
-  panel:
-    backgroundColor: "{colors.surface-elevated}"
-    textColor: "{colors.primary}"
-    rounded: "{rounded.md}"
-    padding: "{spacing.lg}"
-  sidebar-item:
-    backgroundColor: "transparent"
-    textColor: "{colors.secondary}"
-    rounded: "{rounded.md}"
-    padding: "8px 14px"
-  sidebar-item-active:
-    backgroundColor: "{colors.surface-elevated}"
-    textColor: "{colors.primary}"
-    rounded: "{rounded.md}"
-    padding: "8px 14px"
-  sidebar-active-indicator:
-    backgroundColor: "{colors.accent}"
-    rounded: "{rounded.sm}"
-    width: "3px"
-    height: "18px"
-  hairline-border:
-    backgroundColor: "{colors.border}"
-    height: "1px"
-  strong-hairline-border:
-    backgroundColor: "{colors.border-strong}"
-    height: "1px"
-  usage-bar-track:
-    backgroundColor: "{colors.border-strong}"
-    rounded: "{rounded.sm}"
-    height: "7px"
-  usage-bar-fill-codex:
-    backgroundColor: "{colors.codex}"
-    rounded: "{rounded.sm}"
-    height: "7px"
-  usage-bar-fill-claude:
-    backgroundColor: "{colors.claude}"
-    rounded: "{rounded.sm}"
-    height: "7px"
-  usage-bar-fill-cursor:
-    backgroundColor: "{colors.cursor}"
-    rounded: "{rounded.sm}"
-    height: "7px"
-  usage-bar-deficit:
-    backgroundColor: "{colors.danger}"
-    rounded: "{rounded.sm}"
-    height: "7px"
-  status-success:
-    textColor: "{colors.success}"
-    backgroundColor: "transparent"
-    rounded: "{rounded.sm}"
-  status-warning:
-    textColor: "{colors.warning}"
-    backgroundColor: "transparent"
-    rounded: "{rounded.sm}"
-  icon-button:
-    backgroundColor: "{colors.surface-hover}"
-    textColor: "{colors.primary}"
-    rounded: "{rounded.md}"
-    size: "32px"
-  accent-button:
-    backgroundColor: "{colors.accent}"
-    textColor: "{colors.accent-foreground}"
-    rounded: "{rounded.md}"
-    padding: "6px 10px"
-  helper-text:
-    textColor: "{colors.muted}"
-    backgroundColor: "transparent"
-    rounded: "{rounded.sm}"
 ---
 
 ## Overview
 
-MeterBar is a native macOS utility, not a marketing surface. It should feel like a compact Shipcode sibling: dark graphite shell, low-opacity borders, tight controls, restrained accent color, and dense but readable quota information.
+MeterBar is a native macOS 26 utility, not a marketing surface. It should feel like a system app (Mail/Finder/System Settings): native containers, system materials, semantic colors, restrained accent. It has two surfaces:
 
-The app has two surfaces:
+- **Menu bar popover:** immediate quota health and fast refresh/dashboard access.
+- **Companion window:** deeper limits, cost history, and settings, built on `NavigationSplitView`.
 
-- Menu bar popover: immediate quota health and fast refresh/dashboard access.
-- Companion window: deeper limits, cost history, and settings.
+Both surfaces stay lean. Avoid decorative hero layouts, big nested cards, and explanatory copy that does not change the user's decision.
 
-Both surfaces must stay lean. Avoid decorative hero layouts, big cards, nested panels, and explanatory copy that does not change the user's decision.
+## How we adopt Liquid Glass
+
+Liquid Glass is the system's **chrome layer** — the menu bar, the popover surface, toolbars, sidebars, and the occasional floating control. We get it for free by using standard components and **removing** custom chrome. The work is subtraction, not decoration:
+
+- **Do not** paint popover/window backgrounds with a color + material. Let the system popover/window surface (and `NavigationSplitView` sidebar/toolbar) supply the glass.
+- **Do not** wrap content cards in material + a manual hairline border ("fake glass"). Content is **not** a glass layer.
+- **Never** stack a material over another material (glass-on-glass).
+- For genuinely free-floating custom controls only, use a single `.glassEffect(.regular, in:)` inside a `GlassEffectContainer`. Use it sparingly.
 
 ## Colors
 
-Use Apple-style dark graphite tokens as the default. Surfaces are charcoal graphite with subtle elevation, not blue-purple gradients or near-black voids. Borders should remain quiet at 10-16% white.
+Use **semantic system colors** as the default so the UI adapts to light/dark, the user's accent, Increase Contrast, and Reduce Transparency. Never define fixed graphite hex for structural surfaces.
 
-Provider accents are semantic and stable:
-
-- Codex: cyan.
-- Claude: muted Anthropic orange `#d18665`.
-- Cursor: softened green.
-- Deficit: red only where quota is missing versus expected pace.
-- Reserve: green only for positive pace state.
-
-Do not let provider colors take over the whole UI. They are indicators, not themes. Large percentage and cost metrics should use primary text unless the value is exhausted; color belongs on icons, bars, markers, and compact status labels.
+The only custom colors are **provider accents** (Codex cyan, Claude muted orange, Cursor green) and **quota status** (success/warning/danger). Define these in `Assets.xcassets` with light/dark + high-contrast variants. They are semantic indicators — used on glyphs, meter fills, and compact status labels — never as whole-surface themes. Large percentage and cost metrics use `.primary` text unless the value is exhausted.
 
 ## Typography
 
-Use native SF fonts through SwiftUI system font APIs. Keep text compact:
-
-- Dashboard title: `.title`, semibold, not `.largeTitle` unless it is the only focal point.
-- Panel titles: title3/headline semibold.
-- Row labels: subheadline semibold.
-- Metadata: caption, secondary color.
-
-Letter spacing is always zero. Do not scale text with viewport width.
+Native SF fonts via SwiftUI system font APIs. Keep text compact (see frontmatter). On materials, use Regular weight or heavier; avoid thin glyphs. Letter spacing is zero; never scale text with viewport width.
 
 ## Layout & Spacing
 
-Prefer a native utility layout:
-
-- Sidebar width around 178-190px.
-- Dashboard content padding around 22px.
-- Card/panel padding around 14px.
-- Repeated rows use 8-12px vertical spacing.
-- Radius is usually 8px; 10px is the upper bound for companion-window panels.
-
-The menu bar popover is denser than the companion app. It is a single all-in-one overview, not a provider tab strip.
+- Companion window: `NavigationSplitView` with a native `.sidebar` `List`; content in a `ScrollView` with ~22px padding; cards as `GroupBox`.
+- Settings: native `Form` with `.formStyle(.grouped)` and `Section`s.
+- Popover: a single dense overview (native `List`/`Section` or `GroupBox`), not a tab strip. Refresh/dashboard actions only.
+- Repeated rows: 8–12px vertical spacing.
 
 ## Elevation & Depth
 
-Use macOS material sparingly for sidebars and popover chrome. Main content should rely on quiet dark surfaces and thin borders.
-
-Avoid blurred decorative backgrounds, gradient orbs, and nested card stacks. Depth comes from material, border, and spacing, not heavy shadows.
+Depth comes from the system: the glass chrome layer floats above content, and content sits on system grouped/window backgrounds. Convey structure with standard materials, vibrancy, and spacing — not fixed dark surfaces, gradient orbs, or heavy shadows.
 
 ## Shapes
 
-Cards, tabs, and controls use 8px radius. Usage bars use a single clipped rounded track so internal colored segments join seamlessly. Never draw adjacent rounded segments that create cut-looking seams.
+Prefer concentric / container-relative radii (`.rect(cornerRadius:style:.continuous)`, `ConcentricRectangle`, `containerShape`) and `Capsule` for bars/pills. Usage bars use a single clipped rounded (capsule) track so internal colored segments join seamlessly — never draw adjacent rounded segments that create cut-looking seams.
 
 ## Components
 
-Provider labels use `ProviderLogoView` with bundled SVG assets. Do not fall back to generic terminal/system symbols when official provider artwork is available.
+- Use SF Symbols for generic iconography (`Image(systemName:)`). Custom vector artwork is reserved for true brand logos via `ProviderLogoView`.
+- Use native control styles: `.buttonStyle(.borderless/.bordered/.borderedProminent)`, `Button(role: .destructive)`, `.textFieldStyle(.roundedBorder)`, native `Toggle`, `LabeledContent`. Reserve at most one tinted/`.glassProminent` button for the primary action.
+- Use `ContentUnavailableView` for empty/error/no-selection states and `ProgressView` for busy states.
+- Refresh lives in the toolbar (`ToolbarItem(placement: .primaryAction)`), not a hand-animated custom button. Gate any retained animation on `accessibilityReduceMotion`.
 
 Usage bars are remaining-mode:
 
-- Full bar means 100% left.
-- Colored provider fill is current quota left.
+- Full bar means 100% left; colored provider fill is current quota left.
 - Red segment is the quota that should still exist if usage were on pace.
 - Pace marker shows expected remaining unless the row is on pace.
 
-Settings belong in the companion app. The popover should expose dashboard and refresh actions only.
-
-Provider visibility belongs in companion Settings. Disabled providers must stop fetching, disappear from the menu popover and dashboard, stop affecting the menu bar percentage, and be excluded from local cost estimates.
+Provider visibility belongs in companion Settings. Disabled providers must stop fetching, disappear from the popover and dashboard, stop affecting the menu bar percentage, and be excluded from local cost estimates.
 
 ## Do's and Don'ts
 
 Do:
 
-- Keep controls compact and native.
-- Prefer one surface per purpose: popover for quick glance, companion for details/settings.
-- Use official provider logos.
-- Keep dashboards scan-friendly with aligned labels and values.
-- Make expensive scans explicit or backgrounded so windows open immediately.
+- Use native containers and let the system supply glass.
+- Use semantic system colors and vibrancy; keep brand color to provider accents and quota status.
+- Verify every surface in light and dark, and with Reduce Transparency, Increase Contrast, and Reduce Motion enabled.
+- Use official provider logos; keep dashboards scan-friendly with aligned labels and values.
 
 Don't:
 
-- Use web-only shadcn components directly in SwiftUI.
-- Embed React in a web view just to get Tailwind/shadcn styling.
+- Force a color scheme, or paint fixed graphite backgrounds.
+- Wrap content in fake-glass cards, or stack material on material.
 - Use generic SF provider icons where bundled logos exist.
+- Use web-only shadcn/Tailwind components or embed React in a web view.
 - Auto-run heavy filesystem scans during initial window presentation.
-- Let deficit bars look like separated pills.

--- a/.agents/SESSIONS/2026-06-19.md
+++ b/.agents/SESSIONS/2026-06-19.md
@@ -1,0 +1,53 @@
+# Sessions: 2026-06-19
+
+**Summary:** Adopt Apple Liquid Glass / native macOS design
+
+---
+
+## Session 1: Liquid Glass redesign of all surfaces
+
+**Duration:** ~1 session
+**Status:** Code complete; live visual QA pending
+
+### Why
+
+The current UI hand-rolled a dark "graphite glass" look that fought macOS 26 Tahoe's Liquid Glass instead of adopting it. A 10-agent research/audit against Apple's primary sources (HIG *Materials*, *Adopting Liquid Glass*, WWDC25 "Meet Liquid Glass", SwiftUI glass/material API docs) confirmed three systemic anti-patterns: glass-on-glass (painted popover/window backgrounds + fake-glass cards stacked on top), a fixed dark-only hex palette overriding system vibrancy, and hand-rolled chrome the OS now supplies for free.
+
+### Decisions (confirmed with user)
+
+- **Deployment target → macOS 26.** Dropped macOS 14/15 so Liquid Glass APIs are used unconditionally (no `@available` gates).
+- **Appearance → adaptive light + dark.** Removed dark-only construction; rely on semantic system colors.
+- **Scope → full native conversion** of all four view files in one pass.
+- **Companion window:** kept `UsageDashboardWindowController` (NSWindow) and set `NSHostingController.sceneBridgingOptions = .all` + `toolbarStyle = .unified` to surface the SwiftUI `NavigationSplitView` toolbar/title (and their glass) through AppKit — rather than a SwiftUI `Window` scene, because the popover is hosted by the AppDelegate (outside the scene graph), so `openWindow` is unreachable from it.
+- **Menu bar:** kept `NSStatusItem` + `NSPopover` (protects the live "%" status-title feature wired through Combine); only the popover *content* was made native. `NSPopover` is itself a native AppKit glass surface on Tahoe.
+- **SwiftPM:** bumped `swift-tools-version` to 6.2 and `platforms` to `.macOS(.v26)`, but pinned both targets to `.swiftLanguageMode(.v5)` to match the Xcode app target (`SWIFT_VERSION = 5.0`) and avoid a Swift 6 concurrency refactor of existing singletons.
+
+### What was done
+
+- **Project:** `MACOSX_DEPLOYMENT_TARGET = 26.0` (all configs); `Package.swift` → tools 6.2 / `.macOS(.v26)` / Swift 5 language mode. Rewrote `.agents/DESIGN.md` to the semantic/adaptive + Liquid-Glass direction.
+- **Theme (`MeterBarTheme.swift`):** replaced the fixed graphite/border/track/icon hex tokens with semantic system colors; brand accents (`codex/claude/cursor`) became appearance-adaptive via a new `Color.adaptive(light:dark:…)` helper backed by a dynamic `NSColor`; status colors use system `systemGreen/Yellow/Red`; `appAccent` follows `Color.accentColor`. Deleted `LucideSymbol`/`LucideIcon`/`RefreshIconButton`.
+- **Popover (`MenuBarView.swift`):** removed the custom popover background ZStack and header material; deleted `popoverGlassCard()` (fake glass) → `cardSurface()` (opaque `controlBackgroundColor`, concentric corners); SF Symbol header buttons with native `.borderless` style; status badge → neutral `.quaternary` fill + colored glyph; usage bars → `Capsule`.
+- **Window (`UsageDashboardView.swift`):** replaced the custom `HStack` + hand-built sidebar with `NavigationSplitView` + `List(selection:).listStyle(.sidebar)` + bottom "Local Sources" inset; moved title/subtitle to `navigationTitle`/`navigationSubtitle` and refresh into `.toolbar(.primaryAction)`; `dashboardCardBackground()` → opaque system surface; the scanning badge uses real `.glassEffect(.regular, in: .capsule)`; the skeleton chart gates its sweep + bar motion on `accessibilityReduceMotion`; `Color.white.opacity` washes → semantic `.quaternary`/`.primary.opacity`; scan button → SF Symbol `.bordered`.
+- **Settings (`SettingsView.swift`):** rebuilt on `Form { Section }.formStyle(.grouped)`; `SettingsRowView` → `LabeledContent`; `StatusPill` → `Label` + semantic color; `SettingsDivider` → `Divider()`; native `.bordered`/`.borderedProminent` + `Button(role: .destructive)` + `.textFieldStyle(.roundedBorder)`; deleted `SettingsButtonStyle`, `SettingsTextFieldStyle`, `SettingsDesign`.
+
+### Files changed
+
+- `MeterBar.xcodeproj/project.pbxproj`, `Package.swift`
+- `MeterBar/Views/MeterBarTheme.swift`, `MenuBarView.swift`, `UsageDashboardView.swift`, `SettingsView.swift`
+- `.agents/DESIGN.md`, `.agents/SESSIONS/2026-06-19.md`
+
+Net: +491 / −758 lines across the touched files (large net deletion — "adopt by subtraction").
+
+### Verification
+
+- `swift build` — clean.
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — **BUILD SUCCEEDED** (full app + widget + assets, macOS 26 SDK, real glass APIs).
+- `swift test` — 54 tests passed, 2 skipped (network), 0 failures.
+- Repo-wide grep confirms zero residual `graphite*` / `ultraThinMaterial` / `Color.white.opacity` washes / `popoverGlassCard` / Lucide / custom Settings styles in the views.
+- Accessibility handled by construction: system materials auto-adapt to Reduce Transparency / Increase Contrast; Reduce Motion gated explicitly on the skeleton chart; semantic colors adapt light/dark.
+
+### Next steps
+
+- [ ] Live visual QA on macOS 26: confirm the `NavigationSplitView` toolbar (Refresh) renders via `sceneBridgingOptions`, and screenshot the popover/dashboard/settings in light + dark and with Reduce Transparency / Increase Contrast / Reduce Motion. (Automated screenshot was blocked this session — computer-use access dialog timed out.)
+- [ ] Tune the adaptive brand-accent light-mode values once seen on screen.
+- [ ] Confirm CI's macOS runner uses Xcode 26 for the macOS 26 target.

--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -278,7 +278,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.shipshit.MeterBar.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -323,7 +323,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.shipshit.MeterBar.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -391,7 +391,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -449,7 +449,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;
@@ -488,7 +488,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.shipshit.MeterBar;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -534,7 +534,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.shipshit.MeterBar;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -60,7 +60,6 @@ struct MenuBarView: View {
             popoverHeader
 
             Divider()
-                .opacity(0.35)
 
             ScrollView {
                 PopoverOverviewPanel(
@@ -86,12 +85,6 @@ struct MenuBarView: View {
             .frame(height: scrollHeight)
         }
         .frame(width: popoverWidth, height: popoverHeight)
-        .background {
-            ZStack {
-                MeterBarTheme.graphiteBackground.opacity(0.86)
-                Rectangle().fill(.ultraThinMaterial)
-            }
-        }
         .onAppear {
             notifyContentSize()
         }
@@ -122,7 +115,7 @@ struct MenuBarView: View {
             HStack(spacing: 9) {
                 Image(systemName: "chart.line.uptrend.xyaxis")
                     .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(MeterBarTheme.appAccent)
+                    .foregroundStyle(MeterBarTheme.appAccent)
                 Text("MeterBar")
                     .font(.headline)
                     .fontWeight(.semibold)
@@ -131,29 +124,22 @@ struct MenuBarView: View {
             Spacer()
 
             Button(action: openDashboard) {
-                LucideIcon(.panelRight, size: 17, lineWidth: 2.25)
-                    .frame(width: 32, height: 32)
-                    .contentShape(Rectangle())
+                Image(systemName: "sidebar.right")
             }
-            .buttonStyle(.plain)
-            .foregroundColor(MeterBarTheme.toolbarIconForeground)
-            .background(MeterBarTheme.toolbarIconBackground)
-            .clipShape(RoundedRectangle(cornerRadius: 8))
-            .overlay {
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(MeterBarTheme.toolbarIconBorder, lineWidth: 1)
-            }
+            .buttonStyle(.borderless)
             .help("Open Usage Dashboard")
 
-            RefreshIconButton(help: "Refresh usage") {
-                Task {
-                    await dataManager.refreshAll()
-                }
+            Button {
+                Task { await dataManager.refreshAll() }
+            } label: {
+                Image(systemName: "arrow.clockwise")
             }
+            .buttonStyle(.borderless)
+            .help("Refresh usage")
         }
+        .font(.body)
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
-        .background(.ultraThinMaterial)
     }
 
     private func openDashboard() {
@@ -270,11 +256,11 @@ struct PopoverOverviewPanel: View {
             HStack(alignment: .center, spacing: 10) {
                 ZStack {
                     Circle()
-                        .fill(statusColor.opacity(0.20))
+                        .fill(.quaternary)
                         .frame(width: 34, height: 34)
                     Image(systemName: statusIconName)
                         .font(.system(size: 17, weight: .bold))
-                        .foregroundColor(statusColor)
+                        .foregroundStyle(statusColor)
                 }
 
                 VStack(alignment: .leading, spacing: 2) {
@@ -289,7 +275,7 @@ struct PopoverOverviewPanel: View {
                 Spacer(minLength: 0)
             }
             .padding(12)
-            .popoverGlassCard()
+            .cardSurface()
 
             LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 2), spacing: 10) {
                 ForEach(snapshots) { snapshot in
@@ -312,7 +298,7 @@ struct PopoverOverviewPanel: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .popoverGlassCard()
+            .cardSurface()
         }
     }
 }
@@ -479,7 +465,7 @@ private struct PopoverProviderStatusCard: View {
         }
         .padding(11)
         .frame(maxWidth: .infinity, minHeight: 142, alignment: .topLeading)
-        .popoverGlassCard()
+        .cardSurface()
     }
 
     private var updatedText: String {
@@ -673,13 +659,13 @@ struct UsageBar: View {
     var body: some View {
         GeometryReader { proxy in
             ZStack(alignment: .leading) {
-                RoundedRectangle(cornerRadius: 3)
-                    .fill(MeterBarTheme.barTrack)
+                Capsule()
+                    .fill(.quaternary)
                     .frame(height: 7)
                     .offset(y: 4)
 
                 if isExhausted {
-                    RoundedRectangle(cornerRadius: 3)
+                    Capsule()
                         .fill(MeterBarTheme.danger.opacity(0.16))
                         .frame(width: proxy.size.width, height: 7)
                         .offset(y: 4)
@@ -704,7 +690,7 @@ struct UsageBar: View {
                                 .offset(x: actualX)
                         }
                     }
-                    .clipShape(RoundedRectangle(cornerRadius: 3))
+                    .clipShape(Capsule())
                     .offset(y: 4)
 
                     RoundedRectangle(cornerRadius: 1)
@@ -737,21 +723,15 @@ struct UsageBar: View {
 }
 
 private extension View {
-    func popoverGlassCard() -> some View {
-        self
-            .background {
-                ZStack {
-                    MeterBarTheme.graphiteSurface.opacity(0.78)
-                    Rectangle().fill(.thinMaterial).opacity(0.35)
-                }
-            }
-            .overlay {
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(MeterBarTheme.border, lineWidth: 1)
-            }
-            .clipShape(RoundedRectangle(cornerRadius: 8))
+    /// A content surface for cards that sit on the popover's glass chrome.
+    /// Uses an opaque system control background (not a material) so it never
+    /// stacks glass on glass, with concentric continuous corners.
+    func cardSurface() -> some View {
+        background(
+            Color(nsColor: .controlBackgroundColor),
+            in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+        )
     }
-
 }
 
 private struct MenuContentHeightPreferenceKey: PreferenceKey {

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -1,25 +1,37 @@
+import AppKit
 import SwiftUI
 
+/// Color tokens for MeterBar.
+///
+/// MeterBar relies on semantic system colors and native containers so the UI
+/// adapts to light/dark, the user's accent, Increase Contrast, and Reduce
+/// Transparency. The only custom colors are the per-provider brand accents and
+/// quota status — and those are kept appearance-adaptive too. Glass/material is
+/// supplied by the system chrome layer (popover, sidebar, toolbar), not here.
 enum MeterBarTheme {
-    static let anthropicDark = Color(red: 20 / 255, green: 20 / 255, blue: 19 / 255)
-    static let anthropicLight = Color(red: 250 / 255, green: 249 / 255, blue: 245 / 255)
-    static let graphiteBackground = Color(red: 28 / 255, green: 28 / 255, blue: 30 / 255)
-    static let graphiteSurface = Color(red: 36 / 255, green: 36 / 255, blue: 38 / 255)
-    static let graphiteElevated = Color(red: 44 / 255, green: 44 / 255, blue: 46 / 255)
-    static let graphiteHover = Color(red: 58 / 255, green: 58 / 255, blue: 60 / 255)
-    static let appAccent = Color(red: 0 / 255, green: 110 / 255, blue: 219 / 255)
-    static let codexAccent = Color(red: 100 / 255, green: 210 / 255, blue: 255 / 255)
-    static let claudeAccent = Color(red: 209 / 255, green: 134 / 255, blue: 101 / 255)
-    static let cursorAccent = Color(red: 99 / 255, green: 210 / 255, blue: 151 / 255)
-    static let success = Color(red: 48 / 255, green: 209 / 255, blue: 88 / 255)
-    static let warning = Color(red: 255 / 255, green: 214 / 255, blue: 10 / 255)
-    static let danger = Color(red: 255 / 255, green: 69 / 255, blue: 58 / 255)
-    static let barTrack = Color.white.opacity(0.14)
-    static let border = Color.white.opacity(0.10)
-    static let borderStrong = Color.white.opacity(0.16)
-    static let toolbarIconForeground = Color.white.opacity(0.92)
-    static let toolbarIconBackground = graphiteElevated
-    static let toolbarIconBorder = borderStrong
+    // MARK: - Brand accents (semantic indicators only; adapt to light/dark)
+
+    static let codexAccent = Color.adaptive(
+        light: NSColor(srgbRed: 0 / 255, green: 122 / 255, blue: 168 / 255, alpha: 1),
+        dark: NSColor(srgbRed: 100 / 255, green: 210 / 255, blue: 255 / 255, alpha: 1)
+    )
+    static let claudeAccent = Color.adaptive(
+        light: NSColor(srgbRed: 176 / 255, green: 86 / 255, blue: 52 / 255, alpha: 1),
+        dark: NSColor(srgbRed: 209 / 255, green: 134 / 255, blue: 101 / 255, alpha: 1)
+    )
+    static let cursorAccent = Color.adaptive(
+        light: NSColor(srgbRed: 34 / 255, green: 150 / 255, blue: 92 / 255, alpha: 1),
+        dark: NSColor(srgbRed: 99 / 255, green: 210 / 255, blue: 151 / 255, alpha: 1)
+    )
+
+    /// The app's own accent. Follows the user's system accent color.
+    static let appAccent = Color.accentColor
+
+    // MARK: - Quota status (system colors; adapt to appearance + Increase Contrast)
+
+    static let success = Color(nsColor: .systemGreen)
+    static let warning = Color(nsColor: .systemYellow)
+    static let danger = Color(nsColor: .systemRed)
 
     static func accent(for service: ServiceType) -> Color {
         switch service {
@@ -43,126 +55,25 @@ enum MeterBarTheme {
     }
 }
 
-enum LucideSymbol {
-    case panelRight
-    case refreshCw
-    case search
-
-    fileprivate func path() -> Path {
-        var path = Path()
-
-        switch self {
-        case .panelRight:
-            path.addRoundedRect(in: CGRect(x: 3, y: 3, width: 18, height: 18), cornerSize: CGSize(width: 2, height: 2))
-            path.move(to: CGPoint(x: 15, y: 3))
-            path.addLine(to: CGPoint(x: 15, y: 21))
-
-        case .refreshCw:
-            path.move(to: CGPoint(x: 21, y: 12))
-            path.addCurve(to: CGPoint(x: 12, y: 3), control1: CGPoint(x: 21, y: 7.03), control2: CGPoint(x: 16.97, y: 3))
-            path.addCurve(to: CGPoint(x: 5.64, y: 5.64), control1: CGPoint(x: 9.52, y: 3), control2: CGPoint(x: 7.27, y: 4.01))
-            path.move(to: CGPoint(x: 3, y: 8))
-            path.addLine(to: CGPoint(x: 3, y: 3))
-            path.move(to: CGPoint(x: 3, y: 8))
-            path.addLine(to: CGPoint(x: 8, y: 8))
-            path.move(to: CGPoint(x: 3, y: 12))
-            path.addCurve(to: CGPoint(x: 12, y: 21), control1: CGPoint(x: 3, y: 16.97), control2: CGPoint(x: 7.03, y: 21))
-            path.addCurve(to: CGPoint(x: 18.36, y: 18.36), control1: CGPoint(x: 14.48, y: 21), control2: CGPoint(x: 16.73, y: 19.99))
-            path.move(to: CGPoint(x: 21, y: 16))
-            path.addLine(to: CGPoint(x: 21, y: 21))
-            path.move(to: CGPoint(x: 21, y: 16))
-            path.addLine(to: CGPoint(x: 16, y: 16))
-
-        case .search:
-            path.addEllipse(in: CGRect(x: 4, y: 4, width: 11, height: 11))
-            path.move(to: CGPoint(x: 14, y: 14))
-            path.addLine(to: CGPoint(x: 20, y: 20))
-        }
-
-        return path
-    }
-}
-
-struct LucideIcon: View {
-    let symbol: LucideSymbol
-    let size: CGFloat
-    let lineWidth: CGFloat
-
-    init(_ symbol: LucideSymbol, size: CGFloat = 18, lineWidth: CGFloat = 2.25) {
-        self.symbol = symbol
-        self.size = size
-        self.lineWidth = lineWidth
-    }
-
-    var body: some View {
-        GeometryReader { proxy in
-            let scale = min(proxy.size.width, proxy.size.height) / 24
-            let xOffset = (proxy.size.width - (24 * scale)) / 2
-            let yOffset = (proxy.size.height - (24 * scale)) / 2
-            let transform = CGAffineTransform(translationX: xOffset, y: yOffset)
-                .scaledBy(x: scale, y: scale)
-
-            symbol.path()
-                .applying(transform)
-                .stroke(style: StrokeStyle(lineWidth: lineWidth * scale, lineCap: .round, lineJoin: .round))
-        }
-        .frame(width: size, height: size)
-    }
-}
-
-struct RefreshIconButton: View {
-    let title: String?
-    let help: String
-    let isDisabled: Bool
-    let action: () -> Void
-
-    @State private var rotation: Double = 0
-
-    init(
-        title: String? = nil,
-        help: String = "Refresh",
-        isDisabled: Bool = false,
-        action: @escaping () -> Void
-    ) {
-        self.title = title
-        self.help = help
-        self.isDisabled = isDisabled
-        self.action = action
-    }
-
-    var body: some View {
-        Button {
-            guard !isDisabled else { return }
-            withAnimation(.easeInOut(duration: 0.55)) {
-                rotation += 360
+extension Color {
+    /// An appearance-adaptive color backed by a dynamic `NSColor`, resolving the
+    /// correct value for light / dark (and optionally high-contrast) appearances.
+    static func adaptive(
+        light: NSColor,
+        dark: NSColor,
+        lightHighContrast: NSColor? = nil,
+        darkHighContrast: NSColor? = nil
+    ) -> Color {
+        Color(nsColor: NSColor(name: nil) { appearance in
+            switch appearance.bestMatch(from: [
+                .aqua, .darkAqua,
+                .accessibilityHighContrastAqua, .accessibilityHighContrastDarkAqua
+            ]) {
+            case .darkAqua: return dark
+            case .accessibilityHighContrastAqua: return lightHighContrast ?? light
+            case .accessibilityHighContrastDarkAqua: return darkHighContrast ?? dark
+            default: return light
             }
-            action()
-        } label: {
-            HStack(spacing: title == nil ? 0 : 7) {
-                LucideIcon(.refreshCw, size: 17, lineWidth: 2.35)
-                    .rotationEffect(.degrees(rotation))
-                    .frame(width: 18, height: 18)
-
-                if let title {
-                    Text(title)
-                        .font(.caption)
-                        .fontWeight(.semibold)
-                }
-            }
-            .foregroundColor(MeterBarTheme.toolbarIconForeground)
-            .frame(width: title == nil ? 32 : nil, height: 32)
-            .padding(.horizontal, title == nil ? 0 : 10)
-            .background(MeterBarTheme.toolbarIconBackground)
-            .clipShape(RoundedRectangle(cornerRadius: 8))
-            .overlay {
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(MeterBarTheme.toolbarIconBorder, lineWidth: 1)
-            }
-            .contentShape(Rectangle())
-            .opacity(isDisabled ? 0.45 : 1)
-        }
-        .buttonStyle(.plain)
-        .disabled(isDisabled)
-        .help(help)
+        })
     }
 }

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -25,28 +25,7 @@ struct SettingsView: View {
     }
 
     var body: some View {
-        Group {
-            if embeddedInDashboard {
-                settingsContent
-            } else {
-                ScrollView {
-                    settingsContent
-                        .padding(22)
-                }
-                .background(SettingsDesign.background)
-            }
-        }
-        .frame(minWidth: 560, minHeight: 500)
-        .sheet(isPresented: $showingClaudeHelp) {
-            ClaudeHelpView()
-        }
-        .sheet(isPresented: $showingOpenAIHelp) {
-            OpenAIHelpView()
-        }
-    }
-
-    private var settingsContent: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        Form {
             trackedProvidersSection
             if providerVisibility.isEnabled(.claude) {
                 claudeAdminSection
@@ -63,7 +42,17 @@ struct SettingsView: View {
             costTrackingSection
             refreshSection
         }
-        .frame(maxWidth: 760, alignment: .leading)
+        .formStyle(.grouped)
+        .frame(
+            minWidth: embeddedInDashboard ? nil : 560,
+            minHeight: embeddedInDashboard ? nil : 500
+        )
+        .sheet(isPresented: $showingClaudeHelp) {
+            ClaudeHelpView()
+        }
+        .sheet(isPresented: $showingOpenAIHelp) {
+            OpenAIHelpView()
+        }
     }
 
     private var trackedProvidersSection: some View {
@@ -108,7 +97,7 @@ struct SettingsView: View {
 
             SettingsRowView(title: "Admin API Key", detail: "Required for organization usage APIs.") {
                 SecureField("sk-ant-admin...", text: $claudeAdminKey)
-                    .textFieldStyle(SettingsTextFieldStyle())
+                    .textFieldStyle(.roundedBorder)
                     .frame(maxWidth: 330)
             }
 
@@ -118,19 +107,19 @@ struct SettingsView: View {
                         _ = authManager.setClaudeAdminKey(claudeAdminKey)
                         claudeAdminKey = ""
                     }
-                    .buttonStyle(SettingsButtonStyle())
+                    .buttonStyle(.bordered)
                     .disabled(claudeAdminKey.isEmpty)
 
-                    Button("Remove") {
+                    Button("Remove", role: .destructive) {
                         authManager.removeClaudeAdminKey()
                     }
-                    .buttonStyle(SettingsButtonStyle(role: .destructive))
+                    .buttonStyle(.bordered)
                     .disabled(!authManager.isClaudeAuthenticated)
 
                     Button("Help") {
                         showingClaudeHelp = true
                     }
-                    .buttonStyle(SettingsButtonStyle())
+                    .buttonStyle(.bordered)
                 }
             }
         }
@@ -150,7 +139,7 @@ struct SettingsView: View {
                             }
                         }
                     }
-                    .buttonStyle(SettingsButtonStyle())
+                    .buttonStyle(.bordered)
                 }
             }
 
@@ -200,20 +189,20 @@ struct SettingsView: View {
 
             SettingsRowView(title: "New account") {
                 TextField("Account name", text: $newClaudeAccountName)
-                    .textFieldStyle(SettingsTextFieldStyle())
+                    .textFieldStyle(.roundedBorder)
                     .frame(maxWidth: 220)
             }
 
             SettingsRowView(title: "Config directory", detail: "Use a separate CLAUDE_CONFIG_DIR for each extra account.") {
                 HStack(spacing: 8) {
                     TextField("Path", text: $newClaudeConfigDirectory)
-                        .textFieldStyle(SettingsTextFieldStyle())
+                        .textFieldStyle(.roundedBorder)
                         .frame(maxWidth: 280)
 
                     Button("Choose") {
                         chooseClaudeConfigDirectory()
                     }
-                    .buttonStyle(SettingsButtonStyle())
+                    .buttonStyle(.bordered)
                 }
             }
 
@@ -221,7 +210,7 @@ struct SettingsView: View {
                 Button("Add Account") {
                     addClaudeAccount()
                 }
-                .buttonStyle(SettingsButtonStyle(prominent: true))
+                .buttonStyle(.borderedProminent)
                 .disabled(!canAddClaudeAccount)
             }
         }
@@ -238,7 +227,7 @@ struct SettingsView: View {
 
             SettingsRowView(title: "Admin API Key", detail: "Required for platform usage APIs.") {
                 SecureField("Admin API Key", text: $openaiAdminKey)
-                    .textFieldStyle(SettingsTextFieldStyle())
+                    .textFieldStyle(.roundedBorder)
                     .frame(maxWidth: 330)
             }
 
@@ -248,19 +237,19 @@ struct SettingsView: View {
                         _ = authManager.setOpenAIAdminKey(openaiAdminKey)
                         openaiAdminKey = ""
                     }
-                    .buttonStyle(SettingsButtonStyle())
+                    .buttonStyle(.bordered)
                     .disabled(openaiAdminKey.isEmpty)
 
-                    Button("Remove") {
+                    Button("Remove", role: .destructive) {
                         authManager.removeOpenAIAdminKey()
                     }
-                    .buttonStyle(SettingsButtonStyle(role: .destructive))
+                    .buttonStyle(.bordered)
                     .disabled(!authManager.isOpenAIAuthenticated)
 
                     Button("Help") {
                         showingOpenAIHelp = true
                     }
-                    .buttonStyle(SettingsButtonStyle())
+                    .buttonStyle(.bordered)
                 }
             }
         }
@@ -283,7 +272,7 @@ struct SettingsView: View {
                             }
                         }
                     }
-                    .buttonStyle(SettingsButtonStyle())
+                    .buttonStyle(.bordered)
                 }
             }
 
@@ -362,12 +351,12 @@ struct SettingsView: View {
                                 .scaleEffect(0.75)
                             Text("Scanning...")
                         } else {
-                            LucideIcon(.search, size: 13, lineWidth: 2.4)
+                            Image(systemName: "magnifyingglass")
                             Text("Scan 30 Days")
                         }
                     }
                 }
-                .buttonStyle(SettingsButtonStyle(prominent: true))
+                .buttonStyle(.borderedProminent)
                 .disabled(costTracker.isScanning || !canScanCosts)
             }
         }
@@ -390,11 +379,14 @@ struct SettingsView: View {
             }
 
             SettingsRowView(title: "Manual refresh") {
-                RefreshIconButton(title: "Refresh Now", help: "Refresh usage") {
+                Button {
                     Task {
                         await dataManager.refreshAll()
                     }
+                } label: {
+                    Label("Refresh Now", systemImage: "arrow.clockwise")
                 }
+                .buttonStyle(.bordered)
             }
         }
     }
@@ -462,14 +454,6 @@ struct SettingsView: View {
     }
 }
 
-private enum SettingsDesign {
-    static let background = MeterBarTheme.graphiteBackground
-    static let surface = MeterBarTheme.graphiteSurface
-    static let row = Color.white.opacity(0.035)
-    static let border = MeterBarTheme.border.opacity(0.82)
-    static let borderStrong = MeterBarTheme.borderStrong
-}
-
 private struct SettingsPanelSection<Content: View>: View {
     let title: String
     let logoKind: ProviderLogoKind?
@@ -504,38 +488,18 @@ private struct SettingsPanelSection<Content: View>: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 8) {
+        Section {
+            content
+        } header: {
+            HStack(spacing: 6) {
                 if let logoKind {
-                    ProviderLogoView(kind: logoKind, size: 16, foregroundColor: color)
+                    ProviderLogoView(kind: logoKind, size: 14, foregroundColor: color)
                 } else if let systemImage {
                     Image(systemName: systemImage)
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundColor(color)
-                        .frame(width: 16, height: 16)
+                        .foregroundStyle(color)
                 }
-
                 Text(title)
-                    .font(.headline)
-                    .fontWeight(.semibold)
             }
-
-            VStack(alignment: .leading, spacing: 0) {
-                content
-            }
-            .background(SettingsDesign.row)
-            .clipShape(RoundedRectangle(cornerRadius: 8))
-            .overlay {
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(SettingsDesign.border, lineWidth: 1)
-            }
-        }
-        .padding(14)
-        .background(SettingsDesign.surface)
-        .clipShape(RoundedRectangle(cornerRadius: 8))
-        .overlay {
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(SettingsDesign.border, lineWidth: 1)
         }
     }
 }
@@ -552,29 +516,17 @@ private struct SettingsRowView<Content: View>: View {
     }
 
     var body: some View {
-        HStack(alignment: .center, spacing: 16) {
-            VStack(alignment: .leading, spacing: 3) {
+        LabeledContent {
+            content
+        } label: {
+            VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .font(.subheadline)
-                    .fontWeight(.medium)
                 if let detail {
                     Text(detail)
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            content
-                .frame(maxWidth: 380, alignment: .trailing)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 9)
-        .overlay(alignment: .bottom) {
-            Rectangle()
-                .fill(SettingsDesign.border)
-                .frame(height: 1)
-                .padding(.leading, 12)
         }
     }
 }
@@ -586,26 +538,14 @@ private struct SettingsNotice: View {
     var body: some View {
         Text(text)
             .font(.caption)
-            .foregroundColor(color)
+            .foregroundStyle(color)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .overlay(alignment: .bottom) {
-                Rectangle()
-                    .fill(SettingsDesign.border)
-                    .frame(height: 1)
-                    .padding(.leading, 12)
-            }
     }
 }
 
 private struct SettingsDivider: View {
     var body: some View {
-        Rectangle()
-            .fill(SettingsDesign.borderStrong)
-            .frame(height: 1)
-            .padding(.vertical, 8)
-            .padding(.horizontal, 12)
+        Divider()
     }
 }
 
@@ -614,22 +554,9 @@ private struct StatusPill: View {
     let isConnected: Bool
 
     var body: some View {
-        HStack(spacing: 6) {
-            Circle()
-                .fill(isConnected ? MeterBarTheme.success : Color.secondary)
-                .frame(width: 7, height: 7)
-            Text(title)
-                .font(.caption)
-                .fontWeight(.semibold)
-        }
-        .padding(.horizontal, 9)
-        .padding(.vertical, 5)
-        .background((isConnected ? MeterBarTheme.success : Color.secondary).opacity(0.14))
-        .clipShape(RoundedRectangle(cornerRadius: 6))
-        .overlay {
-            RoundedRectangle(cornerRadius: 6)
-                .stroke((isConnected ? MeterBarTheme.success : Color.secondary).opacity(0.18), lineWidth: 1)
-        }
+        Label(title, systemImage: isConnected ? "checkmark.circle.fill" : "circle")
+            .foregroundStyle(isConnected ? MeterBarTheme.success : Color.secondary)
+            .font(.subheadline)
     }
 }
 
@@ -640,7 +567,7 @@ private struct AccountProfileRow: View {
     var body: some View {
         HStack(spacing: 10) {
             Image(systemName: account.isDefault ? "person.crop.circle" : "person.crop.circle.badge.plus")
-                .foregroundColor(MeterBarTheme.claudeAccent)
+                .foregroundStyle(MeterBarTheme.claudeAccent)
                 .frame(width: 18)
 
             VStack(alignment: .leading, spacing: 2) {
@@ -649,99 +576,18 @@ private struct AccountProfileRow: View {
                     .fontWeight(.semibold)
                 Text(account.configDirectory ?? "Default Claude CLI profile")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
 
             Spacer()
 
             if !account.isDefault {
-                Button("Remove", action: onRemove)
-                    .buttonStyle(SettingsButtonStyle(role: .destructive))
+                Button("Remove", role: .destructive, action: onRemove)
+                    .buttonStyle(.bordered)
             }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 9)
-        .overlay(alignment: .bottom) {
-            Rectangle()
-                .fill(SettingsDesign.border)
-                .frame(height: 1)
-                .padding(.leading, 12)
-        }
-    }
-}
-
-private struct SettingsButtonStyle: ButtonStyle {
-    enum Role {
-        case normal
-        case destructive
-    }
-
-    @Environment(\.isEnabled) private var isEnabled
-
-    var role: Role = .normal
-    var prominent = false
-
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .font(.caption)
-            .fontWeight(.semibold)
-            .foregroundColor(textColor)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(backgroundColor.opacity(configuration.isPressed ? 0.70 : 1))
-            .clipShape(RoundedRectangle(cornerRadius: 6))
-            .overlay {
-                RoundedRectangle(cornerRadius: 6)
-                    .stroke(borderColor, lineWidth: 1)
-            }
-            .opacity(isEnabled ? 1 : 0.45)
-    }
-
-    private var textColor: Color {
-        if prominent { return .white }
-        switch role {
-        case .normal:
-            return .primary
-        case .destructive:
-            return MeterBarTheme.danger
-        }
-    }
-
-    private var backgroundColor: Color {
-        if prominent { return MeterBarTheme.appAccent }
-        switch role {
-        case .normal:
-            return Color.white.opacity(0.06)
-        case .destructive:
-            return MeterBarTheme.danger.opacity(0.12)
-        }
-    }
-
-    private var borderColor: Color {
-        if prominent { return MeterBarTheme.appAccent.opacity(0.7) }
-        switch role {
-        case .normal:
-            return SettingsDesign.borderStrong
-        case .destructive:
-            return MeterBarTheme.danger.opacity(0.22)
-        }
-    }
-}
-
-private struct SettingsTextFieldStyle: TextFieldStyle {
-    func _body(configuration: TextField<Self._Label>) -> some View {
-        configuration
-            .textFieldStyle(.plain)
-            .font(.subheadline)
-            .padding(.horizontal, 9)
-            .padding(.vertical, 6)
-            .background(Color.white.opacity(0.045))
-            .clipShape(RoundedRectangle(cornerRadius: 6))
-            .overlay {
-                RoundedRectangle(cornerRadius: 6)
-                    .stroke(SettingsDesign.borderStrong, lineWidth: 1)
-            }
+        .padding(.vertical, 4)
     }
 }
 
@@ -771,7 +617,7 @@ struct ClaudeHelpView: View {
 
             Text("Note: You must be an organization admin to create Admin API keys. Individual accounts cannot access the Usage API.")
                 .font(.caption)
-                .foregroundColor(MeterBarTheme.warning)
+                .foregroundStyle(MeterBarTheme.warning)
 
             HStack {
                 Button("Open Claude Console") {
@@ -819,7 +665,7 @@ struct OpenAIHelpView: View {
 
             Text("Note: You must be an organization owner or admin to create Admin keys.")
                 .font(.caption)
-                .foregroundColor(MeterBarTheme.warning)
+                .foregroundStyle(MeterBarTheme.warning)
 
             HStack {
                 Button("Open OpenAI Settings") {

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -12,6 +12,9 @@ final class UsageDashboardWindowController {
     func show() {
         if window == nil {
             let hostingController = NSHostingController(rootView: UsageDashboardView())
+            // Surface the SwiftUI NavigationSplitView's toolbar and title (and the
+            // Liquid Glass they carry) through the AppKit window.
+            hostingController.sceneBridgingOptions = [.all]
             let window = NSWindow(
                 contentRect: NSRect(x: 0, y: 0, width: 1080, height: 720),
                 styleMask: [.titled, .closable, .miniaturizable, .resizable],
@@ -19,14 +22,15 @@ final class UsageDashboardWindowController {
                 defer: false
             )
             window.title = "MeterBar Usage"
+            window.toolbarStyle = .unified
             window.contentMinSize = NSSize(width: 900, height: 600)
             window.contentViewController = hostingController
             window.isReleasedWhenClosed = false
+            window.center()
             self.window = window
         }
 
         NSApp.activate(ignoringOtherApps: true)
-        window?.center()
         window?.makeKeyAndOrderFront(nil)
     }
 }
@@ -59,17 +63,25 @@ struct UsageDashboardView: View {
     @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
 
-    @State private var selectedSection: DashboardSection = .overview
+    @State private var selectedSection: DashboardSection? = .overview
+
+    private var activeSection: DashboardSection { selectedSection ?? .overview }
 
     var body: some View {
-        HStack(spacing: 10) {
-            sidebar
-
+        NavigationSplitView {
+            List(selection: $selectedSection) {
+                ForEach(DashboardSection.allCases) { section in
+                    Label(section.rawValue, systemImage: section.iconName)
+                        .tag(section)
+                }
+            }
+            .listStyle(.sidebar)
+            .navigationSplitViewColumnWidth(min: 190, ideal: 212, max: 280)
+            .safeAreaInset(edge: .bottom) { sourcesFooter }
+        } detail: {
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
-                    header
-
-                    switch selectedSection {
+                    switch activeSection {
                     case .overview:
                         overviewContent
                     case .limits:
@@ -81,121 +93,42 @@ struct UsageDashboardView: View {
                     }
                 }
                 .padding(22)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .background(MeterBarTheme.graphiteSurface.opacity(0.48))
-            .clipShape(RoundedRectangle(cornerRadius: 14))
-            .overlay {
-                RoundedRectangle(cornerRadius: 14)
-                    .stroke(MeterBarTheme.border.opacity(0.72), lineWidth: 1)
-            }
-        }
-        .padding(10)
-        .background {
-            ZStack {
-                MeterBarTheme.graphiteBackground
-                Rectangle().fill(.ultraThinMaterial).opacity(0.42)
-            }
-        }
-    }
-
-    private var sidebar: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(spacing: 10) {
-                Image(systemName: "chart.line.uptrend.xyaxis")
-                    .font(.system(size: 20, weight: .semibold))
-                    .foregroundColor(MeterBarTheme.appAccent)
-                Text("MeterBar")
-                    .font(.headline)
-                    .fontWeight(.semibold)
-            }
-            .padding(.horizontal, 18)
-            .padding(.top, 22)
-
-            VStack(spacing: 4) {
-                ForEach(DashboardSection.allCases) { section in
+            .navigationTitle(activeSection.rawValue)
+            .navigationSubtitle(sectionSubtitle)
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
                     Button {
-                        selectedSection = section
+                        Task { await refreshDashboard() }
                     } label: {
-                        HStack(spacing: 10) {
-                            Image(systemName: section.iconName)
-                                .frame(width: 22)
-                            Text(section.rawValue)
-                                .font(.subheadline)
-                                .fontWeight(.semibold)
-                            Spacer()
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 8)
-                        .foregroundColor(selectedSection == section ? .primary : .secondary)
-                        .background(selectedSection == section ? MeterBarTheme.graphiteElevated : Color.clear)
-                        .overlay(alignment: .leading) {
-                            if selectedSection == section {
-                                RoundedRectangle(cornerRadius: 2)
-                                    .fill(MeterBarTheme.appAccent)
-                                    .frame(width: 3)
-                                    .padding(.vertical, 7)
-                            }
-                        }
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
-                        .contentShape(Rectangle())
+                        Label("Refresh", systemImage: "arrow.clockwise")
                     }
-                    .buttonStyle(.plain)
+                    .help("Refresh usage")
+                    .disabled(dataManager.isLoading || costTracker.isScanning)
                 }
             }
-            .padding(.horizontal, 12)
-
-            Spacer()
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Local Sources")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                if enabledSourceLabels.isEmpty {
-                    Text("No sources enabled")
-                } else {
-                    ForEach(enabledSourceLabels, id: \.self) { label in
-                        Label(label, systemImage: "checkmark.circle.fill")
-                    }
-                }
-            }
-            .font(.caption)
-            .foregroundColor(.secondary)
-            .padding(.horizontal, 18)
-            .padding(.bottom, 18)
-        }
-        .frame(width: 188)
-        .background(.ultraThinMaterial)
-        .clipShape(RoundedRectangle(cornerRadius: 14))
-        .overlay {
-            RoundedRectangle(cornerRadius: 14)
-                .stroke(MeterBarTheme.border, lineWidth: 1)
         }
     }
 
-    private var header: some View {
-        HStack(alignment: .center) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(selectedSection.rawValue)
-                    .font(.title)
-                    .fontWeight(.semibold)
-                Text(sectionSubtitle)
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-            }
-
-            Spacer()
-
-            RefreshIconButton(
-                title: "Refresh",
-                help: "Refresh usage",
-                isDisabled: dataManager.isLoading || costTracker.isScanning
-            ) {
-                Task {
-                    await refreshDashboard()
+    private var sourcesFooter: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Local Sources")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if enabledSourceLabels.isEmpty {
+                Text("No sources enabled")
+            } else {
+                ForEach(enabledSourceLabels, id: \.self) { label in
+                    Label(label, systemImage: "checkmark.circle.fill")
                 }
             }
         }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 18)
+        .padding(.vertical, 14)
     }
 
     private var overviewContent: some View {
@@ -277,11 +210,9 @@ struct UsageDashboardView: View {
                                     await costTracker.scanCosts(days: 30)
                                 }
                             } label: {
-                                HStack(spacing: 7) {
-                                    LucideIcon(.search, size: 13, lineWidth: 2.4)
-                                    Text("Scan 30 Days")
-                                }
+                                Label("Scan 30 Days", systemImage: "magnifyingglass")
                             }
+                            .buttonStyle(.bordered)
                             .disabled(costTracker.isScanning)
                         }
                         .frame(height: 220, alignment: .center)
@@ -414,7 +345,7 @@ struct UsageDashboardView: View {
     }
 
     private var sectionSubtitle: String {
-        switch selectedSection {
+        switch activeSection {
         case .overview:
             return "Current health and local token history"
         case .limits:
@@ -427,7 +358,7 @@ struct UsageDashboardView: View {
     }
 
     private func refreshDashboard() async {
-        if selectedSection == .costs {
+        if activeSection == .costs {
             await costTracker.scanCosts(days: 30)
         } else {
             await dataManager.refreshAll()
@@ -542,11 +473,11 @@ private struct DashboardStatusHero: View {
         HStack(alignment: .center, spacing: 14) {
             ZStack {
                 Circle()
-                    .fill(color.opacity(0.18))
+                    .fill(.quaternary)
                     .frame(width: 46, height: 46)
                 Image(systemName: iconName)
                     .font(.system(size: 23, weight: .semibold))
-                    .foregroundColor(color)
+                    .foregroundStyle(color)
             }
 
             VStack(alignment: .leading, spacing: 4) {
@@ -677,7 +608,7 @@ private struct CostOverviewStatusCard: View {
             HStack(alignment: .center, spacing: 9) {
                 Image(systemName: "dollarsign.circle.fill")
                     .font(.system(size: 20, weight: .semibold))
-                    .foregroundColor(MeterBarTheme.success)
+                    .foregroundStyle(MeterBarTheme.success)
                 VStack(alignment: .leading, spacing: 2) {
                     Text("API-Rate Estimate")
                         .font(.headline)
@@ -854,6 +785,8 @@ private struct DashboardLimitRow: View {
 private struct CostScanLoadingChart: View {
     let compact: Bool
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     private let barCount = 30
 
     var body: some View {
@@ -884,7 +817,7 @@ private struct CostScanLoadingChart: View {
                         HStack(alignment: .bottom, spacing: spacing) {
                             ForEach(0..<barCount, id: \.self) { index in
                                 let seed = Double(((index * 17) % 11) + 2) / 13
-                                let wave = (sin((time * 3.2) + Double(index) * 0.55) + 1) / 2
+                                let wave = reduceMotion ? 0.5 : (sin((time * 3.2) + Double(index) * 0.55) + 1) / 2
                                 let height = chartHeight * CGFloat(0.14 + (seed * 0.44) + (wave * 0.28))
 
                                 RoundedRectangle(cornerRadius: 3)
@@ -903,16 +836,18 @@ private struct CostScanLoadingChart: View {
                         }
                         .frame(maxWidth: .infinity, maxHeight: chartHeight, alignment: .bottomLeading)
 
-                        Rectangle()
-                            .fill(
-                                LinearGradient(
-                                    colors: [.clear, Color.white.opacity(0.28), .clear],
-                                    startPoint: .leading,
-                                    endPoint: .trailing
+                        if !reduceMotion {
+                            Rectangle()
+                                .fill(
+                                    LinearGradient(
+                                        colors: [.clear, Color.primary.opacity(0.22), .clear],
+                                        startPoint: .leading,
+                                        endPoint: .trailing
+                                    )
                                 )
-                            )
-                            .frame(width: sweepWidth, height: chartHeight)
-                            .offset(x: sweepX)
+                                .frame(width: sweepWidth, height: chartHeight)
+                                .offset(x: sweepX)
+                        }
                     }
                     .clipShape(RoundedRectangle(cornerRadius: 7))
 
@@ -943,12 +878,7 @@ private struct CostScanProgressBadge: View {
                 }
                 .padding(.horizontal, compact ? 9 : 11)
                 .padding(.vertical, compact ? 6 : 8)
-                .background(.ultraThinMaterial)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(Color.white.opacity(0.12), lineWidth: 1)
-                }
+                .glassEffect(.regular, in: .capsule)
 
                 Spacer()
             }
@@ -1159,8 +1089,8 @@ private struct StackedDailyUsageColumn: View {
                 .frame(width: width, height: height, alignment: .bottom)
                 .clipShape(RoundedRectangle(cornerRadius: 3))
             } else {
-                RoundedRectangle(cornerRadius: 1)
-                    .fill(Color.white.opacity(0.10))
+                Capsule()
+                    .fill(.quaternary)
                     .frame(width: width, height: 2)
             }
         }
@@ -1351,8 +1281,7 @@ private struct DailyUsageDetailRow: View {
             }
         }
         .padding(10)
-        .background(Color.white.opacity(0.035))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
 
     private func dateLabel(_ date: Date) -> String {
@@ -1411,8 +1340,7 @@ private struct ProviderCostBreakdown: View {
             }
         }
         .padding(12)
-        .background(Color.white.opacity(0.04))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
 
     private func compact(_ value: Int) -> String {
@@ -1538,18 +1466,12 @@ private func color(for provider: ServiceType) -> Color {
 }
 
 private extension View {
+    /// A content surface for dashboard cards. Opaque system control background
+    /// (not a material) on the window's content layer, with concentric corners.
     func dashboardCardBackground() -> some View {
-        self
-            .background {
-                ZStack {
-                    MeterBarTheme.graphiteSurface.opacity(0.78)
-                    Rectangle().fill(.thinMaterial).opacity(0.30)
-                }
-            }
-            .overlay {
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(MeterBarTheme.border, lineWidth: 1)
-            }
-            .clipShape(RoundedRectangle(cornerRadius: 8))
+        background(
+            Color(nsColor: .controlBackgroundColor),
+            in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+        )
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(
     name: "MeterBar",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v26)
     ],
     products: [
         .library(
@@ -28,12 +28,17 @@ let package = Package(
                 "App/MeterBar.entitlements",
                 "Assets.xcassets",
                 "Resources"
-            ]
+            ],
+            // Match the Xcode app target (SWIFT_VERSION = 5.0). The views target
+            // macOS 26 for Liquid Glass APIs, but stay in Swift 5 language mode so
+            // existing singletons compile without a concurrency refactor.
+            swiftSettings: [.swiftLanguageMode(.v5)]
         ),
         .testTarget(
             name: "MeterBarTests",
             dependencies: ["MeterBar"],
-            path: "MeterBarTests"
+            path: "MeterBarTests",
+            swiftSettings: [.swiftLanguageMode(.v5)]
         ),
     ]
 )


### PR DESCRIPTION
## Why

MeterBar hand-rolled a dark "graphite glass" look that **fought** macOS 26 Tahoe's Liquid Glass rather than adopting it. A research/audit against Apple's primary sources (HIG *Materials*, *Adopting Liquid Glass*, WWDC25 "Meet Liquid Glass", SwiftUI glass/material API docs) found three systemic anti-patterns: glass-on-glass (painted popover/window backgrounds **and** fake-glass content cards stacked on top), a fixed dark-only hex palette overriding system vibrancy, and hand-rolled chrome the OS now supplies for free.

Apple's prescription is **"adopt by subtraction"** — use native containers + semantic colors and *remove* the custom backgrounds, letting the system supply Liquid Glass on the chrome layer. This mirrors the sibling `inbox` app's native patterns.

## Decisions (confirmed with the maintainer)

- **Deployment target → macOS 26** (drop 14/15) so Liquid Glass APIs are used unconditionally.
- **Appearance → adaptive light + dark** (no longer dark-only).
- **Full native conversion** of all four view files in one pass.

## What changed

| Area | Before | After |
|---|---|---|
| **Popover** (`MenuBarView`) | `popoverGlassCard()` fake glass on a painted `graphite + ultraThinMaterial` background (glass-on-glass) | Native `NSPopover` glass shows through; opaque system-surface cards; SF Symbol buttons; `Capsule` meters |
| **Window** (`UsageDashboardView`) | bare `NSWindow` + custom `HStack` sidebar + `.ultraThinMaterial` | `NavigationSplitView` + `List(.sidebar)` + bridged `.toolbar`; `GroupBox` cards; real `.glassEffect` scan badge; Reduce-Motion-gated skeleton |
| **Settings** (`SettingsView`) | `ScrollView` of fake-glass panels + custom button/field styles | `Form{Section}.formStyle(.grouped)`, `LabeledContent`, native `.bordered`/`.borderedProminent`/`role:.destructive` |
| **Color** (`MeterBarTheme`) | fixed graphite hex, dark-only, `Color.white.opacity` washes | semantic system colors that adapt to light/dark, accent, Increase Contrast, Reduce Transparency; brand accents kept but made adaptive |
| **Icons / motion** | custom-drawn `LucideIcon` paths; refresh spin ignoring Reduce Motion | SF Symbols; skeleton sweep gated on `accessibilityReduceMotion` |

Net **−382 lines** (349 added / 731 removed) — most of the work was deletion.

## Reviewer notes

- **macOS 26 minimum** is a hard requirement now (real Liquid Glass APIs). `Package.swift` bumps `swift-tools-version` to 6.2 + `.macOS(.v26)` but pins both targets to `.swiftLanguageMode(.v5)` to match the Xcode app target (`SWIFT_VERSION = 5.0`) and avoid an out-of-scope Swift 6 concurrency refactor.
- **Dashboard toolbar:** kept the AppKit `NSWindow` and used `NSHostingController.sceneBridgingOptions = .all` + `toolbarStyle = .unified` to surface the SwiftUI `NavigationSplitView` toolbar/title into the window (the popover is hosted by the AppDelegate, so a SwiftUI `Window` scene's `openWindow` was unreachable). **Worth eyeballing** that the Refresh toolbar button renders.
- **Menu bar** intentionally stays `NSStatusItem` + `NSPopover` (protects the live "%" status-title feature); only popover *content* was made native.
- **CI:** the macOS runner must use **Xcode 26** to build the macOS 26 target.

## Verification

- `xcodebuild` (full app + widget, macOS 26 SDK, real glass APIs) — **BUILD SUCCEEDED**
- `swift test` — **54 passed**, 0 failures
- Repo-wide grep — zero residual fake-glass / graphite hex / `white.opacity` washes / Lucide / custom styles
- Live visual QA across light/dark + accessibility settings still pending (automated screenshot was blocked this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)