### PR TITLE
[codex] Show refreshing state on usage refresh buttons

### DIFF
--- a/.agents/SESSIONS/2026-06-26.md
+++ b/.agents/SESSIONS/2026-06-26.md
@@ -1,0 +1,36 @@
+# Sessions: 2026-06-26
+
+**Summary:** Refresh icon loading animation
+
+---
+
+## Session 1: Spin refresh icons during active refresh
+
+**Duration:** ~20 minutes
+**Status:** Complete
+
+### What was done
+
+- Added a reusable `RefreshingIcon` SwiftUI view that rotates the refresh symbol while a refresh is active.
+- Wired the menu bar popover refresh button to `UsageDataManager.isLoading`.
+- Wired the usage dashboard toolbar refresh button to the active section refresh state, including cost scans.
+- Updated refresh button help text to say "Refreshing usage" while work is in flight.
+
+### Files changed
+
+- `MeterBar/Views/RefreshingIcon.swift` - New reusable rotating refresh icon.
+- `MeterBar/Views/MenuBarView.swift` - Popover refresh button now spins during usage refresh.
+- `MeterBar/Views/UsageDashboardView.swift` - Dashboard refresh button now spins during usage refresh or cost scans.
+
+### Decisions
+
+- **Decision:** Bind the animation to existing loading/scanning state instead of adding local click-only state.
+  - **Rationale:** The icon reflects real work, including auto-refreshes and refreshes triggered from another view.
+- **Decision:** Respect Reduce Motion by leaving the icon static when motion is reduced.
+  - **Rationale:** The visual clue should not override system accessibility preferences.
+
+### Verification
+
+- `git diff --check` passed.
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` passed.
+- `swift test --skip APIIntegrationTests` passed: 102 tests, 0 failures.

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -133,10 +133,10 @@ struct MenuBarView: View {
             Button {
                 Task { await dataManager.refreshAll() }
             } label: {
-                Image(systemName: "arrow.clockwise")
+                RefreshingIcon(isRefreshing: dataManager.isLoading)
             }
             .buttonStyle(.borderless)
-            .help("Refresh usage")
+            .help(dataManager.isLoading ? "Refreshing usage" : "Refresh usage")
 
             optionsMenu
         }

--- a/MeterBar/Views/RefreshingIcon.swift
+++ b/MeterBar/Views/RefreshingIcon.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct RefreshingIcon: View {
+    let isRefreshing: Bool
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var rotationDegrees = 0.0
+
+    var body: some View {
+        Image(systemName: "arrow.clockwise")
+            .rotationEffect(.degrees(rotationDegrees))
+            .onAppear(perform: updateRotation)
+            .onChange(of: isRefreshing) { _, _ in
+                updateRotation()
+            }
+            .onChange(of: reduceMotion) { _, _ in
+                updateRotation()
+            }
+    }
+
+    private func updateRotation() {
+        if isRefreshing, !reduceMotion {
+            withAnimation(.linear(duration: 0.8).repeatForever(autoreverses: false)) {
+                rotationDegrees = 360
+            }
+        } else {
+            withAnimation(.easeOut(duration: 0.15)) {
+                rotationDegrees = 0
+            }
+        }
+    }
+}

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -96,9 +96,9 @@ struct UsageDashboardView: View {
                     Button {
                         Task { await refreshDashboard() }
                     } label: {
-                        Image(systemName: "arrow.clockwise")
+                        RefreshingIcon(isRefreshing: isRefreshButtonAnimating)
                     }
-                    .help("Refresh usage")
+                    .help(isRefreshButtonAnimating ? "Refreshing usage" : "Refresh usage")
                     .disabled(isRefreshButtonDisabled)
                 }
             }
@@ -397,6 +397,10 @@ struct UsageDashboardView: View {
     }
 
     private var isRefreshButtonDisabled: Bool {
+        isRefreshButtonAnimating
+    }
+
+    private var isRefreshButtonAnimating: Bool {
         switch activeSection {
         case .costs:
             return costTracker.isScanning


### PR DESCRIPTION
## Summary

- Add a reusable `RefreshingIcon` SwiftUI view that rotates the refresh symbol while work is active.
- Use the icon in the menu bar popover refresh button, bound to `UsageDataManager.isLoading`.
- Use the icon in the usage dashboard toolbar, bound to usage refreshes or cost scans depending on the active section.
- Record the session notes for the change.

## Why

Manual refreshes previously gave no clear visual clue after the button was triggered. The icon now reflects the real loading/scanning state, including refreshes kicked off outside the button itself, while respecting Reduce Motion.

## Validation

- `git diff --check`
- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`\n- `swift test --skip APIIntegrationTests` - 102 tests, 0 failures\n