### PR TITLE
Fix 14-day review findings: API hardening, runtime state, verified universal release

### DIFF
--- a/.agents/SESSIONS/2026-07-09.md
+++ b/.agents/SESSIONS/2026-07-09.md
@@ -102,3 +102,37 @@
 - Full Debug app/widget `xcodebuild` passed after the direct-import fix.
 - `swiftlint lint --strict` - 0 violations.
 - `git diff --check` and `bun install --frozen-lockfile` passed for the domain sweep.
+
+## Session 5: 14-Day Review Remediation
+
+**Duration:** ~2 hours
+**Status:** Complete
+
+**What was done:**
+- Updated Anthropic Admin API usage decoding to follow the nested `data[].results[]` response and include uncached, cache-read, and both cache-creation token classes in estimated cost totals.
+- Hardened API refresh behavior with same-window request coalescing, cancellation generation guards, cached fallback, store-owned date selection, and inclusive custom end dates.
+- Removed raw provider response bodies and arbitrary localized errors from user-facing failures and logs; API cost copy now consistently describes estimates and coverage limits.
+- Made readiness checks operate only on enabled providers, avoid unnecessary credential reads, reject API-key-only Codex auth for subscription-quota readiness, and honor `CODEX_HOME` consistently.
+- Corrected threshold notification state so disabled delivery and stale providers cannot cause false recovery alerts, later crossings re-arm, and only true exhaustion claims a reached limit.
+- Kept provider cards expanded for nonblocking secondary quotas and for primary exhaustion covered by enabled extra usage.
+- Moved the universal Release app/widget build into the branch-protection-required CI job and added universal CLI assembly, strict tag/version validation, safe workflow inputs, inside-out ad-hoc signing, architecture checks, codesign checks, and exact entitlement verification.
+- Updated current architecture, setup, implementation, backlog, and README guidance for `meterbar.dev`, `CODEX_HOME`, and the distinction between ad-hoc integrity signing and Developer ID distribution.
+
+**Files changed:**
+- `MeterBar/Services/ApiUsageService.swift`, `ApiUsageStore.swift`, and API views - Correct usage schema, refresh coordination, date selection, privacy, and estimate labeling.
+- `MeterBar/Services/CodexHomeDirectory.swift`, readiness, notification, and provider-card code - Consistent runtime state and quota semantics.
+- `MeterBarTests/` - Regression coverage for API parsing/store behavior, readiness, notifications, paths, and provider-card blocking rules.
+- `.github/workflows/` and `scripts/` - Required universal artifact build plus release validation and signing gates.
+- `README.md`, `.agents/SYSTEM/ARCHITECTURE.md`, and `.agents/docs/` - Current operational and release documentation.
+
+**Verification:**
+- Deterministic full suite: 346 tests passed with credential-dependent `APIIntegrationTests` skipped.
+- Coverage suite: 346 tests passed; 34.7% coverage against the 19% gate.
+- Universal Release app and widget build passed for `x86_64 arm64`.
+- Universal CLI build passed for `x86_64 arm64`; standalone CLI Debug build passed.
+- App, widget, and CLI version agreement passed for `1.6.1`.
+- Individual and deep strict codesign checks passed; signed app/widget entitlements exactly matched their source entitlement files.
+- `swiftlint lint --strict`, `actionlint`, `shellcheck`, release-tag attack cases, and `git diff --check` passed.
+
+**External release prerequisite:**
+- Ad-hoc signing now proves artifact integrity, but public Gatekeeper distribution, notarization, and reliable app-group authorization still require a Developer ID certificate, authorized provisioning profiles, and notarization credentials.

--- a/.agents/SESSIONS/2026-07-10.md
+++ b/.agents/SESSIONS/2026-07-10.md
@@ -1,0 +1,35 @@
+# 2026-07-10
+
+## Session 1: Review Remediation and Release Gate Completion
+
+**Duration:** ~2 hours
+**Status:** Complete
+
+**What was done:**
+- Resumed PR #93 after a quota pause and rechecked master, open pull requests, CI, branch protection, and all review threads before changing anything.
+- Restored v1.0-v1.6 admin keys by migrating the shipped `com.agenticindiedev.quotaguard` Keychain service into `dev.shipshit.meterbar`; current values win, failed migrations preserve the legacy value, successful writes clean it up, and removals delete both services. A partial deletion now re-reads and republishes any surviving credential instead of falsely showing it as removed.
+- Replaced the API usage store's unscoped fallback with normalized per-window, per-credential cache buckets so a failed 30-day/custom refresh cannot display 7-day or previous-organization data.
+- Made quota notifications name Session, Weekly, Sonnet, or Code Review and reserve provider-blocking copy for genuinely blocking exhaustion; secondary quotas and extra-usage-covered limits no longer claim the provider is unavailable.
+- Finished `CODEX_HOME` support in Settings with a resolver-backed display path and added direct `~`, absolute, and custom-home coverage.
+- Scoped CI/E2E workflow tokens to read-only, made the protected `build` context conclusively depend on passing tests and lint, and expanded branch protection to require build, coverage, lint, and secret scan directly.
+- Addressed CodeRabbit's valid path-test and CLI-filter feedback and corrected current macOS 26 / Xcode 26 / Swift 6.2 documentation.
+- Merged `VincentShipsIt/homebrew-tap` PR #4 so the live cask points to `meterbar.dev`, requires macOS Tahoe, describes the unnotarized ad-hoc signature accurately, and removes the canonical lowercase app-group path during zap.
+
+**Files changed:**
+- `MeterBar/Services/KeychainManager.swift` and tests - Upgrade-safe dual-service Keychain migration and deletion.
+- `MeterBar/Services/ApiUsageStore.swift` and tests - Window- and credential-isolated refresh caching.
+- `MeterBar/Services/NotificationDecider.swift` and tests - Quota-specific, blocking-aware notification copy.
+- `MeterBar/Services/CodexHomeDirectory.swift`, `MeterBar/Views/SettingsView.swift`, CLI, and path tests - Complete `CODEX_HOME` behavior and remove redundant filtering.
+- `.github/workflows/ci.yml`, `.github/workflows/e2e.yml`, and current docs - Least privilege, conclusive protected gates, and accurate prerequisites.
+
+**Verification:**
+- Deterministic/coverage suite: 362 tests passed with credential-dependent `APIIntegrationTests` skipped.
+- Line coverage: 35.4% against the 19% gate.
+- Universal Release app, widget, and CLI passed for `x86_64 arm64`; standalone CLI build passed.
+- App, widget, and CLI version agreement passed for `1.6.1`.
+- Individual and deep strict codesign checks passed; signed app/widget entitlements exactly matched source.
+- `swiftlint lint --strict`, `actionlint`, `shellcheck`, release-tag attack cases, and `git diff --check` passed.
+- Homebrew cask: Ruby syntax and `brew style` passed; the merged v1.6.1 URL and SHA remained unchanged.
+
+**External release prerequisite:**
+- Developer ID signing, authorized provisioning, and notarization still require credentials not present in this repository. Ad-hoc signing verifies nested artifact integrity but cannot provide Gatekeeper trust or guaranteed app-group authorization.

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture - MeterBar
 
 **Purpose:** Document what IS implemented (not what WILL BE).
-**Last Updated:** 2026-07-02 (rewritten from a full-repo audit; see `docs/audits/00-repo-map.md`)
+**Last Updated:** 2026-07-09 (rewritten from a full-repo audit; see `docs/audits/00-repo-map.md`)
 
 ---
 
@@ -14,12 +14,12 @@ Providers tracked:
 | Provider | `ServiceType` case | Data source |
 |---|---|---|
 | Claude Code | `.claudeCode` | Shells out to `claude /usage`, regex-parses terminal output. Legacy OAuth fallback (keychain item `Claude Code-credentials`) behind the `ClaudeCodeEnableOAuthFallback` UserDefaults flag |
-| OpenAI Codex CLI | `.codexCli` | Reads `~/.codex/auth.json`, calls `https://chatgpt.com/backend-api/wham/usage` |
+| OpenAI Codex CLI | `.codexCli` | Reads `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`), calls `https://chatgpt.com/backend-api/wham/usage` |
 | Cursor | `.cursor` | Reads session JWT from Cursor's `state.vscdb` SQLite, calls `https://cursor.com/api/usage-summary` |
 | Claude (admin) | `.claude` | Anthropic Admin API key (user-provided, stored in our keychain), `/v1/organizations/usage_report/messages` |
 | OpenAI (admin) | `.openai` | OpenAI Admin API key (user-provided, stored in our keychain), `/v1/organization/usage/completions` |
 
-Plus local **cost estimation**: `CostTracker` scans `~/.claude*/projects/**/*.jsonl` and Codex's `~/.codex/archived_sessions` + `~/.codex/logs_2.sqlite`, priced from a hardcoded per-model table.
+Plus local **cost estimation**: `CostTracker` scans `~/.claude*/projects/**/*.jsonl` and Codex's `$CODEX_HOME/archived_sessions` + `$CODEX_HOME/logs_2.sqlite` (`CODEX_HOME` defaults to `~/.codex`), priced from a hardcoded per-model table.
 
 ---
 
@@ -73,7 +73,7 @@ meterbar/
 - **SharedDataStore** — app-group JSON file (`cached_usage_metrics.json`), atomic writes on a serial queue, `WidgetCenter.reloadTimelines` after save.
 - **ProviderVisibilityStore / DockVisibilityStore / ClaudeCodeAccountStore** — UserDefaults-backed preference stores.
 - **OAuthTokenExpiry** — JWT/unix-timestamp expiry checks (60 s grace; unparseable ⇒ not-expired by design).
-- **ServiceSupport** — shared URLSession config, URLError copy, real (non-container) home dir via `getpwuid`.
+- **ServiceSupport** — shared URLSession config, secret-safe HTTP/URLError mapping, real (non-container) home dir via `getpwuid`.
 - **AppLog** — `os.Logger` categories: app, usage, cost, network, storage. This is the only observability; there is no crash reporting or analytics.
 
 ## App lifecycle
@@ -82,7 +82,7 @@ meterbar/
 
 ## Widget & CLI data contract
 
-The widget and CLI **duplicate** the model structs (`ServiceType`, `UsageLimit`, `UsageMetrics`) and decode the same app-group JSON. Because `JSONDecoder` ignores unknown keys, drift is silent — the widget already drops `extraUsage`/`resetCreditsAvailable`. The JSON contract is locked by tests in `MeterBarTests/CachedMetricsContractTests.swift`; extraction of a shared `MeterBarShared` package is deferred (needs Xcode project changes — see `.agents/docs/DEFERRED_WORK.md` §1).
+The app, widget, and CLI consume the canonical `ServiceType`, `UsageLimit`, and `UsageMetrics` definitions from `Packages/MeterBarShared`. The app-group JSON contract is locked by `CachedMetricsContractTests` and `CachedMetricsReplicaContractTests` so fields and date encoding cannot silently drift across targets.
 
 Dates in the shared JSON use `JSONEncoder`/`JSONDecoder` **default** strategies (seconds since 2001-01-01 reference date). Changing either side's date strategy breaks widget + CLI decode.
 
@@ -90,10 +90,10 @@ Dates in the shared JSON use `JSONEncoder`/`JSONDecoder` **default** strategies 
 
 ## CI / release
 
-- `ci.yml` (push/PR to master, macos-26 + Xcode 26.2): xcodebuild Debug build (app + widget), `swift test` via SwiftPM (real gate), coverage threshold via `scripts/check-coverage.sh`, SwiftLint.
-- `release.yml` (tag `v*`): Release build (unsigned — no Developer ID/notarization yet), builds CLI and embeds it in `Contents/Helpers/`, verifies CLI `--version` matches `CFBundleShortVersionString`, zips via `ditto`, publishes GitHub Release, then calls `update-homebrew.yml` to bump `VincentShipsIt/homebrew-tap` (`Casks/meterbar.rb`) using `TAP_GITHUB_TOKEN`.
+- `ci.yml` (push/PR to master, macos-26 + Xcode 26.2): the branch-protection-required `build` job compiles and verifies universal app, widget, and CLI artifacts; SwiftPM tests, coverage, and SwiftLint remain independent gates.
+- `release.yml` (canonical `vMAJOR.MINOR.PATCH` tag): builds universal arm64+x86_64 app/widget/CLI artifacts, checks tag/app/CLI version agreement, signs nested code inside-out with an ad-hoc hardened-runtime signature, verifies source entitlements and bundle integrity, zips via `ditto`, publishes GitHub Release, then calls `update-homebrew.yml`. Developer ID signing, authorized provisioning, and notarization remain pending credentials.
 - `secret-scan.yml`: gitleaks (pinned + checksum-verified) over full history.
 
 ## Known architectural risks
 
-Tracked in `docs/audits/00-repo-map.md` §6. Headlines: reverse-engineered provider interfaces (R1), unsigned distribution (R2), triplicated model structs (R4), hardcoded pricing (R5), three build systems (R6), god view files (R8).
+Tracked in `docs/audits/00-repo-map.md` §6. Headlines: reverse-engineered provider interfaces (R1), non-notarized distribution (R2), hardcoded pricing (R5), three build systems (R6), and god view files (R8). The shared model drift and unverifiable release-artifact findings have since been remediated.

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -69,7 +69,7 @@ meterbar/
 - **CursorLocalService** — SQLite token extraction + usage-summary endpoint; assumed 500-request default quota when API omits totals.
 - **ClaudeService / OpenAIService** — admin-key usage reports (paginated, 50-page cap) via `ServiceSupport.fetchDecoded`.
 - **CostTracker** (1,029 lines) — JSONL/SQLite log scanning, per-model pricing table, per-day/model/origin breakdowns, cache at `~/Library/Application Support/MeterBar/cost-summary-v1.json`.
-- **AuthenticationManager + KeychainManager** — the two admin keys, stored in keychain service `dev.shipshit.meterbar`.
+- **AuthenticationManager + KeychainManager** — the two admin keys, stored in keychain service `dev.shipshit.meterbar`. Reads migrate the shipped v1.0-v1.6 service `com.agenticindiedev.quotaguard` into the current service, and removals delete both so a legacy key cannot reappear.
 - **SharedDataStore** — app-group JSON file (`cached_usage_metrics.json`), atomic writes on a serial queue, `WidgetCenter.reloadTimelines` after save.
 - **ProviderVisibilityStore / DockVisibilityStore / ClaudeCodeAccountStore** — UserDefaults-backed preference stores.
 - **OAuthTokenExpiry** — JWT/unix-timestamp expiry checks (60 s grace; unparseable ⇒ not-expired by design).
@@ -90,7 +90,7 @@ Dates in the shared JSON use `JSONEncoder`/`JSONDecoder` **default** strategies 
 
 ## CI / release
 
-- `ci.yml` (push/PR to master, macos-26 + Xcode 26.2): the branch-protection-required `build` job compiles and verifies universal app, widget, and CLI artifacts; SwiftPM tests, coverage, and SwiftLint remain independent gates.
+- `ci.yml` (push/PR to master, macos-26 + Xcode 26.2): the branch-protection-required `build` job waits for tests/coverage and SwiftLint, fails explicitly unless both pass, then compiles and verifies universal app, widget, and CLI artifacts. Branch protection also requires the test, lint, and secret-scan contexts directly.
 - `release.yml` (canonical `vMAJOR.MINOR.PATCH` tag): builds universal arm64+x86_64 app/widget/CLI artifacts, checks tag/app/CLI version agreement, signs nested code inside-out with an ad-hoc hardened-runtime signature, verifies source entitlements and bundle integrity, zips via `ditto`, publishes GitHub Release, then calls `update-homebrew.yml`. Developer ID signing, authorized provisioning, and notarization remain pending credentials.
 - `secret-scan.yml`: gitleaks (pinned + checksum-verified) over full history.
 

--- a/.agents/SYSTEM/SUMMARY.md
+++ b/.agents/SYSTEM/SUMMARY.md
@@ -104,11 +104,11 @@
 - Cursor doesn't provide usage API (returns error)
 
 **Development:**
-- **Language:** Swift 5.9+
+- **Language:** Swift 5 language mode with the Swift 6.2 toolchain
 - **UI:** SwiftUI
 - **Widget:** WidgetKit
 - **Storage:** Keychain, UserDefaults, App Groups
-- **Build:** Xcode 15.0+
+- **Build:** Xcode 26+
 
 **Next Priorities:**
 1. Research API endpoints

--- a/.agents/docs/CONTRIBUTING.md
+++ b/.agents/docs/CONTRIBUTING.md
@@ -43,16 +43,16 @@ Thank you for your interest in contributing to MeterBar! This document provides 
 
 ### Prerequisites
 
-- macOS 13.0 or later
-- Xcode 15.0 or later
-- Swift 5.9 or later
+- macOS 26 or later
+- Xcode 26 or later
+- Swift 6.2 toolchain (the project compiles in Swift 5 language mode)
 
 ### Building
 
 1. Clone the repository:
    ```bash
    git clone <repo-url>
-   cd apps/ai-usage-tracker
+   cd meterbar.app
    ```
 
 2. Open in Xcode:
@@ -100,4 +100,3 @@ Use clear, descriptive commit messages:
 ## Questions?
 
 Feel free to open an issue for questions or discussions!
-

--- a/.agents/docs/IMPLEMENTATION_STATUS.md
+++ b/.agents/docs/IMPLEMENTATION_STATUS.md
@@ -13,6 +13,7 @@ under those names; see `docs/audits/00-repo-map.md` for the audited current stat
 - ✅ Cursor via local SQLite token + usage-summary endpoint
 - ✅ Anthropic Admin API org usage (optional, user-provided key)
 - ✅ OpenAI Admin API org usage (optional, user-provided key)
+- ✅ Admin-key migration from the v1.0-v1.6 Keychain service into the current migration-stable service
 
 ### App
 - ✅ Menu bar status item showing most-constrained-quota percentage
@@ -25,7 +26,7 @@ under those names; see `docs/audits/00-repo-map.md` for the audited current stat
 - ✅ `meterbar` CLI (usage/cost subcommands) bundled in `Contents/Helpers/`
 
 ### Infra
-- ✅ CI: required universal app/widget/CLI build + `swift test` gate + coverage check + SwiftLint (`.github/workflows/ci.yml`)
+- ✅ CI: required test/coverage, SwiftLint, secret scan, and universal app/widget/CLI gates (`.github/workflows/ci.yml`)
 - ✅ Release: universal ad-hoc-signed zip with architecture/version/entitlement verification + GitHub Release + Homebrew tap bump
 - ✅ Secret scanning (gitleaks, pinned + checksum-verified)
 

--- a/.agents/docs/IMPLEMENTATION_STATUS.md
+++ b/.agents/docs/IMPLEMENTATION_STATUS.md
@@ -1,6 +1,6 @@
 # Implementation Status
 
-**Last Updated:** 2026-07-02 (rewritten — the previous version described the original planning-phase
+**Last Updated:** 2026-07-09 (rewritten — the previous version described the original planning-phase
 design, including `CodexService`/`CursorService` classes and "Codex cookies" that were never shipped
 under those names; see `docs/audits/00-repo-map.md` for the audited current state)
 
@@ -9,7 +9,7 @@ under those names; see `docs/audits/00-repo-map.md` for the audited current stat
 ### Providers
 - ✅ Claude Code via `claude /usage` CLI parsing (multi-account via `CLAUDE_CONFIG_DIR`)
 - ✅ Claude Code legacy OAuth fallback (opt-in `ClaudeCodeEnableOAuthFallback` UserDefaults flag)
-- ✅ OpenAI Codex CLI via `~/.codex/auth.json` + wham/usage endpoint (incl. extra-usage + reset credits)
+- ✅ OpenAI Codex CLI via `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`) + wham/usage endpoint (incl. extra-usage + reset credits)
 - ✅ Cursor via local SQLite token + usage-summary endpoint
 - ✅ Anthropic Admin API org usage (optional, user-provided key)
 - ✅ OpenAI Admin API org usage (optional, user-provided key)
@@ -25,15 +25,14 @@ under those names; see `docs/audits/00-repo-map.md` for the audited current stat
 - ✅ `meterbar` CLI (usage/cost subcommands) bundled in `Contents/Helpers/`
 
 ### Infra
-- ✅ CI: xcodebuild build + `swift test` gate + coverage check + SwiftLint (`.github/workflows/ci.yml`)
-- ✅ Release: unsigned zip + GitHub Release + Homebrew tap bump
+- ✅ CI: required universal app/widget/CLI build + `swift test` gate + coverage check + SwiftLint (`.github/workflows/ci.yml`)
+- ✅ Release: universal ad-hoc-signed zip with architecture/version/entitlement verification + GitHub Release + Homebrew tap bump
 - ✅ Secret scanning (gitleaks, pinned + checksum-verified)
 
 ## ❌ Not implemented / known gaps
 
-- ❌ Code signing + notarization (releases are unsigned; users must clear quarantine)
-- ❌ Shared `MeterBarShared` package — model structs duplicated in widget + CLI (see `DEFERRED_WORK.md` §1)
+- ❌ Developer ID signing, authorized provisioning, and notarization (ad-hoc signatures do not provide Gatekeeper or app-group authorization)
 - ❌ Crash reporting / telemetry of any kind
-- ❌ Tests for `UsageDataManager` orchestration, `CostTracker` scan paths, view layer, CLI package
+- ❌ Credential-backed provider integration and notarized-install/widget verification remain environment-dependent
 - ❌ Mac App Store distribution (the app is deliberately un-sandboxed so it can read other tools'
   credential/log files; MAS would require a different architecture)

--- a/.agents/docs/ISSUE_BACKLOG.md
+++ b/.agents/docs/ISSUE_BACKLOG.md
@@ -90,7 +90,7 @@ These two issues are one feature with three surfaces. Build the core once:
 
 `ProviderReadiness` service (new, in `MeterBar/Services/`, pure/testable):
 per provider (Claude Code, Codex CLI, Cursor) evaluate ordered checks —
-installed (CLI on PATH / app present) → auth present (`claude` login state, `~/.codex/auth.json`
+installed (CLI on PATH / app present) → auth present (`claude` login state, `$CODEX_HOME/auth.json`
 + token expiry via existing `OAuthTokenExpiry`, Cursor DB readable) → data readable →
 last refresh result/error. Output: `pass/warn/fail` + plain-language recovery action
 (`claude login`, `codex login`, open Cursor, rescan). Redact all secret values.

--- a/.agents/docs/SETUP.md
+++ b/.agents/docs/SETUP.md
@@ -29,7 +29,7 @@ Download the latest release from:
 https://meterbar.dev
 ```
 
-The release build is currently unsigned/not notarized. If macOS blocks the first launch, right-click `MeterBar.app` and choose Open, or run:
+The release build is ad-hoc signed for bundle integrity but is not Developer ID-signed or notarized. If macOS blocks the first launch, right-click `MeterBar.app` and choose Open, or run:
 
 ```bash
 xattr -cr /Applications/MeterBar.app
@@ -91,7 +91,7 @@ open MeterBar.xcodeproj
 1. Install Codex CLI: `npm install -g @openai/codex`
 2. Log in: `codex login`
 3. Select your team/workspace when prompted.
-4. MeterBar reads Codex CLI credentials from `~/.codex/auth.json`.
+4. MeterBar reads Codex CLI credentials from `$CODEX_HOME/auth.json` (`~/.codex/auth.json` by default).
 
 ### Cursor
 

--- a/.agents/docs/SETUP.md
+++ b/.agents/docs/SETUP.md
@@ -4,7 +4,7 @@ This guide will help you set up MeterBar on your Mac.
 
 ## Install Prerequisites
 
-- macOS 13.0 (Ventura) or later
+- macOS 26 or later
 
 ## Installing MeterBar
 
@@ -37,8 +37,8 @@ xattr -cr /Applications/MeterBar.app
 
 ## Development Prerequisites
 
-- Xcode 15.0 or later
-- Swift 5.9 or later
+- Xcode 26 or later
+- Swift 6.2 toolchain (the project compiles in Swift 5 language mode)
 
 ### Development Tools (Recommended)
 
@@ -70,7 +70,7 @@ open MeterBar.xcodeproj
 1. Select the `MeterBar` target
 2. Go to Signing & Capabilities
 3. Add your development team
-4. Enable App Sandbox if needed
+4. Keep the main app unsandboxed so it can read local provider state and run the Claude CLI; the widget remains sandboxed
 
 ### 4. Build and Run
 

--- a/.agents/docs/XCODE_SETUP.md
+++ b/.agents/docs/XCODE_SETUP.md
@@ -1,5 +1,10 @@
 # Xcode Project Setup
 
+> **Historical scaffold reference:** The checked-in `MeterBar.xcodeproj` is the
+> source of truth. Do not recreate it from these legacy steps. Current builds
+> require macOS 26, Xcode 26, the Swift 6.2 toolchain in Swift 5 language mode,
+> and the identifiers documented in `.agents/SYSTEM/ARCHITECTURE.md`.
+
 This guide explains how to set up the Xcode project for MeterBar.
 
 ## Creating the Xcode Project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,16 @@ on:
   pull_request:
     branches: [master]
 
-# Pull requests run only the FAST gates below (SwiftPM build + tests + lint,
-# ~1 min total). The heavy `xcodebuild` app+widget build is expensive and only
-# ever breaks on project-file / widget-target changes, so it runs on pushes to
-# master (post-merge) rather than on every PR.
+# The branch-protection-required `build` context includes the full Xcode app and
+# widget build. This keeps entry-point, project wiring, entitlements, and widget
+# regressions from merging behind a SwiftPM-only green check.
 
 jobs:
-  # Required PR gate. Named "build" to satisfy branch protection. Fast: compiles
-  # the SwiftPM library (Models/Services/Views against MeterBarShared) and the
-  # CLI, without building the full .app / widget bundle.
+  # Required PR gate. Keep this job name stable for branch protection.
   build:
     name: build
     runs-on: macos-26
-    timeout-minutes: 15
+    timeout-minutes: 40
 
     steps:
       - name: Checkout
@@ -27,13 +24,44 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Test release tag validation
+        run: scripts/test-release-tag.sh
+
       - name: Build library (SwiftPM)
         run: swift build
 
-      - name: Build CLI
+      - name: Build universal app and widget (Xcode)
         run: |
-          cd MeterBarCLI
-          swift build
+          set -euo pipefail
+          xcodebuild -project MeterBar.xcodeproj \
+            -scheme MeterBar \
+            -configuration Release \
+            -derivedDataPath "$RUNNER_TEMP/MeterBarDerivedData" \
+            -destination 'generic/platform=macOS' \
+            ARCHS="arm64 x86_64" \
+            ONLY_ACTIVE_ARCH=NO \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
+      - name: Build and inject universal CLI
+        run: |
+          set -euo pipefail
+          APP_PATH="$RUNNER_TEMP/MeterBarDerivedData/Build/Products/Release/MeterBar.app"
+          scripts/build-universal-cli.sh \
+            "$APP_PATH/Contents/Helpers/meterbar" \
+            "$RUNNER_TEMP/MeterBarCLIBuild"
+
+      - name: Verify universal nested bundle
+        run: |
+          set -euo pipefail
+          APP_PATH="$RUNNER_TEMP/MeterBarDerivedData/Build/Products/Release/MeterBar.app"
+          APP_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_PATH/Contents/Info.plist")
+          scripts/sign-and-verify-release.sh "$APP_PATH" "$APP_VERSION"
 
   test:
     name: Tests + coverage gate
@@ -89,34 +117,3 @@ jobs:
       - name: Lint
         # --strict: the tree is currently violation-free, so any new warning fails.
         run: /tmp/swiftlint/swiftlint lint --strict
-
-  # Full app + widget build via xcodebuild. Slow (~3 min) and only sensitive to
-  # project-file / widget-target changes, so it runs on pushes to master rather
-  # than on every PR. This is where the .xcodeproj SwiftPM package wiring
-  # (MeterBarShared linked into both the app and the widget target) is exercised.
-  xcode-build:
-    name: Build (app + widget)
-    if: github.event_name == 'push'
-    runs-on: macos-26
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
-
-      - name: Show Xcode version
-        run: xcodebuild -version
-
-      - name: Build
-        run: |
-          xcodebuild -project MeterBar.xcodeproj \
-            -scheme MeterBar \
-            -configuration Debug \
-            -destination 'platform=macOS' \
-            CODE_SIGN_IDENTITY="-" \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO \
-            build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 # The branch-protection-required `build` context includes the full Xcode app and
 # widget build. This keeps entry-point, project wiring, entitlements, and widget
 # regressions from merging behind a SwiftPM-only green check.
@@ -14,10 +17,23 @@ jobs:
   # Required PR gate. Keep this job name stable for branch protection.
   build:
     name: build
+    needs: [test, lint]
+    if: ${{ always() }}
     runs-on: macos-26
     timeout-minutes: 40
 
     steps:
+      - name: Require tests and lint
+        env:
+          TEST_RESULT: ${{ needs.test.result }}
+          LINT_RESULT: ${{ needs.lint.result }}
+        run: |
+          set -euo pipefail
+          if [[ "$TEST_RESULT" != "success" || "$LINT_RESULT" != "success" ]]; then
+            echo "::error::Required prerequisites failed (tests=$TEST_RESULT, lint=$LINT_RESULT)"
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,10 +1,9 @@
 name: E2E (daily)
 
-# The repo's first scheduled workflow. The per-PR `ci.yml` runs the fast SwiftPM
-# gates on every pull request (including the MenuBarSmokeTests / WidgetRenderingTests
-# smoke suite); this runs the FULL suite + coverage AND the slow app+widget
-# xcodebuild once a day, so the e2e/widget path is exercised without paying the
-# macOS-runner cost on every push. Fixtures only — no Claude/OpenAI credentials.
+# The repo's scheduled defense-in-depth workflow. Per-PR `ci.yml` now includes
+# the full universal app/widget build in its required `build` context; this job
+# repeats the full fixture suite, coverage gate, and Xcode build on a daily cadence.
+# Fixtures only — no Claude/OpenAI credentials.
 #
 # 09:17 UTC daily (off the :00 mark on purpose). Also runnable on demand.
 on:
@@ -34,9 +33,7 @@ jobs:
         run: bash scripts/check-coverage.sh
 
       - name: Build app + widget
-        # Daily safety net for the app-extension target, which the per-PR CI skips
-        # (it only builds on pushes to master). Catches widget-target regressions
-        # within a day rather than only post-merge.
+        # Scheduled safety net in addition to the required per-PR Xcode build.
         run: |
           xcodebuild -project MeterBar.xcodeproj \
             -scheme MeterBar \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,9 @@ on:
     - cron: "17 9 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     name: Full suite + coverage + app/widget build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,20 +5,38 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-26
-    timeout-minutes: 45
+    timeout-minutes: 60
     permissions:
       contents: write
     env:
-      # Keep the pushed tag out of inline shell interpolation. A malicious tag
-      # such as v1$(...) must be data, never executable script.
+      APP_PATH: ${{ github.workspace }}/build/Build/Products/Release/MeterBar.app
+      # Context values enter shell code only through environment variables.
       REF_NAME: ${{ github.ref_name }}
+
+    outputs:
+      release_tag: ${{ steps.version.outputs.tag }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Validate release tag
+        id: version
+        run: |
+          set -euo pipefail
+          RELEASE_VERSION=$(scripts/validate-release-tag.sh "$REF_NAME")
+          {
+            echo "tag=$REF_NAME"
+            echo "version=$RELEASE_VERSION"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
@@ -26,71 +44,67 @@ jobs:
       - name: Show Xcode version
         run: xcodebuild -version
 
-      - name: Build app
+      - name: Build universal app and widget
         run: |
+          set -euo pipefail
           xcodebuild -project MeterBar.xcodeproj \
             -scheme MeterBar \
             -configuration Release \
             -derivedDataPath build \
-            -destination 'platform=macOS' \
+            -destination 'generic/platform=macOS' \
+            ARCHS="arm64 x86_64" \
+            ONLY_ACTIVE_ARCH=NO \
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
             build
 
-      - name: Build CLI
-        run: |
-          cd MeterBarCLI
-          swift build -c release
-          mkdir -p ../build/Build/Products/Release/MeterBar.app/Contents/Helpers
-          cp .build/release/meterbar ../build/Build/Products/Release/MeterBar.app/Contents/Helpers/
-
-      - name: Verify bundled CLI version
+      - name: Build and inject universal CLI
         run: |
           set -euo pipefail
-          APP_PATH=$(find build -name "MeterBar.app" -type d | head -1)
-          [[ -n "$APP_PATH" ]] || { echo "::error::MeterBar.app not found under build/"; exit 1; }
-          APP_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_PATH/Contents/Info.plist")
-          CLI_VERSION=$("$APP_PATH/Contents/Helpers/meterbar" --version)
+          scripts/build-universal-cli.sh \
+            "$APP_PATH/Contents/Helpers/meterbar" \
+            "$RUNNER_TEMP/meterbar-cli-build"
 
-          echo "App version: $APP_VERSION"
-          echo "CLI version: $CLI_VERSION"
-
-          test "$CLI_VERSION" = "$APP_VERSION"
+      # Ad-hoc signing restores nested bundle integrity and embeds the source
+      # entitlements. It is not Developer ID signing or notarization, and without
+      # an authorized profile it cannot guarantee app-group container access.
+      - name: Sign and verify universal artifact
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          scripts/sign-and-verify-release.sh "$APP_PATH" "$RELEASE_VERSION"
 
       - name: Create release package
+        id: package
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
         run: |
           set -euo pipefail
-          VERSION="$REF_NAME"
+          ZIP_NAME="MeterBar-${RELEASE_TAG}.zip"
+          ZIP_PATH="$GITHUB_WORKSPACE/$ZIP_NAME"
+          SHA_NAME="${ZIP_NAME}.sha256"
+          SHA_PATH="$GITHUB_WORKSPACE/$SHA_NAME"
 
-          # Find the built app
-          APP_PATH=$(find build -name "MeterBar.app" -type d | head -1)
-          [[ -n "$APP_PATH" ]] || { echo "::error::MeterBar.app not found under build/"; exit 1; }
-          echo "Found app at: $APP_PATH"
+          ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH"
 
-          # Create zip using ditto (preserves attributes better than zip)
-          cd "$(dirname "$APP_PATH")"
-          ditto -c -k --keepParent "MeterBar.app" "MeterBar-${VERSION}.zip"
-
-          # Compute SHA256
-          SHA256=$(shasum -a 256 "MeterBar-${VERSION}.zip" | cut -d ' ' -f 1)
+          SHA256=$(shasum -a 256 "$ZIP_PATH" | cut -d ' ' -f 1)
           echo "SHA256: $SHA256"
-          echo "$SHA256" > "MeterBar-${VERSION}.zip.sha256"
+          echo "$SHA256" > "$SHA_PATH"
 
-          # Move to workspace root
-          mv "MeterBar-${VERSION}.zip" "${{ github.workspace }}/"
-          mv "MeterBar-${VERSION}.zip.sha256" "${{ github.workspace }}/"
-
-          # Set output for later steps
-          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
-        id: package
+          {
+            echo "sha256=$SHA256"
+            echo "zip_name=$ZIP_NAME"
+            echo "sha_name=$SHA_NAME"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: |
-            MeterBar-${{ github.ref_name }}.zip
-            MeterBar-${{ github.ref_name }}.zip.sha256
+            ${{ steps.package.outputs.zip_name }}
+            ${{ steps.package.outputs.sha_name }}
           draft: false
           prerelease: false
           generate_release_notes: true
@@ -98,11 +112,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Output SHA256
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          RELEASE_SHA256: ${{ steps.package.outputs.sha256 }}
         run: |
           {
             echo "### Release Artifacts"
             echo ""
-            echo "**SHA256:** \`$(cat "MeterBar-${REF_NAME}.zip.sha256")\`"
+            echo "**Tag:** \`$RELEASE_TAG\`"
+            echo "**SHA256:** \`$RELEASE_SHA256\`"
+            echo ""
+            echo "Universal arm64+x86_64 and nested ad-hoc signature integrity verified."
+            echo "Developer ID signing, notarization, and authorized app-group access remain pending credentials/provisioning."
           } >> "$GITHUB_STEP_SUMMARY"
 
   # After the release is published, bump the Homebrew cask in VincentShipsIt/homebrew-tap.
@@ -112,5 +133,5 @@ jobs:
     needs: build
     uses: ./.github/workflows/update-homebrew.yml
     with:
-      version: ${{ github.ref_name }}
+      version: ${{ needs.build.outputs.release_tag }}
     secrets: inherit

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -26,24 +26,32 @@ jobs:
       contents: read
 
     steps:
-      - name: Get version
+      - name: Checkout validation tooling
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Validate version
         id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          # `inputs.version` is populated for both workflow_call and workflow_dispatch.
-          VERSION="${{ inputs.version }}"
-          # Remove 'v' prefix for formula version
-          FORMULA_VERSION="${VERSION#v}"
-          echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "formula=$FORMULA_VERSION" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          FORMULA_VERSION=$(scripts/validate-release-tag.sh "$INPUT_VERSION")
+          {
+            echo "tag=$INPUT_VERSION"
+            echo "formula=$FORMULA_VERSION"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Download SHA256
         id: sha
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
         run: |
           set -euo pipefail
-          VERSION="${{ steps.version.outputs.tag }}"
           curl -fsSL \
             --connect-timeout 15 --max-time 120 --retry 3 \
-            "https://github.com/VincentShipsIt/meterbar.app/releases/download/${VERSION}/MeterBar-${VERSION}.zip.sha256" \
+            "https://github.com/VincentShipsIt/meterbar.app/releases/download/${RELEASE_TAG}/MeterBar-${RELEASE_TAG}.zip.sha256" \
             -o sha256.txt
           # Validate the asset is a bare 64-hex SHA256 before trusting it. On a 404 or
           # redirect-to-error, curl -f fails the step; this guards the case where a 200
@@ -62,25 +70,30 @@ jobs:
           path: homebrew-tap
 
       - name: Update Cask formula
+        env:
+          FORMULA_VERSION: ${{ steps.version.outputs.formula }}
+          RELEASE_SHA256: ${{ steps.sha.outputs.sha256 }}
         run: |
+          set -euo pipefail
           cd homebrew-tap
-          VERSION="${{ steps.version.outputs.formula }}"
-          SHA256="${{ steps.sha.outputs.sha256 }}"
 
           # Update version
-          sed -i "s/version \".*\"/version \"${VERSION}\"/" Casks/meterbar.rb
+          sed -i "s/version \".*\"/version \"${FORMULA_VERSION}\"/" Casks/meterbar.rb
 
           # Update sha256
-          sed -i "s/sha256 \".*\"/sha256 \"${SHA256}\"/" Casks/meterbar.rb
+          sed -i "s/sha256 \".*\"/sha256 \"${RELEASE_SHA256}\"/" Casks/meterbar.rb
 
           echo "Updated formula:"
           cat Casks/meterbar.rb
 
       - name: Commit and push
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
         run: |
+          set -euo pipefail
           cd homebrew-tap
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Casks/meterbar.rb
-          git diff --staged --quiet || git commit -m "Update meterbar to ${{ steps.version.outputs.tag }}"
+          git diff --staged --quiet || git commit -m "Update meterbar to ${RELEASE_TAG}"
           git push

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -454,8 +454,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let decider = NotificationDecider(preferences: notificationPreferences.preferences)
         let now = Date()
         var keys = notifiedLimitKeys
+        let currentMetrics = UsageDataManager.shared.metrics
 
-        for (service, metrics) in UsageDataManager.shared.metrics {
+        for service in ServiceType.allCases {
+            // Disabled providers are removed from UsageDataManager. Evaluate an
+            // empty snapshot so their stale band keys are cleared instead of
+            // suppressing a future crossing after the provider is re-enabled.
+            let metrics = currentMetrics[service] ?? UsageMetrics(service: service, lastUpdated: now)
             let evaluation = decider.evaluate(
                 metrics: metrics,
                 providerEnabled: providerVisibilityStore.isEnabled(service),
@@ -472,17 +477,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func postNotification(_ fired: FiredNotification) {
-        let title: String
-        let body: String
-        switch fired.level {
-        case .warning:
-            title = "\(fired.serviceDisplayName) Usage Warning"
-            body = "You're at \(fired.percentUsed)% of your limit"
-        case .critical:
-            title = "\(fired.serviceDisplayName) Limit Reached"
-            body = "You've reached your usage limit"
-        }
-        sendNotification(identifier: fired.key, title: title, body: body)
+        sendNotification(identifier: fired.key, title: fired.title, body: fired.body)
     }
 
     private func sendNotification(identifier: String, title: String, body: String) {

--- a/MeterBar/Models/ApiUsage.swift
+++ b/MeterBar/Models/ApiUsage.swift
@@ -44,15 +44,20 @@ enum ApiUsageWindow: Equatable, Sendable {
         }
     }
 
-    /// Resolved `[start, end]` for the window, ending now for the presets.
-    func dateRange(now: Date = Date()) -> (start: Date, end: Date) {
+    /// Resolved `[start, end)` for the provider endpoints. Presets end at
+    /// `now`; custom date-only selections include the full final day by using
+    /// the start of the following day as their exclusive endpoint.
+    func dateRange(now: Date = Date(), calendar: Calendar = .current) -> (start: Date, end: Date) {
         switch self {
         case .last7Days:
-            return (Calendar.current.date(byAdding: .day, value: -7, to: now) ?? now, now)
+            return (calendar.date(byAdding: .day, value: -7, to: now) ?? now, now)
         case .last30Days:
-            return (Calendar.current.date(byAdding: .day, value: -30, to: now) ?? now, now)
+            return (calendar.date(byAdding: .day, value: -30, to: now) ?? now, now)
         case let .custom(start, end):
-            return (min(start, end), max(start, end))
+            let firstDay = calendar.startOfDay(for: min(start, end))
+            let lastDay = calendar.startOfDay(for: max(start, end))
+            let exclusiveEnd = calendar.date(byAdding: .day, value: 1, to: lastDay) ?? lastDay
+            return (firstDay, exclusiveEnd)
         }
     }
 }
@@ -89,9 +94,9 @@ struct ApiUsage: Sendable {
 
 // MARK: - ApiUsagePricing
 
-/// Self-contained per-model pricing for the API-usage cost estimate (USD per
-/// million tokens). Separate from `CostTracker`'s subscription pricing so the
-/// two can drift independently; covers Anthropic + OpenAI API models.
+/// Self-contained per-model pricing for an incomplete API-usage cost estimate
+/// (USD per million tokens). Separate from `CostTracker`'s subscription pricing
+/// so the two can drift independently; covers Anthropic + OpenAI API models.
 ///
 /// Prices are approximate list rates verified 2026-07-02 — they rot; update
 /// against the providers' pricing pages.

--- a/MeterBar/Services/AccountActivityInspector.swift
+++ b/MeterBar/Services/AccountActivityInspector.swift
@@ -48,8 +48,14 @@ enum AccountActivityInspector {
 
     /// Codex CLI keeps all state (sqlite + WAL, caches, snapshots) under
     /// `CODEX_HOME`, defaulting to `~/.codex`.
-    static func codexCliActivity() -> Date? {
-        lastActivity(inDirectory: codexHomeDirectory())
+    static func codexCliActivity(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        realHomeDirectory: String = ServiceSupport.realHomeDirectory()
+    ) -> Date? {
+        lastActivity(inDirectory: CodexHomeDirectory.path(
+            environment: environment,
+            realHomeDirectory: realHomeDirectory
+        ))
     }
 
     /// Cursor continuously checkpoints its state database while running; the
@@ -70,12 +76,5 @@ enum AccountActivityInspector {
     private static func modificationDate(atPath path: String) -> Date? {
         let attributes = try? FileManager.default.attributesOfItem(atPath: path)
         return attributes?[.modificationDate] as? Date
-    }
-
-    private static func codexHomeDirectory() -> String {
-        let trimmed = ProcessInfo.processInfo.environment["CODEX_HOME"]?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return (trimmed?.isEmpty == false ? trimmed : nil)
-            ?? "\(ServiceSupport.realHomeDirectory())/.codex"
     }
 }

--- a/MeterBar/Services/ApiUsageService.swift
+++ b/MeterBar/Services/ApiUsageService.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Fetches organization API usage (per-model token counts) from the Anthropic
 /// and OpenAI admin usage endpoints, aggregates it over a window, and prices it
 /// into an `ApiUsage`. Unlike the subscription providers there is no quota — the
-/// card shows real spend and tokens, not a percentage.
+/// card shows tokens and an approximate cost, not a percentage or billing total.
 enum ApiUsageService {
     /// Safety cap on pagination so a misbehaving API can never loop forever.
     private static let maxUsagePages = 50
@@ -66,15 +66,7 @@ enum ApiUsageService {
             pagesFetched += 1
         } while nextPage != nil && pagesFetched < maxUsagePages
 
-        var perModelInput: [String: Int] = [:]
-        var perModelOutput: [String: Int] = [:]
-        for bucket in buckets {
-            let model = bucket.model ?? "unknown"
-            perModelInput[model, default: 0] += (bucket.inputTokens ?? 0) + (bucket.cacheCreationInputTokens ?? 0)
-            perModelOutput[model, default: 0] += bucket.outputTokens ?? 0
-        }
-
-        return aggregate(provider: .anthropic, input: perModelInput, output: perModelOutput, start: start, end: end)
+        return aggregateAnthropic(buckets: buckets, start: start, end: end)
     }
 
     // MARK: - OpenAI
@@ -131,6 +123,24 @@ enum ApiUsageService {
 
     // MARK: - Aggregation
 
+    static func aggregateAnthropic(
+        buckets: [AnthropicUsageBucket],
+        start: Date,
+        end: Date
+    ) -> ApiUsage {
+        var perModelInput: [String: Int] = [:]
+        var perModelOutput: [String: Int] = [:]
+        for bucket in buckets {
+            for result in bucket.results {
+                let model = result.model ?? "unknown"
+                perModelInput[model, default: 0] += result.totalInputTokens
+                perModelOutput[model, default: 0] += result.outputTokens ?? 0
+            }
+        }
+
+        return aggregate(provider: .anthropic, input: perModelInput, output: perModelOutput, start: start, end: end)
+    }
+
     private static func aggregate(
         provider: ApiProvider,
         input: [String: Int],
@@ -184,16 +194,39 @@ struct AnthropicUsageResponse: Codable {
 }
 
 struct AnthropicUsageBucket: Codable {
-    let inputTokens: Int?
+    let results: [AnthropicUsageResult]
+}
+
+struct AnthropicUsageResult: Codable {
+    let uncachedInputTokens: Int?
+    let cacheReadInputTokens: Int?
+    let cacheCreation: AnthropicCacheCreation?
     let outputTokens: Int?
-    let cacheCreationInputTokens: Int?
     let model: String?
 
+    var totalInputTokens: Int {
+        (uncachedInputTokens ?? 0)
+            + (cacheReadInputTokens ?? 0)
+            + (cacheCreation?.ephemeral1HourInputTokens ?? 0)
+            + (cacheCreation?.ephemeral5MinuteInputTokens ?? 0)
+    }
+
     enum CodingKeys: String, CodingKey {
-        case inputTokens = "input_tokens"
+        case uncachedInputTokens = "uncached_input_tokens"
+        case cacheReadInputTokens = "cache_read_input_tokens"
+        case cacheCreation = "cache_creation"
         case outputTokens = "output_tokens"
-        case cacheCreationInputTokens = "cache_creation_input_tokens"
         case model
+    }
+}
+
+struct AnthropicCacheCreation: Codable {
+    let ephemeral1HourInputTokens: Int?
+    let ephemeral5MinuteInputTokens: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case ephemeral1HourInputTokens = "ephemeral_1h_input_tokens"
+        case ephemeral5MinuteInputTokens = "ephemeral_5m_input_tokens"
     }
 }
 

--- a/MeterBar/Services/ApiUsageStore.swift
+++ b/MeterBar/Services/ApiUsageStore.swift
@@ -6,6 +6,8 @@ import Foundation
 /// Only providers with an admin key entered are fetched.
 @MainActor
 final class ApiUsageStore: ObservableObject {
+    typealias UsageFetcher = (ApiProvider, String, ApiUsageWindow) async throws -> ApiUsage
+
     static let shared = ApiUsageStore()
 
     @Published private(set) var usage: [ApiProvider: ApiUsage] = [:]
@@ -13,13 +15,31 @@ final class ApiUsageStore: ObservableObject {
     @Published private(set) var lastError: String?
     @Published private(set) var window: ApiUsageWindow = .last7Days
 
-    private let authManager = AuthenticationManager.shared
+    private let authenticatedProvidersSource: () -> [ApiProvider]
+    private let adminKeySource: (ApiProvider) -> String?
+    private let fetchUsage: UsageFetcher
+    private var refreshTask: Task<Void, Never>?
+    private var refreshGeneration = 0
+    private var activeWindow: ApiUsageWindow?
 
-    private init() {}
+    init(
+        authenticatedProviders: (() -> [ApiProvider])? = nil,
+        adminKey: ((ApiProvider) -> String?)? = nil,
+        fetchUsage: UsageFetcher? = nil
+    ) {
+        let authManager = AuthenticationManager.shared
+        authenticatedProvidersSource = authenticatedProviders ?? {
+            ApiProvider.allCases.filter { authManager.isAuthenticated($0) }
+        }
+        adminKeySource = adminKey ?? { authManager.adminKey(for: $0) }
+        self.fetchUsage = fetchUsage ?? { provider, adminKey, window in
+            try await ApiUsageService.fetch(provider: provider, adminKey: adminKey, window: window)
+        }
+    }
 
     /// Providers the user has entered an admin key for (drives which cards show).
     var authenticatedProviders: [ApiProvider] {
-        ApiProvider.allCases.filter { authManager.isAuthenticated($0) }
+        authenticatedProvidersSource()
     }
 
     var hasAnyAuthenticated: Bool {
@@ -29,38 +49,74 @@ final class ApiUsageStore: ObservableObject {
     func setWindow(_ newWindow: ApiUsageWindow) {
         guard newWindow != window else { return }
         window = newWindow
-        Task { await refresh() }
+        startRefresh(for: newWindow)
     }
 
     func refresh() async {
-        guard !isLoading else { return }
+        if activeWindow == window, let refreshTask {
+            await refreshTask.value
+            return
+        }
+        let task = startRefresh(for: window)
+        await task.value
+    }
+
+    /// Awaits work already scheduled by `setWindow`. Kept internal so focused
+    /// store tests can observe the same path the SwiftUI picker uses.
+    func waitForCurrentRefresh() async {
+        await refreshTask?.value
+    }
+
+    @discardableResult
+    private func startRefresh(for requestedWindow: ApiUsageWindow) -> Task<Void, Never> {
+        refreshGeneration += 1
+        let generation = refreshGeneration
+        refreshTask?.cancel()
+        activeWindow = requestedWindow
+
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await self.performRefresh(for: requestedWindow, generation: generation)
+        }
+        refreshTask = task
+        return task
+    }
+
+    private func performRefresh(for requestedWindow: ApiUsageWindow, generation: Int) async {
+        guard generation == refreshGeneration else { return }
 
         let providers = authenticatedProviders
         guard !providers.isEmpty else {
             usage = [:]
+            lastError = nil
+            isLoading = false
+            activeWindow = nil
             return
         }
 
         isLoading = true
         lastError = nil
-        defer { isLoading = false }
 
         var results: [ApiProvider: ApiUsage] = [:]
+        var refreshError: String?
         for provider in providers {
-            guard let key = authManager.adminKey(for: provider) else { continue }
+            guard !Task.isCancelled, generation == refreshGeneration else { return }
+            guard let key = adminKeySource(provider) else { continue }
             do {
-                results[provider] = try await ApiUsageService.fetch(
-                    provider: provider,
-                    adminKey: key,
-                    window: window
-                )
+                results[provider] = try await fetchUsage(provider, key, requestedWindow)
             } catch {
-                lastError = (error as? ServiceError)?.errorDescription ?? error.localizedDescription
+                guard !Task.isCancelled else { return }
+                refreshError = ServiceSupport.safeErrorMessage(for: error)
                 if let cached = usage[provider] {
                     results[provider] = cached
                 }
             }
         }
+
+        guard !Task.isCancelled, generation == refreshGeneration else { return }
         usage = results
+        lastError = refreshError
+        isLoading = false
+        activeWindow = nil
     }
 }

--- a/MeterBar/Services/ApiUsageStore.swift
+++ b/MeterBar/Services/ApiUsageStore.swift
@@ -1,4 +1,5 @@
 import Combine
+import CryptoKit
 import Foundation
 
 /// Holds the fetched organization API usage per provider and the user-selected
@@ -7,6 +8,35 @@ import Foundation
 @MainActor
 final class ApiUsageStore: ObservableObject {
     typealias UsageFetcher = (ApiProvider, String, ApiUsageWindow) async throws -> ApiUsage
+
+    private enum CacheWindow: Hashable {
+        case last7Days
+        case last30Days
+        case custom(start: Date, end: Date)
+
+        init(_ window: ApiUsageWindow) {
+            switch window {
+            case .last7Days:
+                self = .last7Days
+            case .last30Days:
+                self = .last30Days
+            case .custom:
+                let range = window.dateRange()
+                self = .custom(start: range.start, end: range.end)
+            }
+        }
+    }
+
+    private struct ProviderCredential {
+        let provider: ApiProvider
+        let adminKey: String
+        let identity: Data
+    }
+
+    private struct CacheEntry {
+        let credentialIdentity: Data
+        let usage: ApiUsage
+    }
 
     static let shared = ApiUsageStore()
 
@@ -21,6 +51,8 @@ final class ApiUsageStore: ObservableObject {
     private var refreshTask: Task<Void, Never>?
     private var refreshGeneration = 0
     private var activeWindow: ApiUsageWindow?
+    private var activeCredentialIdentities: [ApiProvider: Data]?
+    private var cache: [CacheWindow: [ApiProvider: CacheEntry]] = [:]
 
     init(
         authenticatedProviders: (() -> [ApiProvider])? = nil,
@@ -53,7 +85,10 @@ final class ApiUsageStore: ObservableObject {
     }
 
     func refresh() async {
-        if activeWindow == window, let refreshTask {
+        let currentIdentities = credentialIdentities(for: currentCredentials())
+        if activeWindow == window,
+           activeCredentialIdentities == currentIdentities,
+           let refreshTask {
             await refreshTask.value
             return
         }
@@ -72,51 +107,150 @@ final class ApiUsageStore: ObservableObject {
         refreshGeneration += 1
         let generation = refreshGeneration
         refreshTask?.cancel()
+
+        let credentials = currentCredentials()
+        let identities = credentialIdentities(for: credentials)
+        let cacheWindow = CacheWindow(requestedWindow)
+        pruneCache(for: identities)
+
         activeWindow = requestedWindow
+        activeCredentialIdentities = identities
+        usage = cachedUsage(for: cacheWindow, credentialIdentities: identities)
+        lastError = nil
+        isLoading = !credentials.isEmpty
 
         let task = Task { [weak self] in
             guard let self else { return }
-            await self.performRefresh(for: requestedWindow, generation: generation)
+            await self.performRefresh(
+                for: requestedWindow,
+                cacheWindow: cacheWindow,
+                credentials: credentials,
+                credentialIdentities: identities,
+                generation: generation
+            )
         }
         refreshTask = task
         return task
     }
 
-    private func performRefresh(for requestedWindow: ApiUsageWindow, generation: Int) async {
+    private func performRefresh(
+        for requestedWindow: ApiUsageWindow,
+        cacheWindow: CacheWindow,
+        credentials: [ProviderCredential],
+        credentialIdentities: [ApiProvider: Data],
+        generation: Int
+    ) async {
         guard generation == refreshGeneration else { return }
 
-        let providers = authenticatedProviders
-        guard !providers.isEmpty else {
+        guard !credentials.isEmpty else {
+            cache = [:]
             usage = [:]
             lastError = nil
             isLoading = false
             activeWindow = nil
+            activeCredentialIdentities = nil
             return
         }
 
-        isLoading = true
-        lastError = nil
-
         var results: [ApiProvider: ApiUsage] = [:]
         var refreshError: String?
-        for provider in providers {
+        for credential in credentials {
             guard !Task.isCancelled, generation == refreshGeneration else { return }
-            guard let key = adminKeySource(provider) else { continue }
             do {
-                results[provider] = try await fetchUsage(provider, key, requestedWindow)
+                results[credential.provider] = try await fetchUsage(
+                    credential.provider,
+                    credential.adminKey,
+                    requestedWindow
+                )
             } catch {
                 guard !Task.isCancelled else { return }
                 refreshError = ServiceSupport.safeErrorMessage(for: error)
-                if let cached = usage[provider] {
-                    results[provider] = cached
+                if let cached = cache[cacheWindow]?[credential.provider],
+                   cached.credentialIdentity == credential.identity {
+                    results[credential.provider] = cached.usage
                 }
             }
         }
 
         guard !Task.isCancelled, generation == refreshGeneration else { return }
+
+        let latestIdentities = self.credentialIdentities(for: currentCredentials())
+        guard latestIdentities == credentialIdentities else {
+            pruneCache(for: latestIdentities)
+            usage = cachedUsage(for: CacheWindow(window), credentialIdentities: latestIdentities)
+            lastError = nil
+            isLoading = false
+            activeWindow = nil
+            activeCredentialIdentities = nil
+            return
+        }
+
+        var updatedCache: [ApiProvider: CacheEntry] = [:]
+        for credential in credentials {
+            if let result = results[credential.provider] {
+                updatedCache[credential.provider] = CacheEntry(
+                    credentialIdentity: credential.identity,
+                    usage: result
+                )
+            }
+        }
+        if updatedCache.isEmpty {
+            cache.removeValue(forKey: cacheWindow)
+        } else {
+            cache[cacheWindow] = updatedCache
+        }
+
         usage = results
         lastError = refreshError
         isLoading = false
         activeWindow = nil
+        activeCredentialIdentities = nil
+    }
+
+    private func currentCredentials() -> [ProviderCredential] {
+        authenticatedProviders.compactMap { provider in
+            guard let adminKey = adminKeySource(provider) else { return nil }
+            return ProviderCredential(
+                provider: provider,
+                adminKey: adminKey,
+                identity: Self.credentialIdentity(for: adminKey)
+            )
+        }
+    }
+
+    private func credentialIdentities(
+        for credentials: [ProviderCredential]
+    ) -> [ApiProvider: Data] {
+        Dictionary(uniqueKeysWithValues: credentials.map { ($0.provider, $0.identity) })
+    }
+
+    private func cachedUsage(
+        for window: CacheWindow,
+        credentialIdentities: [ApiProvider: Data]
+    ) -> [ApiProvider: ApiUsage] {
+        guard let entries = cache[window] else { return [:] }
+        return entries.reduce(into: [:]) { result, item in
+            let (provider, entry) = item
+            if credentialIdentities[provider] == entry.credentialIdentity {
+                result[provider] = entry.usage
+            }
+        }
+    }
+
+    private func pruneCache(for credentialIdentities: [ApiProvider: Data]) {
+        for window in Array(cache.keys) {
+            let matchingEntries = cache[window]?.filter { item in
+                credentialIdentities[item.key] == item.value.credentialIdentity
+            } ?? [:]
+            if matchingEntries.isEmpty {
+                cache.removeValue(forKey: window)
+            } else {
+                cache[window] = matchingEntries
+            }
+        }
+    }
+
+    private static func credentialIdentity(for adminKey: String) -> Data {
+        Data(SHA256.hash(data: Data(adminKey.utf8)))
     }
 }

--- a/MeterBar/Services/AuthenticationManager.swift
+++ b/MeterBar/Services/AuthenticationManager.swift
@@ -9,9 +9,15 @@ final class AuthenticationManager: ObservableObject {
     @Published var claudeAdminKey: String?
     @Published var openaiAdminKey: String?
 
-    private let keychain = KeychainManager.shared
+    private let keychain: KeychainManager
 
-    private init() {
+    private convenience init() {
+        self.init(keychain: .shared)
+    }
+
+    /// Injectable for Keychain failure-path tests; production uses `shared`.
+    init(keychain: KeychainManager) {
+        self.keychain = keychain
         claudeAdminKey = keychain.get(key: ApiProvider.anthropic.keychainKey)
         openaiAdminKey = keychain.get(key: ApiProvider.openai.keychainKey)
     }
@@ -41,12 +47,15 @@ final class AuthenticationManager: ObservableObject {
         return success
     }
 
-    func removeAdminKey(for provider: ApiProvider) {
-        keychain.delete(key: provider.keychainKey)
+    @discardableResult
+    func removeAdminKey(for provider: ApiProvider) -> Bool {
+        let deleted = keychain.delete(key: provider.keychainKey)
+        let remainingValue = deleted ? nil : keychain.get(key: provider.keychainKey)
         switch provider {
-        case .anthropic: claudeAdminKey = nil
-        case .openai: openaiAdminKey = nil
+        case .anthropic: claudeAdminKey = remainingValue
+        case .openai: openaiAdminKey = remainingValue
         }
+        return deleted
     }
 
     var isClaudeAuthenticated: Bool { claudeAdminKey != nil }

--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -5,7 +5,8 @@ import Combine
 import os
 
 /// Service for fetching Codex CLI usage data from https://chatgpt.com/backend-api/wham/usage
-/// Reads authentication token from ~/.codex/auth.json (stored by Codex CLI).
+/// Reads the authentication token from `CODEX_HOME/auth.json` (stored by Codex
+/// CLI; `CODEX_HOME` defaults to `~/.codex`).
 /// Similar to ClaudeCodeLocalService, but for Codex CLI usage tracking.
 ///
 /// The API endpoint returns usage data with:
@@ -21,7 +22,7 @@ class CodexCliLocalService: ObservableObject {
     // Shared URLSession with the standard usage-request timeouts
     private let urlSession = ServiceSupport.session
 
-    /// Raw bytes of `~/.codex/auth.json`, behind a closure so tests can supply a
+    /// Raw bytes of `CODEX_HOME/auth.json`, behind a closure so tests can supply a
     /// fixture without a real credential file on disk (the auth file never
     /// exists on CI). Defaults to reading the real path.
     private let authFileDataProvider: () -> Data?
@@ -37,16 +38,17 @@ class CodexCliLocalService: ObservableObject {
         Task.detached(priority: .utility) { [weak self] in self?.checkAccess() }
     }
 
-    /// Reads `~/.codex/auth.json` from the real (non-sandboxed) home directory.
+    /// Reads `CODEX_HOME/auth.json` using the same resolver as readiness,
+    /// activity, and cost scans.
     private static func defaultAuthFileDataProvider() -> Data? {
-        let path = "\(ServiceSupport.realHomeDirectory())/.codex/auth.json"
+        let path = CodexHomeDirectory.authFilePath()
         guard FileManager.default.fileExists(atPath: path) else { return nil }
         return FileManager.default.contents(atPath: path)
     }
 
     // MARK: - Auth File Access
 
-    /// Read OAuth access token from ~/.codex/auth.json
+    /// Read OAuth access token from `CODEX_HOME/auth.json`.
     /// This file is created and maintained by the Codex CLI when user logs in
     func getAuthToken() -> String? {
         guard let token = readAuthFile()?.tokens?.accessToken else {
@@ -60,7 +62,7 @@ class CodexCliLocalService: ObservableObject {
         return token
     }
 
-    /// Read account ID from ~/.codex/auth.json
+    /// Read account ID from `CODEX_HOME/auth.json`.
     /// Required for the ChatGPT-Account-Id header to get team/workspace data
     func getAccountId() -> String? {
         readAuthFile()?.tokens?.accountId
@@ -100,7 +102,7 @@ class CodexCliLocalService: ObservableObject {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
 
-        // Use Bearer token auth (from ~/.codex/auth.json)
+        // Use Bearer token auth (from CODEX_HOME/auth.json)
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
 
         // CRITICAL: Include ChatGPT-Account-Id header to get team/workspace data
@@ -436,7 +438,7 @@ struct Credits: Codable {
 
 // MARK: - Auth File Models
 
-/// Structure of ~/.codex/auth.json
+/// Structure of `CODEX_HOME/auth.json`.
 struct CodexAuthFile: Codable {
     let openaiApiKey: String?
     let tokens: CodexTokens?

--- a/MeterBar/Services/CodexHomeDirectory.swift
+++ b/MeterBar/Services/CodexHomeDirectory.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Resolves the Codex state directory consistently for every local integration.
+///
+/// Codex honors `CODEX_HOME`; MeterBar must therefore use the same directory for
+/// activity, auth, readiness, and cost scans. Keeping this path logic pure also
+/// lets tests exercise custom homes without mutating the process environment.
+enum CodexHomeDirectory {
+    static func path(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        realHomeDirectory: String = ServiceSupport.realHomeDirectory()
+    ) -> String {
+        guard let rawValue = environment["CODEX_HOME"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !rawValue.isEmpty else {
+            return (realHomeDirectory as NSString).appendingPathComponent(".codex")
+        }
+
+        if rawValue == "~" {
+            return realHomeDirectory
+        }
+        if rawValue.hasPrefix("~/") {
+            return (realHomeDirectory as NSString).appendingPathComponent(String(rawValue.dropFirst(2)))
+        }
+        return (rawValue as NSString).standardizingPath
+    }
+
+    static func authFilePath(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        realHomeDirectory: String = ServiceSupport.realHomeDirectory()
+    ) -> String {
+        (path(environment: environment, realHomeDirectory: realHomeDirectory) as NSString)
+            .appendingPathComponent("auth.json")
+    }
+}

--- a/MeterBar/Services/CodexHomeDirectory.swift
+++ b/MeterBar/Services/CodexHomeDirectory.swift
@@ -32,4 +32,24 @@ enum CodexHomeDirectory {
         (path(environment: environment, realHomeDirectory: realHomeDirectory) as NSString)
             .appendingPathComponent("auth.json")
     }
+
+    /// The resolved auth-file path for user-facing copy, compacting paths under
+    /// the real home directory back to `~/...` while retaining absolute custom
+    /// `CODEX_HOME` paths outside it.
+    static func authFileDisplayPath(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        realHomeDirectory: String = ServiceSupport.realHomeDirectory()
+    ) -> String {
+        let resolvedPath = (authFilePath(
+            environment: environment,
+            realHomeDirectory: realHomeDirectory
+        ) as NSString).standardizingPath
+        let standardizedHome = (realHomeDirectory as NSString).standardizingPath
+        let homePrefix = standardizedHome.hasSuffix("/") ? standardizedHome : "\(standardizedHome)/"
+
+        guard resolvedPath.hasPrefix(homePrefix) else {
+            return resolvedPath
+        }
+        return "~/\(resolvedPath.dropFirst(homePrefix.count))"
+    }
 }

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -520,8 +520,7 @@ class CostTracker: ObservableObject {
     }
 
     private static func scanCodexSessions(since cutoffDate: Date) -> (TokenCost, [DailyTokenUsage])? {
-        let codexDir = URL(fileURLWithPath: ServiceSupport.realHomeDirectory(), isDirectory: true)
-            .appendingPathComponent(".codex")
+        let codexDir = URL(fileURLWithPath: CodexHomeDirectory.path(), isDirectory: true)
         let archivedDir = codexDir.appendingPathComponent("archived_sessions")
         let logsDatabase = codexDir.appendingPathComponent("logs_2.sqlite")
         var context = CodexScanContext(earliestDate: Date(), latestDate: cutoffDate)

--- a/MeterBar/Services/KeychainManager.swift
+++ b/MeterBar/Services/KeychainManager.swift
@@ -36,27 +36,100 @@ struct SecItemKeychainBackend: KeychainBackend {
 final class KeychainManager {
     static let shared = KeychainManager()
 
-    private let service = "dev.shipshit.meterbar"
+    private let currentService: String
+    private let legacyServices: [String]
     private let backend: KeychainBackend
 
     /// Defaults to the real Security-framework backend so `shared` behaves
-    /// exactly as before; tests inject an in-memory fake.
-    init(backend: KeychainBackend = SecItemKeychainBackend()) {
+    /// exactly as before; tests inject an in-memory fake and service names.
+    init(
+        backend: KeychainBackend = SecItemKeychainBackend(),
+        currentService: String = "dev.shipshit.meterbar",
+        legacyServices: [String] = ["com.agenticindiedev.quotaguard"]
+    ) {
         self.backend = backend
+        self.currentService = currentService
+        self.legacyServices = legacyServices
     }
 
     func save(key: String, value: String) -> Bool {
         guard let data = value.data(using: .utf8) else { return false }
+        guard save(data: data, key: key, service: currentService) else { return false }
 
-        let query: [String: Any] = [
+        // A legacy item must remain available until the replacement is safely in
+        // the current service. Cleanup is best-effort because the current write
+        // already succeeded and should remain usable even if Keychain cleanup is
+        // temporarily denied.
+        deleteLegacyItems(key: key)
+        return true
+    }
+
+    func get(key: String) -> String? {
+        switch read(key: key, service: currentService) {
+        case let .value(value):
+            deleteLegacyItems(key: key)
+            return value
+        case .failure:
+            return nil
+        case .notFound:
+            break
+        }
+
+        for legacyService in legacyServices {
+            switch read(key: key, service: legacyService) {
+            case let .value(value):
+                // Return the usable legacy value even if the migration write
+                // fails, and only remove it after the current copy is durable.
+                if let data = value.data(using: .utf8),
+                   save(data: data, key: key, service: currentService) {
+                    deleteLegacyItems(key: key)
+                }
+                return value
+            case .notFound:
+                continue
+            case .failure:
+                return nil
+            }
+        }
+
+        return nil
+    }
+
+    @discardableResult
+    func delete(key: String) -> Bool {
+        // Always attempt every service. Leaving a legacy item behind would make
+        // a deliberately removed credential reappear on the next launch.
+        var allDeleted = true
+        for service in [currentService] + legacyServices {
+            let status = backend.delete(query: baseQuery(key: key, service: service))
+            let deleted = status == errSecSuccess || status == errSecItemNotFound
+            if !deleted {
+                allDeleted = false
+            }
+        }
+        return allDeleted
+    }
+
+    func hasKey(key: String) -> Bool {
+        get(key: key) != nil
+    }
+
+    private enum ReadResult {
+        case value(String)
+        case notFound
+        case failure
+    }
+
+    private func baseQuery(key: String, service: String) -> [String: Any] {
+        [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: key
         ]
+    }
 
-        // Update-then-add instead of delete-then-add. Two concurrent saves with a
-        // delete/add pair can both delete and then race on add (one fails with
-        // errSecDuplicateItem); SecItemUpdate has no such window.
+    private func save(data: Data, key: String, service: String) -> Bool {
+        let query = baseQuery(key: key, service: service)
         let attributes: [String: Any] = [kSecValueData as String: data]
         let updateStatus = backend.update(query: query, attributes: attributes)
 
@@ -72,40 +145,27 @@ final class KeychainManager {
         }
     }
 
-    func get(key: String) -> String? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: key,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne
-        ]
+    private func read(key: String, service: String) -> ReadResult {
+        var query = baseQuery(key: key, service: service)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
 
         var result: AnyObject?
         let status = backend.copyMatching(query: query, result: &result)
-
+        if status == errSecItemNotFound {
+            return .notFound
+        }
         guard status == errSecSuccess,
               let data = result as? Data,
               let value = String(data: data, encoding: .utf8) else {
-            return nil
+            return .failure
         }
-
-        return value
+        return .value(value)
     }
 
-    @discardableResult
-    func delete(key: String) -> Bool {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: key
-        ]
-
-        let status = backend.delete(query: query)
-        return status == errSecSuccess || status == errSecItemNotFound
-    }
-
-    func hasKey(key: String) -> Bool {
-        get(key: key) != nil
+    private func deleteLegacyItems(key: String) {
+        for service in legacyServices {
+            _ = backend.delete(query: baseQuery(key: key, service: service))
+        }
     }
 }

--- a/MeterBar/Services/NotificationDecider.swift
+++ b/MeterBar/Services/NotificationDecider.swift
@@ -21,6 +21,23 @@ struct FiredNotification: Equatable, Sendable {
     let serviceDisplayName: String
     /// Clamped `0...100` percentage used, for the warning body copy.
     let percentUsed: Int
+    /// True only when the quota is actually fully spent. A user can configure
+    /// the critical alert at 10% remaining, which must not claim exhaustion.
+    let isExhausted: Bool
+
+    var title: String {
+        if level == .critical, isExhausted {
+            return "\(serviceDisplayName) Limit Reached"
+        }
+        return "\(serviceDisplayName) \(level == .warning ? "Usage Warning" : "Usage Alert")"
+    }
+
+    var body: String {
+        if level == .critical, isExhausted {
+            return "You've reached your usage limit"
+        }
+        return "You're at \(percentUsed)% of your limit"
+    }
 }
 
 /// The result of evaluating one service's metrics: the notifications to post and
@@ -64,26 +81,19 @@ struct NotificationDecider {
         alreadyNotified: Set<String>,
         now: Date = Date()
     ) -> NotificationEvaluation {
-        // Gate 1: notifications turned off globally.
-        guard preferences.isEnabled else {
-            return NotificationEvaluation(notifications: [], notifiedKeys: alreadyNotified)
-        }
+        // Delivery gates suppress banners, not state transitions. Continuing to
+        // evolve band keys while notifications are disabled (or data is stale)
+        // lets a recovery clear old keys so the next genuine upward crossing is
+        // not silently suppressed.
+        let mayDeliver = preferences.isEnabled
+            && providerEnabled
+            && now.timeIntervalSince(metrics.lastUpdated) <= stalenessThreshold
 
-        // Gate 2: never notify for a provider the user has disabled.
-        guard providerEnabled else {
-            return NotificationEvaluation(notifications: [], notifiedKeys: alreadyNotified)
-        }
-
-        // Gate 3: never notify off stale cached data.
-        guard now.timeIntervalSince(metrics.lastUpdated) <= stalenessThreshold else {
-            return NotificationEvaluation(notifications: [], notifiedKeys: alreadyNotified)
-        }
-
-        let limits: [(limit: UsageLimit, type: String)] = [
+        let limits: [(limit: UsageLimit?, type: String)] = [
             (metrics.sessionLimit, "session"),
             (metrics.weeklyLimit, "weekly"),
             (metrics.codeReviewLimit, "codeReview")
-        ].compactMap { pair in pair.0.map { ($0, pair.1) } }
+        ]
 
         var keys = alreadyNotified
         var fired: [FiredNotification] = []
@@ -96,28 +106,41 @@ struct NotificationDecider {
             let warnKey = "\(baseKey)-warn"
             let criticalKey = "\(baseKey)-critical"
 
-            let bandRank = Self.severityRank(QuotaBand.forLimit(limit))
+            guard let limit else {
+                keys.remove(warnKey)
+                keys.remove(criticalKey)
+                continue
+            }
+
+            let band = QuotaBand.forLimit(limit)
+            let bandRank = Self.severityRank(band)
 
             if bandRank >= criticalRank {
-                // In (or past) the critical band. Supersede any pending warn
-                // alert, then fire once per crossing.
-                keys.remove(warnKey)
-                if keys.insert(criticalKey).inserted {
+                // Preserve the warning key while critical. Otherwise falling
+                // from exhausted to warning would look like a fresh rise and
+                // fire a recovery notification.
+                keys.insert(warnKey)
+                if keys.insert(criticalKey).inserted, mayDeliver {
                     fired.append(FiredNotification(
                         key: criticalKey,
                         level: .critical,
                         serviceDisplayName: metrics.service.displayName,
-                        percentUsed: Int(limit.percentage)
+                        percentUsed: Int(limit.percentage),
+                        isExhausted: band == .exhausted
                     ))
                 }
             } else if bandRank >= warningRank {
                 // In the warning band but not yet critical.
-                if keys.insert(warnKey).inserted {
+                // Dropping below critical re-arms only the critical crossing;
+                // keeping the warning key prevents a banner on recovery.
+                keys.remove(criticalKey)
+                if keys.insert(warnKey).inserted, mayDeliver {
                     fired.append(FiredNotification(
                         key: warnKey,
                         level: .warning,
                         serviceDisplayName: metrics.service.displayName,
-                        percentUsed: Int(limit.percentage)
+                        percentUsed: Int(limit.percentage),
+                        isExhausted: false
                     ))
                 }
             } else {

--- a/MeterBar/Services/NotificationDecider.swift
+++ b/MeterBar/Services/NotificationDecider.swift
@@ -19,6 +19,12 @@ struct FiredNotification: Equatable, Sendable {
     let key: String
     let level: NotificationLevel
     let serviceDisplayName: String
+    /// User-facing quota identity (Session, Weekly, Sonnet, or Code Review).
+    /// Including it keeps simultaneous quota banners distinguishable.
+    let quotaDisplayName: String
+    /// Whether exhausting this quota prevents normal provider usage. Secondary
+    /// quotas and subscription quotas covered by enabled extra usage do not.
+    let blocksProvider: Bool
     /// Clamped `0...100` percentage used, for the warning body copy.
     let percentUsed: Int
     /// True only when the quota is actually fully spent. A user can configure
@@ -27,16 +33,22 @@ struct FiredNotification: Equatable, Sendable {
 
     var title: String {
         if level == .critical, isExhausted {
-            return "\(serviceDisplayName) Limit Reached"
+            let state = blocksProvider ? "Limit Reached" : "Quota Exhausted"
+            return "\(serviceDisplayName) \(quotaDisplayName) \(state)"
         }
-        return "\(serviceDisplayName) \(level == .warning ? "Usage Warning" : "Usage Alert")"
+        let state = level == .warning ? "Usage Warning" : "Usage Alert"
+        return "\(serviceDisplayName) \(quotaDisplayName) \(state)"
     }
 
     var body: String {
         if level == .critical, isExhausted {
-            return "You've reached your usage limit"
+            if blocksProvider {
+                return "You've reached your \(quotaDisplayName.lowercased()) usage limit"
+            }
+            return "The \(quotaDisplayName.lowercased()) quota is exhausted; "
+                + "this quota alone does not block all \(serviceDisplayName) usage"
         }
-        return "You're at \(percentUsed)% of your limit"
+        return "Your \(quotaDisplayName.lowercased()) quota is at \(percentUsed)%"
     }
 }
 
@@ -89,10 +101,10 @@ struct NotificationDecider {
             && providerEnabled
             && now.timeIntervalSince(metrics.lastUpdated) <= stalenessThreshold
 
-        let limits: [(limit: UsageLimit?, type: String)] = [
-            (metrics.sessionLimit, "session"),
-            (metrics.weeklyLimit, "weekly"),
-            (metrics.codeReviewLimit, "codeReview")
+        let limits: [(limit: UsageLimit?, kind: QuotaKind)] = [
+            (metrics.sessionLimit, .session),
+            (metrics.weeklyLimit, .weekly),
+            (metrics.codeReviewLimit, .codeReview)
         ]
 
         var keys = alreadyNotified
@@ -101,8 +113,8 @@ struct NotificationDecider {
         let warningRank = Self.severityRank(preferences.warningThreshold.band)
         let criticalRank = Self.severityRank(preferences.criticalThreshold.band)
 
-        for (limit, limitType) in limits {
-            let baseKey = "\(metrics.service.rawValue)-\(limitType)"
+        for (limit, quotaKind) in limits {
+            let baseKey = "\(metrics.service.rawValue)-\(quotaKind.rawValue)"
             let warnKey = "\(baseKey)-warn"
             let criticalKey = "\(baseKey)-critical"
 
@@ -114,6 +126,8 @@ struct NotificationDecider {
 
             let band = QuotaBand.forLimit(limit)
             let bandRank = Self.severityRank(band)
+            let quotaDisplayName = quotaKind.displayName(for: metrics.service)
+            let blocksProvider = quotaKind != .codeReview && metrics.extraUsage?.state != .on
 
             if bandRank >= criticalRank {
                 // Preserve the warning key while critical. Otherwise falling
@@ -125,6 +139,8 @@ struct NotificationDecider {
                         key: criticalKey,
                         level: .critical,
                         serviceDisplayName: metrics.service.displayName,
+                        quotaDisplayName: quotaDisplayName,
+                        blocksProvider: blocksProvider,
                         percentUsed: Int(limit.percentage),
                         isExhausted: band == .exhausted
                     ))
@@ -139,6 +155,8 @@ struct NotificationDecider {
                         key: warnKey,
                         level: .warning,
                         serviceDisplayName: metrics.service.displayName,
+                        quotaDisplayName: quotaDisplayName,
+                        blocksProvider: blocksProvider,
                         percentUsed: Int(limit.percentage),
                         isExhausted: false
                     ))
@@ -163,6 +181,25 @@ struct NotificationDecider {
         case .tight: return 1
         case .critical: return 2
         case .exhausted: return 3
+        }
+    }
+
+    /// Stable quota key plus provider-specific display copy. `codeReviewLimit`
+    /// represents Sonnet-only usage for Claude and Code Review usage for Codex.
+    private enum QuotaKind: String, Equatable, Sendable {
+        case session
+        case weekly
+        case codeReview
+
+        func displayName(for service: ServiceType) -> String {
+            switch self {
+            case .session:
+                return "Session"
+            case .weekly:
+                return "Weekly"
+            case .codeReview:
+                return service == .claudeCode ? "Sonnet" : "Code Review"
+            }
         }
     }
 }

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -2,7 +2,7 @@ import Foundation
 import MeterBarShared
 
 /// Gathers the real, on-disk facts each provider-readiness check needs
-/// (binary on PATH, keychain credentials, `~/.codex/auth.json`, the Cursor
+/// (binary on PATH, keychain credentials, `CODEX_HOME/auth.json`, the Cursor
 /// state database) and feeds them to the pure `ProviderReadinessEvaluator`.
 ///
 /// This is the impure counterpart to the `MeterBarShared` core: it does the
@@ -14,20 +14,48 @@ import MeterBarShared
 /// All provider error text is sanitized here (`sanitize`) so nothing that could
 /// contain a token, account id, or raw response body reaches a pasteable report.
 public enum ProviderReadinessInspector {
-    /// Readiness reports for every provider, in stable display order.
+    /// Readiness reports for the requested providers, in stable display order.
     ///
     /// - Parameter refreshErrors: each provider's live last-refresh error. The app
     ///   passes these from the main actor (the services publish them); the CLI, a
     ///   one-shot process with no live refresh, passes none.
     public static func reports(
+        providers: Set<ServiceType> = Set(ServiceType.allCases),
         refreshErrors: [ServiceType: ServiceError] = [:],
         now: Date = Date()
     ) -> [ProviderReadiness] {
-        [
-            claudeReport(refreshError: refreshErrors[.claudeCode], now: now),
-            codexReport(refreshError: refreshErrors[.codexCli], now: now),
-            cursorReport(refreshError: refreshErrors[.cursor], now: now)
-        ]
+        reports(
+            providers: providers,
+            refreshErrors: refreshErrors,
+            now: now,
+            claudeReport: { claudeReport(refreshError: $0, now: $1) },
+            codexReport: { codexReport(refreshError: $0, now: $1) },
+            cursorReport: { cursorReport(refreshError: $0, now: $1) }
+        )
+    }
+
+    /// Injectable routing seam used to prove that disabled providers perform no
+    /// filesystem, SQLite, or Keychain work. Production callers use the public
+    /// overload above.
+    static func reports(
+        providers: Set<ServiceType>,
+        refreshErrors: [ServiceType: ServiceError],
+        now: Date,
+        claudeReport: (ServiceError?, Date) -> ProviderReadiness,
+        codexReport: (ServiceError?, Date) -> ProviderReadiness,
+        cursorReport: (ServiceError?, Date) -> ProviderReadiness
+    ) -> [ProviderReadiness] {
+        ServiceType.allCases.compactMap { provider in
+            guard providers.contains(provider) else { return nil }
+            switch provider {
+            case .claudeCode:
+                return claudeReport(refreshErrors[provider], now)
+            case .codexCli:
+                return codexReport(refreshErrors[provider], now)
+            case .cursor:
+                return cursorReport(refreshErrors[provider], now)
+            }
+        }
     }
 
     // MARK: - Per-provider gathering
@@ -37,11 +65,29 @@ public enum ProviderReadinessInspector {
     /// login, and a later breakage surfaces through the refresh-error check.
     static let recentUsageFetchWindow: TimeInterval = 24 * 60 * 60
 
-    static func claudeReport(refreshError: ServiceError? = nil, now: Date = Date()) -> ProviderReadiness {
+    static func claudeReport(
+        refreshError: ServiceError? = nil,
+        now: Date = Date(),
+        cachedMetrics: UsageMetrics? = SharedDataStore.shared.loadMetrics()[.claudeCode],
+        isOAuthFallbackEnabled: () -> Bool = {
+            UserDefaults.standard.bool(forKey: StorageKeys.claudeCodeOAuthFallback)
+        },
+        credentialsData: () -> Data? = { ClaudeCodeLocalService.shared.credentialsData() }
+    ) -> ProviderReadiness {
+        let hasRecentUsageFetch = hasRecentClaudeUsageFetch(metrics: cachedMetrics, now: now)
+        let credentialsJSON: Data?
+        if hasRecentUsageFetch || !isOAuthFallbackEnabled() {
+            credentialsJSON = nil
+        } else {
+            credentialsJSON = credentialsData()
+        }
         let input = ClaudeReadinessInput(
             isCLIInstalled: CLIBinaryLocator.isAvailable(command: "claude", overrideEnvVar: "CLAUDE_CLI_PATH"),
-            credentialsJSON: ClaudeCodeLocalService.shared.credentialsData(),
-            hasRecentUsageFetch: hasRecentClaudeUsageFetch(now: now),
+            // Direct CLI evidence wins, so do not even query Keychain when a
+            // recent successful fetch already proves readiness. The legacy
+            // credential is likewise irrelevant while fallback is disabled.
+            credentialsJSON: credentialsJSON,
+            hasRecentUsageFetch: hasRecentUsageFetch,
             refreshError: sanitize(refreshError),
             now: now
         )
@@ -54,8 +100,8 @@ public enum ProviderReadinessInspector {
     /// app cannot read (issue: keychain-only check false-negatived every
     /// `claude login` user). The cache is the same file `meterbar cost` and the
     /// widget already read, so the app and `meterbar doctor` agree.
-    private static func hasRecentClaudeUsageFetch(now: Date) -> Bool {
-        guard let metrics = SharedDataStore.shared.loadMetrics()[.claudeCode] else {
+    private static func hasRecentClaudeUsageFetch(metrics: UsageMetrics?, now: Date) -> Bool {
+        guard let metrics else {
             return false
         }
         let age = now.timeIntervalSince(metrics.lastUpdated)
@@ -64,7 +110,7 @@ public enum ProviderReadinessInspector {
 
     static func codexReport(refreshError: ServiceError? = nil, now: Date = Date()) -> ProviderReadiness {
         let fileManager = FileManager.default
-        let path = "\(ServiceSupport.realHomeDirectory())/.codex/auth.json"
+        let path = CodexHomeDirectory.authFilePath()
         let exists = fileManager.fileExists(atPath: path)
         let bytes = exists && fileManager.isReadableFile(atPath: path)
             ? fileManager.contents(atPath: path)
@@ -109,10 +155,9 @@ public enum ProviderReadinessInspector {
         "Request timed out"
     ]
 
-    /// Maps a `ServiceError` onto a short, paste-safe string. Crucially, an
-    /// `.apiError` may embed a slice of the raw API response body
-    /// (`ServiceSupport.validate`) — which can contain account data — so only a
-    /// leading HTTP status code (or a whitelisted connectivity message) survives.
+    /// Maps a `ServiceError` onto a short, paste-safe string. API messages stay
+    /// generic here as defense in depth; only a leading HTTP status code (or a
+    /// whitelisted connectivity message) survives.
     static func sanitize(_ error: ServiceError?) -> String? {
         guard let error else { return nil }
         switch error {

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -152,7 +152,12 @@ public enum ProviderReadinessInspector {
     private static let safeNetworkMessages: Set<String> = [
         "No internet connection",
         "DNS lookup failed",
-        "Request timed out"
+        "Request timed out",
+        "Request cancelled",
+        "Network connection lost",
+        "Could not connect to provider",
+        "Secure connection failed",
+        "Network request failed"
     ]
 
     /// Maps a `ServiceError` onto a short, paste-safe string. API messages stay

--- a/MeterBar/Services/ServiceSupport.swift
+++ b/MeterBar/Services/ServiceSupport.swift
@@ -31,7 +31,7 @@ enum ServiceSupport {
     /// other non-2xx status to `.apiError` with a consistent message format.
     /// Returns the typed response for callers that need headers/status.
     @discardableResult
-    static func validate(_ response: URLResponse, data: Data) throws -> HTTPURLResponse {
+    static func validate(_ response: URLResponse, data _: Data) throws -> HTTPURLResponse {
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ServiceError.apiError("Invalid response type")
         }
@@ -41,8 +41,9 @@ enum ServiceSupport {
         }
 
         guard (200...299).contains(httpResponse.statusCode) else {
-            let body = String(data: data, encoding: .utf8) ?? "Unknown error"
-            throw ServiceError.apiError("HTTP \(httpResponse.statusCode): \(body.prefix(200))")
+            // Provider bodies can contain account data or echoed request
+            // details. Keep only the status code in errors and logs.
+            throw ServiceError.apiError("HTTP \(httpResponse.statusCode)")
         }
 
         return httpResponse
@@ -70,14 +71,21 @@ enum ServiceSupport {
     static func serviceError(from error: Error) -> ServiceError {
         switch error {
         case let serviceError as ServiceError:
-            return serviceError
+            return sanitize(serviceError)
         case let urlError as URLError:
-            return .apiError(message(for: urlError))
+            return sanitize(.apiError(message(for: urlError)))
         case is DecodingError:
             return .parsingError
         default:
-            return .apiError(error.localizedDescription)
+            return .apiError("Request failed")
         }
+    }
+
+    /// A stable message safe for user-visible state and `.public` unified logs.
+    /// Unknown error descriptions are deliberately discarded because arbitrary
+    /// provider and transport errors may embed response bodies or credentials.
+    static func safeErrorMessage(for error: Error) -> String {
+        serviceError(from: error).localizedDescription
     }
 
     /// Human-readable message for a `URLError`, shared so error copy stays consistent.
@@ -89,9 +97,44 @@ enum ServiceSupport {
             return "DNS lookup failed"
         case .timedOut:
             return "Request timed out"
+        case .cancelled:
+            return "Request cancelled"
+        case .networkConnectionLost:
+            return "Network connection lost"
+        case .cannotConnectToHost:
+            return "Could not connect to provider"
+        case .secureConnectionFailed, .serverCertificateHasBadDate,
+             .serverCertificateUntrusted, .serverCertificateHasUnknownRoot,
+             .serverCertificateNotYetValid:
+            return "Secure connection failed"
         default:
-            return urlError.localizedDescription
+            return "Network request failed"
         }
+    }
+
+    private static func sanitize(_ error: ServiceError) -> ServiceError {
+        guard case let .apiError(message) = error else { return error }
+
+        let knownSafeMessages: Set<String> = [
+            "No internet connection",
+            "DNS lookup failed",
+            "Request timed out",
+            "Request cancelled",
+            "Network connection lost",
+            "Could not connect to provider",
+            "Secure connection failed",
+            "Network request failed",
+            "Invalid response type",
+            "Request failed"
+        ]
+        if knownSafeMessages.contains(message) {
+            return error
+        }
+
+        if let range = message.range(of: #"HTTP \d{3}"#, options: .regularExpression) {
+            return .apiError(String(message[range]))
+        }
+        return .apiError("Request failed")
     }
 
     /// Runs `block` on the main thread — synchronously when already there, so

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -102,7 +102,8 @@ class UsageDataManager: ObservableObject {
                 newMetrics[service] = try await fetchSimpleProviderMetrics(service)
             } catch {
                 lastError = error
-                let detail = "Failed to fetch \(service.rawValue) metrics: \(error.localizedDescription)"
+                let safeMessage = ServiceSupport.safeErrorMessage(for: error)
+                let detail = "Failed to fetch \(service.rawValue) metrics: \(safeMessage)"
                 AppLog.usage.error("\(detail, privacy: .public)")
             }
         }

--- a/MeterBar/Views/ApiUsageCard.swift
+++ b/MeterBar/Views/ApiUsageCard.swift
@@ -36,6 +36,10 @@ struct ApiUsageSection: View {
           )
         }
 
+        Text("Estimated from available token usage and approximate list rates; provider data may be incomplete.")
+          .font(.caption2)
+          .foregroundColor(.secondary)
+
         if let error = store.lastError {
           Text(error)
             .font(.caption2)
@@ -61,14 +65,9 @@ struct ApiUsageWindowPicker: View {
     var id: String { rawValue }
   }
 
-  @State private var mode: Mode = .sevenDays
-  @State private var customStart =
-    Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
-  @State private var customEnd = Date()
-
   var body: some View {
     VStack(alignment: .trailing, spacing: 6) {
-      Picker("Window", selection: $mode) {
+      Picker("Window", selection: modeBinding) {
         ForEach(Mode.allCases) { mode in
           Text(mode.rawValue).tag(mode)
         }
@@ -76,23 +75,51 @@ struct ApiUsageWindowPicker: View {
       .pickerStyle(.segmented)
       .labelsHidden()
       .fixedSize()
-      .onChange(of: mode) { _, newMode in
-        applyMode(newMode)
-      }
 
-      if mode == .custom {
+      if selectedMode == .custom {
         HStack(spacing: 6) {
-          DatePicker("From", selection: $customStart, displayedComponents: .date)
+          DatePicker("From", selection: customStartBinding, displayedComponents: .date)
             .labelsHidden()
           Text("→").foregroundColor(.secondary)
-          DatePicker("To", selection: $customEnd, displayedComponents: .date)
+          DatePicker("To", selection: customEndBinding, displayedComponents: .date)
             .labelsHidden()
         }
         .font(.caption)
-        .onChange(of: customStart) { _, _ in applyCustom() }
-        .onChange(of: customEnd) { _, _ in applyCustom() }
       }
     }
+  }
+
+  private var selectedMode: Mode {
+    switch store.window {
+    case .last7Days: return .sevenDays
+    case .last30Days: return .thirtyDays
+    case .custom: return .custom
+    }
+  }
+
+  private var modeBinding: Binding<Mode> {
+    Binding(get: { selectedMode }, set: applyMode)
+  }
+
+  private var customStartBinding: Binding<Date> {
+    Binding(
+      get: { customDates.start },
+      set: { store.setWindow(.custom(start: $0, end: customDates.end)) }
+    )
+  }
+
+  private var customEndBinding: Binding<Date> {
+    Binding(
+      get: { customDates.end },
+      set: { store.setWindow(.custom(start: customDates.start, end: $0)) }
+    )
+  }
+
+  private var customDates: (start: Date, end: Date) {
+    if case let .custom(start, end) = store.window {
+      return (start, end)
+    }
+    return store.window.dateRange()
   }
 
   private func applyMode(_ newMode: Mode) {
@@ -102,19 +129,16 @@ struct ApiUsageWindowPicker: View {
     case .thirtyDays:
       store.setWindow(.last30Days)
     case .custom:
-      applyCustom()
+      let dates = customDates
+      store.setWindow(.custom(start: dates.start, end: dates.end))
     }
-  }
-
-  private func applyCustom() {
-    store.setWindow(.custom(start: customStart, end: customEnd))
   }
 }
 
 // MARK: - ApiUsageCard
 
-/// One provider's API spend + tokens over the selected window. No quota bar —
-/// API usage has no cap, so this shows real spend, not a percentage.
+/// One provider's API tokens plus an approximate cost over the selected window.
+/// API usage has no cap, so this does not show a quota percentage.
 struct ApiUsageCard: View {
   let provider: ApiProvider
   let usage: ApiUsage?
@@ -136,7 +160,7 @@ struct ApiUsageCard: View {
             .font(compact ? .subheadline : .headline)
             .fontWeight(.semibold)
           Spacer(minLength: 8)
-          Text(UsageFormat.cost(usage?.estimatedCostUSD ?? 0))
+          Text("Est. \(UsageFormat.cost(usage?.estimatedCostUSD ?? 0))")
             .font(compact ? .headline : .title3)
             .bold()
             .monospacedDigit()

--- a/MeterBar/Views/Components/ProviderStatusBadges.swift
+++ b/MeterBar/Views/Components/ProviderStatusBadges.swift
@@ -18,7 +18,6 @@ struct ProviderStatusBadges: View {
     let resetCreditsAvailable: Int?
     let extraUsage: ExtraUsageStatus?
     let accentColor: Color
-    let hasExhaustedLimit: Bool
     var style: Style = .compact
 
     /// Convenience initializer from a `ProviderSnapshot`, which already carries
@@ -27,7 +26,6 @@ struct ProviderStatusBadges: View {
         self.resetCreditsAvailable = snapshot.resetCreditsAvailable
         self.extraUsage = snapshot.displayedExtraUsage
         self.accentColor = snapshot.accentColor
-        self.hasExhaustedLimit = snapshot.hasExhaustedLimit
         self.style = style
     }
 
@@ -36,7 +34,7 @@ struct ProviderStatusBadges: View {
     }
 
     private var showsExtraUsage: Bool {
-        !hasExhaustedLimit && extraUsage != nil
+        extraUsage != nil
     }
 
     /// Whether either badge will render — lets callers skip the surrounding

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -276,8 +276,9 @@ struct PopoverOverviewPanel: View {
   /// Runs the readiness inspector off the main actor (keychain / file / SQLite
   /// I/O) and publishes the reports back for the checklist.
   private func loadSetupReports() async {
+    let requestedProviders = enabledProviders
     let reports = await Task.detached(priority: .utility) {
-      ProviderReadinessInspector.reports()
+      ProviderReadinessInspector.reports(providers: requestedProviders)
     }.value
     setupReports = reports
   }
@@ -322,42 +323,49 @@ private struct PopoverProviderStatusCard: View {
 
   private var compactExhaustedCard: some View {
     DashboardTile(padding: 11, minHeight: 58, alignment: .center) {
-      TimelineView(.periodic(from: ResetCountdownSchedule.anchor, by: ResetCountdownSchedule.interval)) { timeline in
-        let blockingWindow = BlockingLimitResetCounter.selectBlockingWindow(
-          snapshot.resetWindows,
-          now: timeline.date
-        )
-        let title = BlockingLimitResetCounter.titleText(for: blockingWindow, in: snapshot.resetWindows)
-        let counter = BlockingLimitResetCounter.counterText(for: blockingWindow, now: timeline.date)
+      VStack(alignment: .leading, spacing: 8) {
+        TimelineView(.periodic(from: ResetCountdownSchedule.anchor, by: ResetCountdownSchedule.interval)) { timeline in
+          let blockingWindow = BlockingLimitResetCounter.selectBlockingWindow(
+            snapshot.resetWindows,
+            now: timeline.date
+          )
+          let title = BlockingLimitResetCounter.titleText(for: blockingWindow, in: snapshot.resetWindows)
+          let counter = BlockingLimitResetCounter.counterText(for: blockingWindow, now: timeline.date)
 
-        HStack(alignment: .center, spacing: 9) {
-          ProviderLogoView(kind: snapshot.logoKind, size: 17, foregroundColor: snapshot.accentColor)
+          HStack(alignment: .center, spacing: 9) {
+            ProviderLogoView(kind: snapshot.logoKind, size: 17, foregroundColor: snapshot.accentColor)
 
-          VStack(alignment: .leading, spacing: 1) {
-            Text(snapshot.title)
-              .font(.subheadline)
-              .fontWeight(.semibold)
-              .lineLimit(1)
-            Text(updatedText)
-              .font(.caption2)
-              .foregroundColor(.secondary)
-              .lineLimit(1)
+            VStack(alignment: .leading, spacing: 1) {
+              Text(snapshot.title)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .lineLimit(1)
+              Text(updatedText)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+            }
+
+            Spacer(minLength: 8)
+
+            HStack(spacing: 5) {
+              Image(systemName: "hourglass")
+                .font(.system(size: 10, weight: .semibold))
+              Text("\(title) \(counter)")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.72)
+            }
+            .foregroundColor(snapshot.accentColor)
+            .help("\(title) \(counter)")
           }
+        }
 
-          Spacer(minLength: 8)
-
-          HStack(spacing: 5) {
-            Image(systemName: "hourglass")
-              .font(.system(size: 10, weight: .semibold))
-            Text("\(title) \(counter)")
-              .font(.caption)
-              .fontWeight(.semibold)
-              .monospacedDigit()
-              .lineLimit(1)
-              .minimumScaleFactor(0.72)
-          }
-          .foregroundColor(snapshot.accentColor)
-          .help("\(title) \(counter)")
+        let badges = ProviderStatusBadges(snapshot: snapshot, style: .compact)
+        if badges.hasContent {
+          badges
         }
       }
     }

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -44,8 +44,21 @@ struct ProviderSnapshot: Identifiable {
         primaryLimit.map { QuotaBand.forPercentLeft($0.percentLeft) }
     }
 
+    /// Session/weekly windows that can block normal provider usage. Secondary
+    /// model/code-review quotas remain visible but must not collapse the entire
+    /// provider card or claim the provider is unavailable.
+    var blockingLimits: [SnapshotLimit] {
+        guard extraUsage?.state != .on else { return [] }
+        return limits.filter {
+            ($0.kind == .session || $0.kind == .weekly) && $0.usageLimit.isAtLimit
+        }
+    }
+
+    /// Reset windows used by blocking-state UI. Filtering here prevents a
+    /// simultaneous secondary-quota reset from being presented as the time at
+    /// which normal provider usage resumes.
     var resetWindows: [ResetCountdownWindow] {
-        limits.map {
+        blockingLimits.map {
             ResetCountdownWindow(
                 id: "\(id)-\($0.title)",
                 title: $0.title,
@@ -54,15 +67,13 @@ struct ProviderSnapshot: Identifiable {
         }
     }
 
-    var hasExhaustedLimit: Bool {
-        limits.contains { $0.usageLimit.isAtLimit }
-    }
+    var hasExhaustedLimit: Bool { !blockingLimits.isEmpty }
 
     /// Weekly exhaustion blocks the whole subscription even when the shorter
     /// session window still has room. Compact overview cards should prioritize
     /// that reset instead of spending space on the session gauge.
     var hasExhaustedWeeklyLimit: Bool {
-        limits.contains { $0.kind == .weekly && $0.usageLimit.isAtLimit }
+        blockingLimits.contains { $0.kind == .weekly }
     }
 
     /// Detail panels should focus on the limit that is actually blocking use.

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -553,8 +553,9 @@ struct SettingsView: View {
             color: MeterBarTheme.appAccent
         ) {
             SettingsNotice(
-                text: "Paste an organization admin key to show your pay-as-you-go API spend "
-                    + "(Anthropic / OpenAI) as its own card, separate from subscription quotas. "
+                text: "Paste an organization admin key to estimate pay-as-you-go API cost "
+                    + "(Anthropic / OpenAI) from available usage and approximate list rates. "
+                    + "Provider usage data may be incomplete and is not a billing statement. "
                     + "Keys are stored in the macOS Keychain and only used against the provider's usage API.",
                 color: .secondary
             )
@@ -1598,7 +1599,7 @@ private struct AdminKeySettingsRow: View {
     }
 
     private var connectedMessage: String {
-        "Connected. Usage appears on the billed API card."
+        "Connected. Estimated usage appears on the API cost card."
     }
 }
 

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -233,6 +233,10 @@ struct SettingsView: View {
         providerVisibility.isEnabled(.claudeCode) || providerVisibility.isEnabled(.codexCli)
     }
 
+    private var codexAuthFileDisplayPath: String {
+        CodexHomeDirectory.authFileDisplayPath()
+    }
+
     private var settingsWindow: some View {
         HStack(spacing: 0) {
             settingsSidebar
@@ -396,7 +400,7 @@ struct SettingsView: View {
         SettingsPanelSection(title: "OpenAI Codex", logoKind: .codex, color: MeterBarTheme.codexAccent) {
             SettingsRowView(
                 title: "Connection",
-                detail: "Reads the OAuth session from ~/.codex/auth.json."
+                detail: "Reads the OAuth session from \(codexAuthFileDisplayPath)."
             ) {
                 HStack(spacing: 8) {
                     StatusPill(
@@ -1095,7 +1099,7 @@ struct SettingsView: View {
         case .claudeCode:
             "Claude CLI /usage"
         case .codexCli:
-            "~/.codex/auth.json + ChatGPT usage API"
+            "\(codexAuthFileDisplayPath) + ChatGPT usage API"
         case .cursor:
             "Cursor local state + usage API"
         }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -338,7 +338,7 @@ struct UsageDashboardView: View {
             }
 
             if apiUsageStore.hasAnyAuthenticated {
-                DashboardCard(title: "API spend (billed)") {
+                DashboardCard(title: "Estimated API cost") {
                     ApiUsageSection(store: apiUsageStore, embedded: true)
                 }
             }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -694,9 +694,13 @@ struct UsageDashboardView: View {
         isRunningDiagnostics = true
         defer { isRunningDiagnostics = false }
 
+        let enabledProviders = providerVisibility.enabledServices
         let errors = currentRefreshErrors()
         let reports = await Task.detached(priority: .userInitiated) {
-            ProviderReadinessInspector.reports(refreshErrors: errors)
+            ProviderReadinessInspector.reports(
+                providers: enabledProviders,
+                refreshErrors: errors
+            )
         }.value
         readinessReports = reports
     }

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -314,7 +314,10 @@ struct Doctor: ParsableCommand {
         // Same readiness core the app's Diagnostics view uses. No live refresh in
         // a one-shot CLI run, so last-refresh checks report "no recent errors".
         // Every string below is redacted by the inspector — safe to paste into an issue.
-        let reports = filtered(ProviderReadinessInspector.reports())
+        // Resolve the filter before gathering so `meterbar doctor --provider`
+        // never probes another provider's filesystem, database, or Keychain.
+        let requestedProviders = matchingProviders()
+        let reports = filtered(ProviderReadinessInspector.reports(providers: requestedProviders))
 
         if json {
             try printJSON(reports)
@@ -330,6 +333,16 @@ struct Doctor: ParsableCommand {
             $0.provider.rawValue.lowercased().contains(needle)
                 || $0.provider.displayName.lowercased().contains(needle)
         }
+    }
+
+    private func matchingProviders() -> Set<ServiceType> {
+        guard let needle = provider?.lowercased() else {
+            return Set(ServiceType.allCases)
+        }
+        return Set(ServiceType.allCases.filter {
+            $0.rawValue.lowercased().contains(needle)
+                || $0.displayName.lowercased().contains(needle)
+        })
     }
 
     private func printJSON(_ reports: [ProviderReadiness]) throws {

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -327,12 +327,7 @@ struct Doctor: ParsableCommand {
     }
 
     private func filtered(_ reports: [ProviderReadiness]) -> [ProviderReadiness] {
-        let ordered = reports.sorted { $0.provider.sortOrder < $1.provider.sortOrder }
-        guard let needle = provider?.lowercased() else { return ordered }
-        return ordered.filter {
-            $0.provider.rawValue.lowercased().contains(needle)
-                || $0.provider.displayName.lowercased().contains(needle)
-        }
+        reports.sorted { $0.provider.sortOrder < $1.provider.sortOrder }
     }
 
     private func matchingProviders() -> Set<ServiceType> {

--- a/MeterBarTests/AccountActivityInspectorTests.swift
+++ b/MeterBarTests/AccountActivityInspectorTests.swift
@@ -85,15 +85,6 @@ final class AccountActivityInspectorTests: XCTestCase {
     // MARK: - Provider probes
 
     func testCodexCliActivityHonorsCodexHomeOverride() throws {
-        let previousCodexHome = getenv("CODEX_HOME").map { String(cString: $0) }
-        defer {
-            if let previousCodexHome {
-                setenv("CODEX_HOME", previousCodexHome, 1)
-            } else {
-                unsetenv("CODEX_HOME")
-            }
-        }
-
         let codexHome = tempDir.appendingPathComponent("custom-codex", isDirectory: true)
         try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
         let newest = Date(timeIntervalSinceNow: -90)
@@ -105,9 +96,27 @@ final class AccountActivityInspectorTests: XCTestCase {
             ofItemAtPath: codexHome.path
         )
 
-        setenv("CODEX_HOME", codexHome.path, 1)
-
-        let activity = try XCTUnwrap(AccountActivityInspector.codexCliActivity())
+        let activity = try XCTUnwrap(AccountActivityInspector.codexCliActivity(
+            environment: ["CODEX_HOME": codexHome.path],
+            realHomeDirectory: tempDir.path
+        ))
         XCTAssertEqual(activity.timeIntervalSince1970, newest.timeIntervalSince1970, accuracy: 2)
+    }
+
+    func testCodexHomeResolverDefaultsBlankValuesAndBuildsAuthPath() {
+        let home = tempDir.path
+
+        XCTAssertEqual(CodexHomeDirectory.path(environment: [:], realHomeDirectory: home), "\(home)/.codex")
+        XCTAssertEqual(
+            CodexHomeDirectory.path(environment: ["CODEX_HOME": "   "], realHomeDirectory: home),
+            "\(home)/.codex"
+        )
+        XCTAssertEqual(
+            CodexHomeDirectory.authFilePath(
+                environment: ["CODEX_HOME": "~/custom-codex"],
+                realHomeDirectory: home
+            ),
+            "\(home)/custom-codex/auth.json"
+        )
     }
 }

--- a/MeterBarTests/AccountActivityInspectorTests.swift
+++ b/MeterBarTests/AccountActivityInspectorTests.swift
@@ -112,11 +112,60 @@ final class AccountActivityInspectorTests: XCTestCase {
             "\(home)/.codex"
         )
         XCTAssertEqual(
+            CodexHomeDirectory.path(environment: ["CODEX_HOME": "~"], realHomeDirectory: home),
+            home
+        )
+        XCTAssertEqual(
+            CodexHomeDirectory.authFilePath(environment: ["CODEX_HOME": "~"], realHomeDirectory: home),
+            "\(home)/auth.json"
+        )
+        XCTAssertEqual(
+            CodexHomeDirectory.path(environment: ["CODEX_HOME": "/custom/codex"], realHomeDirectory: home),
+            "/custom/codex"
+        )
+        XCTAssertEqual(
+            CodexHomeDirectory.authFilePath(
+                environment: ["CODEX_HOME": "/custom/codex"],
+                realHomeDirectory: home
+            ),
+            "/custom/codex/auth.json"
+        )
+        XCTAssertEqual(
             CodexHomeDirectory.authFilePath(
                 environment: ["CODEX_HOME": "~/custom-codex"],
                 realHomeDirectory: home
             ),
             "\(home)/custom-codex/auth.json"
+        )
+    }
+
+    func testCodexAuthFileDisplayPathReflectsResolvedCodexHome() {
+        let home = tempDir.path
+
+        XCTAssertEqual(
+            CodexHomeDirectory.authFileDisplayPath(environment: [:], realHomeDirectory: home),
+            "~/.codex/auth.json"
+        )
+        XCTAssertEqual(
+            CodexHomeDirectory.authFileDisplayPath(
+                environment: ["CODEX_HOME": "~/custom-codex"],
+                realHomeDirectory: home
+            ),
+            "~/custom-codex/auth.json"
+        )
+        XCTAssertEqual(
+            CodexHomeDirectory.authFileDisplayPath(
+                environment: ["CODEX_HOME": "~"],
+                realHomeDirectory: home
+            ),
+            "~/auth.json"
+        )
+        XCTAssertEqual(
+            CodexHomeDirectory.authFileDisplayPath(
+                environment: ["CODEX_HOME": "/custom/codex"],
+                realHomeDirectory: home
+            ),
+            "/custom/codex/auth.json"
         )
     }
 }

--- a/MeterBarTests/ApiUsageStoreTests.swift
+++ b/MeterBarTests/ApiUsageStoreTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+@testable import MeterBar
+
+@MainActor
+final class ApiUsageStoreTests: XCTestCase {
+    private actor FetchProbe {
+        private var slowContinuation: CheckedContinuation<ApiUsage, Never>?
+        private(set) var requestedWindows: [ApiUsageWindow] = []
+
+        func fetch(provider: ApiProvider, window: ApiUsageWindow) async -> ApiUsage {
+            requestedWindows.append(window)
+            if window == .last30Days {
+                return await withCheckedContinuation { continuation in
+                    slowContinuation = continuation
+                }
+            }
+            return Self.usage(provider: provider, window: window, inputTokens: 1)
+        }
+
+        var hasPendingSlowRequest: Bool {
+            slowContinuation != nil
+        }
+
+        func completeSlowRequest() {
+            slowContinuation?.resume(
+                returning: Self.usage(provider: .anthropic, window: .last30Days, inputTokens: 30)
+            )
+            slowContinuation = nil
+        }
+
+        private static func usage(
+            provider: ApiProvider,
+            window: ApiUsageWindow,
+            inputTokens: Int
+        ) -> ApiUsage {
+            let now = Date(timeIntervalSince1970: 2_000_000_000)
+            let range = window.dateRange(now: now)
+            return ApiUsage(
+                provider: provider,
+                windowStart: range.start,
+                windowEnd: range.end,
+                inputTokens: inputTokens,
+                outputTokens: 0,
+                estimatedCostUSD: 0,
+                models: []
+            )
+        }
+    }
+
+    func testSupersededWindowRefreshCannotPublishLateResult() async {
+        let probe = FetchProbe()
+        let store = makeStore { provider, window in
+            await probe.fetch(provider: provider, window: window)
+        }
+
+        store.setWindow(.last30Days)
+        for _ in 0..<100 {
+            if await probe.hasPendingSlowRequest { break }
+            await Task.yield()
+        }
+        let hasPendingSlowRequest = await probe.hasPendingSlowRequest
+        guard hasPendingSlowRequest else {
+            XCTFail("scheduled refresh did not reach the controlled fetcher")
+            return
+        }
+
+        let custom = ApiUsageWindow.custom(
+            start: Date(timeIntervalSince1970: 1_900_000_000),
+            end: Date(timeIntervalSince1970: 1_900_086_400)
+        )
+        store.setWindow(custom)
+        await store.waitForCurrentRefresh()
+
+        XCTAssertEqual(store.window, custom)
+        XCTAssertEqual(store.usage[.anthropic]?.inputTokens, 1)
+        XCTAssertFalse(store.isLoading)
+
+        await probe.completeSlowRequest()
+        for _ in 0..<10 { await Task.yield() }
+
+        XCTAssertEqual(store.window, custom)
+        XCTAssertEqual(store.usage[.anthropic]?.inputTokens, 1, "a superseded request must never publish late")
+        let requestedWindows = await probe.requestedWindows
+        XCTAssertEqual(requestedWindows, [.last30Days, custom])
+    }
+
+    func testMatchingRefreshCoalescesWithScheduledWindowRequest() async {
+        let probe = FetchProbe()
+        let store = makeStore { provider, window in
+            await probe.fetch(provider: provider, window: window)
+        }
+
+        store.setWindow(.last30Days)
+        for _ in 0..<100 {
+            if await probe.hasPendingSlowRequest { break }
+            await Task.yield()
+        }
+        let hasPendingSlowRequest = await probe.hasPendingSlowRequest
+        guard hasPendingSlowRequest else {
+            XCTFail("scheduled refresh did not reach the controlled fetcher")
+            return
+        }
+
+        let overlappingRefresh = Task { await store.refresh() }
+        for _ in 0..<10 { await Task.yield() }
+        let requestedBeforeCompletion = await probe.requestedWindows
+        XCTAssertEqual(requestedBeforeCompletion, [.last30Days])
+
+        await probe.completeSlowRequest()
+        await overlappingRefresh.value
+
+        XCTAssertEqual(store.usage[.anthropic]?.inputTokens, 30)
+        XCTAssertFalse(store.isLoading)
+    }
+
+    func testFailedWindowRefreshPreservesCachedUsageAndSanitizesError() async {
+        actor ResponseSequence {
+            private var callCount = 0
+
+            func fetch(provider: ApiProvider, window: ApiUsageWindow) throws -> ApiUsage {
+                callCount += 1
+                if callCount > 1 {
+                    throw ServiceError.apiError("HTTP 500: account@example.test")
+                }
+                let range = window.dateRange(now: Date(timeIntervalSince1970: 2_000_000_000))
+                return ApiUsage(
+                    provider: provider,
+                    windowStart: range.start,
+                    windowEnd: range.end,
+                    inputTokens: 7,
+                    outputTokens: 0,
+                    estimatedCostUSD: 0,
+                    models: []
+                )
+            }
+        }
+
+        let responses = ResponseSequence()
+        let store = makeStore { provider, window in
+            try await responses.fetch(provider: provider, window: window)
+        }
+
+        await store.refresh()
+        XCTAssertEqual(store.usage[.anthropic]?.inputTokens, 7)
+
+        store.setWindow(.last30Days)
+        await store.waitForCurrentRefresh()
+
+        XCTAssertEqual(store.usage[.anthropic]?.inputTokens, 7)
+        XCTAssertEqual(store.lastError, "HTTP 500")
+        XCTAssertFalse(store.lastError?.contains("account@example.test") ?? true)
+        XCTAssertFalse(store.isLoading)
+    }
+
+    private func makeStore(
+        fetch: @escaping (ApiProvider, ApiUsageWindow) async throws -> ApiUsage
+    ) -> ApiUsageStore {
+        ApiUsageStore(
+            authenticatedProviders: { [.anthropic] },
+            adminKey: { _ in "test-admin-key" },
+            fetchUsage: { provider, _, window in
+                try await fetch(provider, window)
+            }
+        )
+    }
+}

--- a/MeterBarTests/ApiUsageStoreTests.swift
+++ b/MeterBarTests/ApiUsageStoreTests.swift
@@ -113,7 +113,7 @@ final class ApiUsageStoreTests: XCTestCase {
         XCTAssertFalse(store.isLoading)
     }
 
-    func testFailedWindowRefreshPreservesCachedUsageAndSanitizesError() async {
+    func testFailedSameWindowRefreshPreservesCachedUsageAndSanitizesError() async {
         actor ResponseSequence {
             private var callCount = 0
 
@@ -143,13 +143,159 @@ final class ApiUsageStoreTests: XCTestCase {
         await store.refresh()
         XCTAssertEqual(store.usage[.anthropic]?.inputTokens, 7)
 
-        store.setWindow(.last30Days)
-        await store.waitForCurrentRefresh()
+        await store.refresh()
 
         XCTAssertEqual(store.usage[.anthropic]?.inputTokens, 7)
         XCTAssertEqual(store.lastError, "HTTP 500")
         XCTAssertFalse(store.lastError?.contains("account@example.test") ?? true)
         XCTAssertFalse(store.isLoading)
+    }
+
+    func testFailedDifferentWindowDoesNotReusePriorWindowCache() async {
+        actor ResponseSequence {
+            func fetch(provider: ApiProvider, window: ApiUsageWindow) throws -> ApiUsage {
+                if window == .last30Days {
+                    throw ServiceError.apiError("HTTP 500: account@example.test")
+                }
+                return ApiUsageStoreTests.usage(provider: provider, window: window, inputTokens: 7)
+            }
+        }
+
+        let responses = ResponseSequence()
+        let store = makeStore { provider, window in
+            try await responses.fetch(provider: provider, window: window)
+        }
+
+        await store.refresh()
+        XCTAssertEqual(store.usage[.anthropic]?.inputTokens, 7)
+
+        store.setWindow(.last30Days)
+        XCTAssertNil(store.usage[.anthropic], "changing windows must synchronously stop showing 7-day data")
+        await store.waitForCurrentRefresh()
+
+        XCTAssertNil(store.usage[.anthropic])
+        XCTAssertEqual(store.lastError, "HTTP 500")
+        XCTAssertFalse(store.lastError?.contains("account@example.test") ?? true)
+        XCTAssertFalse(store.isLoading)
+    }
+
+    func testEquivalentCustomWindowsShareNormalizedCacheBucket() async {
+        actor ResponseSequence {
+            private var callCount = 0
+
+            func fetch(provider: ApiProvider, window: ApiUsageWindow) throws -> ApiUsage {
+                callCount += 1
+                if callCount > 1 {
+                    throw ServiceError.apiError("HTTP 503")
+                }
+                return ApiUsageStoreTests.usage(provider: provider, window: window, inputTokens: 12)
+            }
+        }
+
+        let calendar = Calendar.current
+        let firstDay = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_900_000_000))
+        guard let lastDay = calendar.date(byAdding: .day, value: 2, to: firstDay) else {
+            XCTFail("could not construct custom test window")
+            return
+        }
+        let firstWindow = ApiUsageWindow.custom(
+            start: firstDay.addingTimeInterval(3_600),
+            end: lastDay.addingTimeInterval(7_200)
+        )
+        let equivalentReversedWindow = ApiUsageWindow.custom(
+            start: lastDay.addingTimeInterval(18_000),
+            end: firstDay.addingTimeInterval(10_800)
+        )
+
+        let responses = ResponseSequence()
+        let store = makeStore { provider, window in
+            try await responses.fetch(provider: provider, window: window)
+        }
+
+        store.setWindow(firstWindow)
+        await store.waitForCurrentRefresh()
+        XCTAssertEqual(store.usage[.anthropic]?.inputTokens, 12)
+
+        store.setWindow(equivalentReversedWindow)
+        XCTAssertEqual(
+            store.usage[.anthropic]?.inputTokens,
+            12,
+            "semantically identical date selections should use the same cache bucket"
+        )
+        await store.waitForCurrentRefresh()
+
+        XCTAssertEqual(store.usage[.anthropic]?.inputTokens, 12)
+        XCTAssertEqual(store.lastError, "HTTP 503")
+    }
+
+    func testReplacingCredentialCannotReusePreviousOrganizationCache() async {
+        actor CredentialResponses {
+            func fetch(provider: ApiProvider, key: String, window: ApiUsageWindow) throws -> ApiUsage {
+                if key == "organization-a" {
+                    return ApiUsageStoreTests.usage(provider: provider, window: window, inputTokens: 17)
+                }
+                throw ServiceError.apiError("HTTP 401")
+            }
+        }
+
+        var adminKey = "organization-a"
+        let responses = CredentialResponses()
+        let store = makeCredentialStore(
+            authenticatedProviders: { [.anthropic] },
+            adminKey: { _ in adminKey },
+            fetch: { provider, key, window in
+                try await responses.fetch(provider: provider, key: key, window: window)
+            }
+        )
+
+        await store.refresh()
+        XCTAssertEqual(store.usage[.anthropic]?.inputTokens, 17)
+
+        adminKey = "organization-b"
+        await store.refresh()
+
+        XCTAssertNil(store.usage[.anthropic])
+        XCTAssertEqual(store.lastError, "HTTP 401")
+    }
+
+    func testRemovingCredentialsClearsCacheBeforeSameKeyIsAddedAgain() async {
+        actor ResponseSequence {
+            private var callCount = 0
+
+            func fetch(provider: ApiProvider, window: ApiUsageWindow) throws -> ApiUsage {
+                callCount += 1
+                if callCount > 1 {
+                    throw ServiceError.apiError("HTTP 503")
+                }
+                return ApiUsageStoreTests.usage(provider: provider, window: window, inputTokens: 23)
+            }
+        }
+
+        var providers: [ApiProvider] = [.anthropic]
+        var adminKey: String? = "organization-a"
+        let responses = ResponseSequence()
+        let store = makeCredentialStore(
+            authenticatedProviders: { providers },
+            adminKey: { _ in adminKey },
+            fetch: { provider, _, window in
+                try await responses.fetch(provider: provider, window: window)
+            }
+        )
+
+        await store.refresh()
+        XCTAssertEqual(store.usage[.anthropic]?.inputTokens, 23)
+
+        providers = []
+        adminKey = nil
+        await store.refresh()
+        XCTAssertTrue(store.usage.isEmpty)
+
+        providers = [.anthropic]
+        adminKey = "organization-a"
+        await store.refresh()
+
+        XCTAssertNil(store.usage[.anthropic])
+        XCTAssertEqual(store.lastError, "HTTP 503")
     }
 
     private func makeStore(
@@ -161,6 +307,35 @@ final class ApiUsageStoreTests: XCTestCase {
             fetchUsage: { provider, _, window in
                 try await fetch(provider, window)
             }
+        )
+    }
+
+    private func makeCredentialStore(
+        authenticatedProviders: @escaping () -> [ApiProvider],
+        adminKey: @escaping (ApiProvider) -> String?,
+        fetch: @escaping ApiUsageStore.UsageFetcher
+    ) -> ApiUsageStore {
+        ApiUsageStore(
+            authenticatedProviders: authenticatedProviders,
+            adminKey: adminKey,
+            fetchUsage: fetch
+        )
+    }
+
+    nonisolated private static func usage(
+        provider: ApiProvider,
+        window: ApiUsageWindow,
+        inputTokens: Int
+    ) -> ApiUsage {
+        let range = window.dateRange(now: Date(timeIntervalSince1970: 2_000_000_000))
+        return ApiUsage(
+            provider: provider,
+            windowStart: range.start,
+            windowEnd: range.end,
+            inputTokens: inputTokens,
+            outputTokens: 0,
+            estimatedCostUSD: 0,
+            models: []
         )
     }
 }

--- a/MeterBarTests/ApiUsageTests.swift
+++ b/MeterBarTests/ApiUsageTests.swift
@@ -61,12 +61,26 @@ final class ApiUsageTests: XCTestCase {
     }
 
     func testCustomWindowNormalizesOrder() {
-        let early = Date(timeIntervalSince1970: 100)
-        let late = Date(timeIntervalSince1970: 200)
-        // Even if passed reversed, start <= end.
-        let range = ApiUsageWindow.custom(start: late, end: early).dateRange()
-        XCTAssertEqual(range.start, early)
-        XCTAssertEqual(range.end, late)
+        let calendar = utcCalendar
+        let early = date(year: 2026, month: 7, day: 2, hour: 15)
+        let late = date(year: 2026, month: 7, day: 5, hour: 9)
+
+        // Reversed picker values normalize to the first selected day through
+        // the start of the day after the final selected day.
+        let range = ApiUsageWindow.custom(start: late, end: early).dateRange(calendar: calendar)
+        XCTAssertEqual(range.start, date(year: 2026, month: 7, day: 2))
+        XCTAssertEqual(range.end, date(year: 2026, month: 7, day: 6))
+    }
+
+    func testSameDayCustomWindowIncludesTheWholeSelectedDay() {
+        let selected = date(year: 2026, month: 7, day: 9, hour: 18)
+
+        let range = ApiUsageWindow.custom(start: selected, end: selected)
+            .dateRange(calendar: utcCalendar)
+
+        XCTAssertEqual(range.start, date(year: 2026, month: 7, day: 9))
+        XCTAssertEqual(range.end, date(year: 2026, month: 7, day: 10))
+        XCTAssertEqual(range.end.timeIntervalSince(range.start), 86_400)
     }
 
     // MARK: - DTO decoding
@@ -75,8 +89,26 @@ final class ApiUsageTests: XCTestCase {
         let json = """
         {
           "data": [
-            { "model": "claude-sonnet-4-5", "input_tokens": 1000, "output_tokens": 500,
-              "cache_creation_input_tokens": 200 }
+            {
+              "starting_at": "2026-07-01T00:00:00Z",
+              "ending_at": "2026-07-02T00:00:00Z",
+              "results": [
+                {
+                  "uncached_input_tokens": 1000,
+                  "cache_read_input_tokens": 400,
+                  "cache_creation": {
+                    "ephemeral_1h_input_tokens": 300,
+                    "ephemeral_5m_input_tokens": 200
+                  },
+                  "output_tokens": 500,
+                  "server_tool_use": {
+                    "web_search_requests": 2
+                  },
+                  "model": "claude-sonnet-4-5",
+                  "service_tier": "standard"
+                }
+              ]
+            }
           ],
           "has_more": false,
           "next_page": null
@@ -84,9 +116,24 @@ final class ApiUsageTests: XCTestCase {
         """
         let response = try JSONDecoder().decode(AnthropicUsageResponse.self, from: Data(json.utf8))
         XCTAssertEqual(response.data.count, 1)
-        XCTAssertEqual(response.data[0].inputTokens, 1000)
-        XCTAssertEqual(response.data[0].cacheCreationInputTokens, 200)
+        let result = try XCTUnwrap(response.data.first?.results.first)
+        XCTAssertEqual(result.model, "claude-sonnet-4-5")
+        XCTAssertEqual(result.uncachedInputTokens, 1000)
+        XCTAssertEqual(result.cacheReadInputTokens, 400)
+        XCTAssertEqual(result.cacheCreation?.ephemeral1HourInputTokens, 300)
+        XCTAssertEqual(result.cacheCreation?.ephemeral5MinuteInputTokens, 200)
+        XCTAssertEqual(result.outputTokens, 500)
+        XCTAssertEqual(result.totalInputTokens, 1900)
         XCTAssertEqual(response.hasMore, false)
+
+        let usage = ApiUsageService.aggregateAnthropic(
+            buckets: response.data,
+            start: date(year: 2026, month: 7, day: 1),
+            end: date(year: 2026, month: 7, day: 2)
+        )
+        XCTAssertEqual(usage.inputTokens, 1900)
+        XCTAssertEqual(usage.outputTokens, 500)
+        XCTAssertEqual(usage.models.first?.model, "claude-sonnet-4-5")
     }
 
     func testOpenAIUsageResponseDecodes() throws {
@@ -105,5 +152,51 @@ final class ApiUsageTests: XCTestCase {
         XCTAssertEqual(response.data.first?.results.first?.model, "gpt-4o")
         XCTAssertEqual(response.data.first?.results.first?.outputTokens, 400)
         XCTAssertEqual(response.nextPage, "abc")
+    }
+
+    // MARK: - Safe errors
+
+    func testHTTPValidationDropsProviderResponseBody() throws {
+        let url = try XCTUnwrap(URL(string: "https://api.example.test/usage"))
+        let response = try XCTUnwrap(
+            HTTPURLResponse(url: url, statusCode: 500, httpVersion: nil, headerFields: nil)
+        )
+        let body = Data(#"{"email":"person@example.test","token":"sk-secret"}"#.utf8)
+
+        XCTAssertThrowsError(try ServiceSupport.validate(response, data: body)) { error in
+            XCTAssertEqual((error as? ServiceError)?.errorDescription, "HTTP 500")
+            XCTAssertFalse(error.localizedDescription.contains("person@example.test"))
+            XCTAssertFalse(error.localizedDescription.contains("sk-secret"))
+        }
+    }
+
+    func testSafeErrorMessageDropsUnknownLocalizedDetails() {
+        struct SecretError: LocalizedError {
+            var errorDescription: String? { "provider body contained sk-secret" }
+        }
+
+        XCTAssertEqual(ServiceSupport.safeErrorMessage(for: SecretError()), "Request failed")
+        XCTAssertEqual(
+            ServiceSupport.safeErrorMessage(for: ServiceError.apiError("HTTP 429: account@example.test")),
+            "HTTP 429"
+        )
+
+        let urlError = URLError(
+            .badServerResponse,
+            userInfo: [NSLocalizedDescriptionKey: "request failed for https://example.test?token=sk-secret"]
+        )
+        XCTAssertEqual(ServiceSupport.safeErrorMessage(for: urlError), "Network request failed")
+    }
+
+    // MARK: - Helpers
+
+    private var utcCalendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+        return calendar
+    }
+
+    private func date(year: Int, month: Int, day: Int, hour: Int = 0) -> Date {
+        utcCalendar.date(from: DateComponents(year: year, month: month, day: day, hour: hour)) ?? .distantPast
     }
 }

--- a/MeterBarTests/CodexCliLocalServiceTests.swift
+++ b/MeterBarTests/CodexCliLocalServiceTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import MeterBar
 
 /// Direct coverage for `CodexCliLocalService` without touching the network or a
-/// real `~/.codex/auth.json`:
+/// real `CODEX_HOME/auth.json`:
 ///   - `mapUsageResponse` (the response → `UsageMetrics` mapping extracted from
 ///     `fetchUsageMetrics`) is exercised with decoded fixtures.
 ///   - the auth-file read + token-expiry gating is exercised through the

--- a/MeterBarTests/KeychainManagerTests.swift
+++ b/MeterBarTests/KeychainManagerTests.swift
@@ -7,45 +7,70 @@ import XCTest
 /// CI runners, so the `KeychainBackend` seam lets us verify the update-then-add
 /// fallback, UTF-8 round-tripping, and the not-found → nil path deterministically.
 final class KeychainManagerTests: XCTestCase {
+    private static let currentService = "dev.shipshit.meterbar"
+    private static let legacyService = "com.agenticindiedev.quotaguard"
 
-    /// Minimal in-memory stand-in for the Security framework, keyed by the
-    /// `kSecAttrAccount` value. Mirrors the real semantics the manager relies on:
-    /// update on a missing item returns `errSecItemNotFound`, copy on a missing
-    /// item returns `errSecItemNotFound`, delete is idempotent.
+    /// Minimal in-memory stand-in for the Security framework, keyed by service
+    /// and account. Mirrors the real semantics the manager relies on: update on
+    /// a missing item returns `errSecItemNotFound`, copy on a missing item
+    /// returns `errSecItemNotFound`, and delete is idempotent at the manager.
     private final class InMemoryKeychainBackend: KeychainBackend {
-        private(set) var storage: [String: Data] = [:]
+        private struct ItemKey: Hashable {
+            let service: String
+            let account: String
+        }
+
+        private var storage: [ItemKey: Data] = [:]
         private(set) var addCallCount = 0
         private(set) var updateCallCount = 0
+        var addFailureServices: Set<String> = []
+        var deleteFailureServices: Set<String> = []
 
-        private func account(in query: [String: Any]) -> String? {
-            query[kSecAttrAccount as String] as? String
+        func seed(service: String, account: String, value: String) {
+            storage[ItemKey(service: service, account: account)] = Data(value.utf8)
+        }
+
+        func value(service: String, account: String) -> String? {
+            guard let data = storage[ItemKey(service: service, account: account)] else { return nil }
+            return String(data: data, encoding: .utf8)
+        }
+
+        private func itemKey(in query: [String: Any]) -> ItemKey? {
+            guard let service = query[kSecAttrService as String] as? String,
+                  let account = query[kSecAttrAccount as String] as? String else {
+                return nil
+            }
+            return ItemKey(service: service, account: account)
         }
 
         func update(query: [String: Any], attributes: [String: Any]) -> OSStatus {
             updateCallCount += 1
-            guard let account = account(in: query), storage[account] != nil else {
+            guard let itemKey = itemKey(in: query), storage[itemKey] != nil else {
                 return errSecItemNotFound
             }
             guard let data = attributes[kSecValueData as String] as? Data else {
                 return errSecParam
             }
-            storage[account] = data
+            storage[itemKey] = data
             return errSecSuccess
         }
 
         func add(query: [String: Any]) -> OSStatus {
             addCallCount += 1
-            guard let account = account(in: query),
+            guard let itemKey = itemKey(in: query),
                   let data = query[kSecValueData as String] as? Data else {
                 return errSecParam
             }
-            guard storage[account] == nil else { return errSecDuplicateItem }
-            storage[account] = data
+            if addFailureServices.contains(itemKey.service) {
+                return errSecAuthFailed
+            }
+            guard storage[itemKey] == nil else { return errSecDuplicateItem }
+            storage[itemKey] = data
             return errSecSuccess
         }
 
         func copyMatching(query: [String: Any], result: inout AnyObject?) -> OSStatus {
-            guard let account = account(in: query), let data = storage[account] else {
+            guard let itemKey = itemKey(in: query), let data = storage[itemKey] else {
                 return errSecItemNotFound
             }
             result = data as AnyObject
@@ -53,8 +78,11 @@ final class KeychainManagerTests: XCTestCase {
         }
 
         func delete(query: [String: Any]) -> OSStatus {
-            guard let account = account(in: query) else { return errSecParam }
-            guard storage.removeValue(forKey: account) != nil else { return errSecItemNotFound }
+            guard let itemKey = itemKey(in: query) else { return errSecParam }
+            if deleteFailureServices.contains(itemKey.service) {
+                return errSecAuthFailed
+            }
+            guard storage.removeValue(forKey: itemKey) != nil else { return errSecItemNotFound }
             return errSecSuccess
         }
     }
@@ -119,5 +147,93 @@ final class KeychainManagerTests: XCTestCase {
         XCTAssertTrue(manager.delete(key: "openai"))
         XCTAssertNil(manager.get(key: "openai"))
         XCTAssertEqual(manager.get(key: "anthropic"), "b")
+    }
+
+    func testGetMigratesLegacyItemAfterCurrentWriteSucceeds() {
+        let (manager, backend) = makeManager()
+        backend.seed(service: Self.legacyService, account: "anthropic", value: "legacy-key")
+
+        XCTAssertEqual(manager.get(key: "anthropic"), "legacy-key")
+        XCTAssertEqual(
+            backend.value(service: Self.currentService, account: "anthropic"),
+            "legacy-key"
+        )
+        XCTAssertNil(backend.value(service: Self.legacyService, account: "anthropic"))
+    }
+
+    func testCurrentItemWinsWhenBothServicesContainAValue() {
+        let (manager, backend) = makeManager()
+        backend.seed(service: Self.currentService, account: "openai", value: "current-key")
+        backend.seed(service: Self.legacyService, account: "openai", value: "legacy-key")
+
+        XCTAssertEqual(manager.get(key: "openai"), "current-key")
+        XCTAssertNil(backend.value(service: Self.legacyService, account: "openai"))
+    }
+
+    func testFailedMigrationReturnsAndPreservesLegacyItem() {
+        let (manager, backend) = makeManager()
+        backend.seed(service: Self.legacyService, account: "anthropic", value: "legacy-key")
+        backend.addFailureServices = [Self.currentService]
+
+        XCTAssertEqual(manager.get(key: "anthropic"), "legacy-key")
+        XCTAssertNil(backend.value(service: Self.currentService, account: "anthropic"))
+        XCTAssertEqual(
+            backend.value(service: Self.legacyService, account: "anthropic"),
+            "legacy-key"
+        )
+    }
+
+    func testSuccessfulSaveRemovesStaleLegacyItem() {
+        let (manager, backend) = makeManager()
+        backend.seed(service: Self.legacyService, account: "openai", value: "legacy-key")
+
+        XCTAssertTrue(manager.save(key: "openai", value: "current-key"))
+        XCTAssertEqual(
+            backend.value(service: Self.currentService, account: "openai"),
+            "current-key"
+        )
+        XCTAssertNil(backend.value(service: Self.legacyService, account: "openai"))
+    }
+
+    func testDeleteRemovesCurrentAndLegacyItems() {
+        let (manager, backend) = makeManager()
+        backend.seed(service: Self.currentService, account: "anthropic", value: "current-key")
+        backend.seed(service: Self.legacyService, account: "anthropic", value: "legacy-key")
+
+        XCTAssertTrue(manager.delete(key: "anthropic"))
+        XCTAssertNil(backend.value(service: Self.currentService, account: "anthropic"))
+        XCTAssertNil(backend.value(service: Self.legacyService, account: "anthropic"))
+        XCTAssertNil(manager.get(key: "anthropic"))
+    }
+
+    func testAuthenticationManagerClearsCredentialAfterCompleteDelete() {
+        let (keychain, backend) = makeManager()
+        let account = ApiProvider.anthropic.keychainKey
+        backend.seed(service: Self.currentService, account: account, value: "current-key")
+        let authentication = AuthenticationManager(keychain: keychain)
+
+        XCTAssertTrue(authentication.removeAdminKey(for: .anthropic))
+        XCTAssertNil(authentication.claudeAdminKey)
+        XCTAssertFalse(authentication.isClaudeAuthenticated)
+    }
+
+    func testAuthenticationManagerKeepsSurvivingCredentialAfterPartialDelete() {
+        let (keychain, backend) = makeManager()
+        let account = ApiProvider.anthropic.keychainKey
+        backend.seed(service: Self.currentService, account: account, value: "current-key")
+        let authentication = AuthenticationManager(keychain: keychain)
+
+        // Simulate a stale legacy item appearing after initialization. The
+        // current item deletes, but Keychain denies deletion of the legacy one.
+        backend.seed(service: Self.legacyService, account: account, value: "legacy-key")
+        backend.deleteFailureServices = [Self.legacyService]
+
+        XCTAssertFalse(authentication.removeAdminKey(for: .anthropic))
+        XCTAssertEqual(authentication.claudeAdminKey, "legacy-key")
+        XCTAssertTrue(authentication.isClaudeAuthenticated)
+        XCTAssertEqual(
+            backend.value(service: Self.legacyService, account: account),
+            "legacy-key"
+        )
     }
 }

--- a/MeterBarTests/NotificationDeciderTests.swift
+++ b/MeterBarTests/NotificationDeciderTests.swift
@@ -57,7 +57,7 @@ final class NotificationDeciderTests: XCTestCase {
         XCTAssertTrue(result.notifiedKeys.contains("Claude Code-session-warn"))
     }
 
-    func testCriticalFiresAndSupersedesWarning() {
+    func testCriticalFiresAndPreservesWarningState() {
         // Already warned; usage climbs into the exhausted band.
         let result = decider().evaluate(
             metrics: metrics(session: exhaustedLimit()),
@@ -69,8 +69,9 @@ final class NotificationDeciderTests: XCTestCase {
         XCTAssertEqual(result.notifications.count, 1)
         XCTAssertEqual(result.notifications[0].level, .critical)
         XCTAssertEqual(result.notifications[0].key, "Claude Code-session-critical")
-        // Warn key superseded, critical key recorded.
-        XCTAssertFalse(result.notifiedKeys.contains("Claude Code-session-warn"))
+        // Preserve the warning key so a later recovery into the warning band
+        // cannot look like a new upward crossing.
+        XCTAssertTrue(result.notifiedKeys.contains("Claude Code-session-warn"))
         XCTAssertTrue(result.notifiedKeys.contains("Claude Code-session-critical"))
     }
 
@@ -97,7 +98,7 @@ final class NotificationDeciderTests: XCTestCase {
         )
 
         XCTAssertTrue(result.notifications.isEmpty)
-        XCTAssertEqual(result.notifiedKeys, ["Claude Code-session-critical"])
+        XCTAssertEqual(result.notifiedKeys, ["Claude Code-session-warn", "Claude Code-session-critical"])
     }
 
     // MARK: - Falling
@@ -125,6 +126,18 @@ final class NotificationDeciderTests: XCTestCase {
 
         XCTAssertTrue(result.notifications.isEmpty)
         XCTAssertFalse(result.notifiedKeys.contains("Claude Code-session-warn"))
+    }
+
+    func testRecoveryFromExhaustedIntoWarningBandDoesNotFire() {
+        let result = decider().evaluate(
+            metrics: metrics(session: criticalLimit()),
+            providerEnabled: true,
+            alreadyNotified: ["Claude Code-session-warn", "Claude Code-session-critical"],
+            now: now
+        )
+
+        XCTAssertTrue(result.notifications.isEmpty)
+        XCTAssertEqual(result.notifiedKeys, ["Claude Code-session-warn"])
     }
 
     // MARK: - Threshold change
@@ -157,6 +170,9 @@ final class NotificationDeciderTests: XCTestCase {
             .critical,
             "At the critical threshold the critical band should alert, not warn."
         )
+        XCTAssertFalse(result.notifications[0].isExhausted)
+        XCTAssertEqual(result.notifications[0].title, "Claude Code Usage Alert")
+        XCTAssertFalse(result.notifications[0].body.lowercased().contains("reached"))
     }
 
     // MARK: - Gates
@@ -171,7 +187,7 @@ final class NotificationDeciderTests: XCTestCase {
         )
 
         XCTAssertTrue(result.notifications.isEmpty)
-        XCTAssertTrue(result.notifiedKeys.isEmpty)
+        XCTAssertEqual(result.notifiedKeys, ["Claude Code-session-warn", "Claude Code-session-critical"])
     }
 
     func testDisabledProviderNeverNotifies() {
@@ -183,6 +199,7 @@ final class NotificationDeciderTests: XCTestCase {
         )
 
         XCTAssertTrue(result.notifications.isEmpty)
+        XCTAssertEqual(result.notifiedKeys, ["Claude Code-session-warn", "Claude Code-session-critical"])
     }
 
     func testStaleDataNeverNotifies() {
@@ -195,6 +212,73 @@ final class NotificationDeciderTests: XCTestCase {
         )
 
         XCTAssertTrue(result.notifications.isEmpty, "A two-hour-old cache must not fire alerts.")
+        XCTAssertEqual(result.notifiedKeys, ["Claude Code-session-warn", "Claude Code-session-critical"])
+    }
+
+    func testDisabledRecoveryRearmsNextEnabledCrossing() {
+        let recoveredWhileDisabled = decider().evaluate(
+            metrics: metrics(session: healthyLimit()),
+            providerEnabled: false,
+            alreadyNotified: ["Claude Code-session-warn", "Claude Code-session-critical"],
+            now: now
+        )
+        XCTAssertTrue(recoveredWhileDisabled.notifiedKeys.isEmpty)
+
+        let nextCrossing = decider().evaluate(
+            metrics: metrics(session: criticalLimit()),
+            providerEnabled: true,
+            alreadyNotified: recoveredWhileDisabled.notifiedKeys,
+            now: now
+        )
+        XCTAssertEqual(nextCrossing.notifications.map(\.level), [.warning])
+    }
+
+    func testStaleRecoveryRearmsNextFreshCrossing() {
+        let staleRecovery = decider().evaluate(
+            metrics: metrics(
+                session: healthyLimit(),
+                lastUpdated: now.addingTimeInterval(-NotificationDecider.defaultStalenessThreshold - 1)
+            ),
+            providerEnabled: true,
+            alreadyNotified: ["Claude Code-session-warn"],
+            now: now
+        )
+        XCTAssertTrue(staleRecovery.notifications.isEmpty)
+        XCTAssertTrue(staleRecovery.notifiedKeys.isEmpty)
+
+        let nextCrossing = decider().evaluate(
+            metrics: metrics(session: criticalLimit()),
+            providerEnabled: true,
+            alreadyNotified: staleRecovery.notifiedKeys,
+            now: now
+        )
+        XCTAssertEqual(nextCrossing.notifications.map(\.level), [.warning])
+    }
+
+    func testMissingLimitClearsPreviousBandState() {
+        let result = decider().evaluate(
+            metrics: metrics(session: nil),
+            providerEnabled: false,
+            alreadyNotified: ["Claude Code-session-warn", "Claude Code-session-critical"],
+            now: now
+        )
+
+        XCTAssertTrue(result.notifications.isEmpty)
+        XCTAssertTrue(result.notifiedKeys.isEmpty)
+    }
+
+    func testExhaustedCriticalCopyClaimsLimitReached() {
+        let result = decider().evaluate(
+            metrics: metrics(session: exhaustedLimit()),
+            providerEnabled: true,
+            alreadyNotified: [],
+            now: now
+        )
+
+        let fired = result.notifications[0]
+        XCTAssertTrue(fired.isExhausted)
+        XCTAssertEqual(fired.title, "Claude Code Limit Reached")
+        XCTAssertTrue(fired.body.contains("reached"))
     }
 
     func testDataAtStalenessBoundaryStillNotifies() {

--- a/MeterBarTests/NotificationDeciderTests.swift
+++ b/MeterBarTests/NotificationDeciderTests.swift
@@ -23,6 +23,7 @@ final class NotificationDeciderTests: XCTestCase {
         session: UsageLimit? = nil,
         weekly: UsageLimit? = nil,
         codeReview: UsageLimit? = nil,
+        extraUsage: ExtraUsageStatus? = nil,
         lastUpdated: Date? = nil
     ) -> UsageMetrics {
         UsageMetrics(
@@ -30,6 +31,7 @@ final class NotificationDeciderTests: XCTestCase {
             sessionLimit: session,
             weeklyLimit: weekly,
             codeReviewLimit: codeReview,
+            extraUsage: extraUsage,
             lastUpdated: lastUpdated ?? now
         )
     }
@@ -53,7 +55,10 @@ final class NotificationDeciderTests: XCTestCase {
         XCTAssertEqual(fired.level, .warning)
         XCTAssertEqual(fired.key, "Claude Code-session-warn")
         XCTAssertEqual(fired.serviceDisplayName, "Claude Code")
+        XCTAssertEqual(fired.quotaDisplayName, "Session")
+        XCTAssertTrue(fired.blocksProvider)
         XCTAssertEqual(fired.percentUsed, 95)
+        XCTAssertEqual(fired.title, "Claude Code Session Usage Warning")
         XCTAssertTrue(result.notifiedKeys.contains("Claude Code-session-warn"))
     }
 
@@ -171,7 +176,7 @@ final class NotificationDeciderTests: XCTestCase {
             "At the critical threshold the critical band should alert, not warn."
         )
         XCTAssertFalse(result.notifications[0].isExhausted)
-        XCTAssertEqual(result.notifications[0].title, "Claude Code Usage Alert")
+        XCTAssertEqual(result.notifications[0].title, "Claude Code Session Usage Alert")
         XCTAssertFalse(result.notifications[0].body.lowercased().contains("reached"))
     }
 
@@ -277,8 +282,60 @@ final class NotificationDeciderTests: XCTestCase {
 
         let fired = result.notifications[0]
         XCTAssertTrue(fired.isExhausted)
-        XCTAssertEqual(fired.title, "Claude Code Limit Reached")
+        XCTAssertTrue(fired.blocksProvider)
+        XCTAssertEqual(fired.title, "Claude Code Session Limit Reached")
         XCTAssertTrue(fired.body.contains("reached"))
+    }
+
+    func testClaudeSecondaryExhaustionNamesSonnetWithoutBlockingProvider() {
+        let result = decider().evaluate(
+            metrics: metrics(session: healthyLimit(), codeReview: exhaustedLimit()),
+            providerEnabled: true,
+            alreadyNotified: [],
+            now: now
+        )
+
+        let fired = result.notifications[0]
+        XCTAssertEqual(fired.key, "Claude Code-codeReview-critical")
+        XCTAssertEqual(fired.quotaDisplayName, "Sonnet")
+        XCTAssertFalse(fired.blocksProvider)
+        XCTAssertEqual(fired.title, "Claude Code Sonnet Quota Exhausted")
+        XCTAssertTrue(fired.body.contains("does not block all Claude Code usage"))
+    }
+
+    func testCodexSecondaryExhaustionNamesCodeReviewWithoutBlockingProvider() {
+        let result = decider().evaluate(
+            metrics: metrics(service: .codexCli, session: healthyLimit(), codeReview: exhaustedLimit()),
+            providerEnabled: true,
+            alreadyNotified: [],
+            now: now
+        )
+
+        let fired = result.notifications[0]
+        XCTAssertEqual(fired.key, "Codex CLI-codeReview-critical")
+        XCTAssertEqual(fired.quotaDisplayName, "Code Review")
+        XCTAssertFalse(fired.blocksProvider)
+        XCTAssertEqual(fired.title, "OpenAI Codex Code Review Quota Exhausted")
+        XCTAssertTrue(fired.body.contains("does not block all OpenAI Codex usage"))
+    }
+
+    func testExtraUsageKeepsExhaustedPrimaryQuotaNonblocking() {
+        let result = decider().evaluate(
+            metrics: metrics(
+                service: .codexCli,
+                session: exhaustedLimit(),
+                extraUsage: ExtraUsageStatus(state: .on)
+            ),
+            providerEnabled: true,
+            alreadyNotified: [],
+            now: now
+        )
+
+        let fired = result.notifications[0]
+        XCTAssertEqual(fired.key, "Codex CLI-session-critical")
+        XCTAssertFalse(fired.blocksProvider)
+        XCTAssertEqual(fired.title, "OpenAI Codex Session Quota Exhausted")
+        XCTAssertTrue(fired.body.contains("does not block all OpenAI Codex usage"))
     }
 
     func testDataAtStalenessBoundaryStillNotifies() {
@@ -309,5 +366,24 @@ final class NotificationDeciderTests: XCTestCase {
         XCTAssertEqual(result.notifications.count, 1)
         XCTAssertEqual(result.notifications[0].key, "Claude Code-session-critical")
         XCTAssertFalse(result.notifiedKeys.contains { $0.hasPrefix("Claude Code-weekly") })
+    }
+
+    func testSimultaneouslyExhaustedLimitsProduceDistinguishableBanners() {
+        let result = decider().evaluate(
+            metrics: metrics(session: exhaustedLimit(), codeReview: exhaustedLimit()),
+            providerEnabled: true,
+            alreadyNotified: [],
+            now: now
+        )
+
+        XCTAssertEqual(result.notifications.count, 2)
+        XCTAssertEqual(Set(result.notifications.map(\.title)), [
+            "Claude Code Session Limit Reached",
+            "Claude Code Sonnet Quota Exhausted"
+        ])
+        XCTAssertEqual(Set(result.notifications.map(\.key)), [
+            "Claude Code-session-critical",
+            "Claude Code-codeReview-critical"
+        ])
     }
 }

--- a/MeterBarTests/ProviderReadinessInspectorTests.swift
+++ b/MeterBarTests/ProviderReadinessInspectorTests.swift
@@ -101,6 +101,10 @@ final class ProviderReadinessInspectorTests: XCTestCase {
     func testSafeNetworkMessagesPassThrough() {
         XCTAssertEqual(ProviderReadinessInspector.sanitize(.apiError("No internet connection")), "No internet connection")
         XCTAssertEqual(ProviderReadinessInspector.sanitize(.apiError("Request timed out")), "Request timed out")
+        XCTAssertEqual(
+            ProviderReadinessInspector.sanitize(.apiError("Secure connection failed")),
+            "Secure connection failed"
+        )
     }
 
     func testKnownCasesMapToStableStrings() {

--- a/MeterBarTests/ProviderReadinessInspectorTests.swift
+++ b/MeterBarTests/ProviderReadinessInspectorTests.swift
@@ -1,9 +1,87 @@
 import XCTest
+import MeterBarShared
 @testable import MeterBar
 
 /// Redaction tests for the inspector's error sanitizer — the layer that keeps
 /// `meterbar doctor` / Diagnostics output safe to paste into a public issue.
 final class ProviderReadinessInspectorTests: XCTestCase {
+    func testReportsGatherOnlyRequestedProvidersInStableOrder() {
+        var gathered: [ServiceType] = []
+        let reports = ProviderReadinessInspector.reports(
+            providers: [.cursor, .codexCli],
+            refreshErrors: [:],
+            now: Date(timeIntervalSince1970: 1_000),
+            claudeReport: { _, _ in
+                gathered.append(.claudeCode)
+                return self.report(for: .claudeCode)
+            },
+            codexReport: { _, _ in
+                gathered.append(.codexCli)
+                return self.report(for: .codexCli)
+            },
+            cursorReport: { _, _ in
+                gathered.append(.cursor)
+                return self.report(for: .cursor)
+            }
+        )
+
+        XCTAssertEqual(gathered, [.codexCli, .cursor])
+        XCTAssertEqual(reports.map(\.provider), [.codexCli, .cursor])
+    }
+
+    func testRecentClaudeUsageSkipsCredentialRead() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let recent = UsageMetrics(service: .claudeCode, lastUpdated: now.addingTimeInterval(-60))
+        var didReadCredentials = false
+
+        _ = ProviderReadinessInspector.claudeReport(
+            now: now,
+            cachedMetrics: recent,
+            credentialsData: {
+                didReadCredentials = true
+                return nil
+            }
+        )
+
+        XCTAssertFalse(didReadCredentials)
+    }
+
+    func testStaleClaudeUsageFallsBackToCredentialRead() {
+        let now = Date(timeIntervalSince1970: 100_000)
+        let stale = UsageMetrics(
+            service: .claudeCode,
+            lastUpdated: now.addingTimeInterval(-ProviderReadinessInspector.recentUsageFetchWindow - 1)
+        )
+        var didReadCredentials = false
+
+        _ = ProviderReadinessInspector.claudeReport(
+            now: now,
+            cachedMetrics: stale,
+            isOAuthFallbackEnabled: { true },
+            credentialsData: {
+                didReadCredentials = true
+                return nil
+            }
+        )
+
+        XCTAssertTrue(didReadCredentials)
+    }
+
+    func testDisabledClaudeOAuthFallbackSkipsCredentialReadWithoutRecentUsage() {
+        var didReadCredentials = false
+
+        _ = ProviderReadinessInspector.claudeReport(
+            cachedMetrics: nil,
+            isOAuthFallbackEnabled: { false },
+            credentialsData: {
+                didReadCredentials = true
+                return nil
+            }
+        )
+
+        XCTAssertFalse(didReadCredentials)
+    }
+
     func testApiErrorDropsResponseBodyKeepsStatusCode() {
         let raw = ServiceError.apiError("HTTP 500: {\"user\":\"vincent@genfeed.ai\",\"token\":\"sk-SECRET\"}")
         let sanitized = ProviderReadinessInspector.sanitize(raw)
@@ -34,5 +112,12 @@ final class ProviderReadinessInspectorTests: XCTestCase {
     func testHttpStatusExtraction() {
         XCTAssertEqual(ProviderReadinessInspector.httpStatus(in: "HTTP 404: not found"), 404)
         XCTAssertNil(ProviderReadinessInspector.httpStatus(in: "no status here"))
+    }
+
+    private func report(for provider: ServiceType) -> ProviderReadiness {
+        ProviderReadiness(
+            provider: provider,
+            checks: [ReadinessCheck(id: "test", title: "Test", level: .pass, detail: "Ready")]
+        )
     }
 }

--- a/MeterBarTests/ProviderReadinessTests.swift
+++ b/MeterBarTests/ProviderReadinessTests.swift
@@ -205,8 +205,9 @@ final class ProviderReadinessTests: XCTestCase {
         XCTAssertTrue((report.check("auth")?.recovery ?? "").contains("codex login"))
     }
 
-    func testCodexApiKeyModeIsAuthenticated() {
-        // auth.json with an OPENAI_API_KEY and no OAuth tokens is a valid signed-in state.
+    func testCodexApiKeyModeDoesNotAuthorizeSubscriptionQuota() {
+        // The quota endpoint uses the ChatGPT/Codex OAuth access token. An API
+        // key may authorize platform APIs, but it cannot make this check healthy.
         let json = #"{"OPENAI_API_KEY":"sk-\#(secret)","tokens":null}"#.data(using: .utf8)
         let input = CodexReadinessInput(
             isCLIInstalled: true,
@@ -217,12 +218,15 @@ final class ProviderReadinessTests: XCTestCase {
         )
         let report = ProviderReadinessEvaluator.codexCli(input)
 
-        XCTAssertEqual(report.check("auth")?.level, .pass)
+        XCTAssertEqual(report.check("auth")?.level, .fail)
+        XCTAssertEqual(report.check("data")?.level, .warn)
+        XCTAssertTrue((report.check("auth")?.detail ?? "").contains("subscription quota"))
+        XCTAssertTrue((report.check("auth")?.recovery ?? "").contains("codex login"))
         assertNoSecretLeak(report)
     }
 
     func testCodexBinaryMissingIsWarnNotFail() {
-        // The app reads ~/.codex/auth.json directly, so a missing `codex` binary
+        // The app reads CODEX_HOME/auth.json directly, so a missing `codex` binary
         // is a soft warning, not a hard failure, when auth is otherwise present.
         let input = CodexReadinessInput(
             isCLIInstalled: false,

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -7,13 +7,15 @@ final class ProviderSnapshotTests: XCTestCase {
         service: ServiceType,
         session: Double? = nil,
         weekly: Double? = nil,
-        codeReview: Double? = nil
+        codeReview: Double? = nil,
+        extraUsage: ExtraUsageStatus? = nil
     ) -> UsageMetrics {
         UsageMetrics(
             service: service,
             sessionLimit: session.map { UsageLimit(used: $0, total: 100, resetTime: nil) },
             weeklyLimit: weekly.map { UsageLimit(used: $0, total: 100, resetTime: nil) },
-            codeReviewLimit: codeReview.map { UsageLimit(used: $0, total: 100, resetTime: nil) }
+            codeReviewLimit: codeReview.map { UsageLimit(used: $0, total: 100, resetTime: nil) },
+            extraUsage: extraUsage
         )
     }
 
@@ -173,7 +175,7 @@ final class ProviderSnapshotTests: XCTestCase {
 
         XCTAssertTrue(snapshot.hasExhaustedLimit)
         XCTAssertEqual(snapshot.band, .exhausted)
-        XCTAssertEqual(snapshot.resetWindows.count, 2)
+        XCTAssertEqual(snapshot.resetWindows.map(\.title), ["Session"])
     }
 
     func testWeeklyExhaustionIsDistinctFromSessionExhaustion() {
@@ -194,6 +196,83 @@ final class ProviderSnapshotTests: XCTestCase {
         XCTAssertTrue(weeklyOut.hasExhaustedWeeklyLimit)
         XCTAssertTrue(sessionOut.hasExhaustedLimit)
         XCTAssertFalse(sessionOut.hasExhaustedWeeklyLimit)
+    }
+
+    func testSecondaryQuotaExhaustionDoesNotBlockProvider() {
+        let snapshot = ProviderSnapshotBuilder.snapshot(
+            title: "Codex",
+            service: .codexCli,
+            metrics: makeMetrics(
+                service: .codexCli,
+                session: 20,
+                weekly: 30,
+                codeReview: 100,
+                extraUsage: ExtraUsageStatus(state: .off)
+            ),
+            emptyDetail: ""
+        )
+
+        XCTAssertFalse(snapshot.hasExhaustedLimit)
+        XCTAssertFalse(snapshot.hasExhaustedWeeklyLimit)
+        XCTAssertTrue(snapshot.blockingLimits.isEmpty)
+        XCTAssertTrue(snapshot.resetWindows.isEmpty)
+        XCTAssertEqual(snapshot.detailLimits.map(\.id), ["session", "weekly", "codeReview"])
+        XCTAssertNotNil(snapshot.displayedExtraUsage)
+        XCTAssertTrue(ProviderStatusBadges(snapshot: snapshot).hasContent)
+    }
+
+    func testConfirmedExtraUsageKeepsExhaustedPrimaryWindowNonblocking() {
+        let snapshot = ProviderSnapshotBuilder.snapshot(
+            title: "Codex",
+            service: .codexCli,
+            metrics: makeMetrics(
+                service: .codexCli,
+                session: 100,
+                weekly: 20,
+                extraUsage: ExtraUsageStatus(state: .on, detail: "$5.00 in credits")
+            ),
+            emptyDetail: ""
+        )
+
+        XCTAssertFalse(snapshot.hasExhaustedLimit)
+        XCTAssertTrue(snapshot.blockingLimits.isEmpty)
+        XCTAssertTrue(snapshot.resetWindows.isEmpty)
+        XCTAssertEqual(snapshot.displayedExtraUsage?.state, .on)
+    }
+
+    func testPrimaryExhaustionStillBlocksWhenExtraUsageIsOff() {
+        let snapshot = ProviderSnapshotBuilder.snapshot(
+            title: "Codex",
+            service: .codexCli,
+            metrics: makeMetrics(
+                service: .codexCli,
+                session: 100,
+                weekly: 20,
+                extraUsage: ExtraUsageStatus(state: .off)
+            ),
+            emptyDetail: ""
+        )
+
+        XCTAssertTrue(snapshot.hasExhaustedLimit)
+        XCTAssertEqual(snapshot.blockingLimits.map(\.kind), [.session])
+        XCTAssertEqual(snapshot.resetWindows.map(\.title), ["Session"])
+        XCTAssertTrue(
+            ProviderStatusBadges(snapshot: snapshot).hasContent,
+            "Overage On/Off remains relevant when the subscription quota is exhausted."
+        )
+    }
+
+    func testBlockingResetWindowsExcludeSimultaneouslyExhaustedSecondaryQuota() {
+        let snapshot = ProviderSnapshotBuilder.snapshot(
+            title: "Claude",
+            service: .claudeCode,
+            metrics: makeMetrics(service: .claudeCode, session: 100, weekly: 30, codeReview: 100),
+            emptyDetail: ""
+        )
+
+        XCTAssertTrue(snapshot.hasExhaustedLimit)
+        XCTAssertEqual(snapshot.blockingLimits.map(\.kind), [.session])
+        XCTAssertEqual(snapshot.resetWindows.map(\.title), ["Session"])
     }
 
     func testDetailLimitsHideSessionWhenWeeklyIsExhausted() {

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
@@ -9,7 +9,7 @@ import Foundation
 /// instead of each re-deriving the checks.
 ///
 /// The evaluators are pure functions of fixture-able inputs: the impure
-/// gathering (PATH scan, keychain, `~/.codex/auth.json`, Cursor SQLite) is done
+/// gathering (PATH scan, keychain, `CODEX_HOME/auth.json`, Cursor SQLite) is done
 /// by `ProviderReadinessInspector` in the app target. Every string produced here
 /// is safe to paste into a public GitHub issue — no token, account id, or raw
 /// file/response body is ever emitted.
@@ -156,11 +156,11 @@ public struct ClaudeReadinessInput: Sendable {
 public struct CodexReadinessInput: Sendable {
     /// `codex` resolvable on PATH.
     public var isCLIInstalled: Bool
-    /// `~/.codex/auth.json` exists on disk.
+    /// `CODEX_HOME/auth.json` exists on disk (`CODEX_HOME` defaults to `~/.codex`).
     public var authFileExists: Bool
     /// The auth file could be read (exists and permissions allow it).
     public var authFileReadable: Bool
-    /// Raw `~/.codex/auth.json` bytes when readable, else nil.
+    /// Raw `CODEX_HOME/auth.json` bytes when readable, else nil.
     public var authJSON: Data?
     /// Pre-sanitized last-refresh error (safe to display), nil on success.
     public var refreshError: String?
@@ -315,7 +315,7 @@ public enum ProviderReadinessEvaluator {
     // MARK: Codex CLI
 
     public static func codexCli(_ input: CodexReadinessInput) -> ProviderReadiness {
-        // The app reads ~/.codex/auth.json directly and never execs `codex`, so a
+        // The app reads CODEX_HOME/auth.json directly and never execs `codex`, so a
         // missing binary is a soft warning rather than a hard failure.
         let installed = ReadinessCheck(
             id: ReadinessCheckID.installed,
@@ -323,19 +323,20 @@ public enum ProviderReadinessEvaluator {
             level: input.isCLIInstalled ? .pass : .warn,
             detail: input.isCLIInstalled
                 ? "Codex CLI found on PATH."
-                : "Codex CLI not found on PATH (usage is still read from ~/.codex/auth.json).",
+                : "Codex CLI not found on PATH (usage is still read from CODEX_HOME/auth.json).",
             recovery: input.isCLIInstalled ? nil : "Install the Codex CLI (`npm i -g @openai/codex`) to use `codex login`."
         )
 
         let auth = codexAuthCheck(input)
 
+        let dataReady = input.authFileReadable && auth.level == .pass
         let data = ReadinessCheck(
             id: ReadinessCheckID.data,
             title: "Usage readable",
-            level: input.authFileReadable ? .pass : .warn,
-            detail: input.authFileReadable
-                ? "Usage is readable from ~/.codex/auth.json."
-                : "Usage cannot be read until the auth file is available."
+            level: dataReady ? .pass : .warn,
+            detail: dataReady
+                ? "Subscription usage is readable from CODEX_HOME/auth.json."
+                : "Subscription usage requires a readable Codex OAuth login."
         )
 
         return ProviderReadiness(
@@ -353,7 +354,7 @@ public enum ProviderReadinessEvaluator {
                 id: ReadinessCheckID.auth,
                 title: title,
                 level: .fail,
-                detail: "Not signed in — no ~/.codex/auth.json found.",
+                detail: "Not signed in — no CODEX_HOME/auth.json found.",
                 recovery: loginRecovery
             )
         }
@@ -363,8 +364,8 @@ public enum ProviderReadinessEvaluator {
                 id: ReadinessCheckID.auth,
                 title: title,
                 level: .fail,
-                detail: "~/.codex/auth.json exists but could not be read.",
-                recovery: "Check the permissions on ~/.codex/auth.json, then run `codex login`."
+                detail: "CODEX_HOME/auth.json exists but could not be read.",
+                recovery: "Check the permissions on CODEX_HOME/auth.json, then run `codex login`."
             )
         }
 
@@ -373,26 +374,26 @@ public enum ProviderReadinessEvaluator {
                 id: ReadinessCheckID.auth,
                 title: title,
                 level: .fail,
-                detail: "~/.codex/auth.json could not be parsed.",
+                detail: "CODEX_HOME/auth.json could not be parsed.",
                 recovery: loginRecovery
             )
         }
 
-        if let apiKey = auth.openaiApiKey, !apiKey.isEmpty {
-            return ReadinessCheck(
-                id: ReadinessCheckID.auth,
-                title: title,
-                level: .pass,
-                detail: "Signed in with an OpenAI API key."
-            )
-        }
-
         guard let token = auth.tokens?.accessToken, !token.isEmpty else {
+            if let apiKey = auth.openaiApiKey, !apiKey.isEmpty {
+                return ReadinessCheck(
+                    id: ReadinessCheckID.auth,
+                    title: title,
+                    level: .fail,
+                    detail: "An OpenAI API key is present, but subscription quota requires a Codex OAuth login.",
+                    recovery: loginRecovery
+                )
+            }
             return ReadinessCheck(
                 id: ReadinessCheckID.auth,
                 title: title,
                 level: .fail,
-                detail: "Not signed in — no token in ~/.codex/auth.json.",
+                detail: "Not signed in — no OAuth token in CODEX_HOME/auth.json.",
                 recovery: loginRecovery
             )
         }

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A lightweight macOS menu bar app that monitors Claude Code, Codex CLI, and Curso
 Paste this into your local coding agent to have it install MeterBar for you:
 
 ```text
-Install MeterBar on this Mac. First verify this is macOS 26 or newer and that Homebrew is available. Install with: brew tap VincentShipsIt/tap && brew install --cask VincentShipsIt/tap/meterbar. If Homebrew is missing, ask before installing Homebrew. After installing, verify /Applications/MeterBar.app exists and that the meterbar CLI is linked, then open MeterBar. If macOS blocks the first launch because the app is unsigned, remove quarantine with xattr -cr /Applications/MeterBar.app and open it again. Do not ask me for API keys or paste secrets; for usage data, tell me to run claude login, codex login, and log into Cursor if I want those providers tracked.
+Install MeterBar on this Mac. First verify this is macOS 26 or newer and that Homebrew is available. Install with: brew tap VincentShipsIt/tap && brew install --cask VincentShipsIt/tap/meterbar. If Homebrew is missing, ask before installing Homebrew. After installing, verify /Applications/MeterBar.app exists and that the meterbar CLI is linked, then open MeterBar. If macOS blocks the first launch because the app is not Developer ID-signed or notarized, remove quarantine with xattr -cr /Applications/MeterBar.app and open it again. Do not ask me for API keys or paste secrets; for usage data, tell me to run claude login, codex login, and log into Cursor if I want those providers tracked.
 ```
 
 ### Homebrew (Recommended)
@@ -107,7 +107,7 @@ open MeterBar.xcodeproj
 1. Install Codex CLI: `npm install -g @openai/codex`
 2. Log in: `codex login`
 3. Select your team/workspace when prompted
-4. The app automatically reads credentials from `~/.codex/auth.json`
+4. The app automatically reads credentials from `$CODEX_HOME/auth.json` (`~/.codex/auth.json` by default)
 
 ### Cursor
 
@@ -172,7 +172,7 @@ MeterBar reads usage data from local CLI output, local credential stores, and pr
 claude /usage            # Claude Code usage
 macOS Keychain           # Legacy Claude Code OAuth fallback only
 ~/.claude/               # Claude Code account metadata and local sessions
-~/.codex/auth.json       # Codex CLI OAuth token
+$CODEX_HOME/auth.json    # Codex CLI OAuth token (defaults to ~/.codex/auth.json)
 ~/Library/Application Support/Cursor/  # Cursor local DB
 ```
 
@@ -222,7 +222,7 @@ Run `codex logout && codex login` and select your team workspace when prompted.
 
 ### App can't read credentials
 
-The app reads CLI credential files from your home directory (`~/.codex/auth.json`, Cursor's local database). If you built from source with App Sandbox enabled, those reads will fail — the shipped configuration keeps the main app un-sandboxed for this reason.
+The app reads CLI credential files from `$CODEX_HOME/auth.json` (`~/.codex/auth.json` by default) and Cursor's local database. If you built from source with App Sandbox enabled, those reads will fail — the shipped configuration keeps the main app un-sandboxed for this reason.
 
 ## Contributing
 

--- a/scripts/build-universal-cli.sh
+++ b/scripts/build-universal-cli.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "Usage: $0 OUTPUT_PATH [SCRATCH_DIRECTORY]" >&2
+  exit 64
+fi
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repository_root=$(cd "$script_dir/.." && pwd)
+package_path="$repository_root/MeterBarCLI"
+output_path="$1"
+scratch_root="${2:-${TMPDIR:-/tmp}/meterbar-cli-universal}"
+deployment_target="${MACOSX_DEPLOYMENT_TARGET:-26.0}"
+
+mkdir -p "$(dirname "$output_path")" "$scratch_root"
+
+build_architecture() {
+  local architecture="$1"
+  local triple="${architecture}-apple-macosx${deployment_target}"
+  local scratch_path="$scratch_root/$architecture"
+
+  echo "Building MeterBar CLI for $architecture ($triple)" >&2
+  swift build \
+    --package-path "$package_path" \
+    --configuration release \
+    --triple "$triple" \
+    --scratch-path "$scratch_path" >&2
+
+  swift build \
+    --package-path "$package_path" \
+    --configuration release \
+    --triple "$triple" \
+    --scratch-path "$scratch_path" \
+    --show-bin-path
+}
+
+arm64_bin_dir=$(build_architecture arm64)
+x86_64_bin_dir=$(build_architecture x86_64)
+
+arm64_binary="$arm64_bin_dir/meterbar"
+x86_64_binary="$x86_64_bin_dir/meterbar"
+
+for binary in "$arm64_binary" "$x86_64_binary"; do
+  if [ ! -x "$binary" ]; then
+    echo "Expected CLI executable not found: $binary" >&2
+    exit 1
+  fi
+done
+
+lipo -create "$arm64_binary" "$x86_64_binary" -output "$output_path"
+chmod 755 "$output_path"
+lipo "$output_path" -verify_arch arm64 x86_64
+
+echo "Universal CLI architectures: $(lipo -archs "$output_path")"

--- a/scripts/sign-and-verify-release.sh
+++ b/scripts/sign-and-verify-release.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 APP_PATH EXPECTED_VERSION" >&2
+  exit 64
+fi
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repository_root=$(cd "$script_dir/.." && pwd)
+app_path="$1"
+expected_version="$2"
+widget_path="$app_path/Contents/PlugIns/MeterBarWidgetExtension.appex"
+app_binary="$app_path/Contents/MacOS/MeterBar"
+widget_binary="$widget_path/Contents/MacOS/MeterBarWidgetExtension"
+cli_binary="$app_path/Contents/Helpers/meterbar"
+app_entitlements="$repository_root/MeterBar/MeterBar.entitlements"
+widget_entitlements="$repository_root/MeterBarWidget/MeterBarWidget.entitlements"
+
+if [[ ! "$expected_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "Expected version must match canonical MAJOR.MINOR.PATCH syntax." >&2
+  exit 64
+fi
+
+for directory in "$app_path" "$widget_path"; do
+  if [ ! -d "$directory" ]; then
+    echo "Required bundle not found: $directory" >&2
+    exit 1
+  fi
+done
+
+for file in "$app_binary" "$widget_binary" "$cli_binary" "$app_entitlements" "$widget_entitlements"; do
+  if [ ! -f "$file" ]; then
+    echo "Required release input not found: $file" >&2
+    exit 1
+  fi
+done
+
+verify_universal_binary() {
+  local binary="$1"
+  local label="$2"
+
+  if ! lipo "$binary" -verify_arch arm64 x86_64; then
+    echo "$label is not universal arm64+x86_64: $(file "$binary")" >&2
+    exit 1
+  fi
+  echo "$label architectures: $(lipo -archs "$binary")"
+}
+
+verify_universal_binary "$app_binary" "App"
+verify_universal_binary "$widget_binary" "Widget"
+verify_universal_binary "$cli_binary" "CLI"
+
+app_version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$app_path/Contents/Info.plist")
+cli_version=$("$cli_binary" --version)
+
+echo "Tag version: $expected_version"
+echo "App version: $app_version"
+echo "CLI version: $cli_version"
+
+if [ "$app_version" != "$expected_version" ]; then
+  echo "App version $app_version does not match release version $expected_version." >&2
+  exit 1
+fi
+if [ "$cli_version" != "$expected_version" ]; then
+  echo "CLI version $cli_version does not match release version $expected_version." >&2
+  exit 1
+fi
+
+sign_adhoc() {
+  local target="$1"
+  shift
+  codesign \
+    --force \
+    --sign - \
+    --timestamp=none \
+    --options runtime \
+    --generate-entitlement-der \
+    "$@" \
+    "$target"
+}
+
+# Sign leaf code first so each containing bundle is sealed only after its
+# contents are final. Framework directories are currently absent, but handling
+# them here prevents a future embedded dependency from silently invalidating the
+# outer signature.
+for frameworks_path in "$widget_path/Contents/Frameworks" "$app_path/Contents/Frameworks"; do
+  if [ -d "$frameworks_path" ]; then
+    while IFS= read -r -d '' nested_code; do
+      echo "Signing nested code: $nested_code"
+      sign_adhoc "$nested_code"
+    done < <(find "$frameworks_path" -depth \( -name '*.framework' -o -name '*.dylib' \) -print0)
+  fi
+done
+
+sign_adhoc "$cli_binary"
+sign_adhoc "$widget_path" --entitlements "$widget_entitlements"
+sign_adhoc "$app_path" --entitlements "$app_entitlements"
+
+codesign --verify --strict --verbose=2 "$cli_binary"
+codesign --verify --strict --verbose=2 "$widget_path"
+codesign --verify --deep --strict --verbose=2 "$app_path"
+
+temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/meterbar-release-entitlements.XXXXXX")
+trap 'rm -rf "$temporary_directory"' EXIT
+
+dump_entitlements() {
+  local bundle="$1"
+  local output="$2"
+  local errors="$3"
+
+  if ! codesign -d --entitlements - --xml "$bundle" > "$output" 2> "$errors"; then
+    cat "$errors" >&2
+    return 1
+  fi
+  if [ ! -s "$output" ]; then
+    echo "Signed entitlement dump is empty for $bundle" >&2
+    return 1
+  fi
+}
+
+actual_app_entitlements="$temporary_directory/app.entitlements.plist"
+actual_widget_entitlements="$temporary_directory/widget.entitlements.plist"
+dump_entitlements "$app_path" "$actual_app_entitlements" "$temporary_directory/app.codesign.err"
+dump_entitlements "$widget_path" "$actual_widget_entitlements" "$temporary_directory/widget.codesign.err"
+
+python3 - \
+  "$app_entitlements" "$actual_app_entitlements" \
+  "$widget_entitlements" "$actual_widget_entitlements" <<'PY'
+import plistlib
+import sys
+
+pairs = (
+    ("app", sys.argv[1], sys.argv[2]),
+    ("widget", sys.argv[3], sys.argv[4]),
+)
+
+for label, expected_path, actual_path in pairs:
+    with open(expected_path, "rb") as expected_file:
+        expected = plistlib.load(expected_file)
+    with open(actual_path, "rb") as actual_file:
+        actual = plistlib.load(actual_file)
+    if actual != expected:
+        raise SystemExit(
+            f"{label} signed entitlements differ from source: "
+            f"expected={expected!r} actual={actual!r}"
+        )
+    print(f"{label.capitalize()} signed entitlements match {expected_path}")
+PY
+
+echo "Ad-hoc nested signature integrity verified."
+echo "Developer ID, notarization, and authorized app-group access remain separate release prerequisites."

--- a/scripts/test-release-tag.sh
+++ b/scripts/test-release-tag.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+validator="$script_dir/validate-release-tag.sh"
+
+valid_tags=(v0.0.0 v1.2.3 v12.34.56)
+expected_versions=(0.0.0 1.2.3 12.34.56)
+
+for index in "${!valid_tags[@]}"; do
+  actual=$("$validator" "${valid_tags[$index]}")
+  if [ "$actual" != "${expected_versions[$index]}" ]; then
+    echo "Unexpected normalized version for a valid release tag." >&2
+    exit 1
+  fi
+done
+
+# The command substitution is intentionally literal attack input.
+# shellcheck disable=SC2016
+invalid_tags=(
+  v1
+  v1.2
+  v1.2.3-rc.1
+  v01.2.3
+  'v1$(id).2.3'
+  'v1;id.2.3'
+  1.2.3
+  'v1.2.3 '
+)
+
+for tag in "${invalid_tags[@]}"; do
+  if "$validator" "$tag" >/dev/null 2>&1; then
+    echo "Invalid release tag was accepted." >&2
+    exit 1
+  fi
+done
+
+echo "Release tag validation cases passed."

--- a/scripts/validate-release-tag.sh
+++ b/scripts/validate-release-tag.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 vMAJOR.MINOR.PATCH" >&2
+  exit 64
+fi
+
+tag="$1"
+
+# Releases intentionally accept only canonical, stable SemVer tags. Besides
+# preventing accidental prereleases, this keeps every value later used in a
+# filename, URL, output, or commit message free of shell metacharacters.
+if [[ ! "$tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "Release tag must match canonical vMAJOR.MINOR.PATCH syntax." >&2
+  exit 64
+fi
+
+printf '%s\n' "${tag#v}"


### PR DESCRIPTION
Completes the remediation pass from the 14-day code review and the final independent QA of PR #93.

## What changed

- **API usage and privacy:** decode Anthropic's nested usage schema and cache-token classes, use inclusive custom dates, sanitize provider/network failures, coalesce matching refreshes, and prevent cancelled refreshes from publishing late.
- **Cache correctness:** isolate API usage fallback by normalized window and SHA-256 credential identity, immediately remove prior-window data, and invalidate old-organization cache entries when keys change or disappear.
- **Upgrade safety:** migrate v1.0-v1.6 admin keys from `com.agenticindiedev.quotaguard` into `dev.shipshit.meterbar`; delete both services on removal and retain any surviving value after a partial Keychain failure.
- **Readiness and paths:** inspect enabled providers only, avoid unnecessary credential I/O, consistently honor `CODEX_HOME`, and display its resolved auth path in Settings.
- **Quota state:** re-arm notifications correctly after recovery, avoid false recovery alerts, identify the specific Session/Weekly/Sonnet/Code Review quota, and distinguish blocking exhaustion from secondary or extra-usage-covered exhaustion.
- **Release and CI:** require universal arm64+x86_64 app/widget/CLI artifacts, validate tag/app/CLI versions, sign nested code inside-out, verify architectures/codesign/entitlements, scope workflow tokens to read-only, and make the protected build fail unless tests and lint pass.
- **Documentation:** align current requirements with macOS 26, Xcode 26, Swift tools 6.2 in Swift 5 language mode, and document the remaining Developer ID/notarization prerequisite.

Branch protection now directly requires `build`, `Tests + coverage gate`, `SwiftLint`, and `Secret Scan`. The related live Homebrew metadata correction was merged separately in `VincentShipsIt/homebrew-tap#4`.

## Verification

- 362 deterministic/coverage tests passed with credential-dependent `APIIntegrationTests` skipped locally; 35.4% line coverage against the 19% gate.
- `swiftlint lint --strict`, `actionlint`, `shellcheck`, release-tag attack cases, and `git diff --check` passed.
- Universal Release app, widget, and CLI verified as `x86_64 arm64`.
- App/tag/CLI version agreement passed at `1.6.1`.
- Individual and deep strict codesign checks passed; signed app/widget entitlements exactly match source.

## Remaining external prerequisite

Developer ID signing, authorized provisioning, and notarization still require credentials not present in this repository. The ad-hoc signature verifies nested artifact integrity but does not provide Gatekeeper trust or guaranteed app-group authorization.
