### PR TITLE
Release v1.6.1

### DIFF
--- a/.agents/SESSIONS/2026-07-07.md
+++ b/.agents/SESSIONS/2026-07-07.md
@@ -1,0 +1,358 @@
+# 2026-07-07
+
+## Session 12: Finder-Style Glass Sidebar
+
+**Duration:** ~25 min
+**Status:** Complete
+
+**What was done:**
+- Replaced the bright system-accent sidebar selection with a Finder/MacSweep-style neutral selected row.
+- Added a dedicated rounded glass sidebar surface with material, glass effect, dark tint, gradient, stroke, and shadow.
+- Moved the dashboard sidebar from a flat full-height painted strip to an inset glassmorphism container under the traffic-light/titlebar area.
+- Kept the manual dashboard layout and current provider/card behavior intact.
+
+**Files changed:**
+- `MeterBar/Views/MeterBarTheme.swift` - Added `MeterBarSidebarSurface` and widened the sidebar token to match the MacSweep reference.
+- `MeterBar/Views/UsageDashboardView.swift` - Uses the glass sidebar container and custom Finder-like sidebar rows.
+
+**Validation:**
+- `git diff --check`
+- `swift test --filter ProviderSnapshotTests --filter CostTrackerTests` (29 tests passed)
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app`, relaunched with `--open-dashboard`, confirmed process `2077`, and captured `/tmp/meterbar-glass-sidebar-surface.png`.
+
+**Notes:**
+- Xcode still reports the existing out-of-date CoreSimulator warning before macOS builds; the macOS Release build succeeds.
+
+## Session 11: Dashboard Titlebar Frame Contract
+
+**Duration:** ~60 min
+**Status:** Complete
+
+**What was done:**
+- Checked Apple's titlebar/window guidance and stopped mixing native `NavigationSplitView` chrome with custom titlebar overlays.
+- Reworked the dashboard window to use a full-size transparent AppKit titlebar with a zero-safe-area `NSHostingView`, so SwiftUI content actually paints from the top of the window.
+- Restored visible dashboard content after the manual layout briefly collapsed behind a full-height titlebar material.
+- Kept the custom manual dashboard sidebar/content layout so the sidebar background reaches the traffic-light/titlebar region instead of being cut below it.
+- Added a local `--open-dashboard` launch hook for clean dashboard verification without AppleScript automation prompts.
+- Gated Claude OAuth keychain reads behind the legacy OAuth fallback setting and skipped non-local volumes during cost log scans to avoid repeated local install permission prompts.
+
+**Files changed:**
+- `MeterBar/Views/UsageDashboardView.swift` - Full-size hosting view, manual sidebar/detail frame, transparent titlebar setup, fixed titlebar height collapse.
+- `MeterBar/Views/MeterBarTheme.swift` - Shared dashboard chrome, titlebar/sidebar glass backing, reduced dashboard radius token.
+- `MeterBar/App/MeterBarApp.swift` - Local `--open-dashboard` debug launch hook and menu-panel integration from the toolbar work.
+- `MeterBar/Services/ClaudeCodeLocalService.swift` - Avoid OAuth keychain reads unless fallback is explicitly enabled.
+- `MeterBar/Services/CostTracker.swift` - Do not enumerate non-local volumes during Claude/Codex cost scans.
+
+**Validation:**
+- `git diff --check`
+- `swift test --filter ProviderSnapshotTests --filter CostTrackerTests` (29 tests passed)
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app`, relaunched with `--open-dashboard`, confirmed window `4850`, and captured `/tmp/meterbar-zero-safe-area-window.png`.
+
+**Notes:**
+- Relevant Apple docs: `NSWindow.StyleMask.fullSizeContentView`, `NSWindow.titlebarAppearsTransparent`, and SwiftUI `.hiddenTitleBar`.
+- Xcode still reports the existing out-of-date CoreSimulator warning before macOS builds; the macOS Release build succeeds.
+
+## Session 1: Dashboard Titlebar Background Fix
+
+**Duration:** ~15 min
+**Status:** Complete
+
+**What was done:**
+- Fixed the Usage Dashboard titlebar/header area showing desktop wallpaper instead of the dashboard background.
+- Rebuilt the Release app and installed it into `/Applications/MeterBar.app`.
+- Confirmed the dashboard window is visible after relaunch.
+
+**Files changed:**
+- `MeterBar/Views/UsageDashboardView.swift` - Made the dashboard window background opaque with `.windowBackgroundColor` and let the detail background extend under the titlebar.
+
+**Decisions:**
+- Kept the existing unified/full-size titlebar layout, but removed the clear fallback and top safe-area gap that caused the wallpaper bleed-through.
+
+**Validation:**
+- `git diff --check`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -derivedDataPath build -destination 'platform=macOS' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO build`
+
+**Next steps:**
+- [ ] Commit the fix after visual approval.
+
+## Session 2: Post-Install Dashboard Regression Cleanup
+
+**Duration:** ~35 min
+**Status:** Complete
+
+**What was done:**
+- Restored a glass/material-backed dashboard and popover surface while keeping the titlebar filled behind the native chrome.
+- Added a dedicated `API Usage` dashboard destination and removed the API/cost recap widgets from the Overview grid.
+- Flattened the Costs page so provider cost breakdowns render as top-level cards instead of cards nested inside the trend card.
+- Made provider cards clickable: dashboard provider cards navigate to Limits with that provider first; popover provider cards open the dashboard to the same focused Limits view.
+- Collapsed overview provider cards into a weekly-reset state when the weekly quota is exhausted so the 5-hour session gauge no longer wastes space.
+- Added a regression test for weekly-vs-session exhaustion handling.
+- Rebuilt and installed the Release app at `/Applications/MeterBar.app`, then relaunched and raised the Overview window.
+
+**Files changed:**
+- `MeterBar/Views/UsageDashboardView.swift` - Dashboard navigation store, `API Usage` section, overview cleanup, flattened cost layout, translucent window backing.
+- `MeterBar/Views/MenuBarView.swift` - Material popover background and clickable provider cards.
+- `MeterBar/Views/MeterBarTheme.swift` - Shared material/glass content surfaces.
+- `MeterBar/Views/DashboardProviderCards.swift` - Clickable provider cards and weekly-exhausted compact reset state.
+- `MeterBar/Views/DashboardCostCards.swift` - Provider cost breakdowns promoted to top-level card surfaces.
+- `MeterBar/Views/ApiUsageCard.swift` - API usage cards use the shared material surface.
+- `MeterBar/Views/ProviderSnapshot.swift` - Added weekly-exhaustion helper for overview behavior.
+- `MeterBarTests/ProviderSnapshotTests.swift` - Added weekly/session exhaustion regression coverage.
+
+**Validation:**
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- `swift test` (319 tests passed, 1 skipped)
+- Installed `/Applications/MeterBar.app` and confirmed the live window title is `Overview – Current health and local token history`.
+
+**Notes:**
+- The first unfiltered Release build failed only because local signing profiles were unavailable; the unsigned local build succeeded.
+- Xcode still reports existing Swift 6 actor-isolation warnings unrelated to this UI patch.
+
+## Session 3: Dashboard Polish Regression Follow-Up
+
+**Duration:** ~45 min
+**Status:** Complete
+
+**What was done:**
+- Fixed the dashboard titlebar regression by removing full-size content from the window chrome, letting the native titlebar own its filled material instead of rendering dashboard content underneath it.
+- Removed the duplicate "Local Sources" block from the sidebar; source/provider state remains in Settings.
+- Made the Limits provider card use the same weekly-exhausted reset presentation as the Overview card, so an out weekly quota does not keep showing a useless session gauge.
+- Split the Costs chart area from Daily Details and kept Daily Details as a compact clickable table with expandable provider rows.
+- Made local cost scans nonblocking by moving the heavy pricing/log parsing engine onto a detached nonisolated path and removing the chart lock overlay.
+- Rebuilt, reinstalled, and relaunched the local `/Applications/MeterBar.app`.
+
+**Files changed:**
+- `MeterBar/Views/UsageDashboardView.swift` - native titlebar chrome, navigation-only sidebar, nonblocking scan chart state, daily details card split.
+- `MeterBar/Views/DashboardProviderCards.swift` - Limits cards now collapse weekly-exhausted providers to the reset counter.
+- `MeterBar/Views/DashboardCostCards.swift` - Removed the unused lock-overlay view so cost scans cannot consume app gestures.
+- `MeterBar/Views/DailyUsageChart.swift` - compact expandable daily details table.
+- `MeterBar/Services/CostTracker.swift` - detached nonisolated cost scan engine with test-compatible shims.
+- `.agents/SESSIONS/2026-07-07.md` - session documentation.
+
+**Validation:**
+- `git diff --check`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- `swift test` (319 tests passed, 1 skipped)
+- Installed `/Applications/MeterBar.app`, relaunched it, and confirmed the final process is running.
+- Visual-smoked the dashboard titlebar/daily table before the final dead-overlay cleanup.
+
+**Notes:**
+- The daily details behavior was documented in the 2026-06-26 session notes as issue #59 ("collapsible daily cost rows").
+- The local Xcode install still reports an out-of-date CoreSimulator warning during macOS builds, but the macOS Release build succeeds.
+
+## Session 4: Dashboard Chrome and Toolbar Provider Detail Fix
+
+**Duration:** ~35 min
+**Status:** Complete
+
+**What was done:**
+- Reworked the dashboard window chrome to match MacSweep's full-size transparent titlebar pattern with a MeterBar-owned dark glass window backing.
+- Moved the dashboard refresh control to the primary toolbar action slot so it no longer competes with the native sidebar/collapse control.
+- Added a MacSweep-style separate floating menu-bar detail panel anchored to the toolbar dropdown.
+- Changed popover provider-card clicks to toggle the provider detail panel instead of opening the companion dashboard.
+- Kept explicit "Open Usage Dashboard" and "Open Full View" controls for intentional companion-window navigation.
+- Rebuilt, installed, relaunched, and visually checked the live installed app.
+
+**Files changed:**
+- `MeterBar/Views/MeterBarTheme.swift` - Added shared window chrome and companion glass surface.
+- `MeterBar/Views/UsageDashboardView.swift` - Restored full-size transparent dashboard chrome and moved refresh to the primary toolbar action.
+- `MeterBar/Views/MenuBarDetailPanel.swift` - New anchored side-panel and provider detail content.
+- `MeterBar/Views/MenuBarView.swift` - Popover now captures its host window, uses the shared glass surface, and opens provider details in the side panel.
+- `.agents/SESSIONS/2026-07-07.md` - Session documentation.
+
+**Validation:**
+- `git diff --check`
+- `swift test` (319 tests passed, 1 skipped)
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app`, relaunched it, confirmed process `89201` is running.
+- Captured live screenshots:
+  - `/tmp/meterbar-final-dashboard.png` - dashboard titlebar/sidebar chrome.
+  - `/tmp/meterbar-popover-open.png` - menu-bar dropdown glass surface.
+  - `/tmp/meterbar-provider-detail-panel.png` - provider tile opens side detail panel.
+
+**Notes:**
+- Xcode still reports the existing out-of-date CoreSimulator warning before macOS builds; the macOS Release build succeeds.
+
+## Session 8: Arrowless Toolbar Panel and Titlebar Backing Guard
+
+**Duration:** ~35 min
+**Status:** Complete
+
+**What was done:**
+- Replaced the menu-bar `NSPopover` with a custom borderless `NSPanel` so the broken popover arrow is gone.
+- Removed the redundant toolbar "Quota exhausted" banner and kept the provider rows compact and vertically centered.
+- Removed the bottom "Open Usage Dashboard" toolbar row; dashboard access remains in the header/options controls.
+- Made the secondary provider detail panel close when the primary toolbar panel closes.
+- Increased the secondary provider detail panel's content-based height and used `ViewThatFits` so it renders without scrolling unless the screen-height cap forces it.
+- Tried `window.titlebarAppearsTransparent = false` as a guardrail; Session 10 later superseded this because it produced oversized, non-Finder-like titlebar chrome.
+- Built, installed, relaunched, and visually checked the installed app.
+
+**Files changed:**
+- `MeterBar/App/MeterBarApp.swift` - Uses the new custom menu panel controller and dismisses the provider detail panel with the main panel.
+- `MeterBar/App/MeterBarMenuPanelController.swift` - New arrowless status-bar panel with outside-click/Escape dismissal.
+- `MeterBar/Views/MenuBarView.swift` - Removes the quota banner/footer row and opens provider details from toolbar cards.
+- `MeterBar/Views/MenuBarDetailPanel.swift` - Adds close ownership checks and non-scroll-first detail layout.
+- `MeterBar/Views/DashboardCard.swift` - Adds alignment support for compact centered tiles.
+- `MeterBar/Views/UsageDashboardView.swift` - Keeps the native titlebar backing explicit and documents why.
+- `.agents/SESSIONS/2026-07-07.md` - Session documentation.
+
+**Validation:**
+- `git diff --check`
+- `swift test` compiled and ran, but the live `APIIntegrationTests.testClaudeCodeAPIAccess` check failed with `parsingError` from Claude Code API output; this is external/live-provider behavior, not a compile failure from the UI patch.
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app`, relaunched it, and confirmed process `22187` is running.
+- Captured live screenshots:
+  - `/tmp/meterbar-final-menu-panel-reopened.png` - installed arrowless toolbar panel, no quota banner, no footer row.
+  - `/tmp/meterbar-final-menu-panel-unobstructed.png` - outside dismissal check after macOS prompt clearing.
+
+**Notes:**
+- Xcode still reports the existing out-of-date CoreSimulator warning before macOS builds; the macOS Release build succeeds.
+
+## Session 10: Finder-Style Dashboard Titlebar and Clean Toolbar Header
+
+**Duration:** ~20 min
+**Status:** Complete
+
+**What was done:**
+- Removed the toolbar overlay app name from the menu-bar panel header.
+- Removed the ellipsis/dropdown from the menu-bar panel header; the right-click native status menu remains the app-level escape hatch for Dock/Quit/dashboard actions.
+- Normalized the remaining toolbar header icons to fixed-size square icon buttons.
+- Removed the custom SwiftUI dashboard titlebar blur overlay that created the oversized dead strip.
+- Removed the dashboard native titlebar subtitle so the window uses a compact Finder-style single-line title row.
+- Restored the MacSweep/Finder-style window chrome but changed the window backing to solid MeterBar dark instead of transparent, because MeterBar's `NavigationSplitView` does not paint behind the safe-area titlebar strip.
+- Switched the dashboard toolbar to `.unifiedCompact` to reduce the native titlebar height.
+- Gated Claude OAuth keychain reads behind the existing "Legacy OAuth fallback" setting so CLI-backed local refreshes stop triggering keychain prompts after ad-hoc development installs.
+- Built, installed, relaunched, and visually checked the installed app.
+
+**Files changed:**
+- `MeterBar/Views/MenuBarView.swift` - Cleaner toolbar header: icon-only brand mark, dashboard/refresh buttons only, no dropdown.
+- `MeterBar/Views/UsageDashboardView.swift` - Finder-style dashboard titlebar, no fake overlay, no subtitle.
+- `MeterBar/Views/MeterBarTheme.swift` - Gives the dashboard window a real dark backing instead of a transparent titlebar hole.
+- `MeterBar/Services/ClaudeCodeLocalService.swift` - Avoids reading Claude's OAuth keychain item unless legacy OAuth fallback is enabled.
+- `.agents/SESSIONS/2026-07-07.md` - Session documentation.
+
+**Validation:**
+- `git diff --check`
+- `swift test --filter ProviderSnapshotTests` (14 tests passed)
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app` in place with `ditto`, relaunched it, and confirmed process `74057` is running.
+- Captured live screenshots:
+  - `/tmp/meterbar-titlebar-solid-compact-2.png` - compact installed dashboard titlebar with solid MeterBar backing and no keychain prompt.
+  - `/tmp/meterbar-toolbar-header-no-name-dropdown.png` - installed toolbar header with no app name/dropdown.
+
+**Notes:**
+- Session 10 supersedes the Session 7 titlebar blur overlay and the Session 8 `titlebarAppearsTransparent = false` guardrail.
+- Xcode still reports the existing out-of-date CoreSimulator warning before macOS builds; the macOS Release build succeeds.
+
+## Session 9: Hide Session Detail When Weekly Quota Blocks Usage
+
+**Duration:** ~10 min
+**Status:** Complete
+
+**What was done:**
+- Added `ProviderSnapshot.detailLimits` so detail panels can omit non-actionable quota windows.
+- When the weekly quota is exhausted, the secondary toolbar provider panel no longer shows the short session window row.
+- Kept the blocking weekly reset card visible, and kept any other non-session quota rows available.
+- Updated the secondary panel height calculation to use the filtered detail rows, reducing unnecessary panel height/scroll.
+- Added regression coverage for weekly-out vs session-out behavior.
+- Rebuilt, installed, relaunched, and checked the installed toolbar panel.
+
+**Files changed:**
+- `MeterBar/Views/ProviderSnapshot.swift` - Adds the filtered `detailLimits` rule.
+- `MeterBar/Views/MenuBarDetailPanel.swift` - Renders and sizes the secondary detail panel from `detailLimits`.
+- `MeterBarTests/ProviderSnapshotTests.swift` - Covers weekly-out hiding session and session-out keeping session.
+- `.agents/SESSIONS/2026-07-07.md` - Session documentation.
+
+**Validation:**
+- `git diff --check`
+- `swift test --filter ProviderSnapshotTests` (14 tests passed)
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app`, relaunched it, and confirmed process `43181` is running.
+- Captured `/tmp/meterbar-weekly-detail-filter-menu.png`; main toolbar panel shows Claude collapsed to the weekly reset row.
+
+**Notes:**
+- macOS Accessibility blocked automated coordinate-click verification of the secondary panel, but the compiled panel now consumes the tested `detailLimits` rule.
+- Xcode still reports the existing out-of-date CoreSimulator warning before macOS builds; the macOS Release build succeeds.
+
+## Session 7: Dashboard Titlebar Blur and Radius Trim
+
+**Duration:** ~20 min
+**Status:** Complete
+
+**What was done:**
+- Added a scroll-aware dark material titlebar blur overlay for the companion dashboard so content passing under the titlebar gets a translucent blurred backing.
+- Reduced the companion dashboard corner radius to `14` and applied the same radius to the app content clip and sidebar clip.
+- Kept provider cards, dashboard colors, toolbar popover design, and content layout unchanged.
+- Rebuilt, installed, relaunched, and visually checked the installed companion window.
+
+**Files changed:**
+- `MeterBar/Views/MeterBarTheme.swift` - Added the shared dashboard corner-radius token and kept the app window background transparent for clipped chrome.
+- `MeterBar/Views/UsageDashboardView.swift` - Applied the window/sidebar radius and added the scroll-aware titlebar blur layer.
+- `.agents/SESSIONS/2026-07-07.md` - Session documentation.
+
+**Validation:**
+- `git diff --check`
+- `swift test` (319 tests passed, 1 skipped because Claude Code usage access was unavailable)
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app`, relaunched it, and confirmed process `86908` is running.
+- Captured `/tmp/meterbar-full-after-radius-titlebar.png` and `/tmp/meterbar-full-after-titlebar-scroll.png` for live visual smoke checks.
+
+**Notes:**
+- Xcode still reports the existing out-of-date CoreSimulator warning before macOS builds; the macOS Release build succeeds.
+
+## Session 6: Restore Glossy Companion Dashboard
+
+**Duration:** ~15 min
+**Status:** Complete
+
+**What was done:**
+- Removed the dashboard-only solid card fill path so companion dashboard cards use the same material/tint/stroke surface as the toolbar popover cards.
+- Restored the companion detail background to a dark glossy material treatment with a subtle MeterBar gradient instead of a flat app-surface color.
+- Kept the dark window backing underneath the material so the dashboard reads as dark glass rather than transparent wallpaper.
+- Rebuilt, installed, relaunched, and visually checked the live installed companion dashboard.
+
+**Files changed:**
+- `MeterBar/Views/MeterBarTheme.swift` - Removed `dashboardCardFill`, made all shared card surfaces glossy, and changed `MeterBarDetailBackground` to dark material/gloss.
+- `.agents/SESSIONS/2026-07-07.md` - Session documentation.
+
+**Validation:**
+- `git diff --check`
+- `swift test` (319 tests passed)
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app`, relaunched it, and confirmed process `64367` is running.
+- Captured `/tmp/meterbar-fullscreen.png` and confirmed the installed companion dashboard uses the dark glossy background/card treatment.
+
+**Notes:**
+- Xcode still reports the existing out-of-date CoreSimulator warning before macOS builds; the macOS Release build succeeds.
+
+## Session 5: Toolbar-Only Glass and Compact Exhausted Rows
+
+**Duration:** ~25 min
+**Status:** Complete
+
+**What was done:**
+- Made the toolbar popover/detail panels explicitly opt into the glossy surface style while the companion dashboard uses the solid dashboard card/background treatment.
+- Removed the redundant bottom "Open Usage Dashboard" row from the toolbar overlay; the header/menu actions still provide intentional dashboard access.
+- Collapsed exhausted provider cards in the toolbar overlay into a single row with the blocking reset countdown (for example, "Weekly reset in 3d 2h") instead of a trailing "Out" label plus detail block.
+- Kept the toolbar overlay height screen-aware so normal content does not require scrolling.
+- Rebuilt, installed, relaunched, and visually checked the local app.
+
+**Files changed:**
+- `MeterBar/Views/MeterBarTheme.swift` - Split dashboard vs toolbar card surface styling.
+- `MeterBar/Views/MenuBarView.swift` - Toolbar-only glass style, removed footer dashboard row, compact exhausted provider row.
+- `MeterBar/Views/MenuBarDetailPanel.swift` - Detail panel opts into toolbar glass style.
+- `.agents/SESSIONS/2026-07-07.md` - Session documentation.
+
+**Validation:**
+- `git diff --check`
+- `swift test` (319 tests passed)
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app`, relaunched it, and confirmed process `49232` is running.
+- Captured live screenshots:
+  - `/tmp/meterbar-toolbar-compact-out.png` - toolbar overlay without footer row and with compact Claude reset row.
+  - `/tmp/meterbar-dashboard-solid-split.png` - companion dashboard using the solid dashboard surface.
+
+**Notes:**
+- Xcode still reports the existing out-of-date CoreSimulator warning before macOS builds; the macOS Release build succeeds.

--- a/.agents/SESSIONS/2026-07-08.md
+++ b/.agents/SESSIONS/2026-07-08.md
@@ -105,3 +105,25 @@
 - `git diff --check`
 - `swift test` - 321 tests passed.
 - `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+
+## Session 5: Native Sidebar Under Titlebar
+
+**Duration:** ~20 minutes
+**Status:** Complete
+
+**What was done:**
+- Updated the dashboard window to use native full-size content under a transparent titlebar, matching the MacSweep/Finder-style sidebar behavior without reintroducing fake SwiftUI chrome.
+- Removed the titlebar separator so the sidebar no longer has a hard top border when open.
+- Forced the split-view sidebar visible by default and aligned its width range with MacSweep's native sidebar proportions.
+- Made `--open-dashboard` open the dashboard synchronously during launch so local installs can be verified reliably.
+
+**Files changed:**
+- `MeterBar/Views/UsageDashboardView.swift` - Enables `.fullSizeContentView`, transparent native titlebar, no titlebar separator, stable sidebar visibility, and MacSweep-like column width.
+- `MeterBar/App/MeterBarApp.swift` - Opens the dashboard immediately for the install/test launch argument.
+
+**Verification:**
+- `git diff --check`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/meterbar-release-derived CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app` from the release build and relaunched with `--open-dashboard`.
+- CoreGraphics verified one on-screen MeterBar dashboard window: `cgWindowCount=1`, title `Overview`.

--- a/.agents/SESSIONS/2026-07-08.md
+++ b/.agents/SESSIONS/2026-07-08.md
@@ -103,6 +103,7 @@
 
 **Verification:**
 - `git diff --check`
+- `/tmp/swiftlint/swiftlint lint --strict`
 - `swift test` - 321 tests passed.
 - `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
 

--- a/.agents/SESSIONS/2026-07-08.md
+++ b/.agents/SESSIONS/2026-07-08.md
@@ -21,3 +21,32 @@
 **Notes:**
 - A normal signed Release build still stops on missing local provisioning profiles; the unsigned local Release build succeeds.
 - Terminal `screencapture` returned a black frame in this session, so visual verification was limited to code inspection and the live app process launch.
+
+## Session 2: UI Fix Brief Part A
+
+**Duration:** ~35 minutes
+**Status:** Complete
+
+**What was done:**
+- Created the requested `ui-fix-baseline` branch and baseline commit before making new UI changes.
+- Applied Part A of `.agents/UI-FIX-BRIEF-2026-07-08.md`: secondary popover panels now use a 10pt gap, measure real content height, avoid clipped content, hide scroll indicators, and use a compact primary header.
+- Removed API spend from the menu bar popover so the overlay stays quota-focused.
+- Applied C4 by hiding Claude's extra-usage indicator when the state is `.unknown` because OAuth fallback is disabled.
+- Applied C5 by restoring the dashboard hero icon well to the semantic `.quaternary` fill for light-mode compatibility.
+
+**Files changed:**
+- `.agents/UI-FIX-BRIEF-2026-07-08.md` - Updated audit contract from the external sweep.
+- `MeterBar/Views/MenuBarDetailPanel.swift` - Measured secondary panel height from content, added panel gap, removed the duplicate Status/Updated summary card, and hid fallback scroll indicators.
+- `MeterBar/Views/MenuBarView.swift` - Compacted the popover header, hid primary scroll indicators, updated detail-panel presentation, and removed the popover API spend section.
+- `MeterBar/Views/ProviderSnapshot.swift` - Added a shared display policy for extra-usage visibility.
+- `MeterBar/Views/Components/ProviderStatusBadges.swift` - Used the shared display policy for extra-usage badges.
+- `MeterBar/Views/SettingsView.swift` - Hid the Claude extra-usage row when the gated status is intentionally unavailable.
+- `MeterBar/Views/DashboardProviderCards.swift` - Reverted the hero icon well fill to `.quaternary`.
+
+**Verification:**
+- `git diff --check`
+- `swift test` - 321 tests passed, 1 skipped.
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+
+**Notes:**
+- The dead `meterBarSurfaceStyle` environment plumbing remains for the Part B/C1 native chrome rewrite so this popover pass stays isolated and easy to revert.

--- a/.agents/SESSIONS/2026-07-08.md
+++ b/.agents/SESSIONS/2026-07-08.md
@@ -1,0 +1,23 @@
+## Session 1: Companion Sidebar Titlebar Control
+
+**Duration:** ~15 minutes
+**Status:** Complete
+
+**What was done:**
+- Restored a custom sidebar collapse button in the companion dashboard title area.
+- Added an icons-only collapsed sidebar width so the sidebar can behave like a compact rail instead of clipping labels.
+- Moved the dashboard section title/subtitle into the custom glass titlebar layer.
+- Rebuilt and reinstalled the local `/Applications/MeterBar.app` with the dashboard opened.
+
+**Files changed:**
+- `MeterBar/Views/UsageDashboardView.swift` - Added collapsed sidebar state, collapse control, compact sidebar rows, and titlebar subtitles.
+- `MeterBar/Views/MeterBarTheme.swift` - Added the shared collapsed sidebar width token.
+
+**Verification:**
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app`, relaunched with `--open-dashboard`, and confirmed process `26042` is running.
+
+**Notes:**
+- A normal signed Release build still stops on missing local provisioning profiles; the unsigned local Release build succeeds.
+- Terminal `screencapture` returned a black frame in this session, so visual verification was limited to code inspection and the live app process launch.

--- a/.agents/SESSIONS/2026-07-08.md
+++ b/.agents/SESSIONS/2026-07-08.md
@@ -363,3 +363,28 @@
 - `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/meterbar-release-derived CODE_SIGNING_ALLOWED=NO build`
 - Installed `/Applications/MeterBar.app` from the release build and relaunched with `--open-dashboard`.
 - CoreGraphics verified one on-screen MeterBar dashboard window: `cgWindowCount=1`, blank title.
+
+## Session 16: Homebrew Release Prep
+
+**Duration:** ~15 minutes
+**Status:** Complete
+
+**What was done:**
+- Stopped the UI iteration and prepared the current `master` tree for a Homebrew-backed patch release.
+- Restored daily detail row expansion by making each row a single plain button surface.
+- Tightened Settings account rows so fields stay left and actions align on the right.
+- Softened the glass card border/gradient treatment that was reading too heavy in the installed app.
+- Bumped the app marketing version from `1.6` to `1.6.1` so the existing `v1.6` tag is not reused.
+
+**Files changed:**
+- `MeterBar/Views/DailyUsageChart.swift` - Restored row expansion/collapse through a full-row button.
+- `MeterBar/Views/SettingsView.swift` - Right-aligned account and settings controls without nested list chrome.
+- `MeterBar/Views/MeterBarTheme.swift` - Reduced glass card stroke and background gradient intensity.
+- `MeterBar.xcodeproj/project.pbxproj` - Bumped `MARKETING_VERSION` to `1.6.1`.
+
+**Verification:**
+- `git diff --check`
+- `swift test` - 321 tests passed.
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/meterbar-release-161-derived CODE_SIGNING_ALLOWED=NO build`
+- `cd MeterBarCLI && swift build -c release`
+- Verified bundled CLI version matches app version: `1.6.1`.

--- a/.agents/SESSIONS/2026-07-08.md
+++ b/.agents/SESSIONS/2026-07-08.md
@@ -50,3 +50,31 @@
 
 **Notes:**
 - The dead `meterBarSurfaceStyle` environment plumbing remains for the Part B/C1 native chrome rewrite so this popover pass stays isolated and easy to revert.
+
+## Session 3: Native Dashboard Chrome Rewrite
+
+**Duration:** ~45 minutes
+**Status:** Complete
+
+**What was done:**
+- Applied Part B of `.agents/UI-FIX-BRIEF-2026-07-08.md` by replacing the hand-rolled dashboard chrome with a native `NavigationSplitView`.
+- Removed the custom SwiftUI titlebar overlay, custom sidebar row/hover painting, custom collapse button, manual rounded-window clipping, and `titlebarAppearsTransparent` window setup.
+- Added a native toolbar refresh item and native `NSWindow` title/subtitle updates for the active dashboard section.
+- Removed the `API Usage` dashboard destination and moved authenticated billed API spend into the bottom of Costs as `API spend (billed)`.
+- Applied C1 by deleting dead dashboard/sidebar/titlebar glass views and the unused `meterBarSurfaceStyle` environment system.
+- Simplified companion/dashboard glass surfaces to standard material plus light adaptive tint and accent gradient.
+
+**Files changed:**
+- `MeterBar/Views/UsageDashboardView.swift` - Replaced custom chrome with native split view + toolbar, removed API Usage page, and moved billed API spend under Costs.
+- `MeterBar/Views/MeterBarTheme.swift` - Deleted dead chrome/sidebar/titlebar surfaces, removed manual window chrome constants, and removed unused surface-style environment plumbing.
+- `MeterBar/Views/MenuBarView.swift` - Removed the no-op surface-style writer.
+- `MeterBar/Views/MenuBarDetailPanel.swift` - Removed the no-op surface-style writer from detail panel hosting.
+
+**Verification:**
+- `rg` confirmed zero references to `MeterBarDashboardWindowBacking`, `MeterBarSidebarBackground`, `MeterBarSidebarTitlebarBackground`, `MeterBarSidebarSurface`, `MeterBarTitlebarGlass`, `MeterBarSurfaceStyle`, `meterBarSurfaceStyle`, `MeterBarWindowChrome`, `MeterBarFullSizeHostingView`, `DashboardSidebarRow`, `titlebarAppearsTransparent`, `toolbar = nil`, `case apiUsage`, and `apiUsageContent`.
+- `git diff --check`
+- `swift test` - 321 tests passed, 1 skipped.
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+
+**Notes:**
+- The remaining `Color.white.opacity` grep hits are inside `SocialShareCard`, which is the exported share-image artwork rather than dashboard chrome.

--- a/.agents/SESSIONS/2026-07-08.md
+++ b/.agents/SESSIONS/2026-07-08.md
@@ -127,3 +127,75 @@
 - `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/meterbar-release-derived CODE_SIGNING_ALLOWED=NO build`
 - Installed `/Applications/MeterBar.app` from the release build and relaunched with `--open-dashboard`.
 - CoreGraphics verified one on-screen MeterBar dashboard window: `cgWindowCount=1`, title `Overview`.
+
+## Session 7: Overview Summary And Cost Formatting Fixes
+
+**Duration:** ~20 minutes
+**Status:** Complete, uncommitted pending review
+
+**What was done:**
+- Replaced the Overview "Quota exhausted" hero with compact summary tiles for tightest quota window, 30-day estimate, and tracked sources.
+- Made the tracked-source summary account-aware so multiple Claude profiles count correctly.
+- Fixed currency formatting to include thousands separators, e.g. `$6,954.07`.
+- Reworked Daily Details rows to toggle from the row surface itself instead of a nested plain button, restoring row expansion/collapse behavior.
+
+**Files changed:**
+- `MeterBar/Views/UsageDashboardView.swift` - New overview summary strip and removed redundant quota-exhausted hero.
+- `MeterBar/Views/DailyUsageChart.swift` - Daily rows now use row-level tap handling and accessibility action.
+- `MeterBar/Models/UsageFormatting.swift` - Currency formatting now uses a grouped cached number formatter.
+- `MeterBarTests/UsageFormattingTests.swift` - Added regression coverage for grouped currency.
+
+**Verification:**
+- `git diff --check`
+- `swift test --filter UsageFormattingTests`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/meterbar-release-derived CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app` from the release build and relaunched with `--open-dashboard`.
+- CoreGraphics verified one on-screen MeterBar dashboard window: `cgWindowCount=1`, title `Overview`.
+
+## Session 6: Settings Form And Hidden Title Chrome
+
+**Duration:** ~35 minutes
+**Status:** Complete, uncommitted pending review
+
+**What was done:**
+- Hid the visual dashboard title/subtitle while keeping the native window controls, sidebar toggle, and accessible window title.
+- Added top breathing room to dashboard detail content so native titlebar controls do not overlap page content.
+- Softened global glass strokes and companion surface outlines.
+- Reworked Claude account settings: default/custom profiles share one row layout, default profile shows its effective `~/.claude` path, custom profiles have an inline folder picker, and new-account setup moved to a sheet.
+- Reworked API admin-key rows from cramped inline `LabeledContent` into stacked rows with consistent input styling.
+- Added a shared settings input style for text and secure fields.
+
+**Files changed:**
+- `MeterBar/Views/UsageDashboardView.swift` - Hidden native title text, no titlebar subtitle, and safer detail top spacing.
+- `MeterBar/Views/MeterBarTheme.swift` - Softer glass strokes.
+- `MeterBar/Views/SettingsView.swift` - Modal add-account flow, improved account rows, improved API key rows, and shared input chrome.
+
+**Verification:**
+- `git diff --check`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/meterbar-release-derived CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app` from the release build and relaunched with `--open-dashboard`.
+- CoreGraphics verified one on-screen MeterBar dashboard window: `cgWindowCount=1`, title `Overview`.
+
+## Session 8: Tighter Dashboard Chrome
+
+**Duration:** ~15 minutes
+**Status:** Complete, uncommitted pending review
+
+**What was done:**
+- Reduced shared dashboard card radius from 12pt to 6pt so the main app surface reads less bubbly.
+- Reduced dashboard detail top inset from 22pt to 12pt now that the visible title/subtitle have been removed.
+- Kept the refresh toolbar button with the native navigation controls so collapse and refresh remain grouped instead of splitting controls across an empty titlebar.
+
+**Files changed:**
+- `MeterBar/Views/DashboardCard.swift` - Tighter shared dashboard tile radius.
+- `MeterBar/Views/DashboardProviderCards.swift` - Matching provider-card hit shape radius.
+- `MeterBar/Views/UsageDashboardView.swift` - Tighter detail top padding and navigation-placed refresh control.
+
+**Verification:**
+- `git diff --check`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/meterbar-release-derived CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app` from the release build and relaunched with `--open-dashboard`.
+- CoreGraphics verified one on-screen MeterBar dashboard window: `cgWindowCount=1`, title `Overview`.

--- a/.agents/SESSIONS/2026-07-08.md
+++ b/.agents/SESSIONS/2026-07-08.md
@@ -199,3 +199,167 @@
 - `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/meterbar-release-derived CODE_SIGNING_ALLOWED=NO build`
 - Installed `/Applications/MeterBar.app` from the release build and relaunched with `--open-dashboard`.
 - CoreGraphics verified one on-screen MeterBar dashboard window: `cgWindowCount=1`, title `Overview`.
+
+## Session 9: Shell Radius And Loading State Follow-Up
+
+**Duration:** ~25 minutes
+**Status:** Complete, uncommitted pending review
+
+**What was done:**
+- Moved the radius fix from dashboard tiles to the actual app/sidebar/popover shells.
+- Added explicit AppKit layer clipping for the companion popover and secondary detail panel so transparent panels do not read square behind SwiftUI content.
+- Added an app shell radius token and applied it to the dashboard content view and native sidebar clip.
+- Restored dashboard tile radius to 12pt after confirming the requested radius feedback was about the app/sidebar shell.
+- Replaced the custom spinning refresh glyph with the native circular `ProgressView` loading state.
+- Made the popover header buttons circular glass icon controls.
+- Removed the fixed 420pt width from the Costs API-rate estimate so the estimate card can fill the content column.
+- Reworked embedded Settings from a nested grouped `Form` into the same stacked dashboard section layout as the other pages.
+
+**Files changed:**
+- `MeterBar/Views/MeterBarTheme.swift` - Added app and companion shell radius tokens.
+- `MeterBar/Views/UsageDashboardView.swift` - Dashboard window layer clipping, sidebar clipping, and full-width cost estimate.
+- `MeterBar/App/MeterBarMenuPanelController.swift` - Popover panel layer clipping.
+- `MeterBar/Views/MenuBarDetailPanel.swift` - Secondary panel layer clipping.
+- `MeterBar/Views/MenuBarView.swift` - Circular glass header controls and native loading state.
+- `MeterBar/Views/RefreshingIcon.swift` - Native circular loading indicator.
+- `MeterBar/Views/SettingsView.swift` - Embedded stacked dashboard settings layout.
+- `MeterBar/Views/DashboardCard.swift` - Restored shared tile radius.
+- `MeterBar/Views/DashboardProviderCards.swift` - Restored provider-card hit radius.
+
+**Verification:**
+- `git diff --check`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/meterbar-release-derived CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app` from the release build and relaunched with `--open-dashboard`.
+- CoreGraphics verified one on-screen MeterBar dashboard window: `cgWindowCount=1`, title `Overview`.
+
+## Session 10: Refresh Toolbar Placement
+
+**Duration:** ~10 minutes
+**Status:** Complete, uncommitted pending review
+
+**What was done:**
+- Moved the dashboard refresh toolbar item from the native navigation cluster to the primary action slot so it sits on the right side of the titlebar space.
+
+**Files changed:**
+- `MeterBar/Views/UsageDashboardView.swift` - Changed refresh toolbar placement from `.navigation` to `.primaryAction`.
+
+**Verification:**
+- `git diff --check`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/meterbar-release-derived CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app` from the release build and relaunched with `--open-dashboard`.
+- CoreGraphics verified one on-screen MeterBar dashboard window: `cgWindowCount=1`, title `Overview`.
+
+## Session 11: In-Content Dashboard Page Header
+
+**Duration:** ~10 minutes
+**Status:** Complete, uncommitted pending review
+
+**What was done:**
+- Restored a visible active-page title/subtitle inside dashboard content, following the audit recommendation without bringing back native titlebar text.
+- Kept the refresh toolbar item in the trailing `.primaryAction` slot so it stays on the right side of the titlebar space.
+- Left the native window title accessible via the window name while keeping the visual chrome compact.
+
+**Files changed:**
+- `MeterBar/Views/UsageDashboardView.swift` - Added a compact `dashboardPageHeader` above each dashboard section and kept refresh in `.primaryAction`.
+
+**Verification:**
+- `git diff --check`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/meterbar-release-derived CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app` from the release build and relaunched with `--open-dashboard`.
+- CoreGraphics verified one on-screen MeterBar dashboard window: `cgWindowCount=1`, title `Overview`.
+
+## Session 12: Verified Right-Aligned Refresh Control
+
+**Duration:** ~15 minutes
+**Status:** Complete, uncommitted pending review
+
+**What was done:**
+- Fixed the dashboard refresh placement by removing it from SwiftUI toolbar placement entirely; `.primaryAction` still rendered beside the native sidebar controls in the split-view titlebar.
+- Added a fixed top-right glass refresh button over the dashboard shell so it stays in the empty right-side chrome space regardless of sidebar state.
+- Captured the installed app window after relaunch to visually verify the refresh button is on the right edge.
+
+**Files changed:**
+- `MeterBar/Views/UsageDashboardView.swift` - Wraps the native split view in a top-trailing overlay and styles the refresh button as a circular glass control.
+
+**Verification:**
+- `git diff --check`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/meterbar-release-derived CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app` from the release build and relaunched with `--open-dashboard`.
+- Captured the MeterBar dashboard window to `/tmp/meterbar-dashboard-refresh-overlay.png` and verified the refresh control is visually top-right.
+
+## Session 13: MacSweep Native Chrome Alignment
+
+**Duration:** ~25 minutes
+**Status:** Complete, uncommitted pending review
+
+**What was done:**
+- Audited `../macsweep` and matched its dashboard chrome structure: native `NavigationSplitView`, no custom sidebar clipping/background overrides, and detail-owned `.primaryAction` toolbar actions.
+- Removed the prior floating refresh overlay from MeterBar and restored the refresh control as a native toolbar action group.
+- Restored visible native window title/subtitle updates so toolbar placement behaves like the MacSweep window instead of the hidden-title workaround.
+- Removed the unused app-shell radius token after dropping manual dashboard/sidebar clipping; the companion popover still uses MacSweep's 16pt companion radius.
+
+**Files changed:**
+- `MeterBar/Views/UsageDashboardView.swift` - Uses native visible title/subtitle, unified toolbar style, native primary action toolbar group, and no sidebar shell clipping.
+- `MeterBar/Views/MeterBarTheme.swift` - Removed the unused app-shell radius token while keeping the companion shell radius.
+
+**Verification:**
+- `git diff --check`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/meterbar-release-derived CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app` from the release build and relaunched with `--open-dashboard`.
+- CoreGraphics verified one on-screen MeterBar dashboard window: `cgWindowCount=1`, title `Overview`.
+- Attempted visual capture via `screencapture` and dynamic `CGWindowListCreateImage`; capture returned a black frame on this machine, so visual verification is not claimed for this pass.
+
+## Session 14: Companion Radius And Sidebar Tint
+
+**Duration:** ~20 minutes
+**Status:** Complete, uncommitted pending review
+
+**What was done:**
+- Matched MacSweep's companion shell geometry: the main popover and secondary detail panel now share a 16pt companion shell radius, and the secondary panel uses MacSweep's 12pt panel gap.
+- Updated the companion surface recipe to use material first with a light tint overlay instead of a solid-looking filled surface.
+- Removed the visible dashboard window title/subtitle text while keeping native toolbar geometry and the trailing refresh action.
+- Added a desaturated MeterBar sidebar tint so sidebar selection/hover no longer reads as the stock macOS blue.
+
+**Files changed:**
+- `MeterBar/Views/MeterBarTheme.swift` - Added shared companion shell radius, companion tint, and sidebar menu tint; refined companion surface material layering.
+- `MeterBar/Views/MenuBarDetailPanel.swift` - Uses the shared 16pt companion radius and 12pt gap for the secondary panel.
+- `MeterBar/Views/UsageDashboardView.swift` - Clears visible native title/subtitle text and applies the custom sidebar tint.
+
+**Verification:**
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/meterbar-release-derived CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app` from the release build and relaunched with `--open-dashboard`.
+- CoreGraphics verified one on-screen MeterBar dashboard window: `cgWindowCount=1`, blank title.
+- Visual screenshot capture still returns black on this machine, so visual verification is not claimed for this pass.
+
+## Session 15: Part D DRY Cleanup
+
+**Duration:** ~25 minutes
+**Status:** Complete
+
+**What was done:**
+- Folded the private `OverviewSummaryTile` clone into `DashboardMetricTile` via a compact style variant.
+- Replaced the duplicated AppKit panel clipping methods with one shared `NSPanel.applyCompanionClipping()` helper.
+- Reused one Settings input-surface modifier for editable fields, the default/profile badge, and read-only path pill.
+- Extracted dashboard window title/subtitle/titlebar/toolbar setup into one `applyWindowChrome` function.
+
+**Files changed:**
+- `MeterBar/Views/DashboardCard.swift` - Added `DashboardMetricTile.Style` for regular and compact metric tiles.
+- `MeterBar/Views/UsageDashboardView.swift` - Uses compact `DashboardMetricTile` in the overview strip and centralizes window chrome setup.
+- `MeterBar/Views/MeterBarTheme.swift` - Added the shared `NSPanel.applyCompanionClipping()` helper.
+- `MeterBar/App/MeterBarMenuPanelController.swift` - Uses the shared panel clipping helper.
+- `MeterBar/Views/MenuBarDetailPanel.swift` - Uses the shared panel clipping helper.
+- `MeterBar/Views/SettingsView.swift` - Reuses the shared Settings input surface for fields, badges, and read-only path text.
+
+**Verification:**
+- `git diff --check`
+- Grep checks: no `OverviewSummaryTile`, no `configurePanelClipping`, title/toolbar config only in `applyWindowChrome`.
+- `swift test` - 321 tests passed, 1 skipped.
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Release -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/meterbar-release-derived CODE_SIGNING_ALLOWED=NO build`
+- Installed `/Applications/MeterBar.app` from the release build and relaunched with `--open-dashboard`.
+- CoreGraphics verified one on-screen MeterBar dashboard window: `cgWindowCount=1`, blank title.

--- a/.agents/SESSIONS/2026-07-08.md
+++ b/.agents/SESSIONS/2026-07-08.md
@@ -376,11 +376,15 @@
 - Tightened Settings account rows so fields stay left and actions align on the right.
 - Softened the glass card border/gradient treatment that was reading too heavy in the installed app.
 - Bumped the app marketing version from `1.6` to `1.6.1` so the existing `v1.6` tag is not reused.
+- Addressed release PR review blockers: status-bar clicks no longer dismiss/reopen the popover, API usage refreshes are guarded against overlap, and the add-account placeholder is production-safe.
 
 **Files changed:**
 - `MeterBar/Views/DailyUsageChart.swift` - Restored row expansion/collapse through a full-row button.
 - `MeterBar/Views/SettingsView.swift` - Right-aligned account and settings controls without nested list chrome.
 - `MeterBar/Views/MeterBarTheme.swift` - Reduced glass card stroke and background gradient intensity.
+- `MeterBar/App/MeterBarMenuPanelController.swift` - Keeps status-item clicks out of outside-click dismissal handling.
+- `MeterBar/Services/ApiUsageStore.swift` - Skips refreshes while an API usage refresh is already running.
+- `MeterBar/Views/UsageDashboardView.swift` - Reflects API usage loading in the Costs refresh button state.
 - `MeterBar.xcodeproj/project.pbxproj` - Bumped `MARKETING_VERSION` to `1.6.1`.
 
 **Verification:**

--- a/.agents/SESSIONS/2026-07-08.md
+++ b/.agents/SESSIONS/2026-07-08.md
@@ -78,3 +78,30 @@
 
 **Notes:**
 - The remaining `Color.white.opacity` grep hits are inside `SocialShareCard`, which is the exported share-image artwork rather than dashboard chrome.
+
+## Session 4: Cleanup And Release Chores
+
+**Duration:** ~35 minutes
+**Status:** Complete
+
+**What was done:**
+- Applied C2 by deleting the `dashboardCardBackground` pass-through alias, hoisting provider `updatedText` onto `ProviderSnapshot`, extracting the duplicated provider-limits body, and collapsing daily usage metric/cost cells into one width-parameterized cell.
+- Applied C3 by deleting six `CostTracker` instance test shims, migrating `CostTrackerTests` to static calls, removing `nonisolated` from `CostTracker`, and documenting why local cost scans skip mounted/network volumes.
+- Applied C6 by adding combined accessibility labels to `ProviderOverviewStatusCard`.
+- Verified `MeterBar/Info.plist` is already absent; only `MeterBarWidget/Info.plist` remains.
+- Verified issue #86 against current code: `AccountActivityInspector.codexCliActivity()` honors `CODEX_HOME` through `codexHomeDirectory()`. Closed #86 with that note.
+- Removed the ignored 410MB `build/` derived-data folder.
+
+**Files changed:**
+- `MeterBar/Views/DashboardCard.swift` - Removed the duplicate surface alias.
+- `MeterBar/Views/DashboardProviderCards.swift` - Reused `ProviderSnapshot.updatedText`, extracted provider-limit rendering, and added overview-card accessibility labels.
+- `MeterBar/Views/DailyUsageChart.swift` - Collapsed duplicate table cells.
+- `MeterBar/Views/MenuBarDetailPanel.swift` - Updated popover card surfaces to call `meterBarCardSurface` directly.
+- `MeterBar/Views/ProviderSnapshot.swift` - Added shared `updatedText`.
+- `MeterBar/Services/CostTracker.swift` - Removed test shims and fake `nonisolated`; added local-volume scan note.
+- `MeterBarTests/CostTrackerTests.swift` - Uses static `CostTracker` APIs directly.
+
+**Verification:**
+- `git diff --check`
+- `swift test` - 321 tests passed.
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO build`

--- a/.agents/UI-FIX-BRIEF-2026-07-08.md
+++ b/.agents/UI-FIX-BRIEF-2026-07-08.md
@@ -1,0 +1,183 @@
+# UI Fix Brief — 2026-07-08
+
+Audit of the toolbar popover + companion dashboard after the 07-07/07-08 sessions.
+This is the contract for the next UI pass. Do ONE pass against this brief; do not
+invent a new chrome approach mid-task. If something here conflicts with reality,
+stop and report instead of improvising.
+
+## Why the last 13 sessions looped (read first)
+
+Sessions 1, 3, 4, 7, 8, 10, 11 (07-07) all reworked the same titlebar; sessions
+5 and 6 flip-flopped glass on/off; session 8 set `titlebarAppearsTransparent = false`
+and session 10 reverted it. Root cause: the dashboard window hand-rolls ALL of its
+chrome — fake SwiftUI titlebar overlay, fake sidebar with manual width animation,
+zero-safe-area hosting view hack, manual `layer.cornerRadius` clip — and every
+session patched one symptom of that decision, which surfaced the next symptom.
+
+**The fix is architectural, not cosmetic: go back to native AppKit/SwiftUI chrome
+(NavigationSplitView + native toolbar) and let macOS 26 provide the Finder look,
+the sidebar collapse, and the scroll-edge blur for free. Delete the hand-rolled
+chrome instead of patching it.**
+
+Before touching anything: commit the current working tree to a branch
+(`git checkout -b ui-fix-baseline && git add -A && git commit`). The current
++3,084/−2,294 uncommitted diff is unrevertable churn; every next step must be
+diffable.
+
+---
+
+## Part A — Toolbar popover (small, surgical fixes)
+
+### A1. Secondary panel touches the primary panel
+`MeterBar/Views/MenuBarDetailPanel.swift:47` positions the detail panel at
+`x: anchorFrame.minX - width` — flush against the primary panel. Add a gap
+constant (10pt) to `MeterBarMenuDetailPanelLayout` and use
+`anchorFrame.minX - width - gap`. Keep the tops aligned as today.
+
+### A2. Panel heights must fit content exactly — no clipping, no dead space
+`MenuBarProviderDetailContent.preferredHeight(for:)`
+(`MenuBarDetailPanel.swift:236-242`) estimates height with magic numbers
+(`206 + count*84 + 106 + 52`). When it underestimates, `.clipped()` (line 44)
+cuts content at the edge; when it overestimates (or `minDetailHeight: 260`
+kicks in), the panel shows dead space below the content.
+
+Fix: measure the real content instead of estimating —
+- Render the content in the `NSHostingView`, fix its width to `detailWidth`,
+  and use `fittingSize.height` (or a `GeometryReader` + `PreferenceKey`, the
+  same pattern `MenuBarView` already uses via `MenuContentHeightPreferenceKey`)
+  to size the panel.
+- Delete `preferredHeight(for:)`, delete `.clipped()`, drop `minDetailHeight`
+  (or lower it to ~120 as a floor for the empty state).
+- Keep the screen-height cap; only if capped, fall back to the internal
+  ScrollView (the `ViewThatFits` already does this) — indicators hidden.
+
+### A3. No scrollbars in either panel
+`MenuBarView.swift:60` — the primary panel's `ScrollView` shows indicators.
+Add `.scrollIndicators(.hidden)`. Content-sized panels (A2) should make
+scrolling a screen-height-cap fallback only.
+
+### A4. Compact the headers
+- Primary panel header (`MenuBarView.swift:114-146`): drop the decorative
+  chart-line brand icon; keep only the dashboard + refresh icon buttons,
+  right-aligned, and reduce the header to ~40pt. Update `chromeHeight`
+  (`MenuBarView.swift:8`, hardcoded 56) to match — or better, measure it.
+- Detail panel (`MenuBarDetailPanel.swift`): keep the provider name +
+  "Open Full View" header, but DELETE the "Status / Updated" summary card
+  (`summaryRow`, lines 203-229) — it duplicates what the primary card already
+  shows. The detail panel should only add depth: per-window rows, reset
+  counters, badges.
+
+---
+
+## Part B — Companion dashboard window (architectural)
+
+### B1. Replace hand-rolled chrome with native NavigationSplitView
+Target: Finder-like native window on macOS 26 (min deployment target is
+macOS 26, Liquid Glass is available everywhere).
+
+Delete:
+- `MeterBarFullSizeHostingView` (safe-area hack), `UsageDashboardView.swift:7-13`
+- `applyCompanionWindowRadius` manual corner clip, `UsageDashboardView.swift:60-65`
+  (macOS 26 windows already have continuous rounded corners; masking to 14
+  fights the native shape)
+- the fake `dashboardTitlebar` overlay + `titlebarContentInset` padding
+  (`UsageDashboardView.swift:214-251`, ZStack zIndex hack at 204-209)
+- the manual sidebar (`sidebar`, `sidebarCollapseButton`, `DashboardSidebarRow`
+  hover/selection painting with `Color.white.opacity` — broken in light mode)
+- `MeterBarWindowChrome.titlebarContentInset`, `sidebarTitlebarWidth`,
+  `collapsedSidebarWidth`, `MeterBarTitlebarGlass`,
+  `MeterBarSidebarTitlebarBackground`, `MeterBarSidebarSurface`,
+  `MeterBarSidebarBackground`, `MeterBarDashboardWindowBacking`
+
+Build instead:
+- `NavigationSplitView(columnVisibility:)` with the sidebar as a
+  `List(selection:)` using `.listStyle(.sidebar)` — this gives the native
+  translucent Finder-style sidebar, native row selection/hover, native
+  collapse (system sidebar-toggle toolbar button, full collapse with
+  animation — remove the custom icons-only 72pt rail entirely).
+- Native toolbar: `.navigationTitle(activeSection.rawValue)` +
+  `.navigationSubtitle(activeSection.titlebarSubtitle)`, refresh button as
+  `ToolbarItem(placement: .primaryAction)`. Window keeps
+  `.titled .closable .miniaturizable .resizable`; keep `fullSizeContentView`
+  ONLY if the native toolbar needs content under it — default to NOT setting
+  it and let AppKit manage the titlebar. Do not set `toolbar = nil`,
+  `titleVisibility = .hidden`, or `titlebarAppearsTransparent` manually.
+
+### B2. Scroll-under titlebar = native scroll-edge effect, not a painted strip
+The current `MeterBarTitlebarGlass` is an always-on 48pt strip of
+`.thinMaterial` + 0.58 solid dark tint → the "hardcut" transition. With the
+native toolbar from B1, macOS 26 applies the progressive scroll-edge blur
+automatically as content scrolls under the toolbar (tunable with
+`.scrollEdgeEffectStyle(.soft, for: .top)`). At rest the titlebar is clean;
+scrolled, it blurs gradually. Do not reimplement this with overlays.
+
+### B3. Glassmorphism: follow the conventions, stop stacking tints
+Current state: five different glass recipes (`MeterBarDetailBackground`,
+`MeterBarSidebarBackground`, `MeterBarSidebarSurface`, `MeterBarTitlebarGlass`,
+`MeterBarCompanionSurface`), each = material + a solid near-black overlay at
+0.42–0.82 opacity + an accent gradient. The heavy solid tint kills the
+material blur — that's why the app reads flat/dark instead of glass.
+
+Conventions (macOS 26 / HIG):
+- Backgrounds get standard materials only: sidebar gets its material from
+  `.listStyle(.sidebar)`; the detail area can use
+  `.containerBackground(.thinMaterial, for: .window)` or stay
+  `windowBackgroundColor`. No solid tint layers above 0.2 opacity on top of
+  a material; prefer no tint at all. The subtle brand gradient may stay at
+  current opacities (≤0.15) if desired.
+- `glassEffect(.regular, in:)` is for floating chrome/controls (the popover
+  panels, buttons), NOT stacked on top of an `.ultraThinMaterial` fill
+  (currently double-glassed in `MeterBarSidebarSurface`,
+  `MeterBarTheme.swift:204-208`). One glass layer per surface.
+- One card recipe: keep `meterBarCardSurface` / `MeterBarCompanionSurface`
+  as THE card/panel surface; delete the redundant recipes listed in B1.
+- Adaptive appearance is a hard requirement: kill hardcoded
+  `MeterBarWindowChrome.color` (fixed near-black) as a window/light-mode
+  background and every `Color.white.opacity(...)` selection/hover fill.
+  Native `List` selection replaces the hand-painted sidebar row states.
+  Verify every surface in BOTH light and dark mode plus
+  Reduce Transparency before calling it done.
+
+### B4. Remove the API Usage page
+- Delete the `apiUsage` case from `DashboardSection` and its sidebar entry
+  (`UsageDashboardView.swift:72, 88-89, 108-110, 461-477`).
+- Move the org-admin-key spend into the **Costs** page as a trailing section,
+  rendered only when `apiUsageStore.hasAnyAuthenticated`
+  (`ApiUsageSection(store:embedded:)` already supports this). Label it
+  "API spend (billed)" and keep it visually separate from the local-log
+  estimates — one is real invoiced dollars, the other is an estimate; never
+  sum them.
+- API key entry/management lives in Settings → Accounts (it's already
+  conceptually there; make sure the empty-state copy on Costs doesn't
+  advertise it — subs-only users should never see an API empty state).
+- Remove `ApiUsageSection` from the popover (`MenuBarView.swift:244`) — the
+  popover is quota-at-a-glance only.
+
+---
+
+## Acceptance criteria (verify each, in the running app)
+
+Popover:
+- [ ] Secondary panel has a visible ~10pt gap from the primary panel; tops aligned.
+- [ ] Neither panel ever shows a scrollbar; both hug their content height
+      exactly (no clipped bottom edge, no dead space) for: provider with 1
+      window, 2 windows, exhausted provider, provider with no data.
+- [ ] Primary header is a single compact row (no brand icon); detail panel
+      has no Status/Updated card.
+
+Dashboard:
+- [ ] Window uses a native toolbar + native sidebar; the system sidebar
+      toggle collapses/expands with the standard animation (no icon rail).
+- [ ] At rest, no visible titlebar strip; scrolling content blurs
+      progressively under the toolbar (no hard edge).
+- [ ] Sidebar looks/behaves like Finder's: native material, native selection
+      highlight, correct in light AND dark mode and with Reduce Transparency.
+- [ ] No `safeAreaRect`/`safeAreaInsets` overrides, no manual layer corner
+      radius, no fake titlebar views left in the codebase.
+- [ ] Sidebar has no "API Usage" item; Costs shows the API spend section only
+      when an admin key is authenticated; popover has no API section.
+- [ ] `swift test` passes; Release build succeeds.
+
+Non-goals: do not touch the data layer, providers, cost scanning, snapshot
+builders, or card content/copy beyond what's listed. Do not redesign cards.
+Do not add new surface recipes.

--- a/.agents/UI-FIX-BRIEF-2026-07-08.md
+++ b/.agents/UI-FIX-BRIEF-2026-07-08.md
@@ -19,10 +19,13 @@ session patched one symptom of that decision, which surfaced the next symptom.
 the sidebar collapse, and the scroll-edge blur for free. Delete the hand-rolled
 chrome instead of patching it.**
 
-Before touching anything: commit the current working tree to a branch
-(`git checkout -b ui-fix-baseline && git add -A && git commit`). The current
-+3,084/−2,294 uncommitted diff is unrevertable churn; every next step must be
-diffable.
+Current state (2026-07-08): the churn is committed as baseline `0da923c` on
+branch `ui-fix-baseline`. ONE uncommitted, NON-COMPILING partial edit exists in
+`MeterBar/Views/MenuBarDetailPanel.swift` (someone started A2/A4: changed
+`present(anchor:preferredHeight:content:)` to `present(anchor:content:)` with
+`fittingSize` measurement, but never updated the caller in `MenuBarView.swift:163`).
+**First action: `git checkout -- MeterBar/Views/MenuBarDetailPanel.swift` to get
+back to a compiling tree, then implement A2/A4 properly per this brief.**
 
 ---
 
@@ -155,6 +158,89 @@ Conventions (macOS 26 / HIG):
 
 ---
 
+## Part C — Deep cleanup (verified findings; do alongside Part B)
+
+### C1. Delete dead code (all verified unreferenced)
+- `MeterBarDashboardWindowBacking` — `MeterBar/Views/MeterBarTheme.swift:145-161`
+- `MeterBarSidebarBackground` — `MeterBarTheme.swift:163-189`
+- `MeterBarSidebarTitlebarBackground` — `MeterBarTheme.swift:256-263`
+  (only referenced from the dead view above)
+- The ENTIRE `meterBarSurfaceStyle` environment plumbing —
+  `MeterBarTheme.swift:295-297, 304-318` (`MeterBarSurfaceStyle`,
+  `MeterBarSurfaceStyleKey`, private `EnvironmentValues` extension, View
+  modifier) plus its two no-op call sites `MenuBarView.swift:39` and
+  `MenuBarDetailPanel.swift:42`. It is WRITTEN but never READ — no
+  `@Environment(\.meterBarSurfaceStyle)` exists anywhere. The session-5
+  "toolbar vs dashboard surface split" it was built for never functioned.
+
+### C2. Consolidate duplicates (behavior-preserving)
+- `dashboardCardBackground(cornerRadius:)` (`DashboardCard.swift:99-105`) is a
+  pure pass-through alias of `meterBarCardSurface`. Delete it and update the
+  4 call sites (`DashboardCard.swift:34`, `MenuBarDetailPanel.swift:152/228/298`).
+- `updatedText` is byte-identical in `ProviderOverviewStatusCard`
+  (`DashboardProviderCards.swift:115`) and `ProviderLimitsCard` (`:164`) —
+  hoist onto `ProviderSnapshot`.
+- The exhausted-provider branch (`isEmpty / hasExhaustedWeeklyLimit →
+  BlockingLimitResetCounter / else ForEach`) is duplicated verbatim at
+  `DashboardProviderCards.swift:78-98` and `:137-152` — extract one view.
+- `DailyUsageMetricCell` / `DailyUsageCostCell` (`DailyUsageChart.swift:553-575`)
+  differ only by frame width — collapse into one cell with a width parameter.
+
+### C3. CostTracker cleanup (`MeterBar/Services/CostTracker.swift`)
+- Delete the six test-only shim methods at lines 196-263 (`parseSessionFile`,
+  `claudePricing`, `normalizeClaudeModel`, `scanCodexArchivedSessions`,
+  `calculateCost`, `calculateClaudeCost`) — zero production callers; they exist
+  only so `CostTrackerTests` can call instance methods. Migrate the tests to
+  the static `CostTracker.` calls instead.
+- Remove the `nonisolated` keyword throughout — `CostTracker` is a plain class,
+  not an actor, so every `nonisolated` in the file is a no-op that fakes
+  actor-isolation. Keep `static`.
+- Document (code comment) that `isLocalDirectory` intentionally skips
+  network/mounted volumes so "my usage disappeared" reports are triaged fast.
+
+### C4. Extra-usage indicator regression (`MeterBar/Services/ClaudeCodeLocalService.swift:236`)
+The new `guard isOAuthFallbackEnabled else { return .unknown }` means every
+normal user (fallback defaults to OFF) now permanently sees "unknown" for
+Claude's Extra usage state — the on/off pill silently died. The keychain-prompt
+motivation is valid, so keep the gate, but make the UI honest: when the state
+is `.unknown` AND the fallback is disabled, HIDE the extra-usage row/badge
+(popover, detail panel, settings pill) instead of rendering a dead "unknown"
+indicator. Live usage metrics are unaffected (separate CLI path).
+
+### C5. Light-mode fixes (beyond B3)
+- `DashboardProviderCards.swift:18` — icon well changed from `.quaternary` to
+  `Circle().fill(MeterBarTheme.glassCardTint)`; glassCardTint is a white-alpha
+  overlay tint, near-invisible over a light card. Revert to `.quaternary`.
+- After B1/B3, grep the codebase for `Color.white.opacity` and
+  `MeterBarWindowChrome.color` — every survivor needs a semantic replacement.
+
+### C6. Smaller debts
+- `DailyUsageTableLayout` (`DailyUsageChart.swift:346-352`) hard-codes a
+  ~668pt minimum table width; numeric cells only shrink to 75% then truncate.
+  Acceptable for now at the 900pt min window — fix only if window min shrinks.
+- `ProviderOverviewStatusCard` (`DashboardProviderCards.swift:46-58`): add
+  `.accessibilityElement(children: .combine)` + an `.accessibilityLabel` so
+  VoiceOver reads one named button, not an untitled group.
+- Delete stale `MeterBar/Info.plist` (dead file, hardcodes version 1.0;
+  generated plist wins — remainder of issue #20).
+- Issue #86: one unresolved CodeRabbit thread on
+  `MeterBar/Services/AccountActivityInspector.swift:52` from PR #85 — verify
+  against master and resolve while in there.
+
+---
+
+## Suggested run order (budget-aware)
+
+1. Revert the non-compiling partial edit (see "Current state" above).
+2. **Part A** (popover) + C4 + C5 first — small, high-visibility, cheap to verify.
+3. **Part B** (native chrome rewrite) + C1 (most dead code IS the old chrome).
+4. **C2/C3/C6** cleanup pass, then release chores.
+
+Commit each step separately on top of `ui-fix-baseline` so any step can be
+reverted alone.
+
+---
+
 ## Acceptance criteria (verify each, in the running app)
 
 Popover:
@@ -176,7 +262,16 @@ Dashboard:
       radius, no fake titlebar views left in the codebase.
 - [ ] Sidebar has no "API Usage" item; Costs shows the API spend section only
       when an admin key is authenticated; popover has no API section.
-- [ ] `swift test` passes; Release build succeeds.
+
+Cleanup:
+- [ ] Grep proves zero references to: MeterBarDashboardWindowBacking,
+      MeterBarSidebarBackground, MeterBarSidebarTitlebarBackground,
+      MeterBarSurfaceStyle, meterBarSurfaceStyle, dashboardCardBackground,
+      preferredHeight(for:), and the six CostTracker shims.
+- [ ] Claude Extra-usage row is hidden (not "unknown") when OAuth fallback is
+      disabled; shows real on/off when enabled.
+- [ ] `swift test` passes (including migrated CostTrackerTests); Release build
+      succeeds.
 
 Non-goals: do not touch the data layer, providers, cost scanning, snapshot
 builders, or card content/copy beyond what's listed. Do not redesign cards.

--- a/.agents/UI-FIX-BRIEF-2026-07-08.md
+++ b/.agents/UI-FIX-BRIEF-2026-07-08.md
@@ -276,3 +276,38 @@ Cleanup:
 Non-goals: do not touch the data layer, providers, cost scanning, snapshot
 builders, or card content/copy beyond what's listed. Do not redesign cards.
 Do not add new surface recipes.
+
+---
+
+## Part D — Quality pass on sessions 6–13 output (added after audit #4)
+
+DRY fixes, all small and behavior-preserving:
+
+1. Delete `OverviewSummaryTile` (private, bottom of `UsageDashboardView.swift`)
+   — it clones `DashboardMetricTile` (`DashboardCard.swift:69-97`) with the
+   same props and anatomy. Extend `DashboardMetricTile` with an optional
+   size/style variant (value font, spacing, minHeight, lineLimit/minScale)
+   and use it in `OverviewSummaryStrip`.
+2. `configurePanelClipping(_:)` is duplicated byte-for-byte in
+   `MeterBar/App/MeterBarMenuPanelController.swift` and
+   `MeterBar/Views/MenuBarDetailPanel.swift`. Extract ONE shared helper
+   (e.g. `extension NSPanel { func applyCompanionClipping() }`) driven by
+   `MeterBarTheme.companionShellRadius`.
+3. `SettingsView.swift`: the path-pill view (~line 1055) hand-inlines the same
+   thinMaterial + glassCardStroke recipe as `SettingsInputModifier`; reuse
+   `settingsInput()` or extract the surface part of the modifier. Also fold
+   the one-off material capsule at ~line 951 into the same helper if visually
+   identical.
+4. Window chrome is configured twice (creation in
+   `UsageDashboardWindowController.show()` and updates in the
+   `MeterBarMenuWindowAccessor` callback) — title, subtitle, titleVisibility,
+   toolbarStyle in both. Extract `applyWindowChrome(_ window:, section:)` and
+   call it from both sites.
+
+Acceptance: grep shows one `DashboardMetricTile`-based tile family, one
+panel-clipping helper, zero inline thinMaterial recipes in SettingsView
+outside the shared modifier, and window title/toolbar config written in
+exactly one function. `swift test` + Release build still pass.
+
+Deferred (post-release, do NOT do now): split `SettingsView.swift` (~1,100
+lines) and `UsageDashboardView.swift` (~890 lines) into per-section files.

--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -288,7 +288,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.6;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.shipshit.MeterBar.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -333,7 +333,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.6;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.shipshit.MeterBar.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -498,7 +498,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.6;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.shipshit.MeterBar;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -544,7 +544,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.6;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.shipshit.MeterBar;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -24,7 +24,7 @@ struct MeterBarApp: App {
 
 class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem?
-    private var popover: NSPopover?
+    private var menuPanel: MeterBarMenuPanelController?
     private let providerVisibilityStore = ProviderVisibilityStore.shared
     private let dockVisibilityStore = DockVisibilityStore.shared
     private let notificationPreferences = NotificationPreferencesStore.shared
@@ -72,13 +72,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         button.imagePosition = .imageLeft
         button.font = .systemFont(ofSize: 14, weight: .semibold)
 
-        // Create popover
-        popover = NSPopover()
-        popover?.contentSize = NSSize(width: 520, height: 420)
-        popover?.behavior = .transient
-        popover?.contentViewController = NSHostingController(
-            rootView: MenuBarView { [weak self] size in
-                self?.popover?.contentSize = size
+        menuPanel = MeterBarMenuPanelController(
+            statusButtonProvider: { [weak self] in
+                self?.statusItem?.button
+            },
+            onDismiss: {
+                MeterBarMenuDetailPanel.shared.dismiss()
             }
         )
 
@@ -88,6 +87,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Setup notifications (also handles initial data refresh)
         setupNotifications()
+
+        if CommandLine.arguments.contains("--open-dashboard") {
+            Task { @MainActor in
+                UsageDashboardWindowController.shared.show()
+            }
+        }
     }
 
     /// Left-click opens the popover; right-click (or control-click) opens a
@@ -107,13 +112,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc
     func togglePopover() {
-        guard let button = statusItem?.button,
-              let popover = popover else { return }
+        guard let menuPanel else { return }
 
-        if popover.isShown {
-            popover.performClose(nil)
+        if menuPanel.isShown {
+            menuPanel.dismiss()
         } else {
-            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            menuPanel.show()
             // Opening the popover always pulls fresh data — providers read
             // local files, so this is cheap and the popover never shows a
             // stale snapshot from the last timer tick.
@@ -126,9 +130,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func showStatusMenu() {
         guard let button = statusItem?.button else { return }
 
-        if popover?.isShown == true {
-            popover?.performClose(nil)
-        }
+        menuPanel?.dismiss()
 
         let menu = makeStatusMenu()
         let location = NSPoint(x: 0, y: button.bounds.height + 4)

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -89,9 +89,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         setupNotifications()
 
         if CommandLine.arguments.contains("--open-dashboard") {
-            Task { @MainActor in
-                UsageDashboardWindowController.shared.show()
-            }
+            UsageDashboardWindowController.shared.show()
         }
     }
 

--- a/MeterBar/App/MeterBarMenuPanelController.swift
+++ b/MeterBar/App/MeterBarMenuPanelController.swift
@@ -1,0 +1,133 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class MeterBarMenuPanelController {
+    private let statusButtonProvider: () -> NSStatusBarButton?
+    private let onDismiss: () -> Void
+
+    private var panel: NSPanel?
+    private var contentSize = NSSize(width: 390, height: 420)
+    private var globalMouseMonitor: Any?
+    private var localEventMonitor: Any?
+
+    var isShown: Bool {
+        panel?.isVisible == true
+    }
+
+    init(
+        statusButtonProvider: @escaping () -> NSStatusBarButton?,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.statusButtonProvider = statusButtonProvider
+        self.onDismiss = onDismiss
+    }
+
+    func show() {
+        guard let button = statusButtonProvider() else { return }
+        let panel = ensurePanel()
+        position(panel, anchoredTo: button, size: contentSize)
+        panel.orderFrontRegardless()
+        startEventMonitoring()
+    }
+
+    func dismiss() {
+        stopEventMonitoring()
+        panel?.orderOut(nil)
+        onDismiss()
+    }
+
+    func resize(to size: NSSize) {
+        contentSize = size
+        guard let panel, panel.isVisible, let button = statusButtonProvider() else { return }
+        position(panel, anchoredTo: button, size: size)
+    }
+
+    private func ensurePanel() -> NSPanel {
+        if let panel { return panel }
+
+        let panel = NSPanel(
+            contentRect: NSRect(origin: .zero, size: contentSize),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isFloatingPanel = true
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.hidesOnDeactivate = false
+        panel.level = .statusBar
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
+        panel.contentViewController = NSHostingController(
+            rootView: MenuBarView { [weak self] size in
+                self?.resize(to: size)
+            }
+        )
+
+        self.panel = panel
+        return panel
+    }
+
+    private func position(_ panel: NSPanel, anchoredTo button: NSStatusBarButton, size: NSSize) {
+        guard let buttonWindow = button.window else { return }
+
+        let buttonRectInWindow = button.convert(button.bounds, to: nil)
+        let buttonRect = buttonWindow.convertToScreen(buttonRectInWindow)
+        let screen = buttonWindow.screen ?? NSScreen.main
+        let visibleFrame = screen?.visibleFrame ?? NSScreen.main?.visibleFrame ?? buttonRect
+        let padding: CGFloat = 8
+
+        let x = min(
+            max(buttonRect.midX - (size.width / 2), visibleFrame.minX + padding),
+            visibleFrame.maxX - size.width - padding
+        )
+        let y = max(visibleFrame.minY + padding, buttonRect.minY - size.height - 6)
+
+        panel.setFrame(
+            NSRect(x: x, y: y, width: size.width, height: size.height),
+            display: true
+        )
+    }
+
+    private func startEventMonitoring() {
+        stopEventMonitoring()
+
+        globalMouseMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown]
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.dismiss()
+            }
+        }
+
+        localEventMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown, .keyDown]
+        ) { [weak self] event in
+            guard let self else { return event }
+
+            if event.type == .keyDown, event.keyCode == 53 {
+                dismiss()
+                return nil
+            }
+
+            if event.window === panel || MeterBarMenuDetailPanel.shared.owns(window: event.window) {
+                return event
+            }
+
+            dismiss()
+            return event
+        }
+    }
+
+    private func stopEventMonitoring() {
+        if let globalMouseMonitor {
+            NSEvent.removeMonitor(globalMouseMonitor)
+            self.globalMouseMonitor = nil
+        }
+        if let localEventMonitor {
+            NSEvent.removeMonitor(localEventMonitor)
+            self.localEventMonitor = nil
+        }
+    }
+}

--- a/MeterBar/App/MeterBarMenuPanelController.swift
+++ b/MeterBar/App/MeterBarMenuPanelController.swift
@@ -113,6 +113,10 @@ final class MeterBarMenuPanelController {
                 return nil
             }
 
+            if eventIsInsideStatusButton(event) {
+                return event
+            }
+
             if event.window === panel || MeterBarMenuDetailPanel.shared.owns(window: event.window) {
                 return event
             }
@@ -120,6 +124,18 @@ final class MeterBarMenuPanelController {
             dismiss()
             return event
         }
+    }
+
+    private func eventIsInsideStatusButton(_ event: NSEvent) -> Bool {
+        guard
+            let button = statusButtonProvider(),
+            event.window === button.window
+        else {
+            return false
+        }
+
+        let location = button.convert(event.locationInWindow, from: nil)
+        return button.bounds.contains(location)
     }
 
     private func stopEventMonitoring() {

--- a/MeterBar/App/MeterBarMenuPanelController.swift
+++ b/MeterBar/App/MeterBarMenuPanelController.swift
@@ -59,11 +59,13 @@ final class MeterBarMenuPanelController {
         panel.hidesOnDeactivate = false
         panel.level = .statusBar
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
-        panel.contentViewController = NSHostingController(
+        let hostingController = NSHostingController(
             rootView: MenuBarView { [weak self] size in
                 self?.resize(to: size)
             }
         )
+        panel.contentViewController = hostingController
+        panel.applyCompanionClipping()
 
         self.panel = panel
         return panel

--- a/MeterBar/Models/UsageFormatting.swift
+++ b/MeterBar/Models/UsageFormatting.swift
@@ -17,6 +17,16 @@ public enum UsageFormat {
         return formatter
     }()
 
+    private static let currencyNumber: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.numberStyle = .decimal
+        formatter.usesGroupingSeparator = true
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        return formatter
+    }()
+
     private static let relativeFormatter: RelativeDateTimeFormatter = {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
@@ -44,7 +54,7 @@ public enum UsageFormat {
 
     /// Currency string, e.g. `$12.34`.
     public static func cost(_ value: Double) -> String {
-        String(format: "$%.2f", value)
+        "$\(currencyNumber.string(from: NSNumber(value: value)) ?? String(format: "%.2f", value))"
     }
 
     /// Abbreviated relative time, e.g. `2h ago`, using a cached formatter.

--- a/MeterBar/Services/ApiUsageStore.swift
+++ b/MeterBar/Services/ApiUsageStore.swift
@@ -33,6 +33,8 @@ final class ApiUsageStore: ObservableObject {
     }
 
     func refresh() async {
+        guard !isLoading else { return }
+
         let providers = authenticatedProviders
         guard !providers.isEmpty else {
             usage = [:]

--- a/MeterBar/Services/ClaudeCodeLocalService.swift
+++ b/MeterBar/Services/ClaudeCodeLocalService.swift
@@ -122,8 +122,10 @@ class ClaudeCodeLocalService: ObservableObject {
                     self.authState = .connected(.cli)
                 }
             }
-            // The CLI usage output does not expose the "extra usage" toggle, so query the
-            // OAuth usage endpoint separately for it. Best-effort: failures degrade to .unknown.
+            // The CLI output does not expose the "extra usage" toggle. Only read
+            // Claude's OAuth keychain item when the user explicitly enables the
+            // legacy OAuth fallback; ad-hoc local installs otherwise trigger a
+            // keychain approval prompt on every rebuilt binary.
             let extraUsage = await fetchExtraUsageStatus(account: account)
             return metrics.withExtraUsage(extraUsage)
         } catch {
@@ -231,6 +233,7 @@ class ClaudeCodeLocalService: ObservableObject {
     /// Reads credentials without mutating published state and never throws — any missing token,
     /// expired token, network failure, or decode failure resolves to `.unknown`.
     private func fetchExtraUsageStatus(account: ClaudeCodeAccount) async -> ExtraUsageStatus {
+        guard isOAuthFallbackEnabled else { return .unknown }
         guard account.isDefault else { return .unknown }
         guard let credentials = getCredentials(),
               !OAuthTokenExpiry.isExpired(unixTimestamp: credentials.claudeAiOauth.expiresAt) else {

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -25,7 +25,7 @@ class CostTracker: ObservableObject {
     // NOTE: MeterBarCLI/Sources/MeterBarCLI.swift carries a simplified copy of the
     // "claude-sonnet" entry; keep the two in sync until a shared package exists
     // (.agents/docs/DEFERRED_WORK.md §1).
-    private let pricing: [String: TokenPricing] = [
+    private nonisolated static let pricing: [String: TokenPricing] = [
         "claude-sonnet": TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30),
         "claude-opus": TokenPricing(input: 15.0, output: 75.0, cacheCreation: 18.75, cacheRead: 1.50),
         "claude-haiku": TokenPricing(input: 0.25, output: 1.25, cacheCreation: 0.30, cacheRead: 0.03),
@@ -51,12 +51,17 @@ class CostTracker: ObservableObject {
 
     /// Non-optional fallback so pricing lookups never need a force-unwrap of
     /// `pricing["default"]`. Mirrors the `"default"` entry above.
-    private let defaultPricing = TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30)
+    private nonisolated static let defaultPricing = TokenPricing(
+        input: 3.0,
+        output: 15.0,
+        cacheCreation: 3.75,
+        cacheRead: 0.30
+    )
 
     // Cached regexes. The scan parses tens of thousands of log lines, so
     // allocating an NSRegularExpression per call was a measurable hot-path
     // cost. Date parsing shares the cached FlexibleISO8601 formatters.
-    private static let codexLogValueRegexes: [String: NSRegularExpression] = {
+    private nonisolated static let codexLogValueRegexes: [String: NSRegularExpression] = {
         let keys = [
             "event.timestamp", "input_token_count", "output_token_count",
             "cached_token_count", "reasoning_token_count", "conversation.id",
@@ -123,8 +128,8 @@ class CostTracker: ObservableObject {
         let includeClaudeCode = providerVisibilityStore.isEnabled(.claudeCode)
         let includeCodexCli = providerVisibilityStore.isEnabled(.codexCli)
         let claudeAccounts = ClaudeCodeAccountStore.shared.accounts
-        return await Task.detached(priority: priority) { [self] in
-            buildCostSummary(
+        return await Task.detached(priority: priority) {
+            Self.buildCostSummary(
                 days: days,
                 includeClaudeCode: includeClaudeCode,
                 includeCodexCli: includeCodexCli,
@@ -133,7 +138,7 @@ class CostTracker: ObservableObject {
         }.value
     }
 
-    private func buildCostSummary(
+    private nonisolated static func buildCostSummary(
         days: Int,
         includeClaudeCode: Bool,
         includeCodexCli: Bool,
@@ -145,7 +150,7 @@ class CostTracker: ObservableObject {
 
         // Scan Claude Code sessions
         if includeClaudeCode,
-           let (claudeCost, claudeDailyUsage) = scanClaudeCodeSessions(
+           let (claudeCost, claudeDailyUsage) = Self.scanClaudeCodeSessions(
             since: cutoffDate,
             claudeAccounts: claudeAccounts
            ) {
@@ -154,7 +159,7 @@ class CostTracker: ObservableObject {
         }
 
         if includeCodexCli,
-           let (codexCost, codexDailyUsage) = scanCodexSessions(since: cutoffDate) {
+           let (codexCost, codexDailyUsage) = Self.scanCodexSessions(since: cutoffDate) {
             allCosts.append(codexCost)
             dailyUsage.append(contentsOf: codexDailyUsage)
         }
@@ -188,11 +193,80 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private func scanClaudeCodeSessions(
+    // Instance shims keep existing tests and call sites stable while the heavy
+    // parsing/pricing engine is static + nonisolated for detached scans.
+    nonisolated func parseSessionFile(
+        at url: URL,
+        since cutoffDate: Date
+    ) -> (
+        input: Int,
+        output: Int,
+        cacheCreation: Int,
+        cacheRead: Int,
+        estimatedCost: Double,
+        dates: [Date],
+        daily: [Date: TokenAccumulator],
+        models: [String: TokenAccumulator],
+        origins: [String: TokenAccumulator]
+    ) {
+        Self.parseSessionFile(at: url, since: cutoffDate)
+    }
+
+    nonisolated func claudePricing(for model: String?) -> TokenPricing {
+        Self.claudePricing(for: model)
+    }
+
+    nonisolated func normalizeClaudeModel(_ raw: String) -> String {
+        Self.normalizeClaudeModel(raw)
+    }
+
+    nonisolated func scanCodexArchivedSessions(
+        directory: URL,
+        since cutoffDate: Date,
+        context: inout CodexScanContext
+    ) {
+        Self.scanCodexArchivedSessions(directory: directory, since: cutoffDate, context: &context)
+    }
+
+    nonisolated func calculateCost(
+        input: Int,
+        output: Int,
+        cacheCreation: Int,
+        cacheRead: Int,
+        pricing: TokenPricing
+    ) -> Double {
+        Self.calculateCost(
+            input: input,
+            output: output,
+            cacheCreation: cacheCreation,
+            cacheRead: cacheRead,
+            pricing: pricing
+        )
+    }
+
+    nonisolated func calculateClaudeCost(
+        input: Int,
+        output: Int,
+        cacheCreation: Int,
+        cacheCreationOneHour: Int,
+        cacheRead: Int,
+        pricing: TokenPricing
+    ) -> Double {
+        Self.calculateClaudeCost(
+            input: input,
+            output: output,
+            cacheCreation: cacheCreation,
+            cacheCreationOneHour: cacheCreationOneHour,
+            cacheRead: cacheRead,
+            pricing: pricing
+        )
+    }
+
+    private nonisolated static func scanClaudeCodeSessions(
         since cutoffDate: Date,
         claudeAccounts: [ClaudeCodeAccount]
     ) -> (TokenCost, [DailyTokenUsage])? {
-        let projectRoots = claudeProjectRoots(accounts: claudeAccounts)
+        let projectRoots = Self.claudeProjectRoots(accounts: claudeAccounts)
         guard !projectRoots.isEmpty else { return nil }
 
         var totalInput = 0
@@ -208,6 +282,8 @@ class CostTracker: ObservableObject {
         var originTotals: [String: TokenAccumulator] = [:]
 
         for root in projectRoots {
+            guard Self.isLocalDirectory(root) else { continue }
+
             guard let enumerator = FileManager.default.enumerator(
                 at: root,
                 includingPropertiesForKeys: [.contentModificationDateKey, .isDirectoryKey],
@@ -225,7 +301,7 @@ class CostTracker: ObservableObject {
                 }
 
                 let (input, output, cacheCreate, cacheReadTokens, estimatedCost, dates, daily, models, origins) =
-                    parseSessionFile(at: url, since: cutoffDate)
+                    Self.parseSessionFile(at: url, since: cutoffDate)
 
                 if input > 0 || output > 0 || cacheCreate > 0 || cacheReadTokens > 0 {
                     totalInput += input
@@ -250,8 +326,8 @@ class CostTracker: ObservableObject {
 
         guard totalInput > 0 || totalOutput > 0 || totalCacheCreation > 0 || totalCacheRead > 0 else { return nil }
 
-        let pricing = self.pricing["claude-sonnet"] ?? defaultPricing
-        let fallbackCost = calculateCost(
+        let pricing = Self.pricing["claude-sonnet"] ?? Self.defaultPricing
+        let fallbackCost = Self.calculateCost(
             input: totalInput,
             output: totalOutput,
             cacheCreation: totalCacheCreation,
@@ -270,12 +346,12 @@ class CostTracker: ObservableObject {
             sessionCount: sessionCount,
             periodStart: earliestDate,
             periodEnd: latestDate,
-            modelBreakdowns: makeBreakdowns(from: modelTotals, provider: .claudeCode, pricing: pricing),
-            originBreakdowns: makeBreakdowns(from: originTotals, provider: .claudeCode, pricing: pricing)
-        ), makeDailyUsage(from: dailyTotals, provider: .claudeCode, pricing: pricing))
+            modelBreakdowns: Self.makeBreakdowns(from: modelTotals, provider: .claudeCode, pricing: pricing),
+            originBreakdowns: Self.makeBreakdowns(from: originTotals, provider: .claudeCode, pricing: pricing)
+        ), Self.makeDailyUsage(from: dailyTotals, provider: .claudeCode, pricing: pricing))
     }
 
-    private func claudeProjectRoots(accounts: [ClaudeCodeAccount]) -> [URL] {
+    private nonisolated static func claudeProjectRoots(accounts: [ClaudeCodeAccount]) -> [URL] {
         let fileManager = FileManager.default
         // realHomeDirectory, not homeDirectoryForCurrentUser: in sandboxed
         // builds the latter is the app container, and the scan would silently
@@ -287,7 +363,7 @@ class CostTracker: ObservableObject {
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !env.isEmpty {
             roots.append(contentsOf: env.split(separator: ",").map { part in
-                claudeProjectsURL(forConfigPath: String(part))
+                Self.claudeProjectsURL(forConfigPath: String(part))
             })
         }
 
@@ -296,7 +372,7 @@ class CostTracker: ObservableObject {
 
         for account in accounts {
             guard let configDirectory = account.configDirectory else { continue }
-            roots.append(claudeProjectsURL(forConfigPath: configDirectory))
+            roots.append(Self.claudeProjectsURL(forConfigPath: configDirectory))
         }
 
         if let homeEntries = try? fileManager.contentsOfDirectory(
@@ -312,7 +388,7 @@ class CostTracker: ObservableObject {
         var seen = Set<String>()
         return roots.compactMap { url in
             let standardized = url.standardizedFileURL
-            guard fileManager.fileExists(atPath: standardized.path),
+            guard Self.isLocalDirectory(standardized),
                   seen.insert(standardized.path).inserted else {
                 return nil
             }
@@ -320,7 +396,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private func claudeProjectsURL(forConfigPath rawPath: String) -> URL {
+    private nonisolated static func claudeProjectsURL(forConfigPath rawPath: String) -> URL {
         let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
         let url = URL(fileURLWithPath: (trimmed as NSString).standardizingPath)
         if url.lastPathComponent == "projects" {
@@ -329,7 +405,7 @@ class CostTracker: ObservableObject {
         return url.appendingPathComponent("projects", isDirectory: true)
     }
 
-    func parseSessionFile(
+    nonisolated static func parseSessionFile(
         at url: URL,
         since cutoffDate: Date
     ) -> (
@@ -383,9 +459,9 @@ class CostTracker: ObservableObject {
                     input: intValue(usage["input_tokens"]),
                     output: intValue(usage["output_tokens"]),
                     cacheCreation: intValue(usage["cache_creation_input_tokens"]),
-                    cacheCreationOneHour: claudeOneHourCacheCreationTokens(in: usage),
+                    cacheCreationOneHour: Self.claudeOneHourCacheCreationTokens(in: usage),
                     cacheRead: intValue(usage["cache_read_input_tokens"]),
-                    origin: claudeUsageOrigin(json: json, message: message, url: url)
+                    origin: Self.claudeUsageOrigin(json: json, message: message, url: url)
                 )
 
                 guard event.hasUsage else { continue }
@@ -400,8 +476,8 @@ class CostTracker: ObservableObject {
 
         let events = keyedEvents.keys.sorted().compactMap { keyedEvents[$0] } + unkeyedEvents
         for event in events {
-            let pricing = claudePricing(for: event.model)
-            let eventCost = calculateClaudeCost(
+            let pricing = Self.claudePricing(for: event.model)
+            let eventCost = Self.calculateClaudeCost(
                 input: event.input,
                 output: event.output,
                 cacheCreation: event.cacheCreation,
@@ -424,7 +500,7 @@ class CostTracker: ObservableObject {
                 cacheRead: event.cacheRead,
                 estimatedCostUSD: eventCost
             )
-            modelTotals[displayModelName(event.model), default: TokenAccumulator()].add(
+            modelTotals[Self.displayModelName(event.model), default: TokenAccumulator()].add(
                 input: event.input,
                 output: event.output,
                 cacheCreation: event.cacheCreation,
@@ -444,50 +520,50 @@ class CostTracker: ObservableObject {
                 dates, dailyTotals, modelTotals, originTotals)
     }
 
-    private func claudeOneHourCacheCreationTokens(in usage: [String: Any]) -> Int {
+    private nonisolated static func claudeOneHourCacheCreationTokens(in usage: [String: Any]) -> Int {
         guard let cacheCreation = usage["cache_creation"] as? [String: Any] else { return 0 }
         let total = intValue(usage["cache_creation_input_tokens"])
         let oneHour = intValue(cacheCreation["ephemeral_1h_input_tokens"])
         return min(total, max(0, oneHour))
     }
 
-    func claudePricing(for model: String?) -> TokenPricing {
+    nonisolated static func claudePricing(for model: String?) -> TokenPricing {
         guard let model else {
-            return pricing["claude-sonnet"] ?? defaultPricing
+            return Self.pricing["claude-sonnet"] ?? Self.defaultPricing
         }
 
-        let normalized = normalizeClaudeModel(model)
-        if let exact = pricing[normalized] {
+        let normalized = Self.normalizeClaudeModel(model)
+        if let exact = Self.pricing[normalized] {
             return exact
         }
 
         if normalized.contains("fable") {
-            return pricing["claude-fable-5"] ?? defaultPricing
+            return Self.pricing["claude-fable-5"] ?? Self.defaultPricing
         }
         if normalized.contains("opus") {
-            let base = pricing["claude-opus"] ?? defaultPricing
-            if normalized.contains("4-8") { return pricing["claude-opus-4-8"] ?? base }
-            if normalized.contains("4-7") { return pricing["claude-opus-4-7"] ?? base }
-            if normalized.contains("4-6") { return pricing["claude-opus-4-6"] ?? base }
+            let base = Self.pricing["claude-opus"] ?? Self.defaultPricing
+            if normalized.contains("4-8") { return Self.pricing["claude-opus-4-8"] ?? base }
+            if normalized.contains("4-7") { return Self.pricing["claude-opus-4-7"] ?? base }
+            if normalized.contains("4-6") { return Self.pricing["claude-opus-4-6"] ?? base }
             return base
         }
         if normalized.contains("haiku") {
             return normalized.contains("4-5")
-                ? pricing["claude-haiku-4-5"] ?? (pricing["claude-haiku"] ?? defaultPricing)
-                : pricing["claude-haiku"] ?? defaultPricing
+                ? Self.pricing["claude-haiku-4-5"] ?? (Self.pricing["claude-haiku"] ?? Self.defaultPricing)
+                : Self.pricing["claude-haiku"] ?? Self.defaultPricing
         }
         if normalized.contains("sonnet") {
-            let base = pricing["claude-sonnet"] ?? defaultPricing
-            if normalized.contains("4-6") { return pricing["claude-sonnet-4-6"] ?? base }
-            if normalized.contains("4-5") { return pricing["claude-sonnet-4-5"] ?? base }
-            if normalized.contains("4") { return pricing["claude-sonnet-4"] ?? base }
+            let base = Self.pricing["claude-sonnet"] ?? Self.defaultPricing
+            if normalized.contains("4-6") { return Self.pricing["claude-sonnet-4-6"] ?? base }
+            if normalized.contains("4-5") { return Self.pricing["claude-sonnet-4-5"] ?? base }
+            if normalized.contains("4") { return Self.pricing["claude-sonnet-4"] ?? base }
             return base
         }
 
-        return defaultPricing
+        return Self.defaultPricing
     }
 
-    func normalizeClaudeModel(_ raw: String) -> String {
+    nonisolated static func normalizeClaudeModel(_ raw: String) -> String {
         var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.hasPrefix("anthropic.") {
             trimmed = String(trimmed.dropFirst("anthropic.".count))
@@ -512,23 +588,23 @@ class CostTracker: ObservableObject {
         return trimmed
     }
 
-    private func scanCodexSessions(since cutoffDate: Date) -> (TokenCost, [DailyTokenUsage])? {
+    private nonisolated static func scanCodexSessions(since cutoffDate: Date) -> (TokenCost, [DailyTokenUsage])? {
         let codexDir = URL(fileURLWithPath: ServiceSupport.realHomeDirectory(), isDirectory: true)
             .appendingPathComponent(".codex")
         let archivedDir = codexDir.appendingPathComponent("archived_sessions")
         let logsDatabase = codexDir.appendingPathComponent("logs_2.sqlite")
         var context = CodexScanContext(earliestDate: Date(), latestDate: cutoffDate)
 
-        scanCodexArchivedSessions(directory: archivedDir, since: cutoffDate, context: &context)
-        scanCodexSQLiteLogs(database: logsDatabase, since: cutoffDate, context: &context)
+        Self.scanCodexArchivedSessions(directory: archivedDir, since: cutoffDate, context: &context)
+        Self.scanCodexSQLiteLogs(database: logsDatabase, since: cutoffDate, context: &context)
 
         let totals = context.totals
         guard totals.input > 0 || totals.output > 0 || totals.cacheRead > 0 else { return nil }
 
-        let pricing = self.pricing["codex"] ?? defaultPricing
+        let pricing = Self.pricing["codex"] ?? Self.defaultPricing
         let billableInput = max(0, totals.input - totals.cacheRead)
         let output = totals.output + totals.reasoning
-        let cost = calculateCost(
+        let cost = Self.calculateCost(
             input: billableInput,
             output: output,
             cacheCreation: 0,
@@ -546,19 +622,21 @@ class CostTracker: ObservableObject {
             sessionCount: context.sessionIDs.count,
             periodStart: context.earliestDate,
             periodEnd: context.latestDate,
-            modelBreakdowns: makeBreakdowns(from: context.modelTotals, provider: .codexCli, pricing: pricing),
-            originBreakdowns: makeBreakdowns(from: context.originTotals, provider: .codexCli, pricing: pricing)
-        ), makeDailyUsage(from: context.dailyTotals, provider: .codexCli, pricing: pricing))
+            modelBreakdowns: Self.makeBreakdowns(from: context.modelTotals, provider: .codexCli, pricing: pricing),
+            originBreakdowns: Self.makeBreakdowns(from: context.originTotals, provider: .codexCli, pricing: pricing)
+        ), Self.makeDailyUsage(from: context.dailyTotals, provider: .codexCli, pricing: pricing))
     }
 
     /// Internal (not private) so the archived-session parsing — the Codex
     /// counterpart to `parseSessionFile`, and where CLI-vs-app cost divergence
     /// hides — can be fixture-tested against a temp directory.
-    func scanCodexArchivedSessions(
+    nonisolated static func scanCodexArchivedSessions(
         directory: URL,
         since cutoffDate: Date,
         context: inout CodexScanContext
     ) {
+        guard Self.isLocalDirectory(directory) else { return }
+
         guard let enumerator = FileManager.default.enumerator(
             at: directory,
             includingPropertiesForKeys: [.contentModificationDateKey],
@@ -591,11 +669,11 @@ class CostTracker: ObservableObject {
 
                 let sessionID = (((payload["rate_limits"] as? [String: Any])?["conversation_id"] as? String)
                     ?? fileURL.deletingPathExtension().lastPathComponent)
-                addCodexUsage(
+                Self.addCodexUsage(
                     usage,
                     timestamp: timestamp,
                     sessionID: sessionID,
-                    modelName: codexModelName(from: info, payload: payload),
+                    modelName: Self.codexModelName(from: info, payload: payload),
                     originName: "Codex CLI",
                     context: &context
                 )
@@ -603,7 +681,20 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private func scanCodexSQLiteLogs(
+    private nonisolated static func isLocalDirectory(_ url: URL) -> Bool {
+        let standardized = url.standardizedFileURL
+        var isDirectory: ObjCBool = false
+
+        guard FileManager.default.fileExists(atPath: standardized.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            return false
+        }
+
+        let values = try? standardized.resourceValues(forKeys: [.volumeIsLocalKey])
+        return values?.volumeIsLocal != false
+    }
+
+    private nonisolated static func scanCodexSQLiteLogs(
         database: URL,
         since cutoffDate: Date,
         context: inout CodexScanContext
@@ -627,27 +718,29 @@ class CostTracker: ObservableObject {
         while sqlite3_step(statement) == SQLITE_ROW {
             guard let bodyPointer = sqlite3_column_text(statement, 0) else { continue }
             let body = String(cString: bodyPointer)
-            guard let timestamp = codexLogDate(in: body), timestamp >= cutoffDate else { continue }
+            guard let timestamp = Self.codexLogDate(in: body), timestamp >= cutoffDate else { continue }
 
             let usage: [String: Any] = [
-                "input_tokens": codexLogInt("input_token_count", in: body),
-                "output_tokens": codexLogInt("output_token_count", in: body),
-                "cached_input_tokens": codexLogInt("cached_token_count", in: body),
-                "reasoning_output_tokens": codexLogInt("reasoning_token_count", in: body)
+                "input_tokens": Self.codexLogInt("input_token_count", in: body),
+                "output_tokens": Self.codexLogInt("output_token_count", in: body),
+                "cached_input_tokens": Self.codexLogInt("cached_token_count", in: body),
+                "reasoning_output_tokens": Self.codexLogInt("reasoning_token_count", in: body)
             ]
-            let sessionID = codexLogValue("conversation.id", in: body) ?? codexLogValue("thread.id", in: body) ?? "codex"
-            addCodexUsage(
+            let sessionID = Self.codexLogValue("conversation.id", in: body)
+                ?? Self.codexLogValue("thread.id", in: body)
+                ?? "codex"
+            Self.addCodexUsage(
                 usage,
                 timestamp: timestamp,
                 sessionID: sessionID,
-                modelName: codexLogValue("model", in: body) ?? codexLogValue("slug", in: body),
-                originName: codexLogValue("originator", in: body) ?? "Codex CLI",
+                modelName: Self.codexLogValue("model", in: body) ?? Self.codexLogValue("slug", in: body),
+                originName: Self.codexLogValue("originator", in: body) ?? "Codex CLI",
                 context: &context
             )
         }
     }
 
-    private func addCodexUsage(
+    private nonisolated static func addCodexUsage(
         _ usage: [String: Any],
         timestamp: Date,
         sessionID: String,
@@ -677,13 +770,13 @@ class CostTracker: ObservableObject {
             cacheCreation: 0,
             cacheRead: cached
         )
-        context.modelTotals[displayModelName(modelName), default: TokenAccumulator()].add(
+        context.modelTotals[Self.displayModelName(modelName), default: TokenAccumulator()].add(
             input: input,
             output: output + reasoning,
             cacheCreation: 0,
             cacheRead: cached
         )
-        context.originTotals[displayOriginName(originName), default: TokenAccumulator()].add(
+        context.originTotals[Self.displayOriginName(originName), default: TokenAccumulator()].add(
             input: input,
             output: output + reasoning,
             cacheCreation: 0,
@@ -693,7 +786,7 @@ class CostTracker: ObservableObject {
         if timestamp > context.latestDate { context.latestDate = timestamp }
     }
 
-    private func makeDailyUsage(
+    private nonisolated static func makeDailyUsage(
         from dailyTotals: [Date: TokenAccumulator],
         provider: ServiceType,
         pricing: TokenPricing
@@ -702,7 +795,7 @@ class CostTracker: ObservableObject {
             let billableInput = provider == .codexCli ? max(0, tokens.input - tokens.cacheRead) : tokens.input
             let cost = tokens.estimatedCostUSD > 0
                 ? tokens.estimatedCostUSD
-                : calculateCost(
+                : Self.calculateCost(
                     input: billableInput,
                     output: tokens.output + tokens.reasoning,
                     cacheCreation: tokens.cacheCreation,
@@ -720,7 +813,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private func makeBreakdowns(
+    private nonisolated static func makeBreakdowns(
         from totals: [String: TokenAccumulator],
         provider: ServiceType,
         pricing: TokenPricing
@@ -730,7 +823,7 @@ class CostTracker: ObservableObject {
             let output = tokens.output + tokens.reasoning
             let cost = tokens.estimatedCostUSD > 0
                 ? tokens.estimatedCostUSD
-                : calculateCost(
+                : Self.calculateCost(
                     input: billableInput,
                     output: output,
                     cacheCreation: tokens.cacheCreation,
@@ -756,24 +849,30 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private func mergeDailyTotals(_ target: inout [Date: TokenAccumulator], with source: [Date: TokenAccumulator]) {
+    private nonisolated static func mergeDailyTotals(
+        _ target: inout [Date: TokenAccumulator],
+        with source: [Date: TokenAccumulator]
+    ) {
         for (day, tokens) in source {
             target[day, default: TokenAccumulator()].merge(tokens)
         }
     }
 
-    private func mergeNamedTotals(_ target: inout [String: TokenAccumulator], with source: [String: TokenAccumulator]) {
+    private nonisolated static func mergeNamedTotals(
+        _ target: inout [String: TokenAccumulator],
+        with source: [String: TokenAccumulator]
+    ) {
         for (name, tokens) in source {
             target[name, default: TokenAccumulator()].merge(tokens)
         }
     }
 
-    private func claudeUsageOrigin(json: [String: Any], message: [String: Any], url: URL) -> String {
+    private nonisolated static func claudeUsageOrigin(json: [String: Any], message: [String: Any], url: URL) -> String {
         if url.path.contains("/subagents/") || (json["isSidechain"] as? Bool == true) {
             return "Agents"
         }
 
-        let toolNames = toolUseNames(in: message)
+        let toolNames = Self.toolUseNames(in: message)
         if toolNames.contains(where: { $0.localizedCaseInsensitiveContains("skill") }) {
             return "Skills"
         }
@@ -790,7 +889,7 @@ class CostTracker: ObservableObject {
         return "Main chat"
     }
 
-    private func toolUseNames(in message: [String: Any]) -> [String] {
+    private nonisolated static func toolUseNames(in message: [String: Any]) -> [String] {
         guard let content = message["content"] as? [[String: Any]] else { return [] }
         return content.compactMap { item in
             guard item["type"] as? String == "tool_use" else { return nil }
@@ -798,19 +897,19 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private func codexModelName(from info: [String: Any], payload: [String: Any]) -> String? {
+    private nonisolated static func codexModelName(from info: [String: Any], payload: [String: Any]) -> String? {
         (info["model"] as? String)
             ?? (info["slug"] as? String)
             ?? (payload["model"] as? String)
             ?? (payload["slug"] as? String)
     }
 
-    private func displayModelName(_ raw: String?) -> String {
+    private nonisolated static func displayModelName(_ raw: String?) -> String {
         let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? "Unknown model" : normalizeClaudeModel(trimmed)
+        return trimmed.isEmpty ? "Unknown model" : Self.normalizeClaudeModel(trimmed)
     }
 
-    private func displayOriginName(_ raw: String?) -> String {
+    private nonisolated static func displayOriginName(_ raw: String?) -> String {
         let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !trimmed.isEmpty else { return "Unknown origin" }
         return trimmed
@@ -826,8 +925,14 @@ class CostTracker: ObservableObject {
     /// Cost without a one-hour cache tier — delegates to `calculateClaudeCost`
     /// so there is exactly one pricing formula. (These were near-duplicates
     /// that had drifted: only the Claude variant clamped negative inputs.)
-    func calculateCost(input: Int, output: Int, cacheCreation: Int, cacheRead: Int, pricing: TokenPricing) -> Double {
-        calculateClaudeCost(
+    nonisolated static func calculateCost(
+        input: Int,
+        output: Int,
+        cacheCreation: Int,
+        cacheRead: Int,
+        pricing: TokenPricing
+    ) -> Double {
+        Self.calculateClaudeCost(
             input: input,
             output: output,
             cacheCreation: cacheCreation,
@@ -837,7 +942,7 @@ class CostTracker: ObservableObject {
         )
     }
 
-    func calculateClaudeCost(
+    nonisolated static func calculateClaudeCost(
         input: Int,
         output: Int,
         cacheCreation: Int,
@@ -857,7 +962,7 @@ class CostTracker: ObservableObject {
         return inputCost + outputCost + cacheCreationCost + oneHourCacheCreationCost + cacheReadCost
     }
 
-    private func intValue(_ value: Any?) -> Int {
+    private nonisolated static func intValue(_ value: Any?) -> Int {
         if let value = value as? Int { return value }
         if let value = value as? Int64 { return Int(value) }
         if let value = value as? Double { return Int(value) }
@@ -865,17 +970,17 @@ class CostTracker: ObservableObject {
         return 0
     }
 
-    private func codexLogDate(in text: String) -> Date? {
-        guard let value = codexLogValue("event.timestamp", in: text) else { return nil }
+    private nonisolated static func codexLogDate(in text: String) -> Date? {
+        guard let value = Self.codexLogValue("event.timestamp", in: text) else { return nil }
         return FlexibleISO8601.date(from: value)
     }
 
-    private func codexLogInt(_ key: String, in text: String) -> Int {
-        guard let value = codexLogValue(key, in: text) else { return 0 }
+    private nonisolated static func codexLogInt(_ key: String, in text: String) -> Int {
+        guard let value = Self.codexLogValue(key, in: text) else { return 0 }
         return Int(value) ?? 0
     }
 
-    private func codexLogValue(_ key: String, in text: String) -> String? {
+    private nonisolated static func codexLogValue(_ key: String, in text: String) -> String? {
         let regex: NSRegularExpression
         if let cached = Self.codexLogValueRegexes[key] {
             regex = cached
@@ -899,7 +1004,7 @@ class CostTracker: ObservableObject {
 /// a single `inout` argument.
 ///
 /// Internal (not private) so `scanCodexArchivedSessions` can be fixture-tested.
-struct CodexScanContext {
+struct CodexScanContext: Sendable {
     var totals = TokenAccumulator()
     var dailyTotals: [Date: TokenAccumulator] = [:]
     var modelTotals: [String: TokenAccumulator] = [:]
@@ -910,7 +1015,7 @@ struct CodexScanContext {
     var latestDate: Date
 }
 
-struct TokenPricing {
+struct TokenPricing: Sendable {
     let input: Double      // per million tokens
     let output: Double     // per million tokens
     let cacheCreation: Double
@@ -932,7 +1037,7 @@ struct TokenPricing {
     }
 }
 
-struct TokenAccumulator {
+struct TokenAccumulator: Sendable {
     var input = 0
     var output = 0
     var cacheCreation = 0
@@ -972,7 +1077,7 @@ struct TokenAccumulator {
     }
 }
 
-private struct ClaudeUsageEvent {
+private struct ClaudeUsageEvent: Sendable {
     let timestamp: Date
     let model: String?
     let messageID: String?

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -25,7 +25,7 @@ class CostTracker: ObservableObject {
     // NOTE: MeterBarCLI/Sources/MeterBarCLI.swift carries a simplified copy of the
     // "claude-sonnet" entry; keep the two in sync until a shared package exists
     // (.agents/docs/DEFERRED_WORK.md §1).
-    private nonisolated static let pricing: [String: TokenPricing] = [
+    private static let pricing: [String: TokenPricing] = [
         "claude-sonnet": TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30),
         "claude-opus": TokenPricing(input: 15.0, output: 75.0, cacheCreation: 18.75, cacheRead: 1.50),
         "claude-haiku": TokenPricing(input: 0.25, output: 1.25, cacheCreation: 0.30, cacheRead: 0.03),
@@ -51,7 +51,7 @@ class CostTracker: ObservableObject {
 
     /// Non-optional fallback so pricing lookups never need a force-unwrap of
     /// `pricing["default"]`. Mirrors the `"default"` entry above.
-    private nonisolated static let defaultPricing = TokenPricing(
+    private static let defaultPricing = TokenPricing(
         input: 3.0,
         output: 15.0,
         cacheCreation: 3.75,
@@ -61,7 +61,7 @@ class CostTracker: ObservableObject {
     // Cached regexes. The scan parses tens of thousands of log lines, so
     // allocating an NSRegularExpression per call was a measurable hot-path
     // cost. Date parsing shares the cached FlexibleISO8601 formatters.
-    private nonisolated static let codexLogValueRegexes: [String: NSRegularExpression] = {
+    private static let codexLogValueRegexes: [String: NSRegularExpression] = {
         let keys = [
             "event.timestamp", "input_token_count", "output_token_count",
             "cached_token_count", "reasoning_token_count", "conversation.id",
@@ -138,7 +138,7 @@ class CostTracker: ObservableObject {
         }.value
     }
 
-    private nonisolated static func buildCostSummary(
+    private static func buildCostSummary(
         days: Int,
         includeClaudeCode: Bool,
         includeCodexCli: Bool,
@@ -193,76 +193,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    // Instance shims keep existing tests and call sites stable while the heavy
-    // parsing/pricing engine is static + nonisolated for detached scans.
-    nonisolated func parseSessionFile(
-        at url: URL,
-        since cutoffDate: Date
-    ) -> (
-        input: Int,
-        output: Int,
-        cacheCreation: Int,
-        cacheRead: Int,
-        estimatedCost: Double,
-        dates: [Date],
-        daily: [Date: TokenAccumulator],
-        models: [String: TokenAccumulator],
-        origins: [String: TokenAccumulator]
-    ) {
-        Self.parseSessionFile(at: url, since: cutoffDate)
-    }
-
-    nonisolated func claudePricing(for model: String?) -> TokenPricing {
-        Self.claudePricing(for: model)
-    }
-
-    nonisolated func normalizeClaudeModel(_ raw: String) -> String {
-        Self.normalizeClaudeModel(raw)
-    }
-
-    nonisolated func scanCodexArchivedSessions(
-        directory: URL,
-        since cutoffDate: Date,
-        context: inout CodexScanContext
-    ) {
-        Self.scanCodexArchivedSessions(directory: directory, since: cutoffDate, context: &context)
-    }
-
-    nonisolated func calculateCost(
-        input: Int,
-        output: Int,
-        cacheCreation: Int,
-        cacheRead: Int,
-        pricing: TokenPricing
-    ) -> Double {
-        Self.calculateCost(
-            input: input,
-            output: output,
-            cacheCreation: cacheCreation,
-            cacheRead: cacheRead,
-            pricing: pricing
-        )
-    }
-
-    nonisolated func calculateClaudeCost(
-        input: Int,
-        output: Int,
-        cacheCreation: Int,
-        cacheCreationOneHour: Int,
-        cacheRead: Int,
-        pricing: TokenPricing
-    ) -> Double {
-        Self.calculateClaudeCost(
-            input: input,
-            output: output,
-            cacheCreation: cacheCreation,
-            cacheCreationOneHour: cacheCreationOneHour,
-            cacheRead: cacheRead,
-            pricing: pricing
-        )
-    }
-
-    private nonisolated static func scanClaudeCodeSessions(
+    private static func scanClaudeCodeSessions(
         since cutoffDate: Date,
         claudeAccounts: [ClaudeCodeAccount]
     ) -> (TokenCost, [DailyTokenUsage])? {
@@ -351,7 +282,7 @@ class CostTracker: ObservableObject {
         ), Self.makeDailyUsage(from: dailyTotals, provider: .claudeCode, pricing: pricing))
     }
 
-    private nonisolated static func claudeProjectRoots(accounts: [ClaudeCodeAccount]) -> [URL] {
+    private static func claudeProjectRoots(accounts: [ClaudeCodeAccount]) -> [URL] {
         let fileManager = FileManager.default
         // realHomeDirectory, not homeDirectoryForCurrentUser: in sandboxed
         // builds the latter is the app container, and the scan would silently
@@ -396,7 +327,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private nonisolated static func claudeProjectsURL(forConfigPath rawPath: String) -> URL {
+    private static func claudeProjectsURL(forConfigPath rawPath: String) -> URL {
         let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
         let url = URL(fileURLWithPath: (trimmed as NSString).standardizingPath)
         if url.lastPathComponent == "projects" {
@@ -405,7 +336,7 @@ class CostTracker: ObservableObject {
         return url.appendingPathComponent("projects", isDirectory: true)
     }
 
-    nonisolated static func parseSessionFile(
+    static func parseSessionFile(
         at url: URL,
         since cutoffDate: Date
     ) -> (
@@ -520,14 +451,14 @@ class CostTracker: ObservableObject {
                 dates, dailyTotals, modelTotals, originTotals)
     }
 
-    private nonisolated static func claudeOneHourCacheCreationTokens(in usage: [String: Any]) -> Int {
+    private static func claudeOneHourCacheCreationTokens(in usage: [String: Any]) -> Int {
         guard let cacheCreation = usage["cache_creation"] as? [String: Any] else { return 0 }
         let total = intValue(usage["cache_creation_input_tokens"])
         let oneHour = intValue(cacheCreation["ephemeral_1h_input_tokens"])
         return min(total, max(0, oneHour))
     }
 
-    nonisolated static func claudePricing(for model: String?) -> TokenPricing {
+    static func claudePricing(for model: String?) -> TokenPricing {
         guard let model else {
             return Self.pricing["claude-sonnet"] ?? Self.defaultPricing
         }
@@ -563,7 +494,7 @@ class CostTracker: ObservableObject {
         return Self.defaultPricing
     }
 
-    nonisolated static func normalizeClaudeModel(_ raw: String) -> String {
+    static func normalizeClaudeModel(_ raw: String) -> String {
         var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.hasPrefix("anthropic.") {
             trimmed = String(trimmed.dropFirst("anthropic.".count))
@@ -588,7 +519,7 @@ class CostTracker: ObservableObject {
         return trimmed
     }
 
-    private nonisolated static func scanCodexSessions(since cutoffDate: Date) -> (TokenCost, [DailyTokenUsage])? {
+    private static func scanCodexSessions(since cutoffDate: Date) -> (TokenCost, [DailyTokenUsage])? {
         let codexDir = URL(fileURLWithPath: ServiceSupport.realHomeDirectory(), isDirectory: true)
             .appendingPathComponent(".codex")
         let archivedDir = codexDir.appendingPathComponent("archived_sessions")
@@ -630,7 +561,7 @@ class CostTracker: ObservableObject {
     /// Internal (not private) so the archived-session parsing — the Codex
     /// counterpart to `parseSessionFile`, and where CLI-vs-app cost divergence
     /// hides — can be fixture-tested against a temp directory.
-    nonisolated static func scanCodexArchivedSessions(
+    static func scanCodexArchivedSessions(
         directory: URL,
         since cutoffDate: Date,
         context: inout CodexScanContext
@@ -681,7 +612,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private nonisolated static func isLocalDirectory(_ url: URL) -> Bool {
+    private static func isLocalDirectory(_ url: URL) -> Bool {
         let standardized = url.standardizedFileURL
         var isDirectory: ObjCBool = false
 
@@ -691,10 +622,12 @@ class CostTracker: ObservableObject {
         }
 
         let values = try? standardized.resourceValues(forKeys: [.volumeIsLocalKey])
+        // Intentionally skip network and mounted volumes; cost scans should stay
+        // fast and avoid surprising remote I/O when users point accounts there.
         return values?.volumeIsLocal != false
     }
 
-    private nonisolated static func scanCodexSQLiteLogs(
+    private static func scanCodexSQLiteLogs(
         database: URL,
         since cutoffDate: Date,
         context: inout CodexScanContext
@@ -740,7 +673,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private nonisolated static func addCodexUsage(
+    private static func addCodexUsage(
         _ usage: [String: Any],
         timestamp: Date,
         sessionID: String,
@@ -786,7 +719,7 @@ class CostTracker: ObservableObject {
         if timestamp > context.latestDate { context.latestDate = timestamp }
     }
 
-    private nonisolated static func makeDailyUsage(
+    private static func makeDailyUsage(
         from dailyTotals: [Date: TokenAccumulator],
         provider: ServiceType,
         pricing: TokenPricing
@@ -813,7 +746,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private nonisolated static func makeBreakdowns(
+    private static func makeBreakdowns(
         from totals: [String: TokenAccumulator],
         provider: ServiceType,
         pricing: TokenPricing
@@ -849,7 +782,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private nonisolated static func mergeDailyTotals(
+    private static func mergeDailyTotals(
         _ target: inout [Date: TokenAccumulator],
         with source: [Date: TokenAccumulator]
     ) {
@@ -858,7 +791,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private nonisolated static func mergeNamedTotals(
+    private static func mergeNamedTotals(
         _ target: inout [String: TokenAccumulator],
         with source: [String: TokenAccumulator]
     ) {
@@ -867,7 +800,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private nonisolated static func claudeUsageOrigin(json: [String: Any], message: [String: Any], url: URL) -> String {
+    private static func claudeUsageOrigin(json: [String: Any], message: [String: Any], url: URL) -> String {
         if url.path.contains("/subagents/") || (json["isSidechain"] as? Bool == true) {
             return "Agents"
         }
@@ -889,7 +822,7 @@ class CostTracker: ObservableObject {
         return "Main chat"
     }
 
-    private nonisolated static func toolUseNames(in message: [String: Any]) -> [String] {
+    private static func toolUseNames(in message: [String: Any]) -> [String] {
         guard let content = message["content"] as? [[String: Any]] else { return [] }
         return content.compactMap { item in
             guard item["type"] as? String == "tool_use" else { return nil }
@@ -897,19 +830,19 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private nonisolated static func codexModelName(from info: [String: Any], payload: [String: Any]) -> String? {
+    private static func codexModelName(from info: [String: Any], payload: [String: Any]) -> String? {
         (info["model"] as? String)
             ?? (info["slug"] as? String)
             ?? (payload["model"] as? String)
             ?? (payload["slug"] as? String)
     }
 
-    private nonisolated static func displayModelName(_ raw: String?) -> String {
+    private static func displayModelName(_ raw: String?) -> String {
         let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return trimmed.isEmpty ? "Unknown model" : Self.normalizeClaudeModel(trimmed)
     }
 
-    private nonisolated static func displayOriginName(_ raw: String?) -> String {
+    private static func displayOriginName(_ raw: String?) -> String {
         let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !trimmed.isEmpty else { return "Unknown origin" }
         return trimmed
@@ -925,7 +858,7 @@ class CostTracker: ObservableObject {
     /// Cost without a one-hour cache tier — delegates to `calculateClaudeCost`
     /// so there is exactly one pricing formula. (These were near-duplicates
     /// that had drifted: only the Claude variant clamped negative inputs.)
-    nonisolated static func calculateCost(
+    static func calculateCost(
         input: Int,
         output: Int,
         cacheCreation: Int,
@@ -942,7 +875,7 @@ class CostTracker: ObservableObject {
         )
     }
 
-    nonisolated static func calculateClaudeCost(
+    static func calculateClaudeCost(
         input: Int,
         output: Int,
         cacheCreation: Int,
@@ -962,7 +895,7 @@ class CostTracker: ObservableObject {
         return inputCost + outputCost + cacheCreationCost + oneHourCacheCreationCost + cacheReadCost
     }
 
-    private nonisolated static func intValue(_ value: Any?) -> Int {
+    private static func intValue(_ value: Any?) -> Int {
         if let value = value as? Int { return value }
         if let value = value as? Int64 { return Int(value) }
         if let value = value as? Double { return Int(value) }
@@ -970,17 +903,17 @@ class CostTracker: ObservableObject {
         return 0
     }
 
-    private nonisolated static func codexLogDate(in text: String) -> Date? {
+    private static func codexLogDate(in text: String) -> Date? {
         guard let value = Self.codexLogValue("event.timestamp", in: text) else { return nil }
         return FlexibleISO8601.date(from: value)
     }
 
-    private nonisolated static func codexLogInt(_ key: String, in text: String) -> Int {
+    private static func codexLogInt(_ key: String, in text: String) -> Int {
         guard let value = Self.codexLogValue(key, in: text) else { return 0 }
         return Int(value) ?? 0
     }
 
-    private nonisolated static func codexLogValue(_ key: String, in text: String) -> String? {
+    private static func codexLogValue(_ key: String, in text: String) -> String? {
         let regex: NSRegularExpression
         if let cached = Self.codexLogValueRegexes[key] {
             regex = cached

--- a/MeterBar/Views/ApiUsageCard.swift
+++ b/MeterBar/Views/ApiUsageCard.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import MeterBarShared
+import SwiftUI
 
 // MARK: - ApiUsageSection
 
@@ -7,44 +7,44 @@ import MeterBarShared
 /// org API admin key. Renders the window selector plus one spend card per
 /// authenticated API provider.
 struct ApiUsageSection: View {
-    @ObservedObject var store: ApiUsageStore
-    /// Compact popover layout vs the roomier dashboard layout.
-    var compact: Bool = false
-    /// When embedded in an already-titled container (a dashboard card), hide the
-    /// section's own "API Usage" heading but keep the window picker.
-    var embedded: Bool = false
+  @ObservedObject var store: ApiUsageStore
+  /// Compact popover layout vs the roomier dashboard layout.
+  var compact: Bool = false
+  /// When embedded in an already-titled container (a dashboard card), hide the
+  /// section's own "API Usage" heading but keep the window picker.
+  var embedded: Bool = false
 
-    var body: some View {
-        if store.hasAnyAuthenticated {
-            VStack(alignment: .leading, spacing: compact ? 8 : 12) {
-                HStack {
-                    if !embedded {
-                        Text("API Usage")
-                            .font(compact ? .subheadline : .headline)
-                            .fontWeight(.semibold)
-                    }
-                    Spacer(minLength: 8)
-                    ApiUsageWindowPicker(store: store)
-                }
-
-                ForEach(store.authenticatedProviders) { provider in
-                    ApiUsageCard(
-                        provider: provider,
-                        usage: store.usage[provider],
-                        isLoading: store.isLoading,
-                        compact: compact
-                    )
-                }
-
-                if let error = store.lastError {
-                    Text(error)
-                        .font(.caption2)
-                        .foregroundColor(MeterBarTheme.warning)
-                        .lineLimit(2)
-                }
-            }
+  var body: some View {
+    if store.hasAnyAuthenticated {
+      VStack(alignment: .leading, spacing: compact ? 8 : 12) {
+        HStack {
+          if !embedded {
+            Text("API Usage")
+              .font(compact ? .subheadline : .headline)
+              .fontWeight(.semibold)
+          }
+          Spacer(minLength: 8)
+          ApiUsageWindowPicker(store: store)
         }
+
+        ForEach(store.authenticatedProviders) { provider in
+          ApiUsageCard(
+            provider: provider,
+            usage: store.usage[provider],
+            isLoading: store.isLoading,
+            compact: compact
+          )
+        }
+
+        if let error = store.lastError {
+          Text(error)
+            .font(.caption2)
+            .foregroundColor(MeterBarTheme.warning)
+            .lineLimit(2)
+        }
+      }
     }
+  }
 }
 
 // MARK: - ApiUsageWindowPicker
@@ -52,62 +52,63 @@ struct ApiUsageSection: View {
 /// Segmented 7-day / 30-day selector with a Custom mode that reveals a date
 /// range. Changing any of these refetches through the store.
 struct ApiUsageWindowPicker: View {
-    @ObservedObject var store: ApiUsageStore
+  @ObservedObject var store: ApiUsageStore
 
-    private enum Mode: String, CaseIterable, Identifiable {
-        case sevenDays = "7d"
-        case thirtyDays = "30d"
-        case custom = "Custom"
-        var id: String { rawValue }
-    }
+  private enum Mode: String, CaseIterable, Identifiable {
+    case sevenDays = "7d"
+    case thirtyDays = "30d"
+    case custom = "Custom"
+    var id: String { rawValue }
+  }
 
-    @State private var mode: Mode = .sevenDays
-    @State private var customStart = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
-    @State private var customEnd = Date()
+  @State private var mode: Mode = .sevenDays
+  @State private var customStart =
+    Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
+  @State private var customEnd = Date()
 
-    var body: some View {
-        VStack(alignment: .trailing, spacing: 6) {
-            Picker("Window", selection: $mode) {
-                ForEach(Mode.allCases) { mode in
-                    Text(mode.rawValue).tag(mode)
-                }
-            }
-            .pickerStyle(.segmented)
+  var body: some View {
+    VStack(alignment: .trailing, spacing: 6) {
+      Picker("Window", selection: $mode) {
+        ForEach(Mode.allCases) { mode in
+          Text(mode.rawValue).tag(mode)
+        }
+      }
+      .pickerStyle(.segmented)
+      .labelsHidden()
+      .fixedSize()
+      .onChange(of: mode) { _, newMode in
+        applyMode(newMode)
+      }
+
+      if mode == .custom {
+        HStack(spacing: 6) {
+          DatePicker("From", selection: $customStart, displayedComponents: .date)
             .labelsHidden()
-            .fixedSize()
-            .onChange(of: mode) { _, newMode in
-                applyMode(newMode)
-            }
-
-            if mode == .custom {
-                HStack(spacing: 6) {
-                    DatePicker("From", selection: $customStart, displayedComponents: .date)
-                        .labelsHidden()
-                    Text("→").foregroundColor(.secondary)
-                    DatePicker("To", selection: $customEnd, displayedComponents: .date)
-                        .labelsHidden()
-                }
-                .font(.caption)
-                .onChange(of: customStart) { _, _ in applyCustom() }
-                .onChange(of: customEnd) { _, _ in applyCustom() }
-            }
+          Text("→").foregroundColor(.secondary)
+          DatePicker("To", selection: $customEnd, displayedComponents: .date)
+            .labelsHidden()
         }
+        .font(.caption)
+        .onChange(of: customStart) { _, _ in applyCustom() }
+        .onChange(of: customEnd) { _, _ in applyCustom() }
+      }
     }
+  }
 
-    private func applyMode(_ newMode: Mode) {
-        switch newMode {
-        case .sevenDays:
-            store.setWindow(.last7Days)
-        case .thirtyDays:
-            store.setWindow(.last30Days)
-        case .custom:
-            applyCustom()
-        }
+  private func applyMode(_ newMode: Mode) {
+    switch newMode {
+    case .sevenDays:
+      store.setWindow(.last7Days)
+    case .thirtyDays:
+      store.setWindow(.last30Days)
+    case .custom:
+      applyCustom()
     }
+  }
 
-    private func applyCustom() {
-        store.setWindow(.custom(start: customStart, end: customEnd))
-    }
+  private func applyCustom() {
+    store.setWindow(.custom(start: customStart, end: customEnd))
+  }
 }
 
 // MARK: - ApiUsageCard
@@ -115,74 +116,73 @@ struct ApiUsageWindowPicker: View {
 /// One provider's API spend + tokens over the selected window. No quota bar —
 /// API usage has no cap, so this shows real spend, not a percentage.
 struct ApiUsageCard: View {
-    let provider: ApiProvider
-    let usage: ApiUsage?
-    let isLoading: Bool
-    var compact: Bool = false
+  let provider: ApiProvider
+  let usage: ApiUsage?
+  let isLoading: Bool
+  var compact: Bool = false
 
-    private var accent: Color { MeterBarTheme.accent(for: provider) }
+  private var accent: Color { MeterBarTheme.accent(for: provider) }
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: compact ? 8 : 10) {
-            HStack(spacing: 7) {
-                ProviderLogoView(
-                    kind: .forApiProvider(provider),
-                    size: compact ? 17 : 18,
-                    foregroundColor: accent
-                )
-                Text(provider.displayName)
-                    .font(compact ? .subheadline : .headline)
-                    .fontWeight(.semibold)
-                Spacer(minLength: 8)
-                Text(UsageFormat.cost(usage?.estimatedCostUSD ?? 0))
-                    .font(compact ? .headline : .title3)
-                    .bold()
-                    .monospacedDigit()
-                    .foregroundColor(accent)
-            }
-
-            if isLoading, usage == nil {
-                Text("Loading usage…")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            } else if let usage, usage.hasData {
-                Text(tokenSummary(usage))
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-
-                ForEach(topModels(usage)) { model in
-                    HStack(spacing: 8) {
-                        Text(model.model)
-                            .font(.caption2)
-                            .lineLimit(1)
-                        Spacer(minLength: 6)
-                        Text(UsageFormat.tokens(model.totalTokens))
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                            .monospacedDigit()
-                        Text(UsageFormat.cost(model.estimatedCostUSD))
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                            .monospacedDigit()
-                    }
-                }
-            } else {
-                Text("No API usage in this window.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
+  var body: some View {
+    DashboardTile(cornerRadius: 8, padding: compact ? 10 : 12) {
+      VStack(alignment: .leading, spacing: compact ? 8 : 10) {
+        HStack(spacing: 7) {
+          ProviderLogoView(
+            kind: .forApiProvider(provider),
+            size: compact ? 17 : 18,
+            foregroundColor: accent
+          )
+          Text(provider.displayName)
+            .font(compact ? .subheadline : .headline)
+            .fontWeight(.semibold)
+          Spacer(minLength: 8)
+          Text(UsageFormat.cost(usage?.estimatedCostUSD ?? 0))
+            .font(compact ? .headline : .title3)
+            .bold()
+            .monospacedDigit()
+            .foregroundColor(accent)
         }
-        .padding(compact ? 10 : 12)
-        .frame(maxWidth: .infinity, alignment: .topLeading)
-        .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-    }
 
-    private func tokenSummary(_ usage: ApiUsage) -> String {
-        "\(UsageFormat.tokens(usage.totalTokens)) tokens · "
-            + "\(UsageFormat.tokens(usage.inputTokens)) in / \(UsageFormat.tokens(usage.outputTokens)) out"
-    }
+        if isLoading, usage == nil {
+          Text("Loading usage…")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        } else if let usage, usage.hasData {
+          Text(tokenSummary(usage))
+            .font(.caption)
+            .foregroundColor(.secondary)
 
-    private func topModels(_ usage: ApiUsage) -> [ApiModelUsage] {
-        Array(usage.models.prefix(compact ? 2 : 4))
+          ForEach(topModels(usage)) { model in
+            HStack(spacing: 8) {
+              Text(model.model)
+                .font(.caption2)
+                .lineLimit(1)
+              Spacer(minLength: 6)
+              Text(UsageFormat.tokens(model.totalTokens))
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .monospacedDigit()
+              Text(UsageFormat.cost(model.estimatedCostUSD))
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .monospacedDigit()
+            }
+          }
+        } else {
+          Text("No API usage in this window.")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+      }
     }
+  }
+
+  private func tokenSummary(_ usage: ApiUsage) -> String {
+    "\(UsageFormat.tokens(usage.totalTokens)) tokens · "
+      + "\(UsageFormat.tokens(usage.inputTokens)) in / \(UsageFormat.tokens(usage.outputTokens)) out"
+  }
+
+  private func topModels(_ usage: ApiUsage) -> [ApiModelUsage] {
+    Array(usage.models.prefix(compact ? 2 : 4))
+  }
 }

--- a/MeterBar/Views/Components/ProviderStatusBadges.swift
+++ b/MeterBar/Views/Components/ProviderStatusBadges.swift
@@ -25,7 +25,7 @@ struct ProviderStatusBadges: View {
     /// every field these badges need.
     init(snapshot: ProviderSnapshot, style: Style = .compact) {
         self.resetCreditsAvailable = snapshot.resetCreditsAvailable
-        self.extraUsage = snapshot.extraUsage
+        self.extraUsage = snapshot.displayedExtraUsage
         self.accentColor = snapshot.accentColor
         self.hasExhaustedLimit = snapshot.hasExhaustedLimit
         self.style = style

--- a/MeterBar/Views/Components/ReadinessComponents.swift
+++ b/MeterBar/Views/Components/ReadinessComponents.swift
@@ -1,162 +1,161 @@
-import SwiftUI
 import MeterBarShared
+import SwiftUI
 
 // Shared provider-readiness UI, rendered identically by the dashboard
 // Diagnostics section and the first-run/empty-state checklist. The data comes
 // from `ProviderReadinessInspector`; these views only present it.
 
 extension ReadinessLevel {
-    /// Tint for the check icon/badge.
-    var tint: Color {
-        switch self {
-        case .pass: return .green
-        case .warn: return .orange
-        case .fail: return .red
-        }
+  /// Tint for the check icon/badge.
+  var tint: Color {
+    switch self {
+    case .pass: return .green
+    case .warn: return .orange
+    case .fail: return .red
     }
+  }
 
-    /// SF Symbol shown next to a check.
-    var iconName: String {
-        switch self {
-        case .pass: return "checkmark.circle.fill"
-        case .warn: return "exclamationmark.triangle.fill"
-        case .fail: return "xmark.octagon.fill"
-        }
+  /// SF Symbol shown next to a check.
+  var iconName: String {
+    switch self {
+    case .pass: return "checkmark.circle.fill"
+    case .warn: return "exclamationmark.triangle.fill"
+    case .fail: return "xmark.octagon.fill"
     }
+  }
 
-    /// Short badge label for the provider header.
-    var badgeLabel: String {
-        switch self {
-        case .pass: return "Ready"
-        case .warn: return "Check"
-        case .fail: return "Action needed"
-        }
+  /// Short badge label for the provider header.
+  var badgeLabel: String {
+    switch self {
+    case .pass: return "Ready"
+    case .warn: return "Check"
+    case .fail: return "Action needed"
     }
+  }
 }
 
 /// One readiness check: status icon, title, plain-language detail, and an
 /// optional recovery action rendered as a monospaced call-to-action.
 struct ReadinessCheckRow: View {
-    let check: ReadinessCheck
-    var compact: Bool = false
+  let check: ReadinessCheck
+  var compact: Bool = false
 
-    var body: some View {
-        HStack(alignment: .top, spacing: 8) {
-            Image(systemName: check.level.iconName)
-                .font(.system(size: compact ? 11 : 13, weight: .semibold))
-                .foregroundStyle(check.level.tint)
-                .padding(.top, 1)
+  var body: some View {
+    HStack(alignment: .top, spacing: 8) {
+      Image(systemName: check.level.iconName)
+        .font(.system(size: compact ? 11 : 13, weight: .semibold))
+        .foregroundStyle(check.level.tint)
+        .padding(.top, 1)
 
-            VStack(alignment: .leading, spacing: 2) {
-                Text(check.title)
-                    .font(compact ? .caption : .subheadline)
-                    .fontWeight(.medium)
-                Text(check.detail)
-                    .font(compact ? .caption2 : .caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(check.title)
+          .font(compact ? .caption : .subheadline)
+          .fontWeight(.medium)
+        Text(check.detail)
+          .font(compact ? .caption2 : .caption)
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
 
-                if let recovery = check.recovery {
-                    Text(recovery)
-                        .font(compact ? .caption2 : .caption)
-                        .fontWeight(.medium)
-                        .foregroundStyle(check.level.tint)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .padding(.top, 1)
-                }
-            }
-            Spacer(minLength: 0)
+        if let recovery = check.recovery {
+          Text(recovery)
+            .font(compact ? .caption2 : .caption)
+            .fontWeight(.medium)
+            .foregroundStyle(check.level.tint)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.top, 1)
         }
+      }
+      Spacer(minLength: 0)
     }
+  }
 }
 
 /// A provider's full readiness report: header with logo + overall badge, then
 /// each ordered check.
 struct ReadinessProviderCard: View {
-    let report: ProviderReadiness
-    var compact: Bool = false
+  let report: ProviderReadiness
+  var compact: Bool = false
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: compact ? 8 : 10) {
-            HStack(spacing: 8) {
-                ProviderLogoView(
-                    kind: .forService(report.provider),
-                    size: compact ? 15 : 18,
-                    foregroundColor: .primary
-                )
-                Text(report.provider.displayName)
-                    .font(compact ? .subheadline : .headline)
-                    .fontWeight(.semibold)
-                Spacer(minLength: 0)
-                ReadinessBadge(level: report.overall)
-            }
-
-            VStack(alignment: .leading, spacing: compact ? 7 : 9) {
-                ForEach(report.checks) { check in
-                    ReadinessCheckRow(check: check, compact: compact)
-                }
-            }
+  var body: some View {
+    DashboardTile(padding: compact ? 11 : 14) {
+      VStack(alignment: .leading, spacing: compact ? 8 : 10) {
+        HStack(spacing: 8) {
+          ProviderLogoView(
+            kind: .forService(report.provider),
+            size: compact ? 15 : 18,
+            foregroundColor: .primary
+          )
+          Text(report.provider.displayName)
+            .font(compact ? .subheadline : .headline)
+            .fontWeight(.semibold)
+          Spacer(minLength: 0)
+          ReadinessBadge(level: report.overall)
         }
-        .padding(compact ? 11 : 14)
-        .frame(maxWidth: .infinity, alignment: .topLeading)
-        .meterBarCardSurface()
+
+        VStack(alignment: .leading, spacing: compact ? 7 : 9) {
+          ForEach(report.checks) { check in
+            ReadinessCheckRow(check: check, compact: compact)
+          }
+        }
+      }
     }
+  }
 }
 
 /// Rolled-up status pill for a provider header.
 struct ReadinessBadge: View {
-    let level: ReadinessLevel
+  let level: ReadinessLevel
 
-    var body: some View {
-        Text(level.badgeLabel)
-            .font(.caption2)
-            .fontWeight(.semibold)
-            .foregroundStyle(level.tint)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 3)
-            .background(level.tint.opacity(0.14), in: Capsule())
-    }
+  var body: some View {
+    Text(level.badgeLabel)
+      .font(.caption2)
+      .fontWeight(.semibold)
+      .foregroundStyle(level.tint)
+      .padding(.horizontal, 8)
+      .padding(.vertical, 3)
+      .background(level.tint.opacity(0.14), in: Capsule())
+  }
 }
 
 /// Renders readiness reports as a plain-text block for the "Copy report" button.
 /// Mirrors the `meterbar doctor` layout so a pasted report reads the same whether
 /// it came from the CLI or the app. Every string is already redacted upstream.
 enum DiagnosticsReportText {
-    static func plainText(_ reports: [ProviderReadiness]) -> String {
-        var lines = ["MeterBar Diagnostics", ""]
-        for report in reports {
-            lines.append("\(report.provider.displayName)  [\(report.overall.rawValue.uppercased())]")
-            for check in report.checks {
-                lines.append("  \(symbol(check.level)) \(check.title): \(check.detail)")
-                if let recovery = check.recovery {
-                    lines.append("      -> \(recovery)")
-                }
-            }
-            lines.append("")
+  static func plainText(_ reports: [ProviderReadiness]) -> String {
+    var lines = ["MeterBar Diagnostics", ""]
+    for report in reports {
+      lines.append("\(report.provider.displayName)  [\(report.overall.rawValue.uppercased())]")
+      for check in report.checks {
+        lines.append("  \(symbol(check.level)) \(check.title): \(check.detail)")
+        if let recovery = check.recovery {
+          lines.append("      -> \(recovery)")
         }
-        return lines.joined(separator: "\n")
+      }
+      lines.append("")
     }
+    return lines.joined(separator: "\n")
+  }
 
-    private static func symbol(_ level: ReadinessLevel) -> String {
-        switch level {
-        case .pass: return "[ok]"
-        case .warn: return "[warn]"
-        case .fail: return "[fail]"
-        }
+  private static func symbol(_ level: ReadinessLevel) -> String {
+    switch level {
+    case .pass: return "[ok]"
+    case .warn: return "[warn]"
+    case .fail: return "[fail]"
     }
+  }
 }
 
 /// A stack of provider readiness cards. Used by the dashboard Diagnostics
 /// section (all providers) and the empty-state checklist (unhealthy only).
 struct ReadinessChecklist: View {
-    let reports: [ProviderReadiness]
-    var compact: Bool = false
+  let reports: [ProviderReadiness]
+  var compact: Bool = false
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: compact ? 8 : 12) {
-            ForEach(reports) { report in
-                ReadinessProviderCard(report: report, compact: compact)
-            }
-        }
+  var body: some View {
+    VStack(alignment: .leading, spacing: compact ? 8 : 12) {
+      ForEach(reports) { report in
+        ReadinessProviderCard(report: report, compact: compact)
+      }
     }
+  }
 }

--- a/MeterBar/Views/DailyUsageChart.swift
+++ b/MeterBar/Views/DailyUsageChart.swift
@@ -435,46 +435,47 @@ struct DailyUsageDetailRow: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      HStack(spacing: 8) {
-        HStack(spacing: 7) {
-          Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-            .font(.caption2)
-            .fontWeight(.bold)
+      Button(action: toggle) {
+        HStack(spacing: 8) {
+          HStack(spacing: 7) {
+            Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+              .font(.caption2)
+              .fontWeight(.bold)
+              .foregroundColor(.secondary)
+              .frame(width: 12)
+
+            Text(dateLabel(day.date))
+              .font(.subheadline)
+              .fontWeight(.semibold)
+              .lineLimit(1)
+          }
+          .frame(
+            minWidth: DailyUsageTableLayout.dayColumnMinWidth, maxWidth: .infinity,
+            alignment: .leading)
+
+          Text(providerCountLabel)
+            .font(.caption)
             .foregroundColor(.secondary)
-            .frame(width: 12)
-
-          Text(dateLabel(day.date))
-            .font(.subheadline)
-            .fontWeight(.semibold)
             .lineLimit(1)
+            .frame(width: DailyUsageTableLayout.sourceColumnWidth, alignment: .leading)
+
+          DailyUsageMetricCell(value: UsageFormat.tokens(day.inputTokens))
+          DailyUsageMetricCell(value: UsageFormat.tokens(day.outputTokens))
+          DailyUsageMetricCell(value: UsageFormat.tokens(day.cacheReadTokens))
+          DailyUsageMetricCell(value: UsageFormat.tokens(day.totalTokens), isPrimary: true)
+          DailyUsageMetricCell(
+            value: UsageFormat.cost(day.estimatedCostUSD),
+            width: DailyUsageTableLayout.costColumnWidth,
+            isPrimary: true
+          )
         }
-        .frame(
-          minWidth: DailyUsageTableLayout.dayColumnMinWidth, maxWidth: .infinity,
-          alignment: .leading)
-
-        Text(providerCountLabel)
-          .font(.caption)
-          .foregroundColor(.secondary)
-          .lineLimit(1)
-          .frame(width: DailyUsageTableLayout.sourceColumnWidth, alignment: .leading)
-
-        DailyUsageMetricCell(value: UsageFormat.tokens(day.inputTokens))
-        DailyUsageMetricCell(value: UsageFormat.tokens(day.outputTokens))
-        DailyUsageMetricCell(value: UsageFormat.tokens(day.cacheReadTokens))
-        DailyUsageMetricCell(value: UsageFormat.tokens(day.totalTokens), isPrimary: true)
-        DailyUsageMetricCell(
-          value: UsageFormat.cost(day.estimatedCostUSD),
-          width: DailyUsageTableLayout.costColumnWidth,
-          isPrimary: true
-        )
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .contentShape(Rectangle())
       }
-      .padding(.horizontal, 10)
-      .padding(.vertical, 8)
-      .contentShape(Rectangle())
-      .onTapGesture(perform: toggle)
+      .buttonStyle(.plain)
       .accessibilityLabel(accessibilitySummary)
       .accessibilityHint(isExpanded ? "Collapse day details" : "Show day details")
-      .accessibilityAddTraits(.isButton)
       .accessibilityAction(named: Text(isExpanded ? "Collapse" : "Expand"), toggle)
 
       if isExpanded {

--- a/MeterBar/Views/DailyUsageChart.swift
+++ b/MeterBar/Views/DailyUsageChart.swift
@@ -1,486 +1,610 @@
 import AppKit
-import SwiftUI
 import MeterBarShared
+import SwiftUI
 
 // Daily usage chart + breakdown views extracted from UsageDashboardView.swift (R8 split). Pure move.
 
 struct DailyUsageChart: View {
-    let dailyUsage: [DailyTokenUsage]
-    let daysToShow: Int
+  let dailyUsage: [DailyTokenUsage]
+  let daysToShow: Int
 
-    private let barSpacing: CGFloat = 4
-    private let labelHeight: CGFloat = 22
-    private let legendHeight: CGFloat = 18
+  private let barSpacing: CGFloat = 4
+  private let labelHeight: CGFloat = 22
+  private let legendHeight: CGFloat = 18
 
-    // Precomputed once at init instead of on every SwiftUI body access. The
-    // grouping + 30-day date arithmetic was previously re-run many times per
-    // render (from body, visibleProviders, maxTokens, barWidth, barHeight).
-    private let days: [DailyUsageDay]
+  // Precomputed once at init instead of on every SwiftUI body access. The
+  // grouping + 30-day date arithmetic was previously re-run many times per
+  // render (from body, visibleProviders, maxTokens, barWidth, barHeight).
+  private let days: [DailyUsageDay]
 
-    init(dailyUsage: [DailyTokenUsage], daysToShow: Int = 30) {
-        self.dailyUsage = dailyUsage
-        self.daysToShow = daysToShow
-        self.days = Self.buildDays(from: dailyUsage, daysToShow: daysToShow)
+  init(dailyUsage: [DailyTokenUsage], daysToShow: Int = 30) {
+    self.dailyUsage = dailyUsage
+    self.daysToShow = daysToShow
+    self.days = Self.buildDays(from: dailyUsage, daysToShow: daysToShow)
+  }
+
+  private static let providerOrder: [ServiceType] = [.claudeCode, .codexCli, .cursor]
+
+  private static func buildDays(from dailyUsage: [DailyTokenUsage], daysToShow: Int)
+    -> [DailyUsageDay]
+  {
+    let calendar = Calendar.current
+    let normalizedDaysToShow = max(1, daysToShow)
+    let endDate = calendar.startOfDay(for: Date())
+    let startDate =
+      calendar.date(byAdding: .day, value: -(normalizedDaysToShow - 1), to: endDate) ?? endDate
+    let grouped = Dictionary(grouping: dailyUsage) { calendar.startOfDay(for: $0.date) }
+
+    return (0..<normalizedDaysToShow).compactMap { offset in
+      guard let date = calendar.date(byAdding: .day, value: offset, to: startDate) else {
+        return nil
+      }
+
+      let rows = grouped[date] ?? []
+      let segments = providerOrder.compactMap { provider -> DailyUsageProviderSegment? in
+        let providerRows = rows.filter { $0.provider == provider }
+        let tokens = providerRows.reduce(0) { $0 + $1.totalTokens }
+        guard tokens > 0 else { return nil }
+
+        return DailyUsageProviderSegment(
+          provider: provider,
+          tokens: tokens,
+          cost: providerRows.reduce(0) { $0 + $1.estimatedCostUSD }
+        )
+      }
+
+      return DailyUsageDay(
+        date: date,
+        segments: segments,
+        cost: rows.reduce(0) { $0 + $1.estimatedCostUSD }
+      )
     }
+  }
 
-    private static let providerOrder: [ServiceType] = [.claudeCode, .codexCli, .cursor]
+  private var visibleProviders: [ServiceType] {
+    Self.providerOrder.filter { provider in
+      days.contains { day in
+        day.segments.contains { $0.provider == provider }
+      }
+    }
+  }
 
-    private static func buildDays(from dailyUsage: [DailyTokenUsage], daysToShow: Int) -> [DailyUsageDay] {
-        let calendar = Calendar.current
-        let normalizedDaysToShow = max(1, daysToShow)
-        let endDate = calendar.startOfDay(for: Date())
-        let startDate = calendar.date(byAdding: .day, value: -(normalizedDaysToShow - 1), to: endDate) ?? endDate
-        let grouped = Dictionary(grouping: dailyUsage) { calendar.startOfDay(for: $0.date) }
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      if days.allSatisfy({ $0.totalTokens == 0 }) {
+        Text("No token history found for the last 30 days.")
+          .foregroundColor(.secondary)
+          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+      } else {
+        legend
 
-        return (0..<normalizedDaysToShow).compactMap { offset in
-            guard let date = calendar.date(byAdding: .day, value: offset, to: startDate) else {
-                return nil
-            }
+        GeometryReader { proxy in
+          let width = barWidth(totalWidth: proxy.size.width)
+          let chartHeight = max(40, proxy.size.height - labelHeight)
 
-            let rows = grouped[date] ?? []
-            let segments = providerOrder.compactMap { provider -> DailyUsageProviderSegment? in
-                let providerRows = rows.filter { $0.provider == provider }
-                let tokens = providerRows.reduce(0) { $0 + $1.totalTokens }
-                guard tokens > 0 else { return nil }
-
-                return DailyUsageProviderSegment(
-                    provider: provider,
-                    tokens: tokens,
-                    cost: providerRows.reduce(0) { $0 + $1.estimatedCostUSD }
+          VStack(spacing: 5) {
+            HStack(alignment: .bottom, spacing: barSpacing) {
+              ForEach(days) { day in
+                StackedDailyUsageColumn(
+                  day: day,
+                  width: width,
+                  height: barHeight(totalHeight: chartHeight, tokens: day.totalTokens),
+                  maxHeight: chartHeight,
+                  helpText: helpText(for: day),
+                  colorForProvider: color(for:)
                 )
+              }
             }
+            .frame(maxWidth: .infinity, maxHeight: chartHeight, alignment: .bottomLeading)
 
-            return DailyUsageDay(
-                date: date,
-                segments: segments,
-                cost: rows.reduce(0) { $0 + $1.estimatedCostUSD }
-            )
-        }
-    }
-
-    private var visibleProviders: [ServiceType] {
-        Self.providerOrder.filter { provider in
-            days.contains { day in
-                day.segments.contains { $0.provider == provider }
-            }
-        }
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            if days.allSatisfy({ $0.totalTokens == 0 }) {
-                Text("No token history found for the last 30 days.")
-                    .foregroundColor(.secondary)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-            } else {
-                legend
-
-                GeometryReader { proxy in
-                    let width = barWidth(totalWidth: proxy.size.width)
-                    let chartHeight = max(40, proxy.size.height - labelHeight)
-
-                    VStack(spacing: 5) {
-                        HStack(alignment: .bottom, spacing: barSpacing) {
-                            ForEach(days) { day in
-                                StackedDailyUsageColumn(
-                                    day: day,
-                                    width: width,
-                                    height: barHeight(totalHeight: chartHeight, tokens: day.totalTokens),
-                                    maxHeight: chartHeight,
-                                    helpText: helpText(for: day),
-                                    colorForProvider: color(for:)
-                                )
-                            }
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: chartHeight, alignment: .bottomLeading)
-
-                        HStack(alignment: .top, spacing: barSpacing) {
-                            ForEach(days.indices, id: \.self) { index in
-                                DailyUsageDateLabel(
-                                    date: days[index].date,
-                                    width: width,
-                                    showsMonth: shouldShowMonth(at: index)
-                                )
-                            }
-                        }
-                        .frame(height: labelHeight, alignment: .topLeading)
-                    }
-                }
-            }
-        }
-    }
-
-    private var legend: some View {
-        HStack(spacing: 12) {
-            ForEach(visibleProviders, id: \.self) { provider in
-                HStack(spacing: 5) {
-                    RoundedRectangle(cornerRadius: 2)
-                        .fill(color(for: provider))
-                        .frame(width: 8, height: 8)
-                    Text(provider.displayName)
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                }
-            }
-
-            Spacer(minLength: 0)
-        }
-        .frame(height: legendHeight, alignment: .leading)
-    }
-
-    private var maxTokens: Int {
-        max(days.map(\.totalTokens).max() ?? 1, 1)
-    }
-
-    private func barWidth(totalWidth: CGFloat) -> CGFloat {
-        let gapsWidth = CGFloat(max(0, days.count - 1)) * barSpacing
-        return max(4, (totalWidth - gapsWidth) / CGFloat(max(1, days.count)))
-    }
-
-    private func barHeight(totalHeight: CGFloat, tokens: Int) -> CGFloat {
-        guard tokens > 0 else { return 2 }
-        return max(4, totalHeight * CGFloat(tokens) / CGFloat(maxTokens))
-    }
-
-    private func shouldShowMonth(at index: Int) -> Bool {
-        guard days.indices.contains(index) else { return false }
-        if index == 0 { return true }
-
-        return Calendar.current.component(.day, from: days[index].date) == 1
-    }
-
-    private func helpText(for day: DailyUsageDay) -> String {
-        var lines = [
-            DashboardDateFormat.medium(day.date),
-            "\(UsageFormat.tokens(day.totalTokens)) tokens",
-            UsageFormat.cost(day.cost)
-        ]
-
-        if day.segments.isEmpty {
-            lines.append("No tracked provider usage")
-        } else {
-            lines.append("")
-            for segment in day.segments {
-                lines.append(
-                    "\(segment.provider.displayName): "
-                        + "\(UsageFormat.tokens(segment.tokens)) · \(UsageFormat.cost(segment.cost))"
+            HStack(alignment: .top, spacing: barSpacing) {
+              ForEach(days.indices, id: \.self) { index in
+                DailyUsageDateLabel(
+                  date: days[index].date,
+                  width: width,
+                  showsMonth: shouldShowMonth(at: index)
                 )
+              }
             }
+            .frame(height: labelHeight, alignment: .topLeading)
+          }
         }
+      }
+    }
+  }
 
-        return lines.joined(separator: "\n")
+  private var legend: some View {
+    HStack(spacing: 12) {
+      ForEach(visibleProviders, id: \.self) { provider in
+        HStack(spacing: 5) {
+          RoundedRectangle(cornerRadius: 2)
+            .fill(color(for: provider))
+            .frame(width: 8, height: 8)
+          Text(provider.displayName)
+            .font(.caption2)
+            .foregroundColor(.secondary)
+        }
+      }
+
+      Spacer(minLength: 0)
+    }
+    .frame(height: legendHeight, alignment: .leading)
+  }
+
+  private var maxTokens: Int {
+    max(days.map(\.totalTokens).max() ?? 1, 1)
+  }
+
+  private func barWidth(totalWidth: CGFloat) -> CGFloat {
+    let gapsWidth = CGFloat(max(0, days.count - 1)) * barSpacing
+    return max(4, (totalWidth - gapsWidth) / CGFloat(max(1, days.count)))
+  }
+
+  private func barHeight(totalHeight: CGFloat, tokens: Int) -> CGFloat {
+    guard tokens > 0 else { return 2 }
+    return max(4, totalHeight * CGFloat(tokens) / CGFloat(maxTokens))
+  }
+
+  private func shouldShowMonth(at index: Int) -> Bool {
+    guard days.indices.contains(index) else { return false }
+    if index == 0 { return true }
+
+    return Calendar.current.component(.day, from: days[index].date) == 1
+  }
+
+  private func helpText(for day: DailyUsageDay) -> String {
+    var lines = [
+      DashboardDateFormat.medium(day.date),
+      "\(UsageFormat.tokens(day.totalTokens)) tokens",
+      UsageFormat.cost(day.cost),
+    ]
+
+    if day.segments.isEmpty {
+      lines.append("No tracked provider usage")
+    } else {
+      lines.append("")
+      for segment in day.segments {
+        lines.append(
+          "\(segment.provider.displayName): "
+            + "\(UsageFormat.tokens(segment.tokens)) · \(UsageFormat.cost(segment.cost))"
+        )
+      }
     }
 
-    private func color(for provider: ServiceType) -> Color {
-        MeterBarTheme.accent(for: provider)
-    }
+    return lines.joined(separator: "\n")
+  }
+
+  private func color(for provider: ServiceType) -> Color {
+    MeterBarTheme.accent(for: provider)
+  }
 }
 
 struct StackedDailyUsageColumn: View {
-    let day: DailyUsageDay
-    let width: CGFloat
-    let height: CGFloat
-    let maxHeight: CGFloat
-    let helpText: String
-    let colorForProvider: (ServiceType) -> Color
+  let day: DailyUsageDay
+  let width: CGFloat
+  let height: CGFloat
+  let maxHeight: CGFloat
+  let helpText: String
+  let colorForProvider: (ServiceType) -> Color
 
-    var body: some View {
+  var body: some View {
+    VStack(spacing: 0) {
+      Spacer(minLength: 0)
+
+      if day.totalTokens > 0 {
         VStack(spacing: 0) {
-            Spacer(minLength: 0)
-
-            if day.totalTokens > 0 {
-                VStack(spacing: 0) {
-                    ForEach(day.segments.reversed()) { segment in
-                        Rectangle()
-                            .fill(colorForProvider(segment.provider))
-                            .frame(height: segmentHeight(segment))
-                    }
-                }
-                .frame(width: width, height: height, alignment: .bottom)
-                .clipShape(RoundedRectangle(cornerRadius: 3))
-            } else {
-                Capsule()
-                    .fill(.quaternary)
-                    .frame(width: width, height: 2)
-            }
+          ForEach(day.segments.reversed()) { segment in
+            Rectangle()
+              .fill(colorForProvider(segment.provider))
+              .frame(height: segmentHeight(segment))
+          }
         }
-        .frame(width: width, height: maxHeight, alignment: .bottom)
-        .help(helpText)
+        .frame(width: width, height: height, alignment: .bottom)
+        .clipShape(RoundedRectangle(cornerRadius: 3))
+      } else {
+        Capsule()
+          .fill(.quaternary)
+          .frame(width: width, height: 2)
+      }
     }
+    .frame(width: width, height: maxHeight, alignment: .bottom)
+    .help(helpText)
+  }
 
-    private func segmentHeight(_ segment: DailyUsageProviderSegment) -> CGFloat {
-        guard day.totalTokens > 0 else { return 0 }
-        return max(1, height * CGFloat(segment.tokens) / CGFloat(day.totalTokens))
-    }
+  private func segmentHeight(_ segment: DailyUsageProviderSegment) -> CGFloat {
+    guard day.totalTokens > 0 else { return 0 }
+    return max(1, height * CGFloat(segment.tokens) / CGFloat(day.totalTokens))
+  }
 }
 
 struct DailyUsageDateLabel: View {
-    let date: Date
-    let width: CGFloat
-    let showsMonth: Bool
+  let date: Date
+  let width: CGFloat
+  let showsMonth: Bool
 
-    var body: some View {
-        VStack(spacing: 0) {
-            Text(dayText)
-                .font(.system(size: 8, weight: .medium, design: .monospaced))
-                .foregroundColor(.secondary)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-            Text(showsMonth ? monthText : "")
-                .font(.system(size: 7, weight: .medium))
-                .foregroundColor(.secondary.opacity(0.75))
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-        }
-        .frame(width: width, height: 20, alignment: .top)
-        .help(fullDateText)
+  var body: some View {
+    VStack(spacing: 0) {
+      Text(dayText)
+        .font(.system(size: 8, weight: .medium, design: .monospaced))
+        .foregroundColor(.secondary)
+        .lineLimit(1)
+        .minimumScaleFactor(0.7)
+      Text(showsMonth ? monthText : "")
+        .font(.system(size: 7, weight: .medium))
+        .foregroundColor(.secondary.opacity(0.75))
+        .lineLimit(1)
+        .minimumScaleFactor(0.7)
     }
+    .frame(width: width, height: 20, alignment: .top)
+    .help(fullDateText)
+  }
 
-    private var dayText: String {
-        String(Calendar.current.component(.day, from: date))
-    }
+  private var dayText: String {
+    String(Calendar.current.component(.day, from: date))
+  }
 
-    private var monthText: String {
-        DashboardDateFormat.month(date)
-    }
+  private var monthText: String {
+    DashboardDateFormat.month(date)
+  }
 
-    private var fullDateText: String {
-        DashboardDateFormat.medium(date)
-    }
+  private var fullDateText: String {
+    DashboardDateFormat.medium(date)
+  }
 }
 
 struct DailyUsageDay: Identifiable {
-    var id: Date { date }
-    let date: Date
-    let segments: [DailyUsageProviderSegment]
-    let cost: Double
+  var id: Date { date }
+  let date: Date
+  let segments: [DailyUsageProviderSegment]
+  let cost: Double
 
-    var totalTokens: Int {
-        segments.reduce(0) { $0 + $1.tokens }
-    }
+  var totalTokens: Int {
+    segments.reduce(0) { $0 + $1.tokens }
+  }
 }
 
 struct DailyUsageProviderSegment: Identifiable {
-    var id: ServiceType { provider }
-    let provider: ServiceType
-    let tokens: Int
-    let cost: Double
+  var id: ServiceType { provider }
+  let provider: ServiceType
+  let tokens: Int
+  let cost: Double
 }
 
 struct DailyUsageBreakdownList: View {
-    let dailyUsage: [DailyTokenUsage]
+  let dailyUsage: [DailyTokenUsage]
 
-    @State private var expandedDayIDs: Set<Date> = []
+  @State private var expandedDayIDs: Set<Date> = []
 
-    private var days: [DailyProviderUsageDay] {
-        let grouped = Dictionary(grouping: dailyUsage) { Calendar.current.startOfDay(for: $0.date) }
-        return grouped.map { day, rows in
-            DailyProviderUsageDay(date: day, providers: providerSummaries(from: rows))
-        }
-        .filter { $0.totalTokens > 0 }
-        .sorted { $0.date > $1.date }
+  private var days: [DailyProviderUsageDay] {
+    let grouped = Dictionary(grouping: dailyUsage) { Calendar.current.startOfDay(for: $0.date) }
+    return grouped.map { day, rows in
+      DailyProviderUsageDay(date: day, providers: providerSummaries(from: rows))
     }
+    .filter { $0.totalTokens > 0 }
+    .sorted { $0.date > $1.date }
+  }
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack {
-                Text("Daily Details")
-                    .font(.headline)
-                    .fontWeight(.semibold)
-                Spacer()
-                Text("Last 30 days")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+  var body: some View {
+    VStack(spacing: 0) {
+      DailyUsageTableHeader()
+
+      Divider()
+
+      if days.isEmpty {
+        Text("No daily token history found.")
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+          .frame(maxWidth: .infinity, minHeight: 72, alignment: .center)
+      } else {
+        LazyVStack(spacing: 0) {
+          ForEach(Array(days.enumerated()), id: \.element.id) { index, day in
+            if index > 0 {
+              Divider()
             }
 
-            VStack(spacing: 8) {
-                ForEach(days) { day in
-                    DailyUsageDetailRow(
-                        day: day,
-                        isExpanded: expandedDayIDs.contains(day.id),
-                        toggle: { toggleExpansion(for: day.id) }
-                    )
-                }
-            }
-        }
-    }
-
-    private func toggleExpansion(for dayID: Date) {
-        withAnimation(.snappy(duration: 0.18)) {
-            if expandedDayIDs.contains(dayID) {
-                expandedDayIDs.remove(dayID)
-            } else {
-                expandedDayIDs.insert(dayID)
-            }
-        }
-    }
-
-    private func providerSummaries(from rows: [DailyTokenUsage]) -> [DailyProviderUsageSummary] {
-        let grouped = Dictionary(grouping: rows, by: \.provider)
-        return grouped.map { provider, providerRows in
-            DailyProviderUsageSummary(
-                provider: provider,
-                inputTokens: providerRows.reduce(0) { $0 + $1.inputTokens },
-                outputTokens: providerRows.reduce(0) { $0 + $1.outputTokens },
-                cacheReadTokens: providerRows.reduce(0) { $0 + $1.cacheReadTokens },
-                estimatedCostUSD: providerRows.reduce(0) { $0 + $1.estimatedCostUSD }
+            DailyUsageDetailRow(
+              day: day,
+              isExpanded: expandedDayIDs.contains(day.id),
+              toggle: { toggleExpansion(for: day.id) }
             )
+          }
         }
-        .sorted { lhs, rhs in
-            if lhs.estimatedCostUSD == rhs.estimatedCostUSD {
-                return lhs.totalTokens > rhs.totalTokens
-            }
-            return lhs.estimatedCostUSD > rhs.estimatedCostUSD
-        }
+      }
     }
+  }
+
+  private func toggleExpansion(for dayID: Date) {
+    withAnimation(.snappy(duration: 0.18)) {
+      if expandedDayIDs.contains(dayID) {
+        expandedDayIDs.remove(dayID)
+      } else {
+        expandedDayIDs.insert(dayID)
+      }
+    }
+  }
+
+  private func providerSummaries(from rows: [DailyTokenUsage]) -> [DailyProviderUsageSummary] {
+    let grouped = Dictionary(grouping: rows, by: \.provider)
+    return grouped.map { provider, providerRows in
+      DailyProviderUsageSummary(
+        provider: provider,
+        inputTokens: providerRows.reduce(0) { $0 + $1.inputTokens },
+        outputTokens: providerRows.reduce(0) { $0 + $1.outputTokens },
+        cacheReadTokens: providerRows.reduce(0) { $0 + $1.cacheReadTokens },
+        estimatedCostUSD: providerRows.reduce(0) { $0 + $1.estimatedCostUSD }
+      )
+    }
+    .sorted { lhs, rhs in
+      if lhs.estimatedCostUSD == rhs.estimatedCostUSD {
+        return lhs.totalTokens > rhs.totalTokens
+      }
+      return lhs.estimatedCostUSD > rhs.estimatedCostUSD
+    }
+  }
+}
+
+private enum DailyUsageTableLayout {
+  static let rowSpacing: CGFloat = 10
+  static let dayColumnMinWidth: CGFloat = 142
+  static let sourceColumnWidth: CGFloat = 70
+  static let metricColumnWidth: CGFloat = 76
+  static let costColumnWidth: CGFloat = 72
+}
+
+struct DailyUsageTableHeader: View {
+  var body: some View {
+    HStack(spacing: DailyUsageTableLayout.rowSpacing) {
+      Text("Day")
+        .frame(
+          minWidth: DailyUsageTableLayout.dayColumnMinWidth, maxWidth: .infinity,
+          alignment: .leading)
+      Text("Sources")
+        .frame(width: DailyUsageTableLayout.sourceColumnWidth, alignment: .leading)
+      DailyUsageColumnHeader("Input")
+      DailyUsageColumnHeader("Output")
+      DailyUsageColumnHeader("Cache")
+      DailyUsageColumnHeader("Total")
+      Text("Cost")
+        .frame(width: DailyUsageTableLayout.costColumnWidth, alignment: .trailing)
+    }
+    .font(.caption2)
+    .fontWeight(.semibold)
+    .foregroundColor(.secondary)
+    .textCase(.uppercase)
+    .padding(.horizontal, 10)
+    .padding(.vertical, 7)
+  }
+}
+
+private struct DailyUsageColumnHeader: View {
+  let title: String
+
+  init(_ title: String) {
+    self.title = title
+  }
+
+  var body: some View {
+    Text(title)
+      .frame(width: DailyUsageTableLayout.metricColumnWidth, alignment: .trailing)
+  }
 }
 
 struct DailyProviderUsageDay: Identifiable {
-    var id: Date { date }
-    let date: Date
-    let providers: [DailyProviderUsageSummary]
+  var id: Date { date }
+  let date: Date
+  let providers: [DailyProviderUsageSummary]
 
-    var totalTokens: Int {
-        providers.reduce(0) { $0 + $1.totalTokens }
-    }
+  var inputTokens: Int {
+    providers.reduce(0) { $0 + $1.inputTokens }
+  }
 
-    var estimatedCostUSD: Double {
-        providers.reduce(0) { $0 + $1.estimatedCostUSD }
-    }
+  var outputTokens: Int {
+    providers.reduce(0) { $0 + $1.outputTokens }
+  }
+
+  var cacheReadTokens: Int {
+    providers.reduce(0) { $0 + $1.cacheReadTokens }
+  }
+
+  var totalTokens: Int {
+    providers.reduce(0) { $0 + $1.totalTokens }
+  }
+
+  var estimatedCostUSD: Double {
+    providers.reduce(0) { $0 + $1.estimatedCostUSD }
+  }
 }
 
 struct DailyProviderUsageSummary: Identifiable {
-    var id: ServiceType { provider }
-    let provider: ServiceType
-    let inputTokens: Int
-    let outputTokens: Int
-    let cacheReadTokens: Int
-    let estimatedCostUSD: Double
+  var id: ServiceType { provider }
+  let provider: ServiceType
+  let inputTokens: Int
+  let outputTokens: Int
+  let cacheReadTokens: Int
+  let estimatedCostUSD: Double
 
-    var totalTokens: Int {
-        inputTokens + outputTokens + cacheReadTokens
-    }
+  var totalTokens: Int {
+    inputTokens + outputTokens + cacheReadTokens
+  }
 }
 
 struct DailyUsageDetailRow: View {
-    let day: DailyProviderUsageDay
-    let isExpanded: Bool
-    let toggle: () -> Void
+  let day: DailyProviderUsageDay
+  let isExpanded: Bool
+  let toggle: () -> Void
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: isExpanded ? 8 : 0) {
-            Button(action: toggle) {
-                HStack(spacing: 8) {
-                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                        .font(.caption2)
-                        .fontWeight(.bold)
-                        .foregroundColor(.secondary)
-                        .frame(width: 12)
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      Button(action: toggle) {
+        HStack(spacing: 8) {
+          HStack(spacing: 7) {
+            Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+              .font(.caption2)
+              .fontWeight(.bold)
+              .foregroundColor(.secondary)
+              .frame(width: 12)
 
-                    Text(dateLabel(day.date))
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
+            Text(dateLabel(day.date))
+              .font(.subheadline)
+              .fontWeight(.semibold)
+              .lineLimit(1)
+          }
+          .frame(
+            minWidth: DailyUsageTableLayout.dayColumnMinWidth, maxWidth: .infinity,
+            alignment: .leading)
 
-                    Text(providerCountLabel)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+          Text(providerCountLabel)
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .lineLimit(1)
+            .frame(width: DailyUsageTableLayout.sourceColumnWidth, alignment: .leading)
 
-                    Spacer()
-
-                    Text("\(UsageFormat.tokens(day.totalTokens)) tokens")
-                        .font(.caption)
-                        .fontWeight(.semibold)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.75)
-
-                    Text(UsageFormat.cost(day.estimatedCostUSD))
-                        .font(.caption)
-                        .fontWeight(.semibold)
-                        .foregroundColor(.secondary)
-                }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel(accessibilitySummary)
-            .accessibilityHint(isExpanded ? "Collapse day details" : "Show day details")
-
-            if isExpanded {
-                VStack(spacing: 8) {
-                    ForEach(day.providers) { provider in
-                        DailyProviderUsageSummaryRow(provider: provider)
-                    }
-                }
-                .padding(.top, 6)
-                .transition(.opacity.combined(with: .move(edge: .top)))
-            }
+          DailyUsageMetricCell(value: UsageFormat.tokens(day.inputTokens))
+          DailyUsageMetricCell(value: UsageFormat.tokens(day.outputTokens))
+          DailyUsageMetricCell(value: UsageFormat.tokens(day.cacheReadTokens))
+          DailyUsageMetricCell(value: UsageFormat.tokens(day.totalTokens), isPrimary: true)
+          DailyUsageCostCell(value: UsageFormat.cost(day.estimatedCostUSD), isPrimary: true)
         }
-        .padding(10)
-        .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-    }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel(accessibilitySummary)
+      .accessibilityHint(isExpanded ? "Collapse day details" : "Show day details")
 
-    private var providerCountLabel: String {
-        let count = day.providers.count
-        return count == 1 ? "1 source" : "\(count) sources"
+      if isExpanded {
+        VStack(spacing: 0) {
+          ForEach(day.providers) { provider in
+            DailyProviderUsageSummaryRow(provider: provider)
+          }
+        }
+        .padding(.bottom, 6)
+        .transition(.opacity.combined(with: .move(edge: .top)))
+      }
     }
+  }
 
-    private var accessibilitySummary: String {
-        "\(dateLabel(day.date)), \(UsageFormat.tokens(day.totalTokens)) tokens, "
-            + "\(UsageFormat.cost(day.estimatedCostUSD))"
-    }
+  private var providerCountLabel: String {
+    let count = day.providers.count
+    return count == 1 ? "1 source" : "\(count) sources"
+  }
 
-    private func dateLabel(_ date: Date) -> String {
-        DashboardDateFormat.weekdayMonthDay(date)
-    }
+  private var accessibilitySummary: String {
+    "\(dateLabel(day.date)), \(UsageFormat.tokens(day.totalTokens)) tokens, "
+      + "\(UsageFormat.cost(day.estimatedCostUSD))"
+  }
+
+  private func dateLabel(_ date: Date) -> String {
+    DashboardDateFormat.weekdayMonthDay(date)
+  }
 }
 
 struct DailyProviderUsageSummaryRow: View {
-    let provider: DailyProviderUsageSummary
+  let provider: DailyProviderUsageSummary
 
-    var body: some View {
-        HStack(spacing: 10) {
-            ProviderLogoView(
-                kind: .forService(provider.provider),
-                size: 14,
-                foregroundColor: MeterBarTheme.accent(for: provider.provider)
-            )
-            Text(provider.provider.displayName)
-                .font(.caption)
-                .fontWeight(.semibold)
-                .frame(width: 110, alignment: .leading)
-            UsageDetailMetric(label: "Input", value: UsageFormat.tokens(provider.inputTokens))
-            UsageDetailMetric(label: "Output", value: UsageFormat.tokens(provider.outputTokens))
-            UsageDetailMetric(label: "Cache", value: UsageFormat.tokens(provider.cacheReadTokens))
-            Spacer()
-            Text(UsageFormat.cost(provider.estimatedCostUSD))
-                .font(.caption)
-                .fontWeight(.semibold)
-        }
+  var body: some View {
+    HStack(spacing: DailyUsageTableLayout.rowSpacing) {
+      HStack(spacing: 7) {
+        Spacer()
+          .frame(width: 19)
+
+        ProviderLogoView(
+          kind: .forService(provider.provider),
+          size: 13,
+          foregroundColor: MeterBarTheme.accent(for: provider.provider)
+        )
+        Text(provider.provider.displayName)
+          .font(.caption)
+          .fontWeight(.semibold)
+          .lineLimit(1)
+      }
+      .frame(
+        minWidth: DailyUsageTableLayout.dayColumnMinWidth, maxWidth: .infinity, alignment: .leading)
+
+      Text(providerShortName)
+        .font(.caption2)
+        .foregroundColor(.secondary)
+        .lineLimit(1)
+        .frame(width: DailyUsageTableLayout.sourceColumnWidth, alignment: .leading)
+
+      DailyUsageMetricCell(value: UsageFormat.tokens(provider.inputTokens))
+      DailyUsageMetricCell(value: UsageFormat.tokens(provider.outputTokens))
+      DailyUsageMetricCell(value: UsageFormat.tokens(provider.cacheReadTokens))
+      DailyUsageMetricCell(value: UsageFormat.tokens(provider.totalTokens))
+      DailyUsageCostCell(value: UsageFormat.cost(provider.estimatedCostUSD))
     }
+    .padding(.horizontal, 10)
+    .padding(.vertical, 5)
+  }
+
+  private var providerShortName: String {
+    switch provider.provider {
+    case .claudeCode:
+      return "Claude"
+    case .codexCli:
+      return "Codex"
+    case .cursor:
+      return "Cursor"
+    }
+  }
+}
+
+private struct DailyUsageMetricCell: View {
+  let value: String
+  var isPrimary = false
+
+  var body: some View {
+    Text(value)
+      .font(.caption)
+      .fontWeight(isPrimary ? .semibold : .regular)
+      .monospacedDigit()
+      .lineLimit(1)
+      .minimumScaleFactor(0.75)
+      .foregroundColor(isPrimary ? .primary : .secondary)
+      .frame(width: DailyUsageTableLayout.metricColumnWidth, alignment: .trailing)
+  }
+}
+
+private struct DailyUsageCostCell: View {
+  let value: String
+  var isPrimary = false
+
+  var body: some View {
+    Text(value)
+      .font(.caption)
+      .fontWeight(isPrimary ? .semibold : .regular)
+      .monospacedDigit()
+      .lineLimit(1)
+      .minimumScaleFactor(0.75)
+      .foregroundColor(isPrimary ? .primary : .secondary)
+      .frame(width: DailyUsageTableLayout.costColumnWidth, alignment: .trailing)
+  }
 }
 
 /// Cached date formatters for the dashboard. `DateFormatter` is expensive to
 /// allocate, so the daily chart/labels (30+ per render) share these instances.
 enum DashboardDateFormat {
-    private static let mediumDate: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .none
-        return formatter
-    }()
+  private static let mediumDate: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .medium
+    formatter.timeStyle = .none
+    return formatter
+  }()
 
-    private static let month: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMM"
-        return formatter
-    }()
+  private static let month: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "MMM"
+    return formatter
+  }()
 
-    private static let weekdayMonthDay: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "EEE, MMM d"
-        return formatter
-    }()
+  private static let weekdayMonthDay: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "EEE, MMM d"
+    return formatter
+  }()
 
-    static func medium(_ date: Date) -> String { mediumDate.string(from: date) }
-    static func month(_ date: Date) -> String { month.string(from: date) }
-    static func weekdayMonthDay(_ date: Date) -> String { weekdayMonthDay.string(from: date) }
+  static func medium(_ date: Date) -> String { mediumDate.string(from: date) }
+  static func month(_ date: Date) -> String { month.string(from: date) }
+  static func weekdayMonthDay(_ date: Date) -> String { weekdayMonthDay.string(from: date) }
 }

--- a/MeterBar/Views/DailyUsageChart.swift
+++ b/MeterBar/Views/DailyUsageChart.swift
@@ -25,9 +25,10 @@ struct DailyUsageChart: View {
 
   private static let providerOrder: [ServiceType] = [.claudeCode, .codexCli, .cursor]
 
-  private static func buildDays(from dailyUsage: [DailyTokenUsage], daysToShow: Int)
-    -> [DailyUsageDay]
-  {
+  private static func buildDays(
+    from dailyUsage: [DailyTokenUsage],
+    daysToShow: Int
+  ) -> [DailyUsageDay] {
     let calendar = Calendar.current
     let normalizedDaysToShow = max(1, daysToShow)
     let endDate = calendar.startOfDay(for: Date())
@@ -356,8 +357,10 @@ struct DailyUsageTableHeader: View {
     HStack(spacing: DailyUsageTableLayout.rowSpacing) {
       Text("Day")
         .frame(
-          minWidth: DailyUsageTableLayout.dayColumnMinWidth, maxWidth: .infinity,
-          alignment: .leading)
+          minWidth: DailyUsageTableLayout.dayColumnMinWidth,
+          maxWidth: .infinity,
+          alignment: .leading
+        )
       Text("Sources")
         .frame(width: DailyUsageTableLayout.sourceColumnWidth, alignment: .leading)
       DailyUsageColumnHeader("Input")
@@ -450,8 +453,10 @@ struct DailyUsageDetailRow: View {
               .lineLimit(1)
           }
           .frame(
-            minWidth: DailyUsageTableLayout.dayColumnMinWidth, maxWidth: .infinity,
-            alignment: .leading)
+            minWidth: DailyUsageTableLayout.dayColumnMinWidth,
+            maxWidth: .infinity,
+            alignment: .leading
+          )
 
           Text(providerCountLabel)
             .font(.caption)

--- a/MeterBar/Views/DailyUsageChart.swift
+++ b/MeterBar/Views/DailyUsageChart.swift
@@ -463,7 +463,11 @@ struct DailyUsageDetailRow: View {
           DailyUsageMetricCell(value: UsageFormat.tokens(day.outputTokens))
           DailyUsageMetricCell(value: UsageFormat.tokens(day.cacheReadTokens))
           DailyUsageMetricCell(value: UsageFormat.tokens(day.totalTokens), isPrimary: true)
-          DailyUsageCostCell(value: UsageFormat.cost(day.estimatedCostUSD), isPrimary: true)
+          DailyUsageMetricCell(
+            value: UsageFormat.cost(day.estimatedCostUSD),
+            width: DailyUsageTableLayout.costColumnWidth,
+            isPrimary: true
+          )
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
@@ -532,7 +536,10 @@ struct DailyProviderUsageSummaryRow: View {
       DailyUsageMetricCell(value: UsageFormat.tokens(provider.outputTokens))
       DailyUsageMetricCell(value: UsageFormat.tokens(provider.cacheReadTokens))
       DailyUsageMetricCell(value: UsageFormat.tokens(provider.totalTokens))
-      DailyUsageCostCell(value: UsageFormat.cost(provider.estimatedCostUSD))
+      DailyUsageMetricCell(
+        value: UsageFormat.cost(provider.estimatedCostUSD),
+        width: DailyUsageTableLayout.costColumnWidth
+      )
     }
     .padding(.horizontal, 10)
     .padding(.vertical, 5)
@@ -552,6 +559,7 @@ struct DailyProviderUsageSummaryRow: View {
 
 private struct DailyUsageMetricCell: View {
   let value: String
+  var width = DailyUsageTableLayout.metricColumnWidth
   var isPrimary = false
 
   var body: some View {
@@ -562,23 +570,7 @@ private struct DailyUsageMetricCell: View {
       .lineLimit(1)
       .minimumScaleFactor(0.75)
       .foregroundColor(isPrimary ? .primary : .secondary)
-      .frame(width: DailyUsageTableLayout.metricColumnWidth, alignment: .trailing)
-  }
-}
-
-private struct DailyUsageCostCell: View {
-  let value: String
-  var isPrimary = false
-
-  var body: some View {
-    Text(value)
-      .font(.caption)
-      .fontWeight(isPrimary ? .semibold : .regular)
-      .monospacedDigit()
-      .lineLimit(1)
-      .minimumScaleFactor(0.75)
-      .foregroundColor(isPrimary ? .primary : .secondary)
-      .frame(width: DailyUsageTableLayout.costColumnWidth, alignment: .trailing)
+      .frame(width: width, alignment: .trailing)
   }
 }
 

--- a/MeterBar/Views/DailyUsageChart.swift
+++ b/MeterBar/Views/DailyUsageChart.swift
@@ -435,47 +435,47 @@ struct DailyUsageDetailRow: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      Button(action: toggle) {
-        HStack(spacing: 8) {
-          HStack(spacing: 7) {
-            Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-              .font(.caption2)
-              .fontWeight(.bold)
-              .foregroundColor(.secondary)
-              .frame(width: 12)
-
-            Text(dateLabel(day.date))
-              .font(.subheadline)
-              .fontWeight(.semibold)
-              .lineLimit(1)
-          }
-          .frame(
-            minWidth: DailyUsageTableLayout.dayColumnMinWidth, maxWidth: .infinity,
-            alignment: .leading)
-
-          Text(providerCountLabel)
-            .font(.caption)
+      HStack(spacing: 8) {
+        HStack(spacing: 7) {
+          Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+            .font(.caption2)
+            .fontWeight(.bold)
             .foregroundColor(.secondary)
-            .lineLimit(1)
-            .frame(width: DailyUsageTableLayout.sourceColumnWidth, alignment: .leading)
+            .frame(width: 12)
 
-          DailyUsageMetricCell(value: UsageFormat.tokens(day.inputTokens))
-          DailyUsageMetricCell(value: UsageFormat.tokens(day.outputTokens))
-          DailyUsageMetricCell(value: UsageFormat.tokens(day.cacheReadTokens))
-          DailyUsageMetricCell(value: UsageFormat.tokens(day.totalTokens), isPrimary: true)
-          DailyUsageMetricCell(
-            value: UsageFormat.cost(day.estimatedCostUSD),
-            width: DailyUsageTableLayout.costColumnWidth,
-            isPrimary: true
-          )
+          Text(dateLabel(day.date))
+            .font(.subheadline)
+            .fontWeight(.semibold)
+            .lineLimit(1)
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .contentShape(Rectangle())
+        .frame(
+          minWidth: DailyUsageTableLayout.dayColumnMinWidth, maxWidth: .infinity,
+          alignment: .leading)
+
+        Text(providerCountLabel)
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .lineLimit(1)
+          .frame(width: DailyUsageTableLayout.sourceColumnWidth, alignment: .leading)
+
+        DailyUsageMetricCell(value: UsageFormat.tokens(day.inputTokens))
+        DailyUsageMetricCell(value: UsageFormat.tokens(day.outputTokens))
+        DailyUsageMetricCell(value: UsageFormat.tokens(day.cacheReadTokens))
+        DailyUsageMetricCell(value: UsageFormat.tokens(day.totalTokens), isPrimary: true)
+        DailyUsageMetricCell(
+          value: UsageFormat.cost(day.estimatedCostUSD),
+          width: DailyUsageTableLayout.costColumnWidth,
+          isPrimary: true
+        )
       }
-      .buttonStyle(.plain)
+      .padding(.horizontal, 10)
+      .padding(.vertical, 8)
+      .contentShape(Rectangle())
+      .onTapGesture(perform: toggle)
       .accessibilityLabel(accessibilitySummary)
       .accessibilityHint(isExpanded ? "Collapse day details" : "Show day details")
+      .accessibilityAddTraits(.isButton)
+      .accessibilityAction(named: Text(isExpanded ? "Collapse" : "Expand"), toggle)
 
       if isExpanded {
         VStack(spacing: 0) {

--- a/MeterBar/Views/DashboardCard.swift
+++ b/MeterBar/Views/DashboardCard.swift
@@ -1,47 +1,105 @@
 import AppKit
-import SwiftUI
 import MeterBarShared
+import SwiftUI
 
 // Shared dashboard chrome extracted from UsageDashboardView.swift (R8 split). Pure move.
 
 let overviewTileMinHeight: CGFloat = 220
 
+struct DashboardTile<Content: View>: View {
+  let cornerRadius: CGFloat
+  let padding: CGFloat
+  let minHeight: CGFloat?
+  let alignment: Alignment
+  @ViewBuilder let content: Content
+
+  init(
+    cornerRadius: CGFloat = 12,
+    padding: CGFloat = 14,
+    minHeight: CGFloat? = nil,
+    alignment: Alignment = .topLeading,
+    @ViewBuilder content: () -> Content
+  ) {
+    self.cornerRadius = cornerRadius
+    self.padding = padding
+    self.minHeight = minHeight
+    self.alignment = alignment
+    self.content = content()
+  }
+
+  var body: some View {
+    content
+      .padding(padding)
+      .frame(maxWidth: .infinity, minHeight: minHeight, alignment: alignment)
+      .dashboardCardBackground(cornerRadius: cornerRadius)
+  }
+}
+
 struct DashboardCard<Content: View>: View {
-    let title: String
-    let trailing: String?
-    @ViewBuilder let content: Content
+  let title: String
+  let trailing: String?
+  @ViewBuilder let content: Content
 
-    init(title: String, trailing: String? = nil, @ViewBuilder content: () -> Content) {
-        self.title = title
-        self.trailing = trailing
-        self.content = content()
-    }
+  init(title: String, trailing: String? = nil, @ViewBuilder content: () -> Content) {
+    self.title = title
+    self.trailing = trailing
+    self.content = content()
+  }
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack {
-                Text(title)
-                    .font(.title3)
-                    .bold()
-                Spacer()
-                if let trailing {
-                    Text(trailing)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-            }
-            content
+  var body: some View {
+    DashboardTile {
+      VStack(alignment: .leading, spacing: 14) {
+        HStack {
+          Text(title)
+            .font(.title3)
+            .bold()
+          Spacer()
+          if let trailing {
+            Text(trailing)
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
         }
-        .padding(14)
-        .frame(maxWidth: .infinity, alignment: .topLeading)
-        .dashboardCardBackground()
+        content
+      }
     }
+  }
+}
+
+struct DashboardMetricTile: View {
+  let title: String
+  let value: String
+  let caption: String
+  let systemImage: String
+  let tint: Color
+
+  var body: some View {
+    DashboardTile {
+      VStack(alignment: .leading, spacing: 6) {
+        Label(title, systemImage: systemImage)
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .labelStyle(.titleAndIcon)
+
+        Text(value)
+          .font(.title2)
+          .fontWeight(.semibold)
+          .foregroundStyle(tint)
+          .contentTransition(.numericText())
+
+        Text(caption)
+          .font(.caption2)
+          .foregroundColor(.secondary)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+  }
 }
 
 extension View {
-    /// Dashboard content-card surface. Delegates to the shared `meterBarCardSurface`
-    /// so the dashboard and popover cards stay visually identical.
-    func dashboardCardBackground() -> some View {
-        meterBarCardSurface()
-    }
+  /// Dashboard content-card surface. Delegates to the shared `meterBarCardSurface`
+  /// so the dashboard and popover cards stay visually identical.
+  func dashboardCardBackground(cornerRadius: CGFloat = 12) -> some View {
+    meterBarCardSurface(cornerRadius: cornerRadius)
+  }
 }

--- a/MeterBar/Views/DashboardCard.swift
+++ b/MeterBar/Views/DashboardCard.swift
@@ -14,7 +14,7 @@ struct DashboardTile<Content: View>: View {
   @ViewBuilder let content: Content
 
   init(
-    cornerRadius: CGFloat = 6,
+    cornerRadius: CGFloat = 12,
     padding: CGFloat = 14,
     minHeight: CGFloat? = nil,
     alignment: Alignment = .topLeading,
@@ -67,29 +67,108 @@ struct DashboardCard<Content: View>: View {
 }
 
 struct DashboardMetricTile: View {
+  enum Style {
+    case regular
+    case compact
+
+    var minHeight: CGFloat? {
+      switch self {
+      case .regular:
+        return nil
+      case .compact:
+        return 104
+      }
+    }
+
+    var spacing: CGFloat {
+      switch self {
+      case .regular:
+        return 6
+      case .compact:
+        return 10
+      }
+    }
+
+    var titleFont: Font {
+      .caption
+    }
+
+    var titleWeight: Font.Weight? {
+      switch self {
+      case .regular:
+        return nil
+      case .compact:
+        return .semibold
+      }
+    }
+
+    var valueFont: Font {
+      switch self {
+      case .regular:
+        return .title2
+      case .compact:
+        return .title3
+      }
+    }
+
+    var captionFont: Font {
+      switch self {
+      case .regular:
+        return .caption2
+      case .compact:
+        return .caption
+      }
+    }
+
+    var valueMinimumScaleFactor: CGFloat {
+      switch self {
+      case .regular:
+        return 1
+      case .compact:
+        return 0.72
+      }
+    }
+
+    var captionMinimumScaleFactor: CGFloat {
+      switch self {
+      case .regular:
+        return 1
+      case .compact:
+        return 0.8
+      }
+    }
+  }
+
   let title: String
   let value: String
   let caption: String
   let systemImage: String
   let tint: Color
+  var style: Style = .regular
 
   var body: some View {
-    DashboardTile {
-      VStack(alignment: .leading, spacing: 6) {
+    DashboardTile(minHeight: style.minHeight) {
+      VStack(alignment: .leading, spacing: style.spacing) {
         Label(title, systemImage: systemImage)
-          .font(.caption)
+          .font(style.titleFont)
+          .fontWeight(style.titleWeight)
           .foregroundColor(.secondary)
           .labelStyle(.titleAndIcon)
+          .lineLimit(1)
 
         Text(value)
-          .font(.title2)
+          .font(style.valueFont)
           .fontWeight(.semibold)
           .foregroundStyle(tint)
+          .lineLimit(1)
+          .minimumScaleFactor(style.valueMinimumScaleFactor)
           .contentTransition(.numericText())
 
         Text(caption)
-          .font(.caption2)
+          .font(style.captionFont)
           .foregroundColor(.secondary)
+          .lineLimit(1)
+          .minimumScaleFactor(style.captionMinimumScaleFactor)
       }
       .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/MeterBar/Views/DashboardCard.swift
+++ b/MeterBar/Views/DashboardCard.swift
@@ -31,7 +31,7 @@ struct DashboardTile<Content: View>: View {
     content
       .padding(padding)
       .frame(maxWidth: .infinity, minHeight: minHeight, alignment: alignment)
-      .dashboardCardBackground(cornerRadius: cornerRadius)
+      .meterBarCardSurface(cornerRadius: cornerRadius)
   }
 }
 
@@ -93,13 +93,5 @@ struct DashboardMetricTile: View {
       }
       .frame(maxWidth: .infinity, alignment: .leading)
     }
-  }
-}
-
-extension View {
-  /// Dashboard content-card surface. Delegates to the shared `meterBarCardSurface`
-  /// so the dashboard and popover cards stay visually identical.
-  func dashboardCardBackground(cornerRadius: CGFloat = 12) -> some View {
-    meterBarCardSurface(cornerRadius: cornerRadius)
   }
 }

--- a/MeterBar/Views/DashboardCard.swift
+++ b/MeterBar/Views/DashboardCard.swift
@@ -14,7 +14,7 @@ struct DashboardTile<Content: View>: View {
   @ViewBuilder let content: Content
 
   init(
-    cornerRadius: CGFloat = 12,
+    cornerRadius: CGFloat = 6,
     padding: CGFloat = 14,
     minHeight: CGFloat? = nil,
     alignment: Alignment = .topLeading,

--- a/MeterBar/Views/DashboardCostCards.swift
+++ b/MeterBar/Views/DashboardCostCards.swift
@@ -1,359 +1,322 @@
 import AppKit
-import SwiftUI
 import MeterBarShared
+import SwiftUI
 
 // Cost overview + breakdown cards extracted from UsageDashboardView.swift (R8 split). Pure move.
 
 struct CostOverviewStatusCard: View {
-    let summary: CostSummary?
-    let isScanning: Bool
-    let isRefreshingMissingDays: Bool
-    let formattedTokens: String
+  let summary: CostSummary?
+  let isScanning: Bool
+  let isRefreshingMissingDays: Bool
+  let formattedTokens: String
 
-    private var subtitle: String {
-        if isScanning { return "Scanning local logs" }
-        if isRefreshingMissingDays { return "Updating…" }
-        return "Last 30 days"
-    }
+  private var subtitle: String {
+    if isScanning { return "Scanning local logs" }
+    if isRefreshingMissingDays { return "Updating…" }
+    return "Last 30 days"
+  }
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .center, spacing: 9) {
-                Image(systemName: "dollarsign.circle.fill")
-                    .font(.system(size: 20, weight: .semibold))
-                    .foregroundStyle(MeterBarTheme.success)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("API-Rate Estimate")
-                        .font(.headline)
-                        .fontWeight(.semibold)
-                    Text(subtitle)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                Spacer()
-            }
-
-            if let formattedTotalCost = summary?.formattedTotalCost {
-                Text(formattedTotalCost)
-                    .font(.system(size: 34, weight: .bold))
-                    .foregroundColor(.primary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.75)
-            } else if isScanning {
-                HStack(spacing: 10) {
-                    ProgressView()
-                        .controlSize(.small)
-                    Text("Scanning...")
-                        .font(.system(size: 28, weight: .bold))
-                        .foregroundColor(.primary)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.75)
-                }
-            } else {
-                Text("Scan needed")
-                    .font(.system(size: 34, weight: .bold))
-                    .foregroundColor(.primary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.75)
-            }
-
-            VStack(spacing: 7) {
-                HStack {
-                    Text("Tokens")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                    Spacer()
-                    Text(formattedTokens)
-                        .font(.caption)
-                        .fontWeight(.semibold)
-                }
-                HStack {
-                    Text("Providers")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                    Spacer()
-                    Text("\(summary?.costs.count ?? 0)")
-                        .font(.caption)
-                        .fontWeight(.semibold)
-                }
-            }
+  var body: some View {
+    DashboardTile(minHeight: overviewTileMinHeight) {
+      VStack(alignment: .leading, spacing: 12) {
+        HStack(alignment: .center, spacing: 9) {
+          Image(systemName: "dollarsign.circle.fill")
+            .font(.system(size: 20, weight: .semibold))
+            .foregroundStyle(MeterBarTheme.success)
+          VStack(alignment: .leading, spacing: 2) {
+            Text("API-Rate Estimate")
+              .font(.headline)
+              .fontWeight(.semibold)
+            Text(subtitle)
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+          Spacer()
         }
-        .padding(14)
-        .frame(
-            maxWidth: .infinity,
-            minHeight: overviewTileMinHeight,
-            alignment: .topLeading
-        )
-        .dashboardCardBackground()
+
+        if let formattedTotalCost = summary?.formattedTotalCost {
+          Text(formattedTotalCost)
+            .font(.system(size: 34, weight: .bold))
+            .foregroundColor(.primary)
+            .lineLimit(1)
+            .minimumScaleFactor(0.75)
+        } else if isScanning {
+          HStack(spacing: 10) {
+            ProgressView()
+              .controlSize(.small)
+            Text("Scanning...")
+              .font(.system(size: 28, weight: .bold))
+              .foregroundColor(.primary)
+              .lineLimit(1)
+              .minimumScaleFactor(0.75)
+          }
+        } else {
+          Text("Scan needed")
+            .font(.system(size: 34, weight: .bold))
+            .foregroundColor(.primary)
+            .lineLimit(1)
+            .minimumScaleFactor(0.75)
+        }
+
+        VStack(spacing: 7) {
+          HStack {
+            Text("Tokens")
+              .font(.caption)
+              .foregroundColor(.secondary)
+            Spacer()
+            Text(formattedTokens)
+              .font(.caption)
+              .fontWeight(.semibold)
+          }
+          HStack {
+            Text("Providers")
+              .font(.caption)
+              .foregroundColor(.secondary)
+            Spacer()
+            Text("\(summary?.costs.count ?? 0)")
+              .font(.caption)
+              .fontWeight(.semibold)
+          }
+        }
+      }
     }
+  }
 }
 
 struct CostScanLoadingChart: View {
-    let compact: Bool
+  let compact: Bool
 
-    @Environment(\.accessibilityReduceMotion)
-    private var reduceMotion
+  @Environment(\.accessibilityReduceMotion)
+  private var reduceMotion
 
-    private let barCount = 30
+  private let barCount = 30
 
-    var body: some View {
-        TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
-            GeometryReader { proxy in
-                let spacing: CGFloat = compact ? 4 : 5
-                let labelHeight: CGFloat = compact ? 34 : 44
-                let chartHeight = max(42, proxy.size.height - labelHeight)
-                let barWidth = max(4, (proxy.size.width - CGFloat(barCount - 1) * spacing) / CGFloat(barCount))
-                let time = timeline.date.timeIntervalSinceReferenceDate
-                let sweepWidth = max(42, proxy.size.width * 0.18)
-                let sweepProgress = CGFloat(time.truncatingRemainder(dividingBy: 1.8) / 1.8)
-                let sweepX = sweepProgress * (proxy.size.width + sweepWidth) - sweepWidth
+  var body: some View {
+    TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
+      GeometryReader { proxy in
+        let spacing: CGFloat = compact ? 4 : 5
+        let labelHeight: CGFloat = compact ? 34 : 44
+        let chartHeight = max(42, proxy.size.height - labelHeight)
+        let barWidth = max(
+          4, (proxy.size.width - CGFloat(barCount - 1) * spacing) / CGFloat(barCount))
+        let time = timeline.date.timeIntervalSinceReferenceDate
+        let sweepWidth = max(42, proxy.size.width * 0.18)
+        let sweepProgress = CGFloat(time.truncatingRemainder(dividingBy: 1.8) / 1.8)
+        let sweepX = sweepProgress * (proxy.size.width + sweepWidth) - sweepWidth
 
-                VStack(alignment: .leading, spacing: compact ? 8 : 11) {
-                    HStack(spacing: 8) {
-                        ProgressView()
-                            .controlSize(.small)
-                        Text("Scanning local logs")
-                            .font(compact ? .caption : .subheadline)
-                            .fontWeight(.semibold)
-                        Spacer()
-                        Text("30 days")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
+        VStack(alignment: .leading, spacing: compact ? 8 : 11) {
+          HStack(spacing: 8) {
+            ProgressView()
+              .controlSize(.small)
+            Text("Scanning local logs")
+              .font(compact ? .caption : .subheadline)
+              .fontWeight(.semibold)
+            Spacer()
+            Text("30 days")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
 
-                    ZStack(alignment: .leading) {
-                        HStack(alignment: .bottom, spacing: spacing) {
-                            ForEach(0..<barCount, id: \.self) { index in
-                                let seed = Double(((index * 17) % 11) + 2) / 13
-                                let wave = reduceMotion ? 0.5 : (sin((time * 3.2) + Double(index) * 0.55) + 1) / 2
-                                let height = chartHeight * CGFloat(0.14 + (seed * 0.44) + (wave * 0.28))
+          ZStack(alignment: .leading) {
+            HStack(alignment: .bottom, spacing: spacing) {
+              ForEach(0..<barCount, id: \.self) { index in
+                let seed = Double(((index * 17) % 11) + 2) / 13
+                let wave = reduceMotion ? 0.5 : (sin((time * 3.2) + Double(index) * 0.55) + 1) / 2
+                let height = chartHeight * CGFloat(0.14 + (seed * 0.44) + (wave * 0.28))
 
-                                RoundedRectangle(cornerRadius: 3)
-                                    .fill(
-                                        LinearGradient(
-                                            colors: [
-                                                MeterBarTheme.codexAccent.opacity(0.18 + wave * 0.16),
-                                                MeterBarTheme.cursorAccent.opacity(0.16 + seed * 0.20)
-                                            ],
-                                            startPoint: .bottom,
-                                            endPoint: .top
-                                        )
-                                    )
-                                    .frame(width: barWidth, height: max(4, height))
-                            }
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: chartHeight, alignment: .bottomLeading)
-
-                        if !reduceMotion {
-                            Rectangle()
-                                .fill(
-                                    LinearGradient(
-                                        colors: [.clear, Color.primary.opacity(0.22), .clear],
-                                        startPoint: .leading,
-                                        endPoint: .trailing
-                                    )
-                                )
-                                .frame(width: sweepWidth, height: chartHeight)
-                                .offset(x: sweepX)
-                        }
-                    }
-                    .clipShape(RoundedRectangle(cornerRadius: 7))
-
-                    if !compact {
-                        Text("Parsing Claude and Codex sessions")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
-                .frame(width: proxy.size.width, height: proxy.size.height, alignment: .topLeading)
+                RoundedRectangle(cornerRadius: 3)
+                  .fill(
+                    LinearGradient(
+                      colors: [
+                        MeterBarTheme.codexAccent.opacity(0.18 + wave * 0.16),
+                        MeterBarTheme.cursorAccent.opacity(0.16 + seed * 0.20),
+                      ],
+                      startPoint: .bottom,
+                      endPoint: .top
+                    )
+                  )
+                  .frame(width: barWidth, height: max(4, height))
+              }
             }
+            .frame(maxWidth: .infinity, maxHeight: chartHeight, alignment: .bottomLeading)
+
+            if !reduceMotion {
+              Rectangle()
+                .fill(
+                  LinearGradient(
+                    colors: [.clear, Color.primary.opacity(0.22), .clear],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                  )
+                )
+                .frame(width: sweepWidth, height: chartHeight)
+                .offset(x: sweepX)
+            }
+          }
+          .clipShape(RoundedRectangle(cornerRadius: 7))
+
+          if !compact {
+            Text("Parsing Claude and Codex sessions")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
         }
+        .frame(width: proxy.size.width, height: proxy.size.height, alignment: .topLeading)
+      }
     }
+  }
 }
 
 struct CostScanProgressBadge: View {
-    let compact: Bool
+  let compact: Bool
 
-    var body: some View {
-        VStack {
-            HStack {
-                HStack(spacing: 8) {
-                    ProgressView()
-                        .controlSize(.small)
-                    Text(compact ? "Scanning..." : "Updating local scan")
-                        .font(.caption)
-                        .fontWeight(.semibold)
-                }
-                .padding(.horizontal, compact ? 9 : 11)
-                .padding(.vertical, compact ? 6 : 8)
-                .glassEffect(.regular, in: .capsule)
-
-                Spacer()
-            }
-
-            Spacer()
+  var body: some View {
+    VStack {
+      HStack {
+        HStack(spacing: 8) {
+          ProgressView()
+            .controlSize(.small)
+          Text(compact ? "Scanning..." : "Updating local scan")
+            .font(.caption)
+            .fontWeight(.semibold)
         }
-        .padding(compact ? 8 : 10)
+        .padding(.horizontal, compact ? 9 : 11)
+        .padding(.vertical, compact ? 6 : 8)
+        .glassEffect(.regular, in: .capsule)
+
+        Spacer()
+      }
+
+      Spacer()
     }
-}
-
-struct CostRefreshLockOverlay: View {
-    var body: some View {
-        ZStack {
-            Color(nsColor: .controlBackgroundColor)
-                .opacity(0.62)
-                .contentShape(Rectangle())
-                .gesture(DragGesture(minimumDistance: 0), including: .all)
-
-            VStack(spacing: 7) {
-                HStack(spacing: 8) {
-                    ProgressView()
-                        .controlSize(.small)
-                    Text("Refreshing costs")
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                }
-
-                Text("Scanning local token logs")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .multilineTextAlignment(.center)
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 12)
-            .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-        }
-        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("Refreshing costs")
-        .accessibilityHint("Cost results are locked until the local scan finishes.")
-    }
+    .padding(compact ? 8 : 10)
+  }
 }
 
 struct ProviderCostBreakdown: View {
-    let cost: TokenCost
-    var quotaSnapshot: ProviderSnapshot?
+  let cost: TokenCost
+  var quotaSnapshot: ProviderSnapshot?
 
-    private var logoKind: ProviderLogoKind {
-        .forService(cost.provider)
-    }
+  private var logoKind: ProviderLogoKind {
+    .forService(cost.provider)
+  }
 
-    private var logoColor: Color {
-        MeterBarTheme.accent(for: cost.provider)
-    }
+  private var logoColor: Color {
+    MeterBarTheme.accent(for: cost.provider)
+  }
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack {
-                ProviderTitle(
-                    title: cost.provider.displayName,
-                    logoKind: logoKind,
-                    color: logoColor,
-                    font: .headline
-                )
-                Spacer()
-                Text(cost.formattedCost)
-                    .font(.title3)
-                    .bold()
-            }
-
-            if let quotaSnapshot, quotaSnapshot.hasExhaustedLimit {
-                BlockingLimitResetCounter(
-                    windows: quotaSnapshot.resetWindows,
-                    accentColor: logoColor
-                )
-            }
-
-            HStack(spacing: 14) {
-                CostMetric(label: "Tokens", value: cost.formattedTokens)
-                CostMetric(label: "Input", value: UsageFormat.tokens(cost.inputTokens))
-                CostMetric(label: "Output", value: UsageFormat.tokens(cost.outputTokens))
-                CostMetric(label: "Sessions", value: "\(cost.sessionCount)")
-            }
-
-            if !cost.modelBreakdowns.isEmpty {
-                CostBreakdownSection(title: "Models", items: Array(cost.modelBreakdowns.prefix(6)))
-            }
-
-            if !cost.originBreakdowns.isEmpty {
-                CostBreakdownSection(title: "Usage Origin", items: Array(cost.originBreakdowns.prefix(6)))
-            }
+  var body: some View {
+    DashboardTile {
+      VStack(alignment: .leading, spacing: 10) {
+        HStack {
+          ProviderTitle(
+            title: cost.provider.displayName,
+            logoKind: logoKind,
+            color: logoColor,
+            font: .headline
+          )
+          Spacer()
+          Text(cost.formattedCost)
+            .font(.title3)
+            .bold()
         }
-        .padding(12)
-        .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+        if let quotaSnapshot, quotaSnapshot.hasExhaustedLimit {
+          BlockingLimitResetCounter(
+            windows: quotaSnapshot.resetWindows,
+            accentColor: logoColor
+          )
+        }
+
+        HStack(spacing: 14) {
+          CostMetric(label: "Tokens", value: cost.formattedTokens)
+          CostMetric(label: "Input", value: UsageFormat.tokens(cost.inputTokens))
+          CostMetric(label: "Output", value: UsageFormat.tokens(cost.outputTokens))
+          CostMetric(label: "Sessions", value: "\(cost.sessionCount)")
+        }
+
+        if !cost.modelBreakdowns.isEmpty {
+          CostBreakdownSection(title: "Models", items: Array(cost.modelBreakdowns.prefix(6)))
+        }
+
+        if !cost.originBreakdowns.isEmpty {
+          CostBreakdownSection(title: "Usage Origin", items: Array(cost.originBreakdowns.prefix(6)))
+        }
+      }
     }
+  }
 }
 
 struct CostBreakdownSection: View {
-    let title: String
-    let items: [TokenUsageBreakdown]
+  let title: String
+  let items: [TokenUsageBreakdown]
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 7) {
-            Text(title)
-                .font(.caption)
-                .fontWeight(.semibold)
-                .foregroundColor(.secondary)
+  var body: some View {
+    VStack(alignment: .leading, spacing: 7) {
+      Text(title)
+        .font(.caption)
+        .fontWeight(.semibold)
+        .foregroundColor(.secondary)
 
-            ForEach(items) { item in
-                HStack(spacing: 10) {
-                    Text(item.name)
-                        .font(.caption)
-                        .fontWeight(.semibold)
-                        .lineLimit(1)
-                        .frame(width: 150, alignment: .leading)
+      ForEach(items) { item in
+        HStack(spacing: 10) {
+          Text(item.name)
+            .font(.caption)
+            .fontWeight(.semibold)
+            .lineLimit(1)
+            .frame(width: 150, alignment: .leading)
 
-                    UsageDetailMetric(label: "Tokens", value: UsageFormat.tokens(item.totalTokens))
-                    UsageDetailMetric(label: "Input", value: UsageFormat.tokens(item.inputTokens))
-                    UsageDetailMetric(label: "Output", value: UsageFormat.tokens(item.outputTokens))
-                    UsageDetailMetric(label: "Cache", value: UsageFormat.tokens(item.cacheReadTokens))
+          UsageDetailMetric(label: "Tokens", value: UsageFormat.tokens(item.totalTokens))
+          UsageDetailMetric(label: "Input", value: UsageFormat.tokens(item.inputTokens))
+          UsageDetailMetric(label: "Output", value: UsageFormat.tokens(item.outputTokens))
+          UsageDetailMetric(label: "Cache", value: UsageFormat.tokens(item.cacheReadTokens))
 
-                    Spacer()
+          Spacer()
 
-                    Text(item.formattedCost)
-                        .font(.caption)
-                        .fontWeight(.semibold)
-                }
-                .padding(.vertical, 2)
-            }
+          Text(item.formattedCost)
+            .font(.caption)
+            .fontWeight(.semibold)
         }
-        .padding(.top, 4)
+        .padding(.vertical, 2)
+      }
     }
+    .padding(.top, 4)
+  }
 }
 
 struct CostMetric: View {
-    let label: String
-    let value: String
+  let label: String
+  let value: String
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 3) {
-            Text(label)
-                .font(.caption)
-                .foregroundColor(.secondary)
-            Text(value)
-                .font(.headline)
-                .lineLimit(1)
-                .minimumScaleFactor(0.75)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
+  var body: some View {
+    VStack(alignment: .leading, spacing: 3) {
+      Text(label)
+        .font(.caption)
+        .foregroundColor(.secondary)
+      Text(value)
+        .font(.headline)
+        .lineLimit(1)
+        .minimumScaleFactor(0.75)
     }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
 }
 
 struct UsageDetailMetric: View {
-    let label: String
-    let value: String
+  let label: String
+  let value: String
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 1) {
-            Text(label)
-                .font(.system(size: 9, weight: .medium))
-                .foregroundColor(.secondary)
-            Text(value)
-                .font(.caption)
-                .fontWeight(.semibold)
-                .lineLimit(1)
-                .minimumScaleFactor(0.75)
-        }
-        .frame(width: 58, alignment: .leading)
+  var body: some View {
+    VStack(alignment: .leading, spacing: 1) {
+      Text(label)
+        .font(.system(size: 9, weight: .medium))
+        .foregroundColor(.secondary)
+      Text(value)
+        .font(.caption)
+        .fontWeight(.semibold)
+        .lineLimit(1)
+        .minimumScaleFactor(0.75)
     }
+    .frame(width: 58, alignment: .leading)
+  }
 }

--- a/MeterBar/Views/DashboardProviderCards.swift
+++ b/MeterBar/Views/DashboardProviderCards.swift
@@ -1,230 +1,250 @@
 import AppKit
-import SwiftUI
 import MeterBarShared
+import SwiftUI
 
 // Provider status/limit cards extracted from UsageDashboardView.swift (R8 split). Pure move.
 
 struct DashboardStatusHero: View {
-    let title: String
-    let detail: String
-    let iconName: String
-    let color: Color
+  let title: String
+  let detail: String
+  let iconName: String
+  let color: Color
 
-    var body: some View {
-        HStack(alignment: .center, spacing: 14) {
-            ZStack {
-                Circle()
-                    .fill(.quaternary)
-                    .frame(width: 46, height: 46)
-                Image(systemName: iconName)
-                    .font(.system(size: 23, weight: .semibold))
-                    .foregroundStyle(color)
-            }
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title)
-                    .font(.title3)
-                    .fontWeight(.semibold)
-                Text(detail)
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-            }
-
-            Spacer()
+  var body: some View {
+    DashboardTile {
+      HStack(alignment: .center, spacing: 14) {
+        ZStack {
+          Circle()
+            .fill(MeterBarTheme.glassCardTint)
+            .frame(width: 46, height: 46)
+          Image(systemName: iconName)
+            .font(.system(size: 23, weight: .semibold))
+            .foregroundStyle(color)
         }
-        .padding(14)
-        .dashboardCardBackground()
+
+        VStack(alignment: .leading, spacing: 4) {
+          Text(title)
+            .font(.title3)
+            .fontWeight(.semibold)
+          Text(detail)
+            .font(.subheadline)
+            .foregroundColor(.secondary)
+        }
+
+        Spacer()
+      }
     }
+  }
 }
 
 struct ProviderOverviewStatusCard: View {
-    let snapshot: ProviderSnapshot
+  let snapshot: ProviderSnapshot
+  var onSelect: (() -> Void)?
 
-    private var statusText: String {
-        snapshot.band?.shortLabel ?? "No data"
-    }
+  private var statusText: String {
+    snapshot.band?.shortLabel ?? "No data"
+  }
 
-    private var statusColor: Color {
-        snapshot.band?.color ?? .secondary
-    }
+  private var statusColor: Color {
+    snapshot.band?.color ?? .secondary
+  }
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .center, spacing: 9) {
-                ProviderLogoView(kind: snapshot.logoKind, size: 20, foregroundColor: snapshot.accentColor)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(snapshot.title)
-                        .font(.headline)
-                        .fontWeight(.semibold)
-                    Text(updatedText)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                Spacer()
-                Text(statusText)
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                    .foregroundColor(statusColor)
-            }
-
-            if snapshot.limits.isEmpty {
-                Text("No quota windows reported")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .frame(maxWidth: .infinity, minHeight: 54, alignment: .topLeading)
-            } else {
-                VStack(alignment: .leading, spacing: 12) {
-                    ForEach(snapshot.limits) { limit in
-                        DashboardLimitRow(limit: limit, accentColor: snapshot.accentColor)
-                    }
-                }
-            }
-
-            // Reset-credits + extra-usage badges, matching the popover card
-            // (shared component so the two surfaces can't drift — issue #40).
-            let badges = ProviderStatusBadges(snapshot: snapshot, style: .regular)
-            if badges.hasContent {
-                badges
-            }
+  var body: some View {
+    Group {
+      if let onSelect {
+        Button(action: onSelect) {
+          cardContent
         }
-        .padding(14)
-        .frame(
-            maxWidth: .infinity,
-            minHeight: overviewTileMinHeight,
-            alignment: .topLeading
-        )
-        .dashboardCardBackground()
+        .buttonStyle(.plain)
+        .accessibilityHint("Open \(snapshot.title) quota overview")
+      } else {
+        cardContent
+      }
     }
+  }
 
-    private var updatedText: String {
-        guard let updatedAt = snapshot.updatedAt else { return "No data" }
-        return "Updated \(UsageFormat.relative(updatedAt))"
+  private var cardContent: some View {
+    DashboardTile(minHeight: overviewTileMinHeight) {
+      VStack(alignment: .leading, spacing: 12) {
+        HStack(alignment: .center, spacing: 9) {
+          ProviderLogoView(kind: snapshot.logoKind, size: 20, foregroundColor: snapshot.accentColor)
+          VStack(alignment: .leading, spacing: 2) {
+            Text(snapshot.title)
+              .font(.headline)
+              .fontWeight(.semibold)
+            Text(updatedText)
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+          Spacer()
+          Text(statusText)
+            .font(.caption)
+            .fontWeight(.semibold)
+            .foregroundColor(statusColor)
+        }
+
+        if snapshot.limits.isEmpty {
+          Text("No quota windows reported")
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .frame(maxWidth: .infinity, minHeight: 54, alignment: .topLeading)
+        } else if snapshot.hasExhaustedWeeklyLimit {
+          BlockingLimitResetCounter(
+            windows: snapshot.resetWindows,
+            accentColor: snapshot.accentColor
+          )
+        } else {
+          VStack(alignment: .leading, spacing: 12) {
+            ForEach(snapshot.limits) { limit in
+              DashboardLimitRow(limit: limit, accentColor: snapshot.accentColor)
+            }
+          }
+        }
+
+        // Reset-credits + extra-usage badges, matching the popover card
+        // (shared component so the two surfaces can't drift — issue #40).
+        let badges = ProviderStatusBadges(snapshot: snapshot, style: .regular)
+        if badges.hasContent {
+          badges
+        }
+      }
     }
+    .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+  }
+
+  private var updatedText: String {
+    guard let updatedAt = snapshot.updatedAt else { return "No data" }
+    return "Updated \(UsageFormat.relative(updatedAt))"
+  }
 }
 
 struct ProviderLimitsCard: View {
-    let snapshot: ProviderSnapshot
+  let snapshot: ProviderSnapshot
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                ProviderTitle(
-                    title: snapshot.title,
-                    logoKind: snapshot.logoKind,
-                    color: snapshot.accentColor,
-                    font: .title3
-                )
-                Spacer()
-                Text(updatedText)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-
-            if snapshot.limits.isEmpty {
-                Text("No quota windows reported")
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-            } else {
-                ForEach(snapshot.limits) { limit in
-                    DashboardLimitRow(limit: limit, accentColor: snapshot.accentColor)
-                }
-            }
-
-            // Same reset-credits + extra-usage badges as the popover card.
-            let badges = ProviderStatusBadges(snapshot: snapshot, style: .regular)
-            if badges.hasContent {
-                badges
-            }
+  var body: some View {
+    DashboardTile {
+      VStack(alignment: .leading, spacing: 12) {
+        HStack {
+          ProviderTitle(
+            title: snapshot.title,
+            logoKind: snapshot.logoKind,
+            color: snapshot.accentColor,
+            font: .title3
+          )
+          Spacer()
+          Text(updatedText)
+            .font(.caption)
+            .foregroundColor(.secondary)
         }
-        .padding(14)
-        .frame(maxWidth: .infinity, alignment: .topLeading)
-        .dashboardCardBackground()
-    }
 
-    private var updatedText: String {
-        guard let updatedAt = snapshot.updatedAt else { return "No data" }
-        return "Updated \(UsageFormat.relative(updatedAt))"
+        if snapshot.limits.isEmpty {
+          Text("No quota windows reported")
+            .font(.subheadline)
+            .foregroundColor(.secondary)
+        } else if snapshot.hasExhaustedWeeklyLimit {
+          BlockingLimitResetCounter(
+            windows: snapshot.resetWindows,
+            accentColor: snapshot.accentColor
+          )
+        } else {
+          ForEach(snapshot.limits) { limit in
+            DashboardLimitRow(limit: limit, accentColor: snapshot.accentColor)
+          }
+        }
+
+        // Same reset-credits + extra-usage badges as the popover card.
+        let badges = ProviderStatusBadges(snapshot: snapshot, style: .regular)
+        if badges.hasContent {
+          badges
+        }
+      }
     }
+  }
+
+  private var updatedText: String {
+    guard let updatedAt = snapshot.updatedAt else { return "No data" }
+    return "Updated \(UsageFormat.relative(updatedAt))"
+  }
 }
 
 struct ProviderTitle: View {
-    let title: String
-    let logoKind: ProviderLogoKind
-    let color: Color
-    let font: Font
+  let title: String
+  let logoKind: ProviderLogoKind
+  let color: Color
+  let font: Font
 
-    var body: some View {
-        HStack(spacing: 8) {
-            ProviderLogoView(kind: logoKind, size: 18, foregroundColor: color)
-            Text(title)
-                .font(font)
-                .fontWeight(.semibold)
-        }
+  var body: some View {
+    HStack(spacing: 8) {
+      ProviderLogoView(kind: logoKind, size: 18, foregroundColor: color)
+      Text(title)
+        .font(font)
+        .fontWeight(.semibold)
     }
+  }
 }
 
 struct DashboardLimitRow: View {
-    let limit: SnapshotLimit
-    let accentColor: Color
+  let limit: SnapshotLimit
+  let accentColor: Color
 
-    private var isOut: Bool {
-        limit.percentLeft <= 0
-    }
+  private var isOut: Bool {
+    limit.percentLeft <= 0
+  }
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Text(limit.title)
-                    .font(.subheadline)
-                    .bold()
-                Spacer()
-                Text(isOut ? "Out" : "\(limit.percentLeft)% left")
-                    .font(.subheadline)
-                    .bold()
-                    .foregroundColor(isOut ? MeterBarTheme.danger : .primary)
-            }
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack {
+        Text(limit.title)
+          .font(.subheadline)
+          .bold()
+        Spacer()
+        Text(isOut ? "Out" : "\(limit.percentLeft)% left")
+          .font(.subheadline)
+          .bold()
+          .foregroundColor(isOut ? MeterBarTheme.danger : .primary)
+      }
 
-            UsageBar(
-                usedPercentage: limit.usedPercent,
-                accentColor: accentColor,
-                pace: limit.usageLimit.pace(),
-                paceContext: limit.paceContext
-            )
+      UsageBar(
+        usedPercentage: limit.usedPercent,
+        accentColor: accentColor,
+        pace: limit.usageLimit.pace(),
+        paceContext: limit.paceContext
+      )
 
-            HStack {
-                Text("\(Int(limit.usedPercent.rounded()))% used")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                if let pace = limit.usageLimit.pace() {
-                    Text(pace.leftLabel)
-                        .font(.caption)
-                        .foregroundColor(paceLabelColor(pace))
-                }
-                Spacer()
-                if limit.usageLimit.resetTime != nil {
-                    ResetCountdownLabel(
-                        title: nil,
-                        limit: limit.usageLimit,
-                        font: .caption,
-                        foregroundColor: .secondary,
-                        iconSize: 10
-                    )
-                }
-            }
+      HStack {
+        Text("\(Int(limit.usedPercent.rounded()))% used")
+          .font(.caption)
+          .foregroundColor(.secondary)
+        if let pace = limit.usageLimit.pace() {
+          Text(pace.leftLabel)
+            .font(.caption)
+            .foregroundColor(paceLabelColor(pace))
         }
+        Spacer()
+        if limit.usageLimit.resetTime != nil {
+          ResetCountdownLabel(
+            title: nil,
+            limit: limit.usageLimit,
+            font: .caption,
+            foregroundColor: .secondary,
+            iconSize: 10
+          )
+        }
+      }
     }
+  }
 
-    private func paceLabelColor(_ pace: UsagePace) -> Color {
-        if pace.isExhausted {
-            return MeterBarTheme.danger
-        }
-        switch pace.stage {
-        case .reserve:
-            return MeterBarTheme.success
-        case .deficit:
-            return MeterBarTheme.warning
-        case .onPace:
-            return .secondary
-        }
+  private func paceLabelColor(_ pace: UsagePace) -> Color {
+    if pace.isExhausted {
+      return MeterBarTheme.danger
     }
+    switch pace.stage {
+    case .reserve:
+      return MeterBarTheme.success
+    case .deficit:
+      return MeterBarTheme.warning
+    case .onPace:
+      return .secondary
+    }
+  }
 }

--- a/MeterBar/Views/DashboardProviderCards.swift
+++ b/MeterBar/Views/DashboardProviderCards.swift
@@ -15,7 +15,7 @@ struct DashboardStatusHero: View {
       HStack(alignment: .center, spacing: 14) {
         ZStack {
           Circle()
-            .fill(MeterBarTheme.glassCardTint)
+            .fill(.quaternary)
             .frame(width: 46, height: 46)
           Image(systemName: iconName)
             .font(.system(size: 23, weight: .semibold))

--- a/MeterBar/Views/DashboardProviderCards.swift
+++ b/MeterBar/Views/DashboardProviderCards.swift
@@ -97,7 +97,7 @@ struct ProviderOverviewStatusCard: View {
         }
       }
     }
-    .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
   }
 }
 

--- a/MeterBar/Views/DashboardProviderCards.swift
+++ b/MeterBar/Views/DashboardProviderCards.swift
@@ -56,9 +56,13 @@ struct ProviderOverviewStatusCard: View {
           cardContent
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(snapshot.title), \(statusText), \(snapshot.updatedText)")
         .accessibilityHint("Open \(snapshot.title) quota overview")
       } else {
         cardContent
+          .accessibilityElement(children: .combine)
+          .accessibilityLabel("\(snapshot.title), \(statusText), \(snapshot.updatedText)")
       }
     }
   }
@@ -72,7 +76,7 @@ struct ProviderOverviewStatusCard: View {
             Text(snapshot.title)
               .font(.headline)
               .fontWeight(.semibold)
-            Text(updatedText)
+            Text(snapshot.updatedText)
               .font(.caption)
               .foregroundColor(.secondary)
           }
@@ -83,23 +87,7 @@ struct ProviderOverviewStatusCard: View {
             .foregroundColor(statusColor)
         }
 
-        if snapshot.limits.isEmpty {
-          Text("No quota windows reported")
-            .font(.caption)
-            .foregroundColor(.secondary)
-            .frame(maxWidth: .infinity, minHeight: 54, alignment: .topLeading)
-        } else if snapshot.hasExhaustedWeeklyLimit {
-          BlockingLimitResetCounter(
-            windows: snapshot.resetWindows,
-            accentColor: snapshot.accentColor
-          )
-        } else {
-          VStack(alignment: .leading, spacing: 12) {
-            ForEach(snapshot.limits) { limit in
-              DashboardLimitRow(limit: limit, accentColor: snapshot.accentColor)
-            }
-          }
-        }
+        ProviderLimitsBody(snapshot: snapshot, emptyMinHeight: 54, rowSpacing: 12)
 
         // Reset-credits + extra-usage badges, matching the popover card
         // (shared component so the two surfaces can't drift — issue #40).
@@ -110,11 +98,6 @@ struct ProviderOverviewStatusCard: View {
       }
     }
     .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-  }
-
-  private var updatedText: String {
-    guard let updatedAt = snapshot.updatedAt else { return "No data" }
-    return "Updated \(UsageFormat.relative(updatedAt))"
   }
 }
 
@@ -132,25 +115,12 @@ struct ProviderLimitsCard: View {
             font: .title3
           )
           Spacer()
-          Text(updatedText)
+          Text(snapshot.updatedText)
             .font(.caption)
             .foregroundColor(.secondary)
         }
 
-        if snapshot.limits.isEmpty {
-          Text("No quota windows reported")
-            .font(.subheadline)
-            .foregroundColor(.secondary)
-        } else if snapshot.hasExhaustedWeeklyLimit {
-          BlockingLimitResetCounter(
-            windows: snapshot.resetWindows,
-            accentColor: snapshot.accentColor
-          )
-        } else {
-          ForEach(snapshot.limits) { limit in
-            DashboardLimitRow(limit: limit, accentColor: snapshot.accentColor)
-          }
-        }
+        ProviderLimitsBody(snapshot: snapshot, emptyFont: .subheadline, rowSpacing: 12)
 
         // Same reset-credits + extra-usage badges as the popover card.
         let badges = ProviderStatusBadges(snapshot: snapshot, style: .regular)
@@ -160,10 +130,32 @@ struct ProviderLimitsCard: View {
       }
     }
   }
+}
 
-  private var updatedText: String {
-    guard let updatedAt = snapshot.updatedAt else { return "No data" }
-    return "Updated \(UsageFormat.relative(updatedAt))"
+private struct ProviderLimitsBody: View {
+  let snapshot: ProviderSnapshot
+  var emptyFont: Font = .caption
+  var emptyMinHeight: CGFloat?
+  var rowSpacing: CGFloat = 12
+
+  var body: some View {
+    if snapshot.limits.isEmpty {
+      Text("No quota windows reported")
+        .font(emptyFont)
+        .foregroundColor(.secondary)
+        .frame(maxWidth: .infinity, minHeight: emptyMinHeight, alignment: .topLeading)
+    } else if snapshot.hasExhaustedWeeklyLimit {
+      BlockingLimitResetCounter(
+        windows: snapshot.resetWindows,
+        accentColor: snapshot.accentColor
+      )
+    } else {
+      VStack(alignment: .leading, spacing: rowSpacing) {
+        ForEach(snapshot.limits) { limit in
+          DashboardLimitRow(limit: limit, accentColor: snapshot.accentColor)
+        }
+      }
+    }
   }
 }
 

--- a/MeterBar/Views/DashboardProviderCards.swift
+++ b/MeterBar/Views/DashboardProviderCards.swift
@@ -97,7 +97,7 @@ struct ProviderOverviewStatusCard: View {
         }
       }
     }
-    .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+    .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
   }
 }
 

--- a/MeterBar/Views/MenuBarDetailPanel.swift
+++ b/MeterBar/Views/MenuBarDetailPanel.swift
@@ -86,7 +86,6 @@ final class MeterBarMenuDetailPanel {
     self.panel = panel
     return panel
   }
-
 }
 
 enum MeterBarMenuDetailPanelLayout {
@@ -202,7 +201,6 @@ struct MenuBarProviderDetailContent: View {
         .foregroundStyle(MeterBarTheme.appAccent)
     }
   }
-
 }
 
 private struct MenuBarProviderLimitDetailRow: View {

--- a/MeterBar/Views/MenuBarDetailPanel.swift
+++ b/MeterBar/Views/MenuBarDetailPanel.swift
@@ -22,10 +22,16 @@ final class MeterBarMenuDetailPanel {
 
   private var panel: NSPanel?
 
-  func present(anchor: NSWindow, preferredHeight: CGFloat, content: AnyView) {
+  func present(anchor: NSWindow, content: AnyView) {
     let width = MeterBarMenuDetailPanelLayout.detailWidth
     let panel = ensurePanel()
     panel.level = anchor.level
+    let measuringView = NSHostingView(
+      rootView: content
+        .meterBarSurfaceStyle(.toolbar)
+        .frame(width: width)
+        .fixedSize(horizontal: false, vertical: true)
+    )
 
     let anchorFrame = anchor.frame
     let visibleFrame = anchor.screen?.visibleFrame ?? NSScreen.main?.visibleFrame ?? anchorFrame
@@ -33,7 +39,8 @@ final class MeterBarMenuDetailPanel {
       MeterBarMenuDetailPanelLayout.minDetailHeight,
       visibleFrame.height - (MeterBarMenuDetailPanelLayout.screenPadding * 2)
     )
-    let height = min(max(preferredHeight, MeterBarMenuDetailPanelLayout.minDetailHeight), maxHeight)
+    let measuredHeight = measuringView.fittingSize.height
+    let height = min(max(measuredHeight, MeterBarMenuDetailPanelLayout.minDetailHeight), maxHeight)
     let topY = min(anchorFrame.maxY, visibleFrame.maxY - MeterBarMenuDetailPanelLayout.screenPadding)
     let y = max(visibleFrame.minY + MeterBarMenuDetailPanelLayout.screenPadding, topY - height)
 
@@ -41,10 +48,14 @@ final class MeterBarMenuDetailPanel {
       rootView: content
         .meterBarSurfaceStyle(.toolbar)
         .frame(width: width, height: height)
-        .clipped()
     )
     panel.setFrame(
-      NSRect(x: anchorFrame.minX - width, y: y, width: width, height: height),
+      NSRect(
+        x: anchorFrame.minX - width - MeterBarMenuDetailPanelLayout.panelGap,
+        y: y,
+        width: width,
+        height: height
+      ),
       display: true
     )
     panel.orderFront(nil)
@@ -81,21 +92,14 @@ final class MeterBarMenuDetailPanel {
 enum MeterBarMenuDetailPanelLayout {
   static let detailWidth: CGFloat = 340
   static let cornerRadius: CGFloat = 16
-  static let minDetailHeight: CGFloat = 260
+  static let minDetailHeight: CGFloat = 120
+  static let panelGap: CGFloat = 10
   static let screenPadding: CGFloat = 8
 }
 
 struct MenuBarProviderDetailContent: View {
   let snapshot: ProviderSnapshot
   let onOpenFull: () -> Void
-
-  private var statusText: String {
-    snapshot.band?.shortLabel ?? "No data"
-  }
-
-  private var statusColor: Color {
-    snapshot.band?.color ?? .secondary
-  }
 
   private var detailLimits: [SnapshotLimit] {
     snapshot.detailLimits
@@ -118,6 +122,7 @@ struct MenuBarProviderDetailContent: View {
         ScrollView(showsIndicators: false) {
           detailRows
         }
+        .scrollIndicators(.hidden)
         .scrollContentBackground(.hidden)
       }
     }
@@ -134,8 +139,6 @@ struct MenuBarProviderDetailContent: View {
 
   private var detailRows: some View {
     VStack(alignment: .leading, spacing: 12) {
-      summaryRow
-
       if detailLimits.isEmpty {
         Text(snapshot.emptyDetail)
           .font(.caption)
@@ -200,46 +203,6 @@ struct MenuBarProviderDetailContent: View {
     }
   }
 
-  private var summaryRow: some View {
-    HStack(alignment: .top, spacing: 10) {
-      VStack(alignment: .leading, spacing: 3) {
-        Text("Status")
-          .font(.caption2)
-          .foregroundColor(.secondary)
-        Text(statusText)
-          .font(.subheadline)
-          .fontWeight(.semibold)
-          .foregroundColor(statusColor)
-      }
-
-      Spacer(minLength: 8)
-
-      VStack(alignment: .trailing, spacing: 3) {
-        Text("Updated")
-          .font(.caption2)
-          .foregroundColor(.secondary)
-        Text(updatedText)
-          .font(.caption)
-          .fontWeight(.medium)
-          .foregroundColor(.primary)
-      }
-    }
-    .padding(10)
-    .dashboardCardBackground(cornerRadius: 10)
-  }
-
-  private var updatedText: String {
-    guard let updatedAt = snapshot.updatedAt else { return "No data" }
-    return UsageFormat.relative(updatedAt)
-  }
-
-  static func preferredHeight(for snapshot: ProviderSnapshot) -> CGFloat {
-    let detailLimits = snapshot.detailLimits
-    let limitHeight = detailLimits.isEmpty ? 78 : CGFloat(detailLimits.count) * 84
-    let blockingHeight: CGFloat = snapshot.hasExhaustedLimit ? 106 : 0
-    let badgeHeight: CGFloat = ProviderStatusBadges(snapshot: snapshot, style: .compact).hasContent ? 52 : 0
-    return 206 + limitHeight + blockingHeight + badgeHeight
-  }
 }
 
 private struct MenuBarProviderLimitDetailRow: View {

--- a/MeterBar/Views/MenuBarDetailPanel.swift
+++ b/MeterBar/Views/MenuBarDetailPanel.swift
@@ -28,7 +28,6 @@ final class MeterBarMenuDetailPanel {
     panel.level = anchor.level
     let measuringView = NSHostingView(
       rootView: content
-        .meterBarSurfaceStyle(.toolbar)
         .frame(width: width)
         .fixedSize(horizontal: false, vertical: true)
     )
@@ -46,7 +45,6 @@ final class MeterBarMenuDetailPanel {
 
     panel.contentView = NSHostingView(
       rootView: content
-        .meterBarSurfaceStyle(.toolbar)
         .frame(width: width, height: height)
     )
     panel.setFrame(

--- a/MeterBar/Views/MenuBarDetailPanel.swift
+++ b/MeterBar/Views/MenuBarDetailPanel.swift
@@ -1,0 +1,314 @@
+import AppKit
+import MeterBarShared
+import SwiftUI
+
+struct MeterBarMenuWindowAccessor: NSViewRepresentable {
+  let onResolve: (NSWindow?) -> Void
+
+  func makeNSView(context: Context) -> NSView {
+    let view = NSView()
+    DispatchQueue.main.async { onResolve(view.window) }
+    return view
+  }
+
+  func updateNSView(_ nsView: NSView, context: Context) {
+    DispatchQueue.main.async { onResolve(nsView.window) }
+  }
+}
+
+@MainActor
+final class MeterBarMenuDetailPanel {
+  static let shared = MeterBarMenuDetailPanel()
+
+  private var panel: NSPanel?
+
+  func present(anchor: NSWindow, preferredHeight: CGFloat, content: AnyView) {
+    let width = MeterBarMenuDetailPanelLayout.detailWidth
+    let panel = ensurePanel()
+    panel.level = anchor.level
+
+    let anchorFrame = anchor.frame
+    let visibleFrame = anchor.screen?.visibleFrame ?? NSScreen.main?.visibleFrame ?? anchorFrame
+    let maxHeight = max(
+      MeterBarMenuDetailPanelLayout.minDetailHeight,
+      visibleFrame.height - (MeterBarMenuDetailPanelLayout.screenPadding * 2)
+    )
+    let height = min(max(preferredHeight, MeterBarMenuDetailPanelLayout.minDetailHeight), maxHeight)
+    let topY = min(anchorFrame.maxY, visibleFrame.maxY - MeterBarMenuDetailPanelLayout.screenPadding)
+    let y = max(visibleFrame.minY + MeterBarMenuDetailPanelLayout.screenPadding, topY - height)
+
+    panel.contentView = NSHostingView(
+      rootView: content
+        .meterBarSurfaceStyle(.toolbar)
+        .frame(width: width, height: height)
+        .clipped()
+    )
+    panel.setFrame(
+      NSRect(x: anchorFrame.minX - width, y: y, width: width, height: height),
+      display: true
+    )
+    panel.orderFront(nil)
+  }
+
+  func dismiss() {
+    panel?.orderOut(nil)
+  }
+
+  func owns(window: NSWindow?) -> Bool {
+    guard let window, let panel else { return false }
+    return window === panel
+  }
+
+  private func ensurePanel() -> NSPanel {
+    if let panel { return panel }
+    let panel = NSPanel(
+      contentRect: NSRect(x: 0, y: 0, width: 340, height: 360),
+      styleMask: [.borderless, .nonactivatingPanel],
+      backing: .buffered,
+      defer: false
+    )
+    panel.isFloatingPanel = true
+    panel.isOpaque = false
+    panel.backgroundColor = .clear
+    panel.hasShadow = true
+    panel.hidesOnDeactivate = false
+    panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+    self.panel = panel
+    return panel
+  }
+}
+
+enum MeterBarMenuDetailPanelLayout {
+  static let detailWidth: CGFloat = 340
+  static let cornerRadius: CGFloat = 16
+  static let minDetailHeight: CGFloat = 260
+  static let screenPadding: CGFloat = 8
+}
+
+struct MenuBarProviderDetailContent: View {
+  let snapshot: ProviderSnapshot
+  let onOpenFull: () -> Void
+
+  private var statusText: String {
+    snapshot.band?.shortLabel ?? "No data"
+  }
+
+  private var statusColor: Color {
+    snapshot.band?.color ?? .secondary
+  }
+
+  private var detailLimits: [SnapshotLimit] {
+    snapshot.detailLimits
+  }
+
+  private var quotaWindowHeading: String {
+    detailLimits.count == 1 ? "Quota Window" : "Quota Windows"
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      header
+        .padding(.bottom, 10)
+
+      Divider()
+
+      ViewThatFits(in: .vertical) {
+        detailRows
+
+        ScrollView(showsIndicators: false) {
+          detailRows
+        }
+        .scrollContentBackground(.hidden)
+      }
+    }
+    .padding(14)
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    .background(MeterBarCompanionSurface(radius: MeterBarMenuDetailPanelLayout.cornerRadius))
+    .clipShape(
+      RoundedRectangle(
+        cornerRadius: MeterBarMenuDetailPanelLayout.cornerRadius,
+        style: .continuous
+      )
+    )
+  }
+
+  private var detailRows: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      summaryRow
+
+      if detailLimits.isEmpty {
+        Text(snapshot.emptyDetail)
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(.vertical, 12)
+      } else {
+        if snapshot.hasExhaustedLimit {
+          BlockingLimitResetCounter(
+            windows: snapshot.resetWindows,
+            accentColor: snapshot.accentColor
+          )
+          .padding(10)
+          .dashboardCardBackground(cornerRadius: 10)
+        }
+
+        VStack(alignment: .leading, spacing: 10) {
+          Text(quotaWindowHeading)
+            .font(.caption)
+            .fontWeight(.semibold)
+            .foregroundColor(.secondary)
+
+          ForEach(detailLimits) { limit in
+            MenuBarProviderLimitDetailRow(limit: limit, accentColor: snapshot.accentColor)
+          }
+        }
+      }
+
+      let badges = ProviderStatusBadges(snapshot: snapshot, style: .compact)
+      if badges.hasContent {
+        badges
+          .padding(.top, 2)
+      }
+    }
+    .padding(.top, 12)
+    .frame(maxWidth: .infinity, alignment: .topLeading)
+  }
+
+  private var header: some View {
+    HStack(alignment: .center, spacing: 10) {
+      ProviderLogoView(kind: snapshot.logoKind, size: 20, foregroundColor: snapshot.accentColor)
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text(snapshot.title)
+          .font(.headline)
+          .fontWeight(.semibold)
+          .lineLimit(1)
+        Text(snapshot.service.displayName)
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .lineLimit(1)
+      }
+
+      Spacer(minLength: 0)
+
+      Button(action: onOpenFull) {
+        Label("Open Full View", systemImage: "rectangle.split.2x1")
+      }
+        .buttonStyle(.plain)
+        .font(.caption)
+        .foregroundStyle(MeterBarTheme.appAccent)
+    }
+  }
+
+  private var summaryRow: some View {
+    HStack(alignment: .top, spacing: 10) {
+      VStack(alignment: .leading, spacing: 3) {
+        Text("Status")
+          .font(.caption2)
+          .foregroundColor(.secondary)
+        Text(statusText)
+          .font(.subheadline)
+          .fontWeight(.semibold)
+          .foregroundColor(statusColor)
+      }
+
+      Spacer(minLength: 8)
+
+      VStack(alignment: .trailing, spacing: 3) {
+        Text("Updated")
+          .font(.caption2)
+          .foregroundColor(.secondary)
+        Text(updatedText)
+          .font(.caption)
+          .fontWeight(.medium)
+          .foregroundColor(.primary)
+      }
+    }
+    .padding(10)
+    .dashboardCardBackground(cornerRadius: 10)
+  }
+
+  private var updatedText: String {
+    guard let updatedAt = snapshot.updatedAt else { return "No data" }
+    return UsageFormat.relative(updatedAt)
+  }
+
+  static func preferredHeight(for snapshot: ProviderSnapshot) -> CGFloat {
+    let detailLimits = snapshot.detailLimits
+    let limitHeight = detailLimits.isEmpty ? 78 : CGFloat(detailLimits.count) * 84
+    let blockingHeight: CGFloat = snapshot.hasExhaustedLimit ? 106 : 0
+    let badgeHeight: CGFloat = ProviderStatusBadges(snapshot: snapshot, style: .compact).hasContent ? 52 : 0
+    return 206 + limitHeight + blockingHeight + badgeHeight
+  }
+}
+
+private struct MenuBarProviderLimitDetailRow: View {
+  let limit: SnapshotLimit
+  let accentColor: Color
+
+  private var isOut: Bool {
+    limit.percentLeft <= 0
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack(spacing: 8) {
+        Text(limit.title)
+          .font(.caption)
+          .fontWeight(.semibold)
+        Spacer(minLength: 4)
+        Text(isOut ? "Out" : "\(limit.percentLeft)% left")
+          .font(.caption)
+          .fontWeight(.semibold)
+          .foregroundColor(isOut ? MeterBarTheme.danger : .primary)
+      }
+
+      UsageBar(
+        usedPercentage: limit.usedPercent,
+        accentColor: accentColor,
+        pace: limit.usageLimit.pace(),
+        paceContext: limit.paceContext
+      )
+
+      HStack(spacing: 6) {
+        Text("\(Int(limit.usedPercent.rounded()))% used")
+          .font(.caption2)
+          .foregroundColor(.secondary)
+
+        if let pace = limit.usageLimit.pace() {
+          Text(pace.leftLabel)
+            .font(.caption2)
+            .foregroundColor(paceLabelColor(pace))
+        }
+
+        Spacer(minLength: 6)
+
+        if limit.usageLimit.resetTime != nil {
+          ResetCountdownLabel(
+            title: nil,
+            limit: limit.usageLimit,
+            font: .caption2,
+            foregroundColor: .secondary,
+            iconSize: 9
+          )
+        }
+      }
+    }
+    .padding(10)
+    .dashboardCardBackground(cornerRadius: 10)
+  }
+
+  private func paceLabelColor(_ pace: UsagePace) -> Color {
+    if pace.isExhausted {
+      return MeterBarTheme.danger
+    }
+    switch pace.stage {
+    case .reserve:
+      return MeterBarTheme.success
+    case .deficit:
+      return MeterBarTheme.warning
+    case .onPace:
+      return .secondary
+    }
+  }
+}

--- a/MeterBar/Views/MenuBarDetailPanel.swift
+++ b/MeterBar/Views/MenuBarDetailPanel.swift
@@ -47,6 +47,7 @@ final class MeterBarMenuDetailPanel {
       rootView: content
         .frame(width: width, height: height)
     )
+    panel.applyCompanionClipping()
     panel.setFrame(
       NSRect(
         x: anchorFrame.minX - width - MeterBarMenuDetailPanelLayout.panelGap,
@@ -85,13 +86,14 @@ final class MeterBarMenuDetailPanel {
     self.panel = panel
     return panel
   }
+
 }
 
 enum MeterBarMenuDetailPanelLayout {
   static let detailWidth: CGFloat = 340
-  static let cornerRadius: CGFloat = 16
+  static let cornerRadius = MeterBarTheme.companionShellRadius
   static let minDetailHeight: CGFloat = 120
-  static let panelGap: CGFloat = 10
+  static let panelGap: CGFloat = 12
   static let screenPadding: CGFloat = 8
 }
 

--- a/MeterBar/Views/MenuBarDetailPanel.swift
+++ b/MeterBar/Views/MenuBarDetailPanel.swift
@@ -150,7 +150,7 @@ struct MenuBarProviderDetailContent: View {
             accentColor: snapshot.accentColor
           )
           .padding(10)
-          .dashboardCardBackground(cornerRadius: 10)
+          .meterBarCardSurface(cornerRadius: 10)
         }
 
         VStack(alignment: .leading, spacing: 10) {
@@ -256,7 +256,7 @@ private struct MenuBarProviderLimitDetailRow: View {
       }
     }
     .padding(10)
-    .dashboardCardBackground(cornerRadius: 10)
+    .meterBarCardSurface(cornerRadius: 10)
   }
 
   private func paceLabelColor(_ pace: UsagePace) -> Color {

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -36,7 +36,6 @@ struct MenuBarView: View {
         configureMenuWindow(window)
       }
     )
-    .meterBarSurfaceStyle(.toolbar)
     .onAppear {
       notifyContentSize()
     }

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -1,425 +1,463 @@
 import AppKit
-import SwiftUI
 import MeterBarShared
+import SwiftUI
 
 struct MenuBarView: View {
-    private let popoverWidth: CGFloat = 390
-    private let maxPopoverHeight: CGFloat = 560
-    private let minPopoverHeight: CGFloat = 180
-    private let chromeHeight: CGFloat = 56
+  private let popoverWidth: CGFloat = 390
+  private let minPopoverHeight: CGFloat = 180
+  private let chromeHeight: CGFloat = 56
+  private let screenPadding: CGFloat = 8
 
-    let onContentSizeChange: (NSSize) -> Void
+  let onContentSizeChange: (NSSize) -> Void
 
-    @StateObject private var dataManager = UsageDataManager.shared
-    @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
-    @StateObject private var codexCliService = CodexCliLocalService.shared
-    @StateObject private var cursorService = CursorLocalService.shared
-    @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
-    @StateObject private var providerVisibility = ProviderVisibilityStore.shared
-    @StateObject private var dockVisibility = DockVisibilityStore.shared
+  @StateObject private var dataManager = UsageDataManager.shared
+  @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
+  @StateObject private var codexCliService = CodexCliLocalService.shared
+  @StateObject private var cursorService = CursorLocalService.shared
+  @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
+  @StateObject private var providerVisibility = ProviderVisibilityStore.shared
 
-    @State private var contentHeight: CGFloat = 320
+  @State private var contentHeight: CGFloat = 320
+  @State private var expandedProviderID: ProviderSnapshot.ID?
+  @State private var menuWindow: NSWindow?
 
-    init(onContentSizeChange: @escaping (NSSize) -> Void = { _ in }) {
-        self.onContentSizeChange = onContentSizeChange
+  init(onContentSizeChange: @escaping (NSSize) -> Void = { _ in }) {
+    self.onContentSizeChange = onContentSizeChange
+  }
+
+  var body: some View {
+    mainColumn
+    .frame(width: popoverWidth, height: popoverHeight)
+    .background(MeterBarCompanionSurface(radius: 16))
+    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    .background(
+      MeterBarMenuWindowAccessor { window in
+        menuWindow = window
+        configureMenuWindow(window)
+      }
+    )
+    .meterBarSurfaceStyle(.toolbar)
+    .onAppear {
+      notifyContentSize()
+    }
+    .onDisappear {
+      expandedProviderID = nil
+      MeterBarMenuDetailPanel.shared.dismiss()
+    }
+    .onPreferenceChange(MenuContentHeightPreferenceKey.self) { height in
+      guard height > 0, abs(height - contentHeight) > 1 else { return }
+      contentHeight = height
+      notifyContentSize(height: height)
+    }
+  }
+
+  private var mainColumn: some View {
+    VStack(spacing: 0) {
+      popoverHeader
+
+      Divider()
+
+      ScrollView {
+        PopoverOverviewPanel(
+          snapshots: ProviderSnapshotBuilder.snapshots(
+            ProviderSnapshotBuilder.Input(
+              metrics: dataManager.metrics,
+              claudeAccounts: claudeAccountStore.accounts,
+              claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
+              enabledServices: providerVisibility.enabledServices,
+              claudeCodeHasAccess: claudeCodeService.hasAccess,
+              codexCliHasAccess: codexCliService.hasAccess,
+              cursorHasAccess: cursorService.hasAccess
+            )),
+          openDashboard: openDashboard,
+          openProviderOverview: openProviderDetail
+        )
+        .padding(10)
+        .background(
+          GeometryReader { proxy in
+            Color.clear.preference(
+              key: MenuContentHeightPreferenceKey.self,
+              value: proxy.size.height
+            )
+          }
+        )
+      }
+      .scrollContentBackground(.hidden)
+      .frame(height: scrollHeight)
+    }
+  }
+
+  private var scrollHeight: CGFloat {
+    min(max(80, contentHeight), maximumPopoverHeight - chromeHeight)
+  }
+
+  private var popoverHeight: CGFloat {
+    min(max(chromeHeight + scrollHeight, minPopoverHeight), maximumPopoverHeight)
+  }
+
+  private var maximumPopoverHeight: CGFloat {
+    let visibleHeight = menuWindow?.screen?.visibleFrame.height
+      ?? NSScreen.main?.visibleFrame.height
+      ?? 720
+    return max(minPopoverHeight, min(760, visibleHeight - (screenPadding * 2)))
+  }
+
+  private func notifyContentSize(height: CGFloat? = nil) {
+    let measuredHeight = height ?? contentHeight
+    let maxHeight = maximumPopoverHeight
+    let targetScrollHeight = min(max(80, measuredHeight), maxHeight - chromeHeight)
+    let targetHeight = min(
+      max(chromeHeight + targetScrollHeight, minPopoverHeight), maxHeight)
+    onContentSizeChange(NSSize(width: popoverWidth, height: targetHeight))
+  }
+
+  private var popoverHeader: some View {
+    HStack(spacing: 8) {
+      Image(systemName: "chart.line.uptrend.xyaxis")
+        .font(.system(size: 16, weight: .semibold))
+        .foregroundStyle(MeterBarTheme.appAccent)
+        .frame(width: 28, height: 24)
+
+      Spacer()
+
+      Button(action: openDashboard) {
+        Image(systemName: MenuBarOverlayIcons.dashboard)
+          .font(.system(size: 12, weight: .semibold))
+          .frame(width: 28, height: 24)
+      }
+      .buttonStyle(.glass)
+      .controlSize(.small)
+      .help("Open Usage Dashboard")
+
+      Button {
+        Task { await dataManager.refreshAll() }
+      } label: {
+        RefreshingIcon(isRefreshing: dataManager.isLoading)
+          .font(.system(size: 12, weight: .semibold))
+          .frame(width: 28, height: 24)
+      }
+      .buttonStyle(.glass)
+      .controlSize(.small)
+      .help(dataManager.isLoading ? "Refreshing usage" : "Refresh usage")
+    }
+    .font(.body)
+    .padding(.horizontal, 14)
+    .padding(.vertical, 10)
+  }
+
+  private func openDashboard() {
+    expandedProviderID = nil
+    MeterBarMenuDetailPanel.shared.dismiss()
+    UsageDashboardWindowController.shared.show()
+  }
+
+  private func openProviderDetail(_ snapshot: ProviderSnapshot) {
+    if expandedProviderID == snapshot.id {
+      expandedProviderID = nil
+      MeterBarMenuDetailPanel.shared.dismiss()
+      return
     }
 
-    var body: some View {
-        VStack(spacing: 0) {
-            popoverHeader
-
-            Divider()
-
-            ScrollView {
-                PopoverOverviewPanel(
-                    snapshots: ProviderSnapshotBuilder.snapshots(ProviderSnapshotBuilder.Input(
-                        metrics: dataManager.metrics,
-                        claudeAccounts: claudeAccountStore.accounts,
-                        claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
-                        enabledServices: providerVisibility.enabledServices,
-                        claudeCodeHasAccess: claudeCodeService.hasAccess,
-                        codexCliHasAccess: codexCliService.hasAccess,
-                        cursorHasAccess: cursorService.hasAccess
-                    )),
-                    openDashboard: openDashboard
-                )
-                    .padding(10)
-                    .background(
-                        GeometryReader { proxy in
-                            Color.clear.preference(
-                                key: MenuContentHeightPreferenceKey.self,
-                                value: proxy.size.height
-                            )
-                        }
-                    )
-            }
-            .frame(height: scrollHeight)
+    guard let menuWindow else { return }
+    expandedProviderID = snapshot.id
+    MeterBarMenuDetailPanel.shared.present(
+      anchor: menuWindow,
+      preferredHeight: MenuBarProviderDetailContent.preferredHeight(for: snapshot),
+      content: AnyView(
+        MenuBarProviderDetailContent(snapshot: snapshot) {
+          UsageDashboardWindowController.shared.show(section: .limits, focusedProviderID: snapshot.id)
+          expandedProviderID = nil
+          MeterBarMenuDetailPanel.shared.dismiss()
         }
-        .frame(width: popoverWidth, height: popoverHeight)
-        .onAppear {
-            notifyContentSize()
-        }
-        .onPreferenceChange(MenuContentHeightPreferenceKey.self) { height in
-            guard height > 0, abs(height - contentHeight) > 1 else { return }
-            contentHeight = height
-            notifyContentSize(height: height)
-        }
-    }
+      )
+    )
+  }
 
-    private var scrollHeight: CGFloat {
-        min(max(80, contentHeight), maxPopoverHeight - chromeHeight)
-    }
+  private func configureMenuWindow(_ window: NSWindow?) {
+    guard let window else { return }
+    window.isOpaque = false
+    window.backgroundColor = .clear
+    window.hasShadow = true
+  }
+}
 
-    private var popoverHeight: CGFloat {
-        min(max(chromeHeight + scrollHeight, minPopoverHeight), maxPopoverHeight)
-    }
-
-    private func notifyContentSize(height: CGFloat? = nil) {
-        let measuredHeight = height ?? contentHeight
-        let targetScrollHeight = min(max(80, measuredHeight), maxPopoverHeight - chromeHeight)
-        let targetHeight = min(max(chromeHeight + targetScrollHeight, minPopoverHeight), maxPopoverHeight)
-        onContentSizeChange(NSSize(width: popoverWidth, height: targetHeight))
-    }
-
-    private var popoverHeader: some View {
-        HStack(spacing: 10) {
-            HStack(spacing: 9) {
-                Image(systemName: "chart.line.uptrend.xyaxis")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundStyle(MeterBarTheme.appAccent)
-                Text("MeterBar")
-                    .font(.headline)
-                    .fontWeight(.semibold)
-            }
-
-            Spacer()
-
-            Button(action: openDashboard) {
-                Image(systemName: "sidebar.right")
-            }
-            .buttonStyle(.glass)
-            .controlSize(.small)
-            .help("Open Usage Dashboard")
-
-            Button {
-                Task { await dataManager.refreshAll() }
-            } label: {
-                RefreshingIcon(isRefreshing: dataManager.isLoading)
-            }
-            .buttonStyle(.glass)
-            .controlSize(.small)
-            .help(dataManager.isLoading ? "Refreshing usage" : "Refresh usage")
-
-            optionsMenu
-        }
-        .font(.body)
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-    }
-
-    private var optionsMenu: some View {
-        Menu {
-            Toggle("Show in Dock", isOn: Binding(
-                get: { dockVisibility.showInDock },
-                set: { dockVisibility.setShowInDock($0) }
-            ))
-            Button("Open Usage Dashboard", action: openDashboard)
-            Divider()
-            Button("Quit MeterBar") {
-                NSApp.terminate(nil)
-            }
-        } label: {
-            Image(systemName: "ellipsis")
-        }
-        .menuStyle(.button)
-        .buttonStyle(.glass)
-        .controlSize(.small)
-        .menuIndicator(.hidden)
-        .fixedSize()
-        .help("More options")
-    }
-
-    private func openDashboard() {
-        UsageDashboardWindowController.shared.show()
-    }
+private enum MenuBarOverlayIcons {
+  static let dashboard = "rectangle.split.2x1"
 }
 
 // MARK: - Overview panel
 
 struct PopoverOverviewPanel: View {
-    let snapshots: [ProviderSnapshot]
-    let openDashboard: () -> Void
+  let snapshots: [ProviderSnapshot]
+  let openDashboard: () -> Void
+  let openProviderOverview: (ProviderSnapshot) -> Void
 
-    @StateObject private var apiUsageStore = ApiUsageStore.shared
-    @State private var setupReports: [ProviderReadiness] = []
+  @StateObject private var apiUsageStore = ApiUsageStore.shared
+  @State private var setupReports: [ProviderReadiness] = []
 
-    /// The enabled providers currently shown in the popover.
-    private var enabledProviders: Set<ServiceType> {
-        Set(snapshots.map(\.service))
-    }
+  /// The enabled providers currently shown in the popover.
+  private var enabledProviders: Set<ServiceType> {
+    Set(snapshots.map(\.service))
+  }
 
-    /// Enabled providers that still need setup — drives the first-run checklist.
-    /// The section collapses (renders nothing) once these are all healthy.
-    private var providersNeedingSetup: [ProviderReadiness] {
-        setupReports.filter { enabledProviders.contains($0.provider) && !$0.isHealthy }
-    }
+  /// Enabled providers that still need setup — drives the first-run checklist.
+  /// The section collapses (renders nothing) once these are all healthy.
+  private var providersNeedingSetup: [ProviderReadiness] {
+    setupReports.filter { enabledProviders.contains($0.provider) && !$0.isHealthy }
+  }
 
-    private var tightestLimit: SnapshotLimit? {
-        snapshots.tightestLimit
-    }
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      if snapshots.isEmpty {
+        DashboardTile(padding: 12) {
+          HStack(alignment: .center, spacing: 10) {
+            Image(systemName: "clock.fill")
+              .font(.system(size: 17, weight: .bold))
+              .foregroundStyle(.secondary)
+              .frame(width: 34, height: 34)
 
-    private var overviewBand: QuotaBand? {
-        tightestLimit.map { QuotaBand.forPercentLeft($0.percentLeft) }
-    }
-
-    private var statusColor: Color {
-        overviewBand?.color ?? .secondary
-    }
-
-    private var statusTitle: String {
-        guard !snapshots.isEmpty else { return "No sources enabled" }
-        guard let overviewBand else { return "Waiting for usage" }
-        return overviewBand.overviewTitle
-    }
-
-    private var statusDetail: String {
-        guard !snapshots.isEmpty else {
-            return "Enable a provider in Settings."
-        }
-        guard let tightestLimit else {
-            return "Refresh to load enabled providers."
-        }
-        if tightestLimit.percentLeft <= 0 {
-            return "\(tightestLimit.title) is out until reset across \(sourcesLabel)."
-        }
-        return "\(tightestLimit.title) has \(tightestLimit.percentLeft)% left across \(sourcesLabel)."
-    }
-
-    private var sourcesLabel: String {
-        snapshots.count == 1 ? "1 source" : "\(snapshots.count) sources"
-    }
-
-    private var statusIconName: String {
-        overviewBand?.iconName ?? "clock.fill"
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .center, spacing: 10) {
-                ZStack {
-                    Circle()
-                        .fill(.quaternary)
-                        .frame(width: 34, height: 34)
-                    Image(systemName: statusIconName)
-                        .font(.system(size: 17, weight: .bold))
-                        .foregroundStyle(statusColor)
-                }
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(statusTitle)
-                        .font(.headline)
-                        .fontWeight(.semibold)
-                    Text(statusDetail)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .lineLimit(2)
-                }
-                Spacer(minLength: 0)
+            VStack(alignment: .leading, spacing: 2) {
+              Text("No sources enabled")
+                .font(.headline)
+                .fontWeight(.semibold)
+              Text("Enable a provider in Settings.")
+                .font(.caption)
+                .foregroundColor(.secondary)
             }
-            .padding(12)
-            .cardSurface()
-
-            if !providersNeedingSetup.isEmpty {
-                setupChecklist
-            }
-
-            VStack(spacing: 8) {
-                ForEach(snapshots) { snapshot in
-                    PopoverProviderStatusCard(snapshot: snapshot)
-                }
-            }
-
-            ApiUsageSection(store: apiUsageStore, compact: true)
-
-            Button(action: openDashboard) {
-                HStack {
-                    Label("Open Usage Dashboard", systemImage: "rectangle.split.2x1")
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .cardSurface()
+            Spacer(minLength: 0)
+          }
         }
-        .task {
-            await apiUsageStore.refresh()
+      }
+
+      if !providersNeedingSetup.isEmpty {
+        setupChecklist
+      }
+
+      VStack(spacing: 8) {
+        ForEach(snapshots) { snapshot in
+          PopoverProviderStatusCard(snapshot: snapshot) {
+            openProviderOverview(snapshot)
+          }
         }
-        .task {
-            await loadSetupReports()
-        }
+      }
+
+      ApiUsageSection(store: apiUsageStore, compact: true)
     }
-
-    /// First-run/empty-state checklist: per-provider readiness checks with
-    /// recovery actions for enabled providers that aren't healthy yet. Collapses
-    /// automatically once every enabled provider reports healthy.
-    private var setupChecklist: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 7) {
-                Image(systemName: "checklist")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(MeterBarTheme.appAccent)
-                Text("Finish setup")
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
-                Spacer(minLength: 0)
-            }
-            ReadinessChecklist(reports: providersNeedingSetup, compact: true)
-        }
+    .task {
+      await apiUsageStore.refresh()
     }
-
-    /// Runs the readiness inspector off the main actor (keychain / file / SQLite
-    /// I/O) and publishes the reports back for the checklist.
-    private func loadSetupReports() async {
-        let reports = await Task.detached(priority: .utility) {
-            ProviderReadinessInspector.reports()
-        }.value
-        setupReports = reports
+    .task {
+      await loadSetupReports()
     }
+  }
+
+  /// First-run/empty-state checklist: per-provider readiness checks with
+  /// recovery actions for enabled providers that aren't healthy yet. Collapses
+  /// automatically once every enabled provider reports healthy.
+  private var setupChecklist: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(spacing: 7) {
+        Image(systemName: "checklist")
+          .font(.system(size: 13, weight: .semibold))
+          .foregroundStyle(MeterBarTheme.appAccent)
+        Text("Finish setup")
+          .font(.subheadline)
+          .fontWeight(.semibold)
+        Spacer(minLength: 0)
+      }
+      ReadinessChecklist(reports: providersNeedingSetup, compact: true)
+    }
+  }
+
+  /// Runs the readiness inspector off the main actor (keychain / file / SQLite
+  /// I/O) and publishes the reports back for the checklist.
+  private func loadSetupReports() async {
+    let reports = await Task.detached(priority: .utility) {
+      ProviderReadinessInspector.reports()
+    }.value
+    setupReports = reports
+  }
 }
 
 private struct PopoverProviderStatusCard: View {
-    let snapshot: ProviderSnapshot
+  let snapshot: ProviderSnapshot
+  var onSelect: (() -> Void)?
 
-    private var statusColor: Color {
-        snapshot.band?.color ?? .secondary
-    }
+  private var statusColor: Color {
+    snapshot.band?.color ?? .secondary
+  }
 
-    private var statusText: String {
-        snapshot.band?.shortLabel ?? "Offline"
-    }
+  private var statusText: String {
+    snapshot.band?.shortLabel ?? "Offline"
+  }
 
-    private var isOut: Bool {
-        snapshot.band == .exhausted
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: snapshot.hasExhaustedLimit ? 8 : 10) {
-            HStack(spacing: 7) {
-                ProviderLogoView(kind: snapshot.logoKind, size: 17, foregroundColor: snapshot.accentColor)
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(snapshot.title)
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                        .lineLimit(1)
-                    Text(updatedText)
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-                }
-                Spacer(minLength: 0)
-                Text(statusText)
-                    .font(.caption2)
-                    .fontWeight(.semibold)
-                    .foregroundColor(statusColor)
-            }
-
-            if snapshot.limits.isEmpty {
-                Text(snapshot.emptyDetail)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .frame(maxWidth: .infinity, minHeight: 54, alignment: .topLeading)
-            } else if snapshot.hasExhaustedLimit {
-                CompactBlockingLimitResetRow(
-                    windows: snapshot.resetWindows,
-                    accentColor: snapshot.accentColor
-                )
-            } else {
-                VStack(alignment: .leading, spacing: 9) {
-                    ForEach(snapshot.limits) { limit in
-                        PopoverLimitRow(limit: limit, accentColor: snapshot.accentColor)
-                    }
-                }
-            }
-
-            let badges = ProviderStatusBadges(snapshot: snapshot, style: .compact)
-            if badges.hasContent {
-                badges
-            }
+  var body: some View {
+    Group {
+      if let onSelect {
+        Button(action: onSelect) {
+          cardContent
         }
-        .padding(snapshot.hasExhaustedLimit ? 9 : 11)
-        .frame(maxWidth: .infinity, minHeight: snapshot.hasExhaustedLimit ? 78 : 124, alignment: .topLeading)
-        .opacity(isOut ? 0.72 : 1)
-        .cardSurface()
+        .buttonStyle(.plain)
+        .accessibilityHint("Open \(snapshot.title) provider details")
+      } else {
+        cardContent
+      }
     }
+  }
 
-    private var updatedText: String {
-        guard let updatedAt = snapshot.updatedAt else { return "No data" }
-        return "Updated \(UsageFormat.relative(updatedAt))"
+  private var cardContent: some View {
+    Group {
+      if snapshot.hasExhaustedLimit {
+        compactExhaustedCard
+      } else {
+        expandedCard
+      }
     }
+    .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+  }
+
+  private var compactExhaustedCard: some View {
+    DashboardTile(padding: 11, minHeight: 58, alignment: .center) {
+      TimelineView(.periodic(from: ResetCountdownSchedule.anchor, by: ResetCountdownSchedule.interval)) { timeline in
+        let blockingWindow = BlockingLimitResetCounter.selectBlockingWindow(
+          snapshot.resetWindows,
+          now: timeline.date
+        )
+        let title = BlockingLimitResetCounter.titleText(for: blockingWindow, in: snapshot.resetWindows)
+        let counter = BlockingLimitResetCounter.counterText(for: blockingWindow, now: timeline.date)
+
+        HStack(alignment: .center, spacing: 9) {
+          ProviderLogoView(kind: snapshot.logoKind, size: 17, foregroundColor: snapshot.accentColor)
+
+          VStack(alignment: .leading, spacing: 1) {
+            Text(snapshot.title)
+              .font(.subheadline)
+              .fontWeight(.semibold)
+              .lineLimit(1)
+            Text(updatedText)
+              .font(.caption2)
+              .foregroundColor(.secondary)
+              .lineLimit(1)
+          }
+
+          Spacer(minLength: 8)
+
+          HStack(spacing: 5) {
+            Image(systemName: "hourglass")
+              .font(.system(size: 10, weight: .semibold))
+            Text("\(title) \(counter)")
+              .font(.caption)
+              .fontWeight(.semibold)
+              .monospacedDigit()
+              .lineLimit(1)
+              .minimumScaleFactor(0.72)
+          }
+          .foregroundColor(snapshot.accentColor)
+          .help("\(title) \(counter)")
+        }
+      }
+    }
+  }
+
+  private var expandedCard: some View {
+    DashboardTile(
+      padding: 11,
+      minHeight: 124
+    ) {
+      VStack(alignment: .leading, spacing: 10) {
+        HStack(spacing: 7) {
+          ProviderLogoView(kind: snapshot.logoKind, size: 17, foregroundColor: snapshot.accentColor)
+          VStack(alignment: .leading, spacing: 1) {
+            Text(snapshot.title)
+              .font(.subheadline)
+              .fontWeight(.semibold)
+              .lineLimit(1)
+            Text(updatedText)
+              .font(.caption2)
+              .foregroundColor(.secondary)
+              .lineLimit(1)
+          }
+          Spacer(minLength: 0)
+          Text(statusText)
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .foregroundColor(statusColor)
+        }
+
+        if snapshot.limits.isEmpty {
+          Text(snapshot.emptyDetail)
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .frame(maxWidth: .infinity, minHeight: 54, alignment: .topLeading)
+        } else {
+          VStack(alignment: .leading, spacing: 9) {
+            ForEach(snapshot.limits) { limit in
+              PopoverLimitRow(limit: limit, accentColor: snapshot.accentColor)
+            }
+          }
+        }
+
+        let badges = ProviderStatusBadges(snapshot: snapshot, style: .compact)
+        if badges.hasContent {
+          badges
+        }
+      }
+    }
+  }
+
+  private var updatedText: String {
+    guard let updatedAt = snapshot.updatedAt else { return "No data" }
+    return "Updated \(UsageFormat.relative(updatedAt))"
+  }
 }
 
 private struct PopoverLimitRow: View {
-    let limit: SnapshotLimit
-    let accentColor: Color
+  let limit: SnapshotLimit
+  let accentColor: Color
 
-    private var isOut: Bool {
-        limit.percentLeft <= 0
+  private var isOut: Bool {
+    limit.percentLeft <= 0
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack(spacing: 4) {
+        Text(limit.title)
+          .font(.caption2)
+          .foregroundColor(.secondary)
+          .lineLimit(1)
+        Spacer(minLength: 4)
+        Text(isOut ? "Out" : "\(limit.percentLeft)% left")
+          .font(.caption)
+          .fontWeight(.semibold)
+          .foregroundColor(isOut ? MeterBarTheme.danger : .primary)
+          .lineLimit(1)
+      }
+
+      UsageBar(
+        usedPercentage: limit.usedPercent,
+        accentColor: accentColor,
+        pace: limit.usageLimit.pace(),
+        paceContext: limit.paceContext
+      )
+
+      if limit.usageLimit.resetTime != nil {
+        ResetCountdownLabel(
+          title: limit.title,
+          limit: limit.usageLimit,
+          font: .caption2,
+          foregroundColor: .secondary,
+          iconSize: 9
+        )
+      }
     }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 4) {
-                Text(limit.title)
-                    .font(.caption2)
-                    .foregroundColor(.secondary)
-                    .lineLimit(1)
-                Spacer(minLength: 4)
-                Text(isOut ? "Out" : "\(limit.percentLeft)% left")
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                    .foregroundColor(isOut ? MeterBarTheme.danger : .primary)
-                    .lineLimit(1)
-            }
-
-            UsageBar(
-                usedPercentage: limit.usedPercent,
-                accentColor: accentColor,
-                pace: limit.usageLimit.pace(),
-                paceContext: limit.paceContext
-            )
-
-            if limit.usageLimit.resetTime != nil {
-                ResetCountdownLabel(
-                    title: limit.title,
-                    limit: limit.usageLimit,
-                    font: .caption2,
-                    foregroundColor: .secondary,
-                    iconSize: 9
-                )
-            }
-        }
-    }
-}
-
-private extension View {
-    /// Popover content-card surface. Delegates to the shared `meterBarCardSurface`
-    /// so the popover and dashboard cards stay visually identical.
-    func cardSurface() -> some View {
-        meterBarCardSurface()
-    }
+  }
 }
 
 private struct MenuContentHeightPreferenceKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
+  static var defaultValue: CGFloat = 0
 
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
-    }
+  static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+    value = max(value, nextValue())
+  }
 }

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct MenuBarView: View {
   private let popoverWidth: CGFloat = 390
   private let minPopoverHeight: CGFloat = 180
-  private let chromeHeight: CGFloat = 56
+  private let chromeHeight: CGFloat = 41
   private let screenPadding: CGFloat = 8
 
   let onContentSizeChange: (NSSize) -> Void
@@ -82,6 +82,7 @@ struct MenuBarView: View {
           }
         )
       }
+      .scrollIndicators(.hidden)
       .scrollContentBackground(.hidden)
       .frame(height: scrollHeight)
     }
@@ -113,11 +114,6 @@ struct MenuBarView: View {
 
   private var popoverHeader: some View {
     HStack(spacing: 8) {
-      Image(systemName: "chart.line.uptrend.xyaxis")
-        .font(.system(size: 16, weight: .semibold))
-        .foregroundStyle(MeterBarTheme.appAccent)
-        .frame(width: 28, height: 24)
-
       Spacer()
 
       Button(action: openDashboard) {
@@ -142,7 +138,7 @@ struct MenuBarView: View {
     }
     .font(.body)
     .padding(.horizontal, 14)
-    .padding(.vertical, 10)
+    .padding(.vertical, 8)
   }
 
   private func openDashboard() {
@@ -162,7 +158,6 @@ struct MenuBarView: View {
     expandedProviderID = snapshot.id
     MeterBarMenuDetailPanel.shared.present(
       anchor: menuWindow,
-      preferredHeight: MenuBarProviderDetailContent.preferredHeight(for: snapshot),
       content: AnyView(
         MenuBarProviderDetailContent(snapshot: snapshot) {
           UsageDashboardWindowController.shared.show(section: .limits, focusedProviderID: snapshot.id)
@@ -192,7 +187,6 @@ struct PopoverOverviewPanel: View {
   let openDashboard: () -> Void
   let openProviderOverview: (ProviderSnapshot) -> Void
 
-  @StateObject private var apiUsageStore = ApiUsageStore.shared
   @State private var setupReports: [ProviderReadiness] = []
 
   /// The enabled providers currently shown in the popover.
@@ -240,11 +234,6 @@ struct PopoverOverviewPanel: View {
           }
         }
       }
-
-      ApiUsageSection(store: apiUsageStore, compact: true)
-    }
-    .task {
-      await apiUsageStore.refresh()
     }
     .task {
       await loadSetupReports()

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -28,8 +28,8 @@ struct MenuBarView: View {
   var body: some View {
     mainColumn
     .frame(width: popoverWidth, height: popoverHeight)
-    .background(MeterBarCompanionSurface(radius: 16))
-    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    .background(MeterBarCompanionSurface(radius: MeterBarTheme.companionShellRadius))
+    .clipShape(RoundedRectangle(cornerRadius: MeterBarTheme.companionShellRadius, style: .continuous))
     .background(
       MeterBarMenuWindowAccessor { window in
         menuWindow = window
@@ -118,10 +118,8 @@ struct MenuBarView: View {
       Button(action: openDashboard) {
         Image(systemName: MenuBarOverlayIcons.dashboard)
           .font(.system(size: 12, weight: .semibold))
-          .frame(width: 28, height: 24)
       }
-      .buttonStyle(.glass)
-      .controlSize(.small)
+      .meterBarGlassIconButton()
       .help("Open Usage Dashboard")
 
       Button {
@@ -129,11 +127,10 @@ struct MenuBarView: View {
       } label: {
         RefreshingIcon(isRefreshing: dataManager.isLoading)
           .font(.system(size: 12, weight: .semibold))
-          .frame(width: 28, height: 24)
       }
-      .buttonStyle(.glass)
-      .controlSize(.small)
+      .meterBarGlassIconButton()
       .help(dataManager.isLoading ? "Refreshing usage" : "Refresh usage")
+      .disabled(dataManager.isLoading)
     }
     .font(.body)
     .padding(.horizontal, 14)
@@ -172,6 +169,15 @@ struct MenuBarView: View {
     window.isOpaque = false
     window.backgroundColor = .clear
     window.hasShadow = true
+  }
+}
+
+private extension View {
+  func meterBarGlassIconButton() -> some View {
+    frame(width: 30, height: 30)
+      .contentShape(Circle())
+      .glassEffect(.regular, in: Circle())
+      .buttonStyle(.plain)
   }
 }
 

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -7,119 +7,353 @@ import SwiftUI
 /// MeterBar relies on semantic system colors and native containers so the UI
 /// adapts to light/dark, the user's accent, Increase Contrast, and Reduce
 /// Transparency. The only custom colors are the per-provider brand accents and
-/// quota status — and those are kept appearance-adaptive too. Glass/material is
-/// supplied by the system chrome layer (popover, sidebar, toolbar), not here.
+/// quota status — and those are kept appearance-adaptive too.
 enum MeterBarTheme {
-    // MARK: - Brand accents (semantic indicators only; adapt to light/dark)
+  // MARK: - Brand accents (semantic indicators only; adapt to light/dark)
 
-    static let codexAccent = Color.adaptive(
-        light: NSColor(srgbRed: 0 / 255, green: 122 / 255, blue: 168 / 255, alpha: 1),
-        dark: NSColor(srgbRed: 100 / 255, green: 210 / 255, blue: 255 / 255, alpha: 1)
-    )
-    static let claudeAccent = Color.adaptive(
-        light: NSColor(srgbRed: 176 / 255, green: 86 / 255, blue: 52 / 255, alpha: 1),
-        dark: NSColor(srgbRed: 209 / 255, green: 134 / 255, blue: 101 / 255, alpha: 1)
-    )
-    static let cursorAccent = Color.adaptive(
-        light: NSColor(srgbRed: 34 / 255, green: 150 / 255, blue: 92 / 255, alpha: 1),
-        dark: NSColor(srgbRed: 99 / 255, green: 210 / 255, blue: 151 / 255, alpha: 1)
-    )
-    static let openaiAccent = Color.adaptive(
-        light: NSColor(srgbRed: 16 / 255, green: 163 / 255, blue: 127 / 255, alpha: 1),
-        dark: NSColor(srgbRed: 106 / 255, green: 216 / 255, blue: 185 / 255, alpha: 1)
-    )
+  static let codexAccent = Color.adaptive(
+    light: NSColor(srgbRed: 0 / 255, green: 122 / 255, blue: 168 / 255, alpha: 1),
+    dark: NSColor(srgbRed: 100 / 255, green: 210 / 255, blue: 255 / 255, alpha: 1)
+  )
+  static let claudeAccent = Color.adaptive(
+    light: NSColor(srgbRed: 176 / 255, green: 86 / 255, blue: 52 / 255, alpha: 1),
+    dark: NSColor(srgbRed: 209 / 255, green: 134 / 255, blue: 101 / 255, alpha: 1)
+  )
+  static let cursorAccent = Color.adaptive(
+    light: NSColor(srgbRed: 34 / 255, green: 150 / 255, blue: 92 / 255, alpha: 1),
+    dark: NSColor(srgbRed: 99 / 255, green: 210 / 255, blue: 151 / 255, alpha: 1)
+  )
+  static let openaiAccent = Color.adaptive(
+    light: NSColor(srgbRed: 16 / 255, green: 163 / 255, blue: 127 / 255, alpha: 1),
+    dark: NSColor(srgbRed: 106 / 255, green: 216 / 255, blue: 185 / 255, alpha: 1)
+  )
 
-    /// The app's own accent. Follows the user's system accent color.
-    static let appAccent = Color.accentColor
+  /// The app's own accent. Follows the user's system accent color.
+  static let appAccent = Color.accentColor
 
-    // MARK: - Quota status (system colors; adapt to appearance + Increase Contrast)
+  // MARK: - Quota status (system colors; adapt to appearance + Increase Contrast)
 
-    static let success = Color(nsColor: .systemGreen)
-    // systemOrange (not systemYellow) keeps the amber "Tight" band visually
-    // distinct from green/red at caption sizes (PR #33).
-    static let warning = Color(nsColor: .systemOrange)
-    static let danger = Color(nsColor: .systemRed)
+  static let success = Color(nsColor: .systemGreen)
+  // systemOrange (not systemYellow) keeps the amber "Tight" band visually
+  // distinct from green/red at caption sizes (PR #33).
+  static let warning = Color(nsColor: .systemOrange)
+  static let danger = Color(nsColor: .systemRed)
 
-    static func accent(for service: ServiceType) -> Color {
-        switch service {
-        case .claudeCode:
-            return claudeAccent
-        case .codexCli:
-            return codexAccent
-        case .cursor:
-            return cursorAccent
-        }
+  static let glassCardTint = Color.adaptive(
+    light: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.24),
+    dark: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.07),
+    lightHighContrast: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.34),
+    darkHighContrast: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.13)
+  )
+
+  static let glassCardStroke = Color.adaptive(
+    light: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.12),
+    dark: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.15),
+    lightHighContrast: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.24),
+    darkHighContrast: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.28)
+  )
+
+  static func accent(for service: ServiceType) -> Color {
+    switch service {
+    case .claudeCode:
+      return claudeAccent
+    case .codexCli:
+      return codexAccent
+    case .cursor:
+      return cursorAccent
     }
+  }
 
-    static func accent(for provider: ApiProvider) -> Color {
-        switch provider {
-        case .anthropic:
-            return claudeAccent
-        case .openai:
-            return openaiAccent
-        }
+  static func accent(for provider: ApiProvider) -> Color {
+    switch provider {
+    case .anthropic:
+      return claudeAccent
+    case .openai:
+      return openaiAccent
     }
+  }
 
-    static func quotaStatusColor(percentLeft: Int) -> Color {
-        QuotaBand.forPercentLeft(percentLeft).color
-    }
+  static func quotaStatusColor(percentLeft: Int) -> Color {
+    QuotaBand.forPercentLeft(percentLeft).color
+  }
+}
+
+enum MeterBarWindowChrome {
+  private static let red: CGFloat = 0.080
+  private static let green: CGFloat = 0.086
+  private static let blue: CGFloat = 0.084
+
+  static let dashboardCornerRadius: CGFloat = 14
+  static let titlebarContentInset: CGFloat = 48
+  static let sidebarTitlebarWidth: CGFloat = 256
+  static let collapsedSidebarWidth: CGFloat = 72
+
+  static let color = Color(
+    red: Double(red),
+    green: Double(green),
+    blue: Double(blue)
+  )
+
+  static let backgroundColor = NSColor(
+    calibratedRed: red,
+    green: green,
+    blue: blue,
+    alpha: 1
+  )
 }
 
 extension QuotaBand {
-    /// Appearance-adaptive color for the band (single place where severity
-    /// maps to color, shared by every surface).
-    var color: Color {
-        switch self {
-        case .healthy: return MeterBarTheme.success
-        case .tight: return MeterBarTheme.warning
-        case .critical, .exhausted: return MeterBarTheme.danger
-        }
+  /// Appearance-adaptive color for the band (single place where severity
+  /// maps to color, shared by every surface).
+  var color: Color {
+    switch self {
+    case .healthy: return MeterBarTheme.success
+    case .tight: return MeterBarTheme.warning
+    case .critical, .exhausted: return MeterBarTheme.danger
     }
+  }
 }
 
 struct MeterBarDetailBackground: View {
-    var body: some View {
-        Color(nsColor: .windowBackgroundColor)
+  @Environment(\.accessibilityReduceTransparency)
+  private var reduceTransparency
+
+  var body: some View {
+    ZStack {
+      if reduceTransparency {
+        MeterBarWindowChrome.color
+      } else {
+        Color.clear
+          .background(.regularMaterial)
+
+        MeterBarWindowChrome.color.opacity(0.78)
+
+        LinearGradient(
+          colors: [
+            MeterBarTheme.codexAccent.opacity(0.15),
+            MeterBarTheme.appAccent.opacity(0.08),
+            .clear,
+          ],
+          startPoint: .topLeading,
+          endPoint: .bottomTrailing
+        )
+      }
     }
+  }
+}
+
+struct MeterBarDashboardWindowBacking: View {
+  var body: some View {
+    ZStack(alignment: .topLeading) {
+      MeterBarDetailBackground()
+
+      HStack(spacing: 0) {
+        MeterBarSidebarTitlebarBackground()
+          .frame(width: MeterBarWindowChrome.sidebarTitlebarWidth)
+
+        MeterBarDetailBackground()
+      }
+      .frame(height: MeterBarWindowChrome.titlebarContentInset)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+      .allowsHitTesting(false)
+    }
+  }
+}
+
+struct MeterBarSidebarBackground: View {
+  @Environment(\.accessibilityReduceTransparency)
+  private var reduceTransparency
+
+  var body: some View {
+    ZStack {
+      if reduceTransparency {
+        MeterBarWindowChrome.color
+      } else {
+        Color.clear
+          .background(.regularMaterial)
+
+        MeterBarWindowChrome.color.opacity(0.82)
+
+        LinearGradient(
+          colors: [
+            MeterBarTheme.codexAccent.opacity(0.10),
+            MeterBarTheme.appAccent.opacity(0.06),
+            .clear,
+          ],
+          startPoint: .topLeading,
+          endPoint: .bottomTrailing
+        )
+      }
+    }
+  }
+}
+
+struct MeterBarSidebarSurface: View {
+  var radius: CGFloat = MeterBarWindowChrome.dashboardCornerRadius
+
+  @Environment(\.accessibilityReduceTransparency)
+  private var reduceTransparency
+
+  var body: some View {
+    let shape = RoundedRectangle(cornerRadius: radius, style: .continuous)
+
+    ZStack {
+      if reduceTransparency {
+        shape.fill(MeterBarWindowChrome.color)
+      } else {
+        shape
+          .fill(.ultraThinMaterial)
+          .glassEffect(.regular, in: shape)
+
+        shape.fill(MeterBarWindowChrome.color.opacity(0.42))
+
+        LinearGradient(
+          colors: [
+            MeterBarTheme.codexAccent.opacity(0.18),
+            MeterBarTheme.appAccent.opacity(0.08),
+            .clear,
+          ],
+          startPoint: .topLeading,
+          endPoint: .bottomTrailing
+        )
+        .clipShape(shape)
+      }
+    }
+    .overlay {
+      shape.stroke(MeterBarTheme.glassCardStroke, lineWidth: 1)
+    }
+    .shadow(color: .black.opacity(0.20), radius: 18, y: 10)
+  }
+}
+
+struct MeterBarTitlebarGlass: View {
+  @Environment(\.accessibilityReduceTransparency)
+  private var reduceTransparency
+
+  var body: some View {
+    ZStack {
+      if reduceTransparency {
+        MeterBarWindowChrome.color
+      } else {
+        Color.clear
+          .background(.thinMaterial)
+
+        MeterBarWindowChrome.color.opacity(0.58)
+
+        LinearGradient(
+          colors: [
+            MeterBarTheme.codexAccent.opacity(0.10),
+            .clear,
+          ],
+          startPoint: .topLeading,
+          endPoint: .bottomTrailing
+        )
+      }
+    }
+  }
+}
+
+struct MeterBarSidebarTitlebarBackground: View {
+  var body: some View {
+    MeterBarTitlebarGlass()
+      .overlay {
+        MeterBarWindowChrome.color.opacity(0.18)
+      }
+  }
+}
+
+struct MeterBarCompanionSurface: View {
+  var radius: CGFloat = 16
+
+  var body: some View {
+    RoundedRectangle(cornerRadius: radius, style: .continuous)
+      .fill(.ultraThinMaterial)
+      .overlay {
+        RoundedRectangle(cornerRadius: radius, style: .continuous)
+          .fill(MeterBarWindowChrome.color.opacity(0.74))
+      }
+      .overlay(alignment: .topLeading) {
+        LinearGradient(
+          colors: [
+            MeterBarTheme.codexAccent.opacity(0.20),
+            MeterBarTheme.appAccent.opacity(0.08),
+            .clear,
+          ],
+          startPoint: .topLeading,
+          endPoint: .bottomTrailing
+        )
+        .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
+      }
+      .overlay {
+        RoundedRectangle(cornerRadius: radius, style: .continuous)
+          .stroke(MeterBarTheme.glassCardStroke, lineWidth: 1)
+      }
+  }
 }
 
 extension View {
-    /// Shared content-card surface used by both the popover and the dashboard.
-    /// An opaque system control background (not a material) with concentric
-    /// continuous corners, so cards never stack glass-on-glass — chrome glass
-    /// belongs to the window, sidebar, toolbar, and popover controls. A hairline
-    /// separator keeps the card from disappearing into the companion background.
-    func meterBarCardSurface(cornerRadius: CGFloat = 12) -> some View {
-        background(
-            Color(nsColor: .controlBackgroundColor),
-            in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-        )
-        .overlay {
-            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                .stroke(Color(nsColor: .separatorColor).opacity(0.55), lineWidth: 0.5)
-        }
-    }
+  func meterBarSurfaceStyle(_ style: MeterBarSurfaceStyle) -> some View {
+    environment(\.meterBarSurfaceStyle, style)
+  }
+
+  func meterBarCardSurface(cornerRadius: CGFloat = 12) -> some View {
+    modifier(MeterBarCardSurfaceModifier(cornerRadius: cornerRadius))
+  }
+}
+
+enum MeterBarSurfaceStyle {
+  case dashboard
+  case toolbar
+}
+
+private struct MeterBarSurfaceStyleKey: EnvironmentKey {
+  static let defaultValue: MeterBarSurfaceStyle = .dashboard
+}
+
+private extension EnvironmentValues {
+  var meterBarSurfaceStyle: MeterBarSurfaceStyle {
+    get { self[MeterBarSurfaceStyleKey.self] }
+    set { self[MeterBarSurfaceStyleKey.self] = newValue }
+  }
+}
+
+private struct MeterBarCardSurfaceModifier: ViewModifier {
+  let cornerRadius: CGFloat
+
+  func body(content: Content) -> some View {
+    let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+
+    content
+      .background(.ultraThinMaterial, in: shape)
+      .overlay {
+        shape.fill(MeterBarTheme.glassCardTint)
+      }
+      .overlay {
+        shape.stroke(MeterBarTheme.glassCardStroke, lineWidth: 0.5)
+      }
+  }
 }
 
 extension Color {
-    /// An appearance-adaptive color backed by a dynamic `NSColor`, resolving the
-    /// correct value for light / dark (and optionally high-contrast) appearances.
-    static func adaptive(
-        light: NSColor,
-        dark: NSColor,
-        lightHighContrast: NSColor? = nil,
-        darkHighContrast: NSColor? = nil
-    ) -> Color {
-        Color(nsColor: NSColor(name: nil) { appearance in
-            switch appearance.bestMatch(from: [
-                .aqua, .darkAqua,
-                .accessibilityHighContrastAqua, .accessibilityHighContrastDarkAqua
-            ]) {
-            case .darkAqua: return dark
-            case .accessibilityHighContrastAqua: return lightHighContrast ?? light
-            case .accessibilityHighContrastDarkAqua: return darkHighContrast ?? dark
-            default: return light
-            }
-        })
-    }
+  /// An appearance-adaptive color backed by a dynamic `NSColor`, resolving the
+  /// correct value for light / dark (and optionally high-contrast) appearances.
+  static func adaptive(
+    light: NSColor,
+    dark: NSColor,
+    lightHighContrast: NSColor? = nil,
+    darkHighContrast: NSColor? = nil
+  ) -> Color {
+    Color(
+      nsColor: NSColor(name: nil) { appearance in
+        switch appearance.bestMatch(from: [
+          .aqua, .darkAqua,
+          .accessibilityHighContrastAqua, .accessibilityHighContrastDarkAqua,
+        ]) {
+        case .darkAqua: return dark
+        case .accessibilityHighContrastAqua: return lightHighContrast ?? light
+        case .accessibilityHighContrastDarkAqua: return darkHighContrast ?? dark
+        default: return light
+        }
+      })
+  }
 }

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -78,30 +78,6 @@ enum MeterBarTheme {
   }
 }
 
-enum MeterBarWindowChrome {
-  private static let red: CGFloat = 0.080
-  private static let green: CGFloat = 0.086
-  private static let blue: CGFloat = 0.084
-
-  static let dashboardCornerRadius: CGFloat = 14
-  static let titlebarContentInset: CGFloat = 48
-  static let sidebarTitlebarWidth: CGFloat = 256
-  static let collapsedSidebarWidth: CGFloat = 72
-
-  static let color = Color(
-    red: Double(red),
-    green: Double(green),
-    blue: Double(blue)
-  )
-
-  static let backgroundColor = NSColor(
-    calibratedRed: red,
-    green: green,
-    blue: blue,
-    alpha: 1
-  )
-}
-
 extension QuotaBand {
   /// Appearance-adaptive color for the band (single place where severity
   /// maps to color, shared by every surface).
@@ -121,62 +97,14 @@ struct MeterBarDetailBackground: View {
   var body: some View {
     ZStack {
       if reduceTransparency {
-        MeterBarWindowChrome.color
+        Color(nsColor: .windowBackgroundColor)
       } else {
         Color.clear
           .background(.regularMaterial)
 
-        MeterBarWindowChrome.color.opacity(0.78)
-
         LinearGradient(
           colors: [
-            MeterBarTheme.codexAccent.opacity(0.15),
-            MeterBarTheme.appAccent.opacity(0.08),
-            .clear,
-          ],
-          startPoint: .topLeading,
-          endPoint: .bottomTrailing
-        )
-      }
-    }
-  }
-}
-
-struct MeterBarDashboardWindowBacking: View {
-  var body: some View {
-    ZStack(alignment: .topLeading) {
-      MeterBarDetailBackground()
-
-      HStack(spacing: 0) {
-        MeterBarSidebarTitlebarBackground()
-          .frame(width: MeterBarWindowChrome.sidebarTitlebarWidth)
-
-        MeterBarDetailBackground()
-      }
-      .frame(height: MeterBarWindowChrome.titlebarContentInset)
-      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-      .allowsHitTesting(false)
-    }
-  }
-}
-
-struct MeterBarSidebarBackground: View {
-  @Environment(\.accessibilityReduceTransparency)
-  private var reduceTransparency
-
-  var body: some View {
-    ZStack {
-      if reduceTransparency {
-        MeterBarWindowChrome.color
-      } else {
-        Color.clear
-          .background(.regularMaterial)
-
-        MeterBarWindowChrome.color.opacity(0.82)
-
-        LinearGradient(
-          colors: [
-            MeterBarTheme.codexAccent.opacity(0.10),
+            MeterBarTheme.codexAccent.opacity(0.12),
             MeterBarTheme.appAccent.opacity(0.06),
             .clear,
           ],
@@ -188,28 +116,21 @@ struct MeterBarSidebarBackground: View {
   }
 }
 
-struct MeterBarSidebarSurface: View {
-  var radius: CGFloat = MeterBarWindowChrome.dashboardCornerRadius
-
-  @Environment(\.accessibilityReduceTransparency)
-  private var reduceTransparency
+struct MeterBarCompanionSurface: View {
+  var radius: CGFloat = 16
 
   var body: some View {
     let shape = RoundedRectangle(cornerRadius: radius, style: .continuous)
 
-    ZStack {
-      if reduceTransparency {
-        shape.fill(MeterBarWindowChrome.color)
-      } else {
-        shape
-          .fill(.ultraThinMaterial)
-          .glassEffect(.regular, in: shape)
-
-        shape.fill(MeterBarWindowChrome.color.opacity(0.42))
-
+    shape
+      .fill(.ultraThinMaterial)
+      .overlay {
+        shape.fill(MeterBarTheme.glassCardTint)
+      }
+      .overlay(alignment: .topLeading) {
         LinearGradient(
           colors: [
-            MeterBarTheme.codexAccent.opacity(0.18),
+            MeterBarTheme.codexAccent.opacity(0.14),
             MeterBarTheme.appAccent.opacity(0.08),
             .clear,
           ],
@@ -218,102 +139,15 @@ struct MeterBarSidebarSurface: View {
         )
         .clipShape(shape)
       }
-    }
-    .overlay {
-      shape.stroke(MeterBarTheme.glassCardStroke, lineWidth: 1)
-    }
-    .shadow(color: .black.opacity(0.20), radius: 18, y: 10)
-  }
-}
-
-struct MeterBarTitlebarGlass: View {
-  @Environment(\.accessibilityReduceTransparency)
-  private var reduceTransparency
-
-  var body: some View {
-    ZStack {
-      if reduceTransparency {
-        MeterBarWindowChrome.color
-      } else {
-        Color.clear
-          .background(.thinMaterial)
-
-        MeterBarWindowChrome.color.opacity(0.58)
-
-        LinearGradient(
-          colors: [
-            MeterBarTheme.codexAccent.opacity(0.10),
-            .clear,
-          ],
-          startPoint: .topLeading,
-          endPoint: .bottomTrailing
-        )
-      }
-    }
-  }
-}
-
-struct MeterBarSidebarTitlebarBackground: View {
-  var body: some View {
-    MeterBarTitlebarGlass()
       .overlay {
-        MeterBarWindowChrome.color.opacity(0.18)
-      }
-  }
-}
-
-struct MeterBarCompanionSurface: View {
-  var radius: CGFloat = 16
-
-  var body: some View {
-    RoundedRectangle(cornerRadius: radius, style: .continuous)
-      .fill(.ultraThinMaterial)
-      .overlay {
-        RoundedRectangle(cornerRadius: radius, style: .continuous)
-          .fill(MeterBarWindowChrome.color.opacity(0.74))
-      }
-      .overlay(alignment: .topLeading) {
-        LinearGradient(
-          colors: [
-            MeterBarTheme.codexAccent.opacity(0.20),
-            MeterBarTheme.appAccent.opacity(0.08),
-            .clear,
-          ],
-          startPoint: .topLeading,
-          endPoint: .bottomTrailing
-        )
-        .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
-      }
-      .overlay {
-        RoundedRectangle(cornerRadius: radius, style: .continuous)
-          .stroke(MeterBarTheme.glassCardStroke, lineWidth: 1)
+        shape.stroke(MeterBarTheme.glassCardStroke, lineWidth: 1)
       }
   }
 }
 
 extension View {
-  func meterBarSurfaceStyle(_ style: MeterBarSurfaceStyle) -> some View {
-    environment(\.meterBarSurfaceStyle, style)
-  }
-
   func meterBarCardSurface(cornerRadius: CGFloat = 12) -> some View {
     modifier(MeterBarCardSurfaceModifier(cornerRadius: cornerRadius))
-  }
-}
-
-enum MeterBarSurfaceStyle {
-  case dashboard
-  case toolbar
-}
-
-private struct MeterBarSurfaceStyleKey: EnvironmentKey {
-  static let defaultValue: MeterBarSurfaceStyle = .dashboard
-}
-
-private extension EnvironmentValues {
-  var meterBarSurfaceStyle: MeterBarSurfaceStyle {
-    get { self[MeterBarSurfaceStyleKey.self] }
-    set { self[MeterBarSurfaceStyleKey.self] = newValue }
   }
 }
 

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -64,10 +64,10 @@ enum MeterBarTheme {
   )
 
   static let glassCardStroke = Color.adaptive(
-    light: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.08),
-    dark: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.10),
-    lightHighContrast: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.18),
-    darkHighContrast: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.20)
+    light: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.05),
+    dark: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.06),
+    lightHighContrast: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.14),
+    darkHighContrast: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.16)
   )
 
   static func accent(for service: ServiceType) -> Color {
@@ -121,8 +121,8 @@ struct MeterBarDetailBackground: View {
 
         LinearGradient(
           colors: [
-            MeterBarTheme.codexAccent.opacity(0.12),
-            MeterBarTheme.appAccent.opacity(0.06),
+            MeterBarTheme.codexAccent.opacity(0.04),
+            MeterBarTheme.appAccent.opacity(0.025),
             .clear,
           ],
           startPoint: .topLeading,

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -47,10 +47,10 @@ enum MeterBarTheme {
   )
 
   static let glassCardStroke = Color.adaptive(
-    light: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.12),
-    dark: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.15),
-    lightHighContrast: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.24),
-    darkHighContrast: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.28)
+    light: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.08),
+    dark: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.10),
+    lightHighContrast: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.18),
+    darkHighContrast: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.20)
   )
 
   static func accent(for service: ServiceType) -> Color {
@@ -140,7 +140,7 @@ struct MeterBarCompanionSurface: View {
         .clipShape(shape)
       }
       .overlay {
-        shape.stroke(MeterBarTheme.glassCardStroke, lineWidth: 1)
+        shape.stroke(MeterBarTheme.glassCardStroke, lineWidth: 0.5)
       }
   }
 }

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -9,6 +9,9 @@ import SwiftUI
 /// Transparency. The only custom colors are the per-provider brand accents and
 /// quota status — and those are kept appearance-adaptive too.
 enum MeterBarTheme {
+  /// Matches MacSweep's companion popover and detail-panel shell radius.
+  static let companionShellRadius: CGFloat = 16
+
   // MARK: - Brand accents (semantic indicators only; adapt to light/dark)
 
   static let codexAccent = Color.adaptive(
@@ -30,6 +33,20 @@ enum MeterBarTheme {
 
   /// The app's own accent. Follows the user's system accent color.
   static let appAccent = Color.accentColor
+
+  static let sidebarMenuTint = Color.adaptive(
+    light: NSColor(srgbRed: 82 / 255, green: 108 / 255, blue: 118 / 255, alpha: 1),
+    dark: NSColor(srgbRed: 112 / 255, green: 143 / 255, blue: 154 / 255, alpha: 1),
+    lightHighContrast: NSColor(srgbRed: 50 / 255, green: 78 / 255, blue: 90 / 255, alpha: 1),
+    darkHighContrast: NSColor(srgbRed: 145 / 255, green: 176 / 255, blue: 188 / 255, alpha: 1)
+  )
+
+  static let companionTint = Color.adaptive(
+    light: NSColor(srgbRed: 0.50, green: 0.66, blue: 0.72, alpha: 0.16),
+    dark: NSColor(srgbRed: 0.08, green: 0.20, blue: 0.24, alpha: 0.18),
+    lightHighContrast: NSColor(srgbRed: 0.50, green: 0.66, blue: 0.72, alpha: 0.20),
+    darkHighContrast: NSColor(srgbRed: 0.08, green: 0.20, blue: 0.24, alpha: 0.20)
+  )
 
   // MARK: - Quota status (system colors; adapt to appearance + Increase Contrast)
 
@@ -118,14 +135,23 @@ struct MeterBarDetailBackground: View {
 
 struct MeterBarCompanionSurface: View {
   var radius: CGFloat = 16
+  @Environment(\.accessibilityReduceTransparency)
+  private var reduceTransparency
 
   var body: some View {
     let shape = RoundedRectangle(cornerRadius: radius, style: .continuous)
 
     shape
-      .fill(.ultraThinMaterial)
+      .fill(reduceTransparency ? Color(nsColor: .windowBackgroundColor) : Color.clear)
+      .background {
+        if !reduceTransparency {
+          shape.fill(.ultraThinMaterial)
+        }
+      }
       .overlay {
-        shape.fill(MeterBarTheme.glassCardTint)
+        if !reduceTransparency {
+          shape.fill(MeterBarTheme.companionTint)
+        }
       }
       .overlay(alignment: .topLeading) {
         LinearGradient(
@@ -142,6 +168,15 @@ struct MeterBarCompanionSurface: View {
       .overlay {
         shape.stroke(MeterBarTheme.glassCardStroke, lineWidth: 0.5)
       }
+  }
+}
+
+extension NSPanel {
+  func applyCompanionClipping(radius: CGFloat = MeterBarTheme.companionShellRadius) {
+    contentView?.wantsLayer = true
+    contentView?.layer?.cornerRadius = radius
+    contentView?.layer?.cornerCurve = .continuous
+    contentView?.layer?.masksToBounds = true
   }
 }
 

--- a/MeterBar/Views/OptimizeInsightsView.swift
+++ b/MeterBar/Views/OptimizeInsightsView.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import MeterBarShared
+import SwiftUI
 
 /// The "Optimize" dashboard page (#72): an analytics/UI layer over the same
 /// local `CostSummary` the Costs page already renders. It surfaces where tokens
@@ -11,389 +11,358 @@ import MeterBarShared
 /// nothing uploaded. Lives in its own file (never inside `UsageDashboardView`)
 /// per the dashboard view-split convention.
 struct OptimizeInsightsView: View {
-    @StateObject private var costTracker = CostTracker.shared
-    @StateObject private var providerVisibility = ProviderVisibilityStore.shared
+  @StateObject private var costTracker = CostTracker.shared
+  @StateObject private var providerVisibility = ProviderVisibilityStore.shared
 
-    /// 7/30-day window for the token-burn chart.
-    @State private var chartDays = 30
+  /// 7/30-day window for the token-burn chart.
+  @State private var chartDays = 30
 
-    private var visibleSummary: CostSummary? {
-        costTracker.costSummary?.filtered(to: providerVisibility.enabledServices)
+  private var visibleSummary: CostSummary? {
+    costTracker.costSummary?.filtered(to: providerVisibility.enabledServices)
+  }
+
+  private var insights: OptimizationInsights? {
+    visibleSummary.map { OptimizationInsights(summary: $0) }
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      if costTracker.isScanning, insights?.hasData != true {
+        loadingCard
+      } else if let insights, insights.hasData {
+        content(for: insights)
+      } else {
+        emptyStateCard
+      }
     }
+  }
 
-    private var insights: OptimizationInsights? {
-        visibleSummary.map { OptimizationInsights(summary: $0) }
-    }
+  // MARK: - Populated content
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            if costTracker.isScanning, insights?.hasData != true {
-                loadingCard
-            } else if let insights, insights.hasData {
-                content(for: insights)
-            } else {
-                emptyStateCard
-            }
-        }
-    }
+  @ViewBuilder
+  private func content(for insights: OptimizationInsights) -> some View {
+    scoreHero(for: insights)
+    kpiGrid(for: insights)
+    tokenBurnCard
+    modelBreakdownCard(for: insights)
+    originBreakdownCard(for: insights)
+    recommendationsCard(for: insights)
+  }
 
-    // MARK: - Populated content
-
-    @ViewBuilder
-    private func content(for insights: OptimizationInsights) -> some View {
-        scoreHero(for: insights)
-        kpiGrid(for: insights)
-        tokenBurnCard
-        modelBreakdownCard(for: insights)
-        originBreakdownCard(for: insights)
-        recommendationsCard(for: insights)
-    }
-
-    private func scoreHero(for insights: OptimizationInsights) -> some View {
-        DashboardStatusHero(
-            title: "Optimization score \(insights.optimizationScore)/100 · \(insights.scoreGrade)",
-            detail: "\(insights.scoreHeadline) — based on premium-model share, context size, cache reuse, "
-                + "and how concentrated your usage is.",
-            iconName: "leaf.fill",
-            color: Self.gradeColor(insights.optimizationScore)
-        )
-    }
-
-    private func kpiGrid(for insights: OptimizationInsights) -> some View {
-        LazyVGrid(columns: Self.kpiColumns, alignment: .leading, spacing: 12) {
-            KpiTile(
-                title: "Premium model share",
-                value: insights.formattedPremiumShare,
-                caption: "of tokens on premium models",
-                systemImage: "bolt.fill",
-                tint: Self.shareTint(insights.premiumTokenShare)
-            )
-            KpiTile(
-                title: "Cache reuse",
-                value: insights.formattedCacheReuse,
-                caption: "cache reads vs new context",
-                systemImage: "arrow.triangle.2.circlepath",
-                tint: Self.cacheTint(insights.cacheReuseRatio)
-            )
-            KpiTile(
-                title: "Input : output",
-                value: insights.formattedInputOutputRatio,
-                caption: "context sent vs generated",
-                systemImage: "text.append",
-                tint: .secondary
-            )
-            KpiTile(
-                title: "Last 7 days",
-                value: UsageFormat.tokens(insights.tokens7Day),
-                caption: "\(UsageFormat.tokens(insights.tokens30Day)) over 30 days",
-                systemImage: "calendar",
-                tint: .secondary
-            )
-        }
-        .frame(maxWidth: .infinity)
-    }
-
-    private var tokenBurnCard: some View {
-        DashboardCard(title: "Token Burn", trailing: nil) {
-            VStack(alignment: .leading, spacing: 12) {
-                Picker("Window", selection: $chartDays) {
-                    Text("7 days").tag(7)
-                    Text("30 days").tag(30)
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .frame(maxWidth: 220)
-
-                if let summary = visibleSummary, !summary.dailyUsage.isEmpty {
-                    DailyUsageChart(dailyUsage: summary.dailyUsage, daysToShow: chartDays)
-                        .frame(height: 200)
-                } else {
-                    Text("No daily token history yet.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .frame(height: 200, alignment: .center)
-                        .frame(maxWidth: .infinity)
-                }
-            }
-        }
-    }
-
-    private func modelBreakdownCard(for insights: OptimizationInsights) -> some View {
-        DashboardCard(title: "Token Burn by Model", trailing: nil) {
-            if insights.topModels.isEmpty {
-                Text("No per-model breakdown available in the current scan.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            } else {
-                VStack(spacing: 10) {
-                    ForEach(insights.topModels.prefix(6)) { entry in
-                        RankedBreakdownRow(entry: entry, showsTier: true)
-                    }
-                }
-            }
-        }
-    }
-
-    private func originBreakdownCard(for insights: OptimizationInsights) -> some View {
-        DashboardCard(title: "Top Usage Origins", trailing: nil) {
-            VStack(alignment: .leading, spacing: 10) {
-                Text("Where tokens are spent — agents, tool use, skills, and main chat.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-
-                if insights.topOrigins.isEmpty {
-                    Text("No origin breakdown available in the current scan.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                } else {
-                    ForEach(insights.topOrigins.prefix(6)) { entry in
-                        RankedBreakdownRow(entry: entry, showsTier: false)
-                    }
-                }
-            }
-        }
-    }
-
-    private func recommendationsCard(for insights: OptimizationInsights) -> some View {
-        DashboardCard(title: "Recommendations", trailing: nil) {
-            VStack(alignment: .leading, spacing: 12) {
-                ForEach(insights.recommendations) { recommendation in
-                    RecommendationRow(recommendation: recommendation)
-                }
-
-                Divider()
-
-                Label(
-                    "Computed locally from token totals and model names only — no prompt contents "
-                        + "leave your Mac.",
-                    systemImage: "lock.shield"
-                )
-                .font(.caption2)
-                .foregroundColor(.secondary)
-            }
-        }
-    }
-
-    // MARK: - Empty / loading states
-
-    private var emptyStateCard: some View {
-        DashboardCard(title: "Optimize Your Token Usage", trailing: nil) {
-            VStack(alignment: .leading, spacing: 14) {
-                Text(
-                    "Run a local scan to see which models and workflows burn the most tokens, "
-                        + "how well your cache is reused, and where you can trim spend."
-                )
-                .foregroundColor(.secondary)
-
-                Label(
-                    "The scan reads your local Claude and Codex logs on-device. Only token totals "
-                        + "and model names are analyzed — never prompt contents, and nothing is uploaded.",
-                    systemImage: "lock.shield"
-                )
-                .font(.caption)
-                .foregroundColor(.secondary)
-
-                Button {
-                    Task { await costTracker.scanCosts(days: 30) }
-                } label: {
-                    Label("Scan 30 Days", systemImage: "magnifyingglass")
-                }
-                .buttonStyle(.borderedProminent)
-                .disabled(costTracker.isRefreshInProgress)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-    }
-
-    private var loadingCard: some View {
-        DashboardCard(title: "Optimize Your Token Usage", trailing: "Scanning...") {
-            HStack(spacing: 10) {
-                ProgressView()
-                    .controlSize(.small)
-                Text("Scanning local token logs to build your optimization insights…")
-                    .foregroundColor(.secondary)
-            }
-            .frame(maxWidth: .infinity, minHeight: 120, alignment: .center)
-        }
-    }
-
-    // MARK: - Layout + color helpers
-
-    private static let kpiColumns = Array(
-        repeating: GridItem(.flexible(minimum: 200), spacing: 12, alignment: .top),
-        count: 2
+  private func scoreHero(for insights: OptimizationInsights) -> some View {
+    DashboardStatusHero(
+      title: "Optimization score \(insights.optimizationScore)/100 · \(insights.scoreGrade)",
+      detail:
+        "\(insights.scoreHeadline) — based on premium-model share, context size, cache reuse, "
+        + "and how concentrated your usage is.",
+      iconName: "leaf.fill",
+      color: Self.gradeColor(insights.optimizationScore)
     )
+  }
 
-    private static func gradeColor(_ score: Int) -> Color {
-        switch score {
-        case 70...: return MeterBarTheme.success
-        case 45..<70: return MeterBarTheme.warning
-        default: return MeterBarTheme.danger
-        }
+  private func kpiGrid(for insights: OptimizationInsights) -> some View {
+    LazyVGrid(columns: Self.kpiColumns, alignment: .leading, spacing: 12) {
+      DashboardMetricTile(
+        title: "Premium model share",
+        value: insights.formattedPremiumShare,
+        caption: "of tokens on premium models",
+        systemImage: "bolt.fill",
+        tint: Self.shareTint(insights.premiumTokenShare)
+      )
+      DashboardMetricTile(
+        title: "Cache reuse",
+        value: insights.formattedCacheReuse,
+        caption: "cache reads vs new context",
+        systemImage: "arrow.triangle.2.circlepath",
+        tint: Self.cacheTint(insights.cacheReuseRatio)
+      )
+      DashboardMetricTile(
+        title: "Input : output",
+        value: insights.formattedInputOutputRatio,
+        caption: "context sent vs generated",
+        systemImage: "text.append",
+        tint: .secondary
+      )
+      DashboardMetricTile(
+        title: "Last 7 days",
+        value: UsageFormat.tokens(insights.tokens7Day),
+        caption: "\(UsageFormat.tokens(insights.tokens30Day)) over 30 days",
+        systemImage: "calendar",
+        tint: .secondary
+      )
     }
+    .frame(maxWidth: .infinity)
+  }
 
-    /// Higher premium share is redder; a low share is neutral.
-    private static func shareTint(_ share: Double) -> Color {
-        switch share {
-        case 0.5...: return MeterBarTheme.danger
-        case 0.3..<0.5: return MeterBarTheme.warning
-        default: return .secondary
+  private var tokenBurnCard: some View {
+    DashboardCard(title: "Token Burn", trailing: nil) {
+      VStack(alignment: .leading, spacing: 12) {
+        Picker("Window", selection: $chartDays) {
+          Text("7 days").tag(7)
+          Text("30 days").tag(30)
         }
-    }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .frame(maxWidth: 220)
 
-    /// Higher cache reuse is greener; low reuse is a warning.
-    private static func cacheTint(_ ratio: Double?) -> Color {
-        guard let ratio else { return .secondary }
-        switch ratio {
-        case 0.7...: return MeterBarTheme.success
-        case 0.3..<0.7: return .secondary
-        default: return MeterBarTheme.warning
+        if let summary = visibleSummary, !summary.dailyUsage.isEmpty {
+          DailyUsageChart(dailyUsage: summary.dailyUsage, daysToShow: chartDays)
+            .frame(height: 200)
+        } else {
+          Text("No daily token history yet.")
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .frame(height: 200, alignment: .center)
+            .frame(maxWidth: .infinity)
         }
+      }
     }
-}
+  }
 
-// MARK: - KPI tile
-
-private struct KpiTile: View {
-    let title: String
-    let value: String
-    let caption: String
-    let systemImage: String
-    let tint: Color
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Label(title, systemImage: systemImage)
-                .font(.caption)
-                .foregroundColor(.secondary)
-                .labelStyle(.titleAndIcon)
-
-            Text(value)
-                .font(.title2)
-                .fontWeight(.semibold)
-                .foregroundStyle(tint)
-                .contentTransition(.numericText())
-
-            Text(caption)
-                .font(.caption2)
-                .foregroundColor(.secondary)
+  private func modelBreakdownCard(for insights: OptimizationInsights) -> some View {
+    DashboardCard(title: "Token Burn by Model", trailing: nil) {
+      if insights.topModels.isEmpty {
+        Text("No per-model breakdown available in the current scan.")
+          .font(.caption)
+          .foregroundColor(.secondary)
+      } else {
+        VStack(spacing: 10) {
+          ForEach(insights.topModels.prefix(6)) { entry in
+            RankedBreakdownRow(entry: entry, showsTier: true)
+          }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(14)
-        .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+      }
     }
+  }
+
+  private func originBreakdownCard(for insights: OptimizationInsights) -> some View {
+    DashboardCard(title: "Top Usage Origins", trailing: nil) {
+      VStack(alignment: .leading, spacing: 10) {
+        Text("Where tokens are spent — agents, tool use, skills, and main chat.")
+          .font(.caption)
+          .foregroundColor(.secondary)
+
+        if insights.topOrigins.isEmpty {
+          Text("No origin breakdown available in the current scan.")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        } else {
+          ForEach(insights.topOrigins.prefix(6)) { entry in
+            RankedBreakdownRow(entry: entry, showsTier: false)
+          }
+        }
+      }
+    }
+  }
+
+  private func recommendationsCard(for insights: OptimizationInsights) -> some View {
+    DashboardCard(title: "Recommendations", trailing: nil) {
+      VStack(alignment: .leading, spacing: 12) {
+        ForEach(insights.recommendations) { recommendation in
+          RecommendationRow(recommendation: recommendation)
+        }
+
+        Divider()
+
+        Label(
+          "Computed locally from token totals and model names only — no prompt contents "
+            + "leave your Mac.",
+          systemImage: "lock.shield"
+        )
+        .font(.caption2)
+        .foregroundColor(.secondary)
+      }
+    }
+  }
+
+  // MARK: - Empty / loading states
+
+  private var emptyStateCard: some View {
+    DashboardCard(title: "Optimize Your Token Usage", trailing: nil) {
+      VStack(alignment: .leading, spacing: 14) {
+        Text(
+          "Run a local scan to see which models and workflows burn the most tokens, "
+            + "how well your cache is reused, and where you can trim spend."
+        )
+        .foregroundColor(.secondary)
+
+        Label(
+          "The scan reads your local Claude and Codex logs on-device. Only token totals "
+            + "and model names are analyzed — never prompt contents, and nothing is uploaded.",
+          systemImage: "lock.shield"
+        )
+        .font(.caption)
+        .foregroundColor(.secondary)
+
+        Button {
+          Task { await costTracker.scanCosts(days: 30) }
+        } label: {
+          Label("Scan 30 Days", systemImage: "magnifyingglass")
+        }
+        .buttonStyle(.borderedProminent)
+        .disabled(costTracker.isRefreshInProgress)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+  }
+
+  private var loadingCard: some View {
+    DashboardCard(title: "Optimize Your Token Usage", trailing: "Scanning...") {
+      HStack(spacing: 10) {
+        ProgressView()
+          .controlSize(.small)
+        Text("Scanning local token logs to build your optimization insights…")
+          .foregroundColor(.secondary)
+      }
+      .frame(maxWidth: .infinity, minHeight: 120, alignment: .center)
+    }
+  }
+
+  // MARK: - Layout + color helpers
+
+  private static let kpiColumns = Array(
+    repeating: GridItem(.flexible(minimum: 200), spacing: 12, alignment: .top),
+    count: 2
+  )
+
+  private static func gradeColor(_ score: Int) -> Color {
+    switch score {
+    case 70...: return MeterBarTheme.success
+    case 45..<70: return MeterBarTheme.warning
+    default: return MeterBarTheme.danger
+    }
+  }
+
+  /// Higher premium share is redder; a low share is neutral.
+  private static func shareTint(_ share: Double) -> Color {
+    switch share {
+    case 0.5...: return MeterBarTheme.danger
+    case 0.3..<0.5: return MeterBarTheme.warning
+    default: return .secondary
+    }
+  }
+
+  /// Higher cache reuse is greener; low reuse is a warning.
+  private static func cacheTint(_ ratio: Double?) -> Color {
+    guard let ratio else { return .secondary }
+    switch ratio {
+    case 0.7...: return MeterBarTheme.success
+    case 0.3..<0.7: return .secondary
+    default: return MeterBarTheme.warning
+    }
+  }
 }
 
 // MARK: - Ranked breakdown row
 
 private struct RankedBreakdownRow: View {
-    let entry: RankedTokenEntry
-    let showsTier: Bool
+  let entry: RankedTokenEntry
+  let showsTier: Bool
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 5) {
-            HStack(spacing: 8) {
-                Circle()
-                    .fill(MeterBarTheme.accent(for: entry.provider))
-                    .frame(width: 8, height: 8)
+  var body: some View {
+    VStack(alignment: .leading, spacing: 5) {
+      HStack(spacing: 8) {
+        Circle()
+          .fill(MeterBarTheme.accent(for: entry.provider))
+          .frame(width: 8, height: 8)
 
-                Text(entry.name)
-                    .font(.callout)
-                    .fontWeight(.medium)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
+        Text(entry.name)
+          .font(.callout)
+          .fontWeight(.medium)
+          .lineLimit(1)
+          .truncationMode(.middle)
 
-                if showsTier, entry.tier != .unknown {
-                    Text(entry.tier.label)
-                        .font(.caption2)
-                        .fontWeight(.semibold)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(tierColor.opacity(0.18), in: Capsule())
-                        .foregroundStyle(tierColor)
-                }
-
-                Spacer(minLength: 8)
-
-                Text(entry.formattedTokens)
-                    .font(.callout)
-                    .monospacedDigit()
-                Text(entry.formattedShare)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .monospacedDigit()
-                    .frame(width: 42, alignment: .trailing)
-            }
-
-            ShareBar(fraction: entry.tokenShare, tint: MeterBarTheme.accent(for: entry.provider))
+        if showsTier, entry.tier != .unknown {
+          Text(entry.tier.label)
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(tierColor.opacity(0.18), in: Capsule())
+            .foregroundStyle(tierColor)
         }
-    }
 
-    private var tierColor: Color {
-        switch entry.tier {
-        case .premium: return MeterBarTheme.danger
-        case .standard: return MeterBarTheme.warning
-        case .economy: return MeterBarTheme.success
-        case .unknown: return .secondary
-        }
+        Spacer(minLength: 8)
+
+        Text(entry.formattedTokens)
+          .font(.callout)
+          .monospacedDigit()
+        Text(entry.formattedShare)
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .monospacedDigit()
+          .frame(width: 42, alignment: .trailing)
+      }
+
+      ShareBar(fraction: entry.tokenShare, tint: MeterBarTheme.accent(for: entry.provider))
     }
+  }
+
+  private var tierColor: Color {
+    switch entry.tier {
+    case .premium: return MeterBarTheme.danger
+    case .standard: return MeterBarTheme.warning
+    case .economy: return MeterBarTheme.success
+    case .unknown: return .secondary
+    }
+  }
 }
 
 private struct ShareBar: View {
-    let fraction: Double
-    let tint: Color
+  let fraction: Double
+  let tint: Color
 
-    var body: some View {
-        GeometryReader { proxy in
-            ZStack(alignment: .leading) {
-                Capsule()
-                    .fill(.quaternary)
-                    .frame(height: 4)
-                Capsule()
-                    .fill(tint)
-                    .frame(width: max(2, proxy.size.width * clampedFraction), height: 4)
-            }
-        }
-        .frame(height: 4)
+  var body: some View {
+    GeometryReader { proxy in
+      ZStack(alignment: .leading) {
+        Capsule()
+          .fill(.quaternary)
+          .frame(height: 4)
+        Capsule()
+          .fill(tint)
+          .frame(width: max(2, proxy.size.width * clampedFraction), height: 4)
+      }
     }
+    .frame(height: 4)
+  }
 
-    private var clampedFraction: CGFloat {
-        CGFloat(min(1, max(0, fraction)))
-    }
+  private var clampedFraction: CGFloat {
+    CGFloat(min(1, max(0, fraction)))
+  }
 }
 
 // MARK: - Recommendation row
 
 private struct RecommendationRow: View {
-    let recommendation: OptimizationRecommendation
+  let recommendation: OptimizationRecommendation
 
-    var body: some View {
-        HStack(alignment: .top, spacing: 10) {
-            Image(systemName: recommendation.systemImage)
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(severityColor)
-                .frame(width: 22)
+  var body: some View {
+    HStack(alignment: .top, spacing: 10) {
+      Image(systemName: recommendation.systemImage)
+        .font(.system(size: 15, weight: .semibold))
+        .foregroundStyle(severityColor)
+        .frame(width: 22)
 
-            VStack(alignment: .leading, spacing: 3) {
-                Text(recommendation.title)
-                    .font(.callout)
-                    .fontWeight(.semibold)
-                Text(recommendation.detail)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
+      VStack(alignment: .leading, spacing: 3) {
+        Text(recommendation.title)
+          .font(.callout)
+          .fontWeight(.semibold)
+        Text(recommendation.detail)
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
 
-            Spacer(minLength: 0)
-        }
+      Spacer(minLength: 0)
     }
+  }
 
-    private var severityColor: Color {
-        switch recommendation.severity {
-        case .warning: return MeterBarTheme.danger
-        case .suggestion: return MeterBarTheme.warning
-        case .info: return MeterBarTheme.accent(for: .claudeCode)
-        case .positive: return MeterBarTheme.success
-        }
+  private var severityColor: Color {
+    switch recommendation.severity {
+    case .warning: return MeterBarTheme.danger
+    case .suggestion: return MeterBarTheme.warning
+    case .info: return MeterBarTheme.accent(for: .claudeCode)
+    case .positive: return MeterBarTheme.success
     }
+  }
 }

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -48,6 +48,21 @@ struct ProviderSnapshot: Identifiable {
     var hasExhaustedLimit: Bool {
         limits.contains { $0.usageLimit.isAtLimit }
     }
+
+    /// Weekly exhaustion blocks the whole subscription even when the shorter
+    /// session window still has room. Compact overview cards should prioritize
+    /// that reset instead of spending space on the session gauge.
+    var hasExhaustedWeeklyLimit: Bool {
+        limits.contains { $0.kind == .weekly && $0.usageLimit.isAtLimit }
+    }
+
+    /// Detail panels should focus on the limit that is actually blocking use.
+    /// When the weekly subscription quota is exhausted, the shorter session
+    /// window is no longer actionable, even if it still has room.
+    var detailLimits: [SnapshotLimit] {
+        guard hasExhaustedWeeklyLimit else { return limits }
+        return limits.filter { $0.kind != .session }
+    }
 }
 
 struct SnapshotLimit: Identifiable {

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -21,6 +21,10 @@ struct ProviderSnapshot: Identifiable {
     var logoKind: ProviderLogoKind { .forService(service) }
     var accentColor: Color { MeterBarTheme.accent(for: service) }
 
+    var displayedExtraUsage: ExtraUsageStatus? {
+        ExtraUsageDisplayPolicy.visibleStatus(for: service, status: extraUsage)
+    }
+
     /// Whether the provider has reported metrics at all (drives whether the
     /// dashboard renders a card for it).
     var hasMetrics: Bool { updatedAt != nil }
@@ -62,6 +66,16 @@ struct ProviderSnapshot: Identifiable {
     var detailLimits: [SnapshotLimit] {
         guard hasExhaustedWeeklyLimit else { return limits }
         return limits.filter { $0.kind != .session }
+    }
+}
+
+enum ExtraUsageDisplayPolicy {
+    static func visibleStatus(for service: ServiceType, status: ExtraUsageStatus?) -> ExtraUsageStatus? {
+        guard let status else { return nil }
+        guard service == .claudeCode, status.state == .unknown else {
+            return status
+        }
+        return UserDefaults.standard.bool(forKey: StorageKeys.claudeCodeOAuthFallback) ? status : nil
     }
 }
 

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -25,6 +25,11 @@ struct ProviderSnapshot: Identifiable {
         ExtraUsageDisplayPolicy.visibleStatus(for: service, status: extraUsage)
     }
 
+    var updatedText: String {
+        guard let updatedAt else { return "No data" }
+        return "Updated \(UsageFormat.relative(updatedAt))"
+    }
+
     /// Whether the provider has reported metrics at all (drives whether the
     /// dashboard renders a card for it).
     var hasMetrics: Bool { updatedAt != nil }

--- a/MeterBar/Views/RefreshingIcon.swift
+++ b/MeterBar/Views/RefreshingIcon.swift
@@ -1,36 +1,19 @@
 import SwiftUI
 
-/// A refresh glyph that spins while work is in flight, and respects Reduce Motion.
-/// Bound to real loading/scanning state so it reflects refreshes triggered from
-/// anywhere, not just a local button tap.
+/// Native refresh/loading glyph for toolbar and companion controls.
 struct RefreshingIcon: View {
     let isRefreshing: Bool
 
-    @Environment(\.accessibilityReduceMotion)
-    private var reduceMotion
-    @State private var rotationDegrees = 0.0
-
     var body: some View {
-        Image(systemName: "arrow.clockwise")
-            .rotationEffect(.degrees(rotationDegrees))
-            .onAppear(perform: updateRotation)
-            .onChange(of: isRefreshing) { _, _ in
-                updateRotation()
-            }
-            .onChange(of: reduceMotion) { _, _ in
-                updateRotation()
-            }
-    }
-
-    private func updateRotation() {
-        if isRefreshing, !reduceMotion {
-            withAnimation(.linear(duration: 0.8).repeatForever(autoreverses: false)) {
-                rotationDegrees = 360
-            }
-        } else {
-            withAnimation(.easeOut(duration: 0.15)) {
-                rotationDegrees = 0
+        Group {
+            if isRefreshing {
+                ProgressView()
+                    .controlSize(.small)
+                    .progressViewStyle(.circular)
+            } else {
+                Image(systemName: "arrow.clockwise")
             }
         }
+        .frame(width: 18, height: 18)
     }
 }

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -412,8 +412,11 @@ struct SettingsView: View {
                     .controlSize(.small)
                 }
 
-                List {
-                    ForEach(claudeAccountStore.accounts) { account in
+                VStack(spacing: 0) {
+                    ForEach(Array(claudeAccountStore.accounts.enumerated()), id: \.element.id) { index, account in
+                        if index > 0 {
+                            SettingsDivider()
+                        }
                         AccountProfileRow(
                             account: account,
                             onSave: { name, configDirectory in
@@ -425,14 +428,8 @@ struct SettingsView: View {
                                 Task { await dataManager.refreshAll() }
                             }
                         )
-                        .listRowInsets(EdgeInsets())
-                        .listRowSeparator(.hidden)
                     }
-                    .onMove(perform: moveClaudeAccounts)
                 }
-                .listStyle(.plain)
-                .scrollContentBackground(.hidden)
-                .frame(height: claudeAccountListHeight)
             }
         }
     }
@@ -617,17 +614,9 @@ struct SettingsView: View {
         }
     }
 
-    private var claudeAccountListHeight: CGFloat {
-        min(420, max(118, CGFloat(claudeAccountStore.accounts.count) * 118))
-    }
-
     private func updateClaudeAccount(id: UUID, name: String, configDirectory: String?) {
         claudeAccountStore.updateAccount(id: id, name: name, configDirectory: configDirectory)
         Task { await dataManager.refreshAll() }
-    }
-
-    private func moveClaudeAccounts(from source: IndexSet, to destination: Int) {
-        claudeAccountStore.moveAccounts(fromOffsets: source, toOffset: destination)
     }
 
     private func reconnectClaudeAccount(_ account: ClaudeCodeAccount) {
@@ -708,9 +697,7 @@ private struct SettingsRowView<Content: View>: View {
     }
 
     var body: some View {
-        LabeledContent {
-            content
-        } label: {
+        HStack(alignment: .center, spacing: 16) {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                 if let detail {
@@ -719,6 +706,10 @@ private struct SettingsRowView<Content: View>: View {
                         .foregroundStyle(.secondary)
                 }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            content
+                .fixedSize(horizontal: true, vertical: false)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -924,22 +915,15 @@ private struct AccountProfileRow: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            Image(systemName: "line.3.horizontal")
-                .foregroundStyle(.tertiary)
-                .frame(width: 14)
-                .padding(.top, 10)
-                .help("Drag to reorder")
-
+        HStack(alignment: .center, spacing: 12) {
             Image(systemName: account.isDefault ? "person.crop.circle" : "person.crop.circle.badge.plus")
                 .foregroundStyle(MeterBarTheme.claudeAccent)
                 .frame(width: 18)
-                .padding(.top, 8)
 
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 8) {
                     TextField("Account label", text: $nameDraft)
-                        .settingsInput(width: 260)
+                        .settingsInput(width: 240)
                         .onSubmit(saveChanges)
 
                     Text(account.isDefault ? "Default" : "Profile")
@@ -953,18 +937,19 @@ private struct AccountProfileRow: View {
                         )
                 }
 
-                VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
                     Text(account.isDefault ? "Default config directory" : "Config directory")
                         .font(.caption2)
                         .fontWeight(.semibold)
                         .foregroundStyle(.secondary)
+                        .frame(width: 126, alignment: .leading)
 
                     if account.isDefault {
                         SettingsReadonlyField(text: displayConfigDirectory)
                     } else {
                         HStack(spacing: 8) {
                             TextField("Config directory", text: $configDirectoryDraft)
-                                .settingsInput(width: 320)
+                                .settingsInput(width: 280)
                                 .onSubmit(saveChanges)
 
                             Button {
@@ -978,20 +963,21 @@ private struct AccountProfileRow: View {
                     }
                 }
             }
-
-            Spacer()
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             HStack(spacing: 8) {
                 Button(action: onReconnect) {
                     Image(systemName: "arrow.clockwise")
                 }
                 .buttonStyle(.bordered)
+                .controlSize(.small)
                 .help("Reconnect Claude profile")
 
                 Button(action: saveChanges) {
                     Image(systemName: "checkmark")
                 }
                 .buttonStyle(.bordered)
+                .controlSize(.small)
                 .disabled(!hasChanges || !canSave)
                 .help("Save account changes")
 
@@ -1000,11 +986,13 @@ private struct AccountProfileRow: View {
                         Image(systemName: "trash")
                     }
                     .buttonStyle(.bordered)
+                    .controlSize(.small)
                     .help("Delete account")
                 }
             }
+            .frame(minWidth: 116, alignment: .trailing)
         }
-        .padding(.vertical, 8)
+        .padding(.vertical, 10)
         .onChange(of: account) { _, updatedAccount in
             nameDraft = updatedAccount.name
             configDirectoryDraft = updatedAccount.configDirectory ?? ""
@@ -1060,7 +1048,7 @@ private struct SettingsReadonlyField: View {
             .font(.caption)
             .lineLimit(1)
             .truncationMode(.middle)
-            .settingsInputSurface(width: 320)
+            .settingsInputSurface(width: 280)
             .help(text)
     }
 }

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -164,7 +164,15 @@ struct SettingsView: View {
     }
 
     private var showExtraUsageSection: Bool {
-        providerVisibility.isEnabled(.claudeCode) || providerVisibility.isEnabled(.codexCli)
+        (providerVisibility.isEnabled(.claudeCode) && claudeExtraUsageStatus != nil)
+            || providerVisibility.isEnabled(.codexCli)
+    }
+
+    private var claudeExtraUsageStatus: ExtraUsageStatus? {
+        ExtraUsageDisplayPolicy.visibleStatus(
+            for: .claudeCode,
+            status: dataManager.metrics[.claudeCode]?.extraUsage
+        )
     }
 
     private var extraUsageSection: some View {
@@ -176,11 +184,13 @@ struct SettingsView: View {
             )
 
             if providerVisibility.isEnabled(.claudeCode) {
-                extraUsageRow(
-                    title: "Claude Code",
-                    status: dataManager.metrics[.claudeCode]?.extraUsage,
-                    manageURL: "https://claude.ai/settings"
-                )
+                if let claudeExtraUsageStatus {
+                    extraUsageRow(
+                        title: "Claude Code",
+                        status: claudeExtraUsageStatus,
+                        manageURL: "https://claude.ai/settings"
+                    )
+                }
             }
 
             if providerVisibility.isEnabled(.codexCli) {

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -757,6 +757,10 @@ private struct AdminKeySettingsRow: View {
         draft.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    private var connectedMessage: String {
+        "Connected. Usage appears on the billed API card."
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .firstTextBaseline, spacing: 10) {
@@ -764,7 +768,7 @@ private struct AdminKeySettingsRow: View {
                     Text(provider.displayName)
                         .font(.subheadline)
                         .fontWeight(.semibold)
-                    Text(connected ? "Connected. Usage appears on the billed API card." : "Required for organization usage.")
+                    Text(connected ? connectedMessage : "Required for organization usage.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -33,26 +33,18 @@ struct SettingsView: View {
     }
 
     var body: some View {
-        Form {
-            trackedProvidersSection
-            if providerVisibility.isEnabled(.claudeCode) {
-                claudeCodeSection
+        Group {
+            if embeddedInDashboard {
+                settingsStack
+            } else {
+                ScrollView {
+                    settingsStack
+                        .padding(22)
+                }
+                .scrollContentBackground(.hidden)
+                .background(Color(nsColor: .windowBackgroundColor))
             }
-            if providerVisibility.isEnabled(.cursor) {
-                cursorSection
-            }
-            if showExtraUsageSection {
-                extraUsageSection
-            }
-            apiUsageSection
-            costTrackingSection
-            refreshSection
-            notificationsSection
-            generalSection
         }
-        .formStyle(.grouped)
-        .scrollContentBackground(embeddedInDashboard ? .hidden : .automatic)
-        .background(embeddedInDashboard ? Color.clear : Color(nsColor: .windowBackgroundColor))
         .frame(
             minWidth: embeddedInDashboard ? nil : 560,
             minHeight: embeddedInDashboard ? nil : 500
@@ -76,6 +68,27 @@ struct SettingsView: View {
                 isAddingClaudeAccount = false
             }
         }
+    }
+
+    private var settingsStack: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            trackedProvidersSection
+            if providerVisibility.isEnabled(.claudeCode) {
+                claudeCodeSection
+            }
+            if providerVisibility.isEnabled(.cursor) {
+                cursorSection
+            }
+            if showExtraUsageSection {
+                extraUsageSection
+            }
+            apiUsageSection
+            costTrackingSection
+            refreshSection
+            notificationsSection
+            generalSection
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
     }
 
     private var notificationsSection: some View {
@@ -660,9 +673,7 @@ private struct SettingsPanelSection<Content: View>: View {
     }
 
     var body: some View {
-        Section {
-            content
-        } header: {
+        VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 6) {
                 if let logoKind {
                     ProviderLogoView(kind: logoKind, size: 14, foregroundColor: color)
@@ -671,6 +682,15 @@ private struct SettingsPanelSection<Content: View>: View {
                         .foregroundStyle(color)
                 }
                 Text(title)
+            }
+            .font(.subheadline)
+            .fontWeight(.semibold)
+
+            DashboardTile(padding: 12) {
+                VStack(alignment: .leading, spacing: 10) {
+                    content
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
     }
@@ -700,6 +720,7 @@ private struct SettingsRowView<Content: View>: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
@@ -925,9 +946,11 @@ private struct AccountProfileRow: View {
                         .font(.caption)
                         .fontWeight(.semibold)
                         .foregroundStyle(account.isDefault ? MeterBarTheme.appAccent : MeterBarTheme.claudeAccent)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(.thinMaterial, in: Capsule())
+                        .settingsInputSurface(
+                            horizontalPadding: 8,
+                            verticalPadding: 4,
+                            shape: .capsule
+                        )
                 }
 
                 VStack(alignment: .leading, spacing: 4) {
@@ -1037,14 +1060,7 @@ private struct SettingsReadonlyField: View {
             .font(.caption)
             .lineLimit(1)
             .truncationMode(.middle)
-            .frame(width: 320, alignment: .leading)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
-            .overlay {
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .stroke(MeterBarTheme.glassCardStroke, lineWidth: 0.5)
-            }
+            .settingsInputSurface(width: 320)
             .help(text)
     }
 }
@@ -1057,19 +1073,66 @@ private struct SettingsInputModifier: ViewModifier {
             .textFieldStyle(.plain)
             .font(.subheadline)
             .lineLimit(1)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .frame(width: width)
-            .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
-            .overlay {
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .stroke(MeterBarTheme.glassCardStroke, lineWidth: 0.5)
-            }
+            .settingsInputSurface(width: width)
+    }
+}
+
+private enum SettingsInputSurfaceShape {
+    case roundedRectangle
+    case capsule
+}
+
+private struct SettingsInputSurfaceModifier: ViewModifier {
+    let width: CGFloat?
+    let horizontalPadding: CGFloat
+    let verticalPadding: CGFloat
+    let shape: SettingsInputSurfaceShape
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        switch shape {
+        case .roundedRectangle:
+            let roundedRectangle = RoundedRectangle(cornerRadius: 6, style: .continuous)
+
+            content
+                .padding(.horizontal, horizontalPadding)
+                .padding(.vertical, verticalPadding)
+                .frame(width: width)
+                .background(.thinMaterial, in: roundedRectangle)
+                .overlay {
+                    roundedRectangle.stroke(MeterBarTheme.glassCardStroke, lineWidth: 0.5)
+                }
+        case .capsule:
+            content
+                .padding(.horizontal, horizontalPadding)
+                .padding(.vertical, verticalPadding)
+                .frame(width: width)
+                .background(.thinMaterial, in: Capsule())
+                .overlay {
+                    Capsule().stroke(MeterBarTheme.glassCardStroke, lineWidth: 0.5)
+                }
+        }
     }
 }
 
 private extension View {
     func settingsInput(width: CGFloat? = nil) -> some View {
         modifier(SettingsInputModifier(width: width))
+    }
+
+    func settingsInputSurface(
+        width: CGFloat? = nil,
+        horizontalPadding: CGFloat = 10,
+        verticalPadding: CGFloat = 6,
+        shape: SettingsInputSurfaceShape = .roundedRectangle
+    ) -> some View {
+        modifier(
+            SettingsInputSurfaceModifier(
+                width: width,
+                horizontalPadding: horizontalPadding,
+                verticalPadding: verticalPadding,
+                shape: shape
+            )
+        )
     }
 }

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -839,7 +839,7 @@ private struct AddClaudeAccountSheet: View {
                     Text("Account name")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    TextField("shipshitdev", text: $accountName)
+                    TextField("Work", text: $accountName)
                         .settingsInput()
                 }
 

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -17,8 +17,7 @@ struct SettingsView: View {
     @StateObject private var authManager = AuthenticationManager.shared
     @StateObject private var apiUsageStore = ApiUsageStore.shared
 
-    @State private var newClaudeAccountName: String = ""
-    @State private var newClaudeConfigDirectory: String = ""
+    @State private var isAddingClaudeAccount = false
     @State private var claudeReconnectError: String?
     @State private var claudeAdminKeyDraft: String = ""
     @State private var openaiAdminKeyDraft: String = ""
@@ -70,6 +69,12 @@ struct SettingsView: View {
             Button("OK") { claudeReconnectError = nil }
         } message: {
             Text(claudeReconnectError ?? "Could not open the Claude reconnect flow.")
+        }
+        .sheet(isPresented: $isAddingClaudeAccount) {
+            AddClaudeAccountSheet { name, configDirectory in
+                addClaudeAccount(name: name, configDirectory: configDirectory)
+                isAddingClaudeAccount = false
+            }
         }
     }
 
@@ -269,39 +274,24 @@ struct SettingsView: View {
         helpURL: String
     ) -> some View {
         let connected = authManager.isAuthenticated(provider)
-        return SettingsRowView(
-            title: provider.displayName,
-            detail: connected ? "Connected. Usage appears on the API card." : "Required for organization usage."
-        ) {
-            HStack(spacing: 8) {
-                StatusPill(title: connected ? "Connected" : "Not Connected", isConnected: connected)
-
-                SecureField(placeholder, text: draft)
-                    .textFieldStyle(.roundedBorder)
-                    .frame(maxWidth: 200)
-
-                Button("Save") {
-                    saveAdminKey(provider, draft: draft)
+        return AdminKeySettingsRow(
+            provider: provider,
+            connected: connected,
+            draft: draft,
+            placeholder: placeholder,
+            onSave: {
+                saveAdminKey(provider, draft: draft)
+            },
+            onRemove: {
+                authManager.removeAdminKey(for: provider)
+                Task { await apiUsageStore.refresh() }
+            },
+            onHelp: {
+                if let url = URL(string: helpURL) {
+                    NSWorkspace.shared.open(url)
                 }
-                .buttonStyle(.borderedProminent)
-                .disabled(draft.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-
-                Button("Remove") {
-                    authManager.removeAdminKey(for: provider)
-                    Task { await apiUsageStore.refresh() }
-                }
-                .buttonStyle(.bordered)
-                .disabled(!connected)
-
-                Button("Help") {
-                    if let url = URL(string: helpURL) {
-                        NSWorkspace.shared.open(url)
-                    }
-                }
-                .buttonStyle(.bordered)
-                .help("Open \(helpURL)")
             }
-        }
+        )
     }
 
     private func saveAdminKey(_ provider: ApiProvider, draft: Binding<String>) {
@@ -392,10 +382,22 @@ struct SettingsView: View {
 
             SettingsDivider()
 
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Claude Accounts")
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .center) {
+                    Text("Claude Accounts")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+
+                    Spacer()
+
+                    Button {
+                        isAddingClaudeAccount = true
+                    } label: {
+                        Label("Add Account", systemImage: "plus")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                }
 
                 List {
                     ForEach(claudeAccountStore.accounts) { account in
@@ -418,36 +420,6 @@ struct SettingsView: View {
                 .listStyle(.plain)
                 .scrollContentBackground(.hidden)
                 .frame(height: claudeAccountListHeight)
-            }
-
-            SettingsRowView(title: "New account") {
-                TextField("Account name", text: $newClaudeAccountName)
-                    .textFieldStyle(.roundedBorder)
-                    .frame(maxWidth: 220)
-            }
-
-            SettingsRowView(
-                title: "Config directory",
-                detail: "Use a separate CLAUDE_CONFIG_DIR for each extra account."
-            ) {
-                HStack(spacing: 8) {
-                    TextField("Path", text: $newClaudeConfigDirectory)
-                        .textFieldStyle(.roundedBorder)
-                        .frame(maxWidth: 280)
-
-                    Button("Choose") {
-                        chooseClaudeConfigDirectory()
-                    }
-                    .buttonStyle(.bordered)
-                }
-            }
-
-            SettingsRowView(title: "Add profile") {
-                Button("Add Account") {
-                    addClaudeAccount()
-                }
-                .buttonStyle(.borderedProminent)
-                .disabled(!canAddClaudeAccount)
             }
         }
     }
@@ -594,11 +566,6 @@ struct SettingsView: View {
         }
     }
 
-    private var canAddClaudeAccount: Bool {
-        !newClaudeAccountName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
-            !newClaudeConfigDirectory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    }
-
     private var visibleCostSummary: CostSummary? {
         costTracker.costSummary?.filtered(to: providerVisibility.enabledServices)
     }
@@ -627,35 +594,18 @@ struct SettingsView: View {
         UsageFormat.relative(date)
     }
 
-    private func addClaudeAccount() {
+    private func addClaudeAccount(name: String, configDirectory: String) {
         claudeAccountStore.addAccount(
-            name: newClaudeAccountName,
-            configDirectory: newClaudeConfigDirectory
+            name: name,
+            configDirectory: configDirectory
         )
-        newClaudeAccountName = ""
-        newClaudeConfigDirectory = ""
         Task {
             await dataManager.refreshAll()
         }
     }
 
-    private func chooseClaudeConfigDirectory() {
-        let panel = NSOpenPanel()
-        panel.canChooseFiles = false
-        panel.canChooseDirectories = true
-        panel.allowsMultipleSelection = false
-        panel.prompt = "Use"
-
-        if panel.runModal() == .OK, let url = panel.url {
-            newClaudeConfigDirectory = url.path
-            if newClaudeAccountName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                newClaudeAccountName = url.lastPathComponent
-            }
-        }
-    }
-
     private var claudeAccountListHeight: CGFloat {
-        min(320, max(84, CGFloat(claudeAccountStore.accounts.count) * 84))
+        min(420, max(118, CGFloat(claudeAccountStore.accounts.count) * 118))
     }
 
     private func updateClaudeAccount(id: UUID, name: String, configDirectory: String?) {
@@ -782,6 +732,153 @@ private struct StatusPill: View {
     }
 }
 
+private struct AdminKeySettingsRow: View {
+    let provider: ApiProvider
+    let connected: Bool
+    @Binding var draft: String
+    let placeholder: String
+    let onSave: () -> Void
+    let onRemove: () -> Void
+    let onHelp: () -> Void
+
+    private var trimmedDraft: String {
+        draft.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(provider.displayName)
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                    Text(connected ? "Connected. Usage appears on the billed API card." : "Required for organization usage.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                StatusPill(title: connected ? "Connected" : "Not Connected", isConnected: connected)
+                    .font(.caption)
+            }
+
+            HStack(spacing: 8) {
+                SecureField(placeholder, text: $draft)
+                    .settingsInput()
+                    .frame(minWidth: 220, maxWidth: 340)
+
+                Button("Save", action: onSave)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(trimmedDraft.isEmpty)
+
+                Button("Remove", action: onRemove)
+                    .buttonStyle(.bordered)
+                    .disabled(!connected)
+
+                Button("Help", action: onHelp)
+                    .buttonStyle(.bordered)
+            }
+        }
+        .padding(.vertical, 6)
+    }
+}
+
+private struct AddClaudeAccountSheet: View {
+    @Environment(\.dismiss)
+    private var dismiss
+
+    @State private var accountName = ""
+    @State private var configDirectory = ""
+
+    let onAdd: (String, String) -> Void
+
+    private var trimmedName: String {
+        accountName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedConfigDirectory: String {
+        configDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var canAdd: Bool {
+        !trimmedName.isEmpty && !trimmedConfigDirectory.isEmpty
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(spacing: 10) {
+                ProviderLogoView(kind: .claude, size: 18, foregroundColor: MeterBarTheme.claudeAccent)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Add Claude Account")
+                        .font(.headline)
+                    Text("Use a separate CLAUDE_CONFIG_DIR for this profile.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Account name")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextField("shipshitdev", text: $accountName)
+                        .settingsInput()
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Config directory")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    HStack(spacing: 8) {
+                        TextField("Path", text: $configDirectory)
+                            .settingsInput()
+                        Button("Choose") {
+                            chooseConfigDirectory()
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                }
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button("Add Account") {
+                    guard canAdd else { return }
+                    onAdd(trimmedName, trimmedConfigDirectory)
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(!canAdd)
+            }
+        }
+        .padding(22)
+        .frame(width: 520)
+    }
+
+    private func chooseConfigDirectory() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Use"
+
+        if panel.runModal() == .OK, let url = panel.url {
+            configDirectory = url.path
+            if trimmedName.isEmpty {
+                accountName = url.lastPathComponent
+            }
+        }
+    }
+}
+
 private struct AccountProfileRow: View {
     let account: ClaudeCodeAccount
     let onSave: (String, String?) -> Void
@@ -806,36 +903,56 @@ private struct AccountProfileRow: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 10) {
+        HStack(alignment: .top, spacing: 12) {
             Image(systemName: "line.3.horizontal")
                 .foregroundStyle(.tertiary)
                 .frame(width: 14)
-                .padding(.top, 8)
+                .padding(.top, 10)
                 .help("Drag to reorder")
 
             Image(systemName: account.isDefault ? "person.crop.circle" : "person.crop.circle.badge.plus")
                 .foregroundStyle(MeterBarTheme.claudeAccent)
                 .frame(width: 18)
-                .padding(.top, 4)
+                .padding(.top, 8)
 
-            VStack(alignment: .leading, spacing: 6) {
-                TextField("Account label", text: $nameDraft)
-                    .font(.subheadline)
-                    .textFieldStyle(.roundedBorder)
-                    .frame(maxWidth: 240)
-                    .onSubmit(saveChanges)
-
-                if account.isDefault {
-                    Text("Default Claude CLI profile")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                } else {
-                    TextField("Config directory", text: $configDirectoryDraft)
-                        .font(.caption)
-                        .textFieldStyle(.roundedBorder)
-                        .frame(maxWidth: 300)
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    TextField("Account label", text: $nameDraft)
+                        .settingsInput(width: 260)
                         .onSubmit(saveChanges)
+
+                    Text(account.isDefault ? "Default" : "Profile")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(account.isDefault ? MeterBarTheme.appAccent : MeterBarTheme.claudeAccent)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(.thinMaterial, in: Capsule())
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(account.isDefault ? "Default config directory" : "Config directory")
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.secondary)
+
+                    if account.isDefault {
+                        SettingsReadonlyField(text: displayConfigDirectory)
+                    } else {
+                        HStack(spacing: 8) {
+                            TextField("Config directory", text: $configDirectoryDraft)
+                                .settingsInput(width: 320)
+                                .onSubmit(saveChanges)
+
+                            Button {
+                                chooseConfigDirectory()
+                            } label: {
+                                Image(systemName: "folder")
+                            }
+                            .buttonStyle(.bordered)
+                            .help("Choose config directory")
+                        }
+                    }
                 }
             }
 
@@ -864,7 +981,7 @@ private struct AccountProfileRow: View {
                 }
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, 8)
         .onChange(of: account) { _, updatedAccount in
             nameDraft = updatedAccount.name
             configDirectoryDraft = updatedAccount.configDirectory ?? ""
@@ -879,6 +996,12 @@ private struct AccountProfileRow: View {
         configDirectoryDraft.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    private var displayConfigDirectory: String {
+        account.configDirectory?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            ? account.configDirectory ?? ""
+            : "\(ServiceSupport.realHomeDirectory())/.claude"
+    }
+
     private var hasChanges: Bool {
         trimmedName != account.name ||
             (!account.isDefault && trimmedConfigDirectory != (account.configDirectory ?? ""))
@@ -891,5 +1014,62 @@ private struct AccountProfileRow: View {
     private func saveChanges() {
         guard hasChanges, canSave else { return }
         onSave(trimmedName, account.isDefault ? nil : trimmedConfigDirectory)
+    }
+
+    private func chooseConfigDirectory() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Use"
+
+        if panel.runModal() == .OK, let url = panel.url {
+            configDirectoryDraft = url.path
+        }
+    }
+}
+
+private struct SettingsReadonlyField: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.caption)
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .frame(width: 320, alignment: .leading)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .stroke(MeterBarTheme.glassCardStroke, lineWidth: 0.5)
+            }
+            .help(text)
+    }
+}
+
+private struct SettingsInputModifier: ViewModifier {
+    let width: CGFloat?
+
+    func body(content: Content) -> some View {
+        content
+            .textFieldStyle(.plain)
+            .font(.subheadline)
+            .lineLimit(1)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .frame(width: width)
+            .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .stroke(MeterBarTheme.glassCardStroke, lineWidth: 0.5)
+            }
+    }
+}
+
+private extension View {
+    func settingsInput(width: CGFloat? = nil) -> some View {
+        modifier(SettingsInputModifier(width: width))
     }
 }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -1,7 +1,16 @@
 import AppKit
+import Combine
 import SwiftUI
 import MeterBarShared
 import UniformTypeIdentifiers
+
+private final class MeterBarFullSizeHostingView<Content: View>: NSHostingView<Content> {
+    override var safeAreaRect: NSRect { bounds }
+
+    override var safeAreaInsets: NSEdgeInsets {
+        NSEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+    }
+}
 
 @MainActor
 final class UsageDashboardWindowController {
@@ -11,13 +20,16 @@ final class UsageDashboardWindowController {
 
     private init() {}
 
-    func show() {
+    func show(section: DashboardSection? = nil, focusedProviderID: String? = nil) {
+        if let section {
+            DashboardNavigationStore.shared.navigate(to: section, focusedProviderID: focusedProviderID)
+        } else if let focusedProviderID {
+            DashboardNavigationStore.shared.navigate(to: .limits, focusedProviderID: focusedProviderID)
+        }
+
         if window == nil {
-            let hostingController = NSHostingController(rootView: UsageDashboardView())
-            // Surface the SwiftUI NavigationSplitView title and toolbar through the
-            // AppKit window while the full-size content view keeps the sidebar glass
-            // running behind the titlebar.
-            hostingController.sceneBridgingOptions = [.all]
+            let hostingView = MeterBarFullSizeHostingView(rootView: UsageDashboardView())
+            hostingView.autoresizingMask = [.width, .height]
             let window = NSWindow(
                 contentRect: NSRect(x: 0, y: 0, width: 1040, height: 700),
                 styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
@@ -25,17 +37,17 @@ final class UsageDashboardWindowController {
                 defer: false
             )
             window.title = "MeterBar Usage"
-            window.titleVisibility = .visible
+            window.titleVisibility = .hidden
             window.titlebarAppearsTransparent = true
-            // Unified transparent chrome so the native toolbar/titlebar glass
-            // reads as one surface with the sidebar (MacSweep-style native look).
-            window.toolbarStyle = .unified
             window.titlebarSeparatorStyle = .none
+            window.toolbar = nil
             window.isOpaque = false
-            window.backgroundColor = .clear
+            window.backgroundColor = MeterBarWindowChrome.backgroundColor
+            window.isMovableByWindowBackground = true
             window.isRestorable = false
             window.contentMinSize = NSSize(width: 900, height: 600)
-            window.contentViewController = hostingController
+            window.contentView = hostingView
+            applyCompanionWindowRadius(to: window)
             window.isReleasedWhenClosed = false
             window.center()
             self.window = window
@@ -44,12 +56,20 @@ final class UsageDashboardWindowController {
         NSApp.activate(ignoringOtherApps: true)
         window?.makeKeyAndOrderFront(nil)
     }
+
+    private func applyCompanionWindowRadius(to window: NSWindow) {
+        window.contentView?.wantsLayer = true
+        window.contentView?.layer?.cornerRadius = MeterBarWindowChrome.dashboardCornerRadius
+        window.contentView?.layer?.cornerCurve = .continuous
+        window.contentView?.layer?.masksToBounds = true
+    }
 }
 
-private enum DashboardSection: String, CaseIterable, Identifiable {
+enum DashboardSection: String, CaseIterable, Identifiable {
     case overview = "Overview"
     case limits = "Limits"
     case costs = "Costs"
+    case apiUsage = "API Usage"
     case optimize = "Optimize"
     case diagnostics = "Diagnostics"
     case share = "Share"
@@ -65,6 +85,8 @@ private enum DashboardSection: String, CaseIterable, Identifiable {
             return "chart.bar.fill"
         case .costs:
             return "dollarsign.circle.fill"
+        case .apiUsage:
+            return "server.rack"
         case .optimize:
             return "leaf.fill"
         case .diagnostics:
@@ -74,6 +96,42 @@ private enum DashboardSection: String, CaseIterable, Identifiable {
         case .settings:
             return "gearshape.fill"
         }
+    }
+
+    var titlebarSubtitle: String {
+        switch self {
+        case .overview:
+            return "Current health and local token history"
+        case .limits:
+            return "Every tracked quota window"
+        case .costs:
+            return "Local 30-day token spend"
+        case .apiUsage:
+            return "Provider API usage and spend"
+        case .optimize:
+            return "Where tokens go and how to trim them"
+        case .diagnostics:
+            return "Provider setup health"
+        case .share:
+            return "Social card export"
+        case .settings:
+            return "Accounts, refresh, and local sources"
+        }
+    }
+}
+
+@MainActor
+final class DashboardNavigationStore: ObservableObject {
+    static let shared = DashboardNavigationStore()
+
+    @Published var selectedSection: DashboardSection = .overview
+    @Published var focusedProviderID: ProviderSnapshot.ID?
+
+    private init() {}
+
+    func navigate(to section: DashboardSection, focusedProviderID: ProviderSnapshot.ID? = nil) {
+        selectedSection = section
+        self.focusedProviderID = focusedProviderID
     }
 }
 
@@ -86,15 +144,21 @@ struct UsageDashboardView: View {
     @StateObject private var codexCliService = CodexCliLocalService.shared
     @StateObject private var cursorService = CursorLocalService.shared
     @StateObject private var apiUsageStore = ApiUsageStore.shared
+    @StateObject private var navigation = DashboardNavigationStore.shared
 
-    @State private var selectedSection: DashboardSection = .overview
-    @State private var columnVisibility = NavigationSplitViewVisibility.all
     @State private var readinessReports: [ProviderReadiness] = []
     @State private var isRunningDiagnostics = false
     @State private var socialCardGeneratedAt = Date()
     @State private var socialShareStatus: String?
+    @State private var isSidebarCollapsed = false
 
-    private var activeSection: DashboardSection { selectedSection }
+    private var activeSection: DashboardSection { navigation.selectedSection }
+
+    private var sidebarWidth: CGFloat {
+        isSidebarCollapsed
+            ? MeterBarWindowChrome.collapsedSidebarWidth
+            : MeterBarWindowChrome.sidebarTitlebarWidth
+    }
 
     private var overviewGridColumns: [GridItem] {
         Array(
@@ -104,67 +168,143 @@ struct UsageDashboardView: View {
     }
 
     var body: some View {
-        NavigationSplitView(columnVisibility: $columnVisibility) {
-            sidebar
-                .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 280)
-        } detail: {
-            ZStack {
-                // Keep the detail fill out of the titlebar area so the native
-                // toolbar glass shows there instead of a flat content background.
-                MeterBarDetailBackground()
-                    .ignoresSafeArea(edges: [.horizontal, .bottom])
+        ZStack(alignment: .topLeading) {
+            MeterBarDetailBackground()
+                .ignoresSafeArea()
 
-                detailContent
-            }
-            .navigationTitle(activeSection.rawValue)
-            .navigationSubtitle(sectionSubtitle)
-            .toolbar {
-                ToolbarItem(placement: .navigation) {
-                    Button {
-                        Task { await refreshDashboard() }
-                    } label: {
-                        RefreshingIcon(isRefreshing: isRefreshButtonAnimating)
-                    }
-                    .help(isRefreshButtonAnimating ? "Refreshing usage" : "Refresh usage")
-                    .disabled(isRefreshButtonDisabled)
-                }
-            }
+            appShell
         }
-        .navigationSplitViewStyle(.balanced)
+        .clipShape(
+            RoundedRectangle(
+                cornerRadius: MeterBarWindowChrome.dashboardCornerRadius,
+                style: .continuous
+            )
+        )
         .task {
             await refreshCostsIfMissingDays()
         }
-        .onChange(of: selectedSection) {
+        .onChange(of: navigation.selectedSection) {
             Task { await refreshCostsIfMissingDays() }
-            if selectedSection == .diagnostics {
+            if navigation.selectedSection == .diagnostics {
                 Task { await runDiagnostics() }
+            }
+            if navigation.selectedSection != .limits {
+                navigation.focusedProviderID = nil
             }
         }
     }
 
-    private var sidebar: some View {
-        List(selection: $selectedSection) {
-            ForEach(DashboardSection.allCases) { section in
-                Label(section.rawValue, systemImage: section.iconName)
-                    .tag(section)
-            }
+    private var appShell: some View {
+        HStack(spacing: 0) {
+            sidebar
+                .frame(width: sidebarWidth)
+                .zIndex(2)
+                .animation(.easeInOut(duration: 0.18), value: isSidebarCollapsed)
 
-            Section("Local Sources") {
-                if enabledSourceLabels.isEmpty {
-                    Label("No sources enabled", systemImage: "circle")
-                } else {
-                    ForEach(enabledSourceLabels, id: \.self) { label in
-                        Label(label, systemImage: "checkmark.circle.fill")
+            ZStack(alignment: .top) {
+                detailContent
+
+                dashboardTitlebar
+                    .zIndex(20)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private var dashboardTitlebar: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(activeSection.rawValue)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.primary)
+
+                Text(activeSection.titlebarSubtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Spacer(minLength: 12)
+
+            Button {
+                Task { await refreshDashboard() }
+            } label: {
+                RefreshingIcon(isRefreshing: isRefreshButtonAnimating)
+                    .frame(width: 30, height: 30)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .background(MeterBarTheme.glassCardTint, in: Circle())
+            .overlay(Circle().stroke(MeterBarTheme.glassCardStroke, lineWidth: 0.5))
+            .help(isRefreshButtonAnimating ? "Refreshing usage" : "Refresh usage")
+            .disabled(isRefreshButtonDisabled)
+        }
+        .padding(.leading, 18)
+        .padding(.trailing, 12)
+        .frame(height: MeterBarWindowChrome.titlebarContentInset)
+        .frame(maxWidth: .infinity)
+        .background {
+            MeterBarTitlebarGlass()
+        }
+        .allowsHitTesting(true)
+    }
+
+    private var sidebar: some View {
+        ZStack(alignment: .topTrailing) {
+            MeterBarSidebarSurface()
+                .padding(.leading, 10)
+                .padding(.trailing, isSidebarCollapsed ? 10 : 8)
+                .padding(.vertical, 10)
+
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 4) {
+                    ForEach(DashboardSection.allCases) { section in
+                        DashboardSidebarRow(
+                            section: section,
+                            isSelected: section == activeSection,
+                            isCollapsed: isSidebarCollapsed
+                        ) {
+                            navigation.selectedSection = section
+                        }
                     }
                 }
+                .padding(.horizontal, isSidebarCollapsed ? 20 : 22)
+                .padding(.top, MeterBarWindowChrome.titlebarContentInset + 10)
+                .padding(.bottom, 22)
             }
-            .font(.caption)
-            .foregroundStyle(.secondary)
+
+            sidebarCollapseButton
         }
-        .listStyle(.sidebar)
-        // No background overrides: the native sidebar owns its glass material,
-        // section rendering, and selected-row highlight. Stacking a custom
-        // `.glassEffect` here would double up on the system material.
+        .background(Color.clear)
+    }
+
+    private var sidebarCollapseButton: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.18)) {
+                isSidebarCollapsed.toggle()
+            }
+        } label: {
+            Image(systemName: isSidebarCollapsed ? "sidebar.right" : "sidebar.left")
+                .font(.system(size: 14, weight: .semibold))
+                .symbolRenderingMode(.hierarchical)
+                .frame(width: 30, height: 30)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.secondary)
+        .background(
+            MeterBarTheme.glassCardTint,
+            in: RoundedRectangle(cornerRadius: 9, style: .continuous)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .stroke(MeterBarTheme.glassCardStroke, lineWidth: 0.5)
+        }
+        .padding(.top, 17)
+        .padding(.trailing, isSidebarCollapsed ? 21 : 18)
+        .help(isSidebarCollapsed ? "Show sidebar" : "Hide sidebar")
+        .accessibilityLabel(isSidebarCollapsed ? "Show sidebar" : "Hide sidebar")
+        .zIndex(10)
     }
 
     private var detailContent: some View {
@@ -179,6 +319,8 @@ struct UsageDashboardView: View {
                     limitsContent
                 case .costs:
                     costsContent
+                case .apiUsage:
+                    apiUsageContent
                 case .optimize:
                     OptimizeInsightsView()
                 case .diagnostics:
@@ -190,10 +332,11 @@ struct UsageDashboardView: View {
                 }
             }
             .padding(.horizontal, 22)
-            .padding(.top, 18)
+            .padding(.top, MeterBarWindowChrome.titlebarContentInset + 18)
             .padding(.bottom, 22)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
     private var overviewContent: some View {
@@ -207,30 +350,12 @@ struct UsageDashboardView: View {
 
             LazyVGrid(columns: overviewGridColumns, alignment: .leading, spacing: 12) {
                 ForEach(providerSnapshots) { snapshot in
-                    ProviderOverviewStatusCard(snapshot: snapshot)
+                    ProviderOverviewStatusCard(snapshot: snapshot) {
+                        navigation.navigate(to: .limits, focusedProviderID: snapshot.id)
+                    }
                 }
-
-                CostOverviewStatusCard(
-                    summary: visibleCostSummary,
-                    isScanning: costTracker.isScanning,
-                    isRefreshingMissingDays: costTracker.isRefreshingMissingDays,
-                    formattedTokens: UsageFormat.tokens(visibleCostSummary?.totalTokens ?? 0)
-                )
             }
             .frame(maxWidth: .infinity)
-
-            if apiUsageStore.hasAnyAuthenticated {
-                DashboardCard(title: "Organization API Spend", trailing: "") {
-                    ApiUsageSection(store: apiUsageStore, embedded: true)
-                }
-            }
-
-            DashboardCard(title: "Last 30 Days", trailing: costRefreshStatusText) {
-                costScanChart(height: 180, compact: true)
-            }
-        }
-        .task {
-            await apiUsageStore.refresh()
         }
     }
 
@@ -255,7 +380,7 @@ struct UsageDashboardView: View {
                         .foregroundColor(.secondary)
                 }
             } else {
-                ForEach(providerSnapshots) { snapshot in
+                ForEach(orderedProviderSnapshotsForLimits) { snapshot in
                     ProviderLimitsCard(snapshot: snapshot)
                 }
             }
@@ -265,62 +390,89 @@ struct UsageDashboardView: View {
 
     private var costsContent: some View {
         VStack(alignment: .leading, spacing: 14) {
-            DashboardCard(title: "30 Day API-Rate Token Spend", trailing: costRefreshStatusText) {
-                VStack(alignment: .leading, spacing: 18) {
-                    Text(
-                        "Local subscription logs are estimated using API token rates "
-                            + "so Codex and Claude can be compared."
+            CostOverviewStatusCard(
+                summary: visibleCostSummary,
+                isScanning: costTracker.isScanning,
+                isRefreshingMissingDays: costTracker.isRefreshingMissingDays,
+                formattedTokens: UsageFormat.tokens(visibleCostSummary?.totalTokens ?? 0)
+            )
+            .frame(maxWidth: 420, alignment: .leading)
+
+            costTrendCard
+
+            if let summary = visibleCostSummary, !summary.dailyUsage.isEmpty {
+                DashboardCard(title: "Daily Details", trailing: "Last 30 days") {
+                    DailyUsageBreakdownList(dailyUsage: summary.dailyUsage)
+                }
+            }
+
+            if let summary = visibleCostSummary, !summary.costs.isEmpty {
+                ForEach(summary.costs) { cost in
+                    ProviderCostBreakdown(
+                        cost: cost,
+                        quotaSnapshot: providerSnapshot(for: cost.provider)
                     )
-                        .font(.caption)
+                }
+            } else {
+                DashboardCard(title: "No Local Logs Found") {
+                    Text("Run a local scan to load 30-day token history.")
+                        .font(.subheadline)
                         .foregroundColor(.secondary)
+                }
+            }
+        }
+    }
 
-                    if costTracker.isScanning {
-                        costScanChart(height: 220, compact: false, showsProgressBadge: false)
-                    } else if let summary = visibleCostSummary {
-                        DailyUsageChart(dailyUsage: summary.dailyUsage)
-                            .frame(height: 220)
-                    } else {
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("Run a local scan to load 30-day token history.")
-                                .foregroundColor(.secondary)
-                            Button {
-                                Task {
-                                    await costTracker.scanCosts(days: 30)
-                                }
-                            } label: {
-                                Label("Scan 30 Days", systemImage: "magnifyingglass")
-                            }
-                            .buttonStyle(.bordered)
-                            .disabled(costTracker.isRefreshInProgress)
-                        }
-                        .frame(height: 220, alignment: .center)
-                    }
+    private var costTrendCard: some View {
+        DashboardCard(title: "30 Day Token Spend", trailing: costRefreshStatusText) {
+            VStack(alignment: .leading, spacing: 14) {
+                Text(
+                    "Local subscription logs are estimated using API token rates "
+                        + "so Codex and Claude can be compared."
+                )
+                    .font(.caption)
+                    .foregroundColor(.secondary)
 
-                    Divider()
-
-                    if let summary = visibleCostSummary, !summary.dailyUsage.isEmpty {
-                        DailyUsageBreakdownList(dailyUsage: summary.dailyUsage)
-                        Divider()
-                    }
-
-                    if let summary = visibleCostSummary, !summary.costs.isEmpty {
-                        ForEach(summary.costs) { cost in
-                            ProviderCostBreakdown(
-                                cost: cost,
-                                quotaSnapshot: providerSnapshot(for: cost.provider)
-                            )
-                        }
-                    } else {
-                        Text("No enabled provider token logs found yet.")
+                if costTracker.isScanning {
+                    costScanChart(height: 220, compact: false, showsProgressBadge: true)
+                } else if let summary = visibleCostSummary {
+                    DailyUsageChart(dailyUsage: summary.dailyUsage)
+                        .frame(height: 220)
+                } else {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Run a local scan to load 30-day token history.")
                             .foregroundColor(.secondary)
+                        Button {
+                            Task {
+                                await costTracker.scanCosts(days: 30)
+                            }
+                        } label: {
+                            Label("Scan 30 Days", systemImage: "magnifyingglass")
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(costTracker.isRefreshInProgress)
                     }
+                    .frame(height: 220, alignment: .center)
                 }
             }
-            .overlay {
-                if costTracker.isScanning, visibleCostSummary != nil {
-                    CostRefreshLockOverlay()
+        }
+    }
+
+    private var apiUsageContent: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            if apiUsageStore.hasAnyAuthenticated {
+                ApiUsageSection(store: apiUsageStore)
+            } else {
+                DashboardCard(title: "No API Admin Keys") {
+                    Text("Add an organization admin key in Settings to show OpenAI or Anthropic API usage.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
                 }
             }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .task {
+            await apiUsageStore.refresh()
         }
     }
 
@@ -445,6 +597,15 @@ struct UsageDashboardView: View {
             cursorHasAccess: cursorService.hasAccess
         ))
         .filter(\.hasMetrics)
+    }
+
+    private var orderedProviderSnapshotsForLimits: [ProviderSnapshot] {
+        guard let focusedProviderID = navigation.focusedProviderID else {
+            return providerSnapshots
+        }
+        let focused = providerSnapshots.filter { $0.id == focusedProviderID }
+        guard !focused.isEmpty else { return providerSnapshots }
+        return focused + providerSnapshots.filter { $0.id != focusedProviderID }
     }
 
     /// The snapshot for a provider in the Costs panel — prefers an exhausted
@@ -609,25 +770,6 @@ struct UsageDashboardView: View {
         NSPasteboard.general.setString(text, forType: .string)
     }
 
-    private var sectionSubtitle: String {
-        switch activeSection {
-        case .overview:
-            return "Current health and local token history"
-        case .limits:
-            return "Every tracked quota window"
-        case .costs:
-            return "Local 30-day token spend"
-        case .optimize:
-            return "Where tokens go and how to trim them"
-        case .diagnostics:
-            return "Provider setup health — safe to share"
-        case .share:
-            return "Social card export"
-        case .settings:
-            return "Accounts, refresh, and local sources"
-        }
-    }
-
     private var costRefreshStatusText: String? {
         if costTracker.isScanning {
             return "Scanning..."
@@ -646,13 +788,17 @@ struct UsageDashboardView: View {
         switch activeSection {
         case .costs, .share, .optimize:
             return costTracker.isRefreshInProgress
+        case .apiUsage:
+            return apiUsageStore.isLoading
         case .overview, .limits, .diagnostics, .settings:
             return dataManager.isLoading
         }
     }
 
     private func refreshDashboard() async {
-        if activeSection == .costs || activeSection == .share || activeSection == .optimize {
+        if activeSection == .apiUsage {
+            await apiUsageStore.refresh()
+        } else if activeSection == .costs || activeSection == .share || activeSection == .optimize {
             await costTracker.scanCosts(days: 30)
             socialCardGeneratedAt = Date()
         } else {
@@ -661,7 +807,7 @@ struct UsageDashboardView: View {
     }
 
     private func refreshCostsIfMissingDays() async {
-        let costBackedSections: Set<DashboardSection> = [.overview, .costs, .share, .optimize]
+        let costBackedSections: Set<DashboardSection> = [.costs, .share, .optimize]
         guard costBackedSections.contains(activeSection) else { return }
         await costTracker.refreshMissingDaysInBackground(days: 30)
     }
@@ -747,6 +893,77 @@ struct UsageDashboardView: View {
     private func setSocialShareStatus(_ status: String) {
         withAnimation(.easeInOut(duration: 0.15)) {
             socialShareStatus = status
+        }
+    }
+}
+
+private struct DashboardSidebarRow: View {
+    let section: DashboardSection
+    let isSelected: Bool
+    let isCollapsed: Bool
+    let action: () -> Void
+
+    @State private var isHovering = false
+
+    private let rowHeight: CGFloat = 32
+    private let rowRadius: CGFloat = 8
+
+    var body: some View {
+        Button(action: action) {
+            rowContent
+                .foregroundStyle(.primary)
+                .opacity(isSelected ? 1 : (isHovering ? 0.96 : 0.88))
+                .frame(
+                    maxWidth: .infinity,
+                    minHeight: rowHeight,
+                    maxHeight: rowHeight,
+                    alignment: isCollapsed ? .center : .leading
+                )
+                .padding(.horizontal, isCollapsed ? 0 : 10)
+                .contentShape(rowShape)
+        }
+        .buttonStyle(.plain)
+        .background {
+            sidebarSelectionSurface
+        }
+        .onHover { isHovering = $0 }
+        .help(section.rawValue)
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+
+    @ViewBuilder
+    private var rowContent: some View {
+        if isCollapsed {
+            Image(systemName: section.iconName)
+                .font(.system(size: 15, weight: .semibold))
+                .symbolRenderingMode(.hierarchical)
+        } else {
+            Label(section.rawValue, systemImage: section.iconName)
+                .font(.system(size: 13, weight: .semibold))
+                .labelStyle(.titleAndIcon)
+        }
+    }
+
+    private var rowShape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: rowRadius, style: .continuous)
+    }
+
+    @ViewBuilder
+    private var sidebarSelectionSurface: some View {
+        if isSelected || isHovering {
+            rowShape
+                .fill(Color.white.opacity(isSelected ? 0.13 : 0.065))
+                .overlay {
+                    rowShape.stroke(
+                        Color.white.opacity(isSelected ? 0.18 : 0.10),
+                        lineWidth: 0.6
+                    )
+                }
+                .shadow(
+                    color: .black.opacity(isSelected ? 0.10 : 0),
+                    radius: isSelected ? 5 : 0,
+                    y: isSelected ? 2 : 0
+                )
         }
     }
 }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -23,12 +23,14 @@ final class UsageDashboardWindowController {
             let hostingController = NSHostingController(rootView: UsageDashboardView())
             let window = NSWindow(
                 contentRect: NSRect(x: 0, y: 0, width: 1040, height: 700),
-                styleMask: [.titled, .closable, .miniaturizable, .resizable],
+                styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
                 backing: .buffered,
                 defer: false
             )
             window.title = DashboardNavigationStore.shared.selectedSection.rawValue
             window.subtitle = DashboardNavigationStore.shared.selectedSection.titlebarSubtitle
+            window.titlebarAppearsTransparent = true
+            window.titlebarSeparatorStyle = .none
             window.backgroundColor = .windowBackgroundColor
             window.isRestorable = false
             window.contentMinSize = NSSize(width: 900, height: 600)
@@ -123,7 +125,7 @@ struct UsageDashboardView: View {
     @State private var isRunningDiagnostics = false
     @State private var socialCardGeneratedAt = Date()
     @State private var socialShareStatus: String?
-    @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
+    @State private var columnVisibility: NavigationSplitViewVisibility = .all
 
     private var activeSection: DashboardSection { navigation.selectedSection }
 
@@ -188,7 +190,7 @@ struct UsageDashboardView: View {
         }
         .listStyle(.sidebar)
         .navigationTitle("MeterBar")
-        .navigationSplitViewColumnWidth(min: 220, ideal: 248, max: 280)
+        .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 280)
     }
 
     private var refreshToolbarButton: some View {

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -4,14 +4,6 @@ import SwiftUI
 import MeterBarShared
 import UniformTypeIdentifiers
 
-private final class MeterBarFullSizeHostingView<Content: View>: NSHostingView<Content> {
-    override var safeAreaRect: NSRect { bounds }
-
-    override var safeAreaInsets: NSEdgeInsets {
-        NSEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-    }
-}
-
 @MainActor
 final class UsageDashboardWindowController {
     static let shared = UsageDashboardWindowController()
@@ -28,26 +20,19 @@ final class UsageDashboardWindowController {
         }
 
         if window == nil {
-            let hostingView = MeterBarFullSizeHostingView(rootView: UsageDashboardView())
-            hostingView.autoresizingMask = [.width, .height]
+            let hostingController = NSHostingController(rootView: UsageDashboardView())
             let window = NSWindow(
                 contentRect: NSRect(x: 0, y: 0, width: 1040, height: 700),
-                styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+                styleMask: [.titled, .closable, .miniaturizable, .resizable],
                 backing: .buffered,
                 defer: false
             )
-            window.title = "MeterBar Usage"
-            window.titleVisibility = .hidden
-            window.titlebarAppearsTransparent = true
-            window.titlebarSeparatorStyle = .none
-            window.toolbar = nil
-            window.isOpaque = false
-            window.backgroundColor = MeterBarWindowChrome.backgroundColor
-            window.isMovableByWindowBackground = true
+            window.title = DashboardNavigationStore.shared.selectedSection.rawValue
+            window.subtitle = DashboardNavigationStore.shared.selectedSection.titlebarSubtitle
+            window.backgroundColor = .windowBackgroundColor
             window.isRestorable = false
             window.contentMinSize = NSSize(width: 900, height: 600)
-            window.contentView = hostingView
-            applyCompanionWindowRadius(to: window)
+            window.contentViewController = hostingController
             window.isReleasedWhenClosed = false
             window.center()
             self.window = window
@@ -56,20 +41,12 @@ final class UsageDashboardWindowController {
         NSApp.activate(ignoringOtherApps: true)
         window?.makeKeyAndOrderFront(nil)
     }
-
-    private func applyCompanionWindowRadius(to window: NSWindow) {
-        window.contentView?.wantsLayer = true
-        window.contentView?.layer?.cornerRadius = MeterBarWindowChrome.dashboardCornerRadius
-        window.contentView?.layer?.cornerCurve = .continuous
-        window.contentView?.layer?.masksToBounds = true
-    }
 }
 
-enum DashboardSection: String, CaseIterable, Identifiable {
+enum DashboardSection: String, CaseIterable, Identifiable, Hashable {
     case overview = "Overview"
     case limits = "Limits"
     case costs = "Costs"
-    case apiUsage = "API Usage"
     case optimize = "Optimize"
     case diagnostics = "Diagnostics"
     case share = "Share"
@@ -85,8 +62,6 @@ enum DashboardSection: String, CaseIterable, Identifiable {
             return "chart.bar.fill"
         case .costs:
             return "dollarsign.circle.fill"
-        case .apiUsage:
-            return "server.rack"
         case .optimize:
             return "leaf.fill"
         case .diagnostics:
@@ -106,8 +81,6 @@ enum DashboardSection: String, CaseIterable, Identifiable {
             return "Every tracked quota window"
         case .costs:
             return "Local 30-day token spend"
-        case .apiUsage:
-            return "Provider API usage and spend"
         case .optimize:
             return "Where tokens go and how to trim them"
         case .diagnostics:
@@ -150,14 +123,18 @@ struct UsageDashboardView: View {
     @State private var isRunningDiagnostics = false
     @State private var socialCardGeneratedAt = Date()
     @State private var socialShareStatus: String?
-    @State private var isSidebarCollapsed = false
+    @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
 
     private var activeSection: DashboardSection { navigation.selectedSection }
 
-    private var sidebarWidth: CGFloat {
-        isSidebarCollapsed
-            ? MeterBarWindowChrome.collapsedSidebarWidth
-            : MeterBarWindowChrome.sidebarTitlebarWidth
+    private var selectedSection: Binding<DashboardSection?> {
+        Binding(
+            get: { navigation.selectedSection },
+            set: { section in
+                guard let section else { return }
+                navigation.selectedSection = section
+            }
+        )
     }
 
     private var overviewGridColumns: [GridItem] {
@@ -168,18 +145,26 @@ struct UsageDashboardView: View {
     }
 
     var body: some View {
-        ZStack(alignment: .topLeading) {
-            MeterBarDetailBackground()
-                .ignoresSafeArea()
-
-            appShell
+        NavigationSplitView(columnVisibility: $columnVisibility) {
+            sidebarList
+        } detail: {
+            detailContent
+                .navigationTitle(activeSection.rawValue)
+                .navigationSubtitle(activeSection.titlebarSubtitle)
+                .toolbar {
+                    ToolbarItem(placement: .primaryAction) {
+                        refreshToolbarButton
+                    }
+                }
         }
-        .clipShape(
-            RoundedRectangle(
-                cornerRadius: MeterBarWindowChrome.dashboardCornerRadius,
-                style: .continuous
-            )
-        )
+        .navigationSplitViewStyle(.balanced)
+        .background {
+            MeterBarMenuWindowAccessor { window in
+                guard let window else { return }
+                window.title = activeSection.rawValue
+                window.subtitle = activeSection.titlebarSubtitle
+            }
+        }
         .task {
             await refreshCostsIfMissingDays()
         }
@@ -194,122 +179,30 @@ struct UsageDashboardView: View {
         }
     }
 
-    private var appShell: some View {
-        HStack(spacing: 0) {
-            sidebar
-                .frame(width: sidebarWidth)
-                .zIndex(2)
-                .animation(.easeInOut(duration: 0.18), value: isSidebarCollapsed)
-
-            ZStack(alignment: .top) {
-                detailContent
-
-                dashboardTitlebar
-                    .zIndex(20)
+    private var sidebarList: some View {
+        List(selection: selectedSection) {
+            ForEach(DashboardSection.allCases) { section in
+                Label(section.rawValue, systemImage: section.iconName)
+                    .tag(section)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .listStyle(.sidebar)
+        .navigationTitle("MeterBar")
+        .navigationSplitViewColumnWidth(min: 220, ideal: 248, max: 280)
     }
 
-    private var dashboardTitlebar: some View {
-        HStack(alignment: .center, spacing: 12) {
-            VStack(alignment: .leading, spacing: 1) {
-                Text(activeSection.rawValue)
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(.primary)
-
-                Text(activeSection.titlebarSubtitle)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            Spacer(minLength: 12)
-
-            Button {
-                Task { await refreshDashboard() }
-            } label: {
-                RefreshingIcon(isRefreshing: isRefreshButtonAnimating)
-                    .frame(width: 30, height: 30)
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(.secondary)
-            .background(MeterBarTheme.glassCardTint, in: Circle())
-            .overlay(Circle().stroke(MeterBarTheme.glassCardStroke, lineWidth: 0.5))
-            .help(isRefreshButtonAnimating ? "Refreshing usage" : "Refresh usage")
-            .disabled(isRefreshButtonDisabled)
-        }
-        .padding(.leading, 18)
-        .padding(.trailing, 12)
-        .frame(height: MeterBarWindowChrome.titlebarContentInset)
-        .frame(maxWidth: .infinity)
-        .background {
-            MeterBarTitlebarGlass()
-        }
-        .allowsHitTesting(true)
-    }
-
-    private var sidebar: some View {
-        ZStack(alignment: .topTrailing) {
-            MeterBarSidebarSurface()
-                .padding(.leading, 10)
-                .padding(.trailing, isSidebarCollapsed ? 10 : 8)
-                .padding(.vertical, 10)
-
-            ScrollView(showsIndicators: false) {
-                VStack(spacing: 4) {
-                    ForEach(DashboardSection.allCases) { section in
-                        DashboardSidebarRow(
-                            section: section,
-                            isSelected: section == activeSection,
-                            isCollapsed: isSidebarCollapsed
-                        ) {
-                            navigation.selectedSection = section
-                        }
-                    }
-                }
-                .padding(.horizontal, isSidebarCollapsed ? 20 : 22)
-                .padding(.top, MeterBarWindowChrome.titlebarContentInset + 10)
-                .padding(.bottom, 22)
-            }
-
-            sidebarCollapseButton
-        }
-        .background(Color.clear)
-    }
-
-    private var sidebarCollapseButton: some View {
+    private var refreshToolbarButton: some View {
         Button {
-            withAnimation(.easeInOut(duration: 0.18)) {
-                isSidebarCollapsed.toggle()
-            }
+            Task { await refreshDashboard() }
         } label: {
-            Image(systemName: isSidebarCollapsed ? "sidebar.right" : "sidebar.left")
-                .font(.system(size: 14, weight: .semibold))
-                .symbolRenderingMode(.hierarchical)
-                .frame(width: 30, height: 30)
+            RefreshingIcon(isRefreshing: isRefreshButtonAnimating)
+                .frame(width: 18, height: 18)
         }
-        .buttonStyle(.plain)
-        .foregroundStyle(.secondary)
-        .background(
-            MeterBarTheme.glassCardTint,
-            in: RoundedRectangle(cornerRadius: 9, style: .continuous)
-        )
-        .overlay {
-            RoundedRectangle(cornerRadius: 9, style: .continuous)
-                .stroke(MeterBarTheme.glassCardStroke, lineWidth: 0.5)
-        }
-        .padding(.top, 17)
-        .padding(.trailing, isSidebarCollapsed ? 21 : 18)
-        .help(isSidebarCollapsed ? "Show sidebar" : "Hide sidebar")
-        .accessibilityLabel(isSidebarCollapsed ? "Show sidebar" : "Hide sidebar")
-        .zIndex(10)
+        .help(isRefreshButtonAnimating ? "Refreshing usage" : "Refresh usage")
+        .disabled(isRefreshButtonDisabled)
     }
 
     private var detailContent: some View {
-        // Keep a real scroll backing in the detail column while the sidebar
-        // remains a plain native List.
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
                 switch activeSection {
@@ -319,8 +212,6 @@ struct UsageDashboardView: View {
                     limitsContent
                 case .costs:
                     costsContent
-                case .apiUsage:
-                    apiUsageContent
                 case .optimize:
                     OptimizeInsightsView()
                 case .diagnostics:
@@ -332,9 +223,15 @@ struct UsageDashboardView: View {
                 }
             }
             .padding(.horizontal, 22)
-            .padding(.top, MeterBarWindowChrome.titlebarContentInset + 18)
+            .padding(.top, 22)
             .padding(.bottom, 22)
             .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .scrollContentBackground(.hidden)
+        .scrollEdgeEffectStyle(.soft, for: .top)
+        .background {
+            MeterBarDetailBackground()
+                .ignoresSafeArea()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
@@ -420,6 +317,17 @@ struct UsageDashboardView: View {
                         .foregroundColor(.secondary)
                 }
             }
+
+            if apiUsageStore.hasAnyAuthenticated {
+                DashboardCard(title: "API spend (billed)") {
+                    ApiUsageSection(store: apiUsageStore, embedded: true)
+                }
+            }
+        }
+        .task {
+            if apiUsageStore.hasAnyAuthenticated {
+                await apiUsageStore.refresh()
+            }
         }
     }
 
@@ -455,24 +363,6 @@ struct UsageDashboardView: View {
                     .frame(height: 220, alignment: .center)
                 }
             }
-        }
-    }
-
-    private var apiUsageContent: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            if apiUsageStore.hasAnyAuthenticated {
-                ApiUsageSection(store: apiUsageStore)
-            } else {
-                DashboardCard(title: "No API Admin Keys") {
-                    Text("Add an organization admin key in Settings to show OpenAI or Anthropic API usage.")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                }
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .task {
-            await apiUsageStore.refresh()
         }
     }
 
@@ -788,18 +678,17 @@ struct UsageDashboardView: View {
         switch activeSection {
         case .costs, .share, .optimize:
             return costTracker.isRefreshInProgress
-        case .apiUsage:
-            return apiUsageStore.isLoading
         case .overview, .limits, .diagnostics, .settings:
             return dataManager.isLoading
         }
     }
 
     private func refreshDashboard() async {
-        if activeSection == .apiUsage {
-            await apiUsageStore.refresh()
-        } else if activeSection == .costs || activeSection == .share || activeSection == .optimize {
+        if activeSection == .costs || activeSection == .share || activeSection == .optimize {
             await costTracker.scanCosts(days: 30)
+            if activeSection == .costs, apiUsageStore.hasAnyAuthenticated {
+                await apiUsageStore.refresh()
+            }
             socialCardGeneratedAt = Date()
         } else {
             await dataManager.refreshAll()
@@ -893,77 +782,6 @@ struct UsageDashboardView: View {
     private func setSocialShareStatus(_ status: String) {
         withAnimation(.easeInOut(duration: 0.15)) {
             socialShareStatus = status
-        }
-    }
-}
-
-private struct DashboardSidebarRow: View {
-    let section: DashboardSection
-    let isSelected: Bool
-    let isCollapsed: Bool
-    let action: () -> Void
-
-    @State private var isHovering = false
-
-    private let rowHeight: CGFloat = 32
-    private let rowRadius: CGFloat = 8
-
-    var body: some View {
-        Button(action: action) {
-            rowContent
-                .foregroundStyle(.primary)
-                .opacity(isSelected ? 1 : (isHovering ? 0.96 : 0.88))
-                .frame(
-                    maxWidth: .infinity,
-                    minHeight: rowHeight,
-                    maxHeight: rowHeight,
-                    alignment: isCollapsed ? .center : .leading
-                )
-                .padding(.horizontal, isCollapsed ? 0 : 10)
-                .contentShape(rowShape)
-        }
-        .buttonStyle(.plain)
-        .background {
-            sidebarSelectionSurface
-        }
-        .onHover { isHovering = $0 }
-        .help(section.rawValue)
-        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
-    }
-
-    @ViewBuilder
-    private var rowContent: some View {
-        if isCollapsed {
-            Image(systemName: section.iconName)
-                .font(.system(size: 15, weight: .semibold))
-                .symbolRenderingMode(.hierarchical)
-        } else {
-            Label(section.rawValue, systemImage: section.iconName)
-                .font(.system(size: 13, weight: .semibold))
-                .labelStyle(.titleAndIcon)
-        }
-    }
-
-    private var rowShape: RoundedRectangle {
-        RoundedRectangle(cornerRadius: rowRadius, style: .continuous)
-    }
-
-    @ViewBuilder
-    private var sidebarSelectionSurface: some View {
-        if isSelected || isHovering {
-            rowShape
-                .fill(Color.white.opacity(isSelected ? 0.13 : 0.065))
-                .overlay {
-                    rowShape.stroke(
-                        Color.white.opacity(isSelected ? 0.18 : 0.10),
-                        lineWidth: 0.6
-                    )
-                }
-                .shadow(
-                    color: .black.opacity(isSelected ? 0.10 : 0),
-                    radius: isSelected ? 5 : 0,
-                    y: isSelected ? 2 : 0
-                )
         }
     }
 }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -795,7 +795,12 @@ private struct OverviewSummaryStrip: View {
 
     var body: some View {
         LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
-            TimelineView(.periodic(from: ResetCountdownSchedule.anchor, by: ResetCountdownSchedule.interval)) { timeline in
+            TimelineView(
+                .periodic(
+                    from: ResetCountdownSchedule.anchor,
+                    by: ResetCountdownSchedule.interval
+                )
+            ) { timeline in
                 DashboardMetricTile(
                     title: "Tightest window",
                     value: tightestValue(now: timeline.date),

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -5,6 +5,16 @@ import MeterBarShared
 import UniformTypeIdentifiers
 
 @MainActor
+private func applyWindowChrome(_ window: NSWindow, section _: DashboardSection? = nil) {
+    window.title = ""
+    window.subtitle = ""
+    window.titleVisibility = .visible
+    window.titlebarAppearsTransparent = true
+    window.titlebarSeparatorStyle = .none
+    window.toolbarStyle = .unified
+}
+
+@MainActor
 final class UsageDashboardWindowController {
     static let shared = UsageDashboardWindowController()
 
@@ -27,11 +37,7 @@ final class UsageDashboardWindowController {
                 backing: .buffered,
                 defer: false
             )
-            window.title = DashboardNavigationStore.shared.selectedSection.rawValue
-            window.subtitle = ""
-            window.titleVisibility = .hidden
-            window.titlebarAppearsTransparent = true
-            window.titlebarSeparatorStyle = .none
+            applyWindowChrome(window, section: DashboardNavigationStore.shared.selectedSection)
             window.backgroundColor = .windowBackgroundColor
             window.isRestorable = false
             window.contentMinSize = NSSize(width: 900, height: 600)
@@ -148,23 +154,11 @@ struct UsageDashboardView: View {
     }
 
     var body: some View {
-        NavigationSplitView(columnVisibility: $columnVisibility) {
-            sidebarList
-        } detail: {
-            detailContent
-                .toolbar {
-                    ToolbarItem(placement: .navigation) {
-                        refreshToolbarButton
-                    }
-                }
-        }
-        .navigationSplitViewStyle(.balanced)
+        dashboardSplitView
         .background {
             MeterBarMenuWindowAccessor { window in
                 guard let window else { return }
-                window.title = activeSection.rawValue
-                window.subtitle = ""
-                window.titleVisibility = .hidden
+                applyWindowChrome(window, section: activeSection)
             }
         }
         .task {
@@ -181,6 +175,20 @@ struct UsageDashboardView: View {
         }
     }
 
+    private var dashboardSplitView: some View {
+        NavigationSplitView(columnVisibility: $columnVisibility) {
+            sidebarList
+        } detail: {
+            detailContent
+                .toolbar {
+                    ToolbarItemGroup(placement: .primaryAction) {
+                        refreshToolbarButton
+                    }
+                }
+        }
+        .navigationSplitViewStyle(.balanced)
+    }
+
     private var sidebarList: some View {
         List(selection: selectedSection) {
             ForEach(DashboardSection.allCases) { section in
@@ -189,6 +197,7 @@ struct UsageDashboardView: View {
             }
         }
         .listStyle(.sidebar)
+        .tint(MeterBarTheme.sidebarMenuTint)
         .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 280)
     }
 
@@ -197,7 +206,6 @@ struct UsageDashboardView: View {
             Task { await refreshDashboard() }
         } label: {
             RefreshingIcon(isRefreshing: isRefreshButtonAnimating)
-                .frame(width: 18, height: 18)
         }
         .help(isRefreshButtonAnimating ? "Refreshing usage" : "Refresh usage")
         .disabled(isRefreshButtonDisabled)
@@ -205,7 +213,7 @@ struct UsageDashboardView: View {
 
     private var detailContent: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 16) {
                 switch activeSection {
                 case .overview:
                     overviewContent
@@ -234,6 +242,8 @@ struct UsageDashboardView: View {
             MeterBarDetailBackground()
                 .ignoresSafeArea()
         }
+        .navigationTitle("")
+        .navigationSubtitle("")
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
@@ -295,7 +305,6 @@ struct UsageDashboardView: View {
                 isRefreshingMissingDays: costTracker.isRefreshingMissingDays,
                 formattedTokens: UsageFormat.tokens(visibleCostSummary?.totalTokens ?? 0)
             )
-            .frame(maxWidth: 420, alignment: .leading)
 
             costTrendCard
 
@@ -787,29 +796,32 @@ private struct OverviewSummaryStrip: View {
     var body: some View {
         LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
             TimelineView(.periodic(from: ResetCountdownSchedule.anchor, by: ResetCountdownSchedule.interval)) { timeline in
-                OverviewSummaryTile(
+                DashboardMetricTile(
                     title: "Tightest window",
                     value: tightestValue(now: timeline.date),
                     caption: tightestCaption,
                     systemImage: tightestIconName,
-                    tint: tightestColor
+                    tint: tightestColor,
+                    style: .compact
                 )
             }
 
-            OverviewSummaryTile(
+            DashboardMetricTile(
                 title: "30-day estimate",
                 value: estimatedCost ?? "Scan needed",
                 caption: "\(formattedTokens) tokens",
                 systemImage: "chart.bar.xaxis",
-                tint: MeterBarTheme.success
+                tint: MeterBarTheme.success,
+                style: .compact
             )
 
-            OverviewSummaryTile(
+            DashboardMetricTile(
                 title: "Tracked sources",
                 value: "\(sourceCount)",
                 caption: sourceCaption,
                 systemImage: "checklist.checked",
-                tint: MeterBarTheme.appAccent
+                tint: MeterBarTheme.appAccent,
+                style: .compact
             )
         }
     }
@@ -850,39 +862,5 @@ private struct OverviewSummaryStrip: View {
             return "Reset unknown"
         }
         return countdown == "now" ? "Reset due" : "Resets in \(countdown)"
-    }
-}
-
-private struct OverviewSummaryTile: View {
-    let title: String
-    let value: String
-    let caption: String
-    let systemImage: String
-    let tint: Color
-
-    var body: some View {
-        DashboardTile(minHeight: 104) {
-            VStack(alignment: .leading, spacing: 10) {
-                Label(title, systemImage: systemImage)
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-
-                Text(value)
-                    .font(.title3)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(tint)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.72)
-                    .contentTransition(.numericText())
-
-                Text(caption)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.8)
-            }
-        }
     }
 }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -336,7 +336,7 @@ struct UsageDashboardView: View {
             }
         }
         .task {
-            if apiUsageStore.hasAnyAuthenticated {
+            if apiUsageStore.hasAnyAuthenticated, !apiUsageStore.isLoading {
                 await apiUsageStore.refresh()
             }
         }
@@ -670,7 +670,9 @@ struct UsageDashboardView: View {
 
     private var isRefreshButtonAnimating: Bool {
         switch activeSection {
-        case .costs, .share, .optimize:
+        case .costs:
+            return costTracker.isRefreshInProgress || apiUsageStore.isLoading
+        case .share, .optimize:
             return costTracker.isRefreshInProgress
         case .overview, .limits, .diagnostics, .settings:
             return dataManager.isLoading
@@ -680,7 +682,7 @@ struct UsageDashboardView: View {
     private func refreshDashboard() async {
         if activeSection == .costs || activeSection == .share || activeSection == .optimize {
             await costTracker.scanCosts(days: 30)
-            if activeSection == .costs, apiUsageStore.hasAnyAuthenticated {
+            if activeSection == .costs, apiUsageStore.hasAnyAuthenticated, !apiUsageStore.isLoading {
                 await apiUsageStore.refresh()
             }
             socialCardGeneratedAt = Date()

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -28,7 +28,8 @@ final class UsageDashboardWindowController {
                 defer: false
             )
             window.title = DashboardNavigationStore.shared.selectedSection.rawValue
-            window.subtitle = DashboardNavigationStore.shared.selectedSection.titlebarSubtitle
+            window.subtitle = ""
+            window.titleVisibility = .hidden
             window.titlebarAppearsTransparent = true
             window.titlebarSeparatorStyle = .none
             window.backgroundColor = .windowBackgroundColor
@@ -151,10 +152,8 @@ struct UsageDashboardView: View {
             sidebarList
         } detail: {
             detailContent
-                .navigationTitle(activeSection.rawValue)
-                .navigationSubtitle(activeSection.titlebarSubtitle)
                 .toolbar {
-                    ToolbarItem(placement: .primaryAction) {
+                    ToolbarItem(placement: .navigation) {
                         refreshToolbarButton
                     }
                 }
@@ -164,7 +163,8 @@ struct UsageDashboardView: View {
             MeterBarMenuWindowAccessor { window in
                 guard let window else { return }
                 window.title = activeSection.rawValue
-                window.subtitle = activeSection.titlebarSubtitle
+                window.subtitle = ""
+                window.titleVisibility = .hidden
             }
         }
         .task {
@@ -189,7 +189,6 @@ struct UsageDashboardView: View {
             }
         }
         .listStyle(.sidebar)
-        .navigationTitle("MeterBar")
         .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 280)
     }
 
@@ -225,7 +224,7 @@ struct UsageDashboardView: View {
                 }
             }
             .padding(.horizontal, 22)
-            .padding(.top, 22)
+            .padding(.top, 12)
             .padding(.bottom, 22)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
@@ -240,11 +239,12 @@ struct UsageDashboardView: View {
 
     private var overviewContent: some View {
         VStack(alignment: .leading, spacing: 14) {
-            DashboardStatusHero(
-                title: overviewStatusTitle,
-                detail: overviewStatusDetail,
-                iconName: overviewStatusIconName,
-                color: overviewBand?.color ?? .secondary
+            OverviewSummaryStrip(
+                tightestLimit: tightestLimit,
+                sourceCount: providerSnapshots.count,
+                enabledSourceCount: enabledQuotaSourceCount,
+                estimatedCost: visibleCostSummary?.formattedTotalCost,
+                formattedTokens: UsageFormat.tokens(visibleCostSummary?.totalTokens ?? 0)
             )
 
             LazyVGrid(columns: overviewGridColumns, alignment: .leading, spacing: 12) {
@@ -546,39 +546,22 @@ struct UsageDashboardView: View {
         return labels
     }
 
+    private var enabledQuotaSourceCount: Int {
+        var count = 0
+        if providerVisibility.isEnabled(.codexCli) {
+            count += 1
+        }
+        if providerVisibility.isEnabled(.claudeCode) {
+            count += claudeAccountStore.accounts.count
+        }
+        if providerVisibility.isEnabled(.cursor) {
+            count += 1
+        }
+        return count
+    }
+
     private var tightestLimit: SnapshotLimit? {
         providerSnapshots.tightestLimit
-    }
-
-    private var overviewBand: QuotaBand? {
-        tightestLimit.map { QuotaBand.forPercentLeft($0.percentLeft) }
-    }
-
-    private var overviewStatusTitle: String {
-        guard !providerSnapshots.isEmpty else { return "No sources enabled" }
-        guard let overviewBand else { return "Waiting for usage" }
-        return overviewBand.overviewTitle
-    }
-
-    private var overviewStatusIconName: String {
-        // Neutral states (no providers enabled / no usage yet) should not show
-        // the healthy green shield, which falsely implies tracked quotas look good.
-        overviewBand?.iconName ?? "circle.dashed"
-    }
-
-    private var overviewStatusDetail: String {
-        guard !providerSnapshots.isEmpty else {
-            return "Enable providers in Settings to show quota status."
-        }
-        guard let tightestLimit else {
-            return "Refresh to load enabled provider status."
-        }
-        if tightestLimit.percentLeft <= 0 {
-            return "\(tightestLimit.title) is out until reset. "
-                + "Tracking \(providerSnapshots.count) local provider sources."
-        }
-        return "\(tightestLimit.title) has \(tightestLimit.percentLeft)% left. "
-            + "Tracking \(providerSnapshots.count) local provider sources."
     }
 
     private var diagnosticsContent: some View {
@@ -784,6 +767,122 @@ struct UsageDashboardView: View {
     private func setSocialShareStatus(_ status: String) {
         withAnimation(.easeInOut(duration: 0.15)) {
             socialShareStatus = status
+        }
+    }
+}
+
+private struct OverviewSummaryStrip: View {
+    let tightestLimit: SnapshotLimit?
+    let sourceCount: Int
+    let enabledSourceCount: Int
+    let estimatedCost: String?
+    let formattedTokens: String
+
+    private let columns = [
+        GridItem(.flexible(minimum: 180), spacing: 12),
+        GridItem(.flexible(minimum: 180), spacing: 12),
+        GridItem(.flexible(minimum: 180), spacing: 12)
+    ]
+
+    var body: some View {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
+            TimelineView(.periodic(from: ResetCountdownSchedule.anchor, by: ResetCountdownSchedule.interval)) { timeline in
+                OverviewSummaryTile(
+                    title: "Tightest window",
+                    value: tightestValue(now: timeline.date),
+                    caption: tightestCaption,
+                    systemImage: tightestIconName,
+                    tint: tightestColor
+                )
+            }
+
+            OverviewSummaryTile(
+                title: "30-day estimate",
+                value: estimatedCost ?? "Scan needed",
+                caption: "\(formattedTokens) tokens",
+                systemImage: "chart.bar.xaxis",
+                tint: MeterBarTheme.success
+            )
+
+            OverviewSummaryTile(
+                title: "Tracked sources",
+                value: "\(sourceCount)",
+                caption: sourceCaption,
+                systemImage: "checklist.checked",
+                tint: MeterBarTheme.appAccent
+            )
+        }
+    }
+
+    private var tightestBand: QuotaBand? {
+        tightestLimit.map { QuotaBand.forPercentLeft($0.percentLeft) }
+    }
+
+    private var tightestColor: Color {
+        tightestBand?.color ?? .secondary
+    }
+
+    private var tightestIconName: String {
+        tightestBand?.iconName ?? "circle.dashed"
+    }
+
+    private var tightestCaption: String {
+        guard let tightestLimit else { return "Waiting for provider refresh" }
+        return "\(tightestLimit.title) quota"
+    }
+
+    private var sourceCaption: String {
+        if enabledSourceCount == 0 {
+            return "Enable providers in Settings"
+        }
+        if sourceCount == enabledSourceCount {
+            return "All enabled sources reporting"
+        }
+        return "\(sourceCount) of \(enabledSourceCount) enabled reporting"
+    }
+
+    private func tightestValue(now: Date) -> String {
+        guard let tightestLimit else { return "No data" }
+        guard tightestLimit.usageLimit.isAtLimit else {
+            return "\(tightestLimit.percentLeft)% left"
+        }
+        guard let countdown = tightestLimit.usageLimit.resetCountdownText(now: now) else {
+            return "Reset unknown"
+        }
+        return countdown == "now" ? "Reset due" : "Resets in \(countdown)"
+    }
+}
+
+private struct OverviewSummaryTile: View {
+    let title: String
+    let value: String
+    let caption: String
+    let systemImage: String
+    let tint: Color
+
+    var body: some View {
+        DashboardTile(minHeight: 104) {
+            VStack(alignment: .leading, spacing: 10) {
+                Label(title, systemImage: systemImage)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+
+                Text(value)
+                    .font(.title3)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(tint)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.72)
+                    .contentTransition(.numericText())
+
+                Text(caption)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
         }
     }
 }

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -5,40 +5,38 @@ import XCTest
 /// audit found ~1,000 lines of money math with zero tests, which is exactly
 /// where the CLI-vs-app cost divergence hid.
 final class CostTrackerTests: XCTestCase {
-    private let tracker = CostTracker.shared
-
     // MARK: - Model-id normalization
 
     func testNormalizeClaudeModelStripsDateSuffix() {
-        XCTAssertEqual(tracker.normalizeClaudeModel("claude-opus-4-8-20260101"), "claude-opus-4-8")
-        XCTAssertEqual(tracker.normalizeClaudeModel("claude-fable-5-20260315"), "claude-fable-5")
+        XCTAssertEqual(CostTracker.normalizeClaudeModel("claude-opus-4-8-20260101"), "claude-opus-4-8")
+        XCTAssertEqual(CostTracker.normalizeClaudeModel("claude-fable-5-20260315"), "claude-fable-5")
     }
 
     func testNormalizeClaudeModelStripsBedrockStylePrefixes() {
-        XCTAssertEqual(tracker.normalizeClaudeModel("anthropic.claude-sonnet-4-5"), "claude-sonnet-4-5")
-        XCTAssertEqual(tracker.normalizeClaudeModel("us.anthropic.claude-opus-4-8"), "claude-opus-4-8")
+        XCTAssertEqual(CostTracker.normalizeClaudeModel("anthropic.claude-sonnet-4-5"), "claude-sonnet-4-5")
+        XCTAssertEqual(CostTracker.normalizeClaudeModel("us.anthropic.claude-opus-4-8"), "claude-opus-4-8")
     }
 
     func testNormalizeClaudeModelStripsVersionSuffix() {
-        XCTAssertEqual(tracker.normalizeClaudeModel("anthropic.claude-sonnet-4-5-v1:0"), "claude-sonnet-4-5")
+        XCTAssertEqual(CostTracker.normalizeClaudeModel("anthropic.claude-sonnet-4-5-v1:0"), "claude-sonnet-4-5")
     }
 
     func testNormalizeClaudeModelPassesThroughCleanIds() {
-        XCTAssertEqual(tracker.normalizeClaudeModel("claude-fable-5"), "claude-fable-5")
-        XCTAssertEqual(tracker.normalizeClaudeModel("  claude-haiku-4-5 "), "claude-haiku-4-5")
+        XCTAssertEqual(CostTracker.normalizeClaudeModel("claude-fable-5"), "claude-fable-5")
+        XCTAssertEqual(CostTracker.normalizeClaudeModel("  claude-haiku-4-5 "), "claude-haiku-4-5")
     }
 
     // MARK: - Pricing lookup
 
     func testClaudePricingExactAndFamilyMatches() {
-        XCTAssertEqual(tracker.claudePricing(for: "claude-fable-5").input, 10.0)
+        XCTAssertEqual(CostTracker.claudePricing(for: "claude-fable-5").input, 10.0)
         // Dated ids normalize onto the base id.
-        XCTAssertEqual(tracker.claudePricing(for: "claude-opus-4-8-20260101").input, 5.0)
+        XCTAssertEqual(CostTracker.claudePricing(for: "claude-opus-4-8-20260101").input, 5.0)
         // Family fallback for unknown fable variants.
-        XCTAssertEqual(tracker.claudePricing(for: "claude-fable-9").input, 10.0)
+        XCTAssertEqual(CostTracker.claudePricing(for: "claude-fable-9").input, 10.0)
         // Unknown models get the default (sonnet-rate) pricing.
-        XCTAssertEqual(tracker.claudePricing(for: "mystery-model").input, 3.0)
-        XCTAssertEqual(tracker.claudePricing(for: nil).input, 3.0)
+        XCTAssertEqual(CostTracker.claudePricing(for: "mystery-model").input, 3.0)
+        XCTAssertEqual(CostTracker.claudePricing(for: nil).input, 3.0)
     }
 
     // MARK: - Cost formula
@@ -46,10 +44,10 @@ final class CostTrackerTests: XCTestCase {
     func testCalculateCostMatchesClaudeCostWithoutOneHourTier() {
         let pricing = TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30)
 
-        let simple = tracker.calculateCost(
+        let simple = CostTracker.calculateCost(
             input: 1_000_000, output: 2_000_000, cacheCreation: 500_000, cacheRead: 4_000_000, pricing: pricing
         )
-        let claude = tracker.calculateClaudeCost(
+        let claude = CostTracker.calculateClaudeCost(
             input: 1_000_000, output: 2_000_000, cacheCreation: 500_000,
             cacheCreationOneHour: 0, cacheRead: 4_000_000, pricing: pricing
         )
@@ -64,13 +62,13 @@ final class CostTrackerTests: XCTestCase {
         // to zero instead of producing negative dollars (previously only the
         // Claude variant clamped).
         let pricing = TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30)
-        let cost = tracker.calculateCost(input: -500, output: -1, cacheCreation: -2, cacheRead: -3, pricing: pricing)
+        let cost = CostTracker.calculateCost(input: -500, output: -1, cacheCreation: -2, cacheRead: -3, pricing: pricing)
         XCTAssertEqual(cost, 0, accuracy: 0.0001)
     }
 
     func testOneHourCacheTierPricedSeparately() {
         let pricing = TokenPricing(input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0)
-        let cost = tracker.calculateClaudeCost(
+        let cost = CostTracker.calculateClaudeCost(
             input: 0, output: 0,
             cacheCreation: 2_000_000, cacheCreationOneHour: 1_000_000,
             cacheRead: 0, pricing: pricing
@@ -120,7 +118,7 @@ final class CostTrackerTests: XCTestCase {
         ])
 
         let cutoff = FlexibleISO8601.date(from: "2026-06-01T00:00:00Z")!
-        let result = tracker.parseSessionFile(at: url, since: cutoff)
+        let result = CostTracker.parseSessionFile(at: url, since: cutoff)
 
         XCTAssertEqual(result.input, 107)
         XCTAssertEqual(result.output, 53)
@@ -135,7 +133,7 @@ final class CostTrackerTests: XCTestCase {
         ])
 
         let cutoff = FlexibleISO8601.date(from: "2026-06-01T00:00:00Z")!
-        let result = tracker.parseSessionFile(at: url, since: cutoff)
+        let result = CostTracker.parseSessionFile(at: url, since: cutoff)
 
         XCTAssertEqual(result.input, 42)
         XCTAssertEqual(result.output, 8)
@@ -148,7 +146,7 @@ final class CostTrackerTests: XCTestCase {
         ])
 
         let cutoff = FlexibleISO8601.date(from: "2026-06-01T00:00:00Z")!
-        let result = tracker.parseSessionFile(at: url, since: cutoff)
+        let result = CostTracker.parseSessionFile(at: url, since: cutoff)
 
         XCTAssertEqual(result.estimatedCost, 3.0, accuracy: 0.0001)
         XCTAssertEqual(Array(result.models.keys), ["claude-sonnet-4-5"])
@@ -162,7 +160,7 @@ final class CostTrackerTests: XCTestCase {
         ])
 
         let cutoff = FlexibleISO8601.date(from: "2026-06-01T00:00:00Z")!
-        let result = tracker.parseSessionFile(at: url, since: cutoff)
+        let result = CostTracker.parseSessionFile(at: url, since: cutoff)
 
         XCTAssertEqual(result.input, 5)
     }
@@ -212,7 +210,7 @@ final class CostTrackerTests: XCTestCase {
         let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
         var context = makeContext(cutoff: cutoff)
 
-        tracker.scanCodexArchivedSessions(directory: dir, since: cutoff, context: &context)
+        CostTracker.scanCodexArchivedSessions(directory: dir, since: cutoff, context: &context)
 
         XCTAssertEqual(context.totals.input, 1_000)
         // output accumulates the reasoning tokens on the daily/model rollups, but
@@ -229,7 +227,7 @@ final class CostTrackerTests: XCTestCase {
         let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
         var context = makeContext(cutoff: cutoff)
 
-        tracker.scanCodexArchivedSessions(directory: dir, since: cutoff, context: &context)
+        CostTracker.scanCodexArchivedSessions(directory: dir, since: cutoff, context: &context)
 
         // Identical events collapse to one via the dedup key.
         XCTAssertEqual(context.totals.input, 1_000)
@@ -244,7 +242,7 @@ final class CostTrackerTests: XCTestCase {
         let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
         var context = makeContext(cutoff: cutoff)
 
-        tracker.scanCodexArchivedSessions(directory: dir, since: cutoff, context: &context)
+        CostTracker.scanCodexArchivedSessions(directory: dir, since: cutoff, context: &context)
 
         // Only the post-cutoff line is counted.
         XCTAssertEqual(context.totals.input, 100)

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -175,4 +175,47 @@ final class ProviderSnapshotTests: XCTestCase {
         XCTAssertEqual(snapshot.band, .exhausted)
         XCTAssertEqual(snapshot.resetWindows.count, 2)
     }
+
+    func testWeeklyExhaustionIsDistinctFromSessionExhaustion() {
+        let weeklyOut = ProviderSnapshotBuilder.snapshot(
+            title: "Claude",
+            service: .claudeCode,
+            metrics: makeMetrics(service: .claudeCode, session: 0, weekly: 100),
+            emptyDetail: ""
+        )
+        let sessionOut = ProviderSnapshotBuilder.snapshot(
+            title: "Codex",
+            service: .codexCli,
+            metrics: makeMetrics(service: .codexCli, session: 100, weekly: 0),
+            emptyDetail: ""
+        )
+
+        XCTAssertTrue(weeklyOut.hasExhaustedLimit)
+        XCTAssertTrue(weeklyOut.hasExhaustedWeeklyLimit)
+        XCTAssertTrue(sessionOut.hasExhaustedLimit)
+        XCTAssertFalse(sessionOut.hasExhaustedWeeklyLimit)
+    }
+
+    func testDetailLimitsHideSessionWhenWeeklyIsExhausted() {
+        let snapshot = ProviderSnapshotBuilder.snapshot(
+            title: "Claude",
+            service: .claudeCode,
+            metrics: makeMetrics(service: .claudeCode, session: 0, weekly: 100, codeReview: 40),
+            emptyDetail: ""
+        )
+
+        XCTAssertEqual(snapshot.limits.map(\.id), ["session", "weekly", "codeReview"])
+        XCTAssertEqual(snapshot.detailLimits.map(\.id), ["weekly", "codeReview"])
+    }
+
+    func testDetailLimitsKeepSessionWhenOnlySessionIsExhausted() {
+        let snapshot = ProviderSnapshotBuilder.snapshot(
+            title: "Codex",
+            service: .codexCli,
+            metrics: makeMetrics(service: .codexCli, session: 100, weekly: 25),
+            emptyDetail: ""
+        )
+
+        XCTAssertEqual(snapshot.detailLimits.map(\.id), ["session", "weekly"])
+    }
 }

--- a/MeterBarTests/UsageFormattingTests.swift
+++ b/MeterBarTests/UsageFormattingTests.swift
@@ -41,6 +41,7 @@ final class UsageFormattingTests: XCTestCase {
         XCTAssertEqual(UsageFormat.cost(0), "$0.00")
         XCTAssertEqual(UsageFormat.cost(1.5), "$1.50")
         XCTAssertEqual(UsageFormat.cost(123.456), "$123.46")
+        XCTAssertEqual(UsageFormat.cost(6_954.07), "$6,954.07")
     }
 
     // MARK: - Relative date


### PR DESCRIPTION
## Summary
- prepare MeterBar v1.6.1 for Homebrew release
- restore daily detail row expansion
- right-align Settings account actions and simplify account rows
- soften glass card borders/gradients

## Verification
- git diff --check
- swift test (321 tests passed)
- xcodebuild Release CODE_SIGNING_ALLOWED=NO
- bundled CLI version matches app version: 1.6.1

After merge, tag v1.6.1 to trigger the release workflow and Homebrew tap update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the dashboard and popover with a more native macOS look and refreshed navigation.
  * Added richer usage views, including improved daily charts, breakdown tables, and provider detail panels.
  * Added a modal flow for managing Claude accounts and improved settings layout.

* **Bug Fixes**
  * Improved quota and extra-usage display accuracy, including weekly/session limit handling.
  * Fixed currency formatting and several dashboard spacing, sizing, and loading-state issues.
  * Updated the refresh indicator to show a clearer loading state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->