### PR TITLE
Manage multiple Claude Code accounts

### DIFF
--- a/.agents/SESSIONS/2026-06-29.md
+++ b/.agents/SESSIONS/2026-06-29.md
@@ -10,20 +10,25 @@
 - Added editable config directories and delete actions for custom Claude Code accounts.
 - Preserved the default Claude CLI profile while allowing its label to be renamed.
 - Added a reconnect action that opens an interactive Terminal `claude auth logout/login` flow for the selected profile.
+- Added persisted drag ordering for Claude Code accounts, including the default CLI profile.
+- Compacted exhausted popover cards so accounts at their limit show a smaller reset row instead of the full card body.
 - Added unit coverage for account rename, edit, delete, and default-account guard behavior.
 - Added reconnect-script coverage so default and custom profiles use the correct `CLAUDE_CONFIG_DIR` handling.
 
 **Files changed:**
 - `MeterBar/Models/ClaudeCodeAccount.swift` - account store update/remove persistence.
 - `MeterBar/Services/ClaudeCodeReconnectService.swift` - Terminal-backed Claude auth reconnect flow.
-- `MeterBar/Views/SettingsView.swift` - editable Claude account rows in Settings.
-- `MeterBarTests/ClaudeCodeAccountStoreTests.swift` - account store behavior tests.
+- `MeterBar/Views/SettingsView.swift` - editable and reorderable Claude account rows in Settings.
+- `MeterBar/Views/MenuBarView.swift` - compact exhausted account cards in the popover.
+- `MeterBarTests/ClaudeCodeAccountStoreTests.swift` - account store behavior and ordering tests.
 - `MeterBarTests/ClaudeCodeReconnectServiceTests.swift` - reconnect script generation tests.
 
 **Decisions:**
 - The default Claude profile remains non-deletable because it represents the implicit `~/.claude` profile.
 - Custom account config paths remain editable because a renamed Claude profile may also need a corrected `CLAUDE_CONFIG_DIR`.
 - Reconnect uses Terminal rather than a background process because `claude auth login` is interactive and may require a browser flow.
+- Account order is stored as profile UUIDs so the default profile can be moved without changing what it points to.
+- Exhausted cards still show reset timing, but hide nonessential detail to keep the overlay shorter.
 
 **Verification:**
 - `swift build` passes.

--- a/.agents/SESSIONS/2026-06-29.md
+++ b/.agents/SESSIONS/2026-06-29.md
@@ -1,0 +1,30 @@
+# 2026-06-29
+
+## Session 1: Editable Claude Code Accounts
+
+**Duration:** ~30 minutes
+**Status:** Complete
+
+**What was done:**
+- Added persistent editing for Claude Code account labels.
+- Added editable config directories and delete actions for custom Claude Code accounts.
+- Preserved the default Claude CLI profile while allowing its label to be renamed.
+- Added a reconnect action that opens an interactive Terminal `claude auth logout/login` flow for the selected profile.
+- Added unit coverage for account rename, edit, delete, and default-account guard behavior.
+- Added reconnect-script coverage so default and custom profiles use the correct `CLAUDE_CONFIG_DIR` handling.
+
+**Files changed:**
+- `MeterBar/Models/ClaudeCodeAccount.swift` - account store update/remove persistence.
+- `MeterBar/Services/ClaudeCodeReconnectService.swift` - Terminal-backed Claude auth reconnect flow.
+- `MeterBar/Views/SettingsView.swift` - editable Claude account rows in Settings.
+- `MeterBarTests/ClaudeCodeAccountStoreTests.swift` - account store behavior tests.
+- `MeterBarTests/ClaudeCodeReconnectServiceTests.swift` - reconnect script generation tests.
+
+**Decisions:**
+- The default Claude profile remains non-deletable because it represents the implicit `~/.claude` profile.
+- Custom account config paths remain editable because a renamed Claude profile may also need a corrected `CLAUDE_CONFIG_DIR`.
+- Reconnect uses Terminal rather than a background process because `claude auth login` is interactive and may require a browser flow.
+
+**Verification:**
+- `swift build` passes.
+- `swift test --filter ClaudeCodeAccountStoreTests` is blocked by the active CommandLineTools SwiftPM install missing `XCTest`.

--- a/MeterBar/Models/ClaudeCodeAccount.swift
+++ b/MeterBar/Models/ClaudeCodeAccount.swift
@@ -1,11 +1,21 @@
 import Combine
 import Foundation
 
+// MARK: - ClaudeCodeAccount
+
 struct ClaudeCodeAccount: Codable, Equatable, Identifiable, Sendable {
-    // Fixed sentinel id for the default CLI profile. Built from raw bytes
-    // (00000000-0000-0000-0000-000000000001) so it stays deterministic without a
-    // force-unwrap of `UUID(uuidString:)`.
+    static let defaultName = "Default CLI Profile"
+
+    /// Fixed sentinel id for the default CLI profile. Built from raw bytes
+    /// (00000000-0000-0000-0000-000000000001) so it stays deterministic without a
+    /// force-unwrap of `UUID(uuidString:)`.
     static let defaultID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1))
+
+    static let defaultAccount = ClaudeCodeAccount(
+        id: Self.defaultID,
+        name: Self.defaultName,
+        configDirectory: nil
+    )
 
     let id: UUID
     var name: String
@@ -15,34 +25,42 @@ struct ClaudeCodeAccount: Codable, Equatable, Identifiable, Sendable {
         id == Self.defaultID
     }
 
-    static let defaultAccount = ClaudeCodeAccount(
-        id: Self.defaultID,
-        name: "Default CLI Profile",
-        configDirectory: nil
-    )
 }
 
+// MARK: - ClaudeCodeAccountStore
+
 final class ClaudeCodeAccountStore: ObservableObject {
+
+    // MARK: Lifecycle
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        load()
+    }
+
+    // MARK: Internal
+
     static let shared = ClaudeCodeAccountStore()
 
     @Published private(set) var customAccounts: [ClaudeCodeAccount] = []
-
-    private let userDefaults: UserDefaults
-    private let storageKey = "ClaudeCodeCustomAccounts"
+    @Published private(set) var defaultAccountName = ClaudeCodeAccount.defaultName
 
     var accounts: [ClaudeCodeAccount] {
-        [ClaudeCodeAccount.defaultAccount] + customAccounts
-    }
-
-    private init(userDefaults: UserDefaults = .standard) {
-        self.userDefaults = userDefaults
-        load()
+        [
+            ClaudeCodeAccount(
+                id: ClaudeCodeAccount.defaultID,
+                name: defaultAccountName,
+                configDirectory: nil
+            ),
+        ] + customAccounts
     }
 
     func addAccount(name: String, configDirectory: String) {
         let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedDirectory = configDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedName.isEmpty, !trimmedDirectory.isEmpty else { return }
+        guard !trimmedName.isEmpty, !trimmedDirectory.isEmpty else {
+            return
+        }
 
         let account = ClaudeCodeAccount(
             id: UUID(),
@@ -50,16 +68,69 @@ final class ClaudeCodeAccountStore: ObservableObject {
             configDirectory: (trimmedDirectory as NSString).standardizingPath
         )
         customAccounts.append(account)
-        save()
+        saveCustomAccounts()
+    }
+
+    func updateAccount(id: UUID, name: String, configDirectory: String?) {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            return
+        }
+
+        if id == ClaudeCodeAccount.defaultID {
+            guard trimmedName != defaultAccountName else {
+                return
+            }
+            defaultAccountName = trimmedName
+            saveDefaultAccountName()
+            return
+        }
+
+        guard let index = customAccounts.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+
+        var updatedAccount = customAccounts[index]
+        updatedAccount.name = trimmedName
+
+        if let configDirectory {
+            let trimmedDirectory = configDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedDirectory.isEmpty else {
+                return
+            }
+            updatedAccount.configDirectory = (trimmedDirectory as NSString).standardizingPath
+        }
+
+        guard updatedAccount != customAccounts[index] else {
+            return
+        }
+        var updatedAccounts = customAccounts
+        updatedAccounts[index] = updatedAccount
+        customAccounts = updatedAccounts
+        saveCustomAccounts()
     }
 
     func removeAccount(id: UUID) {
-        guard id != ClaudeCodeAccount.defaultID else { return }
+        guard id != ClaudeCodeAccount.defaultID else {
+            return
+        }
         customAccounts.removeAll { $0.id == id }
-        save()
+        saveCustomAccounts()
     }
 
+    // MARK: Private
+
+    private let userDefaults: UserDefaults
+    private let storageKey = "ClaudeCodeCustomAccounts"
+    private let defaultNameStorageKey = "ClaudeCodeDefaultAccountName"
+
     private func load() {
+        let storedDefaultName = userDefaults.string(forKey: defaultNameStorageKey)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let storedDefaultName, !storedDefaultName.isEmpty {
+            defaultAccountName = storedDefaultName
+        }
+
         guard let data = userDefaults.data(forKey: storageKey),
               let decoded = try? JSONDecoder().decode([ClaudeCodeAccount].self, from: data) else {
             return
@@ -68,8 +139,18 @@ final class ClaudeCodeAccountStore: ObservableObject {
         customAccounts = decoded.filter { !$0.isDefault }
     }
 
-    private func save() {
-        guard let data = try? JSONEncoder().encode(customAccounts) else { return }
+    private func saveCustomAccounts() {
+        guard let data = try? JSONEncoder().encode(customAccounts) else {
+            return
+        }
         userDefaults.set(data, forKey: storageKey)
+    }
+
+    private func saveDefaultAccountName() {
+        if defaultAccountName == ClaudeCodeAccount.defaultName {
+            userDefaults.removeObject(forKey: defaultNameStorageKey)
+        } else {
+            userDefaults.set(defaultAccountName, forKey: defaultNameStorageKey)
+        }
     }
 }

--- a/MeterBar/Models/ClaudeCodeAccount.swift
+++ b/MeterBar/Models/ClaudeCodeAccount.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // MARK: - ClaudeCodeAccount
 
-struct ClaudeCodeAccount: Codable, Equatable, Identifiable, Sendable {
+struct ClaudeCodeAccount: Codable, Equatable, Identifiable {
     static let defaultName = "Default CLI Profile"
 
     /// Fixed sentinel id for the default CLI profile. Built from raw bytes
@@ -44,15 +44,16 @@ final class ClaudeCodeAccountStore: ObservableObject {
 
     @Published private(set) var customAccounts: [ClaudeCodeAccount] = []
     @Published private(set) var defaultAccountName = ClaudeCodeAccount.defaultName
+    @Published private(set) var accountOrder: [UUID] = []
 
     var accounts: [ClaudeCodeAccount] {
-        [
+        orderedAccounts(from: [
             ClaudeCodeAccount(
                 id: ClaudeCodeAccount.defaultID,
                 name: defaultAccountName,
                 configDirectory: nil
             ),
-        ] + customAccounts
+        ] + customAccounts)
     }
 
     func addAccount(name: String, configDirectory: String) {
@@ -68,6 +69,10 @@ final class ClaudeCodeAccountStore: ObservableObject {
             configDirectory: (trimmedDirectory as NSString).standardizingPath
         )
         customAccounts.append(account)
+        if !accountOrder.isEmpty {
+            accountOrder.append(account.id)
+            saveAccountOrder()
+        }
         saveCustomAccounts()
     }
 
@@ -115,7 +120,33 @@ final class ClaudeCodeAccountStore: ObservableObject {
             return
         }
         customAccounts.removeAll { $0.id == id }
+        accountOrder.removeAll { $0 == id }
+        saveAccountOrder()
         saveCustomAccounts()
+    }
+
+    func moveAccounts(fromOffsets source: IndexSet, toOffset destination: Int) {
+        var orderedAccounts = accounts
+        guard !orderedAccounts.isEmpty else {
+            return
+        }
+
+        let movingIndexes = source.sorted()
+        guard movingIndexes.allSatisfy({ orderedAccounts.indices.contains($0) }) else {
+            return
+        }
+
+        let movingAccounts = movingIndexes.map { orderedAccounts[$0] }
+        for index in movingIndexes.reversed() {
+            orderedAccounts.remove(at: index)
+        }
+
+        let removedBeforeDestination = movingIndexes.filter { $0 < destination }.count
+        let adjustedDestination = max(0, min(destination - removedBeforeDestination, orderedAccounts.count))
+        orderedAccounts.insert(contentsOf: movingAccounts, at: adjustedDestination)
+
+        accountOrder = orderedAccounts.map(\.id)
+        saveAccountOrder()
     }
 
     // MARK: Private
@@ -123,6 +154,7 @@ final class ClaudeCodeAccountStore: ObservableObject {
     private let userDefaults: UserDefaults
     private let storageKey = "ClaudeCodeCustomAccounts"
     private let defaultNameStorageKey = "ClaudeCodeDefaultAccountName"
+    private let accountOrderStorageKey = "ClaudeCodeAccountOrder"
 
     private func load() {
         let storedDefaultName = userDefaults.string(forKey: defaultNameStorageKey)?
@@ -131,12 +163,16 @@ final class ClaudeCodeAccountStore: ObservableObject {
             defaultAccountName = storedDefaultName
         }
 
+        accountOrder = userDefaults.stringArray(forKey: accountOrderStorageKey)?
+            .compactMap(UUID.init(uuidString:)) ?? []
+
         guard let data = userDefaults.data(forKey: storageKey),
               let decoded = try? JSONDecoder().decode([ClaudeCodeAccount].self, from: data) else {
             return
         }
 
         customAccounts = decoded.filter { !$0.isDefault }
+        pruneAccountOrder()
     }
 
     private func saveCustomAccounts() {
@@ -151,6 +187,39 @@ final class ClaudeCodeAccountStore: ObservableObject {
             userDefaults.removeObject(forKey: defaultNameStorageKey)
         } else {
             userDefaults.set(defaultAccountName, forKey: defaultNameStorageKey)
+        }
+    }
+
+    private func saveAccountOrder() {
+        if accountOrder.isEmpty {
+            userDefaults.removeObject(forKey: accountOrderStorageKey)
+        } else {
+            userDefaults.set(accountOrder.map(\.uuidString), forKey: accountOrderStorageKey)
+        }
+    }
+
+    private func orderedAccounts(from unorderedAccounts: [ClaudeCodeAccount]) -> [ClaudeCodeAccount] {
+        guard !accountOrder.isEmpty else {
+            return unorderedAccounts
+        }
+
+        let accountsByID = Dictionary(uniqueKeysWithValues: unorderedAccounts.map { ($0.id, $0) })
+        let ordered = accountOrder.compactMap { accountsByID[$0] }
+        let orderedIDs = Set(ordered.map(\.id))
+        let unordered = unorderedAccounts.filter { !orderedIDs.contains($0.id) }
+        return ordered + unordered
+    }
+
+    private func pruneAccountOrder() {
+        guard !accountOrder.isEmpty else {
+            return
+        }
+
+        let validIDs = Set([ClaudeCodeAccount.defaultID] + customAccounts.map(\.id))
+        let prunedOrder = accountOrder.filter { validIDs.contains($0) }
+        if prunedOrder != accountOrder {
+            accountOrder = prunedOrder
+            saveAccountOrder()
         }
     }
 }

--- a/MeterBar/Services/ClaudeCodeReconnectService.swift
+++ b/MeterBar/Services/ClaudeCodeReconnectService.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+// MARK: - ClaudeCodeReconnectService
+
+enum ClaudeCodeReconnectService {
+
+    // MARK: Internal
+
+    static func openReconnectTerminal(for account: ClaudeCodeAccount) throws {
+        let scriptURL = try writeReconnectScript(for: account)
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = ["-a", "Terminal", scriptURL.path]
+
+        do {
+            try process.run()
+        } catch {
+            throw ClaudeCodeReconnectError.launchFailed(error.localizedDescription)
+        }
+    }
+
+    static func reconnectScript(for account: ClaudeCodeAccount) -> String {
+        let homeDirectory = shellQuoted(ServiceSupport.realHomeDirectory())
+        let profileName = shellQuoted(account.name)
+        let configExport = if let configDirectory = account.configDirectory?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !configDirectory.isEmpty {
+            "export CLAUDE_CONFIG_DIR=\(shellQuoted(configDirectory))"
+        } else {
+            "unset CLAUDE_CONFIG_DIR"
+        }
+
+        return """
+        #!/bin/zsh
+        set -u
+
+        export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$HOME/.npm-global/bin:$HOME/.yarn/bin:$HOME/.bun/bin:$HOME/.volta/bin"
+        export HOME=\(homeDirectory)
+        PROFILE_NAME=\(profileName)
+        \(configExport)
+
+        echo "Reconnect Claude Code profile: $PROFILE_NAME"
+        if [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
+          echo "Using CLAUDE_CONFIG_DIR=$CLAUDE_CONFIG_DIR"
+        else
+          echo "Using default Claude CLI profile"
+        fi
+        echo
+
+        if ! command -v claude >/dev/null 2>&1; then
+          echo "Claude CLI was not found on PATH."
+          echo "Install it with: npm install -g @anthropic-ai/claude-code"
+          echo
+          read -r "?Press Return to close this window."
+          exit 127
+        fi
+
+        echo "Logging out existing auth for this profile..."
+        claude auth logout || true
+        echo
+        echo "Starting Claude login. Complete the browser flow when prompted."
+        claude auth login
+        status=$?
+        echo
+
+        if [ $status -eq 0 ]; then
+          echo "Reconnect complete. Return to MeterBar and refresh Claude Code."
+        else
+          echo "Reconnect failed with exit code $status."
+        fi
+
+        echo
+        read -r "?Press Return to close this window."
+        exit $status
+        """
+    }
+
+    // MARK: Private
+
+    private static func writeReconnectScript(for account: ClaudeCodeAccount) throws -> URL {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("MeterBarClaudeReconnect", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let scriptURL = directory.appendingPathComponent("reconnect-\(account.id.uuidString).command")
+        try reconnectScript(for: account).write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: scriptURL.path)
+        return scriptURL
+    }
+
+    private static func shellQuoted(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+}
+
+// MARK: - ClaudeCodeReconnectError
+
+enum ClaudeCodeReconnectError: LocalizedError {
+    case launchFailed(String)
+
+    // MARK: Internal
+
+    var errorDescription: String? {
+        switch self {
+        case let .launchFailed(message):
+            "Could not open Terminal for Claude reconnect: \(message)"
+        }
+    }
+}

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -441,7 +441,7 @@ private struct PopoverProviderStatusCard: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: snapshot.hasExhaustedLimit ? 8 : 10) {
             HStack(spacing: 7) {
                 ProviderLogoView(kind: snapshot.logoKind, size: 17, foregroundColor: snapshot.accentColor)
                 VStack(alignment: .leading, spacing: 1) {
@@ -467,7 +467,7 @@ private struct PopoverProviderStatusCard: View {
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, minHeight: 54, alignment: .topLeading)
             } else if snapshot.hasExhaustedLimit {
-                BlockingLimitResetCounter(
+                CompactBlockingLimitResetRow(
                     windows: snapshot.resetWindows,
                     accentColor: snapshot.accentColor
                 )
@@ -496,7 +496,7 @@ private struct PopoverProviderStatusCard: View {
                 )
             }
 
-            if let extraUsage = snapshot.extraUsage {
+            if !snapshot.hasExhaustedLimit, let extraUsage = snapshot.extraUsage {
                 HStack(spacing: 4) {
                     Image(systemName: "creditcard")
                         .font(.system(size: 9, weight: .semibold))
@@ -509,8 +509,8 @@ private struct PopoverProviderStatusCard: View {
                 }
             }
         }
-        .padding(11)
-        .frame(maxWidth: .infinity, minHeight: 124, alignment: .topLeading)
+        .padding(snapshot.hasExhaustedLimit ? 9 : 11)
+        .frame(maxWidth: .infinity, minHeight: snapshot.hasExhaustedLimit ? 78 : 124, alignment: .topLeading)
         .opacity(isOut ? 0.72 : 1)
         .cardSurface()
     }
@@ -569,6 +569,45 @@ private struct PopoverLimitRow: View {
                     iconSize: 9
                 )
             }
+        }
+    }
+}
+
+private struct CompactBlockingLimitResetRow: View {
+    let windows: [ResetCountdownWindow]
+    let accentColor: Color
+
+    var body: some View {
+        TimelineView(.periodic(from: ResetCountdownSchedule.anchor, by: ResetCountdownSchedule.interval)) { timeline in
+            let blockingWindow = BlockingLimitResetCounter.selectBlockingWindow(windows, now: timeline.date)
+            let title = BlockingLimitResetCounter.titleText(for: blockingWindow, in: windows)
+            let counter = BlockingLimitResetCounter.counterText(for: blockingWindow, now: timeline.date)
+            let detail = BlockingLimitResetCounter.detailText(for: blockingWindow, in: windows)
+
+            HStack(alignment: .center, spacing: 7) {
+                Image(systemName: "hourglass")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(accentColor)
+                    .frame(width: 14, height: 14)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("\(title) \(counter)")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .monospacedDigit()
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                    Text(detail)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .help("\(title) \(counter)")
         }
     }
 }

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -106,6 +106,10 @@ struct SettingsView: View {
         providerVisibility.isEnabled(.claudeCode) || providerVisibility.isEnabled(.codexCli)
     }
 
+    private var claudeAccountListHeight: CGFloat {
+        min(320, max(84, CGFloat(claudeAccountStore.accounts.count) * 84))
+    }
+
     private var generalSection: some View {
         SettingsPanelSection(title: "General", systemImage: "dock.rectangle", color: MeterBarTheme.appAccent) {
             SettingsRowView(
@@ -266,26 +270,39 @@ struct SettingsView: View {
             SettingsDivider()
 
             VStack(alignment: .leading, spacing: 8) {
-                Text("Claude Accounts")
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
-
-                ForEach(claudeAccountStore.accounts) { account in
-                    AccountProfileRow(account: account) { name, configDirectory in
-                        updateClaudeAccount(
-                            id: account.id,
-                            name: name,
-                            configDirectory: configDirectory
-                        )
-                    } onReconnect: {
-                        reconnectClaudeAccount(account)
-                    } onRemove: {
-                        claudeAccountStore.removeAccount(id: account.id)
-                        Task {
-                            await dataManager.refreshAll()
-                        }
-                    }
+                HStack(alignment: .firstTextBaseline) {
+                    Text("Claude Accounts")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                    Spacer()
+                    Text("Drag to reorder")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
+
+                List {
+                    ForEach(claudeAccountStore.accounts) { account in
+                        AccountProfileRow(account: account) { name, configDirectory in
+                            updateClaudeAccount(
+                                id: account.id,
+                                name: name,
+                                configDirectory: configDirectory
+                            )
+                        } onReconnect: {
+                            reconnectClaudeAccount(account)
+                        } onRemove: {
+                            claudeAccountStore.removeAccount(id: account.id)
+                            Task {
+                                await dataManager.refreshAll()
+                            }
+                        }
+                        .listRowInsets(EdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 0))
+                    }
+                    .onMove(perform: moveClaudeAccounts)
+                }
+                .listStyle(.plain)
+                .scrollContentBackground(.hidden)
+                .frame(height: claudeAccountListHeight)
             }
 
             SettingsRowView(title: "New account") {
@@ -589,6 +606,10 @@ struct SettingsView: View {
         }
     }
 
+    private func moveClaudeAccounts(from source: IndexSet, to destination: Int) {
+        claudeAccountStore.moveAccounts(fromOffsets: source, toOffset: destination)
+    }
+
     private func reconnectClaudeAccount(_ account: ClaudeCodeAccount) {
         do {
             try ClaudeCodeReconnectService.openReconnectTerminal(for: account)
@@ -753,6 +774,12 @@ private struct AccountProfileRow: View {
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "line.3.horizontal")
+                .foregroundStyle(.tertiary)
+                .frame(width: 14)
+                .padding(.top, 8)
+                .help("Drag to reorder")
+
             Image(systemName: account.isDefault ? "person.crop.circle" : "person.crop.circle.badge.plus")
                 .foregroundStyle(MeterBarTheme.claudeAccent)
                 .frame(width: 18)
@@ -774,7 +801,7 @@ private struct AccountProfileRow: View {
                     TextField("Config directory", text: $configDirectoryDraft)
                         .font(.caption)
                         .textFieldStyle(.roundedBorder)
-                        .frame(maxWidth: 360)
+                        .frame(maxWidth: 300)
                         .onSubmit(saveChanges)
                 }
             }
@@ -782,16 +809,25 @@ private struct AccountProfileRow: View {
             Spacer()
 
             HStack(spacing: 8) {
-                Button("Reconnect", action: onReconnect)
-                    .buttonStyle(.bordered)
+                Button(action: onReconnect) {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .buttonStyle(.bordered)
+                .help("Reconnect Claude profile")
 
-                Button("Save", action: saveChanges)
-                    .buttonStyle(.bordered)
-                    .disabled(!hasChanges || !canSave)
+                Button(action: saveChanges) {
+                    Image(systemName: "checkmark")
+                }
+                .buttonStyle(.bordered)
+                .disabled(!hasChanges || !canSave)
+                .help("Save account changes")
 
                 if !account.isDefault {
-                    Button("Delete", role: .destructive, action: onRemove)
-                        .buttonStyle(.bordered)
+                    Button(role: .destructive, action: onRemove) {
+                        Image(systemName: "trash")
+                    }
+                    .buttonStyle(.bordered)
+                    .help("Delete account")
                 }
             }
         }

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -1,29 +1,19 @@
-import SwiftUI
 import AppKit
+import SwiftUI
+
+// MARK: - SettingsView
 
 struct SettingsView: View {
-    let embeddedInDashboard: Bool
 
-    @StateObject private var authManager = AuthenticationManager.shared
-    @StateObject private var dataManager = UsageDataManager.shared
-    @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
-    @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
-    @StateObject private var cursorService = CursorLocalService.shared
-    @StateObject private var costTracker = CostTracker.shared
-    @StateObject private var providerVisibility = ProviderVisibilityStore.shared
-    @StateObject private var dockVisibility = DockVisibilityStore.shared
-
-    @State private var claudeAdminKey: String = ""
-    @State private var openaiAdminKey: String = ""
-    @State private var newClaudeAccountName: String = ""
-    @State private var newClaudeConfigDirectory: String = ""
-
-    @State private var showingClaudeHelp = false
-    @State private var showingOpenAIHelp = false
+    // MARK: Lifecycle
 
     init(embeddedInDashboard: Bool = false) {
         self.embeddedInDashboard = embeddedInDashboard
     }
+
+    // MARK: Internal
+
+    let embeddedInDashboard: Bool
 
     var body: some View {
         Form {
@@ -60,6 +50,60 @@ struct SettingsView: View {
         .sheet(isPresented: $showingOpenAIHelp) {
             OpenAIHelpView()
         }
+        .alert(
+            "Claude Reconnect Failed",
+            isPresented: Binding(
+                get: { claudeReconnectError != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        claudeReconnectError = nil
+                    }
+                }
+            )
+        ) {
+            Button("OK") {
+                claudeReconnectError = nil
+            }
+        } message: {
+            Text(claudeReconnectError ?? "Could not open the Claude reconnect flow.")
+        }
+    }
+
+    // MARK: Private
+
+    @StateObject private var authManager = AuthenticationManager.shared
+    @StateObject private var dataManager = UsageDataManager.shared
+    @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
+    @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
+    @StateObject private var cursorService = CursorLocalService.shared
+    @StateObject private var costTracker = CostTracker.shared
+    @StateObject private var providerVisibility = ProviderVisibilityStore.shared
+    @StateObject private var dockVisibility = DockVisibilityStore.shared
+
+    @State private var claudeAdminKey = ""
+    @State private var openaiAdminKey = ""
+    @State private var newClaudeAccountName = ""
+    @State private var newClaudeConfigDirectory = ""
+
+    @State private var showingClaudeHelp = false
+    @State private var showingOpenAIHelp = false
+    @State private var claudeReconnectError: String?
+
+    private var showExtraUsageSection: Bool {
+        providerVisibility.isEnabled(.claudeCode) || providerVisibility.isEnabled(.codexCli)
+    }
+
+    private var canAddClaudeAccount: Bool {
+        !newClaudeAccountName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+            !newClaudeConfigDirectory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var visibleCostSummary: CostSummary? {
+        costTracker.costSummary?.filtered(to: providerVisibility.enabledServices)
+    }
+
+    private var canScanCosts: Bool {
+        providerVisibility.isEnabled(.claudeCode) || providerVisibility.isEnabled(.codexCli)
     }
 
     private var generalSection: some View {
@@ -76,10 +120,6 @@ struct SettingsView: View {
                 .toggleStyle(.switch)
             }
         }
-    }
-
-    private var showExtraUsageSection: Bool {
-        providerVisibility.isEnabled(.claudeCode) || providerVisibility.isEnabled(.codexCli)
     }
 
     private var extraUsageSection: some View {
@@ -105,34 +145,6 @@ struct SettingsView: View {
                     manageURL: "https://chatgpt.com"
                 )
             }
-        }
-    }
-
-    private func extraUsageRow(title: String, status: ExtraUsageStatus?, manageURL: String) -> some View {
-        SettingsRowView(title: title, detail: extraUsageDetailText(status)) {
-            HStack(spacing: 8) {
-                ExtraUsageStatusPill(status: status ?? .unknown)
-
-                Button("Manage") {
-                    if let url = URL(string: manageURL) {
-                        NSWorkspace.shared.open(url)
-                    }
-                }
-                .buttonStyle(.bordered)
-                .help("Open \(manageURL) to change extra usage settings")
-            }
-        }
-    }
-
-    private func extraUsageDetailText(_ status: ExtraUsageStatus?) -> String {
-        guard let status else { return "Waiting for refresh." }
-        switch status.state {
-        case .on:
-            return status.detail.map { "Enabled · \($0)" } ?? "Enabled — overage can be billed beyond your plan."
-        case .off:
-            return "Disabled — capped at your subscription quota."
-        case .unknown:
-            return "Could not determine. Sign in to the CLI and refresh."
         }
     }
 
@@ -259,7 +271,15 @@ struct SettingsView: View {
                     .fontWeight(.semibold)
 
                 ForEach(claudeAccountStore.accounts) { account in
-                    AccountProfileRow(account: account) {
+                    AccountProfileRow(account: account) { name, configDirectory in
+                        updateClaudeAccount(
+                            id: account.id,
+                            name: name,
+                            configDirectory: configDirectory
+                        )
+                    } onReconnect: {
+                        reconnectClaudeAccount(account)
+                    } onRemove: {
                         claudeAccountStore.removeAccount(id: account.id)
                         Task {
                             await dataManager.refreshAll()
@@ -274,7 +294,10 @@ struct SettingsView: View {
                     .frame(maxWidth: 220)
             }
 
-            SettingsRowView(title: "Config directory", detail: "Use a separate CLAUDE_CONFIG_DIR for each extra account.") {
+            SettingsRowView(
+                title: "Config directory",
+                detail: "Use a separate CLAUDE_CONFIG_DIR for each extra account."
+            ) {
                 HStack(spacing: 8) {
                     TextField("Path", text: $newClaudeConfigDirectory)
                         .textFieldStyle(.roundedBorder)
@@ -364,7 +387,10 @@ struct SettingsView: View {
                         .fontWeight(.semibold)
                 }
             } else if !cursorService.hasAccess {
-                SettingsNotice(text: "Reads Cursor IDE credentials from Cursor's local state database.", color: .secondary)
+                SettingsNotice(
+                    text: "Reads Cursor IDE credentials from Cursor's local state database.",
+                    color: .secondary
+                )
                 SettingsNotice(text: "Log in to Cursor IDE first, then check again.", color: MeterBarTheme.warning)
             }
         }
@@ -416,7 +442,10 @@ struct SettingsView: View {
             }
 
             if !canScanCosts {
-                SettingsNotice(text: "Enable Claude Code or OpenAI Codex to scan local token logs.", color: MeterBarTheme.warning)
+                SettingsNotice(
+                    text: "Enable Claude Code or OpenAI Codex to scan local token logs.",
+                    color: MeterBarTheme.warning
+                )
             }
 
             SettingsRowView(title: "Local sessions") {
@@ -472,17 +501,20 @@ struct SettingsView: View {
         }
     }
 
-    private var canAddClaudeAccount: Bool {
-        !newClaudeAccountName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
-            !newClaudeConfigDirectory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    }
+    private func extraUsageRow(title: String, status: ExtraUsageStatus?, manageURL: String) -> some View {
+        SettingsRowView(title: title, detail: extraUsageDetailText(status)) {
+            HStack(spacing: 8) {
+                ExtraUsageStatusPill(status: status ?? .unknown)
 
-    private var visibleCostSummary: CostSummary? {
-        costTracker.costSummary?.filtered(to: providerVisibility.enabledServices)
-    }
-
-    private var canScanCosts: Bool {
-        providerVisibility.isEnabled(.claudeCode) || providerVisibility.isEnabled(.codexCli)
+                Button("Manage") {
+                    if let url = URL(string: manageURL) {
+                        NSWorkspace.shared.open(url)
+                    }
+                }
+                .buttonStyle(.bordered)
+                .help("Open \(manageURL) to change extra usage settings")
+            }
+        }
     }
 
     private func providerToggleRow(title: String, detail: String, service: ServiceType) -> some View {
@@ -498,6 +530,20 @@ struct SettingsView: View {
             ))
             .labelsHidden()
             .toggleStyle(.switch)
+        }
+    }
+
+    private func extraUsageDetailText(_ status: ExtraUsageStatus?) -> String {
+        guard let status else {
+            return "Waiting for refresh."
+        }
+        switch status.state {
+        case .on:
+            return status.detail.map { "Enabled · \($0)" } ?? "Enabled — overage can be billed beyond your plan."
+        case .off:
+            return "Disabled — capped at your subscription quota."
+        case .unknown:
+            return "Could not determine. Sign in to the CLI and refresh."
         }
     }
 
@@ -531,14 +577,32 @@ struct SettingsView: View {
             }
         }
     }
+
+    private func updateClaudeAccount(id: UUID, name: String, configDirectory: String?) {
+        claudeAccountStore.updateAccount(
+            id: id,
+            name: name,
+            configDirectory: configDirectory
+        )
+        Task {
+            await dataManager.refreshAll()
+        }
+    }
+
+    private func reconnectClaudeAccount(_ account: ClaudeCodeAccount) {
+        do {
+            try ClaudeCodeReconnectService.openReconnectTerminal(for: account)
+        } catch {
+            claudeReconnectError = error.localizedDescription
+        }
+    }
 }
 
+// MARK: - SettingsPanelSection
+
 private struct SettingsPanelSection<Content: View>: View {
-    let title: String
-    let logoKind: ProviderLogoKind?
-    let systemImage: String?
-    let color: Color
-    let content: Content
+
+    // MARK: Lifecycle
 
     init(
         title: String,
@@ -566,6 +630,14 @@ private struct SettingsPanelSection<Content: View>: View {
         self.content = content()
     }
 
+    // MARK: Internal
+
+    let title: String
+    let logoKind: ProviderLogoKind?
+    let systemImage: String?
+    let color: Color
+    let content: Content
+
     var body: some View {
         Section {
             content
@@ -583,16 +655,23 @@ private struct SettingsPanelSection<Content: View>: View {
     }
 }
 
+// MARK: - SettingsRowView
+
 private struct SettingsRowView<Content: View>: View {
-    let title: String
-    let detail: String?
-    let content: Content
+
+    // MARK: Lifecycle
 
     init(title: String, detail: String? = nil, @ViewBuilder content: () -> Content) {
         self.title = title
         self.detail = detail
         self.content = content()
     }
+
+    // MARK: Internal
+
+    let title: String
+    let detail: String?
+    let content: Content
 
     var body: some View {
         LabeledContent {
@@ -610,6 +689,8 @@ private struct SettingsRowView<Content: View>: View {
     }
 }
 
+// MARK: - SettingsNotice
+
 private struct SettingsNotice: View {
     let text: String
     let color: Color
@@ -622,11 +703,15 @@ private struct SettingsNotice: View {
     }
 }
 
+// MARK: - SettingsDivider
+
 private struct SettingsDivider: View {
     var body: some View {
         Divider()
     }
 }
+
+// MARK: - StatusPill
 
 private struct StatusPill: View {
     let title: String
@@ -639,36 +724,115 @@ private struct StatusPill: View {
     }
 }
 
+// MARK: - AccountProfileRow
+
 private struct AccountProfileRow: View {
+
+    // MARK: Lifecycle
+
+    init(
+        account: ClaudeCodeAccount,
+        onSave: @escaping (String, String?) -> Void,
+        onReconnect: @escaping () -> Void,
+        onRemove: @escaping () -> Void
+    ) {
+        self.account = account
+        self.onSave = onSave
+        self.onReconnect = onReconnect
+        self.onRemove = onRemove
+        _nameDraft = State(initialValue: account.name)
+        _configDirectoryDraft = State(initialValue: account.configDirectory ?? "")
+    }
+
+    // MARK: Internal
+
     let account: ClaudeCodeAccount
+    let onSave: (String, String?) -> Void
+    let onReconnect: () -> Void
     let onRemove: () -> Void
 
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(alignment: .top, spacing: 10) {
             Image(systemName: account.isDefault ? "person.crop.circle" : "person.crop.circle.badge.plus")
                 .foregroundStyle(MeterBarTheme.claudeAccent)
                 .frame(width: 18)
+                .padding(.top, 4)
 
-            VStack(alignment: .leading, spacing: 2) {
-                Text(account.name)
+            VStack(alignment: .leading, spacing: 6) {
+                TextField("Account label", text: $nameDraft)
                     .font(.subheadline)
-                    .fontWeight(.semibold)
-                Text(account.configDirectory ?? "Default Claude CLI profile")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 240)
+                    .onSubmit(saveChanges)
+
+                if account.isDefault {
+                    Text("Default Claude CLI profile")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                } else {
+                    TextField("Config directory", text: $configDirectoryDraft)
+                        .font(.caption)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 360)
+                        .onSubmit(saveChanges)
+                }
             }
 
             Spacer()
 
-            if !account.isDefault {
-                Button("Remove", role: .destructive, action: onRemove)
+            HStack(spacing: 8) {
+                Button("Reconnect", action: onReconnect)
                     .buttonStyle(.bordered)
+
+                Button("Save", action: saveChanges)
+                    .buttonStyle(.bordered)
+                    .disabled(!hasChanges || !canSave)
+
+                if !account.isDefault {
+                    Button("Delete", role: .destructive, action: onRemove)
+                        .buttonStyle(.bordered)
+                }
             }
         }
         .padding(.vertical, 4)
+        .onChange(of: account) { _, updatedAccount in
+            nameDraft = updatedAccount.name
+            configDirectoryDraft = updatedAccount.configDirectory ?? ""
+        }
+    }
+
+    // MARK: Private
+
+    @State private var nameDraft: String
+    @State private var configDirectoryDraft: String
+
+    private var trimmedName: String {
+        nameDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedConfigDirectory: String {
+        configDirectoryDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var hasChanges: Bool {
+        trimmedName != account.name ||
+            (!account.isDefault && trimmedConfigDirectory != (account.configDirectory ?? ""))
+    }
+
+    private var canSave: Bool {
+        !trimmedName.isEmpty && (account.isDefault || !trimmedConfigDirectory.isEmpty)
+    }
+
+    private func saveChanges() {
+        guard hasChanges, canSave else {
+            return
+        }
+        onSave(trimmedName, account.isDefault ? nil : trimmedConfigDirectory)
     }
 }
+
+// MARK: - AdminKeyHelpView
 
 /// Shared admin-key help sheet. The Claude and OpenAI variants only differ by
 /// copy and the console URL, so they share one layout.
@@ -725,6 +889,8 @@ private struct AdminKeyHelpView: View {
     }
 }
 
+// MARK: - ClaudeHelpView
+
 struct ClaudeHelpView: View {
     var body: some View {
         AdminKeyHelpView(
@@ -735,7 +901,7 @@ struct ClaudeHelpView: View {
                 "Navigate to Settings → Admin Keys",
                 "Click 'Create Admin Key'",
                 "Copy the key (starts with sk-ant-admin...)",
-                "Paste it in the field above"
+                "Paste it in the field above",
             ],
             note: "Note: You must be an organization admin to create Admin API keys. Individual accounts cannot access the Usage API.",
             consoleButtonTitle: "Open Claude Console",
@@ -743,6 +909,8 @@ struct ClaudeHelpView: View {
         )
     }
 }
+
+// MARK: - OpenAIHelpView
 
 struct OpenAIHelpView: View {
     var body: some View {
@@ -754,7 +922,7 @@ struct OpenAIHelpView: View {
                 "Navigate to Settings → Organization → Admin Keys",
                 "Click 'Create new admin key'",
                 "Copy the key",
-                "Paste it in the field above"
+                "Paste it in the field above",
             ],
             note: "Note: You must be an organization owner or admin to create Admin keys.",
             consoleButtonTitle: "Open OpenAI Settings",

--- a/MeterBarTests/ClaudeCodeAccountStoreTests.swift
+++ b/MeterBarTests/ClaudeCodeAccountStoreTests.swift
@@ -82,6 +82,39 @@ final class ClaudeCodeAccountStoreTests: XCTestCase {
         XCTAssertEqual(store.accounts.first?.id, ClaudeCodeAccount.defaultID)
     }
 
+    func testAccountOrderCanMoveDefaultProfileAndPersists() {
+        let store = ClaudeCodeAccountStore(userDefaults: defaults)
+        store.addAccount(name: "shipshitdev", configDirectory: "/tmp/shipshitdev")
+        store.addAccount(name: "genfeedai", configDirectory: "/tmp/genfeedai")
+
+        let initialIDs = store.accounts.map(\.id)
+        XCTAssertEqual(initialIDs.first, ClaudeCodeAccount.defaultID)
+
+        store.moveAccounts(fromOffsets: IndexSet(integer: 0), toOffset: 3)
+
+        let reorderedIDs = store.accounts.map(\.id)
+        XCTAssertEqual(reorderedIDs, [initialIDs[1], initialIDs[2], initialIDs[0]])
+
+        let reloaded = ClaudeCodeAccountStore(userDefaults: defaults)
+        XCTAssertEqual(reloaded.accounts.map(\.id), reorderedIDs)
+    }
+
+    func testRemovingCustomProfilePrunesStoredAccountOrder() {
+        let store = ClaudeCodeAccountStore(userDefaults: defaults)
+        store.addAccount(name: "shipshitdev", configDirectory: "/tmp/shipshitdev")
+        store.addAccount(name: "genfeedai", configDirectory: "/tmp/genfeedai")
+
+        let initialIDs = store.accounts.map(\.id)
+        store.moveAccounts(fromOffsets: IndexSet(integer: 0), toOffset: 3)
+        store.removeAccount(id: initialIDs[1])
+
+        XCTAssertFalse(store.accounts.map(\.id).contains(initialIDs[1]))
+
+        let reloaded = ClaudeCodeAccountStore(userDefaults: defaults)
+        XCTAssertFalse(reloaded.accounts.map(\.id).contains(initialIDs[1]))
+        XCTAssertEqual(reloaded.accounts.map(\.id), [initialIDs[2], initialIDs[0]])
+    }
+
     func testInvalidCustomProfileEditIsIgnored() {
         let store = ClaudeCodeAccountStore(userDefaults: defaults)
         store.addAccount(name: "genfeedai", configDirectory: "/tmp/genfeed-claude-profile")

--- a/MeterBarTests/ClaudeCodeAccountStoreTests.swift
+++ b/MeterBarTests/ClaudeCodeAccountStoreTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import MeterBar
+
+final class ClaudeCodeAccountStoreTests: XCTestCase {
+
+    // MARK: Internal
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "ClaudeCodeAccountStoreTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testDefaultProfileLabelCanBeEditedAndPersists() {
+        let store = ClaudeCodeAccountStore(userDefaults: defaults)
+
+        store.updateAccount(
+            id: ClaudeCodeAccount.defaultID,
+            name: "shipshitdev",
+            configDirectory: nil
+        )
+
+        XCTAssertEqual(store.accounts.first?.name, "shipshitdev")
+
+        let reloaded = ClaudeCodeAccountStore(userDefaults: defaults)
+        XCTAssertEqual(reloaded.accounts.first?.name, "shipshitdev")
+    }
+
+    func testCustomProfileCanBeEditedAndPersists() {
+        let store = ClaudeCodeAccountStore(userDefaults: defaults)
+        store.addAccount(name: "genfeed.ai", configDirectory: "/tmp/old-claude-profile")
+
+        guard let account = store.customAccounts.first else {
+            XCTFail("Expected a custom Claude account")
+            return
+        }
+
+        store.updateAccount(
+            id: account.id,
+            name: "genfeedai",
+            configDirectory: "/tmp/genfeed-claude-profile"
+        )
+
+        XCTAssertEqual(store.customAccounts.first?.name, "genfeedai")
+        XCTAssertEqual(store.customAccounts.first?.configDirectory, "/tmp/genfeed-claude-profile")
+
+        let reloaded = ClaudeCodeAccountStore(userDefaults: defaults)
+        XCTAssertEqual(reloaded.customAccounts.first?.name, "genfeedai")
+        XCTAssertEqual(reloaded.customAccounts.first?.configDirectory, "/tmp/genfeed-claude-profile")
+    }
+
+    func testCustomProfileCanBeRemoved() {
+        let store = ClaudeCodeAccountStore(userDefaults: defaults)
+        store.addAccount(name: "genfeedai", configDirectory: "/tmp/genfeed-claude-profile")
+
+        guard let account = store.customAccounts.first else {
+            XCTFail("Expected a custom Claude account")
+            return
+        }
+
+        store.removeAccount(id: account.id)
+
+        XCTAssertTrue(store.customAccounts.isEmpty)
+
+        let reloaded = ClaudeCodeAccountStore(userDefaults: defaults)
+        XCTAssertTrue(reloaded.customAccounts.isEmpty)
+    }
+
+    func testDefaultProfileCannotBeRemoved() {
+        let store = ClaudeCodeAccountStore(userDefaults: defaults)
+
+        store.removeAccount(id: ClaudeCodeAccount.defaultID)
+
+        XCTAssertEqual(store.accounts.count, 1)
+        XCTAssertEqual(store.accounts.first?.id, ClaudeCodeAccount.defaultID)
+    }
+
+    func testInvalidCustomProfileEditIsIgnored() {
+        let store = ClaudeCodeAccountStore(userDefaults: defaults)
+        store.addAccount(name: "genfeedai", configDirectory: "/tmp/genfeed-claude-profile")
+
+        guard let account = store.customAccounts.first else {
+            XCTFail("Expected a custom Claude account")
+            return
+        }
+
+        store.updateAccount(
+            id: account.id,
+            name: "renamed",
+            configDirectory: "   "
+        )
+
+        XCTAssertEqual(store.customAccounts.first?.name, "genfeedai")
+        XCTAssertEqual(store.customAccounts.first?.configDirectory, "/tmp/genfeed-claude-profile")
+    }
+
+    // MARK: Private
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+}

--- a/MeterBarTests/ClaudeCodeReconnectServiceTests.swift
+++ b/MeterBarTests/ClaudeCodeReconnectServiceTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import MeterBar
+
+final class ClaudeCodeReconnectServiceTests: XCTestCase {
+    func testDefaultProfileReconnectScriptUnsetsClaudeConfigDirectory() {
+        let script = ClaudeCodeReconnectService.reconnectScript(for: .defaultAccount)
+
+        XCTAssertTrue(script.contains("unset CLAUDE_CONFIG_DIR"))
+        XCTAssertTrue(script.contains("claude auth logout || true"))
+        XCTAssertTrue(script.contains("claude auth login"))
+    }
+
+    func testCustomProfileReconnectScriptExportsClaudeConfigDirectory() throws {
+        let account = try ClaudeCodeAccount(
+            id: XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000002")),
+            name: "genfeedai",
+            configDirectory: "/tmp/.claude-genfeedai"
+        )
+
+        let script = ClaudeCodeReconnectService.reconnectScript(for: account)
+
+        XCTAssertTrue(script.contains("PROFILE_NAME='genfeedai'"))
+        XCTAssertTrue(script.contains("export CLAUDE_CONFIG_DIR='/tmp/.claude-genfeedai'"))
+        XCTAssertTrue(script.contains("claude auth logout || true"))
+        XCTAssertTrue(script.contains("claude auth login"))
+    }
+
+    func testReconnectScriptShellQuotesEditableValues() throws {
+        let account = try ClaudeCodeAccount(
+            id: XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000003")),
+            name: "owner's profile",
+            configDirectory: "/tmp/profile's-dir"
+        )
+
+        let script = ClaudeCodeReconnectService.reconnectScript(for: account)
+
+        XCTAssertTrue(script.contains(#"PROFILE_NAME='owner'\''s profile'"#))
+        XCTAssertTrue(script.contains(#"export CLAUDE_CONFIG_DIR='/tmp/profile'\''s-dir'"#))
+    }
+}


### PR DESCRIPTION
## Description

Adds full Claude Code account management for multiple subscription profiles:

- Edit account labels and custom `CLAUDE_CONFIG_DIR` paths.
- Reconnect any profile, including the default CLI profile, via an interactive Terminal auth flow.
- Reorder Claude accounts in Settings so the menu bar overlay follows the preferred order.
- Compact exhausted account cards in the overlay so out-of-quota accounts take less vertical space while still showing reset timing.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing

- [ ] Tested on macOS [version]
- [ ] Tested with [service] authentication
- [ ] Verified widget updates correctly
- [x] Verified menu bar functionality via `swift build`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings from `swift build`
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not included.

## Additional Notes

`swift build` passes. `swift test --filter ClaudeCodeAccountStoreTests` and other XCTest runs are blocked in this local environment because the active CommandLineTools SwiftPM install cannot import `XCTest`; `xcodebuild` is also unavailable until full Xcode is selected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude Code accounts can now be edited, renamed, reordered, and reconnected directly from Settings.
  * Custom accounts can have their config directory updated or removed, and the default profile name can be changed.
  * Exhausted account cards now use a more compact layout in the popover.

* **Bug Fixes**
  * Account changes now persist more reliably, including order, labels, and config directory updates.
  * Reconnect actions handle failures with a clear alert.
  * Default accounts are protected from accidental deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->