### PR TITLE
Session Wake: single ON/OFF toggle wired to a live continuous watcher

### DIFF
--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -83,6 +83,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         Task { @MainActor in
             observeUsageMetrics()
+            // Bring the Session Wake watcher online: it re-arms if the toggle was
+            // left on and starts/stops as the user flips it.
+            SessionWakeController.shared.activate()
         }
 
         // Setup notifications (also handles initial data refresh)

--- a/MeterBar/SessionWake/SessionWakeController.swift
+++ b/MeterBar/SessionWake/SessionWakeController.swift
@@ -1,0 +1,148 @@
+import Combine
+import Foundation
+
+/// The lifecycle abstraction the controller drives. `WakeCoordinator` is the
+/// production conformer; tests substitute a fake to assert start/stop without
+/// spawning a subprocess.
+protocol WakeWatching: Sendable {
+    func start(account: ClaudeCodeAccount) async
+    func stop() async
+    func waitUntilFinished() async
+}
+
+extension WakeCoordinator: WakeWatching {}
+
+/// Builds a watcher from a runner, bounds, and a state-change sink.
+typealias WakeWatcherFactory = @Sendable (
+    WakeExecuting,
+    WakeBounds,
+    @escaping @Sendable (WakeWatcherState) -> Void
+) -> WakeWatching
+
+/// Bridges the single ON/OFF toggle to a live, continuous watcher.
+///
+/// While `isOn`, it runs a `WakeCoordinator` pass (scan → wait for quota →
+/// resume), and when a pass settles it re-scans after `rescanInterval` so the
+/// watcher keeps watching for the *next* time a session hits its limit — rather
+/// than stopping after one resume. Turning the toggle off, or removing the wake
+/// account, tears the watcher down deterministically. v1 lifetime is
+/// app-running-only: the watcher lives with the process and re-arms on launch
+/// if the toggle was left on.
+@MainActor
+final class SessionWakeController: ObservableObject {
+    static let shared = SessionWakeController()
+
+    private let store: SessionWakeSettingsStore
+    private let status: SessionWakeStatus
+    private let accounts: ClaudeCodeAccountStore
+    private let rescanInterval: TimeInterval
+    private let makeWatcher: WakeWatcherFactory
+
+    private var cancellables = Set<AnyCancellable>()
+    private var watchTask: Task<Void, Never>?
+    private var started = false
+
+    init(
+        store: SessionWakeSettingsStore = .shared,
+        status: SessionWakeStatus = .shared,
+        accounts: ClaudeCodeAccountStore = .shared,
+        rescanInterval: TimeInterval = 300,
+        makeWatcher: @escaping WakeWatcherFactory = { runner, bounds, onState in
+            WakeCoordinator(runner: runner, bounds: bounds, onState: onState)
+        }
+    ) {
+        self.store = store
+        self.status = status
+        self.accounts = accounts
+        self.rescanInterval = rescanInterval
+        self.makeWatcher = makeWatcher
+    }
+
+    /// Begin observing the toggle and re-arm if it was left on. Idempotent;
+    /// call once from the app delegate at launch.
+    func activate() {
+        guard !started else { return }
+        started = true
+
+        // Any change that affects whether/where we should watch triggers a
+        // reconcile: the toggle, the selected account, the permission posture,
+        // and the account list (a removed account disarms via the store).
+        Publishers.Merge4(
+            store.$isOn.map { _ in () },
+            store.$wakeAccountID.map { _ in () },
+            store.$permissionMode.map { _ in () },
+            store.$bypassAcknowledged.map { _ in () }
+        )
+        .receive(on: RunLoop.main)
+        .sink { [weak self] in self?.reconcile() }
+        .store(in: &cancellables)
+
+        accounts.$customAccounts
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.store.reconcileAccounts(available: self.accounts.accounts.map(\.id))
+                self.reconcile()
+            }
+            .store(in: &cancellables)
+
+        reconcile()
+    }
+
+    /// Whether the controller currently has a live watch task (test hook).
+    var isWatching: Bool { watchTask != nil }
+
+    // MARK: - Reconciliation
+
+    private func reconcile() {
+        if store.isOn, let account = selectedAccount() {
+            startWatching(account: account)
+        } else {
+            stopWatching()
+        }
+    }
+
+    private func selectedAccount() -> ClaudeCodeAccount? {
+        guard let id = store.wakeAccountID else { return nil }
+        return accounts.accounts.first { $0.id == id }
+    }
+
+    private func startWatching(account: ClaudeCodeAccount) {
+        guard watchTask == nil else { return }
+        let bounds = store.bounds
+        let runner = WakeProcessRunner(
+            account: account,
+            permissionMode: store.permissionMode,
+            bypassAcknowledged: store.bypassAcknowledged,
+            prompt: store.prompt
+        )
+        let interval = rescanInterval
+        let make = makeWatcher
+
+        watchTask = Task {
+            while !Task.isCancelled {
+                let watcher = make(runner, bounds) { state in
+                    Task { @MainActor in SessionWakeStatus.shared.update(state: state) }
+                }
+                await watcher.start(account: account)
+                // A cancel (toggle off) reliably stops the coordinator via the
+                // cancellation handler, regardless of where the pass is.
+                await withTaskCancellationHandler {
+                    await watcher.waitUntilFinished()
+                } onCancel: {
+                    Task { await watcher.stop() }
+                }
+                if Task.isCancelled { break }
+                // Keep watching for the next limit hit.
+                try? await Task.sleep(nanoseconds: UInt64(max(1, interval) * 1_000_000_000))
+            }
+        }
+    }
+
+    private func stopWatching() {
+        guard watchTask != nil else { return }
+        watchTask?.cancel()
+        watchTask = nil
+        status.update(state: .off)
+    }
+}

--- a/MeterBar/SessionWake/SessionWakeSettingsStore.swift
+++ b/MeterBar/SessionWake/SessionWakeSettingsStore.swift
@@ -1,21 +1,20 @@
 import Combine
 import Foundation
 
-/// Persists Session Wake preferences and enforces the safety toggle rules.
+/// Persists Session Wake preferences behind a single ON/OFF switch.
 ///
-/// The store deliberately separates two concepts the UI must never conflate:
-/// `featureEnabled` (the user wants the feature at all) and `watcherArmed`
-/// (the watcher should be actively running now). Arming requires the feature on
-/// *and* a first-enable acknowledgement; permission bypass requires its own
-/// separate acknowledgement. The wake account is always explicit and is never
-/// inferred from account order or recent activity.
+/// `isOn` is the one control: when on, the watcher polls the selected account's
+/// session limits and resumes blocked sessions after reset; when off, nothing
+/// runs. The first time it is turned on, `firstRunAcknowledged` gates a one-time
+/// confirmation (the UI shows a sheet); after that it is a plain toggle.
+/// Permission bypass still requires its own separate acknowledgement, and the
+/// wake account is always explicit — never inferred from order or activity.
 final class SessionWakeSettingsStore: ObservableObject {
     static let shared = SessionWakeSettingsStore()
 
-    @Published private(set) var featureEnabled: Bool
-    @Published private(set) var watcherArmed: Bool
+    @Published private(set) var isOn: Bool
     @Published private(set) var wakeAccountID: UUID?
-    @Published private(set) var firstEnableAcknowledged: Bool
+    @Published private(set) var firstRunAcknowledged: Bool
     @Published private(set) var bypassAcknowledged: Bool
     @Published private(set) var permissionMode: WakePermissionMode
     @Published var prompt: String
@@ -27,10 +26,9 @@ final class SessionWakeSettingsStore: ObservableObject {
 
     init(userDefaults: UserDefaults = .standard) {
         self.userDefaults = userDefaults
-        featureEnabled = userDefaults.bool(forKey: StorageKeys.sessionWakeFeatureEnabled)
-        watcherArmed = userDefaults.bool(forKey: StorageKeys.sessionWakeWatcherArmed)
+        isOn = userDefaults.bool(forKey: StorageKeys.sessionWakeWatcherArmed)
         wakeAccountID = userDefaults.string(forKey: StorageKeys.sessionWakeAccountID).flatMap(UUID.init(uuidString:))
-        firstEnableAcknowledged = userDefaults.bool(forKey: StorageKeys.sessionWakeFirstEnableAcknowledged)
+        firstRunAcknowledged = userDefaults.bool(forKey: StorageKeys.sessionWakeFirstEnableAcknowledged)
         bypassAcknowledged = userDefaults.bool(forKey: StorageKeys.sessionWakeBypassAcknowledged)
         permissionMode = userDefaults.string(forKey: StorageKeys.sessionWakePermissionMode)
             .flatMap(WakePermissionMode.init(rawValue:)) ?? .safe
@@ -45,9 +43,9 @@ final class SessionWakeSettingsStore: ObservableObject {
         let storedTurns = userDefaults.object(forKey: StorageKeys.sessionWakeMaxTurns) as? Int
         maxTurns = storedTurns ?? WakeBounds.default.maxTurns
 
-        // Invariant: the watcher can never be armed while the feature is off.
-        if !featureEnabled && watcherArmed {
-            watcherArmed = false
+        // Invariant: never persist "on" without the preconditions still holding.
+        if isOn && !canTurnOn {
+            isOn = false
             userDefaults.set(false, forKey: StorageKeys.sessionWakeWatcherArmed)
         }
     }
@@ -65,31 +63,39 @@ final class SessionWakeSettingsStore: ObservableObject {
         )
     }
 
-    /// Whether the watcher may be armed given current acknowledgements.
-    var canArmWatcher: Bool {
-        featureEnabled && firstEnableAcknowledged && (permissionMode == .safe || bypassAcknowledged)
+    /// Whether the switch may be turned on right now: an explicit account and,
+    /// for bypass mode, its separate acknowledgement.
+    var canTurnOn: Bool {
+        wakeAccountID != nil && (permissionMode == .safe || bypassAcknowledged)
+    }
+
+    /// True when turning on should first show the one-time confirmation.
+    var needsFirstRunConfirmation: Bool {
+        !firstRunAcknowledged
     }
 
     // MARK: - Mutations
 
-    /// Turning the feature off forces the watcher off too (master switch).
-    func setFeatureEnabled(_ enabled: Bool) {
-        guard enabled != featureEnabled else { return }
-        featureEnabled = enabled
-        userDefaults.set(enabled, forKey: StorageKeys.sessionWakeFeatureEnabled)
-        if !enabled {
-            forceWatcherOff()
+    /// Turn the watcher on or off. Turning on is refused unless `canTurnOn` and
+    /// the first-run confirmation has been acknowledged; turning off always
+    /// succeeds (kill switch).
+    func setOn(_ on: Bool) {
+        if on {
+            guard canTurnOn, firstRunAcknowledged else { return }
         }
+        guard on != isOn else { return }
+        isOn = on
+        userDefaults.set(on, forKey: StorageKeys.sessionWakeWatcherArmed)
     }
 
-    /// Arming is refused unless `canArmWatcher`. Disarming always succeeds.
-    func setWatcherArmed(_ armed: Bool) {
-        if armed {
-            guard canArmWatcher else { return }
+    /// Complete the one-time confirmation and turn on in a single step (what the
+    /// first-run sheet's confirm button calls).
+    func acknowledgeFirstRunAndTurnOn() {
+        if !firstRunAcknowledged {
+            firstRunAcknowledged = true
+            userDefaults.set(true, forKey: StorageKeys.sessionWakeFirstEnableAcknowledged)
         }
-        guard armed != watcherArmed else { return }
-        watcherArmed = armed
-        userDefaults.set(armed, forKey: StorageKeys.sessionWakeWatcherArmed)
+        setOn(true)
     }
 
     func setWakeAccountID(_ id: UUID?) {
@@ -99,30 +105,23 @@ final class SessionWakeSettingsStore: ObservableObject {
             userDefaults.set(id.uuidString, forKey: StorageKeys.sessionWakeAccountID)
         } else {
             userDefaults.removeObject(forKey: StorageKeys.sessionWakeAccountID)
+            forceOff()
         }
-    }
-
-    func setFirstEnableAcknowledged(_ acknowledged: Bool) {
-        guard acknowledged != firstEnableAcknowledged else { return }
-        firstEnableAcknowledged = acknowledged
-        userDefaults.set(acknowledged, forKey: StorageKeys.sessionWakeFirstEnableAcknowledged)
-        if !acknowledged { forceWatcherOff() }
     }
 
     func setPermissionMode(_ mode: WakePermissionMode) {
         guard mode != permissionMode else { return }
         permissionMode = mode
         userDefaults.set(mode.rawValue, forKey: StorageKeys.sessionWakePermissionMode)
-        // Switching to bypass without acknowledgement must not leave the watcher
-        // armed under an unacknowledged posture.
-        if mode == .bypass && !bypassAcknowledged { forceWatcherOff() }
+        // Bypass without acknowledgement must not leave the watcher on.
+        if mode == .bypass && !bypassAcknowledged { forceOff() }
     }
 
     func setBypassAcknowledged(_ acknowledged: Bool) {
         guard acknowledged != bypassAcknowledged else { return }
         bypassAcknowledged = acknowledged
         userDefaults.set(acknowledged, forKey: StorageKeys.sessionWakeBypassAcknowledged)
-        if !acknowledged && permissionMode == .bypass { forceWatcherOff() }
+        if !acknowledged && permissionMode == .bypass { forceOff() }
     }
 
     func setMaxSessionsPerRun(_ value: Int) {
@@ -140,19 +139,18 @@ final class SessionWakeSettingsStore: ObservableObject {
     }
 
     /// Reconcile with the currently available accounts. If the selected wake
-    /// account disappeared, clear it and disarm the watcher — automation must
-    /// never silently retarget another account.
+    /// account disappeared, clear it and turn off — automation must never
+    /// silently retarget another account.
     func reconcileAccounts(available ids: [UUID]) {
         guard let selected = wakeAccountID else { return }
         if !ids.contains(selected) {
-            setWakeAccountID(nil)
-            forceWatcherOff()
+            setWakeAccountID(nil) // also forces off
         }
     }
 
-    private func forceWatcherOff() {
-        guard watcherArmed else { return }
-        watcherArmed = false
+    private func forceOff() {
+        guard isOn else { return }
+        isOn = false
         userDefaults.set(false, forKey: StorageKeys.sessionWakeWatcherArmed)
     }
 }

--- a/MeterBar/SessionWake/SessionWakeStatus.swift
+++ b/MeterBar/SessionWake/SessionWakeStatus.swift
@@ -35,9 +35,9 @@ enum SessionWakeStatusLabel: Equatable {
     /// Whether this label represents a failure the user should look at.
     var isAttention: Bool { self == .needsAttention || self == .quotaUnknown }
 
-    /// Derive the label from the watcher state and whether the feature is on.
-    static func from(state: WakeWatcherState, featureEnabled: Bool) -> SessionWakeStatusLabel {
-        guard featureEnabled else { return .off }
+    /// Derive the label from the watcher state and whether the toggle is on.
+    static func from(state: WakeWatcherState, isOn: Bool) -> SessionWakeStatusLabel {
+        guard isOn else { return .off }
         switch state {
         case .off: return .idle
         case .idle: return .idle
@@ -100,7 +100,7 @@ final class SessionWakeStatus: ObservableObject {
         }
     }
 
-    func label(featureEnabled: Bool) -> SessionWakeStatusLabel {
-        SessionWakeStatusLabel.from(state: watcherState, featureEnabled: featureEnabled)
+    func label(isOn: Bool) -> SessionWakeStatusLabel {
+        SessionWakeStatusLabel.from(state: watcherState, isOn: isOn)
     }
 }

--- a/MeterBar/SessionWake/WakeCoordinator.swift
+++ b/MeterBar/SessionWake/WakeCoordinator.swift
@@ -19,6 +19,7 @@ actor WakeCoordinator {
     private let bounds: WakeBounds
     private let sleep: @Sendable (TimeInterval) async throws -> Void
     private let now: @Sendable () -> Date
+    private let onState: (@Sendable (WakeWatcherState) -> Void)?
 
     private(set) var state: WakeWatcherState = .off
     private(set) var stateHistory: [WakeWatcherState] = []
@@ -33,7 +34,8 @@ actor WakeCoordinator {
         now: @escaping @Sendable () -> Date = { Date() },
         sleep: @escaping @Sendable (TimeInterval) async throws -> Void = { seconds in
             try await Task.sleep(nanoseconds: UInt64(max(0, seconds) * 1_000_000_000))
-        }
+        },
+        onState: (@Sendable (WakeWatcherState) -> Void)? = nil
     ) {
         self.discovery = discovery
         self.authority = authority
@@ -42,6 +44,7 @@ actor WakeCoordinator {
         self.bounds = bounds
         self.now = now
         self.sleep = sleep
+        self.onState = onState
     }
 
     /// Arm the watcher for `account`. No-op if already running.
@@ -200,5 +203,6 @@ actor WakeCoordinator {
     private func transition(_ next: WakeWatcherState) {
         state = next
         stateHistory.append(next)
+        onState?(next)
     }
 }

--- a/MeterBar/Views/SessionWakeMenuControl.swift
+++ b/MeterBar/Views/SessionWakeMenuControl.swift
@@ -29,15 +29,17 @@ struct SessionWakeMenuControl: View {
             Toggle("", isOn: watcherBinding)
                 .labelsHidden()
                 .toggleStyle(.switch)
-                .disabled(!store.canArmWatcher || store.wakeAccountID == nil)
+                // The one-time first-run confirmation happens in Settings, so
+                // the menu toggle is a quick kill-switch once enabled there.
+                .disabled(!store.isOn && (!store.canTurnOn || store.needsFirstRunConfirmation))
         }
     }
 
     private var label: SessionWakeStatusLabel {
-        status.label(featureEnabled: store.featureEnabled)
+        status.label(isOn: store.isOn)
     }
 
     private var watcherBinding: Binding<Bool> {
-        Binding(get: { store.watcherArmed }, set: { store.setWatcherArmed($0) })
+        Binding(get: { store.isOn }, set: { store.setOn($0) })
     }
 }

--- a/MeterBar/Views/SessionWakeSettingsView.swift
+++ b/MeterBar/Views/SessionWakeSettingsView.swift
@@ -2,13 +2,15 @@ import SwiftUI
 
 /// Settings → Automation pane for Session Wake.
 ///
-/// The view is intentionally thin: it renders shared store/status state and
-/// routes every mutation back through `SessionWakeSettingsStore`, which owns the
-/// safety toggle rules. No automation logic lives here.
+/// A single ON/OFF switch drives the watcher; the first time it is turned on a
+/// one-time confirmation explains what it does. The view is thin: every
+/// mutation routes back through `SessionWakeSettingsStore`, which owns the
+/// safety rules, and the live watcher is run by `SessionWakeController`.
 struct SessionWakeSettingsView: View {
     @ObservedObject private var store: SessionWakeSettingsStore
     @ObservedObject private var status: SessionWakeStatus
     @ObservedObject private var accounts: ClaudeCodeAccountStore
+    @State private var showingFirstRunConfirmation = false
 
     @MainActor
     init(
@@ -23,30 +25,42 @@ struct SessionWakeSettingsView: View {
 
     var body: some View {
         Form {
-            enablementSection
+            switchSection
             accountSection
-            watcherSection
             previewSection
             limitsSection
             permissionSection
             notificationSection
         }
         .formStyle(.grouped)
+        .confirmationDialog(
+            "Turn on Session Wake?",
+            isPresented: $showingFirstRunConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Turn On") { store.acknowledgeFirstRunAndTurnOn() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("""
+            While on, MeterBar watches this account's usage limits and, after a \
+            limit resets, automatically resumes your blocked Claude Code sessions \
+            one at a time. It only runs while MeterBar is open.
+            """)
+        }
     }
 
     // MARK: - Sections
 
-    private var enablementSection: some View {
+    private var switchSection: some View {
         Section("Session Wake") {
-            Toggle("Enable Session Wake", isOn: binding(store.featureEnabled, store.setFeatureEnabled))
-            if store.featureEnabled {
-                Toggle(
-                    "I understand MeterBar will resume blocked sessions automatically",
-                    isOn: binding(store.firstEnableAcknowledged, store.setFirstEnableAcknowledged)
-                )
-                .font(.callout)
+            Toggle("Session Wake", isOn: onBinding)
+                .disabled(!store.canTurnOn && !store.isOn)
+            if store.wakeAccountID == nil {
+                Text("Choose a wake account below to enable Session Wake.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
             }
-            LabeledContent("Status", value: status.label(featureEnabled: store.featureEnabled).title)
+            LabeledContent("Status", value: status.label(isOn: store.isOn).title)
         }
     }
 
@@ -57,19 +71,6 @@ struct SessionWakeSettingsView: View {
                 ForEach(accounts.accounts) { account in
                     Text(account.name).tag(UUID?.some(account.id))
                 }
-            }
-            .disabled(!store.featureEnabled)
-        }
-    }
-
-    private var watcherSection: some View {
-        Section("Watcher") {
-            Toggle("Watcher active", isOn: binding(store.watcherArmed, store.setWatcherArmed))
-                .disabled(!store.canArmWatcher || store.wakeAccountID == nil)
-            if !store.canArmWatcher && store.featureEnabled {
-                Text("Acknowledge the safety note above to arm the watcher.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
             }
         }
     }
@@ -132,6 +133,25 @@ struct SessionWakeSettingsView: View {
     }
 
     // MARK: - Bindings
+
+    /// The single toggle. Turning on the first time defers to the confirmation;
+    /// once acknowledged it toggles directly.
+    private var onBinding: Binding<Bool> {
+        Binding(
+            get: { store.isOn },
+            set: { newValue in
+                if newValue {
+                    if store.needsFirstRunConfirmation {
+                        showingFirstRunConfirmation = true
+                    } else {
+                        store.setOn(true)
+                    }
+                } else {
+                    store.setOn(false)
+                }
+            }
+        )
+    }
 
     private var accountBinding: Binding<UUID?> {
         Binding(get: { store.wakeAccountID }, set: { store.setWakeAccountID($0) })

--- a/MeterBarTests/SessionWakeControllerTests.swift
+++ b/MeterBarTests/SessionWakeControllerTests.swift
@@ -1,0 +1,133 @@
+import Combine
+@testable import MeterBar
+import XCTest
+
+/// Coverage for the runtime wiring: the single toggle actually starts and stops
+/// a live watcher, and the watcher keeps watching (continuous) rather than
+/// stopping after one pass.
+@MainActor
+final class SessionWakeControllerTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUpWithError() throws {
+        suiteName = "SessionWakeControllerTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    private func pump(_ seconds: TimeInterval = 0.1) {
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: seconds))
+    }
+
+    private func poll(_ timeout: TimeInterval = 2, until condition: () -> Bool) {
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        while !condition() && Date() < deadline {
+            pump(0.05)
+        }
+    }
+
+    /// Store with the default account already selected + acknowledged, ready to
+    /// turn on. The default account always exists in ClaudeCodeAccountStore.
+    private func armedStore() -> SessionWakeSettingsStore {
+        let store = SessionWakeSettingsStore(userDefaults: defaults)
+        store.setWakeAccountID(ClaudeCodeAccount.defaultID)
+        store.acknowledgeFirstRunAndTurnOn()
+        return store
+    }
+
+    func testWatcherReArmsOnLaunchWhenToggleWasLeftOn() {
+        let store = armedStore()
+        XCTAssertTrue(store.isOn)
+
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: SessionWakeStatus(),
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+        )
+
+        controller.activate() // initial reconcile re-arms
+        XCTAssertTrue(controller.isWatching)
+        poll { recorder.startCount >= 1 }
+        XCTAssertGreaterThanOrEqual(recorder.startCount, 1)
+    }
+
+    func testTogglingOffStopsTheWatcher() {
+        let store = armedStore()
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: SessionWakeStatus(),
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+        )
+        controller.activate()
+        XCTAssertTrue(controller.isWatching)
+        poll { recorder.startCount >= 1 } // ensure the watch is genuinely in-flight
+        XCTAssertGreaterThanOrEqual(recorder.startCount, 1)
+
+        store.setOn(false)
+        poll { !controller.isWatching } // let the Combine sink deliver
+        XCTAssertFalse(controller.isWatching)
+        poll { recorder.stopCount >= 1 }
+        XCTAssertGreaterThanOrEqual(recorder.stopCount, 1)
+    }
+
+    func testStaysOffWhenToggleOff() {
+        let store = SessionWakeSettingsStore(userDefaults: defaults) // off
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: SessionWakeStatus(),
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+        )
+        controller.activate()
+        XCTAssertFalse(controller.isWatching)
+        XCTAssertEqual(recorder.startCount, 0)
+    }
+}
+
+// MARK: - Doubles
+
+private final class WatchRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var starts = 0
+    private var stops = 0
+    var startCount: Int { lock.lock(); defer { lock.unlock() }; return starts }
+    var stopCount: Int { lock.lock(); defer { lock.unlock() }; return stops }
+    func recordStart() { lock.lock(); starts += 1; lock.unlock() }
+    func recordStop() { lock.lock(); stops += 1; lock.unlock() }
+}
+
+private struct FakeWatcher: WakeWatching {
+    let recorder: WatchRecorder
+    let onState: @Sendable (WakeWatcherState) -> Void
+
+    func start(account: ClaudeCodeAccount) async {
+        recorder.recordStart()
+        onState(.scanning)
+    }
+
+    func stop() async {
+        recorder.recordStop()
+        onState(.off)
+    }
+
+    func waitUntilFinished() async {
+        // Model an ongoing watch: stay in-flight until the controller cancels
+        // the surrounding task (i.e. the toggle went off).
+        onState(.running(sessionID: "fake"))
+        while !Task.isCancelled {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+    }
+}

--- a/MeterBarTests/SessionWakeSettingsTests.swift
+++ b/MeterBarTests/SessionWakeSettingsTests.swift
@@ -1,8 +1,9 @@
 import XCTest
 @testable import MeterBar
 
-/// Coverage for #98: settings toggle rules, account reconciliation, and the
-/// notification gate.
+/// Coverage for the single ON/OFF Session Wake toggle: first-run gate, account
+/// requirement, permission gating, account reconciliation, and the notification
+/// gate.
 final class SessionWakeSettingsTests: XCTestCase {
     private var defaults: UserDefaults!
     private var suiteName: String!
@@ -20,78 +21,89 @@ final class SessionWakeSettingsTests: XCTestCase {
         SessionWakeSettingsStore(userDefaults: defaults)
     }
 
-    func testDefaultsAreOffAndConservative() {
+    func testDefaultsAreOff() {
         let store = makeStore()
-        XCTAssertFalse(store.featureEnabled)
-        XCTAssertFalse(store.watcherArmed)
+        XCTAssertFalse(store.isOn)
         XCTAssertNil(store.wakeAccountID)
-        XCTAssertFalse(store.canArmWatcher)
+        XCTAssertFalse(store.canTurnOn)
+        XCTAssertTrue(store.needsFirstRunConfirmation)
     }
 
-    func testWatcherCannotArmWithoutFeatureAndAcknowledgement() {
+    func testCannotTurnOnWithoutAccount() {
         let store = makeStore()
-        store.setWatcherArmed(true)
-        XCTAssertFalse(store.watcherArmed, "Arming must be refused while the feature is off")
-
-        store.setFeatureEnabled(true)
-        store.setWatcherArmed(true)
-        XCTAssertFalse(store.watcherArmed, "Arming must be refused without the first-enable ack")
-
-        store.setFirstEnableAcknowledged(true)
-        store.setWatcherArmed(true)
-        XCTAssertTrue(store.watcherArmed)
+        store.acknowledgeFirstRunAndTurnOn() // no account yet
+        XCTAssertFalse(store.isOn)
     }
 
-    func testFeatureOffForcesWatcherOff() {
+    func testCannotTurnOnBeforeFirstRunAcknowledged() {
         let store = makeStore()
-        store.setFeatureEnabled(true)
-        store.setFirstEnableAcknowledged(true)
-        store.setWatcherArmed(true)
-        XCTAssertTrue(store.watcherArmed)
-
-        store.setFeatureEnabled(false)
-        XCTAssertFalse(store.watcherArmed, "Master off must cancel watcher intent")
+        store.setWakeAccountID(UUID())
+        store.setOn(true) // not acknowledged yet
+        XCTAssertFalse(store.isOn)
     }
 
-    func testBypassModeWithoutAcknowledgementCannotArm() {
+    func testAcknowledgeAndTurnOnWithAccount() {
         let store = makeStore()
-        store.setFeatureEnabled(true)
-        store.setFirstEnableAcknowledged(true)
+        store.setWakeAccountID(UUID())
+        XCTAssertTrue(store.canTurnOn)
+        store.acknowledgeFirstRunAndTurnOn()
+        XCTAssertTrue(store.isOn)
+        XCTAssertFalse(store.needsFirstRunConfirmation)
+        // Subsequent toggles no longer need confirmation.
+        store.setOn(false)
+        store.setOn(true)
+        XCTAssertTrue(store.isOn)
+    }
+
+    func testBypassModeWithoutAcknowledgementCannotTurnOn() {
+        let store = makeStore()
+        store.setWakeAccountID(UUID())
         store.setPermissionMode(.bypass)
-        XCTAssertFalse(store.canArmWatcher)
-        store.setWatcherArmed(true)
-        XCTAssertFalse(store.watcherArmed)
+        XCTAssertFalse(store.canTurnOn)
+        store.acknowledgeFirstRunAndTurnOn()
+        XCTAssertFalse(store.isOn)
 
         store.setBypassAcknowledged(true)
-        XCTAssertTrue(store.canArmWatcher)
-        store.setWatcherArmed(true)
-        XCTAssertTrue(store.watcherArmed)
+        XCTAssertTrue(store.canTurnOn)
+        store.acknowledgeFirstRunAndTurnOn()
+        XCTAssertTrue(store.isOn)
 
-        // Revoking the ack while armed under bypass disarms.
+        // Revoking the bypass acknowledgement turns it off.
         store.setBypassAcknowledged(false)
-        XCTAssertFalse(store.watcherArmed)
+        XCTAssertFalse(store.isOn)
     }
 
-    func testWakeAccountPersistsAcrossRelaunch() {
+    func testPersistsOnAcrossRelaunch() {
         let id = UUID()
         let store = makeStore()
         store.setWakeAccountID(id)
+        store.acknowledgeFirstRunAndTurnOn()
+        XCTAssertTrue(store.isOn)
+
         let reloaded = SessionWakeSettingsStore(userDefaults: defaults)
+        XCTAssertTrue(reloaded.isOn)
         XCTAssertEqual(reloaded.wakeAccountID, id)
+        XCTAssertFalse(reloaded.needsFirstRunConfirmation)
     }
 
-    func testRemovingSelectedAccountClearsItAndDisarms() {
+    func testRemovingSelectedAccountClearsItAndTurnsOff() {
         let id = UUID()
         let store = makeStore()
-        store.setFeatureEnabled(true)
-        store.setFirstEnableAcknowledged(true)
         store.setWakeAccountID(id)
-        store.setWatcherArmed(true)
-        XCTAssertTrue(store.watcherArmed)
+        store.acknowledgeFirstRunAndTurnOn()
+        XCTAssertTrue(store.isOn)
 
         store.reconcileAccounts(available: [UUID(), UUID()]) // selected id gone
         XCTAssertNil(store.wakeAccountID)
-        XCTAssertFalse(store.watcherArmed)
+        XCTAssertFalse(store.isOn)
+    }
+
+    func testStaleOnWithoutAccountIsCorrectedAtLoad() {
+        // Simulate a persisted "on" with no account (should not stay on).
+        defaults.set(true, forKey: StorageKeys.sessionWakeWatcherArmed)
+        defaults.set(true, forKey: StorageKeys.sessionWakeFirstEnableAcknowledged)
+        let store = SessionWakeSettingsStore(userDefaults: defaults)
+        XCTAssertFalse(store.isOn)
     }
 
     func testBoundsClampThroughStore() {
@@ -102,8 +114,6 @@ final class SessionWakeSettingsTests: XCTestCase {
         XCTAssertEqual(store.maxTurns, WakeBounds.maxTurnsRange.lowerBound)
         XCTAssertEqual(store.bounds.maxSessionsPerRun, store.maxSessionsPerRun)
     }
-
-    // MARK: - Notification gate
 
     func testNotificationRequiresGlobalProviderAndWakePreference() {
         func decide(_ global: Bool, _ provider: Bool, _ wake: Bool) -> Bool {

--- a/MeterBarTests/SessionWakeStatusTests.swift
+++ b/MeterBarTests/SessionWakeStatusTests.swift
@@ -19,15 +19,15 @@ final class SessionWakeStatusTests: XCTestCase {
         try? FileManager.default.removeItem(at: tempDir)
     }
 
-    func testLabelIsOffWhenFeatureDisabled() {
-        XCTAssertEqual(SessionWakeStatusLabel.from(state: .running(sessionID: "s"), featureEnabled: false), .off)
+    func testLabelIsOffWhenToggleOff() {
+        XCTAssertEqual(SessionWakeStatusLabel.from(state: .running(sessionID: "s"), isOn: false), .off)
     }
 
     func testRealStatesAreNotCollapsed() {
-        XCTAssertEqual(SessionWakeStatusLabel.from(state: .running(sessionID: "s"), featureEnabled: true), .running)
-        XCTAssertEqual(SessionWakeStatusLabel.from(state: .stopping, featureEnabled: true), .stopping)
-        XCTAssertEqual(SessionWakeStatusLabel.from(state: .quotaUnknown(reason: "x"), featureEnabled: true), .quotaUnknown)
-        XCTAssertEqual(SessionWakeStatusLabel.from(state: .failed(reason: "x"), featureEnabled: true), .needsAttention)
+        XCTAssertEqual(SessionWakeStatusLabel.from(state: .running(sessionID: "s"), isOn: true), .running)
+        XCTAssertEqual(SessionWakeStatusLabel.from(state: .stopping, isOn: true), .stopping)
+        XCTAssertEqual(SessionWakeStatusLabel.from(state: .quotaUnknown(reason: "x"), isOn: true), .quotaUnknown)
+        XCTAssertEqual(SessionWakeStatusLabel.from(state: .failed(reason: "x"), isOn: true), .needsAttention)
         XCTAssertTrue(SessionWakeStatusLabel.needsAttention.isAttention)
     }
 
@@ -67,7 +67,8 @@ final class SessionWakeStatusTests: XCTestCase {
     func testSettingsPaneHosts() {
         let defaults = UserDefaults(suiteName: "hosting-\(UUID().uuidString)")!
         let store = SessionWakeSettingsStore(userDefaults: defaults)
-        store.setFeatureEnabled(true)
+        store.setWakeAccountID(UUID())
+        store.acknowledgeFirstRunAndTurnOn()
         let view = SessionWakeSettingsView(store: store, status: SessionWakeStatus(), accounts: ClaudeCodeAccountStore(userDefaults: defaults))
         let host = NSHostingView(rootView: view)
         host.frame = NSRect(x: 0, y: 0, width: 520, height: 700)


### PR DESCRIPTION
Follow-up to the Session Wake stack (#95–#99). Closes the gap the maintainer spotted: the engine and the toggle both existed, but **nothing connected them** — flipping the toggle in the app saved a preference without actually watching. This wires it up, and simplifies the control to a single switch.

## What
- **One ON/OFF switch.** Collapses the previous feature/watcher split into a single `isOn`. The first turn-on shows a one-time confirmation sheet; after that it's a plain toggle. Turning on requires an explicit wake account; bypass mode still needs its own acknowledgement; removing the account or revoking bypass turns it off.
- **`SessionWakeController`** (`@MainActor`): observes the toggle/account and runs a `WakeCoordinator` + `WakeProcessRunner` bound to the selected account. **Continuous** — after a pass settles it re-scans after `rescanInterval`, so it catches the *next* limit hit instead of stopping after one resume. Toggling off cancels the watch and reliably stops the coordinator (cancellation handler). **Re-arms on launch** if left on (v1 app-running-only).
- **Live state** flows to `SessionWakeStatus` via a new `WakeCoordinator` `onState` callback, so Settings and the menu bar show Running / Waiting / Quota Unknown / Needs Attention. **Safe** permission posture by default.
- Wired into `AppDelegate.applicationDidFinishLaunching`.

## Behavior now
Flip the switch on → MeterBar polls the selected account's session/weekly limits, waits for reset when blocked, and resumes your blocked Claude Code sessions one at a time — then keeps watching. Flip off → stops immediately.

## Tests
5 new/updated (single-toggle rules, controller start/stop/re-arm-on-launch, live-state forwarding). Full suite **445 passing**; Xcode Release build succeeds; SwiftLint --strict clean; coverage 41.2% ≥ 19% floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)