### PR TITLE
fix(doctor): harden readiness diagnostics

### DIFF
--- a/.agents/SESSIONS/2026-07-09.md
+++ b/.agents/SESSIONS/2026-07-09.md
@@ -1,0 +1,26 @@
+## Session 1: Doctor Readiness Edge Cases
+
+**Duration:** ~35 minutes
+**Status:** Complete
+
+**What was done:**
+- Implemented GitHub issue #84.
+- Guarded dashboard diagnostics so concurrent startup/button runs collapse to one active inspection.
+- Updated the diagnostics summary to include ready, warning, and attention provider counts.
+- Made `meterbar doctor --json` throw visible CLI errors on JSON encode or UTF-8 conversion failure.
+- Hardened Claude readiness so readable credentials with missing or blank access tokens fail auth unless a recent usage fetch has already proven the CLI session works.
+- Added regression tests for missing/blank Claude access tokens and warning-count summaries.
+
+**Files changed:**
+- `Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift` - Added readiness summary counts and Claude token validation.
+- `MeterBar/Views/UsageDashboardView.swift` - Uses shared summary text and guards diagnostics execution.
+- `MeterBarCLI/Sources/MeterBarCLI.swift` - Throws on doctor JSON render failures.
+- `MeterBarTests/ProviderReadinessTests.swift` - Added focused regression tests.
+
+**Verification:**
+- `git diff --check`
+- `swift test --filter ProviderReadinessTests` could not run on this machine because the active toolchain cannot import `XCTest` (`no such module 'XCTest'`), matching the repo note that full Xcode is required.
+- `cd MeterBarCLI && swift build`
+
+**Next steps:**
+- [ ] Let GitHub Actions run the XCTest suite on the PR branch.

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -621,21 +621,22 @@ struct UsageDashboardView: View {
 
     private var diagnosticsSummary: String? {
         guard !readinessReports.isEmpty else { return nil }
-        let ready = readinessReports.filter(\.isHealthy).count
-        let attention = readinessReports.filter { $0.overall == .fail }.count
-        return "\(ready) ready · \(attention) need attention"
+        return ProviderReadinessSummary(reports: readinessReports).displayText
     }
 
     /// Runs the readiness inspector off the main actor (it does keychain / file /
     /// SQLite I/O) and publishes the reports back on the main actor.
+    @MainActor
     private func runDiagnostics() async {
+        guard !isRunningDiagnostics else { return }
         isRunningDiagnostics = true
+        defer { isRunningDiagnostics = false }
+
         let errors = currentRefreshErrors()
         let reports = await Task.detached(priority: .userInitiated) {
             ProviderReadinessInspector.reports(refreshErrors: errors)
         }.value
         readinessReports = reports
-        isRunningDiagnostics = false
     }
 
     /// Each provider's live last-refresh error, fed into the readiness core so the

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -317,7 +317,7 @@ struct Doctor: ParsableCommand {
         let reports = filtered(ProviderReadinessInspector.reports())
 
         if json {
-            printJSON(reports)
+            try printJSON(reports)
         } else {
             printText(reports)
         }
@@ -332,14 +332,22 @@ struct Doctor: ParsableCommand {
         }
     }
 
-    private func printJSON(_ reports: [ProviderReadiness]) {
+    private func printJSON(_ reports: [ProviderReadiness]) throws {
         let dtos = reports.map(DoctorReportDTO.init)
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        if let data = try? encoder.encode(dtos),
-           let str = String(data: data, encoding: .utf8) {
-            print(str)
+        let data: Data
+        do {
+            data = try encoder.encode(dtos)
+        } catch {
+            throw ValidationError("Failed to encode doctor JSON: \(error.localizedDescription)")
         }
+
+        guard let str = String(data: data, encoding: .utf8) else {
+            throw ValidationError("Failed to encode doctor JSON as UTF-8.")
+        }
+
+        print(str)
     }
 
     private func printText(_ reports: [ProviderReadiness]) {

--- a/MeterBarTests/ProviderReadinessTests.swift
+++ b/MeterBarTests/ProviderReadinessTests.swift
@@ -113,6 +113,37 @@ final class ProviderReadinessTests: XCTestCase {
         assertNoSecretLeak(report)
     }
 
+    func testClaudeMissingAccessTokenFailsAuth() {
+        let credentials = """
+        {"claudeAiOauth":{"refreshToken":"refresh","expiresAt":2000000,\
+        "scopes":["user:inference"],"subscriptionType":"max","rateLimitTier":"default"}}
+        """
+        let input = ClaudeReadinessInput(
+            isCLIInstalled: true,
+            credentialsJSON: Data(credentials.utf8),
+            now: now
+        )
+        let report = ProviderReadinessEvaluator.claudeCode(input)
+
+        XCTAssertEqual(report.check("auth")?.level, .fail)
+        XCTAssertTrue((report.check("auth")?.detail ?? "").contains("usable access token"))
+        XCTAssertTrue((report.check("auth")?.recovery ?? "").contains("claude login"))
+        XCTAssertEqual(report.overall, .fail)
+    }
+
+    func testClaudeBlankAccessTokenFailsAuth() {
+        let input = ClaudeReadinessInput(
+            isCLIInstalled: true,
+            credentialsJSON: claudeCredentials(accessToken: "   ", expiresAtUnix: 2_000_000),
+            now: now
+        )
+        let report = ProviderReadinessEvaluator.claudeCode(input)
+
+        XCTAssertEqual(report.check("auth")?.level, .fail)
+        XCTAssertTrue((report.check("auth")?.detail ?? "").contains("usable access token"))
+        XCTAssertEqual(report.overall, .fail)
+    }
+
     // MARK: - Codex CLI
 
     func testCodexHealthy() {
@@ -268,6 +299,28 @@ final class ProviderReadinessTests: XCTestCase {
         let data = try JSONEncoder().encode(report)
         let decoded = try JSONDecoder().decode(ProviderReadiness.self, from: data)
         XCTAssertEqual(decoded, report)
+    }
+
+    func testSummaryCountsWarningsSeparatelyFromAttention() {
+        let ready = ProviderReadiness(
+            provider: .claudeCode,
+            checks: [ReadinessCheck(id: "ready", title: "Ready", level: .pass, detail: "Ready.")]
+        )
+        let warning = ProviderReadiness(
+            provider: .codexCli,
+            checks: [ReadinessCheck(id: "warning", title: "Warning", level: .warn, detail: "Warning.")]
+        )
+        let attention = ProviderReadiness(
+            provider: .cursor,
+            checks: [ReadinessCheck(id: "attention", title: "Attention", level: .fail, detail: "Attention.")]
+        )
+
+        let summary = ProviderReadinessSummary(reports: [ready, warning, attention])
+
+        XCTAssertEqual(summary.ready, 1)
+        XCTAssertEqual(summary.warning, 1)
+        XCTAssertEqual(summary.attention, 1)
+        XCTAssertEqual(summary.displayText, "1 ready · 1 warning · 1 needs attention")
     }
 
     // MARK: - Fixtures

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
@@ -84,6 +84,24 @@ public struct ProviderReadiness: Codable, Sendable, Equatable, Identifiable {
     }
 }
 
+/// Rolled-up provider counts shared by dashboard diagnostics and tests.
+public struct ProviderReadinessSummary: Sendable, Equatable {
+    public let ready: Int
+    public let warning: Int
+    public let attention: Int
+
+    public init(reports: [ProviderReadiness]) {
+        ready = reports.filter { $0.overall == .pass }.count
+        warning = reports.filter { $0.overall == .warn }.count
+        attention = reports.filter { $0.overall == .fail }.count
+    }
+
+    public var displayText: String {
+        "\(ready) ready · \(warning) \(warning == 1 ? "warning" : "warnings") · " +
+            "\(attention) \(attention == 1 ? "needs attention" : "need attention")"
+    }
+}
+
 // MARK: - Inputs
 
 /// Outcome of probing Cursor's local SQLite state database. Modeled as an enum
@@ -240,6 +258,18 @@ public enum ProviderReadinessEvaluator {
 
         if let data = input.credentialsJSON,
            let credentials = try? JSONDecoder().decode(ClaudeCredentialsFixture.self, from: data) {
+            guard let accessToken = credentials.claudeAiOauth.accessToken?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+                !accessToken.isEmpty else {
+                return ReadinessCheck(
+                    id: ReadinessCheckID.auth,
+                    title: "Signed in",
+                    level: .fail,
+                    detail: "Claude Code credentials do not contain a usable access token.",
+                    recovery: loginRecovery
+                )
+            }
+
             if let expiresAt = credentials.claudeAiOauth.expiresAt,
                OAuthTokenExpiry.isExpired(unixTimestamp: expiresAt, now: input.now) {
                 return ReadinessCheck(


### PR DESCRIPTION
## Summary
- guard dashboard diagnostics so only one readiness run executes at a time
- include ready, warning, and attention counts in the UI diagnostics summary
- make `meterbar doctor --json` fail visibly on encode/UTF-8 errors
- reject readable Claude credentials with missing or blank access tokens while preserving recent usage-fetch proof

Closes #84

## Verification
- `git diff --check`
- `cd MeterBarCLI && swift build`
- `swift test --filter ProviderReadinessTests` blocked locally: active toolchain cannot import `XCTest` (`no such module XCTest`), matching repo notes that full Xcode is required. PR CI should run the suite.