### PR TITLE
ci(release): migrate signing/notarization to canonical credential names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           # below and destroyed in cleanup — it is generated at runtime, never stored
           # as a secret. Mask it so it is redacted from all step logs, then persist it
           # via $GITHUB_ENV so later steps can unlock the same keychain.
-          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
           echo "::add-mask::$KEYCHAIN_PASSWORD"
           {
             echo "CERT_PATH=$RUNNER_TEMP/build_certificate.p12"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,40 +47,49 @@ jobs:
       - name: Configure signing paths
         run: |
           set -euo pipefail
+          # KEYCHAIN_PASSWORD is a DISPOSABLE password for the temp keychain created
+          # below and destroyed in cleanup — it is generated at runtime, never stored
+          # as a secret. Mask it so it is redacted from all step logs, then persist it
+          # via $GITHUB_ENV so later steps can unlock the same keychain.
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+          echo "::add-mask::$KEYCHAIN_PASSWORD"
           {
             echo "CERT_PATH=$RUNNER_TEMP/build_certificate.p12"
             echo "ASC_KEY_PATH=$RUNNER_TEMP/asc_api_key.p8"
             echo "KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db"
             echo "KEYCHAIN_LIST_BACKUP=$RUNNER_TEMP/original-keychains.list"
+            echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD"
           } >> "$GITHUB_ENV"
 
-      # Fail FAST (before any build work) if any required signing secret is
-      # missing. Releases must be signed + notarized, so an absent secret is
-      # fatal. Only presence is checked (non-empty); values are never printed.
-      - name: Preflight - require signing secrets
+      # Fail FAST (before any build work) if any required signing credential is
+      # missing. Releases must be signed + notarized, so an absent secret/variable
+      # is fatal. Only presence is checked (non-empty); values are never printed.
+      - name: Preflight - require signing credentials
         env:
-          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-          ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
-          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          DEVELOPER_ID_P12_BASE64: ${{ secrets.DEVELOPER_ID_P12_BASE64 }}
+          DEVELOPER_ID_P12_PASSWORD: ${{ secrets.DEVELOPER_ID_P12_PASSWORD }}
+          APPLE_API_PRIVATE_KEY_P8_BASE64: ${{ secrets.APPLE_API_PRIVATE_KEY_P8_BASE64 }}
+          APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ vars.APPLE_API_ISSUER_ID }}
         run: |
           set -euo pipefail
           missing=()
-          for name in BUILD_CERTIFICATE_BASE64 P12_PASSWORD KEYCHAIN_PASSWORD \
-                      ASC_API_KEY_BASE64 ASC_KEY_ID ASC_ISSUER_ID; do
+          # Secrets (key material) and variables (non-sensitive identifiers) are all
+          # required. KEYCHAIN_PASSWORD is intentionally absent — it is generated at
+          # runtime, not stored.
+          for name in DEVELOPER_ID_P12_BASE64 DEVELOPER_ID_P12_PASSWORD \
+                      APPLE_API_PRIVATE_KEY_P8_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER_ID; do
             # Indirect expansion reads the env var named in $name without echoing its value.
             if [ -z "${!name:-}" ]; then
               missing+=("$name")
             fi
           done
           if [ "${#missing[@]}" -ne 0 ]; then
-            echo "::error::Missing required signing secret(s): ${missing[*]}" >&2
-            echo "Add them under Settings > Secrets and variables > Actions (see issue #47 for the recipe), then re-run." >&2
+            echo "::error::Missing required signing credential(s): ${missing[*]}" >&2
+            echo "Set secrets DEVELOPER_ID_P12_BASE64 / DEVELOPER_ID_P12_PASSWORD / APPLE_API_PRIVATE_KEY_P8_BASE64 and variables APPLE_API_KEY_ID / APPLE_API_ISSUER_ID under Settings > Secrets and variables > Actions, then re-run." >&2
             exit 1
           fi
-          echo "All required signing secrets are present."
+          echo "All required signing credentials are present."
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
@@ -116,19 +125,19 @@ jobs:
       - name: Import signing assets
         id: identity
         env:
-          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-          ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
-          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          # KEYCHAIN_PASSWORD is inherited from $GITHUB_ENV (generated in the paths step).
+          DEVELOPER_ID_P12_BASE64: ${{ secrets.DEVELOPER_ID_P12_BASE64 }}
+          DEVELOPER_ID_P12_PASSWORD: ${{ secrets.DEVELOPER_ID_P12_PASSWORD }}
+          APPLE_API_PRIVATE_KEY_P8_BASE64: ${{ secrets.APPLE_API_PRIVATE_KEY_P8_BASE64 }}
+          APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ vars.APPLE_API_ISSUER_ID }}
         run: |
           set -euo pipefail
 
           # Decode straight to disk; -o avoids piping secret bytes through stdout/logs.
           # macOS base64 does not line-wrap by default, so single-line blobs decode cleanly.
-          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o "$CERT_PATH"
-          echo -n "$ASC_API_KEY_BASE64"       | base64 --decode -o "$ASC_KEY_PATH"
+          echo -n "$DEVELOPER_ID_P12_BASE64"         | base64 --decode -o "$CERT_PATH"
+          echo -n "$APPLE_API_PRIVATE_KEY_P8_BASE64" | base64 --decode -o "$ASC_KEY_PATH"
 
           # Capture the ORIGINAL user keychain search list so cleanup can restore it
           # exactly, rather than assuming a hardcoded default that might differ on
@@ -145,7 +154,7 @@ jobs:
           # that would import only the certificate and drop the private key, leaving an
           # unusable identity. -T whitelists codesign/security to use the key headlessly.
           security import "$CERT_PATH" \
-            -P "$P12_PASSWORD" \
+            -P "$DEVELOPER_ID_P12_PASSWORD" \
             -f pkcs12 \
             -k "$KEYCHAIN_PATH" \
             -T /usr/bin/codesign -T /usr/bin/security
@@ -187,8 +196,8 @@ jobs:
           # Non-interactive when all of --key/--key-id/--issuer are supplied.
           xcrun notarytool store-credentials "$NOTARY_PROFILE" \
             --key "$ASC_KEY_PATH" \
-            --key-id "$ASC_KEY_ID" \
-            --issuer "$ASC_ISSUER_ID" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
             --keychain "$KEYCHAIN_PATH"
 
       # Inside-out Developer ID signing with hardened runtime, plus the
@@ -196,9 +205,9 @@ jobs:
       # verification shared with CI (which runs the same script ad-hoc).
       - name: Sign and verify universal artifact
         env:
+          # KEYCHAIN_PASSWORD is inherited from $GITHUB_ENV (generated in the paths step).
           RELEASE_VERSION: ${{ steps.version.outputs.version }}
           SIGNING_IDENTITY: ${{ steps.identity.outputs.hash }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
           set -euo pipefail
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
@@ -211,8 +220,7 @@ jobs:
       # (with a poll-able submission id) instead of silently consuming the whole
       # 60-min job timeout.
       - name: Notarize and staple
-        env:
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        # KEYCHAIN_PASSWORD is inherited from $GITHUB_ENV (generated in the paths step).
         run: |
           set -euo pipefail
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"


### PR DESCRIPTION
## What

Migrates the macOS release CI to the shared **canonical** signing/notarization credential naming used across every app repo (macsweep, shipcode). No behavioral change to the signing, notarization, stapling, or verification logic — only the credential names and the source of the temp-keychain password.

### Reference remapping (`.github/workflows/release.yml`)

| Old | New |
|-----|-----|
| `secrets.BUILD_CERTIFICATE_BASE64` | `secrets.DEVELOPER_ID_P12_BASE64` |
| `secrets.P12_PASSWORD` | `secrets.DEVELOPER_ID_P12_PASSWORD` |
| `secrets.ASC_API_KEY_BASE64` | `secrets.APPLE_API_PRIVATE_KEY_P8_BASE64` |
| `secrets.ASC_KEY_ID` | `vars.APPLE_API_KEY_ID` |
| `secrets.ASC_ISSUER_ID` | `vars.APPLE_API_ISSUER_ID` |
| `secrets.KEYCHAIN_PASSWORD` | runtime `openssl rand -base64 24` (masked, via `$GITHUB_ENV`) |

`KEYCHAIN_PASSWORD` is no longer a stored secret — it is a disposable password for the temp keychain, generated at runtime, masked in logs, and destroyed with the keychain in the always() cleanup.

No hardcoded/derived Team ID exists in the workflow, so no `APPLE_TEAM_ID` substitution was needed (notarytool authenticates via the API key).

### Preserved intact
- create-keychain + `set-keychain-settings -lut` + unlock
- `security import` with `-T /usr/bin/codesign -T /usr/bin/security` and `set-key-partition-list` (non-interactive headless signing)
- single Developer ID Application identity hard-gate, SHA-1 identity resolution
- `notarytool store-credentials` + `submit --wait` + log-on-failure
- `stapler staple` + `spctl`/`codesign --verify`/`stapler validate`
- always() keychain + secret-file cleanup with original search-list restore

## Rollout ordering
1. Merge this PR (release workflow now references only canonical names).
2. Cut a release tag to confirm a signed + notarized release still succeeds.
3. **Only then** delete the now-unused old secrets: `ASC_API_KEY_BASE64`, `ASC_KEY_ID`, `ASC_ISSUER_ID`, `BUILD_CERTIFICATE_BASE64`, `P12_PASSWORD`, `KEYCHAIN_PASSWORD`.

## ⚠️ Blocker to fix before a release will pass
The repo variable `APPLE_API_ISSUER_ID` is currently set to `SXPYGV6KUP` — identical to `APPLE_API_KEY_ID`. An App Store Connect **issuer ID is a UUID**, not the key ID, so `notarytool store-credentials` will fail auth until `APPLE_API_ISSUER_ID` is corrected to the real issuer UUID (the value previously in the `ASC_ISSUER_ID` secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release signing and notarization reliability by generating temporary signing credentials during the release process.
  * Updated credential validation and asset handling to use the current signing and notarization configuration.
  * Reduced exposure of sensitive signing information in workflow logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->