### PR TITLE
docs: document release versioning preference

### DIFF
--- a/.agents/SESSIONS/2026-06-24.md
+++ b/.agents/SESSIONS/2026-06-24.md
@@ -34,4 +34,32 @@
 
 ---
 
-**Total sessions today:** 1
+## Session 2: Release versioning convention captured
+
+**Duration:** ~5 minutes
+**Status:** Complete
+
+### What was done
+
+- Confirmed the newly published release is `v1.5` and should remain as-is.
+- Documented the release-versioning preference so future agents remember to use three-part SemVer.
+- Noted that bugfix releases after `v1.5` should use patch versions such as `1.5.1`.
+
+### Key decisions
+
+- Keep `v1.5` because it was already published and matched the project's prior two-part version convention.
+- Use three-part SemVer for future MeterBar releases.
+- Do not rewrite or delete already-published release tags unless the user explicitly requests it.
+
+### Files changed
+
+- `.agents/SYSTEM/ai/USER-PREFERENCES.md` - Added release-versioning workflow preference.
+- `.agents/SESSIONS/2026-06-24.md` - Added this session note.
+
+### Next steps
+
+- Use `1.5.1` for the next bugfix release after `v1.5`.
+
+---
+
+**Total sessions today:** 2

--- a/.agents/SYSTEM/ai/USER-PREFERENCES.md
+++ b/.agents/SYSTEM/ai/USER-PREFERENCES.md
@@ -1,7 +1,7 @@
 # User Preferences
 
 **Purpose:** Document user-specific preferences that AI agents should follow.
-**Last Updated:** 2025-12-29
+**Last Updated:** 2026-06-24
 
 ---
 
@@ -37,6 +37,8 @@ Add your personal preferences and instructions here. AI agents should read this 
 
 - Document sessions in `SESSIONS/`
 - Track tasks in `TASKS/`
+- Use three-part SemVer for future MeterBar releases. `v1.5` is accepted as the already-published release, but follow-up bugfixes should be `1.5.1`, `1.5.2`, etc. instead of bumping to `1.6`.
+- Do not rewrite or delete an already-published release tag unless explicitly requested.
 
 ---
 
@@ -63,6 +65,13 @@ Add your personal preferences and instructions here. AI agents should read this 
 ## Past Corrections
 
 <!-- Document corrections here so AI remembers -->
+
+### [2026-06-24] - Release Versioning
+
+- `v1.5` was published using the existing two-part project convention.
+- Going forward, prefer three-part SemVer for releases.
+- For bugfix releases after `v1.5`, use patch versions such as `1.5.1`.
+- Avoid rewriting published tags/releases unless explicitly requested.
 
 ### [2025-12-29] - Initial Setup
 


### PR DESCRIPTION
## Summary
- Document that published v1.5 stays as-is
- Capture the preference to use three-part SemVer going forward
- Note that future bugfixes should use patch versions like 1.5.1

## Testing
- Documentation-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release/versioning guidance to clarify the current published release and future patch-version format.
  * Added notes to preserve existing release tags unless changes are explicitly requested.
  * Recorded the latest session and updated the daily session count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->