### PR TITLE
Fix provider status Xcode build

### DIFF
--- a/.agents/SESSIONS/2026-07-09.md
+++ b/.agents/SESSIONS/2026-07-09.md
@@ -85,17 +85,20 @@
 - Replaced remaining current-facing `meterbarapp`/`meterbar.app` site references with `meterbar.dev` while retaining the live GitHub repository slug, `MeterBar.app` bundle name, Swift symbols, and historical session records.
 - Reviewed the nine commits from 2026-06-25 through the v1.6.1 release, including the published release artifact, and recorded correctness, privacy, workflow, notification, and release findings for follow-up.
 - Rebased the Settings alignment work over all preceding merges and retained its lint and coverage regression fixes.
+- Fixed the missing direct `Combine` import exposed by the post-merge app/widget build for `ProviderStatusMonitor`.
 
 **Files changed:**
 - `.agents/SYSTEM/` and `.agents/docs/` - Corrected current repository, app-group, Keychain, setup, and website references.
 - `README.md` and social-share files - Point public product traffic to `https://meterbar.dev`.
 - `.swiftformat`, `scripts/bun.lock`, and `docs/audits/` - Removed stale current-facing product labels while preserving historical context.
 - `MeterBar/Services/ProviderStatusMonitor.swift` and tests - Prevent stale operational state after a failed status refresh.
+- `MeterBar/Services/ProviderStatusMonitor.swift` - Import `Combine` directly for its `ObservableObject` and `@Published` declarations.
 - `MeterBar/Views/SettingsView.swift` and smoke tests - Restore lint and coverage gates for the Settings redesign.
 
 **Verification:**
 - GitHub Actions build, test/coverage, SwiftLint, Secret Scan, and CodeRabbit checks passed for each integrated PR head.
 - Full local suite - 323 tests passed, 1 skipped; 34.3% coverage against the 19% gate.
 - Focused status, readiness, social-share, shared-cache, and Settings smoke tests passed.
+- Full Debug app/widget `xcodebuild` passed after the direct-import fix.
 - `swiftlint lint --strict` - 0 violations.
 - `git diff --check` and `bun install --frozen-lockfile` passed for the domain sweep.

--- a/MeterBar/Services/ProviderStatusMonitor.swift
+++ b/MeterBar/Services/ProviderStatusMonitor.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import MeterBarShared
 


### PR DESCRIPTION
## Summary

- Import `Combine` directly where `ProviderStatusMonitor` declares `ObservableObject` and `@Published` state.
- Restore the Xcode app/widget build that the SwiftPM-only pull-request build did not exercise.
- Record the post-merge verification in the session log.

## Verification

- Full Debug app/widget `xcodebuild` — passed.
- `swift test --filter ProviderStatusMonitorTests` — 4 tests passed.
- `swiftlint lint --strict` — 0 violations.
- `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a build issue that affected the app and widget after merging.
  * Restored missing support needed for real-time status updates, allowing the project to compile successfully again.
  * Verified the full Debug app/widget build passes after the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->