### PR TITLE
Add extra-usage (paid overage) on/off indicator for Claude Code & Codex

### DIFF
--- a/.agents/SESSIONS/2026-06-19.md
+++ b/.agents/SESSIONS/2026-06-19.md
@@ -1,0 +1,76 @@
+# Sessions: 2026-06-19
+
+**Summary:** Surface Claude Code & Codex "extra usage" (paid overage) on/off state in the UI
+
+---
+
+## Session 1: Extra-Usage / Credit Indicator
+
+**Duration:** ~1 hour
+**Status:** Complete
+
+### Goal
+
+Let the user confirm at a glance whether paid **extra usage** (Claude) / **credits** (Codex)
+— i.e. billable overage beyond the subscription quota — is ON or OFF, so they can be sure they
+are not silently being charged. Display on the menu-bar provider cards and in Settings.
+
+### What was done
+
+- Added a shared `ExtraUsageStatus` value type (`on` / `off` / `unknown` + optional detail) to
+  `UsageMetrics`, plus a `withExtraUsage(_:)` copy helper that preserves identity/limits.
+- **Codex:** surfaced the existing-but-unused `credits` payload and added `spend_control` +
+  `credits.overage_limit_reached`. Mapped them to `ExtraUsageStatus` (`CodexCliUsageResponse.extraUsageStatus`).
+- **Claude Code:** the `claude /usage` CLI text does **not** expose the extra-usage toggle
+  (verified: piped + TTY-rendered output contain no extra/credit/spend tokens). Added a
+  best-effort `fetchExtraUsageStatus(account:)` that queries `GET /api/oauth/usage`
+  (`extra_usage.is_enabled` / `spend.enabled`) using the Keychain OAuth token, attached to the
+  CLI metrics. Failure of any kind degrades to `.unknown`.
+- **UI:** added an "Extra usage" row + reusable `ExtraUsageStatusPill` (On=amber / Off=green /
+  Unknown=grey, with explanatory tooltips) to each menu-bar provider card, and an "Extra Usage"
+  section in Settings with per-provider state, detail, and a "Manage" link.
+- Wrote `MeterBarTests/ExtraUsageStatusTests.swift` (23 tests) covering the mapping logic, money
+  formatting, `withExtraUsage`, and Codable backward-compat.
+
+### Safety hardening (from adversarial multi-agent review)
+
+A review pass flagged that the feature must **never** show a confident "Off" when the state is
+actually on/undetermined (a false "Off" gives dangerous false confidence). Fixes applied:
+
+- Codex: an **absent** `credits` object now yields `.unknown` (was `.off`). `.off` is only
+  returned when the credits object is present and explicitly empty (no balance, not unlimited,
+  overage not in use, no spend cap).
+- Codex: on/off no longer keys solely off prepaid balance — `overage_limit_reached` and a
+  configured `spend_control.individual_limit`/`reached` now count as ON signals.
+- Claude: `spend.enabled == false` (without `extra_usage`) now yields `.unknown` (was `.off`),
+  since only `extra_usage.is_enabled` authoritatively proves "Off".
+
+### Files changed
+
+- `MeterBar/Models/UsageMetrics.swift` - Added `ExtraUsageStatus`, `extraUsage` field, `withExtraUsage(_:)`.
+- `MeterBar/Services/CodexCliLocalService.swift` - `spend_control` + `overage_limit_reached` models, safety-biased `extraUsageStatus`, wired into both return paths.
+- `MeterBar/Services/ClaudeCodeLocalService.swift` - `extra_usage`/`spend` models, `extraUsageStatus`, `fetchExtraUsageStatus(account:)`, wired into CLI + legacy OAuth paths.
+- `MeterBar/Views/MenuBarView.swift` - `ExtraUsageStatusPill`, extra-usage row on provider cards.
+- `MeterBar/Views/SettingsView.swift` - "Extra Usage" settings section.
+- `MeterBarTests/ExtraUsageStatusTests.swift` - New: 23 unit tests.
+
+### Decisions
+
+- **Decision:** For Claude, query `/api/oauth/usage` (Keychain token) rather than gate behind the
+  legacy `ClaudeCodeEnableOAuthFallback` flag.
+  - **Rationale:** Chosen by the project owner; it's the only source of the extra-usage flag.
+  - **Known risk:** the app is sandboxed with no `keychain-access-groups` entitlement, so reading
+    Claude Code's `"Claude Code-credentials"` item may fail in the notarized build → Claude shows
+    "Unknown" (never a false "Off"). Worth verifying in a sandboxed build.
+
+- **Decision:** Safety-bias every mapping toward `.unknown` over `.off`.
+  - **Rationale:** The whole point is to confirm overage is OFF; a false "Off" defeats it.
+
+### Verification
+
+- `swift build` passed.
+- `swift test` passed: 77 tests, 2 credential-dependent API tests skipped, 0 failures (23 new).
+- `xcodebuild ... build` (CI gate) passed: **BUILD SUCCEEDED**.
+- SwiftLint: no new violations introduced by this change (pre-existing warnings unchanged).
+- Adversarial 4-dimension review (14 agents): 7 findings confirmed, all actionable ones fixed;
+  the keychain-gating findings were intentionally deferred to the owner's explicit design choice.

--- a/MeterBar/Models/UsageMetrics.swift
+++ b/MeterBar/Models/UsageMetrics.swift
@@ -1,18 +1,58 @@
 import Foundation
 
+/// Whether paid "extra usage" / overage credits are enabled for a service.
+///
+/// Both Claude Code ("extra usage") and Codex ("credits") let an account spend
+/// beyond its subscription quota once exhausted. Surfacing this lets users confirm
+/// at a glance whether they can be billed for overage, or whether usage is hard-capped.
+struct ExtraUsageStatus: Codable, Equatable {
+    enum State: String, Codable {
+        /// Extra paid usage / credits are enabled — overage spending is possible.
+        case on
+        /// Disabled — usage is capped at the subscription quota.
+        case off
+        /// Could not be determined (e.g. token unavailable or request failed).
+        case unknown
+    }
+
+    let state: State
+    /// Short human-readable detail, e.g. "$0.00 used", "$5.00 in credits".
+    let detail: String?
+
+    init(state: State, detail: String? = nil) {
+        self.state = state
+        self.detail = detail
+    }
+
+    static let unknown = ExtraUsageStatus(state: .unknown, detail: nil)
+
+    var isOn: Bool { state == .on }
+
+    /// Formats an amount as USD ("$5.00"); falls back to "<amount> <currency>" for others.
+    static func formatAmount(_ amount: Double, currency: String? = "USD") -> String {
+        let normalized = (currency ?? "USD").uppercased()
+        if normalized == "USD" {
+            return String(format: "$%.2f", amount)
+        }
+        return String(format: "%.2f %@", amount, normalized)
+    }
+}
+
 struct UsageMetrics: Codable, Identifiable {
     let id: UUID
     let service: ServiceType
     let sessionLimit: UsageLimit?
     let weeklyLimit: UsageLimit?
     let codeReviewLimit: UsageLimit?
+    let extraUsage: ExtraUsageStatus?
     let lastUpdated: Date
-    
+
     init(
         service: ServiceType,
         sessionLimit: UsageLimit? = nil,
         weeklyLimit: UsageLimit? = nil,
         codeReviewLimit: UsageLimit? = nil,
+        extraUsage: ExtraUsageStatus? = nil,
         lastUpdated: Date = Date()
     ) {
         self.id = UUID()
@@ -20,7 +60,39 @@ struct UsageMetrics: Codable, Identifiable {
         self.sessionLimit = sessionLimit
         self.weeklyLimit = weeklyLimit
         self.codeReviewLimit = codeReviewLimit
+        self.extraUsage = extraUsage
         self.lastUpdated = lastUpdated
+    }
+
+    private init(
+        id: UUID,
+        service: ServiceType,
+        sessionLimit: UsageLimit?,
+        weeklyLimit: UsageLimit?,
+        codeReviewLimit: UsageLimit?,
+        extraUsage: ExtraUsageStatus?,
+        lastUpdated: Date
+    ) {
+        self.id = id
+        self.service = service
+        self.sessionLimit = sessionLimit
+        self.weeklyLimit = weeklyLimit
+        self.codeReviewLimit = codeReviewLimit
+        self.extraUsage = extraUsage
+        self.lastUpdated = lastUpdated
+    }
+
+    /// Returns a copy with the given extra-usage status, preserving identity, limits, and timestamp.
+    func withExtraUsage(_ status: ExtraUsageStatus?) -> UsageMetrics {
+        UsageMetrics(
+            id: id,
+            service: service,
+            sessionLimit: sessionLimit,
+            weeklyLimit: weeklyLimit,
+            codeReviewLimit: codeReviewLimit,
+            extraUsage: status,
+            lastUpdated: lastUpdated
+        )
     }
     
     var overallStatus: UsageStatus {

--- a/MeterBar/Services/ClaudeCodeLocalService.swift
+++ b/MeterBar/Services/ClaudeCodeLocalService.swift
@@ -114,7 +114,10 @@ class ClaudeCodeLocalService: ObservableObject {
                     self.authState = .connected(.cli)
                 }
             }
-            return metrics
+            // The CLI usage output does not expose the "extra usage" toggle, so query the
+            // OAuth usage endpoint separately for it. Best-effort: failures degrade to .unknown.
+            let extraUsage = await fetchExtraUsageStatus(account: account)
+            return metrics.withExtraUsage(extraUsage)
         } catch {
             if !account.isDefault || !isOAuthFallbackEnabled {
                 let serviceError = serviceError(from: error)
@@ -213,7 +216,8 @@ class ClaudeCodeLocalService: ObservableObject {
                 service: .claudeCode,
                 sessionLimit: sessionLimit,
                 weeklyLimit: weeklyLimit,
-                codeReviewLimit: sonnetLimit
+                codeReviewLimit: sonnetLimit,
+                extraUsage: usageResponse.extraUsageStatus
             )
         } catch let urlError as URLError {
             let errorMessage: String
@@ -242,6 +246,44 @@ class ClaudeCodeLocalService: ObservableObject {
                 self.authState = .error(serviceError.localizedDescription)
             }
             throw serviceError
+        }
+    }
+
+    /// Best-effort fetch of the Claude "extra usage" on/off state from the OAuth usage endpoint.
+    ///
+    /// Only the default account is supported, since its OAuth token lives in the Keychain.
+    /// Reads credentials without mutating published state and never throws — any missing token,
+    /// expired token, network failure, or decode failure resolves to `.unknown`.
+    private func fetchExtraUsageStatus(account: ClaudeCodeAccount) async -> ExtraUsageStatus {
+        guard account.isDefault else { return .unknown }
+        guard let credentials = getCredentials(),
+              !OAuthTokenExpiry.isExpired(unixTimestamp: credentials.claudeAiOauth.expiresAt) else {
+            return .unknown
+        }
+
+        guard let url = URL(string: usageEndpoint) else { return .unknown }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(credentials.claudeAiOauth.accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+        request.timeoutInterval = 15.0
+
+        do {
+            let (data, response) = try await urlSession.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200...299).contains(httpResponse.statusCode) else {
+                return .unknown
+            }
+
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let usageResponse = try decoder.decode(ClaudeCodeUsageResponse.self, from: data)
+            return usageResponse.extraUsageStatus
+        } catch {
+            return .unknown
         }
     }
 
@@ -356,11 +398,105 @@ struct ClaudeCodeUsageResponse: Codable {
     let fiveHour: UsageWindow
     let sevenDay: UsageWindow
     let sevenDaySonnet: UsageWindow?
+    let extraUsage: ClaudeExtraUsage?
+    let spend: ClaudeSpend?
 
     enum CodingKeys: String, CodingKey {
         case fiveHour = "five_hour"
         case sevenDay = "seven_day"
         case sevenDaySonnet = "seven_day_sonnet"
+        case extraUsage = "extra_usage"
+        case spend
+    }
+
+    /// Maps the Claude `extra_usage`/`spend` payload onto the shared extra-usage status.
+    ///
+    /// Claude Code "extra usage" lets Max accounts keep working past their plan limits
+    /// by billing overage to their payment method. The authoritative flag is
+    /// `extra_usage.is_enabled`; `spend.enabled` is used as a fallback.
+    var extraUsageStatus: ExtraUsageStatus {
+        if let extraUsage {
+            guard extraUsage.isEnabled else {
+                return ExtraUsageStatus(state: .off, detail: nil)
+            }
+            return ExtraUsageStatus(state: .on, detail: enabledDetail)
+        }
+
+        // `spend.enabled` only positively confirms ON. A false value is not authoritative for
+        // the extra-usage toggle (only `extra_usage.is_enabled` is), so treat it as unknown
+        // rather than risk a false "Off".
+        if spend?.enabled == true {
+            return ExtraUsageStatus(state: .on, detail: enabledDetail)
+        }
+
+        return .unknown
+    }
+
+    private var enabledDetail: String? {
+        var parts: [String] = []
+        if let spend, let used = spend.used?.amount {
+            parts.append("\(ExtraUsageStatus.formatAmount(used, currency: spend.used?.currency)) used")
+        }
+        if let limit = extraUsage?.monthlyLimit, limit > 0 {
+            parts.append("cap \(ExtraUsageStatus.formatAmount(limit, currency: extraUsage?.currency))/mo")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+}
+
+/// Claude `extra_usage` object from `/api/oauth/usage`.
+struct ClaudeExtraUsage: Codable {
+    let isEnabled: Bool
+    let monthlyLimit: Double?
+    let usedCredits: Double?
+    let utilization: Double?
+    let currency: String?
+    let disabledReason: String?
+
+    enum CodingKeys: String, CodingKey {
+        case isEnabled = "is_enabled"
+        case monthlyLimit = "monthly_limit"
+        case usedCredits = "used_credits"
+        case utilization
+        case currency
+        case disabledReason = "disabled_reason"
+    }
+}
+
+/// Claude `spend` object from `/api/oauth/usage`.
+struct ClaudeSpend: Codable {
+    let used: ClaudeMoney?
+    let limit: ClaudeMoney?
+    let percent: Double?
+    let enabled: Bool?
+    let disabledReason: String?
+
+    enum CodingKeys: String, CodingKey {
+        case used
+        case limit
+        case percent
+        case enabled
+        case disabledReason = "disabled_reason"
+    }
+}
+
+/// Minor-unit money amount (e.g. `amount_minor: 500, exponent: 2` → $5.00).
+struct ClaudeMoney: Codable {
+    let amountMinor: Int?
+    let currency: String?
+    let exponent: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case amountMinor = "amount_minor"
+        case currency
+        case exponent
+    }
+
+    /// Decoded major-unit amount, or nil when no minor amount is present.
+    var amount: Double? {
+        guard let amountMinor else { return nil }
+        let exp = exponent ?? 2
+        return Double(amountMinor) / pow(10, Double(exp))
     }
 }
 

--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -176,7 +176,8 @@ class CodexCliLocalService: ObservableObject {
                     service: .codexCli,
                     sessionLimit: nil,
                     weeklyLimit: nil,
-                    codeReviewLimit: nil
+                    codeReviewLimit: nil,
+                    extraUsage: usageResponse.extraUsageStatus
                 )
             }
 
@@ -218,7 +219,8 @@ class CodexCliLocalService: ObservableObject {
                 service: .codexCli,
                 sessionLimit: sessionLimit,
                 weeklyLimit: weeklyLimit,
-                codeReviewLimit: codeReviewLimit
+                codeReviewLimit: codeReviewLimit,
+                extraUsage: usageResponse.extraUsageStatus
             )
         } catch let urlError as URLError {
             let errorMessage: String
@@ -258,12 +260,98 @@ struct CodexCliUsageResponse: Codable {
     let rateLimit: RateLimit?  // Can be null for free accounts
     let codeReviewRateLimit: CodeReviewRateLimit?
     let credits: Credits?  // Can be null for free accounts
+    let spendControl: SpendControl?
 
     enum CodingKeys: String, CodingKey {
         case planType = "plan_type"
         case rateLimit = "rate_limit"
         case codeReviewRateLimit = "code_review_rate_limit"
         case credits
+        case spendControl = "spend_control"
+    }
+
+    /// Maps the Codex credits/spend payload onto the shared extra-usage status.
+    ///
+    /// Codex "extra usage" means pay-as-you-go credits/overage consumed once the plan's
+    /// rate limit is hit. Because a false "Off" gives dangerous false confidence, this is
+    /// safety-biased: we only report `.off` when the payload positively proves overage is
+    /// disabled (the credits object is present and explicitly empty with no overage signal).
+    /// Any positive signal is `.on`; an absent credits object is `.unknown`, never `.off`.
+    var extraUsageStatus: ExtraUsageStatus {
+        // Positive evidence that overage spending is possible / enabled.
+        if let credits {
+            if credits.unlimited {
+                return ExtraUsageStatus(state: .on, detail: "Unlimited credits")
+            }
+
+            let balance = credits.balance ?? 0
+            if credits.hasCredits || balance > 0 {
+                return ExtraUsageStatus(state: .on, detail: onDetail(balance: balance))
+            }
+
+            if credits.overageLimitReached {
+                return ExtraUsageStatus(state: .on, detail: "Overage in use")
+            }
+        }
+
+        // A configured spend cap (or a reached cap) means overage billing is set up.
+        if let limit = spendControl?.individualLimit, limit > 0 {
+            return ExtraUsageStatus(state: .on, detail: "Overage cap \(ExtraUsageStatus.formatAmount(limit))")
+        }
+        if spendControl?.reached == true {
+            return ExtraUsageStatus(state: .on, detail: "Overage in use")
+        }
+
+        // Authoritative evidence overage is disabled: credits object present and explicitly
+        // empty (no balance, not unlimited, overage not in use).
+        if let credits,
+           !credits.unlimited,
+           !credits.hasCredits,
+           (credits.balance ?? 0) == 0,
+           !credits.overageLimitReached {
+            return ExtraUsageStatus(state: .off, detail: nil)
+        }
+
+        // No credits object at all → we cannot determine the state. Never report a false "Off".
+        return ExtraUsageStatus(state: .unknown, detail: nil)
+    }
+
+    private func onDetail(balance: Double) -> String {
+        var detail = "\(ExtraUsageStatus.formatAmount(balance)) in credits"
+        if let limit = spendControl?.individualLimit, limit > 0 {
+            detail += " · cap \(ExtraUsageStatus.formatAmount(limit))"
+        }
+        return detail
+    }
+}
+
+/// Optional per-account spending cap returned by the Codex usage API.
+struct SpendControl: Codable {
+    let reached: Bool
+    let individualLimit: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case reached
+        case individualLimit = "individual_limit"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        reached = (try? container.decode(Bool.self, forKey: .reached)) ?? false
+
+        if let doubleLimit = try? container.decode(Double.self, forKey: .individualLimit) {
+            individualLimit = doubleLimit
+        } else if let stringLimit = try? container.decode(String.self, forKey: .individualLimit) {
+            individualLimit = Double(stringLimit)
+        } else {
+            individualLimit = nil
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(reached, forKey: .reached)
+        try container.encodeIfPresent(individualLimit, forKey: .individualLimit)
     }
 }
 
@@ -312,6 +400,7 @@ struct LimitWindow: Codable {
 struct Credits: Codable {
     let hasCredits: Bool
     let unlimited: Bool
+    let overageLimitReached: Bool
     let balance: Double?
     let approxLocalMessages: Int?
     let approxCloudMessages: Int?
@@ -319,6 +408,7 @@ struct Credits: Codable {
     enum CodingKeys: String, CodingKey {
         case hasCredits = "has_credits"
         case unlimited
+        case overageLimitReached = "overage_limit_reached"
         case balance
         case approxLocalMessages = "approx_local_messages"
         case approxCloudMessages = "approx_cloud_messages"
@@ -328,6 +418,7 @@ struct Credits: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         hasCredits = (try? container.decode(Bool.self, forKey: .hasCredits)) ?? false
         unlimited = (try? container.decode(Bool.self, forKey: .unlimited)) ?? false
+        overageLimitReached = (try? container.decode(Bool.self, forKey: .overageLimitReached)) ?? false
 
         if let doubleBalance = try? container.decode(Double.self, forKey: .balance) {
             balance = doubleBalance
@@ -345,6 +436,7 @@ struct Credits: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(hasCredits, forKey: .hasCredits)
         try container.encode(unlimited, forKey: .unlimited)
+        try container.encode(overageLimitReached, forKey: .overageLimitReached)
         try container.encodeIfPresent(balance, forKey: .balance)
         try container.encodeIfPresent(approxLocalMessages, forKey: .approxLocalMessages)
         try container.encodeIfPresent(approxCloudMessages, forKey: .approxCloudMessages)

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -325,6 +325,7 @@ private struct PopoverProviderSnapshot: Identifiable {
     let updatedAt: Date?
     let limits: [PopoverLimit]
     let emptyDetail: String
+    let extraUsage: ExtraUsageStatus?
 
     init(
         title: String,
@@ -339,6 +340,7 @@ private struct PopoverProviderSnapshot: Identifiable {
         self.accentColor = accentColor
         self.updatedAt = metrics?.lastUpdated
         self.emptyDetail = emptyDetail
+        self.extraUsage = metrics?.extraUsage
         self.limits = [
             PopoverLimit(title: "Session", limit: metrics?.sessionLimit),
             PopoverLimit(title: "Weekly", limit: metrics?.weeklyLimit),
@@ -472,6 +474,19 @@ private struct PopoverProviderStatusCard: View {
                     .frame(maxWidth: .infinity, minHeight: 54, alignment: .topLeading)
             }
 
+            if let extraUsage = snapshot.extraUsage {
+                HStack(spacing: 4) {
+                    Image(systemName: "creditcard")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(.secondary)
+                    Text("Extra usage")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                    Spacer(minLength: 4)
+                    ExtraUsageStatusPill(status: extraUsage)
+                }
+            }
+
             Text(statusText)
                 .font(.caption2)
                 .fontWeight(.semibold)
@@ -573,6 +588,59 @@ struct NextResetCountdownLabel: View {
         }
 
         return candidates.max(by: { $0.seconds < $1.seconds })?.window
+    }
+}
+
+/// Colored On/Off chip showing whether paid "extra usage" / overage is enabled for a service.
+struct ExtraUsageStatusPill: View {
+    let status: ExtraUsageStatus
+
+    private var label: String {
+        switch status.state {
+        case .on: return "On"
+        case .off: return "Off"
+        case .unknown: return "Unknown"
+        }
+    }
+
+    private var color: Color {
+        switch status.state {
+        case .on: return MeterBarTheme.warning
+        case .off: return MeterBarTheme.success
+        case .unknown: return .secondary
+        }
+    }
+
+    private var tooltip: String {
+        switch status.state {
+        case .on:
+            let base = "Extra usage is ON — overage can be billed beyond your plan."
+            return status.detail.map { "\(base)\n\($0)" } ?? base
+        case .off:
+            return "Extra usage is OFF — usage is capped at your subscription quota."
+        case .unknown:
+            return "Extra usage state could not be determined."
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(color)
+                .frame(width: 6, height: 6)
+            Text(label)
+                .font(.caption2)
+                .fontWeight(.semibold)
+        }
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(color.opacity(0.14))
+        .clipShape(Capsule())
+        .overlay {
+            Capsule()
+                .stroke(color.opacity(0.20), lineWidth: 1)
+        }
+        .help(tooltip)
     }
 }
 

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -60,10 +60,71 @@ struct SettingsView: View {
             if providerVisibility.isEnabled(.cursor) {
                 cursorSection
             }
+            if showExtraUsageSection {
+                extraUsageSection
+            }
             costTrackingSection
             refreshSection
         }
         .frame(maxWidth: 760, alignment: .leading)
+    }
+
+    private var showExtraUsageSection: Bool {
+        providerVisibility.isEnabled(.claudeCode) || providerVisibility.isEnabled(.codexCli)
+    }
+
+    private var extraUsageSection: some View {
+        SettingsPanelSection(title: "Extra Usage", systemImage: "creditcard", color: MeterBarTheme.warning) {
+            SettingsNotice(
+                text: "Extra usage (Claude) and credits (Codex) let a provider bill overage beyond your "
+                    + "plan once your quota is exhausted. \"Off\" means usage is capped at your subscription.",
+                color: .secondary
+            )
+
+            if providerVisibility.isEnabled(.claudeCode) {
+                extraUsageRow(
+                    title: "Claude Code",
+                    status: dataManager.metrics[.claudeCode]?.extraUsage,
+                    manageURL: "https://claude.ai/settings"
+                )
+            }
+
+            if providerVisibility.isEnabled(.codexCli) {
+                extraUsageRow(
+                    title: "OpenAI Codex",
+                    status: dataManager.metrics[.codexCli]?.extraUsage,
+                    manageURL: "https://chatgpt.com"
+                )
+            }
+        }
+    }
+
+    private func extraUsageRow(title: String, status: ExtraUsageStatus?, manageURL: String) -> some View {
+        SettingsRowView(title: title, detail: extraUsageDetailText(status)) {
+            HStack(spacing: 8) {
+                ExtraUsageStatusPill(status: status ?? .unknown)
+
+                Button("Manage") {
+                    if let url = URL(string: manageURL) {
+                        NSWorkspace.shared.open(url)
+                    }
+                }
+                .buttonStyle(SettingsButtonStyle())
+                .help("Open \(manageURL) to change extra usage settings")
+            }
+        }
+    }
+
+    private func extraUsageDetailText(_ status: ExtraUsageStatus?) -> String {
+        guard let status else { return "Waiting for refresh." }
+        switch status.state {
+        case .on:
+            return status.detail.map { "Enabled · \($0)" } ?? "Enabled — overage can be billed beyond your plan."
+        case .off:
+            return "Disabled — capped at your subscription quota."
+        case .unknown:
+            return "Could not determine. Sign in to the CLI and refresh."
+        }
     }
 
     private var trackedProvidersSection: some View {

--- a/MeterBarTests/ExtraUsageStatusTests.swift
+++ b/MeterBarTests/ExtraUsageStatusTests.swift
@@ -1,0 +1,210 @@
+import XCTest
+@testable import MeterBar
+
+final class ExtraUsageStatusTests: XCTestCase {
+    // MARK: - ExtraUsageStatus basics
+
+    func testIsOnReflectsState() {
+        XCTAssertTrue(ExtraUsageStatus(state: .on).isOn)
+        XCTAssertFalse(ExtraUsageStatus(state: .off).isOn)
+        XCTAssertFalse(ExtraUsageStatus(state: .unknown).isOn)
+    }
+
+    func testUnknownConstant() {
+        XCTAssertEqual(ExtraUsageStatus.unknown.state, .unknown)
+        XCTAssertNil(ExtraUsageStatus.unknown.detail)
+    }
+
+    func testFormatAmountUSD() {
+        XCTAssertEqual(ExtraUsageStatus.formatAmount(5), "$5.00")
+        XCTAssertEqual(ExtraUsageStatus.formatAmount(0), "$0.00")
+        XCTAssertEqual(ExtraUsageStatus.formatAmount(12.5, currency: "usd"), "$12.50")
+    }
+
+    func testFormatAmountNonUSD() {
+        XCTAssertEqual(ExtraUsageStatus.formatAmount(5, currency: "EUR"), "5.00 EUR")
+    }
+
+    // MARK: - UsageMetrics integration
+
+    func testDefaultExtraUsageIsNil() {
+        let metrics = UsageMetrics(service: .codexCli)
+        XCTAssertNil(metrics.extraUsage)
+    }
+
+    func testWithExtraUsagePreservesIdentityAndLimits() {
+        let original = UsageMetrics(
+            service: .claudeCode,
+            sessionLimit: UsageLimit(used: 10, total: 100, resetTime: nil),
+            weeklyLimit: UsageLimit(used: 20, total: 100, resetTime: nil)
+        )
+
+        let updated = original.withExtraUsage(ExtraUsageStatus(state: .off))
+
+        XCTAssertEqual(updated.id, original.id)
+        XCTAssertEqual(updated.service, original.service)
+        XCTAssertEqual(updated.sessionLimit, original.sessionLimit)
+        XCTAssertEqual(updated.weeklyLimit, original.weeklyLimit)
+        XCTAssertEqual(updated.lastUpdated, original.lastUpdated)
+        XCTAssertEqual(updated.extraUsage?.state, .off)
+    }
+
+    func testCodableRoundTripWithExtraUsage() throws {
+        let original = UsageMetrics(
+            service: .codexCli,
+            weeklyLimit: UsageLimit(used: 30, total: 100, resetTime: nil),
+            extraUsage: ExtraUsageStatus(state: .on, detail: "$5.00 in credits")
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(UsageMetrics.self, from: data)
+
+        XCTAssertEqual(decoded.extraUsage?.state, .on)
+        XCTAssertEqual(decoded.extraUsage?.detail, "$5.00 in credits")
+    }
+
+    func testDecodingLegacyJSONWithoutExtraUsageYieldsNil() throws {
+        // Older cached payloads have no `extraUsage` key; decoding must not fail.
+        let legacy = """
+        {
+            "id": "1B9E9B4A-3B6C-4A9D-9C5E-3A1F2B3C4D5E",
+            "service": "Codex CLI",
+            "lastUpdated": 770000000
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(UsageMetrics.self, from: legacy)
+        XCTAssertNil(decoded.extraUsage)
+        XCTAssertEqual(decoded.service, .codexCli)
+    }
+
+    // MARK: - Codex mapping
+
+    private func decodeCodex(_ json: String) throws -> CodexCliUsageResponse {
+        try JSONDecoder().decode(CodexCliUsageResponse.self, from: json.data(using: .utf8)!)
+    }
+
+    func testCodexNoCreditsIsUnknown() throws {
+        // Absence of the credits object is absence of information, NOT proof that overage is
+        // off — it must never render a confident "Off".
+        let response = try decodeCodex(#"{"plan_type":"pro"}"#)
+        XCTAssertEqual(response.extraUsageStatus.state, .unknown)
+        XCTAssertNil(response.extraUsageStatus.detail)
+    }
+
+    func testCodexExplicitEmptyCreditsIsOff() throws {
+        // Credits object present and explicitly empty is authoritative evidence of "Off".
+        let response = try decodeCodex(#"""
+        {"plan_type":"pro","credits":{"has_credits":false,"unlimited":false,"overage_limit_reached":false,"balance":"0"},"spend_control":{"reached":false,"individual_limit":null}}
+        """#)
+        XCTAssertEqual(response.extraUsageStatus.state, .off)
+    }
+
+    func testCodexOverageLimitReachedIsOn() throws {
+        let response = try decodeCodex(#"""
+        {"plan_type":"pro","credits":{"has_credits":false,"unlimited":false,"overage_limit_reached":true,"balance":"0"}}
+        """#)
+        XCTAssertEqual(response.extraUsageStatus.state, .on)
+    }
+
+    func testCodexSpendControlCapWithoutCreditsIsOn() throws {
+        // A configured overage cap means overage billing is set up even with a zero balance.
+        let response = try decodeCodex(#"""
+        {"plan_type":"pro","credits":{"has_credits":false,"unlimited":false,"balance":"0"},"spend_control":{"reached":false,"individual_limit":50}}
+        """#)
+        let status = response.extraUsageStatus
+        XCTAssertEqual(status.state, .on)
+        XCTAssertEqual(status.detail?.contains("$50.00"), true)
+    }
+
+    func testCodexUnlimitedIsOn() throws {
+        let response = try decodeCodex(#"""
+        {"plan_type":"pro","credits":{"has_credits":false,"unlimited":true,"balance":"0"}}
+        """#)
+        let status = response.extraUsageStatus
+        XCTAssertEqual(status.state, .on)
+        XCTAssertEqual(status.detail, "Unlimited credits")
+    }
+
+    func testCodexPositiveBalanceIsOn() throws {
+        let response = try decodeCodex(#"""
+        {"plan_type":"pro","credits":{"has_credits":true,"unlimited":false,"balance":"5"}}
+        """#)
+        let status = response.extraUsageStatus
+        XCTAssertEqual(status.state, .on)
+        XCTAssertEqual(status.detail?.contains("$5.00"), true)
+    }
+
+    func testCodexBalanceAsNumberIsOn() throws {
+        let response = try decodeCodex(#"""
+        {"plan_type":"pro","credits":{"has_credits":false,"unlimited":false,"balance":7.5}}
+        """#)
+        let status = response.extraUsageStatus
+        XCTAssertEqual(status.state, .on)
+        XCTAssertEqual(status.detail?.contains("$7.50"), true)
+    }
+
+    func testCodexSpendControlCapAppended() throws {
+        let response = try decodeCodex(#"""
+        {"plan_type":"pro","credits":{"has_credits":true,"balance":"5"},"spend_control":{"reached":false,"individual_limit":50}}
+        """#)
+        let status = response.extraUsageStatus
+        XCTAssertEqual(status.state, .on)
+        XCTAssertEqual(status.detail?.contains("cap $50.00"), true)
+    }
+
+    func testCodexSpendControlNullLimitDecodes() throws {
+        let response = try decodeCodex(#"""
+        {"plan_type":"pro","credits":{"has_credits":true,"balance":"5"},"spend_control":{"reached":false,"individual_limit":null}}
+        """#)
+        XCTAssertEqual(response.spendControl?.individualLimit, nil)
+        XCTAssertEqual(response.extraUsageStatus.state, .on)
+    }
+
+    // MARK: - Claude mapping
+
+    private func decodeClaude(_ json: String) throws -> ClaudeCodeUsageResponse {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(ClaudeCodeUsageResponse.self, from: json.data(using: .utf8)!)
+    }
+
+    private let claudeWindows = #""five_hour":{"utilization":13,"resets_at":"2026-06-19T11:49:59Z"},"seven_day":{"utilization":74,"resets_at":"2026-06-19T19:59:59Z"}"#
+
+    func testClaudeExtraUsageDisabledIsOff() throws {
+        let response = try decodeClaude("{\(claudeWindows),\"extra_usage\":{\"is_enabled\":false}}")
+        XCTAssertEqual(response.extraUsageStatus.state, .off)
+        XCTAssertNil(response.extraUsageStatus.detail)
+    }
+
+    func testClaudeExtraUsageEnabledIsOnWithSpendDetail() throws {
+        let json = "{\(claudeWindows),\"extra_usage\":{\"is_enabled\":true,\"monthly_limit\":50,\"currency\":\"USD\"},\"spend\":{\"used\":{\"amount_minor\":250,\"currency\":\"USD\",\"exponent\":2},\"enabled\":true}}"
+        let status = try decodeClaude(json).extraUsageStatus
+        XCTAssertEqual(status.state, .on)
+        XCTAssertEqual(status.detail?.contains("$2.50 used"), true)
+        XCTAssertEqual(status.detail?.contains("cap $50.00/mo"), true)
+    }
+
+    func testClaudeFallsBackToSpendEnabledWhenNoExtraUsage() throws {
+        let json = "{\(claudeWindows),\"spend\":{\"enabled\":true,\"used\":{\"amount_minor\":0,\"exponent\":2}}}"
+        XCTAssertEqual(try decodeClaude(json).extraUsageStatus.state, .on)
+    }
+
+    func testClaudeSpendDisabledWithoutExtraUsageIsUnknown() throws {
+        // Only extra_usage.is_enabled authoritatively proves "Off"; spend.enabled==false alone
+        // must not produce a false "Off".
+        let json = "{\(claudeWindows),\"spend\":{\"enabled\":false,\"used\":{\"amount_minor\":0,\"exponent\":2}}}"
+        XCTAssertEqual(try decodeClaude(json).extraUsageStatus.state, .unknown)
+    }
+
+    func testClaudeUnknownWhenNoExtraUsageOrSpend() throws {
+        let status = try decodeClaude("{\(claudeWindows)}").extraUsageStatus
+        XCTAssertEqual(status.state, .unknown)
+    }
+
+    func testClaudeMoneyDecodesMinorUnits() throws {
+        let json = "{\(claudeWindows),\"spend\":{\"enabled\":true,\"used\":{\"amount_minor\":1299,\"exponent\":2,\"currency\":\"USD\"}}}"
+        let status = try decodeClaude(json).extraUsageStatus
+        XCTAssertEqual(status.detail?.contains("$12.99 used"), true)
+    }
+}


### PR DESCRIPTION
## Description

Surfaces whether **paid "extra usage" (Claude) / "credits" (Codex)** — i.e. billable overage beyond the subscription quota — is **On / Off / Unknown**, so users can confirm at a glance they won't be silently charged. Shown on each menu-bar provider card and in a new "Extra Usage" section in Settings.

- Adds a shared `ExtraUsageStatus` (`on` / `off` / `unknown` + optional detail) to `UsageMetrics`, plus a `withExtraUsage(_:)` copy helper that preserves identity/limits/timestamp.
- **Codex**: maps the already-fetched `credits` payload, plus newly-modeled `spend_control` and `credits.overage_limit_reached`, to `ExtraUsageStatus`.
- **Claude Code**: the `claude /usage` CLI text does **not** expose the extra-usage toggle (verified piped + TTY-rendered), so the only source is `GET /api/oauth/usage` (`extra_usage.is_enabled` / `spend.enabled`), queried best-effort via the Keychain OAuth token. Any failure degrades to `.unknown`.
- **UI**: `ExtraUsageStatusPill` (On = amber, Off = green, Unknown = grey, with explanatory tooltips) + an "Extra usage" row on provider cards, and a Settings "Extra Usage" section with per-provider state, detail, and a Manage link.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] `swift test`: 77 tests, 0 failures (2 credential-dependent API tests skipped). 23 new unit tests in `ExtraUsageStatusTests.swift`, written test-first per the TDD policy, covering the mapping logic, money formatting, `withExtraUsage`, and Codable backward-compat.
- [x] `xcodebuild ... -scheme MeterBar build` (the CI gate): **BUILD SUCCEEDED**.
- [x] SwiftLint: no new violations introduced.
- [x] Verified cached-data and the widget's separate `UsageMetrics` copy still decode (the new field is optional; unknown JSON keys are ignored both ways).
- [ ] Tested on a notarized/sandboxed build — see Additional Notes (Claude keychain read).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (session notes in `.agents/SESSIONS/2026-06-19.md`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

UI is two new elements: an "Extra usage" row on each provider card (menu bar) and an "Extra Usage" section in Settings, each showing a colored On/Off/Unknown pill. (Rendered mockup shared in the originating session.)

## Additional Notes

**Safety-biased mapping (important):** a false "Off" would defeat the feature's purpose (giving false confidence that overage is disabled). So the mapping only reports `.off` on positive proof and defaults to `.unknown` otherwise — it never shows a confident "Off" when the state is undetermined. This was hardened after an adversarial review caught the Codex path defaulting a missing `credits` object to "Off".

**Sandbox/keychain caveat for Claude (reviewer heads-up):** the app is sandboxed with no `keychain-access-groups` entitlement and can't join Claude Code's keychain access group, so reading the `"Claude Code-credentials"` item may fail in the notarized build → Claude's pill would show **"Unknown"** (Codex is unaffected; it uses a local-file token). Worth verifying in a sandboxed build. The read is intentionally **not** gated behind the legacy `ClaudeCodeEnableOAuthFallback` flag — that was a deliberate design choice (always-on querying) rather than an oversight.
