### PR TITLE
Session Wake #96: fresh quota gate + cancellable watcher state machine

### DIFF
--- a/MeterBar/SessionWake/WakeBounds.swift
+++ b/MeterBar/SessionWake/WakeBounds.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Validated numeric bounds for a wake run.
+///
+/// v1 is deliberately conservative: a bounded number of sessions per run,
+/// per-session turn and timeout caps, and no "unlimited" default anywhere.
+/// Every field is clamped into a sane range at construction so an invalid
+/// preference can never widen the blast radius of automated resumes.
+struct WakeBounds: Equatable, Sendable {
+    /// Seconds between live quota polls while waiting.
+    let pollInterval: TimeInterval
+    /// Seconds to wait past a reset instant before treating quota as open.
+    let bufferAfterReset: TimeInterval
+    /// Seconds to pause between sequential session launches.
+    let gapBetweenSessions: TimeInterval
+    /// Hard wall-clock timeout for a single session launch.
+    let perSessionTimeout: TimeInterval
+    /// Maximum agent turns permitted per resumed session.
+    let maxTurns: Int
+    /// Maximum sessions resumed in one run. Never unlimited.
+    let maxSessionsPerRun: Int
+    /// Upper bound on consecutive quota-unknown polls before giving up, so a
+    /// missing-OAuth account cannot loop forever on a stale transcript.
+    let maxUnknownPolls: Int
+
+    static let pollIntervalRange: ClosedRange<TimeInterval> = 15...900
+    static let bufferRange: ClosedRange<TimeInterval> = 0...1800
+    static let gapRange: ClosedRange<TimeInterval> = 0...600
+    static let timeoutRange: ClosedRange<TimeInterval> = 60...21_600
+    static let maxTurnsRange: ClosedRange<Int> = 1...200
+    static let sessionsRange: ClosedRange<Int> = 1...100
+    static let unknownPollsRange: ClosedRange<Int> = 1...240
+
+    /// Conservative v1 defaults. Bounded sessions, not "all".
+    static let `default` = WakeBounds(
+        pollInterval: 60,
+        bufferAfterReset: 90,
+        gapBetweenSessions: 20,
+        perSessionTimeout: 7200,
+        maxTurns: 40,
+        maxSessionsPerRun: 5,
+        maxUnknownPolls: 30
+    )
+
+    init(
+        pollInterval: TimeInterval,
+        bufferAfterReset: TimeInterval,
+        gapBetweenSessions: TimeInterval,
+        perSessionTimeout: TimeInterval,
+        maxTurns: Int,
+        maxSessionsPerRun: Int,
+        maxUnknownPolls: Int
+    ) {
+        self.pollInterval = pollInterval.clamped(to: WakeBounds.pollIntervalRange)
+        self.bufferAfterReset = bufferAfterReset.clamped(to: WakeBounds.bufferRange)
+        self.gapBetweenSessions = gapBetweenSessions.clamped(to: WakeBounds.gapRange)
+        self.perSessionTimeout = perSessionTimeout.clamped(to: WakeBounds.timeoutRange)
+        self.maxTurns = maxTurns.clamped(to: WakeBounds.maxTurnsRange)
+        self.maxSessionsPerRun = maxSessionsPerRun.clamped(to: WakeBounds.sessionsRange)
+        self.maxUnknownPolls = maxUnknownPolls.clamped(to: WakeBounds.unknownPollsRange)
+    }
+}
+
+extension Comparable {
+    /// Clamp a value into a closed range.
+    func clamped(to range: ClosedRange<Self>) -> Self {
+        min(max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/MeterBar/SessionWake/WakeCoordinator.swift
+++ b/MeterBar/SessionWake/WakeCoordinator.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+/// The single native watcher state machine.
+///
+/// Owns exactly one cancellable structured task and drives the full lifecycle:
+/// scan → (wait | quota-unknown) → run → re-check → …. Fresh quota is fetched
+/// before *every* launch and again after every attempt, so a session that
+/// re-exhausts the window stops the queue and preserves the remaining work
+/// instead of hammering a blocked account.
+///
+/// v1 lifetime is **app-running-only**: the watcher lives with the process.
+/// There is no managed launchd helper in v1; sleep/wake and quit simply end the
+/// watcher, and it is re-armed on next launch by the settings layer (#98).
+actor WakeCoordinator {
+    private let discovery: SessionDiscovery
+    private let authority: WakeQuotaAuthority
+    private let runner: WakeExecuting
+    private let ledger: ReplayLedger
+    private let bounds: WakeBounds
+    private let sleep: @Sendable (TimeInterval) async throws -> Void
+    private let now: @Sendable () -> Date
+
+    private(set) var state: WakeWatcherState = .off
+    private(set) var stateHistory: [WakeWatcherState] = []
+    private var runTask: Task<Void, Never>?
+
+    init(
+        discovery: SessionDiscovery = SessionDiscovery(),
+        authority: WakeQuotaAuthority = WakeQuotaAuthority(),
+        runner: WakeExecuting,
+        ledger: ReplayLedger = ReplayLedger(),
+        bounds: WakeBounds = .default,
+        now: @escaping @Sendable () -> Date = { Date() },
+        sleep: @escaping @Sendable (TimeInterval) async throws -> Void = { seconds in
+            try await Task.sleep(nanoseconds: UInt64(max(0, seconds) * 1_000_000_000))
+        }
+    ) {
+        self.discovery = discovery
+        self.authority = authority
+        self.runner = runner
+        self.ledger = ledger
+        self.bounds = bounds
+        self.now = now
+        self.sleep = sleep
+    }
+
+    /// Arm the watcher for `account`. No-op if already running.
+    func start(account: ClaudeCodeAccount) {
+        guard runTask == nil else { return }
+        runTask = Task { [weak self] in
+            await self?.runLoop(account: account)
+        }
+    }
+
+    /// Cancel any in-flight watch deterministically. Cancels pending sleep/poll
+    /// work; the run loop observes cancellation and returns to `off` itself (and
+    /// the active child, if any, is cancelled by the runner via structured-task
+    /// cancellation in #97). The loop — not `stop()` — owns the final transition
+    /// so `waitUntilFinished()` reflects a settled state.
+    func stop() {
+        guard let task = runTask else {
+            transition(.off)
+            return
+        }
+        transition(.stopping)
+        task.cancel()
+    }
+
+    /// Await the current run (test hook).
+    func waitUntilFinished() async {
+        await runTask?.value
+    }
+
+    // MARK: - Run loop
+
+    /// How the loop should proceed after handling one quota decision.
+    private enum LoopStep: Equatable {
+        case keepGoing
+        case stop
+        case fail(reason: String)
+    }
+
+    private var unknownPolls = 0
+
+    private func runLoop(account: ClaudeCodeAccount) async {
+        transition(.scanning)
+        let discovered = await discovery.discover(configDirectory: account.configDirectory, ledger: ledger)
+        var queue = Array(discovered.filter(\.isExecutable).prefix(bounds.maxSessionsPerRun))
+
+        var summary = WakeRunSummary()
+        summary.skipped = discovered.count - queue.count
+        unknownPolls = 0
+
+        loop: while !queue.isEmpty && !Task.isCancelled {
+            // Fresh quota before EVERY launch.
+            let quota = await authority.freshQuota(account: account)
+            let step = await handle(quota: quota, account: account, queue: &queue, summary: &summary)
+            switch step {
+            case .keepGoing:
+                continue
+            case .stop:
+                break loop
+            case let .fail(reason):
+                summary.remaining = queue.count
+                transition(.failed(reason: reason))
+                runTask = nil
+                return
+            }
+        }
+
+        if Task.isCancelled {
+            transition(.off)
+        } else {
+            summary.remaining = queue.count
+            transition(.completed(summary: summary))
+        }
+        runTask = nil
+    }
+
+    private func handle(
+        quota: WakeQuota,
+        account: ClaudeCodeAccount,
+        queue: inout [WakeSessionCandidate],
+        summary: inout WakeRunSummary
+    ) async -> LoopStep {
+        switch quota {
+        case .available:
+            unknownPolls = 0
+            return await launchNext(account: account, queue: &queue, summary: &summary)
+        case let .blocked(until, _):
+            summary.remaining = queue.count
+            transition(.waiting(until: until))
+            return (try? await sleepUntilRetry(until: until)) == nil ? .stop : .keepGoing
+        case let .unknown(reason):
+            unknownPolls += 1
+            transition(.quotaUnknown(reason: reason))
+            if unknownPolls >= bounds.maxUnknownPolls {
+                return .fail(reason: "fresh quota unavailable after \(unknownPolls) polls")
+            }
+            return (try? await sleep(bounds.pollInterval)) == nil ? .stop : .keepGoing
+        }
+    }
+
+    private func launchNext(
+        account: ClaudeCodeAccount,
+        queue: inout [WakeSessionCandidate],
+        summary: inout WakeRunSummary
+    ) async -> LoopStep {
+        let candidate = queue.removeFirst()
+        transition(.running(sessionID: candidate.sessionID))
+        let outcome = await runner.run(candidate, bounds: bounds)
+        await record(outcome, candidate: candidate, summary: &summary)
+
+        guard !queue.isEmpty else { return .keepGoing }
+
+        // Re-fetch AFTER the attempt; a re-maxed window stops the queue and
+        // preserves the remaining work.
+        let post = await authority.freshQuota(account: account)
+        if case let .blocked(until, _) = post {
+            summary.remaining = queue.count
+            transition(.waiting(until: until))
+            return (try? await sleepUntilRetry(until: until)) == nil ? .stop : .keepGoing
+        }
+        return (try? await sleep(bounds.gapBetweenSessions)) == nil ? .stop : .keepGoing
+    }
+
+    private func record(
+        _ outcome: WakeRunOutcome,
+        candidate: WakeSessionCandidate,
+        summary: inout WakeRunSummary
+    ) async {
+        switch outcome {
+        case .succeeded:
+            summary.resumed += 1
+            // Only a real resume marks the block handled, so a failed attempt
+            // can be retried on a later run.
+            await ledger.record(candidate.fingerprint)
+        case .failed:
+            summary.failed += 1
+        case .skipped:
+            summary.skipped += 1
+        case .cancelled:
+            break
+        }
+    }
+
+    /// Sleep until a reset (plus buffer), or one poll interval when the reset is
+    /// unknown or already elapsed. A past reset only schedules a re-check — it
+    /// never proves availability.
+    private func sleepUntilRetry(until: Date?) async throws {
+        guard let until else {
+            try await sleep(bounds.pollInterval)
+            return
+        }
+        let target = until.addingTimeInterval(bounds.bufferAfterReset)
+        let delay = target.timeIntervalSince(now())
+        try await sleep(max(bounds.pollInterval, delay))
+    }
+
+    private func transition(_ next: WakeWatcherState) {
+        state = next
+        stateHistory.append(next)
+    }
+}

--- a/MeterBar/SessionWake/WakeQuota.swift
+++ b/MeterBar/SessionWake/WakeQuota.swift
@@ -1,0 +1,45 @@
+import Foundation
+import MeterBarShared
+
+/// The account-scoped quota decision that gates every launch.
+///
+/// Only `.available` authorizes running a session. Everything else — a known
+/// block or any doubt at all — refuses to launch. This is the fail-closed
+/// contract: missing, stale, failed, or ambiguous quota is `.unknown`, never
+/// silently treated as available.
+enum WakeQuota: Equatable, Sendable {
+    /// A hard window is open and fresh enough to authorize one launch.
+    case available
+    /// A hard window is exhausted; `until` is its reset instant when known.
+    case blocked(until: Date?, reason: WakeBlockReason)
+    /// Quota could not be established as authority (missing/stale/failed).
+    case unknown(reason: String)
+
+    /// The single predicate the coordinator is allowed to launch on.
+    var allowsLaunch: Bool {
+        if case .available = self { return true }
+        return false
+    }
+
+    /// Classify fresh metrics into a quota decision.
+    ///
+    /// Gates the weekly window before the session window (an exhausted weekly
+    /// limit blocks even when the 5h window is open), and fails closed when the
+    /// session window is absent — an account with no readable session limit
+    /// cannot be proven available.
+    static func classify(_ metrics: UsageMetrics) -> WakeQuota {
+        if let weekly = metrics.weeklyLimit, weekly.isAtLimit {
+            return .blocked(until: weekly.resetTime, reason: .weeklyLimit)
+        }
+        if let codeReview = metrics.codeReviewLimit, codeReview.isAtLimit {
+            return .blocked(until: codeReview.resetTime, reason: .modelWeeklyLimit)
+        }
+        guard let session = metrics.sessionLimit else {
+            return .unknown(reason: "no session-limit window in metrics")
+        }
+        if session.isAtLimit {
+            return .blocked(until: session.resetTime, reason: .sessionLimit)
+        }
+        return .available
+    }
+}

--- a/MeterBar/SessionWake/WakeQuotaAuthority.swift
+++ b/MeterBar/SessionWake/WakeQuotaAuthority.swift
@@ -1,0 +1,54 @@
+import Foundation
+import MeterBarShared
+
+/// Source of *fresh* account-scoped quota. Cached UI metrics are never passed
+/// here — the authority always pulls a live reading so a launch decision can
+/// never rest on stale numbers.
+protocol WakeQuotaProviding: Sendable {
+    func fetchMetrics(account: ClaudeCodeAccount) async throws -> UsageMetrics
+}
+
+/// Default provider: the same `claude /usage` service the app and CLI already
+/// use, scoped to the selected account's `CLAUDE_CONFIG_DIR`.
+struct LiveWakeQuotaProvider: WakeQuotaProviding {
+    func fetchMetrics(account: ClaudeCodeAccount) async throws -> UsageMetrics {
+        try await ClaudeCodeCLIUsageService.shared.fetchUsageMetrics(account: account)
+    }
+}
+
+/// Resolves a fresh quota decision for the selected account, failing closed on
+/// any error, staleness, or ambiguity.
+struct WakeQuotaAuthority: Sendable {
+    private let provider: WakeQuotaProviding
+    /// Metrics older than this are not accepted as execution authority even if
+    /// a fetch returned them.
+    private let maxAge: TimeInterval
+    private let now: @Sendable () -> Date
+
+    init(
+        provider: WakeQuotaProviding = LiveWakeQuotaProvider(),
+        maxAge: TimeInterval = 120,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.provider = provider
+        self.maxAge = maxAge
+        self.now = now
+    }
+
+    /// Fetch and classify fresh quota for `account`.
+    ///
+    /// - A thrown fetch (missing OAuth, CLI error) ⇒ `.unknown` (fail closed).
+    /// - Metrics older than `maxAge` ⇒ `.unknown` (never treat cache as truth).
+    func freshQuota(account: ClaudeCodeAccount) async -> WakeQuota {
+        let metrics: UsageMetrics
+        do {
+            metrics = try await provider.fetchMetrics(account: account)
+        } catch {
+            return .unknown(reason: "quota fetch failed: \(error.localizedDescription)")
+        }
+        if now().timeIntervalSince(metrics.lastUpdated) > maxAge {
+            return .unknown(reason: "quota reading is stale")
+        }
+        return WakeQuota.classify(metrics)
+    }
+}

--- a/MeterBar/SessionWake/WakeWatcherState.swift
+++ b/MeterBar/SessionWake/WakeWatcherState.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// The real, user-visible states of the wake watcher.
+///
+/// These are deliberately distinct rather than collapsed into a single
+/// "Watching" — the UI (#98) and CLI (#99) must be able to tell a caller
+/// exactly why nothing is launching (waiting on reset vs quota-unknown vs
+/// stopping) rather than papering over failures.
+enum WakeWatcherState: Equatable, Sendable {
+    /// Feature disabled or watcher not armed.
+    case off
+    /// Feature on, watcher idle/armed but not currently working.
+    case idle
+    /// Reading transcripts to build the queue.
+    case scanning
+    /// Quota is blocked; waiting until `until` (nil ⇒ unknown reset).
+    case waiting(until: Date?)
+    /// Fresh quota could not be established; not launching.
+    case quotaUnknown(reason: String)
+    /// Actively resuming `sessionID`.
+    case running(sessionID: String)
+    /// A stop was requested; unwinding.
+    case stopping
+    /// The run finished; carries the outcome tally.
+    case completed(summary: WakeRunSummary)
+    /// The run ended abnormally.
+    case failed(reason: String)
+}
+
+/// Tally of a completed (or preserved) wake run.
+struct WakeRunSummary: Equatable, Sendable {
+    var resumed: Int = 0
+    var failed: Int = 0
+    var skipped: Int = 0
+    /// Sessions still queued when the run stopped (e.g. re-exhausted quota).
+    var remaining: Int = 0
+
+    var attempted: Int { resumed + failed }
+}
+
+/// The outcome of running one session, reported by the execution layer (#97).
+enum WakeRunOutcome: Equatable, Sendable {
+    case succeeded
+    case failed(reason: String)
+    case skipped(reason: WakeSkipReason)
+    case cancelled
+}
+
+/// The execution seam the coordinator drives. #96 owns orchestration and state;
+/// the concrete process runner arrives in #97. Keeping it a protocol lets the
+/// state machine be tested without spawning a subprocess.
+protocol WakeExecuting: Sendable {
+    func run(_ candidate: WakeSessionCandidate, bounds: WakeBounds) async -> WakeRunOutcome
+}

--- a/MeterBarTests/WakeCoordinatorTests.swift
+++ b/MeterBarTests/WakeCoordinatorTests.swift
@@ -1,0 +1,252 @@
+import XCTest
+@testable import MeterBar
+@testable import MeterBarShared
+
+/// Coverage for #96: the cancellable watcher state machine and its
+/// fresh-quota-before-every-launch contract.
+final class WakeCoordinatorTests: XCTestCase {
+    private var tempDir: URL!
+    private var accountDir: URL!
+    private var ledgerURL: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WakeCoordinatorTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        accountDir = tempDir.appendingPathComponent("account")
+        ledgerURL = tempDir.appendingPathComponent("ledger.json")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    // MARK: - Fixtures
+
+    /// Write `count` blocked transcripts with existing cwds ⇒ executable.
+    private func writeBlockedSessions(_ count: Int) throws {
+        let projects = accountDir.appendingPathComponent("projects").appendingPathComponent("-proj")
+        try FileManager.default.createDirectory(at: projects, withIntermediateDirectories: true)
+        for index in 0..<count {
+            let object: [String: Any] = [
+                "type": "assistant",
+                "timestamp": "2026-07-10T02:00:0\(index).000Z",
+                "isApiErrorMessage": true,
+                "apiErrorStatus": 429,
+                "cwd": tempDir.path, // exists ⇒ executable
+                "sessionId": "s\(index)",
+                "message": ["role": "assistant", "content": [["type": "text", "text": "session limit resets 3:00am (UTC)"]]]
+            ]
+            let data = try JSONSerialization.data(withJSONObject: object)
+            let line = String(decoding: data, as: UTF8.self)
+            try line.write(to: projects.appendingPathComponent("s\(index).jsonl"), atomically: true, encoding: .utf8)
+        }
+    }
+
+    private func account() -> ClaudeCodeAccount {
+        ClaudeCodeAccount(id: UUID(), name: "test", configDirectory: accountDir.path)
+    }
+
+    private func makeCoordinator(
+        provider: WakeQuotaProviding,
+        runner: WakeExecuting,
+        bounds: WakeBounds = WakeBounds.default,
+        sleep: @escaping @Sendable (TimeInterval) async throws -> Void
+    ) -> WakeCoordinator {
+        WakeCoordinator(
+            discovery: SessionDiscovery(),
+            authority: WakeQuotaAuthority(provider: provider, maxAge: 3600, now: { Date() }),
+            runner: runner,
+            ledger: ReplayLedger(fileURL: ledgerURL),
+            bounds: bounds,
+            now: { Date() },
+            sleep: sleep
+        )
+    }
+
+    private let immediateSleep: @Sendable (TimeInterval) async throws -> Void = { _ in }
+
+    // MARK: - Tests
+
+    func testAvailableRunsWholeQueueAndCompletes() async throws {
+        try writeBlockedSessions(2)
+        let runner = RecordingRunner()
+        let provider = SequencedProvider(repeating: .open)
+        let coordinator = makeCoordinator(provider: provider, runner: runner, sleep: immediateSleep)
+
+        await coordinator.start(account: account())
+        await coordinator.waitUntilFinished()
+
+        let ran = await runner.ran
+        XCTAssertEqual(Set(ran), ["s0", "s1"])
+        if case let .completed(summary) = await coordinator.state {
+            XCTAssertEqual(summary.resumed, 2)
+            XCTAssertEqual(summary.remaining, 0)
+        } else {
+            XCTFail("Expected completed state")
+        }
+        // Fresh quota before each of 2 launches + one post-attempt re-check.
+        let calls = await provider.calls
+        XCTAssertGreaterThanOrEqual(calls, 3)
+    }
+
+    func testUnknownQuotaLaunchesNothing() async throws {
+        try writeBlockedSessions(1)
+        let runner = RecordingRunner()
+        let provider = SequencedProvider(repeating: .fail)
+        let bounds = WakeBounds(
+            pollInterval: 1, bufferAfterReset: 0, gapBetweenSessions: 0,
+            perSessionTimeout: 60, maxTurns: 10, maxSessionsPerRun: 5, maxUnknownPolls: 3
+        )
+        let coordinator = makeCoordinator(provider: provider, runner: runner, bounds: bounds, sleep: immediateSleep)
+
+        await coordinator.start(account: account())
+        await coordinator.waitUntilFinished()
+
+        let ran = await runner.ran
+        XCTAssertTrue(ran.isEmpty)
+        if case .failed = await coordinator.state {} else {
+            XCTFail("Expected failed after exhausting unknown polls")
+        }
+    }
+
+    func testWeeklyBlockDefersLaunchThenRunsWhenOpen() async throws {
+        try writeBlockedSessions(1)
+        let runner = RecordingRunner()
+        // First reading blocked, then open.
+        let provider = SequencedProvider(steps: [.blocked(nil)], repeating: .open)
+        let coordinator = makeCoordinator(provider: provider, runner: runner, sleep: immediateSleep)
+
+        await coordinator.start(account: account())
+        await coordinator.waitUntilFinished()
+
+        let ran = await runner.ran
+        XCTAssertEqual(ran, ["s0"])
+        let history = await coordinator.stateHistory
+        let waitedBeforeRunning = history.firstIndex(where: { if case .waiting = $0 { return true }; return false })
+        let firstRunning = history.firstIndex(where: { if case .running = $0 { return true }; return false })
+        XCTAssertNotNil(waitedBeforeRunning)
+        XCTAssertNotNil(firstRunning)
+        XCTAssertLessThan(waitedBeforeRunning!, firstRunning!)
+    }
+
+    func testReMaxedQuotaStopsQueueThenPreservesRemainingForLater() async throws {
+        try writeBlockedSessions(2)
+        let runner = RecordingRunner()
+        // Open → (after first attempt) blocked ⇒ queue pauses → open ⇒ resumes.
+        // The block between the two launches proves the queue is not drained
+        // blindly: it stops and the remaining session is preserved for later.
+        let provider = SequencedProvider(steps: [.open, .blocked(nil), .open], repeating: .open)
+        let coordinator = makeCoordinator(provider: provider, runner: runner, sleep: immediateSleep)
+
+        await coordinator.start(account: account())
+        await coordinator.waitUntilFinished()
+
+        let ran = await runner.ran
+        XCTAssertEqual(Set(ran), ["s0", "s1"], "Both run, but only after the queue paused on re-exhaustion")
+        XCTAssertEqual(ran.count, 2)
+
+        // Assert ordering: running(s0) → waiting → running(s1).
+        let history = await coordinator.stateHistory
+        var sawFirstRun = false
+        var sawWaitAfterFirst = false
+        var waitPrecededSecondRun = false
+        for state in history {
+            switch state {
+            case .running where !sawFirstRun:
+                sawFirstRun = true
+            case .waiting where sawFirstRun:
+                sawWaitAfterFirst = true
+            case .running where sawWaitAfterFirst:
+                waitPrecededSecondRun = true
+            default:
+                break
+            }
+        }
+        XCTAssertTrue(waitPrecededSecondRun, "Re-exhaustion must pause the queue before resuming remaining work")
+    }
+
+    func testStopCancelsPendingSleepDeterministically() async throws {
+        try writeBlockedSessions(1)
+        let runner = RecordingRunner()
+        let provider = SequencedProvider(repeating: .blocked(nil))
+        // Real (long) sleep so the loop parks in `.waiting` until cancelled.
+        let coordinator = makeCoordinator(
+            provider: provider,
+            runner: runner,
+            sleep: { seconds in try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000)) }
+        )
+
+        await coordinator.start(account: account())
+        try? await Task.sleep(nanoseconds: 80_000_000) // let it reach `.waiting`
+        await coordinator.stop()
+        await coordinator.waitUntilFinished()
+
+        let finalState = await coordinator.state
+        XCTAssertEqual(finalState, .off)
+        let ran = await runner.ran
+        XCTAssertTrue(ran.isEmpty, "No session should launch while blocked")
+    }
+
+    func testSuccessfulResumeIsRecordedInLedger() async throws {
+        try writeBlockedSessions(1)
+        let runner = RecordingRunner(outcome: .succeeded)
+        let provider = SequencedProvider(repeating: .open)
+        let coordinator = makeCoordinator(provider: provider, runner: runner, sleep: immediateSleep)
+
+        await coordinator.start(account: account())
+        await coordinator.waitUntilFinished()
+
+        // A fresh discovery now sees the block as already handled.
+        let ledger = ReplayLedger(fileURL: ledgerURL)
+        let candidates = await SessionDiscovery().discover(configDirectory: accountDir.path, ledger: ledger)
+        XCTAssertEqual(candidates.first?.skipReason, .alreadyHandled)
+    }
+}
+
+// MARK: - Test doubles
+
+private actor RecordingRunner: WakeExecuting {
+    private(set) var ran: [String] = []
+    private let outcome: WakeRunOutcome
+    init(outcome: WakeRunOutcome = .succeeded) { self.outcome = outcome }
+    func run(_ candidate: WakeSessionCandidate, bounds: WakeBounds) async -> WakeRunOutcome {
+        ran.append(candidate.sessionID)
+        return outcome
+    }
+}
+
+private actor SequencedProvider: WakeQuotaProviding {
+    enum Step { case open, blocked(Date?), fail }
+    struct Boom: Error {}
+
+    private var steps: [Step]
+    private let repeatingStep: Step
+    private(set) var calls = 0
+
+    init(steps: [Step] = [], repeating repeatingStep: Step) {
+        self.steps = steps
+        self.repeatingStep = repeatingStep
+    }
+
+    func fetchMetrics(account: ClaudeCodeAccount) async throws -> UsageMetrics {
+        calls += 1
+        let step = steps.isEmpty ? repeatingStep : steps.removeFirst()
+        switch step {
+        case .open:
+            return UsageMetrics(
+                service: .claudeCode,
+                sessionLimit: UsageLimit(used: 10, total: 100, resetTime: nil),
+                lastUpdated: Date()
+            )
+        case let .blocked(reset):
+            return UsageMetrics(
+                service: .claudeCode,
+                sessionLimit: UsageLimit(used: 100, total: 100, resetTime: reset),
+                lastUpdated: Date()
+            )
+        case .fail:
+            throw Boom()
+        }
+    }
+}

--- a/MeterBarTests/WakeQuotaGateTests.swift
+++ b/MeterBarTests/WakeQuotaGateTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+@testable import MeterBar
+@testable import MeterBarShared
+
+/// Coverage for #96: the fresh, fail-closed quota gate and the validated
+/// numeric bounds.
+final class WakeQuotaGateTests: XCTestCase {
+    private func metrics(
+        session: UsageLimit?,
+        weekly: UsageLimit? = nil,
+        codeReview: UsageLimit? = nil,
+        updated: Date = Date()
+    ) -> UsageMetrics {
+        UsageMetrics(
+            service: .claudeCode,
+            sessionLimit: session,
+            weeklyLimit: weekly,
+            codeReviewLimit: codeReview,
+            lastUpdated: updated
+        )
+    }
+
+    private func open(_ reset: Date? = nil) -> UsageLimit {
+        UsageLimit(used: 10, total: 100, resetTime: reset)
+    }
+
+    private func maxed(_ reset: Date?) -> UsageLimit {
+        UsageLimit(used: 100, total: 100, resetTime: reset)
+    }
+
+    // MARK: - Classification
+
+    func testAllOpenIsAvailable() {
+        XCTAssertEqual(WakeQuota.classify(metrics(session: open())), .available)
+    }
+
+    func testSessionMaxedIsBlocked() {
+        let reset = Date(timeIntervalSince1970: 2_000)
+        XCTAssertEqual(WakeQuota.classify(metrics(session: maxed(reset))), .blocked(until: reset, reason: .sessionLimit))
+    }
+
+    func testWeeklyMaxedBlocksEvenWhenSessionOpen() {
+        let reset = Date(timeIntervalSince1970: 9_000)
+        let quota = WakeQuota.classify(metrics(session: open(), weekly: maxed(reset)))
+        XCTAssertEqual(quota, .blocked(until: reset, reason: .weeklyLimit))
+    }
+
+    func testMissingSessionWindowFailsClosed() {
+        guard case .unknown = WakeQuota.classify(metrics(session: nil)) else {
+            return XCTFail("Missing session window must be unknown, not available")
+        }
+    }
+
+    func testAvailableDoesNotAllowLaunchWhenBlockedOrUnknown() {
+        XCTAssertTrue(WakeQuota.available.allowsLaunch)
+        XCTAssertFalse(WakeQuota.blocked(until: nil, reason: .sessionLimit).allowsLaunch)
+        XCTAssertFalse(WakeQuota.unknown(reason: "x").allowsLaunch)
+    }
+
+    // MARK: - Authority (fail-closed)
+
+    func testFetchFailureIsUnknown() async {
+        let authority = WakeQuotaAuthority(provider: ThrowingProvider())
+        let quota = await authority.freshQuota(account: .defaultAccount)
+        guard case .unknown = quota else { return XCTFail("Fetch failure must fail closed") }
+    }
+
+    func testStaleMetricsAreUnknownNotAuthority() async {
+        let stale = metrics(session: open(), updated: Date(timeIntervalSince1970: 0))
+        let authority = WakeQuotaAuthority(
+            provider: StaticProvider(stale),
+            maxAge: 120,
+            now: { Date(timeIntervalSince1970: 10_000) }
+        )
+        guard case .unknown = await authority.freshQuota(account: .defaultAccount) else {
+            return XCTFail("Stale metrics must not be treated as authority")
+        }
+    }
+
+    func testFreshMetricsClassify() async {
+        let fresh = metrics(session: open(), updated: Date(timeIntervalSince1970: 9_950))
+        let authority = WakeQuotaAuthority(
+            provider: StaticProvider(fresh),
+            maxAge: 120,
+            now: { Date(timeIntervalSince1970: 10_000) }
+        )
+        let quota = await authority.freshQuota(account: .defaultAccount)
+        XCTAssertEqual(quota, .available)
+    }
+
+    // MARK: - Bounds
+
+    func testBoundsClampOutOfRangeValues() {
+        let bounds = WakeBounds(
+            pollInterval: 1,          // below min 15
+            bufferAfterReset: -50,    // below min 0
+            gapBetweenSessions: 5_000, // above max 600
+            perSessionTimeout: 5,     // below min 60
+            maxTurns: 9_999,          // above max 200
+            maxSessionsPerRun: 0,     // below min 1 — never unlimited
+            maxUnknownPolls: 0
+        )
+        XCTAssertEqual(bounds.pollInterval, 15)
+        XCTAssertEqual(bounds.bufferAfterReset, 0)
+        XCTAssertEqual(bounds.gapBetweenSessions, 600)
+        XCTAssertEqual(bounds.perSessionTimeout, 60)
+        XCTAssertEqual(bounds.maxTurns, 200)
+        XCTAssertEqual(bounds.maxSessionsPerRun, 1)
+        XCTAssertEqual(bounds.maxUnknownPolls, 1)
+    }
+
+    func testDefaultBoundsAreConservativeAndNotUnlimited() {
+        XCTAssertLessThanOrEqual(WakeBounds.default.maxSessionsPerRun, 100)
+        XCTAssertGreaterThanOrEqual(WakeBounds.default.maxSessionsPerRun, 1)
+        XCTAssertGreaterThan(WakeBounds.default.maxTurns, 0)
+        XCTAssertGreaterThan(WakeBounds.default.perSessionTimeout, 0)
+    }
+}
+
+// MARK: - Providers
+
+private struct ThrowingProvider: WakeQuotaProviding {
+    struct Boom: Error {}
+    func fetchMetrics(account: ClaudeCodeAccount) async throws -> UsageMetrics { throw Boom() }
+}
+
+private struct StaticProvider: WakeQuotaProviding {
+    let metrics: UsageMetrics
+    init(_ metrics: UsageMetrics) { self.metrics = metrics }
+    func fetchMetrics(account: ClaudeCodeAccount) async throws -> UsageMetrics { metrics }
+}


### PR DESCRIPTION
Second of the stacked Session Wake PRs. **Targets `session-wake/95-discovery`** (PR #105) — review/merge #105 first. Closes #96.

## What
- **WakeQuota** — `available` / `blocked(until,reason)` / `unknown(reason)`, **fail-closed**: missing/stale/failed/ambiguous quota is `unknown` and launches nothing. Weekly window gated before the session window.
- **WakeQuotaAuthority** — always pulls a *fresh* account-scoped reading via the existing `claude /usage` service; thrown fetch or stale reading ⇒ `unknown`. Cached UI metrics are never authority.
- **WakeBounds** — validated poll / buffer / gap / timeout / max-turns / session-cap / unknown-poll-cap, clamped at construction. Conservative defaults; sessions-per-run bounded, never unlimited.
- **WakeCoordinator** (actor) — one cancellable structured task; states off / idle / scanning / waiting / quota-unknown / running / stopping / completed / failed. Fresh quota **before every launch and after every attempt**; a re-maxed window stops the queue and preserves remaining work; watcher-off cancels pending sleep deterministically. **v1 lifetime documented: app-running-only** (no managed helper).

The event-anchored reset parsing that keeps "02:10 read at 02:15" from rolling to tomorrow lives in #95's `TranscriptResetParser`; this PR consumes it and never lets a past reset prove availability.

## Acceptance criteria (#96)
- [x] Missing/stale/failed/ambiguous quota ⇒ unknown, launches nothing
- [x] "02:10 reset read at 02:15" never rolls to tomorrow (via #95 parser)
- [x] Missing OAuth can't keep a stale transcript permanently blocked (bounded unknown polls) or fail open
- [x] Exhausted weekly/model window blocks even when 5h window open
- [x] Fresh quota checked before first and every subsequent launch
- [x] A session that re-maxes stops the queue and preserves remaining work
- [x] Watcher-off cancels pending sleep/poll deterministically
- [x] Active-child cancellation semantics decided (structured-task cancellation; runner enforces in #97)
- [x] Numeric bounds validated

## Tests
16 new tests; coordinator tests run under a watchdog (no hangs). SwiftLint --strict clean.

## Stack
#95 → **#96** → #97 → #98 → #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)