### PR TITLE
ci: defer Developer ID signing — restore unsigned release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,28 +5,12 @@ on:
     tags:
       - 'v*'
 
-# Deny-by-default at the top level; the single job elevates to contents: write
-# only because it publishes a GitHub release.
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: macos-26
-    timeout-minutes: 60
+    timeout-minutes: 45
     permissions:
       contents: write
-
-    env:
-      # Apple Developer Team identifier (documentation / disambiguation only;
-      # the actual signing identity is resolved dynamically from the keychain).
-      TEAMID: S329JK3JRB
-      # notarytool keychain-profile name (stored in the temp keychain at runtime).
-      NOTARY_PROFILE: asc-profile
-      # The pushed tag, surfaced as an env var so it is never expanded straight into a
-      # shell `run:` block (a malicious tag like `v1$(...)` would otherwise inject commands
-      # into a job that handles signing secrets). Shell steps reference "$REF_NAME".
-      REF_NAME: ${{ github.ref_name }}
 
     steps:
       - name: Checkout
@@ -38,49 +22,6 @@ jobs:
       - name: Show Xcode version
         run: xcodebuild -version
 
-      # Resolve ephemeral file paths under RUNNER_TEMP (outside the workspace) and export
-      # them for later steps. The `runner` context is NOT available in job-level `env:`,
-      # so these are computed here where $RUNNER_TEMP is a real shell variable, then
-      # written fully-resolved into $GITHUB_ENV.
-      - name: Configure signing paths
-        run: |
-          {
-            echo "CERT_PATH=$RUNNER_TEMP/build_certificate.p12"
-            echo "ASC_KEY_PATH=$RUNNER_TEMP/asc_api_key.p8"
-            echo "KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db"
-            echo "KEYCHAIN_LIST_BACKUP=$RUNNER_TEMP/original-keychains.list"
-          } >> "$GITHUB_ENV"
-
-      # 0) PREFLIGHT: fail FAST (before any build work) if any required signing secret is
-      #    missing. Releases must be signed + notarized, so an absent secret is fatal.
-      #    We only check presence (non-empty), never print values.
-      - name: Preflight - require signing secrets
-        env:
-          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-          ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
-          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
-        run: |
-          set -euo pipefail
-          missing=()
-          for name in BUILD_CERTIFICATE_BASE64 P12_PASSWORD KEYCHAIN_PASSWORD \
-                      ASC_API_KEY_BASE64 ASC_KEY_ID ASC_ISSUER_ID; do
-            # Indirect expansion: read the env var named in $name without echoing its value.
-            if [ -z "${!name:-}" ]; then
-              missing+=("$name")
-            fi
-          done
-          if [ "${#missing[@]}" -ne 0 ]; then
-            echo "::error::Missing required signing secret(s): ${missing[*]}" >&2
-            echo "Add them under Settings > Secrets and variables > Actions, then re-run." >&2
-            exit 1
-          fi
-          echo "All required signing secrets are present."
-
-      # 1) Build the app UNSIGNED exactly as before. Signing is done by hand later,
-      #    inside-out, after the CLI helper is injected.
       - name: Build app
         run: |
           xcodebuild -project MeterBar.xcodeproj \
@@ -93,7 +34,6 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             build
 
-      # 2) Build the CLI helper and inject it into Contents/Helpers (kept as today).
       - name: Build CLI
         run: |
           cd MeterBarCLI
@@ -101,273 +41,30 @@ jobs:
           mkdir -p ../build/Build/Products/Release/MeterBar.app/Contents/Helpers
           cp .build/release/meterbar ../build/Build/Products/Release/MeterBar.app/Contents/Helpers/
 
-      # 3) Import the Developer ID cert + private key into a DEDICATED temporary keychain,
-      #    and store the notarization API key profile in that same keychain.
-      - name: Import signing assets
-        env:
-          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-          ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
-          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
-        run: |
-          set -euo pipefail
-
-          # Decode straight to disk; -o avoids piping secret bytes through stdout/logs.
-          # macOS base64 does not line-wrap by default, so single-line blobs decode cleanly.
-          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o "$CERT_PATH"
-          echo -n "$ASC_API_KEY_BASE64"       | base64 --decode -o "$ASC_KEY_PATH"
-
-          # Capture the ORIGINAL user keychain search list so cleanup can restore it exactly,
-          # rather than assuming a hardcoded default that might differ on this runner image.
-          security list-keychains -d user | tr -d '"' | sed 's/^[[:space:]]*//' > "$KEYCHAIN_LIST_BACKUP"
-
-          # DEDICATED temporary keychain.
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          # -l lock on sleep, -u lock on timeout, -t 21600 = 6h. Bounds key reachability.
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          # Import the identity (cert + private key) from the .p12. Do NOT pass -t cert:
-          # that would import only the certificate and drop the private key, leaving an
-          # unusable identity. -T whitelists codesign/security to use the key headlessly.
-          security import "$CERT_PATH" \
-            -P "$P12_PASSWORD" \
-            -f pkcs12 \
-            -k "$KEYCHAIN_PATH" \
-            -T /usr/bin/codesign -T /usr/bin/security
-
-          # Add temp keychain to the USER search list WITHOUT clobbering login.keychain.
-          # Word-splitting of the existing list into separate args is intentional.
-          # shellcheck disable=SC2046
-          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
-
-          # CRITICAL: authorize non-interactive key access. Without this, codesign on a
-          # headless runner triggers the keychain ACL GUI prompt -> errSecInternalComponent
-          # or an indefinite hang. -T on import alone is NOT sufficient.
-          security set-key-partition-list \
-            -S apple-tool:,apple:,codesign: \
-            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          # HARD GATE: exactly ONE Developer ID Application identity must be present in the
-          # temp keychain. Zero -> nothing to sign with. More than one -> ambiguous .p12,
-          # codesign could silently pick the wrong cert. Fail fast either way.
-          COUNT=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
-            | grep -c "Developer ID Application" || true)
-          echo "Developer ID Application identities found: $COUNT"
-          if [ "$COUNT" -ne 1 ]; then
-            echo "::error::Expected exactly 1 Developer ID Application identity in the temp keychain, found $COUNT." >&2
-            security find-identity -v -p codesigning "$KEYCHAIN_PATH" >&2 || true
-            exit 1
-          fi
-
-          # Store notarization creds in the disposable keychain (validates them immediately,
-          # and they vanish when the keychain is deleted in cleanup). Non-interactive when
-          # all of --key/--key-id/--issuer are supplied.
-          xcrun notarytool store-credentials "$NOTARY_PROFILE" \
-            --key "$ASC_KEY_PATH" \
-            --key-id "$ASC_KEY_ID" \
-            --issuer "$ASC_ISSUER_ID" \
-            --keychain "$KEYCHAIN_PATH"
-
-      # 4) Sign INSIDE-OUT by hand: frameworks (defensive) -> helper -> appex -> outer app.
-      #    No --deep at sign time. Per-target entitlements keep the widget SANDBOXED and the
-      #    main app NON-sandboxed. Only Apple system frameworks are linked and
-      #    swift-argument-parser is statically linked into the meterbar Mach-O, so there are
-      #    NO embedded dylibs to sign today; the Frameworks loop below is a defensive no-op.
-      - name: Codesign (inside-out)
-        id: codesign
-        env:
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-        run: |
-          set -euo pipefail
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          # Resolve the exact Developer ID Application identity by its SHA-1 hash from OUR
-          # keychain ONLY (codesign accepts a hash), so it cannot pick a same-named cert from
-          # another keychain and we never hardcode a CN that may not match the real cert.
-          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
-            | grep "Developer ID Application" | head -1 | awk '{print $2}')
-          if [ -z "${IDENTITY:-}" ]; then
-            echo "::error::No Developer ID Application identity found in $KEYCHAIN_PATH" >&2
-            exit 1
-          fi
-          echo "Using signing identity (SHA-1): $IDENTITY"
-
-          APP_PATH=$(find build -name "MeterBar.app" -type d | head -1)
-          if [ -z "${APP_PATH:-}" ]; then
-            echo "::error::MeterBar.app not found under build/" >&2
-            exit 1
-          fi
-          echo "App: $APP_PATH"
-          echo "app_path=$APP_PATH" >> "$GITHUB_OUTPUT"
-
-          APPEX="$APP_PATH/Contents/PlugIns/MeterBarWidgetExtension.appex"
-          if [ ! -d "$APPEX" ]; then
-            echo "::error::Widget extension not found at $APPEX" >&2
-            exit 1
-          fi
-          HELPER="$APP_PATH/Contents/Helpers/meterbar"
-          if [ ! -f "$HELPER" ]; then
-            echo "::error::Injected helper not found at $HELPER" >&2
-            exit 1
-          fi
-
-          sign() {
-            # $1 = path, remaining args = extra flags (e.g. --entitlements <file>)
-            local target="$1"; shift
-            codesign --force --timestamp --options runtime \
-              --keychain "$KEYCHAIN_PATH" \
-              --sign "$IDENTITY" "$@" \
-              "$target"
-          }
-
-          # 4a) Defensive: any embedded frameworks/dylibs in the OUTER app (deepest first).
-          #     Expected to be empty (only system frameworks are linked). Frameworks take
-          #     NO entitlements.
-          if [ -d "$APP_PATH/Contents/Frameworks" ]; then
-            while IFS= read -r -d '' fw; do
-              echo "Signing app framework: $fw"
-              sign "$fw"
-            done < <(find "$APP_PATH/Contents/Frameworks" -maxdepth 1 \( -name '*.framework' -o -name '*.dylib' \) -print0)
-          fi
-
-          # 4b) The INJECTED CLI helper (a bare Mach-O). MUST be signed with hardened runtime;
-          #     no entitlements needed.
-          sign "$HELPER"
-
-          # 4c) The widget extension - SANDBOXED via its own entitlements file.
-          sign "$APPEX" --entitlements MeterBarWidget/MeterBarWidget.entitlements
-
-          # 4d) The OUTER .app LAST - NON-sandboxed via the main app entitlements. This
-          #     re-seals over the injected helper + appex (the original Xcode signature is
-          #     stale since the helper was added post-build).
-          sign "$APP_PATH" --entitlements MeterBar/MeterBar.entitlements
-
-      # 5) HARD GATE on the per-target entitlement split BEFORE notarizing. The widget appex
-      #    MUST be sandboxed; the main app MUST NOT be sandboxed. Parse the signed-in
-      #    entitlements as clean XML and read the key with PlistBuddy (dotted entitlement
-      #    keys are literal after ':'), which is robust vs. text grepping the single-line XML.
-      - name: Verify entitlement split
-        run: |
-          set -euo pipefail
-          APP_PATH="${{ steps.codesign.outputs.app_path }}"
-          APPEX="$APP_PATH/Contents/PlugIns/MeterBarWidgetExtension.appex"
-          APPEX_ENT="$RUNNER_TEMP/appex.entitlements.plist"
-          APP_ENT="$RUNNER_TEMP/app.entitlements.plist"
-
-          # Dump signed-in entitlements as clean XML; keep stderr so a codesign failure is
-          # diagnosable, and guard against an empty/partial dump confusing the PlistBuddy read.
-          codesign -d --entitlements - --xml "$APPEX" > "$APPEX_ENT" 2> "$RUNNER_TEMP/appex.codesign.err" \
-            || { echo "::error::codesign -d failed for the widget extension"; cat "$RUNNER_TEMP/appex.codesign.err" >&2; exit 1; }
-          codesign -d --entitlements - --xml "$APP_PATH" > "$APP_ENT" 2> "$RUNNER_TEMP/app.codesign.err" \
-            || { echo "::error::codesign -d failed for the main app"; cat "$RUNNER_TEMP/app.codesign.err" >&2; exit 1; }
-          [ -s "$APPEX_ENT" ] || { echo "::error::Empty entitlements dump for the widget extension." >&2; exit 1; }
-          [ -s "$APP_ENT" ]   || { echo "::error::Empty entitlements dump for the main app." >&2; exit 1; }
-
-          echo "::group::Widget extension entitlements"; plutil -p "$APPEX_ENT" || true; echo "::endgroup::"
-          echo "::group::Main app entitlements"; plutil -p "$APP_ENT" || true; echo "::endgroup::"
-
-          # Widget MUST be sandboxed.
-          APPEX_SANDBOX=$(/usr/libexec/PlistBuddy -c "Print :com.apple.security.app-sandbox" "$APPEX_ENT" 2>/dev/null || echo "absent")
-          if [ "$APPEX_SANDBOX" != "true" ]; then
-            echo "::error::Widget extension is NOT sandboxed (app-sandbox=$APPEX_SANDBOX)." >&2
-            exit 1
-          fi
-
-          # Main app MUST NOT be sandboxed (absent or false are both acceptable).
-          APP_SANDBOX=$(/usr/libexec/PlistBuddy -c "Print :com.apple.security.app-sandbox" "$APP_ENT" 2>/dev/null || echo "absent")
-          if [ "$APP_SANDBOX" = "true" ]; then
-            echo "::error::Main app is unexpectedly sandboxed (app-sandbox=true)." >&2
-            exit 1
-          fi
-
-          echo "Entitlement split verified: widget sandboxed (app-sandbox=$APPEX_SANDBOX), main app not sandboxed (app-sandbox=$APP_SANDBOX)."
-
-      # 6) Notarize the signed app, then staple the ticket onto the .app bundle.
-      #    notarytool submit --wait blocks on Apple's servers. The inner '--timeout 40m'
-      #    bounds the wait so an Apple-side backlog fails clearly (with a poll-able
-      #    submission id) instead of silently consuming the whole 60-min job timeout.
-      - name: Notarize and staple
-        env:
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-        run: |
-          set -euo pipefail
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          APP_PATH="${{ steps.codesign.outputs.app_path }}"
-          SUBMIT_ZIP="$RUNNER_TEMP/MeterBar-notarize.zip"
-
-          # A bare .app must be zipped with ditto for a ticket-compatible archive.
-          ditto -c -k --keepParent "$APP_PATH" "$SUBMIT_ZIP"
-
-          # Submit and block until Apple finishes; capture JSON to read id/status.
-          set +e
-          SUBMIT_OUT=$(xcrun notarytool submit "$SUBMIT_ZIP" \
-            --keychain-profile "$NOTARY_PROFILE" \
-            --keychain "$KEYCHAIN_PATH" \
-            --timeout 40m \
-            --wait --output-format json)
-          SUBMIT_RC=$?
-          set -e
-          echo "$SUBMIT_OUT"
-
-          SUBID=$(echo "$SUBMIT_OUT" | /usr/bin/python3 -c 'import sys,json;print(json.load(sys.stdin).get("id",""))' 2>/dev/null || true)
-          STATUS=$(echo "$SUBMIT_OUT" | /usr/bin/python3 -c 'import sys,json;print(json.load(sys.stdin).get("status",""))' 2>/dev/null || true)
-          echo "Notarization id=$SUBID status=$STATUS rc=$SUBMIT_RC"
-
-          if [ "$STATUS" != "Accepted" ] || [ "$SUBMIT_RC" -ne 0 ]; then
-            echo "::error::Notarization did not succeed (status=$STATUS rc=$SUBMIT_RC). Pulling detailed log." >&2
-            if [ -n "${SUBID:-}" ]; then
-              xcrun notarytool log "$SUBID" \
-                --keychain-profile "$NOTARY_PROFILE" \
-                --keychain "$KEYCHAIN_PATH" \
-                "$RUNNER_TEMP/developer_log.json" || true
-              cat "$RUNNER_TEMP/developer_log.json" || true
-            fi
-            exit 1
-          fi
-
-          # Staple the ticket onto the bundle (cannot staple a .zip).
-          xcrun stapler staple "$APP_PATH"
-
-      # 7) Verify Gatekeeper acceptance + signature integrity + stapled ticket. Fail on error.
-      - name: Verify signature, Gatekeeper, and staple
-        run: |
-          set -euo pipefail
-          APP_PATH="${{ steps.codesign.outputs.app_path }}"
-
-          echo "::group::spctl assessment (type execute)"
-          spctl --assess --type execute --verbose=4 "$APP_PATH"
-          echo "::endgroup::"
-
-          echo "::group::codesign --verify --deep --strict"
-          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
-          echo "::endgroup::"
-
-          echo "::group::stapler validate"
-          xcrun stapler validate "$APP_PATH"
-          echo "::endgroup::"
-
-      # 8) Re-zip the STAPLED bundle and compute the SHA256 on that FINAL artifact (this is
-      #    what the Homebrew cask consumes via MeterBar-<version>.zip.sha256). The pre-staple
-      #    zip differs byte-for-byte, so the SHA must be computed here, after stapling.
       - name: Create release package
-        id: package
         run: |
-          set -euo pipefail
-          VERSION="$REF_NAME"
-          APP_PATH="${{ steps.codesign.outputs.app_path }}"
+          VERSION="${{ github.ref_name }}"
 
-          ZIP="${{ github.workspace }}/MeterBar-${VERSION}.zip"
-          ditto -c -k --keepParent "$APP_PATH" "$ZIP"
+          # Find the built app
+          APP_PATH=$(find build -name "MeterBar.app" -type d | head -1)
+          echo "Found app at: $APP_PATH"
 
-          SHA256=$(shasum -a 256 "$ZIP" | cut -d ' ' -f 1)
+          # Create zip using ditto (preserves attributes better than zip)
+          cd $(dirname "$APP_PATH")
+          ditto -c -k --keepParent "MeterBar.app" "MeterBar-${VERSION}.zip"
+
+          # Compute SHA256
+          SHA256=$(shasum -a 256 "MeterBar-${VERSION}.zip" | cut -d ' ' -f 1)
           echo "SHA256: $SHA256"
-          echo "$SHA256" > "${ZIP}.sha256"
+          echo "$SHA256" > "MeterBar-${VERSION}.zip.sha256"
 
-          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
+          # Move to workspace root
+          mv "MeterBar-${VERSION}.zip" "${{ github.workspace }}/"
+          mv "MeterBar-${VERSION}.zip.sha256" "${{ github.workspace }}/"
+
+          # Set output for later steps
+          echo "sha256=$SHA256" >> $GITHUB_OUTPUT
+        id: package
 
       - name: Create Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
@@ -383,28 +80,6 @@ jobs:
 
       - name: Output SHA256
         run: |
-          {
-            echo "### Release Artifacts"
-            echo ""
-            echo "**SHA256:** \`$(cat "MeterBar-${REF_NAME}.zip.sha256")\`"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      # 9) Cleanup - ALWAYS, even on failure. Remove the temp keychain + decoded secrets,
-      #    restore the ORIGINAL captured user keychain search list. Never leak secrets.
-      - name: Clean up keychain and secret files
-        if: ${{ always() }}
-        run: |
-          security delete-keychain "$KEYCHAIN_PATH" || true
-          # Restore the exact original user search list captured before we modified it.
-          if [ -f "$KEYCHAIN_LIST_BACKUP" ] && [ -s "$KEYCHAIN_LIST_BACKUP" ]; then
-            # shellcheck disable=SC2046
-            security list-keychains -d user -s $(cat "$KEYCHAIN_LIST_BACKUP") || true
-          else
-            security list-keychains -d user -s login.keychain-db || true
-          fi
-          rm -f "$CERT_PATH" "$ASC_KEY_PATH" \
-                "$RUNNER_TEMP/MeterBar-notarize.zip" \
-                "$RUNNER_TEMP/developer_log.json" \
-                "$RUNNER_TEMP/appex.entitlements.plist" "$RUNNER_TEMP/app.entitlements.plist" \
-                "$RUNNER_TEMP/appex.codesign.err" "$RUNNER_TEMP/app.codesign.err" \
-                "$KEYCHAIN_LIST_BACKUP" || true
+          echo "### Release Artifacts" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**SHA256:** \`$(cat MeterBar-${{ github.ref_name }}.zip.sha256)\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Description

Reverts the Developer ID signing/notarization pipeline from #43 and restores the previous **unsigned / ad-hoc** release pipeline. Signing is **deferred**, tracked in #47.

## Why

We distribute via **Homebrew Cask**, which strips the `com.apple.quarantine` attribute on install — so an unsigned/ad-hoc app launches without a Gatekeeper prompt. `brew install` works fine without signing. The signed pipeline (#43) also *fails fast* when the six signing secrets are absent, which would block releases until those are configured; we're not ready to set them up yet.

Re-enabling later is a re-apply of #43 + adding the secrets — fully documented in #47.

## Trade-offs accepted for now (see #47)
- Keychain access grant re-prompts on each update (ad-hoc signature changes every build).
- No hardened-runtime posture; direct (non-brew) downloads would hit Gatekeeper warnings.

## Scope

Single file: restores `.github/workflows/release.yml` to its pre-#43 state (unsigned `xcodebuild` + `ditto` zip). No other files touched.

Closes nothing; tracked by #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)