### PR TITLE
Add token optimization insights dashboard (#72)

### DIFF
--- a/.agents/SESSIONS/2026-07-03.md
+++ b/.agents/SESSIONS/2026-07-03.md
@@ -1,0 +1,74 @@
+# Sessions: 2026-07-03
+
+**Summary:** Token optimization insights page (#72)
+
+---
+
+## Session 1: Add "Optimize" dashboard page (#72, Tier 4b)
+
+**Duration:** ~1 session
+**Status:** Complete (tests run in CI — no local XCTest runtime)
+
+### What was done
+
+- Implemented GitHub issue #72 "Add token optimization insights dashboard" (backlog Tier 4b):
+  a new **Optimize** dashboard nav section, separate from Costs, built as an analytics/UI
+  layer over the existing local `CostSummary` — no data-pipeline changes.
+- **TDD:** wrote the recommendation-engine tests first, then the pure model, then the view.
+- **Pure model** `OptimizationInsights` (SocialShareCardContent pattern — pure, no network,
+  no SwiftUI): KPIs (token burn by model, premium-model share, input/output ratio, cache
+  reuse, 7/30-day windows), ranked model + origin breakdowns, a derived 0–100 optimization
+  score with letter grade, and plain-English recommendations. `ModelTier.classify` tiers
+  models (premium/standard/economy) by name-only heuristic.
+- **View** `OptimizeInsightsView` in its own file (never inside `UsageDashboardView.swift`):
+  score hero, KPI grid, 7/30-day token-burn chart (reuses `DailyUsageChart`), ranked
+  model/origin cards, recommendations, and empty/loading states that explain the local scan.
+- Exposed three existing dashboard helpers (`DashboardCard`, `DailyUsageChart`,
+  `DashboardStatusHero`) from `private` → internal so the new page reuses them instead of
+  hand-rolling. Full per-type split of the 1539-line monolith stays deferred (backlog Tier 1f).
+
+### Files changed
+
+- `MeterBar/Models/OptimizationInsights.swift` - new pure recommendation-engine model
+- `MeterBarTests/OptimizationInsightsTests.swift` - new engine tests (written first)
+- `MeterBar/Views/OptimizeInsightsView.swift` - new Optimize dashboard page
+- `MeterBar/Views/UsageDashboardView.swift` - added `.optimize` nav case + routing;
+  made 3 reusable helpers internal
+
+### Decisions
+
+- **Decision:** "Origin" ranked breakdown labelled "Top Usage Origins" (Agents / Tool use /
+  Skills / Main chat), not "projects".
+  - **Context:** Issue asks for "top sessions/projects", but `CostTracker.originBreakdowns`
+    are workflow categories, not project paths.
+  - **Rationale:** Honest to the data actually available; still answers "where do tokens go".
+- **Decision:** Optimization score is a transparent weighted blend of premium share, cache
+  reuse, context bloat (input:output), and origin concentration; constants are named + tunable.
+  - **Rationale:** Deterministic and unit-testable; boundaries/monotonicity are asserted.
+- **Decision:** Privacy boundary enforced in code + copy — only token totals, model names, and
+  derived stats are read; documented in the model header and shown in the UI footnote.
+
+### Mistakes and fixes
+
+- **Mistake:** Early Write/Edit calls used main-repo absolute paths, so new files + the
+  dashboard edit landed in the main checkout instead of this worktree; `touch` then created
+  empty stubs in the worktree, so the first `swift build` "passed" against empty files.
+- **Fix:** Relocated all four files into the worktree, reverted the main repo's
+  `UsageDashboardView.swift`, removed the stray untracked files, then did a clean rebuild.
+- **Prevention:** Always use worktree-absolute paths for Write/Edit/Read in a worktree session.
+
+### Verification
+
+- `swift build` passes (library incl. new model + view + edited dashboard).
+- Line length ≤120; no `xct_specific_matcher` anti-patterns; fixed `redundant_type_annotation`
+  and a `vertical_whitespace_opening_braces` nit. SwiftLint/`swift test` run in CI (no full
+  Xcode locally — CLT lacks XCTest and sourcekit).
+
+### Next steps
+
+- [ ] Confirm CI (build + tests + swiftlint) green on the PR.
+- [ ] Backlog Tier 1f: full per-type split of `UsageDashboardView.swift` still pending.
+
+---
+
+**Total sessions today:** 1

--- a/MeterBar/Models/OptimizationInsights.swift
+++ b/MeterBar/Models/OptimizationInsights.swift
@@ -1,0 +1,435 @@
+import Foundation
+import MeterBarShared
+
+// MARK: - Model tier
+
+/// Coarse cost tier for a model, derived from its (possibly raw) id.
+///
+/// Classification is a pure, name-only heuristic — no network, no prompt
+/// contents. New frontier/economy ids are matched by family substring so the
+/// tiering keeps working as providers ship dated variants.
+enum ModelTier: String, Sendable, Equatable {
+    case premium
+    case standard
+    case economy
+    case unknown
+
+    static func classify(_ modelName: String) -> ModelTier {
+        let name = modelName.lowercased()
+        guard !name.isEmpty, !name.contains("unknown") else { return .unknown }
+
+        // Economy markers win first: a "mini"/"haiku" variant of a frontier
+        // family is still cheap, so check these before the premium families.
+        let economyMarkers = ["haiku", "mini", "nano", "flash", "lite", "small"]
+        if economyMarkers.contains(where: name.contains) { return .economy }
+
+        let premiumMarkers = ["opus", "fable", "gpt-5", "gpt5", "o3", "o1"]
+        if premiumMarkers.contains(where: name.contains) { return .premium }
+
+        let standardMarkers = ["sonnet", "codex", "gpt-4", "gpt4", "gpt-3"]
+        if standardMarkers.contains(where: name.contains) { return .standard }
+
+        return .unknown
+    }
+
+    var isPremium: Bool { self == .premium }
+
+    var label: String {
+        switch self {
+        case .premium: return "Premium"
+        case .standard: return "Standard"
+        case .economy: return "Economy"
+        case .unknown: return "Other"
+        }
+    }
+}
+
+// MARK: - Ranked entry
+
+/// One row of a ranked token breakdown (by model or by usage origin).
+struct RankedTokenEntry: Identifiable, Equatable, Sendable {
+    let id: String
+    let name: String
+    let provider: ServiceType
+    let totalTokens: Int
+    let estimatedCostUSD: Double
+    let sessionCount: Int
+    /// Share of the ranked group's grand total, 0...1.
+    let tokenShare: Double
+
+    var tier: ModelTier { ModelTier.classify(name) }
+
+    var formattedTokens: String { UsageFormat.tokens(totalTokens) }
+    var formattedCost: String { UsageFormat.cost(estimatedCostUSD) }
+    var formattedShare: String { OptimizationInsights.percentString(tokenShare) }
+}
+
+// MARK: - Recommendation
+
+enum RecommendationSeverity: Int, Comparable, Sendable {
+    case positive = 0
+    case info = 1
+    case suggestion = 2
+    case warning = 3
+
+    static func < (lhs: RecommendationSeverity, rhs: RecommendationSeverity) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+/// A single plain-English optimization recommendation. Every field is derived
+/// from local aggregates only — never prompt contents.
+struct OptimizationRecommendation: Identifiable, Equatable, Sendable {
+    let id: String
+    let title: String
+    let detail: String
+    let severity: RecommendationSeverity
+    let systemImage: String
+}
+
+// MARK: - Insights
+
+/// Pure, local-only analytics over the cached `CostSummary`.
+///
+/// **Privacy boundary (hard):** this type reads token totals, model names,
+/// origin/workflow metadata, and derived statistics. It never touches prompt
+/// contents and nothing here is uploaded — every value is computed on-device
+/// from the same cache the Costs page already renders. Kept as a pure model
+/// (no SwiftUI, no I/O) so the recommendation logic is unit-testable, matching
+/// the `SocialShareCardContent` pattern.
+struct OptimizationInsights: Equatable, Sendable {
+    // MARK: Tunable scoring constants
+
+    private enum Score {
+        static let premiumWeight = 0.40
+        static let cacheWeight = 0.25
+        static let bloatWeight = 0.20
+        static let concentrationWeight = 0.15
+
+        /// Input:output ratios at or below this are treated as unbloated.
+        static let idealInputOutputRatio = 8.0
+        /// Ratio at/above which the context-bloat component bottoms out.
+        static let bloatCeilingRatio = 32.0
+        /// Origin share at/below which no concentration penalty applies.
+        static let concentrationFloor = 0.5
+        /// Neutral fill for signals we cannot measure (no output / no cache).
+        static let neutralComponent = 0.5
+    }
+
+    private enum Threshold {
+        static let premiumWarning = 0.5
+        static let premiumSuggestion = 0.3
+        static let cacheReuseWarning = 0.3
+        static let cacheReusePositive = 0.7
+        static let inputOutputSuggestion = 20.0
+        static let originConcentration = 0.5
+        static let trendUpMultiplier = 1.2
+    }
+
+    // MARK: KPIs
+
+    let totalTokens: Int
+    let periodDays: Int
+    let tokens7Day: Int
+    let tokens30Day: Int
+    let premiumTokenShare: Double
+    let inputOutputRatio: Double?
+    let cacheReuseRatio: Double?
+    let topModels: [RankedTokenEntry]
+    let topOrigins: [RankedTokenEntry]
+    let optimizationScore: Int
+    let recommendations: [OptimizationRecommendation]
+
+    var hasData: Bool { totalTokens > 0 }
+
+    var scoreGrade: String {
+        switch optimizationScore {
+        case 85...: return "A"
+        case 70..<85: return "B"
+        case 55..<70: return "C"
+        case 40..<55: return "D"
+        default: return "F"
+        }
+    }
+
+    var scoreHeadline: String {
+        switch optimizationScore {
+        case 85...: return "Lean usage"
+        case 70..<85: return "Efficient"
+        case 55..<70: return "Room to optimize"
+        case 40..<55: return "Heavy usage"
+        default: return "Very heavy usage"
+        }
+    }
+
+    var formattedPremiumShare: String { Self.percentString(premiumTokenShare) }
+
+    var formattedCacheReuse: String {
+        guard let cacheReuseRatio else { return "—" }
+        return Self.percentString(cacheReuseRatio)
+    }
+
+    var formattedInputOutputRatio: String {
+        guard let inputOutputRatio else { return "—" }
+        return String(format: "%.1f : 1", inputOutputRatio)
+    }
+
+    // MARK: Init
+
+    init(summary: CostSummary, now: Date = Date(), calendar: Calendar = .current) {
+        let costs = summary.costs
+
+        // Flatten model + origin breakdowns across every provider.
+        let modelBreakdowns = costs.flatMap(\.modelBreakdowns)
+        let originBreakdowns = costs.flatMap(\.originBreakdowns)
+
+        let modelTokenTotal = modelBreakdowns.reduce(0) { $0 + $1.totalTokens }
+        let originTokenTotal = originBreakdowns.reduce(0) { $0 + $1.totalTokens }
+
+        self.topModels = Self.rank(modelBreakdowns, groupTotal: modelTokenTotal)
+        self.topOrigins = Self.rank(originBreakdowns, groupTotal: originTokenTotal)
+
+        // Aggregate token buckets across providers.
+        let input = costs.reduce(0) { $0 + $1.inputTokens }
+        let output = costs.reduce(0) { $0 + $1.outputTokens }
+        let cacheCreation = costs.reduce(0) { $0 + $1.cacheCreationTokens }
+        let cacheRead = costs.reduce(0) { $0 + $1.cacheReadTokens }
+
+        self.totalTokens = summary.totalTokens
+        self.periodDays = summary.periodDays
+
+        self.premiumTokenShare = Self.premiumShare(of: modelBreakdowns, groupTotal: modelTokenTotal)
+        self.inputOutputRatio = output > 0 ? Double(input) / Double(output) : nil
+
+        let cacheDenominator = cacheRead + cacheCreation
+        self.cacheReuseRatio = cacheDenominator > 0 ? Double(cacheRead) / Double(cacheDenominator) : nil
+
+        self.tokens7Day = Self.windowTokens(summary.dailyUsage, days: 7, now: now, calendar: calendar)
+        self.tokens30Day = Self.windowTokens(summary.dailyUsage, days: 30, now: now, calendar: calendar)
+
+        let topOriginShare = topOrigins.first?.tokenShare ?? 0
+
+        self.optimizationScore = Self.computeScore(
+            premiumShare: premiumTokenShare,
+            inputOutputRatio: inputOutputRatio,
+            cacheReuseRatio: cacheReuseRatio,
+            topOriginShare: topOriginShare
+        )
+
+        if summary.totalTokens > 0 {
+            self.recommendations = Self.buildRecommendations(
+                premiumShare: premiumTokenShare,
+                inputOutputRatio: inputOutputRatio,
+                cacheReuseRatio: cacheReuseRatio,
+                cacheCreationTokens: cacheCreation,
+                topOrigin: topOrigins.first,
+                topModel: topModels.first,
+                tokens7Day: tokens7Day,
+                tokens30Day: tokens30Day
+            )
+        } else {
+            self.recommendations = []
+        }
+    }
+
+    // MARK: - Pure computations
+
+    static func premiumShare(of models: [TokenUsageBreakdown], groupTotal: Int? = nil) -> Double {
+        let total = groupTotal ?? models.reduce(0) { $0 + $1.totalTokens }
+        guard total > 0 else { return 0 }
+        let premiumTokens = models
+            .filter { ModelTier.classify($0.name).isPremium }
+            .reduce(0) { $0 + $1.totalTokens }
+        return Double(premiumTokens) / Double(total)
+    }
+
+    /// Blends four leanness signals into a 0...100 score (higher = leaner).
+    static func computeScore(
+        premiumShare: Double,
+        inputOutputRatio: Double?,
+        cacheReuseRatio: Double?,
+        topOriginShare: Double
+    ) -> Int {
+        let premiumComponent = 1 - clamp01(premiumShare)
+        let cacheComponent = cacheReuseRatio.map(clamp01) ?? Score.neutralComponent
+
+        let bloatComponent: Double
+        if let ratio = inputOutputRatio {
+            let span = Score.bloatCeilingRatio - Score.idealInputOutputRatio
+            let excess = (ratio - Score.idealInputOutputRatio) / span
+            bloatComponent = 1 - clamp01(excess)
+        } else {
+            bloatComponent = Score.neutralComponent
+        }
+
+        let concentrationSpan = 1 - Score.concentrationFloor
+        let concentrationExcess = (clamp01(topOriginShare) - Score.concentrationFloor) / concentrationSpan
+        let concentrationComponent = 1 - clamp01(concentrationExcess)
+
+        let weighted =
+            Score.premiumWeight * premiumComponent
+            + Score.cacheWeight * cacheComponent
+            + Score.bloatWeight * bloatComponent
+            + Score.concentrationWeight * concentrationComponent
+
+        return Int((clamp01(weighted) * 100).rounded())
+    }
+
+    static func buildRecommendations(
+        premiumShare: Double,
+        inputOutputRatio: Double?,
+        cacheReuseRatio: Double?,
+        cacheCreationTokens: Int,
+        topOrigin: RankedTokenEntry?,
+        topModel: RankedTokenEntry?,
+        tokens7Day: Int,
+        tokens30Day: Int
+    ) -> [OptimizationRecommendation] {
+        var recommendations: [OptimizationRecommendation] = []
+
+        // Premium-model routing.
+        if premiumShare >= Threshold.premiumWarning {
+            recommendations.append(OptimizationRecommendation(
+                id: "premium-share",
+                title: "Premium models are doing most of the work",
+                detail: "Premium models handled \(percentString(premiumShare)) of your tokens. "
+                    + "Routing routine edits, summaries, and lookups to a mid-tier or economy model "
+                    + "can cut token spend without much quality loss.",
+                severity: .warning,
+                systemImage: "bolt.badge.automatic"
+            ))
+        } else if premiumShare >= Threshold.premiumSuggestion {
+            recommendations.append(OptimizationRecommendation(
+                id: "premium-share",
+                title: "Consider tiering your model choice",
+                detail: "Premium models handled \(percentString(premiumShare)) of your tokens. "
+                    + "Reserve them for the hardest reasoning and let cheaper models handle the rest.",
+                severity: .suggestion,
+                systemImage: "bolt.badge.automatic"
+            ))
+        }
+
+        // Cache reuse.
+        if let cacheReuseRatio {
+            if cacheReuseRatio < Threshold.cacheReuseWarning, cacheCreationTokens > 0 {
+                recommendations.append(OptimizationRecommendation(
+                    id: "cache-reuse",
+                    title: "Cache reuse is low",
+                    detail: "Only \(percentString(cacheReuseRatio)) of your cache tokens were reuse — "
+                        + "sessions are rebuilding context instead of hitting the cache. Keeping related "
+                        + "work in one session and avoiding long idle gaps improves cache hits.",
+                    severity: .warning,
+                    systemImage: "arrow.triangle.2.circlepath"
+                ))
+            } else if cacheReuseRatio >= Threshold.cacheReusePositive {
+                recommendations.append(OptimizationRecommendation(
+                    id: "cache-reuse",
+                    title: "Cache reuse looks healthy",
+                    detail: "\(percentString(cacheReuseRatio)) of your cache tokens were reuse, "
+                        + "so you're paying the cheap cache-read rate instead of rebuilding context.",
+                    severity: .positive,
+                    systemImage: "checkmark.seal"
+                ))
+            }
+        }
+
+        // Context bloat (input vs output).
+        if let inputOutputRatio, inputOutputRatio > Threshold.inputOutputSuggestion {
+            recommendations.append(OptimizationRecommendation(
+                id: "input-output-ratio",
+                title: "Input tokens dwarf output",
+                detail: "You're sending roughly \(String(format: "%.0f", inputOutputRatio))× as many input "
+                    + "tokens as output. Trimming large pasted context, stale files, or oversized system "
+                    + "prompts is usually the fastest token win.",
+                severity: .suggestion,
+                systemImage: "text.append"
+            ))
+        }
+
+        // Origin concentration.
+        if let topOrigin, topOrigin.tokenShare >= Threshold.originConcentration {
+            recommendations.append(OptimizationRecommendation(
+                id: "origin-concentration",
+                title: "\(topOrigin.name) is your biggest token driver",
+                detail: "\(topOrigin.name) accounts for \(percentString(topOrigin.tokenShare)) of tracked "
+                    + "tokens. It's the highest-leverage place to tune prompts or model choice.",
+                severity: .info,
+                systemImage: "chart.pie"
+            ))
+        }
+
+        // Short-term trend.
+        if tokens30Day > 0 {
+            let recentDailyRate = Double(tokens7Day) / 7.0
+            let monthlyDailyRate = Double(tokens30Day) / 30.0
+            if recentDailyRate > monthlyDailyRate * Threshold.trendUpMultiplier {
+                recommendations.append(OptimizationRecommendation(
+                    id: "trend-up",
+                    title: "Token burn is trending up",
+                    detail: "Your last 7 days are running hotter than your 30-day average. Worth checking "
+                        + "which model or workflow is driving the increase before it compounds.",
+                    severity: .info,
+                    systemImage: "chart.line.uptrend.xyaxis"
+                ))
+            }
+        }
+
+        // Positive fallback so the panel is never empty on healthy usage.
+        if !recommendations.contains(where: { $0.severity >= .suggestion }) {
+            recommendations.append(OptimizationRecommendation(
+                id: "lean",
+                title: "Usage looks lean",
+                detail: "No major optimization flags right now — your model mix, cache reuse, and context "
+                    + "size are in a healthy range. Keep an eye on premium share as usage grows.",
+                severity: .positive,
+                systemImage: "leaf"
+            ))
+        }
+
+        return recommendations.sorted { $0.severity > $1.severity }
+    }
+
+    // MARK: - Helpers
+
+    private static func rank(_ breakdowns: [TokenUsageBreakdown], groupTotal: Int) -> [RankedTokenEntry] {
+        breakdowns
+            .filter { $0.totalTokens > 0 }
+            .sorted { $0.totalTokens > $1.totalTokens }
+            .map { breakdown in
+                RankedTokenEntry(
+                    id: breakdown.id,
+                    name: breakdown.name,
+                    provider: breakdown.provider,
+                    totalTokens: breakdown.totalTokens,
+                    estimatedCostUSD: breakdown.estimatedCostUSD,
+                    sessionCount: breakdown.sessionCount,
+                    tokenShare: groupTotal > 0 ? Double(breakdown.totalTokens) / Double(groupTotal) : 0
+                )
+            }
+    }
+
+    private static func windowTokens(
+        _ dailyUsage: [DailyTokenUsage],
+        days: Int,
+        now: Date,
+        calendar: Calendar
+    ) -> Int {
+        guard days > 0 else { return 0 }
+        let today = calendar.startOfDay(for: now)
+        guard let start = calendar.date(byAdding: .day, value: -(days - 1), to: today) else { return 0 }
+        return dailyUsage
+            .filter { usage in
+                let day = calendar.startOfDay(for: usage.date)
+                return day >= start && day <= today
+            }
+            .reduce(0) { $0 + $1.totalTokens }
+    }
+
+    private static func clamp01(_ value: Double) -> Double {
+        min(1, max(0, value))
+    }
+
+    static func percentString(_ fraction: Double) -> String {
+        "\(Int((clamp01(fraction) * 100).rounded()))%"
+    }
+}

--- a/MeterBar/Models/OptimizationInsights.swift
+++ b/MeterBar/Models/OptimizationInsights.swift
@@ -217,16 +217,15 @@ struct OptimizationInsights: Equatable, Sendable {
         )
 
         if summary.totalTokens > 0 {
-            self.recommendations = Self.buildRecommendations(
+            self.recommendations = Self.buildRecommendations(RecommendationInputs(
                 premiumShare: premiumTokenShare,
                 inputOutputRatio: inputOutputRatio,
                 cacheReuseRatio: cacheReuseRatio,
                 cacheCreationTokens: cacheCreation,
                 topOrigin: topOrigins.first,
-                topModel: topModels.first,
                 tokens7Day: tokens7Day,
                 tokens30Day: tokens30Day
-            )
+            ))
         } else {
             self.recommendations = []
         }
@@ -275,16 +274,27 @@ struct OptimizationInsights: Equatable, Sendable {
         return Int((clamp01(weighted) * 100).rounded())
     }
 
-    static func buildRecommendations(
-        premiumShare: Double,
-        inputOutputRatio: Double?,
-        cacheReuseRatio: Double?,
-        cacheCreationTokens: Int,
-        topOrigin: RankedTokenEntry?,
-        topModel: RankedTokenEntry?,
-        tokens7Day: Int,
-        tokens30Day: Int
-    ) -> [OptimizationRecommendation] {
+    /// Grouped inputs for `buildRecommendations` — keeps the derived signals
+    /// together and the function parameter count in check.
+    struct RecommendationInputs {
+        let premiumShare: Double
+        let inputOutputRatio: Double?
+        let cacheReuseRatio: Double?
+        let cacheCreationTokens: Int
+        let topOrigin: RankedTokenEntry?
+        let tokens7Day: Int
+        let tokens30Day: Int
+    }
+
+    static func buildRecommendations(_ inputs: RecommendationInputs) -> [OptimizationRecommendation] {
+        let premiumShare = inputs.premiumShare
+        let inputOutputRatio = inputs.inputOutputRatio
+        let cacheReuseRatio = inputs.cacheReuseRatio
+        let cacheCreationTokens = inputs.cacheCreationTokens
+        let topOrigin = inputs.topOrigin
+        let tokens7Day = inputs.tokens7Day
+        let tokens30Day = inputs.tokens30Day
+
         var recommendations: [OptimizationRecommendation] = []
 
         // Premium-model routing.

--- a/MeterBar/Views/OptimizeInsightsView.swift
+++ b/MeterBar/Views/OptimizeInsightsView.swift
@@ -1,0 +1,399 @@
+import SwiftUI
+import MeterBarShared
+
+/// The "Optimize" dashboard page (#72): an analytics/UI layer over the same
+/// local `CostSummary` the Costs page already renders. It surfaces where tokens
+/// go (by model and by usage origin), a handful of leanness KPIs, a derived
+/// optimization score, and plain-English recommendations.
+///
+/// Everything shown here is computed on-device by `OptimizationInsights` from
+/// token totals, model names, and workflow metadata only — no prompt contents,
+/// nothing uploaded. Lives in its own file (never inside `UsageDashboardView`)
+/// per the dashboard view-split convention.
+struct OptimizeInsightsView: View {
+    @StateObject private var costTracker = CostTracker.shared
+    @StateObject private var providerVisibility = ProviderVisibilityStore.shared
+
+    /// 7/30-day window for the token-burn chart.
+    @State private var chartDays = 30
+
+    private var visibleSummary: CostSummary? {
+        costTracker.costSummary?.filtered(to: providerVisibility.enabledServices)
+    }
+
+    private var insights: OptimizationInsights? {
+        visibleSummary.map { OptimizationInsights(summary: $0) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            if costTracker.isScanning, insights?.hasData != true {
+                loadingCard
+            } else if let insights, insights.hasData {
+                content(for: insights)
+            } else {
+                emptyStateCard
+            }
+        }
+    }
+
+    // MARK: - Populated content
+
+    @ViewBuilder
+    private func content(for insights: OptimizationInsights) -> some View {
+        scoreHero(for: insights)
+        kpiGrid(for: insights)
+        tokenBurnCard
+        modelBreakdownCard(for: insights)
+        originBreakdownCard(for: insights)
+        recommendationsCard(for: insights)
+    }
+
+    private func scoreHero(for insights: OptimizationInsights) -> some View {
+        DashboardStatusHero(
+            title: "Optimization score \(insights.optimizationScore)/100 · \(insights.scoreGrade)",
+            detail: "\(insights.scoreHeadline) — based on premium-model share, context size, cache reuse, "
+                + "and how concentrated your usage is.",
+            iconName: "leaf.fill",
+            color: Self.gradeColor(insights.optimizationScore)
+        )
+    }
+
+    private func kpiGrid(for insights: OptimizationInsights) -> some View {
+        LazyVGrid(columns: Self.kpiColumns, alignment: .leading, spacing: 12) {
+            KpiTile(
+                title: "Premium model share",
+                value: insights.formattedPremiumShare,
+                caption: "of tokens on premium models",
+                systemImage: "bolt.fill",
+                tint: Self.shareTint(insights.premiumTokenShare)
+            )
+            KpiTile(
+                title: "Cache reuse",
+                value: insights.formattedCacheReuse,
+                caption: "cache reads vs new context",
+                systemImage: "arrow.triangle.2.circlepath",
+                tint: Self.cacheTint(insights.cacheReuseRatio)
+            )
+            KpiTile(
+                title: "Input : output",
+                value: insights.formattedInputOutputRatio,
+                caption: "context sent vs generated",
+                systemImage: "text.append",
+                tint: .secondary
+            )
+            KpiTile(
+                title: "Last 7 days",
+                value: UsageFormat.tokens(insights.tokens7Day),
+                caption: "\(UsageFormat.tokens(insights.tokens30Day)) over 30 days",
+                systemImage: "calendar",
+                tint: .secondary
+            )
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var tokenBurnCard: some View {
+        DashboardCard(title: "Token Burn", trailing: nil) {
+            VStack(alignment: .leading, spacing: 12) {
+                Picker("Window", selection: $chartDays) {
+                    Text("7 days").tag(7)
+                    Text("30 days").tag(30)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(maxWidth: 220)
+
+                if let summary = visibleSummary, !summary.dailyUsage.isEmpty {
+                    DailyUsageChart(dailyUsage: summary.dailyUsage, daysToShow: chartDays)
+                        .frame(height: 200)
+                } else {
+                    Text("No daily token history yet.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .frame(height: 200, alignment: .center)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+        }
+    }
+
+    private func modelBreakdownCard(for insights: OptimizationInsights) -> some View {
+        DashboardCard(title: "Token Burn by Model", trailing: nil) {
+            if insights.topModels.isEmpty {
+                Text("No per-model breakdown available in the current scan.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            } else {
+                VStack(spacing: 10) {
+                    ForEach(insights.topModels.prefix(6)) { entry in
+                        RankedBreakdownRow(entry: entry, showsTier: true)
+                    }
+                }
+            }
+        }
+    }
+
+    private func originBreakdownCard(for insights: OptimizationInsights) -> some View {
+        DashboardCard(title: "Top Usage Origins", trailing: nil) {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Where tokens are spent — agents, tool use, skills, and main chat.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                if insights.topOrigins.isEmpty {
+                    Text("No origin breakdown available in the current scan.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                } else {
+                    ForEach(insights.topOrigins.prefix(6)) { entry in
+                        RankedBreakdownRow(entry: entry, showsTier: false)
+                    }
+                }
+            }
+        }
+    }
+
+    private func recommendationsCard(for insights: OptimizationInsights) -> some View {
+        DashboardCard(title: "Recommendations", trailing: nil) {
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(insights.recommendations) { recommendation in
+                    RecommendationRow(recommendation: recommendation)
+                }
+
+                Divider()
+
+                Label(
+                    "Computed locally from token totals and model names only — no prompt contents "
+                        + "leave your Mac.",
+                    systemImage: "lock.shield"
+                )
+                .font(.caption2)
+                .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Empty / loading states
+
+    private var emptyStateCard: some View {
+        DashboardCard(title: "Optimize Your Token Usage", trailing: nil) {
+            VStack(alignment: .leading, spacing: 14) {
+                Text(
+                    "Run a local scan to see which models and workflows burn the most tokens, "
+                        + "how well your cache is reused, and where you can trim spend."
+                )
+                .foregroundColor(.secondary)
+
+                Label(
+                    "The scan reads your local Claude and Codex logs on-device. Only token totals "
+                        + "and model names are analyzed — never prompt contents, and nothing is uploaded.",
+                    systemImage: "lock.shield"
+                )
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+                Button {
+                    Task { await costTracker.scanCosts(days: 30) }
+                } label: {
+                    Label("Scan 30 Days", systemImage: "magnifyingglass")
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(costTracker.isRefreshInProgress)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var loadingCard: some View {
+        DashboardCard(title: "Optimize Your Token Usage", trailing: "Scanning...") {
+            HStack(spacing: 10) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Scanning local token logs to build your optimization insights…")
+                    .foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity, minHeight: 120, alignment: .center)
+        }
+    }
+
+    // MARK: - Layout + color helpers
+
+    private static let kpiColumns = Array(
+        repeating: GridItem(.flexible(minimum: 200), spacing: 12, alignment: .top),
+        count: 2
+    )
+
+    private static func gradeColor(_ score: Int) -> Color {
+        switch score {
+        case 70...: return MeterBarTheme.success
+        case 45..<70: return MeterBarTheme.warning
+        default: return MeterBarTheme.danger
+        }
+    }
+
+    /// Higher premium share is redder; a low share is neutral.
+    private static func shareTint(_ share: Double) -> Color {
+        switch share {
+        case 0.5...: return MeterBarTheme.danger
+        case 0.3..<0.5: return MeterBarTheme.warning
+        default: return .secondary
+        }
+    }
+
+    /// Higher cache reuse is greener; low reuse is a warning.
+    private static func cacheTint(_ ratio: Double?) -> Color {
+        guard let ratio else { return .secondary }
+        switch ratio {
+        case 0.7...: return MeterBarTheme.success
+        case 0.3..<0.7: return .secondary
+        default: return MeterBarTheme.warning
+        }
+    }
+}
+
+// MARK: - KPI tile
+
+private struct KpiTile: View {
+    let title: String
+    let value: String
+    let caption: String
+    let systemImage: String
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label(title, systemImage: systemImage)
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .labelStyle(.titleAndIcon)
+
+            Text(value)
+                .font(.title2)
+                .fontWeight(.semibold)
+                .foregroundStyle(tint)
+                .contentTransition(.numericText())
+
+            Text(caption)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+}
+
+// MARK: - Ranked breakdown row
+
+private struct RankedBreakdownRow: View {
+    let entry: RankedTokenEntry
+    let showsTier: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(MeterBarTheme.accent(for: entry.provider))
+                    .frame(width: 8, height: 8)
+
+                Text(entry.name)
+                    .font(.callout)
+                    .fontWeight(.medium)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                if showsTier, entry.tier != .unknown {
+                    Text(entry.tier.label)
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(tierColor.opacity(0.18), in: Capsule())
+                        .foregroundStyle(tierColor)
+                }
+
+                Spacer(minLength: 8)
+
+                Text(entry.formattedTokens)
+                    .font(.callout)
+                    .monospacedDigit()
+                Text(entry.formattedShare)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .monospacedDigit()
+                    .frame(width: 42, alignment: .trailing)
+            }
+
+            ShareBar(fraction: entry.tokenShare, tint: MeterBarTheme.accent(for: entry.provider))
+        }
+    }
+
+    private var tierColor: Color {
+        switch entry.tier {
+        case .premium: return MeterBarTheme.danger
+        case .standard: return MeterBarTheme.warning
+        case .economy: return MeterBarTheme.success
+        case .unknown: return .secondary
+        }
+    }
+}
+
+private struct ShareBar: View {
+    let fraction: Double
+    let tint: Color
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(.quaternary)
+                    .frame(height: 4)
+                Capsule()
+                    .fill(tint)
+                    .frame(width: max(2, proxy.size.width * clampedFraction), height: 4)
+            }
+        }
+        .frame(height: 4)
+    }
+
+    private var clampedFraction: CGFloat {
+        CGFloat(min(1, max(0, fraction)))
+    }
+}
+
+// MARK: - Recommendation row
+
+private struct RecommendationRow: View {
+    let recommendation: OptimizationRecommendation
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: recommendation.systemImage)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(severityColor)
+                .frame(width: 22)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(recommendation.title)
+                    .font(.callout)
+                    .fontWeight(.semibold)
+                Text(recommendation.detail)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var severityColor: Color {
+        switch recommendation.severity {
+        case .warning: return MeterBarTheme.danger
+        case .suggestion: return MeterBarTheme.warning
+        case .info: return MeterBarTheme.accent(for: .claudeCode)
+        case .positive: return MeterBarTheme.success
+        }
+    }
+}

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -49,6 +49,7 @@ private enum DashboardSection: String, CaseIterable, Identifiable {
     case overview = "Overview"
     case limits = "Limits"
     case costs = "Costs"
+    case optimize = "Optimize"
     case settings = "Settings"
 
     var id: String { rawValue }
@@ -61,6 +62,8 @@ private enum DashboardSection: String, CaseIterable, Identifiable {
             return "chart.bar.fill"
         case .costs:
             return "dollarsign.circle.fill"
+        case .optimize:
+            return "leaf.fill"
         case .settings:
             return "gearshape.fill"
         }
@@ -162,6 +165,8 @@ struct UsageDashboardView: View {
                     limitsContent
                 case .costs:
                     costsContent
+                case .optimize:
+                    OptimizeInsightsView()
                 case .settings:
                     settingsContent
                 }
@@ -407,6 +412,8 @@ struct UsageDashboardView: View {
             return "Every tracked quota window"
         case .costs:
             return "Local 30-day token spend"
+        case .optimize:
+            return "Where tokens go and how to trim them"
         case .settings:
             return "Accounts, refresh, and local sources"
         }
@@ -428,7 +435,7 @@ struct UsageDashboardView: View {
 
     private var isRefreshButtonAnimating: Bool {
         switch activeSection {
-        case .costs:
+        case .costs, .optimize:
             return costTracker.isRefreshInProgress
         case .overview, .limits, .settings:
             return dataManager.isLoading
@@ -436,7 +443,7 @@ struct UsageDashboardView: View {
     }
 
     private func refreshDashboard() async {
-        if activeSection == .costs {
+        if activeSection == .costs || activeSection == .optimize {
             await costTracker.scanCosts(days: 30)
         } else {
             await dataManager.refreshAll()
@@ -444,14 +451,18 @@ struct UsageDashboardView: View {
     }
 
     private func refreshCostsIfMissingDays() async {
-        guard activeSection == .overview || activeSection == .costs else { return }
+        guard activeSection == .overview || activeSection == .costs || activeSection == .optimize else { return }
         await costTracker.refreshMissingDaysInBackground(days: 30)
     }
 }
 
 private let overviewTileMinHeight: CGFloat = 220
 
-private struct DashboardStatusHero: View {
+// Shared with OptimizeInsightsView (own file) — internal, not private, so the
+// Optimize page can reuse the same card chrome, status hero, and token chart
+// instead of hand-rolling new ones. Full per-type file split is tracked
+// separately (backlog Tier 1f).
+struct DashboardStatusHero: View {
     let title: String
     let detail: String
     let iconName: String
@@ -665,7 +676,7 @@ private struct ProviderLimitsCard: View {
     }
 }
 
-private struct DashboardCard<Content: View>: View {
+struct DashboardCard<Content: View>: View {
     let title: String
     let trailing: String?
     @ViewBuilder let content: Content
@@ -921,7 +932,7 @@ private struct CostRefreshLockOverlay: View {
     }
 }
 
-private struct DailyUsageChart: View {
+struct DailyUsageChart: View {
     let dailyUsage: [DailyTokenUsage]
     let daysToShow: Int
 

--- a/MeterBarTests/OptimizationInsightsTests.swift
+++ b/MeterBarTests/OptimizationInsightsTests.swift
@@ -1,0 +1,372 @@
+import XCTest
+import MeterBarShared
+@testable import MeterBar
+
+/// TDD coverage for the token-optimization recommendation engine (#72).
+///
+/// The engine is a pure, local-only analytics layer over the cached
+/// `CostSummary` — it consumes token totals, model names, and derived stats
+/// only. These tests assert the math and the plain-English recommendation
+/// thresholds without any network or on-disk state, mirroring the
+/// `SocialShareCardContent` pattern.
+final class OptimizationInsightsTests: XCTestCase {
+
+    // MARK: - Model tier classification
+
+    func testClassifyPremiumModels() {
+        XCTAssertEqual(ModelTier.classify("claude-opus-4-8"), .premium)
+        XCTAssertEqual(ModelTier.classify("claude-fable-5"), .premium)
+        XCTAssertEqual(ModelTier.classify("gpt-5"), .premium)
+        XCTAssertEqual(ModelTier.classify("o3"), .premium)
+        // Bedrock/date-suffixed variants still classify by family substring.
+        XCTAssertEqual(ModelTier.classify("us.anthropic.claude-opus-4-8-20260101"), .premium)
+    }
+
+    func testClassifyStandardModels() {
+        XCTAssertEqual(ModelTier.classify("claude-sonnet-4-5"), .standard)
+        XCTAssertEqual(ModelTier.classify("codex"), .standard)
+        XCTAssertEqual(ModelTier.classify("gpt-4o"), .standard)
+    }
+
+    func testClassifyEconomyModels() {
+        XCTAssertEqual(ModelTier.classify("claude-haiku-4-5"), .economy)
+        // Economy markers win over the premium family (a mini variant is cheap).
+        XCTAssertEqual(ModelTier.classify("gpt-5-mini"), .economy)
+        XCTAssertEqual(ModelTier.classify("o4-mini"), .economy)
+    }
+
+    func testClassifyUnknownModels() {
+        XCTAssertEqual(ModelTier.classify(""), .unknown)
+        XCTAssertEqual(ModelTier.classify("Unknown model"), .unknown)
+        XCTAssertEqual(ModelTier.classify("some-random-thing"), .unknown)
+    }
+
+    func testPremiumTierFlag() {
+        XCTAssertTrue(ModelTier.premium.isPremium)
+        XCTAssertFalse(ModelTier.standard.isPremium)
+        XCTAssertFalse(ModelTier.economy.isPremium)
+        XCTAssertFalse(ModelTier.unknown.isPremium)
+    }
+
+    // MARK: - Optimization score
+
+    func testScoreBestCaseIsHundred() {
+        let score = OptimizationInsights.computeScore(
+            premiumShare: 0.0,
+            inputOutputRatio: 4.0,
+            cacheReuseRatio: 1.0,
+            topOriginShare: 0.2
+        )
+        XCTAssertEqual(score, 100)
+    }
+
+    func testScoreWorstCaseIsZero() {
+        let score = OptimizationInsights.computeScore(
+            premiumShare: 1.0,
+            inputOutputRatio: 40.0,
+            cacheReuseRatio: 0.0,
+            topOriginShare: 1.0
+        )
+        XCTAssertEqual(score, 0)
+    }
+
+    func testScoreIsClampedToRange() {
+        let score = OptimizationInsights.computeScore(
+            premiumShare: 2.0,          // out-of-range inputs are clamped
+            inputOutputRatio: 500.0,
+            cacheReuseRatio: -1.0,
+            topOriginShare: 5.0
+        )
+        XCTAssertTrue((0...100).contains(score))
+    }
+
+    func testScoreFallsAsPremiumShareRises() {
+        let lean = OptimizationInsights.computeScore(
+            premiumShare: 0.1, inputOutputRatio: 8.0, cacheReuseRatio: 0.6, topOriginShare: 0.4
+        )
+        let heavy = OptimizationInsights.computeScore(
+            premiumShare: 0.9, inputOutputRatio: 8.0, cacheReuseRatio: 0.6, topOriginShare: 0.4
+        )
+        XCTAssertGreaterThan(lean, heavy)
+    }
+
+    func testScoreFallsAsCacheReuseDrops() {
+        let goodReuse = OptimizationInsights.computeScore(
+            premiumShare: 0.3, inputOutputRatio: 8.0, cacheReuseRatio: 0.9, topOriginShare: 0.4
+        )
+        let poorReuse = OptimizationInsights.computeScore(
+            premiumShare: 0.3, inputOutputRatio: 8.0, cacheReuseRatio: 0.1, topOriginShare: 0.4
+        )
+        XCTAssertGreaterThan(goodReuse, poorReuse)
+    }
+
+    func testScoreTreatsMissingSignalsAsNeutral() {
+        // nil cache + nil ratio must not crash and must stay mid-range, not 0/100.
+        let score = OptimizationInsights.computeScore(
+            premiumShare: 0.5, inputOutputRatio: nil, cacheReuseRatio: nil, topOriginShare: 0.5
+        )
+        XCTAssertTrue((30...70).contains(score), "neutral score was \(score)")
+    }
+
+    // MARK: - Full pipeline from CostSummary
+
+    func testInsightsFromPopulatedSummary() {
+        let insights = OptimizationInsights(summary: Self.populatedSummary(), now: Self.referenceNow)
+
+        XCTAssertTrue(insights.hasData)
+        XCTAssertEqual(insights.totalTokens, Self.populatedSummary().totalTokens)
+
+        // Ranked model breakdown: opus (biggest) ranks first, descending tokens.
+        XCTAssertFalse(insights.topModels.isEmpty)
+        XCTAssertEqual(insights.topModels.first?.name, "claude-opus-4-8")
+        let modelTokens = insights.topModels.map(\.totalTokens)
+        XCTAssertEqual(modelTokens, modelTokens.sorted(by: >))
+
+        // Ranked origin breakdown exists and is descending.
+        XCTAssertFalse(insights.topOrigins.isEmpty)
+        XCTAssertEqual(insights.topOrigins.first?.name, "Agents")
+
+        // Premium share = opus tokens / all model tokens.
+        // opus 3,000,000 of (3,000,000 + 1,000,000 + 400,000) = 0.6818...
+        XCTAssertEqual(insights.premiumTokenShare, 3_000_000.0 / 4_400_000.0, accuracy: 0.0001)
+    }
+
+    func testSevenAndThirtyDayWindows() {
+        let insights = OptimizationInsights(summary: Self.populatedSummary(), now: Self.referenceNow)
+        // Fixture places 100k tokens/day for 40 days. The 7-day window counts the
+        // most recent 7 calendar days (today + 6 back); 30-day counts 30.
+        XCTAssertEqual(insights.tokens7Day, 700_000)
+        XCTAssertEqual(insights.tokens30Day, 3_000_000)
+        XCTAssertGreaterThan(insights.tokens30Day, insights.tokens7Day)
+    }
+
+    func testCacheReuseRatioFromSummary() {
+        let insights = OptimizationInsights(summary: Self.populatedSummary(), now: Self.referenceNow)
+        // Aggregate cacheRead 8,000,000 / (cacheRead 8,000,000 + cacheCreation 2,000,000) = 0.8
+        XCTAssertNotNil(insights.cacheReuseRatio)
+        XCTAssertEqual(insights.cacheReuseRatio ?? 0, 0.8, accuracy: 0.0001)
+    }
+
+    func testInputOutputRatioFromSummary() {
+        let insights = OptimizationInsights(summary: Self.populatedSummary(), now: Self.referenceNow)
+        // input 6,000,000 / output 1,500,000 = 4.0
+        XCTAssertNotNil(insights.inputOutputRatio)
+        XCTAssertEqual(insights.inputOutputRatio ?? 0, 4.0, accuracy: 0.0001)
+    }
+
+    // MARK: - Recommendations
+
+    func testHighPremiumShareProducesWarning() {
+        // 90% premium tokens -> a premium-routing warning must appear.
+        let summary = Self.summary(models: [
+            Self.model(name: "claude-opus-4-8", provider: .claudeCode, total: 9_000_000),
+            Self.model(name: "claude-haiku-4-5", provider: .claudeCode, total: 1_000_000)
+        ])
+        let insights = OptimizationInsights(summary: summary, now: Self.referenceNow)
+
+        let premiumRec = insights.recommendations.first { $0.title.localizedCaseInsensitiveContains("premium") }
+        XCTAssertNotNil(premiumRec)
+        XCTAssertEqual(premiumRec?.severity, .warning)
+    }
+
+    func testLowCacheReuseProducesWarning() {
+        let summary = Self.summary(models: [
+            Self.model(
+                name: "claude-sonnet-4-5",
+                provider: .claudeCode,
+                input: 1_000_000,
+                output: 1_000_000,
+                cacheCreation: 9_000_000,   // churning cache
+                cacheRead: 1_000_000        // reuse ratio 0.1
+            )
+        ])
+        let insights = OptimizationInsights(summary: summary, now: Self.referenceNow)
+
+        let cacheRec = insights.recommendations.first { $0.title.localizedCaseInsensitiveContains("cache") }
+        XCTAssertNotNil(cacheRec)
+        XCTAssertEqual(cacheRec?.severity, .warning)
+    }
+
+    func testLeanUsageProducesPositiveNotWarning() {
+        let summary = Self.summary(models: [
+            Self.model(
+                name: "claude-haiku-4-5",
+                provider: .claudeCode,
+                input: 1_000_000,
+                output: 500_000,
+                cacheCreation: 500_000,
+                cacheRead: 4_500_000        // reuse ratio 0.9
+            )
+        ])
+        let insights = OptimizationInsights(summary: summary, now: Self.referenceNow)
+
+        XCTAssertFalse(insights.recommendations.isEmpty)
+        XCTAssertFalse(
+            insights.recommendations.contains { $0.severity == .warning },
+            "lean usage should not raise warnings"
+        )
+    }
+
+    func testRecommendationsSortedBySeverityDescending() {
+        let insights = OptimizationInsights(summary: Self.populatedSummary(), now: Self.referenceNow)
+        let severities = insights.recommendations.map(\.severity.rawValue)
+        XCTAssertEqual(severities, severities.sorted(by: >))
+    }
+
+    // MARK: - Empty state
+
+    func testEmptySummaryHasNoData() {
+        let empty = CostSummary(costs: [], totalCostUSD: 0, totalTokens: 0, periodDays: 30, dailyUsage: [])
+        let insights = OptimizationInsights(summary: empty, now: Self.referenceNow)
+
+        XCTAssertFalse(insights.hasData)
+        XCTAssertTrue(insights.topModels.isEmpty)
+        XCTAssertTrue(insights.topOrigins.isEmpty)
+        XCTAssertTrue(insights.recommendations.isEmpty)
+    }
+
+    // MARK: - Fixtures
+
+    /// Fixed "now" so daily-window math is deterministic.
+    private static let referenceNow: Date = {
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 7
+        components.day = 3
+        components.hour = 12
+        return Calendar.current.date(from: components) ?? Date(timeIntervalSince1970: 1_783_080_000)
+    }()
+
+    private static func model(
+        name: String,
+        provider: ServiceType,
+        input: Int = 0,
+        output: Int = 0,
+        cacheCreation: Int = 0,
+        cacheRead: Int = 0,
+        total: Int? = nil,
+        sessionCount: Int = 1
+    ) -> TokenUsageBreakdown {
+        // When `total` is supplied, stuff it into input so totalTokens matches
+        // without callers specifying every bucket.
+        let resolvedInput = total ?? input
+        return TokenUsageBreakdown(
+            provider: provider,
+            name: name,
+            inputTokens: resolvedInput,
+            outputTokens: output,
+            cacheCreationTokens: cacheCreation,
+            cacheReadTokens: cacheRead,
+            estimatedCostUSD: Double(resolvedInput + output + cacheCreation + cacheRead) / 1_000_000.0,
+            sessionCount: sessionCount
+        )
+    }
+
+    private static func origin(
+        name: String,
+        provider: ServiceType,
+        total: Int,
+        sessionCount: Int = 1
+    ) -> TokenUsageBreakdown {
+        TokenUsageBreakdown(
+            provider: provider,
+            name: name,
+            inputTokens: total,
+            outputTokens: 0,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 0,
+            estimatedCostUSD: Double(total) / 1_000_000.0,
+            sessionCount: sessionCount
+        )
+    }
+
+    /// Build a single-provider summary from model breakdowns, deriving the
+    /// top-level token buckets so aggregates line up with the breakdowns.
+    private static func summary(models: [TokenUsageBreakdown]) -> CostSummary {
+        let input = models.reduce(0) { $0 + $1.inputTokens }
+        let output = models.reduce(0) { $0 + $1.outputTokens }
+        let cacheCreation = models.reduce(0) { $0 + $1.cacheCreationTokens }
+        let cacheRead = models.reduce(0) { $0 + $1.cacheReadTokens }
+        let cost = models.reduce(0) { $0 + $1.estimatedCostUSD }
+
+        let tokenCost = TokenCost(
+            provider: models.first?.provider ?? .claudeCode,
+            inputTokens: input,
+            outputTokens: output,
+            cacheCreationTokens: cacheCreation,
+            cacheReadTokens: cacheRead,
+            estimatedCostUSD: cost,
+            sessionCount: 1,
+            periodStart: referenceNow.addingTimeInterval(-30 * 86_400),
+            periodEnd: referenceNow,
+            modelBreakdowns: models,
+            originBreakdowns: []
+        )
+        let total = input + output + cacheCreation + cacheRead
+        return CostSummary(
+            costs: [tokenCost],
+            totalCostUSD: cost,
+            totalTokens: total,
+            periodDays: 30,
+            dailyUsage: []
+        )
+    }
+
+    /// A realistic multi-model, multi-origin, 40-day summary.
+    ///
+    /// Model breakdowns use single-bucket totals so the premium-share assertion
+    /// (opus / all-models) reads cleanly; the provider's aggregate token buckets
+    /// are set independently below to drive the input/output and cache ratios.
+    private static func populatedSummary() -> CostSummary {
+        let shareModels = [
+            model(name: "claude-opus-4-8", provider: .claudeCode, total: 3_000_000),
+            model(name: "claude-sonnet-4-5", provider: .claudeCode, total: 1_000_000),
+            model(name: "claude-haiku-4-5", provider: .claudeCode, total: 400_000)
+        ]
+
+        let origins = [
+            origin(name: "Agents", provider: .claudeCode, total: 2_500_000),
+            origin(name: "Main chat", provider: .claudeCode, total: 1_200_000),
+            origin(name: "Tool use", provider: .claudeCode, total: 700_000)
+        ]
+
+        // Aggregate buckets: input 6.0M / output 1.5M (ratio 4.0);
+        // cacheRead 8.0M / cacheCreation 2.0M (reuse 0.8).
+        let tokenCost = TokenCost(
+            provider: .claudeCode,
+            inputTokens: 6_000_000,
+            outputTokens: 1_500_000,
+            cacheCreationTokens: 2_000_000,
+            cacheReadTokens: 8_000_000,
+            estimatedCostUSD: 42.0,
+            sessionCount: 12,
+            periodStart: referenceNow.addingTimeInterval(-40 * 86_400),
+            periodEnd: referenceNow,
+            modelBreakdowns: shareModels,
+            originBreakdowns: origins
+        )
+
+        // 40 days of daily rows at 100k tokens/day (70k input + 30k read).
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: referenceNow)
+        let daily: [DailyTokenUsage] = (0..<40).compactMap { offset in
+            guard let date = calendar.date(byAdding: .day, value: -offset, to: today) else { return nil }
+            return DailyTokenUsage(
+                date: date,
+                provider: .claudeCode,
+                inputTokens: 70_000,
+                outputTokens: 0,
+                cacheReadTokens: 30_000,
+                estimatedCostUSD: 0.5
+            )
+        }
+
+        return CostSummary(
+            costs: [tokenCost],
+            totalCostUSD: 42.0,
+            totalTokens: 17_500_000,
+            periodDays: 40,
+            dailyUsage: daily
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new **Optimize** dashboard section (separate from Costs) that helps users see where their tokens go and what to trim. It's an analytics/UI layer over the existing local `CostSummary` — **no data-pipeline changes**.

Implements issue #72 / backlog Tier 4b.

## What's included

**`OptimizationInsights` — pure recommendation engine** (`MeterBar/Models/OptimizationInsights.swift`)
- KPIs derived from `CostTracker` summary data: token burn by model, premium-model share, input/output ratio, cache reuse (creation vs reuse), 7/30-day token windows.
- Ranked breakdowns: top models and top usage origins (Agents / Tool use / Skills / Main chat).
- Derived **optimization score** (0–100 + letter grade): transparent weighted blend of premium share, cache reuse, context bloat, and origin concentration — named, tunable constants.
- **Plain-English recommendations** with severity, computed locally.
- `ModelTier.classify` tiers models premium/standard/economy by a name-only heuristic.
- Follows the `SocialShareCardContent` pattern: pure model, no network, no SwiftUI, fully unit-tested.

**`OptimizeInsightsView` — own view file** (`MeterBar/Views/OptimizeInsightsView.swift`)
- Score hero, KPI grid, a 7/30-day token-burn chart (reuses the existing `DailyUsageChart`), ranked model + origin cards, and a recommendations list.
- **Empty/loading states** explain how to run a local scan.
- Deliberately **not** placed inside `UsageDashboardView.swift`.

**Nav wiring** (`MeterBar/Views/UsageDashboardView.swift`)
- Adds the `.optimize` `DashboardSection` case (icon, subtitle, refresh routing).
- Exposes `DashboardCard` / `DailyUsageChart` / `DashboardStatusHero` from `private` → internal so the new page reuses them instead of hand-rolling. Full per-type split of the 1539-line monolith stays deferred (backlog Tier 1f).

## Privacy boundary (hard)

Everything is computed on-device from the same cache the Costs page already renders: **token totals, model names, and derived stats only — never prompt contents, nothing uploaded.** Documented in the model header and surfaced as a UI footnote.

## Acceptance criteria

- [x] New page in dashboard nav, separate from Costs
- [x] ≥1 summary KPI and ≥1 ranked breakdown
- [x] Plain-English optimization recommendations
- [x] Recommendations computed from local usage metadata only
- [x] Empty/loading states explain how to run a local scan

## Testing

TDD — recommendation-engine tests written first (`MeterBarTests/OptimizationInsightsTests.swift`): tier classification, premium share, cache reuse, input/output ratio, score monotonicity + boundaries, recommendation thresholds, and empty state.

Local env is Command Line Tools only (no XCTest/sourcekit), so `swift test` and SwiftLint run in **CI**. Verified locally: `swift build` passes; line length ≤120; SwiftLint opt-in nits addressed.

Closes #72