### PR TITLE
Refine Costs refresh locking behavior

### DIFF
--- a/.agents/SESSIONS/2026-06-23.md
+++ b/.agents/SESSIONS/2026-06-23.md
@@ -1,0 +1,37 @@
+# Sessions: 2026-06-23
+
+**Summary:** Cost refresh local lock behavior
+
+---
+
+## Session 1: Lock Costs Content During Refresh
+
+**Duration:** ~20 minutes
+**Status:** Complete
+
+### What was done
+
+- Checked the MacSweep scan/refresh pattern: keep existing results rendered, show local progress, and avoid blocking unrelated navigation/actions.
+- Updated the Costs dashboard refresh so it keeps the current cost content visible and overlays a local lock/progress scrim while local logs are scanned.
+- Changed dashboard refresh-button disabling so a cost scan disables the Costs refresh action only when the Costs section is active, instead of globally disabling refresh elsewhere.
+- Kept the Overview cost card's total cost stable during scans when cached cost data exists.
+
+### Files changed
+
+- `MeterBar/Views/UsageDashboardView.swift` - Local cost-refresh lock overlay, stable scan rendering, and section-aware refresh disabling.
+
+### Decisions
+
+- Used a local overlay on the Costs card rather than replacing the whole page with a loading chart, matching MacSweep's "content owns its scan state" behavior.
+- Left the `CostTracker` background scan path unchanged because it already builds summaries off the main actor and the compile/tests passed.
+
+### Verification
+
+- `swift build` passed.
+- `swift test` passed: 102 tests, 2 skipped for missing Admin API keys, 0 failures.
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` passed.
+- `git diff --check` passed.
+
+### Next steps
+
+- [ ] Manual UI smoke test: open Costs, refresh with existing data, confirm only the Costs card is locked while sidebar/window interactions remain responsive.

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -105,7 +105,7 @@ struct UsageDashboardView: View {
                         Label("Refresh", systemImage: "arrow.clockwise")
                     }
                     .help("Refresh usage")
-                    .disabled(dataManager.isLoading || costTracker.isScanning)
+                    .disabled(isRefreshButtonDisabled)
                 }
             }
         }
@@ -197,7 +197,7 @@ struct UsageDashboardView: View {
                         .foregroundColor(.secondary)
 
                     if costTracker.isScanning {
-                        costScanChart(height: 220, compact: false)
+                        costScanChart(height: 220, compact: false, showsProgressBadge: false)
                     } else if let summary = visibleCostSummary {
                         DailyUsageChart(dailyUsage: summary.dailyUsage)
                             .frame(height: 220)
@@ -235,10 +235,15 @@ struct UsageDashboardView: View {
                     }
                 }
             }
+            .overlay {
+                if costTracker.isScanning, visibleCostSummary != nil {
+                    CostRefreshLockOverlay()
+                }
+            }
         }
     }
 
-    private func costScanChart(height: CGFloat, compact: Bool) -> some View {
+    private func costScanChart(height: CGFloat, compact: Bool, showsProgressBadge: Bool = true) -> some View {
         ZStack {
             if let summary = visibleCostSummary, !summary.dailyUsage.isEmpty {
                 DailyUsageChart(dailyUsage: summary.dailyUsage)
@@ -249,7 +254,7 @@ struct UsageDashboardView: View {
                 DailyUsageChart(dailyUsage: [])
             }
 
-            if costTracker.isScanning, visibleCostSummary?.dailyUsage.isEmpty == false {
+            if showsProgressBadge, costTracker.isScanning, visibleCostSummary?.dailyUsage.isEmpty == false {
                 CostScanProgressBadge(compact: compact)
             }
         }
@@ -354,6 +359,15 @@ struct UsageDashboardView: View {
             return "Local 30-day token spend"
         case .settings:
             return "Accounts, refresh, and local sources"
+        }
+    }
+
+    private var isRefreshButtonDisabled: Bool {
+        switch activeSection {
+        case .costs:
+            return costTracker.isScanning
+        case .overview, .limits, .settings:
+            return dataManager.isLoading
         }
     }
 
@@ -585,7 +599,13 @@ private struct CostOverviewStatusCard: View {
                 Spacer()
             }
 
-            if isScanning {
+            if let formattedTotalCost = summary?.formattedTotalCost {
+                Text(formattedTotalCost)
+                    .font(.system(size: 34, weight: .bold))
+                    .foregroundColor(.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+            } else if isScanning {
                 HStack(spacing: 10) {
                     ProgressView()
                         .controlSize(.small)
@@ -596,7 +616,7 @@ private struct CostOverviewStatusCard: View {
                         .minimumScaleFactor(0.75)
                 }
             } else {
-                Text(summary?.formattedTotalCost ?? "Scan needed")
+                Text("Scan needed")
                     .font(.system(size: 34, weight: .bold))
                     .foregroundColor(.primary)
                     .lineLimit(1)
@@ -851,6 +871,39 @@ private struct CostScanProgressBadge: View {
             Spacer()
         }
         .padding(compact ? 8 : 10)
+    }
+}
+
+private struct CostRefreshLockOverlay: View {
+    var body: some View {
+        ZStack {
+            Color(nsColor: .controlBackgroundColor)
+                .opacity(0.62)
+                .contentShape(Rectangle())
+                .gesture(DragGesture(minimumDistance: 0), including: .all)
+
+            VStack(spacing: 7) {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Refreshing costs")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                }
+
+                Text("Scanning local token logs")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Refreshing costs")
+        .accessibilityHint("Cost results are locked until the local scan finishes.")
     }
 }
 


### PR DESCRIPTION
## Summary
- Keep existing Costs content visible while a local scan runs, instead of swapping the whole card into a loading state.
- Add a local lock/progress overlay for the Costs section during refresh, while leaving unrelated navigation responsive.
- Make the refresh button disable behavior section-aware so Costs scanning does not block refresh controls elsewhere.
- Preserve the total cost display on the overview card when cached cost data is available.

## Testing
- Not run (not requested)
- Existing verification in the session included `swift build`, `swift test`, `xcodebuild` debug build, and `git diff --check`, all passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cost dashboard now displays a lock overlay during refresh operations, providing visual feedback while cost scans complete in the background.

* **Improvements**
  * Cost data remains visible and stable during refresh operations.
  * Refresh button is now scoped to the Costs section only, allowing other sections to remain interactive during cost scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->