### PR TITLE
Fix verified bugs, DRY/optimize, and adopt native Liquid Glass chrome

### DIFF
--- a/.agents/SESSIONS/2026-06-26.md
+++ b/.agents/SESSIONS/2026-06-26.md
@@ -1,0 +1,159 @@
+# Sessions: 2026-06-26
+
+**Summary:** Codebase-wide bug fix, DRY, and optimization pass + open-PR review
+
+---
+
+## Session 1: Verified bug hunt and cleanup across the app
+
+**Duration:** ~3 hours
+**Status:** Complete (uncommitted; awaiting review)
+
+### What was done
+
+Reviewed the four open PRs (#58–#61) and the last 14 days of commits, then ran a
+multi-agent find-and-adversarially-verify pass over every Swift source file.
+70 findings were confirmed (9 high / 23 medium / 38 low) after verification;
+8 were rejected as false positives. Implemented fixes for all confirmed
+correctness/security bugs plus the high-value DRY/perf items.
+
+**Correctness / bug fixes**
+
+- `MeterBarApp`: notifications used a random `UUID().uuidString` identifier, so a
+  user pinned at ≥90% got a fresh banner every 5 minutes. Now uses a stable
+  per-(service, limit, level) identifier and a `notifiedLimitKeys` set so each
+  threshold crossing alerts once and re-arms only after usage drops back below.
+- `MeterBarApp`: the `monitorUsage` loop was `while true` with `try?`, so a
+  cancelled task busy-looped, and the unstructured `Task` was stored nowhere.
+  Now stored in `monitorTask`, loops on `!Task.isCancelled`, and exits cleanly on
+  a thrown `CancellationError`.
+- `MeterBarCLI`: `UsageLimit.used/total` were `Int` while the app serializes them
+  as JSON doubles, so the CLI silently decoded nothing. Changed to `Double`.
+- `ClaudeService` / `OpenAIService`: usage responses decoded `has_more`/`next_page`
+  but never followed pagination, under-counting usage. Both now loop with a
+  `page` cursor (capped at 50 pages).
+- `KeychainManager.save` replaced the racy delete-then-add with `SecItemUpdate`
+  then add-on-not-found.
+- `CostTracker`: Codex dedup key now uses whole-millisecond integer precision
+  instead of a raw `Double` description; `normalizeClaudeModel` strips the
+  `-YYYYMMDD` suffix for all models, not just ones already in the price table.
+- `ClaudeCodeCLIUsageService`: the `DispatchSemaphore.wait` (up to 12 s) ran on a
+  Swift-concurrency cooperative thread. The blocking run now happens on a
+  dedicated GCD queue bridged back through a continuation.
+- `Codex`/`Cursor` services defer their init-time credential/SQLite I/O off the
+  main thread; `SharedDataStore` writes the app-group cache off-main and atomic.
+- `UsageDataManager` claudeCode branch throws a specific `.notAuthenticated`
+  instead of the shared (possibly stale) `lastError`.
+- UI: dashboard hero showed the healthy green shield for "No sources enabled" /
+  "Waiting for usage"; the daily chart's compact token formatter was missing the
+  billions tier ("1000.0M"); the popover status icon now matches the red critical
+  band; popover snapshot id disambiguates same-named accounts; the third popover
+  limit slot is "Sonnet" only for Claude.
+
+**Security / privacy**
+
+- Removed/redirected all `print()` debug logging (Cursor 25, Codex 8, others) that
+  leaked HTTP bodies, usage figures, file paths, and user ids to the console.
+  Library `print()` count is now 0; app/storage logging uses a new `AppLog`
+  (`os.Logger`) with `.public`/redaction.
+
+**DRY / optimization**
+
+- New shared helpers: `AppLog` (logging), `ServiceSupport` (URLSession factory,
+  `URLError` → message, real home dir, `fetchDecoded`), `UsageFormat` (cached
+  compact/grouped token + cost + relative-date formatters).
+- Collapsed `CostTracker.addCodexUsage` (13 params — a SwiftLint
+  `function_parameter_count` error) and its two callers into one `CodexScanContext`.
+- Cached the per-call `ISO8601DateFormatter` (×2 hot paths), `NSRegularExpression`
+  (×~6 per SQLite row), `RelativeDateTimeFormatter`, `DateFormatter`, and
+  `NumberFormatter` allocations.
+- Deduplicated: token formatter (×4 → `UsageFormat`), `logoKind` (×3), card
+  surfaces (`cardSurface`/`dashboardCardBackground` → `meterBarCardSurface`),
+  `RateLimit`/`CodeReviewRateLimit` (typealias), `getRealHomeDirectory` (×3),
+  Claude/OpenAI fetch boilerplate, `loadCachedData`/`loadCachedMetricsFromDisk`,
+  and `ClaudeHelpView`/`OpenAIHelpView` (→ `AdminKeyHelpView`).
+- Precomputed `DailyUsageChart.days` once in `init` instead of per body access.
+- Eliminated all force-unwraps flagged by `force_unwrapping` (pricing table,
+  URL/Date builds, `secondaryWindow`, `ClaudeCodeAccount.defaultID`).
+
+### Files changed
+
+20 modified across `MeterBar/`, `MeterBarCLI/`, `MeterBarWidget/`; 4 new
+(`MeterBar/Services/AppLog.swift`, `MeterBar/Services/ServiceSupport.swift`,
+`MeterBar/Models/UsageFormatting.swift`, `MeterBarTests/UsageFormattingTests.swift`).
+Net ~ −80 lines.
+
+### Decisions
+
+- **Deferred the shared-package extraction** (one `MeterBarShared` target for the
+  forked `ServiceType`/`UsageLimit`/`UsageMetrics` across app/widget/CLI). It
+  requires Xcode project-file surgery that can't be locally verified; the narrow
+  decode bugs it would fix (CLI Int→Double, widget fields) were fixed in place.
+- **`OAuthTokenExpiry.isExpired(jwt:)`** still treats an unparseable token as
+  not-expired (documented): failing to introspect a token must not lock out a
+  session whose format we don't fully understand; the server 401s a bad token.
+- Left the three small stores (ProviderVisibility/DockVisibility/Auth) un-isolated
+  rather than `@MainActor` — `CostTracker` reads them off-main, so isolation would
+  cascade and risk regressions.
+
+### Verification
+
+- `swift build` (MeterBar library) — clean, no warnings, from scratch.
+- `swift build` in `MeterBarCLI/` — clean.
+- `swiftc -parse` on the CI-only app target sources — no syntax errors.
+- Added `UsageFormattingTests` (billions tier regression + grouped/cost).
+- XCTest suite and full `xcodebuild` build/test are CI-only (no full Xcode locally).
+
+### Next steps
+
+- [ ] Run the GitHub CI build+test gate.
+- [ ] Optional: extract `MeterBarShared` to end the app/widget/CLI struct drift
+      (spec in `.agents/docs/DEFERRED_WORK.md`).
+
+---
+
+## Session 2: Consolidate native Liquid Glass chrome + spinning refresh (PRs #58/#61)
+
+**Duration:** ~30 minutes
+**Status:** Complete (uncommitted)
+
+### What was done
+
+Reviewed the two competing sidebar-glass approaches and consolidated the chosen
+one into this branch, superseding the separate PRs.
+
+- **#61 (native sidebar) chosen over #59 (custom inset glass).** Rationale: a
+  `NavigationSplitView` + `.listStyle(.sidebar)` is a *standard* component that
+  gets the system Liquid Glass sidebar material, full-height-under-titlebar
+  blur, and selection highlight for free. Apple's guidance is that chrome glass
+  (sidebar/toolbar/titlebar) is system-owned; `.glassEffect()` is for *custom*
+  floating controls, not re-skinning a standard sidebar. #59's
+  `DashboardSidebarGlassSurface` stacked a custom `.glassEffect` behind a
+  cleared List inset 10pt and clipped to a 22pt radius — "glass on glass" that
+  fights the system material and drops the native under-titlebar bleed. #61 is
+  also the same author's own revised conclusion after trying #59.
+- Brought in #61's chrome: `window.toolbarStyle = .unified`,
+  `titlebarSeparatorStyle = .none`, clear non-opaque backing; detail background
+  no longer paints into the titlebar; Local Sources moved into a native
+  sidebar `Section`; popover header controls use `.buttonStyle(.glass)`.
+- Brought in #58's `RefreshingIcon` (spins on real loading/scanning state,
+  respects Reduce Motion) in both the popover and the dashboard toolbar, and
+  resolved the #58×#61 refresh-button conflict: `RefreshingIcon` + `.glass` +
+  `.controlSize(.small)` + conditional help.
+- Folded #61's card separator into the shared `meterBarCardSurface` (hairline
+  `separatorColor` stroke) so popover and dashboard cards match.
+
+### Files changed
+
+`MeterBar/Views/RefreshingIcon.swift` (new), `MenuBarView.swift`,
+`UsageDashboardView.swift`, `MeterBarTheme.swift`.
+
+### Decisions
+
+- Did not adopt #59's collapsible daily cost rows here (a separate content
+  feature, not the sidebar question). Available to cherry-pick if wanted.
+
+### Verification
+
+- `swift build` — clean, no warnings (validates `.buttonStyle(.glass)`,
+  `.menuStyle(.button)`, the native `Section`, window chrome, `RefreshingIcon`).

--- a/.agents/SESSIONS/2026-06-26.md
+++ b/.agents/SESSIONS/2026-06-26.md
@@ -148,12 +148,47 @@ one into this branch, superseding the separate PRs.
 `MeterBar/Views/RefreshingIcon.swift` (new), `MenuBarView.swift`,
 `UsageDashboardView.swift`, `MeterBarTheme.swift`.
 
-### Decisions
-
-- Did not adopt #59's collapsible daily cost rows here (a separate content
-  feature, not the sidebar question). Available to cherry-pick if wanted.
-
 ### Verification
 
 - `swift build` — clean, no warnings (validates `.buttonStyle(.glass)`,
   `.menuStyle(.button)`, the native `Section`, window chrome, `RefreshingIcon`).
+
+---
+
+## Session 3: Salvage remaining PR features into #62, then close superseded PRs
+
+**Duration:** ~20 minutes
+**Status:** Complete (pushed to #62)
+
+### What was done
+
+Ported the two features that #62 didn't yet cover, so closing the other PRs
+loses nothing:
+
+- **#59 — collapsible daily cost rows.** `DailyUsageBreakdownList` now tracks
+  `expandedDayIDs`; each `DailyUsageDetailRow` is a click-to-expand button
+  (chevron + date + source count + tokens + cost) that reveals per-provider
+  input/output/cache/cost (extracted into `DailyProviderUsageSummaryRow`), with
+  accessibility label/hint and a snappy expand animation.
+- **#60 — background missing-day cost refresh.** Added
+  `CostSummary.needsMissingDailyUsageRefresh(days:lastScanDate:…)`,
+  `CostTracker.isRefreshingMissingDays` / `isRefreshInProgress` /
+  `refreshMissingDaysInBackground(days:)` (utility priority) + a shared
+  `makeCostSummary(days:priority:)`. The dashboard kicks off a non-blocking
+  backfill on `.task` and on section change (Overview/Costs only) when the cache
+  has gaps; manual scans keep the visible "Scanning" UI while backfills show a
+  subtle "Updating…" status. Settings scan button reflects the same.
+
+### Files changed
+
+`MeterBar/Models/TokenCost.swift`, `MeterBar/Services/CostTracker.swift`,
+`MeterBar/Views/UsageDashboardView.swift`, `MeterBar/Views/SettingsView.swift`.
+
+### Outcome
+
+#62 now contains the full content of #58, #59, #60, and #61 — those four PRs
+are superseded and closed with a pointer to #62.
+
+### Verification
+
+- `swift build` — clean, no warnings. Full build/test on CI.

--- a/.agents/docs/DEFERRED_WORK.md
+++ b/.agents/docs/DEFERRED_WORK.md
@@ -1,0 +1,69 @@
+# Deferred Work / Tech Debt
+
+Items intentionally **not** done in the 2026-06-26 cleanup pass, with enough
+detail to pick up later (e.g. on a machine with full Xcode). See
+`.agents/SESSIONS/2026-06-26.md` for the broader context.
+
+---
+
+## 1. Extract a `MeterBarShared` package (end the struct drift)
+
+**Status:** deferred — needs Xcode project-file changes that can't be verified
+without full Xcode. The narrow *decode* bugs it would fix were already fixed in
+place (CLI `Int`→`Double`, widget layout). This is the structural follow-up.
+
+### Problem
+
+`ServiceType`, `UsageLimit`, `UsageMetrics`, and `UsageStatus` are **copied** into
+three targets and have already diverged:
+
+| Type | App (`MeterBar/Models`) | Widget (`MeterBarWidget/UsageWidget.swift`) | CLI (`MeterBarCLI/Sources/MeterBarCLI.swift`) |
+|---|---|---|---|
+| `UsageLimit.used/total` | `Double` + `windowSeconds: TimeInterval?` | `Double`, no `windowSeconds`, adds `clampedUsed/clampedTotal` | was `Int` (fixed → `Double`); no `windowSeconds` |
+| `ServiceType.iconName` | SF Symbol names | asset-catalog names (`ClaudeIcon`…) | n/a |
+| `ServiceType.sortOrder` | absent | present | absent |
+| `UsageMetrics` | has `extraUsage`, `resetCreditsAvailable` | missing both (silently dropped on decode) | partial (`ServiceMetrics`) |
+
+Because `JSONDecoder` ignores unknown keys, the drift is silent today, but any new
+shared field is a latent decode bug across targets.
+
+### Proposed fix
+
+1. Create a local Swift package target `MeterBarShared` (e.g. `Packages/MeterBarShared`
+   or a target inside `MeterBar.xcodeproj`).
+2. Move the canonical `ServiceType`, `UsageLimit`, `UsageMetrics`, `UsageStatus`
+   (+ `UsagePace`/duration helpers) into it. Before moving, reconcile:
+   - keep `windowSeconds: TimeInterval?` on the canonical `UsageLimit`;
+   - move `sortOrder` onto the canonical `ServiceType`;
+   - decide one `iconName` story (e.g. `iconName` = SF Symbol, plus a separate
+     `assetName` for the widget) rather than two conflicting `iconName`s;
+   - keep `extraUsage` / `resetCreditsAvailable` on the canonical `UsageMetrics`.
+3. Add `MeterBarShared` as a dependency of the `MeterBar`, `MeterBarWidget`, and
+   `MeterBarCLI` targets and delete the three forked copies.
+4. Verify with `xcodebuild` (app + widget) and `swift build` (CLI), and run the
+   XCTest suite (needs full Xcode).
+
+### Why it's worth it
+
+One source of truth for the wire format ⇒ no silent decode drift, and the
+widget/CLI automatically gain fields the app adds.
+
+---
+
+## 2. `OAuthTokenExpiry.isExpired(jwt:)` on malformed tokens — left as-is (by design)
+
+**Status:** intentional, documented in code (`MeterBar/Services/OAuthTokenExpiry.swift`).
+
+A code reviewer flagged that `isExpired(jwt:)` returns `false` (not-expired) when
+the token can't be parsed (no `exp` claim / bad base64).
+
+**Decision:** keep returning `false`. If we cannot introspect a token we should
+**not** lock the user out of a session whose format we don't fully understand —
+the server is the source of truth and will `401` a genuinely invalid token on the
+next request (which the services already handle). Flipping this to "malformed ⇒
+expired" risks regressing real Codex setups whose token isn't a standard JWT, and
+that regression can't be reproduced/tested locally without live credentials.
+
+If we ever want the stricter behavior, gate it behind telemetry first (count how
+often `expirationDate(fromJWT:)` returns `nil` for live tokens) before changing
+the default.

--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -279,7 +279,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.shipshit.MeterBar.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -324,7 +324,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.shipshit.MeterBar.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -489,7 +489,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.shipshit.MeterBar;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -535,7 +535,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.shipshit.MeterBar;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -9,11 +9,9 @@ struct MeterBarApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     
     init() {
-        print("═══════════════════════════════════════")
-        print("🎯 MeterBar: App Initializing")
-        print("═══════════════════════════════════════")
+        AppLog.app.info("MeterBar initializing")
     }
-    
+
     var body: some Scene {
         Settings {
             SettingsView()
@@ -27,6 +25,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private let providerVisibilityStore = ProviderVisibilityStore.shared
     private let dockVisibilityStore = DockVisibilityStore.shared
     private var cancellables = Set<AnyCancellable>()
+    private var monitorTask: Task<Void, Never>?
+
+    /// Tracks which (service, limit, level) notifications have already fired so
+    /// the 5-minute monitor loop doesn't re-alert every cycle while usage stays
+    /// above a threshold. Keys are cleared when usage drops back below.
+    private var notifiedLimitKeys: Set<String> = []
 
     func applicationWillFinishLaunching(_ notification: Notification) {
         // Apply the persisted Dock visibility as early as possible so users who
@@ -35,16 +39,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        print("🚀 MeterBar: Application did finish launching")
+        AppLog.app.info("MeterBar finished launching")
 
         // Keep Dock visibility in sync with the user's preference.
         observeDockVisibility()
-        
+
         // Create menu bar item
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        
+
         guard let button = statusItem?.button else {
-            print("❌ Failed to create status item button")
+            AppLog.app.error("Failed to create status item button")
             return
         }
         
@@ -208,13 +212,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 // Request permission only if not yet determined
                 UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, error in
                     if let error = error {
-                        print("Notification permission error: \(error)")
+                        AppLog.app.error("Notification permission error: \(error.localizedDescription, privacy: .public)")
                     } else if !granted {
-                        print("Notification permission denied by user")
+                        AppLog.app.info("Notification permission denied by user")
                     }
                 }
             case .denied:
-                print("Notification permission was previously denied. User can enable in System Settings.")
+                AppLog.app.info("Notification permission previously denied; user can enable it in System Settings.")
             case .authorized, .provisional, .ephemeral:
                 // Already authorized, no action needed
                 break
@@ -222,57 +226,87 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 break
             }
         }
-        
-        // Monitor usage and send notifications
-        Task {
-            await monitorUsage()
+
+        // Monitor usage and send notifications. Store the task so it can be
+        // cancelled, and so it isn't an orphaned unstructured Task.
+        monitorTask?.cancel()
+        monitorTask = Task { @MainActor [weak self] in
+            await self?.monitorUsage()
         }
     }
-    
+
     @MainActor
     private func monitorUsage() async {
         // Initial refresh on app launch
         await UsageDataManager.shared.refreshAll()
 
-        // Check for approaching limits periodically
-        // Note: UsageDataManager handles its own 15-minute auto-refresh
-        // This loop just checks metrics for notification purposes
-        while true {
+        // Check for approaching limits periodically.
+        // Note: UsageDataManager handles its own auto-refresh; this loop only
+        // checks metrics for notification purposes.
+        while !Task.isCancelled {
             for (service, metrics) in UsageDataManager.shared.metrics where providerVisibilityStore.isEnabled(service) {
                 checkAndNotify(metrics: metrics)
             }
 
-            // Wait 5 minutes before next notification check
-            try? await Task.sleep(nanoseconds: 5 * 60 * 1_000_000_000)
-        }
-    }
-    
-    private func checkAndNotify(metrics: UsageMetrics) {
-        let limits = [metrics.sessionLimit, metrics.weeklyLimit, metrics.codeReviewLimit].compactMap { $0 }
-        
-        for limit in limits {
-            if limit.percentage >= 90 && limit.percentage < 100 {
-                sendNotification(
-                    title: "\(metrics.service.displayName) Usage Warning",
-                    body: "You're at \(Int(limit.percentage))% of your limit"
-                )
-            } else if limit.percentage >= 100 {
-                sendNotification(
-                    title: "\(metrics.service.displayName) Limit Reached",
-                    body: "You've reached your usage limit"
-                )
+            // Wait 5 minutes before next notification check. A thrown
+            // CancellationError exits the loop instead of busy-looping.
+            do {
+                try await Task.sleep(nanoseconds: 5 * 60 * 1_000_000_000)
+            } catch {
+                break
             }
         }
     }
-    
-    private func sendNotification(title: String, body: String) {
+
+    private func checkAndNotify(metrics: UsageMetrics) {
+        let limits: [(limit: UsageLimit, type: String)] = [
+            (metrics.sessionLimit, "session"),
+            (metrics.weeklyLimit, "weekly"),
+            (metrics.codeReviewLimit, "codeReview")
+        ].compactMap { pair in pair.0.map { ($0, pair.1) } }
+
+        for (limit, limitType) in limits {
+            let baseKey = "\(metrics.service.rawValue)-\(limitType)"
+            let warnKey = "\(baseKey)-warn"
+            let criticalKey = "\(baseKey)-critical"
+
+            if limit.percentage >= 100 {
+                // Only fire once per crossing; supersede any pending warn alert.
+                notifiedLimitKeys.remove(warnKey)
+                if notifiedLimitKeys.insert(criticalKey).inserted {
+                    sendNotification(
+                        identifier: criticalKey,
+                        title: "\(metrics.service.displayName) Limit Reached",
+                        body: "You've reached your usage limit"
+                    )
+                }
+            } else if limit.percentage >= 90 {
+                if notifiedLimitKeys.insert(warnKey).inserted {
+                    sendNotification(
+                        identifier: warnKey,
+                        title: "\(metrics.service.displayName) Usage Warning",
+                        body: "You're at \(Int(limit.percentage))% of your limit"
+                    )
+                }
+            } else {
+                // Usage fell back below the threshold; allow the next crossing to
+                // notify again.
+                notifiedLimitKeys.remove(warnKey)
+                notifiedLimitKeys.remove(criticalKey)
+            }
+        }
+    }
+
+    private func sendNotification(identifier: String, title: String, body: String) {
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
         content.sound = .default
 
+        // Stable identifier: re-posting the same id replaces the pending request
+        // rather than stacking a new banner every check.
         let request = UNNotificationRequest(
-            identifier: UUID().uuidString,
+            identifier: identifier,
             content: content,
             trigger: nil
         )

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Combine
+import os
 import SwiftUI
 import UserNotifications
 

--- a/MeterBar/Models/ClaudeCodeAccount.swift
+++ b/MeterBar/Models/ClaudeCodeAccount.swift
@@ -2,7 +2,10 @@ import Combine
 import Foundation
 
 struct ClaudeCodeAccount: Codable, Equatable, Identifiable, Sendable {
-    static let defaultID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+    // Fixed sentinel id for the default CLI profile. Built from raw bytes
+    // (00000000-0000-0000-0000-000000000001) so it stays deterministic without a
+    // force-unwrap of `UUID(uuidString:)`.
+    static let defaultID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1))
 
     let id: UUID
     var name: String

--- a/MeterBar/Models/TokenCost.swift
+++ b/MeterBar/Models/TokenCost.swift
@@ -20,13 +20,11 @@ struct TokenCost: Codable, Identifiable, Sendable {
     }
 
     var formattedCost: String {
-        String(format: "$%.2f", estimatedCostUSD)
+        UsageFormat.cost(estimatedCostUSD)
     }
 
     var formattedTokens: String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        return formatter.string(from: NSNumber(value: totalTokens)) ?? "\(totalTokens)"
+        UsageFormat.groupedTokens(totalTokens)
     }
 }
 
@@ -47,13 +45,11 @@ struct TokenUsageBreakdown: Codable, Identifiable, Sendable {
     }
 
     var formattedCost: String {
-        String(format: "$%.2f", estimatedCostUSD)
+        UsageFormat.cost(estimatedCostUSD)
     }
 
     var formattedTokens: String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        return formatter.string(from: NSNumber(value: totalTokens)) ?? "\(totalTokens)"
+        UsageFormat.groupedTokens(totalTokens)
     }
 }
 
@@ -101,7 +97,7 @@ struct CostSummary: Codable, Sendable {
     }
 
     var formattedTotalCost: String {
-        String(format: "$%.2f", totalCostUSD)
+        UsageFormat.cost(totalCostUSD)
     }
 
     var averageDailyCost: Double {
@@ -110,7 +106,7 @@ struct CostSummary: Codable, Sendable {
     }
 
     var formattedDailyCost: String {
-        String(format: "$%.2f/day", averageDailyCost)
+        "\(UsageFormat.cost(averageDailyCost))/day"
     }
 
     func filtered(to enabledServices: Set<ServiceType>) -> CostSummary {

--- a/MeterBar/Models/TokenCost.swift
+++ b/MeterBar/Models/TokenCost.swift
@@ -109,6 +109,36 @@ struct CostSummary: Codable, Sendable {
         "\(UsageFormat.cost(averageDailyCost))/day"
     }
 
+    /// Whether the cached summary is missing daily rows inside the visible window
+    /// and should be quietly backfilled. Returns `false` once a scan has already
+    /// run today (a genuinely zero-usage day shouldn't trigger constant rescans),
+    /// but `true` for legacy caches that have costs/tokens yet no daily rows.
+    func needsMissingDailyUsageRefresh(
+        days: Int,
+        lastScanDate: Date?,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> Bool {
+        guard !costs.isEmpty, totalTokens > 0 else { return false }
+        guard !dailyUsage.isEmpty else { return true }
+
+        let today = calendar.startOfDay(for: now)
+        if let lastScanDate,
+           calendar.startOfDay(for: lastScanDate) >= today {
+            return false
+        }
+
+        let daysToCheck = max(1, days)
+        let startDate = calendar.date(byAdding: .day, value: -(daysToCheck - 1), to: today) ?? today
+        let populatedDays = Set(dailyUsage.compactMap { usage -> Date? in
+            let day = calendar.startOfDay(for: usage.date)
+            guard day >= startDate, day <= today else { return nil }
+            return day
+        })
+
+        return populatedDays.count < daysToCheck
+    }
+
     func filtered(to enabledServices: Set<ServiceType>) -> CostSummary {
         let visibleCosts = costs.filter { enabledServices.contains($0.provider) }
         let visibleDailyUsage = dailyUsage.filter { enabledServices.contains($0.provider) }

--- a/MeterBar/Models/UsageFormatting.swift
+++ b/MeterBar/Models/UsageFormatting.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Shared, cached formatting helpers.
+///
+/// Centralizes the compact token formatter (previously duplicated in four
+/// places — one of which silently dropped the billions tier), grouped integer
+/// formatting, currency formatting, and a cached `RelativeDateTimeFormatter`.
+/// The formatters are created once and reused so hot UI/scan paths don't
+/// reallocate a `NumberFormatter`/`RelativeDateTimeFormatter` on every call.
+enum UsageFormat {
+    private static let groupedInteger: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.numberStyle = .decimal
+        formatter.usesGroupingSeparator = true
+        formatter.maximumFractionDigits = 0
+        return formatter
+    }()
+
+    private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter
+    }()
+
+    /// Compact token count, e.g. `1.2K`, `3.4M`, `5.6B`.
+    static func tokens(_ value: Int) -> String {
+        if value >= 1_000_000_000 {
+            return String(format: "%.1fB", Double(value) / 1_000_000_000)
+        }
+        if value >= 1_000_000 {
+            return String(format: "%.1fM", Double(value) / 1_000_000)
+        }
+        if value >= 1_000 {
+            return String(format: "%.1fK", Double(value) / 1_000)
+        }
+        return "\(value)"
+    }
+
+    /// Full token count with thousands separators, e.g. `1,234,567`.
+    static func groupedTokens(_ value: Int) -> String {
+        groupedInteger.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+
+    /// Currency string, e.g. `$12.34`.
+    static func cost(_ value: Double) -> String {
+        String(format: "$%.2f", value)
+    }
+
+    /// Abbreviated relative time, e.g. `2h ago`, using a cached formatter.
+    static func relative(_ date: Date, to reference: Date = Date()) -> String {
+        relativeFormatter.localizedString(for: date, relativeTo: reference)
+    }
+}

--- a/MeterBar/Services/AppLog.swift
+++ b/MeterBar/Services/AppLog.swift
@@ -1,0 +1,18 @@
+import Foundation
+import os
+
+/// Centralized logging for the app.
+///
+/// Replaces scattered `print(...)` statements (flagged by the `no_print_statements`
+/// SwiftLint rule) with the unified logging system. Using `Logger` keeps diagnostics
+/// out of release stdout, lets the OS apply privacy redaction, and avoids logging
+/// raw API response bodies or token-bearing strings to the console.
+enum AppLog {
+    private static let subsystem = Bundle.main.bundleIdentifier ?? "app.meterbar"
+
+    static let app = Logger(subsystem: subsystem, category: "app")
+    static let usage = Logger(subsystem: subsystem, category: "usage")
+    static let cost = Logger(subsystem: subsystem, category: "cost")
+    static let network = Logger(subsystem: subsystem, category: "network")
+    static let storage = Logger(subsystem: subsystem, category: "storage")
+}

--- a/MeterBar/Services/ClaudeCodeCLIUsageService.swift
+++ b/MeterBar/Services/ClaudeCodeCLIUsageService.swift
@@ -1,9 +1,17 @@
 import Foundation
 
-final class ClaudeCodeCLIUsageService {
+final class ClaudeCodeCLIUsageService: Sendable {
     static let shared = ClaudeCodeCLIUsageService()
 
     private let commandTimeout: TimeInterval = 12
+
+    /// Dedicated queue for the blocking process run so the semaphore wait happens
+    /// on a GCD thread rather than blocking a Swift-concurrency cooperative thread.
+    private let processQueue = DispatchQueue(
+        label: "dev.shipshit.meterbar.ClaudeCLI.process",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
 
     private init() {}
 
@@ -16,7 +24,7 @@ final class ClaudeCodeCLIUsageService {
             throw ClaudeCodeCLIUsageError.cliNotFound
         }
 
-        let output = try runClaudeUsage(binaryPath: binaryPath, account: account)
+        let output = try await runClaudeUsage(binaryPath: binaryPath, account: account)
         return try ClaudeCodeCLIUsageParser.parseMetrics(from: output)
     }
 
@@ -34,7 +42,7 @@ final class ClaudeCodeCLIUsageService {
             .split(separator: ":")
             .map { "\($0)/claude" }
 
-        let homeDir = realHomeDirectory()
+        let homeDir = ServiceSupport.realHomeDirectory()
         let fallbackCandidates = [
             "/opt/homebrew/bin/claude",
             "/usr/local/bin/claude",
@@ -48,17 +56,23 @@ final class ClaudeCodeCLIUsageService {
         return (pathCandidates + fallbackCandidates).first { fileManager.isExecutableFile(atPath: $0) }
     }
 
-    private func realHomeDirectory() -> String {
-        if let pw = getpwuid(getuid()) {
-            return String(cString: pw.pointee.pw_dir)
+    /// Async wrapper that runs the blocking process invocation on `processQueue`
+    /// and bridges the result back via a continuation, so the calling task
+    /// suspends instead of blocking a cooperative thread on the semaphore.
+    private func runClaudeUsage(binaryPath: String, account: ClaudeCodeAccount) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            processQueue.async {
+                do {
+                    let output = try self.runClaudeUsageBlocking(binaryPath: binaryPath, account: account)
+                    continuation.resume(returning: output)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
         }
-        if let home = ProcessInfo.processInfo.environment["HOME"] {
-            return home
-        }
-        return FileManager.default.homeDirectoryForCurrentUser.path
     }
 
-    private func runClaudeUsage(binaryPath: String, account: ClaudeCodeAccount) throws -> String {
+    private func runClaudeUsageBlocking(binaryPath: String, account: ClaudeCodeAccount) throws -> String {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: binaryPath)
         process.arguments = ["/usage"]

--- a/MeterBar/Services/ClaudeCodeLocalService.swift
+++ b/MeterBar/Services/ClaudeCodeLocalService.swift
@@ -13,14 +13,7 @@ class ClaudeCodeLocalService: ObservableObject {
     private let cliUsageService = ClaudeCodeCLIUsageService.shared
     private let oauthFallbackUserDefaultsKey = "ClaudeCodeEnableOAuthFallback"
 
-    // URLSession with timeout configuration
-    private lazy var urlSession: URLSession = {
-        let configuration = URLSessionConfiguration.default
-        configuration.timeoutIntervalForRequest = 30.0
-        configuration.timeoutIntervalForResource = 60.0
-        configuration.waitsForConnectivity = true
-        return URLSession(configuration: configuration)
-    }()
+    private let urlSession = ServiceSupport.makeUsageSession()
 
     @Published private(set) var hasAccess: Bool = false
     @Published private(set) var subscriptionType: String?
@@ -220,17 +213,7 @@ class ClaudeCodeLocalService: ObservableObject {
                 extraUsage: usageResponse.extraUsageStatus
             )
         } catch let urlError as URLError {
-            let errorMessage: String
-            switch urlError.code {
-            case .notConnectedToInternet:
-                errorMessage = "No internet connection"
-            case .cannotFindHost, .dnsLookupFailed:
-                errorMessage = "DNS lookup failed"
-            case .timedOut:
-                errorMessage = "Request timed out"
-            default:
-                errorMessage = urlError.localizedDescription
-            }
+            let errorMessage = ServiceSupport.message(for: urlError)
             let error = ServiceError.apiError(errorMessage)
             await MainActor.run {
                 self.lastError = error

--- a/MeterBar/Services/ClaudeService.swift
+++ b/MeterBar/Services/ClaudeService.swift
@@ -9,6 +9,9 @@ class ClaudeService {
 
     private init() {}
 
+    /// Safety cap on pagination so a misbehaving API can never loop forever.
+    private let maxUsagePages = 50
+
     func fetchUsageMetrics() async throws -> UsageMetrics {
         guard let adminKey = authManager.claudeAdminKey else {
             throw ServiceError.notAuthenticated
@@ -16,7 +19,7 @@ class ClaudeService {
 
         // Calculate time range: last 7 days
         let endDate = Date()
-        let startDate = Calendar.current.date(byAdding: .day, value: -7, to: endDate)!
+        let startDate = Calendar.current.date(byAdding: .day, value: -7, to: endDate) ?? endDate
 
         let dateFormatter = ISO8601DateFormatter()
         dateFormatter.formatOptions = [.withInternetDateTime]
@@ -24,54 +27,55 @@ class ClaudeService {
         let startingAt = dateFormatter.string(from: startDate)
         let endingAt = dateFormatter.string(from: endDate)
 
-        // Build URL with query parameters
-        var components = URLComponents(string: "\(baseURL)/v1/organizations/usage_report/messages")!
-        components.queryItems = [
+        let baseQueryItems = [
             URLQueryItem(name: "starting_at", value: startingAt),
             URLQueryItem(name: "ending_at", value: endingAt),
             URLQueryItem(name: "bucket_width", value: "1d"),
             URLQueryItem(name: "group_by[]", value: "model")
         ]
 
-        guard let url = components.url else {
-            throw ServiceError.invalidURL
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue(adminKey, forHTTPHeaderField: "x-api-key")
-        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw ServiceError.apiError("Invalid response")
-        }
-
-        guard (200...299).contains(httpResponse.statusCode) else {
-            if httpResponse.statusCode == 401 {
-                throw ServiceError.notAuthenticated
-            }
-            let errorMessage = String(data: data, encoding: .utf8) ?? "Unknown error"
-            throw ServiceError.apiError("API error (\(httpResponse.statusCode)): \(errorMessage)")
-        }
-
-        // Parse response
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
 
-        let responseData = try decoder.decode(AnthropicUsageResponse.self, from: data)
+        // Follow pagination: the usage report can return multiple pages, and
+        // ignoring `has_more`/`next_page` silently under-counts usage.
+        var allBuckets: [AnthropicUsageBucket] = []
+        var nextPage: String?
+        var pagesFetched = 0
+
+        repeat {
+            guard var components = URLComponents(string: "\(baseURL)/v1/organizations/usage_report/messages") else {
+                throw ServiceError.invalidURL
+            }
+            var queryItems = baseQueryItems
+            if let nextPage {
+                queryItems.append(URLQueryItem(name: "page", value: nextPage))
+            }
+            components.queryItems = queryItems
+
+            guard let url = components.url else {
+                throw ServiceError.invalidURL
+            }
+
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+            request.setValue(adminKey, forHTTPHeaderField: "x-api-key")
+            request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+            let responseData: AnthropicUsageResponse = try await ServiceSupport.fetchDecoded(request, decoder: decoder)
+            allBuckets.append(contentsOf: responseData.data)
+            nextPage = (responseData.hasMore == true) ? responseData.nextPage : nil
+            pagesFetched += 1
+        } while nextPage != nil && pagesFetched < maxUsagePages
 
         // Aggregate all usage data
         var totalInputTokens: Double = 0
         var totalOutputTokens: Double = 0
-        var totalCachedTokens: Double = 0
 
-        for bucket in responseData.data {
+        for bucket in allBuckets {
             totalInputTokens += Double(bucket.inputTokens ?? 0)
             totalOutputTokens += Double(bucket.outputTokens ?? 0)
-            totalCachedTokens += Double(bucket.inputCachedTokens ?? 0)
         }
 
         let totalTokens = totalInputTokens + totalOutputTokens

--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AppKit
 import Combine
+import os
 
 /// Service for fetching Codex CLI usage data from https://chatgpt.com/backend-api/wham/usage
 /// Reads authentication token from ~/.codex/auth.json (stored by Codex CLI).
@@ -18,41 +19,19 @@ class CodexCliLocalService: ObservableObject {
 
     // Path to Codex CLI auth file
     private var authFilePath: String {
-        let homeDir = getRealHomeDirectory()
+        let homeDir = ServiceSupport.realHomeDirectory()
         return "\(homeDir)/.codex/auth.json"
     }
 
-    /// Get the REAL home directory (not sandboxed container)
-    private func getRealHomeDirectory() -> String {
-        // In sandboxed apps, FileManager.homeDirectoryForCurrentUser returns the container path
-        // We need the actual user home directory to access Codex CLI's auth file
-        if let pw = getpwuid(getuid()) {
-            return String(cString: pw.pointee.pw_dir)
-        }
-        // Fallback to environment variable
-        if let home = ProcessInfo.processInfo.environment["HOME"] {
-            return home
-        }
-        // Last resort - this will be sandboxed but better than nothing
-        return FileManager.default.homeDirectoryForCurrentUser.path
-    }
-
     // URLSession with timeout configuration
-    private lazy var urlSession: URLSession = {
-        let configuration = URLSessionConfiguration.default
-        configuration.timeoutIntervalForRequest = 30.0
-        configuration.timeoutIntervalForResource = 60.0
-        configuration.waitsForConnectivity = true
-        return URLSession(configuration: configuration)
-    }()
+    private let urlSession = ServiceSupport.makeUsageSession()
 
     @Published private(set) var hasAccess: Bool = false
     @Published private(set) var lastError: ServiceError?
     @Published private(set) var subscriptionType: String?
 
     private init() {
-        // Check if we have Codex CLI credentials on init
-        checkAccess()
+        Task.detached(priority: .utility) { [weak self] in self?.checkAccess() }
     }
 
     // MARK: - Auth File Access
@@ -88,14 +67,13 @@ class CodexCliLocalService: ObservableObject {
 
     /// Check and update access status
     func checkAccess() {
-        let token = getAuthToken()
-        let hasToken = token != nil
-        if hasToken {
-            hasAccess = true
-        } else {
-            hasAccess = false
-            subscriptionType = nil
+        let hasToken = getAuthToken() != nil
+        let apply = { [weak self] in
+            guard let self else { return }
+            self.hasAccess = hasToken
+            if !hasToken { self.subscriptionType = nil }
         }
+        if Thread.isMainThread { apply() } else { DispatchQueue.main.async(execute: apply) }
     }
 
     // MARK: - Usage Fetching
@@ -140,8 +118,6 @@ class CodexCliLocalService: ObservableObject {
                 throw ServiceError.apiError("Invalid response type")
             }
 
-            print("[CodexCliLocalService] Usage response status: \(httpResponse.statusCode)")
-
             if httpResponse.statusCode == 401 {
                 await MainActor.run {
                     self.hasAccess = false
@@ -152,7 +128,7 @@ class CodexCliLocalService: ObservableObject {
 
             guard (200...299).contains(httpResponse.statusCode) else {
                 let errorMessage = String(data: data, encoding: .utf8) ?? "Unknown error"
-                print("[CodexCliLocalService] Usage error: \(errorMessage.prefix(200))")
+                AppLog.usage.error("Codex usage HTTP \(httpResponse.statusCode, privacy: .public)")
                 throw ServiceError.apiError("HTTP \(httpResponse.statusCode): \(errorMessage.prefix(100))")
             }
 
@@ -170,7 +146,6 @@ class CodexCliLocalService: ObservableObject {
 
             // Check if rate limits exist (free accounts have null rate_limit)
             guard let rateLimit = usageResponse.rateLimit else {
-                print("[CodexCliLocalService] No rate limit data (free account or no usage yet)")
                 // Return empty metrics for free accounts
                 return UsageMetrics(
                     service: .codexCli,
@@ -185,7 +160,6 @@ class CodexCliLocalService: ObservableObject {
             // Map the response to UsageMetrics
             // Primary window (5 hours = 18000 seconds) = session limit
             let primaryWindow = rateLimit.primaryWindow
-            print("[CodexCliLocalService] Primary window: usedPercent=\(primaryWindow.usedPercent), resetAt=\(primaryWindow.resetAt)")
             let sessionLimit = UsageLimit(
                 used: primaryWindow.usedPercent,
                 total: 100.0,
@@ -195,18 +169,16 @@ class CodexCliLocalService: ObservableObject {
 
             // Secondary window (7 days = 604800 seconds) = weekly limit
             let secondaryWindow = rateLimit.secondaryWindow
-            print("[CodexCliLocalService] Secondary window: usedPercent=\(secondaryWindow?.usedPercent ?? -1), resetAt=\(secondaryWindow?.resetAt ?? 0)")
             let weeklyLimit = UsageLimit(
                 used: secondaryWindow?.usedPercent ?? 0.0,
                 total: 100.0,
-                resetTime: secondaryWindow != nil ? Date(timeIntervalSince1970: Double(secondaryWindow!.resetAt)) : Date(),
+                resetTime: secondaryWindow.map { Date(timeIntervalSince1970: Double($0.resetAt)) } ?? Date(),
                 windowSeconds: secondaryWindow.map { TimeInterval($0.limitWindowSeconds) }
             )
 
             // Code review rate limit (7 days window) = code review limit
             var codeReviewLimit: UsageLimit? = nil
             if let codeReviewPrimary = usageResponse.codeReviewRateLimit?.primaryWindow {
-                print("[CodexCliLocalService] Code review: usedPercent=\(codeReviewPrimary.usedPercent), resetAt=\(codeReviewPrimary.resetAt)")
                 codeReviewLimit = UsageLimit(
                     used: codeReviewPrimary.usedPercent,
                     total: 100.0,
@@ -215,7 +187,6 @@ class CodexCliLocalService: ObservableObject {
                 )
             }
 
-            print("[CodexCliLocalService] Final metrics: session=\(sessionLimit.percentage)%, weekly=\(weeklyLimit.percentage)%, codeReview=\(codeReviewLimit?.percentage ?? -1)%")
             return UsageMetrics(
                 service: .codexCli,
                 sessionLimit: sessionLimit,
@@ -225,24 +196,14 @@ class CodexCliLocalService: ObservableObject {
                 resetCreditsAvailable: usageResponse.resetCreditsAvailable
             )
         } catch let urlError as URLError {
-            let errorMessage: String
-            switch urlError.code {
-            case .notConnectedToInternet:
-                errorMessage = "No internet connection"
-            case .cannotFindHost, .dnsLookupFailed:
-                errorMessage = "DNS lookup failed"
-            case .timedOut:
-                errorMessage = "Request timed out"
-            default:
-                errorMessage = urlError.localizedDescription
-            }
+            let errorMessage = ServiceSupport.message(for: urlError)
             let error = ServiceError.apiError(errorMessage)
             await MainActor.run { self.lastError = error }
             throw error
         } catch let error as ServiceError {
             throw error
-        } catch let decodingError as DecodingError {
-            print("[CodexCliLocalService] Decoding error: \(decodingError)")
+        } catch is DecodingError {
+            AppLog.usage.error("Codex usage decode failed")
             let serviceError = ServiceError.parsingError
             await MainActor.run { self.lastError = serviceError }
             throw serviceError
@@ -390,19 +351,7 @@ struct RateLimit: Codable {
     }
 }
 
-struct CodeReviewRateLimit: Codable {
-    let allowed: Bool
-    let limitReached: Bool
-    let primaryWindow: LimitWindow
-    let secondaryWindow: LimitWindow?
-
-    enum CodingKeys: String, CodingKey {
-        case allowed
-        case limitReached = "limit_reached"
-        case primaryWindow = "primary_window"
-        case secondaryWindow = "secondary_window"
-    }
-}
+typealias CodeReviewRateLimit = RateLimit
 
 struct LimitWindow: Codable {
     let usedPercent: Double

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -29,6 +29,42 @@ class CostTracker: ObservableObject {
         "default": TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30)
     ]
 
+    /// Non-optional fallback so pricing lookups never need a force-unwrap of
+    /// `pricing["default"]`. Mirrors the `"default"` entry above.
+    private let defaultPricing = TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30)
+
+    // Cached formatters/regexes. The scan parses tens of thousands of log lines,
+    // so allocating an ISO8601DateFormatter/NSRegularExpression per call was a
+    // measurable hot-path cost. `ISO8601DateFormatter.date(from:)` and
+    // `NSRegularExpression` are safe to share across reads.
+    private static let fractionalISO8601Formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let plainISO8601Formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    private static let codexLogValueRegexes: [String: NSRegularExpression] = {
+        let keys = [
+            "event.timestamp", "input_token_count", "output_token_count",
+            "cached_token_count", "reasoning_token_count", "conversation.id",
+            "thread.id", "model", "slug", "originator"
+        ]
+        var result: [String: NSRegularExpression] = [:]
+        for key in keys {
+            let pattern = NSRegularExpression.escapedPattern(for: key) + #"=([^\s}]+)"#
+            if let regex = try? NSRegularExpression(pattern: pattern) {
+                result[key] = regex
+            }
+        }
+        return result
+    }()
+
     private init() {
         loadCachedSummary()
     }
@@ -127,7 +163,7 @@ class CostTracker: ObservableObject {
             costSummary = cache.summary
             lastScanDate = cache.lastScanDate
         } catch {
-            print("MeterBar: failed to load cost summary cache: \(error.localizedDescription)")
+            AppLog.cost.error("Failed to load cost summary cache: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -148,7 +184,7 @@ class CostTracker: ObservableObject {
             let data = try encoder.encode(CostSummaryCache(summary: costSummary, lastScanDate: lastScanDate))
             try data.write(to: cacheURL, options: [.atomic])
         } catch {
-            print("MeterBar: failed to save cost summary cache: \(error.localizedDescription)")
+            AppLog.cost.error("Failed to save cost summary cache: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -216,7 +252,7 @@ class CostTracker: ObservableObject {
 
         guard totalInput > 0 || totalOutput > 0 || totalCacheCreation > 0 || totalCacheRead > 0 else { return nil }
 
-        let pricing = self.pricing["claude-sonnet"] ?? self.pricing["default"]!
+        let pricing = self.pricing["claude-sonnet"] ?? defaultPricing
         let fallbackCost = calculateCost(
             input: totalInput,
             output: totalOutput,
@@ -407,15 +443,10 @@ class CostTracker: ObservableObject {
     }
 
     private func parseISO8601(_ value: String) -> Date? {
-        let fractionalFormatter = ISO8601DateFormatter()
-        fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        if let date = fractionalFormatter.date(from: value) {
+        if let date = Self.fractionalISO8601Formatter.date(from: value) {
             return date
         }
-
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime]
-        return formatter.date(from: value)
+        return Self.plainISO8601Formatter.date(from: value)
     }
 
     private func claudeOneHourCacheCreationTokens(in usage: [String: Any]) -> Int {
@@ -427,7 +458,7 @@ class CostTracker: ObservableObject {
 
     private func claudePricing(for model: String?) -> TokenPricing {
         guard let model else {
-            return pricing["claude-sonnet"] ?? pricing["default"]!
+            return pricing["claude-sonnet"] ?? defaultPricing
         }
 
         let normalized = normalizeClaudeModel(model)
@@ -436,27 +467,27 @@ class CostTracker: ObservableObject {
         }
 
         if normalized.contains("fable") {
-            return pricing["claude-fable-5"] ?? pricing["default"]!
+            return pricing["claude-fable-5"] ?? defaultPricing
         }
         if normalized.contains("opus") {
-            if normalized.contains("4-8") { return pricing["claude-opus-4-8"] ?? pricing["claude-opus"]! }
-            if normalized.contains("4-7") { return pricing["claude-opus-4-7"] ?? pricing["claude-opus"]! }
-            if normalized.contains("4-6") { return pricing["claude-opus-4-6"] ?? pricing["claude-opus"]! }
-            return pricing["claude-opus"] ?? pricing["default"]!
+            if normalized.contains("4-8") { return pricing["claude-opus-4-8"] ?? (pricing["claude-opus"] ?? defaultPricing) }
+            if normalized.contains("4-7") { return pricing["claude-opus-4-7"] ?? (pricing["claude-opus"] ?? defaultPricing) }
+            if normalized.contains("4-6") { return pricing["claude-opus-4-6"] ?? (pricing["claude-opus"] ?? defaultPricing) }
+            return pricing["claude-opus"] ?? defaultPricing
         }
         if normalized.contains("haiku") {
             return normalized.contains("4-5")
-                ? pricing["claude-haiku-4-5"] ?? pricing["claude-haiku"]!
-                : pricing["claude-haiku"] ?? pricing["default"]!
+                ? pricing["claude-haiku-4-5"] ?? (pricing["claude-haiku"] ?? defaultPricing)
+                : pricing["claude-haiku"] ?? defaultPricing
         }
         if normalized.contains("sonnet") {
-            if normalized.contains("4-6") { return pricing["claude-sonnet-4-6"] ?? pricing["claude-sonnet"]! }
-            if normalized.contains("4-5") { return pricing["claude-sonnet-4-5"] ?? pricing["claude-sonnet"]! }
-            if normalized.contains("4") { return pricing["claude-sonnet-4"] ?? pricing["claude-sonnet"]! }
-            return pricing["claude-sonnet"] ?? pricing["default"]!
+            if normalized.contains("4-6") { return pricing["claude-sonnet-4-6"] ?? (pricing["claude-sonnet"] ?? defaultPricing) }
+            if normalized.contains("4-5") { return pricing["claude-sonnet-4-5"] ?? (pricing["claude-sonnet"] ?? defaultPricing) }
+            if normalized.contains("4") { return pricing["claude-sonnet-4"] ?? (pricing["claude-sonnet"] ?? defaultPricing) }
+            return pricing["claude-sonnet"] ?? defaultPricing
         }
 
-        return pricing["default"]!
+        return defaultPricing
     }
 
     private func normalizeClaudeModel(_ raw: String) -> String {
@@ -474,11 +505,12 @@ class CostTracker: ObservableObject {
         if let versionRange = trimmed.range(of: #"-v\d+:\d+$"#, options: .regularExpression) {
             trimmed.removeSubrange(versionRange)
         }
+        // Strip a trailing `-YYYYMMDD` release-date suffix so dated model ids
+        // (e.g. `claude-opus-4-8-20260101`) normalize to their base id. This keeps
+        // display names clean and lets pricing match new dated models too, not
+        // only the ones already present in the pricing table.
         if let dateRange = trimmed.range(of: #"-\d{8}$"#, options: .regularExpression) {
-            let base = String(trimmed[..<dateRange.lowerBound])
-            if pricing[base] != nil {
-                return base
-            }
+            return String(trimmed[..<dateRange.lowerBound])
         }
         return trimmed
     }
@@ -487,43 +519,15 @@ class CostTracker: ObservableObject {
         let codexDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex")
         let archivedDir = codexDir.appendingPathComponent("archived_sessions")
         let logsDatabase = codexDir.appendingPathComponent("logs_2.sqlite")
-        var totals = TokenAccumulator()
-        var dailyTotals: [Date: TokenAccumulator] = [:]
-        var modelTotals: [String: TokenAccumulator] = [:]
-        var originTotals: [String: TokenAccumulator] = [:]
-        var eventKeys = Set<String>()
-        var sessionIDs = Set<String>()
-        var earliestDate = Date()
-        var latestDate = cutoffDate
+        var context = CodexScanContext(earliestDate: Date(), latestDate: cutoffDate)
 
-        scanCodexArchivedSessions(
-            directory: archivedDir,
-            since: cutoffDate,
-            totals: &totals,
-            dailyTotals: &dailyTotals,
-            modelTotals: &modelTotals,
-            originTotals: &originTotals,
-            eventKeys: &eventKeys,
-            sessionIDs: &sessionIDs,
-            earliestDate: &earliestDate,
-            latestDate: &latestDate
-        )
-        scanCodexSQLiteLogs(
-            database: logsDatabase,
-            since: cutoffDate,
-            totals: &totals,
-            dailyTotals: &dailyTotals,
-            modelTotals: &modelTotals,
-            originTotals: &originTotals,
-            eventKeys: &eventKeys,
-            sessionIDs: &sessionIDs,
-            earliestDate: &earliestDate,
-            latestDate: &latestDate
-        )
+        scanCodexArchivedSessions(directory: archivedDir, since: cutoffDate, context: &context)
+        scanCodexSQLiteLogs(database: logsDatabase, since: cutoffDate, context: &context)
 
+        let totals = context.totals
         guard totals.input > 0 || totals.output > 0 || totals.cacheRead > 0 else { return nil }
 
-        let pricing = self.pricing["codex"] ?? self.pricing["default"]!
+        let pricing = self.pricing["codex"] ?? defaultPricing
         let billableInput = max(0, totals.input - totals.cacheRead)
         let output = totals.output + totals.reasoning
         let cost = calculateCost(
@@ -541,25 +545,18 @@ class CostTracker: ObservableObject {
             cacheCreationTokens: 0,
             cacheReadTokens: totals.cacheRead,
             estimatedCostUSD: cost,
-            sessionCount: sessionIDs.count,
-            periodStart: earliestDate,
-            periodEnd: latestDate,
-            modelBreakdowns: makeBreakdowns(from: modelTotals, provider: .codexCli, pricing: pricing),
-            originBreakdowns: makeBreakdowns(from: originTotals, provider: .codexCli, pricing: pricing)
-        ), makeDailyUsage(from: dailyTotals, provider: .codexCli, pricing: pricing))
+            sessionCount: context.sessionIDs.count,
+            periodStart: context.earliestDate,
+            periodEnd: context.latestDate,
+            modelBreakdowns: makeBreakdowns(from: context.modelTotals, provider: .codexCli, pricing: pricing),
+            originBreakdowns: makeBreakdowns(from: context.originTotals, provider: .codexCli, pricing: pricing)
+        ), makeDailyUsage(from: context.dailyTotals, provider: .codexCli, pricing: pricing))
     }
 
     private func scanCodexArchivedSessions(
         directory: URL,
         since cutoffDate: Date,
-        totals: inout TokenAccumulator,
-        dailyTotals: inout [Date: TokenAccumulator],
-        modelTotals: inout [String: TokenAccumulator],
-        originTotals: inout [String: TokenAccumulator],
-        eventKeys: inout Set<String>,
-        sessionIDs: inout Set<String>,
-        earliestDate: inout Date,
-        latestDate: inout Date
+        context: inout CodexScanContext
     ) {
         guard let enumerator = FileManager.default.enumerator(
             at: directory,
@@ -569,8 +566,7 @@ class CostTracker: ObservableObject {
             return
         }
 
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let formatter = Self.fractionalISO8601Formatter
 
         for case let fileURL as URL in enumerator where fileURL.pathExtension == "jsonl" {
             guard let values = try? fileURL.resourceValues(forKeys: [.contentModificationDateKey]),
@@ -602,14 +598,7 @@ class CostTracker: ObservableObject {
                     sessionID: sessionID,
                     modelName: codexModelName(from: info, payload: payload),
                     originName: "Codex CLI",
-                    totals: &totals,
-                    dailyTotals: &dailyTotals,
-                    modelTotals: &modelTotals,
-                    originTotals: &originTotals,
-                    eventKeys: &eventKeys,
-                    sessionIDs: &sessionIDs,
-                    earliestDate: &earliestDate,
-                    latestDate: &latestDate
+                    context: &context
                 )
             }
         }
@@ -618,14 +607,7 @@ class CostTracker: ObservableObject {
     private func scanCodexSQLiteLogs(
         database: URL,
         since cutoffDate: Date,
-        totals: inout TokenAccumulator,
-        dailyTotals: inout [Date: TokenAccumulator],
-        modelTotals: inout [String: TokenAccumulator],
-        originTotals: inout [String: TokenAccumulator],
-        eventKeys: inout Set<String>,
-        sessionIDs: inout Set<String>,
-        earliestDate: inout Date,
-        latestDate: inout Date
+        context: inout CodexScanContext
     ) {
         guard FileManager.default.fileExists(atPath: database.path) else { return }
 
@@ -661,14 +643,7 @@ class CostTracker: ObservableObject {
                 sessionID: sessionID,
                 modelName: codexLogValue("model", in: body) ?? codexLogValue("slug", in: body),
                 originName: codexLogValue("originator", in: body) ?? "Codex CLI",
-                totals: &totals,
-                dailyTotals: &dailyTotals,
-                modelTotals: &modelTotals,
-                originTotals: &originTotals,
-                eventKeys: &eventKeys,
-                sessionIDs: &sessionIDs,
-                earliestDate: &earliestDate,
-                latestDate: &latestDate
+                context: &context
             )
         }
     }
@@ -679,14 +654,7 @@ class CostTracker: ObservableObject {
         sessionID: String,
         modelName: String?,
         originName: String?,
-        totals: inout TokenAccumulator,
-        dailyTotals: inout [Date: TokenAccumulator],
-        modelTotals: inout [String: TokenAccumulator],
-        originTotals: inout [String: TokenAccumulator],
-        eventKeys: inout Set<String>,
-        sessionIDs: inout Set<String>,
-        earliestDate: inout Date,
-        latestDate: inout Date
+        context: inout CodexScanContext
     ) {
         let input = intValue(usage["input_tokens"])
         let cached = intValue(usage["cached_input_tokens"])
@@ -694,32 +662,36 @@ class CostTracker: ObservableObject {
         let reasoning = intValue(usage["reasoning_output_tokens"])
         guard input > 0 || output > 0 || cached > 0 || reasoning > 0 else { return }
 
-        let key = "\(timestamp.timeIntervalSince1970)-\(sessionID)-\(input)-\(cached)-\(output)-\(reasoning)"
-        guard eventKeys.insert(key).inserted else { return }
+        // Use whole-millisecond precision for the dedup key so equivalent events
+        // produce a stable, collision-resistant string (raw Double formatting can
+        // vary and risks both false matches and false misses).
+        let timestampMillis = Int((timestamp.timeIntervalSince1970 * 1000).rounded())
+        let key = "\(timestampMillis)-\(sessionID)-\(input)-\(cached)-\(output)-\(reasoning)"
+        guard context.eventKeys.insert(key).inserted else { return }
 
-        sessionIDs.insert(sessionID)
-        totals.add(input: input, output: output, cacheCreation: 0, cacheRead: cached, reasoning: reasoning)
+        context.sessionIDs.insert(sessionID)
+        context.totals.add(input: input, output: output, cacheCreation: 0, cacheRead: cached, reasoning: reasoning)
         let day = Calendar.current.startOfDay(for: timestamp)
-        dailyTotals[day, default: TokenAccumulator()].add(
+        context.dailyTotals[day, default: TokenAccumulator()].add(
             input: input,
             output: output + reasoning,
             cacheCreation: 0,
             cacheRead: cached
         )
-        modelTotals[displayModelName(modelName), default: TokenAccumulator()].add(
+        context.modelTotals[displayModelName(modelName), default: TokenAccumulator()].add(
             input: input,
             output: output + reasoning,
             cacheCreation: 0,
             cacheRead: cached
         )
-        originTotals[displayOriginName(originName), default: TokenAccumulator()].add(
+        context.originTotals[displayOriginName(originName), default: TokenAccumulator()].add(
             input: input,
             output: output + reasoning,
             cacheCreation: 0,
             cacheRead: cached
         )
-        if timestamp < earliestDate { earliestDate = timestamp }
-        if timestamp > latestDate { latestDate = timestamp }
+        if timestamp < context.earliestDate { context.earliestDate = timestamp }
+        if timestamp > context.latestDate { context.latestDate = timestamp }
     }
 
     private func makeDailyUsage(
@@ -890,9 +862,7 @@ class CostTracker: ObservableObject {
 
     private func codexLogDate(in text: String) -> Date? {
         guard let value = codexLogValue("event.timestamp", in: text) else { return nil }
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return formatter.date(from: value)
+        return Self.fractionalISO8601Formatter.date(from: value)
     }
 
     private func codexLogInt(_ key: String, in text: String) -> Int {
@@ -901,9 +871,16 @@ class CostTracker: ObservableObject {
     }
 
     private func codexLogValue(_ key: String, in text: String) -> String? {
-        let pattern = NSRegularExpression.escapedPattern(for: key) + #"=([^\s}]+)"#
-        guard let regex = try? NSRegularExpression(pattern: pattern),
-              let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+        let regex: NSRegularExpression
+        if let cached = Self.codexLogValueRegexes[key] {
+            regex = cached
+        } else {
+            let pattern = NSRegularExpression.escapedPattern(for: key) + #"=([^\s}]+)"#
+            guard let built = try? NSRegularExpression(pattern: pattern) else { return nil }
+            regex = built
+        }
+
+        guard let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
               let range = Range(match.range(at: 1), in: text) else {
             return nil
         }
@@ -914,6 +891,21 @@ class CostTracker: ObservableObject {
 private struct CostSummaryCache: Codable {
     let summary: CostSummary
     let lastScanDate: Date
+}
+
+/// Mutable accumulators threaded through the Codex scan. Bundling these into one
+/// value collapses `addCodexUsage`/`scanCodexArchivedSessions`/`scanCodexSQLiteLogs`
+/// from 10–13 parameters (a SwiftLint `function_parameter_count` error) down to
+/// a single `inout` argument.
+private struct CodexScanContext {
+    var totals = TokenAccumulator()
+    var dailyTotals: [Date: TokenAccumulator] = [:]
+    var modelTotals: [String: TokenAccumulator] = [:]
+    var originTotals: [String: TokenAccumulator] = [:]
+    var eventKeys: Set<String> = []
+    var sessionIDs: Set<String> = []
+    var earliestDate: Date
+    var latestDate: Date
 }
 
 private struct TokenPricing {

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -8,10 +8,16 @@ class CostTracker: ObservableObject {
 
     @Published var costSummary: CostSummary?
     @Published var isScanning: Bool = false
+    @Published var isRefreshingMissingDays: Bool = false
     @Published var lastScanDate: Date?
 
     private let providerVisibilityStore = ProviderVisibilityStore.shared
     private let cacheFileName = "cost-summary-v1.json"
+
+    /// True while either a manual scan or a background missing-day backfill runs.
+    var isRefreshInProgress: Bool {
+        isScanning || isRefreshingMissingDays
+    }
 
     // API-rate estimates per million tokens for local log usage.
     private let pricing: [String: TokenPricing] = [
@@ -72,23 +78,13 @@ class CostTracker: ObservableObject {
 
     func scanCosts(days: Int = 30) async {
         let shouldStart = await MainActor.run {
-            guard !isScanning else { return false }
+            guard !isRefreshInProgress else { return false }
             isScanning = true
             return true
         }
         guard shouldStart else { return }
 
-        let includeClaudeCode = providerVisibilityStore.isEnabled(.claudeCode)
-        let includeCodexCli = providerVisibilityStore.isEnabled(.codexCli)
-        let claudeAccounts = ClaudeCodeAccountStore.shared.accounts
-        let summary = await Task.detached(priority: .userInitiated) { [self] in
-            buildCostSummary(
-                days: days,
-                includeClaudeCode: includeClaudeCode,
-                includeCodexCli: includeCodexCli,
-                claudeAccounts: claudeAccounts
-            )
-        }.value
+        let summary = await makeCostSummary(days: days, priority: .userInitiated)
 
         await MainActor.run {
             costSummary = summary
@@ -96,6 +92,45 @@ class CostTracker: ObservableObject {
             saveCachedSummary()
             isScanning = false
         }
+    }
+
+    /// Quietly backfills missing daily rows when Overview/Costs opens, without the
+    /// visible "Scanning" UI a manual scan shows. No-ops unless the cached summary
+    /// actually has gaps in the visible window (see `needsMissingDailyUsageRefresh`).
+    func refreshMissingDaysInBackground(days: Int = 30) async {
+        let shouldStart = await MainActor.run {
+            guard !isRefreshInProgress,
+                  let visibleSummary = costSummary?.filtered(to: providerVisibilityStore.enabledServices),
+                  visibleSummary.needsMissingDailyUsageRefresh(days: days, lastScanDate: lastScanDate) else {
+                return false
+            }
+            isRefreshingMissingDays = true
+            return true
+        }
+        guard shouldStart else { return }
+
+        let summary = await makeCostSummary(days: days, priority: .utility)
+
+        await MainActor.run {
+            costSummary = summary
+            lastScanDate = Date()
+            saveCachedSummary()
+            isRefreshingMissingDays = false
+        }
+    }
+
+    private func makeCostSummary(days: Int, priority: TaskPriority) async -> CostSummary {
+        let includeClaudeCode = providerVisibilityStore.isEnabled(.claudeCode)
+        let includeCodexCli = providerVisibilityStore.isEnabled(.codexCli)
+        let claudeAccounts = ClaudeCodeAccountStore.shared.accounts
+        return await Task.detached(priority: priority) { [self] in
+            buildCostSummary(
+                days: days,
+                includeClaudeCode: includeClaudeCode,
+                includeCodexCli: includeCodexCli,
+                claudeAccounts: claudeAccounts
+            )
+        }.value
     }
 
     private func buildCostSummary(

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import os
 import SQLite3
 
 class CostTracker: ObservableObject {

--- a/MeterBar/Services/CursorLocalService.swift
+++ b/MeterBar/Services/CursorLocalService.swift
@@ -14,13 +14,26 @@ class CursorLocalService: ObservableObject {
     private let usageSummaryEndpoint = "https://cursor.com/api/usage-summary"
     private let getMeEndpoint = "https://cursor.com/api/dashboard/get-me"
 
-    // URLSession with timeout configuration
-    private lazy var urlSession: URLSession = {
-        let configuration = URLSessionConfiguration.default
-        configuration.timeoutIntervalForRequest = 30.0
-        configuration.timeoutIntervalForResource = 60.0
-        configuration.waitsForConnectivity = true
-        return URLSession(configuration: configuration)
+    // URLSession shared via ServiceSupport for consistent timeout/connectivity config
+    private let urlSession = ServiceSupport.makeUsageSession()
+
+    // Assumed default monthly request quota when the API omits a plan total
+    private let defaultPlanTotal: Double = 500
+
+    // Display headroom estimate when no explicit on-demand limit is returned by the API
+    private let onDemandHeadroomMultiplier: Double = 1.5
+
+    // Cached ISO8601 date formatters to avoid repeated allocations
+    private static let fractionalISO8601: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static let plainISO8601: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
     }()
 
     @Published private(set) var hasAccess: Bool = false
@@ -28,31 +41,16 @@ class CursorLocalService: ObservableObject {
     @Published private(set) var lastError: ServiceError?
 
     private init() {
-        // Check if we have Cursor credentials on init
-        checkAccess()
+        // Defer I/O off main thread; only @Published mutations land on main actor
+        Task.detached(priority: .utility) { [weak self] in self?.checkAccess(forceRescan: false) }
     }
 
     // MARK: - Database Access (cursor-stats approach)
 
-    /// Get the REAL home directory (not sandboxed container)
-    private func getRealHomeDirectory() -> String {
-        // In sandboxed apps, FileManager.homeDirectoryForCurrentUser returns the container path
-        // We need the actual user home directory to access Cursor's database
-        if let pw = getpwuid(getuid()) {
-            return String(cString: pw.pointee.pw_dir)
-        }
-        // Fallback to environment variable
-        if let home = ProcessInfo.processInfo.environment["HOME"] {
-            return home
-        }
-        // Last resort - this will be sandboxed but better than nothing
-        return FileManager.default.homeDirectoryForCurrentUser.path
-    }
-
     /// Get the path to Cursor's state database
     /// Scans multiple possible locations and optionally searches recursively
     private func getCursorDatabasePath(forceRescan: Bool = false) -> String? {
-        let homeDir = getRealHomeDirectory()
+        let homeDir = ServiceSupport.realHomeDirectory()
         let fileManager = FileManager.default
 
         // Primary paths to check (most common locations)
@@ -64,50 +62,40 @@ class CursorLocalService: ObservableObject {
             "\(homeDir)/Library/Application Support/Cursor/User/workspaceStorage/state.vscdb",
             "\(homeDir)/Library/Application Support/Cursor/globalStorage/state.vscdb",
         ]
-        
+
         // Check each path
         for path in pathsToCheck {
             if fileManager.fileExists(atPath: path) {
-                print("[CursorLocalService] Found database at: \(path)")
                 return path
             }
         }
-        
+
         // If not found and forceRescan is true, search recursively in Cursor directories
         if forceRescan {
-            print("[CursorLocalService] Primary paths not found, scanning Cursor directories...")
             let cursorBasePaths = [
                 "\(homeDir)/Library/Application Support/Cursor",
                 "\(homeDir)/.config/Cursor"
             ]
-            
+
             for basePath in cursorBasePaths {
                 if let foundPath = findDatabaseRecursively(in: basePath, filename: "state.vscdb") {
-                    print("[CursorLocalService] Found database via recursive search at: \(foundPath)")
                     return foundPath
                 }
             }
         }
-        
-        // Log all checked paths for debugging
-        print("[CursorLocalService] Database not found. Checked paths:")
-        for path in pathsToCheck {
-            let exists = fileManager.fileExists(atPath: path)
-            print("[CursorLocalService]   \(exists ? "✓" : "✗") \(path)")
-        }
-        
+
         return nil
     }
-    
+
     /// Recursively search for a database file in a directory
     private func findDatabaseRecursively(in directory: String, filename: String) -> String? {
         let fileManager = FileManager.default
-        
+
         guard fileManager.fileExists(atPath: directory),
               let enumerator = fileManager.enumerator(atPath: directory) else {
             return nil
         }
-        
+
         for case let path as String in enumerator {
             if path.hasSuffix(filename) {
                 let fullPath = "\(directory)/\(path)"
@@ -116,7 +104,7 @@ class CursorLocalService: ObservableObject {
                 }
             }
         }
-        
+
         return nil
     }
 
@@ -124,25 +112,21 @@ class CursorLocalService: ObservableObject {
     /// - Parameter forceRescan: If true, will recursively search for database if not found in primary paths
     func getAccessTokenFromDatabase(forceRescan: Bool = false) -> (userId: String, token: String)? {
         guard let dbPath = getCursorDatabasePath(forceRescan: forceRescan) else {
-            if forceRescan {
-                print("[CursorLocalService] Database not found after rescanning all paths")
-            }
             // Database not found - Cursor may not be installed, which is okay
-            // Don't print error on init, only when actively trying to fetch
             return nil
         }
 
         // Verify file exists and is readable before attempting to open
         let isReadable = FileManager.default.isReadableFile(atPath: dbPath)
         if !isReadable {
-            print("[CursorLocalService] Database file not readable (sandbox blocking access)")
+            AppLog.usage.error("Cursor database not readable (sandbox)")
             return nil
         }
 
         var db: OpaquePointer?
         let result = sqlite3_open_v2(dbPath, &db, SQLITE_OPEN_READONLY, nil)
         guard result == SQLITE_OK else {
-            print("[CursorLocalService] SQLite open failed: \(result) - \(String(cString: sqlite3_errmsg(db)))")
+            AppLog.usage.error("Cursor SQLite open failed: \(result, privacy: .public)")
             sqlite3_close(db)
             return nil
         }
@@ -152,18 +136,17 @@ class CursorLocalService: ObservableObject {
         var statement: OpaquePointer?
 
         guard sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK else {
-            print("[CursorLocalService] Failed to prepare query: \(String(cString: sqlite3_errmsg(db)))")
+            AppLog.usage.error("Cursor query prepare failed")
             return nil
         }
         defer { sqlite3_finalize(statement) }
 
         guard sqlite3_step(statement) == SQLITE_ROW else {
-            print("[CursorLocalService] No token found in database")
             return nil
         }
 
         guard let tokenCString = sqlite3_column_text(statement, 0) else {
-            print("[CursorLocalService] Failed to read token value")
+            AppLog.usage.error("Cursor token value unreadable")
             return nil
         }
 
@@ -171,11 +154,10 @@ class CursorLocalService: ObservableObject {
 
         // Decode JWT to extract userId from 'sub' claim
         guard let userId = extractUserIdFromJWT(token) else {
-            print("[CursorLocalService] Failed to extract userId from JWT")
+            AppLog.usage.error("Cursor JWT userId extraction failed")
             return nil
         }
 
-        print("[CursorLocalService] Successfully retrieved token for user: \(userId.prefix(8))...")
         return (userId: userId, token: token)
     }
 
@@ -222,12 +204,13 @@ class CursorLocalService: ObservableObject {
     /// Check and update access status
     /// - Parameter forceRescan: If true, will recursively search for database if not found in primary paths
     func checkAccess(forceRescan: Bool = false) {
-        if let _ = getAccessTokenFromDatabase(forceRescan: forceRescan) {
-            hasAccess = true
-        } else {
-            hasAccess = false
-            subscriptionType = nil
+        let hasToken = getAccessTokenFromDatabase(forceRescan: forceRescan) != nil
+        let apply = { [weak self] in
+            guard let self else { return }
+            self.hasAccess = hasToken
+            if !hasToken { self.subscriptionType = nil }
         }
+        if Thread.isMainThread { apply() } else { DispatchQueue.main.async(execute: apply) }
     }
 
     // MARK: - Usage Fetching
@@ -240,15 +223,12 @@ class CursorLocalService: ObservableObject {
                 self.lastError = error
                 self.hasAccess = false
             }
-            print("[CursorLocalService] No access token found in database after full scan")
             throw error
         }
 
         await MainActor.run {
             self.hasAccess = true
         }
-
-        print("[CursorLocalService] Fetching usage data from Cursor API...")
 
         // Fetch usage summary data (uses /api/usage-summary endpoint)
         let summaryData = try await fetchUsageSummary(userId: userId, token: token)
@@ -262,24 +242,12 @@ class CursorLocalService: ObservableObject {
         // Parse billing cycle end date for reset time
         var resetTime: Date? = nil
         if let billingEnd = summaryData.billingCycleEnd {
-            let dateFormatter = ISO8601DateFormatter()
-            dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-            resetTime = dateFormatter.date(from: billingEnd)
-
-            // Try without fractional seconds if that fails
-            if resetTime == nil {
-                dateFormatter.formatOptions = [.withInternetDateTime]
-                resetTime = dateFormatter.date(from: billingEnd)
-            }
+            resetTime = Self.fractionalISO8601.date(from: billingEnd) ?? Self.plainISO8601.date(from: billingEnd)
         }
 
         // Extract usage from individual plan
         let planUsed = Double(summaryData.individualUsage?.plan?.used ?? 0)
-        let planTotal = Double(summaryData.individualUsage?.plan?.total ?? 500)
-
-        print("[CursorLocalService] Plan type: \(summaryData.membershipType ?? "unknown")")
-        print("[CursorLocalService] Plan usage: \(Int(planUsed)) / \(Int(planTotal))")
-        print("[CursorLocalService] Billing cycle end: \(summaryData.billingCycleEnd ?? "unknown")")
+        let planTotal = Double(summaryData.individualUsage?.plan?.total ?? Int(defaultPlanTotal))
 
         // Create usage metrics using plan data
         let weeklyLimit = UsageLimit(
@@ -296,13 +264,11 @@ class CursorLocalService: ObservableObject {
             if onDemandUsed > 0 || onDemandLimit > 0 {
                 sessionLimit = UsageLimit(
                     used: onDemandUsed,
-                    total: onDemandLimit > 0 ? onDemandLimit : onDemandUsed * 1.5,
+                    total: onDemandLimit > 0 ? onDemandLimit : onDemandUsed * onDemandHeadroomMultiplier,
                     resetTime: resetTime
                 )
             }
         }
-
-        print("[CursorLocalService] Successfully fetched Cursor usage data")
 
         return UsageMetrics(
             service: .cursor,
@@ -341,15 +307,11 @@ class CursorLocalService: ObservableObject {
             request.setValue(value, forHTTPHeaderField: key)
         }
 
-        print("[CursorLocalService] Calling usage-summary endpoint")
-
         let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ServiceError.apiError("Invalid response type")
         }
-
-        print("[CursorLocalService] Usage summary response status: \(httpResponse.statusCode)")
 
         if httpResponse.statusCode == 401 {
             await MainActor.run {
@@ -360,24 +322,17 @@ class CursorLocalService: ObservableObject {
         }
 
         guard (200...299).contains(httpResponse.statusCode) else {
-            let errorMsg = String(data: data, encoding: .utf8) ?? "Unknown error"
-            print("[CursorLocalService] Usage summary error: \(errorMsg.prefix(200))")
-            throw ServiceError.apiError("HTTP \(httpResponse.statusCode): \(errorMsg.prefix(100))")
-        }
-
-        // Debug: print raw response
-        if let rawResponse = String(data: data, encoding: .utf8) {
-            print("[CursorLocalService] Raw usage-summary response: \(rawResponse.prefix(500))")
+            AppLog.usage.error("Cursor usage-summary HTTP \(httpResponse.statusCode, privacy: .public)")
+            throw ServiceError.apiError("HTTP \(httpResponse.statusCode)")
         }
 
         // Parse the response
         let decoder = JSONDecoder()
         do {
             let summaryResponse = try decoder.decode(CursorUsageSummaryResponse.self, from: data)
-            print("[CursorLocalService] Parsed usage summary: used=\(summaryResponse.individualUsage?.plan?.used ?? 0), total=\(summaryResponse.individualUsage?.plan?.total ?? 0)")
             return summaryResponse
         } catch {
-            print("[CursorLocalService] JSON decode error: \(error)")
+            AppLog.usage.error("Cursor usage-summary decode failed")
             throw ServiceError.parsingError
         }
     }

--- a/MeterBar/Services/CursorLocalService.swift
+++ b/MeterBar/Services/CursorLocalService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import AppKit
 import Combine
 import Network

--- a/MeterBar/Services/KeychainManager.swift
+++ b/MeterBar/Services/KeychainManager.swift
@@ -10,20 +10,29 @@ class KeychainManager {
     
     func save(key: String, value: String) -> Bool {
         guard let data = value.data(using: .utf8) else { return false }
-        
+
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
-            kSecAttrAccount as String: key,
-            kSecValueData as String: data
+            kSecAttrAccount as String: key
         ]
-        
-        // Delete existing item
-        SecItemDelete(query as CFDictionary)
-        
-        // Add new item
-        let status = SecItemAdd(query as CFDictionary, nil)
-        return status == errSecSuccess
+
+        // Update-then-add instead of delete-then-add. Two concurrent saves with a
+        // delete/add pair can both delete and then race on add (one fails with
+        // errSecDuplicateItem); SecItemUpdate has no such window.
+        let attributes: [String: Any] = [kSecValueData as String: data]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+
+        switch updateStatus {
+        case errSecSuccess:
+            return true
+        case errSecItemNotFound:
+            var addQuery = query
+            addQuery[kSecValueData as String] = data
+            return SecItemAdd(addQuery as CFDictionary, nil) == errSecSuccess
+        default:
+            return false
+        }
     }
     
     func get(key: String) -> String? {

--- a/MeterBar/Services/OAuthTokenExpiry.swift
+++ b/MeterBar/Services/OAuthTokenExpiry.swift
@@ -2,6 +2,11 @@ import Foundation
 
 enum OAuthTokenExpiry {
     static func isExpired(jwt token: String, graceInterval: TimeInterval = 60, now: Date = Date()) -> Bool {
+        // If the token has no parseable `exp` claim we cannot prove it is expired,
+        // so we treat it as not-expired and let the server be the source of truth
+        // (a truly invalid token simply 401s on the next request). This is a
+        // deliberate availability choice: failing to introspect a token must not
+        // lock out a session whose token format we don't fully understand.
         guard let expirationDate = expirationDate(fromJWT: token) else {
             return false
         }

--- a/MeterBar/Services/OpenAIService.swift
+++ b/MeterBar/Services/OpenAIService.swift
@@ -9,6 +9,9 @@ class OpenAIService {
 
     private init() {}
 
+    /// Safety cap on pagination so a misbehaving API can never loop forever.
+    private let maxUsagePages = 50
+
     func fetchUsageMetrics() async throws -> UsageMetrics {
         guard let adminKey = authManager.openaiAdminKey else {
             throw ServiceError.notAuthenticated
@@ -16,58 +19,59 @@ class OpenAIService {
 
         // Calculate time range: last 7 days (Unix timestamps)
         let endDate = Date()
-        let startDate = Calendar.current.date(byAdding: .day, value: -7, to: endDate)!
+        let startDate = Calendar.current.date(byAdding: .day, value: -7, to: endDate) ?? endDate
 
         let startTime = Int(startDate.timeIntervalSince1970)
         let endTime = Int(endDate.timeIntervalSince1970)
 
-        // Build URL with query parameters
-        var components = URLComponents(string: "\(baseURL)/v1/organization/usage/completions")!
-        components.queryItems = [
+        let baseQueryItems = [
             URLQueryItem(name: "start_time", value: String(startTime)),
             URLQueryItem(name: "end_time", value: String(endTime)),
             URLQueryItem(name: "bucket_width", value: "1d"),
             URLQueryItem(name: "group_by", value: "model")
         ]
 
-        guard let url = components.url else {
-            throw ServiceError.invalidURL
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(adminKey)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw ServiceError.apiError("Invalid response")
-        }
-
-        guard (200...299).contains(httpResponse.statusCode) else {
-            if httpResponse.statusCode == 401 {
-                throw ServiceError.notAuthenticated
-            }
-            let errorMessage = String(data: data, encoding: .utf8) ?? "Unknown error"
-            throw ServiceError.apiError("API error (\(httpResponse.statusCode)): \(errorMessage)")
-        }
-
-        // Parse response
         let decoder = JSONDecoder()
 
-        let responseData = try decoder.decode(OpenAIUsageResponse.self, from: data)
+        // Follow pagination: ignoring `has_more`/`next_page` silently under-counts
+        // usage when the 7-day window spans more than one page of buckets.
+        var allBuckets: [OpenAIUsageBucket] = []
+        var nextPage: String?
+        var pagesFetched = 0
+
+        repeat {
+            guard var components = URLComponents(string: "\(baseURL)/v1/organization/usage/completions") else {
+                throw ServiceError.invalidURL
+            }
+            var queryItems = baseQueryItems
+            if let nextPage {
+                queryItems.append(URLQueryItem(name: "page", value: nextPage))
+            }
+            components.queryItems = queryItems
+
+            guard let url = components.url else {
+                throw ServiceError.invalidURL
+            }
+
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+            request.setValue("Bearer \(adminKey)", forHTTPHeaderField: "Authorization")
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+            let responseData: OpenAIUsageResponse = try await ServiceSupport.fetchDecoded(request, decoder: decoder)
+            allBuckets.append(contentsOf: responseData.data)
+            nextPage = (responseData.hasMore == true) ? responseData.nextPage : nil
+            pagesFetched += 1
+        } while nextPage != nil && pagesFetched < maxUsagePages
 
         // Aggregate all usage data
         var totalInputTokens: Double = 0
         var totalOutputTokens: Double = 0
-        var totalRequests: Double = 0
 
-        for bucket in responseData.data {
+        for bucket in allBuckets {
             for result in bucket.results {
                 totalInputTokens += Double(result.inputTokens ?? 0)
                 totalOutputTokens += Double(result.outputTokens ?? 0)
-                totalRequests += Double(result.numModelRequests ?? 0)
             }
         }
 

--- a/MeterBar/Services/ServiceSupport.swift
+++ b/MeterBar/Services/ServiceSupport.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Shared helpers for the local provider usage services.
+///
+/// Centralizes the previously duplicated URLSession configuration, the
+/// `URLError` → user message mapping, and the real (non-sandboxed) home
+/// directory lookup so all services behave consistently.
+enum ServiceSupport {
+    /// A `URLSession` configured with the standard MeterBar usage-request timeouts.
+    static func makeUsageSession() -> URLSession {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 60
+        configuration.waitsForConnectivity = true
+        return URLSession(configuration: configuration)
+    }
+
+    /// Human-readable message for a `URLError`, shared so error copy stays consistent.
+    static func message(for urlError: URLError) -> String {
+        switch urlError.code {
+        case .notConnectedToInternet:
+            return "No internet connection"
+        case .cannotFindHost, .dnsLookupFailed:
+            return "DNS lookup failed"
+        case .timedOut:
+            return "Request timed out"
+        default:
+            return urlError.localizedDescription
+        }
+    }
+
+    /// Performs `request`, validates the HTTP status, and decodes the body.
+    ///
+    /// Shared by the admin-key API services (Claude/OpenAI usage reports) so the
+    /// status-handling and decode boilerplate lives in one place. Maps 401 to
+    /// `.notAuthenticated` and other non-2xx codes to `.apiError`.
+    static func fetchDecoded<T: Decodable>(
+        _ request: URLRequest,
+        decoder: JSONDecoder,
+        session: URLSession = .shared
+    ) async throws -> T {
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ServiceError.apiError("Invalid response")
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            if httpResponse.statusCode == 401 {
+                throw ServiceError.notAuthenticated
+            }
+            let errorMessage = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw ServiceError.apiError("API error (\(httpResponse.statusCode)): \(errorMessage)")
+        }
+
+        return try decoder.decode(T.self, from: data)
+    }
+
+    /// The real home directory for the current user.
+    ///
+    /// In sandboxed builds `FileManager.homeDirectoryForCurrentUser` returns the
+    /// app container path; CLI credential/log files live under the user's actual
+    /// home, so resolve it via `getpwuid` (with environment and FileManager
+    /// fallbacks).
+    static func realHomeDirectory() -> String {
+        if let pw = getpwuid(getuid()) {
+            return String(cString: pw.pointee.pw_dir)
+        }
+        if let home = ProcessInfo.processInfo.environment["HOME"], !home.isEmpty {
+            return home
+        }
+        return FileManager.default.homeDirectoryForCurrentUser.path
+    }
+}

--- a/MeterBar/Services/SharedDataStore.swift
+++ b/MeterBar/Services/SharedDataStore.swift
@@ -9,31 +9,43 @@ class SharedDataStore {
     
     private let appGroupIdentifier = "group.dev.shipshit.meterbar"
     private let metricsKey = "cached_usage_metrics"
-    
+
+    /// Serial queue for off-main disk writes so callers on the MainActor don't
+    /// block on file I/O, while still serializing writes to the shared file.
+    private let ioQueue = DispatchQueue(label: "dev.shipshit.meterbar.SharedDataStore.io", qos: .utility)
+
     private var containerURL: URL? {
         return FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)
     }
-    
+
     private init() {}
-    
+
     func saveMetrics(_ metrics: [ServiceType: UsageMetrics]) {
         guard let containerURL = containerURL else {
-            print("[SharedDataStore] App Group container not available. Enable App Groups for both app and widget targets.")
+            AppLog.storage.error("App Group container unavailable; enable App Groups for the app and widget targets.")
             return
         }
 
         let fileURL = containerURL.appendingPathComponent("\(metricsKey).json")
-        
+
         let encoded = metrics.reduce(into: [String: UsageMetrics]()) { result, pair in
             result[pair.key.rawValue] = pair.value
         }
-        
-        do {
-            let data = try JSONEncoder().encode(encoded)
-            try data.write(to: fileURL)
-            reloadWidgetTimelines()
-        } catch {
-            print("[SharedDataStore] Failed to save metrics: \(error)")
+
+        guard let data = try? JSONEncoder().encode(encoded) else {
+            AppLog.storage.error("Failed to encode shared metrics")
+            return
+        }
+
+        // Write off the main thread (callers run on the MainActor). Atomic write
+        // avoids a torn file if two saves race.
+        ioQueue.async { [weak self] in
+            do {
+                try data.write(to: fileURL, options: [.atomic])
+                self?.reloadWidgetTimelines()
+            } catch {
+                AppLog.storage.error("Failed to save shared metrics: \(error.localizedDescription, privacy: .public)")
+            }
         }
     }
     

--- a/MeterBar/Services/SharedDataStore.swift
+++ b/MeterBar/Services/SharedDataStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 #if canImport(WidgetKit)
 import WidgetKit
 #endif

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -52,7 +52,7 @@ class UsageDataManager: ObservableObject {
                 newMetrics[.claude] = metrics
             } catch {
                 lastError = error
-                print("Failed to fetch Claude metrics: \(error)")
+                AppLog.usage.error("Failed to fetch Claude metrics: \(error.localizedDescription, privacy: .public)")
             }
         }
 
@@ -77,7 +77,7 @@ class UsageDataManager: ObservableObject {
                 newMetrics[.openai] = metrics
             } catch {
                 lastError = error
-                print("Failed to fetch OpenAI metrics: \(error)")
+                AppLog.usage.error("Failed to fetch OpenAI metrics: \(error.localizedDescription, privacy: .public)")
             }
         }
 
@@ -88,7 +88,7 @@ class UsageDataManager: ObservableObject {
                 newMetrics[.codexCli] = metrics
             } catch {
                 lastError = error
-                print("Failed to fetch Codex CLI metrics: \(error)")
+                AppLog.usage.error("Failed to fetch Codex CLI metrics: \(error.localizedDescription, privacy: .public)")
                 // Preserve cached data if available (graceful degradation)
                 if let cachedMetrics = self.metrics[.codexCli] {
                     newMetrics[.codexCli] = cachedMetrics
@@ -103,7 +103,7 @@ class UsageDataManager: ObservableObject {
                 newMetrics[.cursor] = metrics
             } catch {
                 lastError = error
-                print("Failed to fetch Cursor metrics: \(error)")
+                AppLog.usage.error("Failed to fetch Cursor metrics: \(error.localizedDescription, privacy: .public)")
                 // Preserve cached data if available (graceful degradation)
                 if let cachedMetrics = self.metrics[.cursor] {
                     newMetrics[.cursor] = cachedMetrics
@@ -159,7 +159,10 @@ class UsageDataManager: ObservableObject {
                 } else if let cachedMetric = metrics[service] {
                     newMetrics = cachedMetric
                 } else {
-                    throw lastError ?? ServiceError.notAuthenticated
+                    // No representative account metrics and nothing cached. Throw a
+                    // specific error rather than the shared `lastError`, which may
+                    // hold a stale error from an unrelated provider/account.
+                    throw ServiceError.notAuthenticated
                 }
             case .openai:
                 guard authManager.isOpenAIAuthenticated else {
@@ -217,19 +220,13 @@ class UsageDataManager: ObservableObject {
     }
 
     private func loadCachedData() {
-        guard let data = UserDefaults.standard.data(forKey: cacheKey),
-              let decoded = try? JSONDecoder().decode([String: UsageMetrics].self, from: data) else {
-            return
-        }
-
-        metrics = decoded.reduce(into: [ServiceType: UsageMetrics]()) { result, pair in
-            if let service = ServiceType(rawValue: pair.key) {
-                result[service] = pair.value
-            }
+        let decoded = loadCachedMetricsFromDisk()
+        if !decoded.isEmpty {
+            metrics = decoded
         }
     }
-    
-    /// Load cached metrics from disk without modifying instance state
+
+    /// Decode cached metrics from disk without modifying instance state.
     private func loadCachedMetricsFromDisk() -> [ServiceType: UsageMetrics] {
         guard let data = UserDefaults.standard.data(forKey: cacheKey),
               let decoded = try? JSONDecoder().decode([String: UsageMetrics].self, from: data) else {

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import Combine
 import SwiftUI
 

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -127,16 +127,18 @@ struct MenuBarView: View {
             Button(action: openDashboard) {
                 Image(systemName: "sidebar.right")
             }
-            .buttonStyle(.borderless)
+            .buttonStyle(.glass)
+            .controlSize(.small)
             .help("Open Usage Dashboard")
 
             Button {
                 Task { await dataManager.refreshAll() }
             } label: {
-                Image(systemName: "arrow.clockwise")
+                RefreshingIcon(isRefreshing: dataManager.isLoading)
             }
-            .buttonStyle(.borderless)
-            .help("Refresh usage")
+            .buttonStyle(.glass)
+            .controlSize(.small)
+            .help(dataManager.isLoading ? "Refreshing usage" : "Refresh usage")
 
             optionsMenu
         }
@@ -159,7 +161,9 @@ struct MenuBarView: View {
         } label: {
             Image(systemName: "ellipsis")
         }
-        .menuStyle(.borderlessButton)
+        .menuStyle(.button)
+        .buttonStyle(.glass)
+        .controlSize(.small)
         .menuIndicator(.hidden)
         .fixedSize()
         .help("More options")
@@ -205,7 +209,8 @@ struct PopoverOverviewPanel: View {
                         logoKind: .claude,
                         accentColor: MeterBarTheme.claudeAccent,
                         metrics: accountMetrics[account.id],
-                        emptyDetail: account.isDefault ? "Waiting for refresh" : "Run claude login"
+                        emptyDetail: account.isDefault ? "Waiting for refresh" : "Run claude login",
+                        accountID: account.id
                     ))
                 }
             } else {
@@ -262,14 +267,21 @@ struct PopoverOverviewPanel: View {
             return "Refresh to load enabled providers."
         }
         if tightestLimit.percentLeft <= 0 {
-            return "\(tightestLimit.title) is out until reset across \(snapshots.count) sources."
+            return "\(tightestLimit.title) is out until reset across \(sourcesLabel)."
         }
-        return "\(tightestLimit.title) has \(tightestLimit.percentLeft)% left across \(snapshots.count) sources."
+        return "\(tightestLimit.title) has \(tightestLimit.percentLeft)% left across \(sourcesLabel)."
+    }
+
+    private var sourcesLabel: String {
+        snapshots.count == 1 ? "1 source" : "\(snapshots.count) sources"
     }
 
     private var statusIconName: String {
         guard let tightestLimit else { return "clock.fill" }
-        if tightestLimit.percentLeft <= 0 { return "exclamationmark.octagon.fill" }
+        // Align icon severity with the status color/title bands: the <= 10 "needs
+        // attention" band is red (danger), so it gets the strong octagon icon
+        // rather than the same triangle used for the orange "tight" band.
+        if tightestLimit.percentLeft <= 10 { return "exclamationmark.octagon.fill" }
         if tightestLimit.percentLeft <= 25 { return "exclamationmark.triangle.fill" }
         return "checkmark.shield.fill"
     }
@@ -342,9 +354,13 @@ private struct PopoverProviderSnapshot: Identifiable {
         logoKind: ProviderLogoKind,
         accentColor: Color,
         metrics: UsageMetrics?,
-        emptyDetail: String
+        emptyDetail: String,
+        accountID: UUID? = nil
     ) {
-        self.id = "\(title)-\(logoKind)"
+        // Disambiguate by account id so two accounts that share a display name
+        // (e.g. both "Work") don't collide on a single Identifiable id, which
+        // would corrupt the ForEach that renders the provider cards.
+        self.id = "\(title)-\(logoKind)-\(accountID?.uuidString ?? "default")"
         self.title = title
         self.logoKind = logoKind
         self.accentColor = accentColor
@@ -355,7 +371,7 @@ private struct PopoverProviderSnapshot: Identifiable {
         self.limits = [
             PopoverLimit(title: "Session", limit: metrics?.sessionLimit),
             PopoverLimit(title: "Weekly", limit: metrics?.weeklyLimit),
-            PopoverLimit(title: logoKind == .codex ? "Code Review" : "Sonnet", limit: metrics?.codeReviewLimit)
+            PopoverLimit(title: logoKind == .claude ? "Sonnet" : "Code Review", limit: metrics?.codeReviewLimit)
         ].compactMap { $0 }
     }
 
@@ -506,9 +522,7 @@ private struct PopoverProviderStatusCard: View {
 
     private var updatedText: String {
         guard let updatedAt = snapshot.updatedAt else { return "No data" }
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return "Updated \(formatter.localizedString(for: updatedAt, relativeTo: Date()))"
+        return "Updated \(UsageFormat.relative(updatedAt))"
     }
 }
 
@@ -717,8 +731,11 @@ struct BlockingLimitResetCounter: View {
         }
     }
 
-    /// Selects the exhausted window that actually gates usage. Unknown reset
-    /// times are treated as blocking because they may outlast known reset windows.
+    /// Selects the exhausted window that actually gates usage — the exhausted
+    /// window with the latest known reset time (or the most recently passed one
+    /// within the grace period). If any exhausted window has no known reset time,
+    /// returns `nil` so the card shows a plain "exhausted" state without an
+    /// unreliable countdown rather than guessing.
     static func selectBlockingWindow(
         _ windows: [ResetCountdownWindow],
         now: Date,
@@ -991,14 +1008,10 @@ struct UsageBar: View {
 }
 
 private extension View {
-    /// A content surface for cards that sit on the popover's glass chrome.
-    /// Uses an opaque system control background (not a material) so it never
-    /// stacks glass on glass, with concentric continuous corners.
+    /// Popover content-card surface. Delegates to the shared `meterBarCardSurface`
+    /// so the popover and dashboard cards stay visually identical.
     func cardSurface() -> some View {
-        background(
-            Color(nsColor: .controlBackgroundColor),
-            in: RoundedRectangle(cornerRadius: 12, style: .continuous)
-        )
+        meterBarCardSurface()
     }
 }
 

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -66,6 +66,24 @@ struct MeterBarDetailBackground: View {
     }
 }
 
+extension View {
+    /// Shared content-card surface used by both the popover and the dashboard.
+    /// An opaque system control background (not a material) with concentric
+    /// continuous corners, so cards never stack glass-on-glass — chrome glass
+    /// belongs to the window, sidebar, toolbar, and popover controls. A hairline
+    /// separator keeps the card from disappearing into the companion background.
+    func meterBarCardSurface(cornerRadius: CGFloat = 12) -> some View {
+        background(
+            Color(nsColor: .controlBackgroundColor),
+            in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .stroke(Color(nsColor: .separatorColor).opacity(0.55), lineWidth: 0.5)
+        }
+    }
+}
+
 extension Color {
     /// An appearance-adaptive color backed by a dynamic `NSColor`, resolving the
     /// correct value for light / dark (and optionally high-contrast) appearances.

--- a/MeterBar/Views/RefreshingIcon.swift
+++ b/MeterBar/Views/RefreshingIcon.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// A refresh glyph that spins while work is in flight, and respects Reduce Motion.
+/// Bound to real loading/scanning state so it reflects refreshes triggered from
+/// anywhere, not just a local button tap.
+struct RefreshingIcon: View {
+    let isRefreshing: Bool
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var rotationDegrees = 0.0
+
+    var body: some View {
+        Image(systemName: "arrow.clockwise")
+            .rotationEffect(.degrees(rotationDegrees))
+            .onAppear(perform: updateRotation)
+            .onChange(of: isRefreshing) { _, _ in
+                updateRotation()
+            }
+            .onChange(of: reduceMotion) { _, _ in
+                updateRotation()
+            }
+    }
+
+    private func updateRotation() {
+        if isRefreshing, !reduceMotion {
+            withAnimation(.linear(duration: 0.8).repeatForever(autoreverses: false)) {
+                rotationDegrees = 360
+            }
+        } else {
+            withAnimation(.easeOut(duration: 0.15)) {
+                rotationDegrees = 0
+            }
+        }
+    }
+}

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -502,9 +502,7 @@ struct SettingsView: View {
     }
 
     private func formatDate(_ date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: date, relativeTo: Date())
+        UsageFormat.relative(date)
     }
 
     private func addClaudeAccount() {
@@ -672,37 +670,44 @@ private struct AccountProfileRow: View {
     }
 }
 
-struct ClaudeHelpView: View {
+/// Shared admin-key help sheet. The Claude and OpenAI variants only differ by
+/// copy and the console URL, so they share one layout.
+private struct AdminKeyHelpView: View {
     @Environment(\.dismiss) var dismiss
+
+    let title: String
+    let intro: String
+    let steps: [String]
+    let note: String
+    let consoleButtonTitle: String
+    let consoleURL: String
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("How to get Claude Admin API Key")
+            Text(title)
                 .font(.title2)
                 .bold()
 
-            Text("The Usage API requires an Admin API key, which is different from a regular API key.")
+            Text(intro)
                 .foregroundColor(.secondary)
 
             Divider()
 
             VStack(alignment: .leading, spacing: 8) {
-                Text("1. Go to the Claude Console")
-                Text("2. Navigate to Settings → Admin Keys")
-                Text("3. Click 'Create Admin Key'")
-                Text("4. Copy the key (starts with sk-ant-admin...)")
-                Text("5. Paste it in the field above")
+                ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
+                    Text("\(index + 1). \(step)")
+                }
             }
 
             Divider()
 
-            Text("Note: You must be an organization admin to create Admin API keys. Individual accounts cannot access the Usage API.")
+            Text(note)
                 .font(.caption)
                 .foregroundStyle(MeterBarTheme.warning)
 
             HStack {
-                Button("Open Claude Console") {
-                    if let url = URL(string: "https://console.anthropic.com/settings/admin-keys") {
+                Button(consoleButtonTitle) {
+                    if let url = URL(string: consoleURL) {
                         NSWorkspace.shared.open(url)
                     }
                 }
@@ -720,50 +725,40 @@ struct ClaudeHelpView: View {
     }
 }
 
-struct OpenAIHelpView: View {
-    @Environment(\.dismiss) var dismiss
-
+struct ClaudeHelpView: View {
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("How to get OpenAI Admin API Key")
-                .font(.title2)
-                .bold()
+        AdminKeyHelpView(
+            title: "How to get Claude Admin API Key",
+            intro: "The Usage API requires an Admin API key, which is different from a regular API key.",
+            steps: [
+                "Go to the Claude Console",
+                "Navigate to Settings → Admin Keys",
+                "Click 'Create Admin Key'",
+                "Copy the key (starts with sk-ant-admin...)",
+                "Paste it in the field above"
+            ],
+            note: "Note: You must be an organization admin to create Admin API keys. Individual accounts cannot access the Usage API.",
+            consoleButtonTitle: "Open Claude Console",
+            consoleURL: "https://console.anthropic.com/settings/admin-keys"
+        )
+    }
+}
 
-            Text("The Usage API requires an Admin key from your organization settings.")
-                .foregroundColor(.secondary)
-
-            Divider()
-
-            VStack(alignment: .leading, spacing: 8) {
-                Text("1. Go to OpenAI Platform")
-                Text("2. Navigate to Settings → Organization → Admin Keys")
-                Text("3. Click 'Create new admin key'")
-                Text("4. Copy the key")
-                Text("5. Paste it in the field above")
-            }
-
-            Divider()
-
-            Text("Note: You must be an organization owner or admin to create Admin keys.")
-                .font(.caption)
-                .foregroundStyle(MeterBarTheme.warning)
-
-            HStack {
-                Button("Open OpenAI Settings") {
-                    if let url = URL(string: "https://platform.openai.com/settings/organization/admin-keys") {
-                        NSWorkspace.shared.open(url)
-                    }
-                }
-                .buttonStyle(.borderedProminent)
-
-                Spacer()
-
-                Button("Close") {
-                    dismiss()
-                }
-            }
-        }
-        .padding()
-        .frame(width: 500, height: 400)
+struct OpenAIHelpView: View {
+    var body: some View {
+        AdminKeyHelpView(
+            title: "How to get OpenAI Admin API Key",
+            intro: "The Usage API requires an Admin key from your organization settings.",
+            steps: [
+                "Go to OpenAI Platform",
+                "Navigate to Settings → Organization → Admin Keys",
+                "Click 'Create new admin key'",
+                "Copy the key",
+                "Paste it in the field above"
+            ],
+            note: "Note: You must be an organization owner or admin to create Admin keys.",
+            consoleButtonTitle: "Open OpenAI Settings",
+            consoleURL: "https://platform.openai.com/settings/organization/admin-keys"
+        )
     }
 }

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -426,11 +426,11 @@ struct SettingsView: View {
                     }
                 } label: {
                     HStack(spacing: 7) {
-                        if costTracker.isScanning {
+                        if costTracker.isRefreshInProgress {
                             ProgressView()
                                 .controlSize(.small)
                                 .scaleEffect(0.75)
-                            Text("Scanning...")
+                            Text(costTracker.isRefreshingMissingDays ? "Updating..." : "Scanning...")
                         } else {
                             Image(systemName: "magnifyingglass")
                             Text("Scan 30 Days")
@@ -438,7 +438,7 @@ struct SettingsView: View {
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(costTracker.isScanning || !canScanCosts)
+                .disabled(costTracker.isRefreshInProgress || !canScanCosts)
             }
         }
     }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -112,6 +112,12 @@ struct UsageDashboardView: View {
             }
         }
         .navigationSplitViewStyle(.balanced)
+        .task {
+            await refreshCostsIfMissingDays()
+        }
+        .onChange(of: selectedSection) {
+            Task { await refreshCostsIfMissingDays() }
+        }
     }
 
     private var sidebar: some View {
@@ -178,12 +184,13 @@ struct UsageDashboardView: View {
                 CostOverviewStatusCard(
                     summary: visibleCostSummary,
                     isScanning: costTracker.isScanning,
+                    isRefreshingMissingDays: costTracker.isRefreshingMissingDays,
                     formattedTokens: UsageFormat.tokens(visibleCostSummary?.totalTokens ?? 0)
                 )
             }
             .frame(maxWidth: .infinity)
 
-            DashboardCard(title: "Last 30 Days", trailing: costTracker.isScanning ? "Scanning..." : nil) {
+            DashboardCard(title: "Last 30 Days", trailing: costRefreshStatusText) {
                 costScanChart(height: 180, compact: true)
             }
         }
@@ -224,7 +231,7 @@ struct UsageDashboardView: View {
 
     private var costsContent: some View {
         VStack(alignment: .leading, spacing: 14) {
-            DashboardCard(title: "30 Day API-Rate Token Spend", trailing: costTracker.isScanning ? "Scanning..." : nil) {
+            DashboardCard(title: "30 Day API-Rate Token Spend", trailing: costRefreshStatusText) {
                 VStack(alignment: .leading, spacing: 18) {
                     Text("Local subscription logs are estimated using API token rates so Codex and Claude can be compared.")
                         .font(.caption)
@@ -247,7 +254,7 @@ struct UsageDashboardView: View {
                                 Label("Scan 30 Days", systemImage: "magnifyingglass")
                             }
                             .buttonStyle(.bordered)
-                            .disabled(costTracker.isScanning)
+                            .disabled(costTracker.isRefreshInProgress)
                         }
                         .frame(height: 220, alignment: .center)
                     }
@@ -396,6 +403,16 @@ struct UsageDashboardView: View {
         }
     }
 
+    private var costRefreshStatusText: String? {
+        if costTracker.isScanning {
+            return "Scanning..."
+        }
+        if costTracker.isRefreshingMissingDays {
+            return "Updating..."
+        }
+        return nil
+    }
+
     private var isRefreshButtonDisabled: Bool {
         isRefreshButtonAnimating
     }
@@ -403,7 +420,7 @@ struct UsageDashboardView: View {
     private var isRefreshButtonAnimating: Bool {
         switch activeSection {
         case .costs:
-            return costTracker.isScanning
+            return costTracker.isRefreshInProgress
         case .overview, .limits, .settings:
             return dataManager.isLoading
         }
@@ -415,6 +432,11 @@ struct UsageDashboardView: View {
         } else {
             await dataManager.refreshAll()
         }
+    }
+
+    private func refreshCostsIfMissingDays() async {
+        guard activeSection == .overview || activeSection == .costs else { return }
+        await costTracker.refreshMissingDaysInBackground(days: 30)
     }
 
     private func color(for service: ServiceType) -> Color {
@@ -593,7 +615,14 @@ private struct ProviderOverviewStatusCard: View {
 private struct CostOverviewStatusCard: View {
     let summary: CostSummary?
     let isScanning: Bool
+    let isRefreshingMissingDays: Bool
     let formattedTokens: String
+
+    private var subtitle: String {
+        if isScanning { return "Scanning local logs" }
+        if isRefreshingMissingDays { return "Updating…" }
+        return "Last 30 days"
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -605,7 +634,7 @@ private struct CostOverviewStatusCard: View {
                     Text("API-Rate Estimate")
                         .font(.headline)
                         .fontWeight(.semibold)
-                    Text(isScanning ? "Scanning local logs" : "Last 30 days")
+                    Text(subtitle)
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
@@ -1225,6 +1254,8 @@ private struct DailyUsageProviderSegment: Identifiable {
 private struct DailyUsageBreakdownList: View {
     let dailyUsage: [DailyTokenUsage]
 
+    @State private var expandedDayIDs: Set<Date> = []
+
     private var days: [DailyProviderUsageDay] {
         let grouped = Dictionary(grouping: dailyUsage) { Calendar.current.startOfDay(for: $0.date) }
         return grouped.map { day, rows in
@@ -1248,8 +1279,22 @@ private struct DailyUsageBreakdownList: View {
 
             VStack(spacing: 8) {
                 ForEach(days) { day in
-                    DailyUsageDetailRow(day: day)
+                    DailyUsageDetailRow(
+                        day: day,
+                        isExpanded: expandedDayIDs.contains(day.id),
+                        toggle: { toggleExpansion(for: day.id) }
+                    )
                 }
+            }
+        }
+    }
+
+    private func toggleExpansion(for dayID: Date) {
+        withAnimation(.snappy(duration: 0.18)) {
+            if expandedDayIDs.contains(dayID) {
+                expandedDayIDs.remove(dayID)
+            } else {
+                expandedDayIDs.insert(dayID)
             }
         }
     }
@@ -1303,49 +1348,96 @@ private struct DailyProviderUsageSummary: Identifiable {
 
 private struct DailyUsageDetailRow: View {
     let day: DailyProviderUsageDay
+    let isExpanded: Bool
+    let toggle: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text(dateLabel(day.date))
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
-                Spacer()
-                Text(UsageFormat.tokens(day.totalTokens))
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                Text(UsageFormat.cost(day.estimatedCostUSD))
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
+        VStack(alignment: .leading, spacing: isExpanded ? 8 : 0) {
+            Button(action: toggle) {
+                HStack(spacing: 8) {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption2)
+                        .fontWeight(.bold)
+                        .foregroundColor(.secondary)
+                        .frame(width: 12)
 
-            ForEach(day.providers) { provider in
-                HStack(spacing: 10) {
-                    ProviderLogoView(
-                        kind: providerLogoKind(for: provider.provider),
-                        size: 14,
-                        foregroundColor: color(for: provider.provider)
-                    )
-                    Text(provider.provider.displayName)
-                        .font(.caption)
+                    Text(dateLabel(day.date))
+                        .font(.subheadline)
                         .fontWeight(.semibold)
-                        .frame(width: 110, alignment: .leading)
-                    UsageDetailMetric(label: "Input", value: UsageFormat.tokens(provider.inputTokens))
-                    UsageDetailMetric(label: "Output", value: UsageFormat.tokens(provider.outputTokens))
-                    UsageDetailMetric(label: "Cache", value: UsageFormat.tokens(provider.cacheReadTokens))
+
+                    Text(providerCountLabel)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
                     Spacer()
-                    Text(UsageFormat.cost(provider.estimatedCostUSD))
+
+                    Text("\(UsageFormat.tokens(day.totalTokens)) tokens")
                         .font(.caption)
                         .fontWeight(.semibold)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+
+                    Text(UsageFormat.cost(day.estimatedCostUSD))
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.secondary)
                 }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(accessibilitySummary)
+            .accessibilityHint(isExpanded ? "Collapse day details" : "Show day details")
+
+            if isExpanded {
+                VStack(spacing: 8) {
+                    ForEach(day.providers) { provider in
+                        DailyProviderUsageSummaryRow(provider: provider)
+                    }
+                }
+                .padding(.top, 6)
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
         .padding(10)
         .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
 
+    private var providerCountLabel: String {
+        let count = day.providers.count
+        return count == 1 ? "1 source" : "\(count) sources"
+    }
+
+    private var accessibilitySummary: String {
+        "\(dateLabel(day.date)), \(UsageFormat.tokens(day.totalTokens)) tokens, \(UsageFormat.cost(day.estimatedCostUSD))"
+    }
+
     private func dateLabel(_ date: Date) -> String {
         DashboardDateFormat.weekdayMonthDay(date)
+    }
+}
+
+private struct DailyProviderUsageSummaryRow: View {
+    let provider: DailyProviderUsageSummary
+
+    var body: some View {
+        HStack(spacing: 10) {
+            ProviderLogoView(
+                kind: providerLogoKind(for: provider.provider),
+                size: 14,
+                foregroundColor: color(for: provider.provider)
+            )
+            Text(provider.provider.displayName)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .frame(width: 110, alignment: .leading)
+            UsageDetailMetric(label: "Input", value: UsageFormat.tokens(provider.inputTokens))
+            UsageDetailMetric(label: "Output", value: UsageFormat.tokens(provider.outputTokens))
+            UsageDetailMetric(label: "Cache", value: UsageFormat.tokens(provider.cacheReadTokens))
+            Spacer()
+            Text(UsageFormat.cost(provider.estimatedCostUSD))
+                .font(.caption)
+                .fontWeight(.semibold)
+        }
     }
 }
 

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -25,6 +25,12 @@ final class UsageDashboardWindowController {
             window.title = "MeterBar Usage"
             window.titleVisibility = .visible
             window.titlebarAppearsTransparent = true
+            // Unified transparent chrome so the native toolbar/titlebar glass
+            // reads as one surface with the sidebar (MacSweep-style native look).
+            window.toolbarStyle = .unified
+            window.titlebarSeparatorStyle = .none
+            window.isOpaque = false
+            window.backgroundColor = .clear
             window.isRestorable = false
             window.contentMinSize = NSSize(width: 900, height: 600)
             window.contentViewController = hostingController
@@ -84,8 +90,10 @@ struct UsageDashboardView: View {
                 .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 280)
         } detail: {
             ZStack {
+                // Keep the detail fill out of the titlebar area so the native
+                // toolbar glass shows there instead of a flat content background.
                 MeterBarDetailBackground()
-                    .ignoresSafeArea()
+                    .ignoresSafeArea(edges: [.horizontal, .bottom])
 
                 detailContent
             }
@@ -96,9 +104,9 @@ struct UsageDashboardView: View {
                     Button {
                         Task { await refreshDashboard() }
                     } label: {
-                        Image(systemName: "arrow.clockwise")
+                        RefreshingIcon(isRefreshing: isRefreshButtonAnimating)
                     }
-                    .help("Refresh usage")
+                    .help(isRefreshButtonAnimating ? "Refreshing usage" : "Refresh usage")
                     .disabled(isRefreshButtonDisabled)
                 }
             }
@@ -112,11 +120,23 @@ struct UsageDashboardView: View {
                 Label(section.rawValue, systemImage: section.iconName)
                     .tag(section)
             }
+
+            Section("Local Sources") {
+                if enabledSourceLabels.isEmpty {
+                    Label("No sources enabled", systemImage: "circle")
+                } else {
+                    ForEach(enabledSourceLabels, id: \.self) { label in
+                        Label(label, systemImage: "checkmark.circle.fill")
+                    }
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
         }
         .listStyle(.sidebar)
-        // Keep the sidebar system-owned. Custom backgrounds belong in the detail
-        // pane so the native Liquid Glass sidebar material and selection remain intact.
-        .safeAreaInset(edge: .bottom) { sourcesFooter }
+        // No background overrides: the native sidebar owns its glass material,
+        // section rendering, and selected-row highlight. Stacking a custom
+        // `.glassEffect` here would double up on the system material.
     }
 
     private var detailContent: some View {
@@ -142,26 +162,6 @@ struct UsageDashboardView: View {
         }
     }
 
-    private var sourcesFooter: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Local Sources")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            if enabledSourceLabels.isEmpty {
-                Text("No sources enabled")
-            } else {
-                ForEach(enabledSourceLabels, id: \.self) { label in
-                    Label(label, systemImage: "checkmark.circle.fill")
-                }
-            }
-        }
-        .font(.caption)
-        .foregroundStyle(.secondary)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 18)
-        .padding(.vertical, 14)
-    }
-
     private var overviewContent: some View {
         VStack(alignment: .leading, spacing: 14) {
             DashboardStatusHero(
@@ -178,7 +178,7 @@ struct UsageDashboardView: View {
                 CostOverviewStatusCard(
                     summary: visibleCostSummary,
                     isScanning: costTracker.isScanning,
-                    formattedTokens: formattedTokenCount(visibleCostSummary?.totalTokens ?? 0)
+                    formattedTokens: UsageFormat.tokens(visibleCostSummary?.totalTokens ?? 0)
                 )
             }
             .frame(maxWidth: .infinity)
@@ -397,6 +397,10 @@ struct UsageDashboardView: View {
     }
 
     private var isRefreshButtonDisabled: Bool {
+        isRefreshButtonAnimating
+    }
+
+    private var isRefreshButtonAnimating: Bool {
         switch activeSection {
         case .costs:
             return costTracker.isScanning
@@ -418,22 +422,7 @@ struct UsageDashboardView: View {
     }
 
     private func relativeDate(_ date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: date, relativeTo: Date())
-    }
-
-    private func formattedTokenCount(_ value: Int) -> String {
-        if value >= 1_000_000_000 {
-            return String(format: "%.1fB", Double(value) / 1_000_000_000)
-        }
-        if value >= 1_000_000 {
-            return String(format: "%.1fM", Double(value) / 1_000_000)
-        }
-        if value >= 1_000 {
-            return String(format: "%.1fK", Double(value) / 1_000)
-        }
-        return "\(value)"
+        UsageFormat.relative(date)
     }
 }
 
@@ -449,24 +438,13 @@ private struct DashboardProviderSnapshot: Identifiable {
         self.id = "\(service.rawValue)-\(title)"
         self.title = title
         self.service = service
-        self.logoKind = Self.logoKind(for: service)
+        self.logoKind = providerLogoKind(for: service)
         self.lastUpdated = metrics.lastUpdated
         self.limits = [
             DashboardLimit(title: "Session", limit: metrics.sessionLimit),
             DashboardLimit(title: "Weekly", limit: metrics.weeklyLimit),
             DashboardLimit(title: service == .codexCli ? "Code Review" : "Sonnet", limit: metrics.codeReviewLimit)
         ].compactMap { $0 }
-    }
-
-    private static func logoKind(for service: ServiceType) -> ProviderLogoKind {
-        switch service {
-        case .codexCli, .openai:
-            return .codex
-        case .claude, .claudeCode:
-            return .claude
-        case .cursor:
-            return .cursor
-        }
     }
 }
 
@@ -505,6 +483,12 @@ private struct DashboardStatusHero: View {
         if title.localizedCaseInsensitiveContains("attention")
             || title.localizedCaseInsensitiveContains("tight") {
             return "exclamationmark.triangle.fill"
+        }
+        // Neutral states (no providers enabled / no usage yet) should not show the
+        // healthy green shield, which falsely implies tracked quotas look good.
+        if title.localizedCaseInsensitiveContains("no sources")
+            || title.localizedCaseInsensitiveContains("waiting") {
+            return "circle.dashed"
         }
         return "checkmark.shield.fill"
     }
@@ -602,9 +586,7 @@ private struct ProviderOverviewStatusCard: View {
     }
 
     private func relativeDate(_ date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: date, relativeTo: Date())
+        UsageFormat.relative(date)
     }
 }
 
@@ -982,13 +964,26 @@ private struct CostRefreshLockOverlay: View {
 
 private struct DailyUsageChart: View {
     let dailyUsage: [DailyTokenUsage]
-    var daysToShow: Int = 30
+    let daysToShow: Int
 
     private let barSpacing: CGFloat = 4
     private let labelHeight: CGFloat = 22
     private let legendHeight: CGFloat = 18
 
-    private var days: [DailyUsageDay] {
+    // Precomputed once at init instead of on every SwiftUI body access. The
+    // grouping + 30-day date arithmetic was previously re-run many times per
+    // render (from body, visibleProviders, maxTokens, barWidth, barHeight).
+    private let days: [DailyUsageDay]
+
+    init(dailyUsage: [DailyTokenUsage], daysToShow: Int = 30) {
+        self.dailyUsage = dailyUsage
+        self.daysToShow = daysToShow
+        self.days = Self.buildDays(from: dailyUsage, daysToShow: daysToShow)
+    }
+
+    private static let providerOrder: [ServiceType] = [.claudeCode, .codexCli, .cursor, .claude, .openai]
+
+    private static func buildDays(from dailyUsage: [DailyTokenUsage], daysToShow: Int) -> [DailyUsageDay] {
         let calendar = Calendar.current
         let normalizedDaysToShow = max(1, daysToShow)
         let endDate = calendar.startOfDay(for: Date())
@@ -1021,12 +1016,8 @@ private struct DailyUsageChart: View {
         }
     }
 
-    private var providerOrder: [ServiceType] {
-        [.claudeCode, .codexCli, .cursor, .claude, .openai]
-    }
-
     private var visibleProviders: [ServiceType] {
-        providerOrder.filter { provider in
+        Self.providerOrder.filter { provider in
             days.contains { day in
                 day.segments.contains { $0.provider == provider }
             }
@@ -1118,9 +1109,9 @@ private struct DailyUsageChart: View {
 
     private func helpText(for day: DailyUsageDay) -> String {
         var lines = [
-            fullDateLabel(day.date),
-            "\(formatTokens(day.totalTokens)) tokens",
-            String(format: "$%.2f", day.cost)
+            DashboardDateFormat.medium(day.date),
+            "\(UsageFormat.tokens(day.totalTokens)) tokens",
+            UsageFormat.cost(day.cost)
         ]
 
         if day.segments.isEmpty {
@@ -1128,7 +1119,7 @@ private struct DailyUsageChart: View {
         } else {
             lines.append("")
             for segment in day.segments {
-                lines.append("\(segment.provider.displayName): \(formatTokens(segment.tokens)) · \(String(format: "$%.2f", segment.cost))")
+                lines.append("\(segment.provider.displayName): \(UsageFormat.tokens(segment.tokens)) · \(UsageFormat.cost(segment.cost))")
             }
         }
 
@@ -1137,23 +1128,6 @@ private struct DailyUsageChart: View {
 
     private func color(for provider: ServiceType) -> Color {
         MeterBarTheme.accent(for: provider)
-    }
-
-    private func fullDateLabel(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .none
-        return formatter.string(from: date)
-    }
-
-    private func formatTokens(_ value: Int) -> String {
-        if value >= 1_000_000 {
-            return String(format: "%.1fM", Double(value) / 1_000_000)
-        }
-        if value >= 1_000 {
-            return String(format: "%.1fK", Double(value) / 1_000)
-        }
-        return "\(value)"
     }
 }
 
@@ -1222,16 +1196,11 @@ private struct DailyUsageDateLabel: View {
     }
 
     private var monthText: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMM"
-        return formatter.string(from: date)
+        DashboardDateFormat.month(date)
     }
 
     private var fullDateText: String {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .none
-        return formatter.string(from: date)
+        DashboardDateFormat.medium(date)
     }
 }
 
@@ -1353,7 +1322,7 @@ private struct DailyUsageDetailRow: View {
             ForEach(day.providers) { provider in
                 HStack(spacing: 10) {
                     ProviderLogoView(
-                        kind: logoKind(for: provider.provider),
+                        kind: providerLogoKind(for: provider.provider),
                         size: 14,
                         foregroundColor: color(for: provider.provider)
                     )
@@ -1376,9 +1345,7 @@ private struct DailyUsageDetailRow: View {
     }
 
     private func dateLabel(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "EEE, MMM d"
-        return formatter.string(from: date)
+        DashboardDateFormat.weekdayMonthDay(date)
     }
 }
 
@@ -1386,14 +1353,7 @@ private struct ProviderCostBreakdown: View {
     let cost: TokenCost
 
     private var logoKind: ProviderLogoKind {
-        switch cost.provider {
-        case .codexCli, .openai:
-            return .codex
-        case .claude, .claudeCode:
-            return .claude
-        case .cursor:
-            return .cursor
-        }
+        providerLogoKind(for: cost.provider)
     }
 
     private var logoColor: Color {
@@ -1417,8 +1377,8 @@ private struct ProviderCostBreakdown: View {
 
             HStack(spacing: 14) {
                 CostMetric(label: "Tokens", value: cost.formattedTokens)
-                CostMetric(label: "Input", value: compact(cost.inputTokens))
-                CostMetric(label: "Output", value: compact(cost.outputTokens))
+                CostMetric(label: "Input", value: UsageFormat.tokens(cost.inputTokens))
+                CostMetric(label: "Output", value: UsageFormat.tokens(cost.outputTokens))
                 CostMetric(label: "Sessions", value: "\(cost.sessionCount)")
             }
 
@@ -1432,19 +1392,6 @@ private struct ProviderCostBreakdown: View {
         }
         .padding(12)
         .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-    }
-
-    private func compact(_ value: Int) -> String {
-        if value >= 1_000_000_000 {
-            return String(format: "%.1fB", Double(value) / 1_000_000_000)
-        }
-        if value >= 1_000_000 {
-            return String(format: "%.1fM", Double(value) / 1_000_000)
-        }
-        if value >= 1_000 {
-            return String(format: "%.1fK", Double(value) / 1_000)
-        }
-        return "\(value)"
     }
 }
 
@@ -1522,26 +1469,34 @@ private struct UsageDetailMetric: View {
     }
 }
 
-private enum UsageFormat {
-    static func tokens(_ value: Int) -> String {
-        if value >= 1_000_000_000 {
-            return String(format: "%.1fB", Double(value) / 1_000_000_000)
-        }
-        if value >= 1_000_000 {
-            return String(format: "%.1fM", Double(value) / 1_000_000)
-        }
-        if value >= 1_000 {
-            return String(format: "%.1fK", Double(value) / 1_000)
-        }
-        return "\(value)"
-    }
+/// Cached date formatters for the dashboard. `DateFormatter` is expensive to
+/// allocate, so the daily chart/labels (30+ per render) share these instances.
+private enum DashboardDateFormat {
+    private static let mediumDate: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }()
 
-    static func cost(_ value: Double) -> String {
-        String(format: "$%.2f", value)
-    }
+    private static let month: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM"
+        return formatter
+    }()
+
+    private static let weekdayMonthDay: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEE, MMM d"
+        return formatter
+    }()
+
+    static func medium(_ date: Date) -> String { mediumDate.string(from: date) }
+    static func month(_ date: Date) -> String { month.string(from: date) }
+    static func weekdayMonthDay(_ date: Date) -> String { weekdayMonthDay.string(from: date) }
 }
 
-private func logoKind(for provider: ServiceType) -> ProviderLogoKind {
+private func providerLogoKind(for provider: ServiceType) -> ProviderLogoKind {
     switch provider {
     case .codexCli, .openai:
         return .codex
@@ -1557,12 +1512,9 @@ private func color(for provider: ServiceType) -> Color {
 }
 
 private extension View {
-    /// A content surface for dashboard cards. Opaque system control background
-    /// (not a material) on the window's content layer, with concentric corners.
+    /// Dashboard content-card surface. Delegates to the shared `meterBarCardSurface`
+    /// so the dashboard and popover cards stay visually identical.
     func dashboardCardBackground() -> some View {
-        background(
-            Color(nsColor: .controlBackgroundColor),
-            in: RoundedRectangle(cornerRadius: 12, style: .continuous)
-        )
+        meterBarCardSurface()
     }
 }

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -160,7 +160,7 @@ struct Usage: ParsableCommand {
         let status = statusEmoji(percent: percent)
 
         print("\(label): \(bar) \(String(format: "%.0f%%", percent)) \(status)")
-        print("    \(limit.used)/\(limit.total) used")
+        print("    \(Int(limit.used))/\(Int(limit.total)) used")
         if let reset = limit.resetTime {
             print("    Resets: \(formatDate(reset))")
         }
@@ -286,7 +286,7 @@ struct Cost: ParsableCommand {
         print()
         print("Provider: Claude Code")
         print("Period: Last \(costs.periodDays) days")
-        print("Sessions scanned: \(costs.sessionCount)")
+        print("Files scanned: \(costs.sessionCount)")
         print()
         print("Tokens:")
         print("  Input:          \(formatNumber(costs.inputTokens))")
@@ -298,10 +298,14 @@ struct Cost: ParsableCommand {
         print("Daily Average:  $\(String(format: "%.2f", costs.estimatedCostUSD / Double(costs.periodDays)))/day")
     }
 
-    private func formatNumber(_ num: Int) -> String {
+    private static let numberFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        return formatter.string(from: NSNumber(value: num)) ?? "\(num)"
+        return formatter
+    }()
+
+    private func formatNumber(_ num: Int) -> String {
+        Self.numberFormatter.string(from: NSNumber(value: num)) ?? "\(num)"
     }
 }
 
@@ -314,13 +318,15 @@ struct ServiceMetrics: Codable {
 }
 
 struct UsageLimit: Codable {
-    let used: Int
-    let total: Int
+    // The app serializes these as JSON doubles (e.g. 42.0). Decoding them as Int
+    // fails, which silently produced empty CLI output, so they must be Double.
+    let used: Double
+    let total: Double
     let resetTime: Date?
 
     var percentage: Double {
         guard total > 0 else { return 0 }
-        return (Double(used) / Double(total)) * 100
+        return (used / total) * 100
     }
 }
 

--- a/MeterBarTests/UsageFormattingTests.swift
+++ b/MeterBarTests/UsageFormattingTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import MeterBar
+
+final class UsageFormattingTests: XCTestCase {
+    // MARK: - Compact tokens
+
+    func testCompactTokensBelowThousand() {
+        XCTAssertEqual(UsageFormat.tokens(0), "0")
+        XCTAssertEqual(UsageFormat.tokens(999), "999")
+    }
+
+    func testCompactTokensThousands() {
+        XCTAssertEqual(UsageFormat.tokens(1_000), "1.0K")
+        XCTAssertEqual(UsageFormat.tokens(1_500), "1.5K")
+        XCTAssertEqual(UsageFormat.tokens(999_999), "1000.0K")
+    }
+
+    func testCompactTokensMillions() {
+        XCTAssertEqual(UsageFormat.tokens(1_000_000), "1.0M")
+        XCTAssertEqual(UsageFormat.tokens(2_500_000), "2.5M")
+    }
+
+    func testCompactTokensBillions() {
+        // Regression: a duplicate formatter without the billions tier rendered
+        // 1B as "1000.0M". The shared formatter must use the B suffix.
+        XCTAssertEqual(UsageFormat.tokens(1_000_000_000), "1.0B")
+        XCTAssertEqual(UsageFormat.tokens(3_400_000_000), "3.4B")
+    }
+
+    // MARK: - Grouped tokens
+
+    func testGroupedTokensInsertsSeparators() {
+        XCTAssertEqual(UsageFormat.groupedTokens(1_234_567), "1,234,567")
+        XCTAssertEqual(UsageFormat.groupedTokens(0), "0")
+        XCTAssertEqual(UsageFormat.groupedTokens(999), "999")
+    }
+
+    // MARK: - Cost
+
+    func testCostFormatting() {
+        XCTAssertEqual(UsageFormat.cost(0), "$0.00")
+        XCTAssertEqual(UsageFormat.cost(1.5), "$1.50")
+        XCTAssertEqual(UsageFormat.cost(123.456), "$123.46")
+    }
+
+    // MARK: - Relative date
+
+    func testRelativeDateIsNonEmpty() {
+        let earlier = Date(timeIntervalSince1970: 1_000_000)
+        let reference = earlier.addingTimeInterval(3_600)
+        XCTAssertFalse(UsageFormat.relative(earlier, to: reference).isEmpty)
+    }
+}

--- a/MeterBarWidget/UsageWidget.swift
+++ b/MeterBarWidget/UsageWidget.swift
@@ -152,31 +152,20 @@ class SharedDataStore {
     }
 
     func loadMetrics() -> [ServiceType: UsageMetrics] {
-        guard let containerURL = containerURL else {
-            print("❌ [Widget] App Group container not available")
-            return [:]
-        }
+        guard let containerURL = containerURL else { return [:] }
 
         let fileURL = containerURL.appendingPathComponent("\(metricsKey).json")
-        print("📂 [Widget] Reading from: \(fileURL.path)")
 
-        guard let data = try? Data(contentsOf: fileURL) else {
-            print("❌ [Widget] No data file found")
+        guard let data = try? Data(contentsOf: fileURL),
+              let decoded = try? JSONDecoder().decode([String: UsageMetrics].self, from: data) else {
             return [:]
         }
 
-        guard let decoded = try? JSONDecoder().decode([String: UsageMetrics].self, from: data) else {
-            print("❌ [Widget] Failed to decode JSON")
-            return [:]
-        }
-
-        let metrics = decoded.reduce(into: [ServiceType: UsageMetrics]()) { result, pair in
+        return decoded.reduce(into: [ServiceType: UsageMetrics]()) { result, pair in
             if let service = ServiceType(rawValue: pair.key) {
                 result[service] = pair.value
             }
         }
-        print("✅ [Widget] Loaded \(metrics.count) services")
-        return metrics
     }
 }
 
@@ -349,10 +338,11 @@ struct LargeWidgetView: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                ForEach(entry.sortedServices.prefix(7), id: \.self) { service in
+                let services = Array(entry.sortedServices.prefix(7))
+                ForEach(Array(services.enumerated()), id: \.element) { index, service in
                     if let metrics = entry.metrics[service] {
                         ServiceCompactView(metrics: metrics)
-                        if service != entry.sortedServices.prefix(7).last {
+                        if index < services.count - 1 {
                             Spacer()
                         }
                     }


### PR DESCRIPTION
## Summary

Codebase-wide fix/DRY/optimize pass driven by reviewing the open PRs (#58–#61) and the last 14 days of commits, plus a verified multi-agent bug hunt. **70 findings were confirmed after adversarial verification** (9 high / 23 medium / 38 low); 8 were rejected as false positives.

Net **−83 lines** across 20 modified + 4 new source files.

## Correctness / security

- **Notification spam** — used a random `UUID().uuidString` id, so ≥90% usage produced a new banner every 5 min. Now a stable per-(service, limit, level) id + dedup set that re-arms only after usage drops.
- **Uncancellable monitor loop** — `while true` + `try?` busy-looped on cancellation and the `Task` was unstored. Now `while !Task.isCancelled`, stored handle, clean exit.
- **CLI showed nothing** — `UsageLimit.used/total` were `Int` while the app serializes JSON doubles → silent decode failure. Changed to `Double`.
- **Usage under-counted** — Claude/OpenAI ignored `has_more`/`next_page`. Both now paginate (capped) via a shared `fetchDecoded`.
- Atomic Keychain `save` (was racy delete-then-add); off-main credential/SQLite init + app-group cache writes; `ClaudeCodeCLIUsageService` process run bridged off the cooperative thread pool (was a 12s semaphore block).
- **Removed all token/usage-leaking `print()`** (Cursor 25, Codex 8, others) → `os.Logger` (`AppLog`) with redaction. Library `print()` count is now 0.

## DRY / performance

- New shared `AppLog`, `ServiceSupport`, `UsageFormat`.
- `CodexScanContext` collapses `addCodexUsage`'s 13 params (a SwiftLint `function_parameter_count` error) and its callers.
- Cached `ISO8601DateFormatter` / `NSRegularExpression` / `DateFormatter` / `NumberFormatter` / `RelativeDateTimeFormatter` in hot paths; precompute `DailyUsageChart.days` once.
- Deduped token formatter (×4, fixing a dropped billions tier), `logoKind` (×3), card surfaces, help views, `getRealHomeDirectory` (×3), `RateLimit`/`CodeReviewRateLimit`, the cache decoders. Eliminated every flagged force-unwrap.

## UI — native Liquid Glass (consolidates #58 + #61)

- Unified transparent toolbar/titlebar, **system-owned sidebar** with a native `Local Sources` `Section`, glass popover controls, hairline card separators. (Chose #61's native approach over #59's custom inset glass — standard components get Liquid Glass for free; `.glassEffect()` is for custom floating controls, not re-skinning a standard sidebar.)
- Spinning `RefreshingIcon` bound to real loading/scanning state (respects Reduce Motion) in the popover and dashboard toolbar.

## Supersedes / overlaps

This branch contains the content of **#58** and **#61** (and overlaps #60's cost formatting). Do **not** merge both this branch and those PRs — pick one path to avoid duplicate/conflicting changes on `MenuBarView` / `UsageDashboardView`. #59's collapsible daily-cost rows were intentionally left out (separate feature, cherry-pickable).

## Deferred (documented in `.agents/docs/DEFERRED_WORK.md`)

- `MeterBarShared` package extraction to end the app/widget/CLI struct drift.
- `OAuthTokenExpiry` malformed-token behavior (kept as-is, with rationale).

## Verification

- `swift build` — MeterBar library + CLI, clean, no warnings.
- `swiftc -parse` on the CI-only app-target sources.
- Added `UsageFormattingTests` (billions-tier regression + grouped/cost).
- Full `xcodebuild` build + XCTest suite run on CI (no full Xcode locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refreshed usage dashboard experience with expandable daily breakdowns, improved refresh controls, and more consistent card styling.
  * Added clearer, more consistent formatting for usage, cost, and relative time values across the app.

* **Bug Fixes**
  * Improved background refresh behavior so missing daily usage data can fill in automatically.
  * Reduced duplicate notifications and made alerts behave more reliably during repeated checks.

* **Chores**
  * Updated the app version to 1.6.
  * Added broader logging and stability improvements across usage, cost, and sync flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->