### PR TITLE
test: service-layer tests + coverage ratchet (Tier 3a, #71)

### DIFF
--- a/.agents/SESSIONS/2026-07-03.md
+++ b/.agents/SESSIONS/2026-07-03.md
@@ -1,0 +1,69 @@
+# Sessions: 2026-07-03
+
+**Summary:** Tier 3 test hardening — service-layer tests + coverage ratchet (PR 1), UI/e2e smoke suite (PR 2)
+
+---
+
+## Session 1: Service-layer tests + coverage ratchet (issue #71, ISSUE_BACKLOG Tier 3a)
+
+**Duration:** ~2 hours
+**Status:** Complete (PR from `test/service-layer-coverage`)
+
+### What was done
+
+Added protocol/closure seams to the previously-untested services and fixture-driven
+unit tests, following the existing `CostTrackerTests` / contract-test patterns. No
+behavior change to production paths — every seam defaults to the prior singleton wiring.
+
+**Seams added (production):**
+
+- `KeychainManager` — `KeychainBackend` protocol over the four `SecItem*` primitives;
+  real `SecItemKeychainBackend` default, in-memory fake for tests. The login keychain is
+  unavailable / prompts on CI.
+- `SharedDataStore` — injectable `directoryOverride` + post-write `didWrite` hook +
+  `flushPendingWrites()`. Lets the encode→atomic-write→decode round-trip run against a
+  temp dir without the App Group entitlement.
+- `CodexCliLocalService` — extracted pure `mapUsageResponse(_:)`; injectable
+  `authFileDataProvider` closure for `~/.codex/auth.json`.
+- `CursorLocalService` — extracted pure `mapSummary(_:)`; made `extractUserIdFromJWT`
+  static/internal. Plan-total default + on-demand headroom now static constants.
+- `UsageDataManager` — `SimpleUsageProviding` protocol (Codex/Cursor conform); injectable
+  providers, `ProviderVisibilityStore`, `SharedDataStore`, cache `UserDefaults`, and a
+  `schedulesAutoRefresh` flag (off in tests to avoid the `Timer`).
+- `ProviderVisibilityStore.init` made internal (was private) for isolated-suite tests.
+- `CostTracker.scanCodexArchivedSessions` + `CodexScanContext` made internal for
+  fixture testing (Claude `parseSessionFile` was already covered).
+
+**Tests added:** `KeychainManagerTests`, `SharedDataStoreTests`, `CodexCliLocalServiceTests`,
+`CursorLocalServiceTests`, `UsageDataManagerTests`, plus Codex-scan cases in
+`CostTrackerTests`. Shared `MetricsFixtures` helper (Claude/Codex/Cursor) reused by the
+store + orchestration tests (and by PR 2's widget checks).
+
+### Files changed
+
+- `MeterBar/Services/KeychainManager.swift` — `KeychainBackend` seam
+- `MeterBar/Services/SharedDataStore.swift` — dir override + write hook + flush
+- `MeterBar/Services/CodexCliLocalService.swift` — pure mapping + auth seam
+- `MeterBar/Services/CursorLocalService.swift` — pure mapping + static JWT extract
+- `MeterBar/Services/UsageDataManager.swift` — provider seam + injectable init
+- `MeterBar/Services/ProviderVisibilityStore.swift` — internal init
+- `MeterBar/Services/CostTracker.swift` — internal Codex scan seam
+- `MeterBarTests/{KeychainManager,SharedDataStore,CodexCliLocalService,CursorLocalService,UsageDataManager}Tests.swift` — new
+- `MeterBarTests/MetricsFixtures.swift` — shared fixtures
+- `MeterBarTests/CostTrackerTests.swift` — Codex archived-session cases
+- `.github/workflows/ci.yml` — `COVERAGE_THRESHOLD` ratcheted after CI measured the new baseline
+
+### Decisions
+
+- **Seams via default-argument injection, not a DI framework.** Matches the repo's
+  singleton style; `shared` behavior is byte-identical, tests pass fakes.
+- **Local verification = compile only.** Only Command Line Tools are installed (no XCTest
+  module), so tests are run by CI; locally verified with `swift build`.
+
+### Next steps
+
+- [ ] PR 2: UI/e2e smoke suite + widget rendering validation + first `schedule:` workflow (#18)
+
+---
+
+**Total sessions today:** 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,14 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 20
     env:
-      # Coverage floor enforced by scripts/check-coverage.sh. Measured baseline on
-      # 2026-07-02 was 9.0% line coverage (tests cover models/parsers; the ~3.5k
-      # lines of Views and most Services are untested — docs/audits/00-repo-map.md §5).
-      # Floor sits just under the baseline as a regression gate. Ratchet this up as
-      # coverage improves; never lower it to make a PR pass.
-      COVERAGE_THRESHOLD: 8
+      # Coverage floor enforced by scripts/check-coverage.sh. Baseline was 9.0% on
+      # 2026-07-02; the service-layer test pass (#71 Tier 3a, 2026-07-03) raised the
+      # measured line coverage to 19.2% by seaming + fixture-testing KeychainManager,
+      # SharedDataStore, Codex/Cursor mapping + auth, UsageDataManager orchestration,
+      # and the Codex cost scan. Floor sits just under the measured baseline as a
+      # regression gate. Ratchet this up as coverage improves; never lower it to make
+      # a PR pass.
+      COVERAGE_THRESHOLD: 19
 
     steps:
       - name: Checkout

--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -18,21 +18,30 @@ class CodexCliLocalService: ObservableObject {
     // API endpoint for Codex CLI usage
     private let usageEndpoint = "https://chatgpt.com/backend-api/wham/usage"
 
-    // Path to Codex CLI auth file
-    private var authFilePath: String {
-        let homeDir = ServiceSupport.realHomeDirectory()
-        return "\(homeDir)/.codex/auth.json"
-    }
-
     // Shared URLSession with the standard usage-request timeouts
     private let urlSession = ServiceSupport.session
+
+    /// Raw bytes of `~/.codex/auth.json`, behind a closure so tests can supply a
+    /// fixture without a real credential file on disk (the auth file never
+    /// exists on CI). Defaults to reading the real path.
+    private let authFileDataProvider: () -> Data?
 
     @Published private(set) var hasAccess: Bool = false
     @Published private(set) var lastError: ServiceError?
     @Published private(set) var subscriptionType: String?
 
-    private init() {
+    /// Defaults reproduce the production singleton; tests inject a fixture
+    /// auth-file provider.
+    init(authFileDataProvider: (() -> Data?)? = nil) {
+        self.authFileDataProvider = authFileDataProvider ?? CodexCliLocalService.defaultAuthFileDataProvider
         Task.detached(priority: .utility) { [weak self] in self?.checkAccess() }
+    }
+
+    /// Reads `~/.codex/auth.json` from the real (non-sandboxed) home directory.
+    private static func defaultAuthFileDataProvider() -> Data? {
+        let path = "\(ServiceSupport.realHomeDirectory())/.codex/auth.json"
+        guard FileManager.default.fileExists(atPath: path) else { return nil }
+        return FileManager.default.contents(atPath: path)
     }
 
     // MARK: - Auth File Access
@@ -58,11 +67,7 @@ class CodexCliLocalService: ObservableObject {
     }
 
     private func readAuthFile() -> CodexAuthFile? {
-        guard FileManager.default.fileExists(atPath: authFilePath),
-              let data = FileManager.default.contents(atPath: authFilePath) else {
-            return nil
-        }
-
+        guard let data = authFileDataProvider() else { return nil }
         return try? JSONDecoder().decode(CodexAuthFile.self, from: data)
     }
 
@@ -127,57 +132,7 @@ class CodexCliLocalService: ObservableObject {
                 self.subscriptionType = usageResponse.planType
             }
 
-            // Check if rate limits exist (free accounts have null rate_limit)
-            guard let rateLimit = usageResponse.rateLimit else {
-                // Return empty metrics for free accounts
-                return UsageMetrics(
-                    service: .codexCli,
-                    sessionLimit: nil,
-                    weeklyLimit: nil,
-                    codeReviewLimit: nil,
-                    extraUsage: usageResponse.extraUsageStatus,
-                    resetCreditsAvailable: usageResponse.resetCreditsAvailable
-                )
-            }
-
-            // Map the response to UsageMetrics
-            // Primary window (5 hours = 18000 seconds) = session limit
-            let primaryWindow = rateLimit.primaryWindow
-            let sessionLimit = UsageLimit(
-                used: primaryWindow.usedPercent,
-                total: 100.0,
-                resetTime: Date(timeIntervalSince1970: Double(primaryWindow.resetAt)),
-                windowSeconds: TimeInterval(primaryWindow.limitWindowSeconds)
-            )
-
-            // Secondary window (7 days = 604800 seconds) = weekly limit
-            let secondaryWindow = rateLimit.secondaryWindow
-            let weeklyLimit = UsageLimit(
-                used: secondaryWindow?.usedPercent ?? 0.0,
-                total: 100.0,
-                resetTime: secondaryWindow.map { Date(timeIntervalSince1970: Double($0.resetAt)) } ?? Date(),
-                windowSeconds: secondaryWindow.map { TimeInterval($0.limitWindowSeconds) }
-            )
-
-            // Code review rate limit (7 days window) = code review limit
-            var codeReviewLimit: UsageLimit?
-            if let codeReviewPrimary = usageResponse.codeReviewRateLimit?.primaryWindow {
-                codeReviewLimit = UsageLimit(
-                    used: codeReviewPrimary.usedPercent,
-                    total: 100.0,
-                    resetTime: Date(timeIntervalSince1970: Double(codeReviewPrimary.resetAt)),
-                    windowSeconds: TimeInterval(codeReviewPrimary.limitWindowSeconds)
-                )
-            }
-
-            return UsageMetrics(
-                service: .codexCli,
-                sessionLimit: sessionLimit,
-                weeklyLimit: weeklyLimit,
-                codeReviewLimit: codeReviewLimit,
-                extraUsage: usageResponse.extraUsageStatus,
-                resetCreditsAvailable: usageResponse.resetCreditsAvailable
-            )
+            return CodexCliLocalService.mapUsageResponse(usageResponse)
         } catch {
             let serviceError = ServiceSupport.serviceError(from: error)
             AppLog.usage.error("Codex usage fetch failed: \(serviceError.localizedDescription)")
@@ -189,6 +144,67 @@ class CodexCliLocalService: ObservableObject {
             }
             throw serviceError
         }
+    }
+
+    // MARK: - Response Mapping
+
+    /// Maps a decoded Codex usage response onto the shared `UsageMetrics` shape.
+    /// Pure and side-effect-free so it can be fixture-tested without the network:
+    /// primary window → session limit, secondary window → weekly limit, code
+    /// review window → code review limit. Free accounts (null `rate_limit`) yield
+    /// a metrics object with no windows but the extra-usage / reset-credit signals
+    /// preserved.
+    static func mapUsageResponse(_ usageResponse: CodexCliUsageResponse) -> UsageMetrics {
+        // Free accounts have null rate_limit: no windows, but keep the overage
+        // and reset-credit signals.
+        guard let rateLimit = usageResponse.rateLimit else {
+            return UsageMetrics(
+                service: .codexCli,
+                sessionLimit: nil,
+                weeklyLimit: nil,
+                codeReviewLimit: nil,
+                extraUsage: usageResponse.extraUsageStatus,
+                resetCreditsAvailable: usageResponse.resetCreditsAvailable
+            )
+        }
+
+        // Primary window (5 hours = 18000 seconds) = session limit
+        let primaryWindow = rateLimit.primaryWindow
+        let sessionLimit = UsageLimit(
+            used: primaryWindow.usedPercent,
+            total: 100.0,
+            resetTime: Date(timeIntervalSince1970: Double(primaryWindow.resetAt)),
+            windowSeconds: TimeInterval(primaryWindow.limitWindowSeconds)
+        )
+
+        // Secondary window (7 days = 604800 seconds) = weekly limit
+        let secondaryWindow = rateLimit.secondaryWindow
+        let weeklyLimit = UsageLimit(
+            used: secondaryWindow?.usedPercent ?? 0.0,
+            total: 100.0,
+            resetTime: secondaryWindow.map { Date(timeIntervalSince1970: Double($0.resetAt)) } ?? Date(),
+            windowSeconds: secondaryWindow.map { TimeInterval($0.limitWindowSeconds) }
+        )
+
+        // Code review rate limit (7 days window) = code review limit
+        var codeReviewLimit: UsageLimit?
+        if let codeReviewPrimary = usageResponse.codeReviewRateLimit?.primaryWindow {
+            codeReviewLimit = UsageLimit(
+                used: codeReviewPrimary.usedPercent,
+                total: 100.0,
+                resetTime: Date(timeIntervalSince1970: Double(codeReviewPrimary.resetAt)),
+                windowSeconds: TimeInterval(codeReviewPrimary.limitWindowSeconds)
+            )
+        }
+
+        return UsageMetrics(
+            service: .codexCli,
+            sessionLimit: sessionLimit,
+            weeklyLimit: weeklyLimit,
+            codeReviewLimit: codeReviewLimit,
+            extraUsage: usageResponse.extraUsageStatus,
+            resetCreditsAvailable: usageResponse.resetCreditsAvailable
+        )
     }
 }
 

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -551,7 +551,10 @@ class CostTracker: ObservableObject {
         ), makeDailyUsage(from: context.dailyTotals, provider: .codexCli, pricing: pricing))
     }
 
-    private func scanCodexArchivedSessions(
+    /// Internal (not private) so the archived-session parsing — the Codex
+    /// counterpart to `parseSessionFile`, and where CLI-vs-app cost divergence
+    /// hides — can be fixture-tested against a temp directory.
+    func scanCodexArchivedSessions(
         directory: URL,
         since cutoffDate: Date,
         context: inout CodexScanContext
@@ -894,7 +897,9 @@ class CostTracker: ObservableObject {
 /// value collapses `addCodexUsage`/`scanCodexArchivedSessions`/`scanCodexSQLiteLogs`
 /// from 10–13 parameters (a SwiftLint `function_parameter_count` error) down to
 /// a single `inout` argument.
-private struct CodexScanContext {
+///
+/// Internal (not private) so `scanCodexArchivedSessions` can be fixture-tested.
+struct CodexScanContext {
     var totals = TokenAccumulator()
     var dailyTotals: [Date: TokenAccumulator] = [:]
     var modelTotals: [String: TokenAccumulator] = [:]

--- a/MeterBar/Services/CursorLocalService.swift
+++ b/MeterBar/Services/CursorLocalService.swift
@@ -18,11 +18,12 @@ class CursorLocalService: ObservableObject {
     // Shared URLSession with the standard usage-request timeouts
     private let urlSession = ServiceSupport.session
 
-    // Assumed default monthly request quota when the API omits a plan total
-    private let defaultPlanTotal: Double = 500
+    // Assumed default monthly request quota when the API omits a plan total.
+    // Static so the pure `mapSummary` mapping can share the same constant.
+    private static let defaultPlanTotal: Double = 500
 
     // Display headroom estimate when no explicit on-demand limit is returned by the API
-    private let onDemandHeadroomMultiplier: Double = 1.5
+    private static let onDemandHeadroomMultiplier: Double = 1.5
 
     @Published private(set) var hasAccess: Bool = false
     @Published private(set) var subscriptionType: String?
@@ -137,7 +138,7 @@ class CursorLocalService: ObservableObject {
         let token = String(cString: tokenCString)
 
         // Decode JWT to extract userId from 'sub' claim
-        guard let userId = extractUserIdFromJWT(token) else {
+        guard let userId = Self.extractUserIdFromJWT(token) else {
             AppLog.usage.error("Cursor JWT userId extraction failed")
             return nil
         }
@@ -145,8 +146,9 @@ class CursorLocalService: ObservableObject {
         return (userId: userId, token: token)
     }
 
-    /// Extract userId from JWT token's 'sub' claim
-    private func extractUserIdFromJWT(_ token: String) -> String? {
+    /// Extract userId from JWT token's 'sub' claim.
+    /// Static + internal so it is unit-testable without a Cursor DB or network.
+    static func extractUserIdFromJWT(_ token: String) -> String? {
         guard let sub = JWT.claimString("sub", in: token) else { return nil }
 
         // Extract userId from sub claim
@@ -202,6 +204,16 @@ class CursorLocalService: ObservableObject {
             self.subscriptionType = summaryData.membershipType
         }
 
+        return CursorLocalService.mapSummary(summaryData)
+    }
+
+    /// Maps a decoded Cursor usage-summary response onto the shared
+    /// `UsageMetrics` shape. Pure and side-effect-free so it can be fixture-tested
+    /// without the network or Cursor's SQLite DB: individual plan → weekly limit,
+    /// enabled on-demand usage → session limit. When the API omits a plan total
+    /// the assumed monthly quota is substituted; when on-demand has no explicit
+    /// limit a headroom estimate is used.
+    static func mapSummary(_ summaryData: CursorUsageSummaryResponse) -> UsageMetrics {
         // Parse billing cycle end date for reset time
         var resetTime: Date?
         if let billingEnd = summaryData.billingCycleEnd {

--- a/MeterBar/Services/KeychainManager.swift
+++ b/MeterBar/Services/KeychainManager.swift
@@ -1,13 +1,49 @@
 import Foundation
 import Security
 
+/// The four `SecItem*` primitives `KeychainManager` depends on, behind a
+/// protocol so tests can drive the save/get/delete logic against an in-memory
+/// fake instead of the real login keychain (which is unavailable / prompts on
+/// CI runners). Signatures mirror the C API 1:1 so the production backend is a
+/// thin pass-through.
+protocol KeychainBackend {
+    func update(query: [String: Any], attributes: [String: Any]) -> OSStatus
+    func add(query: [String: Any]) -> OSStatus
+    func copyMatching(query: [String: Any], result: inout AnyObject?) -> OSStatus
+    func delete(query: [String: Any]) -> OSStatus
+}
+
+/// Production backend: forwards straight to the Security framework.
+struct SecItemKeychainBackend: KeychainBackend {
+    func update(query: [String: Any], attributes: [String: Any]) -> OSStatus {
+        SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+    }
+
+    func add(query: [String: Any]) -> OSStatus {
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    func copyMatching(query: [String: Any], result: inout AnyObject?) -> OSStatus {
+        SecItemCopyMatching(query as CFDictionary, &result)
+    }
+
+    func delete(query: [String: Any]) -> OSStatus {
+        SecItemDelete(query as CFDictionary)
+    }
+}
+
 /// Minimal Keychain wrapper for the org API admin keys entered in Settings.
 final class KeychainManager {
     static let shared = KeychainManager()
 
     private let service = "dev.shipshit.meterbar"
+    private let backend: KeychainBackend
 
-    private init() {}
+    /// Defaults to the real Security-framework backend so `shared` behaves
+    /// exactly as before; tests inject an in-memory fake.
+    init(backend: KeychainBackend = SecItemKeychainBackend()) {
+        self.backend = backend
+    }
 
     func save(key: String, value: String) -> Bool {
         guard let data = value.data(using: .utf8) else { return false }
@@ -22,7 +58,7 @@ final class KeychainManager {
         // delete/add pair can both delete and then race on add (one fails with
         // errSecDuplicateItem); SecItemUpdate has no such window.
         let attributes: [String: Any] = [kSecValueData as String: data]
-        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        let updateStatus = backend.update(query: query, attributes: attributes)
 
         switch updateStatus {
         case errSecSuccess:
@@ -30,7 +66,7 @@ final class KeychainManager {
         case errSecItemNotFound:
             var addQuery = query
             addQuery[kSecValueData as String] = data
-            return SecItemAdd(addQuery as CFDictionary, nil) == errSecSuccess
+            return backend.add(query: addQuery) == errSecSuccess
         default:
             return false
         }
@@ -46,7 +82,7 @@ final class KeychainManager {
         ]
 
         var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = backend.copyMatching(query: query, result: &result)
 
         guard status == errSecSuccess,
               let data = result as? Data,
@@ -65,7 +101,7 @@ final class KeychainManager {
             kSecAttrAccount as String: key
         ]
 
-        let status = SecItemDelete(query as CFDictionary)
+        let status = backend.delete(query: query)
         return status == errSecSuccess || status == errSecItemNotFound
     }
 

--- a/MeterBar/Services/ProviderVisibilityStore.swift
+++ b/MeterBar/Services/ProviderVisibilityStore.swift
@@ -14,7 +14,9 @@ final class ProviderVisibilityStore: ObservableObject {
         Set(ServiceType.allCases).subtracting(hiddenServices)
     }
 
-    private init(userDefaults: UserDefaults = .standard) {
+    /// Internal (not private) so tests can construct an instance backed by an
+    /// isolated `UserDefaults` suite; production code uses `shared`.
+    init(userDefaults: UserDefaults = .standard) {
         self.userDefaults = userDefaults
         load()
     }

--- a/MeterBar/Services/SharedDataStore.swift
+++ b/MeterBar/Services/SharedDataStore.swift
@@ -18,11 +18,27 @@ public class SharedDataStore {
     /// block on file I/O, while still serializing writes to the shared file.
     private let ioQueue = DispatchQueue(label: "dev.shipshit.meterbar.SharedDataStore.io", qos: .utility)
 
+    /// Overrides the App Group container location. `nil` in production (the
+    /// container is resolved from the app-group identifier); tests inject a
+    /// temp directory so the encode → atomic-write → decode round-trip can run
+    /// without the App Group entitlement (unavailable to `swift test`).
+    private let directoryOverride: URL?
+
+    /// Invoked after a successful write. Defaults to reloading the widget
+    /// timelines; tests inject a spy to assert the write completed.
+    private let didWrite: () -> Void
+
     private var containerURL: URL? {
-        FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)
+        if let directoryOverride { return directoryOverride }
+        return FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)
     }
 
-    private init() {}
+    /// Defaults reproduce the production singleton exactly; tests inject a
+    /// directory + write spy.
+    init(directoryOverride: URL? = nil, didWrite: (() -> Void)? = nil) {
+        self.directoryOverride = directoryOverride
+        self.didWrite = didWrite ?? SharedDataStore.reloadWidgetTimelines
+    }
 
     func saveMetrics(_ metrics: [ServiceType: UsageMetrics]) {
         guard let containerURL = containerURL else {
@@ -42,7 +58,7 @@ public class SharedDataStore {
         ioQueue.async { [weak self] in
             do {
                 try data.write(to: fileURL, options: [.atomic])
-                self?.reloadWidgetTimelines()
+                self?.didWrite()
             } catch {
                 AppLog.storage.error("Failed to save shared metrics: \(error.localizedDescription, privacy: .public)")
             }
@@ -58,7 +74,13 @@ public class SharedDataStore {
         return MetricsCodec.decode(data)
     }
 
-    private func reloadWidgetTimelines() {
+    /// Blocks until any in-flight async write has completed. Test-only: lets a
+    /// test observe the on-disk result of `saveMetrics` deterministically.
+    func flushPendingWrites() {
+        ioQueue.sync {}
+    }
+
+    private static func reloadWidgetTimelines() {
         #if canImport(WidgetKit)
         if #available(macOS 11.0, *) {
             WidgetCenter.shared.reloadTimelines(ofKind: "UsageWidget")

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -4,6 +4,19 @@ import os
 import Combine
 import SwiftUI
 
+/// The single-account provider surface `UsageDataManager` orchestrates (Codex,
+/// Cursor). Behind a protocol so the manager's merge / graceful-degradation
+/// logic can be tested with stub providers instead of the real network + local
+/// credential files. Claude Code has its own account-aware path and is not part
+/// of this seam.
+protocol SimpleUsageProviding: AnyObject {
+    var hasAccess: Bool { get }
+    func fetchUsageMetrics() async throws -> UsageMetrics
+}
+
+extension CodexCliLocalService: SimpleUsageProviding {}
+extension CursorLocalService: SimpleUsageProviding {}
+
 @MainActor
 class UsageDataManager: ObservableObject {
     static let shared = UsageDataManager()
@@ -24,19 +37,41 @@ class UsageDataManager: ObservableObject {
         }
     }
 
-    private let claudeCodeService = ClaudeCodeLocalService.shared
-    private let cursorService = CursorLocalService.shared
-    private let codexCliService = CodexCliLocalService.shared
-    private let claudeCodeAccountStore = ClaudeCodeAccountStore.shared
-    private let providerVisibilityStore = ProviderVisibilityStore.shared
+    private let claudeCodeService: ClaudeCodeLocalService
+    private let cursorService: SimpleUsageProviding
+    private let codexCliService: SimpleUsageProviding
+    private let claudeCodeAccountStore: ClaudeCodeAccountStore
+    private let providerVisibilityStore: ProviderVisibilityStore
 
     private var refreshTimer: Timer?
     private let cacheKey = StorageKeys.cachedUsageMetrics
-    private let sharedStore = SharedDataStore.shared
+    private let sharedStore: SharedDataStore
+    private let cacheDefaults: UserDefaults
 
-    private init() {
+    /// Defaults wire the production singletons so `shared` behaves exactly as
+    /// before; tests inject stub providers, an isolated `UserDefaults` suite, a
+    /// temp-directory `SharedDataStore`, and disable the auto-refresh timer.
+    init(
+        codexCliService: SimpleUsageProviding = CodexCliLocalService.shared,
+        cursorService: SimpleUsageProviding = CursorLocalService.shared,
+        claudeCodeService: ClaudeCodeLocalService = .shared,
+        claudeCodeAccountStore: ClaudeCodeAccountStore = .shared,
+        providerVisibilityStore: ProviderVisibilityStore = .shared,
+        sharedStore: SharedDataStore = .shared,
+        cacheDefaults: UserDefaults = .standard,
+        schedulesAutoRefresh: Bool = true
+    ) {
+        self.codexCliService = codexCliService
+        self.cursorService = cursorService
+        self.claudeCodeService = claudeCodeService
+        self.claudeCodeAccountStore = claudeCodeAccountStore
+        self.providerVisibilityStore = providerVisibilityStore
+        self.sharedStore = sharedStore
+        self.cacheDefaults = cacheDefaults
         loadCachedData()
-        setupAutoRefresh()
+        if schedulesAutoRefresh {
+            setupAutoRefresh()
+        }
     }
 
     func refreshAll() async {
@@ -164,7 +199,7 @@ class UsageDataManager: ObservableObject {
 
     /// Decode cached metrics from disk without modifying instance state.
     private func loadCachedMetricsFromDisk() -> [ServiceType: UsageMetrics] {
-        guard let data = UserDefaults.standard.data(forKey: cacheKey) else {
+        guard let data = cacheDefaults.data(forKey: cacheKey) else {
             return [:]
         }
         return MetricsCodec.decode(data)
@@ -172,7 +207,7 @@ class UsageDataManager: ObservableObject {
 
     private func saveCachedData() {
         if let data = MetricsCodec.encode(metrics) {
-            UserDefaults.standard.set(data, forKey: cacheKey)
+            cacheDefaults.set(data, forKey: cacheKey)
         }
     }
 

--- a/MeterBarTests/CodexCliLocalServiceTests.swift
+++ b/MeterBarTests/CodexCliLocalServiceTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// Direct coverage for `CodexCliLocalService` without touching the network or a
+/// real `~/.codex/auth.json`:
+///   - `mapUsageResponse` (the response → `UsageMetrics` mapping extracted from
+///     `fetchUsageMetrics`) is exercised with decoded fixtures.
+///   - the auth-file read + token-expiry gating is exercised through the
+///     injected `authFileDataProvider` seam.
+final class CodexCliLocalServiceTests: XCTestCase {
+
+    // MARK: - Fixture helpers
+
+    /// Builds an unsigned JWT (header.payload.signature) with the given claims.
+    /// Only the payload is read by the app, so the header/signature are dummies.
+    private func makeJWT(exp: TimeInterval?, accountId: String? = nil) -> String {
+        var payload: [String: Any] = [:]
+        if let exp { payload["exp"] = exp }
+        if let accountId { payload["account_id"] = accountId }
+        let header = base64URL(Data(#"{"alg":"none","typ":"JWT"}"#.utf8))
+        let body = base64URL(try! JSONSerialization.data(withJSONObject: payload))
+        return "\(header).\(body).sig"
+    }
+
+    private func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    private func decodeResponse(_ json: String) throws -> CodexCliUsageResponse {
+        try JSONDecoder().decode(CodexCliUsageResponse.self, from: Data(json.utf8))
+    }
+
+    // Far-future / past expiries expressed as fixed Unix seconds for determinism.
+    private let futureExp: TimeInterval = 4_102_444_800 // 2100-01-01
+    private let pastExp: TimeInterval = 1_000_000_000    // 2001-09-09
+
+    // MARK: - Response mapping
+
+    func testMapUsageResponseMapsAllThreeWindows() throws {
+        let json = """
+        {
+          "plan_type": "plus",
+          "rate_limit": {
+            "allowed": true,
+            "limit_reached": false,
+            "primary_window": {
+              "used_percent": 40.0,
+              "limit_window_seconds": 18000,
+              "reset_after_seconds": 3600,
+              "reset_at": 1735689600
+            },
+            "secondary_window": {
+              "used_percent": 72.5,
+              "limit_window_seconds": 604800,
+              "reset_after_seconds": 86400,
+              "reset_at": 1736294400
+            }
+          },
+          "code_review_rate_limit": {
+            "allowed": true,
+            "limit_reached": false,
+            "primary_window": {
+              "used_percent": 8.0,
+              "limit_window_seconds": 604800,
+              "reset_after_seconds": 86400,
+              "reset_at": 1736294400
+            }
+          },
+          "rate_limit_reset_credits": { "available_count": 3 }
+        }
+        """
+        let response = try decodeResponse(json)
+        let metrics = CodexCliLocalService.mapUsageResponse(response)
+
+        XCTAssertEqual(metrics.service, .codexCli)
+        XCTAssertEqual(metrics.sessionLimit?.used, 40.0)
+        XCTAssertEqual(metrics.sessionLimit?.total, 100.0)
+        XCTAssertEqual(metrics.sessionLimit?.windowSeconds, 18000)
+        XCTAssertEqual(metrics.sessionLimit?.resetTime, Date(timeIntervalSince1970: 1_735_689_600))
+        XCTAssertEqual(metrics.weeklyLimit?.used, 72.5)
+        XCTAssertEqual(metrics.weeklyLimit?.windowSeconds, 604800)
+        XCTAssertEqual(metrics.codeReviewLimit?.used, 8.0)
+        XCTAssertEqual(metrics.resetCreditsAvailable, 3)
+    }
+
+    func testMapUsageResponseFreeAccountHasNoWindows() throws {
+        // Free accounts return a null rate_limit; the mapping must still surface
+        // the extra-usage signal (here: unknown, since no credits object present).
+        let json = """
+        { "plan_type": "free", "rate_limit": null }
+        """
+        let response = try decodeResponse(json)
+        let metrics = CodexCliLocalService.mapUsageResponse(response)
+
+        XCTAssertNil(metrics.sessionLimit)
+        XCTAssertNil(metrics.weeklyLimit)
+        XCTAssertNil(metrics.codeReviewLimit)
+        XCTAssertEqual(metrics.extraUsage?.state, .unknown)
+    }
+
+    func testMapUsageResponseWithoutSecondaryWindowZeroesWeekly() throws {
+        let json = """
+        {
+          "plan_type": "plus",
+          "rate_limit": {
+            "allowed": true,
+            "limit_reached": false,
+            "primary_window": {
+              "used_percent": 12.0,
+              "limit_window_seconds": 18000,
+              "reset_after_seconds": 3600,
+              "reset_at": 1735689600
+            }
+          }
+        }
+        """
+        let response = try decodeResponse(json)
+        let metrics = CodexCliLocalService.mapUsageResponse(response)
+
+        XCTAssertEqual(metrics.sessionLimit?.used, 12.0)
+        // No secondary window → weekly usage falls back to 0 with a nil windowSeconds.
+        XCTAssertEqual(metrics.weeklyLimit?.used, 0.0)
+        XCTAssertNil(metrics.weeklyLimit?.windowSeconds)
+    }
+
+    // MARK: - Auth-file / token-expiry gating
+
+    private func authFileJSON(accessToken: String, accountId: String) -> Data {
+        Data("""
+        {
+          "OPENAI_API_KEY": null,
+          "tokens": {
+            "id_token": "\(accessToken)",
+            "access_token": "\(accessToken)",
+            "refresh_token": "refresh",
+            "account_id": "\(accountId)"
+          },
+          "last_refresh": "2026-07-01T00:00:00Z"
+        }
+        """.utf8)
+    }
+
+    func testGetAuthTokenReturnsUnexpiredToken() {
+        let token = makeJWT(exp: futureExp)
+        let service = CodexCliLocalService(authFileDataProvider: {
+            self.authFileJSON(accessToken: token, accountId: "acc_1")
+        })
+        XCTAssertEqual(service.getAuthToken(), token)
+        XCTAssertEqual(service.getAccountId(), "acc_1")
+    }
+
+    func testGetAuthTokenRejectsExpiredToken() {
+        let token = makeJWT(exp: pastExp)
+        let service = CodexCliLocalService(authFileDataProvider: {
+            self.authFileJSON(accessToken: token, accountId: "acc_1")
+        })
+        XCTAssertNil(service.getAuthToken())
+    }
+
+    func testGetAuthTokenReturnsNilWhenAuthFileMissing() {
+        let service = CodexCliLocalService(authFileDataProvider: { nil })
+        XCTAssertNil(service.getAuthToken())
+        XCTAssertNil(service.getAccountId())
+    }
+
+    func testGetAuthTokenReturnsNilForMalformedAuthFile() {
+        let service = CodexCliLocalService(authFileDataProvider: { Data("not json".utf8) })
+        XCTAssertNil(service.getAuthToken())
+    }
+}

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -166,4 +166,88 @@ final class CostTrackerTests: XCTestCase {
 
         XCTAssertEqual(result.input, 5)
     }
+
+    // MARK: - Codex archived-session scan
+
+    /// Writes a `.jsonl` into an `archived_sessions` directory and returns that
+    /// directory (the argument `scanCodexArchivedSessions` expects). The file's
+    /// modification date is "now", so it passes the per-file mtime cutoff.
+    private func writeCodexArchive(lines: [String]) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexArchive-\(UUID().uuidString)", isDirectory: true)
+        let dir = root.appendingPathComponent("archived_sessions", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("rollout.jsonl")
+        try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return dir
+    }
+
+    private func codexTokenLine(
+        timestamp: String,
+        conversationID: String = "conv-1",
+        model: String = "gpt-5.5",
+        input: Int = 1_000,
+        output: Int = 500,
+        cached: Int = 200,
+        reasoning: Int = 50
+    ) -> String {
+        """
+        {"timestamp": "\(timestamp)", "payload": {"type": "token_count", \
+        "rate_limits": {"conversation_id": "\(conversationID)"}, \
+        "info": {"model": "\(model)", "last_token_usage": \
+        {"input_tokens": \(input), "output_tokens": \(output), \
+        "cached_input_tokens": \(cached), "reasoning_output_tokens": \(reasoning)}}}}
+        """
+    }
+
+    private func makeContext(cutoff: Date) -> CodexScanContext {
+        CodexScanContext(earliestDate: Date(), latestDate: cutoff)
+    }
+
+    func testScanCodexArchivedSessionsAccumulatesTokenCounts() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexTokenLine(timestamp: "2026-06-15T10:00:00Z")
+        ])
+        let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
+        var context = makeContext(cutoff: cutoff)
+
+        tracker.scanCodexArchivedSessions(directory: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.totals.input, 1_000)
+        // output accumulates the reasoning tokens on the daily/model rollups, but
+        // `totals` keeps output and reasoning separate.
+        XCTAssertEqual(context.totals.output, 500)
+        XCTAssertEqual(context.totals.reasoning, 50)
+        XCTAssertEqual(context.totals.cacheRead, 200)
+        XCTAssertEqual(context.sessionIDs, ["conv-1"])
+    }
+
+    func testScanCodexArchivedSessionsDeduplicatesIdenticalEvents() throws {
+        let line = codexTokenLine(timestamp: "2026-06-15T10:00:00Z")
+        let dir = try writeCodexArchive(lines: [line, line])
+        let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
+        var context = makeContext(cutoff: cutoff)
+
+        tracker.scanCodexArchivedSessions(directory: dir, since: cutoff, context: &context)
+
+        // Identical events collapse to one via the dedup key.
+        XCTAssertEqual(context.totals.input, 1_000)
+        XCTAssertEqual(context.totals.output, 500)
+    }
+
+    func testScanCodexArchivedSessionsHonorsPerLineCutoff() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexTokenLine(timestamp: "2025-01-01T00:00:00Z", conversationID: "old", input: 9_999),
+            codexTokenLine(timestamp: "2026-06-15T10:00:00Z", conversationID: "new", input: 100)
+        ])
+        let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
+        var context = makeContext(cutoff: cutoff)
+
+        tracker.scanCodexArchivedSessions(directory: dir, since: cutoff, context: &context)
+
+        // Only the post-cutoff line is counted.
+        XCTAssertEqual(context.totals.input, 100)
+        XCTAssertEqual(context.sessionIDs, ["new"])
+    }
 }

--- a/MeterBarTests/CursorLocalServiceTests.swift
+++ b/MeterBarTests/CursorLocalServiceTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// Direct coverage for `CursorLocalService`'s pure slices — the summary →
+/// `UsageMetrics` mapping and the JWT `sub` → userId extraction — neither of
+/// which requires Cursor's SQLite DB or the dashboard API.
+final class CursorLocalServiceTests: XCTestCase {
+
+    private func decodeSummary(_ json: String) throws -> CursorUsageSummaryResponse {
+        try JSONDecoder().decode(CursorUsageSummaryResponse.self, from: Data(json.utf8))
+    }
+
+    private func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    private func makeJWT(sub: String) -> String {
+        let header = base64URL(Data(#"{"alg":"none"}"#.utf8))
+        let body = base64URL(try! JSONSerialization.data(withJSONObject: ["sub": sub]))
+        return "\(header).\(body).sig"
+    }
+
+    // MARK: - Summary mapping
+
+    func testMapSummaryUsesPlanUsageForWeeklyLimit() throws {
+        let json = """
+        {
+          "billingCycleStart": "2026-07-01T00:00:00Z",
+          "billingCycleEnd": "2026-08-01T00:00:00Z",
+          "membershipType": "pro",
+          "individualUsage": {
+            "plan": { "used": 137, "total": 500 },
+            "onDemand": { "used": 4, "limit": 20, "enabled": true }
+          }
+        }
+        """
+        let metrics = CursorLocalService.mapSummary(try decodeSummary(json))
+
+        XCTAssertEqual(metrics.service, .cursor)
+        XCTAssertEqual(metrics.weeklyLimit?.used, 137)
+        XCTAssertEqual(metrics.weeklyLimit?.total, 500)
+        XCTAssertEqual(metrics.weeklyLimit?.resetTime, FlexibleISO8601.date(from: "2026-08-01T00:00:00Z"))
+        XCTAssertEqual(metrics.sessionLimit?.used, 4)
+        XCTAssertEqual(metrics.sessionLimit?.total, 20)
+    }
+
+    func testMapSummarySubstitutesDefaultPlanTotalWhenMissing() throws {
+        // When the API omits the plan total, the assumed monthly quota (500) is used.
+        let json = """
+        { "individualUsage": { "plan": { "used": 50 } } }
+        """
+        let metrics = CursorLocalService.mapSummary(try decodeSummary(json))
+        XCTAssertEqual(metrics.weeklyLimit?.used, 50)
+        XCTAssertEqual(metrics.weeklyLimit?.total, 500)
+    }
+
+    func testMapSummaryOmitsSessionLimitWhenOnDemandDisabled() throws {
+        let json = """
+        {
+          "individualUsage": {
+            "plan": { "used": 10, "total": 500 },
+            "onDemand": { "used": 5, "limit": 20, "enabled": false }
+          }
+        }
+        """
+        let metrics = CursorLocalService.mapSummary(try decodeSummary(json))
+        XCTAssertNil(metrics.sessionLimit)
+    }
+
+    func testMapSummaryUsesHeadroomEstimateWhenOnDemandLimitZero() throws {
+        // enabled + used>0 but limit==0 → total falls back to used * 1.5 headroom.
+        let json = """
+        {
+          "individualUsage": {
+            "plan": { "used": 10, "total": 500 },
+            "onDemand": { "used": 8, "limit": 0, "enabled": true }
+          }
+        }
+        """
+        let metrics = CursorLocalService.mapSummary(try decodeSummary(json))
+        XCTAssertEqual(metrics.sessionLimit?.used, 8)
+        XCTAssertEqual(metrics.sessionLimit?.total ?? 0, 12, accuracy: 0.0001)
+    }
+
+    func testMapSummaryOmitsSessionLimitWhenOnDemandAllZero() throws {
+        let json = """
+        {
+          "individualUsage": {
+            "plan": { "used": 10, "total": 500 },
+            "onDemand": { "used": 0, "limit": 0, "enabled": true }
+          }
+        }
+        """
+        let metrics = CursorLocalService.mapSummary(try decodeSummary(json))
+        XCTAssertNil(metrics.sessionLimit)
+    }
+
+    // MARK: - JWT userId extraction
+
+    func testExtractUserIdSplitsAuth0PrefixedSub() {
+        let token = makeJWT(sub: "auth0|user-abc123")
+        XCTAssertEqual(CursorLocalService.extractUserIdFromJWT(token), "user-abc123")
+    }
+
+    func testExtractUserIdReturnsPlainSub() {
+        let token = makeJWT(sub: "user-xyz")
+        XCTAssertEqual(CursorLocalService.extractUserIdFromJWT(token), "user-xyz")
+    }
+
+    func testExtractUserIdReturnsNilForMalformedToken() {
+        XCTAssertNil(CursorLocalService.extractUserIdFromJWT("not-a-jwt"))
+    }
+}

--- a/MeterBarTests/KeychainManagerTests.swift
+++ b/MeterBarTests/KeychainManagerTests.swift
@@ -1,0 +1,123 @@
+import Security
+import XCTest
+@testable import MeterBar
+
+/// Exercises `KeychainManager`'s save/get/delete orchestration against an
+/// in-memory backend. The real login keychain is unavailable (and prompts) on
+/// CI runners, so the `KeychainBackend` seam lets us verify the update-then-add
+/// fallback, UTF-8 round-tripping, and the not-found → nil path deterministically.
+final class KeychainManagerTests: XCTestCase {
+
+    /// Minimal in-memory stand-in for the Security framework, keyed by the
+    /// `kSecAttrAccount` value. Mirrors the real semantics the manager relies on:
+    /// update on a missing item returns `errSecItemNotFound`, copy on a missing
+    /// item returns `errSecItemNotFound`, delete is idempotent.
+    private final class InMemoryKeychainBackend: KeychainBackend {
+        private(set) var storage: [String: Data] = [:]
+        private(set) var addCallCount = 0
+        private(set) var updateCallCount = 0
+
+        private func account(in query: [String: Any]) -> String? {
+            query[kSecAttrAccount as String] as? String
+        }
+
+        func update(query: [String: Any], attributes: [String: Any]) -> OSStatus {
+            updateCallCount += 1
+            guard let account = account(in: query), storage[account] != nil else {
+                return errSecItemNotFound
+            }
+            guard let data = attributes[kSecValueData as String] as? Data else {
+                return errSecParam
+            }
+            storage[account] = data
+            return errSecSuccess
+        }
+
+        func add(query: [String: Any]) -> OSStatus {
+            addCallCount += 1
+            guard let account = account(in: query),
+                  let data = query[kSecValueData as String] as? Data else {
+                return errSecParam
+            }
+            guard storage[account] == nil else { return errSecDuplicateItem }
+            storage[account] = data
+            return errSecSuccess
+        }
+
+        func copyMatching(query: [String: Any], result: inout AnyObject?) -> OSStatus {
+            guard let account = account(in: query), let data = storage[account] else {
+                return errSecItemNotFound
+            }
+            result = data as AnyObject
+            return errSecSuccess
+        }
+
+        func delete(query: [String: Any]) -> OSStatus {
+            guard let account = account(in: query) else { return errSecParam }
+            guard storage.removeValue(forKey: account) != nil else { return errSecItemNotFound }
+            return errSecSuccess
+        }
+    }
+
+    private func makeManager() -> (KeychainManager, InMemoryKeychainBackend) {
+        let backend = InMemoryKeychainBackend()
+        return (KeychainManager(backend: backend), backend)
+    }
+
+    func testSaveThenGetRoundTrips() {
+        let (manager, _) = makeManager()
+        XCTAssertTrue(manager.save(key: "openai", value: "sk-secret"))
+        XCTAssertEqual(manager.get(key: "openai"), "sk-secret")
+    }
+
+    func testFirstSaveFallsBackToAddAfterItemNotFound() {
+        let (manager, backend) = makeManager()
+        XCTAssertTrue(manager.save(key: "anthropic", value: "value-1"))
+        // The item did not exist, so update reported not-found and the manager
+        // fell back to add exactly once.
+        XCTAssertEqual(backend.updateCallCount, 1)
+        XCTAssertEqual(backend.addCallCount, 1)
+    }
+
+    func testOverwriteUsesUpdateWithoutAdding() {
+        let (manager, backend) = makeManager()
+        XCTAssertTrue(manager.save(key: "anthropic", value: "value-1"))
+        XCTAssertTrue(manager.save(key: "anthropic", value: "value-2"))
+        XCTAssertEqual(manager.get(key: "anthropic"), "value-2")
+        // Second save updated in place — only the first save added.
+        XCTAssertEqual(backend.addCallCount, 1)
+        XCTAssertEqual(backend.updateCallCount, 2)
+    }
+
+    func testGetMissingKeyReturnsNil() {
+        let (manager, _) = makeManager()
+        XCTAssertNil(manager.get(key: "absent"))
+    }
+
+    func testHasKeyReflectsPresence() {
+        let (manager, _) = makeManager()
+        XCTAssertFalse(manager.hasKey(key: "cursor"))
+        XCTAssertTrue(manager.save(key: "cursor", value: "token"))
+        XCTAssertTrue(manager.hasKey(key: "cursor"))
+    }
+
+    func testDeleteRemovesKeyAndIsIdempotent() {
+        let (manager, _) = makeManager()
+        XCTAssertTrue(manager.save(key: "cursor", value: "token"))
+        XCTAssertTrue(manager.delete(key: "cursor"))
+        XCTAssertFalse(manager.hasKey(key: "cursor"))
+        // Deleting an absent key still succeeds (errSecItemNotFound is tolerated).
+        XCTAssertTrue(manager.delete(key: "cursor"))
+    }
+
+    func testKeysAreIsolatedByAccount() {
+        let (manager, _) = makeManager()
+        XCTAssertTrue(manager.save(key: "openai", value: "a"))
+        XCTAssertTrue(manager.save(key: "anthropic", value: "b"))
+        XCTAssertEqual(manager.get(key: "openai"), "a")
+        XCTAssertEqual(manager.get(key: "anthropic"), "b")
+        XCTAssertTrue(manager.delete(key: "openai"))
+        XCTAssertNil(manager.get(key: "openai"))
+        XCTAssertEqual(manager.get(key: "anthropic"), "b")
+    }
+}

--- a/MeterBarTests/MetricsFixtures.swift
+++ b/MeterBarTests/MetricsFixtures.swift
@@ -1,0 +1,98 @@
+import Foundation
+import MeterBarShared
+@testable import MeterBar
+
+/// Deterministic `UsageMetrics` fixtures for the three providers, shared across
+/// the service-layer tests (SharedDataStore round-trip, UsageDataManager
+/// orchestration) and the widget-rendering checks. All timestamps are fixed so
+/// nothing depends on wall-clock time.
+enum MetricsFixtures {
+    /// A stable reference instant used for every reset/last-updated field.
+    static let referenceDate = Date(timeIntervalSinceReferenceDate: 700_000_000)
+
+    static func claudeCode(
+        sessionUsedPercent: Double = 42.5,
+        weeklyUsedPercent: Double = 12
+    ) -> UsageMetrics {
+        UsageMetrics(
+            service: .claudeCode,
+            sessionLimit: UsageLimit(
+                used: sessionUsedPercent,
+                total: 100,
+                resetTime: referenceDate,
+                windowSeconds: 5 * 3_600
+            ),
+            weeklyLimit: UsageLimit(
+                used: weeklyUsedPercent,
+                total: 100,
+                resetTime: referenceDate.addingTimeInterval(7 * 24 * 3_600),
+                windowSeconds: 7 * 24 * 3_600
+            ),
+            extraUsage: ExtraUsageStatus(state: .on, detail: "$0.00 used"),
+            lastUpdated: referenceDate
+        )
+    }
+
+    static func codexCli(
+        sessionUsedPercent: Double = 30,
+        weeklyUsedPercent: Double = 55,
+        codeReviewUsedPercent: Double = 5,
+        resetCreditsAvailable: Int? = 2
+    ) -> UsageMetrics {
+        UsageMetrics(
+            service: .codexCli,
+            sessionLimit: UsageLimit(
+                used: sessionUsedPercent,
+                total: 100,
+                resetTime: referenceDate,
+                windowSeconds: 5 * 3_600
+            ),
+            weeklyLimit: UsageLimit(
+                used: weeklyUsedPercent,
+                total: 100,
+                resetTime: referenceDate.addingTimeInterval(7 * 24 * 3_600),
+                windowSeconds: 7 * 24 * 3_600
+            ),
+            codeReviewLimit: UsageLimit(
+                used: codeReviewUsedPercent,
+                total: 100,
+                resetTime: referenceDate.addingTimeInterval(7 * 24 * 3_600),
+                windowSeconds: 7 * 24 * 3_600
+            ),
+            extraUsage: ExtraUsageStatus(state: .off, detail: nil),
+            resetCreditsAvailable: resetCreditsAvailable,
+            lastUpdated: referenceDate
+        )
+    }
+
+    static func cursor(
+        planUsed: Double = 137,
+        planTotal: Double = 500,
+        onDemandUsed: Double = 3.5,
+        onDemandTotal: Double = 20
+    ) -> UsageMetrics {
+        UsageMetrics(
+            service: .cursor,
+            sessionLimit: UsageLimit(
+                used: onDemandUsed,
+                total: onDemandTotal,
+                resetTime: referenceDate
+            ),
+            weeklyLimit: UsageLimit(
+                used: planUsed,
+                total: planTotal,
+                resetTime: referenceDate
+            ),
+            lastUpdated: referenceDate
+        )
+    }
+
+    /// One populated metric per provider, keyed by `ServiceType`.
+    static func allProviders() -> [ServiceType: UsageMetrics] {
+        [
+            .claudeCode: claudeCode(),
+            .codexCli: codexCli(),
+            .cursor: cursor()
+        ]
+    }
+}

--- a/MeterBarTests/SharedDataStoreTests.swift
+++ b/MeterBarTests/SharedDataStoreTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// Covers `SharedDataStore`'s disk I/O path — encode → atomic write → decode —
+/// which the wire-format contract tests do not exercise (they round-trip through
+/// the codec only). The App Group container is unavailable to `swift test`, so
+/// the `directoryOverride` seam points writes at a temp directory.
+final class SharedDataStoreTests: XCTestCase {
+    private var tempDirectory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SharedDataStoreTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDirectory {
+            try? FileManager.default.removeItem(at: tempDirectory)
+        }
+        tempDirectory = nil
+        try super.tearDownWithError()
+    }
+
+    func testSaveThenLoadRoundTripsAllProviders() throws {
+        var didWriteCount = 0
+        let store = SharedDataStore(directoryOverride: tempDirectory) { didWriteCount += 1 }
+
+        let metrics = MetricsFixtures.allProviders()
+        store.saveMetrics(metrics)
+        store.flushPendingWrites()
+
+        // The post-write hook fired exactly once (widget reload in production).
+        XCTAssertEqual(didWriteCount, 1)
+
+        let loaded = store.loadMetrics()
+        XCTAssertEqual(Set(loaded.keys), Set(metrics.keys))
+        XCTAssertEqual(loaded[.claudeCode]?.sessionLimit, metrics[.claudeCode]?.sessionLimit)
+        XCTAssertEqual(loaded[.codexCli]?.resetCreditsAvailable, 2)
+        XCTAssertEqual(loaded[.cursor]?.weeklyLimit?.total, 500)
+    }
+
+    func testFileWrittenAtExpectedPath() throws {
+        let store = SharedDataStore(directoryOverride: tempDirectory) {}
+        store.saveMetrics([.claudeCode: MetricsFixtures.claudeCode()])
+        store.flushPendingWrites()
+
+        let expected = tempDirectory.appendingPathComponent("\(StorageKeys.cachedUsageMetrics).json")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: expected.path))
+    }
+
+    func testLoadReturnsEmptyWhenNoFileWritten() {
+        let store = SharedDataStore(directoryOverride: tempDirectory) {}
+        XCTAssertTrue(store.loadMetrics().isEmpty)
+    }
+
+    func testLatestSaveOverwritesPreviousContents() throws {
+        let store = SharedDataStore(directoryOverride: tempDirectory) {}
+
+        store.saveMetrics(MetricsFixtures.allProviders())
+        store.flushPendingWrites()
+
+        // A subsequent save with a single provider replaces the file wholesale.
+        store.saveMetrics([.cursor: MetricsFixtures.cursor(planUsed: 400)])
+        store.flushPendingWrites()
+
+        let loaded = store.loadMetrics()
+        XCTAssertEqual(Set(loaded.keys), [.cursor])
+        XCTAssertEqual(loaded[.cursor]?.weeklyLimit?.used, 400)
+    }
+}

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// Orchestration coverage for `UsageDataManager.refreshAll` / `refresh(service:)`
+/// — merge, graceful degradation on fetch failure, disabled-provider handling —
+/// driven through the provider seam so no network or local credentials are
+/// touched. Claude Code is hidden in every scenario (its account-aware path is
+/// out of scope here), leaving Codex + Cursor as the single-account providers.
+@MainActor
+final class UsageDataManagerTests: XCTestCase {
+
+    /// Stub provider whose access flag and fetch result are fully controlled.
+    private final class StubProvider: SimpleUsageProviding {
+        var hasAccess: Bool
+        var result: Result<UsageMetrics, Error>
+        private(set) var fetchCount = 0
+
+        init(hasAccess: Bool, result: Result<UsageMetrics, Error>) {
+            self.hasAccess = hasAccess
+            self.result = result
+        }
+
+        func fetchUsageMetrics() async throws -> UsageMetrics {
+            fetchCount += 1
+            return try result.get()
+        }
+    }
+
+    private enum StubError: Error { case fetchFailed }
+
+    private var tempDirectory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("UsageDataManagerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDirectory { try? FileManager.default.removeItem(at: tempDirectory) }
+        tempDirectory = nil
+        try super.tearDownWithError()
+    }
+
+    /// Builds a manager with isolated stores. `hidden` always includes
+    /// `.claudeCode`; `preload` seeds the on-disk cache before construction so
+    /// graceful-degradation paths have something to preserve.
+    private func makeManager(
+        codex: StubProvider,
+        cursor: StubProvider,
+        hidden: Set<ServiceType> = [],
+        preload: [ServiceType: UsageMetrics] = [:]
+    ) -> (manager: UsageDataManager, sharedStore: SharedDataStore) {
+        let suiteName = "UsageDataManagerTests-\(UUID().uuidString)"
+        let cacheDefaults = UserDefaults(suiteName: suiteName)!
+        if !preload.isEmpty, let data = MetricsCodec.encode(preload) {
+            cacheDefaults.set(data, forKey: StorageKeys.cachedUsageMetrics)
+        }
+
+        let visibilityDefaults = UserDefaults(suiteName: "\(suiteName)-vis")!
+        let visibility = ProviderVisibilityStore(userDefaults: visibilityDefaults)
+        for service in hidden.union([.claudeCode]) {
+            visibility.set(service, isEnabled: false)
+        }
+
+        let sharedStore = SharedDataStore(directoryOverride: tempDirectory) {}
+
+        let manager = UsageDataManager(
+            codexCliService: codex,
+            cursorService: cursor,
+            providerVisibilityStore: visibility,
+            sharedStore: sharedStore,
+            cacheDefaults: cacheDefaults,
+            schedulesAutoRefresh: false
+        )
+        return (manager, sharedStore)
+    }
+
+    func testRefreshAllMergesBothEnabledProviders() async {
+        let codex = StubProvider(hasAccess: true, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: true, result: .success(MetricsFixtures.cursor()))
+        let (manager, sharedStore) = makeManager(codex: codex, cursor: cursor)
+
+        await manager.refreshAll()
+
+        XCTAssertEqual(Set(manager.metrics.keys), [.codexCli, .cursor])
+        XCTAssertEqual(manager.metrics[.codexCli]?.resetCreditsAvailable, 2)
+        XCTAssertFalse(manager.isLoading)
+
+        // The merged snapshot is mirrored to the App Group file for the widget.
+        sharedStore.flushPendingWrites()
+        XCTAssertEqual(Set(sharedStore.loadMetrics().keys), [.codexCli, .cursor])
+    }
+
+    func testRefreshAllPreservesCachedMetricsWhenProviderFails() async {
+        // Cursor previously cached a distinctive value; this refresh it throws.
+        let cachedCursor = MetricsFixtures.cursor(planUsed: 999)
+        let codex = StubProvider(hasAccess: true, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: true, result: .failure(StubError.fetchFailed))
+        let (manager, _) = makeManager(
+            codex: codex,
+            cursor: cursor,
+            preload: [.codexCli: MetricsFixtures.codexCli(), .cursor: cachedCursor]
+        )
+
+        await manager.refreshAll()
+
+        // Codex refreshed; Cursor degraded gracefully to its cached value.
+        XCTAssertEqual(Set(manager.metrics.keys), [.codexCli, .cursor])
+        XCTAssertEqual(manager.metrics[.cursor]?.weeklyLimit?.used, 999)
+        XCTAssertNotNil(manager.lastError)
+    }
+
+    func testRefreshAllSkipsDisabledProvider() async {
+        let codex = StubProvider(hasAccess: true, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: true, result: .success(MetricsFixtures.cursor()))
+        let (manager, _) = makeManager(codex: codex, cursor: cursor, hidden: [.cursor])
+
+        await manager.refreshAll()
+
+        XCTAssertEqual(Set(manager.metrics.keys), [.codexCli])
+        XCTAssertEqual(cursor.fetchCount, 0, "disabled provider must not be fetched")
+    }
+
+    func testRefreshAllSkipsProviderWithoutAccess() async {
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: true, result: .success(MetricsFixtures.cursor()))
+        let (manager, _) = makeManager(codex: codex, cursor: cursor)
+
+        await manager.refreshAll()
+
+        XCTAssertEqual(codex.fetchCount, 0, "provider without access must not be fetched")
+        XCTAssertEqual(Set(manager.metrics.keys), [.cursor])
+    }
+
+    func testRefreshSingleDisabledServiceRemovesIt() async {
+        let codex = StubProvider(hasAccess: true, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: true, result: .success(MetricsFixtures.cursor()))
+        let (manager, sharedStore) = makeManager(
+            codex: codex,
+            cursor: cursor,
+            hidden: [.cursor],
+            preload: [.cursor: MetricsFixtures.cursor()]
+        )
+
+        // Cursor is disabled, so refreshing it should drop the cached entry.
+        await manager.refresh(service: .cursor)
+
+        XCTAssertNil(manager.metrics[.cursor])
+        sharedStore.flushPendingWrites()
+        XCTAssertNil(sharedStore.loadMetrics()[.cursor])
+    }
+}


### PR DESCRIPTION
## What

Tier 3a of \`.agents/docs/ISSUE_BACKLOG.md\` — direct unit coverage for the services the 2026-07-02 audit confirmed untested at HEAD, plus a coverage-floor ratchet.

Every change adds a **test seam** and defaults it to the prior singleton wiring, so production behavior is byte-identical.

### Seams + tests

| Service | Seam | Tests |
|---|---|---|
| `KeychainManager` | `KeychainBackend` protocol over `SecItem*`; in-memory fake | save/get/delete, update-then-add fallback, isolation |
| `SharedDataStore` | injectable `directoryOverride` + `didWrite` hook + `flushPendingWrites()` | encode→atomic-write→decode round-trip, overwrite, empty |
| `CodexCliLocalService` | pure `mapUsageResponse(_:)`; injectable `authFileDataProvider` | 3-window mapping, free-account, token-expiry gating |
| `CursorLocalService` | pure `mapSummary(_:)`; static `extractUserIdFromJWT` | plan/on-demand mapping, default plan-total, headroom, JWT `sub` |
| `UsageDataManager` | `SimpleUsageProviding` protocol + injectable stores | merge, graceful degradation on fetch failure, disabled/no-access skip |
| `CostTracker` | internal `scanCodexArchivedSessions` + `CodexScanContext` | Codex archived-session accumulation, dedup, per-line cutoff |

`ProviderVisibilityStore.init` made internal for isolated-suite tests. Shared `MetricsFixtures` helper (Claude/Codex/Cursor).

### Coverage ratchet

`COVERAGE_THRESHOLD` in \`ci.yml\` raised to just under the new CI-measured baseline (see commit after CI runs). Never lowered.

## Verification

Local machine has Command Line Tools only (no XCTest module), so the suite runs in **CI** (\`swift test\` via \`scripts/check-coverage.sh\`); locally verified with \`swift build\`.

Refs #71.