### PR TITLE
Recover dashboard shell and harden release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, develop]
+    branches: [master]
   pull_request:
-    branches: [master, develop]
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: write
+    env:
+      # Keep the pushed tag out of inline shell interpolation. A malicious tag
+      # such as v1$(...) must be data, never executable script.
+      REF_NAME: ${{ github.ref_name }}
 
     steps:
       - name: Checkout
@@ -43,14 +47,15 @@ jobs:
 
       - name: Create release package
         run: |
-          VERSION="${{ github.ref_name }}"
+          set -euo pipefail
+          VERSION="$REF_NAME"
 
           # Find the built app
           APP_PATH=$(find build -name "MeterBar.app" -type d | head -1)
           echo "Found app at: $APP_PATH"
 
           # Create zip using ditto (preserves attributes better than zip)
-          cd $(dirname "$APP_PATH")
+          cd "$(dirname "$APP_PATH")"
           ditto -c -k --keepParent "MeterBar.app" "MeterBar-${VERSION}.zip"
 
           # Compute SHA256
@@ -63,7 +68,7 @@ jobs:
           mv "MeterBar-${VERSION}.zip.sha256" "${{ github.workspace }}/"
 
           # Set output for later steps
-          echo "sha256=$SHA256" >> $GITHUB_OUTPUT
+          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
         id: package
 
       - name: Create Release
@@ -80,9 +85,11 @@ jobs:
 
       - name: Output SHA256
         run: |
-          echo "### Release Artifacts" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**SHA256:** \`$(cat MeterBar-${{ github.ref_name }}.zip.sha256)\`" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### Release Artifacts"
+            echo ""
+            echo "**SHA256:** \`$(cat "MeterBar-${REF_NAME}.zip.sha256")\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # After the release is published, bump the Homebrew cask in VincentShipsIt/homebrew-tap.
   # Called directly (not via `release: published`) because GITHUB_TOKEN-created releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
 
           # Find the built app
           APP_PATH=$(find build -name "MeterBar.app" -type d | head -1)
+          [[ -n "$APP_PATH" ]] || { echo "::error::MeterBar.app not found under build/"; exit 1; }
           echo "Found app at: $APP_PATH"
 
           # Create zip using ditto (preserves attributes better than zip)

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -27,6 +27,21 @@ enum MeterBarTheme {
     /// The app's own accent. Follows the user's system accent color.
     static let appAccent = Color.accentColor
 
+    // MARK: - Dashboard detail surface
+
+    static let detailBackgroundTop = Color.adaptive(
+        light: NSColor(srgbRed: 0.965, green: 0.970, blue: 0.966, alpha: 1),
+        dark: NSColor(srgbRed: 0.080, green: 0.086, blue: 0.084, alpha: 1)
+    )
+    static let detailBackgroundMid = Color.adaptive(
+        light: NSColor(srgbRed: 0.942, green: 0.948, blue: 0.944, alpha: 1),
+        dark: NSColor(srgbRed: 0.052, green: 0.058, blue: 0.056, alpha: 1)
+    )
+    static let detailBackgroundBottom = Color.adaptive(
+        light: NSColor(srgbRed: 0.922, green: 0.928, blue: 0.924, alpha: 1),
+        dark: NSColor(srgbRed: 0.034, green: 0.038, blue: 0.038, alpha: 1)
+    )
+
     // MARK: - Quota status (system colors; adapt to appearance + Increase Contrast)
 
     static let success = Color(nsColor: .systemGreen)
@@ -57,6 +72,37 @@ enum MeterBarTheme {
         // metric turns red across the whole critical band, agreeing with the
         // adjacent status label, while staying neutral for healthy quotas.
         percentLeft <= 10 ? danger : .primary
+    }
+}
+
+struct MeterBarDetailBackground: View {
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    MeterBarTheme.detailBackgroundTop,
+                    MeterBarTheme.detailBackgroundMid,
+                    MeterBarTheme.detailBackgroundBottom
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+
+            VStack(spacing: 0) {
+                LinearGradient(
+                    colors: [
+                        MeterBarTheme.cursorAccent.opacity(0.13),
+                        MeterBarTheme.codexAccent.opacity(0.04),
+                        .clear
+                    ],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+                .frame(height: 1)
+
+                Spacer()
+            }
+        }
     }
 }
 

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -12,17 +12,20 @@ final class UsageDashboardWindowController {
     func show() {
         if window == nil {
             let hostingController = NSHostingController(rootView: UsageDashboardView())
-            // Surface the SwiftUI NavigationSplitView's toolbar and title (and the
-            // Liquid Glass they carry) through the AppKit window.
+            // Surface the SwiftUI NavigationSplitView title and toolbar through the
+            // AppKit window while the full-size content view keeps the sidebar glass
+            // running behind the titlebar.
             hostingController.sceneBridgingOptions = [.all]
             let window = NSWindow(
-                contentRect: NSRect(x: 0, y: 0, width: 1080, height: 720),
-                styleMask: [.titled, .closable, .miniaturizable, .resizable],
+                contentRect: NSRect(x: 0, y: 0, width: 1040, height: 700),
+                styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
                 backing: .buffered,
                 defer: false
             )
             window.title = "MeterBar Usage"
-            window.toolbarStyle = .unified
+            window.titleVisibility = .visible
+            window.titlebarAppearsTransparent = true
+            window.isRestorable = false
             window.contentMinSize = NSSize(width: 900, height: 600)
             window.contentViewController = hostingController
             window.isReleasedWhenClosed = false
@@ -63,51 +66,72 @@ struct UsageDashboardView: View {
     @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
 
-    @State private var selectedSection: DashboardSection? = .overview
+    @State private var selectedSection: DashboardSection = .overview
+    @State private var columnVisibility = NavigationSplitViewVisibility.all
 
-    private var activeSection: DashboardSection { selectedSection ?? .overview }
+    private var activeSection: DashboardSection { selectedSection }
 
     var body: some View {
-        NavigationSplitView {
-            List(selection: $selectedSection) {
-                ForEach(DashboardSection.allCases) { section in
-                    Label(section.rawValue, systemImage: section.iconName)
-                        .tag(section)
-                }
-            }
-            .listStyle(.sidebar)
-            .navigationSplitViewColumnWidth(min: 190, ideal: 212, max: 280)
-            .safeAreaInset(edge: .bottom) { sourcesFooter }
+        NavigationSplitView(columnVisibility: $columnVisibility) {
+            sidebar
+                .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 280)
         } detail: {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 18) {
-                    switch activeSection {
-                    case .overview:
-                        overviewContent
-                    case .limits:
-                        limitsContent
-                    case .costs:
-                        costsContent
-                    case .settings:
-                        settingsContent
-                    }
-                }
-                .padding(22)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            ZStack {
+                MeterBarDetailBackground()
+                    .ignoresSafeArea()
+
+                detailContent
             }
             .navigationTitle(activeSection.rawValue)
             .navigationSubtitle(sectionSubtitle)
             .toolbar {
-                ToolbarItem(placement: .primaryAction) {
+                ToolbarItem(placement: .navigation) {
                     Button {
                         Task { await refreshDashboard() }
                     } label: {
-                        Label("Refresh", systemImage: "arrow.clockwise")
+                        Image(systemName: "arrow.clockwise")
                     }
                     .help("Refresh usage")
                     .disabled(isRefreshButtonDisabled)
                 }
             }
+        }
+        .navigationSplitViewStyle(.balanced)
+    }
+
+    private var sidebar: some View {
+        List(selection: $selectedSection) {
+            ForEach(DashboardSection.allCases) { section in
+                Label(section.rawValue, systemImage: section.iconName)
+                    .tag(section)
+            }
+        }
+        .listStyle(.sidebar)
+        // Keep the sidebar system-owned. Custom backgrounds belong in the detail
+        // pane so the native Liquid Glass sidebar material and selection remain intact.
+        .safeAreaInset(edge: .bottom) { sourcesFooter }
+    }
+
+    private var detailContent: some View {
+        // Keep a real scroll backing in the detail column while the sidebar
+        // remains a plain native List.
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                switch activeSection {
+                case .overview:
+                    overviewContent
+                case .limits:
+                    limitsContent
+                case .costs:
+                    costsContent
+                case .settings:
+                    settingsContent
+                }
+            }
+            .padding(.horizontal, 22)
+            .padding(.top, 18)
+            .padding(.bottom, 22)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
@@ -457,6 +481,8 @@ private struct DashboardLimit: Identifiable {
     }
 }
 
+private let overviewTileHeight: CGFloat = 260
+
 private struct DashboardStatusHero: View {
     let title: String
     let detail: String
@@ -552,6 +578,12 @@ private struct ProviderOverviewStatusCard: View {
             }
         }
         .padding(14)
+        .frame(
+            maxWidth: .infinity,
+            minHeight: overviewTileHeight,
+            maxHeight: overviewTileHeight,
+            alignment: .topLeading
+        )
         .dashboardCardBackground()
     }
 
@@ -635,6 +667,12 @@ private struct CostOverviewStatusCard: View {
             }
         }
         .padding(14)
+        .frame(
+            maxWidth: .infinity,
+            minHeight: overviewTileHeight,
+            maxHeight: overviewTileHeight,
+            alignment: .topLeading
+        )
         .dashboardCardBackground()
     }
 }


### PR DESCRIPTION
## Summary
- Recover the missing companion dashboard shell work from the hidden Codex snapshot: full-height native sidebar/titlebar, detail-only adaptive background, balanced split view, and fixed peer overview tile heights.
- Remove stale `develop` CI triggers now that `master` is the active trunk.
- Harden release shell steps by routing `github.ref_name` through `$REF_NAME` before bash sees it, and clean up release script quoting.

## Root Cause
The dashboard shell work existed only in a local hidden `refs/codex/snapshots/*` ref and never reached `master` or `v1.5`.

## Verification
- `git diff --check`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `swift build`
- `swift test --skip APIIntegrationTests` — 102 tests, 0 failures
- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refreshed dashboard background with a smoother gradient and divider styling.
  * Updated the usage dashboard layout for a more polished split-view experience and clearer section navigation.
  * Replaced the text refresh control with a cleaner refresh icon.

* **Bug Fixes**
  * Improved window sizing and title-bar behavior for the dashboard.
  * Standardized dashboard card heights for a more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->