### PR TITLE
Place reset countdowns under matching quota bars

### DIFF
--- a/.agents/SESSIONS/2026-06-24.md
+++ b/.agents/SESSIONS/2026-06-24.md
@@ -1,0 +1,37 @@
+# Sessions: 2026-06-24
+
+**Summary:** Popover reset countdown placement
+
+---
+
+## Session 1: Place reset countdowns under their matching quota bars
+
+**Duration:** ~20 minutes
+**Status:** Complete
+
+### What was done
+
+- Checked open PRs #50 and #51. #50 is related to exhausted quota-card handling but does not fix
+  the normal per-bar reset countdown layout; #51 is unrelated cost refresh behavior.
+- Moved popover quota reset countdowns into each `PopoverLimitRow`, immediately under the matching
+  Session, Weekly, Sonnet, or Code Review bar.
+- Removed the aggregate provider-card reset countdown footer so a Session reset no longer appears
+  below the Weekly bar.
+- Checked the companion Usage Dashboard: it already renders reset countdowns per quota row, so no
+  UI relocation was needed there.
+- Removed a stale dashboard `resetWindows` adapter left over from the older aggregate reset pattern.
+
+### Files changed
+
+- `MeterBar/Views/MenuBarView.swift` - Reset countdowns now render below their matching quota bar.
+- `MeterBar/Views/UsageDashboardView.swift` - Removed unused reset-window adapter.
+
+### Verification
+
+- `swift test --filter ResetCountdownTests` passed: 11 tests, 0 failures.
+- `git diff --check` passed.
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` passed.
+
+---
+
+**Total sessions today:** 1

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -452,13 +452,6 @@ private struct PopoverProviderStatusCard: View {
                         PopoverLimitRow(limit: limit, accentColor: snapshot.accentColor)
                     }
                 }
-
-                NextResetCountdownLabel(
-                    windows: snapshot.resetWindows,
-                    font: .caption2,
-                    foregroundColor: .secondary,
-                    iconSize: 10
-                )
             }
 
             if let resetCount = snapshot.resetCreditsAvailable, resetCount > 0 {
@@ -540,6 +533,16 @@ private struct PopoverLimitRow: View {
                 pace: limit.usageLimit.pace(),
                 paceContext: paceContext
             )
+
+            if limit.usageLimit.resetTime != nil {
+                ResetCountdownLabel(
+                    title: limit.title,
+                    limit: limit.usageLimit,
+                    font: .caption2,
+                    foregroundColor: .secondary,
+                    iconSize: 9
+                )
+            }
         }
     }
 }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -410,16 +410,6 @@ private struct DashboardProviderSnapshot: Identifiable {
         ].compactMap { $0 }
     }
 
-    var resetWindows: [ResetCountdownWindow] {
-        limits.map {
-            ResetCountdownWindow(
-                id: "\(id)-\($0.title)",
-                title: $0.title,
-                limit: $0.usageLimit
-            )
-        }
-    }
-
     private static func logoKind(for service: ServiceType) -> ProviderLogoKind {
         switch service {
         case .codexCli, .openai:


### PR DESCRIPTION
## Summary
- Move popover reset countdowns into each quota row so they appear under the matching bar
- Remove the aggregate provider footer countdown that could show the wrong reset context
- Drop the unused dashboard `resetWindows` adapter left over from the old layout

## Testing
- `swift test --filter ResetCountdownTests` passed
- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` passed
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Reset countdowns now appear directly beneath each matching quota bar, making it easier to see when Session, Weekly, Sonnet, and Code Review limits will refresh.
  * Countdown labels use a more compact icon style to better fit within the provider cards.

* **Bug Fixes**
  * Removed the older aggregated reset countdown footer so countdown timing is shown in the right place for each usage bar.
  * Cleaned up dashboard behavior to match the updated quota display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->