### PR TITLE
Session Wake #95: native discovery, terminal-state classification, replay ledger

### DIFF
--- a/.agents/SESSIONS/2026-07-10.md
+++ b/.agents/SESSIONS/2026-07-10.md
@@ -66,3 +66,17 @@
 **Follow-ups:**
 - The Homebrew cask's uninstall/zap entries reference the old bundle id and app-group paths - update with the v1.6.2 release.
 - Old `group.dev.shipshit.meterbar` container and `dev.shipshit.meterbar` LaunchAgent/notification grants are orphaned on existing installs; users re-grant notifications once.
+
+## Session 4: Session Wake — begin native implementation (epic #94, #95–#99)
+
+**Status:** In progress (stacked PRs)
+
+**Context / gate:** Signing blocker #47 is closed; release pipeline ships signed+notarized universal artifacts (#100). With maintainer approval in-session, epic #94 was moved out of the planning gate to authorize Session Wake implementation. Delivery: five stacked PRs (#95 → #99), merged sequentially, each TDD + green on build/tests+coverage/SwiftLint/secret-scan. v1 Claude Code only; Codex deferred. No Python/shell watcher bundled or invoked.
+
+**Concurrent-agent incident (important):** Partway through PR1, the shared worktree filled with a second, overlapping Session Wake implementation (#96–#98 scaffolding + tests) written by a concurrent FleetView session, colliding with my #95 files (duplicate `WakeSessionCandidate`). Per maintainer direction I snapshotted the worktree defensively; before I could adopt the concurrent work as a base it deleted its own files, leaving only my #95 implementation. Resolution: proceed solo on my tested base and **commit early** so any future concurrent clobbering is git-recoverable. Watch for renewed churn in `MeterBar/SessionWake/`.
+
+**PR1 (#95) — done, open as #105:**
+- `TranscriptClassifier` (latest-decisive-event), `TranscriptResetParser` (event-anchored, no roll-to-tomorrow, never proves availability), `WakeBlockReason`, `SessionDiscovery` actor (account-scoped, bounded off-main tail, subagent exclusion, dedup, dead-cwd skip), `BlockFingerprint` + `ReplayLedger` (0600, fails safe), `WakePaths`.
+- 19 new tests; full suite 388 passing; SwiftLint --strict clean. Fixtures mirror real Claude JSONL (`isApiErrorMessage`/`apiErrorStatus:429`).
+
+**Next:** PR2 (#96) quota gate + cancellable watcher state machine, branched off `session-wake/95-discovery`.

--- a/.agents/docs/PRD-session-wake.md
+++ b/.agents/docs/PRD-session-wake.md
@@ -1,0 +1,241 @@
+# PRD: Session Wake — Auto-Resume Blocked CLI Sessions After Quota Reset
+
+## Executive Summary
+
+MeterBar already tells users **when** their Claude Code and Codex CLI quotas reset. **Session Wake** adds the action layer: discover sessions blocked on usage limits, wait until the primary quota window opens, then headlessly resume them one at a time with a configurable prompt (default: `continue`).
+
+This turns MeterBar from a passive monitor into an overnight automation tool — especially for power users running many parallel agent sessions who hit the 5-hour session limit before quota resets.
+
+**v1 scope:** Claude Code only, headless CLI resume, single active account per machine, opt-in from Settings.
+
+---
+
+## Problem Statement
+
+Power users of Claude Code and Codex CLI routinely run many long-lived sessions across worktrees and projects. When the 5-hour session limit is exhausted:
+
+1. Sessions stop mid-task with only a rate-limit message in the transcript.
+2. Users must manually reopen each session and type `continue` after reset — tedious at scale (10–30+ sessions).
+3. MeterBar shows reset countdowns but provides no recovery path.
+4. External workarounds (launchd + Python scripts) exist but are invisible, machine-specific, and disconnected from the quota data MeterBar already fetches.
+
+Users going to bed with blocked sessions wake up to idle agents unless they manually intervene or maintain bespoke automation.
+
+---
+
+## Goals
+
+### Primary goals
+- Detect Claude Code sessions blocked on usage limits from local transcript data.
+- Wait until the active account's 5h quota window is available (API reset time + configurable buffer).
+- Resume blocked sessions sequentially via headless CLI without GUI automation.
+- Surface status in MeterBar UI and optional macOS notifications.
+
+### Non-goals (v1)
+- Resuming live Claude Desktop GUI sessions via `osascript` / Accessibility.
+- Codex thread resume (defer to v1.1).
+- Multi-machine orchestration (Mac Studio + MBP coordination).
+- Consuming OpenAI/Anthropic "reset credits" automatically.
+- Replacing or conflicting with user's existing `launchd` jobs (coexist, don't fight).
+
+### Success metrics
+- User can enable Session Wake, go to bed blocked, and find ≥1 session actively resumed after reset without manual CLI interaction.
+- Zero resume attempts while quota is still blocked (no rate-limit spam).
+- Blocked session count in UI matches manual audit of `*.jsonl` transcripts within ±1.
+
+---
+
+## User Stories
+
+1. **As a developer hitting session limits**, I want MeterBar to resume my blocked Claude sessions after reset so I don't manually type `continue` in 20 terminals.
+2. **As a multi-account user**, I want Session Wake to respect my active `CLAUDE_CONFIG_DIR` profile so only the correct account's sessions are resumed.
+3. **As a cautious user**, I want a dry-run/preview of which sessions would be resumed before enabling overnight automation.
+4. **As a morning user**, I want a notification summarizing how many sessions resumed successfully vs skipped/failed.
+5. **As a user who changes plans**, I want a dedicated **Wake Watcher** toggle I can flip off anytime so MeterBar stops polling and does not resume sessions until I turn it back on.
+
+---
+
+## Functional Requirements
+
+### FR-1: Blocked session discovery (Claude)
+- Scan `CLAUDE_CONFIG_DIR/projects/**/*.jsonl` (fallback: active account dir from MeterBar's configured Claude profile).
+- A session is **blocked** when the transcript tail contains `error: rate_limit` or an API error message containing `session limit`.
+- Exclude `/subagents/` transcript paths.
+- Deduplicate by `session_id`.
+- Resolve `cwd` from session metadata (`sessions/*.json`) or transcript fields.
+
+### FR-2: Quota gate
+- Reuse existing Claude usage fetch (`ClaudeCodeCLIUsageService` / OAuth usage API) to read primary 5h window utilization and `resets_at`.
+- **Do not resume** when primary window is blocked (`utilization >= 100` or equivalent).
+- **`--wait` mode:** poll usage until primary window is unblocked, sleeping until `resets_at + bufferSecs` (default buffer: 90s).
+- Poll interval configurable (default: 60s).
+
+### FR-3: Sequential headless resume
+- For each blocked session (oldest-first or most-recently-updated-first — document choice):
+  ```bash
+  claude -r <session_id> -p "<prompt>" \
+    --print --output-format text \
+    --dangerously-skip-permissions
+  ```
+- Set `CLAUDE_CONFIG_DIR` to the MeterBar-configured account directory.
+- Configurable inter-session gap (default: 20s).
+- Configurable per-session timeout (default: 7200s).
+- Configurable max sessions per run (default: unlimited; 0 = all).
+- Configurable prompt (default: `continue`).
+- File lock to prevent concurrent wake runs.
+
+### FR-4: Settings UI (`Settings → Automation`)
+
+Two independent toggles — feature config vs active watcher:
+
+| Setting | Type | Default | Behavior |
+|---------|------|---------|----------|
+| **Enable Session Wake** | toggle | off | Master switch. When off: no discovery runs, no resume, watcher cannot start. Persists user intent to use the feature. |
+| **Wake Watcher** | toggle | off | **Active on/off for the quota watcher.** When on: MeterBar polls quota and runs the wait→resume loop (if blocked). When off: **immediately cancels** any in-progress watch, stops polling, and does not resume until toggled on again. |
+| Max sessions per run | int | 0 (all) | Only applies when watcher runs |
+| Gap between sessions (seconds) | int | 20 | |
+| Buffer after reset (seconds) | int | 90 | |
+| Resume prompt | string | see `resume-quota-prompt.txt` pattern | |
+| Notify on completion | toggle | on | |
+
+**Toggle rules (required):**
+- `Enable Session Wake` off → `Wake Watcher` forced off and disabled in UI.
+- `Wake Watcher` on while quota already open → run resume pass immediately (no wait).
+- `Wake Watcher` off mid-wait → cancel sleep/poll loop within one poll interval; log "watcher stopped by user".
+- Watcher state persisted across app relaunch **only if** user left `Wake Watcher` on (optional: prompt on launch "Resume watching for quota reset?").
+- Menu bar popover exposes the same **Wake Watcher** toggle for quick kill-switch without opening Settings.
+
+### FR-5: Dashboard / popover surfacing
+- When Claude 5h window is blocked, show: **"N sessions waiting · resets {countdown}"**.
+- **Watcher status chip:** `Watching` (poll active) · `Idle` (feature on, watcher off) · `Off` (feature disabled).
+- Actions:
+  - **Preview** (dry-run list)
+  - **Wake Watcher** toggle (same binding as Settings — primary control surface)
+  - **Resume Now** (one-shot, only if quota available; does not require watcher on)
+- Show last run summary: resumed / skipped / failed counts + timestamp.
+- Link to log file.
+
+### FR-6: Notifications
+- Optional notification when wake watch starts: *"Watching for Claude quota reset — N sessions queued"*.
+- Optional notification on completion: *"Session Wake: resumed X/Y Claude sessions"*.
+- Respect existing `NotificationPreferences` and provider enablement.
+
+### FR-7: CLI extension
+```bash
+meterbar wake [--provider claude] [--wait] [--dry-run] [--limit N] [--session-id UUID]
+```
+- JSON output mode for scripting: `--json`
+- Exit 0 when quota blocked and not waiting; exit 0 after successful run.
+
+### FR-8: Logging
+- Write logs to `~/Library/Logs/MeterBar/session-wake-YYYYMMDD-HHMMSS.log` (or `~/.meterbar/logs/` — pick one, document in Settings).
+- Log: quota state, session list, per-session exit code + tail snippet, timing.
+
+### FR-9: Account model compatibility
+- Support MeterBar's existing multi-account Claude profiles (`CLAUDE_CONFIG_DIR` per profile).
+- v1: wake **only the active/default profile** selected in MeterBar Settings.
+- Optionally run `sync-active-account-sessions.sh` equivalent (link account sessions into `~/.claude/projects`) before resume if MeterBar already has this pattern.
+
+---
+
+## Technical Design Notes
+
+### Reference implementation
+A working Python driver exists on the author's machines (`~/.claude/scripts/resume-quota-sessions.py`) with:
+- `active_claude_account_dir()` from `~/.claude-active-account`
+- `discover_claude_targets()` from transcript tails
+- `wait_for_client_quota()` polling
+- `--session-id`, `--wait-for-quota`, `--dry-run` flags
+
+Port core logic into Swift (`MeterBarShared` for pure discovery; app target for `Process` execution) or bundle script initially with MeterBar invoking it — prefer native Swift long-term.
+
+### Architecture sketch
+```
+MeterBarShared
+  └── BlockedSessionDiscovery (pure: parse jsonl tails)
+
+MeterBar
+  ├── SessionWakeScheduler (Timer + quota observation from UsageDataManager)
+  ├── SessionWakeRunner (Process spawn, lock file, sequential queue)
+  └── SessionWakeStore (UserDefaults: prefs, last run stats)
+
+MeterBarCLI
+  └── Wake command (thin wrapper around shared runner or script)
+```
+
+### Security / permissions
+- App is already un-sandboxed — required to read `~/.claude*` and spawn `claude`.
+- No new network endpoints beyond existing usage APIs.
+- Do not log OAuth tokens or full transcript content.
+
+---
+
+## Acceptance Criteria
+
+- [ ] **AC-1:** With Claude 5h at 100%, Preview shows blocked session count > 0 matching manual `rg rate_limit` audit.
+- [ ] **AC-2:** Resume Now does nothing (clean message) when quota blocked; no CLI invocations fired.
+- [ ] **AC-3:** With `--wait` / Wake Watch enabled, MeterBar waits until `resets_at + buffer` before first resume.
+- [ ] **AC-4:** After reset, at least one blocked session receives a new transcript entry (user prompt + non-rate-limit assistant response or tool use).
+- [ ] **AC-5:** Sessions resume one at a time with configured gap; second session does not start until first process exits.
+- [ ] **AC-6:** Concurrent wake attempts are rejected via lock file.
+- [ ] **AC-7:** Only the MeterBar-selected Claude account dir is scanned/resumed.
+- [ ] **AC-8:** `meterbar wake --dry-run --json` returns structured session list.
+- [ ] **AC-9:** Completion notification fires with accurate resumed/failed counts when enabled.
+- [ ] **AC-10:** Feature is off by default; no background wake without explicit opt-in.
+- [ ] **AC-11:** `Wake Watcher` toggle off stops an in-progress watch within one poll interval; no further `claude -r` invocations fire.
+- [ ] **AC-12:** `Wake Watcher` toggle is available in Settings **and** menu bar popover; both stay in sync.
+- [ ] **AC-13:** With `Enable Session Wake` off, watcher toggle is disabled and any active watch is cancelled.
+
+---
+
+## Verification Plan
+
+### Manual
+1. Exhaust Claude 5h quota with 2+ sessions blocked.
+2. Enable Session Wake → Preview → confirm session list.
+3. Tap Resume Now while blocked → confirm no-op + user-visible message.
+4. Turn **Wake Watcher** on → confirm app logs "waiting until {time}" and status chip shows `Watching`.
+5. Turn **Wake Watcher** off mid-wait → confirm polling stops and status returns to `Idle`.
+6. After reset (watcher still on) → confirm sessions resume sequentially; check transcript tails.
+7. Confirm notification and last-run summary in UI.
+
+### Automated
+- Unit tests: `BlockedSessionDiscovery` with fixture `*.jsonl` tails (blocked vs healthy vs subagent paths).
+- Unit tests: quota gate logic (blocked / unblocked / wait scheduling math).
+- CLI contract test: `meterbar wake --dry-run --json` schema snapshot.
+
+### Regression
+- Existing usage fetch, notifications, and multi-account Claude settings unaffected when Session Wake is disabled.
+
+---
+
+## Milestones
+
+### v1.0 (MVP)
+- Claude only, Settings + Dashboard card, Wake Watch, CLI `meterbar wake`, logging, notifications.
+
+### v1.1
+- Codex `codex exec resume` support.
+- Per-session picker (resume subset).
+
+### v2.0
+- Scheduled profiles per machine.
+- Menu bar compact "watching" indicator.
+- Integration with reset credits flow (user-confirmed).
+
+---
+
+## Open Questions
+
+1. Sort order for resume queue: oldest-blocked first vs most-recently-active first?
+2. Should MeterBar install/manage a `launchd` helper, or only run while the app is open / via CLI `nohup`?
+3. Native Swift vs bundled script for v1 speed-to-ship?
+4. Show blocked sessions list in Dashboard even when quota is not exhausted (stale blocked from earlier window)?
+
+---
+
+## References
+
+- MeterBar README: reset countdowns, multi-account Claude, `meterbar usage --json`
+- Existing services: `ClaudeCodeLocalService`, `ClaudeCodeCLIUsageService`, `NotificationDecider`, `UsageLimit.resetTime`
+- Prototype driver: `resume-quota-sessions.py` / `.sh` (author's `~/.claude/scripts/`)

--- a/MeterBar/Services/AppLog.swift
+++ b/MeterBar/Services/AppLog.swift
@@ -14,4 +14,5 @@ enum AppLog {
     static let usage = Logger(subsystem: subsystem, category: "usage")
     static let cost = Logger(subsystem: subsystem, category: "cost")
     static let storage = Logger(subsystem: subsystem, category: "storage")
+    static let wake = Logger(subsystem: subsystem, category: "wake")
 }

--- a/MeterBar/SessionWake/ReplayLedger.swift
+++ b/MeterBar/SessionWake/ReplayLedger.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Durable record of handled block fingerprints so a resumed session is never
 /// rediscovered and resumed again after the app relaunches.

--- a/MeterBar/SessionWake/ReplayLedger.swift
+++ b/MeterBar/SessionWake/ReplayLedger.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Durable record of handled block fingerprints so a resumed session is never
+/// rediscovered and resumed again after the app relaunches.
+///
+/// Backed by a single JSON file written atomically with `0600` permissions.
+/// An unreadable or corrupt ledger fails safe to *empty* (nothing handled yet)
+/// rather than throwing — a lost ledger should at worst allow one redundant
+/// resume, never crash discovery.
+actor ReplayLedger {
+    private let fileURL: URL
+    private var handled: Set<String>
+    private var loaded = false
+
+    /// - Parameter fileURL: ledger location; defaults to the private base dir.
+    init(fileURL: URL? = nil) {
+        self.fileURL = fileURL
+            ?? WakePaths.defaultBaseDirectory().appendingPathComponent("replay-ledger.json")
+        self.handled = []
+    }
+
+    /// Whether this block was already handled in a previous or current run.
+    func contains(_ fingerprint: BlockFingerprint) -> Bool {
+        loadIfNeeded()
+        return handled.contains(fingerprint.value)
+    }
+
+    /// Mark a block fingerprint as handled and persist immediately.
+    func record(_ fingerprint: BlockFingerprint) {
+        loadIfNeeded()
+        guard handled.insert(fingerprint.value).inserted else { return }
+        persist()
+    }
+
+    /// Test/diagnostic accessor for the current handled count.
+    func count() -> Int {
+        loadIfNeeded()
+        return handled.count
+    }
+
+    private func loadIfNeeded() {
+        guard !loaded else { return }
+        loaded = true
+        guard let data = try? Data(contentsOf: fileURL),
+              let stored = try? JSONDecoder().decode([String].self, from: data) else {
+            handled = []
+            return
+        }
+        handled = Set(stored)
+    }
+
+    private func persist() {
+        do {
+            try WakePaths.ensurePrivateDirectory(fileURL.deletingLastPathComponent())
+            let data = try JSONEncoder().encode(handled.sorted())
+            try data.write(to: fileURL, options: .atomic)
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: fileURL.path
+            )
+        } catch {
+            AppLog.wake.error("Failed to persist replay ledger: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/MeterBar/SessionWake/SessionDiscovery.swift
+++ b/MeterBar/SessionWake/SessionDiscovery.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+/// Read-only discovery of blocked Claude Code sessions for the selected account.
+///
+/// Discovery is strictly preview-safe: it only reads transcript tails and the
+/// filesystem. It performs no subprocess, no transcript write, no lock
+/// mutation, and never reads a directory other than the selected account's.
+/// All work runs on this actor, off the main actor, with a bounded tail read
+/// per transcript so a huge history cannot stall the scan.
+actor SessionDiscovery {
+    struct Configuration {
+        /// Bytes read from the end of each transcript. The decisive tail of a
+        /// session is always near the end, so a bounded window is sufficient
+        /// and keeps scanning incremental.
+        var maxTailBytes: Int = 64 * 1024
+        var fileManager: FileManager = .default
+
+        init(maxTailBytes: Int = 64 * 1024, fileManager: FileManager = .default) {
+            self.maxTailBytes = maxTailBytes
+            self.fileManager = fileManager
+        }
+    }
+
+    private let configuration: Configuration
+
+    init(configuration: Configuration = Configuration()) {
+        self.configuration = configuration
+    }
+
+    /// The `projects` root for an account, honoring an explicit
+    /// `CLAUDE_CONFIG_DIR` override and otherwise `~/.claude`.
+    static func projectsDirectory(configDirectory: String?) -> URL {
+        let trimmed = configDirectory?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let base: String
+        if let trimmed, !trimmed.isEmpty {
+            base = trimmed
+        } else {
+            base = "\(ServiceSupport.realHomeDirectory())/.claude"
+        }
+        return URL(fileURLWithPath: base, isDirectory: true)
+            .appendingPathComponent("projects", isDirectory: true)
+    }
+
+    /// Discover blocked sessions for `configDirectory`, consulting `ledger` to
+    /// flag already-handled blocks. Subagent transcripts are excluded outright.
+    ///
+    /// - Returns: one executable-or-skip candidate per unique session, newest
+    ///   block first.
+    func discover(configDirectory: String?, ledger: ReplayLedger) async -> [WakeSessionCandidate] {
+        let projects = SessionDiscovery.projectsDirectory(configDirectory: configDirectory)
+        let transcripts = transcriptURLs(under: projects)
+
+        // Keep the newest block per sessionID (a resumed session can re-block).
+        var bySession: [String: WakeSessionCandidate] = [:]
+
+        for url in transcripts {
+            guard let lines = readTail(of: url) else { continue }
+            let fallbackID = url.deletingPathExtension().lastPathComponent
+            let summary = TranscriptClassifier.classify(sessionID: fallbackID, lines: lines)
+
+            // Subagent transcripts are never resume targets.
+            if summary.isSidechain { continue }
+
+            guard case let .blocked(reason, blockedAt, resetHint) = summary.state else { continue }
+
+            let fingerprint = BlockFingerprint(
+                sessionID: summary.sessionID,
+                blockedAt: blockedAt,
+                reason: reason
+            )
+            let (canonicalCwd, cwdSkip) = resolveWorkingDirectory(summary.cwd)
+            let alreadyHandled = await ledger.contains(fingerprint)
+
+            let skip: WakeSkipReason? = alreadyHandled ? .alreadyHandled : cwdSkip
+
+            let candidate = WakeSessionCandidate(
+                sessionID: summary.sessionID,
+                transcriptPath: url.path,
+                workingDirectory: canonicalCwd,
+                gitBranch: summary.gitBranch,
+                reason: reason,
+                blockedAt: blockedAt,
+                resetHint: resetHint,
+                fingerprint: fingerprint,
+                skipReason: skip
+            )
+
+            if let existing = bySession[summary.sessionID], existing.blockedAt >= blockedAt {
+                continue
+            }
+            bySession[summary.sessionID] = candidate
+        }
+
+        return bySession.values.sorted { $0.blockedAt > $1.blockedAt }
+    }
+
+    // MARK: - Filesystem
+
+    private func transcriptURLs(under projects: URL) -> [URL] {
+        guard let enumerator = configuration.fileManager.enumerator(
+            at: projects,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+        var urls: [URL] = []
+        for case let url as URL in enumerator where url.pathExtension == "jsonl" {
+            urls.append(url)
+        }
+        return urls
+    }
+
+    /// Read up to `maxTailBytes` from the end of `url`, returned as lines.
+    /// Returns nil only when the file cannot be opened at all.
+    private func readTail(of url: URL) -> [String]? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+
+        let size = (try? handle.seekToEnd()) ?? 0
+        let start = size > UInt64(configuration.maxTailBytes)
+            ? size - UInt64(configuration.maxTailBytes)
+            : 0
+        try? handle.seek(toOffset: start)
+        let data = (try? handle.readToEnd()) ?? Data()
+        guard let string = String(data: data, encoding: .utf8) else { return [] }
+        return string.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+    }
+
+    /// Canonicalize and validate the transcript's working directory.
+    private func resolveWorkingDirectory(_ raw: String?) -> (String?, WakeSkipReason?) {
+        guard let raw, !raw.isEmpty else { return (nil, .unknownWorkingDirectory) }
+        let canonical = URL(fileURLWithPath: raw).resolvingSymlinksInPath().path
+        var isDirectory: ObjCBool = false
+        let exists = configuration.fileManager.fileExists(atPath: canonical, isDirectory: &isDirectory)
+        if !exists || !isDirectory.boolValue {
+            return (canonical, .missingWorkingDirectory)
+        }
+        return (canonical, nil)
+    }
+}

--- a/MeterBar/SessionWake/TranscriptClassifier.swift
+++ b/MeterBar/SessionWake/TranscriptClassifier.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+/// The terminal state of a Claude Code transcript, derived from the *latest
+/// decisive event* rather than "does the file contain a rate-limit string".
+///
+/// A transcript that hit a limit and then made further progress is `.active`,
+/// not `.blocked` — the historical limit is stale. Only a limit that is the
+/// last decisive event makes a session eligible for wake.
+enum TranscriptState: Equatable, Sendable {
+    /// The last decisive event is a usage limit.
+    case blocked(reason: WakeBlockReason, blockedAt: Date, resetHint: TranscriptResetParser.Result?)
+    /// The last decisive event is successful assistant/tool activity.
+    case active(lastActivityAt: Date)
+    /// No decisive event was found (empty/metadata-only transcript).
+    case indeterminate
+}
+
+/// Metadata a classified transcript exposes to discovery.
+struct TranscriptSummary: Equatable, Sendable {
+    let sessionID: String
+    let cwd: String?
+    let gitBranch: String?
+    /// True when any decisive entry was a subagent/sidechain entry.
+    let isSidechain: Bool
+    let state: TranscriptState
+}
+
+/// Classifies raw JSONL transcript lines. Pure and side-effect free so it can
+/// run off the main actor and be exhaustively fixture-tested.
+enum TranscriptClassifier {
+    /// A single decoded transcript record, tolerant of the widely varying
+    /// Claude Code JSONL schema. Non-object or malformed lines are dropped by
+    /// the caller before reaching here.
+    private struct Record {
+        let type: String?
+        let timestamp: Date?
+        let isSidechain: Bool
+        let isApiError: Bool
+        let apiErrorStatus: Int?
+        let role: String?
+        let text: String
+        let sessionID: String?
+        let cwd: String?
+        let gitBranch: String?
+
+        init?(object: [String: Any]) {
+            self.type = object["type"] as? String
+            self.timestamp = (object["timestamp"] as? String).flatMap(Record.date(from:))
+            self.isSidechain = object["isSidechain"] as? Bool ?? false
+            self.isApiError = object["isApiErrorMessage"] as? Bool ?? false
+            self.apiErrorStatus = object["apiErrorStatus"] as? Int
+            self.sessionID = object["sessionId"] as? String
+            self.cwd = object["cwd"] as? String
+            self.gitBranch = object["gitBranch"] as? String
+
+            let message = object["message"] as? [String: Any]
+            self.role = message?["role"] as? String ?? object["role"] as? String
+            self.text = Record.extractText(from: message?["content"] ?? object["content"])
+        }
+
+        private static let isoFormatter: ISO8601DateFormatter = {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            return formatter
+        }()
+
+        private static let isoFormatterNoFraction: ISO8601DateFormatter = {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime]
+            return formatter
+        }()
+
+        static func date(from string: String) -> Date? {
+            isoFormatter.date(from: string) ?? isoFormatterNoFraction.date(from: string)
+        }
+
+        private static func extractText(from content: Any?) -> String {
+            if let string = content as? String { return string }
+            guard let blocks = content as? [[String: Any]] else { return "" }
+            return blocks.compactMap { $0["text"] as? String }.joined(separator: "\n")
+        }
+    }
+
+    /// Classify the ordered JSONL `lines` of one transcript.
+    static func classify(sessionID fallbackID: String, lines: [String]) -> TranscriptSummary {
+        var resolvedSessionID: String?
+        var cwd: String?
+        var gitBranch: String?
+        var sawSidechain = false
+
+        var lastDecisiveState: TranscriptState = .indeterminate
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty,
+                  let data = trimmed.data(using: .utf8),
+                  let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+                  let record = Record(object: object) else {
+                // Malformed/truncated JSONL must not crash or poison the scan.
+                continue
+            }
+
+            resolvedSessionID = resolvedSessionID ?? record.sessionID
+            if let recordCwd = record.cwd, !recordCwd.isEmpty { cwd = recordCwd }
+            if let branch = record.gitBranch, !branch.isEmpty { gitBranch = branch }
+            if record.isSidechain { sawSidechain = true }
+
+            guard let timestamp = record.timestamp else { continue }
+
+            if isBlockingEvent(record) {
+                let reason = WakeBlockReason.classify(messageText: record.text)
+                let resetHint = TranscriptResetParser.parse(
+                    messageText: record.text,
+                    eventTimestamp: timestamp
+                )
+                lastDecisiveState = .blocked(reason: reason, blockedAt: timestamp, resetHint: resetHint)
+            } else if isSuccessfulActivity(record) {
+                lastDecisiveState = .active(lastActivityAt: timestamp)
+            }
+        }
+
+        return TranscriptSummary(
+            sessionID: resolvedSessionID ?? fallbackID,
+            cwd: cwd,
+            gitBranch: gitBranch,
+            isSidechain: sawSidechain,
+            state: lastDecisiveState
+        )
+    }
+
+    /// A 429/limit assistant error is the only kind of blocking event.
+    private static func isBlockingEvent(_ record: Record) -> Bool {
+        guard record.isApiError else { return false }
+        if record.apiErrorStatus == 429 { return true }
+        // Some builds omit the status code; fall back to the message body.
+        let text = record.text.lowercased()
+        return text.contains("limit") && (text.contains("resets") || text.contains("usage") || text.contains("session"))
+    }
+
+    /// Real forward progress: a non-error assistant reply, or a tool result /
+    /// user turn that lands after a limit and therefore clears it.
+    private static func isSuccessfulActivity(_ record: Record) -> Bool {
+        if record.isApiError { return false }
+        switch record.type {
+        case "assistant":
+            return record.role == "assistant" || !record.text.isEmpty
+        case "user", "tool_result":
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/MeterBar/SessionWake/TranscriptResetParser.swift
+++ b/MeterBar/SessionWake/TranscriptResetParser.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Parses the human-readable reset hint embedded in a Claude rate-limit
+/// message ("resets 7:30am (Europe/Malta)") into an absolute instant.
+///
+/// The transcript never states a date, only a wall-clock time and (usually) an
+/// IANA timezone. This parser resolves that clock time to the occurrence
+/// *closest in time* to the rate-limit event, which is the only anchor we have.
+/// Choosing the nearest occurrence — rather than always rolling forward — is
+/// what keeps a "02:10 reset read at 02:15" from being mistaken for tomorrow
+/// (#96). The parser deliberately does **not** decide whether quota is
+/// available; a returned instant in the past means "already elapsed, re-check",
+/// never "proven available".
+enum TranscriptResetParser {
+    struct Result: Equatable, Sendable {
+        /// The absolute reset instant, anchored to the event timestamp.
+        let resetAt: Date
+        /// The timezone the transcript named, if any (nil ⇒ current zone used).
+        let timeZoneIdentifier: String?
+
+        /// Whether `resetAt` already elapsed relative to the anchoring event.
+        /// A past reset may schedule a refresh but can never prove availability.
+        func isElapsed(relativeTo reference: Date) -> Bool {
+            resetAt <= reference
+        }
+    }
+
+    // "resets 7:30am (Europe/Malta)" / "resets 2:10am" / "resets **2:10am ...**"
+    private static let pattern = try? NSRegularExpression(
+        pattern: #"resets\s*\**\s*(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*\**\s*(?:\(([^)]+)\))?"#,
+        options: [.caseInsensitive]
+    )
+
+    /// Parse `messageText`, anchoring the clock time to `eventTimestamp`.
+    ///
+    /// - Returns: the nearest absolute occurrence of the stated clock time, or
+    ///   nil when no reset hint is present.
+    static func parse(messageText: String, eventTimestamp: Date) -> Result? {
+        guard let pattern else { return nil }
+        let range = NSRange(messageText.startIndex..., in: messageText)
+        guard let match = pattern.firstMatch(in: messageText, range: range) else {
+            return nil
+        }
+
+        func group(_ index: Int) -> String? {
+            guard match.numberOfRanges > index,
+                  let r = Range(match.range(at: index), in: messageText) else {
+                return nil
+            }
+            return String(messageText[r])
+        }
+
+        guard let hourString = group(1), let rawHour = Int(hourString) else {
+            return nil
+        }
+        let minute = group(2).flatMap(Int.init) ?? 0
+        let meridiem = group(3)?.lowercased()
+        let tzIdentifier = group(4)?.trimmingCharacters(in: .whitespaces)
+
+        var hour = rawHour
+        if let meridiem {
+            if meridiem == "pm", hour < 12 { hour += 12 }
+            if meridiem == "am", hour == 12 { hour = 0 }
+        }
+        guard (0...23).contains(hour), (0...59).contains(minute) else {
+            return nil
+        }
+
+        let timeZone = tzIdentifier.flatMap(TimeZone.init(identifier:)) ?? .current
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+
+        // Build the clock time on the event's calendar day, then pick whichever
+        // of {yesterday, today, tomorrow} lands closest to the event instant.
+        var components = calendar.dateComponents([.year, .month, .day], from: eventTimestamp)
+        components.hour = hour
+        components.minute = minute
+        components.second = 0
+        guard let sameDay = calendar.date(from: components) else { return nil }
+
+        let candidates = [-1, 0, 1].compactMap {
+            calendar.date(byAdding: .day, value: $0, to: sameDay)
+        }
+        guard let nearest = candidates.min(by: {
+            abs($0.timeIntervalSince(eventTimestamp)) < abs($1.timeIntervalSince(eventTimestamp))
+        }) else {
+            return nil
+        }
+
+        return Result(resetAt: nearest, timeZoneIdentifier: tzIdentifier)
+    }
+}

--- a/MeterBar/SessionWake/WakeBlockReason.swift
+++ b/MeterBar/SessionWake/WakeBlockReason.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// A typed reason a Claude Code session stopped on a usage limit.
+///
+/// The transcript only ever spells the reason in prose ("session limit",
+/// "usage limit", "weekly limit"), so discovery maps that prose onto a closed
+/// set the rest of Session Wake can gate on without re-parsing strings.
+enum WakeBlockReason: String, Codable, Equatable, Sendable, CaseIterable {
+    /// The rolling 5-hour session window ("You've hit your session limit").
+    case sessionLimit
+    /// A generic usage limit that is not explicitly the weekly window.
+    case usageLimit
+    /// A weekly account-wide limit ("weekly limit").
+    case weeklyLimit
+    /// A model-specific weekly limit (e.g. Opus) called out separately.
+    case modelWeeklyLimit
+
+    /// Classify a rate-limit message body into a typed reason.
+    ///
+    /// Casing and surrounding markdown are ignored; the first specific phrase
+    /// wins so "opus weekly limit" is not collapsed into the generic weekly
+    /// case, and "weekly" is preferred over the plain "usage limit" fallback.
+    static func classify(messageText: String) -> WakeBlockReason {
+        let text = messageText.lowercased()
+        if text.contains("opus") && text.contains("weekly") {
+            return .modelWeeklyLimit
+        }
+        if text.contains("weekly limit") || text.contains("weekly usage") {
+            return .weeklyLimit
+        }
+        if text.contains("session limit") {
+            return .sessionLimit
+        }
+        return .usageLimit
+    }
+}

--- a/MeterBar/SessionWake/WakePaths.swift
+++ b/MeterBar/SessionWake/WakePaths.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Central resolver for Session Wake's private on-disk state.
+///
+/// Everything lives under one base directory created with `0700` so ledger and
+/// (later) log files inherit private permissions. The base is overridable so
+/// tests never touch the real Application Support tree.
+enum WakePaths {
+    /// Default base: `~/Library/Application Support/MeterBar/session-wake`.
+    static func defaultBaseDirectory() -> URL {
+        let support = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: "\(ServiceSupport.realHomeDirectory())/Library/Application Support")
+        return support
+            .appendingPathComponent("MeterBar", isDirectory: true)
+            .appendingPathComponent("session-wake", isDirectory: true)
+    }
+
+    /// Ensure `directory` exists with private (`0700`) permissions.
+    @discardableResult
+    static func ensurePrivateDirectory(_ directory: URL) throws -> URL {
+        let fileManager = FileManager.default
+        if !fileManager.fileExists(atPath: directory.path) {
+            try fileManager.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+        } else {
+            try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+        }
+        return directory
+    }
+}

--- a/MeterBar/SessionWake/WakeSession.swift
+++ b/MeterBar/SessionWake/WakeSession.swift
@@ -1,0 +1,57 @@
+import CryptoKit
+import Foundation
+
+/// A deterministic identity for a single blocking event, used to guarantee a
+/// handled block is never resumed twice (even across app relaunch).
+///
+/// It intentionally keys on the *event* (session + block instant + reason), not
+/// the file, so re-scanning the same transcript yields the same fingerprint,
+/// while a genuinely new block later in the same session produces a new one.
+struct BlockFingerprint: Codable, Equatable, Hashable, Sendable {
+    let value: String
+
+    init(sessionID: String, blockedAt: Date, reason: WakeBlockReason) {
+        // Second precision: the same event re-read must hash identically.
+        let epochSecond = Int(blockedAt.timeIntervalSince1970.rounded())
+        let seed = "\(sessionID)|\(epochSecond)|\(reason.rawValue)"
+        let digest = SHA256.hash(data: Data(seed.utf8))
+        self.value = digest.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+/// Why a discovered candidate cannot be executed as-is.
+enum WakeSkipReason: String, Codable, Equatable, Sendable {
+    /// The transcript's resolved cwd no longer exists (deleted worktree).
+    case missingWorkingDirectory
+    /// The transcript never recorded a working directory.
+    case unknownWorkingDirectory
+    /// This block fingerprint was already handled (replay ledger hit).
+    case alreadyHandled
+    /// The transcript belongs to a subagent/sidechain.
+    case subagent
+}
+
+/// A blocked Claude Code session that Session Wake could resume.
+///
+/// `skipReason == nil` means the candidate is executable; a non-nil reason
+/// means it is preview-only and must never be launched. Discovery records the
+/// reason rather than silently dropping the candidate so the UI/CLI can explain
+/// why a visible blocked session was not resumed.
+struct WakeSessionCandidate: Equatable, Sendable, Identifiable {
+    let sessionID: String
+    let transcriptPath: String
+    /// Canonicalized (symlinks resolved) working directory, if resolvable.
+    let workingDirectory: String?
+    let gitBranch: String?
+    let reason: WakeBlockReason
+    let blockedAt: Date
+    /// Absolute reset instant parsed from the transcript, anchored to the event.
+    let resetHint: TranscriptResetParser.Result?
+    let fingerprint: BlockFingerprint
+    let skipReason: WakeSkipReason?
+
+    var id: String { fingerprint.value }
+
+    /// True only when the candidate is safe to hand to the runner.
+    var isExecutable: Bool { skipReason == nil }
+}

--- a/MeterBarTests/SessionWakeDiscoveryTests.swift
+++ b/MeterBarTests/SessionWakeDiscoveryTests.swift
@@ -1,0 +1,336 @@
+import XCTest
+@testable import MeterBar
+
+/// Coverage for #95: native discovery, terminal-state classification, and the
+/// replay ledger. Fixtures mirror the real Claude Code JSONL schema
+/// (`type:"assistant"`, `isApiErrorMessage:true`, `apiErrorStatus:429`,
+/// `message.content[].text`).
+final class SessionWakeDiscoveryTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SessionWakeTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    // MARK: - Fixture builders
+
+    private func ts(_ iso: String) -> String { iso }
+
+    private func assistantText(_ text: String, timestamp: String, cwd: String, sidechain: Bool = false) -> String {
+        let object: [String: Any] = [
+            "type": "assistant",
+            "timestamp": timestamp,
+            "isSidechain": sidechain,
+            "cwd": cwd,
+            "sessionId": "s",
+            "gitBranch": "main",
+            "message": ["role": "assistant", "content": [["type": "text", "text": text]]]
+        ]
+        return jsonLine(object)
+    }
+
+    private func rateLimit(_ text: String, timestamp: String, cwd: String, status: Int = 429, sidechain: Bool = false) -> String {
+        let object: [String: Any] = [
+            "type": "assistant",
+            "timestamp": timestamp,
+            "isApiErrorMessage": true,
+            "apiErrorStatus": status,
+            "isSidechain": sidechain,
+            "cwd": cwd,
+            "sessionId": "s",
+            "gitBranch": "main",
+            "message": ["role": "assistant", "content": [["type": "text", "text": text]]]
+        ]
+        return jsonLine(object)
+    }
+
+    private func jsonLine(_ object: [String: Any]) -> String {
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return String(data: data, encoding: .utf8)!
+    }
+
+    @discardableResult
+    private func writeTranscript(
+        account: String = "acct",
+        project: String = "-Users-me-proj",
+        session: String = "session-a",
+        lines: [String]
+    ) throws -> URL {
+        let dir = tempDir
+            .appendingPathComponent(account)
+            .appendingPathComponent("projects")
+            .appendingPathComponent(project)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("\(session).jsonl")
+        try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private func accountConfigDir(_ account: String = "acct") -> String {
+        tempDir.appendingPathComponent(account).path
+    }
+
+    // MARK: - Classifier: latest-decisive-event
+
+    func testHistoricalRateLimitFollowedByProgressIsNotBlocked() {
+        let cwd = tempDir.path
+        let lines = [
+            rateLimit("You've hit your session limit · resets 2:10am (UTC)", timestamp: "2026-07-10T02:00:00.000Z", cwd: cwd),
+            assistantText("Resumed work and finished the task.", timestamp: "2026-07-10T03:30:00.000Z", cwd: cwd)
+        ]
+        let summary = TranscriptClassifier.classify(sessionID: "s", lines: lines)
+        if case .active = summary.state {} else {
+            XCTFail("Expected active after later progress, got \(summary.state)")
+        }
+    }
+
+    func testLatestEventBlockedIsBlocked() {
+        let cwd = tempDir.path
+        let lines = [
+            assistantText("Working…", timestamp: "2026-07-10T01:00:00.000Z", cwd: cwd),
+            rateLimit("You've hit your session limit · resets 7:30am (Europe/Malta)", timestamp: "2026-07-10T02:00:00.000Z", cwd: cwd)
+        ]
+        let summary = TranscriptClassifier.classify(sessionID: "s", lines: lines)
+        guard case let .blocked(reason, _, _) = summary.state else {
+            return XCTFail("Expected blocked, got \(summary.state)")
+        }
+        XCTAssertEqual(reason, .sessionLimit)
+    }
+
+    func testCasingAndMarkdownVariantsClassify() {
+        let cwd = tempDir.path
+        let variants = [
+            "You've hit your session limit · resets **2:10am (Europe/Malta)**",
+            "you've hit your USAGE LIMIT · resets 2:30am",
+            "Claude AI usage limit reached · resets 9:00pm (America/New_York)"
+        ]
+        for text in variants {
+            let summary = TranscriptClassifier.classify(
+                sessionID: "s",
+                lines: [rateLimit(text, timestamp: "2026-07-10T00:00:00.000Z", cwd: cwd)]
+            )
+            guard case .blocked = summary.state else {
+                return XCTFail("Variant not classified as blocked: \(text)")
+            }
+        }
+    }
+
+    func testWeeklyAndModelWeeklyReasons() {
+        XCTAssertEqual(WakeBlockReason.classify(messageText: "You've hit your weekly limit"), .weeklyLimit)
+        XCTAssertEqual(WakeBlockReason.classify(messageText: "Opus weekly limit reached"), .modelWeeklyLimit)
+        XCTAssertEqual(WakeBlockReason.classify(messageText: "session limit"), .sessionLimit)
+        XCTAssertEqual(WakeBlockReason.classify(messageText: "some other limit"), .usageLimit)
+    }
+
+    func testMissingStatusCodeFallsBackToMessageBody() {
+        let object: [String: Any] = [
+            "type": "assistant",
+            "timestamp": "2026-07-10T00:00:00.000Z",
+            "isApiErrorMessage": true,
+            "cwd": tempDir.path,
+            "sessionId": "s",
+            "message": ["role": "assistant", "content": [["type": "text", "text": "usage limit reached, resets 1:00am"]]]
+        ]
+        let summary = TranscriptClassifier.classify(sessionID: "s", lines: [jsonLine(object)])
+        guard case .blocked = summary.state else {
+            return XCTFail("Expected blocked from message body, got \(summary.state)")
+        }
+    }
+
+    func testMalformedAndTruncatedLinesDoNotCrash() {
+        let cwd = tempDir.path
+        let lines = [
+            "{not valid json",
+            "",
+            "[1,2,3]",
+            "\"a bare string\"",
+            rateLimit("You've hit your session limit · resets 2:10am (UTC)", timestamp: "2026-07-10T02:00:00.000Z", cwd: cwd),
+            "{\"type\":\"assistant\",\"timestamp\":\"broken" // truncated final line
+        ]
+        let summary = TranscriptClassifier.classify(sessionID: "s", lines: lines)
+        guard case .blocked = summary.state else {
+            return XCTFail("Expected blocked despite malformed lines, got \(summary.state)")
+        }
+    }
+
+    // MARK: - Reset parser
+
+    func testResetJustPassedDoesNotRollToTomorrow() throws {
+        // "02:10 reset read at 02:15" must resolve to today 02:10, not tomorrow.
+        let event = ISO8601DateFormatter().date(from: "2026-07-10T02:15:00Z")!
+        let result = try XCTUnwrap(TranscriptResetParser.parse(
+            messageText: "You've hit your session limit · resets 2:10am (UTC)",
+            eventTimestamp: event
+        ))
+        XCTAssertEqual(result.resetAt.timeIntervalSince1970, event.timeIntervalSince1970 - 300, accuracy: 1)
+        XCTAssertTrue(result.isElapsed(relativeTo: event))
+    }
+
+    func testResetPicksNearestOccurrenceAcrossMidnight() throws {
+        let event = ISO8601DateFormatter().date(from: "2026-07-10T23:50:00Z")!
+        let result = try XCTUnwrap(TranscriptResetParser.parse(
+            messageText: "resets 0:30am (UTC)",
+            eventTimestamp: event
+        ))
+        // Nearest 00:30 occurrence is 40 minutes in the future (next day).
+        XCTAssertEqual(result.resetAt.timeIntervalSince1970, event.timeIntervalSince1970 + 2_400, accuracy: 1)
+        XCTAssertFalse(result.isElapsed(relativeTo: event))
+    }
+
+    func testResetHandlesPMandNoHint() throws {
+        let event = ISO8601DateFormatter().date(from: "2026-07-10T10:00:00Z")!
+        let pm = try XCTUnwrap(TranscriptResetParser.parse(messageText: "resets 9:00pm (UTC)", eventTimestamp: event))
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        XCTAssertEqual(calendar.component(.hour, from: pm.resetAt), 21)
+        XCTAssertNil(TranscriptResetParser.parse(messageText: "no reset hint here", eventTimestamp: event))
+    }
+
+    // MARK: - Discovery
+
+    func testDiscoversExecutableBlockedSession() async throws {
+        let cwd = tempDir.path // an existing directory ⇒ executable
+        try writeTranscript(lines: [
+            rateLimit("You've hit your session limit · resets 2:10am (UTC)", timestamp: "2026-07-10T02:00:00.000Z", cwd: cwd)
+        ])
+        let discovery = SessionDiscovery()
+        let ledger = ReplayLedger(fileURL: tempDir.appendingPathComponent("ledger.json"))
+        let candidates = await discovery.discover(configDirectory: accountConfigDir(), ledger: ledger)
+        XCTAssertEqual(candidates.count, 1)
+        let candidate = try XCTUnwrap(candidates.first)
+        XCTAssertTrue(candidate.isExecutable)
+        XCTAssertEqual(candidate.workingDirectory, cwd)
+        XCTAssertEqual(candidate.reason, .sessionLimit)
+    }
+
+    func testSubagentTranscriptsExcluded() async throws {
+        let cwd = tempDir.path
+        try writeTranscript(session: "subagent", lines: [
+            rateLimit("You've hit your session limit · resets 2:10am (UTC)", timestamp: "2026-07-10T02:00:00.000Z", cwd: cwd, sidechain: true)
+        ])
+        let discovery = SessionDiscovery()
+        let ledger = ReplayLedger(fileURL: tempDir.appendingPathComponent("ledger.json"))
+        let candidates = await discovery.discover(configDirectory: accountConfigDir(), ledger: ledger)
+        XCTAssertTrue(candidates.isEmpty)
+    }
+
+    func testDeadWorktreeRecordsSkipNotExecutable() async throws {
+        let deadCwd = tempDir.appendingPathComponent("deleted-worktree").path
+        try writeTranscript(lines: [
+            rateLimit("You've hit your session limit · resets 2:10am (UTC)", timestamp: "2026-07-10T02:00:00.000Z", cwd: deadCwd)
+        ])
+        let discovery = SessionDiscovery()
+        let ledger = ReplayLedger(fileURL: tempDir.appendingPathComponent("ledger.json"))
+        let candidates = await discovery.discover(configDirectory: accountConfigDir(), ledger: ledger)
+        let candidate = try XCTUnwrap(candidates.first)
+        XCTAssertFalse(candidate.isExecutable)
+        XCTAssertEqual(candidate.skipReason, .missingWorkingDirectory)
+    }
+
+    func testMissingCwdMetadataRecordsUnknownSkip() async throws {
+        let object: [String: Any] = [
+            "type": "assistant",
+            "timestamp": "2026-07-10T02:00:00.000Z",
+            "isApiErrorMessage": true,
+            "apiErrorStatus": 429,
+            "sessionId": "s",
+            "message": ["role": "assistant", "content": [["type": "text", "text": "session limit, resets 2:10am (UTC)"]]]
+        ]
+        try writeTranscript(lines: [jsonLine(object)])
+        let discovery = SessionDiscovery()
+        let ledger = ReplayLedger(fileURL: tempDir.appendingPathComponent("ledger.json"))
+        let candidates = await discovery.discover(configDirectory: accountConfigDir(), ledger: ledger)
+        let candidate = try XCTUnwrap(candidates.first)
+        XCTAssertEqual(candidate.skipReason, .unknownWorkingDirectory)
+    }
+
+    func testDuplicateSessionKeepsNewestBlock() async throws {
+        let cwd = tempDir.path
+        try writeTranscript(lines: [
+            rateLimit("session limit resets 1:00am (UTC)", timestamp: "2026-07-10T01:00:00.000Z", cwd: cwd),
+            assistantText("progress", timestamp: "2026-07-10T01:30:00.000Z", cwd: cwd),
+            rateLimit("session limit resets 3:00am (UTC)", timestamp: "2026-07-10T02:30:00.000Z", cwd: cwd)
+        ])
+        let discovery = SessionDiscovery()
+        let ledger = ReplayLedger(fileURL: tempDir.appendingPathComponent("ledger.json"))
+        let candidates = await discovery.discover(configDirectory: accountConfigDir(), ledger: ledger)
+        XCTAssertEqual(candidates.count, 1)
+        let blockedAt = try XCTUnwrap(candidates.first?.blockedAt)
+        XCTAssertEqual(
+            blockedAt.timeIntervalSince1970,
+            ISO8601DateFormatter().date(from: "2026-07-10T02:30:00Z")!.timeIntervalSince1970,
+            accuracy: 1
+        )
+    }
+
+    func testAccountScopedDiscoveryNeverReadsOtherAccount() async throws {
+        let cwd = tempDir.path
+        try writeTranscript(account: "acct", lines: [
+            rateLimit("session limit resets 2:10am (UTC)", timestamp: "2026-07-10T02:00:00.000Z", cwd: cwd)
+        ])
+        try writeTranscript(account: "other", session: "session-b", lines: [
+            rateLimit("session limit resets 2:10am (UTC)", timestamp: "2026-07-10T02:00:00.000Z", cwd: cwd)
+        ])
+        let discovery = SessionDiscovery()
+        let ledger = ReplayLedger(fileURL: tempDir.appendingPathComponent("ledger.json"))
+        let candidates = await discovery.discover(configDirectory: accountConfigDir("acct"), ledger: ledger)
+        XCTAssertEqual(candidates.count, 1)
+    }
+
+    func testActiveSessionProducesNoCandidate() async throws {
+        let cwd = tempDir.path
+        try writeTranscript(lines: [
+            assistantText("all good", timestamp: "2026-07-10T02:00:00.000Z", cwd: cwd)
+        ])
+        let discovery = SessionDiscovery()
+        let ledger = ReplayLedger(fileURL: tempDir.appendingPathComponent("ledger.json"))
+        let candidates = await discovery.discover(configDirectory: accountConfigDir(), ledger: ledger)
+        XCTAssertTrue(candidates.isEmpty)
+    }
+
+    // MARK: - Replay ledger
+
+    func testHandledFingerprintNotRediscoveredAfterRelaunch() async throws {
+        let cwd = tempDir.path
+        try writeTranscript(lines: [
+            rateLimit("session limit resets 2:10am (UTC)", timestamp: "2026-07-10T02:00:00.000Z", cwd: cwd)
+        ])
+        let ledgerURL = tempDir.appendingPathComponent("ledger.json")
+        let discovery = SessionDiscovery()
+
+        let firstLedger = ReplayLedger(fileURL: ledgerURL)
+        let first = await discovery.discover(configDirectory: accountConfigDir(), ledger: firstLedger)
+        let fingerprint = try XCTUnwrap(first.first?.fingerprint)
+        await firstLedger.record(fingerprint)
+
+        // Simulate relaunch with a fresh ledger instance reading the same file.
+        let secondLedger = ReplayLedger(fileURL: ledgerURL)
+        let second = await discovery.discover(configDirectory: accountConfigDir(), ledger: secondLedger)
+        XCTAssertEqual(second.first?.skipReason, .alreadyHandled)
+        XCTAssertFalse(second.first?.isExecutable ?? true)
+    }
+
+    func testLedgerFingerprintIsStableForSameEvent() {
+        let at = ISO8601DateFormatter().date(from: "2026-07-10T02:00:00Z")!
+        let a = BlockFingerprint(sessionID: "s", blockedAt: at, reason: .sessionLimit)
+        let b = BlockFingerprint(sessionID: "s", blockedAt: at, reason: .sessionLimit)
+        let c = BlockFingerprint(sessionID: "s", blockedAt: at.addingTimeInterval(3_600), reason: .sessionLimit)
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+    }
+
+    func testCorruptLedgerFailsSafeToEmpty() async throws {
+        let ledgerURL = tempDir.appendingPathComponent("ledger.json")
+        try Data("not json".utf8).write(to: ledgerURL)
+        let ledger = ReplayLedger(fileURL: ledgerURL)
+        let fingerprint = BlockFingerprint(sessionID: "s", blockedAt: Date(), reason: .sessionLimit)
+        let contained = await ledger.contains(fingerprint)
+        XCTAssertFalse(contained)
+    }
+}


### PR DESCRIPTION
First of the stacked Session Wake PRs (epic #94, gate lifted with maintainer approval after signing blocker #47 closed). Closes #95.

## What
Native Swift discovery for blocked Claude Code sessions. Strictly preview-safe — reads transcript tails and the filesystem only; no subprocess, no transcript write, no lock mutation, never reads a non-selected account.

- **TranscriptClassifier** — *latest-decisive-event* semantics: a historical rate-limit followed by later assistant/tool activity is `active`, not blocked. Tolerant of malformed/truncated JSONL.
- **TranscriptResetParser** — resolves `resets 2:10am (Europe/Malta)` to the nearest absolute occurrence anchored to the event timestamp, so a just-elapsed reset never rolls to tomorrow; it never proves availability (that gate is #96).
- **WakeBlockReason** — typed session / usage / weekly / model-weekly.
- **SessionDiscovery** (actor) — account-scoped scan of `projects/*.jsonl`, bounded off-main tail read, subagent exclusion, session-ID dedup, cwd canonicalization, structured dead-worktree skip.
- **BlockFingerprint + ReplayLedger** — per-event fingerprint persisted `0600`; a handled block is never rediscovered after relaunch; corrupt ledger fails safe to empty.

Fixtures mirror the real Claude Code JSONL schema (`type:"assistant"`, `isApiErrorMessage:true`, `apiErrorStatus:429`, `message.content[].text`).

## Acceptance criteria (#95)
- [x] Historical rate-limit + later success ⇒ not blocked
- [x] Handled fingerprint not rediscovered after relaunch
- [x] Both rate-limit shapes + casing/markdown variants have fixtures
- [x] Subagent transcripts excluded
- [x] Malformed/truncated JSONL cannot crash the scan
- [x] Missing/deleted worktree ⇒ structured skip, not executable
- [x] Account-scoped; never reads another account
- [x] Dry-run/preview performs zero subprocess/filesystem mutation
- [x] Tests cover duplicates, stale, missing metadata, dead cwd, later recovery

## Tests
19 new tests; full suite 388 passing. SwiftLint --strict clean on production sources.

## Stack
Part of #95 → #96 → #97 → #98 → #99, merged sequentially. This is the base; subsequent PRs build the quota gate, runner, UI, and CLI on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the foundation for Session Wake, which detects blocked Claude Code sessions and identifies resumable sessions.
  * Added support for recognizing usage, weekly, session, and model-specific limits, including reset times.
  * Added secure local tracking to prevent previously handled sessions from being replayed.
  * Added account-scoped discovery, duplicate-session handling, and safeguards for invalid or sidechain sessions.
  * Added centralized logging for Session Wake activity.

* **Tests**
  * Added comprehensive coverage for transcript parsing, discovery, reset timing, account isolation, and replay prevention.

* **Documentation**
  * Added product requirements for Session Wake automation, controls, notifications, CLI behavior, and rollout milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->