### PR TITLE
feat: surface Codex "reset available" (banked rate-limit resets)

### DIFF
--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -279,7 +279,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.shipshit.MeterBar.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -324,7 +324,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.shipshit.MeterBar.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -489,7 +489,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.shipshit.MeterBar;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -535,7 +535,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.shipshit.MeterBar;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MeterBar/Models/UsageMetrics.swift
+++ b/MeterBar/Models/UsageMetrics.swift
@@ -45,6 +45,9 @@ struct UsageMetrics: Codable, Identifiable {
     let weeklyLimit: UsageLimit?
     let codeReviewLimit: UsageLimit?
     let extraUsage: ExtraUsageStatus?
+    /// Number of banked rate-limit resets the account can trigger on demand.
+    /// Codex-only (OpenAI "reset credits"); `nil` for providers/accounts without the feature.
+    let resetCreditsAvailable: Int?
     let lastUpdated: Date
 
     init(
@@ -53,6 +56,7 @@ struct UsageMetrics: Codable, Identifiable {
         weeklyLimit: UsageLimit? = nil,
         codeReviewLimit: UsageLimit? = nil,
         extraUsage: ExtraUsageStatus? = nil,
+        resetCreditsAvailable: Int? = nil,
         lastUpdated: Date = Date()
     ) {
         self.id = UUID()
@@ -61,6 +65,7 @@ struct UsageMetrics: Codable, Identifiable {
         self.weeklyLimit = weeklyLimit
         self.codeReviewLimit = codeReviewLimit
         self.extraUsage = extraUsage
+        self.resetCreditsAvailable = resetCreditsAvailable
         self.lastUpdated = lastUpdated
     }
 
@@ -71,6 +76,7 @@ struct UsageMetrics: Codable, Identifiable {
         weeklyLimit: UsageLimit?,
         codeReviewLimit: UsageLimit?,
         extraUsage: ExtraUsageStatus?,
+        resetCreditsAvailable: Int?,
         lastUpdated: Date
     ) {
         self.id = id
@@ -79,10 +85,12 @@ struct UsageMetrics: Codable, Identifiable {
         self.weeklyLimit = weeklyLimit
         self.codeReviewLimit = codeReviewLimit
         self.extraUsage = extraUsage
+        self.resetCreditsAvailable = resetCreditsAvailable
         self.lastUpdated = lastUpdated
     }
 
-    /// Returns a copy with the given extra-usage status, preserving identity, limits, and timestamp.
+    /// Returns a copy with the given extra-usage status, preserving identity, limits,
+    /// reset credits, and timestamp.
     func withExtraUsage(_ status: ExtraUsageStatus?) -> UsageMetrics {
         UsageMetrics(
             id: id,
@@ -91,6 +99,7 @@ struct UsageMetrics: Codable, Identifiable {
             weeklyLimit: weeklyLimit,
             codeReviewLimit: codeReviewLimit,
             extraUsage: status,
+            resetCreditsAvailable: resetCreditsAvailable,
             lastUpdated: lastUpdated
         )
     }

--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -177,7 +177,8 @@ class CodexCliLocalService: ObservableObject {
                     sessionLimit: nil,
                     weeklyLimit: nil,
                     codeReviewLimit: nil,
-                    extraUsage: usageResponse.extraUsageStatus
+                    extraUsage: usageResponse.extraUsageStatus,
+                    resetCreditsAvailable: usageResponse.resetCreditsAvailable
                 )
             }
 
@@ -220,7 +221,8 @@ class CodexCliLocalService: ObservableObject {
                 sessionLimit: sessionLimit,
                 weeklyLimit: weeklyLimit,
                 codeReviewLimit: codeReviewLimit,
-                extraUsage: usageResponse.extraUsageStatus
+                extraUsage: usageResponse.extraUsageStatus,
+                resetCreditsAvailable: usageResponse.resetCreditsAvailable
             )
         } catch let urlError as URLError {
             let errorMessage: String
@@ -261,6 +263,7 @@ struct CodexCliUsageResponse: Codable {
     let codeReviewRateLimit: CodeReviewRateLimit?
     let credits: Credits?  // Can be null for free accounts
     let spendControl: SpendControl?
+    let rateLimitResetCredits: RateLimitResetCredits?
 
     enum CodingKeys: String, CodingKey {
         case planType = "plan_type"
@@ -268,6 +271,14 @@ struct CodexCliUsageResponse: Codable {
         case codeReviewRateLimit = "code_review_rate_limit"
         case credits
         case spendControl = "spend_control"
+        case rateLimitResetCredits = "rate_limit_reset_credits"
+    }
+
+    /// Number of banked "rate-limit resets" the account can trigger on demand
+    /// (OpenAI feature: save a quota reset and use it when you hit a limit).
+    /// `nil` when the field is absent/null — i.e. the account has none banked.
+    var resetCreditsAvailable: Int? {
+        rateLimitResetCredits?.availableCount
     }
 
     /// Maps the Codex credits/spend payload onto the shared extra-usage status.
@@ -352,6 +363,16 @@ struct SpendControl: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(reached, forKey: .reached)
         try container.encodeIfPresent(individualLimit, forKey: .individualLimit)
+    }
+}
+
+/// Banked rate-limit resets the account can trigger on demand, from the Codex usage API.
+struct RateLimitResetCredits: Codable {
+    /// How many resets are currently available to use. `nil` if absent/null.
+    let availableCount: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case availableCount = "available_count"
     }
 }
 

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -335,6 +335,7 @@ private struct PopoverProviderSnapshot: Identifiable {
     let limits: [PopoverLimit]
     let emptyDetail: String
     let extraUsage: ExtraUsageStatus?
+    let resetCreditsAvailable: Int?
 
     init(
         title: String,
@@ -350,6 +351,7 @@ private struct PopoverProviderSnapshot: Identifiable {
         self.updatedAt = metrics?.lastUpdated
         self.emptyDetail = emptyDetail
         self.extraUsage = metrics?.extraUsage
+        self.resetCreditsAvailable = metrics?.resetCreditsAvailable
         self.limits = [
             PopoverLimit(title: "Session", limit: metrics?.sessionLimit),
             PopoverLimit(title: "Weekly", limit: metrics?.weeklyLimit),
@@ -454,6 +456,20 @@ private struct PopoverProviderStatusCard: View {
                 )
             }
 
+            if let resetCount = snapshot.resetCreditsAvailable, resetCount > 0 {
+                HStack(spacing: 4) {
+                    Image(systemName: "arrow.clockwise.circle.fill")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(snapshot.accentColor)
+                    Text(Self.resetCreditsLabel(resetCount))
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.primary)
+                    Spacer(minLength: 4)
+                }
+                .help("\(Self.resetCreditsLabel(resetCount)) — banked quota resets you can trigger when you hit a rate limit.")
+            }
+
             if let extraUsage = snapshot.extraUsage {
                 HStack(spacing: 4) {
                     Image(systemName: "creditcard")
@@ -470,6 +486,11 @@ private struct PopoverProviderStatusCard: View {
         .padding(11)
         .frame(maxWidth: .infinity, minHeight: 124, alignment: .topLeading)
         .cardSurface()
+    }
+
+    /// "1 reset available" / "N resets available" — the count of banked rate-limit resets.
+    static func resetCreditsLabel(_ count: Int) -> String {
+        "\(count) reset\(count == 1 ? "" : "s") available"
     }
 
     private var updatedText: String {

--- a/MeterBarTests/CodexResetCreditsTests.swift
+++ b/MeterBarTests/CodexResetCreditsTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import MeterBar
+
+/// Tests for parsing and carrying Codex "banked rate-limit resets" — the
+/// `rate_limit_reset_credits.available_count` field on the wham/usage payload,
+/// surfaced in the UI as "N reset available".
+final class CodexResetCreditsTests: XCTestCase {
+    private func decode(_ json: String) throws -> CodexCliUsageResponse {
+        try JSONDecoder().decode(CodexCliUsageResponse.self, from: Data(json.utf8))
+    }
+
+    func testDecodesAvailableResetCount() throws {
+        let response = try decode(#"""
+        { "plan_type": "pro", "rate_limit": null, "rate_limit_reset_credits": { "available_count": 1 } }
+        """#)
+        XCTAssertEqual(response.resetCreditsAvailable, 1)
+    }
+
+    func testAbsentResetCreditsIsNil() throws {
+        let response = try decode(#"{ "plan_type": "pro", "rate_limit": null }"#)
+        XCTAssertNil(response.resetCreditsAvailable)
+    }
+
+    func testNullResetCreditsIsNil() throws {
+        let response = try decode(#"{ "plan_type": "pro", "rate_limit_reset_credits": null }"#)
+        XCTAssertNil(response.resetCreditsAvailable)
+    }
+
+    func testNullAvailableCountIsNil() throws {
+        let response = try decode(#"{ "plan_type": "pro", "rate_limit_reset_credits": { "available_count": null } }"#)
+        XCTAssertNil(response.resetCreditsAvailable)
+    }
+
+    /// Mirrors the real wham/usage payload, including fields the app does not model
+    /// (`additional_rate_limits`, `spend_control`, `promo`) to prove forward-compatible
+    /// decoding doesn't break when ChatGPT adds keys.
+    func testDecodesAlongsideUnknownFields() throws {
+        let response = try decode(#"""
+        {
+          "plan_type": "pro",
+          "rate_limit": {
+            "allowed": true, "limit_reached": false,
+            "primary_window": { "used_percent": 0, "limit_window_seconds": 18000, "reset_after_seconds": 18000, "reset_at": 1781959611 },
+            "secondary_window": { "used_percent": 35, "limit_window_seconds": 604800, "reset_after_seconds": 426296, "reset_at": 1782367907 }
+          },
+          "additional_rate_limits": [ { "limit_name": "GPT-5.3-Codex-Spark", "metered_feature": "codex_bengalfox", "rate_limit": null } ],
+          "credits": { "has_credits": false, "unlimited": false, "overage_limit_reached": false, "balance": "0" },
+          "spend_control": { "reached": false, "individual_limit": null },
+          "promo": null,
+          "rate_limit_reset_credits": { "available_count": 1 }
+        }
+        """#)
+        XCTAssertEqual(response.resetCreditsAvailable, 1)
+        XCTAssertEqual(response.rateLimit?.secondaryWindow?.usedPercent, 35)
+    }
+
+    func testUsageMetricsCarriesResetCredits() {
+        let metrics = UsageMetrics(service: .codexCli, resetCreditsAvailable: 2)
+        XCTAssertEqual(metrics.resetCreditsAvailable, 2)
+
+        // withExtraUsage must preserve the reset-credit count alongside the new status.
+        let updated = metrics.withExtraUsage(.unknown)
+        XCTAssertEqual(updated.resetCreditsAvailable, 2)
+        XCTAssertEqual(updated.extraUsage, .unknown)
+    }
+
+    func testUsageMetricsResetCreditsDefaultsNil() {
+        XCTAssertNil(UsageMetrics(service: .claudeCode).resetCreditsAvailable)
+    }
+}


### PR DESCRIPTION
## Why

Codex/ChatGPT paid plans can **bank rate-limit resets** and trigger one when they hit a limit (OpenAI feature, announced 2026-06-12). The `wham/usage` payload MeterBar already fetches each refresh carries this as `rate_limit_reset_credits.available_count` — but it was unparsed, so the popover never showed it. This is the "1 reset available" users see in ChatGPT's own usage menu.

Verified live against the real endpoint (`available_count: 1`).

## What changed

| Layer | Change |
|---|---|
| **Model** | New `RateLimitResetCredits` + `CodexCliUsageResponse.resetCreditsAvailable` (`MeterBar/Services/CodexCliLocalService.swift`) |
| **Metrics** | New `UsageMetrics.resetCreditsAvailable: Int?`, preserved through `withExtraUsage` |
| **Service** | Threaded into both `UsageMetrics` returns (normal + free-account paths) |
| **UI** | "**N reset available**" badge on the Codex popover card, shown only when `> 0`, next to the existing Extra-usage row (`MenuBarView.swift`) |
| **Version** | `MARKETING_VERSION` 1.3 → 1.4 (ships this feature; also distinguishes from the pre-redesign 1.3 build) |

## Claude has no equivalent

I probed `api.anthropic.com/api/oauth/usage` live — its payload has no reset-credit field (only `five_hour`/`seven_day`/`seven_day_sonnet`/`extra_usage`/`limits[]`/`spend`). So this is **Codex-only** by necessity.

## Tests

TDD per the repo policy — 7 new tests in `MeterBarTests/CodexResetCreditsTests.swift` (decode present/absent/null, forward-compat with unknown fields like `additional_rate_limits`, and `UsageMetrics` carry/`withExtraUsage` preservation). Full unit suite: **96/96 green** (`swift test --skip APIIntegrationTests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visibility of banked on-demand rate-limit reset credits in the menu bar. The interface now displays available reset counts per provider with proper singular/plural formatting and informational tooltips for additional context.

* **Chores**
  * Updated application version to 1.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->