### PR TITLE
Session Wake: Settings, wake-account selection, status UI, and notifications (#98)

### DIFF
--- a/.agents/SESSIONS/2026-07-10.md
+++ b/.agents/SESSIONS/2026-07-10.md
@@ -66,3 +66,22 @@
 **Follow-ups:**
 - The Homebrew cask's uninstall/zap entries reference the old bundle id and app-group paths - update with the v1.6.2 release.
 - Old `group.dev.shipshit.meterbar` container and `dev.shipshit.meterbar` LaunchAgent/notification grants are orphaned on existing installs; users re-grant notifications once.
+
+## Session 4: Session Wake Control Surfaces (#98)
+
+**Status:** Complete (PR opened)
+
+**Context / correction:** Issue #98 layers UI over the shared native coordinator from #95–#97. Those issues are still OPEN — no merged PRs, and #96 is being implemented concurrently in the primary worktree (uncommitted `MeterBar/SessionWake/Wake*` primitives). #98 was therefore built as a **self-contained UI seam** that compiles against master and does not import the uncommitted #96 types, with vocabulary aligned to them for frictionless later integration. Approach chosen by the maintainer (protocol-seam over duplicating automation in views).
+
+**What was done (TDD, tests first):**
+- `SessionWakeStatus` — presentation lifecycle enum (Off, Idle, Armed, Scanning, Waiting, Quota Unknown, Running, Stopping, Completed, Needs Attention) with label/detail/tone/symbol; plus `SessionWakeRunSummary` and `SessionWakeEligibility`. Distinct labels so no state collapses into "Watching".
+- `SessionWakeSettingsStore` — UserDefaults-backed, separates **feature enablement** from **watcher intent**; explicit persisted `wakeAccountID` (never inferred); first-enable + permission-bypass acknowledgements; notify prefs; account-removal reconcile that safely suspends; fail-safe load (armed watcher never resurrects while feature off).
+- `SessionWakeCoordinator` — observable UI seam (`status`/`lastRun`/`eligibility` + `preview`/`resumeNow`/`armWatcher`/`stopWatcher`). `StubSessionWakeCoordinator` is the honest interim `shared` (inert, no subprocess/fs work — dry-run "no mutation" holds trivially; mirrors settings intent via Combine). `PreviewSessionWakeCoordinator` injects any state for previews/tests. Real #95–#97 coordinator subclasses this later.
+- `SessionWakeNotificationDecider` — pure, gated on global notifications + Claude provider visibility + per-event Session Wake prefs.
+- Views: new `Settings → Automation` pane (feature toggle w/ first-enable sheet, explicit account picker, permission-bypass confirmation, notify toggles), shared `SessionWakeStatusView` / `SessionWakeStatusBadge` / `SessionWakeWatcherControl`, and `SessionWakePopoverCard` giving the menu bar the same Wake Watcher kill-switch. Both surfaces bind the same shared singletons. Liquid Glass card surfaces, adaptive tone colors.
+
+**Verification:**
+- `swift test`: 407 passed, 0 failures (38 new across store/status/decider/coordinator/view-hosting; hosting tests cover standalone + embedded Settings and every status).
+- `swiftlint lint` clean (project-wide). Coverage gate 38.4% (CI floor 19%).
+
+**Deliberately deferred to #95–#97/#99 integration:** real discovery/quota/runner wiring behind the seam; mapping `WakeQuotaState`/runner outcomes → `SessionWakeStatus`/`SessionWakeRunSummary`; live notification posting from the app delegate.

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -30,4 +30,23 @@ enum StorageKeys {
     static let notificationWarningThreshold = "NotificationWarningThreshold"
     /// Raw value of the `NotificationThreshold` at which a critical alert notifies.
     static let notificationCriticalThreshold = "NotificationCriticalThreshold"
+
+    // MARK: Session Wake (issue #98)
+
+    /// Master switch: whether the Session Wake feature is enabled at all.
+    static let sessionWakeFeatureEnabled = "SessionWakeFeatureEnabled"
+    /// Runtime intent: whether the quota watcher is armed. Separate from feature
+    /// enablement so a user can keep the feature configured but the watcher off.
+    static let sessionWakeWatcherArmed = "SessionWakeWatcherArmed"
+    /// UUID string of the explicitly-selected wake account. Never inferred from
+    /// account order or recent activity.
+    static let sessionWakeAccountID = "SessionWakeAccountID"
+    /// Whether the user completed the first-enable safety acknowledgement.
+    static let sessionWakeFirstEnableAcknowledged = "SessionWakeFirstEnableAcknowledged"
+    /// Whether the user separately acknowledged permission bypass for resumes.
+    static let sessionWakePermissionBypassAcknowledged = "SessionWakePermissionBypassAcknowledged"
+    /// Whether to notify when a wake run completes.
+    static let sessionWakeNotifyOnCompletion = "SessionWakeNotifyOnCompletion"
+    /// Whether to notify when the watcher starts waiting for a reset.
+    static let sessionWakeNotifyOnWatchStart = "SessionWakeNotifyOnWatchStart"
 }

--- a/MeterBar/SessionWake/SessionWakeCoordinator.swift
+++ b/MeterBar/SessionWake/SessionWakeCoordinator.swift
@@ -1,0 +1,137 @@
+import Combine
+import Foundation
+
+/// The UI-facing seam over the shared Session Wake automation core.
+///
+/// Issue #98 delivers the control surfaces (Settings, account selection, status,
+/// notifications) *over* the native coordinator built in #95–#97. To keep this
+/// branch self-contained and to keep automation logic out of views, the surfaces
+/// bind to this small observable seam rather than to the discovery / quota-gate /
+/// runner types directly. The real coordinator (once #95–#97 land) subclasses
+/// this and drives `status` / `lastRun` / `eligibility` from its state machine;
+/// until then the honest `StubSessionWakeCoordinator` is installed as `shared`.
+///
+/// Views must not implement discovery, quota, or resume logic — they only read
+/// this state and call the intent methods.
+class SessionWakeCoordinator: ObservableObject {
+    /// The process-wide coordinator. Replaced with the native implementation
+    /// when the #95–#97 coordinator lands; the stub is a no-op placeholder that
+    /// performs no subprocess or filesystem work.
+    static let shared: SessionWakeCoordinator = StubSessionWakeCoordinator()
+
+    /// The current presentation status. One shared binding drives both the
+    /// Settings pane and the menu-bar popover.
+    @Published private(set) var status: SessionWakeStatus = .off
+    /// The most recent completed run's counts, or nil if none this session.
+    @Published private(set) var lastRun: SessionWakeRunSummary?
+    /// The latest read-only Preview result, or nil before the first Preview.
+    @Published private(set) var eligibility: SessionWakeEligibility?
+
+    // MARK: Intents (overridden by concrete coordinators)
+
+    /// Runs a read-only dry run and publishes `eligibility`. Permitted even when
+    /// the feature is disabled; must never spawn a process or mutate the disk.
+    func preview() async {}
+
+    /// One-shot resume, only when fresh quota proves availability. Does not
+    /// require the watcher to be armed.
+    func resumeNow() async {}
+
+    /// Begins the watch loop for the selected account.
+    func armWatcher() {}
+
+    /// Cancels any in-progress watch within one poll interval and stops polling.
+    func stopWatcher() {}
+
+    // MARK: State plumbing for subclasses
+
+    /// Reflects persisted settings intent into the idle-family status when no
+    /// run is in flight. Concrete coordinators call this from their settings
+    /// observation so "Off / Idle / Armed" always match the store.
+    func reflectSettings(featureEnabled: Bool, watcherArmed: Bool) {
+        // Never stomp on an in-flight run; only reconcile the resting states.
+        switch status {
+        case .off, .idle, .armed:
+            apply(status: Self.restingStatus(featureEnabled: featureEnabled, watcherArmed: watcherArmed))
+        case .scanning, .waiting, .quotaUnknown, .running, .stopping, .completed, .needsAttention:
+            break
+        }
+    }
+
+    /// The resting status implied purely by persisted intent.
+    static func restingStatus(featureEnabled: Bool, watcherArmed: Bool) -> SessionWakeStatus {
+        guard featureEnabled else { return .off }
+        return watcherArmed ? .armed : .idle
+    }
+
+    func apply(status: SessionWakeStatus) {
+        self.status = status
+    }
+
+    func apply(eligibility: SessionWakeEligibility?) {
+        self.eligibility = eligibility
+    }
+
+    func apply(lastRun: SessionWakeRunSummary?) {
+        self.lastRun = lastRun
+    }
+}
+
+// MARK: - StubSessionWakeCoordinator
+
+/// The interim production coordinator installed until the native automation core
+/// (#95–#97) is wired in. It is deliberately inert: it reflects settings intent
+/// into the resting status and reports that discovery is not yet available,
+/// rather than fabricating session counts. Because it performs no subprocess or
+/// filesystem work, the dry-run "no mutation" invariant holds trivially.
+final class StubSessionWakeCoordinator: SessionWakeCoordinator {
+    private var cancellables: Set<AnyCancellable> = []
+
+    override init() {
+        super.init()
+        // Keep the resting status (Off / Idle / Armed) honest by mirroring the
+        // persisted intent. The real coordinator (#95–#97) will additionally
+        // drive the active states from its watcher state machine.
+        let settings = SessionWakeSettingsStore.shared
+        reflectSettings(
+            featureEnabled: settings.isFeatureEnabled,
+            watcherArmed: settings.isWatcherArmed
+        )
+        settings.$isFeatureEnabled
+            .combineLatest(settings.$isWatcherArmed)
+            .sink { [weak self] featureEnabled, watcherArmed in
+                self?.reflectSettings(featureEnabled: featureEnabled, watcherArmed: watcherArmed)
+            }
+            .store(in: &cancellables)
+    }
+
+    override func preview() async {
+        apply(eligibility: SessionWakeEligibility(
+            eligibleCount: 0,
+            note: "Session Wake discovery is not available in this build yet."
+        ))
+    }
+}
+
+// MARK: - PreviewSessionWakeCoordinator
+
+/// A fully-injectable coordinator for SwiftUI previews and view tests. Lets a
+/// caller pin any status / eligibility / last-run so every state can be rendered
+/// and asserted without the automation core.
+final class PreviewSessionWakeCoordinator: SessionWakeCoordinator {
+    init(
+        status: SessionWakeStatus = .idle,
+        eligibility: SessionWakeEligibility? = nil,
+        lastRun: SessionWakeRunSummary? = nil
+    ) {
+        super.init()
+        apply(status: status)
+        apply(eligibility: eligibility)
+        apply(lastRun: lastRun)
+    }
+
+    /// Test/preview hook to drive an arbitrary status transition.
+    func set(status: SessionWakeStatus) {
+        apply(status: status)
+    }
+}

--- a/MeterBar/SessionWake/SessionWakeNotificationDecider.swift
+++ b/MeterBar/SessionWake/SessionWakeNotificationDecider.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// A Session Wake notification the decider decided should be posted.
+///
+/// Mirrors `FiredNotification` (the quota-crossing analogue): the decider stays
+/// pure and the app delegate owns the `UNUserNotificationCenter` interaction.
+struct FiredWakeNotification: Equatable, Sendable {
+    /// Stable identifier — re-posting the same id replaces the banner rather
+    /// than stacking a duplicate.
+    let key: String
+    let title: String
+    let body: String
+}
+
+/// Decides — deterministically, with no side effects — whether a Session Wake
+/// event should surface a notification, honoring three independent gates
+/// (issue #98 acceptance criterion):
+///
+/// 1. the **global** usage-notification switch (`NotificationPreferences`),
+/// 2. **provider visibility** — Session Wake is Claude-only in v1, so a hidden
+///    Claude Code provider suppresses its notifications, and
+/// 3. the **Session Wake** per-event preferences (`notifyOnWatchStart` /
+///    `notifyOnCompletion`).
+///
+/// Every gate must pass; any one being off returns `nil`.
+struct SessionWakeNotificationDecider {
+    /// The three gate axes plus the per-event Session Wake toggles, as a pure
+    /// value so callers can assemble it from their stores without this type
+    /// reaching into singletons.
+    struct Gates: Equatable, Sendable {
+        /// Global usage-notification switch (`NotificationPreferencesStore`).
+        let notificationsEnabled: Bool
+        /// Whether the Claude Code provider is visible (`ProviderVisibilityStore`).
+        let claudeProviderEnabled: Bool
+        /// Session Wake "notify when watching starts" preference.
+        let notifyOnWatchStart: Bool
+        /// Session Wake "notify on completion" preference.
+        let notifyOnCompletion: Bool
+    }
+
+    /// A notification fired when the watcher begins waiting for a reset.
+    func watchStartNotification(queuedCount: Int, gates: Gates) -> FiredWakeNotification? {
+        guard gates.notificationsEnabled,
+              gates.claudeProviderEnabled,
+              gates.notifyOnWatchStart else {
+            return nil
+        }
+
+        let noun = queuedCount == 1 ? "session" : "sessions"
+        return FiredWakeNotification(
+            key: "session-wake-watch-start",
+            title: "Session Wake — Watching for Reset",
+            body: "Watching for the Claude quota reset — \(queuedCount) \(noun) queued."
+        )
+    }
+
+    /// A notification fired when a wake run completes, summarizing the outcome.
+    func completionNotification(
+        summary: SessionWakeRunSummary,
+        gates: Gates
+    ) -> FiredWakeNotification? {
+        guard gates.notificationsEnabled,
+              gates.claudeProviderEnabled,
+              gates.notifyOnCompletion else {
+            return nil
+        }
+
+        let sessionNoun = summary.attempted == 1 ? "session" : "sessions"
+        var body = "Resumed \(summary.resumed) of \(summary.attempted) Claude \(sessionNoun)."
+        if summary.failed > 0 {
+            let failNoun = summary.failed == 1 ? "failure" : "failures"
+            body += " \(summary.failed) \(failNoun)."
+        }
+
+        return FiredWakeNotification(
+            key: "session-wake-completion",
+            title: "Session Wake — Run Complete",
+            body: body
+        )
+    }
+}

--- a/MeterBar/SessionWake/SessionWakeSettingsStore.swift
+++ b/MeterBar/SessionWake/SessionWakeSettingsStore.swift
@@ -1,0 +1,201 @@
+import Combine
+import Foundation
+
+/// Persists Session Wake control intent (issue #98).
+///
+/// Deliberately separates two axes the epic (#94) requires to stay independent:
+///
+/// - **Feature enablement** (`isFeatureEnabled`) — whether the user has opted in
+///   at all. When off, no background discovery or resume may run.
+/// - **Watcher intent** (`isWatcherArmed`) — whether the quota watcher is live.
+///   Turning the feature off forces the watcher off; the watcher can never be
+///   armed while the feature is off, no account is selected, or the first-enable
+///   acknowledgement is missing.
+///
+/// The selected `wakeAccountID` is **explicit** and persisted — it is never
+/// inferred from account order, recent menu-bar activity, or
+/// `~/.claude-active-account`. Mirrors the small `ObservableObject` +
+/// `UserDefaults` pattern of `NotificationPreferencesStore` /
+/// `ProviderVisibilityStore`, injectable for tests.
+final class SessionWakeSettingsStore: ObservableObject {
+    static let shared = SessionWakeSettingsStore()
+
+    @Published private(set) var isFeatureEnabled: Bool
+    @Published private(set) var isWatcherArmed: Bool
+    @Published private(set) var wakeAccountID: UUID?
+    @Published private(set) var hasAcknowledgedFirstEnable: Bool
+    @Published private(set) var hasAcknowledgedPermissionBypass: Bool
+    @Published private(set) var notifyOnCompletion: Bool
+    @Published private(set) var notifyOnWatchStart: Bool
+
+    private let userDefaults: UserDefaults
+
+    /// Internal (not private) so tests can construct an instance backed by an
+    /// isolated `UserDefaults` suite; production code uses `shared`.
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+
+        // Read into locals first so the final `isWatcherArmed` assignment does
+        // not reference any not-yet-initialized `@Published` property (Swift's
+        // definite-initialization rejects that with property wrappers).
+        let featureEnabled = userDefaults.bool(forKey: StorageKeys.sessionWakeFeatureEnabled)
+        let armed = userDefaults.bool(forKey: StorageKeys.sessionWakeWatcherArmed)
+        let acknowledged = userDefaults.bool(forKey: StorageKeys.sessionWakeFirstEnableAcknowledged)
+        let accountID = userDefaults.string(forKey: StorageKeys.sessionWakeAccountID)
+            .flatMap(UUID.init(uuidString:))
+
+        isFeatureEnabled = featureEnabled
+        hasAcknowledgedFirstEnable = acknowledged
+        hasAcknowledgedPermissionBypass = userDefaults
+            .bool(forKey: StorageKeys.sessionWakePermissionBypassAcknowledged)
+        wakeAccountID = accountID
+
+        // Notification defaults preserve "on" when the user has never chosen.
+        notifyOnCompletion = userDefaults
+            .object(forKey: StorageKeys.sessionWakeNotifyOnCompletion) == nil
+            ? true
+            : userDefaults.bool(forKey: StorageKeys.sessionWakeNotifyOnCompletion)
+        notifyOnWatchStart = userDefaults
+            .object(forKey: StorageKeys.sessionWakeNotifyOnWatchStart) == nil
+            ? true
+            : userDefaults.bool(forKey: StorageKeys.sessionWakeNotifyOnWatchStart)
+
+        // Fail safe on load: the watcher can only be armed if every precondition
+        // holds. A relaunch with the feature disabled (or no account) must never
+        // resurrect a live watcher.
+        let shouldArm = armed && Self.canArmWatcher(
+            featureEnabled: featureEnabled,
+            accountID: accountID,
+            acknowledged: acknowledged
+        )
+        isWatcherArmed = shouldArm
+        if shouldArm != armed {
+            userDefaults.set(shouldArm, forKey: StorageKeys.sessionWakeWatcherArmed)
+        }
+    }
+
+    // MARK: Derived
+
+    /// Whether arming the watcher is currently permitted. Surfaced so the UI can
+    /// disable the toggle rather than silently swallow an invalid arm request.
+    var canArmWatcher: Bool {
+        Self.canArmWatcher(
+            featureEnabled: isFeatureEnabled,
+            accountID: wakeAccountID,
+            acknowledged: hasAcknowledgedFirstEnable
+        )
+    }
+
+    // MARK: Feature enablement
+
+    /// Enables or disables the feature. Enabling is gated on the first-enable
+    /// acknowledgement — call `acknowledgeFirstEnable()` first (the UI presents
+    /// the safety sheet). Disabling always succeeds and forces the watcher off.
+    func setFeatureEnabled(_ enabled: Bool) {
+        if enabled {
+            guard hasAcknowledgedFirstEnable else { return }
+            guard !isFeatureEnabled else { return }
+            isFeatureEnabled = true
+            persist(true, forKey: StorageKeys.sessionWakeFeatureEnabled)
+        } else {
+            guard isFeatureEnabled || isWatcherArmed else { return }
+            isFeatureEnabled = false
+            persist(false, forKey: StorageKeys.sessionWakeFeatureEnabled)
+            // Master-off cancels watcher intent (issue #98 acceptance criterion).
+            forceWatcherOff()
+        }
+    }
+
+    /// Records the first-enable safety acknowledgement. Idempotent.
+    func acknowledgeFirstEnable() {
+        guard !hasAcknowledgedFirstEnable else { return }
+        hasAcknowledgedFirstEnable = true
+        persist(true, forKey: StorageKeys.sessionWakeFirstEnableAcknowledged)
+    }
+
+    // MARK: Watcher intent
+
+    /// Arms or disarms the watcher. Arming is rejected (no-op) unless the feature
+    /// is enabled, an account is selected, and the first-enable acknowledgement
+    /// is present. Disarming always succeeds.
+    func setWatcherArmed(_ armed: Bool) {
+        if armed {
+            guard canArmWatcher, !isWatcherArmed else { return }
+            isWatcherArmed = true
+            persist(true, forKey: StorageKeys.sessionWakeWatcherArmed)
+        } else {
+            guard isWatcherArmed else { return }
+            isWatcherArmed = false
+            persist(false, forKey: StorageKeys.sessionWakeWatcherArmed)
+        }
+    }
+
+    // MARK: Account selection
+
+    /// Explicitly selects (or clears) the wake account. Changing the selection
+    /// while the watcher is armed safely disarms it, so discovery/quota/execution
+    /// never straddle two accounts (issue #98 acceptance criterion).
+    func selectWakeAccount(_ id: UUID?) {
+        guard id != wakeAccountID else { return }
+        wakeAccountID = id
+        if let id {
+            persist(id.uuidString, forKey: StorageKeys.sessionWakeAccountID)
+        } else {
+            userDefaults.removeObject(forKey: StorageKeys.sessionWakeAccountID)
+        }
+        // A changed or cleared account invalidates any in-flight watch.
+        forceWatcherOff()
+    }
+
+    /// Reconciles the selection against the accounts that currently exist. If the
+    /// selected account was removed, the selection is cleared and the watcher is
+    /// suspended. Called whenever the account list changes.
+    func reconcile(availableAccountIDs: Set<UUID>) {
+        guard let id = wakeAccountID, !availableAccountIDs.contains(id) else { return }
+        wakeAccountID = nil
+        userDefaults.removeObject(forKey: StorageKeys.sessionWakeAccountID)
+        forceWatcherOff()
+    }
+
+    // MARK: Permission bypass
+
+    func setPermissionBypassAcknowledged(_ acknowledged: Bool) {
+        guard acknowledged != hasAcknowledgedPermissionBypass else { return }
+        hasAcknowledgedPermissionBypass = acknowledged
+        persist(acknowledged, forKey: StorageKeys.sessionWakePermissionBypassAcknowledged)
+    }
+
+    // MARK: Notification preferences
+
+    func setNotifyOnCompletion(_ enabled: Bool) {
+        guard enabled != notifyOnCompletion else { return }
+        notifyOnCompletion = enabled
+        persist(enabled, forKey: StorageKeys.sessionWakeNotifyOnCompletion)
+    }
+
+    func setNotifyOnWatchStart(_ enabled: Bool) {
+        guard enabled != notifyOnWatchStart else { return }
+        notifyOnWatchStart = enabled
+        persist(enabled, forKey: StorageKeys.sessionWakeNotifyOnWatchStart)
+    }
+
+    // MARK: Private
+
+    private func forceWatcherOff() {
+        guard isWatcherArmed else { return }
+        isWatcherArmed = false
+        persist(false, forKey: StorageKeys.sessionWakeWatcherArmed)
+    }
+
+    private static func canArmWatcher(featureEnabled: Bool, accountID: UUID?, acknowledged: Bool) -> Bool {
+        featureEnabled && accountID != nil && acknowledged
+    }
+
+    private func persist(_ value: Bool, forKey key: String) {
+        userDefaults.set(value, forKey: key)
+    }
+
+    private func persist(_ value: String, forKey key: String) {
+        userDefaults.set(value, forKey: key)
+    }
+}

--- a/MeterBar/SessionWake/SessionWakeStatus.swift
+++ b/MeterBar/SessionWake/SessionWakeStatus.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+// MARK: - SessionWakeTone
+
+/// Semantic tone for a wake status, mapped to concrete adaptive colors at the
+/// view layer (so this model stays free of SwiftUI and unit-testable). Keeping
+/// the palette choice out of the enum lets light/dark appearances resolve the
+/// actual `Color` through `MeterBarTheme`.
+enum SessionWakeTone: Equatable, Sendable {
+    case neutral
+    case active
+    case waiting
+    case warning
+    case danger
+    case success
+}
+
+// MARK: - SessionWakeStatus
+
+/// The user-facing lifecycle of the Session Wake watcher.
+///
+/// These are **presentation** states, deliberately distinct from the automation
+/// core's quota gate (`WakeQuotaState` from #96) and runner outcomes (#97). The
+/// shared coordinator seam maps its internal state into exactly one of these so
+/// the Settings pane and the menu-bar popover render from one vocabulary and no
+/// real state is collapsed into a single "Watching" label (issue #98).
+enum SessionWakeStatus: Equatable, Sendable {
+    /// Feature disabled entirely — no discovery, no polling, no resume.
+    case off
+    /// Feature enabled but the watcher is not armed. Read-only Preview is still
+    /// permitted; nothing runs in the background.
+    case idle
+    /// Watcher armed and between cycles, waiting for the next scan/poll tick.
+    case armed
+    /// Actively discovering blocked sessions for the selected account.
+    case scanning
+    /// Quota is blocked; the watcher is counting down to the reset window.
+    /// `until` is nil when the reset instant itself is unknown (conservative
+    /// re-poll). `blockedCount` is how many sessions are queued.
+    case waiting(until: Date?, blockedCount: Int)
+    /// Fresh quota could not prove availability; the gate fails closed and
+    /// nothing launches. `reason` is a short, already-humanized explanation.
+    case quotaUnknown(reason: String)
+    /// Resuming sessions sequentially. `completed` of `total` finished so far.
+    case running(completed: Int, total: Int)
+    /// The user disarmed mid-run; the active attempt is being cancelled.
+    case stopping
+    /// The most recent run finished. The count summary lives in the
+    /// coordinator's `lastRun`; this state just marks the transient terminal.
+    case completed
+    /// A failure the user should see (e.g. selected account removed, runner
+    /// error). `message` is a short, user-facing sentence.
+    case needsAttention(String)
+
+    /// Whether the watcher is engaged in any background activity. Drives the
+    /// menu-bar activity affordance and prevents "Off/Idle" from looking busy.
+    var isWatcherActive: Bool {
+        switch self {
+        case .armed, .scanning, .waiting, .running, .stopping:
+            return true
+        case .off, .idle, .quotaUnknown, .completed, .needsAttention:
+            return false
+        }
+    }
+
+    /// Short chip label shown in both surfaces.
+    var label: String {
+        switch self {
+        case .off: return "Off"
+        case .idle: return "Idle"
+        case .armed: return "Armed"
+        case .scanning: return "Scanning"
+        case .waiting: return "Waiting"
+        case .quotaUnknown: return "Quota Unknown"
+        case .running: return "Running"
+        case .stopping: return "Stopping"
+        case .completed: return "Completed"
+        case .needsAttention: return "Needs Attention"
+        }
+    }
+
+    /// One-line detail beneath the label; nil when the label is self-sufficient.
+    var detail: String? {
+        switch self {
+        case .off:
+            return "Session Wake is disabled."
+        case .idle:
+            return "Enabled — watcher off. Preview is available."
+        case .armed:
+            return "Waiting for the next scan."
+        case .scanning:
+            return "Looking for blocked sessions."
+        case let .waiting(_, blockedCount):
+            let noun = blockedCount == 1 ? "session" : "sessions"
+            return "\(blockedCount) \(noun) waiting for quota reset."
+        case let .quotaUnknown(reason):
+            return reason
+        case let .running(completed, total):
+            return "Resuming \(completed) of \(total)."
+        case .stopping:
+            return "Stopping the watcher."
+        case .completed:
+            return "Last run finished."
+        case let .needsAttention(message):
+            return message
+        }
+    }
+
+    /// SF Symbol representing the state.
+    var systemImage: String {
+        switch self {
+        case .off: return "moon.zzz"
+        case .idle: return "pause.circle"
+        case .armed: return "dot.radiowaves.left.and.right"
+        case .scanning: return "magnifyingglass"
+        case .waiting: return "clock"
+        case .quotaUnknown: return "questionmark.circle"
+        case .running: return "play.circle"
+        case .stopping: return "stop.circle"
+        case .completed: return "checkmark.circle"
+        case .needsAttention: return "exclamationmark.triangle"
+        }
+    }
+
+    var tone: SessionWakeTone {
+        switch self {
+        case .off, .idle: return .neutral
+        case .armed, .scanning, .running: return .active
+        case .waiting: return .waiting
+        case .quotaUnknown: return .warning
+        case .stopping: return .warning
+        case .completed: return .success
+        case .needsAttention: return .danger
+        }
+    }
+}
+
+// MARK: - SessionWakeRunSummary
+
+/// The result of one completed wake run, derived from the runner's structured
+/// outcomes (#97). Counts are display-truth: they mirror the runner rather than
+/// re-deriving anything, so "Completion counts match structured runner
+/// outcomes" (issue #98) holds by construction.
+struct SessionWakeRunSummary: Equatable, Sendable, Codable {
+    let resumed: Int
+    let skipped: Int
+    let failed: Int
+    let finishedAt: Date
+
+    var attempted: Int { resumed + skipped + failed }
+
+    /// Compact "2 resumed · 1 skipped · 0 failed" summary line.
+    var countsLine: String {
+        "\(resumed) resumed · \(skipped) skipped · \(failed) failed"
+    }
+}
+
+// MARK: - SessionWakeEligibility
+
+/// A single class of skipped session with its count, e.g. "dead worktree: 2".
+struct SessionWakeSkip: Equatable, Sendable {
+    let reason: String
+    let count: Int
+}
+
+/// The read-only Preview result: how many sessions are eligible to resume and
+/// why others are skipped. Produced without any subprocess or filesystem
+/// mutation (dry-run invariant, epic #94).
+struct SessionWakeEligibility: Equatable, Sendable {
+    /// Sessions that would be resumed if quota were available.
+    let eligibleCount: Int
+    /// Per-reason breakdown of sessions that would be skipped.
+    let skips: [SessionWakeSkip]
+    /// Optional advisory shown when discovery is unavailable in this build
+    /// (interim, until the #95 discovery layer is wired to the coordinator).
+    let note: String?
+
+    init(eligibleCount: Int, skips: [SessionWakeSkip] = [], note: String? = nil) {
+        self.eligibleCount = eligibleCount
+        self.skips = skips
+        self.note = note
+    }
+
+    var skippedCount: Int {
+        skips.reduce(0) { $0 + $1.count }
+    }
+}

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -57,21 +57,25 @@ struct MenuBarView: View {
       Divider()
 
       ScrollView {
-        PopoverOverviewPanel(
-          snapshots: ProviderSnapshotBuilder.snapshots(
-            ProviderSnapshotBuilder.Input(
-              metrics: dataManager.metrics,
-              claudeAccounts: claudeAccountStore.accounts,
-              claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
-              enabledServices: providerVisibility.enabledServices,
-              claudeCodeHasAccess: claudeCodeService.hasAccess,
-              codexCliHasAccess: codexCliService.hasAccess,
-              cursorHasAccess: cursorService.hasAccess
-            )),
-          openDashboard: openDashboard,
-          openStatusDashboard: openStatusDashboard,
-          openProviderOverview: openProviderDetail
-        )
+        VStack(spacing: 10) {
+          PopoverOverviewPanel(
+            snapshots: ProviderSnapshotBuilder.snapshots(
+              ProviderSnapshotBuilder.Input(
+                metrics: dataManager.metrics,
+                claudeAccounts: claudeAccountStore.accounts,
+                claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
+                enabledServices: providerVisibility.enabledServices,
+                claudeCodeHasAccess: claudeCodeService.hasAccess,
+                codexCliHasAccess: codexCliService.hasAccess,
+                cursorHasAccess: cursorService.hasAccess
+              )),
+            openDashboard: openDashboard,
+            openStatusDashboard: openStatusDashboard,
+            openProviderOverview: openProviderDetail
+          )
+
+          SessionWakePopoverCard()
+        }
         .padding(10)
         .background(
           GeometryReader { proxy in

--- a/MeterBar/Views/SessionWakeStatusView.swift
+++ b/MeterBar/Views/SessionWakeStatusView.swift
@@ -1,3 +1,4 @@
+import MeterBarShared
 import SwiftUI
 
 // MARK: - SessionWakeTone color mapping

--- a/MeterBar/Views/SessionWakeStatusView.swift
+++ b/MeterBar/Views/SessionWakeStatusView.swift
@@ -1,0 +1,289 @@
+import SwiftUI
+
+// MARK: - SessionWakeTone color mapping
+
+extension SessionWakeTone {
+    /// Resolves the semantic tone to an adaptive theme color. Kept out of the
+    /// model so `SessionWakeStatus` stays SwiftUI-free and unit-testable.
+    var color: Color {
+        switch self {
+        case .neutral: return .secondary
+        case .active: return MeterBarTheme.appAccent
+        case .waiting: return MeterBarTheme.appAccent
+        case .warning: return MeterBarTheme.warning
+        case .danger: return MeterBarTheme.danger
+        case .success: return MeterBarTheme.success
+        }
+    }
+}
+
+// MARK: - SessionWakeStatusBadge
+
+/// Compact icon + label pill for a wake status. Shared by the Settings pane and
+/// the menu-bar popover so both render the same vocabulary.
+struct SessionWakeStatusBadge: View {
+    let status: SessionWakeStatus
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Image(systemName: status.systemImage)
+                .font(.system(size: 11, weight: .semibold))
+            Text(status.label)
+                .font(.caption)
+                .fontWeight(.semibold)
+        }
+        .foregroundStyle(status.tone.color)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(
+            Capsule(style: .continuous)
+                .fill(status.tone.color.opacity(0.14))
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Session Wake status: \(status.label)")
+    }
+}
+
+// MARK: - SessionWakeStatusView
+
+/// The read-only status surface: badge, detail, selected account, reset
+/// countdown, Preview eligibility, and last-run counts. Rendered identically in
+/// the Settings Automation pane and the menu-bar popover from one shared state
+/// binding (issue #98). No control logic lives here — see
+/// ``SessionWakeWatcherControl``.
+struct SessionWakeStatusView: View {
+    @ObservedObject var coordinator: SessionWakeCoordinator
+    @ObservedObject var settings: SessionWakeSettingsStore
+    @ObservedObject var accountStore: ClaudeCodeAccountStore
+
+    init(
+        coordinator: SessionWakeCoordinator = .shared,
+        settings: SessionWakeSettingsStore = .shared,
+        accountStore: ClaudeCodeAccountStore = .shared
+    ) {
+        self.coordinator = coordinator
+        self.settings = settings
+        self.accountStore = accountStore
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .center, spacing: 8) {
+                SessionWakeStatusBadge(status: coordinator.status)
+                Spacer(minLength: 6)
+                accountLabel
+            }
+
+            if let detail = coordinator.status.detail {
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            resetCountdown
+
+            eligibilitySummary
+
+            lastRunSummary
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: Private
+
+    private var selectedAccountName: String? {
+        guard let id = settings.wakeAccountID else { return nil }
+        return accountStore.accounts.first { $0.id == id }?.name
+    }
+
+    @ViewBuilder private var accountLabel: some View {
+        if let name = selectedAccountName {
+            HStack(spacing: 4) {
+                Image(systemName: "person.crop.circle")
+                    .font(.system(size: 10))
+                Text(name)
+                    .font(.caption2)
+                    .lineLimit(1)
+            }
+            .foregroundStyle(.secondary)
+        } else {
+            Text("No account selected")
+                .font(.caption2)
+                .foregroundStyle(MeterBarTheme.warning)
+        }
+    }
+
+    @ViewBuilder private var resetCountdown: some View {
+        if case let .waiting(until, _) = coordinator.status, let until {
+            HStack(spacing: 4) {
+                Image(systemName: "clock")
+                    .font(.system(size: 10))
+                Text("Resets \(until, style: .relative)")
+                    .font(.caption2)
+            }
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder private var eligibilitySummary: some View {
+        if let eligibility = coordinator.eligibility {
+            VStack(alignment: .leading, spacing: 3) {
+                Text("\(eligibility.eligibleCount) eligible · \(eligibility.skippedCount) skipped")
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.secondary)
+
+                ForEach(eligibility.skips, id: \.reason) { skip in
+                    Text("· \(skip.reason): \(skip.count)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let note = eligibility.note {
+                    Text(note)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private var lastRunSummary: some View {
+        if let lastRun = coordinator.lastRun {
+            HStack(spacing: 4) {
+                Image(systemName: "checkmark.seal")
+                    .font(.system(size: 10))
+                Text("Last run: \(lastRun.countsLine)")
+                    .font(.caption2)
+            }
+            .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - SessionWakeWatcherControl
+
+/// The shared watcher control: the Wake Watcher kill-switch plus Preview and
+/// Resume Now actions. Used in both Settings and the popover so both operate the
+/// exact same persisted intent and coordinator (issue #98: "one shared state
+/// binding"). Arming is disabled unless every precondition holds; Preview stays
+/// available even while the feature is off (read-only dry run).
+struct SessionWakeWatcherControl: View {
+    @ObservedObject var coordinator: SessionWakeCoordinator
+    @ObservedObject var settings: SessionWakeSettingsStore
+
+    /// Compact layout drops button labels' verbosity for the narrow popover.
+    var isCompact = false
+
+    init(
+        coordinator: SessionWakeCoordinator = .shared,
+        settings: SessionWakeSettingsStore = .shared,
+        isCompact: Bool = false
+    ) {
+        self.coordinator = coordinator
+        self.settings = settings
+        self.isCompact = isCompact
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Toggle(isOn: watcherBinding) {
+                if !isCompact {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Wake Watcher")
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                        Text("Poll quota and resume when the window reopens.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    Text("Wake Watcher")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                }
+            }
+            .toggleStyle(.switch)
+            .disabled(!settings.canArmWatcher && !settings.isWatcherArmed)
+
+            HStack(spacing: 8) {
+                Button {
+                    Task { await coordinator.preview() }
+                } label: {
+                    Label("Preview", systemImage: "eye")
+                        .font(.caption)
+                }
+                .buttonStyle(.bordered)
+                .help("Read-only dry run of which sessions would resume. Makes no changes.")
+
+                Button {
+                    Task { await coordinator.resumeNow() }
+                } label: {
+                    Label("Resume Now", systemImage: "play.fill")
+                        .font(.caption)
+                }
+                .buttonStyle(.bordered)
+                .disabled(!settings.isFeatureEnabled)
+                .help("Resume once, only if quota is currently available.")
+            }
+        }
+    }
+
+    private var watcherBinding: Binding<Bool> {
+        Binding(
+            get: { settings.isWatcherArmed },
+            set: { settings.setWatcherArmed($0) }
+        )
+    }
+}
+
+// MARK: - SessionWakePopoverCard
+
+/// The Session Wake card for the menu-bar popover. Renders only when the Claude
+/// Code provider is visible and the feature is enabled, giving the user the same
+/// status and the same Wake Watcher kill-switch as Settings without opening it
+/// (issue #98 / PRD FR-4). Reads the same shared singletons, so both surfaces
+/// stay in sync.
+struct SessionWakePopoverCard: View {
+    @ObservedObject var coordinator: SessionWakeCoordinator
+    @ObservedObject var settings: SessionWakeSettingsStore
+    @ObservedObject var providerVisibility: ProviderVisibilityStore
+
+    init(
+        coordinator: SessionWakeCoordinator = .shared,
+        settings: SessionWakeSettingsStore = .shared,
+        providerVisibility: ProviderVisibilityStore = .shared
+    ) {
+        self.coordinator = coordinator
+        self.settings = settings
+        self.providerVisibility = providerVisibility
+    }
+
+    var body: some View {
+        if providerVisibility.isEnabled(.claudeCode), settings.isFeatureEnabled {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 6) {
+                    Image(systemName: "powersleep")
+                        .font(.caption)
+                        .foregroundStyle(MeterBarTheme.appAccent)
+                    Text("Session Wake")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                    Spacer(minLength: 6)
+                }
+
+                SessionWakeStatusView(coordinator: coordinator, settings: settings)
+
+                SessionWakeWatcherControl(
+                    coordinator: coordinator,
+                    settings: settings,
+                    isCompact: true
+                )
+            }
+            .padding(10)
+            .meterBarCardSurface(cornerRadius: 10)
+        }
+    }
+}

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 
 private enum SettingsPane: Hashable, Identifiable {
     case general
+    case automation
     case apiUsage
     case costTracking
     case provider(ServiceType)
@@ -16,7 +17,7 @@ private enum SettingsPane: Hashable, Identifiable {
     static let windowMinHeight: CGFloat = 560
     static let sidebarWidth: CGFloat = 238
     static let detailMaxWidth: CGFloat = 760
-    static let appPanes: [SettingsPane] = [.general, .apiUsage, .costTracking]
+    static let appPanes: [SettingsPane] = [.general, .automation, .apiUsage, .costTracking]
     static let providerPanes: [SettingsPane] = ServiceType.allCases
         .sorted { $0.sortOrder < $1.sortOrder }
         .map(SettingsPane.provider)
@@ -25,6 +26,8 @@ private enum SettingsPane: Hashable, Identifiable {
         switch self {
         case .general:
             "general"
+        case .automation:
+            "automation"
         case .apiUsage:
             "api-usage"
         case .costTracking:
@@ -38,6 +41,8 @@ private enum SettingsPane: Hashable, Identifiable {
         switch self {
         case .general:
             "General"
+        case .automation:
+            "Automation"
         case .apiUsage:
             "API Usage"
         case .costTracking:
@@ -51,6 +56,8 @@ private enum SettingsPane: Hashable, Identifiable {
         switch self {
         case .general:
             "Launch, refresh, notifications"
+        case .automation:
+            "Session Wake"
         case .apiUsage:
             "Admin keys and overage"
         case .costTracking:
@@ -71,6 +78,8 @@ private enum SettingsPane: Hashable, Identifiable {
         switch self {
         case .general:
             "gearshape.fill"
+        case .automation:
+            "powersleep"
         case .apiUsage:
             "network"
         case .costTracking:
@@ -90,6 +99,7 @@ private enum SettingsPane: Hashable, Identifiable {
     var color: Color {
         switch self {
         case .general,
+             .automation,
              .apiUsage:
             MeterBarTheme.appAccent
         case .costTracking:
@@ -153,6 +163,35 @@ struct SettingsView: View {
                 isAddingClaudeAccount = false
             }
         }
+        .sheet(isPresented: $isPresentingWakeFirstEnable) {
+            SessionWakeFirstEnableSheet {
+                sessionWakeSettings.acknowledgeFirstEnable()
+                sessionWakeSettings.setFeatureEnabled(true)
+                isPresentingWakeFirstEnable = false
+            } onCancel: {
+                isPresentingWakeFirstEnable = false
+            }
+        }
+        .confirmationDialog(
+            "Skip permission prompts?",
+            isPresented: $isConfirmingWakeBypass,
+            titleVisibility: .visible
+        ) {
+            Button("Skip Permission Prompts", role: .destructive) {
+                sessionWakeSettings.setPermissionBypassAcknowledged(true)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(
+                "Resumed sessions will run with --dangerously-skip-permissions, so they can "
+                    + "act without asking. Only enable this for accounts and projects you trust."
+            )
+        }
+        .onChange(of: claudeAccountStore.accounts) {
+            sessionWakeSettings.reconcile(
+                availableAccountIDs: Set(claudeAccountStore.accounts.map(\.id))
+            )
+        }
     }
 
     // MARK: Private
@@ -166,11 +205,15 @@ struct SettingsView: View {
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
     @StateObject private var dockVisibility = DockVisibilityStore.shared
     @StateObject private var notificationPreferences = NotificationPreferencesStore.shared
+    @StateObject private var sessionWakeSettings = SessionWakeSettingsStore.shared
+    @StateObject private var sessionWakeCoordinator = SessionWakeCoordinator.shared
     @StateObject private var launchAtLogin = LaunchAtLoginStore.shared
     @StateObject private var authManager = AuthenticationManager.shared
     @StateObject private var apiUsageStore = ApiUsageStore.shared
 
     @State private var isAddingClaudeAccount = false
+    @State private var isPresentingWakeFirstEnable = false
+    @State private var isConfirmingWakeBypass = false
     @State private var claudeReconnectError: String?
     @State private var claudeAdminKeyDraft = ""
     @State private var openaiAdminKeyDraft = ""
@@ -333,6 +376,8 @@ struct SettingsView: View {
                 refreshSection
                 notificationsSection
                 generalSection
+            case .automation:
+                automationSection
             case .apiUsage:
                 if showExtraUsageSection {
                     extraUsageSection
@@ -391,6 +436,9 @@ struct SettingsView: View {
             costTrackingSection
             refreshSection
             notificationsSection
+            if providerVisibility.isEnabled(.claudeCode) {
+                automationSection
+            }
             generalSection
         }
         .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -428,6 +476,126 @@ struct SettingsView: View {
                 }
             } else if !codexCliService.hasAccess {
                 SettingsNotice(text: "Run codex login, then check again.", color: MeterBarTheme.warning)
+            }
+        }
+    }
+
+    private var automationSection: some View {
+        SettingsPanelSection(title: "Session Wake", systemImage: "powersleep", color: MeterBarTheme.appAccent) {
+            SettingsNotice(
+                text: "Session Wake resumes Claude Code sessions that stopped on a usage limit, "
+                    + "once your quota window reopens. Claude Code only. Preview is a read-only "
+                    + "dry run and never changes anything.",
+                color: .secondary
+            )
+
+            SettingsRowView(
+                title: "Enable Session Wake",
+                detail: "Master switch. When off, nothing runs in the background."
+            ) {
+                Toggle("", isOn: Binding(
+                    get: { sessionWakeSettings.isFeatureEnabled },
+                    set: { enabled in
+                        if enabled {
+                            if sessionWakeSettings.hasAcknowledgedFirstEnable {
+                                sessionWakeSettings.setFeatureEnabled(true)
+                            } else {
+                                isPresentingWakeFirstEnable = true
+                            }
+                        } else {
+                            sessionWakeSettings.setFeatureEnabled(false)
+                        }
+                    }
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+            }
+
+            if sessionWakeSettings.isFeatureEnabled {
+                SettingsDivider()
+
+                SettingsRowView(
+                    title: "Wake account",
+                    detail: "Explicitly choose which Claude profile to resume. Never inferred."
+                ) {
+                    Picker("", selection: Binding(
+                        get: { sessionWakeSettings.wakeAccountID },
+                        set: { sessionWakeSettings.selectWakeAccount($0) }
+                    )) {
+                        Text("None").tag(UUID?.none)
+                        ForEach(claudeAccountStore.accounts) { account in
+                            Text(account.name).tag(Optional(account.id))
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .frame(width: 240)
+                }
+
+                SessionWakeStatusView(
+                    coordinator: sessionWakeCoordinator,
+                    settings: sessionWakeSettings,
+                    accountStore: claudeAccountStore
+                )
+                .padding(.top, 2)
+
+                SessionWakeWatcherControl(
+                    coordinator: sessionWakeCoordinator,
+                    settings: sessionWakeSettings
+                )
+
+                SettingsDivider()
+
+                SettingsRowView(
+                    title: "Skip permission prompts",
+                    detail: "Resumes run with --dangerously-skip-permissions. Off by default; "
+                        + "turning it on needs a separate confirmation."
+                ) {
+                    Toggle("", isOn: Binding(
+                        get: { sessionWakeSettings.hasAcknowledgedPermissionBypass },
+                        set: { enabled in
+                            if enabled {
+                                isConfirmingWakeBypass = true
+                            } else {
+                                sessionWakeSettings.setPermissionBypassAcknowledged(false)
+                            }
+                        }
+                    ))
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                }
+
+                SettingsRowView(
+                    title: "Notify on completion",
+                    detail: "Summarize resumed / skipped / failed counts when a run finishes."
+                ) {
+                    Toggle("", isOn: Binding(
+                        get: { sessionWakeSettings.notifyOnCompletion },
+                        set: { sessionWakeSettings.setNotifyOnCompletion($0) }
+                    ))
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                }
+
+                SettingsRowView(
+                    title: "Notify when watching starts",
+                    detail: "Let you know the watcher is waiting for the quota reset."
+                ) {
+                    Toggle("", isOn: Binding(
+                        get: { sessionWakeSettings.notifyOnWatchStart },
+                        set: { sessionWakeSettings.setNotifyOnWatchStart($0) }
+                    ))
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                }
+
+                if !notificationPreferences.isEnabled {
+                    SettingsNotice(
+                        text: "Global notifications are off, so Session Wake will not post banners "
+                            + "until you re-enable them under Notifications.",
+                        color: MeterBarTheme.warning
+                    )
+                }
             }
         }
     }
@@ -1608,6 +1776,64 @@ private struct AdminKeySettingsRow: View {
 }
 
 // MARK: - AddClaudeAccountSheet
+
+private struct SessionWakeFirstEnableSheet: View {
+    let onAcknowledge: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(spacing: 10) {
+                Image(systemName: "powersleep")
+                    .font(.title2)
+                    .foregroundStyle(MeterBarTheme.appAccent)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Enable Session Wake")
+                        .font(.headline)
+                    Text("Automatically resume blocked Claude Code sessions.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 10) {
+                bullet("Session Wake runs the Claude CLI headlessly to resume sessions that "
+                    + "stopped on a usage limit.")
+                bullet("It only ever touches the Claude account you explicitly select.")
+                bullet("Resumes happen one at a time, after your quota window reopens, within "
+                    + "conservative limits.")
+                bullet("You can stop the watcher at any time from Settings or the menu bar.")
+            }
+            .font(.callout)
+
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    onCancel()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button("Enable") {
+                    onAcknowledge()
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(22)
+        .frame(width: 480)
+    }
+
+    private func bullet(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.caption)
+                .foregroundStyle(MeterBarTheme.success)
+            Text(text)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
 
 private struct AddClaudeAccountSheet: View {
     // MARK: Internal

--- a/MeterBarTests/SessionWakeCoordinatorTests.swift
+++ b/MeterBarTests/SessionWakeCoordinatorTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import MeterBar
+
+@MainActor
+final class SessionWakeCoordinatorTests: XCTestCase {
+    func testRestingStatusReflectsIntent() {
+        XCTAssertEqual(
+            SessionWakeCoordinator.restingStatus(featureEnabled: false, watcherArmed: false),
+            .off
+        )
+        XCTAssertEqual(
+            SessionWakeCoordinator.restingStatus(featureEnabled: true, watcherArmed: false),
+            .idle
+        )
+        XCTAssertEqual(
+            SessionWakeCoordinator.restingStatus(featureEnabled: true, watcherArmed: true),
+            .armed
+        )
+        XCTAssertEqual(
+            SessionWakeCoordinator.restingStatus(featureEnabled: false, watcherArmed: true),
+            .off,
+            "A disabled feature is always Off regardless of stale armed intent."
+        )
+    }
+
+    func testReflectSettingsUpdatesRestingStatesOnly() {
+        let coordinator = PreviewSessionWakeCoordinator(status: .idle)
+        coordinator.reflectSettings(featureEnabled: true, watcherArmed: true)
+        XCTAssertEqual(coordinator.status, .armed)
+
+        coordinator.reflectSettings(featureEnabled: false, watcherArmed: false)
+        XCTAssertEqual(coordinator.status, .off)
+    }
+
+    func testReflectSettingsDoesNotStompActiveRun() {
+        let coordinator = PreviewSessionWakeCoordinator(status: .running(completed: 1, total: 3))
+        coordinator.reflectSettings(featureEnabled: true, watcherArmed: false)
+        XCTAssertEqual(
+            coordinator.status,
+            .running(completed: 1, total: 3),
+            "Settings reflection must not overwrite an in-flight run."
+        )
+    }
+
+    func testStubPreviewIsInertAndReportsUnavailable() async {
+        let stub = StubSessionWakeCoordinator()
+        await stub.preview()
+        XCTAssertEqual(stub.eligibility?.eligibleCount, 0)
+        XCTAssertNotNil(stub.eligibility?.note, "The stub honestly reports discovery is unavailable.")
+    }
+
+    func testSharedCoordinatorIsInstalled() {
+        // The seam always has a coordinator; until #95–#97 land it is the stub.
+        XCTAssertTrue(SessionWakeCoordinator.shared is StubSessionWakeCoordinator)
+    }
+}

--- a/MeterBarTests/SessionWakeNotificationDeciderTests.swift
+++ b/MeterBarTests/SessionWakeNotificationDeciderTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import MeterBar
+
+final class SessionWakeNotificationDeciderTests: XCTestCase {
+    private let decider = SessionWakeNotificationDecider()
+
+    private func gates(
+        global: Bool = true,
+        provider: Bool = true,
+        watchStart: Bool = true,
+        completion: Bool = true
+    ) -> SessionWakeNotificationDecider.Gates {
+        SessionWakeNotificationDecider.Gates(
+            notificationsEnabled: global,
+            claudeProviderEnabled: provider,
+            notifyOnWatchStart: watchStart,
+            notifyOnCompletion: completion
+        )
+    }
+
+    private let summary = SessionWakeRunSummary(resumed: 2, skipped: 1, failed: 0, finishedAt: Date())
+
+    // MARK: All gates open
+
+    func testWatchStartFiresWhenAllGatesOpen() {
+        let fired = decider.watchStartNotification(queuedCount: 3, gates: gates())
+        XCTAssertNotNil(fired)
+        XCTAssertEqual(fired?.key, "session-wake-watch-start")
+        XCTAssertTrue(fired?.body.contains("3 sessions") ?? false)
+    }
+
+    func testCompletionFiresWhenAllGatesOpen() {
+        let fired = decider.completionNotification(summary: summary, gates: gates())
+        XCTAssertNotNil(fired)
+        XCTAssertEqual(fired?.key, "session-wake-completion")
+        XCTAssertTrue(fired?.body.contains("Resumed 2 of 3") ?? false)
+    }
+
+    // MARK: Global gate
+
+    func testGlobalOffSuppressesBoth() {
+        XCTAssertNil(decider.watchStartNotification(queuedCount: 1, gates: gates(global: false)))
+        XCTAssertNil(decider.completionNotification(summary: summary, gates: gates(global: false)))
+    }
+
+    // MARK: Provider visibility gate
+
+    func testHiddenClaudeProviderSuppressesBoth() {
+        XCTAssertNil(decider.watchStartNotification(queuedCount: 1, gates: gates(provider: false)))
+        XCTAssertNil(decider.completionNotification(summary: summary, gates: gates(provider: false)))
+    }
+
+    // MARK: Per-event Session Wake gates
+
+    func testWatchStartPreferenceGatesOnlyWatchStart() {
+        XCTAssertNil(decider.watchStartNotification(queuedCount: 1, gates: gates(watchStart: false)))
+        XCTAssertNotNil(decider.completionNotification(summary: summary, gates: gates(watchStart: false)))
+    }
+
+    func testCompletionPreferenceGatesOnlyCompletion() {
+        XCTAssertNotNil(decider.watchStartNotification(queuedCount: 1, gates: gates(completion: false)))
+        XCTAssertNil(decider.completionNotification(summary: summary, gates: gates(completion: false)))
+    }
+
+    // MARK: Copy
+
+    func testCompletionBodyMentionsFailuresWhenPresent() {
+        let failing = SessionWakeRunSummary(resumed: 1, skipped: 0, failed: 2, finishedAt: Date())
+        let fired = decider.completionNotification(summary: failing, gates: gates())
+        XCTAssertTrue(fired?.body.contains("2 failures") ?? false)
+    }
+
+    func testWatchStartSingularCopy() {
+        let fired = decider.watchStartNotification(queuedCount: 1, gates: gates())
+        XCTAssertTrue(fired?.body.contains("1 session queued") ?? false)
+    }
+}

--- a/MeterBarTests/SessionWakeSettingsStoreTests.swift
+++ b/MeterBarTests/SessionWakeSettingsStoreTests.swift
@@ -1,0 +1,194 @@
+import Combine
+import XCTest
+@testable import MeterBar
+
+final class SessionWakeSettingsStoreTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "SessionWakeSettingsStoreTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    private func makeStore() -> SessionWakeSettingsStore {
+        SessionWakeSettingsStore(userDefaults: defaults)
+    }
+
+    // MARK: Defaults
+
+    func testDefaultsAreSafeAndOff() {
+        let store = makeStore()
+        XCTAssertFalse(store.isFeatureEnabled)
+        XCTAssertFalse(store.isWatcherArmed)
+        XCTAssertNil(store.wakeAccountID)
+        XCTAssertFalse(store.hasAcknowledgedFirstEnable)
+        XCTAssertFalse(store.hasAcknowledgedPermissionBypass)
+        XCTAssertTrue(store.notifyOnCompletion, "Completion notifications default on.")
+        XCTAssertTrue(store.notifyOnWatchStart)
+    }
+
+    // MARK: First-enable acknowledgement gates enabling
+
+    func testEnablingRequiresFirstEnableAcknowledgement() {
+        let store = makeStore()
+
+        store.setFeatureEnabled(true)
+        XCTAssertFalse(store.isFeatureEnabled, "Feature must not enable without acknowledgement.")
+
+        store.acknowledgeFirstEnable()
+        store.setFeatureEnabled(true)
+        XCTAssertTrue(store.isFeatureEnabled, "After acknowledgement, enabling succeeds.")
+    }
+
+    // MARK: Feature vs watcher separation
+
+    func testWatcherCannotArmWhileFeatureOff() {
+        let store = makeStore()
+        store.acknowledgeFirstEnable()
+        store.selectWakeAccount(UUID())
+
+        // Feature still off.
+        store.setWatcherArmed(true)
+        XCTAssertFalse(store.isWatcherArmed, "Watcher cannot arm while the feature is off.")
+    }
+
+    func testWatcherCannotArmWithoutSelectedAccount() {
+        let store = makeStore()
+        store.acknowledgeFirstEnable()
+        store.setFeatureEnabled(true)
+
+        store.setWatcherArmed(true)
+        XCTAssertFalse(store.isWatcherArmed, "Watcher cannot arm without an explicit account.")
+        XCTAssertFalse(store.canArmWatcher)
+    }
+
+    func testWatcherArmsWhenAllPreconditionsHold() {
+        let store = makeStore()
+        store.acknowledgeFirstEnable()
+        store.setFeatureEnabled(true)
+        store.selectWakeAccount(UUID())
+
+        XCTAssertTrue(store.canArmWatcher)
+        store.setWatcherArmed(true)
+        XCTAssertTrue(store.isWatcherArmed)
+    }
+
+    func testDisablingFeatureForcesWatcherOff() {
+        let store = makeStore()
+        store.acknowledgeFirstEnable()
+        store.setFeatureEnabled(true)
+        store.selectWakeAccount(UUID())
+        store.setWatcherArmed(true)
+        XCTAssertTrue(store.isWatcherArmed)
+
+        store.setFeatureEnabled(false)
+        XCTAssertFalse(store.isFeatureEnabled)
+        XCTAssertFalse(store.isWatcherArmed, "Master-off cancels watcher intent.")
+    }
+
+    // MARK: Account selection safety
+
+    func testChangingAccountWhileArmedDisarms() {
+        let store = makeStore()
+        store.acknowledgeFirstEnable()
+        store.setFeatureEnabled(true)
+        store.selectWakeAccount(UUID())
+        store.setWatcherArmed(true)
+        XCTAssertTrue(store.isWatcherArmed)
+
+        store.selectWakeAccount(UUID())
+        XCTAssertFalse(store.isWatcherArmed, "Switching accounts safely suspends the watcher.")
+    }
+
+    func testReconcileClearsRemovedAccountAndSuspends() {
+        let store = makeStore()
+        let account = UUID()
+        store.acknowledgeFirstEnable()
+        store.setFeatureEnabled(true)
+        store.selectWakeAccount(account)
+        store.setWatcherArmed(true)
+
+        // The account list no longer contains the selection.
+        store.reconcile(availableAccountIDs: [UUID()])
+        XCTAssertNil(store.wakeAccountID, "A removed account clears the selection.")
+        XCTAssertFalse(store.isWatcherArmed, "A removed account suspends the watcher.")
+    }
+
+    func testReconcileKeepsStillPresentAccount() {
+        let store = makeStore()
+        let account = UUID()
+        store.acknowledgeFirstEnable()
+        store.setFeatureEnabled(true)
+        store.selectWakeAccount(account)
+        store.setWatcherArmed(true)
+
+        store.reconcile(availableAccountIDs: [account, UUID()])
+        XCTAssertEqual(store.wakeAccountID, account)
+        XCTAssertTrue(store.isWatcherArmed)
+    }
+
+    // MARK: Persistence
+
+    func testSelectionAndIntentSurviveRelaunch() {
+        let account = UUID()
+        do {
+            let store = makeStore()
+            store.acknowledgeFirstEnable()
+            store.setFeatureEnabled(true)
+            store.selectWakeAccount(account)
+            store.setWatcherArmed(true)
+            store.setNotifyOnCompletion(false)
+        }
+
+        let reloaded = makeStore()
+        XCTAssertTrue(reloaded.isFeatureEnabled)
+        XCTAssertTrue(reloaded.isWatcherArmed)
+        XCTAssertEqual(reloaded.wakeAccountID, account)
+        XCTAssertFalse(reloaded.notifyOnCompletion)
+    }
+
+    func testWatcherNeverResurrectsWhenFeatureDisabledOnLoad() {
+        // Simulate a corrupt/hand-edited defaults blob: armed=true but feature=false.
+        defaults.set(true, forKey: StorageKeys.sessionWakeWatcherArmed)
+        defaults.set(false, forKey: StorageKeys.sessionWakeFeatureEnabled)
+        defaults.set(true, forKey: StorageKeys.sessionWakeFirstEnableAcknowledged)
+
+        let store = makeStore()
+        XCTAssertFalse(store.isWatcherArmed, "A disabled feature must never load an armed watcher.")
+    }
+
+    func testPermissionBypassIsSeparateAndPersists() {
+        do {
+            let store = makeStore()
+            XCTAssertFalse(store.hasAcknowledgedPermissionBypass)
+            store.setPermissionBypassAcknowledged(true)
+        }
+        let reloaded = makeStore()
+        XCTAssertTrue(reloaded.hasAcknowledgedPermissionBypass)
+    }
+
+    // MARK: Publish hygiene
+
+    func testNoRedundantPublishOnUnchangedNotify() {
+        let store = makeStore()
+        var count = 0
+        let cancellable = store.$notifyOnCompletion.dropFirst().sink { _ in count += 1 }
+
+        store.setNotifyOnCompletion(true) // already the default
+        XCTAssertEqual(count, 0)
+
+        store.setNotifyOnCompletion(false)
+        XCTAssertEqual(count, 1)
+
+        cancellable.cancel()
+    }
+}

--- a/MeterBarTests/SessionWakeStatusTests.swift
+++ b/MeterBarTests/SessionWakeStatusTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import MeterBar
+
+final class SessionWakeStatusTests: XCTestCase {
+    func testDistinctStatesAreNotCollapsed() {
+        // Every state the issue enumerates must have a distinct label so the UI
+        // never collapses "Running / Stopping / Quota Unknown" into "Watching".
+        let states: [SessionWakeStatus] = [
+            .off,
+            .idle,
+            .armed,
+            .scanning,
+            .waiting(until: nil, blockedCount: 3),
+            .quotaUnknown(reason: "Not authenticated"),
+            .running(completed: 1, total: 4),
+            .stopping,
+            .completed,
+            .needsAttention("Account removed")
+        ]
+        let labels = Set(states.map(\.label))
+        XCTAssertEqual(labels.count, states.count, "Each state must render a unique label.")
+    }
+
+    func testWatcherActiveOnlyForEngagedStates() {
+        XCTAssertFalse(SessionWakeStatus.off.isWatcherActive)
+        XCTAssertFalse(SessionWakeStatus.idle.isWatcherActive)
+        XCTAssertTrue(SessionWakeStatus.armed.isWatcherActive)
+        XCTAssertTrue(SessionWakeStatus.scanning.isWatcherActive)
+        XCTAssertTrue(SessionWakeStatus.waiting(until: nil, blockedCount: 0).isWatcherActive)
+        XCTAssertTrue(SessionWakeStatus.running(completed: 0, total: 1).isWatcherActive)
+        XCTAssertTrue(SessionWakeStatus.stopping.isWatcherActive)
+        XCTAssertFalse(SessionWakeStatus.quotaUnknown(reason: "x").isWatcherActive)
+        XCTAssertFalse(SessionWakeStatus.completed.isWatcherActive)
+        XCTAssertFalse(SessionWakeStatus.needsAttention("x").isWatcherActive)
+    }
+
+    func testWaitingDetailPluralizes() {
+        XCTAssertEqual(
+            SessionWakeStatus.waiting(until: nil, blockedCount: 1).detail,
+            "1 session waiting for quota reset."
+        )
+        XCTAssertEqual(
+            SessionWakeStatus.waiting(until: nil, blockedCount: 2).detail,
+            "2 sessions waiting for quota reset."
+        )
+    }
+
+    func testTonesMapToSeverity() {
+        XCTAssertEqual(SessionWakeStatus.off.tone, .neutral)
+        XCTAssertEqual(SessionWakeStatus.running(completed: 0, total: 1).tone, .active)
+        XCTAssertEqual(SessionWakeStatus.waiting(until: nil, blockedCount: 0).tone, .waiting)
+        XCTAssertEqual(SessionWakeStatus.quotaUnknown(reason: "x").tone, .warning)
+        XCTAssertEqual(SessionWakeStatus.completed.tone, .success)
+        XCTAssertEqual(SessionWakeStatus.needsAttention("x").tone, .danger)
+    }
+
+    func testRunSummaryCounts() {
+        let summary = SessionWakeRunSummary(resumed: 2, skipped: 1, failed: 1, finishedAt: Date())
+        XCTAssertEqual(summary.attempted, 4)
+        XCTAssertEqual(summary.countsLine, "2 resumed · 1 skipped · 1 failed")
+    }
+
+    func testEligibilitySkippedCount() {
+        let eligibility = SessionWakeEligibility(
+            eligibleCount: 3,
+            skips: [
+                SessionWakeSkip(reason: "dead worktree", count: 2),
+                SessionWakeSkip(reason: "subagent", count: 1)
+            ]
+        )
+        XCTAssertEqual(eligibility.skippedCount, 3)
+    }
+}

--- a/MeterBarTests/SessionWakeViewHostingTests.swift
+++ b/MeterBarTests/SessionWakeViewHostingTests.swift
@@ -1,0 +1,99 @@
+import AppKit
+@testable import MeterBar
+import SwiftUI
+import XCTest
+
+/// Hosting smoke tests for the Session Wake surfaces. They confirm the views
+/// build and lay out non-trivially for every status the coordinator can report,
+/// across both the standalone Settings window and the embedded/dashboard stack
+/// (issue #98: "Store and SwiftUI hosting tests cover both standalone Settings
+/// and embedded/dashboard surfaces").
+@MainActor
+final class SessionWakeViewHostingTests: XCTestCase {
+    private func host<V: View>(_ view: V, width: CGFloat = 360, height: CGFloat = 320) -> NSHostingView<V> {
+        let hostingView = NSHostingView(rootView: view)
+        hostingView.frame = NSRect(x: 0, y: 0, width: width, height: height)
+        hostingView.layoutSubtreeIfNeeded()
+        return hostingView
+    }
+
+    // MARK: Every status renders
+
+    func testStatusViewRendersEveryState() {
+        let states: [SessionWakeStatus] = [
+            .off,
+            .idle,
+            .armed,
+            .scanning,
+            .waiting(until: Date(timeIntervalSinceNow: 3_600), blockedCount: 4),
+            .quotaUnknown(reason: "Not authenticated"),
+            .running(completed: 1, total: 4),
+            .stopping,
+            .completed,
+            .needsAttention("Selected account was removed")
+        ]
+
+        for status in states {
+            let coordinator = PreviewSessionWakeCoordinator(
+                status: status,
+                eligibility: SessionWakeEligibility(
+                    eligibleCount: 3,
+                    skips: [SessionWakeSkip(reason: "dead worktree", count: 1)]
+                ),
+                lastRun: SessionWakeRunSummary(resumed: 2, skipped: 1, failed: 0, finishedAt: Date())
+            )
+            let hostingView = host(SessionWakeStatusView(coordinator: coordinator))
+            XCTAssertGreaterThan(
+                hostingView.fittingSize.height,
+                0,
+                "Status \(status.label) should lay out."
+            )
+        }
+    }
+
+    func testWatcherControlBuilds() {
+        let coordinator = PreviewSessionWakeCoordinator(status: .idle)
+        let hostingView = host(SessionWakeWatcherControl(coordinator: coordinator))
+        XCTAssertGreaterThan(hostingView.fittingSize.width, 0)
+    }
+
+    func testStatusBadgeBuilds() {
+        let hostingView = host(SessionWakeStatusBadge(status: .running(completed: 2, total: 5)), width: 160, height: 40)
+        XCTAssertGreaterThan(hostingView.fittingSize.width, 0)
+    }
+
+    // MARK: Popover card visibility
+
+    func testPopoverCardHiddenWhenFeatureDisabled() {
+        let suite = "SessionWakeViewHostingTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)
+        defer { defaults?.removePersistentDomain(forName: suite) }
+        let settings = SessionWakeSettingsStore(userDefaults: defaults ?? .standard)
+        let visibility = ProviderVisibilityStore(userDefaults: defaults ?? .standard)
+
+        // Feature off → the card collapses to nothing.
+        let card = SessionWakePopoverCard(
+            coordinator: PreviewSessionWakeCoordinator(status: .off),
+            settings: settings,
+            providerVisibility: visibility
+        )
+        let hostingView = host(card, width: 320, height: 60)
+        XCTAssertLessThan(
+            hostingView.fittingSize.height,
+            10,
+            "The popover card should be empty when Session Wake is disabled."
+        )
+    }
+
+    // MARK: Settings surfaces both build with the Automation pane present
+
+    func testStandaloneSettingsBuildsWithAutomationPane() {
+        let hostingView = host(SettingsView(), width: 920, height: 620)
+        XCTAssertGreaterThanOrEqual(hostingView.fittingSize.width, 840)
+    }
+
+    func testEmbeddedSettingsBuildsWithAutomationPane() {
+        let hostingView = host(SettingsView(embeddedInDashboard: true), width: 920, height: 1_200)
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 400)
+    }
+}


### PR DESCRIPTION
Implements #98 — the user-facing Session Wake control surfaces. Parent epic #94.

## Important context: dependency status

#98 is specified to sit **over the shared native coordinator from #95–#97**. Those three issues are still **open** — no merged PRs — and #96 is being implemented concurrently in another worktree (uncommitted `MeterBar/SessionWake/Wake*` quota-gate primitives). This PR is therefore built as a **self-contained UI seam**:

- It compiles against `master` and does **not** import the uncommitted #96 types.
- Its vocabulary (states, block/skip reasons, run outcomes) is aligned to the emerging #96/#97 types so integration is frictionless.
- `SessionWakeCoordinator` is the seam the real coordinator subclasses later; the interim `shared` is an **honest inert stub** (no subprocess/filesystem work — the dry-run "no mutation" invariant holds trivially).

No automation logic lives in views (per the issue's explicit constraint).

## What's included

- **`SessionWakeStatus`** — presentation lifecycle: Off · Idle · Armed · Scanning · Waiting · Quota Unknown · Running · Stopping · Completed · Needs Attention. Each state has a distinct label, so nothing collapses into "Watching". Plus `SessionWakeRunSummary` and `SessionWakeEligibility`.
- **`SessionWakeSettingsStore`** — UserDefaults-backed. Separates **feature enablement** from **watcher intent**; persists an **explicit** `wakeAccountID` (never inferred from order/activity/`~/.claude-active-account`); first-enable **and** separate permission-bypass acknowledgements; notify prefs; account-removal reconcile that safely suspends the watcher; fail-safe load (an armed watcher never resurrects while the feature is off).
- **`SessionWakeNotificationDecider`** — pure; gated on the global notification switch **and** Claude provider visibility **and** per-event Session Wake prefs.
- **Views** — `Settings → Automation` pane (feature toggle with first-enable safety sheet, explicit account picker, permission-bypass confirmation, notify toggles); shared `SessionWakeStatusView` / `SessionWakeStatusBadge` / `SessionWakeWatcherControl`; and a menu-bar `SessionWakePopoverCard` exposing the same Wake Watcher kill-switch. Both surfaces bind the **same** shared singletons. Native Liquid Glass card surfaces, adaptive light/dark tone colors.

## Acceptance criteria mapping

- Feature off prevents background discovery/resume, Preview still allowed → store gating + stub `preview()` works regardless of feature state.
- Master-off cancels watcher intent → `setFeatureEnabled(false)` forces watcher off.
- Settings + menu-bar controls share one binding → both use `SessionWakeSettingsStore.shared` / `SessionWakeCoordinator.shared`.
- wakeAccountID persists and is explicit; removing/changing it suspends the watcher → `selectWakeAccount` / `reconcile`.
- Running/stopping/failure/quota-unknown states are visible, not collapsed → distinct `SessionWakeStatus` cases + tests.
- Notifications respect global + provider + Session Wake prefs → `SessionWakeNotificationDecider` + tests.
- Store and SwiftUI hosting tests cover standalone Settings **and** embedded/dashboard surfaces → included.

Live discovery/quota/runner wiring, `WakeQuotaState`/runner-outcome → presentation mapping, and app-delegate notification posting are deliberately deferred to the #95–#97 / #99 integration.

## Verification

- `swift test`: **407 passed, 0 failures** (38 new: store, status, decider, coordinator, and SwiftUI hosting across every status + standalone/embedded Settings).
- `swiftlint lint`: clean (project-wide).
- Coverage gate: **38.4%** (CI floor 19%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)