### PR TITLE
[codex] Format cost totals and refresh missing days

### DIFF
--- a/.agents/SESSIONS/2026-06-26.md
+++ b/.agents/SESSIONS/2026-06-26.md
@@ -1,0 +1,48 @@
+# Sessions: 2026-06-26
+
+**Summary:** Cost formatting and missing-day background refresh
+
+---
+
+## Session 1: Format cost numbers and backfill missing cost days
+
+**Duration:** ~25 minutes
+**Status:** Complete
+
+### What was done
+
+- Added deterministic comma-separated USD and token formatting for local cost displays.
+- Switched dashboard cost totals, token totals, daily tooltips, and provider detail metrics away from abbreviated values.
+- Added a missing-daily-usage predicate to detect legacy or stale cached cost summaries with gaps in the visible 30-day window.
+- Added a non-blocking background cost refresh path that runs with utility priority when Overview or Costs is opened and daily rows need backfilling.
+- Kept manual scans using the existing visible scanning state, while background backfills show only a subtle "Updating..." status.
+- Added tests for cost formatting and missing-day refresh detection.
+
+### Files changed
+
+- `MeterBar/Models/TokenCost.swift` - Shared cost/token formatting and missing-day refresh detection.
+- `MeterBar/Services/CostTracker.swift` - Separate manual scan and background missing-day refresh states.
+- `MeterBar/Views/UsageDashboardView.swift` - Comma-formatted cost UI and automatic background backfill trigger.
+- `MeterBar/Views/SettingsView.swift` - Cost scan button reflects background refresh state.
+- `MeterBarTests/TokenCostTests.swift` - Formatting and missing-day predicate coverage.
+
+### Decisions
+
+- **Decision:** Use comma-separated full token counts in cost views instead of K/M/B abbreviations.
+  - **Rationale:** The user specifically asked for thousands commas, and the screenshot showed the abbreviated total as part of the same issue.
+- **Decision:** Treat a missing-day backfill as a separate background refresh state from manual scans.
+  - **Rationale:** Cached charts should remain readable while the app quietly fills gaps.
+- **Decision:** Do not repeat gap backfills after a scan has already run today unless the cache is legacy-style with no daily usage rows.
+  - **Rationale:** A day with genuinely zero usage should not cause constant rescans.
+
+### Verification
+
+- `swift test --filter TokenCostTests` passed: 15 tests, 0 failures.
+- `swift test --skip APIIntegrationTests` passed: 107 tests, 0 failures.
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` passed.
+- `git diff --check` passed.
+- `swiftlint lint --quiet MeterBar/Models/TokenCost.swift MeterBar/Services/CostTracker.swift MeterBar/Views/UsageDashboardView.swift MeterBar/Views/SettingsView.swift` was attempted but still reports pre-existing lint violations in the touched larger files, including the existing `CostTracker.addCodexUsage` parameter-count error and existing print/force-unwrap warnings.
+
+### Next steps
+
+- [ ] Optionally do a broader CostTracker lint cleanup in a separate pass.

--- a/MeterBar/Models/TokenCost.swift
+++ b/MeterBar/Models/TokenCost.swift
@@ -1,5 +1,31 @@
 import Foundation
 
+enum TokenCostFormat {
+    static func usd(_ value: Double) -> String {
+        let sign = value < 0 ? "-" : ""
+        return "\(sign)$\(decimal(abs(value), fractionDigits: 2))"
+    }
+
+    static func tokens(_ value: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.numberStyle = .decimal
+        formatter.usesGroupingSeparator = true
+        formatter.maximumFractionDigits = 0
+        return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+
+    private static func decimal(_ value: Double, fractionDigits: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.numberStyle = .decimal
+        formatter.usesGroupingSeparator = true
+        formatter.minimumFractionDigits = fractionDigits
+        formatter.maximumFractionDigits = fractionDigits
+        return formatter.string(from: NSNumber(value: value)) ?? String(format: "%.\(fractionDigits)f", value)
+    }
+}
+
 struct TokenCost: Codable, Identifiable, Sendable {
     var id: String { provider.rawValue }
 
@@ -20,13 +46,11 @@ struct TokenCost: Codable, Identifiable, Sendable {
     }
 
     var formattedCost: String {
-        String(format: "$%.2f", estimatedCostUSD)
+        TokenCostFormat.usd(estimatedCostUSD)
     }
 
     var formattedTokens: String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        return formatter.string(from: NSNumber(value: totalTokens)) ?? "\(totalTokens)"
+        TokenCostFormat.tokens(totalTokens)
     }
 }
 
@@ -47,13 +71,11 @@ struct TokenUsageBreakdown: Codable, Identifiable, Sendable {
     }
 
     var formattedCost: String {
-        String(format: "$%.2f", estimatedCostUSD)
+        TokenCostFormat.usd(estimatedCostUSD)
     }
 
     var formattedTokens: String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        return formatter.string(from: NSNumber(value: totalTokens)) ?? "\(totalTokens)"
+        TokenCostFormat.tokens(totalTokens)
     }
 }
 
@@ -101,7 +123,7 @@ struct CostSummary: Codable, Sendable {
     }
 
     var formattedTotalCost: String {
-        String(format: "$%.2f", totalCostUSD)
+        TokenCostFormat.usd(totalCostUSD)
     }
 
     var averageDailyCost: Double {
@@ -110,7 +132,33 @@ struct CostSummary: Codable, Sendable {
     }
 
     var formattedDailyCost: String {
-        String(format: "$%.2f/day", averageDailyCost)
+        "\(TokenCostFormat.usd(averageDailyCost))/day"
+    }
+
+    func needsMissingDailyUsageRefresh(
+        days: Int,
+        lastScanDate: Date?,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> Bool {
+        guard !costs.isEmpty, totalTokens > 0 else { return false }
+        guard !dailyUsage.isEmpty else { return true }
+
+        let today = calendar.startOfDay(for: now)
+        if let lastScanDate,
+           calendar.startOfDay(for: lastScanDate) >= today {
+            return false
+        }
+
+        let daysToCheck = max(1, days)
+        let startDate = calendar.date(byAdding: .day, value: -(daysToCheck - 1), to: today) ?? today
+        let populatedDays = Set(dailyUsage.compactMap { usage -> Date? in
+            let day = calendar.startOfDay(for: usage.date)
+            guard day >= startDate, day <= today else { return nil }
+            return day
+        })
+
+        return populatedDays.count < daysToCheck
     }
 
     func filtered(to enabledServices: Set<ServiceType>) -> CostSummary {

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -7,10 +7,15 @@ class CostTracker: ObservableObject {
 
     @Published var costSummary: CostSummary?
     @Published var isScanning: Bool = false
+    @Published var isRefreshingMissingDays: Bool = false
     @Published var lastScanDate: Date?
 
     private let providerVisibilityStore = ProviderVisibilityStore.shared
     private let cacheFileName = "cost-summary-v1.json"
+
+    var isRefreshInProgress: Bool {
+        isScanning || isRefreshingMissingDays
+    }
 
     // API-rate estimates per million tokens for local log usage.
     private let pricing: [String: TokenPricing] = [
@@ -35,23 +40,13 @@ class CostTracker: ObservableObject {
 
     func scanCosts(days: Int = 30) async {
         let shouldStart = await MainActor.run {
-            guard !isScanning else { return false }
+            guard !isRefreshInProgress else { return false }
             isScanning = true
             return true
         }
         guard shouldStart else { return }
 
-        let includeClaudeCode = providerVisibilityStore.isEnabled(.claudeCode)
-        let includeCodexCli = providerVisibilityStore.isEnabled(.codexCli)
-        let claudeAccounts = ClaudeCodeAccountStore.shared.accounts
-        let summary = await Task.detached(priority: .userInitiated) { [self] in
-            buildCostSummary(
-                days: days,
-                includeClaudeCode: includeClaudeCode,
-                includeCodexCli: includeCodexCli,
-                claudeAccounts: claudeAccounts
-            )
-        }.value
+        let summary = await makeCostSummary(days: days, priority: .userInitiated)
 
         await MainActor.run {
             costSummary = summary
@@ -59,6 +54,43 @@ class CostTracker: ObservableObject {
             saveCachedSummary()
             isScanning = false
         }
+    }
+
+    func refreshMissingDaysInBackground(days: Int = 30) async {
+        let shouldStart = await MainActor.run {
+            guard !isRefreshInProgress,
+                  let visibleSummary = costSummary?.filtered(to: providerVisibilityStore.enabledServices),
+                  visibleSummary.needsMissingDailyUsageRefresh(days: days, lastScanDate: lastScanDate) else {
+                return false
+            }
+
+            isRefreshingMissingDays = true
+            return true
+        }
+        guard shouldStart else { return }
+
+        let summary = await makeCostSummary(days: days, priority: .utility)
+
+        await MainActor.run {
+            costSummary = summary
+            lastScanDate = Date()
+            saveCachedSummary()
+            isRefreshingMissingDays = false
+        }
+    }
+
+    private func makeCostSummary(days: Int, priority: TaskPriority) async -> CostSummary {
+        let includeClaudeCode = providerVisibilityStore.isEnabled(.claudeCode)
+        let includeCodexCli = providerVisibilityStore.isEnabled(.codexCli)
+        let claudeAccounts = ClaudeCodeAccountStore.shared.accounts
+        return await Task.detached(priority: priority) { [self] in
+            buildCostSummary(
+                days: days,
+                includeClaudeCode: includeClaudeCode,
+                includeCodexCli: includeCodexCli,
+                claudeAccounts: claudeAccounts
+            )
+        }.value
     }
 
     private func buildCostSummary(

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -426,11 +426,11 @@ struct SettingsView: View {
                     }
                 } label: {
                     HStack(spacing: 7) {
-                        if costTracker.isScanning {
+                        if costTracker.isRefreshInProgress {
                             ProgressView()
                                 .controlSize(.small)
                                 .scaleEffect(0.75)
-                            Text("Scanning...")
+                            Text(costTracker.isRefreshingMissingDays ? "Updating..." : "Scanning...")
                         } else {
                             Image(systemName: "magnifyingglass")
                             Text("Scan 30 Days")
@@ -438,7 +438,7 @@ struct SettingsView: View {
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(costTracker.isScanning || !canScanCosts)
+                .disabled(costTracker.isRefreshInProgress || !canScanCosts)
             }
         }
     }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -104,6 +104,14 @@ struct UsageDashboardView: View {
             }
         }
         .navigationSplitViewStyle(.balanced)
+        .task {
+            await refreshCostsIfMissingDays()
+        }
+        .onChange(of: selectedSection) {
+            Task {
+                await refreshCostsIfMissingDays()
+            }
+        }
     }
 
     private var sidebar: some View {
@@ -178,12 +186,13 @@ struct UsageDashboardView: View {
                 CostOverviewStatusCard(
                     summary: visibleCostSummary,
                     isScanning: costTracker.isScanning,
-                    formattedTokens: formattedTokenCount(visibleCostSummary?.totalTokens ?? 0)
+                    isRefreshingMissingDays: costTracker.isRefreshingMissingDays,
+                    formattedTokens: TokenCostFormat.tokens(visibleCostSummary?.totalTokens ?? 0)
                 )
             }
             .frame(maxWidth: .infinity)
 
-            DashboardCard(title: "Last 30 Days", trailing: costTracker.isScanning ? "Scanning..." : nil) {
+            DashboardCard(title: "Last 30 Days", trailing: costRefreshStatusText) {
                 costScanChart(height: 180, compact: true)
             }
         }
@@ -224,7 +233,7 @@ struct UsageDashboardView: View {
 
     private var costsContent: some View {
         VStack(alignment: .leading, spacing: 14) {
-            DashboardCard(title: "30 Day API-Rate Token Spend", trailing: costTracker.isScanning ? "Scanning..." : nil) {
+            DashboardCard(title: "30 Day API-Rate Token Spend", trailing: costRefreshStatusText) {
                 VStack(alignment: .leading, spacing: 18) {
                     Text("Local subscription logs are estimated using API token rates so Codex and Claude can be compared.")
                         .font(.caption)
@@ -247,7 +256,7 @@ struct UsageDashboardView: View {
                                 Label("Scan 30 Days", systemImage: "magnifyingglass")
                             }
                             .buttonStyle(.bordered)
-                            .disabled(costTracker.isScanning)
+                            .disabled(costTracker.isRefreshInProgress)
                         }
                         .frame(height: 220, alignment: .center)
                     }
@@ -396,10 +405,20 @@ struct UsageDashboardView: View {
         }
     }
 
+    private var costRefreshStatusText: String? {
+        if costTracker.isScanning {
+            return "Scanning..."
+        }
+        if costTracker.isRefreshingMissingDays {
+            return "Updating..."
+        }
+        return nil
+    }
+
     private var isRefreshButtonDisabled: Bool {
         switch activeSection {
         case .costs:
-            return costTracker.isScanning
+            return costTracker.isRefreshInProgress
         case .overview, .limits, .settings:
             return dataManager.isLoading
         }
@@ -413,6 +432,11 @@ struct UsageDashboardView: View {
         }
     }
 
+    private func refreshCostsIfMissingDays() async {
+        guard activeSection == .overview || activeSection == .costs else { return }
+        await costTracker.refreshMissingDaysInBackground(days: 30)
+    }
+
     private func color(for service: ServiceType) -> Color {
         MeterBarTheme.accent(for: service)
     }
@@ -421,19 +445,6 @@ struct UsageDashboardView: View {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
         return formatter.localizedString(for: date, relativeTo: Date())
-    }
-
-    private func formattedTokenCount(_ value: Int) -> String {
-        if value >= 1_000_000_000 {
-            return String(format: "%.1fB", Double(value) / 1_000_000_000)
-        }
-        if value >= 1_000_000 {
-            return String(format: "%.1fM", Double(value) / 1_000_000)
-        }
-        if value >= 1_000 {
-            return String(format: "%.1fK", Double(value) / 1_000)
-        }
-        return "\(value)"
     }
 }
 
@@ -611,6 +622,7 @@ private struct ProviderOverviewStatusCard: View {
 private struct CostOverviewStatusCard: View {
     let summary: CostSummary?
     let isScanning: Bool
+    let isRefreshingMissingDays: Bool
     let formattedTokens: String
 
     var body: some View {
@@ -623,7 +635,7 @@ private struct CostOverviewStatusCard: View {
                     Text("API-Rate Estimate")
                         .font(.headline)
                         .fontWeight(.semibold)
-                    Text(isScanning ? "Scanning local logs" : "Last 30 days")
+                    Text(statusText)
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
@@ -682,6 +694,16 @@ private struct CostOverviewStatusCard: View {
             alignment: .topLeading
         )
         .dashboardCardBackground()
+    }
+
+    private var statusText: String {
+        if isScanning {
+            return "Scanning local logs"
+        }
+        if isRefreshingMissingDays {
+            return "Updating missing days"
+        }
+        return "Last 30 days"
     }
 }
 
@@ -837,7 +859,6 @@ private struct DashboardLimitRow: View {
             return .secondary
         }
     }
-
 }
 
 private struct CostScanLoadingChart: View {
@@ -856,7 +877,9 @@ private struct CostScanLoadingChart: View {
                 let barWidth = max(4, (proxy.size.width - CGFloat(barCount - 1) * spacing) / CGFloat(barCount))
                 let time = timeline.date.timeIntervalSinceReferenceDate
                 let sweepWidth = max(42, proxy.size.width * 0.18)
-                let sweepX = CGFloat(time.truncatingRemainder(dividingBy: 1.8) / 1.8) * (proxy.size.width + sweepWidth) - sweepWidth
+                let sweepX = CGFloat(time.truncatingRemainder(dividingBy: 1.8) / 1.8)
+                    * (proxy.size.width + sweepWidth)
+                    - sweepWidth
 
                 VStack(alignment: .leading, spacing: compact ? 8 : 11) {
                     HStack(spacing: 8) {
@@ -1120,7 +1143,7 @@ private struct DailyUsageChart: View {
         var lines = [
             fullDateLabel(day.date),
             "\(formatTokens(day.totalTokens)) tokens",
-            String(format: "$%.2f", day.cost)
+            TokenCostFormat.usd(day.cost)
         ]
 
         if day.segments.isEmpty {
@@ -1128,7 +1151,8 @@ private struct DailyUsageChart: View {
         } else {
             lines.append("")
             for segment in day.segments {
-                lines.append("\(segment.provider.displayName): \(formatTokens(segment.tokens)) · \(String(format: "$%.2f", segment.cost))")
+                let segmentUsage = "\(formatTokens(segment.tokens)) · \(TokenCostFormat.usd(segment.cost))"
+                lines.append("\(segment.provider.displayName): \(segmentUsage)")
             }
         }
 
@@ -1147,13 +1171,7 @@ private struct DailyUsageChart: View {
     }
 
     private func formatTokens(_ value: Int) -> String {
-        if value >= 1_000_000 {
-            return String(format: "%.1fM", Double(value) / 1_000_000)
-        }
-        if value >= 1_000 {
-            return String(format: "%.1fK", Double(value) / 1_000)
-        }
-        return "\(value)"
+        TokenCostFormat.tokens(value)
     }
 }
 
@@ -1435,16 +1453,7 @@ private struct ProviderCostBreakdown: View {
     }
 
     private func compact(_ value: Int) -> String {
-        if value >= 1_000_000_000 {
-            return String(format: "%.1fB", Double(value) / 1_000_000_000)
-        }
-        if value >= 1_000_000 {
-            return String(format: "%.1fM", Double(value) / 1_000_000)
-        }
-        if value >= 1_000 {
-            return String(format: "%.1fK", Double(value) / 1_000)
-        }
-        return "\(value)"
+        TokenCostFormat.tokens(value)
     }
 }
 
@@ -1524,20 +1533,11 @@ private struct UsageDetailMetric: View {
 
 private enum UsageFormat {
     static func tokens(_ value: Int) -> String {
-        if value >= 1_000_000_000 {
-            return String(format: "%.1fB", Double(value) / 1_000_000_000)
-        }
-        if value >= 1_000_000 {
-            return String(format: "%.1fM", Double(value) / 1_000_000)
-        }
-        if value >= 1_000 {
-            return String(format: "%.1fK", Double(value) / 1_000)
-        }
-        return "\(value)"
+        TokenCostFormat.tokens(value)
     }
 
     static func cost(_ value: Double) -> String {
-        String(format: "$%.2f", value)
+        TokenCostFormat.usd(value)
     }
 }
 

--- a/MeterBarTests/TokenCostTests.swift
+++ b/MeterBarTests/TokenCostTests.swift
@@ -33,6 +33,9 @@ final class TokenCostTests: XCTestCase {
 
         let cost3 = makeTokenCost(estimatedCostUSD: 123.456)
         XCTAssertEqual(cost3.formattedCost, "$123.46")
+
+        let cost4 = makeTokenCost(estimatedCostUSD: 8_385.09)
+        XCTAssertEqual(cost4.formattedCost, "$8,385.09")
     }
 
     func testFormattedTokens() {
@@ -42,9 +45,7 @@ final class TokenCostTests: XCTestCase {
             cacheCreationTokens: 0,
             cacheReadTokens: 0
         )
-        // Should be formatted with decimal separators
-        XCTAssertTrue(cost.formattedTokens.contains("1"))
-        XCTAssertTrue(cost.formattedTokens.contains("234"))
+        XCTAssertEqual(cost.formattedTokens, "1,234,567")
     }
 
     func testIdProperty() {
@@ -88,10 +89,22 @@ final class TokenCostTests: XCTestCase {
         XCTAssertEqual(summary.formattedTotalCost, "$4.25")
     }
 
+    func testCostSummaryTotalCostUsesThousandsSeparator() {
+        let summary = CostSummary(costs: [], totalCostUSD: 12_345.60, totalTokens: 10000, periodDays: 30)
+
+        XCTAssertEqual(summary.formattedTotalCost, "$12,345.60")
+    }
+
     func testCostSummaryAverageDailyCost() {
         let summary = CostSummary(costs: [], totalCostUSD: 30.0, totalTokens: 100000, periodDays: 30)
         XCTAssertEqual(summary.averageDailyCost, 1.0, accuracy: 0.01)
         XCTAssertEqual(summary.formattedDailyCost, "$1.00/day")
+    }
+
+    func testCostSummaryDailyCostUsesThousandsSeparator() {
+        let summary = CostSummary(costs: [], totalCostUSD: 37_036.80, totalTokens: 100000, periodDays: 30)
+
+        XCTAssertEqual(summary.formattedDailyCost, "$1,234.56/day")
     }
 
     func testCostSummaryAverageDailyCostZeroDays() {
@@ -106,7 +119,61 @@ final class TokenCostTests: XCTestCase {
         XCTAssertEqual(summary.formattedTotalCost, "$0.00")
     }
 
+    func testMissingDailyUsageRefreshIsNeededForLegacyCostCache() {
+        let now = makeDate(year: 2026, month: 6, day: 26)
+        let summary = CostSummary(
+            costs: [makeTokenCost()],
+            totalCostUSD: 10,
+            totalTokens: 1_000,
+            periodDays: 30,
+            dailyUsage: []
+        )
+
+        XCTAssertTrue(summary.needsMissingDailyUsageRefresh(days: 30, lastScanDate: now, now: now, calendar: utcCalendar))
+    }
+
+    func testMissingDailyUsageRefreshIsNeededWhenScannedBeforeTodayAndWindowHasGaps() {
+        let now = makeDate(year: 2026, month: 6, day: 26)
+        let previousScan = makeDate(year: 2026, month: 6, day: 25)
+        let summary = CostSummary(
+            costs: [makeTokenCost()],
+            totalCostUSD: 10,
+            totalTokens: 1_000,
+            periodDays: 3,
+            dailyUsage: [
+                makeDailyUsage(date: makeDate(year: 2026, month: 6, day: 24)),
+                makeDailyUsage(date: makeDate(year: 2026, month: 6, day: 26)),
+            ]
+        )
+
+        XCTAssertTrue(
+            summary.needsMissingDailyUsageRefresh(days: 3, lastScanDate: previousScan, now: now, calendar: utcCalendar)
+        )
+    }
+
+    func testMissingDailyUsageRefreshIsSkippedAfterTodayScan() {
+        let now = makeDate(year: 2026, month: 6, day: 26)
+        let summary = CostSummary(
+            costs: [makeTokenCost()],
+            totalCostUSD: 10,
+            totalTokens: 1_000,
+            periodDays: 3,
+            dailyUsage: [
+                makeDailyUsage(date: makeDate(year: 2026, month: 6, day: 24)),
+                makeDailyUsage(date: makeDate(year: 2026, month: 6, day: 26)),
+            ]
+        )
+
+        XCTAssertFalse(summary.needsMissingDailyUsageRefresh(days: 3, lastScanDate: now, now: now, calendar: utcCalendar))
+    }
+
     // MARK: - Helpers
+
+    private var utcCalendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
 
     private func makeTokenCost(
         provider: ServiceType = .claudeCode,
@@ -128,5 +195,34 @@ final class TokenCostTests: XCTestCase {
             periodStart: Date().addingTimeInterval(-86400 * 30),
             periodEnd: Date()
         )
+    }
+
+    private func makeDailyUsage(
+        date: Date,
+        provider: ServiceType = .claudeCode,
+        inputTokens: Int = 1_000,
+        outputTokens: Int = 0,
+        cacheReadTokens: Int = 0,
+        estimatedCostUSD: Double = 1
+    ) -> DailyTokenUsage {
+        DailyTokenUsage(
+            date: date,
+            provider: provider,
+            inputTokens: inputTokens,
+            outputTokens: outputTokens,
+            cacheReadTokens: cacheReadTokens,
+            estimatedCostUSD: estimatedCostUSD
+        )
+    }
+
+    private func makeDate(year: Int, month: Int, day: Int) -> Date {
+        DateComponents(
+            calendar: utcCalendar,
+            timeZone: TimeZone(secondsFromGMT: 0),
+            year: year,
+            month: month,
+            day: day,
+            hour: 12
+        ).date!
     }
 }


### PR DESCRIPTION
## Summary

- Format local cost USD values and token counts with thousands separators across the dashboard and cost details.
- Add missing-day detection for cached cost summaries and run a non-blocking background backfill when Overview or Costs opens.
- Keep manual scans using the existing visible scanning state while background backfills only show a subtle updating status.
- Add focused tests for formatting and missing-day refresh detection, plus session documentation.

## Why

The cost card could show large totals without thousands grouping and token totals in abbreviated form, making values harder to scan. Cached cost charts could also retain missing daily rows until the user manually refreshed.

## Validation

- `swift test --filter TokenCostTests`
- `swift test --skip APIIntegrationTests`
- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`

Note: `swiftlint` was attempted on touched app files but still reports pre-existing violations in larger files, including `CostTracker` parameter-count and existing print/force-unwrap warnings.
