### PR TITLE
Re-apply Developer ID signing + notarization to release pipeline

### DIFF
--- a/.agents/SESSIONS/2026-07-02.md
+++ b/.agents/SESSIONS/2026-07-02.md
@@ -1,0 +1,62 @@
+# Sessions: 2026-07-02
+
+**Summary:** Un-defer Developer ID signing + notarization (issue #47, audit risk R2)
+
+---
+
+## Session 1: Re-apply Developer ID signing/notarization to release.yml
+
+**Status:** Complete
+
+### What was done
+
+- Re-applied the full signing/notarization pipeline from **PR #43** (reverted by #48, deferred
+  via issue #47) to `.github/workflows/release.yml`, merged with everything master gained since
+  the revert:
+  - Kept the **"Verify bundled CLI version"** gate from #54.
+  - Kept the **`update-homebrew`** follow-up job (its own `permissions: contents: read` is
+    compatible with the new deny-by-default top-level permissions).
+  - Kept the `REF_NAME` tag-injection hardening (already on master, also required by #47).
+- Pipeline (verbatim from the reviewed #43): preflight secrets gate → unsigned build → inject
+  CLI helper → temp-keychain import (exactly-one-identity gate, `set-key-partition-list`) →
+  inside-out codesign (frameworks defensive → `Contents/Helpers/meterbar` →
+  `MeterBarWidgetExtension.appex` sandboxed → outer `.app`, all `--options runtime --timestamp`)
+  → entitlement-split hard gate → `notarytool submit --wait --timeout 40m` (ASC API key,
+  keychain profile) → `stapler staple` → `spctl`/`codesign --verify --deep --strict`/`stapler
+  validate` → re-zip stapled bundle → SHA256 on the **final** artifact → `always()` cleanup
+  restoring the original keychain search list.
+- Job `timeout-minutes` 45 → 60 (notarization wait headroom).
+- Docs: dropped the `xattr -cr` workaround from `README.md` (manual-download note + agent
+  install prompt) and `.agents/docs/SETUP.md`; both now state releases are signed + notarized.
+
+### Decisions
+
+- **Decision:** Reuse PR #43's workflow verbatim instead of the freshly drafted version.
+  - **Context:** A first draft this session re-derived the pipeline and reintroduced the exact
+    `security import -t cert` private-key-dropping bug #43's review had already caught, and used
+    ad-hoc secret names (`DEVELOPER_ID_CERT_P12`, Apple-ID+app-specific-password auth).
+  - **Rationale:** #43 was design-panel + adversarially reviewed and locally validated on macOS;
+    issue #47 documents its exact 6 secrets as the re-enable recipe Vincent will follow.
+- **Decision:** Secret names follow **issue #47** (`BUILD_CERTIFICATE_BASE64`, `P12_PASSWORD`,
+  `KEYCHAIN_PASSWORD`, `ASC_API_KEY_BASE64`, `ASC_KEY_ID`, `ASC_ISSUER_ID`), not the task
+  prompt's `DEVELOPER_ID_CERT_P12` shorthand — #47 is the canonical documented recipe.
+- **Decision:** notarytool auth via App Store Connect API key (as #43), not Apple ID +
+  app-specific password — non-interactive, no 2FA edge cases.
+- **Decision:** App-group entitlement stays bare `group.dev.shipshit.meterbar` (unchanged from
+  #43's caveat) — rewriting to the team-prefixed form changes the Group Container path at
+  runtime; still needs verification on a real signed install (#47 acceptance criteria).
+
+### Verification
+
+- `actionlint` (embedded shellcheck) clean on the final `release.yml`.
+- Full pipeline can only be proven on a real tag push once the 6 secrets exist.
+
+### Next steps
+
+- [ ] Vincent: create/export the Developer ID Application cert (team S329JK3JRB) + ASC API key,
+      add the 6 secrets per issue #47's table.
+- [ ] First signed release: confirm `spctl` says "Notarized Developer ID" and the app↔widget
+      Group Container resolves on a real install.
+- [ ] Homebrew tap repo: cask may still carry unsigned-app caveats/`no_quarantine` — check after
+      first signed release (separate repo, out of this PR's scope).
+- [ ] Close #47 once the first signed release ships.

--- a/.agents/docs/SETUP.md
+++ b/.agents/docs/SETUP.md
@@ -29,11 +29,7 @@ Download the latest release from:
 https://github.com/VincentShipsIt/meterbar.app/releases
 ```
 
-The release build is currently unsigned/not notarized. If macOS blocks the first launch, right-click `MeterBar.app` and choose Open, or run:
-
-```bash
-xattr -cr /Applications/MeterBar.app
-```
+Release builds are signed with a Developer ID certificate and notarized by Apple, so the app opens normally after download.
 
 ## Development Prerequisites
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,27 @@ on:
     tags:
       - 'v*'
 
+# Deny-by-default at the top level; the build job elevates to contents: write
+# only because it publishes a GitHub release.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-26
-    timeout-minutes: 45
+    timeout-minutes: 60
     permissions:
       contents: write
+
     env:
-      # Keep the pushed tag out of inline shell interpolation. A malicious tag
-      # such as v1$(...) must be data, never executable script.
+      # Apple Developer Team identifier (documentation / disambiguation only;
+      # the actual signing identity is resolved dynamically from the keychain).
+      TEAMID: S329JK3JRB
+      # notarytool keychain-profile name (stored in the temp keychain at runtime).
+      NOTARY_PROFILE: asc-profile
+      # The pushed tag, surfaced as an env var so it is never expanded straight into a
+      # shell `run:` block (a malicious tag like `v1$(...)` would otherwise inject commands
+      # into a job that handles signing secrets). Shell steps reference "$REF_NAME".
       REF_NAME: ${{ github.ref_name }}
 
     steps:
@@ -26,6 +38,49 @@ jobs:
       - name: Show Xcode version
         run: xcodebuild -version
 
+      # Resolve ephemeral file paths under RUNNER_TEMP (outside the workspace) and export
+      # them for later steps. The `runner` context is NOT available in job-level `env:`,
+      # so these are computed here where $RUNNER_TEMP is a real shell variable, then
+      # written fully-resolved into $GITHUB_ENV.
+      - name: Configure signing paths
+        run: |
+          {
+            echo "CERT_PATH=$RUNNER_TEMP/build_certificate.p12"
+            echo "ASC_KEY_PATH=$RUNNER_TEMP/asc_api_key.p8"
+            echo "KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db"
+            echo "KEYCHAIN_LIST_BACKUP=$RUNNER_TEMP/original-keychains.list"
+          } >> "$GITHUB_ENV"
+
+      # 0) PREFLIGHT: fail FAST (before any build work) if any required signing secret is
+      #    missing. Releases must be signed + notarized, so an absent secret is fatal.
+      #    We only check presence (non-empty), never print values.
+      - name: Preflight - require signing secrets
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in BUILD_CERTIFICATE_BASE64 P12_PASSWORD KEYCHAIN_PASSWORD \
+                      ASC_API_KEY_BASE64 ASC_KEY_ID ASC_ISSUER_ID; do
+            # Indirect expansion: read the env var named in $name without echoing its value.
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "::error::Missing required signing secret(s): ${missing[*]}" >&2
+            echo "Add them under Settings > Secrets and variables > Actions (see issue #47 for the recipe), then re-run." >&2
+            exit 1
+          fi
+          echo "All required signing secrets are present."
+
+      # 1) Build the app UNSIGNED exactly as before. Signing is done by hand later,
+      #    inside-out, after the CLI helper is injected.
       - name: Build app
         run: |
           xcodebuild -project MeterBar.xcodeproj \
@@ -38,6 +93,7 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             build
 
+      # 2) Build the CLI helper and inject it into Contents/Helpers (kept as today).
       - name: Build CLI
         run: |
           cd MeterBarCLI
@@ -58,32 +114,273 @@ jobs:
 
           test "$CLI_VERSION" = "$APP_VERSION"
 
+      # 3) Import the Developer ID cert + private key into a DEDICATED temporary keychain,
+      #    and store the notarization API key profile in that same keychain.
+      - name: Import signing assets
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+
+          # Decode straight to disk; -o avoids piping secret bytes through stdout/logs.
+          # macOS base64 does not line-wrap by default, so single-line blobs decode cleanly.
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o "$CERT_PATH"
+          echo -n "$ASC_API_KEY_BASE64"       | base64 --decode -o "$ASC_KEY_PATH"
+
+          # Capture the ORIGINAL user keychain search list so cleanup can restore it exactly,
+          # rather than assuming a hardcoded default that might differ on this runner image.
+          security list-keychains -d user | tr -d '"' | sed 's/^[[:space:]]*//' > "$KEYCHAIN_LIST_BACKUP"
+
+          # DEDICATED temporary keychain.
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          # -l lock on sleep, -u lock on timeout, -t 21600 = 6h. Bounds key reachability.
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import the identity (cert + private key) from the .p12. Do NOT pass -t cert:
+          # that would import only the certificate and drop the private key, leaving an
+          # unusable identity. -T whitelists codesign/security to use the key headlessly.
+          security import "$CERT_PATH" \
+            -P "$P12_PASSWORD" \
+            -f pkcs12 \
+            -k "$KEYCHAIN_PATH" \
+            -T /usr/bin/codesign -T /usr/bin/security
+
+          # Add temp keychain to the USER search list WITHOUT clobbering login.keychain.
+          # Word-splitting of the existing list into separate args is intentional.
+          # shellcheck disable=SC2046
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+          # CRITICAL: authorize non-interactive key access. Without this, codesign on a
+          # headless runner triggers the keychain ACL GUI prompt -> errSecInternalComponent
+          # or an indefinite hang. -T on import alone is NOT sufficient.
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # HARD GATE: exactly ONE Developer ID Application identity must be present in the
+          # temp keychain. Zero -> nothing to sign with. More than one -> ambiguous .p12,
+          # codesign could silently pick the wrong cert. Fail fast either way.
+          COUNT=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | grep -c "Developer ID Application" || true)
+          echo "Developer ID Application identities found: $COUNT"
+          if [ "$COUNT" -ne 1 ]; then
+            echo "::error::Expected exactly 1 Developer ID Application identity in the temp keychain, found $COUNT." >&2
+            security find-identity -v -p codesigning "$KEYCHAIN_PATH" >&2 || true
+            exit 1
+          fi
+
+          # Store notarization creds in the disposable keychain (validates them immediately,
+          # and they vanish when the keychain is deleted in cleanup). Non-interactive when
+          # all of --key/--key-id/--issuer are supplied.
+          xcrun notarytool store-credentials "$NOTARY_PROFILE" \
+            --key "$ASC_KEY_PATH" \
+            --key-id "$ASC_KEY_ID" \
+            --issuer "$ASC_ISSUER_ID" \
+            --keychain "$KEYCHAIN_PATH"
+
+      # 4) Sign INSIDE-OUT by hand: frameworks (defensive) -> helper -> appex -> outer app.
+      #    No --deep at sign time. Per-target entitlements keep the widget SANDBOXED and the
+      #    main app NON-sandboxed. Only Apple system frameworks are linked and
+      #    swift-argument-parser is statically linked into the meterbar Mach-O, so there are
+      #    NO embedded dylibs to sign today; the Frameworks loop below is a defensive no-op.
+      - name: Codesign (inside-out)
+        id: codesign
+        env:
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Resolve the exact Developer ID Application identity by its SHA-1 hash from OUR
+          # keychain ONLY (codesign accepts a hash), so it cannot pick a same-named cert from
+          # another keychain and we never hardcode a CN that may not match the real cert.
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | grep "Developer ID Application" | head -1 | awk '{print $2}')
+          if [ -z "${IDENTITY:-}" ]; then
+            echo "::error::No Developer ID Application identity found in $KEYCHAIN_PATH" >&2
+            exit 1
+          fi
+          echo "Using signing identity (SHA-1): $IDENTITY"
+
+          APP_PATH=$(find build -name "MeterBar.app" -type d | head -1)
+          if [ -z "${APP_PATH:-}" ]; then
+            echo "::error::MeterBar.app not found under build/" >&2
+            exit 1
+          fi
+          echo "App: $APP_PATH"
+          echo "app_path=$APP_PATH" >> "$GITHUB_OUTPUT"
+
+          APPEX="$APP_PATH/Contents/PlugIns/MeterBarWidgetExtension.appex"
+          if [ ! -d "$APPEX" ]; then
+            echo "::error::Widget extension not found at $APPEX" >&2
+            exit 1
+          fi
+          HELPER="$APP_PATH/Contents/Helpers/meterbar"
+          if [ ! -f "$HELPER" ]; then
+            echo "::error::Injected helper not found at $HELPER" >&2
+            exit 1
+          fi
+
+          sign() {
+            # $1 = path, remaining args = extra flags (e.g. --entitlements <file>)
+            local target="$1"; shift
+            codesign --force --timestamp --options runtime \
+              --keychain "$KEYCHAIN_PATH" \
+              --sign "$IDENTITY" "$@" \
+              "$target"
+          }
+
+          # 4a) Defensive: any embedded frameworks/dylibs in the OUTER app (deepest first).
+          #     Expected to be empty (only system frameworks are linked). Frameworks take
+          #     NO entitlements.
+          if [ -d "$APP_PATH/Contents/Frameworks" ]; then
+            while IFS= read -r -d '' fw; do
+              echo "Signing app framework: $fw"
+              sign "$fw"
+            done < <(find "$APP_PATH/Contents/Frameworks" -maxdepth 1 \( -name '*.framework' -o -name '*.dylib' \) -print0)
+          fi
+
+          # 4b) The INJECTED CLI helper (a bare Mach-O). MUST be signed with hardened runtime;
+          #     no entitlements needed.
+          sign "$HELPER"
+
+          # 4c) The widget extension - SANDBOXED via its own entitlements file.
+          sign "$APPEX" --entitlements MeterBarWidget/MeterBarWidget.entitlements
+
+          # 4d) The OUTER .app LAST - NON-sandboxed via the main app entitlements. This
+          #     re-seals over the injected helper + appex (the original Xcode signature is
+          #     stale since the helper was added post-build).
+          sign "$APP_PATH" --entitlements MeterBar/MeterBar.entitlements
+
+      # 5) HARD GATE on the per-target entitlement split BEFORE notarizing. The widget appex
+      #    MUST be sandboxed; the main app MUST NOT be sandboxed. Parse the signed-in
+      #    entitlements as clean XML and read the key with PlistBuddy (dotted entitlement
+      #    keys are literal after ':'), which is robust vs. text grepping the single-line XML.
+      - name: Verify entitlement split
+        run: |
+          set -euo pipefail
+          APP_PATH="${{ steps.codesign.outputs.app_path }}"
+          APPEX="$APP_PATH/Contents/PlugIns/MeterBarWidgetExtension.appex"
+          APPEX_ENT="$RUNNER_TEMP/appex.entitlements.plist"
+          APP_ENT="$RUNNER_TEMP/app.entitlements.plist"
+
+          # Dump signed-in entitlements as clean XML; keep stderr so a codesign failure is
+          # diagnosable, and guard against an empty/partial dump confusing the PlistBuddy read.
+          codesign -d --entitlements - --xml "$APPEX" > "$APPEX_ENT" 2> "$RUNNER_TEMP/appex.codesign.err" \
+            || { echo "::error::codesign -d failed for the widget extension"; cat "$RUNNER_TEMP/appex.codesign.err" >&2; exit 1; }
+          codesign -d --entitlements - --xml "$APP_PATH" > "$APP_ENT" 2> "$RUNNER_TEMP/app.codesign.err" \
+            || { echo "::error::codesign -d failed for the main app"; cat "$RUNNER_TEMP/app.codesign.err" >&2; exit 1; }
+          [ -s "$APPEX_ENT" ] || { echo "::error::Empty entitlements dump for the widget extension." >&2; exit 1; }
+          [ -s "$APP_ENT" ]   || { echo "::error::Empty entitlements dump for the main app." >&2; exit 1; }
+
+          echo "::group::Widget extension entitlements"; plutil -p "$APPEX_ENT" || true; echo "::endgroup::"
+          echo "::group::Main app entitlements"; plutil -p "$APP_ENT" || true; echo "::endgroup::"
+
+          # Widget MUST be sandboxed.
+          APPEX_SANDBOX=$(/usr/libexec/PlistBuddy -c "Print :com.apple.security.app-sandbox" "$APPEX_ENT" 2>/dev/null || echo "absent")
+          if [ "$APPEX_SANDBOX" != "true" ]; then
+            echo "::error::Widget extension is NOT sandboxed (app-sandbox=$APPEX_SANDBOX)." >&2
+            exit 1
+          fi
+
+          # Main app MUST NOT be sandboxed (absent or false are both acceptable).
+          APP_SANDBOX=$(/usr/libexec/PlistBuddy -c "Print :com.apple.security.app-sandbox" "$APP_ENT" 2>/dev/null || echo "absent")
+          if [ "$APP_SANDBOX" = "true" ]; then
+            echo "::error::Main app is unexpectedly sandboxed (app-sandbox=true)." >&2
+            exit 1
+          fi
+
+          echo "Entitlement split verified: widget sandboxed (app-sandbox=$APPEX_SANDBOX), main app not sandboxed (app-sandbox=$APP_SANDBOX)."
+
+      # 6) Notarize the signed app, then staple the ticket onto the .app bundle.
+      #    notarytool submit --wait blocks on Apple's servers. The inner '--timeout 40m'
+      #    bounds the wait so an Apple-side backlog fails clearly (with a poll-able
+      #    submission id) instead of silently consuming the whole 60-min job timeout.
+      - name: Notarize and staple
+        env:
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          APP_PATH="${{ steps.codesign.outputs.app_path }}"
+          SUBMIT_ZIP="$RUNNER_TEMP/MeterBar-notarize.zip"
+
+          # A bare .app must be zipped with ditto for a ticket-compatible archive.
+          ditto -c -k --keepParent "$APP_PATH" "$SUBMIT_ZIP"
+
+          # Submit and block until Apple finishes; capture JSON to read id/status.
+          set +e
+          SUBMIT_OUT=$(xcrun notarytool submit "$SUBMIT_ZIP" \
+            --keychain-profile "$NOTARY_PROFILE" \
+            --keychain "$KEYCHAIN_PATH" \
+            --timeout 40m \
+            --wait --output-format json)
+          SUBMIT_RC=$?
+          set -e
+          echo "$SUBMIT_OUT"
+
+          SUBID=$(echo "$SUBMIT_OUT" | /usr/bin/python3 -c 'import sys,json;print(json.load(sys.stdin).get("id",""))' 2>/dev/null || true)
+          STATUS=$(echo "$SUBMIT_OUT" | /usr/bin/python3 -c 'import sys,json;print(json.load(sys.stdin).get("status",""))' 2>/dev/null || true)
+          echo "Notarization id=$SUBID status=$STATUS rc=$SUBMIT_RC"
+
+          if [ "$STATUS" != "Accepted" ] || [ "$SUBMIT_RC" -ne 0 ]; then
+            echo "::error::Notarization did not succeed (status=$STATUS rc=$SUBMIT_RC). Pulling detailed log." >&2
+            if [ -n "${SUBID:-}" ]; then
+              xcrun notarytool log "$SUBID" \
+                --keychain-profile "$NOTARY_PROFILE" \
+                --keychain "$KEYCHAIN_PATH" \
+                "$RUNNER_TEMP/developer_log.json" || true
+              cat "$RUNNER_TEMP/developer_log.json" || true
+            fi
+            exit 1
+          fi
+
+          # Staple the ticket onto the bundle (cannot staple a .zip).
+          xcrun stapler staple "$APP_PATH"
+
+      # 7) Verify Gatekeeper acceptance + signature integrity + stapled ticket. Fail on error.
+      - name: Verify signature, Gatekeeper, and staple
+        run: |
+          set -euo pipefail
+          APP_PATH="${{ steps.codesign.outputs.app_path }}"
+
+          echo "::group::spctl assessment (type execute)"
+          spctl --assess --type execute --verbose=4 "$APP_PATH"
+          echo "::endgroup::"
+
+          echo "::group::codesign --verify --deep --strict"
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          echo "::endgroup::"
+
+          echo "::group::stapler validate"
+          xcrun stapler validate "$APP_PATH"
+          echo "::endgroup::"
+
+      # 8) Re-zip the STAPLED bundle and compute the SHA256 on that FINAL artifact (this is
+      #    what the Homebrew cask consumes via MeterBar-<version>.zip.sha256). The pre-staple
+      #    zip differs byte-for-byte, so the SHA must be computed here, after stapling.
       - name: Create release package
+        id: package
         run: |
           set -euo pipefail
           VERSION="$REF_NAME"
+          APP_PATH="${{ steps.codesign.outputs.app_path }}"
 
-          # Find the built app
-          APP_PATH=$(find build -name "MeterBar.app" -type d | head -1)
-          [[ -n "$APP_PATH" ]] || { echo "::error::MeterBar.app not found under build/"; exit 1; }
-          echo "Found app at: $APP_PATH"
+          ZIP="${{ github.workspace }}/MeterBar-${VERSION}.zip"
+          ditto -c -k --keepParent "$APP_PATH" "$ZIP"
 
-          # Create zip using ditto (preserves attributes better than zip)
-          cd "$(dirname "$APP_PATH")"
-          ditto -c -k --keepParent "MeterBar.app" "MeterBar-${VERSION}.zip"
-
-          # Compute SHA256
-          SHA256=$(shasum -a 256 "MeterBar-${VERSION}.zip" | cut -d ' ' -f 1)
+          SHA256=$(shasum -a 256 "$ZIP" | cut -d ' ' -f 1)
           echo "SHA256: $SHA256"
-          echo "$SHA256" > "MeterBar-${VERSION}.zip.sha256"
+          echo "$SHA256" > "${ZIP}.sha256"
 
-          # Move to workspace root
-          mv "MeterBar-${VERSION}.zip" "${{ github.workspace }}/"
-          mv "MeterBar-${VERSION}.zip.sha256" "${{ github.workspace }}/"
-
-          # Set output for later steps
           echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
-        id: package
 
       - name: Create Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
@@ -104,6 +401,26 @@ jobs:
             echo ""
             echo "**SHA256:** \`$(cat "MeterBar-${REF_NAME}.zip.sha256")\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # 9) Cleanup - ALWAYS, even on failure. Remove the temp keychain + decoded secrets,
+      #    restore the ORIGINAL captured user keychain search list. Never leak secrets.
+      - name: Clean up keychain and secret files
+        if: ${{ always() }}
+        run: |
+          security delete-keychain "$KEYCHAIN_PATH" || true
+          # Restore the exact original user search list captured before we modified it.
+          if [ -f "$KEYCHAIN_LIST_BACKUP" ] && [ -s "$KEYCHAIN_LIST_BACKUP" ]; then
+            # shellcheck disable=SC2046
+            security list-keychains -d user -s $(cat "$KEYCHAIN_LIST_BACKUP") || true
+          else
+            security list-keychains -d user -s login.keychain-db || true
+          fi
+          rm -f "$CERT_PATH" "$ASC_KEY_PATH" \
+                "$RUNNER_TEMP/MeterBar-notarize.zip" \
+                "$RUNNER_TEMP/developer_log.json" \
+                "$RUNNER_TEMP/appex.entitlements.plist" "$RUNNER_TEMP/app.entitlements.plist" \
+                "$RUNNER_TEMP/appex.codesign.err" "$RUNNER_TEMP/app.codesign.err" \
+                "$KEYCHAIN_LIST_BACKUP" || true
 
   # After the release is published, bump the Homebrew cask in VincentShipsIt/homebrew-tap.
   # Called directly (not via `release: published`) because GITHUB_TOKEN-created releases

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A lightweight macOS menu bar app that monitors Claude Code, Codex CLI, and Curso
 Paste this into your local coding agent to have it install MeterBar for you:
 
 ```text
-Install MeterBar on this Mac. First verify this is macOS 13 or newer and that Homebrew is available. Install with: brew tap VincentShipsIt/tap && brew install --cask VincentShipsIt/tap/meterbar. If Homebrew is missing, ask before installing Homebrew. After installing, verify /Applications/MeterBar.app exists and that the meterbar CLI is linked, then open MeterBar. If macOS blocks the first launch because the app is unsigned, remove quarantine with xattr -cr /Applications/MeterBar.app and open it again. Do not ask me for API keys or paste secrets; for usage data, tell me to run claude login, codex login, and log into Cursor if I want those providers tracked.
+Install MeterBar on this Mac. First verify this is macOS 13 or newer and that Homebrew is available. Install with: brew tap VincentShipsIt/tap && brew install --cask VincentShipsIt/tap/meterbar. If Homebrew is missing, ask before installing Homebrew. After installing, verify /Applications/MeterBar.app exists and that the meterbar CLI is linked, then open MeterBar. Do not ask me for API keys or paste secrets; for usage data, tell me to run claude login, codex login, and log into Cursor if I want those providers tracked.
 ```
 
 ### Homebrew (Recommended)
@@ -77,10 +77,7 @@ brew upgrade --cask VincentShipsIt/tap/meterbar
 
 Download the latest release from the [Releases](https://github.com/VincentShipsIt/meterbar.app/releases) page.
 
-> **Note**: Since the app isn't notarized, you may need to right-click and select "Open" the first time, or run:
-> ```bash
-> xattr -cr /Applications/MeterBar.app
-> ```
+Releases are signed with a Developer ID certificate and notarized by Apple, so the app opens normally after download — no Gatekeeper workarounds needed.
 
 ### Build from Source
 


### PR DESCRIPTION
## Summary

Un-defers **#47** (audit risk R2: unsigned, un-notarized release zips + `xattr -cr` workaround in README).

- Restores the reviewed signing/notarization pipeline from **#43** (reverted by #48) into `release.yml`, merged with everything master gained since: the bundled-CLI version gate (#54), the `update-homebrew` follow-up job, and the `REF_NAME` tag-injection hardening.
- Pipeline: preflight secrets gate → unsigned build → inject CLI helper → temp-keychain import (exactly-one-identity gate) → **inside-out codesign with hardened runtime + timestamp** (`Contents/Helpers/meterbar` → sandboxed `MeterBarWidgetExtension.appex` → outer `.app`) → entitlement-split hard gate → `notarytool submit --wait --timeout 40m` (ASC API key) → `stapler staple` → `spctl` / `codesign --verify --deep --strict` / `stapler validate` → SHA256 computed on the **final stapled** zip → `always()` keychain cleanup.
- README + `.agents/docs/SETUP.md`: dropped the `xattr -cr` quarantine workaround (manual-download note and agent install prompt); both now state releases are signed + notarized.
- Job timeout 45 → 60 min for the notarization wait; top-level permissions now deny-by-default.

## Before merging / before the next tag push

⚠️ The workflow **fails fast** without the 6 Actions secrets from #47's table (exact export commands there): `BUILD_CERTIFICATE_BASE64`, `P12_PASSWORD`, `KEYCHAIN_PASSWORD`, `ASC_API_KEY_BASE64`, `ASC_KEY_ID`, `ASC_ISSUER_ID`. Team ID `S329JK3JRB` is baked in as documentation only; the identity is resolved from the imported cert.

Secret names follow issue #47's documented recipe rather than the `DEVELOPER_ID_CERT_P12` shorthand from the task request — #47 is the canonical re-enable doc.

## Verification

- `actionlint` (incl. embedded shellcheck) clean.
- End-to-end proof requires a real tag push once secrets exist. On first signed release, also verify the app↔widget Group Container resolves (bare `group.dev.shipshit.meterbar` under Developer ID — caveat carried from #43/#47) and check the Homebrew tap cask for stale unsigned-app caveats.

Closes #47 acceptance items 1 & 4 (pipeline + tag hardening); remaining items need the secrets and a real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)