### PR TITLE
feat(session-wake): fresh quota gate + cancellable watcher state machine (#96)

### DIFF
--- a/.agents/SESSIONS/2026-07-10.md
+++ b/.agents/SESSIONS/2026-07-10.md
@@ -66,3 +66,57 @@
 **Follow-ups:**
 - The Homebrew cask's uninstall/zap entries reference the old bundle id and app-group paths - update with the v1.6.2 release.
 - Old `group.dev.shipshit.meterbar` container and `dev.shipshit.meterbar` LaunchAgent/notification grants are orphaned on existing installs; users re-grant notifications once.
+
+## Session 4: Issue #96 — Fresh quota gate + cancellable watcher state machine
+
+**Status:** Complete (implementation), draft PR stacked on #95.
+
+**Coordination note (important):** #96 was implemented while a concurrent agent
+was actively building #95 (discovery/ledger) + #98 (UI scaffolding) on branch
+`session-wake/95-discovery`, uncommitted, in the primary checkout. #95 owns the
+canonical `WakeBlockReason`, `WakeSessionCandidate`, `SessionDiscovery`,
+`ReplayLedger`, and `TranscriptResetParser`; its `SessionWakeCoordinator` is a
+UI seam that explicitly *stubs* the real coordinator "once #95–#97 land". #96 is
+exactly that real coordinator. Per maintainer direction (asked + answered), #96
+was built in its own worktree by **snapshotting** #95's discovery/ledger core as
+a base and implementing on top, consuming #95's real types. The snapshot is base
+material to be dropped on rebase once #95 lands on master (delivery order
+#95 -> #96 -> #97 still holds; #96 cannot merge before #95).
+
+**What was built (#96, `MeterBar/SessionWake/`):**
+- `WakeQuotaState` / `WakeQuotaAuthority` — account-scoped quota authority that
+  **fails closed**: unauthorized/failed/stale/ambiguous quota all resolve to
+  `unknown` and launch nothing. Gates every hard window (session, weekly,
+  model-weekly); an exhausted weekly/model cap blocks even when the 5h window is
+  open; blocked reports the farthest reset (unknown reset dominates). Every gate
+  is a *fresh* fetch — cached UI metrics are never authority.
+- `WakeBounds` — validated numeric bounds (poll/buffer/gap/timeout/maxTurns/
+  sessionCap), clamped at init; non-finite -> lower bound; `sessionCap` is finite
+  by construction (epic #94: "unlimited is never the default", overriding the
+  PRD's "0 = all").
+- `WakeWatcherState` + `WakeCoordinator` (actor) — the single cancellable
+  structured task. States: off/armed/scanning/waiting/quotaUnknown/running/
+  stopping/completed/failed. Re-fetches quota before every launch and after
+  every completed attempt; preserves the remaining queue and returns to waiting
+  when quota re-maxes; `stop()` cancels pending sleep/run work and awaits the
+  loop's deterministic unwind.
+- `WakeAutomationSeams` — runner/candidate-source/ledger/sleeper protocols +
+  adapters over #95's `SessionDiscovery`/`ReplayLedger`. Runner + process
+  locking are #97; UI is #98.
+- Active-child cancellation + v1 lifetime (app-running-only) decided and
+  recorded in DECISIONS **ADR-010**.
+
+**Verification:**
+- 407 tests pass (33 new across bounds, quota authority, reset behavior at the
+  gate, seams, and the coordinator state machine). `swiftlint lint --strict`
+  clean (incl. a force-unwrap fixed in the snapshotted `SessionDiscovery`).
+- #96 new-code line coverage 88.5% (every new file >= 84.7%); CI coverage floor
+  (19%) satisfied at 36.6% overall.
+- Runner spawn/quota-CLI spawn paths are the injected seams (#97 territory) and
+  are exercised via fakes rather than real subprocesses.
+
+**Follow-ups / integration:**
+- Rebase onto the real #95 branch once it lands; drop the snapshot base commit.
+- #97 provides the safe process runner (`WakeSessionRunning`), locking, and
+  private logging; #98 wires `WakeCoordinator` under its `SessionWakeCoordinator`
+  UI seam and the account selection.

--- a/.agents/SYSTEM/architecture/DECISIONS.md
+++ b/.agents/SYSTEM/architecture/DECISIONS.md
@@ -284,4 +284,81 @@ Cache usage metrics in UserDefaults:
 
 ---
 
+### ADR-010: Session Wake watcher lifetime and active-child cancellation (v1)
+
+**Date:** 2026-07-10
+**Status:** Accepted
+**Issue:** #96 (Session Wake — Fresh quota gate and cancellable watcher state machine)
+
+#### Context
+
+Session Wake needs a long-lived component that waits for a quota reset and then
+resumes blocked Claude Code sessions. #96 requires an explicit, tested decision
+for the watcher's lifetime (app-running-only vs. a managed background helper)
+covering sleep/wake, app quit, crash, and relaunch — plus what happens to a
+child `claude` session that is mid-run when the user turns the watcher off.
+
+#### Decision
+
+**Lifetime: app-running-only. No managed helper (no launchd/XPC daemon) in v1.**
+
+The watcher is a single cancellable structured `Task` owned by the
+`WakeCoordinator` actor, tied to the app process lifetime:
+
+- **Quit / crash:** the task dies with the app. Nothing resumes while MeterBar
+  is not running. This is intentional — a background daemon that resumes agent
+  sessions unattended is a larger security/permissions surface than v1 accepts
+  (permission bypass, private logging, and the mutual-exclusion protocol are
+  #97 concerns). The legacy launchd watcher stays paused; it is not replaced by
+  a new daemon here.
+- **Relaunch:** the coordinator starts in `.off`. Re-arming is an explicit user
+  action (persisted "Wake Watcher" intent lives in #98's settings store). #95's
+  replay ledger guarantees a block already handled before the quit is not
+  resumed again after relaunch.
+- **Sleep / wake:** waits are driven in poll-interval-bounded chunks against a
+  wall-clock deadline, and **every** launch is gated on a *fresh* quota fetch.
+  A timer that is paused across system sleep therefore costs at most one extra
+  poll cycle; the watcher never launches on a stale timer — it re-proves quota
+  on wake.
+
+**Active-child cancellation: cooperative-cancel, preserve, never record.**
+
+When the watcher is turned off while a child session is running:
+
+- The structured task is cancelled; the runner (#97) receives cooperative
+  cancellation and terminates the child within a bounded grace, returning
+  `.interrupted`.
+- The in-flight candidate is **not** consumed: it stays at the front of the
+  preserved queue and its block fingerprint is **not** written to the replay
+  ledger, so a later armed run can retry it.
+- `stop()` awaits the task's full unwind before reporting `.off`, so "watcher
+  off" is deterministic rather than best-effort.
+
+#### Consequences
+
+- **Easier:** no signing/entitlement surface for a helper; no daemon lifecycle
+  to manage; cancellation is deterministic and unit-testable with fakes.
+- **Easier:** fail-closed by construction — missing/stale/ambiguous quota and a
+  passed reset all launch nothing.
+- **More difficult:** no overnight resume when the Mac is fully asleep or the
+  app is quit. Documented as a v1 limitation; a managed helper is a possible
+  v2 follow-up.
+- **More difficult:** interrupting a child mid-turn may leave that session's
+  work partially done; it is retried from its last transcript state, not from a
+  checkpoint.
+
+#### Alternatives Considered
+
+- **launchd/XPC managed helper (rejected for v1):** enables resume while the app
+  is closed, but multiplies the signing, permission-bypass, and private-logging
+  surface the epic defers to later issues; the legacy launchd watcher is being
+  retired, not re-created.
+- **Let the active child finish on watcher-off (rejected):** makes "off" mean
+  "off after the current session," which is surprising for a kill switch and
+  leaves a subprocess running unbounded after the user opted out.
+- **Force-kill without preserving the candidate (rejected):** would either drop
+  the work or, if recorded as handled, silently skip it on the next run.
+
+---
+
 <!-- Add new ADRs above this line -->

--- a/MeterBar/Services/AppLog.swift
+++ b/MeterBar/Services/AppLog.swift
@@ -14,4 +14,5 @@ enum AppLog {
     static let usage = Logger(subsystem: subsystem, category: "usage")
     static let cost = Logger(subsystem: subsystem, category: "cost")
     static let storage = Logger(subsystem: subsystem, category: "storage")
+    static let wake = Logger(subsystem: subsystem, category: "wake")
 }

--- a/MeterBar/SessionWake/ReplayLedger.swift
+++ b/MeterBar/SessionWake/ReplayLedger.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Durable record of handled block fingerprints so a resumed session is never
 /// rediscovered and resumed again after the app relaunches.

--- a/MeterBar/SessionWake/ReplayLedger.swift
+++ b/MeterBar/SessionWake/ReplayLedger.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Durable record of handled block fingerprints so a resumed session is never
+/// rediscovered and resumed again after the app relaunches.
+///
+/// Backed by a single JSON file written atomically with `0600` permissions.
+/// An unreadable or corrupt ledger fails safe to *empty* (nothing handled yet)
+/// rather than throwing — a lost ledger should at worst allow one redundant
+/// resume, never crash discovery.
+actor ReplayLedger {
+    private let fileURL: URL
+    private var handled: Set<String>
+    private var loaded = false
+
+    /// - Parameter fileURL: ledger location; defaults to the private base dir.
+    init(fileURL: URL? = nil) {
+        self.fileURL = fileURL
+            ?? WakePaths.defaultBaseDirectory().appendingPathComponent("replay-ledger.json")
+        self.handled = []
+    }
+
+    /// Whether this block was already handled in a previous or current run.
+    func contains(_ fingerprint: BlockFingerprint) -> Bool {
+        loadIfNeeded()
+        return handled.contains(fingerprint.value)
+    }
+
+    /// Mark a block fingerprint as handled and persist immediately.
+    func record(_ fingerprint: BlockFingerprint) {
+        loadIfNeeded()
+        guard handled.insert(fingerprint.value).inserted else { return }
+        persist()
+    }
+
+    /// Test/diagnostic accessor for the current handled count.
+    func count() -> Int {
+        loadIfNeeded()
+        return handled.count
+    }
+
+    private func loadIfNeeded() {
+        guard !loaded else { return }
+        loaded = true
+        guard let data = try? Data(contentsOf: fileURL),
+              let stored = try? JSONDecoder().decode([String].self, from: data) else {
+            handled = []
+            return
+        }
+        handled = Set(stored)
+    }
+
+    private func persist() {
+        do {
+            try WakePaths.ensurePrivateDirectory(fileURL.deletingLastPathComponent())
+            let data = try JSONEncoder().encode(handled.sorted())
+            try data.write(to: fileURL, options: .atomic)
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: fileURL.path
+            )
+        } catch {
+            AppLog.wake.error("Failed to persist replay ledger: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/MeterBar/SessionWake/SessionDiscovery.swift
+++ b/MeterBar/SessionWake/SessionDiscovery.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+/// Read-only discovery of blocked Claude Code sessions for the selected account.
+///
+/// Discovery is strictly preview-safe: it only reads transcript tails and the
+/// filesystem. It performs no subprocess, no transcript write, no lock
+/// mutation, and never reads a directory other than the selected account's.
+/// All work runs on this actor, off the main actor, with a bounded tail read
+/// per transcript so a huge history cannot stall the scan.
+actor SessionDiscovery {
+    struct Configuration {
+        /// Bytes read from the end of each transcript. The decisive tail of a
+        /// session is always near the end, so a bounded window is sufficient
+        /// and keeps scanning incremental.
+        var maxTailBytes: Int = 64 * 1024
+        var fileManager: FileManager = .default
+
+        init(maxTailBytes: Int = 64 * 1024, fileManager: FileManager = .default) {
+            self.maxTailBytes = maxTailBytes
+            self.fileManager = fileManager
+        }
+    }
+
+    private let configuration: Configuration
+
+    init(configuration: Configuration = Configuration()) {
+        self.configuration = configuration
+    }
+
+    /// The `projects` root for an account, honoring an explicit
+    /// `CLAUDE_CONFIG_DIR` override and otherwise `~/.claude`.
+    static func projectsDirectory(configDirectory: String?) -> URL {
+        let trimmed = configDirectory?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let base: String
+        if let trimmed, !trimmed.isEmpty {
+            base = trimmed
+        } else {
+            base = "\(ServiceSupport.realHomeDirectory())/.claude"
+        }
+        return URL(fileURLWithPath: base, isDirectory: true)
+            .appendingPathComponent("projects", isDirectory: true)
+    }
+
+    /// Discover blocked sessions for `configDirectory`, consulting `ledger` to
+    /// flag already-handled blocks. Subagent transcripts are excluded outright.
+    ///
+    /// - Returns: one executable-or-skip candidate per unique session, newest
+    ///   block first.
+    func discover(configDirectory: String?, ledger: ReplayLedger) async -> [WakeSessionCandidate] {
+        let projects = SessionDiscovery.projectsDirectory(configDirectory: configDirectory)
+        let transcripts = transcriptURLs(under: projects)
+
+        // Keep the newest block per sessionID (a resumed session can re-block).
+        var bySession: [String: WakeSessionCandidate] = [:]
+
+        for url in transcripts {
+            guard let lines = readTail(of: url) else { continue }
+            let fallbackID = url.deletingPathExtension().lastPathComponent
+            let summary = TranscriptClassifier.classify(sessionID: fallbackID, lines: lines)
+
+            // Subagent transcripts are never resume targets.
+            if summary.isSidechain { continue }
+
+            guard case let .blocked(reason, blockedAt, resetHint) = summary.state else { continue }
+
+            let fingerprint = BlockFingerprint(
+                sessionID: summary.sessionID,
+                blockedAt: blockedAt,
+                reason: reason
+            )
+            let (canonicalCwd, cwdSkip) = resolveWorkingDirectory(summary.cwd)
+            let alreadyHandled = await ledger.contains(fingerprint)
+
+            let skip: WakeSkipReason? = alreadyHandled ? .alreadyHandled : cwdSkip
+
+            let candidate = WakeSessionCandidate(
+                sessionID: summary.sessionID,
+                transcriptPath: url.path,
+                workingDirectory: canonicalCwd,
+                gitBranch: summary.gitBranch,
+                reason: reason,
+                blockedAt: blockedAt,
+                resetHint: resetHint,
+                fingerprint: fingerprint,
+                skipReason: skip
+            )
+
+            if let existing = bySession[summary.sessionID], existing.blockedAt >= blockedAt {
+                continue
+            }
+            bySession[summary.sessionID] = candidate
+        }
+
+        return bySession.values.sorted { $0.blockedAt > $1.blockedAt }
+    }
+
+    // MARK: - Filesystem
+
+    private func transcriptURLs(under projects: URL) -> [URL] {
+        guard let enumerator = configuration.fileManager.enumerator(
+            at: projects,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+        var urls: [URL] = []
+        for case let url as URL in enumerator where url.pathExtension == "jsonl" {
+            urls.append(url)
+        }
+        return urls
+    }
+
+    /// Read up to `maxTailBytes` from the end of `url`, returned as lines.
+    /// Returns nil only when the file cannot be opened at all.
+    private func readTail(of url: URL) -> [String]? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+
+        let size = (try? handle.seekToEnd()) ?? 0
+        let start = size > UInt64(configuration.maxTailBytes)
+            ? size - UInt64(configuration.maxTailBytes)
+            : 0
+        try? handle.seek(toOffset: start)
+        let data = (try? handle.readToEnd()) ?? Data()
+        guard let string = String(data: data, encoding: .utf8) else { return [] }
+        return string.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+    }
+
+    /// Canonicalize and validate the transcript's working directory.
+    private func resolveWorkingDirectory(_ raw: String?) -> (String?, WakeSkipReason?) {
+        guard let raw, !raw.isEmpty else { return (nil, .unknownWorkingDirectory) }
+        let canonical = URL(fileURLWithPath: raw).resolvingSymlinksInPath().path
+        var isDirectory: ObjCBool = false
+        let exists = configuration.fileManager.fileExists(atPath: canonical, isDirectory: &isDirectory)
+        if !exists || !isDirectory.boolValue {
+            return (canonical, .missingWorkingDirectory)
+        }
+        return (canonical, nil)
+    }
+}

--- a/MeterBar/SessionWake/TranscriptClassifier.swift
+++ b/MeterBar/SessionWake/TranscriptClassifier.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+/// The terminal state of a Claude Code transcript, derived from the *latest
+/// decisive event* rather than "does the file contain a rate-limit string".
+///
+/// A transcript that hit a limit and then made further progress is `.active`,
+/// not `.blocked` — the historical limit is stale. Only a limit that is the
+/// last decisive event makes a session eligible for wake.
+enum TranscriptState: Equatable, Sendable {
+    /// The last decisive event is a usage limit.
+    case blocked(reason: WakeBlockReason, blockedAt: Date, resetHint: TranscriptResetParser.Result?)
+    /// The last decisive event is successful assistant/tool activity.
+    case active(lastActivityAt: Date)
+    /// No decisive event was found (empty/metadata-only transcript).
+    case indeterminate
+}
+
+/// Metadata a classified transcript exposes to discovery.
+struct TranscriptSummary: Equatable, Sendable {
+    let sessionID: String
+    let cwd: String?
+    let gitBranch: String?
+    /// True when any decisive entry was a subagent/sidechain entry.
+    let isSidechain: Bool
+    let state: TranscriptState
+}
+
+/// Classifies raw JSONL transcript lines. Pure and side-effect free so it can
+/// run off the main actor and be exhaustively fixture-tested.
+enum TranscriptClassifier {
+    /// A single decoded transcript record, tolerant of the widely varying
+    /// Claude Code JSONL schema. Non-object or malformed lines are dropped by
+    /// the caller before reaching here.
+    private struct Record {
+        let type: String?
+        let timestamp: Date?
+        let isSidechain: Bool
+        let isApiError: Bool
+        let apiErrorStatus: Int?
+        let role: String?
+        let text: String
+        let sessionID: String?
+        let cwd: String?
+        let gitBranch: String?
+
+        init?(object: [String: Any]) {
+            self.type = object["type"] as? String
+            self.timestamp = (object["timestamp"] as? String).flatMap(Record.date(from:))
+            self.isSidechain = object["isSidechain"] as? Bool ?? false
+            self.isApiError = object["isApiErrorMessage"] as? Bool ?? false
+            self.apiErrorStatus = object["apiErrorStatus"] as? Int
+            self.sessionID = object["sessionId"] as? String
+            self.cwd = object["cwd"] as? String
+            self.gitBranch = object["gitBranch"] as? String
+
+            let message = object["message"] as? [String: Any]
+            self.role = message?["role"] as? String ?? object["role"] as? String
+            self.text = Record.extractText(from: message?["content"] ?? object["content"])
+        }
+
+        private static let isoFormatter: ISO8601DateFormatter = {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            return formatter
+        }()
+
+        private static let isoFormatterNoFraction: ISO8601DateFormatter = {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime]
+            return formatter
+        }()
+
+        static func date(from string: String) -> Date? {
+            isoFormatter.date(from: string) ?? isoFormatterNoFraction.date(from: string)
+        }
+
+        private static func extractText(from content: Any?) -> String {
+            if let string = content as? String { return string }
+            guard let blocks = content as? [[String: Any]] else { return "" }
+            return blocks.compactMap { $0["text"] as? String }.joined(separator: "\n")
+        }
+    }
+
+    /// Classify the ordered JSONL `lines` of one transcript.
+    static func classify(sessionID fallbackID: String, lines: [String]) -> TranscriptSummary {
+        var resolvedSessionID: String?
+        var cwd: String?
+        var gitBranch: String?
+        var sawSidechain = false
+
+        var lastDecisiveState: TranscriptState = .indeterminate
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty,
+                  let data = trimmed.data(using: .utf8),
+                  let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+                  let record = Record(object: object) else {
+                // Malformed/truncated JSONL must not crash or poison the scan.
+                continue
+            }
+
+            resolvedSessionID = resolvedSessionID ?? record.sessionID
+            if let recordCwd = record.cwd, !recordCwd.isEmpty { cwd = recordCwd }
+            if let branch = record.gitBranch, !branch.isEmpty { gitBranch = branch }
+            if record.isSidechain { sawSidechain = true }
+
+            guard let timestamp = record.timestamp else { continue }
+
+            if isBlockingEvent(record) {
+                let reason = WakeBlockReason.classify(messageText: record.text)
+                let resetHint = TranscriptResetParser.parse(
+                    messageText: record.text,
+                    eventTimestamp: timestamp
+                )
+                lastDecisiveState = .blocked(reason: reason, blockedAt: timestamp, resetHint: resetHint)
+            } else if isSuccessfulActivity(record) {
+                lastDecisiveState = .active(lastActivityAt: timestamp)
+            }
+        }
+
+        return TranscriptSummary(
+            sessionID: resolvedSessionID ?? fallbackID,
+            cwd: cwd,
+            gitBranch: gitBranch,
+            isSidechain: sawSidechain,
+            state: lastDecisiveState
+        )
+    }
+
+    /// A 429/limit assistant error is the only kind of blocking event.
+    private static func isBlockingEvent(_ record: Record) -> Bool {
+        guard record.isApiError else { return false }
+        if record.apiErrorStatus == 429 { return true }
+        // Some builds omit the status code; fall back to the message body.
+        let text = record.text.lowercased()
+        return text.contains("limit") && (text.contains("resets") || text.contains("usage") || text.contains("session"))
+    }
+
+    /// Real forward progress: a non-error assistant reply, or a tool result /
+    /// user turn that lands after a limit and therefore clears it.
+    private static func isSuccessfulActivity(_ record: Record) -> Bool {
+        if record.isApiError { return false }
+        switch record.type {
+        case "assistant":
+            return record.role == "assistant" || !record.text.isEmpty
+        case "user", "tool_result":
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/MeterBar/SessionWake/TranscriptResetParser.swift
+++ b/MeterBar/SessionWake/TranscriptResetParser.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Parses the human-readable reset hint embedded in a Claude rate-limit
+/// message ("resets 7:30am (Europe/Malta)") into an absolute instant.
+///
+/// The transcript never states a date, only a wall-clock time and (usually) an
+/// IANA timezone. This parser resolves that clock time to the occurrence
+/// *closest in time* to the rate-limit event, which is the only anchor we have.
+/// Choosing the nearest occurrence — rather than always rolling forward — is
+/// what keeps a "02:10 reset read at 02:15" from being mistaken for tomorrow
+/// (#96). The parser deliberately does **not** decide whether quota is
+/// available; a returned instant in the past means "already elapsed, re-check",
+/// never "proven available".
+enum TranscriptResetParser {
+    struct Result: Equatable, Sendable {
+        /// The absolute reset instant, anchored to the event timestamp.
+        let resetAt: Date
+        /// The timezone the transcript named, if any (nil ⇒ current zone used).
+        let timeZoneIdentifier: String?
+
+        /// Whether `resetAt` already elapsed relative to the anchoring event.
+        /// A past reset may schedule a refresh but can never prove availability.
+        func isElapsed(relativeTo reference: Date) -> Bool {
+            resetAt <= reference
+        }
+    }
+
+    // "resets 7:30am (Europe/Malta)" / "resets 2:10am" / "resets **2:10am ...**"
+    private static let pattern = try? NSRegularExpression(
+        pattern: #"resets\s*\**\s*(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*\**\s*(?:\(([^)]+)\))?"#,
+        options: [.caseInsensitive]
+    )
+
+    /// Parse `messageText`, anchoring the clock time to `eventTimestamp`.
+    ///
+    /// - Returns: the nearest absolute occurrence of the stated clock time, or
+    ///   nil when no reset hint is present.
+    static func parse(messageText: String, eventTimestamp: Date) -> Result? {
+        guard let pattern else { return nil }
+        let range = NSRange(messageText.startIndex..., in: messageText)
+        guard let match = pattern.firstMatch(in: messageText, range: range) else {
+            return nil
+        }
+
+        func group(_ index: Int) -> String? {
+            guard match.numberOfRanges > index,
+                  let r = Range(match.range(at: index), in: messageText) else {
+                return nil
+            }
+            return String(messageText[r])
+        }
+
+        guard let hourString = group(1), let rawHour = Int(hourString) else {
+            return nil
+        }
+        let minute = group(2).flatMap(Int.init) ?? 0
+        let meridiem = group(3)?.lowercased()
+        let tzIdentifier = group(4)?.trimmingCharacters(in: .whitespaces)
+
+        var hour = rawHour
+        if let meridiem {
+            if meridiem == "pm", hour < 12 { hour += 12 }
+            if meridiem == "am", hour == 12 { hour = 0 }
+        }
+        guard (0...23).contains(hour), (0...59).contains(minute) else {
+            return nil
+        }
+
+        let timeZone = tzIdentifier.flatMap(TimeZone.init(identifier:)) ?? .current
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+
+        // Build the clock time on the event's calendar day, then pick whichever
+        // of {yesterday, today, tomorrow} lands closest to the event instant.
+        var components = calendar.dateComponents([.year, .month, .day], from: eventTimestamp)
+        components.hour = hour
+        components.minute = minute
+        components.second = 0
+        guard let sameDay = calendar.date(from: components) else { return nil }
+
+        let candidates = [-1, 0, 1].compactMap {
+            calendar.date(byAdding: .day, value: $0, to: sameDay)
+        }
+        guard let nearest = candidates.min(by: {
+            abs($0.timeIntervalSince(eventTimestamp)) < abs($1.timeIntervalSince(eventTimestamp))
+        }) else {
+            return nil
+        }
+
+        return Result(resetAt: nearest, timeZoneIdentifier: tzIdentifier)
+    }
+}

--- a/MeterBar/SessionWake/WakeAutomationSeams.swift
+++ b/MeterBar/SessionWake/WakeAutomationSeams.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Terminal outcome of a single session run.
+enum WakeRunOutcome: Equatable, Sendable {
+    /// The session ran to completion; record its block fingerprint in the ledger.
+    case completed
+    /// The session failed; it is consumed (its fingerprint recorded) so the
+    /// queue does not spin on it, and the watcher continues to the next.
+    case failed(String)
+    /// The run was cancelled mid-flight (watcher turned off). The candidate is
+    /// **not** consumed — it stays at the front of the preserved queue and its
+    /// fingerprint is not recorded, so a later armed run can retry it.
+    case interrupted
+}
+
+/// Runs one session with the per-session guards. Implemented by #97's safe
+/// process runner. Implementations MUST observe task cancellation and terminate
+/// the child cooperatively, returning `.interrupted`.
+protocol WakeSessionRunning: Sendable {
+    func run(_ candidate: WakeSessionCandidate, maxTurns: Int, timeout: TimeInterval) async -> WakeRunOutcome
+}
+
+/// Account-scoped source of currently-eligible resume candidates. The seam over
+/// #95's `SessionDiscovery`; implementations MUST be read-only (Preview/dry-run
+/// performs zero mutation) and return only executable candidates.
+protocol WakeCandidateSource: Sendable {
+    func candidates(configDirectory: String?) async -> [WakeSessionCandidate]
+}
+
+/// Records a handled block so it is never resumed again. The seam over #95's
+/// `ReplayLedger`.
+protocol WakeBlockLedger: Sendable {
+    func record(_ fingerprint: BlockFingerprint) async
+}
+
+/// Cancellable delay primitive. Injected so the coordinator's timing is
+/// deterministic under test and its sleeps are provably cancellable.
+protocol WakeSleeper: Sendable {
+    /// Sleeps for `seconds`. Returns `false` if the surrounding task was
+    /// cancelled (before or during the wait), `true` if it elapsed normally.
+    func sleep(_ seconds: TimeInterval) async -> Bool
+}
+
+/// Production sleeper. Uses `Task.sleep`, which throws `CancellationError` on
+/// cancellation — mapped to a `false` return. Waits are driven in
+/// poll-interval-bounded chunks by the coordinator, so a system sleep/wake that
+/// pauses the timer only delays the next fresh re-fetch by at most one chunk
+/// rather than silently over-trusting a long timer.
+struct TaskSleeper: WakeSleeper {
+    func sleep(_ seconds: TimeInterval) async -> Bool {
+        guard seconds > 0 else { return !Task.isCancelled }
+        do {
+            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            return true
+        } catch {
+            return false
+        }
+    }
+}
+
+// MARK: - Adapters over #95's concrete discovery/ledger
+
+/// Adapts #95's `SessionDiscovery` actor to the ``WakeCandidateSource`` seam,
+/// keeping only executable candidates (skipped/preview-only ones never launch).
+struct DiscoveryCandidateSource: WakeCandidateSource {
+    let discovery: SessionDiscovery
+    let ledger: ReplayLedger
+
+    func candidates(configDirectory: String?) async -> [WakeSessionCandidate] {
+        await discovery
+            .discover(configDirectory: configDirectory, ledger: ledger)
+            .filter(\.isExecutable)
+    }
+}
+
+/// Adapts #95's `ReplayLedger` actor to the ``WakeBlockLedger`` seam.
+struct ReplayLedgerRecorder: WakeBlockLedger {
+    let ledger: ReplayLedger
+
+    func record(_ fingerprint: BlockFingerprint) async {
+        await ledger.record(fingerprint)
+    }
+}

--- a/MeterBar/SessionWake/WakeBlockReason.swift
+++ b/MeterBar/SessionWake/WakeBlockReason.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// A typed reason a Claude Code session stopped on a usage limit.
+///
+/// The transcript only ever spells the reason in prose ("session limit",
+/// "usage limit", "weekly limit"), so discovery maps that prose onto a closed
+/// set the rest of Session Wake can gate on without re-parsing strings.
+enum WakeBlockReason: String, Codable, Equatable, Sendable, CaseIterable {
+    /// The rolling 5-hour session window ("You've hit your session limit").
+    case sessionLimit
+    /// A generic usage limit that is not explicitly the weekly window.
+    case usageLimit
+    /// A weekly account-wide limit ("weekly limit").
+    case weeklyLimit
+    /// A model-specific weekly limit (e.g. Opus) called out separately.
+    case modelWeeklyLimit
+
+    /// Classify a rate-limit message body into a typed reason.
+    ///
+    /// Casing and surrounding markdown are ignored; the first specific phrase
+    /// wins so "opus weekly limit" is not collapsed into the generic weekly
+    /// case, and "weekly" is preferred over the plain "usage limit" fallback.
+    static func classify(messageText: String) -> WakeBlockReason {
+        let text = messageText.lowercased()
+        if text.contains("opus") && text.contains("weekly") {
+            return .modelWeeklyLimit
+        }
+        if text.contains("weekly limit") || text.contains("weekly usage") {
+            return .weeklyLimit
+        }
+        if text.contains("session limit") {
+            return .sessionLimit
+        }
+        return .usageLimit
+    }
+}

--- a/MeterBar/SessionWake/WakeBounds.swift
+++ b/MeterBar/SessionWake/WakeBounds.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Validated numeric bounds for the Session Wake watcher (issue #96).
+///
+/// Every value is clamped into a conservative, documented range at
+/// initialization, so an out-of-range or non-finite preference can never widen a
+/// safety window. Two invariants are enforced structurally rather than by
+/// convention:
+///
+/// - **Unlimited sessions are never representable.** `sessionCap` always
+///   resolves to a finite value in `sessionCapRange`. The PRD's historical
+///   "0 = all" default is deliberately *not* honored — epic #94 requires that
+///   unlimited never be the default (see ``default``).
+/// - **Every guard is finite and positive.** `maxTurns`, `sessionTimeout`, and
+///   `pollInterval` cannot be zero or negative, so a session can neither run
+///   turn-unbounded nor spin the poll loop with a zero delay.
+struct WakeBounds: Equatable, Sendable {
+    /// How often the watcher re-scans and re-polls quota while idle or waiting.
+    let pollInterval: TimeInterval
+    /// Extra delay added *after* a quota reset before re-fetching, so the
+    /// watcher never launches on the exact reset boundary while the server is
+    /// still settling. Matches the PRD's 90 s default buffer.
+    let resetBuffer: TimeInterval
+    /// Minimum gap enforced between two consecutive session launches.
+    let interSessionGap: TimeInterval
+    /// Hard wall-clock timeout for a single session run, handed to the runner.
+    let sessionTimeout: TimeInterval
+    /// Per-session max-turns guard handed to the runner, in addition to the
+    /// timeout. Bounds runaway agent loops that stay under the wall-clock limit.
+    let maxTurns: Int
+    /// Maximum number of sessions the watcher will launch in one armed run.
+    /// Finite by construction — this is the "conservative bounded default"
+    /// required by #96, replacing the PRD's unbounded "resume all".
+    let sessionCap: Int
+
+    // MARK: Documented, enforced ranges
+
+    static let pollIntervalRange: ClosedRange<TimeInterval> = 15...3_600
+    static let resetBufferRange: ClosedRange<TimeInterval> = 0...900
+    static let interSessionGapRange: ClosedRange<TimeInterval> = 0...3_600
+    static let sessionTimeoutRange: ClosedRange<TimeInterval> = 30...14_400
+    static let maxTurnsRange: ClosedRange<Int> = 1...500
+    static let sessionCapRange: ClosedRange<Int> = 1...200
+
+    /// Conservative defaults. Values mirror the PRD (poll 60 s, buffer 90 s,
+    /// gap 20 s, timeout 7200 s) except `sessionCap`, which is a finite ceiling
+    /// (25) rather than the PRD's unlimited default, and `maxTurns` (40), which
+    /// the PRD did not specify but #96 requires.
+    static let `default` = WakeBounds(
+        pollInterval: 60,
+        resetBuffer: 90,
+        interSessionGap: 20,
+        sessionTimeout: 7_200,
+        maxTurns: 40,
+        sessionCap: 25
+    )
+
+    init(
+        pollInterval: TimeInterval,
+        resetBuffer: TimeInterval,
+        interSessionGap: TimeInterval,
+        sessionTimeout: TimeInterval,
+        maxTurns: Int,
+        sessionCap: Int
+    ) {
+        self.pollInterval = Self.pollIntervalRange.clamping(pollInterval)
+        self.resetBuffer = Self.resetBufferRange.clamping(resetBuffer)
+        self.interSessionGap = Self.interSessionGapRange.clamping(interSessionGap)
+        self.sessionTimeout = Self.sessionTimeoutRange.clamping(sessionTimeout)
+        self.maxTurns = Self.maxTurnsRange.clamping(maxTurns)
+        self.sessionCap = Self.sessionCapRange.clamping(sessionCap)
+    }
+}
+
+extension ClosedRange where Bound == TimeInterval {
+    /// Clamps `value` into the range. Non-finite input (NaN / ±∞) resolves to
+    /// the lower bound so a corrupt preference always fails to the safe side.
+    func clamping(_ value: TimeInterval) -> TimeInterval {
+        guard value.isFinite else { return lowerBound }
+        return Swift.min(Swift.max(value, lowerBound), upperBound)
+    }
+}
+
+extension ClosedRange where Bound == Int {
+    func clamping(_ value: Int) -> Int {
+        Swift.min(Swift.max(value, lowerBound), upperBound)
+    }
+}

--- a/MeterBar/SessionWake/WakeCoordinator.swift
+++ b/MeterBar/SessionWake/WakeCoordinator.swift
@@ -1,0 +1,243 @@
+import Foundation
+
+/// The single native wake watcher state machine (#96).
+///
+/// Owns exactly one cancellable structured `Task`. Every timing-sensitive step —
+/// scan, quota gate, session run, sleep — happens inside that task, and turning
+/// the watcher off cancels it deterministically: ``stop()`` awaits the loop's
+/// full unwind before reporting `.off`.
+///
+/// This is the "real coordinator" that #95's discovery/ledger and #98's
+/// `SessionWakeCoordinator` UI seam are built to plug into. It consumes #95's
+/// `WakeSessionCandidate`/`ReplayLedger` via the ``WakeCandidateSource`` /
+/// ``WakeBlockLedger`` seams and #97's runner via ``WakeSessionRunning``.
+///
+/// ## Quota is fetched fresh on every cycle
+/// The loop re-gates quota (a fresh account-scoped fetch) at the top of every
+/// tick, so quota is proven fresh immediately before each launch and, because a
+/// completed attempt falls through to the next tick, immediately after each
+/// completed attempt as well. Cached UI metrics are never consulted, and a reset
+/// instant that has already passed never proves availability — it just lets the
+/// loop fall through to a fresh re-fetch.
+///
+/// ## Queue preservation
+/// `queue` persists across ticks. A block, an `unknown` gate, or a session that
+/// re-maxes quota all return the watcher to a wait/poll state with the remaining
+/// queue intact — no work is dropped.
+///
+/// ## Active-child cancellation (v1 decision — see DECISIONS ADR-010)
+/// When the watcher is turned off while a child session is running, the runner
+/// receives cooperative cancellation and returns `.interrupted`. The in-flight
+/// candidate is **not** consumed: it stays at the front of the preserved queue
+/// and its fingerprint is not recorded, so a later armed run can retry it.
+actor WakeCoordinator {
+    private var state: WakeWatcherState = .off
+    private var task: Task<Void, Never>?
+    private var isStopping = false
+
+    private var queue: [WakeSessionCandidate] = []
+    private var launchedCount = 0
+
+    private let account: ClaudeCodeAccount
+    private let bounds: WakeBounds
+    private let authority: WakeQuotaAuthority
+    private let candidateSource: WakeCandidateSource
+    private let ledger: WakeBlockLedger
+    private let runner: WakeSessionRunning
+    private let sleeper: WakeSleeper
+    private let now: @Sendable () -> Date
+    private var observer: (@Sendable (WakeWatcherState) -> Void)?
+
+    init(
+        account: ClaudeCodeAccount,
+        bounds: WakeBounds = .default,
+        authority: WakeQuotaAuthority,
+        candidateSource: WakeCandidateSource,
+        ledger: WakeBlockLedger,
+        runner: WakeSessionRunning,
+        sleeper: WakeSleeper = TaskSleeper(),
+        now: @escaping @Sendable () -> Date = { Date() },
+        observer: (@Sendable (WakeWatcherState) -> Void)? = nil
+    ) {
+        self.account = account
+        self.bounds = bounds
+        self.authority = authority
+        self.candidateSource = candidateSource
+        self.ledger = ledger
+        self.runner = runner
+        self.sleeper = sleeper
+        self.now = now
+        self.observer = observer
+    }
+
+    // MARK: - Introspection (test + UI seams)
+
+    var currentState: WakeWatcherState { state }
+    var pendingQueueIDs: [String] { queue.map(\.id) }
+    var launchedSessionCount: Int { launchedCount }
+
+    func setObserver(_ observer: @escaping @Sendable (WakeWatcherState) -> Void) {
+        self.observer = observer
+    }
+
+    // MARK: - Lifecycle
+
+    /// Arms the watcher. No-op if a task is already running (single-task invariant).
+    func start() {
+        guard task == nil else { return }
+        isStopping = false
+        queue.removeAll()
+        launchedCount = 0
+        transition(.armed)
+        AppLog.wake.info("Wake watcher armed for account \(self.account.id.uuidString, privacy: .public)")
+        task = Task { [weak self] in
+            guard let self else { return }
+            await self.runLoop()
+            await self.loopDidExit()
+        }
+    }
+
+    /// Turns the watcher off, cancelling all pending sleep/poll/run work and
+    /// awaiting the loop's deterministic unwind before returning `.off`.
+    func stop() async {
+        guard let task else {
+            transition(.off)
+            return
+        }
+        isStopping = true
+        transition(.stopping)
+        task.cancel()
+        await task.value
+        self.task = nil
+        isStopping = false
+        transition(.off)
+        AppLog.wake.info("Wake watcher stopped")
+    }
+
+    private func loopDidExit() {
+        task = nil
+        // If we exited for any reason other than an explicit stop() (which sets
+        // .off itself), settle a non-terminal state back to off so a spurious
+        // interruption can never leave the watcher wedged mid-cycle.
+        if !isStopping, state.isActive {
+            transition(.off)
+        }
+    }
+
+    // MARK: - Run loop
+
+    private func runLoop() async {
+        while !Task.isCancelled {
+            transition(.scanning)
+            let discovered = await candidateSource.candidates(configDirectory: account.configDirectory)
+            if Task.isCancelled { return }
+            mergeIntoQueue(discovered)
+
+            if queue.isEmpty {
+                transition(.armed)
+                if await sleeper.sleep(bounds.pollInterval) == false { return }
+                continue
+            }
+
+            // Fresh quota gate — runs before every launch and (via the next
+            // tick) after every completed attempt.
+            let quota = await authority.currentState(accountID: account.id)
+            if Task.isCancelled { return }
+
+            switch quota {
+            case .available:
+                break
+            case let .blocked(until, reason):
+                AppLog.wake.info("Quota blocked (\(String(describing: reason), privacy: .public)); waiting")
+                transition(.waiting(until: until))
+                if await waitForReset(until: until) == false { return }
+                continue
+            case let .unknown(reason):
+                AppLog.wake.info("Quota unknown (\(String(describing: reason), privacy: .public)); re-polling")
+                transition(.quotaUnknown(reason))
+                if await sleeper.sleep(bounds.pollInterval) == false { return }
+                continue
+            }
+
+            guard let candidate = queue.first else { continue }
+
+            if await runCandidate(candidate) == .stopLoop { return }
+            if Task.isCancelled { return }
+
+            if launchedCount >= bounds.sessionCap {
+                AppLog.wake.info("Session cap reached (\(self.bounds.sessionCap)); run complete")
+                transition(.completed)
+                return
+            }
+
+            if await sleeper.sleep(bounds.interSessionGap) == false { return }
+        }
+    }
+
+    private enum LoopStep { case stopLoop, keepGoing }
+
+    private func runCandidate(_ candidate: WakeSessionCandidate) async -> LoopStep {
+        transition(.running(candidateID: candidate.id))
+        let outcome = await runner.run(
+            candidate,
+            maxTurns: bounds.maxTurns,
+            timeout: bounds.sessionTimeout
+        )
+
+        switch outcome {
+        case .interrupted:
+            // Preserve the candidate at the front of the queue; do not consume
+            // it or record its fingerprint. stop()/loopDidExit finalizes state.
+            AppLog.wake.info("Session interrupted; candidate preserved for retry")
+            return .stopLoop
+        case .completed:
+            await ledger.record(candidate.fingerprint)
+            dequeueFront()
+            launchedCount += 1
+            transition(.completed)
+            return .keepGoing
+        case let .failed(message):
+            // Consume so the queue does not spin on a persistently failing
+            // candidate, but surface the failure and keep the watcher running.
+            await ledger.record(candidate.fingerprint)
+            dequeueFront()
+            launchedCount += 1
+            transition(.failed(message))
+            return .keepGoing
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func waitForReset(until: Date?) async -> Bool {
+        guard let until else {
+            return await sleeper.sleep(bounds.pollInterval)
+        }
+        let target = until.addingTimeInterval(bounds.resetBuffer)
+        let remaining = target.timeIntervalSince(now())
+        // Cap each wait at one poll interval so a system sleep/wake that pauses
+        // the timer only costs one extra cycle before quota is re-proven fresh,
+        // and a reset that has already passed (remaining <= 0) falls straight
+        // through to a fresh re-fetch rather than proving availability.
+        let chunk = Swift.min(Swift.max(remaining, 0), bounds.pollInterval)
+        return await sleeper.sleep(chunk)
+    }
+
+    private func mergeIntoQueue(_ discovered: [WakeSessionCandidate]) {
+        let existing = Set(queue.map(\.id))
+        for candidate in discovered where !existing.contains(candidate.id) {
+            queue.append(candidate)
+        }
+    }
+
+    private func dequeueFront() {
+        guard !queue.isEmpty else { return }
+        queue.removeFirst()
+    }
+
+    private func transition(_ next: WakeWatcherState) {
+        guard next != state else { return }
+        state = next
+        observer?(next)
+    }
+}

--- a/MeterBar/SessionWake/WakeCoordinator.swift
+++ b/MeterBar/SessionWake/WakeCoordinator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// The single native wake watcher state machine (#96).
 ///

--- a/MeterBar/SessionWake/WakePaths.swift
+++ b/MeterBar/SessionWake/WakePaths.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Central resolver for Session Wake's private on-disk state.
+///
+/// Everything lives under one base directory created with `0700` so ledger and
+/// (later) log files inherit private permissions. The base is overridable so
+/// tests never touch the real Application Support tree.
+enum WakePaths {
+    /// Default base: `~/Library/Application Support/MeterBar/session-wake`.
+    static func defaultBaseDirectory() -> URL {
+        let support = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: "\(ServiceSupport.realHomeDirectory())/Library/Application Support")
+        return support
+            .appendingPathComponent("MeterBar", isDirectory: true)
+            .appendingPathComponent("session-wake", isDirectory: true)
+    }
+
+    /// Ensure `directory` exists with private (`0700`) permissions.
+    @discardableResult
+    static func ensurePrivateDirectory(_ directory: URL) throws -> URL {
+        let fileManager = FileManager.default
+        if !fileManager.fileExists(atPath: directory.path) {
+            try fileManager.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+        } else {
+            try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+        }
+        return directory
+    }
+}

--- a/MeterBar/SessionWake/WakeQuotaAuthority.swift
+++ b/MeterBar/SessionWake/WakeQuotaAuthority.swift
@@ -1,0 +1,147 @@
+import Foundation
+import MeterBarShared
+
+/// Outcome of a single fresh, account-scoped quota fetch. Deliberately distinct
+/// from `UsageMetrics` so the authority can distinguish "no auth" from "fetch
+/// failed" from "got data" and fail closed in every non-success case.
+enum WakeQuotaFetch: Sendable {
+    /// Fresh metrics plus the wall-clock instant they were fetched.
+    case success(UsageMetrics, fetchedAt: Date)
+    /// The account is not authenticated (missing/invalid OAuth login).
+    case unauthorized
+    /// The fetch itself failed (CLI not found, timeout, non-zero exit, parse).
+    case failure(String)
+}
+
+/// Fetches fresh quota for one account. The seam over the concrete CLI service,
+/// so the authority and coordinator are testable without spawning `claude`.
+protocol WakeQuotaFetching: Sendable {
+    func fetchFreshQuota(accountID: UUID) async -> WakeQuotaFetch
+}
+
+/// Pure decision logic mapping a fetch outcome to a ``WakeQuotaState``.
+///
+/// Fail-closed by construction: only a fresh, unambiguous `success` with at
+/// least one usable window and no exhausted hard window yields `.available`.
+struct WakeQuotaEvaluator: Sendable {
+    /// Fetched metrics older than this (relative to `now`) are treated as stale
+    /// and yield `unknown`. Also rejects fetches dated in the future by the same
+    /// magnitude (a clock that jumped backwards).
+    let freshnessWindow: TimeInterval
+
+    init(freshnessWindow: TimeInterval = 90) {
+        self.freshnessWindow = Swift.max(1, freshnessWindow)
+    }
+
+    func evaluate(_ fetch: WakeQuotaFetch, now: Date) -> WakeQuotaState {
+        switch fetch {
+        case .unauthorized:
+            return .unknown(reason: .missingAuthorization)
+        case let .failure(message):
+            return .unknown(reason: .fetchFailed(message))
+        case let .success(metrics, fetchedAt):
+            let age = now.timeIntervalSince(fetchedAt)
+            guard abs(age) <= freshnessWindow else {
+                return .unknown(reason: .stale(age: age))
+            }
+            guard metrics.hasData else {
+                return .unknown(reason: .ambiguous("No quota windows present"))
+            }
+            return classify(metrics)
+        }
+    }
+
+    /// Gates every hard blocking window. If any window is at-limit the gate is
+    /// closed; the reported `until`/`reason` come from the exhausted window with
+    /// the farthest reset (an unknown reset counts as farthest — most
+    /// conservative), so an exhausted weekly/model cap blocks a launch even when
+    /// the 5-hour session window is open.
+    private func classify(_ metrics: UsageMetrics) -> WakeQuotaState {
+        let windows: [(limit: UsageLimit?, reason: WakeBlockReason)] = [
+            (metrics.sessionLimit, .sessionLimit),
+            (metrics.weeklyLimit, .weeklyLimit),
+            (metrics.codeReviewLimit, .modelWeeklyLimit)
+        ]
+
+        let exhausted = windows.compactMap { window -> (until: Date?, reason: WakeBlockReason)? in
+            guard let limit = window.limit, limit.isAtLimit else { return nil }
+            return (limit.resetTime, window.reason)
+        }
+
+        guard let farthest = exhausted.max(by: { lhs, rhs in
+            (lhs.until ?? .distantFuture) < (rhs.until ?? .distantFuture)
+        }) else {
+            return .available
+        }
+        return .blocked(until: farthest.until, reason: farthest.reason)
+    }
+}
+
+/// The account-scoped quota authority. Combines a fresh fetch with the pure
+/// evaluator. Every call performs a *new* fetch — callers must invoke it
+/// immediately before each launch and after each completed attempt so cached UI
+/// metrics are never used as execution authority.
+struct WakeQuotaAuthority: Sendable {
+    let fetcher: WakeQuotaFetching
+    let evaluator: WakeQuotaEvaluator
+    let now: @Sendable () -> Date
+
+    init(
+        fetcher: WakeQuotaFetching,
+        evaluator: WakeQuotaEvaluator = WakeQuotaEvaluator(),
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.fetcher = fetcher
+        self.evaluator = evaluator
+        self.now = now
+    }
+
+    func currentState(accountID: UUID) async -> WakeQuotaState {
+        let fetch = await fetcher.fetchFreshQuota(accountID: accountID)
+        return evaluator.evaluate(fetch, now: now())
+    }
+}
+
+/// Concrete fetcher backed by `ClaudeCodeCLIUsageService`. Runs the CLI fresh
+/// against the selected account's `CLAUDE_CONFIG_DIR` and stamps the fetch time.
+struct ClaudeCLIQuotaFetcher: WakeQuotaFetching {
+    let service: ClaudeCodeCLIUsageService
+    /// Resolves a wake account id to its profile. Injected so the fetcher stays
+    /// account-scoped and never reads another account.
+    let accountLookup: @Sendable (UUID) -> ClaudeCodeAccount?
+
+    init(
+        service: ClaudeCodeCLIUsageService = .shared,
+        accountLookup: @escaping @Sendable (UUID) -> ClaudeCodeAccount?
+    ) {
+        self.service = service
+        self.accountLookup = accountLookup
+    }
+
+    func fetchFreshQuota(accountID: UUID) async -> WakeQuotaFetch {
+        guard let account = accountLookup(accountID) else {
+            return .failure("No wake account resolved for \(accountID.uuidString)")
+        }
+        do {
+            let metrics = try await service.fetchUsageMetrics(account: account)
+            return .success(metrics, fetchedAt: Date())
+        } catch {
+            if Self.looksLikeAuthorizationFailure(error) {
+                return .unauthorized
+            }
+            return .failure(error.localizedDescription)
+        }
+    }
+
+    /// Heuristic mapping of a CLI failure to "not logged in". Precision is not
+    /// safety-critical: both `.unauthorized` and `.failure` fail closed to
+    /// `unknown`. This only sharpens the surfaced reason for the UI.
+    static func looksLikeAuthorizationFailure(_ error: Error) -> Bool {
+        let message = error.localizedDescription.lowercased()
+        let markers = [
+            "log in", "login", "logged out", "not authenticated",
+            "unauthorized", "authenticate", "/login", "oauth"
+        ]
+        return markers.contains { message.contains($0) }
+    }
+}

--- a/MeterBar/SessionWake/WakeQuotaState.swift
+++ b/MeterBar/SessionWake/WakeQuotaState.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Why the quota authority could not *prove* availability. Every case fails
+/// closed: the watcher launches nothing while quota is `unknown` (#96).
+enum WakeQuotaUnknownReason: Equatable, Sendable {
+    /// No fetch has happened yet this gate cycle.
+    case notFetched
+    /// A fetch succeeded but is older than the freshness window. `age` is the
+    /// measured staleness in seconds (may be negative if the clock moved back).
+    case stale(age: TimeInterval)
+    /// The fresh fetch failed (CLI error, timeout, parse failure).
+    case fetchFailed(String)
+    /// The fetch returned but its shape is ambiguous (no usable windows).
+    case ambiguous(String)
+    /// The account is not authenticated (missing/invalid OAuth). Fails closed
+    /// so a missing login can never make quota fail open, and can never keep a
+    /// stale transcript permanently "blocked" — it is re-evaluated each cycle.
+    case missingAuthorization
+}
+
+/// The single source of execution authority for a wake account.
+///
+/// The block `reason` reuses discovery's `WakeBlockReason` (#95) so the whole
+/// pipeline shares one typed vocabulary for *why* a window is closed. Cached UI
+/// metrics are never mapped to this type — only a freshly fetched,
+/// freshness-checked result is (see ``WakeQuotaAuthority``).
+enum WakeQuotaState: Equatable, Sendable {
+    /// Fresh quota proves at least one launch is permitted right now.
+    case available
+    /// A hard window is exhausted. `until` is the absolute reset (nil when the
+    /// reset time is itself unknown — the watcher then re-polls conservatively).
+    case blocked(until: Date?, reason: WakeBlockReason)
+    /// Availability cannot be proven; nothing launches.
+    case unknown(reason: WakeQuotaUnknownReason)
+
+    /// The only state that authorizes a launch. `blocked` and `unknown` both
+    /// return `false` — the gate is fail-closed.
+    var permitsLaunch: Bool {
+        if case .available = self { return true }
+        return false
+    }
+}

--- a/MeterBar/SessionWake/WakeSession.swift
+++ b/MeterBar/SessionWake/WakeSession.swift
@@ -1,0 +1,57 @@
+import CryptoKit
+import Foundation
+
+/// A deterministic identity for a single blocking event, used to guarantee a
+/// handled block is never resumed twice (even across app relaunch).
+///
+/// It intentionally keys on the *event* (session + block instant + reason), not
+/// the file, so re-scanning the same transcript yields the same fingerprint,
+/// while a genuinely new block later in the same session produces a new one.
+struct BlockFingerprint: Codable, Equatable, Hashable, Sendable {
+    let value: String
+
+    init(sessionID: String, blockedAt: Date, reason: WakeBlockReason) {
+        // Second precision: the same event re-read must hash identically.
+        let epochSecond = Int(blockedAt.timeIntervalSince1970.rounded())
+        let seed = "\(sessionID)|\(epochSecond)|\(reason.rawValue)"
+        let digest = SHA256.hash(data: Data(seed.utf8))
+        self.value = digest.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+/// Why a discovered candidate cannot be executed as-is.
+enum WakeSkipReason: String, Codable, Equatable, Sendable {
+    /// The transcript's resolved cwd no longer exists (deleted worktree).
+    case missingWorkingDirectory
+    /// The transcript never recorded a working directory.
+    case unknownWorkingDirectory
+    /// This block fingerprint was already handled (replay ledger hit).
+    case alreadyHandled
+    /// The transcript belongs to a subagent/sidechain.
+    case subagent
+}
+
+/// A blocked Claude Code session that Session Wake could resume.
+///
+/// `skipReason == nil` means the candidate is executable; a non-nil reason
+/// means it is preview-only and must never be launched. Discovery records the
+/// reason rather than silently dropping the candidate so the UI/CLI can explain
+/// why a visible blocked session was not resumed.
+struct WakeSessionCandidate: Equatable, Sendable, Identifiable {
+    let sessionID: String
+    let transcriptPath: String
+    /// Canonicalized (symlinks resolved) working directory, if resolvable.
+    let workingDirectory: String?
+    let gitBranch: String?
+    let reason: WakeBlockReason
+    let blockedAt: Date
+    /// Absolute reset instant parsed from the transcript, anchored to the event.
+    let resetHint: TranscriptResetParser.Result?
+    let fingerprint: BlockFingerprint
+    let skipReason: WakeSkipReason?
+
+    var id: String { fingerprint.value }
+
+    /// True only when the candidate is safe to hand to the runner.
+    var isExecutable: Bool { skipReason == nil }
+}

--- a/MeterBar/SessionWake/WakeWatcherState.swift
+++ b/MeterBar/SessionWake/WakeWatcherState.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// The observable states of the single native wake watcher (#96).
+///
+/// There is exactly one state machine and one cancellable structured task
+/// (owned by ``WakeCoordinator``). Every listed state maps to a concrete point
+/// in the run loop, so the UI (#98) can render an unambiguous status chip.
+enum WakeWatcherState: Equatable, Sendable {
+    /// Watcher disabled. No task running, no pending sleep/poll work.
+    case off
+    /// Enabled and idle — armed, waiting for the next poll to re-scan.
+    case armed
+    /// Scanning the account for eligible candidates.
+    case scanning
+    /// A hard quota window is exhausted; waiting until `until` (or re-polling on
+    /// the poll interval when the reset instant is unknown).
+    case waiting(until: Date?)
+    /// Quota freshness could not be proven; nothing launches and the watcher
+    /// re-polls. Distinct from `waiting` so the UI can flag a soft failure.
+    case quotaUnknown(WakeQuotaUnknownReason)
+    /// A session is actively running.
+    case running(candidateID: String)
+    /// Stopping in response to a user turning the watcher off; the in-flight
+    /// task is being cancelled and unwound deterministically.
+    case stopping
+    /// The armed run finished all eligible work (or hit the session cap).
+    case completed
+    /// The run loop failed unrecoverably.
+    case failed(String)
+
+    /// Whether the watcher currently owns a live structured task. `off` and the
+    /// terminal `completed`/`failed` states do not.
+    var isActive: Bool {
+        switch self {
+        case .off, .completed, .failed:
+            return false
+        case .armed, .scanning, .waiting, .quotaUnknown, .running, .stopping:
+            return true
+        }
+    }
+}

--- a/MeterBarTests/WakeBoundsTests.swift
+++ b/MeterBarTests/WakeBoundsTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import MeterBar
+
+/// Numeric-bounds validation for the wake watcher (#96 acceptance:
+/// "Numeric bounds for polling, buffer, gap, timeout, max turns, and session
+/// cap are validated").
+final class WakeBoundsTests: XCTestCase {
+    func testDefaultsAreWithinRangeAndConservative() {
+        let bounds = WakeBounds.default
+        XCTAssertTrue(WakeBounds.pollIntervalRange.contains(bounds.pollInterval))
+        XCTAssertTrue(WakeBounds.resetBufferRange.contains(bounds.resetBuffer))
+        XCTAssertTrue(WakeBounds.interSessionGapRange.contains(bounds.interSessionGap))
+        XCTAssertTrue(WakeBounds.sessionTimeoutRange.contains(bounds.sessionTimeout))
+        XCTAssertTrue(WakeBounds.maxTurnsRange.contains(bounds.maxTurns))
+        XCTAssertTrue(WakeBounds.sessionCapRange.contains(bounds.sessionCap))
+        // PRD-aligned values.
+        XCTAssertEqual(bounds.pollInterval, 60)
+        XCTAssertEqual(bounds.resetBuffer, 90)
+        XCTAssertEqual(bounds.interSessionGap, 20)
+        XCTAssertEqual(bounds.sessionTimeout, 7_200)
+    }
+
+    func testSessionCapIsNeverUnlimited() {
+        // Epic #94: "Unlimited sessions are never the default." The PRD's
+        // historical "0 = all" must resolve to a finite floor, not infinity.
+        XCTAssertEqual(WakeBounds(
+            pollInterval: 60, resetBuffer: 90, interSessionGap: 20,
+            sessionTimeout: 7_200, maxTurns: 40, sessionCap: 0
+        ).sessionCap, WakeBounds.sessionCapRange.lowerBound)
+
+        XCTAssertEqual(WakeBounds(
+            pollInterval: 60, resetBuffer: 90, interSessionGap: 20,
+            sessionTimeout: 7_200, maxTurns: 40, sessionCap: -5
+        ).sessionCap, WakeBounds.sessionCapRange.lowerBound)
+
+        XCTAssertGreaterThanOrEqual(WakeBounds.default.sessionCap, 1)
+        XCTAssertLessThanOrEqual(WakeBounds.default.sessionCap, WakeBounds.sessionCapRange.upperBound)
+    }
+
+    func testLowClampToLowerBound() {
+        let bounds = WakeBounds(
+            pollInterval: 1, resetBuffer: -50, interSessionGap: -1,
+            sessionTimeout: 1, maxTurns: 0, sessionCap: 0
+        )
+        XCTAssertEqual(bounds.pollInterval, WakeBounds.pollIntervalRange.lowerBound)
+        XCTAssertEqual(bounds.resetBuffer, WakeBounds.resetBufferRange.lowerBound)
+        XCTAssertEqual(bounds.interSessionGap, WakeBounds.interSessionGapRange.lowerBound)
+        XCTAssertEqual(bounds.sessionTimeout, WakeBounds.sessionTimeoutRange.lowerBound)
+        XCTAssertEqual(bounds.maxTurns, WakeBounds.maxTurnsRange.lowerBound)
+        XCTAssertEqual(bounds.sessionCap, WakeBounds.sessionCapRange.lowerBound)
+    }
+
+    func testHighClampToUpperBound() {
+        let bounds = WakeBounds(
+            pollInterval: 999_999, resetBuffer: 999_999, interSessionGap: 999_999,
+            sessionTimeout: 999_999, maxTurns: 999_999, sessionCap: 999_999
+        )
+        XCTAssertEqual(bounds.pollInterval, WakeBounds.pollIntervalRange.upperBound)
+        XCTAssertEqual(bounds.resetBuffer, WakeBounds.resetBufferRange.upperBound)
+        XCTAssertEqual(bounds.interSessionGap, WakeBounds.interSessionGapRange.upperBound)
+        XCTAssertEqual(bounds.sessionTimeout, WakeBounds.sessionTimeoutRange.upperBound)
+        XCTAssertEqual(bounds.maxTurns, WakeBounds.maxTurnsRange.upperBound)
+        XCTAssertEqual(bounds.sessionCap, WakeBounds.sessionCapRange.upperBound)
+    }
+
+    func testNonFiniteInputFailsToLowerBound() {
+        let bounds = WakeBounds(
+            pollInterval: .nan, resetBuffer: .infinity, interSessionGap: -.infinity,
+            sessionTimeout: .nan, maxTurns: 40, sessionCap: 25
+        )
+        XCTAssertEqual(bounds.pollInterval, WakeBounds.pollIntervalRange.lowerBound)
+        XCTAssertEqual(bounds.resetBuffer, WakeBounds.resetBufferRange.lowerBound)
+        XCTAssertEqual(bounds.interSessionGap, WakeBounds.interSessionGapRange.lowerBound)
+        XCTAssertEqual(bounds.sessionTimeout, WakeBounds.sessionTimeoutRange.lowerBound)
+    }
+
+    func testValidValuesPassThroughUnchanged() {
+        let bounds = WakeBounds(
+            pollInterval: 120, resetBuffer: 45, interSessionGap: 30,
+            sessionTimeout: 3_600, maxTurns: 100, sessionCap: 10
+        )
+        XCTAssertEqual(bounds.pollInterval, 120)
+        XCTAssertEqual(bounds.resetBuffer, 45)
+        XCTAssertEqual(bounds.interSessionGap, 30)
+        XCTAssertEqual(bounds.sessionTimeout, 3_600)
+        XCTAssertEqual(bounds.maxTurns, 100)
+        XCTAssertEqual(bounds.sessionCap, 10)
+    }
+}

--- a/MeterBarTests/WakeCoordinatorTests.swift
+++ b/MeterBarTests/WakeCoordinatorTests.swift
@@ -1,0 +1,307 @@
+import XCTest
+import MeterBarShared
+@testable import MeterBar
+
+/// State-machine behavior for the single native wake watcher (#96).
+final class WakeCoordinatorTests: XCTestCase {
+    private let now = Date(timeIntervalSinceReferenceDate: 700_000_000)
+
+    private func makeAuthority(_ fetches: [WakeQuotaFetch]) -> (WakeQuotaAuthority, ScriptedQuotaFetcher) {
+        let fetcher = ScriptedQuotaFetcher(fetches)
+        let authority = WakeQuotaAuthority(
+            fetcher: fetcher,
+            evaluator: WakeQuotaEvaluator(freshnessWindow: 90),
+            now: { self.now }
+        )
+        return (authority, fetcher)
+    }
+
+    private func boundsWithCap(_ cap: Int) -> WakeBounds {
+        WakeBounds(
+            pollInterval: 60, resetBuffer: 90, interSessionGap: 20,
+            sessionTimeout: 7_200, maxTurns: 40, sessionCap: cap
+        )
+    }
+
+    private func makeCoordinator(
+        bounds: WakeBounds = .default,
+        authority: WakeQuotaAuthority,
+        candidates: WakeCandidateSource,
+        runner: WakeSessionRunning,
+        ledger: InMemoryLedger,
+        sleeper: WakeSleeper
+    ) -> WakeCoordinator {
+        WakeCoordinator(
+            account: wakeTestAccount(),
+            bounds: bounds,
+            authority: authority,
+            candidateSource: candidates,
+            ledger: ledger,
+            runner: runner,
+            sleeper: sleeper,
+            now: { self.now }
+        )
+    }
+
+    // MARK: - Fail-closed: unknown quota launches nothing
+
+    private func assertFailsClosed(
+        _ fetch: WakeQuotaFetch,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let (authority, fetcher) = makeAuthority([fetch])
+        let runner = StubRunner(mode: .outcome(.completed))
+        let coordinator = makeCoordinator(
+            authority: authority,
+            candidates: StubCandidateSource(constant: [wakeCandidate("c1")]),
+            runner: runner,
+            ledger: InMemoryLedger(),
+            sleeper: BlockingSleeper()
+        )
+
+        await coordinator.start()
+        let reached = await wakeWaitUntil {
+            if case .quotaUnknown = await coordinator.currentState { return true }
+            return false
+        }
+        XCTAssertTrue(reached, "Expected the gate to reach quotaUnknown", file: file, line: line)
+        XCTAssertTrue(runner.runs.isEmpty, "Unknown quota must launch nothing", file: file, line: line)
+        XCTAssertGreaterThanOrEqual(fetcher.callCount, 1, "Quota must be checked", file: file, line: line)
+
+        await coordinator.stop()
+        let final = await coordinator.currentState
+        XCTAssertEqual(final, .off, file: file, line: line)
+    }
+
+    func testMissingAuthorizationLaunchesNothing() async {
+        await assertFailsClosed(.unauthorized)
+    }
+
+    func testFetchFailureLaunchesNothing() async {
+        await assertFailsClosed(.failure("cli error"))
+    }
+
+    func testStaleQuotaLaunchesNothing() async {
+        await assertFailsClosed(WakeMetricsFixture.available(fetchedAt: now.addingTimeInterval(-1_000)))
+    }
+
+    func testAmbiguousQuotaLaunchesNothing() async {
+        await assertFailsClosed(.success(UsageMetrics(service: .claudeCode), fetchedAt: now))
+    }
+
+    // MARK: - Fresh gate before first launch, then runs when available
+
+    func testFreshQuotaCheckedBeforeFirstLaunchThenRuns() async {
+        let candidate = wakeCandidate("c1")
+        let (authority, fetcher) = makeAuthority([WakeMetricsFixture.available(fetchedAt: now)])
+        let runner = StubRunner(mode: .outcome(.completed))
+        let ledger = InMemoryLedger()
+        let coordinator = makeCoordinator(
+            bounds: boundsWithCap(1),
+            authority: authority,
+            candidates: StubCandidateSource(constant: [candidate]),
+            runner: runner,
+            ledger: ledger,
+            sleeper: ImmediateSleeper()
+        )
+
+        await coordinator.start()
+        let done = await wakeWaitUntil { await coordinator.currentState == .completed }
+        XCTAssertTrue(done, "Watcher should complete after the single capped run")
+        XCTAssertEqual(runner.runs, [candidate.id])
+        XCTAssertGreaterThanOrEqual(fetcher.callCount, 1, "Fresh quota must be checked before launch")
+        XCTAssertTrue(ledger.recorded.contains(candidate.fingerprint.value),
+                      "Completed session must be recorded in the ledger")
+    }
+
+    // MARK: - Past reset never proves availability
+
+    func testPastResetNeverProvesAvailability() async {
+        // A blocked window whose reset already elapsed must not itself authorize
+        // a launch — only a subsequent *fresh* available fetch may.
+        let runner = StubRunner(mode: .outcome(.completed))
+        let (authority, fetcher) = makeAuthority([
+            WakeMetricsFixture.blocked(fetchedAt: now, until: now.addingTimeInterval(-3_600))
+        ])
+        let coordinator = makeCoordinator(
+            authority: authority,
+            candidates: StubCandidateSource(constant: [wakeCandidate("c1")]),
+            runner: runner,
+            ledger: InMemoryLedger(),
+            sleeper: ImmediateSleeper()
+        )
+
+        await coordinator.start()
+        let waited = await wakeWaitUntil {
+            guard case .waiting = await coordinator.currentState else { return false }
+            return fetcher.callCount >= 2   // proves it re-fetches rather than launching
+        }
+        XCTAssertTrue(waited, "A passed reset must drive a fresh re-fetch, not a launch")
+        XCTAssertTrue(runner.runs.isEmpty, "A passed reset alone must never launch a session")
+
+        await coordinator.stop()
+        let offState = await coordinator.currentState
+        XCTAssertEqual(offState, .off)
+    }
+
+    // MARK: - Re-maxed quota stops the queue and preserves remaining work
+
+    func testSessionThatRemaxesQuotaStopsQueueAndPreservesRemaining() async {
+        let c1 = wakeCandidate("c1")
+        let c2 = wakeCandidate("c2")
+        // First gate available (runs c1), second gate (after c1 completes)
+        // reports the quota re-exhausted, so c2 must never launch.
+        let (authority, _) = makeAuthority([
+            WakeMetricsFixture.available(fetchedAt: now),
+            WakeMetricsFixture.blocked(fetchedAt: now, until: now.addingTimeInterval(3_600))
+        ])
+        let runner = StubRunner(mode: .outcome(.completed))
+        let coordinator = makeCoordinator(
+            authority: authority,
+            candidates: StubCandidateSource(constant: [c1, c2]),
+            runner: runner,
+            ledger: InMemoryLedger(),
+            sleeper: ImmediateSleeper()
+        )
+
+        await coordinator.start()
+        let stopped = await wakeWaitUntil {
+            guard case .waiting = await coordinator.currentState else { return false }
+            return runner.runs == [c1.id]
+        }
+        XCTAssertTrue(stopped, "Watcher must return to waiting after quota re-exhausts")
+        XCTAssertEqual(runner.runs, [c1.id], "The second candidate must not launch while blocked")
+
+        let pending = await coordinator.pendingQueueIDs
+        XCTAssertTrue(pending.contains(c2.id), "Remaining queue work must be preserved")
+
+        await coordinator.stop()
+        let offState = await coordinator.currentState
+        XCTAssertEqual(offState, .off)
+    }
+
+    // MARK: - Watcher-off cancels pending sleep/poll deterministically
+
+    func testWatcherOffCancelsPendingSleepDeterministically() async {
+        let (authority, _) = makeAuthority([
+            WakeMetricsFixture.blocked(fetchedAt: now, until: now.addingTimeInterval(3_600))
+        ])
+        let runner = StubRunner(mode: .outcome(.completed))
+        let sleeper = BlockingSleeper()
+        let coordinator = makeCoordinator(
+            authority: authority,
+            candidates: StubCandidateSource(constant: [wakeCandidate("c1")]),
+            runner: runner,
+            ledger: InMemoryLedger(),
+            sleeper: sleeper
+        )
+
+        await coordinator.start()
+        let waiting = await wakeWaitUntil {
+            if case .waiting = await coordinator.currentState { return true }
+            return false
+        }
+        XCTAssertTrue(waiting, "Watcher should be waiting on the blocked reset")
+
+        await coordinator.stop()
+        XCTAssertTrue(sleeper.wasCancelled, "The pending sleep must be cancelled by stop()")
+        XCTAssertTrue(runner.runs.isEmpty, "No session should run while blocked")
+        let offState = await coordinator.currentState
+        XCTAssertEqual(offState, .off)
+    }
+
+    // MARK: - Active-child cancellation semantics
+
+    func testActiveChildCancellationPreservesCandidateAndDoesNotRecord() async {
+        let candidate = wakeCandidate("c1")
+        let (authority, _) = makeAuthority([WakeMetricsFixture.available(fetchedAt: now)])
+        let runner = StubRunner(mode: .blockUntilCancelled)
+        let ledger = InMemoryLedger()
+        let coordinator = makeCoordinator(
+            authority: authority,
+            candidates: StubCandidateSource(constant: [candidate]),
+            runner: runner,
+            ledger: ledger,
+            sleeper: ImmediateSleeper()
+        )
+
+        await coordinator.start()
+        let running = await wakeWaitUntil {
+            if case .running = await coordinator.currentState { return true }
+            return false
+        }
+        XCTAssertTrue(running, "A session should be running before we cancel")
+
+        await coordinator.stop()
+
+        XCTAssertEqual(runner.runs, [candidate.id], "The candidate should have been attempted once")
+        XCTAssertFalse(ledger.recorded.contains(candidate.fingerprint.value),
+                       "Interrupted work must not be recorded as handled")
+        let pending = await coordinator.pendingQueueIDs
+        XCTAssertTrue(pending.contains(candidate.id), "Interrupted candidate must be preserved for retry")
+        let offState = await coordinator.currentState
+        XCTAssertEqual(offState, .off)
+    }
+
+    // MARK: - Session cap is a hard finite bound
+
+    func testSessionCapBoundsLaunchesAndPreservesRemainder() async {
+        let c1 = wakeCandidate("c1")
+        let c2 = wakeCandidate("c2")
+        let c3 = wakeCandidate("c3")
+        let (authority, _) = makeAuthority([WakeMetricsFixture.available(fetchedAt: now)])
+        let runner = StubRunner(mode: .outcome(.completed))
+        let coordinator = makeCoordinator(
+            bounds: boundsWithCap(2),
+            authority: authority,
+            candidates: StubCandidateSource(constant: [c1, c2, c3]),
+            runner: runner,
+            ledger: InMemoryLedger(),
+            sleeper: ImmediateSleeper()
+        )
+
+        await coordinator.start()
+        let completed = await wakeWaitUntil { await coordinator.currentState == .completed }
+        XCTAssertTrue(completed, "Watcher should complete once the cap is reached")
+        XCTAssertEqual(runner.runs, [c1.id, c2.id], "Only up to the session cap may launch")
+        let pending = await coordinator.pendingQueueIDs
+        XCTAssertTrue(pending.contains(c3.id), "Candidates beyond the cap must be preserved")
+    }
+
+    // MARK: - Re-arm / idempotent start
+
+    func testStartIsIdempotentAndReArmsAfterCompletion() async {
+        let (authority, _) = makeAuthority([WakeMetricsFixture.available(fetchedAt: now)])
+        let coordinator = makeCoordinator(
+            bounds: boundsWithCap(1),
+            authority: authority,
+            candidates: StubCandidateSource(constant: [wakeCandidate("c1")]),
+            runner: StubRunner(mode: .outcome(.completed)),
+            ledger: InMemoryLedger(),
+            sleeper: ImmediateSleeper()
+        )
+
+        await coordinator.start()
+        await coordinator.start()   // no-op while active (single-task invariant)
+        _ = await wakeWaitUntil { await coordinator.currentState == .completed }
+        await coordinator.stop()
+        let offState = await coordinator.currentState
+        XCTAssertEqual(offState, .off)
+    }
+}
+
+/// Direct coverage of the watcher-state helpers.
+final class WakeWatcherStateTests: XCTestCase {
+    func testIsActiveMapping() {
+        XCTAssertFalse(WakeWatcherState.off.isActive)
+        XCTAssertFalse(WakeWatcherState.completed.isActive)
+        XCTAssertFalse(WakeWatcherState.failed("x").isActive)
+        XCTAssertTrue(WakeWatcherState.armed.isActive)
+        XCTAssertTrue(WakeWatcherState.scanning.isActive)
+        XCTAssertTrue(WakeWatcherState.waiting(until: nil).isActive)
+        XCTAssertTrue(WakeWatcherState.quotaUnknown(.notFetched).isActive)
+        XCTAssertTrue(WakeWatcherState.running(candidateID: "x").isActive)
+        XCTAssertTrue(WakeWatcherState.stopping.isActive)
+    }
+}

--- a/MeterBarTests/WakeQuotaAuthorityTests.swift
+++ b/MeterBarTests/WakeQuotaAuthorityTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+import MeterBarShared
+@testable import MeterBar
+
+/// Quota-authority behavior (#96): missing/stale/failed/ambiguous quota fails
+/// closed; every hard window is gated; cached metrics are never authority.
+final class WakeQuotaAuthorityTests: XCTestCase {
+    private let now = Date(timeIntervalSinceReferenceDate: 700_000_000)
+    private lazy var evaluator = WakeQuotaEvaluator(freshnessWindow: 90)
+
+    private func metrics(
+        session: UsageLimit? = nil,
+        weekly: UsageLimit? = nil,
+        model: UsageLimit? = nil
+    ) -> UsageMetrics {
+        UsageMetrics(
+            service: .claudeCode,
+            sessionLimit: session,
+            weeklyLimit: weekly,
+            codeReviewLimit: model
+        )
+    }
+
+    // MARK: - Fail-closed cases
+
+    func testUnauthorizedIsUnknownMissingAuthorization() {
+        XCTAssertEqual(
+            evaluator.evaluate(.unauthorized, now: now),
+            .unknown(reason: .missingAuthorization)
+        )
+    }
+
+    func testFailureIsUnknownFetchFailed() {
+        XCTAssertEqual(
+            evaluator.evaluate(.failure("boom"), now: now),
+            .unknown(reason: .fetchFailed("boom"))
+        )
+    }
+
+    func testStaleSuccessIsUnknown() {
+        let stale = metrics(session: UsageLimit(used: 10, total: 100, resetTime: nil))
+        let state = evaluator.evaluate(.success(stale, fetchedAt: now.addingTimeInterval(-200)), now: now)
+        guard case .unknown(.stale) = state else {
+            return XCTFail("Expected .unknown(.stale), got \(state)")
+        }
+    }
+
+    func testFutureDatedSuccessIsUnknownStale() {
+        let future = metrics(session: UsageLimit(used: 10, total: 100, resetTime: nil))
+        let state = evaluator.evaluate(.success(future, fetchedAt: now.addingTimeInterval(200)), now: now)
+        guard case .unknown(.stale) = state else {
+            return XCTFail("Expected .unknown(.stale) for a backwards clock, got \(state)")
+        }
+    }
+
+    func testAmbiguousEmptyMetricsIsUnknown() {
+        let state = evaluator.evaluate(.success(metrics(), fetchedAt: now), now: now)
+        guard case .unknown(.ambiguous) = state else {
+            return XCTFail("Expected .unknown(.ambiguous), got \(state)")
+        }
+    }
+
+    // MARK: - Available / blocked
+
+    func testFreshOpenSessionIsAvailable() {
+        let open = metrics(session: UsageLimit(used: 10, total: 100, resetTime: nil))
+        XCTAssertEqual(evaluator.evaluate(.success(open, fetchedAt: now), now: now), .available)
+    }
+
+    func testExhaustedSessionIsBlocked() {
+        let reset = now.addingTimeInterval(3_600)
+        let exhausted = metrics(session: UsageLimit(used: 100, total: 100, resetTime: reset))
+        XCTAssertEqual(
+            evaluator.evaluate(.success(exhausted, fetchedAt: now), now: now),
+            .blocked(until: reset, reason: .sessionLimit)
+        )
+    }
+
+    /// An exhausted weekly window blocks a launch even when the 5-hour session
+    /// window is open.
+    func testExhaustedWeeklyBlocksEvenWhenSessionOpen() {
+        let reset = now.addingTimeInterval(86_400)
+        let combined = metrics(
+            session: UsageLimit(used: 10, total: 100, resetTime: nil),
+            weekly: UsageLimit(used: 100, total: 100, resetTime: reset)
+        )
+        XCTAssertEqual(
+            evaluator.evaluate(.success(combined, fetchedAt: now), now: now),
+            .blocked(until: reset, reason: .weeklyLimit)
+        )
+    }
+
+    /// A model-specific weekly window also blocks with session + weekly open.
+    func testExhaustedModelWeeklyBlocks() {
+        let reset = now.addingTimeInterval(86_400)
+        let combined = metrics(
+            session: UsageLimit(used: 10, total: 100, resetTime: nil),
+            weekly: UsageLimit(used: 20, total: 100, resetTime: nil),
+            model: UsageLimit(used: 100, total: 100, resetTime: reset)
+        )
+        XCTAssertEqual(
+            evaluator.evaluate(.success(combined, fetchedAt: now), now: now),
+            .blocked(until: reset, reason: .modelWeeklyLimit)
+        )
+    }
+
+    /// When multiple windows are exhausted, the farthest reset is reported (most
+    /// conservative wait).
+    func testBlockedReportsFarthestReset() {
+        let soon = now.addingTimeInterval(3_600)
+        let later = now.addingTimeInterval(86_400)
+        let both = metrics(
+            session: UsageLimit(used: 100, total: 100, resetTime: soon),
+            weekly: UsageLimit(used: 100, total: 100, resetTime: later)
+        )
+        XCTAssertEqual(
+            evaluator.evaluate(.success(both, fetchedAt: now), now: now),
+            .blocked(until: later, reason: .weeklyLimit)
+        )
+    }
+
+    /// An unknown reset counts as the farthest — a blocked window with no known
+    /// reset dominates, so the watcher never launches on optimistic timing.
+    func testUnknownResetDominatesAsFarthest() {
+        let soon = now.addingTimeInterval(3_600)
+        let both = metrics(
+            session: UsageLimit(used: 100, total: 100, resetTime: nil),
+            weekly: UsageLimit(used: 100, total: 100, resetTime: soon)
+        )
+        let state = evaluator.evaluate(.success(both, fetchedAt: now), now: now)
+        guard case let .blocked(until, _) = state else {
+            return XCTFail("Expected .blocked, got \(state)")
+        }
+        XCTAssertNil(until)
+    }
+
+    func testPermitsLaunchOnlyWhenAvailable() {
+        XCTAssertTrue(WakeQuotaState.available.permitsLaunch)
+        XCTAssertFalse(WakeQuotaState.blocked(until: now, reason: .sessionLimit).permitsLaunch)
+        XCTAssertFalse(WakeQuotaState.unknown(reason: .notFetched).permitsLaunch)
+    }
+
+    // MARK: - Authority wiring
+
+    func testAuthorityFetchesFreshAndEvaluates() async {
+        let fetcher = ScriptedQuotaFetcher([WakeMetricsFixture.available(fetchedAt: now)])
+        let authority = WakeQuotaAuthority(
+            fetcher: fetcher,
+            evaluator: evaluator,
+            now: { self.now }
+        )
+        let state = await authority.currentState(accountID: UUID())
+        XCTAssertEqual(state, .available)
+        XCTAssertEqual(fetcher.callCount, 1, "Authority must perform a fresh fetch")
+    }
+
+    func testAuthorityFailsClosedOnFetchError() async {
+        let fetcher = ScriptedQuotaFetcher([.failure("cli exploded")])
+        let authority = WakeQuotaAuthority(fetcher: fetcher, evaluator: evaluator, now: { self.now })
+        let state = await authority.currentState(accountID: UUID())
+        XCTAssertEqual(state, .unknown(reason: .fetchFailed("cli exploded")))
+    }
+}

--- a/MeterBarTests/WakeSeamsTests.swift
+++ b/MeterBarTests/WakeSeamsTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import MeterBar
+
+/// Coverage for the #96 automation seams and the concrete CLI quota fetcher's
+/// pure/injectable paths (the process-spawning path is exercised by #97).
+final class WakeSeamsTests: XCTestCase {
+    // MARK: - TaskSleeper
+
+    func testTaskSleeperZeroDurationReturnsTrue() async {
+        let elapsed = await TaskSleeper().sleep(0)
+        XCTAssertTrue(elapsed)
+    }
+
+    func testTaskSleeperReturnsFalseWhenCancelled() async {
+        let task = Task { await TaskSleeper().sleep(60) }
+        task.cancel()
+        let elapsed = await task.value
+        XCTAssertFalse(elapsed, "A cancelled sleep must report it did not elapse")
+    }
+
+    // MARK: - ReplayLedgerRecorder (adapter over #95 ledger)
+
+    func testReplayLedgerRecorderPersistsFingerprint() async {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("wake-ledger-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let ledger = ReplayLedger(fileURL: tmp)
+        let recorder = ReplayLedgerRecorder(ledger: ledger)
+        let fingerprint = BlockFingerprint(
+            sessionID: "session-a",
+            blockedAt: Date(timeIntervalSinceReferenceDate: 1),
+            reason: .sessionLimit
+        )
+
+        await recorder.record(fingerprint)
+
+        let contains = await ledger.contains(fingerprint)
+        XCTAssertTrue(contains, "Recorded fingerprint must be persisted in the ledger")
+    }
+
+    // MARK: - DiscoveryCandidateSource (adapter over #95 discovery)
+
+    func testDiscoveryCandidateSourceReturnsEmptyForMissingProjects() async {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("wake-account-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let source = DiscoveryCandidateSource(
+            discovery: SessionDiscovery(),
+            ledger: ReplayLedger(fileURL: tmp.appendingPathComponent("ledger.json"))
+        )
+
+        let candidates = await source.candidates(configDirectory: tmp.path)
+        XCTAssertTrue(candidates.isEmpty, "An account with no transcripts yields no candidates")
+    }
+
+    // MARK: - ClaudeCLIQuotaFetcher pure paths
+
+    func testQuotaFetcherFailsClosedWhenAccountUnresolved() async {
+        let fetcher = ClaudeCLIQuotaFetcher(accountLookup: { _ in nil })
+        let result = await fetcher.fetchFreshQuota(accountID: UUID())
+        guard case .failure = result else {
+            return XCTFail("Unresolved account must fail (fails closed), got \(result)")
+        }
+    }
+
+    func testAuthorizationHeuristicClassifiesLoginPrompts() {
+        XCTAssertTrue(ClaudeCLIQuotaFetcher.looksLikeAuthorizationFailure(
+            ClaudeCodeCLIUsageError.commandFailed("Please run /login to authenticate")))
+        XCTAssertTrue(ClaudeCLIQuotaFetcher.looksLikeAuthorizationFailure(
+            ClaudeCodeCLIUsageError.commandFailed("You are logged out")))
+        XCTAssertFalse(ClaudeCLIQuotaFetcher.looksLikeAuthorizationFailure(
+            ClaudeCodeCLIUsageError.timedOut))
+        XCTAssertFalse(ClaudeCLIQuotaFetcher.looksLikeAuthorizationFailure(
+            ClaudeCodeCLIUsageError.cliNotFound))
+    }
+}

--- a/MeterBarTests/WakeTestDoubles.swift
+++ b/MeterBarTests/WakeTestDoubles.swift
@@ -1,0 +1,281 @@
+import Foundation
+import MeterBarShared
+@testable import MeterBar
+
+// MARK: - Cancellation helper
+
+/// Resumes when the surrounding task is cancelled. Used by the blocking sleeper
+/// and the block-until-cancelled runner to model a genuinely pending suspension
+/// that `WakeCoordinator.stop()` must cancel deterministically.
+final class WakeCancellationBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var cancelled = false
+
+    func park(_ continuation: CheckedContinuation<Void, Never>) {
+        lock.lock()
+        defer { lock.unlock() }
+        if cancelled {
+            continuation.resume()
+        } else {
+            self.continuation = continuation
+        }
+    }
+
+    func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
+        cancelled = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+func suspendUntilCancelled() async {
+    let box = WakeCancellationBox()
+    await withTaskCancellationHandler {
+        await withCheckedContinuation { continuation in
+            box.park(continuation)
+        }
+    } onCancel: {
+        box.cancel()
+    }
+}
+
+// MARK: - Quota fetcher
+
+/// Returns a scripted sequence of fetch outcomes, repeating the last element.
+final class ScriptedQuotaFetcher: WakeQuotaFetching, @unchecked Sendable {
+    private let lock = NSLock()
+    private var outcomes: [WakeQuotaFetch]
+    private(set) var callCount = 0
+
+    init(_ outcomes: [WakeQuotaFetch]) {
+        self.outcomes = outcomes
+    }
+
+    func fetchFreshQuota(accountID: UUID) async -> WakeQuotaFetch {
+        await Task.yield()
+        lock.lock()
+        defer { lock.unlock() }
+        callCount += 1
+        if outcomes.count > 1 {
+            return outcomes.removeFirst()
+        }
+        return outcomes.first ?? .failure("no scripted outcome")
+    }
+}
+
+enum WakeMetricsFixture {
+    static func available(fetchedAt: Date) -> WakeQuotaFetch {
+        .success(
+            UsageMetrics(
+                service: .claudeCode,
+                sessionLimit: UsageLimit(used: 10, total: 100, resetTime: nil)
+            ),
+            fetchedAt: fetchedAt
+        )
+    }
+
+    static func blocked(fetchedAt: Date, until: Date?) -> WakeQuotaFetch {
+        .success(
+            UsageMetrics(
+                service: .claudeCode,
+                sessionLimit: UsageLimit(used: 100, total: 100, resetTime: until)
+            ),
+            fetchedAt: fetchedAt
+        )
+    }
+}
+
+// MARK: - Candidate source (adapts #95 discovery seam)
+
+final class StubCandidateSource: WakeCandidateSource, @unchecked Sendable {
+    private let lock = NSLock()
+    private var perCall: [[WakeSessionCandidate]]
+    private(set) var callCount = 0
+
+    init(_ perCall: [[WakeSessionCandidate]]) {
+        self.perCall = perCall
+    }
+
+    convenience init(constant candidates: [WakeSessionCandidate]) {
+        self.init([candidates])
+    }
+
+    func candidates(configDirectory: String?) async -> [WakeSessionCandidate] {
+        await Task.yield()
+        lock.lock()
+        defer { lock.unlock() }
+        callCount += 1
+        if perCall.count > 1 {
+            return perCall.removeFirst()
+        }
+        return perCall.first ?? []
+    }
+}
+
+// MARK: - Runner
+
+final class StubRunner: WakeSessionRunning, @unchecked Sendable {
+    enum Mode {
+        case outcome(WakeRunOutcome)
+        case blockUntilCancelled
+    }
+
+    private let lock = NSLock()
+    private let mode: Mode
+    private var recorded: [String] = []
+    private let onStarted: (@Sendable () -> Void)?
+
+    init(mode: Mode, onStarted: (@Sendable () -> Void)? = nil) {
+        self.mode = mode
+        self.onStarted = onStarted
+    }
+
+    var runs: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recorded
+    }
+
+    func run(_ candidate: WakeSessionCandidate, maxTurns: Int, timeout: TimeInterval) async -> WakeRunOutcome {
+        lock.lock()
+        recorded.append(candidate.id)
+        lock.unlock()
+        onStarted?()
+
+        switch mode {
+        case let .outcome(outcome):
+            await Task.yield()
+            return outcome
+        case .blockUntilCancelled:
+            await suspendUntilCancelled()
+            return .interrupted
+        }
+    }
+}
+
+// MARK: - Ledger
+
+final class InMemoryLedger: WakeBlockLedger, @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedValues: Set<String> = []
+
+    var recorded: Set<String> {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedValues
+    }
+
+    func record(_ fingerprint: BlockFingerprint) async {
+        lock.lock()
+        defer { lock.unlock() }
+        recordedValues.insert(fingerprint.value)
+    }
+}
+
+// MARK: - Sleepers
+
+/// Returns immediately, recording each requested duration. Honors cancellation.
+final class ImmediateSleeper: WakeSleeper, @unchecked Sendable {
+    private let lock = NSLock()
+    private var recorded: [TimeInterval] = []
+
+    var durations: [TimeInterval] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recorded
+    }
+
+    func sleep(_ seconds: TimeInterval) async -> Bool {
+        lock.lock()
+        recorded.append(seconds)
+        lock.unlock()
+        await Task.yield()
+        return !Task.isCancelled
+    }
+}
+
+/// Suspends until the surrounding task is cancelled, then returns `false`.
+/// Models a genuinely pending sleep so cancellation can be asserted.
+final class BlockingSleeper: WakeSleeper, @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelledFlag = false
+
+    var wasCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelledFlag
+    }
+
+    func sleep(_ seconds: TimeInterval) async -> Bool {
+        await suspendUntilCancelled()
+        lock.lock()
+        cancelledFlag = true
+        lock.unlock()
+        return false
+    }
+}
+
+// MARK: - Observer
+
+final class WakeStateRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var states: [WakeWatcherState] = []
+
+    var observer: @Sendable (WakeWatcherState) -> Void {
+        { [weak self] state in
+            guard let self else { return }
+            self.lock.lock()
+            self.states.append(state)
+            self.lock.unlock()
+        }
+    }
+
+    var recorded: [WakeWatcherState] {
+        lock.lock()
+        defer { lock.unlock() }
+        return states
+    }
+}
+
+// MARK: - Async polling helper
+
+/// Polls `condition` until it holds or `timeout` elapses. Uses wall-clock
+/// `Date()` (test-only) rather than any injected clock.
+func wakeWaitUntil(
+    timeout: TimeInterval = 3,
+    _ condition: @Sendable () async -> Bool
+) async -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if await condition() { return true }
+        try? await Task.sleep(nanoseconds: 2_000_000)
+    }
+    return await condition()
+}
+
+// MARK: - Candidate factory (builds a real #95 candidate)
+
+func wakeCandidate(
+    _ session: String,
+    reason: WakeBlockReason = .sessionLimit,
+    blockedAt: Date = Date(timeIntervalSinceReferenceDate: 700_000_000)
+) -> WakeSessionCandidate {
+    WakeSessionCandidate(
+        sessionID: session,
+        transcriptPath: "/tmp/\(session).jsonl",
+        workingDirectory: "/tmp/\(session)",
+        gitBranch: nil,
+        reason: reason,
+        blockedAt: blockedAt,
+        resetHint: nil,
+        fingerprint: BlockFingerprint(sessionID: session, blockedAt: blockedAt, reason: reason),
+        skipReason: nil
+    )
+}
+
+func wakeTestAccount() -> ClaudeCodeAccount {
+    ClaudeCodeAccount(id: UUID(), name: "Wake Test", configDirectory: nil)
+}


### PR DESCRIPTION
Implements **#96 — Fresh quota gate and cancellable watcher state machine** (epic #94). Former blocker #47 is closed; implementation authorized by the maintainer.

> **Draft — stacked on the in-progress #95.** #96 is delivery-gated on #95 (order #95 → #96 → #97) and cannot merge before #95 lands. See "Coordination" below.

## What this delivers

The single native watcher state machine and an account-scoped quota authority that **fails closed** when quota freshness cannot be proven.

**Quota authority** — `WakeQuotaState`, `WakeQuotaAuthority`
- Every gate is a *fresh* account-scoped fetch. Cached UI metrics are never execution authority.
- Missing OAuth, fetch failure, stale (or future-dated) data, and ambiguous shape all resolve to `unknown` → launches nothing.
- Gates every hard window (session / weekly / model-weekly): an exhausted weekly or model cap blocks a launch even when the 5-hour window is open. Blocked reports the farthest reset; an unknown reset dominates (most conservative).

**Watcher** — `WakeWatcherState`, `WakeCoordinator` (actor)
- One cancellable structured `Task`. States: off / armed / scanning / waiting / quotaUnknown / running / stopping / completed / failed.
- Re-fetches quota before every launch **and** after every completed attempt; preserves the remaining queue and returns to waiting when a session re-maxes quota.
- `stop()` cancels pending sleep/run work and awaits the loop's deterministic unwind.
- **Active-child cancellation:** cooperative-cancel, preserve the candidate, never record it. v1 lifetime is **app-running-only** (no managed helper) — decided and documented in **ADR-010**.

**Bounds** — `WakeBounds`: poll / buffer / gap / timeout / maxTurns / sessionCap validated and clamped; non-finite → lower bound; `sessionCap` is **finite by construction** (epic #94: "unlimited is never the default", overriding the PRD's "0 = all").

**Seams** — `WakeAutomationSeams`: runner / candidate-source / ledger / sleeper protocols + adapters over #95's `SessionDiscovery` / `ReplayLedger`. The process runner + locking are #97; the UI is #98 (this coordinator is the "real coordinator" #98's `SessionWakeCoordinator` stubs).

## Acceptance criteria (#96)

- [x] Missing / stale / failed / ambiguous quota is `unknown` and launches nothing
- [x] The "02:10 reset read at 02:15" case never rolls to tomorrow (#95's `TranscriptResetParser`); #96 additionally proves a passed reset never authorizes a launch — only a fresh `available` fetch does
- [x] Missing OAuth cannot keep a stale transcript permanently blocked or make quota fail open (`missingAuthorization` is re-evaluated fresh each cycle)
- [x] An exhausted weekly/model window prevents launch even when the 5h window is open
- [x] Fresh quota is checked before the first launch and every subsequent launch
- [x] A session that re-maxes quota stops the queue and preserves remaining work
- [x] Watcher-off cancels pending sleep/poll work deterministically
- [x] Active-child cancellation semantics are explicitly decided and tested (ADR-010)
- [x] Numeric bounds for polling, buffer, gap, timeout, max turns, and session cap are validated

## Coordination (please read)

While implementing #96 I found **#95 being actively built by a concurrent agent** on `session-wake/95-discovery`, uncommitted, in the primary checkout. #95 owns `WakeBlockReason`, `WakeSessionCandidate`, `SessionDiscovery`, `ReplayLedger`, `TranscriptResetParser`; its `SessionWakeCoordinator` is a UI seam that explicitly *stubs* the real coordinator "once #95–#97 land". Per your answer (stack on a #95 snapshot), this branch:

1. **Commit 1** snapshots #95's discovery/ledger core as base material (to be **dropped on rebase** once #95 lands), plus a force-unwrap lint fix so `swiftlint --strict` passes.
2. **Commit 2** is the #96 implementation, consuming #95's real types.

I removed the #96 files I had accidentally written into the #95 agent's checkout so its tree is unpolluted (kept only the shared `AppLog.wake` category its `ReplayLedger` needs).

## Verification

- **407 tests pass** (33 new: bounds, quota authority, gate reset behavior, seams, coordinator state machine)
- `swiftlint lint --strict` clean
- **#96 new-code line coverage 88.5%** (every new file ≥ 84.7%); CI coverage floor (19%) satisfied at 36.6% overall
- Runner spawn / quota-CLI spawn are the injected seams (#97 territory), exercised via fakes rather than real subprocesses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
