### PR TITLE
Add provider status pages

### DIFF
--- a/.agents/SESSIONS/2026-07-09.md
+++ b/.agents/SESSIONS/2026-07-09.md
@@ -1,0 +1,29 @@
+# 2026-07-09
+
+## Session 1: Provider Status Pages
+
+**Duration:** ~45 minutes
+**Status:** Complete, uncommitted pending review
+
+**What was done:**
+- Added a shared provider-status monitor for Claude, OpenAI/Codex, and Cursor public status pages.
+- Added status-page parsing for Statuspage-style `status.json` and `components.json` feeds.
+- Added a compact provider-status row to the menu-bar popover.
+- Added a full companion dashboard Status section with per-provider component rows and open-page actions.
+- Added a right-click native Status Pages submenu with cached provider/component status and refresh/open actions.
+
+**Files changed:**
+- `MeterBar/Services/ProviderStatusMonitor.swift` - Status models, feed parser, client, and shared monitor.
+- `MeterBar/Views/ProviderStatusViews.swift` - Dashboard cards and compact popover status row.
+- `MeterBar/App/MeterBarApp.swift` - Native status-menu subtree.
+- `MeterBar/Views/MenuBarView.swift` - Popover entry point for provider status.
+- `MeterBar/Views/UsageDashboardView.swift` - Companion dashboard Status section and refresh behavior.
+- `MeterBarTests/ProviderStatusMonitorTests.swift` - Fixture coverage for parser and provider URL mapping.
+
+**Verification:**
+- `git diff --check`
+- `swiftc -typecheck $(rg --files MeterBar -g '*.swift') -I .build/arm64-apple-macosx/debug/Modules -target arm64-apple-macosx26.0 -sdk /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -swift-version 5 -default-isolation MainActor`
+- `swift test --filter ProviderStatusMonitorTests` could not run in this local environment because `xcode-select` points to `/Library/Developer/CommandLineTools` and SwiftPM cannot import `XCTest`.
+
+**Notes:**
+- The popover intentionally stays compact; the full component list lives in the companion dashboard and native status submenu.

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -87,6 +87,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Setup notifications (also handles initial data refresh)
         setupNotifications()
+        Task {
+            await ProviderStatusMonitor.shared.refreshAllIfNeeded()
+        }
 
         if CommandLine.arguments.contains("--open-dashboard") {
             UsageDashboardWindowController.shared.show()
@@ -155,6 +158,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         dashboardItem.target = self
         menu.addItem(dashboardItem)
 
+        let statusItem = NSMenuItem(title: "Status Pages", action: nil, keyEquivalent: "")
+        statusItem.image = NSImage(systemSymbolName: "waveform.path.ecg", accessibilityDescription: nil)
+        statusItem.submenu = makeProviderStatusMenu()
+        menu.addItem(statusItem)
+
         menu.addItem(.separator())
 
         let quitItem = NSMenuItem(
@@ -168,6 +176,154 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return menu
     }
 
+    private func makeProviderStatusMenu() -> NSMenu {
+        let menu = NSMenu()
+        let monitor = ProviderStatusMonitor.shared
+
+        if monitor.reports.isEmpty, !monitor.isRefreshing {
+            Task {
+                await monitor.refreshAllIfNeeded()
+            }
+        }
+
+        for service in ServiceType.allCases {
+            let item = NSMenuItem(
+                title: providerStatusMenuTitle(for: service),
+                action: nil,
+                keyEquivalent: ""
+            )
+            item.image = statusDotImage(for: providerStatusMenuIndicator(for: service))
+            item.submenu = makeProviderStatusSubmenu(for: service)
+            menu.addItem(item)
+        }
+
+        menu.addItem(.separator())
+
+        let refreshItem = NSMenuItem(
+            title: "Refresh Status Pages",
+            action: #selector(refreshProviderStatusesFromStatusMenu),
+            keyEquivalent: ""
+        )
+        refreshItem.target = self
+        refreshItem.image = NSImage(systemSymbolName: "arrow.clockwise", accessibilityDescription: nil)
+        refreshItem.isEnabled = !monitor.isRefreshing
+        menu.addItem(refreshItem)
+
+        return menu
+    }
+
+    private func makeProviderStatusSubmenu(for service: ServiceType) -> NSMenu {
+        let menu = NSMenu()
+        let monitor = ProviderStatusMonitor.shared
+
+        if let report = monitor.reports[service] {
+            let summaryItem = disabledMenuItem(
+                title: report.summary.description ?? report.summary.indicator.summaryLabel,
+                image: statusDotImage(for: report.summary.indicator)
+            )
+            menu.addItem(summaryItem)
+
+            if !report.components.isEmpty {
+                menu.addItem(.separator())
+                for component in report.components {
+                    menu.addItem(makeStatusComponentMenuItem(component))
+                }
+            }
+        } else if let error = monitor.errors[service] {
+            menu.addItem(disabledMenuItem(title: error, image: statusDotImage(for: .critical)))
+        } else {
+            menu.addItem(disabledMenuItem(title: "Checking status...", image: statusDotImage(for: .unknown)))
+        }
+
+        menu.addItem(.separator())
+
+        let openItem = NSMenuItem(
+            title: "Open \(service.statusPageDisplayName) Status Page",
+            action: #selector(openProviderStatusPageFromStatusMenu(_:)),
+            keyEquivalent: ""
+        )
+        openItem.target = self
+        openItem.representedObject = service.rawValue
+        openItem.image = NSImage(systemSymbolName: "arrow.up.right.square", accessibilityDescription: nil)
+        menu.addItem(openItem)
+
+        return menu
+    }
+
+    private func makeStatusComponentMenuItem(_ component: ProviderStatusComponent) -> NSMenuItem {
+        let item = NSMenuItem(
+            title: "\(component.name)  \(component.statusLabel)",
+            action: nil,
+            keyEquivalent: ""
+        )
+        item.image = statusDotImage(for: component.indicator)
+
+        if component.isGroup {
+            let submenu = NSMenu()
+            for child in component.children {
+                submenu.addItem(makeStatusComponentMenuItem(child))
+            }
+            item.submenu = submenu
+        } else {
+            item.isEnabled = false
+        }
+
+        return item
+    }
+
+    private func providerStatusMenuTitle(for service: ServiceType) -> String {
+        let monitor = ProviderStatusMonitor.shared
+        if let report = monitor.reports[service] {
+            let summary = report.summary.description ?? report.summary.indicator.summaryLabel
+            return "\(service.statusPageDisplayName) — \(summary)"
+        }
+        if monitor.errors[service] != nil {
+            return "\(service.statusPageDisplayName) — Unavailable"
+        }
+        return "\(service.statusPageDisplayName) — Checking..."
+    }
+
+    private func providerStatusMenuIndicator(for service: ServiceType) -> ProviderStatusIndicator {
+        let monitor = ProviderStatusMonitor.shared
+        if let report = monitor.reports[service] {
+            return report.summary.indicator
+        }
+        if monitor.errors[service] != nil {
+            return .critical
+        }
+        return .unknown
+    }
+
+    private func disabledMenuItem(title: String, image: NSImage? = nil) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.image = image
+        item.isEnabled = false
+        return item
+    }
+
+    private func statusDotImage(for indicator: ProviderStatusIndicator) -> NSImage {
+        let image = NSImage(size: NSSize(width: 10, height: 10))
+        image.lockFocus()
+        statusDotColor(for: indicator).setFill()
+        NSBezierPath(ovalIn: NSRect(x: 2, y: 2, width: 6, height: 6)).fill()
+        image.unlockFocus()
+        image.isTemplate = false
+        return image
+    }
+
+    private func statusDotColor(for indicator: ProviderStatusIndicator) -> NSColor {
+        switch indicator {
+        case .none:
+            return .systemGreen
+        case .minor, .maintenance:
+            return .systemOrange
+        case .major, .critical:
+            return .systemRed
+        case .unknown:
+            return .tertiaryLabelColor
+        }
+    }
+
     @objc
     private func toggleShowInDock() {
         dockVisibilityStore.setShowInDock(!dockVisibilityStore.showInDock)
@@ -176,6 +332,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @objc
     private func openDashboardFromStatusMenu() {
         UsageDashboardWindowController.shared.show()
+    }
+
+    @objc
+    private func refreshProviderStatusesFromStatusMenu() {
+        Task {
+            await ProviderStatusMonitor.shared.refreshAll()
+        }
+    }
+
+    @objc
+    private func openProviderStatusPageFromStatusMenu(_ sender: NSMenuItem) {
+        guard let rawValue = sender.representedObject as? String,
+              let service = ServiceType(rawValue: rawValue),
+              let url = service.statusPageURL else { return }
+        NSWorkspace.shared.open(url)
     }
 
     @objc

--- a/MeterBar/Services/ProviderStatusMonitor.swift
+++ b/MeterBar/Services/ProviderStatusMonitor.swift
@@ -1,0 +1,382 @@
+import Foundation
+import MeterBarShared
+
+struct ProviderStatusSummary: Equatable {
+    let indicator: ProviderStatusIndicator
+    let description: String?
+    let updatedAt: Date?
+}
+
+struct ProviderStatusReport: Identifiable, Equatable {
+    var id: ServiceType { service }
+
+    let service: ServiceType
+    let pageName: String
+    let pageURL: URL
+    let summary: ProviderStatusSummary
+    let components: [ProviderStatusComponent]
+    let fetchedAt: Date
+
+    var displayName: String {
+        service.statusPageDisplayName
+    }
+
+    var hasIssue: Bool {
+        summary.indicator.hasIssue || components.contains { $0.hasIssue }
+    }
+}
+
+enum ProviderStatusIndicator: String, Codable, Equatable {
+    case none
+    case minor
+    case major
+    case critical
+    case maintenance
+    case unknown
+
+    var hasIssue: Bool {
+        switch self {
+        case .none:
+            return false
+        case .minor, .major, .critical, .maintenance, .unknown:
+            return true
+        }
+    }
+
+    var summaryLabel: String {
+        switch self {
+        case .none:
+            return "Operational"
+        case .minor:
+            return "Partial Degradation"
+        case .major:
+            return "Major Outage"
+        case .critical:
+            return "Critical Issue"
+        case .maintenance:
+            return "Maintenance"
+        case .unknown:
+            return "Unknown"
+        }
+    }
+
+    var rank: Int {
+        switch self {
+        case .none:
+            return 0
+        case .maintenance, .unknown:
+            return 1
+        case .minor:
+            return 2
+        case .major:
+            return 3
+        case .critical:
+            return 4
+        }
+    }
+
+    static func statuspageIndicator(_ rawValue: String) -> ProviderStatusIndicator {
+        ProviderStatusIndicator(rawValue: rawValue) ?? .unknown
+    }
+
+    static func componentIndicator(for status: String) -> ProviderStatusIndicator {
+        switch status {
+        case "operational":
+            return .none
+        case "degraded_performance":
+            return .minor
+        case "partial_outage":
+            return .major
+        case "major_outage", "full_outage":
+            return .critical
+        case "under_maintenance":
+            return .maintenance
+        default:
+            return .unknown
+        }
+    }
+}
+
+struct ProviderStatusComponent: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let indicator: ProviderStatusIndicator
+    let status: String
+    var children: [ProviderStatusComponent] = []
+
+    var isGroup: Bool {
+        !children.isEmpty
+    }
+
+    var hasIssue: Bool {
+        indicator.hasIssue || children.contains { $0.hasIssue }
+    }
+
+    var statusLabel: String {
+        Self.label(forStatuspageStatus: status)
+    }
+
+    static func label(forStatuspageStatus status: String) -> String {
+        switch status {
+        case "operational":
+            return "Operational"
+        case "degraded_performance":
+            return "Degraded"
+        case "partial_outage":
+            return "Partial Outage"
+        case "major_outage", "full_outage":
+            return "Major Outage"
+        case "under_maintenance":
+            return "Maintenance"
+        default:
+            return "Unknown"
+        }
+    }
+}
+
+extension ServiceType {
+    var statusPageDisplayName: String {
+        switch self {
+        case .claudeCode:
+            return "Claude"
+        case .codexCli:
+            return "OpenAI"
+        case .cursor:
+            return "Cursor"
+        }
+    }
+
+    var statusPageURLString: String {
+        switch self {
+        case .claudeCode:
+            return "https://status.claude.com/"
+        case .codexCli:
+            return "https://status.openai.com/"
+        case .cursor:
+            return "https://status.cursor.com/"
+        }
+    }
+
+    var statusPageURL: URL? {
+        URL(string: statusPageURLString)
+    }
+}
+
+enum ProviderStatusFeedParser {
+    static func parseStatuspageStatus(data: Data) throws -> (pageName: String?, summary: ProviderStatusSummary) {
+        struct Response: Decodable {
+            struct Page: Decodable {
+                let name: String?
+                let updatedAt: Date?
+
+                private enum CodingKeys: String, CodingKey {
+                    case name
+                    case updatedAt = "updated_at"
+                }
+            }
+
+            struct Status: Decodable {
+                let indicator: String
+                let description: String?
+            }
+
+            let page: Page?
+            let status: Status
+        }
+
+        let response = try statusDecoder.decode(Response.self, from: data)
+        let summary = ProviderStatusSummary(
+            indicator: .statuspageIndicator(response.status.indicator),
+            description: response.status.description,
+            updatedAt: response.page?.updatedAt
+        )
+        return (response.page?.name, summary)
+    }
+
+    static func parseStatuspageComponents(data: Data) throws -> [ProviderStatusComponent] {
+        struct Response: Decodable {
+            struct Component: Decodable {
+                let id: String
+                let name: String
+                let status: String
+                let group: Bool?
+                let groupID: String?
+                let position: Int?
+
+                private enum CodingKeys: String, CodingKey {
+                    case id
+                    case name
+                    case status
+                    case group
+                    case position
+                    case groupID = "group_id"
+                }
+            }
+
+            let components: [Component]?
+        }
+
+        let response = try JSONDecoder().decode(Response.self, from: data)
+        let components = (response.components ?? [])
+            .filter { normalizedName($0.name) != nil }
+            .sorted { ($0.position ?? 0) < ($1.position ?? 0) }
+
+        func makeRow(_ component: Response.Component, children: [ProviderStatusComponent]) -> ProviderStatusComponent {
+            ProviderStatusComponent(
+                id: component.id,
+                name: normalizedName(component.name) ?? component.name,
+                indicator: .componentIndicator(for: component.status),
+                status: component.status,
+                children: children
+            )
+        }
+
+        var childrenByGroup: [String: [ProviderStatusComponent]] = [:]
+        for component in components where component.group != true {
+            guard let groupID = component.groupID else { continue }
+            childrenByGroup[groupID, default: []].append(makeRow(component, children: []))
+        }
+
+        return components.compactMap { component in
+            if component.group == true {
+                return makeRow(component, children: childrenByGroup[component.id] ?? [])
+            }
+            if component.groupID != nil {
+                return nil
+            }
+            return makeRow(component, children: [])
+        }
+    }
+
+    private static var statusDecoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let rawValue = try container.decode(String.self)
+            guard let date = FlexibleISO8601.date(from: rawValue) else {
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Invalid ISO8601 date"
+                )
+            }
+            return date
+        }
+        return decoder
+    }
+
+    private static func normalizedName(_ name: String?) -> String? {
+        guard let value = name?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+}
+
+struct ProviderStatusClient {
+    let session: URLSession
+
+    func fetchReport(for service: ServiceType) async throws -> ProviderStatusReport {
+        guard let baseURL = service.statusPageURL else {
+            throw ServiceError.invalidURL
+        }
+
+        let parsedStatus = try await fetchStatus(from: baseURL)
+        let components = (try? await fetchComponents(from: baseURL)) ?? []
+        return ProviderStatusReport(
+            service: service,
+            pageName: parsedStatus.pageName ?? service.statusPageDisplayName,
+            pageURL: baseURL,
+            summary: parsedStatus.summary,
+            components: components,
+            fetchedAt: Date()
+        )
+    }
+
+    private func fetchStatus(
+        from baseURL: URL
+    ) async throws -> (pageName: String?, summary: ProviderStatusSummary) {
+        let url = baseURL.appendingPathComponent("api/v2/status.json")
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        let (data, response) = try await session.data(for: request)
+        try ServiceSupport.validate(response, data: data)
+        return try ProviderStatusFeedParser.parseStatuspageStatus(data: data)
+    }
+
+    private func fetchComponents(from baseURL: URL) async throws -> [ProviderStatusComponent] {
+        let url = baseURL.appendingPathComponent("api/v2/components.json")
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        let (data, response) = try await session.data(for: request)
+        try ServiceSupport.validate(response, data: data)
+        return try ProviderStatusFeedParser.parseStatuspageComponents(data: data)
+    }
+}
+
+@MainActor
+final class ProviderStatusMonitor: ObservableObject {
+    static let shared = ProviderStatusMonitor()
+
+    @Published private(set) var reports: [ServiceType: ProviderStatusReport] = [:]
+    @Published private(set) var errors: [ServiceType: String] = [:]
+    @Published private(set) var isRefreshing = false
+
+    private let client: ProviderStatusClient
+    private var lastRefresh: Date?
+    private let freshnessWindow: TimeInterval = 5 * 60
+
+    init(client: ProviderStatusClient? = nil) {
+        self.client = client ?? ProviderStatusClient(session: ServiceSupport.session)
+    }
+
+    func refreshAllIfNeeded() async {
+        if let lastRefresh, Date().timeIntervalSince(lastRefresh) < freshnessWindow {
+            return
+        }
+        await refreshAll()
+    }
+
+    func refreshAll(services: [ServiceType] = ServiceType.allCases) async {
+        guard !isRefreshing else { return }
+        isRefreshing = true
+
+        let client = self.client
+        await withTaskGroup(of: (ServiceType, Result<ProviderStatusReport, Error>).self) { group in
+            for service in services {
+                group.addTask {
+                    do {
+                        return (service, .success(try await client.fetchReport(for: service)))
+                    } catch {
+                        return (service, .failure(error))
+                    }
+                }
+            }
+
+            for await (service, result) in group {
+                switch result {
+                case .success(let report):
+                    reports[service] = report
+                    errors.removeValue(forKey: service)
+                case .failure(let error):
+                    errors[service] = ProviderStatusMonitor.message(for: error)
+                }
+            }
+        }
+
+        lastRefresh = Date()
+        isRefreshing = false
+    }
+
+    private static func message(for error: Error) -> String {
+        if let serviceError = error as? ServiceError {
+            return serviceError.localizedDescription
+        }
+        if let urlError = error as? URLError {
+            return ServiceSupport.message(for: urlError)
+        }
+        if error is DecodingError {
+            return "Failed to parse status feed"
+        }
+        return error.localizedDescription
+    }
+}

--- a/MeterBar/Services/ProviderStatusMonitor.swift
+++ b/MeterBar/Services/ProviderStatusMonitor.swift
@@ -358,6 +358,7 @@ final class ProviderStatusMonitor: ObservableObject {
                     reports[service] = report
                     errors.removeValue(forKey: service)
                 case .failure(let error):
+                    reports.removeValue(forKey: service)
                     errors[service] = ProviderStatusMonitor.message(for: error)
                 }
             }

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -69,6 +69,7 @@ struct MenuBarView: View {
               cursorHasAccess: cursorService.hasAccess
             )),
           openDashboard: openDashboard,
+          openStatusDashboard: openStatusDashboard,
           openProviderOverview: openProviderDetail
         )
         .padding(10)
@@ -143,6 +144,12 @@ struct MenuBarView: View {
     UsageDashboardWindowController.shared.show()
   }
 
+  private func openStatusDashboard() {
+    expandedProviderID = nil
+    MeterBarMenuDetailPanel.shared.dismiss()
+    UsageDashboardWindowController.shared.show(section: .status)
+  }
+
   private func openProviderDetail(_ snapshot: ProviderSnapshot) {
     if expandedProviderID == snapshot.id {
       expandedProviderID = nil
@@ -190,6 +197,7 @@ private enum MenuBarOverlayIcons {
 struct PopoverOverviewPanel: View {
   let snapshots: [ProviderSnapshot]
   let openDashboard: () -> Void
+  let openStatusDashboard: () -> Void
   let openProviderOverview: (ProviderSnapshot) -> Void
 
   @State private var setupReports: [ProviderReadiness] = []
@@ -231,6 +239,8 @@ struct PopoverOverviewPanel: View {
       if !providersNeedingSetup.isEmpty {
         setupChecklist
       }
+
+      PopoverProviderStatusSummaryCard(openStatusDashboard: openStatusDashboard)
 
       VStack(spacing: 8) {
         ForEach(snapshots) { snapshot in

--- a/MeterBar/Views/ProviderStatusViews.swift
+++ b/MeterBar/Views/ProviderStatusViews.swift
@@ -1,0 +1,272 @@
+import AppKit
+import MeterBarShared
+import SwiftUI
+
+extension ProviderStatusIndicator {
+    var tint: Color {
+        switch self {
+        case .none:
+            return MeterBarTheme.success
+        case .minor, .maintenance:
+            return MeterBarTheme.warning
+        case .major, .critical:
+            return MeterBarTheme.danger
+        case .unknown:
+            return .secondary
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .none:
+            return "checkmark.circle.fill"
+        case .minor:
+            return "exclamationmark.triangle.fill"
+        case .major, .critical:
+            return "xmark.octagon.fill"
+        case .maintenance:
+            return "wrench.and.screwdriver.fill"
+        case .unknown:
+            return "questionmark.circle.fill"
+        }
+    }
+}
+
+struct ProviderStatusBadge: View {
+    let indicator: ProviderStatusIndicator
+    let label: String
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Image(systemName: indicator.symbolName)
+                .font(.system(size: 10, weight: .semibold))
+            Text(label)
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .lineLimit(1)
+        }
+        .foregroundStyle(indicator.tint)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(indicator.tint.opacity(0.14), in: Capsule())
+        .overlay {
+            Capsule().stroke(indicator.tint.opacity(0.18), lineWidth: 1)
+        }
+    }
+}
+
+struct ProviderStatusDashboardCard: View {
+    let service: ServiceType
+    let report: ProviderStatusReport?
+    let error: String?
+    let openStatusPage: (ServiceType) -> Void
+
+    private var indicator: ProviderStatusIndicator {
+        report?.summary.indicator ?? (error == nil ? .unknown : .critical)
+    }
+
+    private var headline: String {
+        report?.summary.description ?? report?.summary.indicator.summaryLabel ?? "Loading status"
+    }
+
+    var body: some View {
+        DashboardTile {
+            VStack(alignment: .leading, spacing: 12) {
+                header
+
+                if let error, report == nil {
+                    statusError(error)
+                } else if let report {
+                    if report.components.isEmpty {
+                        Text("No component details published by \(report.pageName).")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        VStack(alignment: .leading, spacing: 7) {
+                            ForEach(report.components) { component in
+                                ProviderStatusComponentRows(component: component)
+                            }
+                        }
+                    }
+                } else {
+                    Text("Fetching provider status.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: 10) {
+            ProviderLogoView(
+                kind: .forService(service),
+                size: 19,
+                foregroundColor: MeterBarTheme.accent(for: service)
+            )
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(service.statusPageDisplayName)
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 10)
+
+            ProviderStatusBadge(indicator: indicator, label: headline)
+
+            Button {
+                openStatusPage(service)
+            } label: {
+                Image(systemName: "arrow.up.right.square")
+            }
+            .buttonStyle(.borderless)
+            .help("Open \(service.statusPageDisplayName) status page")
+        }
+    }
+
+    private var subtitle: String {
+        if let updatedAt = report?.summary.updatedAt {
+            return "Updated \(UsageFormat.relative(updatedAt))"
+        }
+        if let fetchedAt = report?.fetchedAt {
+            return "Checked \(UsageFormat.relative(fetchedAt))"
+        }
+        return service.statusPageURLString
+    }
+
+    private func statusError(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: ProviderStatusIndicator.critical.symbolName)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(MeterBarTheme.danger)
+                .padding(.top, 1)
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+private struct ProviderStatusComponentRows: View {
+    let component: ProviderStatusComponent
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            ProviderStatusComponentRow(component: component)
+            if component.isGroup {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(component.children) { child in
+                        ProviderStatusComponentRow(component: child, indented: true)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct ProviderStatusComponentRow: View {
+    let component: ProviderStatusComponent
+    var indented = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(component.indicator.tint)
+                .frame(width: 8, height: 8)
+
+            Text(component.name)
+                .font(.subheadline)
+                .lineLimit(1)
+
+            Spacer(minLength: 12)
+
+            Text(component.statusLabel)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .padding(.leading, indented ? 18 : 0)
+    }
+}
+
+struct PopoverProviderStatusSummaryCard: View {
+    @StateObject private var statusMonitor = ProviderStatusMonitor.shared
+
+    let openStatusDashboard: () -> Void
+
+    private var reports: [ProviderStatusReport] {
+        ServiceType.allCases.compactMap { statusMonitor.reports[$0] }
+    }
+
+    private var worstIndicator: ProviderStatusIndicator {
+        reports
+            .map(\.summary.indicator)
+            .max { $0.rank < $1.rank } ?? (statusMonitor.isRefreshing ? .unknown : .none)
+    }
+
+    private var summaryText: String {
+        if statusMonitor.isRefreshing, reports.isEmpty {
+            return "Checking provider status"
+        }
+
+        let issueCount = reports.filter(\.hasIssue).count
+        if issueCount == 0, reports.count == ServiceType.allCases.count {
+            return "All provider pages operational"
+        }
+        if issueCount == 1 {
+            return "1 provider needs attention"
+        }
+        if issueCount > 1 {
+            return "\(issueCount) providers need attention"
+        }
+        return "Status pages available"
+    }
+
+    var body: some View {
+        Button(action: openStatusDashboard) {
+            DashboardTile(padding: 11, minHeight: 58, alignment: .center) {
+                HStack(spacing: 10) {
+                    Image(systemName: "waveform.path.ecg")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(worstIndicator.tint)
+                        .frame(width: 18)
+
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("Provider Status")
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                            .lineLimit(1)
+                        Text(summaryText)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+
+                    Spacer(minLength: 8)
+
+                    HStack(spacing: 5) {
+                        ForEach(ServiceType.allCases) { service in
+                            Circle()
+                                .fill((statusMonitor.reports[service]?.summary.indicator ?? .unknown).tint)
+                                .frame(width: 7, height: 7)
+                                .help(service.statusPageDisplayName)
+                        }
+                    }
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .task {
+            await statusMonitor.refreshAllIfNeeded()
+        }
+    }
+}

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -55,6 +55,7 @@ final class UsageDashboardWindowController {
 enum DashboardSection: String, CaseIterable, Identifiable, Hashable {
     case overview = "Overview"
     case limits = "Limits"
+    case status = "Status"
     case costs = "Costs"
     case optimize = "Optimize"
     case diagnostics = "Diagnostics"
@@ -69,6 +70,8 @@ enum DashboardSection: String, CaseIterable, Identifiable, Hashable {
             return "gauge.with.dots.needle.bottom.50percent"
         case .limits:
             return "chart.bar.fill"
+        case .status:
+            return "waveform.path.ecg"
         case .costs:
             return "dollarsign.circle.fill"
         case .optimize:
@@ -88,6 +91,8 @@ enum DashboardSection: String, CaseIterable, Identifiable, Hashable {
             return "Current health and local token history"
         case .limits:
             return "Every tracked quota window"
+        case .status:
+            return "Provider service health"
         case .costs:
             return "Local 30-day token spend"
         case .optimize:
@@ -126,6 +131,7 @@ struct UsageDashboardView: View {
     @StateObject private var codexCliService = CodexCliLocalService.shared
     @StateObject private var cursorService = CursorLocalService.shared
     @StateObject private var apiUsageStore = ApiUsageStore.shared
+    @StateObject private var providerStatusMonitor = ProviderStatusMonitor.shared
     @StateObject private var navigation = DashboardNavigationStore.shared
 
     @State private var readinessReports: [ProviderReadiness] = []
@@ -219,6 +225,8 @@ struct UsageDashboardView: View {
                     overviewContent
                 case .limits:
                     limitsContent
+                case .status:
+                    statusPagesContent
                 case .costs:
                     costsContent
                 case .optimize:
@@ -340,6 +348,60 @@ struct UsageDashboardView: View {
                 await apiUsageStore.refresh()
             }
         }
+    }
+
+    private var statusPagesContent: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            DashboardCard(title: "Provider Status Pages", trailing: statusPagesSummary) {
+                HStack(alignment: .center, spacing: 10) {
+                    Text("Live status from each provider's public status page.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+
+                    Spacer()
+
+                    Button {
+                        Task { await providerStatusMonitor.refreshAll() }
+                    } label: {
+                        Label("Refresh Status", systemImage: "arrow.clockwise")
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(providerStatusMonitor.isRefreshing)
+                }
+            }
+
+            ForEach(ServiceType.allCases) { service in
+                ProviderStatusDashboardCard(
+                    service: service,
+                    report: providerStatusMonitor.reports[service],
+                    error: providerStatusMonitor.errors[service],
+                    openStatusPage: openStatusPage
+                )
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .task {
+            await providerStatusMonitor.refreshAllIfNeeded()
+        }
+    }
+
+    private var statusPagesSummary: String? {
+        if providerStatusMonitor.isRefreshing {
+            return "Refreshing..."
+        }
+
+        let issueCount = providerStatusMonitor.reports.values.filter(\.hasIssue).count
+        if issueCount == 0, providerStatusMonitor.reports.count == ServiceType.allCases.count {
+            return "All operational"
+        }
+        if issueCount == 1 {
+            return "1 issue"
+        }
+        if issueCount > 1 {
+            return "\(issueCount) issues"
+        }
+        return nil
     }
 
     private var costTrendCard: some View {
@@ -674,13 +736,17 @@ struct UsageDashboardView: View {
             return costTracker.isRefreshInProgress || apiUsageStore.isLoading
         case .share, .optimize:
             return costTracker.isRefreshInProgress
+        case .status:
+            return providerStatusMonitor.isRefreshing
         case .overview, .limits, .diagnostics, .settings:
             return dataManager.isLoading
         }
     }
 
     private func refreshDashboard() async {
-        if activeSection == .costs || activeSection == .share || activeSection == .optimize {
+        if activeSection == .status {
+            await providerStatusMonitor.refreshAll()
+        } else if activeSection == .costs || activeSection == .share || activeSection == .optimize {
             await costTracker.scanCosts(days: 30)
             if activeSection == .costs, apiUsageStore.hasAnyAuthenticated, !apiUsageStore.isLoading {
                 await apiUsageStore.refresh()
@@ -689,6 +755,11 @@ struct UsageDashboardView: View {
         } else {
             await dataManager.refreshAll()
         }
+    }
+
+    private func openStatusPage(for service: ServiceType) {
+        guard let url = service.statusPageURL else { return }
+        NSWorkspace.shared.open(url)
     }
 
     private func refreshCostsIfMissingDays() async {

--- a/MeterBarTests/ProviderStatusMonitorTests.swift
+++ b/MeterBarTests/ProviderStatusMonitorTests.swift
@@ -1,0 +1,79 @@
+import MeterBarShared
+@testable import MeterBar
+import XCTest
+
+final class ProviderStatusMonitorTests: XCTestCase {
+    func testParsesStatuspageSummary() throws {
+        let json = """
+        {
+          "page": {
+            "name": "OpenAI",
+            "updated_at": "2026-07-09T14:48:49.467Z"
+          },
+          "status": {
+            "indicator": "minor",
+            "description": "Partial System Degradation"
+          }
+        }
+        """
+
+        let parsed = try ProviderStatusFeedParser.parseStatuspageStatus(data: Data(json.utf8))
+
+        XCTAssertEqual(parsed.pageName, "OpenAI")
+        XCTAssertEqual(parsed.summary.indicator, .minor)
+        XCTAssertEqual(parsed.summary.description, "Partial System Degradation")
+        XCTAssertNotNil(parsed.summary.updatedAt)
+    }
+
+    func testParsesStatuspageComponentsAndGroupsChildren() throws {
+        let json = """
+        {
+          "components": [
+            {
+              "id": "group-api",
+              "name": "APIs",
+              "status": "degraded_performance",
+              "group": true,
+              "position": 1
+            },
+            {
+              "id": "chat",
+              "name": "ChatGPT",
+              "status": "operational",
+              "group": false,
+              "position": 2
+            },
+            {
+              "id": "responses",
+              "name": "Responses API",
+              "status": "partial_outage",
+              "group": false,
+              "group_id": "group-api",
+              "position": 3
+            }
+          ]
+        }
+        """
+
+        let components = try ProviderStatusFeedParser.parseStatuspageComponents(data: Data(json.utf8))
+
+        XCTAssertEqual(components.count, 2)
+        XCTAssertEqual(components[0].name, "APIs")
+        XCTAssertTrue(components[0].isGroup)
+        XCTAssertEqual(components[0].indicator, .minor)
+        XCTAssertEqual(components[0].children.map(\.name), ["Responses API"])
+        XCTAssertEqual(components[0].children.first?.indicator, .major)
+        XCTAssertEqual(components[1].name, "ChatGPT")
+        XCTAssertEqual(components[1].statusLabel, "Operational")
+    }
+
+    func testServiceTypeStatusPageURLs() throws {
+        XCTAssertEqual(ServiceType.claudeCode.statusPageDisplayName, "Claude")
+        XCTAssertEqual(ServiceType.codexCli.statusPageDisplayName, "OpenAI")
+        XCTAssertEqual(ServiceType.cursor.statusPageDisplayName, "Cursor")
+
+        XCTAssertEqual(try XCTUnwrap(ServiceType.claudeCode.statusPageURL).absoluteString, "https://status.claude.com/")
+        XCTAssertEqual(try XCTUnwrap(ServiceType.codexCli.statusPageURL).absoluteString, "https://status.openai.com/")
+        XCTAssertEqual(try XCTUnwrap(ServiceType.cursor.statusPageURL).absoluteString, "https://status.cursor.com/")
+    }
+}

--- a/MeterBarTests/ProviderStatusMonitorTests.swift
+++ b/MeterBarTests/ProviderStatusMonitorTests.swift
@@ -1,8 +1,44 @@
+import Foundation
 import MeterBarShared
 @testable import MeterBar
 import XCTest
 
 final class ProviderStatusMonitorTests: XCTestCase {
+    private final class StubURLProtocol: URLProtocol {
+        static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+        override class func canInit(with request: URLRequest) -> Bool {
+            true
+        }
+
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+            request
+        }
+
+        override func startLoading() {
+            guard let handler = Self.handler else {
+                client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+                return
+            }
+
+            do {
+                let (response, data) = try handler(request)
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(self, didLoad: data)
+                client?.urlProtocolDidFinishLoading(self)
+            } catch {
+                client?.urlProtocol(self, didFailWithError: error)
+            }
+        }
+
+        override func stopLoading() {}
+    }
+
+    override func tearDown() {
+        StubURLProtocol.handler = nil
+        super.tearDown()
+    }
+
     func testParsesStatuspageSummary() throws {
         let json = """
         {
@@ -75,5 +111,43 @@ final class ProviderStatusMonitorTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(ServiceType.claudeCode.statusPageURL).absoluteString, "https://status.claude.com/")
         XCTAssertEqual(try XCTUnwrap(ServiceType.codexCli.statusPageURL).absoluteString, "https://status.openai.com/")
         XCTAssertEqual(try XCTUnwrap(ServiceType.cursor.statusPageURL).absoluteString, "https://status.cursor.com/")
+    }
+
+    @MainActor
+    func testRefreshFailureClearsPreviouslySuccessfulReport() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        let monitor = ProviderStatusMonitor(
+            client: ProviderStatusClient(session: URLSession(configuration: configuration))
+        )
+
+        StubURLProtocol.handler = { request in
+            let url = try XCTUnwrap(request.url)
+            let response = try XCTUnwrap(
+                HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+            )
+            let data: Data
+            if request.url?.lastPathComponent == "status.json" {
+                data = Data(
+                    #"{"page":{"name":"Claude"},"status":{"indicator":"none","description":"Operational"}}"#
+                        .utf8
+                )
+            } else {
+                data = Data(#"{"components":[]}"#.utf8)
+            }
+            return (response, data)
+        }
+
+        await monitor.refreshAll(services: [.claudeCode])
+        XCTAssertNotNil(monitor.reports[.claudeCode])
+        XCTAssertNil(monitor.errors[.claudeCode])
+
+        StubURLProtocol.handler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        await monitor.refreshAll(services: [.claudeCode])
+        XCTAssertNil(monitor.reports[.claudeCode])
+        XCTAssertNotNil(monitor.errors[.claudeCode])
     }
 }


### PR DESCRIPTION
## Summary
- Add a shared status-page monitor for Claude, OpenAI/Codex, and Cursor public status feeds
- Add a full companion dashboard Status section plus compact popover entry
- Add right-click native Status Pages submenus with component rows, refresh, and open-page actions
- Add fixture parser tests for status summaries, components, groups, and provider URL mapping

## Verification
- git diff --check
- swiftc -typecheck MeterBar/Services/ProviderStatusMonitor.swift
MeterBar/Services/CostTracker.swift
MeterBar/Services/DockVisibilityStore.swift
MeterBar/Services/NotificationPreferencesStore.swift
MeterBar/Services/UsageDataManager.swift
MeterBar/Services/ApiUsageService.swift
MeterBar/Services/ServiceError.swift
MeterBar/Services/ProviderReadinessInspector.swift
MeterBar/Services/SharedDataStore.swift
MeterBar/Services/ApiUsageStore.swift
MeterBar/Services/AppLog.swift
MeterBar/Services/ProviderVisibilityStore.swift
MeterBar/Services/CLIBinaryLocator.swift
MeterBar/Services/ClaudeCodeCLIUsageService.swift
MeterBar/Services/ClaudeCodeReconnectService.swift
MeterBar/Services/LaunchAtLoginService.swift
MeterBar/Services/AuthenticationManager.swift
MeterBar/Services/KeychainManager.swift
MeterBar/Services/NotificationDecider.swift
MeterBar/Services/ServiceSupport.swift
MeterBar/Services/CursorLocalService.swift
MeterBar/Services/LaunchAtLoginStore.swift
MeterBar/Services/AccountActivityInspector.swift
MeterBar/Services/ClaudeCodeLocalService.swift
MeterBar/Services/CodexCliLocalService.swift
MeterBar/Views/ProviderSnapshot.swift
MeterBar/Views/MeterBarTheme.swift
MeterBar/Views/ApiUsageCard.swift
MeterBar/Views/MenuBarDetailPanel.swift
MeterBar/Views/DashboardCostCards.swift
MeterBar/Views/Components/ProviderComponents.swift
MeterBar/Views/Components/ReadinessComponents.swift
MeterBar/Views/Components/ResetCountdowns.swift
MeterBar/Views/Components/ProviderStatusBadges.swift
MeterBar/Views/ProviderStatusViews.swift
MeterBar/Views/SocialShareCard.swift
MeterBar/Views/DashboardCard.swift
MeterBar/Views/MenuBarView.swift
MeterBar/Views/OptimizeInsightsView.swift
MeterBar/Views/DailyUsageChart.swift
MeterBar/Views/SettingsView.swift
MeterBar/Views/DashboardProviderCards.swift
MeterBar/Views/UsageDashboardView.swift
MeterBar/Views/RefreshingIcon.swift
MeterBar/Models/FlexibleISO8601.swift
MeterBar/Models/ApiUsage.swift
MeterBar/Models/StatusItemLimitSelector.swift
MeterBar/Models/RefreshInterval.swift
MeterBar/Models/StorageKeys.swift
MeterBar/Models/TokenCost.swift
MeterBar/Models/CostSummaryStore.swift
MeterBar/Models/UsageFormatting.swift
MeterBar/Models/ClaudeCodeAccount.swift
MeterBar/Models/NotificationThreshold.swift
MeterBar/Models/SocialShareCardContent.swift
MeterBar/Models/OptimizationInsights.swift
MeterBar/App/MeterBarMenuPanelController.swift
MeterBar/App/MeterBarApp.swift -I .build/arm64-apple-macosx/debug/Modules -target arm64-apple-macosx26.0 -sdk /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -swift-version 5 -default-isolation MainActor
- swift test --filter ProviderStatusMonitorTests could not run locally because xcode-select points to /Library/Developer/CommandLineTools and SwiftPM cannot import XCTest; PR CI should run the full Xcode-backed suite