### PR TITLE
build: drop stale "Widget" exclude from MeterBar SwiftPM target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,6 @@ let package = Package(
             dependencies: [],
             path: "MeterBar",
             exclude: [
-                "Widget",
                 "App/MeterBarApp.swift",
                 "Info.plist",
                 "MeterBar.entitlements",


### PR DESCRIPTION
## What

Remove the dead `"Widget"` entry from the `MeterBar` target's `exclude:` array in `Package.swift`.

## Why

There is no `MeterBar/Widget` path. The widget lives in the separate `MeterBarWidget/` target (an Xcode-project target, excluded from the SwiftPM `MeterBar` path). Because the excluded path doesn't exist, SwiftPM emitted this warning on **every** `swift build` / `swift package describe`:

```
warning: Invalid Exclude '.../MeterBar/Widget': File not found.
```

This is the remaining stale exclude in that array (the sibling cleanup dropped the dangling `"App/MeterBar.entitlements"` entry).

## Verification

| Check | Before | After |
| --- | --- | --- |
| `swift build` | `Build complete!` + 1 Invalid Exclude warning | `Build complete!`, **0 warnings** |
| `swift package describe` | Invalid Exclude warning | **clean** (no warnings) |
| `xcodebuild -scheme MeterBar -configuration Debug` (ad-hoc sign) | — | **`** BUILD SUCCEEDED **`** (MeterBar + MeterBarWidgetExtension) |

Diff is a single line:

```diff
             exclude: [
-                "Widget",
                 "App/MeterBarApp.swift",
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)