### PR TITLE
ci: auto-bump Homebrew cask on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,3 +83,13 @@ jobs:
           echo "### Release Artifacts" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**SHA256:** \`$(cat MeterBar-${{ github.ref_name }}.zip.sha256)\`" >> $GITHUB_STEP_SUMMARY
+
+  # After the release is published, bump the Homebrew cask in VincentShipsIt/homebrew-tap.
+  # Called directly (not via `release: published`) because GITHUB_TOKEN-created releases
+  # do not cascade-trigger workflows — so this guarantees the tap always tracks the release.
+  update-homebrew:
+    needs: build
+    uses: ./.github/workflows/update-homebrew.yml
+    with:
+      version: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,8 +1,17 @@
 name: Update Homebrew
 
 on:
-  release:
-    types: [published]
+  # Called automatically by the Release workflow after it publishes a tag.
+  # (A `release: published` trigger does NOT work here: the release is created
+  # by the Release job's GITHUB_TOKEN, and GitHub will not cascade-trigger
+  # workflows from that token — so the tap would silently never update.)
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to update (e.g., v1.0.0)'
+        required: true
+        type: string
+  # Manual fallback / re-run.
   workflow_dispatch:
     inputs:
       version:
@@ -20,11 +29,8 @@ jobs:
       - name: Get version
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
-          else
-            VERSION="${{ github.event.release.tag_name }}"
-          fi
+          # `inputs.version` is populated for both workflow_call and workflow_dispatch.
+          VERSION="${{ inputs.version }}"
           # Remove 'v' prefix for formula version
           FORMULA_VERSION="${VERSION#v}"
           echo "tag=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why

The `Update Homebrew` workflow listens on `release: published`, but a release created by the Release job's `GITHUB_TOKEN` **does not cascade-trigger** other workflows (GitHub's recursion guard). So after every release the tap silently failed to update and had to be dispatched by hand (e.g. v1.4).

## What

- **`update-homebrew.yml`** → reusable: add `workflow_call` (with a `version` input), keep `workflow_dispatch` as a manual fallback, drop the dead `release: published` trigger. Version now read from `inputs.version` (works for both). The hardened sha256 download (#45) is unchanged.
- **`release.yml`** → after the release publishes, a new `update-homebrew` job (`needs: build`) calls the reusable workflow with `version: ${{ github.ref_name }}` and `secrets: inherit`.

Result: one `git push origin vX.Y` does **build → publish → tap bump** end to end, no manual step, no fragile cross-workflow trigger.

## Validation

- `actionlint` clean on the reusable-workflow wiring (only pre-existing shellcheck style nits in the untouched build-job scripts remain).
- Both YAMLs parse.
- Required `build` check unaffected (workflow-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)