### PR TITLE
Single-column popover cards, dim exhausted providers, narrower popover

### DIFF
--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -35,7 +35,7 @@ enum ProviderLogoKind: Equatable {
 }
 
 struct MenuBarView: View {
-    private let popoverWidth: CGFloat = 430
+    private let popoverWidth: CGFloat = 390
     private let maxPopoverHeight: CGFloat = 560
     private let minPopoverHeight: CGFloat = 180
     private let chromeHeight: CGFloat = 56
@@ -300,7 +300,7 @@ struct PopoverOverviewPanel: View {
             .padding(12)
             .cardSurface()
 
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 2), spacing: 10) {
+            VStack(spacing: 8) {
                 ForEach(snapshots) { snapshot in
                     PopoverProviderStatusCard(snapshot: snapshot)
                 }
@@ -413,6 +413,11 @@ private struct PopoverProviderStatusCard: View {
         return "Healthy"
     }
 
+    private var isOut: Bool {
+        guard let primaryLimit else { return false }
+        return primaryLimit.percentLeft <= 0
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 7) {
@@ -469,6 +474,7 @@ private struct PopoverProviderStatusCard: View {
         }
         .padding(11)
         .frame(maxWidth: .infinity, minHeight: 124, alignment: .topLeading)
+        .opacity(isOut ? 0.72 : 1)
         .cardSurface()
     }
 


### PR DESCRIPTION
## What

Three UI tweaks salvaged from the local native-redesign WIP branch. The rest of that WIP was superseded by #36 (native Liquid Glass); these three are genuine improvements master was missing, and they layer cleanly on top of #36/#35.

- **Single-column provider cards** — `VStack` instead of the 2-column `LazyVGrid`. Now that #35 gives each card its own per-window bars (Session / Weekly / third), full-width stacked cards read better than two ~190px columns.
- **Dim exhausted providers** — a provider card fades to 0.72 opacity when its quota is spent (`isOut`).
- **Narrower popover** — 430 → 390, pairing with the single-column layout.

## Verification

- `xcodebuild ... build` (the CI gate) — **BUILD SUCCEEDED**
- Diff is 8 insertions / 2 deletions, all in `MenuBarView.swift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized popover width for improved interface fit
  * Reorganized provider cards layout for better display
  * Added visual dimming for inactive providers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->