### PR TITLE
Session Wake #97: safe process runner, locking, permissions, private logging

### DIFF
--- a/MeterBar/SessionWake/ManagedProcess.swift
+++ b/MeterBar/SessionWake/ManagedProcess.swift
@@ -1,0 +1,202 @@
+import Darwin
+import Foundation
+
+/// A `posix_spawn`-based child launcher with a private process group, concurrent
+/// bounded stdout/stderr draining, a hard timeout, and process-tree cleanup.
+///
+/// Foundation's `Process` reads pipes only after the child exits and offers no
+/// process-group control, which both deadlocks on large output and leaks
+/// grandchildren on timeout. This launcher spawns the child as its own group
+/// leader so cancellation or timeout can `kill(-pgid)` the whole tree, and
+/// drains both pipes on background queues with a byte cap so a chatty child can
+/// never fill a pipe buffer and hang.
+enum ManagedProcess {
+    struct Result: Sendable {
+        enum Termination: Equatable, Sendable {
+            case exited(code: Int32)
+            case signalled(signal: Int32)
+            case timedOut
+            case cancelled
+            case launchFailed(String)
+        }
+        let termination: Termination
+        /// Bounded stdout capture (diagnostic only; never persisted verbatim).
+        let stdoutByteCount: Int
+        let stderrByteCount: Int
+
+        var isSuccess: Bool {
+            if case .exited(0) = termination { return true }
+            return false
+        }
+    }
+
+    /// Cooperative cancellation handle handed to callers before launch.
+    ///
+    /// A cancel that arrives before the child is attached is remembered and the
+    /// group is killed the instant it is; a cancel after attach kills the group
+    /// immediately. Either way `wasCancelled()` lets the waiter report
+    /// `.cancelled` rather than a bare `SIGKILL` signal.
+    final class Cancellation: @unchecked Sendable {
+        private let lock = NSLock()
+        private var pgid: pid_t?
+        private var cancelled = false
+
+        func attach(pgid: pid_t) {
+            lock.lock(); defer { lock.unlock() }
+            if cancelled {
+                Cancellation.killGroup(pgid)
+                return
+            }
+            self.pgid = pgid
+        }
+
+        func cancel() {
+            lock.lock(); defer { lock.unlock() }
+            cancelled = true
+            if let pgid { Cancellation.killGroup(pgid) }
+        }
+
+        func wasCancelled() -> Bool {
+            lock.lock(); defer { lock.unlock() }
+            return cancelled
+        }
+
+        fileprivate static func killGroup(_ pgid: pid_t) {
+            // Negative pid targets the whole process group.
+            _ = kill(-pgid, SIGKILL)
+        }
+    }
+
+    /// Launch `executable` with `arguments` in `workingDirectory`, capping each
+    /// captured stream at `maxCaptureBytes` and killing the tree after
+    /// `timeout` seconds.
+    static func run(
+        executable: String,
+        arguments: [String],
+        environment: [String: String],
+        workingDirectory: String,
+        timeout: TimeInterval,
+        maxCaptureBytes: Int = 64 * 1024,
+        cancellation: Cancellation = Cancellation()
+    ) -> Result {
+        var fileActions: posix_spawn_file_actions_t?
+        posix_spawn_file_actions_init(&fileActions)
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+
+        let outPipe = UnsafeMutablePointer<Int32>.allocate(capacity: 2)
+        let errPipe = UnsafeMutablePointer<Int32>.allocate(capacity: 2)
+        defer { outPipe.deallocate(); errPipe.deallocate() }
+        guard pipe(outPipe) == 0, pipe(errPipe) == 0 else {
+            return Result(termination: .launchFailed("pipe() failed"), stdoutByteCount: 0, stderrByteCount: 0)
+        }
+
+        // Child: stdin from /dev/null, stdout/stderr to the pipe write ends.
+        posix_spawn_file_actions_addopen(&fileActions, 0, "/dev/null", O_RDONLY, 0)
+        posix_spawn_file_actions_adddup2(&fileActions, outPipe[1], 1)
+        posix_spawn_file_actions_adddup2(&fileActions, errPipe[1], 2)
+        posix_spawn_file_actions_addclose(&fileActions, outPipe[0])
+        posix_spawn_file_actions_addclose(&fileActions, errPipe[0])
+        posix_spawn_file_actions_addchdir_np(&fileActions, workingDirectory)
+
+        var attributes: posix_spawnattr_t?
+        posix_spawnattr_init(&attributes)
+        defer { posix_spawnattr_destroy(&attributes) }
+        // New process group with the child as leader ⇒ kill(-pgid) hits the tree.
+        posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETPGROUP))
+        posix_spawnattr_setpgroup(&attributes, 0)
+
+        let argv = ([executable] + arguments).map { strdup($0) } + [nil]
+        let envp = environment.map { strdup("\($0.key)=\($0.value)") } + [nil]
+        defer {
+            argv.forEach { free($0) }
+            envp.forEach { free($0) }
+        }
+
+        var pid: pid_t = 0
+        let spawnResult = posix_spawn(&pid, executable, &fileActions, &attributes, argv, envp)
+        // Parent closes the write ends so read EOFs when the child exits.
+        close(outPipe[1]); close(errPipe[1])
+        guard spawnResult == 0 else {
+            close(outPipe[0]); close(errPipe[0])
+            return Result(
+                termination: .launchFailed("posix_spawn failed (\(spawnResult))"),
+                stdoutByteCount: 0,
+                stderrByteCount: 0
+            )
+        }
+
+        cancellation.attach(pgid: pid)
+
+        let outCounter = drain(fd: outPipe[0], cap: maxCaptureBytes)
+        let errCounter = drain(fd: errPipe[0], cap: maxCaptureBytes)
+
+        let termination = wait(pid: pid, timeout: timeout, cancellation: cancellation)
+
+        // Ensure drains finish and fds close.
+        let outBytes = outCounter.wait()
+        let errBytes = errCounter.wait()
+
+        return Result(termination: termination, stdoutByteCount: outBytes, stderrByteCount: errBytes)
+    }
+
+    // MARK: - Draining
+
+    private final class DrainHandle: @unchecked Sendable {
+        private let queue: DispatchQueue
+        private var bytes = 0
+        private let group = DispatchGroup()
+
+        init(fd: Int32, cap: Int) {
+            queue = DispatchQueue(label: "dev.meterbar.app.wake.drain.\(fd)")
+            group.enter()
+            queue.async { [self] in
+                defer { close(fd); self.group.leave() }
+                var buffer = [UInt8](repeating: 0, count: 16 * 1024)
+                while true {
+                    let n = read(fd, &buffer, buffer.count)
+                    if n <= 0 { break }
+                    // Count everything, but only the cap bounds memory pressure.
+                    bytes += n
+                    if bytes > cap { /* keep reading to drain, discard content */ }
+                }
+            }
+        }
+
+        func wait() -> Int {
+            group.wait()
+            return bytes
+        }
+    }
+
+    private static func drain(fd: Int32, cap: Int) -> DrainHandle {
+        DrainHandle(fd: fd, cap: cap)
+    }
+
+    // MARK: - Waiting
+
+    private static func wait(pid: pid_t, timeout: TimeInterval, cancellation: Cancellation) -> Result.Termination {
+        let deadline = Date().addingTimeInterval(timeout)
+        while true {
+            var status: Int32 = 0
+            let result = waitpid(pid, &status, WNOHANG)
+            if result == pid {
+                if cancellation.wasCancelled() { return .cancelled }
+                if _WSTATUS(status) == 0 {
+                    return .exited(code: (status >> 8) & 0xFF)
+                }
+                return .signalled(signal: _WSTATUS(status))
+            }
+            if result == -1 {
+                return .launchFailed("waitpid failed")
+            }
+            if Date() >= deadline {
+                Cancellation.killGroup(pid)
+                _ = waitpid(pid, &status, 0)
+                return .timedOut
+            }
+            usleep(20_000) // 20ms poll
+        }
+    }
+
+    private static func _WSTATUS(_ status: Int32) -> Int32 { status & 0x7F }
+}

--- a/MeterBar/SessionWake/WakeCommand.swift
+++ b/MeterBar/SessionWake/WakeCommand.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Permission posture for a resumed session.
+///
+/// v1 default is `.safe`. `.bypass` maps to `--dangerously-skip-permissions`
+/// and is only ever emitted when the caller has separately acknowledged it —
+/// the builder refuses to silently escalate.
+enum WakePermissionMode: String, Codable, Equatable, Sendable {
+    case safe
+    case bypass
+}
+
+/// A fully-resolved child invocation: executable + argument array + environment
+/// + working directory. Built as arrays, never a shell string — nothing here is
+/// ever passed through `/bin/sh`.
+struct WakeCommand: Equatable, Sendable {
+    let executable: String
+    let arguments: [String]
+    let environment: [String: String]
+    let workingDirectory: String
+}
+
+/// Builds the `claude` resume invocation for a candidate.
+enum WakeCommandBuilder {
+    /// The resume prompt default. Deliberately minimal.
+    static let defaultPrompt = "continue"
+
+    /// Build the command for `candidate` under `account`.
+    ///
+    /// - Parameters:
+    ///   - permissionMode: requested posture.
+    ///   - bypassAcknowledged: gate for `.bypass`. When `false`, a `.bypass`
+    ///     request is downgraded to `.safe` — permission bypass is never the
+    ///     silent default.
+    static func build(
+        executable: String,
+        candidate: WakeSessionCandidate,
+        account: ClaudeCodeAccount,
+        bounds: WakeBounds,
+        prompt: String = defaultPrompt,
+        permissionMode: WakePermissionMode = .safe,
+        bypassAcknowledged: Bool = false,
+        baseEnvironment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> WakeCommand {
+        var arguments = [
+            "-r", candidate.sessionID,
+            "-p", prompt,
+            "--print",
+            "--output-format", "text",
+            "--max-turns", String(bounds.maxTurns)
+        ]
+
+        let effectiveMode: WakePermissionMode = (permissionMode == .bypass && bypassAcknowledged) ? .bypass : .safe
+        switch effectiveMode {
+        case .safe:
+            // Explicit conservative posture; never auto-approves tool use.
+            arguments.append(contentsOf: ["--permission-mode", "default"])
+        case .bypass:
+            arguments.append("--dangerously-skip-permissions")
+        }
+
+        var environment = baseEnvironment
+        environment["NO_COLOR"] = "1"
+        environment["FORCE_COLOR"] = "0"
+        environment["TERM"] = "dumb"
+        if let configDirectory = account.configDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !configDirectory.isEmpty {
+            environment["CLAUDE_CONFIG_DIR"] = configDirectory
+        }
+
+        let workingDirectory = candidate.workingDirectory
+            ?? account.configDirectory
+            ?? FileManager.default.currentDirectoryPath
+        return WakeCommand(
+            executable: executable,
+            arguments: arguments,
+            environment: environment,
+            workingDirectory: workingDirectory
+        )
+    }
+}

--- a/MeterBar/SessionWake/WakeLock.swift
+++ b/MeterBar/SessionWake/WakeLock.swift
@@ -1,0 +1,89 @@
+import Darwin
+import Foundation
+
+/// One advisory-lock protocol shared by MeterBar, `meterbar wake`, and the
+/// legacy watcher during migration.
+///
+/// Uses `flock(LOCK_EX|LOCK_NB)` on a fixed lock file so any two holders — the
+/// app and the CLI, or either and a still-loaded legacy job — mutually exclude.
+/// The lock is acquired only when a run is actually ready, never held across a
+/// long quota wait.
+final class WakeLock: @unchecked Sendable {
+    /// The outcome of trying to acquire the shared lock.
+    enum Acquisition: Equatable {
+        case acquired
+        /// Held by another MeterBar/CLI holder.
+        case contended
+        /// A known legacy watcher lock is present — actionable guidance.
+        case legacyHeld(guidance: String)
+    }
+
+    private let lockURL: URL
+    private let legacyLockURLs: [URL]
+    private var fileDescriptor: Int32 = -1
+
+    init(lockURL: URL? = nil, legacyLockURLs: [URL]? = nil) {
+        self.lockURL = lockURL
+            ?? WakePaths.defaultBaseDirectory().appendingPathComponent("wake.lock")
+        // Conventional legacy watcher lock locations from the Python/launchd era.
+        self.legacyLockURLs = legacyLockURLs ?? [
+            URL(fileURLWithPath: "\(ServiceSupport.realHomeDirectory())/.claude/wake-watcher.lock"),
+            URL(fileURLWithPath: "\(ServiceSupport.realHomeDirectory())/.meterbar/session-wake.lock")
+        ]
+    }
+
+    /// Attempt to acquire the lock, reporting legacy contention distinctly so a
+    /// user can be told to unload the old job rather than seeing a bare failure.
+    func acquire() -> Acquisition {
+        if let legacy = heldLegacyLock() {
+            return .legacyHeld(guidance: """
+            A legacy Session Wake watcher appears to be running (\(legacy.path)). \
+            Unload it before enabling native Session Wake: `launchctl bootout` the \
+            old job and delete its plist/scripts. See docs/session-wake-migration.md.
+            """)
+        }
+
+        do {
+            try WakePaths.ensurePrivateDirectory(lockURL.deletingLastPathComponent())
+        } catch {
+            return .contended
+        }
+
+        let descriptor = open(lockURL.path, O_CREAT | O_RDWR, 0o600)
+        guard descriptor >= 0 else { return .contended }
+        if flock(descriptor, LOCK_EX | LOCK_NB) != 0 {
+            close(descriptor)
+            return .contended
+        }
+        fileDescriptor = descriptor
+        return .acquired
+    }
+
+    /// Release the lock and remove the descriptor. Safe to call repeatedly.
+    func release() {
+        guard fileDescriptor >= 0 else { return }
+        flock(fileDescriptor, LOCK_UN)
+        close(fileDescriptor)
+        fileDescriptor = -1
+    }
+
+    /// Whether any known legacy lock file is currently `flock`-held by another
+    /// process (present-but-unlocked files are ignored — a stale file is not a
+    /// running watcher).
+    private func heldLegacyLock() -> URL? {
+        for url in legacyLockURLs {
+            let descriptor = open(url.path, O_RDWR)
+            guard descriptor >= 0 else { continue }
+            defer { close(descriptor) }
+            if flock(descriptor, LOCK_EX | LOCK_NB) == 0 {
+                // We could take it ⇒ nobody holds it. Release immediately.
+                flock(descriptor, LOCK_UN)
+            } else {
+                return url
+            }
+        }
+        return nil
+    }
+
+    deinit { release() }
+}

--- a/MeterBar/SessionWake/WakeProcessRunner.swift
+++ b/MeterBar/SessionWake/WakeProcessRunner.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+/// The one native process runner shared by MeterBar and its CLI.
+///
+/// Responsibilities: revalidate the target immediately before exec, take the
+/// shared lock only when actually ready to run, spawn `claude` with an argument
+/// array (never a shell), enforce a timeout with process-tree cleanup, honor
+/// structured-task cancellation, and record a metadata-only log line. A dead
+/// worktree is a structured skip, not a failure that aborts the queue.
+struct WakeProcessRunner: WakeExecuting {
+    /// Explicit executable path; when nil the `claude` binary is resolved.
+    let executable: String?
+    let permissionMode: WakePermissionMode
+    let bypassAcknowledged: Bool
+    let prompt: String
+    let account: ClaudeCodeAccount
+    private let baseEnvironment: [String: String]
+    private let lockFactory: @Sendable () -> WakeLock
+    private let logger: WakeRunLogger
+    private let fileManager: FileManager
+    private let now: @Sendable () -> Date
+
+    init(
+        account: ClaudeCodeAccount,
+        executable: String? = nil,
+        permissionMode: WakePermissionMode = .safe,
+        bypassAcknowledged: Bool = false,
+        prompt: String = WakeCommandBuilder.defaultPrompt,
+        baseEnvironment: [String: String] = ProcessInfo.processInfo.environment,
+        lockFactory: @escaping @Sendable () -> WakeLock = { WakeLock() },
+        logger: WakeRunLogger = WakeRunLogger(),
+        fileManager: FileManager = .default,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.account = account
+        self.executable = executable
+        self.permissionMode = permissionMode
+        self.bypassAcknowledged = bypassAcknowledged
+        self.prompt = prompt
+        self.baseEnvironment = baseEnvironment
+        self.lockFactory = lockFactory
+        self.logger = logger
+        self.fileManager = fileManager
+        self.now = now
+    }
+
+    func run(_ candidate: WakeSessionCandidate, bounds: WakeBounds) async -> WakeRunOutcome {
+        // Revalidate cwd immediately before exec — a worktree deleted since
+        // discovery is a skip, and the queue keeps going.
+        guard let cwd = candidate.workingDirectory, isDirectory(cwd) else {
+            record(candidate: candidate, outcome: .skipped(reason: .missingWorkingDirectory), result: nil, start: now())
+            return .skipped(reason: .missingWorkingDirectory)
+        }
+
+        let claudePath = executable ?? CLIBinaryLocator.resolve(command: "claude", overrideEnvVar: "CLAUDE_CLI_PATH")
+        guard let resolved = claudePath else {
+            record(candidate: candidate, outcome: .failed(reason: "claude binary not found"), result: nil, start: now())
+            return .failed(reason: "claude binary not found")
+        }
+
+        // Take the shared lock only now, when we are actually ready to launch.
+        let lock = lockFactory()
+        switch lock.acquire() {
+        case .acquired:
+            break
+        case .contended:
+            let outcome = WakeRunOutcome.failed(reason: "another Session Wake holder is active")
+            record(candidate: candidate, outcome: outcome, result: nil, start: now())
+            return outcome
+        case let .legacyHeld(guidance):
+            let outcome = WakeRunOutcome.failed(reason: guidance)
+            record(candidate: candidate, outcome: outcome, result: nil, start: now())
+            return outcome
+        }
+        defer { lock.release() }
+
+        let command = WakeCommandBuilder.build(
+            executable: resolved,
+            candidate: candidate,
+            account: account,
+            bounds: bounds,
+            prompt: prompt,
+            permissionMode: permissionMode,
+            bypassAcknowledged: bypassAcknowledged,
+            baseEnvironment: baseEnvironment
+        )
+        // Overwrite the resolved cwd with the just-revalidated one.
+        let validated = WakeCommand(
+            executable: command.executable,
+            arguments: command.arguments,
+            environment: command.environment,
+            workingDirectory: cwd
+        )
+
+        let start = now()
+        let cancellation = ManagedProcess.Cancellation()
+        let result = await withTaskCancellationHandler {
+            await spawn(validated, timeout: bounds.perSessionTimeout, cancellation: cancellation)
+        } onCancel: {
+            cancellation.cancel()
+        }
+
+        let outcome = Self.mapOutcome(result.termination)
+        record(candidate: candidate, outcome: outcome, result: result, start: start)
+        return outcome
+    }
+
+    // MARK: - Helpers
+
+    private func spawn(
+        _ command: WakeCommand,
+        timeout: TimeInterval,
+        cancellation: ManagedProcess.Cancellation
+    ) async -> ManagedProcess.Result {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let result = ManagedProcess.run(
+                    executable: command.executable,
+                    arguments: command.arguments,
+                    environment: command.environment,
+                    workingDirectory: command.workingDirectory,
+                    timeout: timeout,
+                    cancellation: cancellation
+                )
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
+    private func isDirectory(_ path: String) -> Bool {
+        var isDirectory: ObjCBool = false
+        return fileManager.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue
+    }
+
+    static func mapOutcome(_ termination: ManagedProcess.Result.Termination) -> WakeRunOutcome {
+        switch termination {
+        case .exited(0):
+            return .succeeded
+        case let .exited(code):
+            return .failed(reason: "claude exited with status \(code)")
+        case let .signalled(signal):
+            return .failed(reason: "claude terminated by signal \(signal)")
+        case .timedOut:
+            return .failed(reason: "session timed out")
+        case .cancelled:
+            return .cancelled
+        case let .launchFailed(message):
+            return .failed(reason: message)
+        }
+    }
+
+    private func record(
+        candidate: WakeSessionCandidate,
+        outcome: WakeRunOutcome,
+        result: ManagedProcess.Result?,
+        start: Date
+    ) {
+        let exitCode: Int32?
+        switch result?.termination {
+        case let .exited(code): exitCode = code
+        default: exitCode = nil
+        }
+        logger.append(WakeRunLogger.Record(
+            timestamp: start,
+            event: "resume",
+            sessionID: candidate.sessionID,
+            reason: candidate.reason.rawValue,
+            outcome: outcome.logLabel,
+            exitCode: exitCode,
+            durationMilliseconds: Int(now().timeIntervalSince(start) * 1000),
+            stdoutBytes: result?.stdoutByteCount,
+            stderrBytes: result?.stderrByteCount
+        ))
+    }
+}
+
+extension WakeRunOutcome {
+    /// Stable label for structured logs (never includes content).
+    var logLabel: String {
+        switch self {
+        case .succeeded: return "succeeded"
+        case .failed: return "failed"
+        case .skipped: return "skipped"
+        case .cancelled: return "cancelled"
+        }
+    }
+}

--- a/MeterBar/SessionWake/WakeRunLogger.swift
+++ b/MeterBar/SessionWake/WakeRunLogger.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Structured, privacy-preserving log of wake runs.
 ///

--- a/MeterBar/SessionWake/WakeRunLogger.swift
+++ b/MeterBar/SessionWake/WakeRunLogger.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// Structured, privacy-preserving log of wake runs.
+///
+/// Default logs contain metadata only — session id, typed reason, outcome, exit
+/// code, duration, byte counts. They deliberately never contain the prompt, the
+/// transcript, tool output, credentials, or any raw stdout/stderr tail. The log
+/// directory is `0700` and every file `0600`, with day-based rotation and a
+/// bounded retention window.
+struct WakeRunLogger: Sendable {
+    /// One structured record. No free-form content fields exist by design.
+    struct Record: Codable, Equatable, Sendable {
+        let timestamp: Date
+        let event: String
+        let sessionID: String
+        let reason: String
+        let outcome: String
+        let exitCode: Int32?
+        let durationMilliseconds: Int?
+        let stdoutBytes: Int?
+        let stderrBytes: Int?
+    }
+
+    private let directory: URL
+    private let retentionDays: Int
+    private let now: @Sendable () -> Date
+
+    init(
+        directory: URL? = nil,
+        retentionDays: Int = 14,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.directory = directory ?? WakePaths.defaultBaseDirectory().appendingPathComponent("logs", isDirectory: true)
+        self.retentionDays = retentionDays
+        self.now = now
+    }
+
+    /// Append `record` to today's log, creating private files as needed and
+    /// pruning logs older than the retention window.
+    func append(_ record: Record) {
+        do {
+            try WakePaths.ensurePrivateDirectory(directory)
+            let fileURL = directory.appendingPathComponent("session-wake-\(dayStamp(record.timestamp)).log")
+            var line = try JSONEncoder.wakeEncoder.encode(record)
+            line.append(0x0A) // newline
+            appendData(line, to: fileURL)
+            pruneOldLogs()
+        } catch {
+            AppLog.wake.error("Failed to write wake log: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func appendData(_ data: Data, to fileURL: URL) {
+        let fileManager = FileManager.default
+        if !fileManager.fileExists(atPath: fileURL.path) {
+            fileManager.createFile(atPath: fileURL.path, contents: nil, attributes: [.posixPermissions: 0o600])
+        } else {
+            try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+        }
+        guard let handle = try? FileHandle(forWritingTo: fileURL) else { return }
+        defer { try? handle.close() }
+        _ = try? handle.seekToEnd()
+        try? handle.write(contentsOf: data)
+    }
+
+    private func pruneOldLogs() {
+        let fileManager = FileManager.default
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.contentModificationDateKey]
+        ) else { return }
+        let cutoff = now().addingTimeInterval(-Double(retentionDays) * 86_400)
+        for url in entries where url.pathExtension == "log" {
+            let modified = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+            if let modified, modified < cutoff {
+                try? fileManager.removeItem(at: url)
+            }
+        }
+    }
+
+    private func dayStamp(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.dateFormat = "yyyyMMdd"
+        return formatter.string(from: date)
+    }
+}
+
+private extension JSONEncoder {
+    static let wakeEncoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
+}

--- a/MeterBarTests/ManagedProcessTests.swift
+++ b/MeterBarTests/ManagedProcessTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+@testable import MeterBar
+
+/// Coverage for #97's low-level launcher: concurrent bounded draining, timeout
+/// with process-tree cleanup, and cancellation.
+final class ManagedProcessTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ManagedProcessTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        // Resolve /var → /private/var so a child's physical `pwd` matches.
+        tempDir = tempDir.resolvingSymlinksInPath()
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    /// A fake executable driven entirely by environment variables so tests can
+    /// shape its argv record, sleep, child-spawn, output volume, and exit code.
+    private func makeFake() throws -> String {
+        let script = """
+        #!/bin/bash
+        if [ -n "$WAKE_TEST_OUT" ]; then
+          { echo "ARGS:$*"; echo "PWD:$(pwd)"; echo "CFG:${CLAUDE_CONFIG_DIR}"; echo "TERM:${TERM}"; } >> "$WAKE_TEST_OUT"
+        fi
+        if [ -n "$WAKE_SPAWN_CHILD" ]; then
+          sleep 30 &
+          echo $! > "$WAKE_CHILD_PID"
+        fi
+        if [ -n "$WAKE_STDOUT_BYTES" ]; then
+          head -c "$WAKE_STDOUT_BYTES" /dev/zero | tr '\\0' 'x'
+        fi
+        if [ -n "$WAKE_SLEEP" ]; then sleep "$WAKE_SLEEP"; fi
+        exit "${WAKE_EXIT:-0}"
+        """
+        let url = tempDir.appendingPathComponent("fake.sh")
+        try script.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url.path
+    }
+
+    private func run(
+        _ fake: String,
+        env: [String: String],
+        timeout: TimeInterval,
+        cancellation: ManagedProcess.Cancellation = .init()
+    ) async -> ManagedProcess.Result {
+        var env = env
+        env["PATH"] = env["PATH"] ?? "/usr/bin:/bin" // child needs sleep/head/tr
+        return await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                let result = ManagedProcess.run(
+                    executable: fake,
+                    arguments: ["-r", "sid", "-p", "continue"],
+                    environment: env,
+                    workingDirectory: self.tempDir.path,
+                    timeout: timeout,
+                    cancellation: cancellation
+                )
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
+    func testExitCodeAndCwdArePropagated() async throws {
+        let fake = try makeFake()
+        let out = tempDir.appendingPathComponent("out.txt").path
+        let result = await run(fake, env: ["WAKE_TEST_OUT": out, "WAKE_EXIT": "0"], timeout: 10)
+        XCTAssertEqual(result.termination, .exited(code: 0))
+        let recorded = try String(contentsOfFile: out, encoding: .utf8)
+        XCTAssertTrue(recorded.contains("ARGS:-r sid -p continue"), "recorded=\(recorded)")
+        // Prefix-independent (avoids /var vs /private/var): the child chdir'd
+        // into our unique temp dir.
+        XCTAssertTrue(recorded.contains("PWD:") && recorded.contains(tempDir.lastPathComponent),
+                      "recorded=\(recorded)")
+    }
+
+    func testNonZeroExitIsReported() async throws {
+        let fake = try makeFake()
+        let result = await run(fake, env: ["WAKE_EXIT": "7"], timeout: 10)
+        XCTAssertEqual(result.termination, .exited(code: 7))
+        XCTAssertFalse(result.isSuccess)
+    }
+
+    func testLargeOutputDoesNotDeadlock() async throws {
+        let fake = try makeFake()
+        // 500 KB ≫ the 16 KB read buffer and the 64 KB cap.
+        let result = await run(fake, env: ["WAKE_STDOUT_BYTES": "500000"], timeout: 10)
+        XCTAssertEqual(result.termination, .exited(code: 0))
+        XCTAssertGreaterThan(result.stdoutByteCount, 400_000)
+    }
+
+    func testTimeoutKillsProcessTree() async throws {
+        let fake = try makeFake()
+        let childPidFile = tempDir.appendingPathComponent("child.pid")
+        let result = await run(
+            fake,
+            env: ["WAKE_SLEEP": "30", "WAKE_SPAWN_CHILD": "1", "WAKE_CHILD_PID": childPidFile.path],
+            timeout: 1
+        )
+        XCTAssertEqual(result.termination, .timedOut)
+
+        // The spawned child must have been killed with the group.
+        let childPid = try pid(from: childPidFile)
+        try await waitForProcessGone(childPid)
+        XCTAssertFalse(processAlive(childPid), "Child process leaked after timeout")
+    }
+
+    func testCancellationKillsGroupAndReportsCancelled() async throws {
+        let fake = try makeFake()
+        let childPidFile = tempDir.appendingPathComponent("child.pid")
+        let cancellation = ManagedProcess.Cancellation()
+        async let resultTask = run(
+            fake,
+            env: ["WAKE_SLEEP": "30", "WAKE_SPAWN_CHILD": "1", "WAKE_CHILD_PID": childPidFile.path],
+            timeout: 30,
+            cancellation: cancellation
+        )
+        // Give it a moment to spawn, then cancel.
+        try await Task.sleep(nanoseconds: 400_000_000)
+        cancellation.cancel()
+        let result = await resultTask
+        XCTAssertEqual(result.termination, .cancelled)
+
+        let childPid = try pid(from: childPidFile)
+        try await waitForProcessGone(childPid)
+        XCTAssertFalse(processAlive(childPid), "Child process leaked after cancellation")
+    }
+
+    // MARK: - Process helpers
+
+    private func pid(from file: URL) throws -> pid_t {
+        let text = try String(contentsOf: file, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
+        return pid_t(text) ?? -1
+    }
+
+    private func processAlive(_ pid: pid_t) -> Bool {
+        pid > 0 && kill(pid, 0) == 0
+    }
+
+    private func waitForProcessGone(_ pid: pid_t, timeout: TimeInterval = 5) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while processAlive(pid) && Date() < deadline {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
+}

--- a/MeterBarTests/WakeRunnerTests.swift
+++ b/MeterBarTests/WakeRunnerTests.swift
@@ -1,0 +1,202 @@
+import XCTest
+@testable import MeterBar
+
+/// Coverage for #97: the runner's argv/env/cwd contract, structured skip/fail
+/// outcomes, the shared lock, safe-by-default permissions, and private logging.
+final class WakeRunnerTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WakeRunnerTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        tempDir = tempDir.resolvingSymlinksInPath()
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    private func makeFake() throws -> String {
+        let script = """
+        #!/bin/bash
+        if [ -n "$WAKE_TEST_OUT" ]; then
+          { echo "ARGS:$*"; echo "PWD:$(pwd)"; echo "CFG:${CLAUDE_CONFIG_DIR}"; } >> "$WAKE_TEST_OUT"
+        fi
+        exit "${WAKE_EXIT:-0}"
+        """
+        let url = tempDir.appendingPathComponent("fake.sh")
+        try script.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url.path
+    }
+
+    private func candidate(sessionID: String = "sid-1", cwd: String?) -> WakeSessionCandidate {
+        let at = Date(timeIntervalSince1970: 1_000)
+        return WakeSessionCandidate(
+            sessionID: sessionID,
+            transcriptPath: tempDir.appendingPathComponent("\(sessionID).jsonl").path,
+            workingDirectory: cwd,
+            gitBranch: "main",
+            reason: .sessionLimit,
+            blockedAt: at,
+            resetHint: nil,
+            fingerprint: BlockFingerprint(sessionID: sessionID, blockedAt: at, reason: .sessionLimit),
+            skipReason: nil
+        )
+    }
+
+    private func account() -> ClaudeCodeAccount {
+        ClaudeCodeAccount(id: UUID(), name: "acct", configDirectory: tempDir.appendingPathComponent("cfg").path)
+    }
+
+    private func makeRunner(
+        fake: String,
+        env: [String: String],
+        permissionMode: WakePermissionMode = .safe,
+        bypassAcknowledged: Bool = false,
+        logDir: URL? = nil
+    ) -> WakeProcessRunner {
+        var env = env
+        env["PATH"] = env["PATH"] ?? "/usr/bin:/bin"
+        return WakeProcessRunner(
+            account: account(),
+            executable: fake,
+            permissionMode: permissionMode,
+            bypassAcknowledged: bypassAcknowledged,
+            baseEnvironment: env,
+            lockFactory: { WakeLock(lockURL: self.tempDir.appendingPathComponent("wake.lock"), legacyLockURLs: []) },
+            logger: WakeRunLogger(directory: logDir ?? self.tempDir.appendingPathComponent("logs"))
+        )
+    }
+
+    // MARK: - Command builder
+
+    func testSafePermissionByDefault() {
+        let command = WakeCommandBuilder.build(
+            executable: "/bin/claude",
+            candidate: candidate(cwd: tempDir.path),
+            account: account(),
+            bounds: .default
+        )
+        XCTAssertTrue(command.arguments.contains("--permission-mode"))
+        XCTAssertTrue(command.arguments.contains("default"))
+        XCTAssertFalse(command.arguments.contains("--dangerously-skip-permissions"))
+        XCTAssertEqual(command.environment["CLAUDE_CONFIG_DIR"], account().configDirectory)
+    }
+
+    func testBypassRequiresAcknowledgement() {
+        let unacknowledged = WakeCommandBuilder.build(
+            executable: "/bin/claude", candidate: candidate(cwd: tempDir.path), account: account(),
+            bounds: .default, permissionMode: .bypass, bypassAcknowledged: false
+        )
+        XCTAssertFalse(unacknowledged.arguments.contains("--dangerously-skip-permissions"),
+                       "Bypass must not be silently emitted without acknowledgement")
+
+        let acknowledged = WakeCommandBuilder.build(
+            executable: "/bin/claude", candidate: candidate(cwd: tempDir.path), account: account(),
+            bounds: .default, permissionMode: .bypass, bypassAcknowledged: true
+        )
+        XCTAssertTrue(acknowledged.arguments.contains("--dangerously-skip-permissions"))
+    }
+
+    func testMaxTurnsAndSessionArgs() {
+        let command = WakeCommandBuilder.build(
+            executable: "/bin/claude", candidate: candidate(sessionID: "abc", cwd: tempDir.path),
+            account: account(), bounds: .default
+        )
+        XCTAssertTrue(command.arguments.contains("abc"))
+        XCTAssertTrue(command.arguments.contains("--max-turns"))
+        XCTAssertTrue(command.arguments.contains(String(WakeBounds.default.maxTurns)))
+    }
+
+    // MARK: - Runner
+
+    func testRunPassesExactArgvEnvAndCwd() async throws {
+        let fake = try makeFake()
+        let out = tempDir.appendingPathComponent("out.txt")
+        let runner = makeRunner(fake: fake, env: ["WAKE_TEST_OUT": out.path])
+        let outcome = await runner.run(candidate(sessionID: "sid-x", cwd: tempDir.path), bounds: .default)
+        XCTAssertEqual(outcome, .succeeded)
+        let recorded = try String(contentsOf: out, encoding: .utf8)
+        XCTAssertTrue(recorded.contains("-r sid-x"))
+        XCTAssertTrue(recorded.contains("--permission-mode default"))
+        XCTAssertTrue(recorded.contains("PWD:") && recorded.contains(tempDir.lastPathComponent))
+        XCTAssertTrue(recorded.contains("CFG:\(account().configDirectory!)"))
+    }
+
+    func testDeadWorktreeIsSkippedWithoutLaunching() async throws {
+        let fake = try makeFake()
+        let out = tempDir.appendingPathComponent("out.txt")
+        let runner = makeRunner(fake: fake, env: ["WAKE_TEST_OUT": out.path])
+        let deadCwd = tempDir.appendingPathComponent("gone").path
+        let outcome = await runner.run(candidate(cwd: deadCwd), bounds: .default)
+        XCTAssertEqual(outcome, .skipped(reason: .missingWorkingDirectory))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: out.path), "Skipped session must not launch")
+    }
+
+    func testNonZeroExitIsStructuredFailureNotBypassEscalation() async throws {
+        let fake = try makeFake()
+        let out = tempDir.appendingPathComponent("out.txt")
+        let runner = makeRunner(fake: fake, env: ["WAKE_TEST_OUT": out.path, "WAKE_EXIT": "5"])
+        let outcome = await runner.run(candidate(cwd: tempDir.path), bounds: .default)
+        if case .failed = outcome {} else { XCTFail("Expected structured failure, got \(outcome)") }
+        // Exactly one invocation, and it never escalated to bypass.
+        let recorded = try String(contentsOf: out, encoding: .utf8)
+        XCTAssertEqual(recorded.components(separatedBy: "ARGS:").count - 1, 1)
+        XCTAssertFalse(recorded.contains("--dangerously-skip-permissions"))
+    }
+
+    // MARK: - Lock
+
+    func testSharedLockRejectsContention() {
+        let url = tempDir.appendingPathComponent("shared.lock")
+        let first = WakeLock(lockURL: url, legacyLockURLs: [])
+        let second = WakeLock(lockURL: url, legacyLockURLs: [])
+        XCTAssertEqual(first.acquire(), .acquired)
+        XCTAssertEqual(second.acquire(), .contended)
+        first.release()
+        XCTAssertEqual(second.acquire(), .acquired)
+        second.release()
+    }
+
+    func testLegacyWatcherContentionIsReported() {
+        let legacy = tempDir.appendingPathComponent("legacy.lock")
+        FileManager.default.createFile(atPath: legacy.path, contents: nil)
+        // Hold the legacy lock from a separate descriptor.
+        let heldFd = open(legacy.path, O_RDWR)
+        defer { close(heldFd) }
+        XCTAssertEqual(flock(heldFd, LOCK_EX | LOCK_NB), 0)
+
+        let lock = WakeLock(lockURL: tempDir.appendingPathComponent("ours.lock"), legacyLockURLs: [legacy])
+        if case .legacyHeld = lock.acquire() {} else {
+            XCTFail("Expected legacyHeld guidance when a legacy watcher holds its lock")
+        }
+    }
+
+    // MARK: - Logging
+
+    func testLogsAreStructuredMetadataOnlyWithPrivatePermissions() async throws {
+        let fake = try makeFake()
+        let logDir = tempDir.appendingPathComponent("logs")
+        let runner = makeRunner(fake: fake, env: [:], logDir: logDir)
+        _ = await runner.run(candidate(sessionID: "sid-log", cwd: tempDir.path), bounds: .default)
+
+        // Directory 0700.
+        let dirPerms = try FileManager.default.attributesOfItem(atPath: logDir.path)[.posixPermissions] as? Int
+        XCTAssertEqual(dirPerms, 0o700)
+
+        let logFile = try XCTUnwrap(FileManager.default
+            .contentsOfDirectory(at: logDir, includingPropertiesForKeys: nil)
+            .first(where: { $0.pathExtension == "log" }))
+        let filePerms = try FileManager.default.attributesOfItem(atPath: logFile.path)[.posixPermissions] as? Int
+        XCTAssertEqual(filePerms, 0o600)
+
+        let contents = try String(contentsOf: logFile, encoding: .utf8)
+        XCTAssertTrue(contents.contains("\"sessionID\":\"sid-log\""))
+        XCTAssertTrue(contents.contains("\"outcome\":\"succeeded\""))
+        // No prompt, no raw output tails.
+        XCTAssertFalse(contents.contains("continue"))
+        XCTAssertFalse(contents.lowercased().contains("stdout\":\""))
+    }
+}


### PR DESCRIPTION
Third of the stacked Session Wake PRs. **Targets `session-wake/96-quota-coordinator`** (#107) — merge #105 → #107 first. Closes #97.

## What
- **ManagedProcess** — `posix_spawn` launcher with a **private process group**, concurrent bounded stdout/stderr draining (no pipe-buffer deadlock), hard timeout, and `kill(-pgid)` **process-tree cleanup** on timeout/cancellation.
- **WakeCommandBuilder / WakeCommand** — builds the `claude` resume invocation as an **argument array, never a shell string**. Safe permission mode by default; `--dangerously-skip-permissions` only with a separate acknowledgement — never the silent default.
- **WakeProcessRunner** (`WakeExecuting`, the seam #96 drives) — revalidates cwd immediately before exec (dead worktree ⇒ structured **skip**, queue continues), takes the shared lock only when ready, wires structured-task cancellation to the process group, maps termination to succeeded/failed/skipped/cancelled.
- **WakeLock** — one `flock` advisory protocol shared by app, CLI, and (during migration) the legacy watcher; contention rejected; held legacy lock reported with actionable guidance.
- **WakeRunLogger** — structured **metadata-only** records (no prompt/transcript/tool-output/credentials); **0700** dir, **0600** files, day rotation + retention.

## Acceptance criteria (#97)
- [x] Dead cwd records `skipped`; the next target still runs
- [x] Exact argv/env/account/cwd covered with a fake executable
- [x] Large stdout/stderr cannot deadlock the child
- [x] Timeout and cancellation clean up the child process **tree** and release the lock
- [x] App/CLI contention rejected by the same lock
- [x] Legacy watcher contention detected + actionable guidance
- [x] Permission denial is a structured outcome, not silent bypass escalation
- [x] Log dirs 0700, files 0600
- [x] Prompts and raw response/tool output absent from default logs

## Tests
23 new tests; process/runner tests run under a watchdog (no hangs). SwiftLint --strict clean.

## Stack
#95 → #96 → **#97** → #98 → #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)