### PR TITLE
docs: record project cleanup session

### DIFF
--- a/.agents/SESSIONS/2026-06-25.md
+++ b/.agents/SESSIONS/2026-06-25.md
@@ -1,0 +1,43 @@
+# Sessions: 2026-06-25
+
+**Summary:** GitHub project and issue roadmap cleanup
+
+---
+
+## Session 1: Align MeterBar GitHub planning state
+
+**Duration:** In progress
+**Status:** In Progress
+
+### What was done
+
+- Audited GitHub issues, PRs, releases, owner Projects, and recent session decisions for consistency.
+- Confirmed MeterBar had no dedicated GitHub Project board; created owner Project #6 named `MeterBar` and linked it to `VincentShipsIt/meterbar.app`.
+- Renamed the active milestone from `v0.1.0` to `v1.5.1` after user confirmed the next release target.
+- Closed issue #19 as completed/stale after verifying `swift test --skip APIIntegrationTests` passed with 102 tests and 0 failures.
+- Updated issue #20 so Developer ID signing/notarization is explicitly deferred to #47 and no longer part of active release-blocker scope.
+- Updated stale `v0.1.0` wording in active issues to `v1.5.1`.
+- Added #31 and #40 to the `v1.5.1` milestone and labeled them.
+- Left #13 open and documented why: `WidgetCenter.reloadTimelines` is implemented, but the widget-local duplicate `SharedDataStore` still exists.
+- Added Project fields for `Roadmap` using `v1.5.1 - [Topic]` buckets and `Target date`.
+
+### Decisions
+
+- **Decision:** Use a dedicated MeterBar GitHub Project with Kanban and Roadmap views.
+  - **Rationale:** Issues and milestones alone were not enough to show current work across status and release/topic lanes.
+- **Decision:** Use `v1.5.1` as the active patch milestone.
+  - **Rationale:** `v1.5` is already published; future bugfixes should use three-part SemVer.
+- **Decision:** Keep Developer ID signing deferred.
+  - **Rationale:** Current Homebrew distribution accepts unsigned/ad-hoc releases; signing is tracked separately in #47.
+- **Decision:** Keep #13 open.
+  - **Rationale:** The issue's literal SharedDataStore unification requirement is not complete.
+
+### Verification
+
+- `swift test --skip APIIntegrationTests` passed: 102 tests, 0 failures.
+
+### Next steps
+
+- [ ] Finish Project item field assignment after GitHub GraphQL rate limit resets.
+- [ ] Create/verify Kanban and Roadmap Project views if exposed by GitHub Projects API/UI.
+


### PR DESCRIPTION
Tracks the June 25 project cleanup session note that was left untracked locally.