### PR TITLE
Fix bundled CLI version reporting

### DIFF
--- a/.agents/SESSIONS/2026-06-24.md
+++ b/.agents/SESSIONS/2026-06-24.md
@@ -62,4 +62,72 @@
 
 ---
 
-**Total sessions today:** 2
+## Session 3: Release cleanup, install docs, and CLI version PR
+
+**Duration:** ~1 hour
+**Status:** Complete
+
+### Flow
+
+```mermaid
+flowchart TD
+    A["Verify release state"] --> B["Prune stale local branches/worktrees"]
+    B --> C["Validate public install path"]
+    C --> D["Update README/setup install docs"]
+    D --> E["Upgrade installed MeterBar to v1.5"]
+    E --> F["Diagnose CLI version mismatch"]
+    F --> G["Open PR #54 with fix and release guard"]
+```
+
+### What was done
+
+- Ran release cleanup dry-run and confirmed no stranded or merged-but-not-in-trunk branches.
+- Removed stale local branches `develop`, `ship/13`, and `ship/14`.
+- Repaired and removed stale `ship/13` and `ship/14` worktrees that still pointed at the old repo path.
+- Verified the Homebrew cask and GitHub release assets for MeterBar.
+- Updated README install instructions with an agent install prompt, fully-qualified Homebrew cask commands, and the correct source clone directory.
+- Updated `.agents/docs/SETUP.md` to replace stale cookie/API-key setup instructions with current CLI/local-state setup.
+- Upgraded installed MeterBar via Homebrew from `1.4` to `1.5`.
+- Confirmed the bundled CLI reported stale version `1.0.0` even though the app/cask were `1.5`.
+- Fixed the CLI version source so bundled `meterbar --version` reads the enclosing `MeterBar.app` bundle version.
+- Added a release workflow guard that fails packaging if the bundled CLI version differs from the app version.
+- Opened PR #54: `Fix bundled CLI version reporting`.
+
+### Key decisions
+
+- Use the GitHub PR merge state as the cleanup oracle because this repo uses squash-style merges.
+- Use `VincentShipsIt/tap/meterbar` in docs to avoid ambiguity when multiple taps provide a `meterbar` cask.
+- Treat source-built CLI version output as `development`; released/Homebrew builds should report the app bundle version.
+- Add release-time validation instead of relying on manual version checks after publishing.
+
+### Files changed
+
+- `README.md` - Added agent install prompt, fully-qualified Homebrew commands, and fixed `cd meterbar.app`.
+- `.agents/docs/SETUP.md` - Updated installation/authentication setup to match the current product.
+- `MeterBarCLI/Sources/MeterBarCLI.swift` - Replaced hardcoded CLI version with app bundle version lookup.
+- `.github/workflows/release.yml` - Added bundled CLI/app version consistency check.
+- `.agents/SESSIONS/2026-06-24.md` - Added this session note.
+
+### Mistakes and fixes
+
+- `git worktree remove` initially failed because secondary worktrees had stale `.git` pointers to the old repo path. Fixed with `git worktree repair`, then removed normally without force.
+- `brew upgrade --cask meterbar` failed because two taps exposed `meterbar`. Fixed by using the fully-qualified `vincentshipsit/tap/meterbar` cask and updating docs.
+- Local SwiftPM release build hit stale module-cache paths after the repo move, then hung in release compilation after cleaning. Verified the fix with a debug build plus a fake app-bundle simulation instead; GitHub CI passed on PR #54.
+
+### Verification
+
+- `brew upgrade --cask vincentshipsit/tap/meterbar` upgraded MeterBar `1.4 -> 1.5`.
+- `/Applications/MeterBar.app` reported app version `1.5`.
+- `swift run --package-path MeterBarCLI meterbar --version` returned `development` outside an app bundle.
+- Fake `MeterBar.app` bundle with `CFBundleShortVersionString = 1.5` made the symlinked CLI report `1.5`.
+- `git diff --check` passed.
+- PR #54 checks passed: CI build, Secret Scan, and CodeRabbit.
+
+### Next steps
+
+- Merge PR #54.
+- Cut the next patch release after merge so the installed Homebrew CLI reports the same version as the GUI.
+
+---
+
+**Total sessions today:** 3

--- a/.agents/docs/SETUP.md
+++ b/.agents/docs/SETUP.md
@@ -2,9 +2,41 @@
 
 This guide will help you set up MeterBar on your Mac.
 
-## Prerequisites
+## Install Prerequisites
 
 - macOS 13.0 (Ventura) or later
+
+## Installing MeterBar
+
+### Homebrew (Recommended)
+
+```bash
+brew tap VincentShipsIt/tap
+brew install --cask VincentShipsIt/tap/meterbar
+```
+
+To update:
+
+```bash
+brew upgrade --cask VincentShipsIt/tap/meterbar
+```
+
+### Manual Download
+
+Download the latest release from:
+
+```text
+https://github.com/VincentShipsIt/meterbar.app/releases
+```
+
+The release build is currently unsigned/not notarized. If macOS blocks the first launch, right-click `MeterBar.app` and choose Open, or run:
+
+```bash
+xattr -cr /Applications/MeterBar.app
+```
+
+## Development Prerequisites
+
 - Xcode 15.0 or later
 - Swift 5.9 or later
 
@@ -23,21 +55,14 @@ These tools help maintain consistent code style across the project.
 ### 1. Clone the Repository
 
 ```bash
-git clone <repository-url>
-cd apps/ai-usage-tracker
+git clone https://github.com/VincentShipsIt/meterbar.app.git
+cd meterbar.app
 ```
 
 ### 2. Open in Xcode
 
 ```bash
 open MeterBar.xcodeproj
-```
-
-If you don't have an Xcode project yet, you can create one:
-
-```bash
-# Create Xcode project from Package.swift
-swift package generate-xcodeproj
 ```
 
 ### 3. Configure the Project
@@ -54,38 +79,24 @@ swift package generate-xcodeproj
 
 ## Authentication Setup
 
-### Claude
+### Claude Code
 
-1. Open Safari and navigate to `https://claude.ai`
-2. Log in to your account
-3. Open Developer Tools (`Cmd+Option+I`)
-4. Go to Storage > Cookies > `claude.ai`
-5. Find the session key cookie (usually named `sessionKey` or similar)
-6. Copy the cookie value
-7. Open MeterBar Settings
-8. Paste the session key in the Claude section
-9. Click "Save"
+1. Install Claude Code CLI: `npm install -g @anthropic-ai/claude-code`
+2. Log in: `claude login`
+3. MeterBar runs `claude /usage` and parses the CLI usage output.
+4. Add extra Claude accounts in Settings by pointing each account at a separate `CLAUDE_CONFIG_DIR`.
 
-### Codex
+### Codex CLI
 
-1. Open Safari and navigate to the Codex dashboard
-2. Log in to your account
-3. Open Developer Tools (`Cmd+Option+I`)
-4. Go to Storage > Cookies
-5. Copy relevant cookies (you may need to copy multiple cookies)
-6. Open MeterBar Settings
-7. Paste the cookies in the Codex section
-8. Click "Save"
+1. Install Codex CLI: `npm install -g @openai/codex`
+2. Log in: `codex login`
+3. Select your team/workspace when prompted.
+4. MeterBar reads Codex CLI credentials from `~/.codex/auth.json`.
 
 ### Cursor
 
-1. Open Cursor IDE
-2. Go to Settings > Account
-3. Find your API key
-4. Copy the API key
-5. Open MeterBar Settings
-6. Paste the API key in the Cursor section
-7. Click "Save"
+1. Install and log into Cursor IDE.
+2. MeterBar reads usage from Cursor's local state database.
 
 ## Widget Setup
 
@@ -125,10 +136,10 @@ Click the icon to see detailed usage metrics for all connected services.
 
 ### Authentication Not Working
 
-1. Verify your credentials are correct
-2. Check that you're logged in to the service in Safari
-3. Try removing and re-adding your credentials
-4. Check the console for error messages
+1. Re-run `claude login` or `codex login`.
+2. For Codex team accounts, select the correct team/workspace during login.
+3. For Cursor, open Cursor IDE and confirm you are signed in.
+4. Check the console for error messages.
 
 ### Notifications Not Appearing
 
@@ -138,9 +149,9 @@ Click the icon to see detailed usage metrics for all connected services.
 
 ## Security Notes
 
-- All credentials are stored securely in macOS Keychain
-- No data is sent to external servers
-- All processing happens on your device
+- Credentials remain in their original CLI or app-managed locations.
+- MeterBar calls only the official provider APIs needed to fetch usage.
+- Local parsing and display happen on your device.
 - The app is open source for transparency
 
 ## Development
@@ -180,4 +191,3 @@ To run linting on every build, add a "Run Script Phase" to your target:
 - Check the [README](README.md) for general information
 - Open an issue on GitHub for bugs or feature requests
 - See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,9 @@ jobs:
 
       - name: Verify bundled CLI version
         run: |
+          set -euo pipefail
           APP_PATH=$(find build -name "MeterBar.app" -type d | head -1)
+          [[ -n "$APP_PATH" ]] || { echo "::error::MeterBar.app not found under build/"; exit 1; }
           APP_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_PATH/Contents/Info.plist")
           CLI_VERSION=$("$APP_PATH/Contents/Helpers/meterbar" --version)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,17 @@ jobs:
           mkdir -p ../build/Build/Products/Release/MeterBar.app/Contents/Helpers
           cp .build/release/meterbar ../build/Build/Products/Release/MeterBar.app/Contents/Helpers/
 
+      - name: Verify bundled CLI version
+        run: |
+          APP_PATH=$(find build -name "MeterBar.app" -type d | head -1)
+          APP_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_PATH/Contents/Info.plist")
+          CLI_VERSION=$("$APP_PATH/Contents/Helpers/meterbar" --version)
+
+          echo "App version: $APP_VERSION"
+          echo "CLI version: $CLI_VERSION"
+
+          test "$CLI_VERSION" = "$APP_VERSION"
+
       - name: Create release package
         run: |
           VERSION="${{ github.ref_name }}"

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import Darwin
 import Foundation
 
 @main
@@ -18,8 +19,9 @@ private enum MeterBarCLIVersion {
     }
 
     private static var appBundleVersion: String? {
-        let executableURL = URL(fileURLWithPath: CommandLine.arguments[0])
-            .resolvingSymlinksInPath()
+        guard let executableURL = processExecutableURL else {
+            return nil
+        }
 
         let contentsURL = executableURL
             .deletingLastPathComponent() // meterbar
@@ -34,6 +36,21 @@ private enum MeterBarCLIVersion {
         }
 
         return version
+    }
+
+    private static var processExecutableURL: URL? {
+        var size = UInt32(PATH_MAX)
+        var buffer = [CChar](repeating: 0, count: Int(size))
+
+        if _NSGetExecutablePath(&buffer, &size) == -1 {
+            buffer = [CChar](repeating: 0, count: Int(size))
+            guard _NSGetExecutablePath(&buffer, &size) == 0 else {
+                return nil
+            }
+        }
+
+        return URL(fileURLWithPath: String(cString: buffer))
+            .resolvingSymlinksInPath()
     }
 }
 

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -6,10 +6,35 @@ struct MeterBarCLI: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "meterbar",
         abstract: "Track AI coding assistant usage from the command line",
-        version: "1.0.0",
+        version: MeterBarCLIVersion.current,
         subcommands: [Usage.self, Cost.self],
         defaultSubcommand: Usage.self
     )
+}
+
+private enum MeterBarCLIVersion {
+    static var current: String {
+        appBundleVersion ?? "development"
+    }
+
+    private static var appBundleVersion: String? {
+        let executableURL = URL(fileURLWithPath: CommandLine.arguments[0])
+            .resolvingSymlinksInPath()
+
+        let contentsURL = executableURL
+            .deletingLastPathComponent() // meterbar
+            .deletingLastPathComponent() // Helpers
+
+        let infoURL = contentsURL.appendingPathComponent("Info.plist")
+        guard let data = try? Data(contentsOf: infoURL),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
+              let version = plist["CFBundleShortVersionString"] as? String,
+              !version.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+
+        return version
+    }
 }
 
 struct Usage: ParsableCommand {

--- a/README.md
+++ b/README.md
@@ -53,16 +53,24 @@ A lightweight macOS menu bar app that monitors Claude Code, Codex CLI, and Curso
 
 ## Installation
 
+### Agent Install Prompt
+
+Paste this into your local coding agent to have it install MeterBar for you:
+
+```text
+Install MeterBar on this Mac. First verify this is macOS 13 or newer and that Homebrew is available. Install with: brew tap VincentShipsIt/tap && brew install --cask VincentShipsIt/tap/meterbar. If Homebrew is missing, ask before installing Homebrew. After installing, verify /Applications/MeterBar.app exists and that the meterbar CLI is linked, then open MeterBar. If macOS blocks the first launch because the app is unsigned, remove quarantine with xattr -cr /Applications/MeterBar.app and open it again. Do not ask me for API keys or paste secrets; for usage data, tell me to run claude login, codex login, and log into Cursor if I want those providers tracked.
+```
+
 ### Homebrew (Recommended)
 
 ```bash
 brew tap VincentShipsIt/tap
-brew install --cask meterbar
+brew install --cask VincentShipsIt/tap/meterbar
 ```
 
 To update:
 ```bash
-brew upgrade --cask meterbar
+brew upgrade --cask VincentShipsIt/tap/meterbar
 ```
 
 ### Manual Download
@@ -80,7 +88,7 @@ Prerequisites: macOS 13.0+, Xcode 15.0+
 
 ```bash
 git clone https://github.com/VincentShipsIt/meterbar.app.git
-cd meterbarapp
+cd meterbar.app
 open MeterBar.xcodeproj
 # Build and run (Cmd+R)
 ```


### PR DESCRIPTION
## Description

Fixes the bundled `meterbar --version` output so it reads the enclosing `MeterBar.app` bundle version instead of a stale hardcoded `1.0.0`. Adds a release workflow guard that fails packaging if the bundled CLI version diverges from the app version. Also updates install docs to use the fully-qualified Homebrew cask and adds the agent install prompt.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing

- [x] `swift run --package-path MeterBarCLI meterbar --version` returns `development` outside an app bundle
- [x] Fake `MeterBar.app` bundle with symlinked CLI reports matching `CFBundleShortVersionString` (`1.5`)
- [x] `git diff --check`
- [ ] Tested on macOS full Xcode build (local `xcodebuild` unavailable because active developer directory is Command Line Tools)
- [ ] Tested with service authentication
- [ ] Verified widget updates correctly
- [ ] Verified menu bar functionality

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings in focused checks
- [x] I have added release validation that proves the fix is effective
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes

The installed v1.5 app bundle is correct today; the bundled CLI binary reports `1.0.0` because its ArgumentParser configuration had an independent hardcoded version string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer Mac install and setup guidance, including Homebrew, manual download, and first-run steps.
  * Added a ready-to-paste agent install prompt in the main README.
* **Bug Fixes**
  * Fixed build-from-source instructions to use the correct project directory.
  * Updated CLI version reporting so the app and bundled CLI stay in sync.
  * Added a release check that fails if app and CLI versions don’t match.
* **Documentation**
  * Expanded authentication, troubleshooting, security notes, and getting-help sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->