### PR TITLE
feat(session-wake): native discovery, terminal-state classification, and replay ledger (#95)

### DIFF
--- a/.agents/SESSIONS/2026-07-10.md
+++ b/.agents/SESSIONS/2026-07-10.md
@@ -66,3 +66,20 @@
 **Follow-ups:**
 - The Homebrew cask's uninstall/zap entries reference the old bundle id and app-group paths - update with the v1.6.2 release.
 - Old `group.dev.shipshit.meterbar` container and `dev.shipshit.meterbar` LaunchAgent/notification grants are orphaned on existing installs; users re-grant notifications once.
+
+## Session 4: Session Wake — Native Discovery, Terminal-State Classification, Replay Ledger (#95)
+
+**Status:** Complete (PR opened)
+
+**What was done:**
+- Implemented issue #95 (first Session Wake child of epic #94; the #47 signing blocker is closed). New `MeterBar/Services/SessionWake/` module, native Swift only — no Python/shell watcher code bundled or invoked.
+- `ClaudeTranscriptTailClassifier`: latest-decisive-event classification of transcript JSONL tails. Recognizes both rate-limit shapes (structured `error:"rate_limit"`/`apiErrorStatus:429` synthetic assistant messages, and the legacy `usage limit reached|<epoch>` text marker) with casing variants; typed `SessionBlockReason` (session/weekly/Opus-weekly/unknown); absolute block + reset timestamps. Time-of-day reset fallbacks ("resets 7:30am (Europe/Malta)", "resets Jul 15 at 10pm") are anchored to the event timestamp — never "now" — so a just-passed reset is not rolled to tomorrow, and are flagged approximate (can schedule a refresh, can never prove quota). Sidechain lines never classify; malformed/truncated lines are skipped.
+- `SessionWakeReplayLedger` + `SessionBlockFingerprint` (SHA-256 of sessionID|blockedAt|reason): persistent handled-block ledger at `~/Library/Application Support/MeterBar/session-wake-ledger-v1.json`; handled fingerprints are never rediscovered across relaunch; corrupt ledger degrades to empty; capacity-pruned; reads never touch disk state.
+- `SessionWakeDiscovery` (actor, off main actor): account-scoped scan of exactly one `<CLAUDE_CONFIG_DIR>/projects` root; bounded newest-first enumeration with tail-only reads; deterministic sessionID dedupe; cwd canonicalization (standardize + resolve symlinks) with structured skip reasons (`missingWorkingDirectory`, `missingMetadata`, `staleBlock`); automatic eligibility limited to the current blocking window (reset + grace, or fallback window when no reset parsed); strictly read-only preview.
+- TDD: 36 new tests written first (`ClaudeTranscriptTailClassifierTests`, `SessionWakeReplayLedgerTests`, `SessionWakeDiscoveryTests`, shared `SessionWakeFixtures`), covering both shapes + casing, later recovery, duplicates, stale sessions, dead cwd, missing metadata, subagent exclusion, account scoping, malformed JSONL, tail-bounded reads, and a filesystem-snapshot zero-mutation proof.
+
+**Verification:**
+- 413 tests pass (`swift test`); new-code line coverage 83–100% per file (classifier 97%, discovery 90%, ledger 83%, models 100%).
+- `swiftlint lint --strict` clean; Xcode app target builds (`BUILD SUCCEEDED`; needed explicit `import os` for AppLog interpolation).
+
+**Follow-ups:** #96 (quota gate + watcher state machine) consumes `BlockedSessionCandidate`/`resetIsApproximate`; ledger `markHandled` is only to be called by the future execution path, never by discovery/preview.

--- a/MeterBar/Services/SessionWake/ClaudeTranscriptTailClassifier.swift
+++ b/MeterBar/Services/SessionWake/ClaudeTranscriptTailClassifier.swift
@@ -1,0 +1,243 @@
+import Foundation
+
+/// Classifies the tail of a Claude Code transcript (JSONL) into a terminal
+/// state using latest-decisive-event semantics — not "contains rate limit".
+///
+/// Decisive events, newest wins:
+/// - A rate-limit synthetic assistant message → `.blocked`
+///   - Shape A (current): `"isApiErrorMessage":true` with `"error":"rate_limit"`
+///     or `"apiErrorStatus":429`
+///   - Shape B (legacy): assistant text "… usage limit reached|<unix-epoch>"
+/// - Successful assistant output or a user tool_result → `.progressed`
+///
+/// Sidechain (subagent) lines never classify the session. Malformed or
+/// truncated lines are skipped; they can neither crash nor poison the scan.
+enum ClaudeTranscriptTailClassifier {
+    struct ParsedReset: Equatable {
+        let date: Date
+        let isApproximate: Bool
+    }
+
+    // MARK: - Classification
+
+    static func classify(jsonl: String) -> ClaudeTranscriptTailSummary {
+        var summary = ClaudeTranscriptTailSummary()
+        var eventCount = 0
+        var sidechainCount = 0
+
+        for line in jsonl.split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let object = try? JSONSerialization.jsonObject(with: Data(line.utf8)),
+                  let json = object as? [String: Any],
+                  let type = json["type"] as? String,
+                  type == "assistant" || type == "user" else {
+                continue
+            }
+
+            eventCount += 1
+            if json["isSidechain"] as? Bool == true {
+                sidechainCount += 1
+                continue
+            }
+
+            let timestamp = (json["timestamp"] as? String).flatMap(FlexibleISO8601.date(from:))
+            updateMetadata(in: &summary, from: json, timestamp: timestamp)
+
+            if let event = blockEvent(from: json, type: type, timestamp: timestamp) {
+                summary.terminalState = .blocked(event)
+            } else if isDecisiveProgress(json: json, type: type) {
+                summary.terminalState = .progressed(lastActivityAt: timestamp)
+            }
+        }
+
+        if eventCount > 0 && sidechainCount == eventCount {
+            summary.isSubagentTranscript = true
+            summary.terminalState = .indeterminate
+        }
+        return summary
+    }
+
+    // MARK: - Reset parsing
+
+    /// Parses an absolute reset timestamp out of a rate-limit message text.
+    ///
+    /// Supported forms:
+    /// - Legacy exact epoch: "… usage limit reached|1752130800"
+    /// - Time-of-day fallback: "resets 7:30am (Europe/Malta)", "resets 19:00"
+    /// - Month-day fallback: "resets Jul 15 at 10pm (Europe/Malta)"
+    ///
+    /// Fallback forms are anchored to the rate-limit **event** timestamp (never
+    /// "now"), so a reset that has just passed at scan time is not rolled to
+    /// tomorrow. They are flagged approximate: transcript text may schedule a
+    /// refresh but can never prove quota is available.
+    static func resetDate(fromMessageText text: String, anchoredTo eventDate: Date) -> ParsedReset? {
+        if let epochDate = legacyEpochReset(in: text) {
+            return ParsedReset(date: epochDate, isApproximate: false)
+        }
+        guard let match = Self.resetsClauseRegex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text))
+        else {
+            return nil
+        }
+
+        func group(_ name: String) -> String? {
+            let range = match.range(withName: name)
+            guard range.location != NSNotFound, let swiftRange = Range(range, in: text) else { return nil }
+            return String(text[swiftRange])
+        }
+
+        guard var hour = group("hour").flatMap({ Int($0) }) else { return nil }
+        let minute = group("minute").flatMap { Int($0) } ?? 0
+        if let meridiem = group("ampm")?.lowercased() {
+            hour %= 12
+            if meridiem == "pm" { hour += 12 }
+        }
+        guard (0...23).contains(hour), (0...59).contains(minute) else { return nil }
+
+        var calendar = Calendar(identifier: .gregorian)
+        if let zoneName = group("zone"), let zone = TimeZone(identifier: zoneName) {
+            calendar.timeZone = zone
+        }
+
+        var components = calendar.dateComponents([.year, .month, .day], from: eventDate)
+        components.hour = hour
+        components.minute = minute
+        components.second = 0
+
+        let explicitMonth = group("month").flatMap { monthNumber(fromAbbreviation: $0) }
+        if let explicitMonth {
+            components.month = explicitMonth
+            components.day = group("day").flatMap { Int($0) }
+            if let year = group("year").flatMap({ Int($0) }) {
+                components.year = year
+            }
+        }
+
+        guard var resolved = calendar.date(from: components) else { return nil }
+        if resolved < eventDate {
+            // The block always precedes its reset. A time-of-day earlier than
+            // the event means the next day; an explicit month-day earlier than
+            // the event means the next year (December → January windows).
+            let unit: Calendar.Component = explicitMonth == nil ? .day : .year
+            guard let rolled = calendar.date(byAdding: unit, value: 1, to: resolved) else { return nil }
+            resolved = rolled
+        }
+        return ParsedReset(date: resolved, isApproximate: true)
+    }
+
+    // MARK: - Private
+
+    private static func updateMetadata(
+        in summary: inout ClaudeTranscriptTailSummary,
+        from json: [String: Any],
+        timestamp: Date?
+    ) {
+        if let sessionID = nonEmptyString(json["sessionId"]) {
+            summary.sessionID = sessionID
+        }
+        if let cwd = nonEmptyString(json["cwd"]) {
+            summary.workingDirectory = cwd
+        }
+        if let branch = nonEmptyString(json["gitBranch"]) {
+            summary.gitBranch = branch
+        }
+        if let timestamp, summary.lastEventAt.map({ timestamp > $0 }) ?? true {
+            summary.lastEventAt = timestamp
+        }
+    }
+
+    private static func blockEvent(from json: [String: Any], type: String, timestamp: Date?) -> SessionBlockEvent? {
+        guard type == "assistant", let blockedAt = timestamp else { return nil }
+        let text = messageText(in: json)
+
+        let isStructuredRateLimit = json["isApiErrorMessage"] as? Bool == true
+            && ((json["error"] as? String)?.lowercased() == "rate_limit" || json["apiErrorStatus"] as? Int == 429)
+        let isLegacyMarker = legacyEpochReset(in: text) != nil
+            || text.range(of: #"usage limit reached\|"#, options: [.regularExpression, .caseInsensitive]) != nil
+
+        guard isStructuredRateLimit || isLegacyMarker else { return nil }
+
+        let reset = resetDate(fromMessageText: text, anchoredTo: blockedAt)
+        return SessionBlockEvent(
+            reason: blockReason(fromMessageText: text),
+            blockedAt: blockedAt,
+            resetAt: reset?.date,
+            resetIsApproximate: reset?.isApproximate ?? false
+        )
+    }
+
+    private static func isDecisiveProgress(json: [String: Any], type: String) -> Bool {
+        guard let message = json["message"] as? [String: Any] else { return false }
+        if type == "assistant" {
+            // Any non-error assistant output is real forward progress. Other
+            // API errors (e.g. 500s) are neither progress nor a block.
+            return json["isApiErrorMessage"] as? Bool != true
+        }
+        // A user line only counts when it carries tool results — plain user
+        // text after a block proves nothing about quota.
+        guard let content = message["content"] as? [[String: Any]] else { return false }
+        return content.contains { $0["type"] as? String == "tool_result" }
+    }
+
+    private static func blockReason(fromMessageText text: String) -> SessionBlockReason {
+        let lowercased = text.lowercased()
+        if lowercased.contains("opus"), lowercased.contains("weekly") {
+            return .opusWeeklyLimit
+        }
+        if lowercased.contains("weekly limit") {
+            return .weeklyLimit
+        }
+        if lowercased.contains("session limit") {
+            return .sessionLimit
+        }
+        return .unknownRateLimit
+    }
+
+    private static func messageText(in json: [String: Any]) -> String {
+        guard let message = json["message"] as? [String: Any] else { return "" }
+        if let text = message["content"] as? String {
+            return text
+        }
+        guard let content = message["content"] as? [[String: Any]] else { return "" }
+        let texts: [String] = content.compactMap { item in
+            item["type"] as? String == "text" ? item["text"] as? String : nil
+        }
+        return texts.joined(separator: "\n")
+    }
+
+    private static func legacyEpochReset(in text: String) -> Date? {
+        guard let match = Self.legacyEpochRegex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+              let range = Range(match.range(at: 1), in: text),
+              let epoch = TimeInterval(text[range]) else {
+            return nil
+        }
+        return Date(timeIntervalSince1970: epoch)
+    }
+
+    private static func monthNumber(fromAbbreviation value: String) -> Int? {
+        let months = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"]
+        guard let index = months.firstIndex(of: String(value.lowercased().prefix(3))) else { return nil }
+        return index + 1
+    }
+
+    private static func nonEmptyString(_ value: Any?) -> String? {
+        guard let string = value as? String, !string.isEmpty else { return nil }
+        return string
+    }
+
+    // Compiled once; NSRegularExpression is thread-safe.
+    private static let legacyEpochRegex: NSRegularExpression = {
+        // "usage limit reached|1752130800" — 9-12 digits covers 2001-2286.
+        (try? NSRegularExpression(
+            pattern: #"usage limit reached\|(\d{9,12})"#,
+            options: [.caseInsensitive]
+        )) ?? NSRegularExpression()
+    }()
+
+    private static let resetsClauseRegex: NSRegularExpression = {
+        let pattern = #"resets\s+"# +
+            #"(?:(?<month>jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s+"# +
+            #"(?<day>\d{1,2})(?:,\s*(?<year>\d{4}))?\s+at\s+)?"# +
+            #"(?<hour>\d{1,2})(?::(?<minute>\d{2}))?\s*(?<ampm>am|pm)?"# +
+            #"(?:\s*\((?<zone>[^)]+)\))?"#
+        return (try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive])) ?? NSRegularExpression()
+    }()
+}

--- a/MeterBar/Services/SessionWake/SessionWakeDiscovery.swift
+++ b/MeterBar/Services/SessionWake/SessionWakeDiscovery.swift
@@ -1,0 +1,223 @@
+import Foundation
+import os
+
+// MARK: - Configuration
+
+struct SessionWakeDiscoveryConfiguration: Sendable {
+    /// Bytes read from the end of each transcript (latest-decisive-event
+    /// classification only needs the tail).
+    var tailByteLimit = 262_144
+    /// Newest-first cap on transcripts classified per scan.
+    var maxTranscripts = 400
+    /// Transcripts whose file wasn't modified within this window are skipped.
+    var maxTranscriptAge: TimeInterval = 14 * 24 * 3600
+    /// A block with no parseable reset stays "current" this long after the
+    /// blocking event; afterwards it is preview-only (`.staleBlock`).
+    var fallbackBlockWindow: TimeInterval = 8 * 3600
+    /// A block with a known reset stays "current" until reset + this grace.
+    var resetGracePeriod: TimeInterval = 3600
+
+    static let `default` = SessionWakeDiscoveryConfiguration()
+}
+
+// MARK: - Discovery
+
+/// Account-scoped, read-only discovery of blocked Claude Code sessions
+/// (issue #95). All file I/O happens on this actor, off the main actor, with
+/// bounded tail reads and a newest-first transcript cap.
+///
+/// Discovery is strictly a preview: it never spawns a process, writes a file,
+/// touches the replay ledger storage, or mutates any account state.
+actor SessionWakeDiscovery {
+    private let ledger: SessionWakeReplayLedger
+    private let configuration: SessionWakeDiscoveryConfiguration
+    private let homeDirectoryPath: String
+
+    init(
+        ledger: SessionWakeReplayLedger = .shared,
+        configuration: SessionWakeDiscoveryConfiguration = .default,
+        homeDirectoryPath: String = ServiceSupport.realHomeDirectory()
+    ) {
+        self.ledger = ledger
+        self.configuration = configuration
+        self.homeDirectoryPath = homeDirectoryPath
+    }
+
+    /// Scans only the selected account's projects directory — never another
+    /// configured account's — and returns deduplicated blocked-session
+    /// candidates, newest block first.
+    func discoverBlockedSessions(for account: ClaudeCodeAccount, now: Date = Date()) -> [BlockedSessionCandidate] {
+        let transcripts = transcriptURLs(in: projectsDirectory(for: account), now: now)
+
+        var bySessionID: [String: BlockedSessionCandidate] = [:]
+        for url in transcripts {
+            guard let candidate = candidate(forTranscriptAt: url, now: now) else { continue }
+            if let existing = bySessionID[candidate.sessionID], !supersedes(candidate, existing) {
+                continue
+            }
+            bySessionID[candidate.sessionID] = candidate
+        }
+
+        return bySessionID.values.sorted {
+            if $0.blockEvent.blockedAt != $1.blockEvent.blockedAt {
+                return $0.blockEvent.blockedAt > $1.blockEvent.blockedAt
+            }
+            return $0.transcriptURL.path < $1.transcriptURL.path
+        }
+    }
+
+    // MARK: - Directory resolution
+
+    /// `<configDirectory>/projects`, defaulting to `~/.claude/projects` for
+    /// the default CLI profile. Exactly one root per account.
+    private func projectsDirectory(for account: ClaudeCodeAccount) -> URL {
+        let trimmed = account.configDirectory?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let trimmed, !trimmed.isEmpty else {
+            return URL(fileURLWithPath: homeDirectoryPath, isDirectory: true)
+                .appendingPathComponent(".claude/projects", isDirectory: true)
+        }
+        let base = URL(fileURLWithPath: (trimmed as NSString).standardizingPath, isDirectory: true)
+        if base.lastPathComponent == "projects" {
+            return base
+        }
+        return base.appendingPathComponent("projects", isDirectory: true)
+    }
+
+    // MARK: - Enumeration (bounded)
+
+    private func transcriptURLs(in projectsRoot: URL, now: Date) -> [URL] {
+        let fileManager = FileManager.default
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: projectsRoot.path, isDirectory: &isDirectory),
+              isDirectory.boolValue,
+              let enumerator = fileManager.enumerator(
+                  at: projectsRoot,
+                  includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
+                  options: [.skipsHiddenFiles]
+              ) else {
+            return []
+        }
+
+        var found: [(url: URL, modified: Date)] = []
+        let oldestAllowed = now.addingTimeInterval(-configuration.maxTranscriptAge)
+        while let url = enumerator.nextObject() as? URL {
+            guard url.pathExtension == "jsonl",
+                  !url.pathComponents.contains("subagents"),
+                  let values = try? url.resourceValues(forKeys: [.contentModificationDateKey, .isRegularFileKey]),
+                  values.isRegularFile == true,
+                  let modified = values.contentModificationDate,
+                  modified >= oldestAllowed else {
+                continue
+            }
+            found.append((url, modified))
+        }
+
+        return found
+            .sorted {
+                if $0.modified != $1.modified {
+                    return $0.modified > $1.modified
+                }
+                return $0.url.path < $1.url.path
+            }
+            .prefix(configuration.maxTranscripts)
+            .map(\.url)
+    }
+
+    // MARK: - Candidate construction
+
+    private func candidate(forTranscriptAt url: URL, now: Date) -> BlockedSessionCandidate? {
+        guard let tail = readTail(of: url) else { return nil }
+        let summary = ClaudeTranscriptTailClassifier.classify(jsonl: tail)
+
+        guard !summary.isSubagentTranscript,
+              case .blocked(let event) = summary.terminalState else {
+            return nil
+        }
+
+        let sessionID = summary.sessionID ?? url.deletingPathExtension().lastPathComponent
+        let fingerprint = SessionBlockFingerprint.make(
+            sessionID: sessionID,
+            blockedAt: event.blockedAt,
+            reason: event.reason
+        )
+        // Handled blocks are never rediscovered, including after relaunch.
+        guard !ledger.containsHandled(fingerprint) else { return nil }
+
+        let (projectDirectory, eligibility) = resolveEligibility(for: summary, event: event, now: now)
+        return BlockedSessionCandidate(
+            sessionID: sessionID,
+            transcriptURL: url,
+            projectDirectory: projectDirectory,
+            gitBranch: summary.gitBranch,
+            blockEvent: event,
+            fingerprint: fingerprint,
+            eligibility: eligibility
+        )
+    }
+
+    private func resolveEligibility(
+        for summary: ClaudeTranscriptTailSummary,
+        event: SessionBlockEvent,
+        now: Date
+    ) -> (projectDirectory: String?, eligibility: SessionWakeEligibility) {
+        guard let rawWorkingDirectory = summary.workingDirectory else {
+            return (nil, .previewOnly(.missingMetadata))
+        }
+
+        let standardized = (rawWorkingDirectory as NSString).standardizingPath
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: standardized, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            // Structured skip, never an executable target.
+            return (nil, .previewOnly(.missingWorkingDirectory(rawWorkingDirectory)))
+        }
+        let canonical = URL(fileURLWithPath: standardized, isDirectory: true).resolvingSymlinksInPath().path
+
+        guard isCurrentWindow(event: event, now: now) else {
+            return (canonical, .previewOnly(.staleBlock))
+        }
+        return (canonical, .eligible)
+    }
+
+    /// Automatic eligibility is limited to the current blocking event/window;
+    /// anything older is historical and stays preview-only.
+    private func isCurrentWindow(event: SessionBlockEvent, now: Date) -> Bool {
+        if let resetAt = event.resetAt {
+            return now <= resetAt.addingTimeInterval(configuration.resetGracePeriod)
+        }
+        return now.timeIntervalSince(event.blockedAt) <= configuration.fallbackBlockWindow
+    }
+
+    /// Deterministic dedupe: latest block wins; equal timestamps tie-break on
+    /// the lexicographically first transcript path.
+    private func supersedes(_ candidate: BlockedSessionCandidate, _ existing: BlockedSessionCandidate) -> Bool {
+        if candidate.blockEvent.blockedAt != existing.blockEvent.blockedAt {
+            return candidate.blockEvent.blockedAt > existing.blockEvent.blockedAt
+        }
+        return candidate.transcriptURL.path < existing.transcriptURL.path
+    }
+
+    /// Reads at most `tailByteLimit` bytes from the end of the file. A tail
+    /// that starts mid-line is fine: the classifier skips the partial line.
+    private func readTail(of url: URL) -> String? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        do {
+            let size = try handle.seekToEnd()
+            let limit = UInt64(configuration.tailByteLimit)
+            let offset = size > limit ? size - limit : 0
+            try handle.seek(toOffset: offset)
+            guard let data = try handle.readToEnd() else { return "" }
+            // Lossy decoding on purpose: a bounded tail read can split a
+            // multi-byte UTF-8 character, and a failable init would then drop
+            // the whole transcript — including its decisive event.
+            // swiftlint:disable:next optional_data_string_conversion
+            return String(decoding: data, as: UTF8.self)
+        } catch {
+            AppLog.usage.error(
+                "Session wake tail read failed: \(error.localizedDescription, privacy: .public)"
+            )
+            return nil
+        }
+    }
+}

--- a/MeterBar/Services/SessionWake/SessionWakeModels.swift
+++ b/MeterBar/Services/SessionWake/SessionWakeModels.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+// MARK: - Block reason
+
+/// Typed reason a Claude Code session stopped on a rate limit (issue #95).
+enum SessionBlockReason: String, Codable, Sendable {
+    case sessionLimit
+    case weeklyLimit
+    case opusWeeklyLimit
+    case unknownRateLimit
+}
+
+// MARK: - Block event
+
+/// A single blocking rate-limit event with absolute timestamps.
+///
+/// `resetIsApproximate` is true when `resetAt` was derived from human-facing
+/// transcript text (a time-of-day fallback). Per the Session Wake epic, such a
+/// fallback may schedule a refresh but can never prove quota is available —
+/// downstream consumers (#96) must re-fetch fresh quota before acting.
+struct SessionBlockEvent: Equatable, Sendable {
+    let reason: SessionBlockReason
+    let blockedAt: Date
+    let resetAt: Date?
+    let resetIsApproximate: Bool
+}
+
+// MARK: - Terminal state
+
+/// Latest-decisive-event classification of a transcript tail. A historical
+/// rate limit followed by later successful assistant/tool activity classifies
+/// as `.progressed`, never `.blocked`.
+enum SessionTerminalState: Equatable, Sendable {
+    case blocked(SessionBlockEvent)
+    case progressed(lastActivityAt: Date?)
+    case indeterminate
+}
+
+/// Everything the classifier could extract from a transcript tail.
+struct ClaudeTranscriptTailSummary: Equatable, Sendable {
+    var terminalState: SessionTerminalState = .indeterminate
+    var sessionID: String?
+    var workingDirectory: String?
+    var gitBranch: String?
+    var isSubagentTranscript = false
+    var lastEventAt: Date?
+}
+
+// MARK: - Eligibility
+
+/// Structured reason a discovered block is preview-only instead of eligible
+/// for automatic wake.
+enum SessionWakeSkipReason: Equatable, Sendable {
+    /// The blocking event/window is historical; only the current window is
+    /// automatically eligible.
+    case staleBlock
+    /// The session's original cwd (project/worktree) no longer exists. The
+    /// associated value is the raw path recorded in the transcript.
+    case missingWorkingDirectory(String)
+    /// The transcript lacks the metadata needed to act on it (e.g. no cwd).
+    case missingMetadata
+}
+
+enum SessionWakeEligibility: Equatable, Sendable {
+    case eligible
+    case previewOnly(SessionWakeSkipReason)
+}
+
+// MARK: - Candidate
+
+/// A discovered blocked session. Strictly a description — discovery never
+/// mutates anything; acting on a candidate is later work (#96/#97).
+struct BlockedSessionCandidate: Equatable, Identifiable, Sendable {
+    var id: String { fingerprint }
+
+    let sessionID: String
+    let transcriptURL: URL
+    /// Canonicalized (standardized, symlink-resolved) original project or
+    /// worktree directory. Nil when the directory is missing — a dead cwd
+    /// must never surface as an executable target.
+    let projectDirectory: String?
+    let gitBranch: String?
+    let blockEvent: SessionBlockEvent
+    let fingerprint: String
+    let eligibility: SessionWakeEligibility
+}

--- a/MeterBar/Services/SessionWake/SessionWakeReplayLedger.swift
+++ b/MeterBar/Services/SessionWake/SessionWakeReplayLedger.swift
@@ -1,0 +1,110 @@
+import CryptoKit
+import Foundation
+import os
+
+// MARK: - Fingerprint
+
+/// Deterministic identity of a single blocking event, used to guarantee a
+/// handled block is never rediscovered or resumed twice — including across
+/// app relaunches.
+enum SessionBlockFingerprint {
+    static func make(sessionID: String, blockedAt: Date, reason: SessionBlockReason) -> String {
+        let payload = "\(sessionID)|\(Int(blockedAt.timeIntervalSince1970.rounded()))|\(reason.rawValue)"
+        return Data(SHA256.hash(data: Data(payload.utf8)))
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+}
+
+// MARK: - Replay ledger
+
+/// Persistent set of handled block fingerprints
+/// (`~/Library/Application Support/MeterBar/session-wake-ledger-v1.json`).
+///
+/// Reads are strictly read-only: `containsHandled` never creates or touches
+/// the storage file, so discovery/preview stays mutation-free. Only an
+/// explicit `markHandled` (a later, non-preview action) writes.
+final class SessionWakeReplayLedger {
+    struct Entry: Codable, Equatable {
+        let fingerprint: String
+        let handledAt: Date
+    }
+
+    static let shared = SessionWakeReplayLedger(storageURL: SessionWakeReplayLedger.defaultStorageURL)
+
+    static var defaultStorageURL: URL? {
+        guard let supportDirectory = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            return nil
+        }
+        return supportDirectory
+            .appendingPathComponent("MeterBar", isDirectory: true)
+            .appendingPathComponent("session-wake-ledger-v1.json")
+    }
+
+    private let storageURL: URL?
+    private let maxEntries: Int
+    private let lock = NSLock()
+    private var cachedEntries: [Entry]?
+
+    init(storageURL: URL?, maxEntries: Int = 500) {
+        self.storageURL = storageURL
+        self.maxEntries = max(1, maxEntries)
+    }
+
+    func containsHandled(_ fingerprint: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return loadedEntries().contains { $0.fingerprint == fingerprint }
+    }
+
+    func markHandled(_ fingerprint: String, at date: Date = Date()) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        var entries = loadedEntries().filter { $0.fingerprint != fingerprint }
+        entries.append(Entry(fingerprint: fingerprint, handledAt: date))
+        entries.sort { $0.handledAt < $1.handledAt }
+        if entries.count > maxEntries {
+            entries.removeFirst(entries.count - maxEntries)
+        }
+        cachedEntries = entries
+        persist(entries)
+    }
+
+    // MARK: - Private (callers hold `lock`)
+
+    private func loadedEntries() -> [Entry] {
+        if let cachedEntries {
+            return cachedEntries
+        }
+        var entries: [Entry] = []
+        if let storageURL, let data = try? Data(contentsOf: storageURL) {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            // A corrupt ledger degrades to empty rather than failing the scan.
+            entries = (try? decoder.decode([Entry].self, from: data)) ?? []
+        }
+        cachedEntries = entries
+        return entries
+    }
+
+    private func persist(_ entries: [Entry]) {
+        guard let storageURL else { return }
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        do {
+            try FileManager.default.createDirectory(
+                at: storageURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let data = try encoder.encode(entries)
+            try data.write(to: storageURL, options: [.atomic])
+        } catch {
+            AppLog.storage.error("Session wake ledger save failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/MeterBarTests/ClaudeTranscriptTailClassifierTests.swift
+++ b/MeterBarTests/ClaudeTranscriptTailClassifierTests.swift
@@ -1,0 +1,286 @@
+import XCTest
+@testable import MeterBar
+
+final class ClaudeTranscriptTailClassifierTests: XCTestCase {
+    private func date(_ iso: String) -> Date {
+        guard let parsed = FlexibleISO8601.date(from: iso) else {
+            XCTFail("bad fixture date \(iso)")
+            return Date(timeIntervalSince1970: 0)
+        }
+        return parsed
+    }
+
+    // MARK: - Shape A (structured rate_limit)
+
+    func testStructuredRateLimitIsClassifiedBlocked() {
+        let jsonl = SessionWakeFixtures.jsonl([
+            SessionWakeFixtures.assistantProgressLine(timestamp: "2026-07-10T04:00:00.000Z"),
+            SessionWakeFixtures.rateLimitLine(timestamp: "2026-07-10T04:14:15.397Z")
+        ])
+
+        let summary = ClaudeTranscriptTailClassifier.classify(jsonl: jsonl)
+
+        guard case .blocked(let event) = summary.terminalState else {
+            return XCTFail("expected blocked, got \(summary.terminalState)")
+        }
+        XCTAssertEqual(event.reason, .sessionLimit)
+        XCTAssertEqual(event.blockedAt, date("2026-07-10T04:14:15.397Z"))
+        XCTAssertEqual(summary.sessionID, SessionWakeFixtures.defaultSessionID)
+        XCTAssertEqual(summary.workingDirectory, "/tmp/project")
+        XCTAssertEqual(summary.gitBranch, "claude/test-branch")
+        XCTAssertFalse(summary.isSubagentTranscript)
+    }
+
+    func testStructuredRateLimitCasingVariantsAreRecognized() {
+        for errorField in ["rate_limit", "RATE_LIMIT", "Rate_Limit"] {
+            let jsonl = SessionWakeFixtures.jsonl([
+                SessionWakeFixtures.rateLimitLine(errorField: errorField)
+            ])
+            let summary = ClaudeTranscriptTailClassifier.classify(jsonl: jsonl)
+            guard case .blocked = summary.terminalState else {
+                return XCTFail("expected blocked for error field '\(errorField)'")
+            }
+        }
+    }
+
+    func testStatus429WithoutErrorFieldIsBlocked() {
+        let jsonl = SessionWakeFixtures.jsonl([
+            SessionWakeFixtures.rateLimitLine(errorField: "", apiErrorStatus: 429)
+        ])
+        guard case .blocked = ClaudeTranscriptTailClassifier.classify(jsonl: jsonl).terminalState else {
+            return XCTFail("expected blocked for 429 status")
+        }
+    }
+
+    func testWeeklyAndOpusReasonsAreTyped() {
+        let weekly = SessionWakeFixtures.jsonl([
+            SessionWakeFixtures.rateLimitLine(text: "You've hit your weekly limit · resets Jul 15 at 7am (Europe/Malta)")
+        ])
+        guard case .blocked(let weeklyEvent) = ClaudeTranscriptTailClassifier.classify(jsonl: weekly).terminalState else {
+            return XCTFail("expected blocked")
+        }
+        XCTAssertEqual(weeklyEvent.reason, .weeklyLimit)
+
+        let opus = SessionWakeFixtures.jsonl([
+            SessionWakeFixtures.rateLimitLine(text: "You've hit your Opus weekly limit · resets Jul 15 at 7am")
+        ])
+        guard case .blocked(let opusEvent) = ClaudeTranscriptTailClassifier.classify(jsonl: opus).terminalState else {
+            return XCTFail("expected blocked")
+        }
+        XCTAssertEqual(opusEvent.reason, .opusWeeklyLimit)
+    }
+
+    // MARK: - Shape B (legacy pipe-epoch)
+
+    func testLegacyPipeEpochIsBlockedWithExactReset() {
+        let epoch = 1_752_130_800
+        let jsonl = SessionWakeFixtures.jsonl([
+            SessionWakeFixtures.legacyLimitLine(resetEpoch: epoch)
+        ])
+
+        guard case .blocked(let event) = ClaudeTranscriptTailClassifier.classify(jsonl: jsonl).terminalState else {
+            return XCTFail("expected blocked")
+        }
+        XCTAssertEqual(event.resetAt, Date(timeIntervalSince1970: TimeInterval(epoch)))
+        XCTAssertFalse(event.resetIsApproximate, "epoch markers are exact")
+    }
+
+    func testLegacyMarkerCasingVariantsAreRecognized() {
+        for marker in [
+            "Claude AI usage limit reached",
+            "Claude usage limit reached",
+            "CLAUDE AI USAGE LIMIT REACHED",
+            "claude ai usage limit reached"
+        ] {
+            let jsonl = SessionWakeFixtures.jsonl([
+                SessionWakeFixtures.legacyLimitLine(marker: marker)
+            ])
+            guard case .blocked = ClaudeTranscriptTailClassifier.classify(jsonl: jsonl).terminalState else {
+                return XCTFail("expected blocked for marker '\(marker)'")
+            }
+        }
+    }
+
+    // MARK: - Latest-decisive-event semantics
+
+    func testHistoricalBlockFollowedByAssistantProgressIsNotBlocked() {
+        let jsonl = SessionWakeFixtures.jsonl([
+            SessionWakeFixtures.rateLimitLine(timestamp: "2026-07-10T04:14:15.397Z"),
+            SessionWakeFixtures.assistantProgressLine(timestamp: "2026-07-10T09:00:00.000Z")
+        ])
+
+        guard case .progressed = ClaudeTranscriptTailClassifier.classify(jsonl: jsonl).terminalState else {
+            return XCTFail("later assistant activity must clear the block")
+        }
+    }
+
+    func testHistoricalBlockFollowedByToolResultIsNotBlocked() {
+        let jsonl = SessionWakeFixtures.jsonl([
+            SessionWakeFixtures.rateLimitLine(timestamp: "2026-07-10T04:14:15.397Z"),
+            SessionWakeFixtures.userToolResultLine(timestamp: "2026-07-10T09:01:00.000Z")
+        ])
+
+        guard case .progressed = ClaudeTranscriptTailClassifier.classify(jsonl: jsonl).terminalState else {
+            return XCTFail("later tool activity must clear the block")
+        }
+    }
+
+    func testPlainUserTextAfterBlockIsNotDecisive() {
+        let jsonl = SessionWakeFixtures.jsonl([
+            SessionWakeFixtures.rateLimitLine(timestamp: "2026-07-10T04:14:15.397Z"),
+            SessionWakeFixtures.userTextLine(timestamp: "2026-07-10T04:20:00.000Z"),
+            SessionWakeFixtures.summaryLine()
+        ])
+
+        guard case .blocked = ClaudeTranscriptTailClassifier.classify(jsonl: jsonl).terminalState else {
+            return XCTFail("plain user text must not clear the block")
+        }
+    }
+
+    func testSecondBlockAfterRecoveryUsesLatestBlockEvent() {
+        let jsonl = SessionWakeFixtures.jsonl([
+            SessionWakeFixtures.rateLimitLine(timestamp: "2026-07-09T20:00:00.000Z"),
+            SessionWakeFixtures.assistantProgressLine(timestamp: "2026-07-10T01:00:00.000Z"),
+            SessionWakeFixtures.rateLimitLine(timestamp: "2026-07-10T04:14:15.397Z")
+        ])
+
+        guard case .blocked(let event) = ClaudeTranscriptTailClassifier.classify(jsonl: jsonl).terminalState else {
+            return XCTFail("expected blocked")
+        }
+        XCTAssertEqual(event.blockedAt, date("2026-07-10T04:14:15.397Z"))
+    }
+
+    // MARK: - Subagents
+
+    func testSidechainLinesAreIgnoredForClassification() {
+        // Sidechain block after mainline progress must not mark the session blocked.
+        let jsonl = SessionWakeFixtures.jsonl([
+            SessionWakeFixtures.assistantProgressLine(timestamp: "2026-07-10T04:00:00.000Z"),
+            SessionWakeFixtures.rateLimitLine(timestamp: "2026-07-10T04:30:00.000Z", isSidechain: true)
+        ])
+
+        guard case .progressed = ClaudeTranscriptTailClassifier.classify(jsonl: jsonl).terminalState else {
+            return XCTFail("sidechain events must not classify the session")
+        }
+    }
+
+    func testAllSidechainTranscriptIsFlaggedSubagent() {
+        let jsonl = SessionWakeFixtures.jsonl([
+            SessionWakeFixtures.assistantProgressLine(isSidechain: true),
+            SessionWakeFixtures.rateLimitLine(isSidechain: true)
+        ])
+
+        let summary = ClaudeTranscriptTailClassifier.classify(jsonl: jsonl)
+        XCTAssertTrue(summary.isSubagentTranscript)
+        guard case .indeterminate = summary.terminalState else {
+            return XCTFail("subagent transcripts have no mainline terminal state")
+        }
+    }
+
+    // MARK: - Robustness
+
+    func testMalformedAndTruncatedLinesDoNotCrashOrPoison() {
+        let jsonl = [
+            "sionId\":\"partial-head-from-tail-read\"}",
+            "not json at all",
+            "{\"type\":\"assistant\",\"timestamp\":12345}",
+            "{}",
+            SessionWakeFixtures.rateLimitLine(timestamp: "2026-07-10T04:14:15.397Z"),
+            "{\"truncated\":\"line with no closing brace"
+        ].joined(separator: "\n")
+
+        guard case .blocked = ClaudeTranscriptTailClassifier.classify(jsonl: jsonl).terminalState else {
+            return XCTFail("malformed neighbors must not poison the decisive event")
+        }
+    }
+
+    func testEmptyTranscriptIsIndeterminate() {
+        let summary = ClaudeTranscriptTailClassifier.classify(jsonl: "")
+        guard case .indeterminate = summary.terminalState else {
+            return XCTFail("expected indeterminate")
+        }
+        XCTAssertNil(summary.sessionID)
+    }
+
+    // MARK: - Reset parsing
+
+    func testTimeOnlyResetIsAnchoredToEventDayInZone() {
+        // Event 04:14Z; Malta is UTC+2 in July, so 7:30am Malta == 05:30Z same day.
+        let event = date("2026-07-10T04:14:15Z")
+        let parsed = ClaudeTranscriptTailClassifier.resetDate(
+            fromMessageText: "You've hit your session limit · resets 7:30am (Europe/Malta)",
+            anchoredTo: event
+        )
+
+        XCTAssertEqual(parsed?.date, date("2026-07-10T05:30:00Z"))
+        XCTAssertEqual(parsed?.isApproximate, true, "text fallbacks can never prove quota")
+    }
+
+    func testResetTimeEarlierThanEventRollsToNextDay() {
+        // Block at 8pm Malta, "resets 7:30am" means tomorrow morning.
+        let event = date("2026-07-10T18:00:00Z")
+        let parsed = ClaudeTranscriptTailClassifier.resetDate(
+            fromMessageText: "resets 7:30am (Europe/Malta)",
+            anchoredTo: event
+        )
+
+        XCTAssertEqual(parsed?.date, date("2026-07-11T05:30:00Z"))
+    }
+
+    func testResetJustPassedAtScanTimeIsNotRolledToTomorrow() {
+        // Anchoring is to the EVENT timestamp: the event (04:14Z) precedes
+        // 7:30am Malta (05:30Z), so the reset stays on the event's day even
+        // when "now" is minutes past it.
+        let event = date("2026-07-10T04:14:15Z")
+        let parsed = ClaudeTranscriptTailClassifier.resetDate(
+            fromMessageText: "resets 7:30am (Europe/Malta)",
+            anchoredTo: event
+        )
+
+        guard let resetDate = parsed?.date else { return XCTFail("expected a reset date") }
+        XCTAssertEqual(resetDate, date("2026-07-10T05:30:00Z"))
+        let scanTime = date("2026-07-10T05:35:00Z")
+        XCTAssertLessThan(resetDate, scanTime, "a just-passed reset stays in the past")
+    }
+
+    func testMonthDayResetForm() {
+        let event = date("2026-07-10T04:14:15Z")
+        let parsed = ClaudeTranscriptTailClassifier.resetDate(
+            fromMessageText: "You've hit your weekly limit · resets Jul 15 at 10pm (Europe/Malta)",
+            anchoredTo: event
+        )
+
+        // 10pm Malta on Jul 15 == 20:00Z.
+        XCTAssertEqual(parsed?.date, date("2026-07-15T20:00:00Z"))
+    }
+
+    func testTwentyFourHourClockResetForm() {
+        let event = date("2026-07-10T04:14:15Z")
+        let parsed = ClaudeTranscriptTailClassifier.resetDate(
+            fromMessageText: "resets 19:00 (Europe/Malta)",
+            anchoredTo: event
+        )
+
+        XCTAssertEqual(parsed?.date, date("2026-07-10T17:00:00Z"))
+    }
+
+    func testUnparseableResetTextYieldsNil() {
+        let parsed = ClaudeTranscriptTailClassifier.resetDate(
+            fromMessageText: "You've hit your session limit",
+            anchoredTo: Date(timeIntervalSince1970: 1_750_000_000)
+        )
+        XCTAssertNil(parsed)
+    }
+
+    func testBlockedEventCarriesParsedResetFromText() {
+        let jsonl = SessionWakeFixtures.jsonl([
+            SessionWakeFixtures.rateLimitLine(timestamp: "2026-07-10T04:14:15.397Z")
+        ])
+
+        guard case .blocked(let event) = ClaudeTranscriptTailClassifier.classify(jsonl: jsonl).terminalState else {
+            return XCTFail("expected blocked")
+        }
+        XCTAssertEqual(event.resetAt, date("2026-07-10T05:30:00Z"))
+        XCTAssertEqual(event.resetIsApproximate, true)
+    }
+}

--- a/MeterBarTests/SessionWakeDiscoveryTests.swift
+++ b/MeterBarTests/SessionWakeDiscoveryTests.swift
@@ -1,0 +1,358 @@
+import XCTest
+@testable import MeterBar
+
+final class SessionWakeDiscoveryTests: XCTestCase {
+    private var tempDir: URL!
+    private var configDir: URL!
+    private var projectsDir: URL!
+    private var workDir: URL!
+    private var ledgerURL: URL!
+    private var ledger: SessionWakeReplayLedger!
+
+    /// Scan time shortly after the fixtures' 04:14Z block, before its 05:30Z reset.
+    private let now = FlexibleISO8601.date(from: "2026-07-10T05:00:00Z") ?? Date()
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SessionWakeDiscoveryTests-\(UUID().uuidString)")
+        configDir = tempDir.appendingPathComponent("claude-config")
+        projectsDir = configDir.appendingPathComponent("projects")
+        workDir = tempDir.appendingPathComponent("workdir")
+        ledgerURL = tempDir.appendingPathComponent("ledger.json")
+        try FileManager.default.createDirectory(at: projectsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)
+        ledger = SessionWakeReplayLedger(storageURL: ledgerURL)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    private func makeAccount(configDirectory: URL? = nil) -> ClaudeCodeAccount {
+        ClaudeCodeAccount(
+            id: UUID(),
+            name: "Test Account",
+            configDirectory: (configDirectory ?? configDir).path
+        )
+    }
+
+    private func makeDiscovery(
+        configuration: SessionWakeDiscoveryConfiguration = .default
+    ) -> SessionWakeDiscovery {
+        SessionWakeDiscovery(ledger: ledger, configuration: configuration)
+    }
+
+    private func projectDir(_ name: String = "-tmp-project") -> URL {
+        projectsDir.appendingPathComponent(name)
+    }
+
+    // MARK: - Happy path
+
+    func testBlockedSessionIsDiscoveredEligible() async throws {
+        try SessionWakeFixtures.writeTranscript(
+            lines: [SessionWakeFixtures.rateLimitLine(cwd: workDir.path)],
+            named: "\(SessionWakeFixtures.defaultSessionID).jsonl",
+            in: projectDir()
+        )
+
+        let candidates = await makeDiscovery().discoverBlockedSessions(for: makeAccount(), now: now)
+
+        XCTAssertEqual(candidates.count, 1)
+        let candidate = try XCTUnwrap(candidates.first)
+        XCTAssertEqual(candidate.sessionID, SessionWakeFixtures.defaultSessionID)
+        XCTAssertEqual(candidate.eligibility, .eligible)
+        XCTAssertEqual(candidate.blockEvent.reason, .sessionLimit)
+        XCTAssertEqual(
+            candidate.projectDirectory,
+            URL(fileURLWithPath: workDir.path).resolvingSymlinksInPath().path
+        )
+        XCTAssertFalse(candidate.fingerprint.isEmpty)
+        XCTAssertEqual(candidate.id, candidate.fingerprint, "Identifiable id is the fingerprint")
+    }
+
+    func testWorkingDirectoryIsCanonicalized() async throws {
+        let messyPath = workDir.path + "/./"
+        try SessionWakeFixtures.writeTranscript(
+            lines: [SessionWakeFixtures.rateLimitLine(cwd: messyPath)],
+            named: "\(SessionWakeFixtures.defaultSessionID).jsonl",
+            in: projectDir()
+        )
+
+        let candidates = await makeDiscovery().discoverBlockedSessions(for: makeAccount(), now: now)
+
+        XCTAssertEqual(
+            candidates.first?.projectDirectory,
+            URL(fileURLWithPath: workDir.path).resolvingSymlinksInPath().path
+        )
+    }
+
+    // MARK: - Later recovery
+
+    func testBlockFollowedByLaterProgressIsNotACandidate() async throws {
+        try SessionWakeFixtures.writeTranscript(
+            lines: [
+                SessionWakeFixtures.rateLimitLine(cwd: workDir.path, timestamp: "2026-07-10T04:14:15.397Z"),
+                SessionWakeFixtures.assistantProgressLine(cwd: workDir.path, timestamp: "2026-07-10T04:50:00.000Z")
+            ],
+            named: "\(SessionWakeFixtures.defaultSessionID).jsonl",
+            in: projectDir()
+        )
+
+        let candidates = await makeDiscovery().discoverBlockedSessions(for: makeAccount(), now: now)
+        XCTAssertTrue(candidates.isEmpty, "recovered sessions must not be candidates")
+    }
+
+    // MARK: - Replay ledger
+
+    func testHandledFingerprintIsNotRediscoveredAfterRelaunch() async throws {
+        try SessionWakeFixtures.writeTranscript(
+            lines: [SessionWakeFixtures.rateLimitLine(cwd: workDir.path)],
+            named: "\(SessionWakeFixtures.defaultSessionID).jsonl",
+            in: projectDir()
+        )
+
+        let first = await makeDiscovery().discoverBlockedSessions(for: makeAccount(), now: now)
+        let fingerprint = try XCTUnwrap(first.first?.fingerprint)
+        ledger.markHandled(fingerprint, at: now)
+
+        // Fresh ledger + discovery instances simulate an app relaunch.
+        ledger = SessionWakeReplayLedger(storageURL: ledgerURL)
+        let second = await makeDiscovery().discoverBlockedSessions(for: makeAccount(), now: now)
+        XCTAssertTrue(second.isEmpty, "handled blocks must not be rediscovered")
+    }
+
+    // MARK: - Skip reasons
+
+    func testMissingWorkingDirectoryYieldsStructuredSkip() async throws {
+        let deadPath = tempDir.appendingPathComponent("deleted-worktree").path
+        try SessionWakeFixtures.writeTranscript(
+            lines: [SessionWakeFixtures.rateLimitLine(cwd: deadPath)],
+            named: "\(SessionWakeFixtures.defaultSessionID).jsonl",
+            in: projectDir()
+        )
+
+        let candidates = await makeDiscovery().discoverBlockedSessions(for: makeAccount(), now: now)
+
+        let candidate = try XCTUnwrap(candidates.first)
+        XCTAssertEqual(candidate.eligibility, .previewOnly(.missingWorkingDirectory(deadPath)))
+        XCTAssertNil(candidate.projectDirectory, "a dead cwd must not produce an executable target")
+    }
+
+    func testStaleBlockIsPreviewOnly() async throws {
+        // Reset (05:30Z on Jul 10) long past by scan time two days later.
+        try SessionWakeFixtures.writeTranscript(
+            lines: [SessionWakeFixtures.rateLimitLine(cwd: workDir.path)],
+            named: "\(SessionWakeFixtures.defaultSessionID).jsonl",
+            in: projectDir()
+        )
+
+        let later = now.addingTimeInterval(48 * 3600)
+        let candidates = await makeDiscovery().discoverBlockedSessions(for: makeAccount(), now: later)
+
+        XCTAssertEqual(candidates.first?.eligibility, .previewOnly(.staleBlock))
+    }
+
+    func testBlockWithoutResetUsesFallbackWindow() async throws {
+        let text = "You've hit your session limit"
+        try SessionWakeFixtures.writeTranscript(
+            lines: [SessionWakeFixtures.rateLimitLine(cwd: workDir.path, text: text)],
+            named: "\(SessionWakeFixtures.defaultSessionID).jsonl",
+            in: projectDir()
+        )
+
+        var configuration = SessionWakeDiscoveryConfiguration.default
+        configuration.fallbackBlockWindow = 8 * 3600
+
+        let fresh = await makeDiscovery(configuration: configuration)
+            .discoverBlockedSessions(for: makeAccount(), now: now)
+        XCTAssertEqual(fresh.first?.eligibility, .eligible)
+
+        let stale = await makeDiscovery(configuration: configuration)
+            .discoverBlockedSessions(for: makeAccount(), now: now.addingTimeInterval(9 * 3600))
+        XCTAssertEqual(stale.first?.eligibility, .previewOnly(.staleBlock))
+    }
+
+    func testMissingMetadataYieldsStructuredSkip() async throws {
+        // A rate-limit line with no cwd at all.
+        let line = """
+        {"isSidechain":false,"type":"assistant","timestamp":"2026-07-10T04:14:15.397Z",\
+        "message":{"role":"assistant","content":[{"type":"text","text":"You've hit your session limit \
+        · resets 7:30am (Europe/Malta)"}]},"error":"rate_limit","isApiErrorMessage":true,\
+        "sessionId":"\(SessionWakeFixtures.defaultSessionID)"}
+        """
+        try SessionWakeFixtures.writeTranscript(
+            lines: [line],
+            named: "\(SessionWakeFixtures.defaultSessionID).jsonl",
+            in: projectDir()
+        )
+
+        let candidates = await makeDiscovery().discoverBlockedSessions(for: makeAccount(), now: now)
+        XCTAssertEqual(candidates.first?.eligibility, .previewOnly(.missingMetadata))
+    }
+
+    // MARK: - Deduplication
+
+    func testDuplicateSessionIDsAreDeduplicatedDeterministically() async throws {
+        // Same session appears in two project directories; the newer block wins.
+        try SessionWakeFixtures.writeTranscript(
+            lines: [SessionWakeFixtures.rateLimitLine(cwd: workDir.path, timestamp: "2026-07-10T03:00:00.000Z")],
+            named: "\(SessionWakeFixtures.defaultSessionID).jsonl",
+            in: projectDir("-tmp-project-a")
+        )
+        try SessionWakeFixtures.writeTranscript(
+            lines: [SessionWakeFixtures.rateLimitLine(cwd: workDir.path, timestamp: "2026-07-10T04:14:15.397Z")],
+            named: "\(SessionWakeFixtures.defaultSessionID).jsonl",
+            in: projectDir("-tmp-project-b")
+        )
+
+        let candidates = await makeDiscovery().discoverBlockedSessions(for: makeAccount(), now: now)
+
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertEqual(
+            candidates.first?.blockEvent.blockedAt,
+            FlexibleISO8601.date(from: "2026-07-10T04:14:15.397Z")
+        )
+    }
+
+    func testDuplicateTieBreaksOnTranscriptPath() async throws {
+        for name in ["-tmp-project-b", "-tmp-project-a"] {
+            try SessionWakeFixtures.writeTranscript(
+                lines: [SessionWakeFixtures.rateLimitLine(cwd: workDir.path)],
+                named: "\(SessionWakeFixtures.defaultSessionID).jsonl",
+                in: projectDir(name)
+            )
+        }
+
+        let candidates = await makeDiscovery().discoverBlockedSessions(for: makeAccount(), now: now)
+
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertTrue(
+            candidates.first?.transcriptURL.path.contains("-tmp-project-a") == true,
+            "equal-timestamp duplicates must tie-break on the lexicographically first path"
+        )
+    }
+
+    // MARK: - Subagents
+
+    func testAllSidechainTranscriptsAreExcluded() async throws {
+        try SessionWakeFixtures.writeTranscript(
+            lines: [SessionWakeFixtures.rateLimitLine(cwd: workDir.path, isSidechain: true)],
+            named: "\(UUID().uuidString).jsonl",
+            in: projectDir()
+        )
+
+        let candidates = await makeDiscovery().discoverBlockedSessions(for: makeAccount(), now: now)
+        XCTAssertTrue(candidates.isEmpty, "subagent transcripts must be excluded")
+    }
+
+    func testSubagentsDirectoryIsExcluded() async throws {
+        try SessionWakeFixtures.writeTranscript(
+            lines: [SessionWakeFixtures.rateLimitLine(cwd: workDir.path)],
+            named: "\(UUID().uuidString).jsonl",
+            in: projectDir().appendingPathComponent("subagents")
+        )
+
+        let candidates = await makeDiscovery().discoverBlockedSessions(for: makeAccount(), now: now)
+        XCTAssertTrue(candidates.isEmpty)
+    }
+
+    // MARK: - Account scoping
+
+    func testDiscoveryIsScopedToTheSelectedAccount() async throws {
+        let otherConfig = tempDir.appendingPathComponent("other-claude-config")
+        let otherProjects = otherConfig.appendingPathComponent("projects/-tmp-other")
+        try SessionWakeFixtures.writeTranscript(
+            lines: [SessionWakeFixtures.rateLimitLine(sessionID: UUID().uuidString, cwd: workDir.path)],
+            named: "other-session.jsonl",
+            in: otherProjects
+        )
+        try SessionWakeFixtures.writeTranscript(
+            lines: [SessionWakeFixtures.rateLimitLine(cwd: workDir.path)],
+            named: "\(SessionWakeFixtures.defaultSessionID).jsonl",
+            in: projectDir()
+        )
+
+        let candidates = await makeDiscovery().discoverBlockedSessions(for: makeAccount(), now: now)
+
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertEqual(candidates.first?.sessionID, SessionWakeFixtures.defaultSessionID)
+        XCTAssertFalse(candidates.first?.transcriptURL.path.contains("other-claude-config") ?? true)
+    }
+
+    func testMissingProjectsDirectoryYieldsNoCandidates() async {
+        let account = makeAccount(configDirectory: tempDir.appendingPathComponent("nonexistent"))
+        let candidates = await makeDiscovery().discoverBlockedSessions(for: account, now: now)
+        XCTAssertTrue(candidates.isEmpty)
+    }
+
+    // MARK: - Robustness & bounds
+
+    func testMalformedTranscriptFilesCannotPoisonTheScan() async throws {
+        let project = projectDir()
+        try SessionWakeFixtures.writeTranscript(
+            lines: ["garbage {{{", "\u{0000}\u{0001}binary-ish"],
+            named: "\(UUID().uuidString).jsonl",
+            in: project
+        )
+        try SessionWakeFixtures.writeTranscript(
+            lines: [SessionWakeFixtures.rateLimitLine(cwd: workDir.path)],
+            named: "\(SessionWakeFixtures.defaultSessionID).jsonl",
+            in: project
+        )
+
+        let candidates = await makeDiscovery().discoverBlockedSessions(for: makeAccount(), now: now)
+        XCTAssertEqual(candidates.count, 1)
+    }
+
+    func testOnlyTailBytesAreReadFromLargeTranscripts() async throws {
+        // A huge prefix of noise; the decisive block event sits at the tail.
+        var lines = (0..<50).map { _ in SessionWakeFixtures.userTextLine(cwd: workDir.path) }
+        lines.append(SessionWakeFixtures.rateLimitLine(cwd: workDir.path))
+
+        var configuration = SessionWakeDiscoveryConfiguration.default
+        configuration.tailByteLimit = 4096
+
+        try SessionWakeFixtures.writeTranscript(
+            lines: lines,
+            named: "\(SessionWakeFixtures.defaultSessionID).jsonl",
+            in: projectDir()
+        )
+
+        let candidates = await makeDiscovery(configuration: configuration)
+            .discoverBlockedSessions(for: makeAccount(), now: now)
+        XCTAssertEqual(candidates.count, 1)
+    }
+
+    // MARK: - Read-only preview
+
+    func testDiscoveryPerformsZeroFilesystemMutations() async throws {
+        try SessionWakeFixtures.writeTranscript(
+            lines: [SessionWakeFixtures.rateLimitLine(cwd: workDir.path)],
+            named: "\(SessionWakeFixtures.defaultSessionID).jsonl",
+            in: projectDir()
+        )
+
+        let before = try snapshot(of: tempDir)
+        _ = await makeDiscovery().discoverBlockedSessions(for: makeAccount(), now: now)
+        let after = try snapshot(of: tempDir)
+
+        XCTAssertEqual(before, after, "preview must not create, modify, or delete any file")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: ledgerURL.path),
+                       "discovery must not write the replay ledger")
+    }
+
+    /// Recursive path -> (size, modification date) map used to prove read-only behavior.
+    private func snapshot(of root: URL) throws -> [String: String] {
+        var result: [String: String] = [:]
+        let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey]
+        )
+        while let url = enumerator?.nextObject() as? URL {
+            let values = try url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
+            let stamp = values.contentModificationDate.map { String($0.timeIntervalSinceReferenceDate) } ?? "-"
+            result[url.path] = "\(values.fileSize ?? -1)|\(stamp)"
+        }
+        return result
+    }
+}

--- a/MeterBarTests/SessionWakeFixtures.swift
+++ b/MeterBarTests/SessionWakeFixtures.swift
@@ -1,0 +1,123 @@
+import Foundation
+@testable import MeterBar
+
+/// JSONL fixture builders for Session Wake tests.
+///
+/// Shapes mirror real Claude Code transcripts:
+/// - Shape A: the current structured synthetic assistant error
+///   (`"error":"rate_limit"`, `"isApiErrorMessage":true`, `apiErrorStatus:429`)
+///   with a human text like "You've hit your session limit · resets 7:30am (Europe/Malta)".
+/// - Shape B: the legacy synthetic text marker
+///   "Claude AI usage limit reached|<unix-epoch>".
+enum SessionWakeFixtures {
+    static let defaultSessionID = "a8e1387f-3594-41c1-b1f1-cc7b94c6ef63"
+
+    // MARK: - Line builders
+
+    /// Shape A: current structured rate-limit synthetic assistant message.
+    static func rateLimitLine(
+        sessionID: String = defaultSessionID,
+        cwd: String = "/tmp/project",
+        timestamp: String = "2026-07-10T04:14:15.397Z",
+        text: String = "You've hit your session limit · resets 7:30am (Europe/Malta)",
+        errorField: String = "rate_limit",
+        apiErrorStatus: Int = 429,
+        isSidechain: Bool = false,
+        gitBranch: String = "claude/test-branch"
+    ) -> String {
+        """
+        {"parentUuid":"81c537f3-8b44-464b-825f-ede3788782b8","isSidechain":\(isSidechain),\
+        "type":"assistant","uuid":"4f946454-65d3-4d7a-9108-707a53694db9","timestamp":"\(timestamp)",\
+        "message":{"id":"msg_1","model":"<synthetic>","role":"assistant","stop_reason":"stop_sequence",\
+        "type":"message","content":[{"type":"text","text":"\(text)"}]},\
+        "requestId":"req_011Ccsj8dFKF9qszdbmxG7Ft","error":"\(errorField)","isApiErrorMessage":true,\
+        "apiErrorStatus":\(apiErrorStatus),"userType":"external","cwd":"\(cwd)",\
+        "sessionId":"\(sessionID)","version":"2.1.202","gitBranch":"\(gitBranch)"}
+        """
+    }
+
+    /// Shape B: legacy pipe-epoch text marker. No structured error fields.
+    static func legacyLimitLine(
+        sessionID: String = defaultSessionID,
+        cwd: String = "/tmp/project",
+        timestamp: String = "2026-07-10T04:14:15Z",
+        marker: String = "Claude AI usage limit reached",
+        resetEpoch: Int = 1_752_130_800
+    ) -> String {
+        """
+        {"isSidechain":false,"type":"assistant","uuid":"11946454-65d3-41c1-9108-707a53694db9",\
+        "timestamp":"\(timestamp)","message":{"id":"msg_2","model":"<synthetic>","role":"assistant",\
+        "type":"message","content":[{"type":"text","text":"\(marker)|\(resetEpoch)"}]},\
+        "isApiErrorMessage":true,"cwd":"\(cwd)","sessionId":"\(sessionID)"}
+        """
+    }
+
+    /// A successful (non-error) assistant message — decisive progress.
+    static func assistantProgressLine(
+        sessionID: String = defaultSessionID,
+        cwd: String = "/tmp/project",
+        timestamp: String = "2026-07-10T05:00:00.000Z",
+        isSidechain: Bool = false,
+        text: String = "Done. All tests pass."
+    ) -> String {
+        """
+        {"isSidechain":\(isSidechain),"type":"assistant","uuid":"22946454-65d3-41c1-9108-707a53694db9",\
+        "timestamp":"\(timestamp)","message":{"id":"msg_3","model":"claude-fable-5","role":"assistant",\
+        "type":"message","content":[{"type":"text","text":"\(text)"}],\
+        "usage":{"input_tokens":10,"output_tokens":25}},\
+        "cwd":"\(cwd)","sessionId":"\(sessionID)"}
+        """
+    }
+
+    /// A user line carrying a tool_result — decisive progress.
+    static func userToolResultLine(
+        sessionID: String = defaultSessionID,
+        cwd: String = "/tmp/project",
+        timestamp: String = "2026-07-10T05:01:00.000Z",
+        isSidechain: Bool = false
+    ) -> String {
+        """
+        {"isSidechain":\(isSidechain),"type":"user","uuid":"33946454-65d3-41c1-9108-707a53694db9",\
+        "timestamp":"\(timestamp)","message":{"role":"user",\
+        "content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]},\
+        "cwd":"\(cwd)","sessionId":"\(sessionID)"}
+        """
+    }
+
+    /// A plain user text message — NOT decisive (typing after a block proves nothing).
+    static func userTextLine(
+        sessionID: String = defaultSessionID,
+        cwd: String = "/tmp/project",
+        timestamp: String = "2026-07-10T05:02:00.000Z"
+    ) -> String {
+        """
+        {"isSidechain":false,"type":"user","uuid":"44946454-65d3-41c1-9108-707a53694db9",\
+        "timestamp":"\(timestamp)","message":{"role":"user","content":"are you back?"},\
+        "cwd":"\(cwd)","sessionId":"\(sessionID)"}
+        """
+    }
+
+    static func summaryLine() -> String {
+        """
+        {"type":"summary","summary":"Fixing the widget","leafUuid":"55946454-65d3-41c1-9108-707a53694db9"}
+        """
+    }
+
+    // MARK: - File helpers
+
+    static func jsonl(_ lines: [String]) -> String {
+        lines.joined(separator: "\n") + "\n"
+    }
+
+    @discardableResult
+    static func writeTranscript(
+        lines: [String],
+        named fileName: String,
+        in projectDirectory: URL
+    ) throws -> URL {
+        try FileManager.default.createDirectory(at: projectDirectory, withIntermediateDirectories: true)
+        let url = projectDirectory.appendingPathComponent(fileName)
+        try jsonl(lines).data(using: .utf8)?.write(to: url)
+        return url
+    }
+}

--- a/MeterBarTests/SessionWakeReplayLedgerTests.swift
+++ b/MeterBarTests/SessionWakeReplayLedgerTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+@testable import MeterBar
+
+final class SessionWakeReplayLedgerTests: XCTestCase {
+    private var tempDir: URL!
+    private var ledgerURL: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SessionWakeReplayLedgerTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        ledgerURL = tempDir.appendingPathComponent("ledger.json")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    // MARK: - Fingerprint
+
+    func testFingerprintIsDeterministic() {
+        let blockedAt = Date(timeIntervalSince1970: 1_752_120_855)
+        let first = SessionBlockFingerprint.make(
+            sessionID: "abc", blockedAt: blockedAt, reason: .sessionLimit
+        )
+        let second = SessionBlockFingerprint.make(
+            sessionID: "abc", blockedAt: blockedAt, reason: .sessionLimit
+        )
+        XCTAssertEqual(first, second)
+        XCTAssertFalse(first.isEmpty)
+    }
+
+    func testFingerprintDiscriminatesSessionTimeAndReason() {
+        let blockedAt = Date(timeIntervalSince1970: 1_752_120_855)
+        let base = SessionBlockFingerprint.make(sessionID: "abc", blockedAt: blockedAt, reason: .sessionLimit)
+
+        XCTAssertNotEqual(
+            base,
+            SessionBlockFingerprint.make(sessionID: "abd", blockedAt: blockedAt, reason: .sessionLimit)
+        )
+        XCTAssertNotEqual(
+            base,
+            SessionBlockFingerprint.make(
+                sessionID: "abc",
+                blockedAt: blockedAt.addingTimeInterval(1),
+                reason: .sessionLimit
+            )
+        )
+        XCTAssertNotEqual(
+            base,
+            SessionBlockFingerprint.make(sessionID: "abc", blockedAt: blockedAt, reason: .weeklyLimit)
+        )
+    }
+
+    // MARK: - Ledger persistence
+
+    func testMarkHandledPersistsAcrossInstances() {
+        let fingerprint = "deadbeef"
+        let ledger = SessionWakeReplayLedger(storageURL: ledgerURL)
+        XCTAssertFalse(ledger.containsHandled(fingerprint))
+
+        ledger.markHandled(fingerprint, at: Date(timeIntervalSince1970: 1_752_120_855))
+        XCTAssertTrue(ledger.containsHandled(fingerprint))
+
+        // Simulates app relaunch: a fresh instance reads the same file.
+        let relaunched = SessionWakeReplayLedger(storageURL: ledgerURL)
+        XCTAssertTrue(relaunched.containsHandled(fingerprint))
+    }
+
+    func testCorruptLedgerFileIsToleratedAsEmpty() throws {
+        try Data("not json{{{".utf8).write(to: ledgerURL)
+        let ledger = SessionWakeReplayLedger(storageURL: ledgerURL)
+        XCTAssertFalse(ledger.containsHandled("anything"))
+
+        // And it can still record new entries afterwards.
+        ledger.markHandled("abc", at: Date(timeIntervalSince1970: 1))
+        XCTAssertTrue(SessionWakeReplayLedger(storageURL: ledgerURL).containsHandled("abc"))
+    }
+
+    func testLedgerPrunesOldestBeyondCapacity() {
+        let ledger = SessionWakeReplayLedger(storageURL: ledgerURL, maxEntries: 3)
+        for index in 0..<5 {
+            ledger.markHandled("fp-\(index)", at: Date(timeIntervalSince1970: TimeInterval(index)))
+        }
+
+        let relaunched = SessionWakeReplayLedger(storageURL: ledgerURL, maxEntries: 3)
+        XCTAssertFalse(relaunched.containsHandled("fp-0"))
+        XCTAssertFalse(relaunched.containsHandled("fp-1"))
+        XCTAssertTrue(relaunched.containsHandled("fp-2"))
+        XCTAssertTrue(relaunched.containsHandled("fp-3"))
+        XCTAssertTrue(relaunched.containsHandled("fp-4"))
+    }
+
+    func testContainsHandledDoesNotCreateStorageFile() {
+        let ledger = SessionWakeReplayLedger(storageURL: ledgerURL)
+        _ = ledger.containsHandled("abc")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: ledgerURL.path),
+                       "read-only queries must not touch disk")
+    }
+}


### PR DESCRIPTION
Implements #95, the first Session Wake child issue of epic #94. The former blocker #47 (Developer ID signing + notarization) is closed, satisfying the planning gate.

## What

New native Swift module `MeterBar/Services/SessionWake/` — the legacy Python/shell watcher remains reference material only and is not bundled, invoked, or ported line-for-line.

- **`ClaudeTranscriptTailClassifier`** — latest-decisive-event classification of transcript JSONL tails (not "contains rate limit"):
  - Both supported rate-limit shapes with casing variants: the structured synthetic assistant error (`"error":"rate_limit"` / `"apiErrorStatus":429` with `"isApiErrorMessage":true`) and the legacy `… usage limit reached|<unix-epoch>` text marker.
  - Typed `SessionBlockReason` (session / weekly / Opus-weekly / unknown) plus absolute block and reset timestamps.
  - Time-of-day reset fallbacks (`resets 7:30am (Europe/Malta)`, `resets Jul 15 at 10pm (…)`, 24h clock) are anchored to the **event** timestamp — never "now" — so a reset that has just passed is not rolled to tomorrow; all text-derived resets are flagged `resetIsApproximate` (may schedule a refresh, can never prove quota — per the epic's invariants for #96).
  - Sidechain (subagent) lines never classify a session; all-sidechain transcripts are excluded. Malformed/truncated JSONL lines are skipped and cannot crash or poison the scan.
- **`SessionWakeReplayLedger` + `SessionBlockFingerprint`** — SHA-256 fingerprint of `sessionID|blockedAt|reason`; persistent ledger at `~/Library/Application Support/MeterBar/session-wake-ledger-v1.json`. Handled blocks are never rediscovered, including across app relaunch. Corrupt ledger degrades to empty; entries are capacity-pruned; read queries never touch disk state. `markHandled` is reserved for the future execution path (#96/#97) — discovery never calls it.
- **`SessionWakeDiscovery`** (actor — all file I/O off the main actor) — scans exactly one account-scoped `<configDirectory>/projects` root (default `~/.claude/projects`), never another configured account. Bounded scanning: newest-first transcript cap, freshness horizon, tail-only reads (256 KiB). Deterministic sessionID dedupe (latest block wins, path tie-break). The original project/worktree cwd is canonicalized (standardized + symlink-resolved); a missing/deleted worktree yields a structured `previewOnly(.missingWorkingDirectory)` skip and a `nil` project directory rather than an executable target. Automatic eligibility is limited to the current blocking window (reset + grace, or a fallback window when no reset parsed); anything older is `previewOnly(.staleBlock)`. Discovery is strictly read-only: no subprocess, no file writes, no ledger/account mutation.

## Acceptance criteria mapping (issue #95)

- Historical rate-limit + later assistant/tool activity ⇒ not blocked: `testHistoricalBlockFollowedBy…`, `testBlockFollowedByLaterProgressIsNotACandidate`
- Handled fingerprint not rediscovered after relaunch: `testHandledFingerprintIsNotRediscoveredAfterRelaunch`, `testMarkHandledPersistsAcrossInstances`
- Both rate-limit shapes + casing variants have fixtures: `SessionWakeFixtures` (shape A structured, shape B pipe-epoch), casing-variant tests
- Subagent transcripts excluded: sidechain classifier tests + `testAllSidechainTranscriptsAreExcluded`, `testSubagentsDirectoryIsExcluded`
- Malformed/truncated JSONL cannot crash or poison: classifier + discovery malformed tests
- Missing/deleted worktrees ⇒ structured skip, no executable target: `testMissingWorkingDirectoryYieldsStructuredSkip`
- Account-scoped discovery: `testDiscoveryIsScopedToTheSelectedAccount`
- Preview performs zero mutations: `testDiscoveryPerformsZeroFilesystemMutations` (recursive size+mtime snapshot equality) + `testContainsHandledDoesNotCreateStorageFile`
- Duplicates, stale sessions, missing metadata, dead cwd, later recovery all covered: see `SessionWakeDiscoveryTests`

## Verification

- TDD: 36 new tests authored before implementation; 413 total pass via `swift test`
- New-code line coverage per file: classifier 97%, discovery 90%, ledger 83%, models 100%
- `swiftlint lint --strict` clean; Xcode app target `BUILD SUCCEEDED`; `scripts/check-coverage.sh` gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)