### PR TITLE
Provider readiness: doctor + diagnostics + onboarding checklist (Tier 2a)

### DIFF
--- a/.agents/SESSIONS/2026-07-03.md
+++ b/.agents/SESSIONS/2026-07-03.md
@@ -1,0 +1,145 @@
+# Sessions: 2026-07-03
+
+**Summary:** Tier 2a — provider-readiness core + three surfaces (`meterbar doctor`, Diagnostics view, empty-state checklist), closing #22 + #25
+
+---
+
+## Session 1: Provider readiness (onboarding + diagnostics)
+
+**Duration:** ~2 hours
+**Status:** Complete (PR opened from `claude/pensive-einstein-07e0b3`)
+
+### What was done
+
+Implemented Tier 2a of `.agents/docs/ISSUE_BACKLOG.md`: one feature, one shared core,
+three surfaces. Consolidates GitHub issues #22 (onboarding readiness checklist) and
+#25 (diagnostics panel + `meterbar doctor`).
+
+**Shared pure core (`Packages/MeterBarShared/ProviderReadiness.swift`).**
+`ProviderReadinessEvaluator` with per-provider evaluators (Claude Code, Codex CLI,
+Cursor) returning an ordered `[ReadinessCheck]` — installed → auth → data → refresh —
+each `pass/warn/fail` with a plain-language recovery action (`claude login`,
+`codex login`, open Cursor, rescan) and a redaction-safe detail. Inputs are
+fixture-able value types (`Data?` auth blobs, `CursorDatabaseProbe` enum for the
+SQLite read that can't be exercised purely). `ProviderReadiness.overall` rolls the
+checks up to the worst level; `Codable`/`Sendable` throughout for CLI JSON + async.
+
+**Moved `OAuthTokenExpiry` + `JWT`** from `MeterBar/Services/` into `MeterBarShared`
+(made `public`) so the core parses token expiry via the existing helper instead of
+re-deriving it — mirroring how the metrics wire-format types were unified. The three
+provider services already `import MeterBarShared`, so they resolve the symbols
+unchanged; only the test import was updated.
+
+**Impure inspector (`MeterBar/Services/ProviderReadinessInspector.swift`).** Gathers
+the real facts (binary on PATH, keychain blob, `~/.codex/auth.json` bytes+readability,
+Cursor DB probe) and feeds the core. Lives in the app library so both the app surfaces
+**and** `MeterBarCLI` share one implementation (the CLI already links `MeterBar`).
+Centralizes error redaction: `.apiError` may embed a slice of the raw API response
+body (`ServiceSupport.validate`), so `sanitize` strips everything except a leading
+`HTTP NNN` status (or a whitelisted connectivity message).
+
+**Surface 1 — `meterbar doctor`** (`MeterBarCLI.swift`): new subcommand following the
+Usage/Cost conventions (text + `--json`, `--provider` filter). Verified end-to-end on
+the real machine — correctly flagged an expired Claude session and a locked Cursor DB.
+
+**Surface 2 — Diagnostics view**: new `Diagnostics` section in the dashboard
+`NavigationSplitView` nav, rendering the same reports plus a "Copy report" button
+(paste-safe plain text) and "Re-run checks". Inspector I/O runs off the main actor.
+
+**Surface 3 — empty-state checklist**: `PopoverOverviewPanel` renders a compact
+"Finish setup" checklist for enabled-but-unhealthy providers with recovery actions;
+collapses automatically once every enabled provider is healthy.
+
+**Reusable UI** (`MeterBar/Views/Components/ReadinessComponents.swift`):
+`ReadinessCheckRow` / `ReadinessProviderCard` / `ReadinessBadge` / `ReadinessChecklist`
+shared by surfaces 2 and 3.
+
+**Refactor (DRY):** extracted `CLIBinaryLocator` from the private path-resolution logic
+in `ClaudeCodeCLIUsageService` (now delegates to it); the inspector reuses it for both
+`claude` and `codex`. Added `credentialsData()` (Claude keychain blob) and
+`probeReadinessDatabase()` (Cursor) accessors so the inspector reuses the services'
+keychain/SQLite paths instead of duplicating them.
+
+### TDD
+
+Tests written before the core:
+
+- `MeterBarTests/ProviderReadinessTests.swift` — fixture-driven per-check tests for all
+  three providers: missing auth file, expired token (JWT + unix), unreadable Cursor DB,
+  API-key mode, binary-missing-is-warn, healthy, refresh-error surfacing, JSON
+  round-trip, and secret-leak assertions.
+- `MeterBarTests/ProviderReadinessInspectorTests.swift` — redaction tests for the error
+  sanitizer (response body dropped, HTTP code kept, connectivity messages passed
+  through, known cases mapped).
+
+Because only Command Line Tools are installed locally (no XCTest), the core was also
+verified via a throwaway SwiftPM executable in the scratchpad linking `MeterBarShared`
+and running the same fixtures — **all 35 assertions passed**. Full XCTest suite runs in
+CI (macOS runner with full Xcode).
+
+### Files changed
+
+- `Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift` - new pure core
+- `Packages/MeterBarShared/Sources/MeterBarShared/OAuthTokenExpiry.swift` - moved here, made public
+- `MeterBar/Services/ProviderReadinessInspector.swift` - new impure gatherer + redaction
+- `MeterBar/Services/CLIBinaryLocator.swift` - new shared PATH resolver
+- `MeterBar/Views/Components/ReadinessComponents.swift` - new shared readiness UI
+- `MeterBarCLI/Sources/MeterBarCLI.swift` - new `Doctor` subcommand
+- `MeterBar/Views/UsageDashboardView.swift` - Diagnostics nav section + content
+- `MeterBar/Views/MenuBarView.swift` - empty-state "Finish setup" checklist
+- `MeterBar/Services/ClaudeCodeCLIUsageService.swift` - delegate to `CLIBinaryLocator`
+- `MeterBar/Services/ClaudeCodeLocalService.swift` - `credentialsData()` accessor
+- `MeterBar/Services/CursorLocalService.swift` - `probeReadinessDatabase()` accessor
+- `MeterBar/Services/ServiceError.swift` - made `public` + `Sendable` (CLI/async use)
+- `MeterBarTests/ProviderReadinessTests.swift`, `ProviderReadinessInspectorTests.swift` - new tests
+- `MeterBarTests/OAuthTokenExpiryTests.swift` - import `MeterBarShared` after move
+
+### Decisions
+
+- **Decision:** Pure core parses the auth-file bytes itself (via small purpose-built
+  decoders) rather than taking pre-computed booleans.
+  - **Rationale:** Makes one set of fixture tests exercise decode + expiry + leveling +
+    redaction together, and keeps the "expired token" / "missing file" cases meaningful.
+    The authoritative decoders stay in the services; the core reads only the couple of
+    fields readiness needs (noted in a comment to keep them in sync).
+- **Decision:** Cursor auth modeled as a `CursorDatabaseProbe` enum, not raw bytes.
+  - **Rationale:** The SQLite read (on a file that locks while Cursor runs) can't be
+    exercised in a pure unit test; the impure inspector maps the real read onto the enum
+    and the evaluator turns it into checks — so "unreadable DB" is still a real fixture.
+- **Decision:** Redact `.apiError` down to `HTTP NNN` (or a whitelisted connectivity
+  message) in the inspector, not the core.
+  - **Rationale:** `ServiceError` lives in the app target; centralizing sanitization
+    there lets the same paste-safe mapping serve the CLI and the app, and keeps the raw
+    response body (which can contain account data) out of every surface.
+- **Decision:** Codex "installed" (missing `codex` binary) is a `warn`, not `fail`.
+  - **Rationale:** the app reads `~/.codex/auth.json` directly and never execs `codex`,
+    so a missing binary doesn't block usage when auth is present.
+
+### Mistakes and fixes
+
+- **Mistake:** `ProviderReadinessInspector`/`ServiceError` were internal → the CLI
+  (separate module) couldn't see them.
+- **Fix:** made both `public`; added `Sendable` to `ServiceError` for the detached-task
+  diagnostics run.
+- **Mistake:** adding `.diagnostics` to `DashboardSection` broke a second
+  `switch activeSection` (refresh-button animation) — non-exhaustive.
+- **Fix:** added the case; caught by `swift build`.
+
+### Verification
+
+- `swift build` green for all three SwiftPM targets (library, `MeterBarShared`, CLI).
+- Standalone scratchpad harness: 35/35 core assertions pass.
+- `meterbar doctor` run on the real machine (text, `--json`, `--provider`); output
+  scanned for token-like substrings — clean.
+- SwiftLint (`--strict`, `included: MeterBar`) can't run locally (needs full-Xcode
+  sourcekit); checked line-length + rule conventions by hand against changed
+  `MeterBar/` files. Full XCTest + lint run in CI.
+
+### Next steps
+
+- [ ] Confirm CI green (XCTest + SwiftLint + xcodebuild app/widget build).
+- [ ] Tier 2b (notification preferences) and 2c (launch at login) remain.
+
+---
+
+**Total sessions today:** 1

--- a/MeterBar/Services/CLIBinaryLocator.swift
+++ b/MeterBar/Services/CLIBinaryLocator.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Resolves a CLI executable by scanning `PATH` and the common install
+/// locations MeterBar runs from (Homebrew, npm-global, yarn, bun, volta, etc.).
+///
+/// This was previously private to `ClaudeCodeCLIUsageService`; it is factored
+/// out so provider-readiness diagnostics can ask "is `codex` / `claude` on
+/// PATH?" without re-deriving the same fallback list.
+enum CLIBinaryLocator {
+    /// The install-location fallbacks checked after `PATH`, for `command`.
+    private static func fallbackCandidates(for command: String, home: String) -> [String] {
+        [
+            "/opt/homebrew/bin/\(command)",
+            "/usr/local/bin/\(command)",
+            "\(home)/.local/bin/\(command)",
+            "\(home)/.npm-global/bin/\(command)",
+            "\(home)/.yarn/bin/\(command)",
+            "\(home)/.bun/bin/\(command)",
+            "\(home)/.volta/bin/\(command)",
+        ]
+    }
+
+    /// The resolved absolute path to `command`, or nil if it isn't found.
+    ///
+    /// - Parameter overrideEnvVar: an environment variable (e.g. `CLAUDE_CLI_PATH`)
+    ///   whose value, if it points at an executable, wins over any PATH lookup.
+    static func resolve(
+        command: String,
+        overrideEnvVar: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) -> String? {
+        if let overrideEnvVar,
+           let override = environment[overrideEnvVar]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !override.isEmpty,
+           fileManager.isExecutableFile(atPath: override) {
+            return override
+        }
+
+        let pathCandidates = (environment["PATH"] ?? "")
+            .split(separator: ":")
+            .map { "\($0)/\(command)" }
+
+        let fallbacks = fallbackCandidates(for: command, home: ServiceSupport.realHomeDirectory())
+
+        return (pathCandidates + fallbacks).first { fileManager.isExecutableFile(atPath: $0) }
+    }
+
+    /// Whether `command` resolves to an executable.
+    static func isAvailable(command: String, overrideEnvVar: String? = nil) -> Bool {
+        resolve(command: command, overrideEnvVar: overrideEnvVar) != nil
+    }
+}

--- a/MeterBar/Services/ClaudeCodeCLIUsageService.swift
+++ b/MeterBar/Services/ClaudeCodeCLIUsageService.swift
@@ -30,31 +30,7 @@ final class ClaudeCodeCLIUsageService: Sendable {
     }
 
     private func resolveClaudeBinaryPath() -> String? {
-        let environment = ProcessInfo.processInfo.environment
-        let fileManager = FileManager.default
-
-        if let override = environment["CLAUDE_CLI_PATH"]?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !override.isEmpty,
-           fileManager.isExecutableFile(atPath: override) {
-            return override
-        }
-
-        let pathCandidates = (environment["PATH"] ?? "")
-            .split(separator: ":")
-            .map { "\($0)/claude" }
-
-        let homeDir = ServiceSupport.realHomeDirectory()
-        let fallbackCandidates = [
-            "/opt/homebrew/bin/claude",
-            "/usr/local/bin/claude",
-            "\(homeDir)/.local/bin/claude",
-            "\(homeDir)/.npm-global/bin/claude",
-            "\(homeDir)/.yarn/bin/claude",
-            "\(homeDir)/.bun/bin/claude",
-            "\(homeDir)/.volta/bin/claude",
-        ]
-
-        return (pathCandidates + fallbackCandidates).first { fileManager.isExecutableFile(atPath: $0) }
+        CLIBinaryLocator.resolve(command: "claude", overrideEnvVar: "CLAUDE_CLI_PATH")
     }
 
     /// Async wrapper that runs the blocking process invocation on `processQueue`

--- a/MeterBar/Services/ClaudeCodeLocalService.swift
+++ b/MeterBar/Services/ClaudeCodeLocalService.swift
@@ -54,6 +54,16 @@ class ClaudeCodeLocalService: ObservableObject {
     }
 
     private func getCredentials() -> ClaudeCodeCredentials? {
+        guard let data = credentialsData() else { return nil }
+        return try? JSONDecoder().decode(ClaudeCodeCredentials.self, from: data)
+    }
+
+    /// The raw "Claude Code-credentials" keychain blob, or nil if absent/unreadable.
+    ///
+    /// Exposed for provider-readiness diagnostics, which pass the bytes to the
+    /// pure readiness core (it reads only the expiry claim — never surfaces the
+    /// token). Reading the raw blob here keeps the keychain query in one place.
+    func credentialsData() -> Data? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: keychainService,
@@ -64,18 +74,11 @@ class ClaudeCodeLocalService: ObservableObject {
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
 
-        guard status == errSecSuccess,
-              let data = result as? Data,
-              let jsonString = String(data: data, encoding: .utf8) else {
+        guard status == errSecSuccess, let data = result as? Data else {
             return nil
         }
 
-        guard let jsonData = jsonString.data(using: .utf8),
-              let credentials = try? JSONDecoder().decode(ClaudeCodeCredentials.self, from: jsonData) else {
-            return nil
-        }
-
-        return credentials
+        return data
     }
 
     /// Check and update access status

--- a/MeterBar/Services/CursorLocalService.swift
+++ b/MeterBar/Services/CursorLocalService.swift
@@ -145,6 +145,43 @@ class CursorLocalService: ObservableObject {
         return (userId: userId, token: token)
     }
 
+    /// Probe the Cursor state database for provider-readiness diagnostics,
+    /// mapping the SQLite read onto the shared `CursorDatabaseProbe` states.
+    /// Uses the same path scan and read-only open as `getAccessTokenFromDatabase`,
+    /// but reports *why* auth is unavailable (not found / unreadable / no token)
+    /// instead of just a token, and never returns the token value itself.
+    func probeReadinessDatabase() -> CursorDatabaseProbe {
+        guard let dbPath = getCursorDatabasePath(forceRescan: false)
+            ?? getCursorDatabasePath(forceRescan: true) else {
+            return .notFound
+        }
+
+        guard FileManager.default.isReadableFile(atPath: dbPath) else {
+            return .unreadable
+        }
+
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(dbPath, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
+            sqlite3_close(db)
+            return .unreadable
+        }
+        defer { sqlite3_close(db) }
+
+        let query = "SELECT value FROM ItemTable WHERE key = 'cursorAuth/accessToken'"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK else {
+            return .unreadable
+        }
+        defer { sqlite3_finalize(statement) }
+
+        guard sqlite3_step(statement) == SQLITE_ROW,
+              let tokenCString = sqlite3_column_text(statement, 0) else {
+            return .missingToken
+        }
+
+        return String(cString: tokenCString).isEmpty ? .missingToken : .tokenPresent
+    }
+
     /// Extract userId from JWT token's 'sub' claim
     private func extractUserIdFromJWT(_ token: String) -> String? {
         guard let sub = JWT.claimString("sub", in: token) else { return nil }

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -1,0 +1,123 @@
+import Foundation
+import MeterBarShared
+
+/// Gathers the real, on-disk facts each provider-readiness check needs
+/// (binary on PATH, keychain credentials, `~/.codex/auth.json`, the Cursor
+/// state database) and feeds them to the pure `ProviderReadinessEvaluator`.
+///
+/// This is the impure counterpart to the `MeterBarShared` core: it does the
+/// filesystem / keychain / SQLite I/O the evaluators cannot. It lives in the app
+/// library so both the app surfaces (Diagnostics view, empty-state checklist)
+/// and `MeterBarCLI` (`meterbar doctor`) share one implementation — mirroring how
+/// the CLI already reuses `SharedDataStore` / `CostSummaryStore`.
+///
+/// All provider error text is sanitized here (`sanitize`) so nothing that could
+/// contain a token, account id, or raw response body reaches a pasteable report.
+public enum ProviderReadinessInspector {
+    /// Readiness reports for every provider, in stable display order.
+    ///
+    /// - Parameter refreshErrors: each provider's live last-refresh error. The app
+    ///   passes these from the main actor (the services publish them); the CLI, a
+    ///   one-shot process with no live refresh, passes none.
+    public static func reports(
+        refreshErrors: [ServiceType: ServiceError] = [:],
+        now: Date = Date()
+    ) -> [ProviderReadiness] {
+        [
+            claudeReport(refreshError: refreshErrors[.claudeCode], now: now),
+            codexReport(refreshError: refreshErrors[.codexCli], now: now),
+            cursorReport(refreshError: refreshErrors[.cursor], now: now)
+        ]
+    }
+
+    // MARK: - Per-provider gathering
+
+    static func claudeReport(refreshError: ServiceError? = nil, now: Date = Date()) -> ProviderReadiness {
+        let input = ClaudeReadinessInput(
+            isCLIInstalled: CLIBinaryLocator.isAvailable(command: "claude", overrideEnvVar: "CLAUDE_CLI_PATH"),
+            credentialsJSON: ClaudeCodeLocalService.shared.credentialsData(),
+            refreshError: sanitize(refreshError),
+            now: now
+        )
+        return ProviderReadinessEvaluator.claudeCode(input)
+    }
+
+    static func codexReport(refreshError: ServiceError? = nil, now: Date = Date()) -> ProviderReadiness {
+        let fileManager = FileManager.default
+        let path = "\(ServiceSupport.realHomeDirectory())/.codex/auth.json"
+        let exists = fileManager.fileExists(atPath: path)
+        let bytes = exists && fileManager.isReadableFile(atPath: path)
+            ? fileManager.contents(atPath: path)
+            : nil
+
+        let input = CodexReadinessInput(
+            isCLIInstalled: CLIBinaryLocator.isAvailable(command: "codex"),
+            authFileExists: exists,
+            authFileReadable: bytes != nil,
+            authJSON: bytes,
+            refreshError: sanitize(refreshError),
+            now: now
+        )
+        return ProviderReadinessEvaluator.codexCli(input)
+    }
+
+    static func cursorReport(refreshError: ServiceError? = nil, now: Date = Date()) -> ProviderReadiness {
+        let probe = CursorLocalService.shared.probeReadinessDatabase()
+        let input = CursorReadinessInput(
+            isInstalled: probe != .notFound || cursorAppPresent(),
+            database: probe,
+            refreshError: sanitize(refreshError),
+            now: now
+        )
+        return ProviderReadinessEvaluator.cursor(input)
+    }
+
+    // MARK: - Helpers
+
+    private static func cursorAppPresent() -> Bool {
+        let fileManager = FileManager.default
+        let home = ServiceSupport.realHomeDirectory()
+        return fileManager.fileExists(atPath: "/Applications/Cursor.app")
+            || fileManager.fileExists(atPath: "\(home)/Applications/Cursor.app")
+    }
+
+    /// Known connectivity messages that carry no account data and are safe to
+    /// show verbatim (produced by `ServiceSupport.message(for:)`).
+    private static let safeNetworkMessages: Set<String> = [
+        "No internet connection",
+        "DNS lookup failed",
+        "Request timed out"
+    ]
+
+    /// Maps a `ServiceError` onto a short, paste-safe string. Crucially, an
+    /// `.apiError` may embed a slice of the raw API response body
+    /// (`ServiceSupport.validate`) — which can contain account data — so only a
+    /// leading HTTP status code (or a whitelisted connectivity message) survives.
+    static func sanitize(_ error: ServiceError?) -> String? {
+        guard let error else { return nil }
+        switch error {
+        case .notAuthenticated:
+            return "Not authenticated"
+        case .invalidURL:
+            return "Invalid request URL"
+        case .parsingError:
+            return "Could not parse the provider response"
+        case let .apiError(message):
+            if safeNetworkMessages.contains(message) {
+                return message
+            }
+            if let status = httpStatus(in: message) {
+                return "API error (HTTP \(status))"
+            }
+            return "API error"
+        }
+    }
+
+    /// The first `HTTP NNN` status code embedded in a message, if any.
+    static func httpStatus(in message: String) -> Int? {
+        guard let range = message.range(of: #"HTTP \d{3}"#, options: .regularExpression) else {
+            return nil
+        }
+        return Int(message[range].dropFirst("HTTP ".count))
+    }
+}

--- a/MeterBar/Services/ServiceError.swift
+++ b/MeterBar/Services/ServiceError.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 /// Shared error type for all provider usage services.
-enum ServiceError: LocalizedError {
+public enum ServiceError: LocalizedError, Sendable {
     case notAuthenticated
     case invalidURL
     case apiError(String)
     case parsingError
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .notAuthenticated:
             return "Not authenticated. Sign in to the provider's CLI and refresh."

--- a/MeterBar/Views/Components/ReadinessComponents.swift
+++ b/MeterBar/Views/Components/ReadinessComponents.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+import MeterBarShared
+
+// Shared provider-readiness UI, rendered identically by the dashboard
+// Diagnostics section and the first-run/empty-state checklist. The data comes
+// from `ProviderReadinessInspector`; these views only present it.
+
+extension ReadinessLevel {
+    /// Tint for the check icon/badge.
+    var tint: Color {
+        switch self {
+        case .pass: return .green
+        case .warn: return .orange
+        case .fail: return .red
+        }
+    }
+
+    /// SF Symbol shown next to a check.
+    var iconName: String {
+        switch self {
+        case .pass: return "checkmark.circle.fill"
+        case .warn: return "exclamationmark.triangle.fill"
+        case .fail: return "xmark.octagon.fill"
+        }
+    }
+
+    /// Short badge label for the provider header.
+    var badgeLabel: String {
+        switch self {
+        case .pass: return "Ready"
+        case .warn: return "Check"
+        case .fail: return "Action needed"
+        }
+    }
+}
+
+/// One readiness check: status icon, title, plain-language detail, and an
+/// optional recovery action rendered as a monospaced call-to-action.
+struct ReadinessCheckRow: View {
+    let check: ReadinessCheck
+    var compact: Bool = false
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: check.level.iconName)
+                .font(.system(size: compact ? 11 : 13, weight: .semibold))
+                .foregroundStyle(check.level.tint)
+                .padding(.top, 1)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(check.title)
+                    .font(compact ? .caption : .subheadline)
+                    .fontWeight(.medium)
+                Text(check.detail)
+                    .font(compact ? .caption2 : .caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let recovery = check.recovery {
+                    Text(recovery)
+                        .font(compact ? .caption2 : .caption)
+                        .fontWeight(.medium)
+                        .foregroundStyle(check.level.tint)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.top, 1)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+    }
+}
+
+/// A provider's full readiness report: header with logo + overall badge, then
+/// each ordered check.
+struct ReadinessProviderCard: View {
+    let report: ProviderReadiness
+    var compact: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: compact ? 8 : 10) {
+            HStack(spacing: 8) {
+                ProviderLogoView(
+                    kind: .forService(report.provider),
+                    size: compact ? 15 : 18,
+                    foregroundColor: .primary
+                )
+                Text(report.provider.displayName)
+                    .font(compact ? .subheadline : .headline)
+                    .fontWeight(.semibold)
+                Spacer(minLength: 0)
+                ReadinessBadge(level: report.overall)
+            }
+
+            VStack(alignment: .leading, spacing: compact ? 7 : 9) {
+                ForEach(report.checks) { check in
+                    ReadinessCheckRow(check: check, compact: compact)
+                }
+            }
+        }
+        .padding(compact ? 11 : 14)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .meterBarCardSurface()
+    }
+}
+
+/// Rolled-up status pill for a provider header.
+struct ReadinessBadge: View {
+    let level: ReadinessLevel
+
+    var body: some View {
+        Text(level.badgeLabel)
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .foregroundStyle(level.tint)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(level.tint.opacity(0.14), in: Capsule())
+    }
+}
+
+/// Renders readiness reports as a plain-text block for the "Copy report" button.
+/// Mirrors the `meterbar doctor` layout so a pasted report reads the same whether
+/// it came from the CLI or the app. Every string is already redacted upstream.
+enum DiagnosticsReportText {
+    static func plainText(_ reports: [ProviderReadiness]) -> String {
+        var lines = ["MeterBar Diagnostics", ""]
+        for report in reports {
+            lines.append("\(report.provider.displayName)  [\(report.overall.rawValue.uppercased())]")
+            for check in report.checks {
+                lines.append("  \(symbol(check.level)) \(check.title): \(check.detail)")
+                if let recovery = check.recovery {
+                    lines.append("      -> \(recovery)")
+                }
+            }
+            lines.append("")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func symbol(_ level: ReadinessLevel) -> String {
+        switch level {
+        case .pass: return "[ok]"
+        case .warn: return "[warn]"
+        case .fail: return "[fail]"
+        }
+    }
+}
+
+/// A stack of provider readiness cards. Used by the dashboard Diagnostics
+/// section (all providers) and the empty-state checklist (unhealthy only).
+struct ReadinessChecklist: View {
+    let reports: [ProviderReadiness]
+    var compact: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: compact ? 8 : 12) {
+            ForEach(reports) { report in
+                ReadinessProviderCard(report: report, compact: compact)
+            }
+        }
+    }
+}

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -151,6 +151,18 @@ struct PopoverOverviewPanel: View {
     let openDashboard: () -> Void
 
     @StateObject private var apiUsageStore = ApiUsageStore.shared
+    @State private var setupReports: [ProviderReadiness] = []
+
+    /// The enabled providers currently shown in the popover.
+    private var enabledProviders: Set<ServiceType> {
+        Set(snapshots.map(\.service))
+    }
+
+    /// Enabled providers that still need setup — drives the first-run checklist.
+    /// The section collapses (renders nothing) once these are all healthy.
+    private var providersNeedingSetup: [ProviderReadiness] {
+        setupReports.filter { enabledProviders.contains($0.provider) && !$0.isHealthy }
+    }
 
     private var tightestLimit: SnapshotLimit? {
         snapshots.tightestLimit
@@ -217,6 +229,10 @@ struct PopoverOverviewPanel: View {
             .padding(12)
             .cardSurface()
 
+            if !providersNeedingSetup.isEmpty {
+                setupChecklist
+            }
+
             VStack(spacing: 8) {
                 ForEach(snapshots) { snapshot in
                     PopoverProviderStatusCard(snapshot: snapshot)
@@ -245,6 +261,36 @@ struct PopoverOverviewPanel: View {
         .task {
             await apiUsageStore.refresh()
         }
+        .task {
+            await loadSetupReports()
+        }
+    }
+
+    /// First-run/empty-state checklist: per-provider readiness checks with
+    /// recovery actions for enabled providers that aren't healthy yet. Collapses
+    /// automatically once every enabled provider reports healthy.
+    private var setupChecklist: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 7) {
+                Image(systemName: "checklist")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(MeterBarTheme.appAccent)
+                Text("Finish setup")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                Spacer(minLength: 0)
+            }
+            ReadinessChecklist(reports: providersNeedingSetup, compact: true)
+        }
+    }
+
+    /// Runs the readiness inspector off the main actor (keychain / file / SQLite
+    /// I/O) and publishes the reports back for the checklist.
+    private func loadSetupReports() async {
+        let reports = await Task.detached(priority: .utility) {
+            ProviderReadinessInspector.reports()
+        }.value
+        setupReports = reports
     }
 }
 

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -49,6 +49,7 @@ private enum DashboardSection: String, CaseIterable, Identifiable {
     case overview = "Overview"
     case limits = "Limits"
     case costs = "Costs"
+    case diagnostics = "Diagnostics"
     case settings = "Settings"
 
     var id: String { rawValue }
@@ -61,6 +62,8 @@ private enum DashboardSection: String, CaseIterable, Identifiable {
             return "chart.bar.fill"
         case .costs:
             return "dollarsign.circle.fill"
+        case .diagnostics:
+            return "stethoscope"
         case .settings:
             return "gearshape.fill"
         }
@@ -79,6 +82,8 @@ struct UsageDashboardView: View {
 
     @State private var selectedSection: DashboardSection = .overview
     @State private var columnVisibility = NavigationSplitViewVisibility.all
+    @State private var readinessReports: [ProviderReadiness] = []
+    @State private var isRunningDiagnostics = false
 
     private var activeSection: DashboardSection { selectedSection }
 
@@ -122,6 +127,9 @@ struct UsageDashboardView: View {
         }
         .onChange(of: selectedSection) {
             Task { await refreshCostsIfMissingDays() }
+            if selectedSection == .diagnostics {
+                Task { await runDiagnostics() }
+            }
         }
     }
 
@@ -162,6 +170,8 @@ struct UsageDashboardView: View {
                     limitsContent
                 case .costs:
                     costsContent
+                case .diagnostics:
+                    diagnosticsContent
                 case .settings:
                     settingsContent
                 }
@@ -399,6 +409,87 @@ struct UsageDashboardView: View {
             + "Tracking \(providerSnapshots.count) local provider sources."
     }
 
+    private var diagnosticsContent: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            DashboardCard(title: "Provider Diagnostics", trailing: diagnosticsSummary) {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("These checks run locally. Every line is redacted — safe to paste into a GitHub issue.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+
+                    HStack(spacing: 10) {
+                        Button {
+                            Task { await runDiagnostics() }
+                        } label: {
+                            Label("Re-run checks", systemImage: "arrow.clockwise")
+                        }
+                        .disabled(isRunningDiagnostics)
+
+                        Button {
+                            copyDiagnosticsToClipboard()
+                        } label: {
+                            Label("Copy report", systemImage: "doc.on.doc")
+                        }
+                        .disabled(readinessReports.isEmpty)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            }
+
+            if readinessReports.isEmpty {
+                DashboardCard(title: "Running checks…") {
+                    Text("Gathering provider setup status.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+            } else {
+                ReadinessChecklist(reports: readinessReports)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .task {
+            if readinessReports.isEmpty {
+                await runDiagnostics()
+            }
+        }
+    }
+
+    private var diagnosticsSummary: String? {
+        guard !readinessReports.isEmpty else { return nil }
+        let ready = readinessReports.filter(\.isHealthy).count
+        let attention = readinessReports.filter { $0.overall == .fail }.count
+        return "\(ready) ready · \(attention) need attention"
+    }
+
+    /// Runs the readiness inspector off the main actor (it does keychain / file /
+    /// SQLite I/O) and publishes the reports back on the main actor.
+    private func runDiagnostics() async {
+        isRunningDiagnostics = true
+        let errors = currentRefreshErrors()
+        let reports = await Task.detached(priority: .userInitiated) {
+            ProviderReadinessInspector.reports(refreshErrors: errors)
+        }.value
+        readinessReports = reports
+        isRunningDiagnostics = false
+    }
+
+    /// Each provider's live last-refresh error, fed into the readiness core so the
+    /// "Last refresh" check reflects the app's actual runtime state.
+    private func currentRefreshErrors() -> [ServiceType: ServiceError] {
+        var result: [ServiceType: ServiceError] = [:]
+        if let error = claudeCodeService.lastError { result[.claudeCode] = error }
+        if let error = codexCliService.lastError { result[.codexCli] = error }
+        if let error = cursorService.lastError { result[.cursor] = error }
+        return result
+    }
+
+    private func copyDiagnosticsToClipboard() {
+        let text = DiagnosticsReportText.plainText(readinessReports)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+
     private var sectionSubtitle: String {
         switch activeSection {
         case .overview:
@@ -407,6 +498,8 @@ struct UsageDashboardView: View {
             return "Every tracked quota window"
         case .costs:
             return "Local 30-day token spend"
+        case .diagnostics:
+            return "Provider setup health — safe to share"
         case .settings:
             return "Accounts, refresh, and local sources"
         }
@@ -430,7 +523,7 @@ struct UsageDashboardView: View {
         switch activeSection {
         case .costs:
             return costTracker.isRefreshInProgress
-        case .overview, .limits, .settings:
+        case .overview, .limits, .diagnostics, .settings:
             return dataManager.isLoading
         }
     }

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -10,7 +10,7 @@ struct MeterBarCLI: ParsableCommand {
         commandName: "meterbar",
         abstract: "Track AI coding assistant usage from the command line",
         version: MeterBarCLIVersion.current,
-        subcommands: [Usage.self, Cost.self],
+        subcommands: [Usage.self, Cost.self, Doctor.self],
         defaultSubcommand: Usage.self
     )
 }
@@ -222,5 +222,102 @@ struct Cost: ParsableCommand {
         print("Total:          \(summary.formattedTotalCost)")
         print("Daily Average:  \(summary.formattedDailyCost)")
         print("Tokens:         \(UsageFormat.groupedTokens(summary.totalTokens))")
+    }
+}
+
+struct Doctor: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Diagnose provider setup (installed, signed in, data readable)"
+    )
+
+    @Flag(name: .shortAndLong, help: "Output as JSON")
+    var json: Bool = false
+
+    @Option(name: .shortAndLong, help: "Filter by provider (claude, codex, cursor)")
+    var provider: String?
+
+    func run() throws {
+        // Same readiness core the app's Diagnostics view uses. No live refresh in
+        // a one-shot CLI run, so last-refresh checks report "no recent errors".
+        // Every string below is redacted by the inspector — safe to paste into an issue.
+        let reports = filtered(ProviderReadinessInspector.reports())
+
+        if json {
+            printJSON(reports)
+        } else {
+            printText(reports)
+        }
+    }
+
+    private func filtered(_ reports: [ProviderReadiness]) -> [ProviderReadiness] {
+        let ordered = reports.sorted { $0.provider.sortOrder < $1.provider.sortOrder }
+        guard let needle = provider?.lowercased() else { return ordered }
+        return ordered.filter {
+            $0.provider.rawValue.lowercased().contains(needle)
+                || $0.provider.displayName.lowercased().contains(needle)
+        }
+    }
+
+    private func printJSON(_ reports: [ProviderReadiness]) {
+        let dtos = reports.map(DoctorReportDTO.init)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        if let data = try? encoder.encode(dtos),
+           let str = String(data: data, encoding: .utf8) {
+            print(str)
+        }
+    }
+
+    private func printText(_ reports: [ProviderReadiness]) {
+        print("╭─────────────────────────────────────────╮")
+        print("│             MeterBar Doctor             │")
+        print("╰─────────────────────────────────────────╯")
+        print()
+
+        if reports.isEmpty {
+            print("No matching providers.")
+            return
+        }
+
+        for report in reports {
+            print("▸ \(report.provider.displayName)  [\(report.overall.rawValue.uppercased())]")
+            for check in report.checks {
+                print("  \(symbol(for: check.level)) \(check.title): \(check.detail)")
+                if let recovery = check.recovery {
+                    print("      → \(recovery)")
+                }
+            }
+            print()
+        }
+
+        let healthy = reports.filter { $0.isHealthy }.count
+        let failing = reports.filter { $0.overall == .fail }.count
+        let warning = reports.filter { $0.overall == .warn }.count
+        print("Summary: \(healthy) healthy, \(failing) need attention, \(warning) with warnings.")
+    }
+
+    private func symbol(for level: ReadinessLevel) -> String {
+        switch level {
+        case .pass: return "✓"
+        case .warn: return "⚠"
+        case .fail: return "✗"
+        }
+    }
+}
+
+/// JSON shape for `meterbar doctor --json`: the report plus its rolled-up
+/// `overall`/`healthy` (which are computed, so not part of the core's own
+/// Codable form). Redacted upstream by `ProviderReadinessInspector`.
+private struct DoctorReportDTO: Encodable {
+    let provider: String
+    let overall: String
+    let healthy: Bool
+    let checks: [ReadinessCheck]
+
+    init(_ report: ProviderReadiness) {
+        provider = report.provider.rawValue
+        overall = report.overall.rawValue
+        healthy = report.isHealthy
+        checks = report.checks
     }
 }

--- a/MeterBarTests/OAuthTokenExpiryTests.swift
+++ b/MeterBarTests/OAuthTokenExpiryTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import MeterBar
+import MeterBarShared
 
 final class OAuthTokenExpiryTests: XCTestCase {
     func testJWTExpiryUsesGraceInterval() {

--- a/MeterBarTests/ProviderReadinessInspectorTests.swift
+++ b/MeterBarTests/ProviderReadinessInspectorTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import MeterBar
+
+/// Redaction tests for the inspector's error sanitizer — the layer that keeps
+/// `meterbar doctor` / Diagnostics output safe to paste into a public issue.
+final class ProviderReadinessInspectorTests: XCTestCase {
+    func testApiErrorDropsResponseBodyKeepsStatusCode() {
+        let raw = ServiceError.apiError("HTTP 500: {\"user\":\"vincent@genfeed.ai\",\"token\":\"sk-SECRET\"}")
+        let sanitized = ProviderReadinessInspector.sanitize(raw)
+
+        XCTAssertEqual(sanitized, "API error (HTTP 500)")
+        XCTAssertFalse(sanitized?.contains("SECRET") ?? false)
+        XCTAssertFalse(sanitized?.contains("vincent@genfeed.ai") ?? false)
+    }
+
+    func testApiErrorWithoutStatusIsGeneric() {
+        let sanitized = ProviderReadinessInspector.sanitize(.apiError("Bearer sk-SECRET leaked here"))
+
+        XCTAssertEqual(sanitized, "API error")
+        XCTAssertFalse(sanitized?.contains("SECRET") ?? false)
+    }
+
+    func testSafeNetworkMessagesPassThrough() {
+        XCTAssertEqual(ProviderReadinessInspector.sanitize(.apiError("No internet connection")), "No internet connection")
+        XCTAssertEqual(ProviderReadinessInspector.sanitize(.apiError("Request timed out")), "Request timed out")
+    }
+
+    func testKnownCasesMapToStableStrings() {
+        XCTAssertEqual(ProviderReadinessInspector.sanitize(.notAuthenticated), "Not authenticated")
+        XCTAssertEqual(ProviderReadinessInspector.sanitize(.parsingError), "Could not parse the provider response")
+        XCTAssertNil(ProviderReadinessInspector.sanitize(nil))
+    }
+
+    func testHttpStatusExtraction() {
+        XCTAssertEqual(ProviderReadinessInspector.httpStatus(in: "HTTP 404: not found"), 404)
+        XCTAssertNil(ProviderReadinessInspector.httpStatus(in: "no status here"))
+    }
+}

--- a/MeterBarTests/ProviderReadinessTests.swift
+++ b/MeterBarTests/ProviderReadinessTests.swift
@@ -1,0 +1,265 @@
+import XCTest
+import MeterBarShared
+
+/// Fixture-driven unit tests for the pure `ProviderReadinessEvaluator` core.
+///
+/// These exercise the check logic without any filesystem/keychain/SQLite I/O:
+/// every input is a fixture (missing auth file, expired token, unreadable DB,
+/// healthy). The impure gathering lives in `ProviderReadinessInspector`; this
+/// suite is what lets the leveling + redaction logic be trusted.
+final class ProviderReadinessTests: XCTestCase {
+    // Fixed clock so token-expiry checks are deterministic.
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+
+    // A token value that must never appear in user-facing output.
+    private let secret = "SECRET-TOKEN-DO-NOT-LEAK-abc123"
+
+    // MARK: - Claude Code
+
+    func testClaudeHealthy() {
+        let input = ClaudeReadinessInput(
+            isCLIInstalled: true,
+            credentialsJSON: claudeCredentials(accessToken: secret, expiresAtUnix: 2_000_000),
+            refreshError: nil,
+            now: now
+        )
+        let report = ProviderReadinessEvaluator.claudeCode(input)
+
+        XCTAssertEqual(report.provider, .claudeCode)
+        XCTAssertEqual(report.overall, .pass)
+        XCTAssertTrue(report.isHealthy)
+        XCTAssertEqual(report.check("installed")?.level, .pass)
+        XCTAssertEqual(report.check("auth")?.level, .pass)
+        XCTAssertEqual(report.check("data")?.level, .pass)
+        XCTAssertEqual(report.check("refresh")?.level, .pass)
+        assertNoSecretLeak(report)
+    }
+
+    func testClaudeNotInstalledFailsWithLoginRecovery() {
+        let input = ClaudeReadinessInput(isCLIInstalled: false, credentialsJSON: nil, now: now)
+        let report = ProviderReadinessEvaluator.claudeCode(input)
+
+        XCTAssertEqual(report.overall, .fail)
+        XCTAssertFalse(report.isHealthy)
+        XCTAssertEqual(report.check("installed")?.level, .fail)
+        XCTAssertTrue((report.check("installed")?.recovery ?? "").contains("claude login"))
+    }
+
+    func testClaudeMissingCredentialsFailsAuth() {
+        let input = ClaudeReadinessInput(isCLIInstalled: true, credentialsJSON: nil, now: now)
+        let report = ProviderReadinessEvaluator.claudeCode(input)
+
+        XCTAssertEqual(report.check("auth")?.level, .fail)
+        XCTAssertTrue((report.check("auth")?.recovery ?? "").contains("claude login"))
+        XCTAssertEqual(report.overall, .fail)
+    }
+
+    func testClaudeExpiredTokenFailsAuth() {
+        let input = ClaudeReadinessInput(
+            isCLIInstalled: true,
+            credentialsJSON: claudeCredentials(accessToken: secret, expiresAtUnix: 500_000), // past
+            now: now
+        )
+        let report = ProviderReadinessEvaluator.claudeCode(input)
+
+        XCTAssertEqual(report.check("auth")?.level, .fail)
+        XCTAssertTrue((report.check("auth")?.detail.lowercased() ?? "").contains("expired"))
+        XCTAssertTrue((report.check("auth")?.recovery ?? "").contains("claude login"))
+        assertNoSecretLeak(report)
+    }
+
+    // MARK: - Codex CLI
+
+    func testCodexHealthy() {
+        let input = CodexReadinessInput(
+            isCLIInstalled: true,
+            authFileExists: true,
+            authFileReadable: true,
+            authJSON: codexAuth(accessToken: makeJWT(expiration: 2_000_000)),
+            now: now
+        )
+        let report = ProviderReadinessEvaluator.codexCli(input)
+
+        XCTAssertEqual(report.provider, .codexCli)
+        XCTAssertEqual(report.overall, .pass)
+        XCTAssertEqual(report.check("auth")?.level, .pass)
+        assertNoSecretLeak(report)
+    }
+
+    func testCodexMissingAuthFileFailsWithLoginRecovery() {
+        let input = CodexReadinessInput(
+            isCLIInstalled: true,
+            authFileExists: false,
+            authFileReadable: false,
+            authJSON: nil,
+            now: now
+        )
+        let report = ProviderReadinessEvaluator.codexCli(input)
+
+        XCTAssertEqual(report.check("auth")?.level, .fail)
+        XCTAssertTrue((report.check("auth")?.recovery ?? "").contains("codex login"))
+        XCTAssertEqual(report.overall, .fail)
+    }
+
+    func testCodexUnreadableAuthFileFailsAuth() {
+        let input = CodexReadinessInput(
+            isCLIInstalled: true,
+            authFileExists: true,
+            authFileReadable: false,
+            authJSON: nil,
+            now: now
+        )
+        let report = ProviderReadinessEvaluator.codexCli(input)
+
+        XCTAssertEqual(report.check("auth")?.level, .fail)
+        XCTAssertNotEqual(report.check("data")?.level, .pass)
+    }
+
+    func testCodexExpiredTokenFailsAuth() {
+        let input = CodexReadinessInput(
+            isCLIInstalled: true,
+            authFileExists: true,
+            authFileReadable: true,
+            authJSON: codexAuth(accessToken: makeJWT(expiration: 500_000)), // past
+            now: now
+        )
+        let report = ProviderReadinessEvaluator.codexCli(input)
+
+        XCTAssertEqual(report.check("auth")?.level, .fail)
+        XCTAssertTrue((report.check("auth")?.recovery ?? "").contains("codex login"))
+    }
+
+    func testCodexApiKeyModeIsAuthenticated() {
+        // auth.json with an OPENAI_API_KEY and no OAuth tokens is a valid signed-in state.
+        let json = #"{"OPENAI_API_KEY":"sk-\#(secret)","tokens":null}"#.data(using: .utf8)
+        let input = CodexReadinessInput(
+            isCLIInstalled: true,
+            authFileExists: true,
+            authFileReadable: true,
+            authJSON: json,
+            now: now
+        )
+        let report = ProviderReadinessEvaluator.codexCli(input)
+
+        XCTAssertEqual(report.check("auth")?.level, .pass)
+        assertNoSecretLeak(report)
+    }
+
+    func testCodexBinaryMissingIsWarnNotFail() {
+        // The app reads ~/.codex/auth.json directly, so a missing `codex` binary
+        // is a soft warning, not a hard failure, when auth is otherwise present.
+        let input = CodexReadinessInput(
+            isCLIInstalled: false,
+            authFileExists: true,
+            authFileReadable: true,
+            authJSON: codexAuth(accessToken: makeJWT(expiration: 2_000_000)),
+            now: now
+        )
+        let report = ProviderReadinessEvaluator.codexCli(input)
+
+        XCTAssertEqual(report.check("installed")?.level, .warn)
+        XCTAssertEqual(report.check("auth")?.level, .pass)
+        XCTAssertNotEqual(report.overall, .fail)
+    }
+
+    // MARK: - Cursor
+
+    func testCursorHealthy() {
+        let input = CursorReadinessInput(isInstalled: true, database: .tokenPresent, now: now)
+        let report = ProviderReadinessEvaluator.cursor(input)
+
+        XCTAssertEqual(report.provider, .cursor)
+        XCTAssertEqual(report.overall, .pass)
+        XCTAssertEqual(report.check("auth")?.level, .pass)
+    }
+
+    func testCursorUnreadableDatabaseFails() {
+        let input = CursorReadinessInput(isInstalled: true, database: .unreadable, now: now)
+        let report = ProviderReadinessEvaluator.cursor(input)
+
+        XCTAssertEqual(report.check("auth")?.level, .fail)
+        XCTAssertEqual(report.check("data")?.level, .fail)
+        XCTAssertTrue((report.check("auth")?.recovery ?? "").contains("Cursor"))
+        XCTAssertEqual(report.overall, .fail)
+    }
+
+    func testCursorNotFoundFailsInstalled() {
+        let input = CursorReadinessInput(isInstalled: false, database: .notFound, now: now)
+        let report = ProviderReadinessEvaluator.cursor(input)
+
+        XCTAssertEqual(report.check("installed")?.level, .fail)
+        XCTAssertEqual(report.overall, .fail)
+    }
+
+    func testCursorMissingTokenFailsAuthButDataReadable() {
+        let input = CursorReadinessInput(isInstalled: true, database: .missingToken, now: now)
+        let report = ProviderReadinessEvaluator.cursor(input)
+
+        XCTAssertEqual(report.check("auth")?.level, .fail)
+        XCTAssertTrue((report.check("auth")?.recovery ?? "").contains("Cursor"))
+        XCTAssertEqual(report.check("data")?.level, .pass)
+    }
+
+    // MARK: - Refresh + redaction (shared behavior)
+
+    func testRefreshErrorSurfacesAndOverallDegrades() {
+        let input = CursorReadinessInput(
+            isInstalled: true,
+            database: .tokenPresent,
+            refreshError: "API error (HTTP 500)",
+            now: now
+        )
+        let report = ProviderReadinessEvaluator.cursor(input)
+
+        XCTAssertEqual(report.check("refresh")?.level, .fail)
+        XCTAssertTrue((report.check("refresh")?.detail ?? "").contains("HTTP 500"))
+        XCTAssertEqual(report.overall, .fail)
+    }
+
+    func testReportIsCodableForJSONOutput() throws {
+        let report = ProviderReadinessEvaluator.cursor(
+            CursorReadinessInput(isInstalled: true, database: .tokenPresent, now: now)
+        )
+        let data = try JSONEncoder().encode(report)
+        let decoded = try JSONDecoder().decode(ProviderReadiness.self, from: data)
+        XCTAssertEqual(decoded, report)
+    }
+
+    // MARK: - Fixtures
+
+    private func assertNoSecretLeak(_ report: ProviderReadiness, file: StaticString = #filePath, line: UInt = #line) {
+        for check in report.checks {
+            XCTAssertFalse(check.detail.contains(secret), "secret leaked into detail: \(check.detail)", file: file, line: line)
+            XCTAssertFalse((check.recovery ?? "").contains(secret), "secret leaked into recovery", file: file, line: line)
+        }
+    }
+
+    private func claudeCredentials(accessToken: String, expiresAtUnix: Int64) -> Data {
+        let json = """
+        {"claudeAiOauth":{"accessToken":"\(accessToken)","refreshToken":"refresh","expiresAt":\(expiresAtUnix),\
+        "scopes":["user:inference"],"subscriptionType":"max","rateLimitTier":"default"}}
+        """
+        return Data(json.utf8)
+    }
+
+    private func codexAuth(accessToken: String, accountId: String = "acct_test") -> Data {
+        let json = """
+        {"OPENAI_API_KEY":null,"tokens":{"id_token":"id","access_token":"\(accessToken)",\
+        "refresh_token":"refresh","account_id":"\(accountId)"},"last_refresh":"2026-07-03T00:00:00Z"}
+        """
+        return Data(json.utf8)
+    }
+
+    private func makeJWT(expiration: TimeInterval) -> String {
+        let payload = #"{"exp":\#(Int(expiration))}"#
+        return "header.\(base64URL(payload)).signature"
+    }
+
+    private func base64URL(_ value: String) -> String {
+        Data(value.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/Packages/MeterBarShared/Sources/MeterBarShared/OAuthTokenExpiry.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/OAuthTokenExpiry.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-enum OAuthTokenExpiry {
-    static func isExpired(jwt token: String, graceInterval: TimeInterval = 60, now: Date = Date()) -> Bool {
+public enum OAuthTokenExpiry {
+    public static func isExpired(jwt token: String, graceInterval: TimeInterval = 60, now: Date = Date()) -> Bool {
         // If the token has no parseable `exp` claim we cannot prove it is expired,
         // so we treat it as not-expired and let the server be the source of truth
         // (a truly invalid token simply 401s on the next request). This is a
@@ -14,17 +14,17 @@ enum OAuthTokenExpiry {
         return expirationDate <= now.addingTimeInterval(graceInterval)
     }
 
-    static func isExpired(unixTimestamp rawTimestamp: Int64, graceInterval: TimeInterval = 60, now: Date = Date()) -> Bool {
+    public static func isExpired(unixTimestamp rawTimestamp: Int64, graceInterval: TimeInterval = 60, now: Date = Date()) -> Bool {
         expirationDate(fromUnixTimestamp: rawTimestamp) <= now.addingTimeInterval(graceInterval)
     }
 
-    static func expirationDate(fromUnixTimestamp rawTimestamp: Int64) -> Date {
+    public static func expirationDate(fromUnixTimestamp rawTimestamp: Int64) -> Date {
         let timestamp = Double(rawTimestamp)
         let seconds = timestamp > 10_000_000_000 ? timestamp / 1_000 : timestamp
         return Date(timeIntervalSince1970: seconds)
     }
 
-    static func expirationDate(fromJWT token: String) -> Date? {
+    public static func expirationDate(fromJWT token: String) -> Date? {
         guard let payloadData = JWT.payloadData(token),
               let payload = try? JSONDecoder().decode(JWTPayload.self, from: payloadData),
               let expiration = payload.exp else {
@@ -43,16 +43,16 @@ private struct JWTPayload: Decodable {
 /// tokens are only read locally to extract claims, never validated).
 /// Shared by OAuthTokenExpiry (`exp`) and CursorLocalService (`sub`), which
 /// previously each hand-rolled the same base64url decode.
-enum JWT {
+public enum JWT {
     /// The decoded payload (second segment) of a JWT, or nil if malformed.
-    static func payloadData(_ token: String) -> Data? {
+    public static func payloadData(_ token: String) -> Data? {
         let parts = token.split(separator: ".")
         guard parts.count >= 2 else { return nil }
         return decodeBase64URL(String(parts[1]))
     }
 
     /// A string claim from the JWT payload, e.g. `claimString("sub", in: token)`.
-    static func claimString(_ claim: String, in token: String) -> String? {
+    public static func claimString(_ claim: String, in token: String) -> String? {
         guard let data = payloadData(token),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return nil

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
@@ -1,0 +1,464 @@
+import Foundation
+
+/// Pure, testable provider-readiness check logic shared by the app and the CLI.
+///
+/// This is the single core behind three surfaces: the `meterbar doctor` CLI
+/// subcommand, the app's Diagnostics view, and the first-run/empty-state
+/// checklist. Lives in `MeterBarShared` — mirroring how the wire-format metrics
+/// types were unified — so `MeterBarCLI` and `MeterBar` genuinely share it
+/// instead of each re-deriving the checks.
+///
+/// The evaluators are pure functions of fixture-able inputs: the impure
+/// gathering (PATH scan, keychain, `~/.codex/auth.json`, Cursor SQLite) is done
+/// by `ProviderReadinessInspector` in the app target. Every string produced here
+/// is safe to paste into a public GitHub issue — no token, account id, or raw
+/// file/response body is ever emitted.
+
+// MARK: - Result types
+
+/// Severity of a single readiness check.
+public enum ReadinessLevel: String, Codable, Sendable, CaseIterable {
+    case pass
+    case warn
+    case fail
+
+    /// Ordering used to roll individual checks up into an overall status.
+    public var severity: Int {
+        switch self {
+        case .pass: return 0
+        case .warn: return 1
+        case .fail: return 2
+        }
+    }
+}
+
+/// Stable identifiers for the ordered checks every provider reports, so surfaces
+/// can look up a specific check without stringly-typed drift.
+public enum ReadinessCheckID {
+    public static let installed = "installed"
+    public static let auth = "auth"
+    public static let data = "data"
+    public static let refresh = "refresh"
+}
+
+/// One evaluated check: a pass/warn/fail plus a redacted, plain-language detail
+/// and an optional recovery action the user can act on.
+public struct ReadinessCheck: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let title: String
+    public let level: ReadinessLevel
+    public let detail: String
+    public let recovery: String?
+
+    public init(id: String, title: String, level: ReadinessLevel, detail: String, recovery: String? = nil) {
+        self.id = id
+        self.title = title
+        self.level = level
+        self.detail = detail
+        self.recovery = recovery
+    }
+}
+
+/// The full readiness report for one provider: an ordered list of checks
+/// (installed → auth → data → refresh) plus a rolled-up overall status.
+public struct ProviderReadiness: Codable, Sendable, Equatable, Identifiable {
+    public let provider: ServiceType
+    public let checks: [ReadinessCheck]
+
+    public init(provider: ServiceType, checks: [ReadinessCheck]) {
+        self.provider = provider
+        self.checks = checks
+    }
+
+    public var id: String { provider.rawValue }
+
+    /// The worst level across all checks (fail > warn > pass).
+    public var overall: ReadinessLevel {
+        checks.map(\.level).max(by: { $0.severity < $1.severity }) ?? .pass
+    }
+
+    public var isHealthy: Bool { overall == .pass }
+
+    public func check(_ id: String) -> ReadinessCheck? {
+        checks.first { $0.id == id }
+    }
+}
+
+// MARK: - Inputs
+
+/// Outcome of probing Cursor's local SQLite state database. Modeled as an enum
+/// because the database read (SQLite, on a file that locks while Cursor runs)
+/// cannot be exercised purely — the impure inspector maps the real read onto
+/// one of these cases and the evaluator turns it into checks.
+public enum CursorDatabaseProbe: String, Codable, Sendable, Equatable {
+    /// No `state.vscdb` found in any known location.
+    case notFound
+    /// Found, but the file could not be opened/read (permissions or Cursor lock).
+    case unreadable
+    /// Readable, but no `cursorAuth/accessToken` row — not signed in.
+    case missingToken
+    /// Readable and a session token is present.
+    case tokenPresent
+}
+
+/// Fixture-able facts for the Claude Code readiness evaluation.
+public struct ClaudeReadinessInput: Sendable {
+    /// `claude` resolvable on PATH.
+    public var isCLIInstalled: Bool
+    /// Raw keychain blob for the "Claude Code-credentials" item (nil if absent).
+    public var credentialsJSON: Data?
+    /// Pre-sanitized last-refresh error (safe to display), nil on success.
+    public var refreshError: String?
+    public var now: Date
+
+    public init(
+        isCLIInstalled: Bool,
+        credentialsJSON: Data? = nil,
+        refreshError: String? = nil,
+        now: Date = Date()
+    ) {
+        self.isCLIInstalled = isCLIInstalled
+        self.credentialsJSON = credentialsJSON
+        self.refreshError = refreshError
+        self.now = now
+    }
+}
+
+/// Fixture-able facts for the Codex CLI readiness evaluation.
+public struct CodexReadinessInput: Sendable {
+    /// `codex` resolvable on PATH.
+    public var isCLIInstalled: Bool
+    /// `~/.codex/auth.json` exists on disk.
+    public var authFileExists: Bool
+    /// The auth file could be read (exists and permissions allow it).
+    public var authFileReadable: Bool
+    /// Raw `~/.codex/auth.json` bytes when readable, else nil.
+    public var authJSON: Data?
+    /// Pre-sanitized last-refresh error (safe to display), nil on success.
+    public var refreshError: String?
+    public var now: Date
+
+    public init(
+        isCLIInstalled: Bool,
+        authFileExists: Bool,
+        authFileReadable: Bool,
+        authJSON: Data? = nil,
+        refreshError: String? = nil,
+        now: Date = Date()
+    ) {
+        self.isCLIInstalled = isCLIInstalled
+        self.authFileExists = authFileExists
+        self.authFileReadable = authFileReadable
+        self.authJSON = authJSON
+        self.refreshError = refreshError
+        self.now = now
+    }
+}
+
+/// Fixture-able facts for the Cursor readiness evaluation.
+public struct CursorReadinessInput: Sendable {
+    /// Cursor is installed (its app bundle and/or state database are present).
+    public var isInstalled: Bool
+    /// Outcome of probing the Cursor state database for the session token.
+    public var database: CursorDatabaseProbe
+    /// Pre-sanitized last-refresh error (safe to display), nil on success.
+    public var refreshError: String?
+    public var now: Date
+
+    public init(
+        isInstalled: Bool,
+        database: CursorDatabaseProbe,
+        refreshError: String? = nil,
+        now: Date = Date()
+    ) {
+        self.isInstalled = isInstalled
+        self.database = database
+        self.refreshError = refreshError
+        self.now = now
+    }
+}
+
+// MARK: - Evaluator
+
+public enum ProviderReadinessEvaluator {
+    // MARK: Claude Code
+
+    public static func claudeCode(_ input: ClaudeReadinessInput) -> ProviderReadiness {
+        let installed = ReadinessCheck(
+            id: ReadinessCheckID.installed,
+            title: "CLI installed",
+            level: input.isCLIInstalled ? .pass : .fail,
+            detail: input.isCLIInstalled
+                ? "Claude Code CLI found on PATH."
+                : "Claude Code CLI not found on PATH.",
+            recovery: input.isCLIInstalled ? nil : "Install Claude Code, then run `claude login`."
+        )
+
+        let auth = claudeAuthCheck(input)
+
+        let dataReady = input.isCLIInstalled && auth.level == .pass
+        let data = ReadinessCheck(
+            id: ReadinessCheckID.data,
+            title: "Usage readable",
+            level: dataReady ? .pass : .warn,
+            detail: dataReady
+                ? "Usage is readable via the Claude CLI."
+                : "Usage becomes readable once the CLI is installed and signed in."
+        )
+
+        return ProviderReadiness(
+            provider: .claudeCode,
+            checks: [installed, auth, data, refreshCheck(input.refreshError)]
+        )
+    }
+
+    private static func claudeAuthCheck(_ input: ClaudeReadinessInput) -> ReadinessCheck {
+        let loginRecovery = "Run `claude login`."
+
+        guard let data = input.credentialsJSON,
+              let credentials = try? JSONDecoder().decode(ClaudeCredentialsFixture.self, from: data) else {
+            return ReadinessCheck(
+                id: ReadinessCheckID.auth,
+                title: "Signed in",
+                level: .fail,
+                detail: "Not signed in — no Claude Code credentials found.",
+                recovery: loginRecovery
+            )
+        }
+
+        if let expiresAt = credentials.claudeAiOauth.expiresAt,
+           OAuthTokenExpiry.isExpired(unixTimestamp: expiresAt, now: input.now) {
+            return ReadinessCheck(
+                id: ReadinessCheckID.auth,
+                title: "Signed in",
+                level: .fail,
+                detail: "Claude Code session has expired.",
+                recovery: loginRecovery
+            )
+        }
+
+        return ReadinessCheck(
+            id: ReadinessCheckID.auth,
+            title: "Signed in",
+            level: .pass,
+            detail: "Signed in to Claude Code."
+        )
+    }
+
+    // MARK: Codex CLI
+
+    public static func codexCli(_ input: CodexReadinessInput) -> ProviderReadiness {
+        // The app reads ~/.codex/auth.json directly and never execs `codex`, so a
+        // missing binary is a soft warning rather than a hard failure.
+        let installed = ReadinessCheck(
+            id: ReadinessCheckID.installed,
+            title: "CLI installed",
+            level: input.isCLIInstalled ? .pass : .warn,
+            detail: input.isCLIInstalled
+                ? "Codex CLI found on PATH."
+                : "Codex CLI not found on PATH (usage is still read from ~/.codex/auth.json).",
+            recovery: input.isCLIInstalled ? nil : "Install the Codex CLI (`npm i -g @openai/codex`) to use `codex login`."
+        )
+
+        let auth = codexAuthCheck(input)
+
+        let data = ReadinessCheck(
+            id: ReadinessCheckID.data,
+            title: "Usage readable",
+            level: input.authFileReadable ? .pass : .warn,
+            detail: input.authFileReadable
+                ? "Usage is readable from ~/.codex/auth.json."
+                : "Usage cannot be read until the auth file is available."
+        )
+
+        return ProviderReadiness(
+            provider: .codexCli,
+            checks: [installed, auth, data, refreshCheck(input.refreshError)]
+        )
+    }
+
+    private static func codexAuthCheck(_ input: CodexReadinessInput) -> ReadinessCheck {
+        let loginRecovery = "Run `codex login`."
+        let title = "Signed in"
+
+        guard input.authFileExists else {
+            return ReadinessCheck(
+                id: ReadinessCheckID.auth,
+                title: title,
+                level: .fail,
+                detail: "Not signed in — no ~/.codex/auth.json found.",
+                recovery: loginRecovery
+            )
+        }
+
+        guard input.authFileReadable, let data = input.authJSON else {
+            return ReadinessCheck(
+                id: ReadinessCheckID.auth,
+                title: title,
+                level: .fail,
+                detail: "~/.codex/auth.json exists but could not be read.",
+                recovery: "Check the permissions on ~/.codex/auth.json, then run `codex login`."
+            )
+        }
+
+        guard let auth = try? JSONDecoder().decode(CodexAuthFixture.self, from: data) else {
+            return ReadinessCheck(
+                id: ReadinessCheckID.auth,
+                title: title,
+                level: .fail,
+                detail: "~/.codex/auth.json could not be parsed.",
+                recovery: loginRecovery
+            )
+        }
+
+        if let apiKey = auth.openaiApiKey, !apiKey.isEmpty {
+            return ReadinessCheck(
+                id: ReadinessCheckID.auth,
+                title: title,
+                level: .pass,
+                detail: "Signed in with an OpenAI API key."
+            )
+        }
+
+        guard let token = auth.tokens?.accessToken, !token.isEmpty else {
+            return ReadinessCheck(
+                id: ReadinessCheckID.auth,
+                title: title,
+                level: .fail,
+                detail: "Not signed in — no token in ~/.codex/auth.json.",
+                recovery: loginRecovery
+            )
+        }
+
+        if OAuthTokenExpiry.isExpired(jwt: token, now: input.now) {
+            return ReadinessCheck(
+                id: ReadinessCheckID.auth,
+                title: title,
+                level: .fail,
+                detail: "Codex access token has expired.",
+                recovery: loginRecovery
+            )
+        }
+
+        return ReadinessCheck(
+            id: ReadinessCheckID.auth,
+            title: title,
+            level: .pass,
+            detail: "Signed in to Codex."
+        )
+    }
+
+    // MARK: Cursor
+
+    public static func cursor(_ input: CursorReadinessInput) -> ProviderReadiness {
+        let installed = ReadinessCheck(
+            id: ReadinessCheckID.installed,
+            title: "Installed",
+            level: input.isInstalled ? .pass : .fail,
+            detail: input.isInstalled
+                ? "Cursor is installed."
+                : "Cursor was not found on this Mac.",
+            recovery: input.isInstalled ? nil : "Install Cursor and sign in."
+        )
+
+        let auth = cursorAuthCheck(input.database)
+
+        let dataReadable = input.database == .tokenPresent || input.database == .missingToken
+        let data = ReadinessCheck(
+            id: ReadinessCheckID.data,
+            title: "Data readable",
+            level: dataReadable ? .pass : .fail,
+            detail: dataReadable
+                ? "Cursor's local database is readable."
+                : "Cursor's local database could not be read."
+        )
+
+        return ProviderReadiness(
+            provider: .cursor,
+            checks: [installed, auth, data, refreshCheck(input.refreshError)]
+        )
+    }
+
+    private static func cursorAuthCheck(_ probe: CursorDatabaseProbe) -> ReadinessCheck {
+        let title = "Signed in"
+        switch probe {
+        case .tokenPresent:
+            return ReadinessCheck(id: ReadinessCheckID.auth, title: title, level: .pass, detail: "Signed in to Cursor.")
+        case .missingToken:
+            return ReadinessCheck(
+                id: ReadinessCheckID.auth,
+                title: title,
+                level: .fail,
+                detail: "Not signed in to Cursor.",
+                recovery: "Open Cursor and sign in."
+            )
+        case .notFound:
+            return ReadinessCheck(
+                id: ReadinessCheckID.auth,
+                title: title,
+                level: .fail,
+                detail: "Cursor's local database was not found.",
+                recovery: "Open Cursor and sign in."
+            )
+        case .unreadable:
+            return ReadinessCheck(
+                id: ReadinessCheckID.auth,
+                title: title,
+                level: .fail,
+                detail: "Cursor's local database could not be read.",
+                recovery: "Quit Cursor (its database locks while running), then rescan."
+            )
+        }
+    }
+
+    // MARK: Shared
+
+    private static func refreshCheck(_ error: String?) -> ReadinessCheck {
+        guard let error, !error.isEmpty else {
+            return ReadinessCheck(
+                id: ReadinessCheckID.refresh,
+                title: "Last refresh",
+                level: .pass,
+                detail: "No recent refresh errors."
+            )
+        }
+        return ReadinessCheck(
+            id: ReadinessCheckID.refresh,
+            title: "Last refresh",
+            level: .fail,
+            detail: "Last refresh failed: \(error)"
+        )
+    }
+}
+
+// MARK: - Minimal auth-file decoders
+
+// Purpose-built decoders for just the fields readiness needs. The authoritative
+// decoders live in the provider services (ClaudeCodeCredentials / CodexAuthFile);
+// these read a couple of fields each so the pure core can be fixture-tested
+// without linking the app-only models. Keep field mappings in sync if the auth
+// file formats change.
+
+private struct ClaudeCredentialsFixture: Decodable {
+    struct OAuth: Decodable {
+        let accessToken: String?
+        let expiresAt: Int64?
+    }
+    let claudeAiOauth: OAuth
+}
+
+private struct CodexAuthFixture: Decodable {
+    struct Tokens: Decodable {
+        let accessToken: String?
+        enum CodingKeys: String, CodingKey {
+            case accessToken = "access_token"
+        }
+    }
+    let openaiApiKey: String?
+    let tokens: Tokens?
+
+    enum CodingKeys: String, CodingKey {
+        case openaiApiKey = "OPENAI_API_KEY"
+        case tokens
+    }
+}


### PR DESCRIPTION
Closes #22, Closes #25

Implements **Tier 2a** of the issue backlog: one feature, one shared core, three surfaces. Consolidates the onboarding readiness checklist (#22) and the diagnostics panel + `meterbar doctor` (#25).

## Shared core (pure, testable)
`Packages/MeterBarShared/ProviderReadiness.swift` — `ProviderReadinessEvaluator` runs per-provider ordered checks (**installed → auth present → data readable → last refresh**) for Claude Code, Codex CLI, and Cursor. Each check is `pass`/`warn`/`fail` with a plain-language recovery action (`claude login`, `codex login`, open Cursor, rescan) and a **redaction-safe** detail — output is safe to paste into a GitHub issue.

Inputs are fixture-able value types (auth-file `Data`, a `CursorDatabaseProbe` enum for the SQLite read that can't be exercised purely). `OAuthTokenExpiry` + `JWT` were moved into `MeterBarShared` (made `public`) so the core and the CLI share the existing expiry helper — mirroring how the metrics wire-format types were unified. The three provider services already `import MeterBarShared`, so they resolve the symbols unchanged.

## Impure inspector (shared by app + CLI)
`MeterBar/Services/ProviderReadinessInspector.swift` gathers the real facts (binary on PATH, keychain blob, `~/.codex/auth.json` bytes + readability, Cursor DB probe) and feeds the core. It lives in the app library so the app surfaces **and** `MeterBarCLI` share one implementation. All error text is sanitized here: `.apiError` may embed a slice of the raw API response body, so only a leading `HTTP NNN` status (or a whitelisted connectivity message) survives.

## Three surfaces
1. **`meterbar doctor`** — new CLI subcommand following the Usage/Cost conventions (text + `--json` + `--provider` filter).
2. **Diagnostics view** — new section in the dashboard nav rendering the same reports, with a paste-safe "Copy report" button and "Re-run checks". Inspector I/O runs off the main actor.
3. **Empty-state checklist** — the popover renders a compact "Finish setup" checklist for enabled-but-unhealthy providers with recovery actions; it collapses once every enabled provider is healthy.

Shared readiness UI lives in `MeterBar/Views/Components/ReadinessComponents.swift`.

## DRY refactor
Extracted `CLIBinaryLocator` from the private path-resolution logic in `ClaudeCodeCLIUsageService` (now delegates to it); the inspector reuses it for both `claude` and `codex`. Added `credentialsData()` (Claude keychain blob) and `probeReadinessDatabase()` (Cursor) accessors so the inspector reuses the services' keychain/SQLite paths instead of duplicating them.

## Testing (TDD)
Fixture-driven tests written **before** the core:
- `ProviderReadinessTests` — per-check cases for all three providers: missing auth file, expired token (JWT + unix), unreadable Cursor DB, API-key mode, binary-missing-is-warn, healthy, refresh-error surfacing, JSON round-trip, and secret-leak assertions.
- `ProviderReadinessInspectorTests` — redaction tests for the error sanitizer (response body dropped, HTTP status kept, connectivity messages passed through).

Local has Command Line Tools only (no XCTest), so the core was additionally verified via a standalone SwiftPM harness against the same fixtures — **35/35 assertions pass**. `swift build` is green for all three SwiftPM targets. `meterbar doctor` was run on a real machine (it correctly flagged an expired Claude session and a locked Cursor DB) and its output scanned for token-like substrings — clean. Full XCTest + SwiftLint `--strict` run in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new provider diagnostics experience in the app, including a Diagnostics section, setup checklist, and copyable report output.
  * Added a new CLI `doctor` command with text and JSON output for provider readiness checks.
  * Improved readiness checks across Claude, Codex, and Cursor with clearer status details and recovery guidance.

* **Bug Fixes**
  * Reduced sensitive information in diagnostic messages and reports.
  * Improved detection of provider availability and local setup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->