### PR TITLE
[codex] Collapse daily cost rows by default

### DIFF
--- a/.agents/SESSIONS/2026-06-25.md
+++ b/.agents/SESSIONS/2026-06-25.md
@@ -79,3 +79,35 @@
 - `swift test --filter MeterBarThemeTests` passed: 3 tests, 0 failures.
 - `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` passed.
 - `swift test --skip APIIntegrationTests` passed: 102 tests, 0 failures.
+
+---
+
+## Session 3: Dashboard daily rows and sidebar glass
+
+**Duration:** ~25 minutes
+**Status:** Complete
+
+### What was done
+
+- Changed the Costs daily detail list so each day is collapsed by default and shows one summary row with date, source count, total tokens, and cost.
+- Added click-to-expand behavior for each daily row, revealing the per-provider input, output, cache, and cost details.
+- Gave the dashboard sidebar an explicit inset rounded Liquid Glass surface, with a transparent window backing so the material reads like the MacSweep sidebar.
+- Centralized the sidebar inset and corner radius values in dashboard chrome constants.
+
+### Files changed
+
+- `MeterBar/Views/UsageDashboardView.swift` - Collapsible daily cost rows and dashboard sidebar glass/inset styling.
+- `MeterBar/Views/MeterBarTheme.swift` - Updated chrome-material comment to match the dashboard-owned glass surface.
+
+### Decisions
+
+- **Decision:** Collapse the Costs daily details rather than the quota-window rows.
+  - **Rationale:** The requested "total / day" summary maps to the Costs Daily Details view shown in the screenshot.
+- **Decision:** Use a 10 pt sidebar inset and 22 pt continuous corner radius.
+  - **Rationale:** This gives MeterBar the same kind of inset rounded sidebar chrome as MacSweep while keeping native sidebar selection behavior.
+
+### Verification
+
+- `git diff --check` passed.
+- `swift test --skip APIIntegrationTests` passed: 102 tests, 0 failures.
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` passed.

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -7,7 +7,7 @@ import SwiftUI
 /// adapts to light/dark, the user's accent, Increase Contrast, and Reduce
 /// Transparency. The only custom colors are the per-provider brand accents and
 /// quota status — and those are kept appearance-adaptive too. Glass/material is
-/// supplied by the system chrome layer (popover, sidebar, toolbar), not here.
+/// supplied by the app's chrome layer (popover, dashboard sidebar, toolbar), not here.
 enum MeterBarTheme {
     // MARK: - Brand accents (semantic indicators only; adapt to light/dark)
 

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -25,6 +25,8 @@ final class UsageDashboardWindowController {
             window.title = "MeterBar Usage"
             window.titleVisibility = .visible
             window.titlebarAppearsTransparent = true
+            window.isOpaque = false
+            window.backgroundColor = .clear
             window.isRestorable = false
             window.contentMinSize = NSSize(width: 900, height: 600)
             window.contentViewController = hostingController
@@ -58,6 +60,11 @@ private enum DashboardSection: String, CaseIterable, Identifiable {
             return "gearshape.fill"
         }
     }
+}
+
+private enum DashboardChrome {
+    static let sidebarInset: CGFloat = 10
+    static let sidebarCornerRadius: CGFloat = 22
 }
 
 struct UsageDashboardView: View {
@@ -107,16 +114,24 @@ struct UsageDashboardView: View {
     }
 
     private var sidebar: some View {
-        List(selection: $selectedSection) {
-            ForEach(DashboardSection.allCases) { section in
-                Label(section.rawValue, systemImage: section.iconName)
-                    .tag(section)
+        ZStack {
+            DashboardSidebarGlassSurface()
+
+            List(selection: $selectedSection) {
+                ForEach(DashboardSection.allCases) { section in
+                    Label(section.rawValue, systemImage: section.iconName)
+                        .tag(section)
+                        .listRowBackground(Color.clear)
+                }
             }
+            .listStyle(.sidebar)
+            .scrollContentBackground(.hidden)
+            .background(Color.clear)
+            .safeAreaInset(edge: .bottom) { sourcesFooter }
+            .clipShape(RoundedRectangle(cornerRadius: DashboardChrome.sidebarCornerRadius, style: .continuous))
         }
-        .listStyle(.sidebar)
-        // Keep the sidebar system-owned. Custom backgrounds belong in the detail
-        // pane so the native Liquid Glass sidebar material and selection remain intact.
-        .safeAreaInset(edge: .bottom) { sourcesFooter }
+        .padding(DashboardChrome.sidebarInset)
+        .background(Color.clear)
     }
 
     private var detailContent: some View {
@@ -753,6 +768,21 @@ private struct DashboardCard<Content: View>: View {
     }
 }
 
+private struct DashboardSidebarGlassSurface: View {
+    var body: some View {
+        let shape = RoundedRectangle(cornerRadius: DashboardChrome.sidebarCornerRadius, style: .continuous)
+
+        shape
+            .fill(Color.clear)
+            .glassEffect(.regular, in: shape)
+            .overlay(
+                shape
+                    .strokeBorder(Color.primary.opacity(0.12), lineWidth: 1)
+            )
+            .allowsHitTesting(false)
+    }
+}
+
 private struct ProviderTitle: View {
     let title: String
     let logoKind: ProviderLogoKind
@@ -1256,6 +1286,8 @@ private struct DailyUsageProviderSegment: Identifiable {
 private struct DailyUsageBreakdownList: View {
     let dailyUsage: [DailyTokenUsage]
 
+    @State private var expandedDayIDs: Set<Date> = []
+
     private var days: [DailyProviderUsageDay] {
         let grouped = Dictionary(grouping: dailyUsage) { Calendar.current.startOfDay(for: $0.date) }
         return grouped.map { day, rows in
@@ -1279,8 +1311,22 @@ private struct DailyUsageBreakdownList: View {
 
             VStack(spacing: 8) {
                 ForEach(days) { day in
-                    DailyUsageDetailRow(day: day)
+                    DailyUsageDetailRow(
+                        day: day,
+                        isExpanded: expandedDayIDs.contains(day.id),
+                        toggle: { toggleExpansion(for: day.id) }
+                    )
                 }
+            }
+        }
+    }
+
+    private func toggleExpansion(for dayID: Date) {
+        withAnimation(.snappy(duration: 0.18)) {
+            if expandedDayIDs.contains(dayID) {
+                expandedDayIDs.remove(dayID)
+            } else {
+                expandedDayIDs.insert(dayID)
             }
         }
     }
@@ -1334,51 +1380,98 @@ private struct DailyProviderUsageSummary: Identifiable {
 
 private struct DailyUsageDetailRow: View {
     let day: DailyProviderUsageDay
+    let isExpanded: Bool
+    let toggle: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text(dateLabel(day.date))
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
-                Spacer()
-                Text(UsageFormat.tokens(day.totalTokens))
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                Text(UsageFormat.cost(day.estimatedCostUSD))
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
+        VStack(alignment: .leading, spacing: isExpanded ? 8 : 0) {
+            Button(action: toggle) {
+                HStack(spacing: 8) {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption2)
+                        .fontWeight(.bold)
+                        .foregroundColor(.secondary)
+                        .frame(width: 12)
 
-            ForEach(day.providers) { provider in
-                HStack(spacing: 10) {
-                    ProviderLogoView(
-                        kind: logoKind(for: provider.provider),
-                        size: 14,
-                        foregroundColor: color(for: provider.provider)
-                    )
-                    Text(provider.provider.displayName)
-                        .font(.caption)
+                    Text(dateLabel(day.date))
+                        .font(.subheadline)
                         .fontWeight(.semibold)
-                        .frame(width: 110, alignment: .leading)
-                    UsageDetailMetric(label: "Input", value: UsageFormat.tokens(provider.inputTokens))
-                    UsageDetailMetric(label: "Output", value: UsageFormat.tokens(provider.outputTokens))
-                    UsageDetailMetric(label: "Cache", value: UsageFormat.tokens(provider.cacheReadTokens))
+
+                    Text(providerCountLabel)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
                     Spacer()
-                    Text(UsageFormat.cost(provider.estimatedCostUSD))
+
+                    Text("\(UsageFormat.tokens(day.totalTokens)) tokens")
                         .font(.caption)
                         .fontWeight(.semibold)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+
+                    Text(UsageFormat.cost(day.estimatedCostUSD))
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.secondary)
                 }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(accessibilitySummary)
+            .accessibilityHint(isExpanded ? "Collapse day details" : "Show day details")
+
+            if isExpanded {
+                VStack(spacing: 8) {
+                    ForEach(day.providers) { provider in
+                        DailyProviderUsageSummaryRow(provider: provider)
+                    }
+                }
+                .padding(.top, 6)
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
         .padding(10)
         .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
 
+    private var providerCountLabel: String {
+        let count = day.providers.count
+        return count == 1 ? "1 source" : "\(count) sources"
+    }
+
+    private var accessibilitySummary: String {
+        "\(dateLabel(day.date)), \(UsageFormat.tokens(day.totalTokens)) tokens, \(UsageFormat.cost(day.estimatedCostUSD))"
+    }
+
     private func dateLabel(_ date: Date) -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = "EEE, MMM d"
         return formatter.string(from: date)
+    }
+}
+
+private struct DailyProviderUsageSummaryRow: View {
+    let provider: DailyProviderUsageSummary
+
+    var body: some View {
+        HStack(spacing: 10) {
+            ProviderLogoView(
+                kind: logoKind(for: provider.provider),
+                size: 14,
+                foregroundColor: color(for: provider.provider)
+            )
+            Text(provider.provider.displayName)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .frame(width: 110, alignment: .leading)
+            UsageDetailMetric(label: "Input", value: UsageFormat.tokens(provider.inputTokens))
+            UsageDetailMetric(label: "Output", value: UsageFormat.tokens(provider.outputTokens))
+            UsageDetailMetric(label: "Cache", value: UsageFormat.tokens(provider.cacheReadTokens))
+            Spacer()
+            Text(UsageFormat.cost(provider.estimatedCostUSD))
+                .font(.caption)
+                .fontWeight(.semibold)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Collapse Costs daily detail rows by default so each day shows one summary line with date, source count, total tokens, and cost.
- Add click-to-expand details for provider-level input, output, cache, and cost rows.
- Give the dashboard sidebar an explicit inset rounded Liquid Glass surface with transparent window backing so MeterBar matches the MacSweep-style sidebar treatment more closely.

## Impact

The Costs dashboard is easier to scan at a 30-day range, while detailed per-provider usage remains one click away. The dashboard shell also has more consistent sidebar spacing, radius, and glass behavior.

## Validation

- `git diff --check`
- `swift test --skip APIIntegrationTests` passed: 102 tests, 0 failures
- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` passed
