### PR TITLE
feat(menubar): follow recently used accounts with sticky selection + refresh popover on open

### DIFF
--- a/.agents/SESSIONS/2026-07-06.md
+++ b/.agents/SESSIONS/2026-07-06.md
@@ -1,0 +1,79 @@
+# 2026-07-06
+
+## Session 1 — Menu bar follows the accounts actually in use + refresh-on-open
+
+### Flow
+
+```text
+statusItem click ──> togglePopover ──> popover.show + refreshAll()   (new: refresh-on-open)
+
+$metrics publish ──> updateStatusItem
+                       │
+                       ├─ statusLimitCandidates(in:)          (AppDelegate, per enabled provider)
+                       │    ├─ claude:<uuid> ── AccountActivityInspector.claudeCodeActivity(configDir)
+                       │    ├─ codex ────────── AccountActivityInspector.codexCliActivity()
+                       │    └─ cursor ───────── AccountActivityInspector.cursorActivity()
+                       │
+                       └─ StatusItemLimitSelector.select(candidates, previousKey: shownStatusItemKey)
+                            ├─ active = lastActivity within 30 min
+                            ├─ pool = active.isEmpty ? all : active     (fallback = old behavior)
+                            ├─ sticky: keep previous while ≤ 5 %-left points looser than tightest
+                            └─ else tightest of pool (tie-break on key)
+```
+
+### Affected components
+
+- App: `MeterBar/App/MeterBarApp.swift` (AppDelegate status item + popover)
+- New logic (SPM-testable): `MeterBar/Models/StatusItemLimitSelector.swift`,
+  `MeterBar/Services/AccountActivityInspector.swift`
+- Tests: `MeterBarTests/StatusItemLimitSelectorTests.swift`,
+  `MeterBarTests/AccountActivityInspectorTests.swift`
+
+### What was done
+
+- [x] Answered Vincent's refresh question: popover open did **not** refresh; data came from the
+      auto-refresh timer, manual refresh = header button.
+- [x] Added refresh-on-open: `togglePopover` fires `refreshAll()` whenever the popover shows.
+- [x] Replaced `mostConstrainedPrimaryLimit` (tightest quota across ALL enabled accounts —
+      a drained idle account pinned the number forever) with activity-aware sticky selection.
+- [x] Activity detection: shallow (depth-1) mtime probe of each account's config dir —
+      `CLAUDE_CONFIG_DIR`-per-account for Claude, `~/.codex` for Codex, `state.vscdb(-wal)`
+      candidate paths for Cursor. Verified on-disk that top-level entries (`sessions/`,
+      `session-env/`, sqlite WAL) are hot during live sessions.
+- [x] Tooltip/a11y label now names the shown account ("62% left on Ship (Claude Code)").
+- [x] TDD: 13 selector tests (active filtering, 30-min boundary, 5-pt hysteresis both edges,
+      idle fallback, sticky-in-fallback, unknown previous key, deterministic ties) + 6
+      inspector tests (temp-dir mtime fixtures) written before implementation.
+
+### Key decisions
+
+- **Tightest-active + sticky (Vincent's pick via AskUserQuestion):** one number, follows
+  accounts with activity in the last **30 min**; switches only when the shown account goes
+  idle or another active account is **>5 %-left points** tighter. No ping-pong when one
+  Claude + one Codex run concurrently.
+- **Fallback = old behavior:** with no detectable activity anywhere, all enabled accounts
+  compete (tightest overall), so the menu bar never goes blank.
+- **Selector + inspector live outside `App/`** because `Package.swift` excludes
+  `App/MeterBarApp.swift` from the SPM target — logic in Models/Services stays `swift test`-able.
+- **Depth-1 mtime scan, not recursive:** `projects/` has hundreds of entries; top-level
+  churn (session files, WAL, snapshots) is already a reliable liveness signal.
+
+### Verification
+
+- `swift test` impossible locally (CLT only, no XCTest) — CI runs the full suite + coverage gate.
+- App-target sources (incl. excluded `MeterBarApp.swift`) typechecked locally with the
+  project's real flags: `swiftc -typecheck -swift-version 5 -default-isolation MainActor` → 0 errors.
+- Local SwiftLint also needs full Xcode (sourcekitd crash); CI lint job covers it.
+
+### Mistakes and fixes
+
+- First typecheck ran without `-default-isolation MainActor` and flagged pre-existing master
+  code as errors; matched the `.pbxproj` settings (`SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`)
+  before trusting the result.
+
+### Next steps
+
+- CI green → merge. Post-merge `xcode-build` job exercises the app-target compile of
+  `MeterBarApp.swift` (PR gate builds only the SPM library).
+- Possible follow-up: surface the shown account in the popover header, and make the 30-min
+  window / 5-pt hysteresis user-tunable if defaults feel off in daily use.

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -36,6 +36,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// above a threshold. Keys are cleared when usage drops back below.
     private var notifiedLimitKeys: Set<String> = []
 
+    /// The account whose quota the menu bar title currently shows; feeds the
+    /// sticky selection so concurrent Claude + Codex use doesn't flip the title.
+    private var shownStatusItemKey: String?
+
     func applicationWillFinishLaunching(_ notification: Notification) {
         // Apply the persisted Dock visibility as early as possible so users who
         // hide MeterBar from the Dock don't see a brief Dock-icon flash.
@@ -110,6 +114,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             popover.performClose(nil)
         } else {
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            // Opening the popover always pulls fresh data — providers read
+            // local files, so this is cheap and the popover never shows a
+            // stale snapshot from the last timer tick.
+            Task { await UsageDataManager.shared.refreshAll() }
         }
     }
 
@@ -364,39 +372,63 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func updateStatusItem(metrics: [ServiceType: UsageMetrics]) {
         guard let button = statusItem?.button else { return }
 
-        guard let limit = mostConstrainedPrimaryLimit(in: metrics) else {
+        guard let selection = StatusItemLimitSelector.select(
+            candidates: statusLimitCandidates(in: metrics),
+            previousKey: shownStatusItemKey
+        ) else {
+            shownStatusItemKey = nil
             button.title = ""
             button.imagePosition = .imageOnly
             button.toolTip = "MeterBar"
             return
         }
 
-        let percent = percentLeft(for: limit)
+        shownStatusItemKey = selection.key
+        let percent = percentLeft(for: selection.limit)
         button.imagePosition = .imageLeft
         button.title = " \(percent)%"
-        button.toolTip = "MeterBar: \(percent)% left on the tightest quota"
-        button.setAccessibilityLabel("MeterBar \(percent)% left on the tightest quota")
+        button.toolTip = "MeterBar: \(percent)% left on \(selection.displayName)"
+        button.setAccessibilityLabel("MeterBar \(percent)% left on \(selection.displayName)")
     }
 
+    /// Every enabled account/provider quota that may own the menu bar title,
+    /// tagged with its latest on-disk activity so `StatusItemLimitSelector`
+    /// can follow the accounts actually in use.
     @MainActor
-    private func mostConstrainedPrimaryLimit(in metrics: [ServiceType: UsageMetrics]) -> UsageLimit? {
-        let claudeLimits = providerVisibilityStore.isEnabled(.claudeCode)
-            ? ClaudeCodeAccountStore.shared.accounts.compactMap {
-                claudeMetrics(for: $0, metrics: metrics)?.sessionLimit
-            }
-            : []
+    private func statusLimitCandidates(in metrics: [ServiceType: UsageMetrics]) -> [StatusLimitCandidate] {
+        var candidates: [StatusLimitCandidate] = []
 
-        var limits = claudeLimits
+        if providerVisibilityStore.isEnabled(.claudeCode) {
+            for account in ClaudeCodeAccountStore.shared.accounts {
+                guard let limit = claudeMetrics(for: account, metrics: metrics)?.sessionLimit else { continue }
+                candidates.append(StatusLimitCandidate(
+                    key: "claude:\(account.id.uuidString)",
+                    displayName: "\(account.name) (\(ServiceType.claudeCode.displayName))",
+                    limit: limit,
+                    lastActivity: AccountActivityInspector.claudeCodeActivity(
+                        configDirectory: account.configDirectory
+                    )
+                ))
+            }
+        }
         if providerVisibilityStore.isEnabled(.codexCli), let codexLimit = metrics[.codexCli]?.sessionLimit {
-            limits.append(codexLimit)
+            candidates.append(StatusLimitCandidate(
+                key: "codex",
+                displayName: ServiceType.codexCli.displayName,
+                limit: codexLimit,
+                lastActivity: AccountActivityInspector.codexCliActivity()
+            ))
         }
         if providerVisibilityStore.isEnabled(.cursor), let cursorLimit = metrics[.cursor]?.weeklyLimit {
-            limits.append(cursorLimit)
+            candidates.append(StatusLimitCandidate(
+                key: "cursor",
+                displayName: ServiceType.cursor.displayName,
+                limit: cursorLimit,
+                lastActivity: AccountActivityInspector.cursorActivity()
+            ))
         }
 
-        return limits.min { lhs, rhs in
-            percentLeft(for: lhs) < percentLeft(for: rhs)
-        }
+        return candidates
     }
 
     @MainActor

--- a/MeterBar/Models/StatusItemLimitSelector.swift
+++ b/MeterBar/Models/StatusItemLimitSelector.swift
@@ -1,0 +1,65 @@
+import Foundation
+import MeterBarShared
+
+/// One account/provider quota competing for the menu bar percentage slot.
+struct StatusLimitCandidate: Equatable {
+    /// Stable identity across refreshes (e.g. "claude:<uuid>", "codex", "cursor")
+    /// so the sticky selection can recognize the previously shown account.
+    let key: String
+    /// Human-readable label for the status item tooltip.
+    let displayName: String
+    let limit: UsageLimit
+    /// Most recent on-disk activity for the account, nil when undetectable.
+    let lastActivity: Date?
+}
+
+/// Picks which quota the menu bar title shows.
+///
+/// The menu bar used to pin the tightest quota across *all* enabled accounts,
+/// so a drained account that wasn't in use dominated the number forever. This
+/// selector instead follows the accounts with recent on-disk activity, and is
+/// sticky: when several accounts are active at once (one Claude + one Codex),
+/// the shown account only changes when it goes idle or another active account
+/// becomes clearly tighter — never ping-ponging on small fluctuations.
+enum StatusItemLimitSelector {
+    /// Activity newer than this counts as "in use".
+    static let activityWindow: TimeInterval = 30 * 60
+    /// Keep the previously shown account while it is within this many
+    /// %-left points of the tightest candidate.
+    static let hysteresisPoints = 5
+
+    static func select(
+        candidates: [StatusLimitCandidate],
+        previousKey: String?,
+        now: Date = Date(),
+        activityWindow: TimeInterval = Self.activityWindow,
+        hysteresisPoints: Int = Self.hysteresisPoints
+    ) -> StatusLimitCandidate? {
+        guard !candidates.isEmpty else { return nil }
+
+        let active = candidates.filter { candidate in
+            guard let lastActivity = candidate.lastActivity else { return false }
+            return now.timeIntervalSince(lastActivity) <= activityWindow
+        }
+
+        // No detectable activity anywhere: fall back to the old behavior and
+        // let every enabled account compete.
+        let pool = active.isEmpty ? candidates : active
+
+        guard let tightest = pool.min(by: { lhs, rhs in
+            let lhsLeft = QuotaMath.percentLeft(for: lhs.limit)
+            let rhsLeft = QuotaMath.percentLeft(for: rhs.limit)
+            // Tie-break on key so equal quotas resolve deterministically.
+            return (lhsLeft, lhs.key) < (rhsLeft, rhs.key)
+        }) else { return nil }
+
+        if let previousKey,
+           let previous = pool.first(where: { $0.key == previousKey }),
+           QuotaMath.percentLeft(for: previous.limit)
+               <= QuotaMath.percentLeft(for: tightest.limit) + hysteresisPoints {
+            return previous
+        }
+
+        return tightest
+    }
+}

--- a/MeterBar/Services/AccountActivityInspector.swift
+++ b/MeterBar/Services/AccountActivityInspector.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Detects when an account was last actually *used* by probing modification
+/// dates of the files its CLI/app writes during a session.
+///
+/// The probe is intentionally shallow (a config directory plus its immediate
+/// children) — Claude Code and Codex both touch top-level entries constantly
+/// while a session runs (`sessions/`, `session-env/`, sqlite WAL files), so a
+/// depth-1 scan is a reliable and cheap activity signal.
+enum AccountActivityInspector {
+    /// Newest modification date among a directory and its top-level entries,
+    /// or nil when the directory doesn't exist.
+    static func lastActivity(inDirectory path: String) -> Date? {
+        let fileManager = FileManager.default
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            return nil
+        }
+
+        var newest = modificationDate(atPath: path)
+        let entries = (try? fileManager.contentsOfDirectory(atPath: path)) ?? []
+        for entry in entries {
+            let entryPath = (path as NSString).appendingPathComponent(entry)
+            guard let date = modificationDate(atPath: entryPath) else { continue }
+            if newest.map({ date > $0 }) ?? true {
+                newest = date
+            }
+        }
+        return newest
+    }
+
+    /// Newest modification date among the paths that exist, or nil when none do.
+    static func lastActivity(atPaths paths: [String]) -> Date? {
+        paths.compactMap(modificationDate(atPath:)).max()
+    }
+
+    // MARK: - Provider probes
+
+    /// Claude Code writes session state under its config directory
+    /// (`CLAUDE_CONFIG_DIR`, default `~/.claude`), one directory per account.
+    static func claudeCodeActivity(configDirectory: String?) -> Date? {
+        let trimmed = configDirectory?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let directory = (trimmed?.isEmpty == false ? trimmed : nil)
+            ?? "\(ServiceSupport.realHomeDirectory())/.claude"
+        return lastActivity(inDirectory: directory)
+    }
+
+    /// Codex CLI keeps all state (sqlite + WAL, caches, snapshots) in `~/.codex`.
+    static func codexCliActivity() -> Date? {
+        lastActivity(inDirectory: "\(ServiceSupport.realHomeDirectory())/.codex")
+    }
+
+    /// Cursor continuously checkpoints its state database while running; the
+    /// WAL sibling is the hottest file. Mirrors the candidate paths used by
+    /// `CursorLocalService.getCursorDatabasePath`.
+    static func cursorActivity() -> Date? {
+        let homeDir = ServiceSupport.realHomeDirectory()
+        let databasePaths = [
+            "\(homeDir)/Library/Application Support/Cursor/User/globalStorage/state.vscdb",
+            "\(homeDir)/Library/Application Support/Cursor/state.vscdb",
+            "\(homeDir)/.config/Cursor/User/globalStorage/state.vscdb",
+            "\(homeDir)/Library/Application Support/Cursor/User/workspaceStorage/state.vscdb",
+            "\(homeDir)/Library/Application Support/Cursor/globalStorage/state.vscdb"
+        ]
+        return lastActivity(atPaths: databasePaths.flatMap { [$0, "\($0)-wal"] })
+    }
+
+    private static func modificationDate(atPath path: String) -> Date? {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: path)
+        return attributes?[.modificationDate] as? Date
+    }
+}

--- a/MeterBar/Services/AccountActivityInspector.swift
+++ b/MeterBar/Services/AccountActivityInspector.swift
@@ -46,9 +46,10 @@ enum AccountActivityInspector {
         return lastActivity(inDirectory: directory)
     }
 
-    /// Codex CLI keeps all state (sqlite + WAL, caches, snapshots) in `~/.codex`.
+    /// Codex CLI keeps all state (sqlite + WAL, caches, snapshots) under
+    /// `CODEX_HOME`, defaulting to `~/.codex`.
     static func codexCliActivity() -> Date? {
-        lastActivity(inDirectory: "\(ServiceSupport.realHomeDirectory())/.codex")
+        lastActivity(inDirectory: codexHomeDirectory())
     }
 
     /// Cursor continuously checkpoints its state database while running; the
@@ -69,5 +70,12 @@ enum AccountActivityInspector {
     private static func modificationDate(atPath path: String) -> Date? {
         let attributes = try? FileManager.default.attributesOfItem(atPath: path)
         return attributes?[.modificationDate] as? Date
+    }
+
+    private static func codexHomeDirectory() -> String {
+        let trimmed = ProcessInfo.processInfo.environment["CODEX_HOME"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (trimmed?.isEmpty == false ? trimmed : nil)
+            ?? "\(ServiceSupport.realHomeDirectory())/.codex"
     }
 }

--- a/MeterBarTests/AccountActivityInspectorTests.swift
+++ b/MeterBarTests/AccountActivityInspectorTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import MeterBar
+
+final class AccountActivityInspectorTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AccountActivityInspectorTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    private func createEntry(named name: String, modifiedAt date: Date, isDirectory: Bool = false) throws {
+        let url = tempDir.appendingPathComponent(name)
+        if isDirectory {
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        } else {
+            try Data("x".utf8).write(to: url)
+        }
+        try FileManager.default.setAttributes([.modificationDate: date], ofItemAtPath: url.path)
+    }
+
+    // MARK: - Directory probe
+
+    func testMissingDirectoryReturnsNil() {
+        let missing = tempDir.appendingPathComponent("does-not-exist").path
+        XCTAssertNil(AccountActivityInspector.lastActivity(inDirectory: missing))
+    }
+
+    func testReturnsNewestTopLevelEntryDate() throws {
+        let older = Date(timeIntervalSinceNow: -3_600)
+        let newest = Date(timeIntervalSinceNow: -60)
+        try createEntry(named: "history.jsonl", modifiedAt: older)
+        try createEntry(named: "sessions", modifiedAt: newest, isDirectory: true)
+        // Pin the directory itself older than its children so the entry scan,
+        // not the container mtime, must supply the answer.
+        try FileManager.default.setAttributes(
+            [.modificationDate: older],
+            ofItemAtPath: tempDir.path
+        )
+
+        let activity = try XCTUnwrap(AccountActivityInspector.lastActivity(inDirectory: tempDir.path))
+        XCTAssertEqual(activity.timeIntervalSince1970, newest.timeIntervalSince1970, accuracy: 2)
+    }
+
+    func testEmptyDirectoryFallsBackToItsOwnDate() throws {
+        let pinned = Date(timeIntervalSinceNow: -7_200)
+        try FileManager.default.setAttributes(
+            [.modificationDate: pinned],
+            ofItemAtPath: tempDir.path
+        )
+
+        let activity = try XCTUnwrap(AccountActivityInspector.lastActivity(inDirectory: tempDir.path))
+        XCTAssertEqual(activity.timeIntervalSince1970, pinned.timeIntervalSince1970, accuracy: 2)
+    }
+
+    // MARK: - Path-list probe
+
+    func testPathListReturnsNewestExistingFile() throws {
+        let older = Date(timeIntervalSinceNow: -3_600)
+        let newest = Date(timeIntervalSinceNow: -120)
+        try createEntry(named: "state.vscdb", modifiedAt: older)
+        try createEntry(named: "state.vscdb-wal", modifiedAt: newest)
+
+        let activity = AccountActivityInspector.lastActivity(atPaths: [
+            tempDir.appendingPathComponent("state.vscdb").path,
+            tempDir.appendingPathComponent("state.vscdb-wal").path,
+            tempDir.appendingPathComponent("missing.db").path
+        ])
+
+        let unwrapped = try XCTUnwrap(activity)
+        XCTAssertEqual(unwrapped.timeIntervalSince1970, newest.timeIntervalSince1970, accuracy: 2)
+    }
+
+    func testPathListWithNoExistingFilesReturnsNil() {
+        XCTAssertNil(AccountActivityInspector.lastActivity(atPaths: [
+            tempDir.appendingPathComponent("nope.db").path
+        ]))
+    }
+}

--- a/MeterBarTests/AccountActivityInspectorTests.swift
+++ b/MeterBarTests/AccountActivityInspectorTests.swift
@@ -81,4 +81,33 @@ final class AccountActivityInspectorTests: XCTestCase {
             tempDir.appendingPathComponent("nope.db").path
         ]))
     }
+
+    // MARK: - Provider probes
+
+    func testCodexCliActivityHonorsCodexHomeOverride() throws {
+        let previousCodexHome = getenv("CODEX_HOME").map { String(cString: $0) }
+        defer {
+            if let previousCodexHome {
+                setenv("CODEX_HOME", previousCodexHome, 1)
+            } else {
+                unsetenv("CODEX_HOME")
+            }
+        }
+
+        let codexHome = tempDir.appendingPathComponent("custom-codex", isDirectory: true)
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        let newest = Date(timeIntervalSinceNow: -90)
+        let history = codexHome.appendingPathComponent("history.jsonl")
+        try Data("{}".utf8).write(to: history)
+        try FileManager.default.setAttributes([.modificationDate: newest], ofItemAtPath: history.path)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: -3_600)],
+            ofItemAtPath: codexHome.path
+        )
+
+        setenv("CODEX_HOME", codexHome.path, 1)
+
+        let activity = try XCTUnwrap(AccountActivityInspector.codexCliActivity())
+        XCTAssertEqual(activity.timeIntervalSince1970, newest.timeIntervalSince1970, accuracy: 2)
+    }
 }

--- a/MeterBarTests/StatusItemLimitSelectorTests.swift
+++ b/MeterBarTests/StatusItemLimitSelectorTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import MeterBar
+import MeterBarShared
+
+final class StatusItemLimitSelectorTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+    private func candidate(
+        key: String,
+        percentUsed: Double,
+        activeMinutesAgo: Double? = nil,
+        displayName: String? = nil
+    ) -> StatusLimitCandidate {
+        StatusLimitCandidate(
+            key: key,
+            displayName: displayName ?? key,
+            limit: UsageLimit(used: percentUsed, total: 100, resetTime: nil),
+            lastActivity: activeMinutesAgo.map { now.addingTimeInterval(-$0 * 60) }
+        )
+    }
+
+    private func select(
+        _ candidates: [StatusLimitCandidate],
+        previousKey: String? = nil
+    ) -> StatusLimitCandidate? {
+        StatusItemLimitSelector.select(candidates: candidates, previousKey: previousKey, now: now)
+    }
+
+    // MARK: - Basics
+
+    func testEmptyCandidatesReturnsNil() {
+        XCTAssertNil(select([]))
+    }
+
+    func testSingleCandidateIsSelectedEvenWhenIdle() {
+        let only = candidate(key: "codex", percentUsed: 20, activeMinutesAgo: nil)
+        XCTAssertEqual(select([only])?.key, "codex")
+    }
+
+    // MARK: - Active-account filtering
+
+    func testTightestAmongActiveWinsOverTighterIdleAccount() {
+        // The idle account is far tighter (10% left) but hasn't been used;
+        // the menu bar should follow the accounts actually in use.
+        let idleTight = candidate(key: "claude:old", percentUsed: 90, activeMinutesAgo: nil)
+        let activeLoose = candidate(key: "claude:ship", percentUsed: 40, activeMinutesAgo: 5)
+        XCTAssertEqual(select([idleTight, activeLoose])?.key, "claude:ship")
+    }
+
+    func testStaleActivityBeyondWindowCountsAsIdle() {
+        let stale = candidate(key: "claude:old", percentUsed: 90, activeMinutesAgo: 31)
+        let active = candidate(key: "codex", percentUsed: 40, activeMinutesAgo: 5)
+        XCTAssertEqual(select([stale, active])?.key, "codex")
+    }
+
+    func testActivityExactlyAtWindowBoundaryCountsAsActive() {
+        let boundary = candidate(key: "claude:ship", percentUsed: 90, activeMinutesAgo: 30)
+        let active = candidate(key: "codex", percentUsed: 40, activeMinutesAgo: 5)
+        XCTAssertEqual(select([boundary, active])?.key, "claude:ship")
+    }
+
+    func testFallsBackToTightestOverallWhenNothingIsActive() {
+        // Preserves the pre-feature behavior when no account shows recent use.
+        let loose = candidate(key: "codex", percentUsed: 20, activeMinutesAgo: nil)
+        let tight = candidate(key: "claude:ship", percentUsed: 80, activeMinutesAgo: 120)
+        XCTAssertEqual(select([loose, tight])?.key, "claude:ship")
+    }
+
+    // MARK: - Sticky selection (hysteresis)
+
+    func testKeepsPreviousActiveAccountWithinHysteresis() {
+        // codex is tighter by 4 points — inside the 5-point band, so no flip.
+        let claude = candidate(key: "claude:ship", percentUsed: 60, activeMinutesAgo: 2)
+        let codex = candidate(key: "codex", percentUsed: 64, activeMinutesAgo: 1)
+        XCTAssertEqual(select([claude, codex], previousKey: "claude:ship")?.key, "claude:ship")
+    }
+
+    func testKeepsPreviousAtExactHysteresisBoundary() {
+        let claude = candidate(key: "claude:ship", percentUsed: 60, activeMinutesAgo: 2)
+        let codex = candidate(key: "codex", percentUsed: 65, activeMinutesAgo: 1)
+        XCTAssertEqual(select([claude, codex], previousKey: "claude:ship")?.key, "claude:ship")
+    }
+
+    func testSwitchesWhenPreviousIsClearlyLooserThanTightestActive() {
+        let claude = candidate(key: "claude:ship", percentUsed: 60, activeMinutesAgo: 2)
+        let codex = candidate(key: "codex", percentUsed: 70, activeMinutesAgo: 1)
+        XCTAssertEqual(select([claude, codex], previousKey: "claude:ship")?.key, "codex")
+    }
+
+    func testSwitchesAwayFromPreviousWhenItGoesIdle() {
+        let claude = candidate(key: "claude:ship", percentUsed: 90, activeMinutesAgo: nil)
+        let codex = candidate(key: "codex", percentUsed: 40, activeMinutesAgo: 1)
+        XCTAssertEqual(select([claude, codex], previousKey: "claude:ship")?.key, "codex")
+    }
+
+    func testStickyAlsoAppliesToIdleFallbackPool() {
+        // Nothing active: pool is "all", and the previously shown account stays
+        // put while within the hysteresis band.
+        let claude = candidate(key: "claude:ship", percentUsed: 60, activeMinutesAgo: nil)
+        let codex = candidate(key: "codex", percentUsed: 63, activeMinutesAgo: nil)
+        XCTAssertEqual(select([claude, codex], previousKey: "claude:ship")?.key, "claude:ship")
+    }
+
+    func testUnknownPreviousKeyFallsBackToTightest() {
+        let claude = candidate(key: "claude:ship", percentUsed: 60, activeMinutesAgo: 2)
+        let codex = candidate(key: "codex", percentUsed: 40, activeMinutesAgo: 1)
+        XCTAssertEqual(select([claude, codex], previousKey: "cursor")?.key, "codex")
+    }
+
+    // MARK: - Determinism
+
+    func testEqualPercentagesTieBreakByKeyForStableOutput() {
+        let a = candidate(key: "claude:a", percentUsed: 50, activeMinutesAgo: 1)
+        let b = candidate(key: "claude:b", percentUsed: 50, activeMinutesAgo: 1)
+        XCTAssertEqual(select([b, a])?.key, "claude:a")
+        XCTAssertEqual(select([a, b])?.key, "claude:a")
+    }
+}

--- a/MeterBarTests/StatusItemLimitSelectorTests.swift
+++ b/MeterBarTests/StatusItemLimitSelectorTests.swift
@@ -103,7 +103,7 @@ final class StatusItemLimitSelectorTests: XCTestCase {
 
     func testUnknownPreviousKeyFallsBackToTightest() {
         let claude = candidate(key: "claude:ship", percentUsed: 60, activeMinutesAgo: 2)
-        let codex = candidate(key: "codex", percentUsed: 40, activeMinutesAgo: 1)
+        let codex = candidate(key: "codex", percentUsed: 80, activeMinutesAgo: 1)
         XCTAssertEqual(select([claude, codex], previousKey: "cursor")?.key, "codex")
     }
 


### PR DESCRIPTION
## What

- **Menu bar % now follows the accounts you're actually using.** Previously the title pinned the tightest quota across *all* enabled accounts, so a drained account that wasn't in use dominated the number forever. `StatusItemLimitSelector` now restricts the competition to accounts with on-disk activity in the last **30 minutes** and falls back to the old tightest-overall behavior when nothing is active.
- **Sticky selection (no icon ping-pong).** With one Claude + one Codex active at the same time, the shown account only changes when it goes idle or another active account becomes **>5 %-left points** tighter.
- **Activity detection** (`AccountActivityInspector`): shallow depth-1 mtime probe of each account's config dir — per-account `CLAUDE_CONFIG_DIR` for Claude Code, `~/.codex` for Codex, `state.vscdb(-wal)` candidate paths for Cursor. Verified on-disk that top-level entries (`sessions/`, `session-env/`, sqlite WAL) are hot during live sessions.
- **Refresh-on-open:** clicking the menu bar icon now fires `refreshAll()` when the popover opens, so it never shows a stale snapshot from the last timer tick.
- Tooltip/accessibility label now name the shown account ("62% left on Ship (Claude Code)") instead of "the tightest quota".

## Tests (written first, TDD)

- `StatusItemLimitSelectorTests` (13): active filtering, 30-min boundary inclusive, hysteresis at/over the 5-pt edge, switch on idle, idle-pool fallback + stickiness there, unknown previous key, deterministic tie-break.
- `AccountActivityInspectorTests` (6): temp-dir mtime fixtures for the directory and path-list probes.

Selector + inspector live in `Models`/`Services` (not `App/`) because `Package.swift` excludes `App/MeterBarApp.swift` from the SPM target — keeps the logic `swift test`-able.

## Verification

- Local `swift test` impossible (CLT only, no XCTest) — CI test + coverage gate is the check.
- App-target sources incl. the SPM-excluded `MeterBarApp.swift` typechecked locally with the project's real flags (`-swift-version 5 -default-isolation MainActor`): **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The menu bar title/icon/tooltip/accessibility labels now track the account/provider that’s been used most recently, with a sticky “hysteresis” to prevent jitter.
  * Opening the popover now refreshes usage data immediately for more up-to-date information.
* **Bug Fixes**
  * Improved recent-activity detection across supported providers, including more reliable file timestamp probing and deterministic selection when usage ties or when no recent activity is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->