### PR TITLE
Re-apply Developer ID signing + notarization to release pipeline

### DIFF
--- a/.agents/SESSIONS/2026-07-10.md
+++ b/.agents/SESSIONS/2026-07-10.md
@@ -33,3 +33,17 @@
 
 **External release prerequisite:**
 - Developer ID signing, authorized provisioning, and notarization still require credentials not present in this repository. Ad-hoc signing verifies nested artifact integrity but cannot provide Gatekeeper trust or guaranteed app-group authorization.
+
+## Session 2: Developer ID Signing + Notarization Pipeline (issue #47)
+
+**Status:** Complete (repo side); blocked on Actions secrets before the next tag push
+
+**What was done:**
+- Un-deferred issue #47 by grafting the reviewed #43/#48-reverted signing pipeline into the current post-#93 release workflow, rather than resurrecting the stale `claude/peaceful-cerf-475f93` branch (its `release.yml` predates the universal-build/verify rewrite and conflicts with master).
+- Extended `scripts/sign-and-verify-release.sh` with opt-in `SIGNING_IDENTITY`/`SIGNING_KEYCHAIN` env vars: Developer ID + secure timestamp + hardened runtime when set, unchanged ad-hoc path when unset — CI PR builds and tag releases now share one inside-out signing and verification implementation (universal arch, version agreement, entitlement split).
+- `release.yml` additions: fail-fast secrets preflight before any build work; temp-keychain import with original-search-list backup, single-identity hard gate, and SHA-1-pinned identity resolution; `notarytool submit --wait --timeout 40m` with failure-log retrieval; `stapler staple`; `spctl`/deep-codesign/`stapler validate` gates; SHA256 computed on the final stapled zip; `always()` cleanup restoring the captured keychain list.
+- Docs: README and SETUP now state releases after v1.6.1 are signed/notarized and keep the `xattr -cr` note only for v1.6.1 and earlier.
+
+**Verification:** `bash -n` + `shellcheck` on the script, `actionlint` on the workflow, `scripts/test-release-tag.sh` attack cases.
+
+**Blocked on (user, issue #47 recipe):** create the Developer ID Application cert (team S329JK3JRB) + ASC API key, add the 6 Actions secrets, then tag the next release. Post-release: verify app-group container on a real install and update the tap cask description (it still says ad-hoc/unnotarized).

--- a/.agents/docs/SETUP.md
+++ b/.agents/docs/SETUP.md
@@ -29,7 +29,7 @@ Download the latest release from:
 https://meterbar.dev
 ```
 
-The release build is ad-hoc signed for bundle integrity but is not Developer ID-signed or notarized. If macOS blocks the first launch, right-click `MeterBar.app` and choose Open, or run:
+Releases after v1.6.1 are Developer ID signed, notarized, and stapled — direct downloads open without Gatekeeper warnings. For v1.6.1 and earlier (ad-hoc signed only), right-click `MeterBar.app` and choose Open on first launch, or run:
 
 ```bash
 xattr -cr /Applications/MeterBar.app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
       APP_PATH: ${{ github.workspace }}/build/Build/Products/Release/MeterBar.app
       # Context values enter shell code only through environment variables.
       REF_NAME: ${{ github.ref_name }}
+      # notarytool keychain-profile name (stored in the temp keychain at runtime).
+      NOTARY_PROFILE: asc-profile
 
     outputs:
       release_tag: ${{ steps.version.outputs.tag }}
@@ -37,6 +39,48 @@ jobs:
             echo "tag=$REF_NAME"
             echo "version=$RELEASE_VERSION"
           } >> "$GITHUB_OUTPUT"
+
+      # Resolve ephemeral file paths under RUNNER_TEMP (outside the workspace) and
+      # export them for later steps. The `runner` context is NOT available in
+      # job-level `env:`, so these are computed here where $RUNNER_TEMP is a real
+      # shell variable, then written fully-resolved into $GITHUB_ENV.
+      - name: Configure signing paths
+        run: |
+          set -euo pipefail
+          {
+            echo "CERT_PATH=$RUNNER_TEMP/build_certificate.p12"
+            echo "ASC_KEY_PATH=$RUNNER_TEMP/asc_api_key.p8"
+            echo "KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db"
+            echo "KEYCHAIN_LIST_BACKUP=$RUNNER_TEMP/original-keychains.list"
+          } >> "$GITHUB_ENV"
+
+      # Fail FAST (before any build work) if any required signing secret is
+      # missing. Releases must be signed + notarized, so an absent secret is
+      # fatal. Only presence is checked (non-empty); values are never printed.
+      - name: Preflight - require signing secrets
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in BUILD_CERTIFICATE_BASE64 P12_PASSWORD KEYCHAIN_PASSWORD \
+                      ASC_API_KEY_BASE64 ASC_KEY_ID ASC_ISSUER_ID; do
+            # Indirect expansion reads the env var named in $name without echoing its value.
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "::error::Missing required signing secret(s): ${missing[*]}" >&2
+            echo "Add them under Settings > Secrets and variables > Actions (see issue #47 for the recipe), then re-run." >&2
+            exit 1
+          fi
+          echo "All required signing secrets are present."
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
@@ -66,16 +110,169 @@ jobs:
             "$APP_PATH/Contents/Helpers/meterbar" \
             "$RUNNER_TEMP/meterbar-cli-build"
 
-      # Ad-hoc signing restores nested bundle integrity and embeds the source
-      # entitlements. It is not Developer ID signing or notarization, and without
-      # an authorized profile it cannot guarantee app-group container access.
+      # Import the Developer ID cert + private key into a DEDICATED temporary
+      # keychain, and store the notarization API key profile in that same
+      # keychain. Everything created here is removed by the always() cleanup step.
+      - name: Import signing assets
+        id: identity
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+
+          # Decode straight to disk; -o avoids piping secret bytes through stdout/logs.
+          # macOS base64 does not line-wrap by default, so single-line blobs decode cleanly.
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o "$CERT_PATH"
+          echo -n "$ASC_API_KEY_BASE64"       | base64 --decode -o "$ASC_KEY_PATH"
+
+          # Capture the ORIGINAL user keychain search list so cleanup can restore it
+          # exactly, rather than assuming a hardcoded default that might differ on
+          # this runner image.
+          security list-keychains -d user | tr -d '"' | sed 's/^[[:space:]]*//' > "$KEYCHAIN_LIST_BACKUP"
+
+          # DEDICATED temporary keychain.
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          # -l lock on sleep, -u lock on timeout, -t 21600 = 6h. Bounds key reachability.
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import the identity (cert + private key) from the .p12. Do NOT pass -t cert:
+          # that would import only the certificate and drop the private key, leaving an
+          # unusable identity. -T whitelists codesign/security to use the key headlessly.
+          security import "$CERT_PATH" \
+            -P "$P12_PASSWORD" \
+            -f pkcs12 \
+            -k "$KEYCHAIN_PATH" \
+            -T /usr/bin/codesign -T /usr/bin/security
+
+          # Add temp keychain to the USER search list WITHOUT clobbering login.keychain.
+          # Word-splitting of the existing list into separate args is intentional.
+          # shellcheck disable=SC2046
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+          # CRITICAL: authorize non-interactive key access. Without this, codesign on a
+          # headless runner triggers the keychain ACL GUI prompt -> errSecInternalComponent
+          # or an indefinite hang. -T on import alone is NOT sufficient.
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # HARD GATE: exactly ONE Developer ID Application identity must be present in
+          # the temp keychain. Zero -> nothing to sign with. More than one -> ambiguous
+          # .p12, codesign could silently pick the wrong cert. Fail fast either way.
+          COUNT=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | grep -c "Developer ID Application" || true)
+          echo "Developer ID Application identities found: $COUNT"
+          if [ "$COUNT" -ne 1 ]; then
+            echo "::error::Expected exactly 1 Developer ID Application identity in the temp keychain, found $COUNT." >&2
+            security find-identity -v -p codesigning "$KEYCHAIN_PATH" >&2 || true
+            exit 1
+          fi
+
+          # Resolve the exact identity by its SHA-1 hash from OUR keychain ONLY
+          # (codesign accepts a hash), so it can never match a same-named cert
+          # from another keychain and no CN is hardcoded.
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | grep "Developer ID Application" | head -1 | awk '{print $2}')
+          echo "Using signing identity (SHA-1): $IDENTITY"
+          echo "hash=$IDENTITY" >> "$GITHUB_OUTPUT"
+
+          # Store notarization creds in the disposable keychain (validates them
+          # immediately, and they vanish when the keychain is deleted in cleanup).
+          # Non-interactive when all of --key/--key-id/--issuer are supplied.
+          xcrun notarytool store-credentials "$NOTARY_PROFILE" \
+            --key "$ASC_KEY_PATH" \
+            --key-id "$ASC_KEY_ID" \
+            --issuer "$ASC_ISSUER_ID" \
+            --keychain "$KEYCHAIN_PATH"
+
+      # Inside-out Developer ID signing with hardened runtime, plus the
+      # universal-architecture, version-agreement, and entitlement-split
+      # verification shared with CI (which runs the same script ad-hoc).
       - name: Sign and verify universal artifact
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          SIGNING_IDENTITY: ${{ steps.identity.outputs.hash }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
           set -euo pipefail
-          scripts/sign-and-verify-release.sh "$APP_PATH" "$RELEASE_VERSION"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          SIGNING_KEYCHAIN="$KEYCHAIN_PATH" \
+            scripts/sign-and-verify-release.sh "$APP_PATH" "$RELEASE_VERSION"
 
+      # Notarize the signed app, then staple the ticket onto the .app bundle.
+      # notarytool submit --wait blocks on Apple's servers. The inner
+      # '--timeout 40m' bounds the wait so an Apple-side backlog fails clearly
+      # (with a poll-able submission id) instead of silently consuming the whole
+      # 60-min job timeout.
+      - name: Notarize and staple
+        env:
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          SUBMIT_ZIP="$RUNNER_TEMP/MeterBar-notarize.zip"
+
+          # A bare .app must be zipped with ditto for a ticket-compatible archive.
+          ditto -c -k --keepParent "$APP_PATH" "$SUBMIT_ZIP"
+
+          # Submit and block until Apple finishes; capture JSON to read id/status.
+          set +e
+          SUBMIT_OUT=$(xcrun notarytool submit "$SUBMIT_ZIP" \
+            --keychain-profile "$NOTARY_PROFILE" \
+            --keychain "$KEYCHAIN_PATH" \
+            --timeout 40m \
+            --wait --output-format json)
+          SUBMIT_RC=$?
+          set -e
+          echo "$SUBMIT_OUT"
+
+          SUBID=$(echo "$SUBMIT_OUT" | /usr/bin/python3 -c 'import sys,json;print(json.load(sys.stdin).get("id",""))' 2>/dev/null || true)
+          STATUS=$(echo "$SUBMIT_OUT" | /usr/bin/python3 -c 'import sys,json;print(json.load(sys.stdin).get("status",""))' 2>/dev/null || true)
+          echo "Notarization id=$SUBID status=$STATUS rc=$SUBMIT_RC"
+
+          if [ "$STATUS" != "Accepted" ] || [ "$SUBMIT_RC" -ne 0 ]; then
+            echo "::error::Notarization did not succeed (status=$STATUS rc=$SUBMIT_RC). Pulling detailed log." >&2
+            if [ -n "${SUBID:-}" ]; then
+              xcrun notarytool log "$SUBID" \
+                --keychain-profile "$NOTARY_PROFILE" \
+                --keychain "$KEYCHAIN_PATH" \
+                "$RUNNER_TEMP/developer_log.json" || true
+              cat "$RUNNER_TEMP/developer_log.json" || true
+            fi
+            exit 1
+          fi
+
+          # Staple the ticket onto the bundle (cannot staple a .zip).
+          xcrun stapler staple "$APP_PATH"
+
+      # Gatekeeper acceptance + signature integrity + stapled ticket. Fail on error.
+      - name: Verify signature, Gatekeeper, and staple
+        run: |
+          set -euo pipefail
+
+          echo "::group::spctl assessment (type execute)"
+          spctl --assess --type execute --verbose=4 "$APP_PATH"
+          echo "::endgroup::"
+
+          echo "::group::codesign --verify --deep --strict"
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          echo "::endgroup::"
+
+          echo "::group::stapler validate"
+          xcrun stapler validate "$APP_PATH"
+          echo "::endgroup::"
+
+      # Zip the STAPLED bundle and compute the SHA256 on that FINAL artifact
+      # (this is what the Homebrew cask consumes via MeterBar-<version>.zip.sha256).
+      # The pre-staple notarization zip differs byte-for-byte, so the SHA must be
+      # computed here, after stapling.
       - name: Create release package
         id: package
         env:
@@ -122,9 +319,26 @@ jobs:
             echo "**Tag:** \`$RELEASE_TAG\`"
             echo "**SHA256:** \`$RELEASE_SHA256\`"
             echo ""
-            echo "Universal arm64+x86_64 and nested ad-hoc signature integrity verified."
-            echo "Developer ID signing, notarization, and authorized app-group access remain pending credentials/provisioning."
+            echo "Universal arm64+x86_64, Developer ID signed, notarized, and stapled."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Cleanup - ALWAYS, even on failure. Remove the temp keychain + decoded
+      # secrets, restore the ORIGINAL captured user keychain search list.
+      - name: Clean up keychain and secret files
+        if: ${{ always() }}
+        run: |
+          security delete-keychain "$KEYCHAIN_PATH" || true
+          # Restore the exact original user search list captured before it was modified.
+          if [ -f "$KEYCHAIN_LIST_BACKUP" ] && [ -s "$KEYCHAIN_LIST_BACKUP" ]; then
+            # shellcheck disable=SC2046
+            security list-keychains -d user -s $(cat "$KEYCHAIN_LIST_BACKUP") || true
+          else
+            security list-keychains -d user -s login.keychain-db || true
+          fi
+          rm -f "$CERT_PATH" "$ASC_KEY_PATH" \
+                "$RUNNER_TEMP/MeterBar-notarize.zip" \
+                "$RUNNER_TEMP/developer_log.json" \
+                "$KEYCHAIN_LIST_BACKUP" || true
 
   # After the release is published, bump the Homebrew cask in VincentShipsIt/homebrew-tap.
   # Called directly (not via `release: published`) because GITHUB_TOKEN-created releases

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A lightweight macOS menu bar app that monitors Claude Code, Codex CLI, and Curso
 Paste this into your local coding agent to have it install MeterBar for you:
 
 ```text
-Install MeterBar on this Mac. First verify this is macOS 26 or newer and that Homebrew is available. Install with: brew tap VincentShipsIt/tap && brew install --cask VincentShipsIt/tap/meterbar. If Homebrew is missing, ask before installing Homebrew. After installing, verify /Applications/MeterBar.app exists and that the meterbar CLI is linked, then open MeterBar. If macOS blocks the first launch because the app is not Developer ID-signed or notarized, remove quarantine with xattr -cr /Applications/MeterBar.app and open it again. Do not ask me for API keys or paste secrets; for usage data, tell me to run claude login, codex login, and log into Cursor if I want those providers tracked.
+Install MeterBar on this Mac. First verify this is macOS 26 or newer and that Homebrew is available. Install with: brew tap VincentShipsIt/tap && brew install --cask VincentShipsIt/tap/meterbar. If Homebrew is missing, ask before installing Homebrew. After installing, verify /Applications/MeterBar.app exists and that the meterbar CLI is linked, then open MeterBar. Do not ask me for API keys or paste secrets; for usage data, tell me to run claude login, codex login, and log into Cursor if I want those providers tracked.
 ```
 
 ### Homebrew (Recommended)
@@ -77,10 +77,7 @@ brew upgrade --cask VincentShipsIt/tap/meterbar
 
 Download the latest release from [meterbar.dev](https://meterbar.dev).
 
-> **Note**: Since the app isn't notarized, you may need to right-click and select "Open" the first time, or run:
-> ```bash
-> xattr -cr /Applications/MeterBar.app
-> ```
+Releases after v1.6.1 are Developer ID signed and notarized, so direct downloads open without Gatekeeper warnings. For v1.6.1 and earlier (unsigned), right-click and select "Open" the first time, or run `xattr -cr /Applications/MeterBar.app`.
 
 ### Build from Source
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew upgrade --cask VincentShipsIt/tap/meterbar
 
 Download the latest release from [meterbar.dev](https://meterbar.dev).
 
-Releases after v1.6.1 are Developer ID signed and notarized, so direct downloads open without Gatekeeper warnings. For v1.6.1 and earlier (unsigned), right-click and select "Open" the first time, or run `xattr -cr /Applications/MeterBar.app`.
+Releases after v1.6.1 are Developer ID signed and notarized, so direct downloads open without Gatekeeper warnings. For v1.6.1 and earlier (ad-hoc signed only), right-click and select "Open" the first time, or run `xattr -cr /Applications/MeterBar.app`.
 
 ### Build from Source
 

--- a/scripts/sign-and-verify-release.sh
+++ b/scripts/sign-and-verify-release.sh
@@ -3,6 +3,17 @@ set -euo pipefail
 
 if [ "$#" -ne 2 ]; then
   echo "Usage: $0 APP_PATH EXPECTED_VERSION" >&2
+  echo "Signs ad-hoc by default; set SIGNING_IDENTITY (and optionally" >&2
+  echo "SIGNING_KEYCHAIN) to sign with a Developer ID identity instead." >&2
+  exit 64
+fi
+
+# Developer ID mode is opt-in via environment so CI PR builds keep the
+# credential-free ad-hoc path while tag releases sign for real.
+signing_identity="${SIGNING_IDENTITY:-}"
+signing_keychain="${SIGNING_KEYCHAIN:-}"
+if [ -n "$signing_keychain" ] && [ -z "$signing_identity" ]; then
+  echo "SIGNING_KEYCHAIN requires SIGNING_IDENTITY." >&2
   exit 64
 fi
 
@@ -67,17 +78,36 @@ if [ "$cli_version" != "$expected_version" ]; then
   exit 1
 fi
 
-sign_adhoc() {
+sign_code() {
   local target="$1"
   shift
-  codesign \
-    --force \
-    --sign - \
-    --timestamp=none \
-    --options runtime \
-    --generate-entitlement-der \
-    "$@" \
-    "$target"
+  if [ -n "$signing_identity" ]; then
+    # Developer ID: a secure timestamp is required for notarization, and the
+    # explicit keychain pins the identity to the CI temp keychain so codesign
+    # cannot resolve a same-named certificate from another keychain.
+    local keychain_args=()
+    if [ -n "$signing_keychain" ]; then
+      keychain_args=(--keychain "$signing_keychain")
+    fi
+    codesign \
+      --force \
+      --sign "$signing_identity" \
+      "${keychain_args[@]}" \
+      --timestamp \
+      --options runtime \
+      --generate-entitlement-der \
+      "$@" \
+      "$target"
+  else
+    codesign \
+      --force \
+      --sign - \
+      --timestamp=none \
+      --options runtime \
+      --generate-entitlement-der \
+      "$@" \
+      "$target"
+  fi
 }
 
 # Sign leaf code first so each containing bundle is sealed only after its
@@ -88,14 +118,14 @@ for frameworks_path in "$widget_path/Contents/Frameworks" "$app_path/Contents/Fr
   if [ -d "$frameworks_path" ]; then
     while IFS= read -r -d '' nested_code; do
       echo "Signing nested code: $nested_code"
-      sign_adhoc "$nested_code"
+      sign_code "$nested_code"
     done < <(find "$frameworks_path" -depth \( -name '*.framework' -o -name '*.dylib' \) -print0)
   fi
 done
 
-sign_adhoc "$cli_binary"
-sign_adhoc "$widget_path" --entitlements "$widget_entitlements"
-sign_adhoc "$app_path" --entitlements "$app_entitlements"
+sign_code "$cli_binary"
+sign_code "$widget_path" --entitlements "$widget_entitlements"
+sign_code "$app_path" --entitlements "$app_entitlements"
 
 codesign --verify --strict --verbose=2 "$cli_binary"
 codesign --verify --strict --verbose=2 "$widget_path"
@@ -148,5 +178,10 @@ for label, expected_path, actual_path in pairs:
     print(f"{label.capitalize()} signed entitlements match {expected_path}")
 PY
 
-echo "Ad-hoc nested signature integrity verified."
-echo "Developer ID, notarization, and authorized app-group access remain separate release prerequisites."
+if [ -n "$signing_identity" ]; then
+  echo "Developer ID nested signature integrity verified (identity: $signing_identity)."
+  echo "Notarization and stapling run as separate release steps."
+else
+  echo "Ad-hoc nested signature integrity verified."
+  echo "Developer ID, notarization, and authorized app-group access remain separate release prerequisites."
+fi


### PR DESCRIPTION
Un-defers #47 (audit risk R2). Closes #47's repo-side work.

## What changed

- **`scripts/sign-and-verify-release.sh`**: opt-in `SIGNING_IDENTITY` / `SIGNING_KEYCHAIN` env vars. When set, signs Developer ID with `--timestamp --options runtime`, pinned to the CI temp keychain; when unset, the ad-hoc path is byte-identical to before. CI PR builds and tag releases now share one inside-out signing + verification implementation (universal arch check, tag/app/CLI version agreement, entitlement-split match).
- **`.github/workflows/release.yml`**: grafts the reviewed #43 flow into the current post-#93 pipeline —
  - fail-fast preflight for the 6 signing secrets before any build work (names only, never values)
  - temp-keychain import: original search-list backup, `set-key-partition-list` for headless codesign, hard gate on exactly one Developer ID Application identity, SHA-1-pinned identity resolution
  - `notarytool store-credentials` in the disposable keychain; `submit --wait --timeout 40m` with failure-log retrieval; `stapler staple`
  - verification gates: `spctl --assess --type execute`, `codesign --verify --deep --strict`, `stapler validate`
  - SHA256 computed on the **final stapled** zip (what the Homebrew cask consumes)
  - `always()` cleanup deletes the temp keychain/secret files and restores the captured keychain search list
- **Docs**: README + SETUP scope the `xattr -cr` quarantine workaround to v1.6.1 and earlier.

Deliberately NOT merged from `claude/peaceful-cerf-475f93`: that branch's `release.yml` predates the #93 universal-build rewrite and conflicts with it; this PR re-implements its content on top of master instead.

## Verification

- `shellcheck` on all scripts, `actionlint` on the workflow, `scripts/test-release-tag.sh` attack cases, `bash -n`.
- New env-guard behavior exercised (`SIGNING_KEYCHAIN` without `SIGNING_IDENTITY` → exit 64).
- The ad-hoc path is exercised by the required PR `build` check (CI runs the same script).

## Before the next tag push (not blocked by this PR)

Add the 6 Actions secrets per the recipe in #47: `BUILD_CERTIFICATE_BASE64`, `P12_PASSWORD`, `KEYCHAIN_PASSWORD`, `ASC_API_KEY_BASE64`, `ASC_KEY_ID`, `ASC_ISSUER_ID`. Until then, a tag push fails fast at preflight with an actionable error. Post-release: verify the app-group container on a real signed install and update the tap cask description (it still says ad-hoc/unnotarized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release builds now support Developer ID signing, notarization, and stapling for improved macOS installation experience.
  * Release validation now checks signatures, Gatekeeper acceptance, and notarization status.
  * Signing credentials and temporary build artifacts are securely cleaned up after each release.

* **Documentation**
  * Updated installation guidance to explain post-v1.6.1 signing and notarization behavior.
  * Improved the installation script to verify macOS, Homebrew, app availability, and CLI setup.
  * Added release-session documentation for signing prerequisites and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->