### PR TITLE
[codex] Harmonize companion glass styling

### DIFF
--- a/.agents/SESSIONS/2026-06-26.md
+++ b/.agents/SESSIONS/2026-06-26.md
@@ -1,0 +1,41 @@
+# Sessions: 2026-06-26
+
+**Summary:** Companion window and popover glass/style alignment
+
+---
+
+## Session 1: Harmonize dashboard chrome and quota cards
+
+**Duration:** ~35 minutes
+**Status:** Complete
+
+### What was done
+
+- Aligned the Usage Dashboard host window with the MacSweep-style native chrome setup: transparent full-size titlebar, unified toolbar, hidden titlebar separator, clear non-opaque window backing.
+- Stopped the dashboard detail background from painting into the titlebar chrome so the header can use native toolbar glass instead of a flat/opaque content fill.
+- Moved Local Sources from a custom sidebar bottom inset into the native sidebar `List` so the sidebar keeps its system-owned glass/selection behavior.
+- Added one shared MeterBar content panel surface and reused it for both companion dashboard cards and menu bar popover cards.
+- Updated popover header controls to use native macOS glass button styling.
+
+### Files changed
+
+- `MeterBar/Views/UsageDashboardView.swift` - Dashboard window chrome, sidebar structure, and card surface usage.
+- `MeterBar/Views/MenuBarView.swift` - Popover header glass controls and shared card surface usage.
+- `MeterBar/Views/MeterBarTheme.swift` - Shared MeterBar panel surface.
+
+### Decisions
+
+- Keep glass in the chrome/control layer: titlebar, toolbar, sidebar, popover controls.
+- Keep quota/provider cards as content panels, not fake-glass cards, but give them a visible native separator so they no longer disappear into the companion background.
+- Use the native sidebar `List` for Local Sources instead of a custom inset because the custom inset made the sidebar feel flatter.
+
+### Verification
+
+- `git diff --check` passed.
+- `swift test --filter MeterBarThemeTests` passed: 3 tests, 0 failures.
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` passed.
+- `swift test --skip APIIntegrationTests` passed: 102 tests, 0 failures.
+
+### Next steps
+
+- [ ] Visually smoke-test the dashboard in light/dark mode with live app data after launching the built app.

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -127,7 +127,8 @@ struct MenuBarView: View {
             Button(action: openDashboard) {
                 Image(systemName: "sidebar.right")
             }
-            .buttonStyle(.borderless)
+            .buttonStyle(.glass)
+            .controlSize(.small)
             .help("Open Usage Dashboard")
 
             Button {
@@ -135,7 +136,8 @@ struct MenuBarView: View {
             } label: {
                 Image(systemName: "arrow.clockwise")
             }
-            .buttonStyle(.borderless)
+            .buttonStyle(.glass)
+            .controlSize(.small)
             .help("Refresh usage")
 
             optionsMenu
@@ -159,7 +161,9 @@ struct MenuBarView: View {
         } label: {
             Image(systemName: "ellipsis")
         }
-        .menuStyle(.borderlessButton)
+        .menuStyle(.button)
+        .buttonStyle(.glass)
+        .controlSize(.small)
         .menuIndicator(.hidden)
         .fixedSize()
         .help("More options")
@@ -991,14 +995,9 @@ struct UsageBar: View {
 }
 
 private extension View {
-    /// A content surface for cards that sit on the popover's glass chrome.
-    /// Uses an opaque system control background (not a material) so it never
-    /// stacks glass on glass, with concentric continuous corners.
+    /// Shared content card surface for popover cards.
     func cardSurface() -> some View {
-        background(
-            Color(nsColor: .controlBackgroundColor),
-            in: RoundedRectangle(cornerRadius: 12, style: .continuous)
-        )
+        meterBarPanelSurface()
     }
 }
 

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -66,6 +66,31 @@ struct MeterBarDetailBackground: View {
     }
 }
 
+private struct MeterBarPanelSurfaceModifier: ViewModifier {
+    let cornerRadius: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                Color(nsColor: .controlBackgroundColor),
+                in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .stroke(Color(nsColor: .separatorColor).opacity(0.55), lineWidth: 0.5)
+            }
+    }
+}
+
+extension View {
+    /// Shared MeterBar content panel surface. Chrome glass belongs to the window,
+    /// sidebar, popover, and toolbar; cards use a native content fill plus a
+    /// subtle separator so companion and popover panels read as one system.
+    func meterBarPanelSurface(cornerRadius: CGFloat = 12) -> some View {
+        modifier(MeterBarPanelSurfaceModifier(cornerRadius: cornerRadius))
+    }
+}
+
 extension Color {
     /// An appearance-adaptive color backed by a dynamic `NSColor`, resolving the
     /// correct value for light / dark (and optionally high-contrast) appearances.

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -25,6 +25,10 @@ final class UsageDashboardWindowController {
             window.title = "MeterBar Usage"
             window.titleVisibility = .visible
             window.titlebarAppearsTransparent = true
+            window.toolbarStyle = .unified
+            window.titlebarSeparatorStyle = .none
+            window.isOpaque = false
+            window.backgroundColor = .clear
             window.isRestorable = false
             window.contentMinSize = NSSize(width: 900, height: 600)
             window.contentViewController = hostingController
@@ -85,7 +89,7 @@ struct UsageDashboardView: View {
         } detail: {
             ZStack {
                 MeterBarDetailBackground()
-                    .ignoresSafeArea()
+                    .ignoresSafeArea(edges: [.horizontal, .bottom])
 
                 detailContent
             }
@@ -112,11 +116,22 @@ struct UsageDashboardView: View {
                 Label(section.rawValue, systemImage: section.iconName)
                     .tag(section)
             }
+
+            Section("Local Sources") {
+                if enabledSourceLabels.isEmpty {
+                    Label("No sources enabled", systemImage: "circle")
+                } else {
+                    ForEach(enabledSourceLabels, id: \.self) { label in
+                        Label(label, systemImage: "checkmark.circle.fill")
+                    }
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
         }
         .listStyle(.sidebar)
-        // Keep the sidebar system-owned. Custom backgrounds belong in the detail
-        // pane so the native Liquid Glass sidebar material and selection remain intact.
-        .safeAreaInset(edge: .bottom) { sourcesFooter }
+        // No background overrides: the native sidebar owns its glass material,
+        // section rendering, and selected-row highlight.
     }
 
     private var detailContent: some View {
@@ -140,26 +155,6 @@ struct UsageDashboardView: View {
             .padding(.bottom, 22)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-    }
-
-    private var sourcesFooter: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Local Sources")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            if enabledSourceLabels.isEmpty {
-                Text("No sources enabled")
-            } else {
-                ForEach(enabledSourceLabels, id: \.self) { label in
-                    Label(label, systemImage: "checkmark.circle.fill")
-                }
-            }
-        }
-        .font(.caption)
-        .foregroundStyle(.secondary)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 18)
-        .padding(.vertical, 14)
     }
 
     private var overviewContent: some View {
@@ -1557,12 +1552,8 @@ private func color(for provider: ServiceType) -> Color {
 }
 
 private extension View {
-    /// A content surface for dashboard cards. Opaque system control background
-    /// (not a material) on the window's content layer, with concentric corners.
+    /// Shared content card surface for the companion dashboard.
     func dashboardCardBackground() -> some View {
-        background(
-            Color(nsColor: .controlBackgroundColor),
-            in: RoundedRectangle(cornerRadius: 12, style: .continuous)
-        )
+        meterBarPanelSurface()
     }
 }


### PR DESCRIPTION
## Summary

- Align the Usage Dashboard window chrome with the MacSweep-style native glass setup: unified transparent titlebar, no separator, and clear non-opaque backing.
- Keep the dashboard detail background out of the titlebar area so native toolbar glass is visible instead of a flat content fill.
- Move Local Sources into the native sidebar list and share one MeterBar panel surface across companion cards and menu bar popover cards.
- Update popover header controls to use native macOS glass button styling.

## Why

The companion window mixed a transparent titlebar with content backgrounds that painted into the chrome, which made the header look wrong and left the sidebar feeling flatter than MacSweep. The popover and companion cards also had duplicated styling, so the two surfaces did not feel like one product.

## Validation

- `git diff --check`
- `swift test --filter MeterBarThemeTests`
- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`\n- `swift test --skip APIIntegrationTests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the dashboard’s window appearance for a more native macOS look and feel.
  * Moved the “Local Sources” area into the main sidebar list, with cleaner empty-state and item display.
  * Updated header and overflow controls to use macOS-style glass buttons.

* **Bug Fixes**
  * Fixed background styling so content no longer bleeds into the title bar.
  * Standardized card and popover surfaces for more consistent visuals across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->