### PR TITLE
Session Wake #98: settings, wake-account selection, status UI, notifications

### DIFF
--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -30,4 +30,27 @@ enum StorageKeys {
     static let notificationWarningThreshold = "NotificationWarningThreshold"
     /// Raw value of the `NotificationThreshold` at which a critical alert notifies.
     static let notificationCriticalThreshold = "NotificationCriticalThreshold"
+
+    // MARK: - Session Wake (#98)
+
+    /// Master enablement for the Session Wake feature (Bool, default off).
+    static let sessionWakeFeatureEnabled = "SessionWakeFeatureEnabled"
+    /// Runtime intent for the watcher, distinct from feature enablement (Bool).
+    static let sessionWakeWatcherArmed = "SessionWakeWatcherArmed"
+    /// Explicitly selected wake account id (UUID string). Never inferred.
+    static let sessionWakeAccountID = "SessionWakeAccountID"
+    /// Whether the user completed the first-enable safety acknowledgement (Bool).
+    static let sessionWakeFirstEnableAcknowledged = "SessionWakeFirstEnableAcknowledged"
+    /// Whether the user separately acknowledged permission-bypass mode (Bool).
+    static let sessionWakeBypassAcknowledged = "SessionWakeBypassAcknowledged"
+    /// Permission posture raw value (`WakePermissionMode`).
+    static let sessionWakePermissionMode = "SessionWakePermissionMode"
+    /// Resume prompt text.
+    static let sessionWakePrompt = "SessionWakePrompt"
+    /// Notify when a wake run completes (Bool, default on).
+    static let sessionWakeNotifyOnCompletion = "SessionWakeNotifyOnCompletion"
+    /// Max sessions resumed per run (Int).
+    static let sessionWakeMaxSessionsPerRun = "SessionWakeMaxSessionsPerRun"
+    /// Per-session max agent turns (Int).
+    static let sessionWakeMaxTurns = "SessionWakeMaxTurns"
 }

--- a/MeterBar/SessionWake/SessionWakeNotificationDecider.swift
+++ b/MeterBar/SessionWake/SessionWakeNotificationDecider.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Inputs that gate a Session Wake notification. Pure value so the decision is
+/// trivially testable and free of store/singleton coupling.
+struct SessionWakeNotificationContext: Equatable, Sendable {
+    /// The global notifications master switch (NotificationPreferencesStore).
+    let globalNotificationsEnabled: Bool
+    /// Whether the Claude provider is visible/enabled (ProviderVisibilityStore).
+    let claudeProviderEnabled: Bool
+    /// The Session Wake "notify on completion" preference.
+    let notifyOnCompletion: Bool
+}
+
+/// Decides whether Session Wake may post a notification. A wake notification is
+/// suppressed unless the global switch, the Claude provider, and the Session
+/// Wake preference all allow it — Session Wake never overrides the user's global
+/// or provider-level choices.
+enum SessionWakeNotificationDecider {
+    static func shouldNotifyOnCompletion(_ context: SessionWakeNotificationContext) -> Bool {
+        context.globalNotificationsEnabled
+            && context.claudeProviderEnabled
+            && context.notifyOnCompletion
+    }
+
+    /// Whether a "watch started" notification may post. Same gate; watch-start
+    /// notifications are informational and never bypass the global/provider gate.
+    static func shouldNotifyOnWatchStart(_ context: SessionWakeNotificationContext) -> Bool {
+        shouldNotifyOnCompletion(context)
+    }
+}

--- a/MeterBar/SessionWake/SessionWakeSettingsStore.swift
+++ b/MeterBar/SessionWake/SessionWakeSettingsStore.swift
@@ -1,0 +1,158 @@
+import Combine
+import Foundation
+
+/// Persists Session Wake preferences and enforces the safety toggle rules.
+///
+/// The store deliberately separates two concepts the UI must never conflate:
+/// `featureEnabled` (the user wants the feature at all) and `watcherArmed`
+/// (the watcher should be actively running now). Arming requires the feature on
+/// *and* a first-enable acknowledgement; permission bypass requires its own
+/// separate acknowledgement. The wake account is always explicit and is never
+/// inferred from account order or recent activity.
+final class SessionWakeSettingsStore: ObservableObject {
+    static let shared = SessionWakeSettingsStore()
+
+    @Published private(set) var featureEnabled: Bool
+    @Published private(set) var watcherArmed: Bool
+    @Published private(set) var wakeAccountID: UUID?
+    @Published private(set) var firstEnableAcknowledged: Bool
+    @Published private(set) var bypassAcknowledged: Bool
+    @Published private(set) var permissionMode: WakePermissionMode
+    @Published var prompt: String
+    @Published var notifyOnCompletion: Bool
+    @Published private(set) var maxSessionsPerRun: Int
+    @Published private(set) var maxTurns: Int
+
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        featureEnabled = userDefaults.bool(forKey: StorageKeys.sessionWakeFeatureEnabled)
+        watcherArmed = userDefaults.bool(forKey: StorageKeys.sessionWakeWatcherArmed)
+        wakeAccountID = userDefaults.string(forKey: StorageKeys.sessionWakeAccountID).flatMap(UUID.init(uuidString:))
+        firstEnableAcknowledged = userDefaults.bool(forKey: StorageKeys.sessionWakeFirstEnableAcknowledged)
+        bypassAcknowledged = userDefaults.bool(forKey: StorageKeys.sessionWakeBypassAcknowledged)
+        permissionMode = userDefaults.string(forKey: StorageKeys.sessionWakePermissionMode)
+            .flatMap(WakePermissionMode.init(rawValue:)) ?? .safe
+        prompt = userDefaults.string(forKey: StorageKeys.sessionWakePrompt) ?? WakeCommandBuilder.defaultPrompt
+        if userDefaults.object(forKey: StorageKeys.sessionWakeNotifyOnCompletion) == nil {
+            notifyOnCompletion = true
+        } else {
+            notifyOnCompletion = userDefaults.bool(forKey: StorageKeys.sessionWakeNotifyOnCompletion)
+        }
+        let storedSessions = userDefaults.object(forKey: StorageKeys.sessionWakeMaxSessionsPerRun) as? Int
+        maxSessionsPerRun = storedSessions ?? WakeBounds.default.maxSessionsPerRun
+        let storedTurns = userDefaults.object(forKey: StorageKeys.sessionWakeMaxTurns) as? Int
+        maxTurns = storedTurns ?? WakeBounds.default.maxTurns
+
+        // Invariant: the watcher can never be armed while the feature is off.
+        if !featureEnabled && watcherArmed {
+            watcherArmed = false
+            userDefaults.set(false, forKey: StorageKeys.sessionWakeWatcherArmed)
+        }
+    }
+
+    /// Bounds derived from persisted prefs, always validated/clamped.
+    var bounds: WakeBounds {
+        WakeBounds(
+            pollInterval: WakeBounds.default.pollInterval,
+            bufferAfterReset: WakeBounds.default.bufferAfterReset,
+            gapBetweenSessions: WakeBounds.default.gapBetweenSessions,
+            perSessionTimeout: WakeBounds.default.perSessionTimeout,
+            maxTurns: maxTurns,
+            maxSessionsPerRun: maxSessionsPerRun,
+            maxUnknownPolls: WakeBounds.default.maxUnknownPolls
+        )
+    }
+
+    /// Whether the watcher may be armed given current acknowledgements.
+    var canArmWatcher: Bool {
+        featureEnabled && firstEnableAcknowledged && (permissionMode == .safe || bypassAcknowledged)
+    }
+
+    // MARK: - Mutations
+
+    /// Turning the feature off forces the watcher off too (master switch).
+    func setFeatureEnabled(_ enabled: Bool) {
+        guard enabled != featureEnabled else { return }
+        featureEnabled = enabled
+        userDefaults.set(enabled, forKey: StorageKeys.sessionWakeFeatureEnabled)
+        if !enabled {
+            forceWatcherOff()
+        }
+    }
+
+    /// Arming is refused unless `canArmWatcher`. Disarming always succeeds.
+    func setWatcherArmed(_ armed: Bool) {
+        if armed {
+            guard canArmWatcher else { return }
+        }
+        guard armed != watcherArmed else { return }
+        watcherArmed = armed
+        userDefaults.set(armed, forKey: StorageKeys.sessionWakeWatcherArmed)
+    }
+
+    func setWakeAccountID(_ id: UUID?) {
+        guard id != wakeAccountID else { return }
+        wakeAccountID = id
+        if let id {
+            userDefaults.set(id.uuidString, forKey: StorageKeys.sessionWakeAccountID)
+        } else {
+            userDefaults.removeObject(forKey: StorageKeys.sessionWakeAccountID)
+        }
+    }
+
+    func setFirstEnableAcknowledged(_ acknowledged: Bool) {
+        guard acknowledged != firstEnableAcknowledged else { return }
+        firstEnableAcknowledged = acknowledged
+        userDefaults.set(acknowledged, forKey: StorageKeys.sessionWakeFirstEnableAcknowledged)
+        if !acknowledged { forceWatcherOff() }
+    }
+
+    func setPermissionMode(_ mode: WakePermissionMode) {
+        guard mode != permissionMode else { return }
+        permissionMode = mode
+        userDefaults.set(mode.rawValue, forKey: StorageKeys.sessionWakePermissionMode)
+        // Switching to bypass without acknowledgement must not leave the watcher
+        // armed under an unacknowledged posture.
+        if mode == .bypass && !bypassAcknowledged { forceWatcherOff() }
+    }
+
+    func setBypassAcknowledged(_ acknowledged: Bool) {
+        guard acknowledged != bypassAcknowledged else { return }
+        bypassAcknowledged = acknowledged
+        userDefaults.set(acknowledged, forKey: StorageKeys.sessionWakeBypassAcknowledged)
+        if !acknowledged && permissionMode == .bypass { forceWatcherOff() }
+    }
+
+    func setMaxSessionsPerRun(_ value: Int) {
+        let clamped = value.clamped(to: WakeBounds.sessionsRange)
+        guard clamped != maxSessionsPerRun else { return }
+        maxSessionsPerRun = clamped
+        userDefaults.set(clamped, forKey: StorageKeys.sessionWakeMaxSessionsPerRun)
+    }
+
+    func setMaxTurns(_ value: Int) {
+        let clamped = value.clamped(to: WakeBounds.maxTurnsRange)
+        guard clamped != maxTurns else { return }
+        maxTurns = clamped
+        userDefaults.set(clamped, forKey: StorageKeys.sessionWakeMaxTurns)
+    }
+
+    /// Reconcile with the currently available accounts. If the selected wake
+    /// account disappeared, clear it and disarm the watcher — automation must
+    /// never silently retarget another account.
+    func reconcileAccounts(available ids: [UUID]) {
+        guard let selected = wakeAccountID else { return }
+        if !ids.contains(selected) {
+            setWakeAccountID(nil)
+            forceWatcherOff()
+        }
+    }
+
+    private func forceWatcherOff() {
+        guard watcherArmed else { return }
+        watcherArmed = false
+        userDefaults.set(false, forKey: StorageKeys.sessionWakeWatcherArmed)
+    }
+}

--- a/MeterBar/SessionWake/SessionWakeStatus.swift
+++ b/MeterBar/SessionWake/SessionWakeStatus.swift
@@ -1,0 +1,106 @@
+import Combine
+import Foundation
+
+/// Pure mapping from watcher state to the user-facing status surface.
+///
+/// Real states are surfaced distinctly (Running / Stopping / Quota Unknown /
+/// Needs Attention) rather than collapsed into "Watching", so the UI and CLI
+/// can always explain why nothing is launching.
+enum SessionWakeStatusLabel: Equatable {
+    case off
+    case idle
+    case scanning
+    case waiting
+    case quotaUnknown
+    case running
+    case stopping
+    case completed
+    case needsAttention
+
+    /// The short chip title.
+    var title: String {
+        switch self {
+        case .off: return "Off"
+        case .idle: return "Idle"
+        case .scanning: return "Scanning"
+        case .waiting: return "Waiting"
+        case .quotaUnknown: return "Quota Unknown"
+        case .running: return "Running"
+        case .stopping: return "Stopping"
+        case .completed: return "Completed"
+        case .needsAttention: return "Needs Attention"
+        }
+    }
+
+    /// Whether this label represents a failure the user should look at.
+    var isAttention: Bool { self == .needsAttention || self == .quotaUnknown }
+
+    /// Derive the label from the watcher state and whether the feature is on.
+    static func from(state: WakeWatcherState, featureEnabled: Bool) -> SessionWakeStatusLabel {
+        guard featureEnabled else { return .off }
+        switch state {
+        case .off: return .idle
+        case .idle: return .idle
+        case .scanning: return .scanning
+        case .waiting: return .waiting
+        case .quotaUnknown: return .quotaUnknown
+        case .running: return .running
+        case .stopping: return .stopping
+        case .completed: return .completed
+        case .failed: return .needsAttention
+        }
+    }
+}
+
+/// Shared observable status surface consumed by both the Settings pane and the
+/// menu-bar control, so the two controls always reflect one source of truth.
+@MainActor
+final class SessionWakeStatus: ObservableObject {
+    static let shared = SessionWakeStatus()
+
+    @Published private(set) var watcherState: WakeWatcherState = .off
+    @Published private(set) var previewCandidates: [WakeSessionCandidate] = []
+    @Published private(set) var isPreviewing = false
+    @Published private(set) var lastSummary: WakeRunSummary?
+
+    private let discovery: SessionDiscovery
+    private let ledgerFactory: @Sendable () -> ReplayLedger
+
+    init(
+        discovery: SessionDiscovery = SessionDiscovery(),
+        ledgerFactory: @escaping @Sendable () -> ReplayLedger = { ReplayLedger() }
+    ) {
+        self.discovery = discovery
+        self.ledgerFactory = ledgerFactory
+    }
+
+    /// Number of executable (resumable) candidates in the last preview.
+    var eligibleCount: Int { previewCandidates.filter(\.isExecutable).count }
+
+    /// Skip reasons and their counts, for explaining non-resumed sessions.
+    var skipSummary: [WakeSkipReason: Int] {
+        Dictionary(grouping: previewCandidates.compactMap(\.skipReason), by: { $0 })
+            .mapValues(\.count)
+    }
+
+    /// Read-only preview of resumable sessions. Explicitly permitted even while
+    /// the feature/watcher are off — it performs no subprocess or mutation.
+    func preview(configDirectory: String?) async {
+        isPreviewing = true
+        defer { isPreviewing = false }
+        let ledger = ledgerFactory()
+        previewCandidates = await discovery.discover(configDirectory: configDirectory, ledger: ledger)
+    }
+
+    /// Mirror a new coordinator state into the published surface.
+    func update(state: WakeWatcherState) {
+        watcherState = state
+        if case let .completed(summary) = state {
+            lastSummary = summary
+        }
+    }
+
+    func label(featureEnabled: Bool) -> SessionWakeStatusLabel {
+        SessionWakeStatusLabel.from(state: watcherState, featureEnabled: featureEnabled)
+    }
+}

--- a/MeterBar/Views/SessionWakeMenuControl.swift
+++ b/MeterBar/Views/SessionWakeMenuControl.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+/// Compact Session Wake control for the menu-bar panel.
+///
+/// Binds to the same shared `SessionWakeSettingsStore` / `SessionWakeStatus` as
+/// the Settings pane, so the watcher toggle and status chip stay in sync across
+/// both surfaces (one state binding, two control surfaces).
+struct SessionWakeMenuControl: View {
+    @ObservedObject private var store: SessionWakeSettingsStore
+    @ObservedObject private var status: SessionWakeStatus
+
+    init(store: SessionWakeSettingsStore = .shared, status: SessionWakeStatus = .shared) {
+        self.store = store
+        self.status = status
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Label {
+                Text("Session Wake")
+            } icon: {
+                Image(systemName: "moon.zzz")
+            }
+            Spacer()
+            Text(label.title)
+                .font(.caption)
+                .foregroundStyle(label.isAttention ? .orange : .secondary)
+            Toggle("", isOn: watcherBinding)
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .disabled(!store.canArmWatcher || store.wakeAccountID == nil)
+        }
+    }
+
+    private var label: SessionWakeStatusLabel {
+        status.label(featureEnabled: store.featureEnabled)
+    }
+
+    private var watcherBinding: Binding<Bool> {
+        Binding(get: { store.watcherArmed }, set: { store.setWatcherArmed($0) })
+    }
+}

--- a/MeterBar/Views/SessionWakeSettingsView.swift
+++ b/MeterBar/Views/SessionWakeSettingsView.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+
+/// Settings → Automation pane for Session Wake.
+///
+/// The view is intentionally thin: it renders shared store/status state and
+/// routes every mutation back through `SessionWakeSettingsStore`, which owns the
+/// safety toggle rules. No automation logic lives here.
+struct SessionWakeSettingsView: View {
+    @ObservedObject private var store: SessionWakeSettingsStore
+    @ObservedObject private var status: SessionWakeStatus
+    @ObservedObject private var accounts: ClaudeCodeAccountStore
+
+    init(
+        store: SessionWakeSettingsStore = .shared,
+        status: SessionWakeStatus = .shared,
+        accounts: ClaudeCodeAccountStore = .shared
+    ) {
+        self.store = store
+        self.status = status
+        self.accounts = accounts
+    }
+
+    var body: some View {
+        Form {
+            enablementSection
+            accountSection
+            watcherSection
+            previewSection
+            limitsSection
+            permissionSection
+            notificationSection
+        }
+        .formStyle(.grouped)
+    }
+
+    // MARK: - Sections
+
+    private var enablementSection: some View {
+        Section("Session Wake") {
+            Toggle("Enable Session Wake", isOn: binding(store.featureEnabled, store.setFeatureEnabled))
+            if store.featureEnabled {
+                Toggle(
+                    "I understand MeterBar will resume blocked sessions automatically",
+                    isOn: binding(store.firstEnableAcknowledged, store.setFirstEnableAcknowledged)
+                )
+                .font(.callout)
+            }
+            LabeledContent("Status", value: status.label(featureEnabled: store.featureEnabled).title)
+        }
+    }
+
+    private var accountSection: some View {
+        Section("Wake account") {
+            Picker("Account", selection: accountBinding) {
+                Text("None selected").tag(UUID?.none)
+                ForEach(accounts.accounts) { account in
+                    Text(account.name).tag(UUID?.some(account.id))
+                }
+            }
+            .disabled(!store.featureEnabled)
+        }
+    }
+
+    private var watcherSection: some View {
+        Section("Watcher") {
+            Toggle("Watcher active", isOn: binding(store.watcherArmed, store.setWatcherArmed))
+                .disabled(!store.canArmWatcher || store.wakeAccountID == nil)
+            if !store.canArmWatcher && store.featureEnabled {
+                Text("Acknowledge the safety note above to arm the watcher.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var previewSection: some View {
+        Section("Preview") {
+            Button("Preview resumable sessions") {
+                Task { await status.preview(configDirectory: selectedConfigDirectory) }
+            }
+            .disabled(status.isPreviewing)
+            LabeledContent("Eligible", value: "\(status.eligibleCount)")
+            ForEach(Array(status.skipSummary.keys), id: \.self) { reason in
+                LabeledContent(reason.rawValue, value: "\(status.skipSummary[reason] ?? 0)")
+                    .font(.footnote)
+            }
+            if let summary = status.lastSummary {
+                let detail = "\(summary.resumed) resumed · \(summary.failed) failed · \(summary.skipped) skipped"
+                LabeledContent("Last run", value: detail)
+                    .font(.footnote)
+            }
+        }
+    }
+
+    private var limitsSection: some View {
+        Section("Limits") {
+            Stepper(
+                "Max sessions per run: \(store.maxSessionsPerRun)",
+                value: binding(store.maxSessionsPerRun, store.setMaxSessionsPerRun),
+                in: WakeBounds.sessionsRange
+            )
+            Stepper(
+                "Max turns per session: \(store.maxTurns)",
+                value: binding(store.maxTurns, store.setMaxTurns),
+                in: WakeBounds.maxTurnsRange
+            )
+            TextField("Resume prompt", text: $store.prompt)
+        }
+    }
+
+    private var permissionSection: some View {
+        Section("Permissions") {
+            Picker("Permission mode", selection: binding(store.permissionMode, store.setPermissionMode)) {
+                Text("Safe").tag(WakePermissionMode.safe)
+                Text("Bypass").tag(WakePermissionMode.bypass)
+            }
+            if store.permissionMode == .bypass {
+                Toggle(
+                    "I acknowledge bypassing permission prompts is risky",
+                    isOn: binding(store.bypassAcknowledged, store.setBypassAcknowledged)
+                )
+                .font(.callout)
+            }
+        }
+    }
+
+    private var notificationSection: some View {
+        Section("Notifications") {
+            Toggle("Notify when a run completes", isOn: $store.notifyOnCompletion)
+        }
+    }
+
+    // MARK: - Bindings
+
+    private var accountBinding: Binding<UUID?> {
+        Binding(get: { store.wakeAccountID }, set: { store.setWakeAccountID($0) })
+    }
+
+    private var selectedConfigDirectory: String? {
+        accounts.accounts.first(where: { $0.id == store.wakeAccountID })?.configDirectory
+    }
+
+    private func binding<Value>(_ value: Value, _ setter: @escaping (Value) -> Void) -> Binding<Value> {
+        Binding(get: { value }, set: { setter($0) })
+    }
+}

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -8,6 +8,7 @@ private enum SettingsPane: Hashable, Identifiable {
     case general
     case apiUsage
     case costTracking
+    case automation
     case provider(ServiceType)
 
     // MARK: Internal
@@ -16,7 +17,7 @@ private enum SettingsPane: Hashable, Identifiable {
     static let windowMinHeight: CGFloat = 560
     static let sidebarWidth: CGFloat = 238
     static let detailMaxWidth: CGFloat = 760
-    static let appPanes: [SettingsPane] = [.general, .apiUsage, .costTracking]
+    static let appPanes: [SettingsPane] = [.general, .apiUsage, .costTracking, .automation]
     static let providerPanes: [SettingsPane] = ServiceType.allCases
         .sorted { $0.sortOrder < $1.sortOrder }
         .map(SettingsPane.provider)
@@ -29,6 +30,8 @@ private enum SettingsPane: Hashable, Identifiable {
             "api-usage"
         case .costTracking:
             "cost-tracking"
+        case .automation:
+            "automation"
         case let .provider(service):
             "provider-\(service.rawValue)"
         }
@@ -42,6 +45,8 @@ private enum SettingsPane: Hashable, Identifiable {
             "API Usage"
         case .costTracking:
             "Cost Tracking"
+        case .automation:
+            "Automation"
         case let .provider(service):
             service.displayName
         }
@@ -55,6 +60,8 @@ private enum SettingsPane: Hashable, Identifiable {
             "Admin keys and overage"
         case .costTracking:
             "Local token spend"
+        case .automation:
+            "Session Wake auto-resume"
         case let .provider(service):
             switch service {
             case .claudeCode:
@@ -75,6 +82,8 @@ private enum SettingsPane: Hashable, Identifiable {
             "network"
         case .costTracking:
             "chart.bar.xaxis"
+        case .automation:
+            "moon.zzz.fill"
         case .provider:
             nil
         }
@@ -90,7 +99,8 @@ private enum SettingsPane: Hashable, Identifiable {
     var color: Color {
         switch self {
         case .general,
-             .apiUsage:
+             .apiUsage,
+             .automation:
             MeterBarTheme.appAccent
         case .costTracking:
             MeterBarTheme.success
@@ -340,6 +350,8 @@ struct SettingsView: View {
                 apiUsageSection
             case .costTracking:
                 costTrackingSection
+            case .automation:
+                SessionWakeSettingsView()
             case let .provider(service):
                 providerSettingsPane(for: service)
             }

--- a/MeterBarTests/SessionWakeSettingsTests.swift
+++ b/MeterBarTests/SessionWakeSettingsTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+@testable import MeterBar
+
+/// Coverage for #98: settings toggle rules, account reconciliation, and the
+/// notification gate.
+final class SessionWakeSettingsTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUpWithError() throws {
+        suiteName = "SessionWakeSettingsTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    private func makeStore() -> SessionWakeSettingsStore {
+        SessionWakeSettingsStore(userDefaults: defaults)
+    }
+
+    func testDefaultsAreOffAndConservative() {
+        let store = makeStore()
+        XCTAssertFalse(store.featureEnabled)
+        XCTAssertFalse(store.watcherArmed)
+        XCTAssertNil(store.wakeAccountID)
+        XCTAssertFalse(store.canArmWatcher)
+    }
+
+    func testWatcherCannotArmWithoutFeatureAndAcknowledgement() {
+        let store = makeStore()
+        store.setWatcherArmed(true)
+        XCTAssertFalse(store.watcherArmed, "Arming must be refused while the feature is off")
+
+        store.setFeatureEnabled(true)
+        store.setWatcherArmed(true)
+        XCTAssertFalse(store.watcherArmed, "Arming must be refused without the first-enable ack")
+
+        store.setFirstEnableAcknowledged(true)
+        store.setWatcherArmed(true)
+        XCTAssertTrue(store.watcherArmed)
+    }
+
+    func testFeatureOffForcesWatcherOff() {
+        let store = makeStore()
+        store.setFeatureEnabled(true)
+        store.setFirstEnableAcknowledged(true)
+        store.setWatcherArmed(true)
+        XCTAssertTrue(store.watcherArmed)
+
+        store.setFeatureEnabled(false)
+        XCTAssertFalse(store.watcherArmed, "Master off must cancel watcher intent")
+    }
+
+    func testBypassModeWithoutAcknowledgementCannotArm() {
+        let store = makeStore()
+        store.setFeatureEnabled(true)
+        store.setFirstEnableAcknowledged(true)
+        store.setPermissionMode(.bypass)
+        XCTAssertFalse(store.canArmWatcher)
+        store.setWatcherArmed(true)
+        XCTAssertFalse(store.watcherArmed)
+
+        store.setBypassAcknowledged(true)
+        XCTAssertTrue(store.canArmWatcher)
+        store.setWatcherArmed(true)
+        XCTAssertTrue(store.watcherArmed)
+
+        // Revoking the ack while armed under bypass disarms.
+        store.setBypassAcknowledged(false)
+        XCTAssertFalse(store.watcherArmed)
+    }
+
+    func testWakeAccountPersistsAcrossRelaunch() {
+        let id = UUID()
+        let store = makeStore()
+        store.setWakeAccountID(id)
+        let reloaded = SessionWakeSettingsStore(userDefaults: defaults)
+        XCTAssertEqual(reloaded.wakeAccountID, id)
+    }
+
+    func testRemovingSelectedAccountClearsItAndDisarms() {
+        let id = UUID()
+        let store = makeStore()
+        store.setFeatureEnabled(true)
+        store.setFirstEnableAcknowledged(true)
+        store.setWakeAccountID(id)
+        store.setWatcherArmed(true)
+        XCTAssertTrue(store.watcherArmed)
+
+        store.reconcileAccounts(available: [UUID(), UUID()]) // selected id gone
+        XCTAssertNil(store.wakeAccountID)
+        XCTAssertFalse(store.watcherArmed)
+    }
+
+    func testBoundsClampThroughStore() {
+        let store = makeStore()
+        store.setMaxSessionsPerRun(9_999)
+        store.setMaxTurns(0)
+        XCTAssertEqual(store.maxSessionsPerRun, WakeBounds.sessionsRange.upperBound)
+        XCTAssertEqual(store.maxTurns, WakeBounds.maxTurnsRange.lowerBound)
+        XCTAssertEqual(store.bounds.maxSessionsPerRun, store.maxSessionsPerRun)
+    }
+
+    // MARK: - Notification gate
+
+    func testNotificationRequiresGlobalProviderAndWakePreference() {
+        func decide(_ global: Bool, _ provider: Bool, _ wake: Bool) -> Bool {
+            SessionWakeNotificationDecider.shouldNotifyOnCompletion(
+                .init(globalNotificationsEnabled: global, claudeProviderEnabled: provider, notifyOnCompletion: wake)
+            )
+        }
+        XCTAssertTrue(decide(true, true, true))
+        XCTAssertFalse(decide(false, true, true))
+        XCTAssertFalse(decide(true, false, true))
+        XCTAssertFalse(decide(true, true, false))
+    }
+}

--- a/MeterBarTests/SessionWakeStatusTests.swift
+++ b/MeterBarTests/SessionWakeStatusTests.swift
@@ -1,0 +1,89 @@
+import AppKit
+@testable import MeterBar
+import SwiftUI
+import XCTest
+
+/// Coverage for #98: state→label mapping, read-only preview while disabled, and
+/// SwiftUI hosting for both the Settings pane and the menu-bar control.
+@MainActor
+final class SessionWakeStatusTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SessionWakeStatusTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    func testLabelIsOffWhenFeatureDisabled() {
+        XCTAssertEqual(SessionWakeStatusLabel.from(state: .running(sessionID: "s"), featureEnabled: false), .off)
+    }
+
+    func testRealStatesAreNotCollapsed() {
+        XCTAssertEqual(SessionWakeStatusLabel.from(state: .running(sessionID: "s"), featureEnabled: true), .running)
+        XCTAssertEqual(SessionWakeStatusLabel.from(state: .stopping, featureEnabled: true), .stopping)
+        XCTAssertEqual(SessionWakeStatusLabel.from(state: .quotaUnknown(reason: "x"), featureEnabled: true), .quotaUnknown)
+        XCTAssertEqual(SessionWakeStatusLabel.from(state: .failed(reason: "x"), featureEnabled: true), .needsAttention)
+        XCTAssertTrue(SessionWakeStatusLabel.needsAttention.isAttention)
+    }
+
+    func testCompletionSummaryMatchesRunnerOutcome() {
+        let status = SessionWakeStatus()
+        status.update(state: .completed(summary: WakeRunSummary(resumed: 3, failed: 1, skipped: 2, remaining: 0)))
+        XCTAssertEqual(status.lastSummary?.resumed, 3)
+        XCTAssertEqual(status.lastSummary?.failed, 1)
+    }
+
+    func testPreviewWorksWhileFeatureDisabled() async throws {
+        // Write a blocked transcript with an existing cwd ⇒ one eligible session.
+        let projects = tempDir.appendingPathComponent("projects").appendingPathComponent("-proj")
+        try FileManager.default.createDirectory(at: projects, withIntermediateDirectories: true)
+        let object: [String: Any] = [
+            "type": "assistant",
+            "timestamp": "2026-07-10T02:00:00.000Z",
+            "isApiErrorMessage": true,
+            "apiErrorStatus": 429,
+            "cwd": tempDir.path,
+            "sessionId": "s0",
+            "message": ["role": "assistant", "content": [["type": "text", "text": "session limit resets 3:00am (UTC)"]]]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: object)
+        try String(decoding: data, as: UTF8.self)
+            .write(to: projects.appendingPathComponent("s0.jsonl"), atomically: true, encoding: .utf8)
+
+        let ledgerURL = tempDir.appendingPathComponent("l.json")
+        let status = SessionWakeStatus(ledgerFactory: { ReplayLedger(fileURL: ledgerURL) })
+        await status.preview(configDirectory: tempDir.path)
+        XCTAssertEqual(status.eligibleCount, 1)
+        XCTAssertFalse(status.isPreviewing)
+    }
+
+    // MARK: - SwiftUI hosting
+
+    func testSettingsPaneHosts() {
+        let defaults = UserDefaults(suiteName: "hosting-\(UUID().uuidString)")!
+        let store = SessionWakeSettingsStore(userDefaults: defaults)
+        store.setFeatureEnabled(true)
+        let view = SessionWakeSettingsView(store: store, status: SessionWakeStatus(), accounts: ClaudeCodeAccountStore(userDefaults: defaults))
+        let host = NSHostingView(rootView: view)
+        host.frame = NSRect(x: 0, y: 0, width: 520, height: 700)
+        host.layoutSubtreeIfNeeded()
+        XCTAssertGreaterThan(host.fittingSize.height, 100)
+    }
+
+    func testMenuControlHosts() {
+        let defaults = UserDefaults(suiteName: "hosting-\(UUID().uuidString)")!
+        let view = SessionWakeMenuControl(
+            store: SessionWakeSettingsStore(userDefaults: defaults),
+            status: SessionWakeStatus()
+        )
+        let host = NSHostingView(rootView: view)
+        host.frame = NSRect(x: 0, y: 0, width: 320, height: 44)
+        host.layoutSubtreeIfNeeded()
+        XCTAssertGreaterThan(host.fittingSize.width, 0)
+    }
+}


### PR DESCRIPTION
Fourth of the stacked Session Wake PRs. **Targets `session-wake/97-runner-lock`** (#108) — merge #105 → #107 → #108 first. Closes #98.

## What
User-facing control surfaces over the shared native coordinator; no automation logic in views.

- **SessionWakeSettingsStore** — separates `featureEnabled` from `watcherArmed`. Arming requires feature on + first-enable ack; bypass requires its own ack. `wakeAccountID` is always explicit, never inferred. Feature-off / ack-revoke force the watcher off; a removed wake account is cleared and disarms. Bounds clamped through the store.
- **SessionWakeNotificationDecider** — a wake notification is gated by the global switch AND Claude provider visibility AND the wake preference.
- **SessionWakeStatus / SessionWakeStatusLabel** — shared observable surface for Settings + menu bar. Real states surfaced distinctly (Running / Stopping / Quota Unknown / Needs Attention), not collapsed into "Watching". Read-only Preview allowed while disabled.
- **SessionWakeSettingsView** — dedicated **Settings → Automation** pane, wired into `SettingsPane`. **SessionWakeMenuControl** exposes the same watcher toggle + status in the menu bar, bound to the same store/status.

## Acceptance criteria (#98)
- [x] Feature off prevents background discovery/resume but still permits read-only Preview
- [x] Master-off cancels watcher intent and prevents further launches
- [x] Settings and menu-bar controls use one shared state binding
- [x] Selected wake account persists and is used consistently
- [x] Removing/changing the active wake account cancels/suspends the watcher
- [x] Running/stopping/failure/quota-unknown states visible, not collapsed
- [x] Completion counts match structured runner outcomes
- [x] Notifications respect global settings, provider visibility, and wake prefs
- [x] Store + SwiftUI hosting tests cover standalone Settings and menu surfaces

## Tests
14 new; existing settings smoke tests still green. SwiftLint --strict clean.

## Stack
#95 → #96 → #97 → **#98** → #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)