### PR TITLE
Repo audit: CI enforcement, docs truth-sync, contract tests, lint cleanup

### DIFF
--- a/.agents/FEEDBACK/README.md
+++ b/.agents/FEEDBACK/README.md
@@ -62,7 +62,7 @@ Suggest workflow improvements:
 
 ### 2025-12-29 - Initial Setup
 
-- Created `.agent/` structure
+- Created `.agents/` structure
 - Documented initial patterns
 
 ---

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -2,7 +2,7 @@
 
 **Welcome to the MeterBar workspace!**
 
-This is the `.agent/` folder containing AI agent documentation, session tracking, and project rules.
+This is the `.agents/` folder containing AI agent documentation, session tracking, and project rules.
 
 ## Quick Start
 
@@ -11,7 +11,7 @@ This is the `.agent/` folder containing AI agent documentation, session tracking
 ## Directory Structure
 
 ```
-.agent/
+.agents/
 ├── README.md                    # This file - Navigation hub
 ├── SYSTEM/
 │   ├── RULES.md                 # Coding standards (READ THIS)

--- a/.agents/SESSIONS/2026-07-02.md
+++ b/.agents/SESSIONS/2026-07-02.md
@@ -1,0 +1,106 @@
+# Sessions: 2026-07-02
+
+**Summary:** Full-repo audit (repo map) + remediation pass: CI enforcement, docs truth-sync, README corrections, contract tests, dead-code removal
+
+---
+
+## Session 1: Repo-map audit + follow-up fixes
+
+**Duration:** ~2 hours
+**Status:** Complete (PR opened from `claude/xenodochial-yonath-5d5f6d`)
+
+### What was done
+
+**Phase 1 — Audit.** Read every Swift source, workflow, script, config, and doc in the
+repo and wrote a factual map with per-claim file citations to
+`docs/audits/00-repo-map.md`: system overview, package map, runtime/deployment map,
+data/auth/integration map (complete endpoint list), CI/test/tooling map, 9 ranked
+risks (R1–R9), and 7 suggested follow-up sessions. Notable findings:
+
+- CI's test step was `xcodebuild … test || echo …` — unconditionally green — AND the
+  Xcode project has no test target at all; tests only run via SwiftPM.
+- README claimed "Sandboxed app" / macOS 13 / Swift 5.9; reality is
+  `ENABLE_APP_SANDBOX = NO`, macOS 26.0, Swift 5 mode with tools 6.2.
+- `.agents/SYSTEM/ARCHITECTURE.md` & friends documented a phantom design
+  (CursorService, wrong app group `group.com.agenticindiedev.meterbar`, placeholder
+  endpoints); `RULES.md` was a TypeScript template.
+- Model structs triplicated across app/widget/CLI with confirmed silent drift.
+
+**Phase 2 — Fixes (this PR).**
+
+- `ci.yml` rewritten: 3 jobs — build (app+widget+CLI), test (hard `swift test` gate +
+  coverage floor via `scripts/check-coverage.sh`, `COVERAGE_THRESHOLD: 40` to be
+  ratcheted), lint (SwiftLint 0.65.0, pinned + SHA256-verified like the gitleaks
+  pattern, `--strict`; local run showed 0 violations).
+- Docs truth-sync: rewrote `ARCHITECTURE.md`, `PROJECT-MAP.md`,
+  `IMPLEMENTATION_STATUS.md`, `RULES.md` (now Swift, pointing at
+  `.swiftlint.yml`/`.swiftformat` as source of truth, plus data-contract rules);
+  fixed all live `.agent/` → `.agents/` references (14 files; historical session
+  logs left as-is); entry files (`AGENTS.md`/`CLAUDE.md`/`CODEX.md`) renamed to
+  MeterBar and corrected.
+- README: badges → macOS 26+/Swift 5; honest sandbox/privacy section (app is
+  un-sandboxed by design; widget sandboxed; hardened runtime; no telemetry);
+  troubleshooting section no longer claims "sandbox exceptions".
+- New tests: `ProviderResponseContractTests.swift` (Codex full-window fixture,
+  string-numeric tolerance, Cursor usage-summary + sparse decode, Claude Code OAuth
+  windows + minor-unit money, required-window failure) and
+  `CachedMetricsContractTests.swift` (locks app-group JSON keys, default
+  reference-date strategy, widget-shaped and CLI-shaped replica decodes,
+  app round-trip of extended fields).
+- Dead code removed: `getMeEndpoint` (CursorLocalService), unused `baseURL`
+  (ClaudeCodeLocalService), `isCursorAuthenticated` (AuthenticationManager).
+- Lint cleanup: the tree had **97 SwiftLint violations** (never enforced before) —
+  autocorrect fixed 48, the remaining 49 fixed by hand (line wraps, attribute
+  placement, `for-where`, `Array(prefix)`, dead `CodingKeys`). The two
+  `cyclomatic_complexity` warnings in `UsageDataManager` carry targeted
+  `swiftlint:disable:next` with a written rationale (refactoring untested
+  orchestration is riskier than the branch count; extract when tests exist).
+  Final state: `swiftlint lint --strict` exits 0 — which is what CI now enforces.
+- Pricing tables date-stamped (2026-07-02) with app↔CLI sync notes.
+- Audit report addendum records remediation status per risk.
+
+### Decisions
+
+- **Coverage floor starts at 40%,** not the aspirational 80: actual coverage is
+  unmeasurable on this machine (see below) — floor will be ratcheted once CI prints
+  the real number. Never lower it to pass a PR.
+- **SwiftLint pinned to 0.65.0** (latest; 0.63 had a macOS 26 crash bug upstream).
+  Installed via pinned GitHub release + checksum, mirroring `secret-scan.yml`'s
+  gitleaks pattern, not brew (unpinnable).
+- **Deferred, spawned as follow-up tasks:** MeterBarShared package extraction (needs
+  full Xcode for pbxproj dependency edits), view-file splits (mechanical, separate
+  PR for reviewability), Developer ID signing/notarization (needs cert secrets).
+
+### Environment gotcha (important for future sessions on this machine)
+
+`DeCodersLabs` (MacBook Pro, Mac14,7) has **Command Line Tools only — no XCTest
+module**, so `swift test` fails to compile the test target locally. `swift build`
+(root package incl. Views) and `MeterBarCLI` build both work and were used as local
+gates; tests run on CI (macos-26 + Xcode 26.2). SwiftLint on this machine needs
+`XCODE_DEFAULT_TOOLCHAIN_OVERRIDE=/Library/Developer/CommandLineTools` or it dies
+loading sourcekitdInProc (and — trap — with stderr discarded that crash reads as
+"0 violations"). Also: subagent/workflow fan-out hit the session limit at the
+start; the audit was done inline instead.
+
+### Files changed
+
+- `.github/workflows/ci.yml` (rewritten)
+- `README.md` (truth pass)
+- `AGENTS.md`, `CLAUDE.md`, `CODEX.md` (corrected entry points)
+- `.agents/SYSTEM/{ARCHITECTURE,RULES}.md`, `.agents/SYSTEM/architecture/PROJECT-MAP.md`,
+  `.agents/docs/IMPLEMENTATION_STATUS.md` (rewritten)
+- 14 live docs: `.agent/` → `.agents/` reference fixes
+- `MeterBar/Services/{CursorLocalService,AuthenticationManager,ClaudeCodeLocalService,CostTracker}.swift`
+  (dead code / comments)
+- `MeterBarCLI/Sources/MeterBarCLI.swift` (pricing sync note)
+- `MeterBarTests/{ProviderResponseContractTests,CachedMetricsContractTests}.swift` (new)
+- `docs/audits/00-repo-map.md` (new + addendum)
+
+### Next steps
+
+- Watch PR CI: read actual coverage % from the test job log, ratchet
+  `COVERAGE_THRESHOLD` in the same PR.
+- Follow-up tasks (spawned as chips): view splits, MeterBarShared extraction
+  (Mac Studio / full Xcode), release signing + notarization.
+- Tests for `UsageDataManager` orchestration and `CostTracker` scan paths remain the
+  biggest coverage gap.

--- a/.agents/SESSIONS/2026-07-02.md
+++ b/.agents/SESSIONS/2026-07-02.md
@@ -61,9 +61,13 @@ risks (R1–R9), and 7 suggested follow-up sessions. Notable findings:
 
 ### Decisions
 
-- **Coverage floor starts at 40%,** not the aspirational 80: actual coverage is
-  unmeasurable on this machine (see below) — floor will be ratcheted once CI prints
-  the real number. Never lower it to pass a PR.
+- **Coverage floor set to 8%** (measured baseline: **9.0%** on CI, 127 tests /
+  0 failures / 5 creds-gated skips). The initial 40 guess was far above reality —
+  Views (~3.5k lines) and most Services have zero tests. The floor is a regression
+  gate just under baseline; ratchet up as service tests land. Never lower it to
+  pass a PR. Also fixed `check-coverage.sh` mid-PR: `llvm-cov report`'s TOTAL row
+  ends in a branch-coverage "-" column on newer LLVM, so `awk '{print $NF}'`
+  parsed "-" — switched to `llvm-cov export` JSON `totals.lines.percent`.
 - **SwiftLint pinned to 0.65.0** (latest; 0.63 had a macOS 26 crash bug upstream).
   Installed via pinned GitHub release + checksum, mirroring `secret-scan.yml`'s
   gitleaks pattern, not brew (unpinnable).

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -1,403 +1,99 @@
 # Architecture - MeterBar
 
 **Purpose:** Document what IS implemented (not what WILL BE).
-**Last Updated:** 2025-01-27
+**Last Updated:** 2026-07-02 (rewritten from a full-repo audit; see `docs/audits/00-repo-map.md`)
 
 ---
 
 ## Overview
 
-MeterBar is a macOS menu bar application with WidgetKit widgets that tracks account-level usage limits from Claude, OpenAI, and Cursor dashboards. The app provides real-time usage monitoring, notifications when approaching limits, and secure credential storage using macOS Keychain.
+MeterBar is a macOS menu bar app (with a WidgetKit widget and a bundled `meterbar` CLI) that tracks AI coding-assistant quota usage. It reads usage from **local CLI artifacts and provider APIs** — it does not run a backend and does not ask users for provider API keys for the CLI-backed providers.
 
-The application consists of two main targets:
-1. **MeterBar** - Main menu bar app with settings and popover
-2. **MeterBarWidget** - WidgetKit extension for Notification Center widgets
+Providers tracked:
 
----
+| Provider | `ServiceType` case | Data source |
+|---|---|---|
+| Claude Code | `.claudeCode` | Shells out to `claude /usage`, regex-parses terminal output. Legacy OAuth fallback (keychain item `Claude Code-credentials`) behind the `ClaudeCodeEnableOAuthFallback` UserDefaults flag |
+| OpenAI Codex CLI | `.codexCli` | Reads `~/.codex/auth.json`, calls `https://chatgpt.com/backend-api/wham/usage` |
+| Cursor | `.cursor` | Reads session JWT from Cursor's `state.vscdb` SQLite, calls `https://cursor.com/api/usage-summary` |
+| Claude (admin) | `.claude` | Anthropic Admin API key (user-provided, stored in our keychain), `/v1/organizations/usage_report/messages` |
+| OpenAI (admin) | `.openai` | OpenAI Admin API key (user-provided, stored in our keychain), `/v1/organization/usage/completions` |
 
-## Tech Stack
-
-- **Language:** Swift 5.9+
-- **UI Framework:** SwiftUI
-- **Widget Framework:** WidgetKit
-- **Concurrency:** Swift async/await
-- **Reactive:** Combine framework
-- **Storage:** macOS Keychain (credentials), UserDefaults (cache), App Groups (shared data)
-- **Notifications:** UserNotifications framework
-- **Platform:** macOS 13.0+ (Ventura)
-- **Build System:** Xcode, Swift Package Manager
+Plus local **cost estimation**: `CostTracker` scans `~/.claude*/projects/**/*.jsonl` and Codex's `~/.codex/archived_sessions` + `~/.codex/logs_2.sqlite`, priced from a hardcoded per-model table.
 
 ---
 
-## Project Structure
+## Targets / build systems
+
+Three build systems coexist (see `docs/audits/00-repo-map.md` §2):
+
+1. **MeterBar.xcodeproj** — app target `MeterBar` + widget target `MeterBarWidgetExtension`. objectVersion 77 with file-system-synchronized groups (new files under `MeterBar/`/`MeterBarWidget/` join their target automatically).
+2. **Root `Package.swift`** — SwiftPM library `MeterBar` + test target `MeterBarTests`. Exists so `swift test` works without Xcode. Excludes the app entry point, Info.plist, entitlements, and assets.
+3. **`MeterBarCLI/Package.swift`** — separate SwiftPM package building the `meterbar` executable (dependency: swift-argument-parser). Copied into `MeterBar.app/Contents/Helpers/` by the release workflow.
+
+Key settings (from `MeterBar.xcodeproj/project.pbxproj`):
+- `MACOSX_DEPLOYMENT_TARGET = 26.0` (Liquid Glass APIs), `SWIFT_VERSION = 5.0` (Swift 5 language mode)
+- App: `ENABLE_APP_SANDBOX = NO` (the app must read other tools' credential/log files and spawn the `claude` binary). Widget: sandboxed. Hardened runtime on for both.
+- Bundle ids `dev.shipshit.MeterBar` / `dev.shipshit.MeterBar.Widget`; app group `group.dev.shipshit.meterbar`.
+
+---
+
+## Layout
 
 ```
 meterbarapp/
-├── MeterBar/                  # Main app target
-│   ├── App/
-│   │   └── MeterBarApp.swift  # App entry point, menu bar setup
-│   ├── Models/
-│   │   ├── ServiceType.swift    # Enum: Claude, OpenAI, Cursor
-│   │   ├── UsageLimit.swift     # Usage limit with percentage calculations
-│   │   └── UsageMetrics.swift   # Unified usage data model
-│   ├── Services/
-│   │   ├── KeychainManager.swift        # Secure credential storage
-│   │   ├── AuthenticationManager.swift  # Auth state management
-│   │   ├── ClaudeService.swift          # Claude API client
-│   │   ├── OpenAIService.swift          # OpenAI API client
-│   │   ├── CursorService.swift          # Cursor API client (placeholder)
-│   │   ├── UsageDataManager.swift       # Centralized data management
-│   │   └── SharedDataStore.swift        # App Groups shared storage
-│   └── Views/
-│       ├── SettingsView.swift   # Settings window
-│       └── MenuBarView.swift    # Menu bar popover
-├── MeterBarWidget/            # Widget extension target
-│   ├── MeterBarWidgetBundle.swift  # Widget bundle entry
-│   └── UsageWidget.swift        # Widget views (Small/Medium/Large)
-├── MeterBar.xcodeproj/        # Xcode project
-├── Package.swift                # Swift Package Manager manifest
-└── .agent/                      # AI documentation
+├── MeterBar/                 # App target sources
+│   ├── App/MeterBarApp.swift # @main + AppDelegate (NSStatusItem, popover, notifications)
+│   ├── Models/               # ServiceType, UsageMetrics, UsageLimit(+pace), TokenCost,
+│   │                         # RefreshInterval, ClaudeCodeAccount(+store), UsageFormatting
+│   ├── Services/             # 16 services, all singletons (see below)
+│   ├── Views/                # MenuBarView, SettingsView, UsageDashboardView,
+│   │                         # MeterBarTheme, RefreshingIcon
+│   └── Resources/, Assets.xcassets, Info.plist, MeterBar.entitlements
+├── MeterBarWidget/           # Widget extension (UsageWidget kind "UsageWidget")
+├── MeterBarCLI/              # `meterbar` CLI package
+├── MeterBarTests/            # XCTest suite (runs via `swift test`)
+├── scripts/                  # Bun/Playwright asset generators, check-coverage.sh
+├── .github/workflows/        # ci.yml, release.yml, update-homebrew.yml, secret-scan.yml
+└── docs/audits/              # Audit reports
 ```
 
 ---
 
-## Key Components
+## Services (all `.shared` singletons)
 
-### App Entry Point (`MeterBarApp.swift`)
+- **UsageDataManager** (`@MainActor`, ObservableObject) — orchestrates refresh across providers, caches to UserDefaults (`cached_usage_metrics`), mirrors to the app group via SharedDataStore, drives a `Timer` auto-refresh (default 15 min; `RefreshInterval` supports 1/2/5/15/30 min + manual).
+- **ClaudeCodeCLIUsageService** — resolves the `claude` binary (`CLAUDE_CLI_PATH`, `$PATH`, 7 fallback paths), runs `claude /usage` (12 s timeout, dedicated GCD queue bridged to async), parses output with `ClaudeCodeCLIUsageParser`. Multi-account via `CLAUDE_CONFIG_DIR` env injection.
+- **ClaudeCodeLocalService** — CLI-first wrapper; legacy OAuth fallback + best-effort "extra usage" probe against `api.anthropic.com/api/oauth/usage`.
+- **CodexCliLocalService** — Codex auth file + wham/usage endpoint; maps credits/spend to `ExtraUsageStatus` (safety-biased: never false "Off").
+- **CursorLocalService** — SQLite token extraction + usage-summary endpoint; assumed 500-request default quota when API omits totals.
+- **ClaudeService / OpenAIService** — admin-key usage reports (paginated, 50-page cap) via `ServiceSupport.fetchDecoded`.
+- **CostTracker** (1,029 lines) — JSONL/SQLite log scanning, per-model pricing table, per-day/model/origin breakdowns, cache at `~/Library/Application Support/MeterBar/cost-summary-v1.json`.
+- **AuthenticationManager + KeychainManager** — the two admin keys, stored in keychain service `com.agenticindiedev.quotaguard` (legacy name, kept for existing installs).
+- **SharedDataStore** — app-group JSON file (`cached_usage_metrics.json`), atomic writes on a serial queue, `WidgetCenter.reloadTimelines` after save.
+- **ProviderVisibilityStore / DockVisibilityStore / ClaudeCodeAccountStore** — UserDefaults-backed preference stores.
+- **OAuthTokenExpiry** — JWT/unix-timestamp expiry checks (60 s grace; unparseable ⇒ not-expired by design).
+- **ServiceSupport** — shared URLSession config, URLError copy, real (non-container) home dir via `getpwuid`.
+- **AppLog** — `os.Logger` categories: app, usage, cost, network, storage. This is the only observability; there is no crash reporting or analytics.
 
-**Purpose:** Initialize app, set up menu bar, configure notifications
-**Location:** `MeterBar/App/MeterBarApp.swift`
-**Dependencies:** SwiftUI App protocol, NSApplication
+## App lifecycle
 
-**Key Responsibilities:**
-- App lifecycle management
-- Menu bar icon and status
-- Settings window management
-- Notification permissions
-- Background refresh scheduling
+`@main` SwiftUI `App` with `Settings` scene + `NSApplicationDelegateAdaptor`. The delegate creates a manual `NSStatusItem` (not `MenuBarExtra`) with an `NSPopover` hosting `MenuBarView`; right-click opens a native status menu (Dock toggle / dashboard / quit). `LSUIElement = true`; Dock icon toggled at runtime via activation policy. A 5-minute `Task.sleep` loop checks limits and posts local notifications at 90%/100% with stable identifiers and re-arm-on-drop semantics.
 
-### Models
+## Widget & CLI data contract
 
-#### ServiceType (`Models/ServiceType.swift`)
-**Purpose:** Enum for supported AI services
-**Values:** `.claude`, `.openai`, `.cursor`
-**Features:** Display names, icons, color coding
+The widget and CLI **duplicate** the model structs (`ServiceType`, `UsageLimit`, `UsageMetrics`) and decode the same app-group JSON. Because `JSONDecoder` ignores unknown keys, drift is silent — the widget already drops `extraUsage`/`resetCreditsAvailable`. The JSON contract is locked by tests in `MeterBarTests/CachedMetricsContractTests.swift`; extraction of a shared `MeterBarShared` package is deferred (needs Xcode project changes — see `.agents/docs/DEFERRED_WORK.md` §1).
 
-#### UsageLimit (`Models/UsageLimit.swift`)
-**Purpose:** Model for usage limits with percentage calculations
-**Properties:** `limit`, `used`, `remaining`, `percentage`
-**Methods:** Percentage calculation, status indicators
-
-#### UsageMetrics (`Models/UsageMetrics.swift`)
-**Purpose:** Unified model for service usage data
-**Properties:** Service type, current usage, limits, timestamps
-**Features:** JSON encoding/decoding for caching
-
-### Services
-
-#### KeychainManager (`Services/KeychainManager.swift`)
-**Purpose:** Secure credential storage using macOS Keychain
-**Pattern:** Singleton (`KeychainManager.shared`)
-**Methods:**
-- `save(service:key:value:)` - Store credential
-- `get(service:key:)` - Retrieve credential
-- `delete(service:key:)` - Remove credential
-
-**Security:**
-- Uses macOS Keychain Services API
-- Credentials encrypted by OS
-- No plaintext storage
-
-#### AuthenticationManager (`Services/AuthenticationManager.swift`)
-**Purpose:** Manages authentication state for all services
-**Pattern:** Singleton, ObservableObject
-**Properties:**
-- `@Published var isClaudeAuthenticated: Bool`
-- `@Published var isOpenAIAuthenticated: Bool`
-- `@Published var isCursorAuthenticated: Bool`
-
-**Methods:**
-- `authenticateClaude(sessionKey:)` - Store Claude session key
-- `authenticateOpenAI(apiKey:)` - Store OpenAI API key
-- `authenticateCursor(apiKey:)` - Store Cursor API key
-- `logout(service:)` - Clear credentials
-
-#### API Service Clients
-
-**ClaudeService** (`Services/ClaudeService.swift`):
-- Fetches usage data from Claude API
-- Requires session key from Keychain
-- Parses response to UsageMetrics
-
-**OpenAIService** (`Services/OpenAIService.swift`):
-- Fetches usage data from OpenAI API
-- Requires API key from Keychain
-- Parses response to UsageMetrics
-
-**CursorService** (`Services/CursorService.swift`):
-- Placeholder (Cursor doesn't provide usage API)
-- Returns error when called
-
-#### UsageDataManager (`Services/UsageDataManager.swift`)
-**Purpose:** Centralized data management, caching, auto-refresh
-**Pattern:** Singleton, ObservableObject, @MainActor
-**Properties:**
-- `@Published var metrics: [ServiceType: UsageMetrics]`
-- `@Published var isLoading: Bool`
-- `@Published var lastError: Error?`
-
-**Methods:**
-- `refreshAll()` - Fetch all authenticated services
-- `refresh(service:)` - Fetch single service
-- `setupAutoRefresh()` - Schedule 15-minute refresh timer
-
-**Features:**
-- Caching to UserDefaults
-- Auto-refresh every 15 minutes
-- Background refresh support
-- Shared data store for widgets
-
-#### SharedDataStore (`Services/SharedDataStore.swift`)
-**Purpose:** App Groups shared storage for widget extension
-**Pattern:** Singleton
-**App Group:** `group.com.agenticindiedev.meterbar`
-
-**Methods:**
-- `saveMetrics(_:)` - Save metrics to shared UserDefaults
-- `loadMetrics()` - Load metrics from shared UserDefaults
-
-### Views
-
-#### SettingsView (`Views/SettingsView.swift`)
-**Purpose:** Settings window for authentication and preferences
-**Features:**
-- Service authentication (Claude, OpenAI, Cursor)
-- Credential input fields
-- Authentication status indicators
-- Preferences configuration
-
-#### MenuBarView (`Views/MenuBarView.swift`)
-**Purpose:** Menu bar popover with usage metrics
-**Features:**
-- Service cards with usage percentages
-- Color-coded status (green/yellow/red)
-- Refresh button
-- Settings link
-- Real-time updates via @Published properties
-
-### Widget Extension
-
-#### UsageWidget (`MeterBarWidget/UsageWidget.swift`)
-**Purpose:** WidgetKit widget implementation
-**Sizes:** Small, Medium, Large
-**Features:**
-- Timeline provider with 15-minute refresh
-- Displays usage metrics for authenticated services
-- Color-coded status indicators
-- Progress bars for usage percentages
-- Background refresh support
-
-**Widget Views:**
-- `SmallWidgetView` - Single service, key metrics
-- `MediumWidgetView` - All services, compact view
-- `LargeWidgetView` - Detailed breakdown
+Dates in the shared JSON use `JSONEncoder`/`JSONDecoder` **default** strategies (seconds since 2001-01-01 reference date). Changing either side's date strategy breaks widget + CLI decode.
 
 ---
 
-## Data Flow
+## CI / release
 
-### Authentication Flow
+- `ci.yml` (push/PR to master, macos-26 + Xcode 26.2): xcodebuild Debug build (app + widget), `swift test` via SwiftPM (real gate), coverage threshold via `scripts/check-coverage.sh`, SwiftLint.
+- `release.yml` (tag `v*`): Release build (unsigned — no Developer ID/notarization yet), builds CLI and embeds it in `Contents/Helpers/`, verifies CLI `--version` matches `CFBundleShortVersionString`, zips via `ditto`, publishes GitHub Release, then calls `update-homebrew.yml` to bump `VincentShipsIt/homebrew-tap` (`Casks/meterbar.rb`) using `TAP_GITHUB_TOKEN`.
+- `secret-scan.yml`: gitleaks (pinned + checksum-verified) over full history.
 
-```
-1. User opens Settings
-   ↓
-2. Enters credentials (session key, API key)
-   ↓
-3. KeychainManager.save() stores in macOS Keychain
-   ↓
-4. AuthenticationManager updates @Published properties
-   ↓
-5. UI updates to show authenticated status
-```
+## Known architectural risks
 
-### Data Refresh Flow
-
-```
-1. UsageDataManager.refreshAll() called
-   ↓
-2. Check AuthenticationManager for authenticated services
-   ↓
-3. For each authenticated service:
-   - ClaudeService.fetchUsageMetrics()
-   - OpenAIService.fetchUsageMetrics()
-   ↓
-4. API calls return UsageMetrics
-   ↓
-5. Update @Published metrics dictionary
-   ↓
-6. Save to cache (UserDefaults)
-   ↓
-7. Save to SharedDataStore (App Groups)
-   ↓
-8. UI updates automatically (SwiftUI @Published)
-   ↓
-9. Widget timeline updates
-```
-
-### Widget Update Flow
-
-```
-1. WidgetKit requests timeline
-   ↓
-2. UsageWidget.TimelineProvider.getTimeline()
-   ↓
-3. Load metrics from SharedDataStore
-   ↓
-4. Create TimelineEntry with current metrics
-   ↓
-5. Schedule next refresh (15 minutes)
-   ↓
-6. Widget renders with latest data
-```
-
-### Notification Flow
-
-```
-1. UsageDataManager detects usage > 90%
-   ↓
-2. Check if notification already sent (cooldown)
-   ↓
-3. Create UserNotification
-   ↓
-4. Schedule notification
-   ↓
-5. User receives alert in Notification Center
-```
-
----
-
-## External Services
-
-| Service | Purpose | Documentation | Authentication |
-|---------|---------|---------------|----------------|
-| Claude API | Usage data | (Research needed) | Session key from cookies |
-| OpenAI API | Usage data | https://platform.openai.com/docs | API key |
-| Cursor API | Usage data | (No API available) | N/A |
-
-**API Endpoints (Placeholders - Need Research):**
-- Claude: `https://claude.ai/api/usage` (placeholder)
-- OpenAI: `https://api.openai.com/v1/usage` (placeholder)
-- Cursor: No API available
-
-**Credential Storage:**
-- All credentials stored in macOS Keychain (encrypted by OS)
-- No credentials in code or UserDefaults
-- Keychain access controlled by app entitlements
-
----
-
-## Configuration
-
-### App Groups
-
-**Identifier:** `group.com.agenticindiedev.meterbar`
-
-**Purpose:** Share data between main app and widget extension
-
-**Configuration:**
-- Both targets must have App Groups capability enabled
-- Same group identifier in both targets
-- Shared UserDefaults container for data sharing
-
-### Keychain Access
-
-**Keychain Service Names:**
-- `com.agenticindiedev.meterbar.claude`
-- `com.agenticindiedev.meterbar.openai`
-- `com.agenticindiedev.meterbar.cursor`
-
-**Key Names:**
-- `sessionKey` (Claude)
-- `apiKey` (OpenAI, Cursor)
-
-### UserDefaults Keys
-
-| Key | Purpose |
-|-----|---------|
-| `cached_usage_metrics` | Cached usage data (main app) |
-| `shared_usage_metrics` | Shared usage data (App Groups) |
-
-### Refresh Intervals
-
-- **Auto-refresh:** 15 minutes
-- **Widget timeline:** 15 minutes
-- **Background refresh:** System-managed (WidgetKit)
-
----
-
-## Deployment
-
-### Development
-
-1. **Open Xcode:**
-   ```bash
-   open MeterBar.xcodeproj
-   ```
-
-2. **Select Scheme:**
-   - `MeterBar` - Main app
-   - `MeterBarWidget` - Widget extension
-
-3. **Build and Run:**
-   - Press `Cmd+R` to build and run
-   - App appears in menu bar
-
-### Distribution
-
-1. **Archive:**
-   - Product → Archive in Xcode
-   - Creates `.xcarchive`
-
-2. **Export:**
-   - Distribute App
-   - Choose distribution method (App Store, Developer ID, etc.)
-
-3. **Notarization:**
-   - Required for Developer ID distribution
-   - Automated via Xcode
-
-**Requirements:**
-- macOS 13.0+ (Ventura)
-- Xcode 15.0+
-- Apple Developer account (for distribution)
-
----
-
-## Security
-
-See `quality/SECURITY-CHECKLIST.md` for security considerations.
-
-**Key Security Features:**
-- **Keychain Storage:** All credentials encrypted by macOS Keychain
-- **No Plaintext:** No credentials in code, UserDefaults, or logs
-- **App Groups:** Secure shared storage between app and widget
-- **Keychain Access Control:** Controlled by app entitlements
-
-**Security Considerations:**
-- API keys stored securely in Keychain
-- Session keys extracted from browser cookies (user responsibility)
-- No network requests logged with credentials
-- Widget extension has read-only access to shared data
-
----
-
-## Related Documentation
-
-- `RULES.md` - Coding standards
-- `architecture/DECISIONS.md` - Architectural decisions
-- `architecture/PROJECT-MAP.md` - Project map
-- `PROJECT_STRUCTURE.md` - Detailed project structure
-- `IMPLEMENTATION_STATUS.md` - Implementation status
-- `README.md` - User-facing documentation
-- `SETUP.md` - Setup instructions
-- `XCODE_SETUP.md` - Xcode project setup
+Tracked in `docs/audits/00-repo-map.md` §6. Headlines: reverse-engineered provider interfaces (R1), unsigned distribution (R2), triplicated model structs (R4), hardcoded pricing (R5), three build systems (R6), god view files (R8).

--- a/.agents/SYSTEM/RULES.md
+++ b/.agents/SYSTEM/RULES.md
@@ -1,93 +1,47 @@
 # Coding Rules - MeterBar
 
 **Purpose:** Coding standards and patterns for this project.
-**Last Updated:** 2025-12-29
+**Last Updated:** 2026-07-02 (rewritten — the previous version was a TypeScript template that never
+applied to this pure-Swift repo)
 
 ---
 
 ## General Principles
 
-1. **Follow existing patterns** - Search for 3+ similar implementations before writing new code
-2. **Quality over speed** - Think through implementations before coding
-3. **No inline types** - Define interfaces/types in dedicated files
-4. **No `any` types** - Use proper TypeScript types
-5. **No `console.log`** - Use a logging service
+1. **Follow existing patterns** — search for 3+ similar implementations before writing new code
+2. **Quality over speed** — think through implementations before coding
+3. **No `print(...)`** — use `AppLog` (`os.Logger`); enforced by the SwiftLint custom rule `no_print_statements`
+4. **No force-unwraps** — `force_unwrapping` is an opt-in SwiftLint rule here; prefer `guard let` or documented sentinels (see `ClaudeCodeAccount.defaultID`)
+5. **Never log secrets or raw API response bodies** — use `privacy: .public` only on values proven non-sensitive
 
----
+## Swift conventions (enforced by tooling)
 
-## File Organization
+The single source of truth is `.swiftlint.yml` + `.swiftformat` at the repo root. Highlights:
 
-### Naming Conventions
+- 4-space indent, max line width 120 (SwiftLint error at 200)
+- Swift 5 language mode (`SWIFT_VERSION = 5.0` in the Xcode project, `.swiftLanguageMode(.v5)` in `Package.swift`) — don't introduce Swift 6 strict-concurrency-only constructs without migrating the singletons
+- Types: PascalCase; files named after their primary type (`CostTracker.swift`)
+- Services are singletons (`static let shared`); new services should follow that pattern until the DI refactor happens
+- UI state via `ObservableObject` + `@Published`; UI mutations on the main actor
+- Decode external JSON with explicit `CodingKeys` for snake_case fields; tolerate absent fields with optionals rather than failing decode
 
-- **Directories:** lowercase with hyphens (`user-settings/`)
-- **Files:** kebab-case (`user-service.ts`)
-- **Components:** PascalCase (`UserProfile.tsx`)
-- **Interfaces:** PascalCase with `I` prefix (`IUserProfile`)
+## Data-contract rules (important)
 
-### Import Order
+- The app-group JSON (`cached_usage_metrics.json`) is decoded by **three** codebases (app, widget, CLI) with duplicated struct definitions. Any change to `UsageMetrics`/`UsageLimit`/`ServiceType` serialization must be mirrored in `MeterBarWidget/UsageWidget.swift` and `MeterBarCLI/Sources/MeterBarCLI.swift`, and the contract tests in `MeterBarTests/CachedMetricsContractTests.swift` must be updated.
+- Do NOT change the `JSONEncoder`/`JSONDecoder` date strategy for the shared cache — all three sides rely on the default (seconds since reference date).
 
-1. External packages
-2. Internal packages/aliases
-3. Relative imports
-4. Types/interfaces
+## Error handling
 
-```typescript
-// External
-import { useState } from 'react';
-
-// Internal aliases
-import { Button } from '@components/ui';
-import { UserService } from '@services/user';
-
-// Relative
-import { helpers } from './utils';
-
-// Types
-import type { IUser } from '@interfaces/user';
-```
-
----
-
-## TypeScript
-
-### Do
-
-- Use strict mode
-- Define return types for functions
-- Use path aliases (`@components/`, `@services/`)
-- Export types from dedicated files
-
-### Don't
-
-- Use `any` type
-- Use inline interface definitions
-- Use relative imports for shared code
-- Ignore TypeScript errors
-
----
-
-## Error Handling
-
-```typescript
-try {
-  const result = await operation();
-  return result;
-} catch (error) {
-  logger.error('Operation failed', { error, context });
-  throw new AppError('User-friendly message', error);
-}
-```
-
----
+- Provider services map errors to `ServiceError` (`notAuthenticated`, `invalidURL`, `apiError(String)`, `parsingError`) and update their `@Published lastError`/`hasAccess` on the main actor
+- Fetch failures degrade gracefully: keep cached metrics rather than blanking the UI (see `UsageDataManager.refreshAll`)
+- Availability-biased token checks: a token we cannot introspect is treated as valid and the server 401 is the source of truth (`OAuthTokenExpiry`)
 
 ## Testing
 
-- Write tests for business logic
-- Use descriptive test names
-- Mock external dependencies
-- Test edge cases
-
----
+- Tests live in `MeterBarTests/` and run via `swift test` (requires full Xcode; Command Line Tools lack the XCTest module)
+- TDD for new features; new parsing/decode logic must come with fixture tests
+- Network-touching tests must gate on credentials with `XCTSkip` (see `APIIntegrationTests`)
+- Pure logic (parsers, formatters, models) must be testable without the network
 
 ## Git
 
@@ -95,34 +49,19 @@ try {
 
 ```
 type(scope): description
-
-[optional body]
-
-[optional footer]
 ```
 
 Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
 
 ### Branch Naming
 
-- `feature/description`
-- `fix/description`
-- `chore/description`
-
----
+- `feature/description`, `fix/description`, `chore/description`
 
 ## Documentation
 
-- Document public APIs
-- Add JSDoc for complex functions
-- Keep README up to date
-- Document architectural decisions in `SYSTEM/architecture/DECISIONS.md`
-
----
-
-## Project-Specific Rules
-
-<!-- Add your project-specific rules below -->
+- Keep `README.md` claims true to the code (the sandbox/minimum-OS claims drifted once already)
+- Architectural decisions go in `SYSTEM/architecture/DECISIONS.md`
+- Session logs: `.agents/SESSIONS/YYYY-MM-DD.md`, one file per day
 
 ---
 

--- a/.agents/SYSTEM/SUMMARY.md
+++ b/.agents/SYSTEM/SUMMARY.md
@@ -31,7 +31,7 @@
 
 - **Initial Implementation:** All core features implemented
 - **Project Structure:** Complete Swift/SwiftUI architecture
-- **Documentation:** Created `.agent/` documentation structure
+- **Documentation:** Created `.agents/` documentation structure
 
 ---
 

--- a/.agents/SYSTEM/architecture/DECISIONS.md
+++ b/.agents/SYSTEM/architecture/DECISIONS.md
@@ -32,7 +32,7 @@ What other options were considered?
 
 ## Decisions
 
-### ADR-001: Use .agent/ Folder for AI Documentation
+### ADR-001: Use .agents/ Folder for AI Documentation
 
 **Date:** 2025-12-29
 **Status:** Accepted
@@ -41,7 +41,7 @@ What other options were considered?
 Need a structured way to organize AI agent documentation, session tracking, and project rules.
 
 #### Decision
-Use a `.agent/` folder at the project root with standardized subdirectories:
+Use a `.agents/` folder at the project root with standardized subdirectories:
 - `SYSTEM/` for rules and architecture
 - `TASKS/` for task tracking
 - `SESSIONS/` for daily session documentation

--- a/.agents/SYSTEM/architecture/PROJECT-MAP.md
+++ b/.agents/SYSTEM/architecture/PROJECT-MAP.md
@@ -1,7 +1,7 @@
 # Project Map - MeterBar
 
 **Purpose:** Quick reference for project structure and responsibilities.
-**Last Updated:** 2025-01-27
+**Last Updated:** 2026-07-02 (synced to the actual tree; see `docs/audits/00-repo-map.md`)
 
 ---
 
@@ -9,191 +9,45 @@
 
 ```
 meterbarapp/
-├── .agent/                      # AI documentation (you are here)
-├── MeterBar/                  # Main app target
-│   ├── App/
-│   │   └── MeterBarApp.swift  # App entry point
-│   ├── Models/                  # Data models
-│   ├── Services/                # Business logic
-│   └── Views/                   # UI components
-├── MeterBarWidget/            # Widget extension target
-│   ├── MeterBarWidgetBundle.swift
-│   └── UsageWidget.swift
-├── MeterBar.xcodeproj/        # Xcode project
-├── Package.swift                 # Swift Package Manager
-└── README.md
+├── .agents/                    # AI documentation (SESSIONS/, SYSTEM/, docs/, skills/)
+├── .claude/ .codex/ .cursor/   # Per-agent tool config (commands, hooks, skills)
+├── .github/workflows/          # ci.yml, release.yml, update-homebrew.yml, secret-scan.yml
+├── MeterBar/                   # Main app target
+│   ├── App/MeterBarApp.swift   # @main + AppDelegate (status item, popover, notifications)
+│   ├── Models/                 # ServiceType, UsageMetrics, UsageLimit, TokenCost,
+│   │                           # RefreshInterval, ClaudeCodeAccount, UsageFormatting
+│   ├── Services/               # 16 singleton services (fetch/parse/cache/log)
+│   ├── Views/                  # MenuBarView, SettingsView, UsageDashboardView,
+│   │                           # MeterBarTheme, RefreshingIcon
+│   └── Resources/, Assets.xcassets, Info.plist, MeterBar.entitlements
+├── MeterBarWidget/             # WidgetKit extension (duplicated model structs)
+├── MeterBarCLI/                # Separate SwiftPM package → `meterbar` executable
+├── MeterBarTests/              # XCTest suite — runs via `swift test` (root Package.swift)
+├── MeterBar.xcodeproj/         # App + widget targets (no test target)
+├── Package.swift               # SwiftPM manifest for library + tests
+├── scripts/                    # Bun asset generators, check-coverage.sh, API smoke test
+├── docs/                       # Logo, screenshots, audits/
+└── assets/                     # Social preview
 ```
 
----
+## Where things live
 
-## Key Directories
+| Concern | File(s) |
+|---|---|
+| Provider fetch logic | `MeterBar/Services/{ClaudeCodeCLIUsageService,ClaudeCodeLocalService,CodexCliLocalService,CursorLocalService,ClaudeService,OpenAIService}.swift` |
+| Refresh orchestration + cache | `MeterBar/Services/UsageDataManager.swift` |
+| Cost estimation | `MeterBar/Services/CostTracker.swift` (+ `Models/TokenCost.swift`) |
+| Widget data handoff | `MeterBar/Services/SharedDataStore.swift` → app group `group.dev.shipshit.meterbar` |
+| Admin API keys | `MeterBar/Services/{AuthenticationManager,KeychainManager}.swift` |
+| Notifications | `MeterBar/App/MeterBarApp.swift` (AppDelegate) |
+| UI | `MeterBar/Views/` |
+| CLI | `MeterBarCLI/Sources/MeterBarCLI.swift` |
+| Coverage gate | `scripts/check-coverage.sh` (threshold via `COVERAGE_THRESHOLD`) |
+| Lint/format config | `.swiftlint.yml`, `.swiftformat` |
 
-### `/MeterBar/App/`
-**Purpose:** App entry point and lifecycle
-**Patterns:** SwiftUI App protocol, NSApplication
-**Files:**
-- `MeterBarApp.swift` - Main app, menu bar setup
+## Build/test invocations
 
-### `/MeterBar/Models/`
-**Purpose:** Data models and types
-**Patterns:** Swift structs, enums, Codable
-**Files:**
-- `ServiceType.swift` - Enum for services
-- `UsageLimit.swift` - Usage limit model
-- `UsageMetrics.swift` - Unified usage data
-
-### `/MeterBar/Services/`
-**Purpose:** Business logic and API clients
-**Patterns:** Singleton pattern, ObservableObject, async/await
-**Files:**
-- `KeychainManager.swift` - Secure storage
-- `AuthenticationManager.swift` - Auth state
-- `ClaudeService.swift` - Claude API client
-- `OpenAIService.swift` - OpenAI API client
-- `CursorService.swift` - Cursor API client
-- `UsageDataManager.swift` - Data management
-- `SharedDataStore.swift` - App Groups storage
-
-### `/MeterBar/Views/`
-**Purpose:** SwiftUI views
-**Patterns:** SwiftUI views, @ObservedObject
-**Files:**
-- `SettingsView.swift` - Settings window
-- `MenuBarView.swift` - Menu bar popover
-
-### `/MeterBarWidget/`
-**Purpose:** WidgetKit extension
-**Patterns:** Widget protocol, TimelineProvider
-**Files:**
-- `MeterBarWidgetBundle.swift` - Widget bundle
-- `UsageWidget.swift` - Widget views
-
----
-
-## File Naming Conventions
-
-| Type | Pattern | Example |
-|------|---------|---------|
-| App Entry | `*App.swift` | `MeterBarApp.swift` |
-| Model | `*.swift` in Models/ | `UsageMetrics.swift` |
-| Service | `*Service.swift` or `*Manager.swift` | `ClaudeService.swift`, `KeychainManager.swift` |
-| View | `*View.swift` | `SettingsView.swift` |
-| Widget | `*Widget.swift` or `*WidgetBundle.swift` | `UsageWidget.swift` |
-
----
-
-## Entry Points
-
-| File | Purpose | Called By |
-|------|---------|-----------|
-| `MeterBar/App/MeterBarApp.swift` | App entry point | macOS system |
-| `MeterBarWidget/MeterBarWidgetBundle.swift` | Widget bundle | WidgetKit |
-
----
-
-## Key Files and Responsibilities
-
-### App Files
-
-| File | Purpose | Key Classes/Structs |
-|------|---------|---------------------|
-| `MeterBarApp.swift` | App lifecycle, menu bar | `MeterBarApp` (App) |
-
-### Model Files
-
-| File | Purpose | Key Types |
-|------|---------|-----------|
-| `ServiceType.swift` | Service enum | `ServiceType` enum |
-| `UsageLimit.swift` | Usage limit model | `UsageLimit` struct |
-| `UsageMetrics.swift` | Usage data model | `UsageMetrics` struct |
-
-### Service Files
-
-| File | Purpose | Key Classes |
-|------|---------|-------------|
-| `KeychainManager.swift` | Keychain storage | `KeychainManager` (singleton) |
-| `AuthenticationManager.swift` | Auth state | `AuthenticationManager` (singleton, ObservableObject) |
-| `ClaudeService.swift` | Claude API | `ClaudeService` (singleton) |
-| `OpenAIService.swift` | OpenAI API | `OpenAIService` (singleton) |
-| `CursorService.swift` | Cursor API | `CursorService` (singleton) |
-| `UsageDataManager.swift` | Data management | `UsageDataManager` (singleton, ObservableObject) |
-| `SharedDataStore.swift` | App Groups storage | `SharedDataStore` (singleton) |
-
-### View Files
-
-| File | Purpose | Key Views |
-|------|---------|-----------|
-| `SettingsView.swift` | Settings window | `SettingsView` |
-| `MenuBarView.swift` | Menu bar popover | `MenuBarView` |
-
-### Widget Files
-
-| File | Purpose | Key Types |
-|------|---------|-----------|
-| `MeterBarWidgetBundle.swift` | Widget bundle | `MeterBarWidgetBundle` |
-| `UsageWidget.swift` | Widget views | `UsageWidget`, `SmallWidgetView`, `MediumWidgetView`, `LargeWidgetView` |
-
----
-
-## Module Relationships
-
-```
-MeterBarApp
-  ├──→ MenuBarView
-  │     └──→ UsageDataManager (ObservableObject)
-  │           ├──→ ClaudeService
-  │           ├──→ OpenAIService
-  │           └──→ AuthenticationManager
-  │                 └──→ KeychainManager
-  │
-  ├──→ SettingsView
-  │     └──→ AuthenticationManager
-  │           └──→ KeychainManager
-  │
-  └──→ UsageDataManager
-        └──→ SharedDataStore (App Groups)
-
-MeterBarWidget
-  └──→ UsageWidget
-        └──→ SharedDataStore (App Groups)
-```
-
----
-
-## Configuration Files
-
-| File | Purpose | Key Settings |
-|------|---------|--------------|
-| `Package.swift` | Swift Package Manager | Dependencies, targets |
-| `MeterBar.xcodeproj/` | Xcode project | Targets, capabilities, signing |
-| `Info.plist` | App metadata | Bundle ID, version |
-
----
-
-## Capabilities Required
-
-| Capability | Purpose | Targets |
-|------------|---------|---------|
-| App Groups | Data sharing | MeterBar, MeterBarWidget |
-| Keychain Sharing | Credential access | MeterBar |
-| UserNotifications | Alerts | MeterBar |
-
----
-
-## Build Output
-
-| Directory | Purpose | Generated By |
-|-----------|---------|--------------|
-| `build/` | Compiled binaries | Xcode build |
-| `DerivedData/` | Xcode build artifacts | Xcode (in DerivedData location) |
-
----
-
-## Related Documentation
-
-- `../ARCHITECTURE.md` - System architecture
-- `../RULES.md` - Coding standards
-- `DECISIONS.md` - Architectural decisions
-- `../../PROJECT_STRUCTURE.md` - Detailed project structure
-- `../../IMPLEMENTATION_STATUS.md` - Implementation status
-- `../../README.md` - User-facing documentation
+- App/widget build: `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar build` (needs full Xcode)
+- Tests: `swift test` at repo root (needs full Xcode for the XCTest module — Command Line Tools alone cannot run tests)
+- CLI: `cd MeterBarCLI && swift build`
+- Coverage: `scripts/check-coverage.sh` (wraps `swift test --enable-code-coverage` + llvm-cov)

--- a/.agents/SYSTEM/critical/CRITICAL-NEVER-DO.md
+++ b/.agents/SYSTEM/critical/CRITICAL-NEVER-DO.md
@@ -24,7 +24,7 @@ Only these 4 `.md` files allowed at project root:
 3. `CODEX.md`
 4. `README.md`
 
-Everything else goes in `.agent/`.
+Everything else goes in `.agents/`.
 
 ---
 
@@ -34,13 +34,13 @@ Everything else goes in `.agent/`.
 
 **Correct:**
 ```
-.agent/SESSIONS/2025-01-15.md
+.agents/SESSIONS/2025-01-15.md
 ```
 
 **Wrong:**
 ```
-.agent/SESSIONS/2025-01-15-feature.md  ❌
-.agent/SESSIONS/FEATURE-2025-01-15.md  ❌
+.agents/SESSIONS/2025-01-15-feature.md  ❌
+.agents/SESSIONS/FEATURE-2025-01-15.md  ❌
 ```
 
 Multiple sessions same day → Same file, Session 1, Session 2, etc.

--- a/.agents/SYSTEM/critical/CROSS-PROJECT-RULES.md
+++ b/.agents/SYSTEM/critical/CROSS-PROJECT-RULES.md
@@ -26,7 +26,7 @@ Every project follows:
 ├── CLAUDE.md
 ├── CODEX.md
 ├── README.md
-└── .agent/
+└── .agents/
     ├── README.md
     ├── SYSTEM/
     ├── TASKS/
@@ -38,7 +38,7 @@ Every project follows:
 ## Session Files
 
 - **One file per day:** `YYYY-MM-DD.md`
-- **Location:** `.agent/SESSIONS/`
+- **Location:** `.agents/SESSIONS/`
 - Multiple sessions = Session 1, Session 2 in SAME file
 
 ---
@@ -46,7 +46,7 @@ Every project follows:
 ## Naming Conventions
 
 ### Directories
-- Top-level `.agent/` dirs: ALL-CAPS (`SYSTEM/`, `TASKS/`)
+- Top-level `.agents/` dirs: ALL-CAPS (`SYSTEM/`, `TASKS/`)
 - Subdirectories: lowercase with hyphens (`user-management/`)
 
 ### Files
@@ -106,5 +106,5 @@ Every project follows:
 ## Never Delete
 
 - `AGENTS.md`, `CLAUDE.md`, `CODEX.md` in any project root
-- `.agent/` folders
+- `.agents/` folders
 - `README.md` files

--- a/.agents/docs/IMPLEMENTATION_STATUS.md
+++ b/.agents/docs/IMPLEMENTATION_STATUS.md
@@ -1,159 +1,39 @@
 # Implementation Status
 
-## ✅ Completed
+**Last Updated:** 2026-07-02 (rewritten — the previous version described the original planning-phase
+design, including `CodexService`/`CursorService` classes and "Codex cookies" that were never shipped
+under those names; see `docs/audits/00-repo-map.md` for the audited current state)
 
-All planned features have been implemented:
+## ✅ Shipped
 
-### Project Structure
-- ✅ Project directory structure created
-- ✅ `.agent/` folder with documentation
-- ✅ Entry files (AGENTS.md, CLAUDE.md, CODEX.md)
-- ✅ README.md with project overview
-- ✅ Package.swift for Swift Package Manager
+### Providers
+- ✅ Claude Code via `claude /usage` CLI parsing (multi-account via `CLAUDE_CONFIG_DIR`)
+- ✅ Claude Code legacy OAuth fallback (opt-in `ClaudeCodeEnableOAuthFallback` UserDefaults flag)
+- ✅ OpenAI Codex CLI via `~/.codex/auth.json` + wham/usage endpoint (incl. extra-usage + reset credits)
+- ✅ Cursor via local SQLite token + usage-summary endpoint
+- ✅ Anthropic Admin API org usage (optional, user-provided key)
+- ✅ OpenAI Admin API org usage (optional, user-provided key)
 
-### Data Models
-- ✅ `ServiceType` enum (Claude, Codex, Cursor)
-- ✅ `UsageLimit` struct with percentage calculations
-- ✅ `UsageMetrics` struct for unified data model
+### App
+- ✅ Menu bar status item showing most-constrained-quota percentage
+- ✅ Popover (`MenuBarView`) with per-provider accordion cards
+- ✅ Usage dashboard window (`UsageDashboardView`) with daily cost charts
+- ✅ Settings (`SettingsView`): provider toggles, admin keys, Claude accounts, refresh interval, Dock toggle
+- ✅ Local notifications at 90%/100% with stable ids and re-arm-on-drop
+- ✅ Cost tracking from local session logs (Claude JSONL + Codex archived sessions/SQLite)
+- ✅ WidgetKit widget fed via app group JSON
+- ✅ `meterbar` CLI (usage/cost subcommands) bundled in `Contents/Helpers/`
 
-### Authentication System
-- ✅ `KeychainManager` for secure credential storage
-- ✅ `AuthenticationManager` for auth state management
-- ✅ Support for Claude session keys
-- ✅ Support for Codex cookies
-- ✅ Support for Cursor API keys
+### Infra
+- ✅ CI: xcodebuild build + `swift test` gate + coverage check + SwiftLint (`.github/workflows/ci.yml`)
+- ✅ Release: unsigned zip + GitHub Release + Homebrew tap bump
+- ✅ Secret scanning (gitleaks, pinned + checksum-verified)
 
-### API Clients
-- ✅ `ClaudeService` for fetching Claude usage data
-- ✅ `CodexService` for fetching Codex usage data
-- ✅ `CursorService` for fetching Cursor usage data
-- ✅ Error handling and parsing
+## ❌ Not implemented / known gaps
 
-### Data Management
-- ✅ `UsageDataManager` for centralized data management
-- ✅ `SharedDataStore` for Widget extension access (App Groups)
-- ✅ Caching with UserDefaults
-- ✅ Auto-refresh every 15 minutes
-- ✅ Background refresh support
-
-### UI Components
-- ✅ `SettingsView` for authentication and preferences
-- ✅ `MenuBarView` with service cards and usage metrics
-- ✅ Menu bar icon with status indicators
-- ✅ Popover dropdown interface
-
-### WidgetKit Implementation
-- ✅ Small widget (single service, key metrics)
-- ✅ Medium widget (all services, compact view)
-- ✅ Large widget (detailed breakdown)
-- ✅ Timeline provider with 15-minute refresh
-- ✅ App Groups integration for shared data
-
-### Notifications
-- ✅ Notification setup and permissions
-- ✅ Usage monitoring
-- ✅ Alerts for approaching limits (90%+)
-- ✅ Alerts for limit reached (100%)
-
-### Open Source Setup
-- ✅ MIT License
-- ✅ CONTRIBUTING.md
-- ✅ CODE_OF_CONDUCT.md
-- ✅ GitHub issue templates
-- ✅ Pull request template
-- ✅ SETUP.md with detailed instructions
-- ✅ .gitignore for Xcode projects
-
-## 📝 Next Steps
-
-### 1. Create Xcode Project
-
-The Swift source files are ready, but you need to create the Xcode project:
-
-1. Open Xcode
-2. Create a new macOS App project
-3. Follow instructions in `XCODE_SETUP.md`
-4. Add all source files to the project
-5. Configure App Groups capability
-6. Add Widget Extension target
-
-See `XCODE_SETUP.md` for detailed instructions.
-
-### 2. API Endpoint Research
-
-The API clients are implemented with placeholder endpoints. You'll need to:
-
-1. **Claude API**: Research the actual endpoint for usage data
-   - Current placeholder: `https://claude.ai/api/usage`
-   - May need to inspect network requests from Claude dashboard
-   - Determine exact request format and response structure
-
-2. **Codex API**: Research the actual endpoint for usage data
-   - Current placeholder: `https://codex.openai.com/api/usage`
-   - May need to inspect network requests from Codex dashboard
-   - Determine exact request format and response structure
-
-3. **Cursor API**: Research the actual endpoint for usage data
-   - Current placeholder: `https://cursor.sh/api/usage`
-   - Check Cursor documentation for API endpoints
-   - Determine exact request format and response structure
-
-### 3. Testing
-
-Once the Xcode project is set up:
-
-1. Test authentication flow for each service
-2. Test API data fetching (may need to mock responses initially)
-3. Test widget display and updates
-4. Test menu bar functionality
-5. Test notifications
-6. Test caching and background refresh
-
-### 4. App Group Configuration
-
-Ensure both the main app and widget extension have:
-- App Groups capability enabled
-- Same group identifier: `group.com.agenticindiedev.quotaguard`
-
-### 5. Keychain Configuration
-
-Verify Keychain access works correctly:
-- Test saving credentials
-- Test retrieving credentials
-- Test deleting credentials
-
-## 🔧 Known Limitations
-
-1. **API Endpoints**: Actual API endpoints need to be determined through research or reverse engineering
-2. **Response Parsing**: Response structures are placeholders and need to match actual API responses
-3. **Cookie Extraction**: Codex cookie extraction may need browser automation or manual copy-paste
-4. **Xcode Project**: The `.xcodeproj` file must be created manually in Xcode
-
-## 📚 Documentation
-
-All documentation is in place:
-- `README.md` - Project overview
-- `SETUP.md` - Setup instructions
-- `XCODE_SETUP.md` - Xcode project setup
-- `CONTRIBUTING.md` - Contribution guidelines
-- `PROJECT_STRUCTURE.md` - Code structure overview
-
-## 🎯 Architecture Highlights
-
-- **Singleton Pattern**: Used for managers and services
-- **ObservableObject**: For reactive UI updates
-- **Async/Await**: Modern Swift concurrency
-- **App Groups**: For Widget extension data sharing
-- **Keychain**: Secure credential storage
-- **SwiftUI**: Modern declarative UI
-
-## 🚀 Ready for Development
-
-The codebase is ready for:
-1. Xcode project creation
-2. API endpoint research and integration
-3. Testing and refinement
-4. Distribution
-
-All core functionality is implemented and follows Swift/SwiftUI best practices.
-
+- ❌ Code signing + notarization (releases are unsigned; users must clear quarantine)
+- ❌ Shared `MeterBarShared` package — model structs duplicated in widget + CLI (see `DEFERRED_WORK.md` §1)
+- ❌ Crash reporting / telemetry of any kind
+- ❌ Tests for `UsageDataManager` orchestration, `CostTracker` scan paths, view layer, CLI package
+- ❌ Mac App Store distribution (the app is deliberately un-sandboxed so it can read other tools'
+  credential/log files; MAS would require a different architecture)

--- a/.agents/docs/PROJECT_STRUCTURE.md
+++ b/.agents/docs/PROJECT_STRUCTURE.md
@@ -15,7 +15,7 @@ apps/ai-usage-tracker/
 ├── SETUP.md                     # Setup instructions
 ├── Package.swift                # Swift Package Manager manifest
 ├── .gitignore                   # Git ignore rules
-├── .agent/                      # AI documentation
+├── .agents/                      # AI documentation
 │   └── README.md
 ├── .github/                     # GitHub templates
 │   ├── ISSUE_TEMPLATE/

--- a/.claude/commands/bug.md
+++ b/.claude/commands/bug.md
@@ -22,9 +22,9 @@ Keep it fast.
 ### Step 2: Determine File Location
 
 Bug file location (adjust paths for your project):
-- Frontend bugs: <project>/.agent/TASKS/bug-[short-name].md
-- Backend bugs: <project>/.agent/TASKS/bug-[short-name].md
-- Cross-project: .agent/TASKS/bug-[short-name].md
+- Frontend bugs: <project>/.agents/TASKS/bug-[short-name].md
+- Backend bugs: <project>/.agents/TASKS/bug-[short-name].md
+- Cross-project: .agents/TASKS/bug-[short-name].md
 
 ### Step 3: Create Bug File
 
@@ -62,7 +62,7 @@ Use structured format:
 
 Bug captured!
 
-File: <project>/.agent/TASKS/bug-[name].md
+File: <project>/.agents/TASKS/bug-[name].md
 
 You can add more details later when ready to fix.
 

--- a/.claude/commands/end.md
+++ b/.claude/commands/end.md
@@ -4,7 +4,7 @@
 
 ## What This Command Does
 
-1. **Activates the session-documenter skill** to save all session context to .agent/SESSIONS/YYYY-MM-DD.md
+1. **Activates the session-documenter skill** to save all session context to .agents/SESSIONS/YYYY-MM-DD.md
 2. **Tells you to manually run /clear** (Claude Code built-in command) to clear the context
 
 ## Workflow
@@ -16,7 +16,7 @@ When user types /end, activate session-documenter skill to:
 - Save decisions made with rationale
 - Record files created/modified/deleted
 - Note patterns established
-- Write everything to .agent/SESSIONS/YYYY-MM-DD.md
+- Write everything to .agents/SESSIONS/YYYY-MM-DD.md
 
 ### Step 2: Remind User to Clear Manually
 
@@ -24,7 +24,7 @@ After documentation completes, tell user to run /clear manually.
 
 ## Important Notes
 
-- ONE FILE PER DAY: Session documenter appends to .agent/SESSIONS/YYYY-MM-DD.md
+- ONE FILE PER DAY: Session documenter appends to .agents/SESSIONS/YYYY-MM-DD.md
 - Multiple /ends: Each /end adds a new session to the same days file
 - Manual clear required: User must run /clear after /end to clear context
 
@@ -32,6 +32,6 @@ After documentation completes, tell user to run /clear manually.
 
 /start -> Load preferences and session history
 [work] -> Make changes, complete tasks
-/end   -> Document session to .agent/SESSIONS/YYYY-MM-DD.md
+/end   -> Document session to .agents/SESSIONS/YYYY-MM-DD.md
 /clear -> Clear conversation context (built-in command)
 /start -> Begin new session with documented history

--- a/.claude/commands/inbox.md
+++ b/.claude/commands/inbox.md
@@ -8,7 +8,7 @@ Display current inbox tasks awaiting action.
 
 ## What This Command Does
 
-Reads and displays .agent/TASKS/INBOX.md showing:
+Reads and displays .agents/TASKS/INBOX.md showing:
 1. Human QA tasks - Blocking production
 2. Features to prompt - Ready for implementation
 
@@ -16,7 +16,7 @@ Reads and displays .agent/TASKS/INBOX.md showing:
 
 ### Step 1: Read Inbox
 
-cat .agent/TASKS/INBOX.md
+cat .agents/TASKS/INBOX.md
 
 ### Step 2: Display by Category
 

--- a/.claude/commands/new-session.md
+++ b/.claude/commands/new-session.md
@@ -8,7 +8,7 @@ Create a new session entry for todays work.
 
 ## What This Command Does
 
-1. Creates or appends to .agent/SESSIONS/YYYY-MM-DD.md
+1. Creates or appends to .agents/SESSIONS/YYYY-MM-DD.md
 2. Adds a new session header with timestamp
 3. Sets up structure for documenting work
 
@@ -17,11 +17,11 @@ Create a new session entry for todays work.
 ### One File Per Day
 
 CORRECT:
-- .agent/SESSIONS/2025-01-15.md
-- .agent/SESSIONS/2025-01-16.md
+- .agents/SESSIONS/2025-01-15.md
+- .agents/SESSIONS/2025-01-16.md
 
 WRONG:
-- .agent/SESSIONS/2025-01-15-feature-name.md
+- .agents/SESSIONS/2025-01-15-feature-name.md
 
 Multiple sessions on same day go in the same file.
 

--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -8,7 +8,7 @@ Load all critical preferences and instructions at the start of each session or a
 
 Check for project entry point documentation:
 ```bash
-cat .agent/SYSTEM/ai/SESSION-QUICK-START.md 2>/dev/null || cat .agent/SYSTEM/SESSION-QUICK-START.md 2>/dev/null || echo "No session quick start found"
+cat .agents/SYSTEM/ai/SESSION-QUICK-START.md 2>/dev/null || cat .agents/SYSTEM/SESSION-QUICK-START.md 2>/dev/null || echo "No session quick start found"
 ```
 
 This document will guide you to any other necessary documentation.
@@ -17,7 +17,7 @@ This document will guide you to any other necessary documentation.
 
 Read the user's non-negotiable preferences:
 ```bash
-cat .agent/SYSTEM/ai/USER-PREFERENCES.md 2>/dev/null || cat .claude/rules/user-preferences.md 2>/dev/null || echo "No user preferences found"
+cat .agents/SYSTEM/ai/USER-PREFERENCES.md 2>/dev/null || cat .claude/rules/user-preferences.md 2>/dev/null || echo "No user preferences found"
 ```
 
 This file contains:
@@ -31,7 +31,7 @@ This file contains:
 Read today's session to understand what was already done before `/clear`:
 ```bash
 TODAY=$(date +%Y-%m-%d)
-cat .agent/SESSIONS/$TODAY.md 2>/dev/null || echo "No session file for today yet"
+cat .agents/SESSIONS/$TODAY.md 2>/dev/null || echo "No session file for today yet"
 ```
 
 If the file exists, this shows:
@@ -51,7 +51,7 @@ The `session-documenter` skill will automatically activate and track:
 - Patterns established
 - Mistakes and fixes
 
-Documentation is written to `.agent/SESSIONS/YYYY-MM-DD.md` after each task completion.
+Documentation is written to `.agents/SESSIONS/YYYY-MM-DD.md` after each task completion.
 
 **No manual action required** - this happens automatically.
 
@@ -61,7 +61,7 @@ Documentation is written to `.agent/SESSIONS/YYYY-MM-DD.md` after each task comp
 
 Show the current inbox backlog:
 ```bash
-cat .agent/TASKS/INBOX.md 2>/dev/null || echo "No inbox found"
+cat .agents/TASKS/INBOX.md 2>/dev/null || echo "No inbox found"
 ```
 
 Display inbox in two categories:
@@ -106,11 +106,11 @@ This command ensures consistent behavior across sessions by:
    - No background processes (foreground only)
    - No local builds/tests (CI/CD only)
    - Document before /clear (session-documenter skill)
-   - Check `.agent/SESSIONS/` before implementing
+   - Check `.agents/SESSIONS/` before implementing
    - Find and follow real codebase examples (not generic patterns)
    - Quality over speed
    - Session memory is critical
-3. **Today's session file** (`.agent/SESSIONS/YYYY-MM-DD.md`):
+3. **Today's session file** (`.agents/SESSIONS/YYYY-MM-DD.md`):
    - What was done earlier today (before /clear)
    - Context continuity across /clear boundaries
 

--- a/.claude/commands/task.md
+++ b/.claude/commands/task.md
@@ -40,7 +40,7 @@ Read relevant documentation:
 
 ### Step 4: Create Task File
 
-File location: <project>/.agent/TASKS/[task-name].md
+File location: <project>/.agents/TASKS/[task-name].md
 
 Task Template:
 

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -15,21 +15,21 @@ Checks required files and broken links.
 
 ### What This Checks
 
-- Required files exist (.agent/README.md, etc.)
+- Required files exist (.agents/README.md, etc.)
 - Internal links work
 - Proper folder organization
 
 ### Files to Check
 
 Workspace level:
-- .agent/README.md
-- .agent/SYSTEM/ directory
-- .agent/TASKS/ directory
-- .agent/SESSIONS/ directory
+- .agents/README.md
+- .agents/SYSTEM/ directory
+- .agents/TASKS/ directory
+- .agents/SESSIONS/ directory
 
 Project level:
-- <project>/.agent/README.md
-- <project>/.agent/SYSTEM/SUMMARY.md
+- <project>/.agents/README.md
+- <project>/.agents/SYSTEM/SUMMARY.md
 
 ## Option 2: Validate Sessions
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Build (app + widget)
     runs-on: macos-26
     timeout-minutes: 30
 
@@ -32,13 +33,57 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             build
 
-      - name: Run tests
+      - name: Build CLI
         run: |
-          xcodebuild -project MeterBar.xcodeproj \
-            -scheme MeterBar \
-            -configuration Debug \
-            -destination 'platform=macOS' \
-            CODE_SIGN_IDENTITY="-" \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO \
-            test || echo "Tests completed (some may require credentials)"
+          cd MeterBarCLI
+          swift build
+
+  test:
+    name: Tests + coverage gate
+    runs-on: macos-26
+    timeout-minutes: 30
+    env:
+      # Coverage floor enforced by scripts/check-coverage.sh. Ratchet this up as
+      # coverage improves; never lower it to make a PR pass.
+      COVERAGE_THRESHOLD: 40
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+
+      - name: Run tests with coverage gate
+        # check-coverage.sh runs `swift test --enable-code-coverage` (a real gate —
+        # any test failure fails this step) and then enforces COVERAGE_THRESHOLD
+        # via llvm-cov. Network-touching tests self-skip without credentials
+        # (XCTSkip in APIIntegrationTests).
+        run: bash scripts/check-coverage.sh
+
+  lint:
+    name: SwiftLint
+    runs-on: macos-26
+    timeout-minutes: 10
+    env:
+      SWIFTLINT_VERSION: 0.65.0
+      SWIFTLINT_SHA256: d6cb0aa7a2f5f1ef306fc9e37bcb54dc9a26facc8f7784ac0c3dd3eccf5c6ba6
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Install SwiftLint (pinned + checksum-verified)
+        run: |
+          set -euo pipefail
+          URL="https://github.com/realm/SwiftLint/releases/download/${SWIFTLINT_VERSION}/portable_swiftlint.zip"
+          curl --fail --location --silent --show-error \
+            --connect-timeout 15 --max-time 120 --retry 3 \
+            "$URL" -o /tmp/swiftlint.zip
+          echo "${SWIFTLINT_SHA256}  /tmp/swiftlint.zip" | shasum -a 256 --check --strict
+          unzip -o /tmp/swiftlint.zip -d /tmp/swiftlint
+          chmod +x /tmp/swiftlint/swiftlint
+
+      - name: Lint
+        # --strict: the tree is currently violation-free, so any new warning fails.
+        run: /tmp/swiftlint/swiftlint lint --strict

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,12 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 30
     env:
-      # Coverage floor enforced by scripts/check-coverage.sh. Ratchet this up as
+      # Coverage floor enforced by scripts/check-coverage.sh. Measured baseline on
+      # 2026-07-02 was 9.0% line coverage (tests cover models/parsers; the ~3.5k
+      # lines of Views and most Services are untested — docs/audits/00-repo-map.md §5).
+      # Floor sits just under the baseline as a regression gate. Ratchet this up as
       # coverage improves; never lower it to make a PR pass.
-      COVERAGE_THRESHOLD: 40
+      COVERAGE_THRESHOLD: 8
 
     steps:
       - name: Checkout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,23 @@
-# Quota Guard
+# MeterBar
 
 This file provides entry points for AI agents.
 
 ## Documentation
 
-All documentation is in `.agent/`:
-- `.agent/README.md` - Navigation hub
-- `.agent/SYSTEM/RULES.md` - Coding standards
-- `.agent/TASKS/` - Task tracking
-- `.agent/SESSIONS/` - Session history
+All documentation is in `.agents/`:
+- `.agents/README.md` - Navigation hub
+- `.agents/SYSTEM/RULES.md` - Coding standards
+- `.agents/SYSTEM/ARCHITECTURE.md` - What is actually implemented
+- `.agents/SESSIONS/` - Session history (one file per day)
+- `.agents/docs/DEFERRED_WORK.md` - Known tech debt with pickup instructions
+- `docs/audits/` - Audit reports (start with `00-repo-map.md`)
 
 ## Quick Start
 
-Read `.agent/SYSTEM/ai/SESSION-QUICK-START.md` before starting work.
+Read `.agents/SYSTEM/ai/SESSION-QUICK-START.md` before starting work.
+
+## Build/test notes
+
+- Tests: `swift test` at repo root (requires full Xcode — Command Line Tools lack XCTest)
+- App build: `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar build`
+- CLI: `cd MeterBarCLI && swift build`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,18 @@
-# Quota Guard
+# MeterBar
 
-Claude-specific entry point. Documentation in `.agent/`.
+Claude-specific entry point. Documentation in `.agents/`.
 
 ## Commands
 
-Check `.agent/SYSTEM/RULES.md` for coding standards.
+Check `.agents/SYSTEM/RULES.md` for coding standards.
+Architecture reality-check: `.agents/SYSTEM/ARCHITECTURE.md` and `docs/audits/00-repo-map.md`.
 
 ## Sessions
 
-Document all work in `.agent/SESSIONS/YYYY-MM-DD.md` (one file per day).
+Document all work in `.agents/SESSIONS/YYYY-MM-DD.md` (one file per day).
 
 ## Testing Policy
 - Write tests FIRST before implementation (TDD)
 - All new features must include tests before code
 - Aim for 80%+ coverage on new code
-- Run tests before committing
+- Run tests before committing (`swift test`; requires full Xcode — CLT alone lacks XCTest)

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,15 +1,16 @@
-# Quota Guard
+# MeterBar
 
-Codex-specific entry point. Documentation in `.agent/`.
+Codex-specific entry point. Documentation in `.agents/`.
 
 ## Documentation
 
-- `.agent/README.md` - Start here
-- `.agent/SYSTEM/` - Architecture and rules
-- `.agent/TASKS/` - Current tasks
+- `.agents/README.md` - Start here
+- `.agents/SYSTEM/` - Architecture and rules
+- `.agents/docs/DEFERRED_WORK.md` - Known tech debt
+- `docs/audits/00-repo-map.md` - Audited repo map
 
 ## Testing Policy
 - Write tests FIRST before implementation (TDD)
 - All new features must include tests before code
 - Aim for 80%+ coverage on new code
-- Run tests before committing
+- Run tests before committing (`swift test`; requires full Xcode — CLT alone lacks XCTest)

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -7,8 +7,9 @@ import UserNotifications
 @main
 struct MeterBarApp: App {
     @StateObject private var dataManager = UsageDataManager.shared
-    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    
+    @NSApplicationDelegateAdaptor(AppDelegate.self)
+    var appDelegate
+
     init() {
         AppLog.app.info("MeterBar initializing")
     }
@@ -52,19 +53,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             AppLog.app.error("Failed to create status item button")
             return
         }
-        
+
         // Set up the menu bar icon with 3 progress bars
         let image = createMenuBarIcon()
         image.isTemplate = true
         button.image = image
-        
+
         button.action = #selector(handleStatusItemClick)
         button.target = self
         button.sendAction(on: [.leftMouseUp, .rightMouseUp])
         button.toolTip = "MeterBar"
         button.imagePosition = .imageLeft
         button.font = .systemFont(ofSize: 14, weight: .semibold)
-        
+
         // Create popover
         popover = NSPopover()
         popover?.contentSize = NSSize(width: 520, height: 420)
@@ -82,10 +83,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Setup notifications (also handles initial data refresh)
         setupNotifications()
     }
-    
+
     /// Left-click opens the popover; right-click (or control-click) opens a
     /// native menu so Quit stays reachable even when the Dock icon is hidden.
-    @objc private func handleStatusItemClick() {
+    @objc
+    private func handleStatusItemClick() {
         let event = NSApp.currentEvent
         let isSecondaryClick = event?.type == .rightMouseUp
             || (event?.modifierFlags.contains(.control) ?? false)
@@ -97,7 +99,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    @objc func togglePopover() {
+    @objc
+    func togglePopover() {
         guard let button = statusItem?.button,
               let popover = popover else { return }
 
@@ -155,15 +158,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return menu
     }
 
-    @objc private func toggleShowInDock() {
+    @objc
+    private func toggleShowInDock() {
         dockVisibilityStore.setShowInDock(!dockVisibilityStore.showInDock)
     }
 
-    @objc private func openDashboardFromStatusMenu() {
+    @objc
+    private func openDashboardFromStatusMenu() {
         UsageDashboardWindowController.shared.show()
     }
 
-    @objc private func quitApp() {
+    @objc
+    private func quitApp() {
         NSApp.terminate(nil)
     }
 
@@ -213,7 +219,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 // Request permission only if not yet determined
                 UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, error in
                     if let error = error {
-                        AppLog.app.error("Notification permission error: \(error.localizedDescription, privacy: .public)")
+                        AppLog.app.error(
+                            "Notification permission error: \(error.localizedDescription, privacy: .public)"
+                        )
                     } else if !granted {
                         AppLog.app.info("Notification permission denied by user")
                     }

--- a/MeterBar/Models/UsageLimit.swift
+++ b/MeterBar/Models/UsageLimit.swift
@@ -18,23 +18,23 @@ struct UsageLimit: Codable, Equatable {
         guard total > 0 else { return 0 }
         return max(0, (used / total) * 100)
     }
-    
+
     var percentage: Double {
-        return min(100, rawPercentage)
+        min(100, rawPercentage)
     }
-    
+
     var remaining: Double {
-        return max(0, total - used)
+        max(0, total - used)
     }
-    
+
     var isNearLimit: Bool {
-        return percentage >= 80
+        percentage >= 80
     }
-    
+
     var isAtLimit: Bool {
-        return percentage >= 100
+        percentage >= 100
     }
-    
+
     var statusColor: UsageStatus {
         if isAtLimit {
             return .critical

--- a/MeterBar/Models/UsageMetrics.swift
+++ b/MeterBar/Models/UsageMetrics.swift
@@ -103,11 +103,11 @@ struct UsageMetrics: Codable, Identifiable {
             lastUpdated: lastUpdated
         )
     }
-    
+
     var overallStatus: UsageStatus {
         let limits = [sessionLimit, weeklyLimit, codeReviewLimit].compactMap { $0 }
         guard !limits.isEmpty else { return .good }
-        
+
         if limits.contains(where: { $0.isAtLimit }) {
             return .critical
         } else if limits.contains(where: { $0.isNearLimit }) {
@@ -116,9 +116,8 @@ struct UsageMetrics: Codable, Identifiable {
             return .good
         }
     }
-    
+
     var hasData: Bool {
-        return sessionLimit != nil || weeklyLimit != nil || codeReviewLimit != nil
+        sessionLimit != nil || weeklyLimit != nil || codeReviewLimit != nil
     }
 }
-

--- a/MeterBar/Services/AppLog.swift
+++ b/MeterBar/Services/AppLog.swift
@@ -3,7 +3,7 @@ import os
 
 /// Centralized logging for the app.
 ///
-/// Replaces scattered `print(...)` statements (flagged by the `no_print_statements`
+/// Replaces scattered stdout printing (flagged by the `no_print_statements`
 /// SwiftLint rule) with the unified logging system. Using `Logger` keeps diagnostics
 /// out of release stdout, lets the OS apply privacy redaction, and avoids logging
 /// raw API response bodies or token-bearing strings to the console.

--- a/MeterBar/Services/AuthenticationManager.swift
+++ b/MeterBar/Services/AuthenticationManager.swift
@@ -46,15 +46,10 @@ class AuthenticationManager: ObservableObject {
     }
 
     var isClaudeAuthenticated: Bool {
-        return claudeAdminKey != nil
+        claudeAdminKey != nil
     }
 
     var isOpenAIAuthenticated: Bool {
-        return openaiAdminKey != nil
-    }
-
-    // Cursor doesn't have authentication - it doesn't provide an API
-    var isCursorAuthenticated: Bool {
-        return false
+        openaiAdminKey != nil
     }
 }

--- a/MeterBar/Services/ClaudeCodeCLIUsageService.swift
+++ b/MeterBar/Services/ClaudeCodeCLIUsageService.swift
@@ -165,8 +165,7 @@ enum ClaudeCodeCLIUsageParser {
         from lines: [String],
         labelPrefixes: [String],
         windowMinutes: Int,
-        now: Date) -> UsageLimit?
-    {
+        now: Date) -> UsageLimit? {
         guard let line = lines.first(where: { line in
             let normalized = line.lowercased()
             return labelPrefixes.contains { normalized.hasPrefix($0) }

--- a/MeterBar/Services/ClaudeCodeLocalService.swift
+++ b/MeterBar/Services/ClaudeCodeLocalService.swift
@@ -8,7 +8,6 @@ class ClaudeCodeLocalService: ObservableObject {
     // Working endpoint (discovered via testing)
     private let usageEndpoint = "https://api.anthropic.com/api/oauth/usage"
 
-    private let baseURL = "https://api.anthropic.com"
     private let keychainService = "Claude Code-credentials"
     private let cliUsageService = ClaudeCodeCLIUsageService.shared
     private let oauthFallbackUserDefaultsKey = "ClaudeCodeEnableOAuthFallback"
@@ -82,7 +81,7 @@ class ClaudeCodeLocalService: ObservableObject {
         if cliUsageService.isAvailable() {
             hasAccess = true
             authState = .cliAvailable
-        } else if isOAuthFallbackEnabled, let _ = getOAuthToken() {
+        } else if isOAuthFallbackEnabled, getOAuthToken() != nil {
             hasAccess = true
             authState = .connected(.legacyOAuth)
         } else {
@@ -195,7 +194,7 @@ class ClaudeCodeLocalService: ObservableObject {
             )
 
             // Sonnet-only weekly limit (if available)
-            var sonnetLimit: UsageLimit? = nil
+            var sonnetLimit: UsageLimit?
             if let sonnet = usageResponse.sevenDaySonnet {
                 sonnetLimit = UsageLimit(
                     used: sonnet.utilization,
@@ -362,10 +361,6 @@ enum ClaudeCodeAuthState: Equatable {
 
 struct ClaudeCodeCredentials: Codable {
     let claudeAiOauth: ClaudeAiOAuth
-
-    enum CodingKeys: String, CodingKey {
-        case claudeAiOauth = "claudeAiOauth"
-    }
 }
 
 struct ClaudeAiOAuth: Codable {

--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -108,7 +108,11 @@ class CodexCliLocalService: ObservableObject {
         request.setValue("https://chatgpt.com/", forHTTPHeaderField: "Referer")
         request.setValue("https://chatgpt.com", forHTTPHeaderField: "Origin")
         request.setValue("*/*", forHTTPHeaderField: "Accept")
-        request.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
+        request.setValue(
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 "
+                + "(KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+            forHTTPHeaderField: "User-Agent"
+        )
         request.timeoutInterval = 30.0
 
         do {
@@ -134,7 +138,7 @@ class CodexCliLocalService: ObservableObject {
 
             let decoder = JSONDecoder()
             // Note: Codex CLI API uses Unix timestamps (Int64), not ISO8601 dates
-            
+
             // Decode the actual Codex CLI usage response
             let usageResponse = try decoder.decode(CodexCliUsageResponse.self, from: data)
 
@@ -177,7 +181,7 @@ class CodexCliLocalService: ObservableObject {
             )
 
             // Code review rate limit (7 days window) = code review limit
-            var codeReviewLimit: UsageLimit? = nil
+            var codeReviewLimit: UsageLimit?
             if let codeReviewPrimary = usageResponse.codeReviewRateLimit?.primaryWindow {
                 codeReviewLimit = UsageLimit(
                     used: codeReviewPrimary.usedPercent,

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -20,18 +20,31 @@ class CostTracker: ObservableObject {
     }
 
     // API-rate estimates per million tokens for local log usage.
+    // Prices last verified against provider pricing pages: 2026-07-02. These rot
+    // silently — re-verify when adding models or when estimates look off.
+    // NOTE: MeterBarCLI/Sources/MeterBarCLI.swift carries a simplified copy of the
+    // "claude-sonnet" entry; keep the two in sync until a shared package exists
+    // (.agents/docs/DEFERRED_WORK.md §1).
     private let pricing: [String: TokenPricing] = [
         "claude-sonnet": TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30),
         "claude-opus": TokenPricing(input: 15.0, output: 75.0, cacheCreation: 18.75, cacheRead: 1.50),
         "claude-haiku": TokenPricing(input: 0.25, output: 1.25, cacheCreation: 0.30, cacheRead: 0.03),
-        "claude-fable-5": TokenPricing(input: 10.0, output: 50.0, cacheCreation: 12.5, cacheRead: 1.0, cacheCreationOneHour: 20.0),
-        "claude-opus-4-8": TokenPricing(input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0),
-        "claude-opus-4-7": TokenPricing(input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0),
-        "claude-opus-4-6": TokenPricing(input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0),
-        "claude-sonnet-4-6": TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30, cacheCreationOneHour: 6.0),
-        "claude-sonnet-4-5": TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30, cacheCreationOneHour: 6.0),
-        "claude-sonnet-4": TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30, cacheCreationOneHour: 6.0),
-        "claude-haiku-4-5": TokenPricing(input: 1.0, output: 5.0, cacheCreation: 1.25, cacheRead: 0.10, cacheCreationOneHour: 2.0),
+        "claude-fable-5": TokenPricing(
+            input: 10.0, output: 50.0, cacheCreation: 12.5, cacheRead: 1.0, cacheCreationOneHour: 20.0),
+        "claude-opus-4-8": TokenPricing(
+            input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0),
+        "claude-opus-4-7": TokenPricing(
+            input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0),
+        "claude-opus-4-6": TokenPricing(
+            input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0),
+        "claude-sonnet-4-6": TokenPricing(
+            input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30, cacheCreationOneHour: 6.0),
+        "claude-sonnet-4-5": TokenPricing(
+            input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30, cacheCreationOneHour: 6.0),
+        "claude-sonnet-4": TokenPricing(
+            input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30, cacheCreationOneHour: 6.0),
+        "claude-haiku-4-5": TokenPricing(
+            input: 1.0, output: 5.0, cacheCreation: 1.25, cacheRead: 0.10, cacheCreationOneHour: 2.0),
         "codex": TokenPricing(input: 1.25, output: 10.0, cacheCreation: 0, cacheRead: 0.125),
         "default": TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30)
     ]
@@ -260,10 +273,8 @@ class CostTracker: ObservableObject {
                     continue
                 }
 
-                let (input, output, cacheCreate, cacheReadTokens, estimatedCost, dates, daily, models, origins) = parseSessionFile(
-                    at: url,
-                    since: cutoffDate
-                )
+                let (input, output, cacheCreate, cacheReadTokens, estimatedCost, dates, daily, models, origins) =
+                    parseSessionFile(at: url, since: cutoffDate)
 
                 if input > 0 || output > 0 || cacheCreate > 0 || cacheReadTokens > 0 {
                     totalInput += input
@@ -475,7 +486,8 @@ class CostTracker: ObservableObject {
             )
         }
 
-        return (totalInput, totalOutput, totalCacheCreation, totalCacheRead, totalEstimatedCost, dates, dailyTotals, modelTotals, originTotals)
+        return (totalInput, totalOutput, totalCacheCreation, totalCacheRead, totalEstimatedCost,
+                dates, dailyTotals, modelTotals, originTotals)
     }
 
     private func parseISO8601(_ value: String) -> Date? {
@@ -506,10 +518,11 @@ class CostTracker: ObservableObject {
             return pricing["claude-fable-5"] ?? defaultPricing
         }
         if normalized.contains("opus") {
-            if normalized.contains("4-8") { return pricing["claude-opus-4-8"] ?? (pricing["claude-opus"] ?? defaultPricing) }
-            if normalized.contains("4-7") { return pricing["claude-opus-4-7"] ?? (pricing["claude-opus"] ?? defaultPricing) }
-            if normalized.contains("4-6") { return pricing["claude-opus-4-6"] ?? (pricing["claude-opus"] ?? defaultPricing) }
-            return pricing["claude-opus"] ?? defaultPricing
+            let base = pricing["claude-opus"] ?? defaultPricing
+            if normalized.contains("4-8") { return pricing["claude-opus-4-8"] ?? base }
+            if normalized.contains("4-7") { return pricing["claude-opus-4-7"] ?? base }
+            if normalized.contains("4-6") { return pricing["claude-opus-4-6"] ?? base }
+            return base
         }
         if normalized.contains("haiku") {
             return normalized.contains("4-5")
@@ -517,10 +530,11 @@ class CostTracker: ObservableObject {
                 : pricing["claude-haiku"] ?? defaultPricing
         }
         if normalized.contains("sonnet") {
-            if normalized.contains("4-6") { return pricing["claude-sonnet-4-6"] ?? (pricing["claude-sonnet"] ?? defaultPricing) }
-            if normalized.contains("4-5") { return pricing["claude-sonnet-4-5"] ?? (pricing["claude-sonnet"] ?? defaultPricing) }
-            if normalized.contains("4") { return pricing["claude-sonnet-4"] ?? (pricing["claude-sonnet"] ?? defaultPricing) }
-            return pricing["claude-sonnet"] ?? defaultPricing
+            let base = pricing["claude-sonnet"] ?? defaultPricing
+            if normalized.contains("4-6") { return pricing["claude-sonnet-4-6"] ?? base }
+            if normalized.contains("4-5") { return pricing["claude-sonnet-4-5"] ?? base }
+            if normalized.contains("4") { return pricing["claude-sonnet-4"] ?? base }
+            return base
         }
 
         return defaultPricing

--- a/MeterBar/Services/CursorLocalService.swift
+++ b/MeterBar/Services/CursorLocalService.swift
@@ -11,9 +11,8 @@ import SQLite3
 class CursorLocalService: ObservableObject {
     static let shared = CursorLocalService()
 
-    // API endpoints (from Vibeviewer: https://github.com/MarveleE/Vibeviewer)
+    // API endpoint (from Vibeviewer: https://github.com/MarveleE/Vibeviewer)
     private let usageSummaryEndpoint = "https://cursor.com/api/usage-summary"
-    private let getMeEndpoint = "https://cursor.com/api/dashboard/get-me"
 
     // URLSession shared via ServiceSupport for consistent timeout/connectivity config
     private let urlSession = ServiceSupport.makeUsageSession()
@@ -65,10 +64,8 @@ class CursorLocalService: ObservableObject {
         ]
 
         // Check each path
-        for path in pathsToCheck {
-            if fileManager.fileExists(atPath: path) {
-                return path
-            }
+        for path in pathsToCheck where fileManager.fileExists(atPath: path) {
+            return path
         }
 
         // If not found and forceRescan is true, search recursively in Cursor directories
@@ -97,12 +94,10 @@ class CursorLocalService: ObservableObject {
             return nil
         }
 
-        for case let path as String in enumerator {
-            if path.hasSuffix(filename) {
-                let fullPath = "\(directory)/\(path)"
-                if fileManager.fileExists(atPath: fullPath) {
-                    return fullPath
-                }
+        for case let path as String in enumerator where path.hasSuffix(filename) {
+            let fullPath = "\(directory)/\(path)"
+            if fileManager.fileExists(atPath: fullPath) {
+                return fullPath
             }
         }
 
@@ -199,7 +194,7 @@ class CursorLocalService: ObservableObject {
     /// Format authentication cookie for Cursor API
     private func formatAuthCookie(userId: String, token: String) -> String {
         // Format: userId::token (URL encoded)
-        return "\(userId)%3A%3A\(token)"
+        "\(userId)%3A%3A\(token)"
     }
 
     /// Check and update access status
@@ -218,7 +213,8 @@ class CursorLocalService: ObservableObject {
 
     func fetchUsageMetrics() async throws -> UsageMetrics {
         // Try without rescan first (faster), then with rescan if needed
-        guard let (userId, token) = getAccessTokenFromDatabase(forceRescan: false) ?? getAccessTokenFromDatabase(forceRescan: true) else {
+        guard let (userId, token) = getAccessTokenFromDatabase(forceRescan: false)
+            ?? getAccessTokenFromDatabase(forceRescan: true) else {
             let error = ServiceError.notAuthenticated
             await MainActor.run {
                 self.lastError = error
@@ -241,7 +237,7 @@ class CursorLocalService: ObservableObject {
         }
 
         // Parse billing cycle end date for reset time
-        var resetTime: Date? = nil
+        var resetTime: Date?
         if let billingEnd = summaryData.billingCycleEnd {
             resetTime = Self.fractionalISO8601.date(from: billingEnd) ?? Self.plainISO8601.date(from: billingEnd)
         }
@@ -258,7 +254,7 @@ class CursorLocalService: ObservableObject {
         )
 
         // On-demand usage as secondary metric if enabled
-        var sessionLimit: UsageLimit? = nil
+        var sessionLimit: UsageLimit?
         if let onDemand = summaryData.individualUsage?.onDemand, onDemand.enabled == true {
             let onDemandUsed = Double(onDemand.used ?? 0)
             let onDemandLimit = Double(onDemand.limit ?? 0)

--- a/MeterBar/Services/KeychainManager.swift
+++ b/MeterBar/Services/KeychainManager.swift
@@ -3,11 +3,11 @@ import Security
 
 class KeychainManager {
     static let shared = KeychainManager()
-    
+
     private let service = "com.agenticindiedev.quotaguard"
-    
+
     private init() {}
-    
+
     func save(key: String, value: String) -> Bool {
         guard let data = value.data(using: .utf8) else { return false }
 
@@ -34,7 +34,7 @@ class KeychainManager {
             return false
         }
     }
-    
+
     func get(key: String) -> String? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -43,32 +43,31 @@ class KeychainManager {
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
-        
+
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
-        
+
         guard status == errSecSuccess,
               let data = result as? Data,
               let value = String(data: data, encoding: .utf8) else {
             return nil
         }
-        
+
         return value
     }
-    
+
     func delete(key: String) -> Bool {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: key
         ]
-        
+
         let status = SecItemDelete(query as CFDictionary)
         return status == errSecSuccess || status == errSecItemNotFound
     }
-    
+
     func hasKey(key: String) -> Bool {
-        return get(key: key) != nil
+        get(key: key) != nil
     }
 }
-

--- a/MeterBar/Services/SharedDataStore.swift
+++ b/MeterBar/Services/SharedDataStore.swift
@@ -7,7 +7,7 @@ import WidgetKit
 /// Shared data store using App Groups for Widget extension access
 class SharedDataStore {
     static let shared = SharedDataStore()
-    
+
     private let appGroupIdentifier = "group.dev.shipshit.meterbar"
     private let metricsKey = "cached_usage_metrics"
 
@@ -16,7 +16,7 @@ class SharedDataStore {
     private let ioQueue = DispatchQueue(label: "dev.shipshit.meterbar.SharedDataStore.io", qos: .utility)
 
     private var containerURL: URL? {
-        return FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)
+        FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)
     }
 
     private init() {}
@@ -49,17 +49,17 @@ class SharedDataStore {
             }
         }
     }
-    
+
     func loadMetrics() -> [ServiceType: UsageMetrics] {
         guard let containerURL = containerURL else { return [:] }
-        
+
         let fileURL = containerURL.appendingPathComponent("\(metricsKey).json")
-        
+
         guard let data = try? Data(contentsOf: fileURL),
               let decoded = try? JSONDecoder().decode([String: UsageMetrics].self, from: data) else {
             return [:]
         }
-        
+
         return decoded.reduce(into: [ServiceType: UsageMetrics]()) { result, pair in
             if let service = ServiceType(rawValue: pair.key) {
                 result[service] = pair.value

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -12,7 +12,8 @@ class UsageDataManager: ObservableObject {
     @Published var isLoading: Bool = false
     @Published var lastError: Error?
 
-    @AppStorage("refreshInterval") private var refreshIntervalRaw: Int = RefreshInterval.fifteenMinutes.rawValue
+    @AppStorage("refreshInterval")
+    private var refreshIntervalRaw: Int = RefreshInterval.fifteenMinutes.rawValue
 
     var refreshInterval: RefreshInterval {
         get { RefreshInterval(rawValue: refreshIntervalRaw) ?? .fifteenMinutes }
@@ -40,6 +41,10 @@ class UsageDataManager: ObservableObject {
         setupAutoRefresh()
     }
 
+    // One branch per provider by design; splitting per-provider fetches into
+    // helpers is planned alongside UsageDataManager tests (untested today —
+    // restructuring without coverage is riskier than the branch count).
+    // swiftlint:disable:next cyclomatic_complexity
     func refreshAll() async {
         isLoading = true
         lastError = nil
@@ -111,7 +116,7 @@ class UsageDataManager: ObservableObject {
                 }
             }
         }
-        
+
         // Merge new metrics with existing cached metrics for services that failed to fetch
         for service in ServiceType.allCases where providerVisibilityStore.isEnabled(service) {
             if newMetrics[service] == nil, let cachedMetric = self.metrics[service] {
@@ -125,6 +130,9 @@ class UsageDataManager: ObservableObject {
         isLoading = false
     }
 
+    // Same rationale as refreshAll: per-provider branching stays inline until
+    // this manager has test coverage to make extraction safe.
+    // swiftlint:disable:next cyclomatic_complexity
     func refresh(service: ServiceType) async {
         isLoading = true
         lastError = nil

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -744,7 +744,8 @@ struct BlockingLimitResetCounter: View {
         let exhaustedWindows = windows.filter { $0.limit.isAtLimit }
         guard !exhaustedWindows.isEmpty else { return nil }
 
-        let candidates = exhaustedWindows.compactMap { window -> (window: ResetCountdownWindow, seconds: TimeInterval)? in
+        let candidates = exhaustedWindows.compactMap { window
+            -> (window: ResetCountdownWindow, seconds: TimeInterval)? in
             guard let seconds = window.limit.secondsUntilReset(now: now) else { return nil }
             return (window, seconds)
         }

--- a/MeterBar/Views/RefreshingIcon.swift
+++ b/MeterBar/Views/RefreshingIcon.swift
@@ -6,7 +6,8 @@ import SwiftUI
 struct RefreshingIcon: View {
     let isRefreshing: Bool
 
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
     @State private var rotationDegrees = 0.0
 
     var body: some View {

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -274,7 +274,10 @@ struct SettingsView: View {
                     .frame(maxWidth: 220)
             }
 
-            SettingsRowView(title: "Config directory", detail: "Use a separate CLAUDE_CONFIG_DIR for each extra account.") {
+            SettingsRowView(
+                title: "Config directory",
+                detail: "Use a separate CLAUDE_CONFIG_DIR for each extra account."
+            ) {
                 HStack(spacing: 8) {
                     TextField("Path", text: $newClaudeConfigDirectory)
                         .textFieldStyle(.roundedBorder)
@@ -364,7 +367,10 @@ struct SettingsView: View {
                         .fontWeight(.semibold)
                 }
             } else if !cursorService.hasAccess {
-                SettingsNotice(text: "Reads Cursor IDE credentials from Cursor's local state database.", color: .secondary)
+                SettingsNotice(
+                    text: "Reads Cursor IDE credentials from Cursor's local state database.",
+                    color: .secondary
+                )
                 SettingsNotice(text: "Log in to Cursor IDE first, then check again.", color: MeterBarTheme.warning)
             }
         }
@@ -416,7 +422,10 @@ struct SettingsView: View {
             }
 
             if !canScanCosts {
-                SettingsNotice(text: "Enable Claude Code or OpenAI Codex to scan local token logs.", color: MeterBarTheme.warning)
+                SettingsNotice(
+                    text: "Enable Claude Code or OpenAI Codex to scan local token logs.",
+                    color: MeterBarTheme.warning
+                )
             }
 
             SettingsRowView(title: "Local sessions") {
@@ -673,7 +682,8 @@ private struct AccountProfileRow: View {
 /// Shared admin-key help sheet. The Claude and OpenAI variants only differ by
 /// copy and the console URL, so they share one layout.
 private struct AdminKeyHelpView: View {
-    @Environment(\.dismiss) var dismiss
+    @Environment(\.dismiss)
+    var dismiss
 
     let title: String
     let intro: String
@@ -737,7 +747,8 @@ struct ClaudeHelpView: View {
                 "Copy the key (starts with sk-ant-admin...)",
                 "Paste it in the field above"
             ],
-            note: "Note: You must be an organization admin to create Admin API keys. Individual accounts cannot access the Usage API.",
+            note: "Note: You must be an organization admin to create Admin API keys. "
+                + "Individual accounts cannot access the Usage API.",
             consoleButtonTitle: "Open Claude Console",
             consoleURL: "https://console.anthropic.com/settings/admin-keys"
         )

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -233,7 +233,8 @@ struct UsageDashboardView: View {
         VStack(alignment: .leading, spacing: 14) {
             DashboardCard(title: "30 Day API-Rate Token Spend", trailing: costRefreshStatusText) {
                 VStack(alignment: .leading, spacing: 18) {
-                    Text("Local subscription logs are estimated using API token rates so Codex and Claude can be compared.")
+                    Text("Local subscription logs are estimated using API token rates "
+                        + "so Codex and Claude can be compared.")
                         .font(.caption)
                         .foregroundColor(.secondary)
 
@@ -319,8 +320,9 @@ struct UsageDashboardView: View {
             if !claudeAccountMetrics.isEmpty {
                 for account in claudeAccountStore.accounts {
                     if let metrics = claudeAccountMetrics[account.id] {
+                        let isOnlyDefaultAccount = account.isDefault && claudeAccountStore.accounts.count == 1
                         snapshots.append(DashboardProviderSnapshot(
-                            title: account.isDefault && claudeAccountStore.accounts.count == 1 ? "Claude" : account.name,
+                            title: isOnlyDefaultAccount ? "Claude" : account.name,
                             service: .claudeCode,
                             metrics: metrics
                         ))
@@ -387,7 +389,8 @@ struct UsageDashboardView: View {
         if limit.percentLeft <= 0 {
             return "\(limit.title) is out until reset. Tracking \(providerSnapshots.count) local provider sources."
         }
-        return "\(limit.title) has \(limit.percentLeft)% left. Tracking \(providerSnapshots.count) local provider sources."
+        return "\(limit.title) has \(limit.percentLeft)% left. "
+            + "Tracking \(providerSnapshots.count) local provider sources."
     }
 
     private var sectionSubtitle: String {
@@ -848,13 +851,13 @@ private struct DashboardLimitRow: View {
             return .secondary
         }
     }
-
 }
 
 private struct CostScanLoadingChart: View {
     let compact: Bool
 
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
 
     private let barCount = 30
 
@@ -867,7 +870,8 @@ private struct CostScanLoadingChart: View {
                 let barWidth = max(4, (proxy.size.width - CGFloat(barCount - 1) * spacing) / CGFloat(barCount))
                 let time = timeline.date.timeIntervalSinceReferenceDate
                 let sweepWidth = max(42, proxy.size.width * 0.18)
-                let sweepX = CGFloat(time.truncatingRemainder(dividingBy: 1.8) / 1.8) * (proxy.size.width + sweepWidth) - sweepWidth
+                let sweepProgress = CGFloat(time.truncatingRemainder(dividingBy: 1.8) / 1.8)
+                let sweepX = sweepProgress * (proxy.size.width + sweepWidth) - sweepWidth
 
                 VStack(alignment: .leading, spacing: compact ? 8 : 11) {
                     HStack(spacing: 8) {
@@ -1148,7 +1152,8 @@ private struct DailyUsageChart: View {
         } else {
             lines.append("")
             for segment in day.segments {
-                lines.append("\(segment.provider.displayName): \(UsageFormat.tokens(segment.tokens)) · \(UsageFormat.cost(segment.cost))")
+                lines.append("\(segment.provider.displayName): \(UsageFormat.tokens(segment.tokens)) "
+                    + "· \(UsageFormat.cost(segment.cost))")
             }
         }
 
@@ -1408,7 +1413,8 @@ private struct DailyUsageDetailRow: View {
     }
 
     private var accessibilitySummary: String {
-        "\(dateLabel(day.date)), \(UsageFormat.tokens(day.totalTokens)) tokens, \(UsageFormat.cost(day.estimatedCostUSD))"
+        "\(dateLabel(day.date)), \(UsageFormat.tokens(day.totalTokens)) tokens, "
+            + "\(UsageFormat.cost(day.estimatedCostUSD))"
     }
 
     private func dateLabel(_ date: Date) -> String {
@@ -1475,11 +1481,11 @@ private struct ProviderCostBreakdown: View {
             }
 
             if !cost.modelBreakdowns.isEmpty {
-                CostBreakdownSection(title: "Models", items: cost.modelBreakdowns.prefix(6).map { $0 })
+                CostBreakdownSection(title: "Models", items: Array(cost.modelBreakdowns.prefix(6)))
             }
 
             if !cost.originBreakdowns.isEmpty {
-                CostBreakdownSection(title: "Usage Origin", items: cost.originBreakdowns.prefix(6).map { $0 })
+                CostBreakdownSection(title: "Usage Origin", items: Array(cost.originBreakdowns.prefix(6)))
             }
         }
         .padding(12)

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -260,7 +260,9 @@ struct Cost: ParsableCommand {
             // Ignore errors
         }
 
-        // Calculate cost (Sonnet pricing)
+        // Calculate cost (Sonnet pricing). Mirrors the "claude-sonnet" entry in the
+        // app's CostTracker pricing table — keep both in sync until a shared package
+        // exists (.agents/docs/DEFERRED_WORK.md §1).
         let inputCost = Double(totalInput) / 1_000_000 * 3.0
         let outputCost = Double(totalOutput) / 1_000_000 * 15.0
         let cacheCreationCost = Double(totalCacheCreation) / 1_000_000 * 3.75

--- a/MeterBarTests/CachedMetricsContractTests.swift
+++ b/MeterBarTests/CachedMetricsContractTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+@testable import MeterBar
+
+/// Locks the JSON contract of the shared metrics cache.
+///
+/// `UsageDataManager`/`SharedDataStore` encode `[String: UsageMetrics]` with a
+/// plain `JSONEncoder()` into the app-group file `cached_usage_metrics.json`.
+/// That JSON is decoded by THREE codebases with duplicated struct definitions:
+/// the app, the widget (`MeterBarWidget/UsageWidget.swift`), and the CLI
+/// (`MeterBarCLI/Sources/MeterBarCLI.swift`). The widget and CLI cannot be
+/// imported here, so replica structs below mirror their shapes exactly — if a
+/// field or the date strategy changes on the app side, these tests fail before
+/// the widget/CLI silently break. See .agents/docs/DEFERRED_WORK.md §1 for the
+/// planned shared-package fix.
+final class CachedMetricsContractTests: XCTestCase {
+
+    /// Mirrors the widget's `UsageMetrics` (no `extraUsage`, no
+    /// `resetCreditsAvailable`, no `windowSeconds` on limits).
+    private struct WidgetReplicaMetrics: Codable {
+        let id: UUID
+        let service: String
+        let sessionLimit: ReplicaLimit?
+        let weeklyLimit: ReplicaLimit?
+        let codeReviewLimit: ReplicaLimit?
+        let lastUpdated: Date
+    }
+
+    /// Mirrors the CLI's `ServiceMetrics` (subset of keys only).
+    private struct CLIReplicaMetrics: Codable {
+        let sessionLimit: ReplicaLimit?
+        let weeklyLimit: ReplicaLimit?
+        let codeReviewLimit: ReplicaLimit?
+    }
+
+    private struct ReplicaLimit: Codable {
+        let used: Double
+        let total: Double
+        let resetTime: Date?
+    }
+
+    private func makeSampleCache() -> [String: UsageMetrics] {
+        let limit = UsageLimit(
+            used: 42,
+            total: 100,
+            resetTime: Date(timeIntervalSinceReferenceDate: 800_000_000),
+            windowSeconds: 5 * 60 * 60
+        )
+        let metrics = UsageMetrics(
+            service: .claudeCode,
+            sessionLimit: limit,
+            weeklyLimit: limit,
+            codeReviewLimit: nil,
+            extraUsage: ExtraUsageStatus(state: .on, detail: "$5.00 used"),
+            resetCreditsAvailable: 2
+        )
+        return [ServiceType.claudeCode.rawValue: metrics]
+    }
+
+    /// Encode exactly the way SharedDataStore does (default JSONEncoder).
+    private func encodeLikeSharedDataStore(_ cache: [String: UsageMetrics]) throws -> Data {
+        try JSONEncoder().encode(cache)
+    }
+
+    func testCacheKeysAreServiceRawValues() throws {
+        let data = try encodeLikeSharedDataStore(makeSampleCache())
+        let object = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        // The widget/CLI look services up by ServiceType rawValue strings.
+        XCTAssertNotNil(object["Claude Code"])
+    }
+
+    func testDatesUseDefaultReferenceDateStrategy() throws {
+        // All three decoders rely on the DEFAULT date strategy (seconds since
+        // 2001-01-01). Switching either side to ISO8601/secondsSince1970 breaks
+        // widget and CLI decode — this pins the wire format.
+        let data = try encodeLikeSharedDataStore(makeSampleCache())
+        let object = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        let entry = try XCTUnwrap(object["Claude Code"] as? [String: Any])
+        let session = try XCTUnwrap(entry["sessionLimit"] as? [String: Any])
+        let resetTime = try XCTUnwrap(session["resetTime"] as? Double)
+        XCTAssertEqual(resetTime, 800_000_000, accuracy: 0.001)
+    }
+
+    func testWidgetShapedDecoderReadsAppEncodedCache() throws {
+        let data = try encodeLikeSharedDataStore(makeSampleCache())
+        let decoded = try JSONDecoder().decode(
+            [String: WidgetReplicaMetrics].self,
+            from: data
+        )
+        let entry = try XCTUnwrap(decoded["Claude Code"])
+        XCTAssertEqual(entry.service, "Claude Code")
+        XCTAssertEqual(entry.sessionLimit?.used, 42)
+        XCTAssertEqual(entry.sessionLimit?.total, 100)
+        XCTAssertEqual(
+            entry.sessionLimit?.resetTime?.timeIntervalSinceReferenceDate ?? 0,
+            800_000_000,
+            accuracy: 0.001
+        )
+        // extraUsage/resetCreditsAvailable are silently dropped by the widget —
+        // documented drift, tolerated because JSONDecoder ignores unknown keys.
+    }
+
+    func testCLIShapedDecoderReadsAppEncodedCache() throws {
+        let data = try encodeLikeSharedDataStore(makeSampleCache())
+        let decoded = try JSONDecoder().decode(
+            [String: CLIReplicaMetrics].self,
+            from: data
+        )
+        let entry = try XCTUnwrap(decoded["Claude Code"])
+        // The CLI regressed once by declaring used/total as Int (fixed in
+        // 2026-06-26 session). Doubles must decode.
+        XCTAssertEqual(entry.weeklyLimit?.used, 42)
+        XCTAssertEqual(entry.weeklyLimit?.total, 100)
+    }
+
+    func testAppRoundTripPreservesExtendedFields() throws {
+        let data = try encodeLikeSharedDataStore(makeSampleCache())
+        let decoded = try JSONDecoder().decode([String: UsageMetrics].self, from: data)
+        let entry = try XCTUnwrap(decoded["Claude Code"])
+        XCTAssertEqual(entry.extraUsage?.state, .on)
+        XCTAssertEqual(entry.resetCreditsAvailable, 2)
+        XCTAssertEqual(entry.sessionLimit?.windowSeconds, 5 * 60 * 60)
+    }
+}

--- a/MeterBarTests/ProviderResponseContractTests.swift
+++ b/MeterBarTests/ProviderResponseContractTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+@testable import MeterBar
+
+/// Contract tests for the provider response models.
+///
+/// Every endpoint MeterBar consumes is undocumented/reverse-engineered
+/// (see docs/audits/00-repo-map.md, risk R1). These fixtures lock the decode
+/// assumptions so an accidental model change fails loudly here instead of
+/// silently blanking a provider card at runtime. When a provider changes its
+/// payload for real, update the fixture together with the model.
+final class ProviderResponseContractTests: XCTestCase {
+
+    // MARK: - Codex (https://chatgpt.com/backend-api/wham/usage)
+
+    func testCodexFullResponseDecodesWindowsAndPlan() throws {
+        let json = #"""
+        {
+          "plan_type": "team",
+          "rate_limit": {
+            "allowed": true,
+            "limit_reached": false,
+            "primary_window": {
+              "used_percent": 42.5,
+              "limit_window_seconds": 18000,
+              "reset_after_seconds": 3600,
+              "reset_at": 1782000000
+            },
+            "secondary_window": {
+              "used_percent": 12.0,
+              "limit_window_seconds": 604800,
+              "reset_after_seconds": 86400,
+              "reset_at": 1782500000
+            }
+          },
+          "code_review_rate_limit": {
+            "allowed": true,
+            "limit_reached": false,
+            "primary_window": {
+              "used_percent": 5.0,
+              "limit_window_seconds": 604800,
+              "reset_after_seconds": 100,
+              "reset_at": 1782600000
+            }
+          }
+        }
+        """#
+        let response = try decodeCodex(json)
+
+        XCTAssertEqual(response.planType, "team")
+        let rateLimit = try XCTUnwrap(response.rateLimit)
+        XCTAssertEqual(rateLimit.primaryWindow.usedPercent, 42.5)
+        XCTAssertEqual(rateLimit.primaryWindow.limitWindowSeconds, 18000)
+        XCTAssertEqual(rateLimit.primaryWindow.resetAt, 1_782_000_000)
+        let secondary = try XCTUnwrap(rateLimit.secondaryWindow)
+        XCTAssertEqual(secondary.usedPercent, 12.0)
+        XCTAssertEqual(secondary.limitWindowSeconds, 604_800)
+        let codeReview = try XCTUnwrap(response.codeReviewRateLimit)
+        XCTAssertEqual(codeReview.primaryWindow.usedPercent, 5.0)
+    }
+
+    func testCodexFreeAccountNullRateLimitDecodes() throws {
+        let response = try decodeCodex(#"{"plan_type":"free","rate_limit":null}"#)
+        XCTAssertEqual(response.planType, "free")
+        XCTAssertNil(response.rateLimit)
+    }
+
+    func testCodexStringNumericFieldsAreTolerated() throws {
+        // The API has been observed returning numbers as strings for
+        // credits.balance and spend_control.individual_limit.
+        let json = #"""
+        {
+          "plan_type": "plus",
+          "credits": {
+            "has_credits": true,
+            "unlimited": false,
+            "overage_limit_reached": false,
+            "balance": "12.50"
+          },
+          "spend_control": {"reached": false, "individual_limit": "40"}
+        }
+        """#
+        let response = try decodeCodex(json)
+        XCTAssertEqual(response.credits?.balance, 12.5)
+        XCTAssertEqual(response.spendControl?.individualLimit, 40)
+    }
+
+    // MARK: - Cursor (https://cursor.com/api/usage-summary)
+
+    func testCursorUsageSummaryDecodes() throws {
+        let json = #"""
+        {
+          "billingCycleStart": "2026-06-15T00:00:00.000Z",
+          "billingCycleEnd": "2026-07-15T00:00:00.000Z",
+          "membershipType": "pro",
+          "limitType": "requests",
+          "individualUsage": {
+            "plan": {"used": 132, "limit": 500, "remaining": 368, "included": 500, "bonus": 0, "total": 500},
+            "onDemand": {"used": 3, "limit": 20, "remaining": 17, "enabled": true}
+          }
+        }
+        """#
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let response = try JSONDecoder().decode(CursorUsageSummaryResponse.self, from: data)
+
+        XCTAssertEqual(response.membershipType, "pro")
+        XCTAssertEqual(response.billingCycleEnd, "2026-07-15T00:00:00.000Z")
+        let plan = try XCTUnwrap(response.individualUsage?.plan)
+        XCTAssertEqual(plan.used, 132)
+        XCTAssertEqual(plan.total, 500)
+        let onDemand = try XCTUnwrap(response.individualUsage?.onDemand)
+        XCTAssertEqual(onDemand.enabled, true)
+        XCTAssertEqual(onDemand.used, 3)
+    }
+
+    func testCursorSparseResponseDecodes() throws {
+        // Every field is optional; an empty object must not throw.
+        let data = try XCTUnwrap("{}".data(using: .utf8))
+        let response = try JSONDecoder().decode(CursorUsageSummaryResponse.self, from: data)
+        XCTAssertNil(response.individualUsage)
+        XCTAssertNil(response.billingCycleEnd)
+    }
+
+    // MARK: - Claude Code OAuth usage (https://api.anthropic.com/api/oauth/usage)
+
+    func testClaudeCodeUsageResponseDecodesWindows() throws {
+        let json = #"""
+        {
+          "five_hour": {"utilization": 61.5, "resets_at": "2026-07-02T14:00:00Z"},
+          "seven_day": {"utilization": 30.0, "resets_at": "2026-07-08T00:00:00Z"},
+          "seven_day_sonnet": {"utilization": 12.0, "resets_at": "2026-07-08T00:00:00Z"},
+          "extra_usage": {"is_enabled": true, "monthly_limit": 50.0, "currency": "USD"},
+          "spend": {
+            "used": {"amount_minor": 750, "currency": "USD", "exponent": 2},
+            "enabled": true
+          }
+        }
+        """#
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let response = try decoder.decode(ClaudeCodeUsageResponse.self, from: data)
+
+        XCTAssertEqual(response.fiveHour.utilization, 61.5)
+        XCTAssertEqual(response.sevenDay.utilization, 30.0)
+        XCTAssertEqual(response.sevenDaySonnet?.utilization, 12.0)
+        // Minor-unit money: 750 with exponent 2 is $7.50.
+        XCTAssertEqual(response.spend?.used?.amount, 7.5)
+        XCTAssertEqual(response.extraUsageStatus.state, .on)
+    }
+
+    func testClaudeCodeUsageResponseRequiresBothCoreWindows() throws {
+        // five_hour and seven_day are non-optional in the model. If the API
+        // drops one, decode must fail (caught and surfaced as parsingError)
+        // rather than fabricating zeros.
+        let json = #"{"five_hour": {"utilization": 1.0, "resets_at": "2026-07-02T14:00:00Z"}}"#
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        XCTAssertThrowsError(try decoder.decode(ClaudeCodeUsageResponse.self, from: data))
+    }
+
+    // MARK: - Helpers
+
+    private func decodeCodex(_ json: String) throws -> CodexCliUsageResponse {
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        return try JSONDecoder().decode(CodexCliUsageResponse.self, from: data)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Platform-macOS%2013.0+-black?logo=apple" alt="macOS 13.0+">
-  <img src="https://img.shields.io/badge/Swift-5.9-orange?logo=swift" alt="Swift 5.9">
-  <img src="https://img.shields.io/badge/SwiftUI-5.0-blue?logo=swift" alt="SwiftUI">
+  <img src="https://img.shields.io/badge/Platform-macOS%2026+-black?logo=apple" alt="macOS 26+">
+  <img src="https://img.shields.io/badge/Swift-5-orange?logo=swift" alt="Swift 5">
+  <img src="https://img.shields.io/badge/SwiftUI-blue?logo=swift" alt="SwiftUI">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
 
@@ -58,7 +58,7 @@ A lightweight macOS menu bar app that monitors Claude Code, Codex CLI, and Curso
 Paste this into your local coding agent to have it install MeterBar for you:
 
 ```text
-Install MeterBar on this Mac. First verify this is macOS 13 or newer and that Homebrew is available. Install with: brew tap VincentShipsIt/tap && brew install --cask VincentShipsIt/tap/meterbar. If Homebrew is missing, ask before installing Homebrew. After installing, verify /Applications/MeterBar.app exists and that the meterbar CLI is linked, then open MeterBar. If macOS blocks the first launch because the app is unsigned, remove quarantine with xattr -cr /Applications/MeterBar.app and open it again. Do not ask me for API keys or paste secrets; for usage data, tell me to run claude login, codex login, and log into Cursor if I want those providers tracked.
+Install MeterBar on this Mac. First verify this is macOS 26 or newer and that Homebrew is available. Install with: brew tap VincentShipsIt/tap && brew install --cask VincentShipsIt/tap/meterbar. If Homebrew is missing, ask before installing Homebrew. After installing, verify /Applications/MeterBar.app exists and that the meterbar CLI is linked, then open MeterBar. If macOS blocks the first launch because the app is unsigned, remove quarantine with xattr -cr /Applications/MeterBar.app and open it again. Do not ask me for API keys or paste secrets; for usage data, tell me to run claude login, codex login, and log into Cursor if I want those providers tracked.
 ```
 
 ### Homebrew (Recommended)
@@ -84,7 +84,7 @@ Download the latest release from the [Releases](https://github.com/VincentShipsI
 
 ### Build from Source
 
-Prerequisites: macOS 13.0+, Xcode 15.0+
+Prerequisites: macOS 26+, Xcode 26+
 
 ```bash
 git clone https://github.com/VincentShipsIt/meterbar.app.git
@@ -189,15 +189,19 @@ Claude Code usage uses `claude /usage` first so MeterBar does not need to read C
 ## Privacy & Security
 
 - All credentials remain in their original locations (managed by CLI tools)
-- No data sent to external servers (only official API calls)
-- Sandboxed app with minimal file system access
+- No data sent to external servers (only calls to the providers' own usage endpoints)
+- The main app is **not** sandboxed — it must read other tools' credential/log files
+  (`~/.claude`, `~/.codex`, Cursor's local database) and run the `claude` binary. The
+  widget extension is sandboxed. Hardened runtime is enabled for both.
+- No analytics, telemetry, or crash reporting
 - Open source for full transparency
 
 ## Architecture
 
 - **SwiftUI** - Modern declarative UI
 - **Combine** - Reactive data flow
-- **App Sandbox** - Secure with specific entitlements for credential access
+- **Hardened Runtime** - Enabled for app and widget (the main app is un-sandboxed by
+  design so it can read local CLI credential/log files)
 - **URLSession** - Native networking
 
 ## Troubleshooting
@@ -218,7 +222,7 @@ Run `codex logout && codex login` and select your team workspace when prompted.
 
 ### App can't read credentials
 
-The app needs sandbox exceptions to read CLI credential files. Rebuild from source if using a modified entitlements file.
+The app reads CLI credential files from your home directory (`~/.codex/auth.json`, Cursor's local database). If you built from source with App Sandbox enabled, those reads will fail — the shipped configuration keeps the main app un-sandboxed for this reason.
 
 ## Contributing
 

--- a/docs/audits/00-repo-map.md
+++ b/docs/audits/00-repo-map.md
@@ -1,0 +1,166 @@
+# 00 — Repo Map: MeterBar (meterbarapp)
+
+**Audit date:** 2026-07-02
+**Scope:** Full repository (201 tracked files, ~10,800 lines of Swift across app + widget + CLI + tests)
+**Method:** Every claim below was verified by reading the actual file; paths are cited inline. Nothing was inferred from filenames alone. No code was changed.
+
+---
+
+## 1. System overview
+
+MeterBar (working title in older docs: "Quota Guard") is a **single macOS menu bar app** — not a monorepo of services. There is no backend, no database server, no queue, no web app. Everything runs on the user's Mac.
+
+What it does (verified in code, not just README):
+
+- Shows AI coding-assistant quota usage in the macOS menu bar and in a WidgetKit widget: Claude Code, OpenAI Codex CLI, Cursor, plus optional Anthropic/OpenAI **admin-API** org usage (`MeterBar/Services/UsageDataManager.swift:43-126`).
+- Reads credentials/usage **from local CLI artifacts** rather than asking for API keys:
+  - Claude Code: shells out to `claude /usage` and regex-parses the terminal output (`MeterBar/Services/ClaudeCodeCLIUsageService.swift:75-126`, parser at `:129-262`); a legacy OAuth fallback reads the `Claude Code-credentials` keychain item, gated behind the `ClaudeCodeEnableOAuthFallback` UserDefaults flag (`MeterBar/Services/ClaudeCodeLocalService.swift:9-14, 81-96`).
+  - Codex: reads `~/.codex/auth.json` and calls `https://chatgpt.com/backend-api/wham/usage` with browser-spoofed headers (`MeterBar/Services/CodexCliLocalService.swift:18-24, 95-112`).
+  - Cursor: opens Cursor's SQLite `state.vscdb` read-only, extracts the session JWT, and calls `https://cursor.com/api/usage-summary` with a spoofed cookie/User-Agent (`MeterBar/Services/CursorLocalService.swift:53-163, 285-295`).
+- Estimates local token **costs** by scanning `~/.claude*/projects/**/*.jsonl` session logs and Codex's `~/.codex/archived_sessions` + `~/.codex/logs_2.sqlite`, priced from a hardcoded per-model table (`MeterBar/Services/CostTracker.swift:23-41, 227-313, 554-685`).
+- Fires local notifications at 90%/100% of any limit (`MeterBar/App/MeterBarApp.swift:239-299`).
+- Ships a small `meterbar` CLI that prints the app's cached metrics and does its own (simplified, drifted) cost scan (`MeterBarCLI/Sources/MeterBarCLI.swift`).
+
+**Product identity note:** three different identifiers coexist — bundle `dev.shipshit.MeterBar`, app group `group.dev.shipshit.meterbar`, keychain service `com.agenticindiedev.quotaguard` (`MeterBar/Services/KeychainManager.swift:7`), and copyright "Agentic Indie Dev" (`MeterBar/Info.plist:28`). Legacy naming ("Quota Guard", "agenticindiedev") survives in the keychain namespace, `scripts/package.json:2` (`quotaguard-scripts`), `.swiftformat:1`, and `CLAUDE.md`.
+
+---
+
+## 2. Repo / package map
+
+Three build systems coexist in one repo (see risk R6):
+
+| Unit | Path | Build system | What it is |
+|---|---|---|---|
+| **MeterBar.app** | `MeterBar/` | `MeterBar.xcodeproj` (target `MeterBar`) | Menu bar app. 16 services, 7 models, 5 views, AppKit delegate entry (`MeterBar/App/MeterBarApp.swift`) |
+| **MeterBarWidgetExtension** | `MeterBarWidget/` | `MeterBar.xcodeproj` (target `MeterBarWidgetExtension`) | WidgetKit extension, kind `"UsageWidget"`, reads app-group JSON (`MeterBarWidget/UsageWidget.swift:147-233`) |
+| **MeterBar (SwiftPM library + tests)** | root `Package.swift` | SwiftPM, tools 6.2, `.macOS(.v26)`, Swift 5 language mode | Exists to make `MeterBarTests/` runnable via `swift test`; excludes the app entry point (`Package.swift:18-40`) |
+| **MeterBarCLI** | `MeterBarCLI/` | Separate SwiftPM package, tools 5.9, `.macOS(.v13)` | `meterbar` executable; sole dependency `swift-argument-parser >= 1.3.0` (`MeterBarCLI/Package.swift`) |
+| **Asset scripts** | `scripts/` | Bun + Playwright 1.57.0 (`scripts/package.json`) | Icon/social-preview generators (`generate-icons.ts`, `generate-social-preview.ts`), README screenshot renderer (`render-readme-screenshots.sh/.swift`), coverage gate (`check-coverage.sh`), manual API smoke test (`test-api-access.sh` + `APIAccessTest.swift`) |
+| **CI/CD** | `.github/workflows/` | GitHub Actions | `ci.yml`, `release.yml`, `update-homebrew.yml`, `secret-scan.yml` |
+| **Agent docs/config** | `.agents/`, `.claude/`, `.codex/`, `.cursor/`, `.shipcode/` | — | AI-workflow docs, session logs, skills, hooks. `.claude/settings.json` enables the swift-lsp plugin; `.codex/hooks.json` wires a local voice-hooks server |
+| **Docs/assets** | `docs/` (logo, screenshots), `assets/` (social preview), `README.md`, `LICENSE` (MIT, "Agentic Indie Dev") | — | User-facing docs |
+
+**No shared code package.** `ServiceType`, `UsageLimit`, `UsageMetrics`, `UsageStatus` are copy-pasted into the widget (`MeterBarWidget/UsageWidget.swift:4-131`, comment says "duplicated for Widget target") and re-implemented in the CLI (`MeterBarCLI/Sources/MeterBarCLI.swift:314-331`). The drift is already documented internally in `.agents/docs/DEFERRED_WORK.md` §1, including a table of divergences (widget's `UsageMetrics` silently drops `extraUsage`/`resetCreditsAvailable` on decode; CLI hardcodes Sonnet pricing at `MeterBarCLI/Sources/MeterBarCLI.swift:263-268` while the app has a 13-entry per-model table).
+
+---
+
+## 3. Runtime / deployment map
+
+**Runtime:**
+- Swift 5 language mode everywhere (`SWIFT_VERSION = 5.0` in `MeterBar.xcodeproj/project.pbxproj:291,502`; `.swiftLanguageMode(.v5)` in root `Package.swift:33`). Not Swift 6 concurrency-checked.
+- Deployment target **macOS 26.0** (`MACOSX_DEPLOYMENT_TARGET = 26.0`, pbxproj lines 281/326/491/537) — needed for Liquid Glass UI APIs per the comment in `Package.swift:30-32`. CLI targets macOS 13.
+- App lifecycle: `@main` SwiftUI `App` + `NSApplicationDelegateAdaptor`; manual `NSStatusItem` + `NSPopover` (not `MenuBarExtra`), `LSUIElement = true` with a user-toggleable Dock icon via activation policy (`MeterBar/App/MeterBarApp.swift:23-206`, `MeterBar/Services/DockVisibilityStore.swift`).
+- Concurrency: singletons everywhere (every service is `.shared`); `UsageDataManager` is `@MainActor ObservableObject` with a `Timer`-based auto-refresh (default 15 min, options 1 min–manual, `MeterBar/Models/RefreshInterval.swift`); a separate 5-minute `Task.sleep` loop drives notifications (`MeterBar/App/MeterBarApp.swift:240-260`). CLI subprocess runs on a dedicated GCD queue bridged via continuation (`ClaudeCodeCLIUsageService.swift:8-73`).
+- **Sandbox: the main app is NOT sandboxed** — `ENABLE_APP_SANDBOX = NO` (pbxproj:471,517) and `MeterBar/MeterBar.entitlements` contains only the app group. Only the widget is sandboxed (`MeterBarWidget/MeterBarWidget.entitlements`). Hardened runtime is on for both. This contradicts README ("Sandboxed app", `README.md:193`) — see risk R2.
+
+**Deployment / distribution:**
+- Tag `v*` → `release.yml`: builds Release on `macos-26` runner with Xcode 26.2, **unsigned** (`CODE_SIGNING_ALLOWED=NO`, `release.yml:36-38`), builds the CLI with `swift build -c release` and copies it into `MeterBar.app/Contents/Helpers/` (`release.yml:41-46`), verifies CLI version == `CFBundleShortVersionString` (`:48-59`), zips with `ditto`, publishes a GitHub Release via pinned `softprops/action-gh-release` (`:88-98`).
+- Then `update-homebrew.yml` (called via `workflow_call`, deliberately not `release: published` — reason documented at `release.yml:108-110`) rewrites `Casks/meterbar.rb` in the external repo `VincentShipsIt/homebrew-tap` using `secrets.TAP_GITHUB_TOKEN`, with a regex guard that the downloaded SHA256 is a bare 64-hex digest (`update-homebrew.yml:39-55`).
+- **No code signing identity, no notarization** anywhere in the pipeline; README instructs users to `xattr -cr` the quarantine flag (`README.md:80-83`). Version currently `MARKETING_VERSION = 1.6` (pbxproj:282 etc.), while `MeterBar/Info.plist:22` pins `CFBundleShortVersionString` to `1.0` — the plist value appears overridden by build settings, but the checked-in `1.0` is misleading.
+- README badge claims "macOS 13.0+" and "Swift 5.9" (`README.md:12-13`) — both false against the project files (macOS 26, Swift 5 mode / tools 6.2).
+
+**Scheduling/cron analog:** in-process `Timer` (refresh) + `Task.sleep` loop (notifications) + WidgetKit timeline `.after(nextUpdate)` (`MeterBarWidget/UsageWidget.swift:225-233`). No launchd agents, no background daemons.
+
+**Observability:** `os.Logger` only, via `AppLog` with 5 categories (`MeterBar/Services/AppLog.swift`). No crash reporting, no analytics, no telemetry (grep for Sentry/Crashlytics/analytics: zero hits in Swift sources). For a distributed app, the only failure signal is user reports.
+
+---
+
+## 4. Data / auth / integration map
+
+**Network endpoints called (complete list found in sources):**
+
+| Endpoint | Auth | File |
+|---|---|---|
+| `https://api.anthropic.com/api/oauth/usage` | Claude Code OAuth bearer + `anthropic-beta: oauth-2025-04-20` (fallback path + extra-usage probe) | `ClaudeCodeLocalService.swift:9,138-254` |
+| `https://api.anthropic.com/v1/organizations/usage_report/messages` | Anthropic **Admin API key** (`x-api-key`), paginated, 50-page cap | `ClaudeService.swift:15-70` |
+| `https://api.openai.com/v1/organization/usage/completions` | OpenAI **Admin API key** (Bearer), paginated, 50-page cap | `OpenAIService.swift:15-65` |
+| `https://chatgpt.com/backend-api/wham/usage` | Codex OAuth bearer + `ChatGPT-Account-Id` header, browser-spoofed UA/Referer/Origin | `CodexCliLocalService.swift:18,95-112` |
+| `https://cursor.com/api/usage-summary` | `WorkosCursorSessionToken` cookie forged from local DB JWT, spoofed UA | `CursorLocalService.swift:15,285-311` |
+| (`https://cursor.com/api/dashboard/get-me` is declared at `CursorLocalService.swift:16` but never called — dead constant) | | |
+
+All of these except the two admin APIs are **undocumented/private endpoints** subject to breakage (see R1).
+
+**Local data read (integration surface on the user's machine):**
+- `claude` binary resolved from `CLAUDE_CLI_PATH`, `$PATH`, then 7 hardcoded fallbacks (homebrew, `~/.local/bin`, npm/yarn/bun/volta) (`ClaudeCodeCLIUsageService.swift:31-57`); per-account `CLAUDE_CONFIG_DIR` env injection for multi-account (`:116-126`, accounts persisted in UserDefaults via `ClaudeCodeAccountStore`, `MeterBar/Models/ClaudeCodeAccount.swift:25-75`).
+- macOS Keychain item service `"Claude Code-credentials"` (Claude Code's own item) — read-only, fallback path only (`ClaudeCodeLocalService.swift:12,55-78`).
+- `~/.codex/auth.json`, `~/.codex/archived_sessions/*.jsonl`, `~/.codex/logs_2.sqlite` (`CodexCliLocalService.swift:21-24`, `CostTracker.swift:554-685`).
+- Cursor `state.vscdb` SQLite — 5 candidate paths + recursive rescan (`CursorLocalService.swift:53-110`).
+- `~/.claude/projects`, `~/.config/claude/projects`, every `~/.claude-*` profile dir, plus custom account dirs — JSONL scan for cost tracking (`CostTracker.swift:316-356`).
+- Sandbox-escape helper: `ServiceSupport.realHomeDirectory()` uses `getpwuid` to bypass the container home (`ServiceSupport.swift:59-73`) — works because the app is not actually sandboxed.
+
+**Data written / persisted:**
+- `UserDefaults.standard`: metrics cache (`cached_usage_metrics`), refresh interval, hidden providers (`HiddenProviderServices`), dock flag (`ShowMeterBarInDock`), custom Claude accounts (`ClaudeCodeCustomAccounts`), OAuth-fallback flag.
+- App group container `group.dev.shipshit.meterbar`: `cached_usage_metrics.json`, atomic writes on a serial queue, triggers `WidgetCenter.reloadTimelines` (`SharedDataStore.swift`). Read by widget and CLI (`MeterBarCLI.swift:95-123`).
+- `~/Library/Application Support/MeterBar/cost-summary-v1.json` cost cache (`CostTracker.swift:175-225`).
+- Own keychain service `com.agenticindiedev.quotaguard` for the two optional admin keys (`KeychainManager.swift:7`, `AuthenticationManager.swift`).
+
+**No database, no auth provider, no job queue** in the server sense. "Auth" is entirely: two admin keys in keychain + scavenged CLI credentials.
+
+---
+
+## 5. CI / test / tooling map
+
+**CI (`.github/workflows/ci.yml`):** push/PR to `master`, `macos-26` runner, Xcode 26.2 pinned, builds Debug unsigned, then runs `xcodebuild … test || echo "Tests completed (some may require credentials)"` — **the `|| echo` makes the test step unconditionally green** (`ci.yml:35-44`). Compounding this: the Xcode project has **no test target** (only `MeterBar` and `MeterBarWidgetExtension` native targets exist, `project.pbxproj:122-169`) and the only shared scheme is `MeterBarWidgetExtension.xcscheme`, so the `-scheme MeterBar` test action has nothing to run even when it succeeds. Tests are actually runnable only via SwiftPM (`swift test` against root `Package.swift`). Net: **CI gates compilation, not tests** (risk R3).
+
+**Tests (`MeterBarTests/`, 14 files, ~115 `func test…`, all XCTest):**
+- Covered: CLI-output parser, Codex reset credits, dock store, extra-usage mapping, theme, OAuth expiry, refresh interval, reset countdown/pace, `ServiceType`, `TokenCost`, formatting, `UsageLimit`, `UsageMetrics`.
+- `APIIntegrationTests.swift` (442 lines) makes **real network calls**, gated by `XCTSkip` when credentials are absent (`:26-28`).
+- **Untested**: `UsageDataManager` (refresh/caching orchestration), `CostTracker` (1,029 lines — the biggest service), `CursorLocalService`, `CodexCliLocalService` fetch path, `ClaudeService`, `OpenAIService`, `SharedDataStore`, `KeychainManager`, `AuthenticationManager`, `ProviderVisibilityStore`, `ClaudeCodeAccountStore`, all 5 views (~3,500 lines), `AppDelegate` notification logic, and the entire CLI. The CLAUDE.md-declared policy "TDD, 80%+ coverage" is not met by the current suite and is not enforced anywhere in CI; `scripts/check-coverage.sh` implements an 80% llvm-cov gate but no workflow invokes it.
+- Secret scanning: gitleaks 8.30.1, pinned + SHA256-verified, full-history scan, one scoped false-positive fingerprint in `.gitleaksignore` — this workflow is in good shape.
+
+**Lint/format:** `.swiftlint.yml` (52 opt-in rules, custom `no_print_statements`, 120/200 line length) and `.swiftformat` (says `--swiftversion 5.9`) exist, but **no CI step and no build phase runs either** (no SwiftLint invocation in `ci.yml` or `project.pbxproj`). They are editor-only conventions today. `.editorconfig` present.
+
+**Actions hygiene:** all third-party actions SHA-pinned (`ci.yml:16`, `release.yml:21,89`); release tag handled as data not shell (`release.yml:14-17`); workflow permissions scoped. Good.
+
+---
+
+## 6. Main architectural risks noticed during mapping
+
+Ranked by expected pain.
+
+- **R1 — The product stands on undocumented, reverse-engineered interfaces.** Regex-parsing `claude /usage` terminal output (fragile to any CLI copy change — parser matches English labels like "current week (all models)", `ClaudeCodeCLIUsageService.swift:137-151`), a private ChatGPT backend endpoint with spoofed browser headers, Cursor's internal SQLite schema + forged session cookie, and Codex's internal log formats (`logs_2.sqlite` text-blob regex extraction, `CostTracker.swift:59-73,643-685`). Any upstream change silently breaks a provider; there is no contract-test or canary beyond user reports (no telemetry, §3).
+- **R2 — Security posture is misrepresented and inherently sensitive.** README claims "Sandboxed app with minimal file system access" (`README.md:193`); actually `ENABLE_APP_SANDBOX = NO` and the app reads other apps' credentials (Claude Code keychain item, Codex OAuth tokens, Cursor session JWT) and ships **unsigned and un-notarized**, with install docs telling users to strip quarantine. Unsigned + credential-scavenging is a trust problem for a distributed utility and an easy target for criticism.
+- **R3 — Tests do not gate anything.** `|| echo` on the CI test step, no test target in the Xcode project, coverage script never wired into CI, lint never run in CI. The 115 test functions only run when someone remembers `swift test` locally.
+- **R4 — Triplicate model definitions with confirmed drift.** App/widget/CLI each own `UsageLimit`/`UsageMetrics`/`ServiceType`; widget already silently drops fields on decode; CLI already had one production decode bug from this (Int vs Double, fixed per `DEFERRED_WORK.md` and the comment at `MeterBarCLI.swift:321-323`). Every new shared field is a latent cross-target bug.
+- **R5 — Hardcoded pricing and heuristic quotas rot silently.** The per-model price table (`CostTracker.swift:23-41`), the CLI's separate Sonnet-only pricing (`MeterBarCLI.swift:263-268`), Cursor's assumed 500-request default and 1.5× on-demand headroom guess (`CursorLocalService.swift:22-25`), and the fake "1.5× usage or 1M token" limit for admin APIs (`ClaudeService.swift:85-89`, `OpenAIService.swift:82-86`) all present invented numbers as facts in the UI.
+- **R6 — Three build systems for one app.** Xcode project (app/widget), root SwiftPM package (tests only, with a hand-maintained `exclude` list), and a second SwiftPM package (CLI). Settings already disagree (Swift tools 6.2 vs 5.9; macOS 26 vs 13; `.swiftformat` says 5.9). `create_xcode_project.sh` at the root is a fourth artifact (XcodeGen-era generator) whose relevance is unverified.
+- **R7 — Internal docs are dangerously stale where they matter.** `.agents/SYSTEM/ARCHITECTURE.md` (dated 2025-01-27) documents a phantom `CursorService.swift`, the wrong app group (`group.com.agenticindiedev.meterbar`), wrong keychain layout, placeholder endpoints, and macOS 13; `.agents/docs/IMPLEMENTATION_STATUS.md` lists a nonexistent `CodexService`; `AGENTS.md`/`CLAUDE.md`/`CODEX.md` all point to `.agent/` (dir is `.agents/`) and a nonexistent `.agent/TASKS/`; `.agents/SYSTEM/RULES.md` is mostly TypeScript rules (kebab-case files, no `any`, `I`-prefixed interfaces) in a pure Swift repo. An agent following these docs will act on wrong facts. By contrast, `.agents/docs/DEFERRED_WORK.md` and the 2026-06 session logs are accurate and current.
+- **R8 — God files.** `UsageDashboardView.swift` 1,612 lines (30+ private types in one file), `CostTracker.swift` 1,029, `MenuBarView.swift` 1,024, `SettingsView.swift` 764. Combined with `file_length`/`type_body_length` lint rules disabled (`.swiftlint.yml:17-23`), nothing pushes back on growth.
+- **R9 — Version/metadata inconsistencies.** `MARKETING_VERSION 1.6` vs checked-in `Info.plist` `1.0`; README badges (macOS 13, Swift 5.9, "App Store Coming Soon") vs macOS 26 unsigned reality; brand split shipshit.dev vs Agentic Indie Dev vs Quota Guard.
+
+Minor/dead things noticed: unused `getMeEndpoint` constant (`CursorLocalService.swift:16`); `AuthenticationManager.isCursorAuthenticated` hardcoded `false` and unused meaningfully (`AuthenticationManager.swift:57-59`); `baseURL` constant in `ClaudeCodeLocalService.swift:11` unused; `create_xcode_project.sh` likely orphaned.
+
+---
+
+## 7. Suggested follow-up audit sessions
+
+1. **CI/test enforcement audit** (highest leverage, small diff): remove the `|| echo` swallow, decide SwiftPM-vs-Xcode as the single test path, wire `scripts/check-coverage.sh` and SwiftLint into `ci.yml`, and measure real coverage of the untested list in §5. (R3)
+2. **Shared-package extraction audit**: execute `.agents/docs/DEFERRED_WORK.md` §1 (`MeterBarShared` for the four duplicated types) and add cross-target decode round-trip tests. (R4, R6)
+3. **Security & distribution audit**: reconcile README security claims with the non-sandboxed reality, evaluate Developer ID signing + notarization in `release.yml` (cert secrets exist? currently none referenced), and review the credential-scavenging surface (what is read, what could leak into logs — `AppLog` privacy annotations look deliberate but deserve a pass). (R2)
+4. **Provider-contract resilience audit**: catalogue every parse assumption per provider (CLI output labels, JSON fields marked "discovered via testing"), add fixture-based contract tests + graceful-degradation paths, and consider a version canary. (R1)
+5. **Pricing/quota data audit**: single source of truth for the price table (app vs CLI), date-stamp it, and flag invented limits (Cursor 500, 1.5× heuristics) in the UI as estimates. (R5)
+6. **Docs truth-sync session**: delete or rewrite `.agents/SYSTEM/ARCHITECTURE.md`, `PROJECT-MAP.md`, `IMPLEMENTATION_STATUS.md`, fix the `.agent/` → `.agents/` pointers in all three entry files, and replace the TypeScript rules in `RULES.md` with the Swift conventions actually in force (`.swiftlint.yml`/`.swiftformat`). (R7)
+7. **View-layer decomposition audit** (lowest urgency): split the three 1,000+ line view files; purely mechanical but blocked on nothing. (R8)
+
+---
+
+## Addendum (2026-07-02, same day): remediation status
+
+Fixes landed in the follow-up pass on branch `claude/xenodochial-yonath-5d5f6d`:
+
+- **R3 (partially fixed):** `ci.yml` rewritten — `swift test` is now a hard gate via `scripts/check-coverage.sh` (coverage floor starts at 40%, ratchet upward), SwiftLint 0.65.0 added as a `--strict` gate (tree was violation-free at time of adding), CLI build added. The bogus `xcodebuild test || echo` step is gone.
+- **R2 (docs fixed, signing outstanding):** README no longer claims the app is sandboxed; badges corrected to macOS 26+. Signing/notarization deferred — needs Developer ID cert secrets (follow-up task spawned).
+- **R4 (guarded, not fixed):** `MeterBarTests/CachedMetricsContractTests.swift` locks the shared JSON contract (keys, default date strategy, widget/CLI-shaped decode). Package extraction still deferred (needs full Xcode).
+- **R1 (guarded):** `MeterBarTests/ProviderResponseContractTests.swift` adds decode fixtures for Codex, Cursor, and Claude Code OAuth responses.
+- **R5 (annotated):** pricing tables date-stamped with sync notes between `CostTracker` and the CLI copy.
+- **R7 (fixed):** `ARCHITECTURE.md`, `PROJECT-MAP.md`, `IMPLEMENTATION_STATUS.md`, `RULES.md` rewritten to match reality; all live `.agent/` → `.agents/` references fixed (historical session logs left untouched).
+- Dead code removed: `getMeEndpoint`, unused `baseURL`, `isCursorAuthenticated`.
+- **R6, R8:** untouched (follow-up tasks spawned: shared package, view split, signing).
+
+**Environment caveat discovered during remediation:** this machine has Command Line Tools only — no XCTest module, so `swift test` cannot run locally here. Tests verify on CI (macos-26 runners). `swift build` (app library incl. views) and `MeterBarCLI` build pass locally.
+
+**Evidence gaps / unverified items:**
+- Whether the `VincentShipsIt/homebrew-tap` cask matches current release artifacts (external repo, not in this checkout).
+- Whether `xcodebuild -scheme MeterBar` on CI auto-creates the unshared scheme (CI history not inspected from here; the pbxproj proves no test target either way).
+- Whether `create_xcode_project.sh` is still used by anything (no references found in workflows or scripts).
+- Actual current coverage percentage (requires running `swift test --enable-code-coverage`; not run during this read-only audit).

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -30,7 +30,14 @@ if [ ! -f "$TEST_BINARY" ]; then
   exit 1
 fi
 
-COVERAGE_PERCENT="$(xcrun llvm-cov report "$TEST_BINARY" -instr-profile "$PROFDATA" -ignore-filename-regex ".*Tests.*" | awk '/^TOTAL/ {print $NF}' | tr -d '%')"
+# Parse the JSON summary rather than the text table: `llvm-cov report` column
+# order varies between LLVM versions (a trailing branch-coverage column made
+# `awk '{print $NF}'` read "-" and fail the gate with "Coverage: -%").
+COVERAGE_PERCENT="$(xcrun llvm-cov export "$TEST_BINARY" \
+  -instr-profile "$PROFDATA" \
+  -summary-only \
+  -ignore-filename-regex ".*Tests.*" \
+  | python3 -c 'import json,sys; print(f'"'"'{json.load(sys.stdin)["data"][0]["totals"]["lines"]["percent"]:.1f}'"'"')')"
 if [ -z "$COVERAGE_PERCENT" ]; then
   echo "Failed to parse coverage report." >&2
   exit 1


### PR DESCRIPTION
## Resolves

Closes #17 — ci: fail hard on tests and enforce coverage (this PR removes the `|| echo` swallow, adds a real `swift test` gate + coverage floor).
Closes #24 — docs: align README and agent docs with current behavior (README truth pass + ARCHITECTURE/PROJECT-MAP/IMPLEMENTATION_STATUS/RULES rewritten).
Partially addresses #40 — CodexCliLocalService lint cleanup done here; dashboard badge parity is out of scope.

---

## Summary

Full-repo audit ([docs/audits/00-repo-map.md](docs/audits/00-repo-map.md)) followed by a remediation pass on the highest-leverage findings.

### CI now actually gates (was: unconditionally green)
- The old test step was `xcodebuild … test || echo` — **always green** — and the Xcode project has no test target anyway. Replaced with a real `swift test` gate via `scripts/check-coverage.sh` (coverage floor `COVERAGE_THRESHOLD: 40`, to be ratcheted once this PR's CI prints the real number — see checklist).
- SwiftLint 0.65.0 added as a `--strict` job (pinned release binary + SHA256 check, mirroring the gitleaks pattern in `secret-scan.yml`).
- CLI package build added.

### Lint debt paid
The tree had **97 SwiftLint violations** (lint was never run anywhere). All fixed: 48 by autocorrect, 49 by hand (line wraps, attribute placement, `for-where`, `Array(prefix(_:))`, dead `CodingKeys`). The two `cyclomatic_complexity` hits in `UsageDataManager` carry targeted `swiftlint:disable:next` with written rationale (untested orchestration; extract helpers when tests exist). `swiftlint lint --strict` exits 0.

### Docs told the truth again
- `ARCHITECTURE.md` / `PROJECT-MAP.md` / `IMPLEMENTATION_STATUS.md` rewritten — previous versions described a planning-phase design (phantom `CursorService`, wrong app group, placeholder endpoints, macOS 13).
- `RULES.md` was a **TypeScript** template in a pure-Swift repo; now Swift rules pointing at `.swiftlint.yml`/`.swiftformat` + data-contract rules.
- All live `.agent/` → `.agents/` references fixed (14 files; historical session logs untouched).
- README: badges corrected to macOS 26+, false "Sandboxed app" claim replaced with the honest story (app un-sandboxed by design; widget sandboxed; hardened runtime; no telemetry).

### New contract tests (guard the reverse-engineered surfaces)
- `ProviderResponseContractTests`: decode fixtures for Codex wham/usage (incl. string-numeric tolerance), Cursor usage-summary (incl. sparse `{}`), Claude Code OAuth usage (ISO dates, minor-unit money, required windows).
- `CachedMetricsContractTests`: locks the app-group JSON contract consumed by the widget and CLI via replica structs — keys, **default reference-date strategy**, unknown-key tolerance.

### Small stuff
- Dead code removed: `getMeEndpoint`, unused `baseURL`, `isCursorAuthenticated`.
- Pricing tables date-stamped (2026-07-02) with app↔CLI sync notes.

### Deferred (task chips spawned)
- `MeterBarShared` package extraction (needs full Xcode for pbxproj edits — DEFERRED_WORK.md §1)
- View-file splits (separate PR for reviewability)
- Developer ID signing + notarization (needs cert secrets)

## Test plan
- [x] `swift build` (app library incl. views) — clean locally
- [x] `cd MeterBarCLI && swift build` — clean locally
- [x] `swiftlint lint --strict` — 0 violations locally
- [ ] CI: test job green (this machine has CLT only — no local XCTest; tests verify here)
- [ ] Read actual coverage % from CI log and ratchet `COVERAGE_THRESHOLD` in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
