### PR TITLE
Notification preferences + Launch at Login (Tiers 2b, 2c)

### DIFF
--- a/.agents/SESSIONS/2026-07-03.md
+++ b/.agents/SESSIONS/2026-07-03.md
@@ -1,0 +1,85 @@
+# Sessions: 2026-07-03
+
+**Summary:** Notification prefs + Launch at Login
+
+---
+
+## Session 1: Tier 2b + 2c — notification preferences & Launch at Login
+
+**Duration:** ~1 hour
+**Status:** Complete (pending CI)
+
+### What was done
+
+Implemented backlog Tiers 2b + 2c (issues #23 and #27) in one PR, TDD-style.
+
+**2b — Notification preferences (#23):**
+- Kept the existing band-crossing dedup (`notifiedLimitKeys`); extracted the
+  threshold-crossing decision out of `AppDelegate.checkAndNotify` into a pure,
+  unit-tested `NotificationDecider`.
+- Thresholds wired into the shared `QuotaBand.forLimit` evaluation (bands ranked
+  by severity) — **not** a parallel percentage path. Users pick which band warns
+  and which alerts via `NotificationThreshold` (tight / critical / exhausted).
+- Added a global on/off toggle + two threshold pickers to Settings, persisted via
+  `NotificationPreferencesStore` (same `UserDefaults` pattern as
+  `DockVisibilityStore`).
+- Decider gates: never notify when globally off, when the provider is disabled,
+  or when the metric is stale (>1h old vs `lastUpdated`).
+
+**2c — Launch at Login (#27):**
+- `LaunchAtLoginControlling` protocol seam + `SMAppServiceLaunchAtLogin`
+  (`SMAppService.mainApp`) concrete wrapper.
+- `LaunchAtLoginStore` holds status, drives register/unregister, surfaces
+  registration errors inline, and re-reads `SMAppService.mainApp.status` on
+  Settings appear (it can change behind the app's back).
+- Settings row (Toggle + inline error) added to the General section.
+
+### Files changed
+
+- `MeterBar/Services/NotificationDecider.swift` - new pure decision + gates
+- `MeterBar/Models/NotificationThreshold.swift` - new threshold enum + prefs value
+- `MeterBar/Services/NotificationPreferencesStore.swift` - new UserDefaults store
+- `MeterBar/Services/LaunchAtLoginService.swift` - new protocol seam + SMAppService wrapper
+- `MeterBar/Services/LaunchAtLoginStore.swift` - new toggle/status store
+- `MeterBar/App/MeterBarApp.swift` - `checkAndNotify` now delegates to the decider
+- `MeterBar/Views/SettingsView.swift` - Notifications section + Launch at Login row
+- `MeterBar/Models/StorageKeys.swift` - 3 new keys
+- `MeterBarTests/NotificationDeciderTests.swift` - crossing matrix + gates
+- `MeterBarTests/NotificationPreferencesStoreTests.swift` - defaults/persistence
+- `MeterBarTests/LaunchAtLoginStoreTests.swift` - toggle logic via fake controller
+
+### Decisions
+
+- **Decision:** Put all decision/toggle logic in SwiftPM-compiled files, keep the
+  `MeterBarApp.swift` (AppDelegate) edit trivial.
+  - **Context:** The SwiftPM `MeterBar` target excludes `App/MeterBarApp.swift`;
+    PR CI only runs `swift build` (SwiftPM) + `swift test`, not the full
+    `xcodebuild`. Logic left in the delegate would be neither compiled nor tested
+    on PRs.
+  - **Rationale:** The pure `NotificationDecider` / stores are fully compiled and
+    unit-tested; the delegate just threads the dedup set and formats copy.
+
+- **Decision:** Thresholds map to `QuotaBand`, ranked by severity, rather than a
+  new numeric threshold.
+  - **Context:** #23 explicitly requires wiring into the existing band evaluation.
+  - **Rationale:** One source of truth for "how full is this quota"; defaults
+    (warn `.critical`, alert `.exhausted`) reproduce the prior behavior exactly.
+
+- **Decision:** 1-hour staleness bound.
+  - **Rationale:** Longer than every non-manual refresh interval (max 30 min) so
+    fresh data is never suppressed, short enough to drop an ancient cache.
+
+### Mistakes and fixes
+
+- **Mistake:** N/A — no rework this session.
+- **Note:** `swift test` and SwiftLint can't run locally (CLT-only: no XCTest
+  module, no sourcekitd). Verified via `swift build` (library compiles) + manual
+  line-length/whitespace scan; the XCTest suite + SwiftLint run on CI.
+
+### Next steps
+
+- [ ] Confirm PR CI green (build + tests + coverage + lint).
+
+---
+
+**Total sessions today:** 1

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -27,6 +27,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var popover: NSPopover?
     private let providerVisibilityStore = ProviderVisibilityStore.shared
     private let dockVisibilityStore = DockVisibilityStore.shared
+    private let notificationPreferences = NotificationPreferencesStore.shared
     private var cancellables = Set<AnyCancellable>()
     private var monitorTask: Task<Void, Never>?
 
@@ -254,9 +255,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Note: UsageDataManager handles its own auto-refresh; this loop only
         // checks metrics for notification purposes.
         while !Task.isCancelled {
-            for (service, metrics) in UsageDataManager.shared.metrics where providerVisibilityStore.isEnabled(service) {
-                checkAndNotify(metrics: metrics)
-            }
+            checkAndNotify()
 
             // Wait 5 minutes before next notification check. A thrown
             // CancellationError exits the loop instead of busy-looping.
@@ -268,46 +267,43 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    private func checkAndNotify(metrics: UsageMetrics) {
-        let limits: [(limit: UsageLimit, type: String)] = [
-            (metrics.sessionLimit, "session"),
-            (metrics.weeklyLimit, "weekly"),
-            (metrics.codeReviewLimit, "codeReview")
-        ].compactMap { pair in pair.0.map { ($0, pair.1) } }
+    /// Evaluates every tracked service's metrics against the user's notification
+    /// preferences and posts any warning/critical crossings. All decision logic
+    /// lives in the pure, unit-tested `NotificationDecider`; this method only
+    /// threads the dedup key set and turns fired decisions into banners.
+    private func checkAndNotify() {
+        let decider = NotificationDecider(preferences: notificationPreferences.preferences)
+        let now = Date()
+        var keys = notifiedLimitKeys
 
-        for (limit, limitType) in limits {
-            let baseKey = "\(metrics.service.rawValue)-\(limitType)"
-            let warnKey = "\(baseKey)-warn"
-            let criticalKey = "\(baseKey)-critical"
-
-            // Same bands as every other surface: warn in the critical band
-            // (≤10% left ≡ the old ≥90% used), alert when exhausted.
-            switch QuotaBand.forLimit(limit) {
-            case .exhausted:
-                // Only fire once per crossing; supersede any pending warn alert.
-                notifiedLimitKeys.remove(warnKey)
-                if notifiedLimitKeys.insert(criticalKey).inserted {
-                    sendNotification(
-                        identifier: criticalKey,
-                        title: "\(metrics.service.displayName) Limit Reached",
-                        body: "You've reached your usage limit"
-                    )
-                }
-            case .critical:
-                if notifiedLimitKeys.insert(warnKey).inserted {
-                    sendNotification(
-                        identifier: warnKey,
-                        title: "\(metrics.service.displayName) Usage Warning",
-                        body: "You're at \(Int(limit.percentage))% of your limit"
-                    )
-                }
-            case .healthy, .tight:
-                // Usage fell back below the threshold; allow the next crossing to
-                // notify again.
-                notifiedLimitKeys.remove(warnKey)
-                notifiedLimitKeys.remove(criticalKey)
+        for (service, metrics) in UsageDataManager.shared.metrics {
+            let evaluation = decider.evaluate(
+                metrics: metrics,
+                providerEnabled: providerVisibilityStore.isEnabled(service),
+                alreadyNotified: keys,
+                now: now
+            )
+            keys = evaluation.notifiedKeys
+            for fired in evaluation.notifications {
+                postNotification(fired)
             }
         }
+
+        notifiedLimitKeys = keys
+    }
+
+    private func postNotification(_ fired: FiredNotification) {
+        let title: String
+        let body: String
+        switch fired.level {
+        case .warning:
+            title = "\(fired.serviceDisplayName) Usage Warning"
+            body = "You're at \(fired.percentUsed)% of your limit"
+        case .critical:
+            title = "\(fired.serviceDisplayName) Limit Reached"
+            body = "You've reached your usage limit"
+        }
+        sendNotification(identifier: fired.key, title: title, body: body)
     }
 
     private func sendNotification(identifier: String, title: String, body: String) {

--- a/MeterBar/Models/NotificationThreshold.swift
+++ b/MeterBar/Models/NotificationThreshold.swift
@@ -1,0 +1,68 @@
+import Foundation
+import MeterBarShared
+
+/// A user-selectable notification threshold, expressed in terms of the shared
+/// `QuotaBand` severities rather than a parallel percentage scale.
+///
+/// Notifications are decided by mapping each threshold to its `QuotaBand` and
+/// comparing against `QuotaBand.forLimit(limit)` — the exact same band math the
+/// menu bar, popover, widget, and CLI already use. This keeps a single source of
+/// truth for "how full is this quota"; the user only picks *which band* should
+/// warn and which should alert.
+enum NotificationThreshold: String, CaseIterable, Identifiable, Sendable {
+    /// 25% or less remaining.
+    case tight
+    /// 10% or less remaining.
+    case critical
+    /// Quota fully spent.
+    case exhausted
+
+    var id: String { rawValue }
+
+    /// The shared quota band this threshold corresponds to.
+    var band: QuotaBand {
+        switch self {
+        case .tight: return .tight
+        case .critical: return .critical
+        case .exhausted: return .exhausted
+        }
+    }
+
+    /// Human-readable label for the Settings pickers.
+    var displayName: String {
+        switch self {
+        case .tight: return "When quota is tight (25% left)"
+        case .critical: return "When quota is critical (10% left)"
+        case .exhausted: return "When quota is exhausted"
+        }
+    }
+
+    /// The choices offered for the "warn me" picker — early-warning bands only.
+    static let warningOptions: [NotificationThreshold] = [.tight, .critical]
+
+    /// The choices offered for the "alert me" picker — the more severe bands.
+    static let criticalOptions: [NotificationThreshold] = [.critical, .exhausted]
+}
+
+/// The pure inputs the notification decision depends on: whether notifications
+/// are on at all, and the two configurable band thresholds.
+///
+/// Defaults preserve the pre-preferences behavior exactly — warn in the
+/// `.critical` band (≤10% left ≡ the old ≥90% used) and alert when `.exhausted`.
+struct NotificationPreferences: Equatable, Sendable {
+    var isEnabled: Bool
+    var warningThreshold: NotificationThreshold
+    var criticalThreshold: NotificationThreshold
+
+    init(
+        isEnabled: Bool = true,
+        warningThreshold: NotificationThreshold = .critical,
+        criticalThreshold: NotificationThreshold = .exhausted
+    ) {
+        self.isEnabled = isEnabled
+        self.warningThreshold = warningThreshold
+        self.criticalThreshold = criticalThreshold
+    }
+
+    static let `default` = NotificationPreferences()
+}

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -22,4 +22,10 @@ enum StorageKeys {
     static let claudeCodeDefaultAccountName = "ClaudeCodeDefaultAccountName"
     /// Persisted account display order (array of UUID strings).
     static let claudeCodeAccountOrder = "ClaudeCodeAccountOrder"
+    /// Global on/off switch for usage notifications.
+    static let notificationsEnabled = "NotificationsEnabled"
+    /// Raw value of the `NotificationThreshold` at which a warning notifies.
+    static let notificationWarningThreshold = "NotificationWarningThreshold"
+    /// Raw value of the `NotificationThreshold` at which a critical alert notifies.
+    static let notificationCriticalThreshold = "NotificationCriticalThreshold"
 }

--- a/MeterBar/Services/LaunchAtLoginService.swift
+++ b/MeterBar/Services/LaunchAtLoginService.swift
@@ -1,0 +1,47 @@
+import Foundation
+import ServiceManagement
+
+/// The login-item states MeterBar cares about, mapped from `SMAppService.Status`
+/// so the store and its tests never depend on ServiceManagement directly.
+enum LaunchAtLoginStatus: Equatable, Sendable {
+    /// Registered and will launch at login.
+    case enabled
+    /// Not registered.
+    case notRegistered
+    /// Registered but the user must approve it in System Settings › Login Items.
+    case requiresApproval
+    /// The login item could not be found (e.g. running from an unexpected path).
+    case notFound
+    case unknown
+}
+
+/// The seam the `LaunchAtLoginStore` toggles against. The concrete
+/// implementation wraps `SMAppService.mainApp`; tests substitute a fake so the
+/// toggle logic is exercised without touching the real login-item database.
+protocol LaunchAtLoginControlling {
+    func currentStatus() -> LaunchAtLoginStatus
+    func register() throws
+    func unregister() throws
+}
+
+/// Thin `SMAppService.mainApp` wrapper. macOS 13+ (deployment target is 26), so
+/// no availability guard is needed.
+struct SMAppServiceLaunchAtLogin: LaunchAtLoginControlling {
+    func currentStatus() -> LaunchAtLoginStatus {
+        switch SMAppService.mainApp.status {
+        case .enabled: return .enabled
+        case .notRegistered: return .notRegistered
+        case .requiresApproval: return .requiresApproval
+        case .notFound: return .notFound
+        @unknown default: return .unknown
+        }
+    }
+
+    func register() throws {
+        try SMAppService.mainApp.register()
+    }
+
+    func unregister() throws {
+        try SMAppService.mainApp.unregister()
+    }
+}

--- a/MeterBar/Services/LaunchAtLoginStore.swift
+++ b/MeterBar/Services/LaunchAtLoginStore.swift
@@ -1,0 +1,62 @@
+import Combine
+import Foundation
+
+/// Backs the Settings "Launch at Login" row.
+///
+/// Holds the current `SMAppService.mainApp` status and drives register /
+/// unregister through the injected `LaunchAtLoginControlling` seam. The status
+/// can change behind the app's back (a user can remove the login item in System
+/// Settings), so `refreshStatus()` re-reads it whenever Settings appears, and
+/// registration failures surface via `lastError` for inline display.
+final class LaunchAtLoginStore: ObservableObject {
+    static let shared = LaunchAtLoginStore()
+
+    @Published private(set) var status: LaunchAtLoginStatus
+    @Published private(set) var lastError: String?
+
+    private let controller: LaunchAtLoginControlling
+
+    init(controller: LaunchAtLoginControlling = SMAppServiceLaunchAtLogin()) {
+        self.controller = controller
+        status = controller.currentStatus()
+    }
+
+    /// Whether MeterBar is currently registered to launch at login.
+    var isEnabled: Bool { status == .enabled }
+
+    /// Row subtitle that adapts to the current status (including the
+    /// approval-required case the user must resolve in System Settings).
+    var detailText: String {
+        switch status {
+        case .enabled:
+            return "MeterBar opens automatically when you log in."
+        case .requiresApproval:
+            return "Approve MeterBar in System Settings › General › Login Items to finish enabling this."
+        case .notRegistered, .notFound, .unknown:
+            return "Open MeterBar automatically when you log in."
+        }
+    }
+
+    /// Re-reads the live login-item status. Call when Settings appears so an
+    /// external change (toggled in System Settings) is reflected.
+    func refreshStatus() {
+        status = controller.currentStatus()
+    }
+
+    /// Registers or unregisters the login item, surfacing any failure inline and
+    /// always re-reading the resulting status so the toggle reflects reality.
+    func setEnabled(_ enabled: Bool) {
+        lastError = nil
+        do {
+            if enabled {
+                try controller.register()
+            } else {
+                try controller.unregister()
+            }
+        } catch {
+            let action = enabled ? "enable" : "disable"
+            lastError = "Couldn't \(action) Launch at Login: \(error.localizedDescription)"
+        }
+        status = controller.currentStatus()
+    }
+}

--- a/MeterBar/Services/NotificationDecider.swift
+++ b/MeterBar/Services/NotificationDecider.swift
@@ -1,0 +1,145 @@
+import Foundation
+import MeterBarShared
+
+/// Which of the two notification levels a quota crossing produces.
+enum NotificationLevel: String, Equatable, Sendable {
+    /// Early warning — the quota entered the user's warning band.
+    case warning
+    /// Alert — the quota entered the user's critical band.
+    case critical
+}
+
+/// A single notification the decider decided should be posted this cycle.
+///
+/// Carries only what the delegate needs to compose copy; the delegate owns the
+/// actual `UNUserNotificationCenter` interaction so this stays pure.
+struct FiredNotification: Equatable, Sendable {
+    /// Stable identifier — re-posting the same id replaces the pending banner
+    /// instead of stacking a new one, and dedupes repeat crossings.
+    let key: String
+    let level: NotificationLevel
+    let serviceDisplayName: String
+    /// Clamped `0...100` percentage used, for the warning body copy.
+    let percentUsed: Int
+}
+
+/// The result of evaluating one service's metrics: the notifications to post and
+/// the updated set of already-notified keys (threaded back into the next cycle).
+struct NotificationEvaluation: Equatable, Sendable {
+    let notifications: [FiredNotification]
+    let notifiedKeys: Set<String>
+}
+
+/// Pure threshold-crossing decision extracted from `AppDelegate.checkAndNotify`.
+///
+/// Given a service's metrics, the user's preferences, and the set of bands
+/// already notified, it decides — deterministically, with no side effects and no
+/// hidden clock — which notifications should fire and how the dedup key set
+/// should change. This is the unit under test for the crossing matrix
+/// (rising / falling / repeat / threshold-change), plus the global-off,
+/// provider-disabled, and staleness gates.
+struct NotificationDecider {
+    let preferences: NotificationPreferences
+    /// Cached metrics older than this (relative to `now`) never notify, so a
+    /// stale on-disk cache from a previous session can't fire alerts about a
+    /// quota that may since have reset.
+    let stalenessThreshold: TimeInterval
+
+    /// One hour: comfortably longer than every non-manual refresh interval
+    /// (max 30 min), so fresh data is never mistaken for stale, while still
+    /// suppressing genuinely ancient cached values.
+    static let defaultStalenessThreshold: TimeInterval = 3_600
+
+    init(
+        preferences: NotificationPreferences,
+        stalenessThreshold: TimeInterval = NotificationDecider.defaultStalenessThreshold
+    ) {
+        self.preferences = preferences
+        self.stalenessThreshold = stalenessThreshold
+    }
+
+    func evaluate(
+        metrics: UsageMetrics,
+        providerEnabled: Bool,
+        alreadyNotified: Set<String>,
+        now: Date = Date()
+    ) -> NotificationEvaluation {
+        // Gate 1: notifications turned off globally.
+        guard preferences.isEnabled else {
+            return NotificationEvaluation(notifications: [], notifiedKeys: alreadyNotified)
+        }
+
+        // Gate 2: never notify for a provider the user has disabled.
+        guard providerEnabled else {
+            return NotificationEvaluation(notifications: [], notifiedKeys: alreadyNotified)
+        }
+
+        // Gate 3: never notify off stale cached data.
+        guard now.timeIntervalSince(metrics.lastUpdated) <= stalenessThreshold else {
+            return NotificationEvaluation(notifications: [], notifiedKeys: alreadyNotified)
+        }
+
+        let limits: [(limit: UsageLimit, type: String)] = [
+            (metrics.sessionLimit, "session"),
+            (metrics.weeklyLimit, "weekly"),
+            (metrics.codeReviewLimit, "codeReview")
+        ].compactMap { pair in pair.0.map { ($0, pair.1) } }
+
+        var keys = alreadyNotified
+        var fired: [FiredNotification] = []
+
+        let warningRank = Self.severityRank(preferences.warningThreshold.band)
+        let criticalRank = Self.severityRank(preferences.criticalThreshold.band)
+
+        for (limit, limitType) in limits {
+            let baseKey = "\(metrics.service.rawValue)-\(limitType)"
+            let warnKey = "\(baseKey)-warn"
+            let criticalKey = "\(baseKey)-critical"
+
+            let bandRank = Self.severityRank(QuotaBand.forLimit(limit))
+
+            if bandRank >= criticalRank {
+                // In (or past) the critical band. Supersede any pending warn
+                // alert, then fire once per crossing.
+                keys.remove(warnKey)
+                if keys.insert(criticalKey).inserted {
+                    fired.append(FiredNotification(
+                        key: criticalKey,
+                        level: .critical,
+                        serviceDisplayName: metrics.service.displayName,
+                        percentUsed: Int(limit.percentage)
+                    ))
+                }
+            } else if bandRank >= warningRank {
+                // In the warning band but not yet critical.
+                if keys.insert(warnKey).inserted {
+                    fired.append(FiredNotification(
+                        key: warnKey,
+                        level: .warning,
+                        serviceDisplayName: metrics.service.displayName,
+                        percentUsed: Int(limit.percentage)
+                    ))
+                }
+            } else {
+                // Fell back below both thresholds; allow the next crossing to
+                // notify again.
+                keys.remove(warnKey)
+                keys.remove(criticalKey)
+            }
+        }
+
+        return NotificationEvaluation(notifications: fired, notifiedKeys: keys)
+    }
+
+    /// Orders the shared quota bands by severity so a user-selected threshold
+    /// band can be compared against a limit's current band. This only ranks the
+    /// existing `QuotaBand` cases — it is not a second threshold scheme.
+    private static func severityRank(_ band: QuotaBand) -> Int {
+        switch band {
+        case .healthy: return 0
+        case .tight: return 1
+        case .critical: return 2
+        case .exhausted: return 3
+        }
+    }
+}

--- a/MeterBar/Services/NotificationPreferencesStore.swift
+++ b/MeterBar/Services/NotificationPreferencesStore.swift
@@ -1,0 +1,61 @@
+import Combine
+import Foundation
+
+/// Persists the user's notification preferences: the global on/off switch and
+/// the warning/critical band thresholds.
+///
+/// Mirrors `DockVisibilityStore` / `ProviderVisibilityStore` — a small
+/// `ObservableObject` backed by `UserDefaults`, injectable for tests. Defaults
+/// preserve the pre-preferences behavior (notifications on, warn at `.critical`,
+/// alert at `.exhausted`), so existing installs see no change until they opt in.
+final class NotificationPreferencesStore: ObservableObject {
+    static let shared = NotificationPreferencesStore()
+
+    @Published private(set) var isEnabled: Bool
+    @Published private(set) var warningThreshold: NotificationThreshold
+    @Published private(set) var criticalThreshold: NotificationThreshold
+
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+
+        if userDefaults.object(forKey: StorageKeys.notificationsEnabled) == nil {
+            isEnabled = true
+        } else {
+            isEnabled = userDefaults.bool(forKey: StorageKeys.notificationsEnabled)
+        }
+
+        warningThreshold = userDefaults.string(forKey: StorageKeys.notificationWarningThreshold)
+            .flatMap(NotificationThreshold.init(rawValue:)) ?? .critical
+        criticalThreshold = userDefaults.string(forKey: StorageKeys.notificationCriticalThreshold)
+            .flatMap(NotificationThreshold.init(rawValue:)) ?? .exhausted
+    }
+
+    /// The current preferences as a pure value, for handing to `NotificationDecider`.
+    var preferences: NotificationPreferences {
+        NotificationPreferences(
+            isEnabled: isEnabled,
+            warningThreshold: warningThreshold,
+            criticalThreshold: criticalThreshold
+        )
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        guard enabled != isEnabled else { return }
+        isEnabled = enabled
+        userDefaults.set(enabled, forKey: StorageKeys.notificationsEnabled)
+    }
+
+    func setWarningThreshold(_ threshold: NotificationThreshold) {
+        guard threshold != warningThreshold else { return }
+        warningThreshold = threshold
+        userDefaults.set(threshold.rawValue, forKey: StorageKeys.notificationWarningThreshold)
+    }
+
+    func setCriticalThreshold(_ threshold: NotificationThreshold) {
+        guard threshold != criticalThreshold else { return }
+        criticalThreshold = threshold
+        userDefaults.set(threshold.rawValue, forKey: StorageKeys.notificationCriticalThreshold)
+    }
+}

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -12,6 +12,8 @@ struct SettingsView: View {
     @StateObject private var costTracker = CostTracker.shared
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
     @StateObject private var dockVisibility = DockVisibilityStore.shared
+    @StateObject private var notificationPreferences = NotificationPreferencesStore.shared
+    @StateObject private var launchAtLogin = LaunchAtLoginStore.shared
     @StateObject private var authManager = AuthenticationManager.shared
     @StateObject private var apiUsageStore = ApiUsageStore.shared
 
@@ -46,6 +48,7 @@ struct SettingsView: View {
             apiUsageSection
             costTrackingSection
             refreshSection
+            notificationsSection
             generalSection
         }
         .formStyle(.grouped)
@@ -70,8 +73,77 @@ struct SettingsView: View {
         }
     }
 
+    private var notificationsSection: some View {
+        SettingsPanelSection(title: "Notifications", systemImage: "bell.badge", color: MeterBarTheme.appAccent) {
+            SettingsRowView(
+                title: "Usage notifications",
+                detail: "Notify when a tracked quota crosses a threshold. "
+                    + "Disabled providers and stale data never notify."
+            ) {
+                Toggle("", isOn: Binding(
+                    get: { notificationPreferences.isEnabled },
+                    set: { notificationPreferences.setEnabled($0) }
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+            }
+
+            if notificationPreferences.isEnabled {
+                SettingsRowView(
+                    title: "Warn me",
+                    detail: "First heads-up as a quota tightens."
+                ) {
+                    Picker("", selection: Binding(
+                        get: { notificationPreferences.warningThreshold },
+                        set: { notificationPreferences.setWarningThreshold($0) }
+                    )) {
+                        ForEach(NotificationThreshold.warningOptions) { threshold in
+                            Text(threshold.displayName).tag(threshold)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .frame(width: 240)
+                }
+
+                SettingsRowView(
+                    title: "Alert me",
+                    detail: "Stronger alert as a quota runs out."
+                ) {
+                    Picker("", selection: Binding(
+                        get: { notificationPreferences.criticalThreshold },
+                        set: { notificationPreferences.setCriticalThreshold($0) }
+                    )) {
+                        ForEach(NotificationThreshold.criticalOptions) { threshold in
+                            Text(threshold.displayName).tag(threshold)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .frame(width: 240)
+                }
+            }
+        }
+    }
+
     private var generalSection: some View {
         SettingsPanelSection(title: "General", systemImage: "dock.rectangle", color: MeterBarTheme.appAccent) {
+            SettingsRowView(
+                title: "Launch at Login",
+                detail: launchAtLogin.detailText
+            ) {
+                Toggle("", isOn: Binding(
+                    get: { launchAtLogin.isEnabled },
+                    set: { launchAtLogin.setEnabled($0) }
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+            }
+
+            if let error = launchAtLogin.lastError {
+                SettingsNotice(text: error, color: MeterBarTheme.warning)
+            }
+
             SettingsRowView(
                 title: "Show in Dock",
                 detail: "Show MeterBar's icon in the Dock. MeterBar always stays in the menu bar."
@@ -83,6 +155,11 @@ struct SettingsView: View {
                 .labelsHidden()
                 .toggleStyle(.switch)
             }
+        }
+        .onAppear {
+            // The login-item status can change behind the app's back in System
+            // Settings, so re-read it whenever settings is shown.
+            launchAtLogin.refreshStatus()
         }
     }
 

--- a/MeterBarTests/LaunchAtLoginStoreTests.swift
+++ b/MeterBarTests/LaunchAtLoginStoreTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import MeterBar
+
+final class LaunchAtLoginStoreTests: XCTestCase {
+    private enum FakeError: LocalizedError {
+        case boom
+        var errorDescription: String? { "operation not permitted" }
+    }
+
+    /// Test double for `SMAppService.mainApp`: records calls, mutates its own
+    /// status on success, and can be told to throw.
+    private final class FakeController: LaunchAtLoginControlling {
+        var status: LaunchAtLoginStatus
+        var registerError: Error?
+        var unregisterError: Error?
+        private(set) var registerCallCount = 0
+        private(set) var unregisterCallCount = 0
+
+        init(status: LaunchAtLoginStatus = .notRegistered) {
+            self.status = status
+        }
+
+        func currentStatus() -> LaunchAtLoginStatus { status }
+
+        func register() throws {
+            registerCallCount += 1
+            if let registerError { throw registerError }
+            status = .enabled
+        }
+
+        func unregister() throws {
+            unregisterCallCount += 1
+            if let unregisterError { throw unregisterError }
+            status = .notRegistered
+        }
+    }
+
+    func testInitialStatusReflectsController() {
+        let store = LaunchAtLoginStore(controller: FakeController(status: .enabled))
+        XCTAssertTrue(store.isEnabled)
+        XCTAssertNil(store.lastError)
+    }
+
+    func testEnablingRegistersAndReflectsStatus() {
+        let controller = FakeController(status: .notRegistered)
+        let store = LaunchAtLoginStore(controller: controller)
+
+        store.setEnabled(true)
+
+        XCTAssertEqual(controller.registerCallCount, 1)
+        XCTAssertTrue(store.isEnabled)
+        XCTAssertEqual(store.status, .enabled)
+        XCTAssertNil(store.lastError)
+    }
+
+    func testDisablingUnregisters() {
+        let controller = FakeController(status: .enabled)
+        let store = LaunchAtLoginStore(controller: controller)
+
+        store.setEnabled(false)
+
+        XCTAssertEqual(controller.unregisterCallCount, 1)
+        XCTAssertFalse(store.isEnabled)
+        XCTAssertEqual(store.status, .notRegistered)
+    }
+
+    func testRegisterErrorIsSurfacedAndStatusUnchanged() {
+        let controller = FakeController(status: .notRegistered)
+        controller.registerError = FakeError.boom
+        let store = LaunchAtLoginStore(controller: controller)
+
+        store.setEnabled(true)
+
+        XCTAssertFalse(store.isEnabled, "A failed register must not report enabled.")
+        XCTAssertNotNil(store.lastError)
+        XCTAssertTrue(store.lastError?.contains("enable") ?? false)
+        XCTAssertTrue(store.lastError?.contains("operation not permitted") ?? false)
+    }
+
+    func testUnregisterErrorIsSurfaced() {
+        let controller = FakeController(status: .enabled)
+        controller.unregisterError = FakeError.boom
+        let store = LaunchAtLoginStore(controller: controller)
+
+        store.setEnabled(false)
+
+        XCTAssertTrue(store.isEnabled, "A failed unregister leaves the item enabled.")
+        XCTAssertTrue(store.lastError?.contains("disable") ?? false)
+    }
+
+    func testRefreshStatusReflectsExternalChange() {
+        let controller = FakeController(status: .enabled)
+        let store = LaunchAtLoginStore(controller: controller)
+        XCTAssertTrue(store.isEnabled)
+
+        // User removes the login item in System Settings behind the app's back.
+        controller.status = .notRegistered
+        store.refreshStatus()
+
+        XCTAssertFalse(store.isEnabled)
+    }
+
+    func testRequiresApprovalIsNotEnabledAndExplains() {
+        let store = LaunchAtLoginStore(controller: FakeController(status: .requiresApproval))
+        XCTAssertFalse(store.isEnabled)
+        XCTAssertTrue(store.detailText.contains("System Settings"))
+    }
+
+    func testErrorClearsOnSuccessfulRetry() {
+        let controller = FakeController(status: .notRegistered)
+        controller.registerError = FakeError.boom
+        let store = LaunchAtLoginStore(controller: controller)
+        store.setEnabled(true)
+        XCTAssertNotNil(store.lastError)
+
+        controller.registerError = nil
+        store.setEnabled(true)
+
+        XCTAssertNil(store.lastError, "A successful retry should clear the prior error.")
+        XCTAssertTrue(store.isEnabled)
+    }
+}

--- a/MeterBarTests/NotificationDeciderTests.swift
+++ b/MeterBarTests/NotificationDeciderTests.swift
@@ -1,0 +1,229 @@
+import XCTest
+import MeterBarShared
+@testable import MeterBar
+
+/// Crossing matrix + gate coverage for the pure notification decision extracted
+/// from `AppDelegate.checkAndNotify`.
+final class NotificationDeciderTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - Band fixtures (chosen so QuotaBand.forLimit lands where we want)
+
+    /// 90% left → healthy.
+    private func healthyLimit() -> UsageLimit { UsageLimit(used: 10, total: 100, resetTime: nil) }
+    /// 20% left → tight.
+    private func tightLimit() -> UsageLimit { UsageLimit(used: 80, total: 100, resetTime: nil) }
+    /// 5% left → critical.
+    private func criticalLimit() -> UsageLimit { UsageLimit(used: 95, total: 100, resetTime: nil) }
+    /// 0% left → exhausted.
+    private func exhaustedLimit() -> UsageLimit { UsageLimit(used: 100, total: 100, resetTime: nil) }
+
+    private func metrics(
+        service: ServiceType = .claudeCode,
+        session: UsageLimit? = nil,
+        weekly: UsageLimit? = nil,
+        codeReview: UsageLimit? = nil,
+        lastUpdated: Date? = nil
+    ) -> UsageMetrics {
+        UsageMetrics(
+            service: service,
+            sessionLimit: session,
+            weeklyLimit: weekly,
+            codeReviewLimit: codeReview,
+            lastUpdated: lastUpdated ?? now
+        )
+    }
+
+    private func decider(_ preferences: NotificationPreferences = .default) -> NotificationDecider {
+        NotificationDecider(preferences: preferences)
+    }
+
+    // MARK: - Rising
+
+    func testWarningFiresOnRiseIntoCriticalBand() {
+        let result = decider().evaluate(
+            metrics: metrics(session: criticalLimit()),
+            providerEnabled: true,
+            alreadyNotified: [],
+            now: now
+        )
+
+        XCTAssertEqual(result.notifications.count, 1)
+        let fired = result.notifications[0]
+        XCTAssertEqual(fired.level, .warning)
+        XCTAssertEqual(fired.key, "Claude Code-session-warn")
+        XCTAssertEqual(fired.serviceDisplayName, "Claude Code")
+        XCTAssertEqual(fired.percentUsed, 95)
+        XCTAssertTrue(result.notifiedKeys.contains("Claude Code-session-warn"))
+    }
+
+    func testCriticalFiresAndSupersedesWarning() {
+        // Already warned; usage climbs into the exhausted band.
+        let result = decider().evaluate(
+            metrics: metrics(session: exhaustedLimit()),
+            providerEnabled: true,
+            alreadyNotified: ["Claude Code-session-warn"],
+            now: now
+        )
+
+        XCTAssertEqual(result.notifications.count, 1)
+        XCTAssertEqual(result.notifications[0].level, .critical)
+        XCTAssertEqual(result.notifications[0].key, "Claude Code-session-critical")
+        // Warn key superseded, critical key recorded.
+        XCTAssertFalse(result.notifiedKeys.contains("Claude Code-session-warn"))
+        XCTAssertTrue(result.notifiedKeys.contains("Claude Code-session-critical"))
+    }
+
+    // MARK: - Repeat (dedup)
+
+    func testWarningDoesNotRepeatWhileStillInBand() {
+        let result = decider().evaluate(
+            metrics: metrics(session: criticalLimit()),
+            providerEnabled: true,
+            alreadyNotified: ["Claude Code-session-warn"],
+            now: now
+        )
+
+        XCTAssertTrue(result.notifications.isEmpty)
+        XCTAssertEqual(result.notifiedKeys, ["Claude Code-session-warn"])
+    }
+
+    func testCriticalDoesNotRepeatWhileExhausted() {
+        let result = decider().evaluate(
+            metrics: metrics(session: exhaustedLimit()),
+            providerEnabled: true,
+            alreadyNotified: ["Claude Code-session-critical"],
+            now: now
+        )
+
+        XCTAssertTrue(result.notifications.isEmpty)
+        XCTAssertEqual(result.notifiedKeys, ["Claude Code-session-critical"])
+    }
+
+    // MARK: - Falling
+
+    func testFallingBelowThresholdsClearsKeys() {
+        let result = decider().evaluate(
+            metrics: metrics(session: healthyLimit()),
+            providerEnabled: true,
+            alreadyNotified: ["Claude Code-session-warn", "Claude Code-session-critical"],
+            now: now
+        )
+
+        XCTAssertTrue(result.notifications.isEmpty)
+        XCTAssertTrue(result.notifiedKeys.isEmpty, "Recovered quota should reset so the next crossing re-notifies.")
+    }
+
+    func testTightBandClearsUnderDefaultThresholds() {
+        // Default warning threshold is .critical, so the .tight band does not warn.
+        let result = decider().evaluate(
+            metrics: metrics(session: tightLimit()),
+            providerEnabled: true,
+            alreadyNotified: ["Claude Code-session-warn"],
+            now: now
+        )
+
+        XCTAssertTrue(result.notifications.isEmpty)
+        XCTAssertFalse(result.notifiedKeys.contains("Claude Code-session-warn"))
+    }
+
+    // MARK: - Threshold change
+
+    func testThresholdChangeWarnsEarlierAtTight() {
+        let prefs = NotificationPreferences(warningThreshold: .tight, criticalThreshold: .exhausted)
+        let result = decider(prefs).evaluate(
+            metrics: metrics(session: tightLimit()),
+            providerEnabled: true,
+            alreadyNotified: [],
+            now: now
+        )
+
+        XCTAssertEqual(result.notifications.count, 1)
+        XCTAssertEqual(result.notifications[0].level, .warning)
+    }
+
+    func testCriticalThresholdLoweredToCriticalBandFiresAlert() {
+        let prefs = NotificationPreferences(warningThreshold: .tight, criticalThreshold: .critical)
+        let result = decider(prefs).evaluate(
+            metrics: metrics(session: criticalLimit()),
+            providerEnabled: true,
+            alreadyNotified: [],
+            now: now
+        )
+
+        XCTAssertEqual(result.notifications.count, 1)
+        XCTAssertEqual(
+            result.notifications[0].level,
+            .critical,
+            "At the critical threshold the critical band should alert, not warn."
+        )
+    }
+
+    // MARK: - Gates
+
+    func testGlobalDisableSuppressesEverything() {
+        let prefs = NotificationPreferences(isEnabled: false)
+        let result = decider(prefs).evaluate(
+            metrics: metrics(session: exhaustedLimit()),
+            providerEnabled: true,
+            alreadyNotified: [],
+            now: now
+        )
+
+        XCTAssertTrue(result.notifications.isEmpty)
+        XCTAssertTrue(result.notifiedKeys.isEmpty)
+    }
+
+    func testDisabledProviderNeverNotifies() {
+        let result = decider().evaluate(
+            metrics: metrics(session: exhaustedLimit()),
+            providerEnabled: false,
+            alreadyNotified: [],
+            now: now
+        )
+
+        XCTAssertTrue(result.notifications.isEmpty)
+    }
+
+    func testStaleDataNeverNotifies() {
+        let stale = metrics(session: exhaustedLimit(), lastUpdated: now.addingTimeInterval(-7_200))
+        let result = decider().evaluate(
+            metrics: stale,
+            providerEnabled: true,
+            alreadyNotified: [],
+            now: now
+        )
+
+        XCTAssertTrue(result.notifications.isEmpty, "A two-hour-old cache must not fire alerts.")
+    }
+
+    func testDataAtStalenessBoundaryStillNotifies() {
+        let edge = metrics(
+            session: exhaustedLimit(),
+            lastUpdated: now.addingTimeInterval(-NotificationDecider.defaultStalenessThreshold)
+        )
+        let result = decider().evaluate(
+            metrics: edge,
+            providerEnabled: true,
+            alreadyNotified: [],
+            now: now
+        )
+
+        XCTAssertEqual(result.notifications.count, 1, "Data exactly at the staleness edge is still fresh enough.")
+    }
+
+    // MARK: - Multiple limits
+
+    func testLimitsEvaluatedIndependently() {
+        let result = decider().evaluate(
+            metrics: metrics(session: exhaustedLimit(), weekly: healthyLimit()),
+            providerEnabled: true,
+            alreadyNotified: [],
+            now: now
+        )
+
+        XCTAssertEqual(result.notifications.count, 1)
+        XCTAssertEqual(result.notifications[0].key, "Claude Code-session-critical")
+        XCTAssertFalse(result.notifiedKeys.contains { $0.hasPrefix("Claude Code-weekly") })
+    }
+}

--- a/MeterBarTests/NotificationPreferencesStoreTests.swift
+++ b/MeterBarTests/NotificationPreferencesStoreTests.swift
@@ -1,0 +1,73 @@
+import Combine
+import XCTest
+@testable import MeterBar
+
+final class NotificationPreferencesStoreTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "NotificationPreferencesStoreTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testDefaultsPreserveLegacyBehavior() {
+        let store = NotificationPreferencesStore(userDefaults: defaults)
+
+        XCTAssertTrue(store.isEnabled, "Notifications should be on by default, matching prior behavior.")
+        XCTAssertEqual(store.warningThreshold, .critical)
+        XCTAssertEqual(store.criticalThreshold, .exhausted)
+    }
+
+    func testDisablingPersists() {
+        let store = NotificationPreferencesStore(userDefaults: defaults)
+        store.setEnabled(false)
+        XCTAssertFalse(store.isEnabled)
+
+        let reloaded = NotificationPreferencesStore(userDefaults: defaults)
+        XCTAssertFalse(reloaded.isEnabled, "The global toggle should survive a relaunch.")
+    }
+
+    func testThresholdSelectionsPersist() {
+        let store = NotificationPreferencesStore(userDefaults: defaults)
+        store.setWarningThreshold(.tight)
+        store.setCriticalThreshold(.critical)
+
+        let reloaded = NotificationPreferencesStore(userDefaults: defaults)
+        XCTAssertEqual(reloaded.warningThreshold, .tight)
+        XCTAssertEqual(reloaded.criticalThreshold, .critical)
+    }
+
+    func testPreferencesValueReflectsState() {
+        let store = NotificationPreferencesStore(userDefaults: defaults)
+        store.setEnabled(false)
+        store.setWarningThreshold(.tight)
+
+        let prefs = store.preferences
+        XCTAssertFalse(prefs.isEnabled)
+        XCTAssertEqual(prefs.warningThreshold, .tight)
+        XCTAssertEqual(prefs.criticalThreshold, .exhausted)
+    }
+
+    func testSettingSameValueDoesNotPublishRedundantly() {
+        let store = NotificationPreferencesStore(userDefaults: defaults)
+        var publishedCount = 0
+        let cancellable = store.$isEnabled.dropFirst().sink { _ in publishedCount += 1 }
+
+        store.setEnabled(true) // already the default — no change expected
+        XCTAssertEqual(publishedCount, 0)
+
+        store.setEnabled(false) // genuine change
+        XCTAssertEqual(publishedCount, 1)
+
+        cancellable.cancel()
+    }
+}


### PR DESCRIPTION
Implements Tiers **2b** and **2c** of `.agents/docs/ISSUE_BACKLOG.md` in one PR.

## 2b — Notification preferences (#23)

The band-crossing dedup already existed; this adds user-facing preferences and makes the decision testable.

- **Pure decision:** the threshold-crossing logic is extracted out of `AppDelegate.checkAndNotify` into `NotificationDecider.evaluate(...)` — no side effects, injected `now`. `checkAndNotify` now only threads the dedup key set and formats banner copy.
- **Wired into `QuotaBand`, not a parallel path:** thresholds are chosen as bands (`tight` / `critical` / `exhausted`) and compared against `QuotaBand.forLimit(limit)` by severity rank. Defaults (`warn = .critical`, `alert = .exhausted`) reproduce the previous behavior exactly.
- **Gates (all tested):** never notify when globally disabled, when the provider is disabled, or off **stale** cached data (`lastUpdated` older than 1h).
- **Settings:** new *Notifications* section — global on/off toggle + "Warn me" / "Alert me" band pickers. Persisted via `NotificationPreferencesStore` (same `UserDefaults` pattern as `DockVisibilityStore`).

## 2c — Launch at Login (#27)

- `LaunchAtLoginControlling` protocol seam + `SMAppServiceLaunchAtLogin` wrapper around `SMAppService.mainApp` — so the toggle logic is unit-testable without touching the real login-item DB.
- `LaunchAtLoginStore` reflects `SMAppService.mainApp.status`, re-reads it on Settings appear (it can change behind the app's back in System Settings), and surfaces registration errors inline in the row.
- Settings *General* section gains a **Launch at Login** toggle with inline error text.

## Tests (TDD)

- `NotificationDeciderTests` — crossing matrix (rising / falling / repeat / threshold-change) + global-off / provider-disabled / staleness gates + staleness boundary + independent multi-limit evaluation.
- `NotificationPreferencesStoreTests` — defaults preserve legacy behavior, persistence across reload, no redundant publishes.
- `LaunchAtLoginStoreTests` — enable/disable register-unregister, error surfacing, external status change, requires-approval, error-clears-on-retry (via a fake controller).

## Notes / verification

- No shared cache / widget / CLI **data-contract** changes.
- All new logic lives in SwiftPM-compiled files (the `MeterBar` target excludes `App/MeterBarApp.swift`), so it's covered by PR CI's `swift build` + `swift test`. Verified locally with `swift build`; the XCTest suite + SwiftLint run on CI (CLT-only local env lacks XCTest/sourcekitd).

Closes #23, Closes #27