### PR TITLE
ci: fail + validate the homebrew sha256 download

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -27,16 +27,27 @@ jobs:
           fi
           # Remove 'v' prefix for formula version
           FORMULA_VERSION="${VERSION#v}"
-          echo "tag=$VERSION" >> $GITHUB_OUTPUT
-          echo "formula=$FORMULA_VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "formula=$FORMULA_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Download SHA256
         run: |
+          set -euo pipefail
           VERSION="${{ steps.version.outputs.tag }}"
-          curl -sL "https://github.com/VincentShipsIt/meterbar.app/releases/download/${VERSION}/MeterBar-${VERSION}.zip.sha256" -o sha256.txt
-          SHA256=$(cat sha256.txt)
+          # --fail so a missing/404 asset is an error (not a 0-exit with an HTML error body),
+          # mirroring secret-scan.yml's curl usage.
+          curl --fail --location --silent --show-error \
+            "https://github.com/VincentShipsIt/meterbar.app/releases/download/${VERSION}/MeterBar-${VERSION}.zip.sha256" \
+            -o sha256.txt
+          # Validate the payload is a bare 64-hex SHA256 before it is written into the cask;
+          # otherwise an unexpected body would be committed as the hash and break `brew install`.
+          SHA256=$(tr -d '[:space:]' < sha256.txt)
+          if [[ ! "$SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::Downloaded sha256 is not a valid 64-hex digest: '$SHA256'" >&2
+            exit 1
+          fi
           echo "SHA256: $SHA256"
-          echo "sha256=$SHA256" >> $GITHUB_OUTPUT
+          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
         id: sha
 
       - name: Checkout homebrew-tap


### PR DESCRIPTION
## Description

Hardens the **"Download SHA256"** step in [`.github/workflows/update-homebrew.yml`](.github/workflows/update-homebrew.yml), which consumes the `MeterBar-<tag>.zip.sha256` sidecar produced by `release.yml` and writes it into the Homebrew cask.

It fetched the hash with `curl -sL` (no `--fail`) and used the body verbatim. On a missing/404 asset — e.g. a `workflow_dispatch` run with a mistyped `version`, an asset-name mismatch, or assets not yet propagated — `curl` exits **0** and writes the error/HTML body into `sha256.txt`. That body is then `sed`'d straight into `Casks/meterbar.rb` and committed+pushed, publishing a cask whose `sha256` no longer matches the real artifact, so **every `brew install` fails checksum verification** — with no failure surfaced in the pipeline.

This matters more now that [#43](https://github.com/VincentShipsIt/meterbar.app/pull/43) computes that hash on the **final notarized + stapled** artifact: a silently-corrupted hash would defeat the integrity guarantee that change establishes. Surfaced by the adversarial review of #43.

## Change

- `set -euo pipefail`.
- `curl --fail --location --silent --show-error` (a 4xx/5xx now fails the step) — mirrors the pattern already in `secret-scan.yml`.
- Validate the payload is a bare 64‑hex SHA256 (`^[0-9a-f]{64}$`, whitespace-trimmed) before it's used; fail with a clear `::error::` otherwise.
- Quote the adjacent `$GITHUB_OUTPUT` redirects in the "Get version" step (shellcheck SC2086), so the file lints clean.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `actionlint` (with embedded `shellcheck`) — **clean** on the whole file.
- Self-tested the validation locally: accepts a 64-hex digest (incl. trailing whitespace), rejects `Not Found`, an HTML error body, and an uppercase string (`shasum` emits lowercase).

No behavior change on the happy path (the `release: published` trigger uploads the asset before publishing, so the fetch succeeds and the 64‑hex value passes straight through). It only changes the failure path: a bad/missing asset now **fails loudly** instead of poisoning the cask.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (`actionlint` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)