### PR TITLE
Dashboard layout audit: sidebar groups, toolbar settings, card fixes

### DIFF
--- a/.agents/SESSIONS/2026-07-11.md
+++ b/.agents/SESSIONS/2026-07-11.md
@@ -1,0 +1,26 @@
+# 2026-07-11
+
+## Session 1: Dashboard layout/spacing audit + fixes
+
+**Duration:** ~30 min
+**Status:** Complete
+
+**What was done:**
+- Audited the dashboard against the user's five screenshot findings, then implemented all of them (TDD: `DashboardLayoutTests` written first).
+- Token Burn (Optimize): moved the 7/30-day segmented picker from a body row into the card header's trailing slot. Enabled by a new `ViewBuilder` trailing variant on `DashboardCard`; the existing `String?` API is preserved via a convenience init + `DashboardCardCaption`, so all other call sites are source-compatible.
+- Costs: removed the `overviewTileMinHeight` (220pt) floor from `CostOverviewStatusCard` — that constant exists to equalize Overview grid tiles, but the card is full-width and alone on the Costs page, which produced the large dead space under "API-Rate Estimate". Overview grid tiles keep the floor.
+- Limits: removed the "All Quota Windows" in-content page title (only page that had one) and its "Refreshing..." caption — the animating toolbar refresh icon already conveys that state. Page-level stack spacing aligned to 14 like the other pages.
+- Sidebar: replaced the flat 8-item list with `DashboardSection.sidebarGroups` — Overview/Limits/Costs/Optimize (headerless), "Health" (Status, Diagnostics), "Utilities" (Share). Settings left the sidebar.
+- Toolbar: added a Settings gear next to the refresh button (trailing group); it routes to the existing `settingsContent` section (fills to `gearshape.fill` when active), so `navigate(to: .settings)` deep links (e.g. the empty-Limits hint) keep working.
+- Cleanup: dropped redundant `trailing: nil` arguments in `OptimizeInsightsView`.
+
+**Files changed:**
+- `MeterBar/Views/DashboardCard.swift` - Generic trailing-view slot + `DashboardCardCaption` back-compat shim.
+- `MeterBar/Views/DashboardCostCards.swift` - Cost overview card hugs content (no 220pt min height).
+- `MeterBar/Views/OptimizeInsightsView.swift` - Picker in Token Burn header; redundant args removed.
+- `MeterBar/Views/UsageDashboardView.swift` - Sidebar groups, toolbar gear, Limits header removal, spacing.
+- `MeterBarTests/DashboardLayoutTests.swift` - New: sidebar group invariants, trailing-slot smoke tests, cost-card height regression test.
+
+**Verification:**
+- `swift build` clean; full `swift test` suite passed (incl. 5 new `DashboardLayoutTests`).
+- `swiftlint` clean on all changed files.

--- a/MeterBar/Views/DashboardCard.swift
+++ b/MeterBar/Views/DashboardCard.swift
@@ -35,14 +35,18 @@ struct DashboardTile<Content: View>: View {
   }
 }
 
-struct DashboardCard<Content: View>: View {
+struct DashboardCard<Content: View, Trailing: View>: View {
   let title: String
-  let trailing: String?
+  let trailing: Trailing
   @ViewBuilder let content: Content
 
-  init(title: String, trailing: String? = nil, @ViewBuilder content: () -> Content) {
+  init(
+    title: String,
+    @ViewBuilder trailing: () -> Trailing,
+    @ViewBuilder content: () -> Content
+  ) {
     self.title = title
-    self.trailing = trailing
+    self.trailing = trailing()
     self.content = content()
   }
 
@@ -54,14 +58,32 @@ struct DashboardCard<Content: View>: View {
             .font(.title3)
             .bold()
           Spacer()
-          if let trailing {
-            Text(trailing)
-              .font(.caption)
-              .foregroundColor(.secondary)
-          }
+          trailing
         }
         content
       }
+    }
+  }
+}
+
+extension DashboardCard where Trailing == DashboardCardCaption {
+  init(title: String, trailing: String? = nil, @ViewBuilder content: () -> Content) {
+    self.init(title: title) {
+      DashboardCardCaption(text: trailing)
+    } content: {
+      content()
+    }
+  }
+}
+
+struct DashboardCardCaption: View {
+  let text: String?
+
+  var body: some View {
+    if let text {
+      Text(text)
+        .font(.caption)
+        .foregroundColor(.secondary)
     }
   }
 }

--- a/MeterBar/Views/DashboardCostCards.swift
+++ b/MeterBar/Views/DashboardCostCards.swift
@@ -17,7 +17,7 @@ struct CostOverviewStatusCard: View {
   }
 
   var body: some View {
-    DashboardTile(minHeight: overviewTileMinHeight) {
+    DashboardTile {
       VStack(alignment: .leading, spacing: 12) {
         HStack(alignment: .center, spacing: 9) {
           Image(systemName: "dollarsign.circle.fill")

--- a/MeterBar/Views/OptimizeInsightsView.swift
+++ b/MeterBar/Views/OptimizeInsightsView.swift
@@ -95,32 +95,30 @@ struct OptimizeInsightsView: View {
   }
 
   private var tokenBurnCard: some View {
-    DashboardCard(title: "Token Burn", trailing: nil) {
-      VStack(alignment: .leading, spacing: 12) {
-        Picker("Window", selection: $chartDays) {
-          Text("7 days").tag(7)
-          Text("30 days").tag(30)
-        }
-        .pickerStyle(.segmented)
-        .labelsHidden()
-        .frame(maxWidth: 220)
-
-        if let summary = visibleSummary, !summary.dailyUsage.isEmpty {
-          DailyUsageChart(dailyUsage: summary.dailyUsage, daysToShow: chartDays)
-            .frame(height: 200)
-        } else {
-          Text("No daily token history yet.")
-            .font(.caption)
-            .foregroundColor(.secondary)
-            .frame(height: 200, alignment: .center)
-            .frame(maxWidth: .infinity)
-        }
+    DashboardCard(title: "Token Burn") {
+      Picker("Window", selection: $chartDays) {
+        Text("7 days").tag(7)
+        Text("30 days").tag(30)
+      }
+      .pickerStyle(.segmented)
+      .labelsHidden()
+      .fixedSize()
+    } content: {
+      if let summary = visibleSummary, !summary.dailyUsage.isEmpty {
+        DailyUsageChart(dailyUsage: summary.dailyUsage, daysToShow: chartDays)
+          .frame(height: 200)
+      } else {
+        Text("No daily token history yet.")
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .frame(height: 200, alignment: .center)
+          .frame(maxWidth: .infinity)
       }
     }
   }
 
   private func modelBreakdownCard(for insights: OptimizationInsights) -> some View {
-    DashboardCard(title: "Token Burn by Model", trailing: nil) {
+    DashboardCard(title: "Token Burn by Model") {
       if insights.topModels.isEmpty {
         Text("No per-model breakdown available in the current scan.")
           .font(.caption)
@@ -136,7 +134,7 @@ struct OptimizeInsightsView: View {
   }
 
   private func originBreakdownCard(for insights: OptimizationInsights) -> some View {
-    DashboardCard(title: "Top Usage Origins", trailing: nil) {
+    DashboardCard(title: "Top Usage Origins") {
       VStack(alignment: .leading, spacing: 10) {
         Text("Where tokens are spent — agents, tool use, skills, and main chat.")
           .font(.caption)
@@ -156,7 +154,7 @@ struct OptimizeInsightsView: View {
   }
 
   private func recommendationsCard(for insights: OptimizationInsights) -> some View {
-    DashboardCard(title: "Recommendations", trailing: nil) {
+    DashboardCard(title: "Recommendations") {
       VStack(alignment: .leading, spacing: 12) {
         ForEach(insights.recommendations) { recommendation in
           RecommendationRow(recommendation: recommendation)
@@ -178,7 +176,7 @@ struct OptimizeInsightsView: View {
   // MARK: - Empty / loading states
 
   private var emptyStateCard: some View {
-    DashboardCard(title: "Optimize Your Token Usage", trailing: nil) {
+    DashboardCard(title: "Optimize Your Token Usage") {
       VStack(alignment: .leading, spacing: 14) {
         Text(
           "Run a local scan to see which models and workflows burn the most tokens, "

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -85,6 +85,22 @@ enum DashboardSection: String, CaseIterable, Identifiable, Hashable {
         }
     }
 
+    /// Sidebar layout: frequency-ordered monitoring pages first, then health
+    /// checks, then utilities. Settings is reached via the toolbar gear, not
+    /// the sidebar (app-level function, not a content destination).
+    struct SidebarGroup: Identifiable {
+        let title: String?
+        let sections: [DashboardSection]
+
+        var id: String { sections.first?.id ?? title ?? "" }
+    }
+
+    static let sidebarGroups: [SidebarGroup] = [
+        SidebarGroup(title: nil, sections: [.overview, .limits, .costs, .optimize]),
+        SidebarGroup(title: "Health", sections: [.status, .diagnostics]),
+        SidebarGroup(title: "Utilities", sections: [.share]),
+    ]
+
     var titlebarSubtitle: String {
         switch self {
         case .overview:
@@ -188,6 +204,7 @@ struct UsageDashboardView: View {
             detailContent
                 .toolbar {
                     ToolbarItemGroup(placement: .primaryAction) {
+                        settingsToolbarButton
                         refreshToolbarButton
                     }
                 }
@@ -197,9 +214,17 @@ struct UsageDashboardView: View {
 
     private var sidebarList: some View {
         List(selection: selectedSection) {
-            ForEach(DashboardSection.allCases) { section in
-                Label(section.rawValue, systemImage: section.iconName)
-                    .tag(section)
+            ForEach(DashboardSection.sidebarGroups) { group in
+                Section {
+                    ForEach(group.sections) { section in
+                        Label(section.rawValue, systemImage: section.iconName)
+                            .tag(section)
+                    }
+                } header: {
+                    if let title = group.title {
+                        Text(title)
+                    }
+                }
             }
         }
         .listStyle(.sidebar)
@@ -215,6 +240,16 @@ struct UsageDashboardView: View {
         }
         .help(isRefreshButtonAnimating ? "Refreshing usage" : "Refresh usage")
         .disabled(isRefreshButtonDisabled)
+    }
+
+    private var settingsToolbarButton: some View {
+        Button {
+            navigation.navigate(to: .settings)
+        } label: {
+            Image(systemName: "gearshape")
+                .symbolVariant(activeSection == .settings ? .fill : .none)
+        }
+        .help("Settings")
     }
 
     private var detailContent: some View {
@@ -277,19 +312,7 @@ struct UsageDashboardView: View {
     }
 
     private var limitsContent: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Text("All Quota Windows")
-                    .font(.title3)
-                    .bold()
-                Spacer()
-                if dataManager.isLoading {
-                    Text("Refreshing...")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-            }
-
+        VStack(alignment: .leading, spacing: 14) {
             if providerSnapshots.isEmpty {
                 DashboardCard(title: "No Quota Windows") {
                     Text("Enable providers in Settings to show quota windows.")

--- a/MeterBarTests/DashboardLayoutTests.swift
+++ b/MeterBarTests/DashboardLayoutTests.swift
@@ -1,0 +1,87 @@
+import AppKit
+@testable import MeterBar
+import SwiftUI
+import XCTest
+
+/// Layout-audit coverage (2026-07-11): sidebar grouping, toolbar settings
+/// entry, header-hosted card controls, and content-hugging cost card.
+@MainActor
+final class DashboardLayoutTests: XCTestCase {
+    // MARK: - Sidebar groups
+
+    func testSidebarGroupsCoverEverySectionExceptSettings() {
+        let flattened = DashboardSection.sidebarGroups.flatMap(\.sections)
+
+        XCTAssertEqual(Set(flattened).count, flattened.count, "sidebar must not repeat a section")
+        XCTAssertFalse(flattened.contains(.settings), "settings moves to the toolbar gear")
+        XCTAssertEqual(
+            Set(flattened),
+            Set(DashboardSection.allCases).subtracting([.settings]),
+            "every non-settings section must stay reachable from the sidebar"
+        )
+    }
+
+    func testSidebarGroupOrderLeadsWithMonitoringPages() {
+        let groups = DashboardSection.sidebarGroups
+
+        XCTAssertEqual(groups.first?.sections.first, .overview)
+        XCTAssertEqual(groups.first?.sections, [.overview, .limits, .costs, .optimize])
+        XCTAssertTrue(
+            groups.contains { $0.sections == [.status, .diagnostics] },
+            "health pages group together"
+        )
+    }
+
+    // MARK: - DashboardCard trailing view slot
+
+    func testDashboardCardAcceptsTrailingControl() {
+        let card = DashboardCard(title: "Token Burn") {
+            Picker("Window", selection: .constant(30)) {
+                Text("7 days").tag(7)
+                Text("30 days").tag(30)
+            }
+            .pickerStyle(.segmented)
+        } content: {
+            Text("chart")
+        }
+
+        let hostingView = NSHostingView(rootView: card)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 600, height: 400)
+        hostingView.layoutSubtreeIfNeeded()
+
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+    }
+
+    func testDashboardCardStringTrailingStillBuilds() {
+        let card = DashboardCard(title: "Daily Details", trailing: "Last 30 days") {
+            Text("rows")
+        }
+
+        let hostingView = NSHostingView(rootView: card)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 600, height: 400)
+        hostingView.layoutSubtreeIfNeeded()
+
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+    }
+
+    // MARK: - Cost overview card hugs content
+
+    func testCostOverviewCardHasNoArtificialMinHeight() {
+        let card = CostOverviewStatusCard(
+            summary: nil,
+            isScanning: false,
+            isRefreshingMissingDays: false,
+            formattedTokens: "0"
+        )
+
+        let hostingView = NSHostingView(rootView: card)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 700, height: 400)
+        hostingView.layoutSubtreeIfNeeded()
+
+        XCTAssertLessThan(
+            hostingView.fittingSize.height,
+            overviewTileMinHeight,
+            "costs-page card should hug its content instead of padding to the overview grid height"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Implements the five findings from the dashboard layout/spacing audit:

- **Token Burn (Optimize)**: 7/30-day segmented picker moves from a body row into the card header's trailing slot. Enabled by a new `ViewBuilder` trailing variant on `DashboardCard`; the existing `trailing: String?` API is preserved via a convenience init + `DashboardCardCaption`, so all other call sites are untouched.
- **Costs**: `CostOverviewStatusCard` no longer inherits `overviewTileMinHeight` (220pt) — that floor equalizes the Overview grid tiles, but the card is full-width and alone on the Costs page, which produced the large dead space under "API-Rate Estimate". Overview grid keeps the floor.
- **Limits**: removed the "All Quota Windows" in-content page title (the only page that had one) and its "Refreshing..." caption — the animating toolbar refresh icon already conveys that state. Page spacing aligned to 14 like the other pages.
- **Sidebar**: flat 8-item list becomes `DashboardSection.sidebarGroups` — Overview / Limits / Costs / Optimize (headerless), **Health** (Status, Diagnostics), **Utilities** (Share).
- **Toolbar**: Settings leaves the sidebar for a gear button next to refresh (fills when active). It routes to the existing settings section, so `navigate(to: .settings)` deep links (e.g. the empty-Limits hint) keep working.

Cleanup: redundant `trailing: nil` args dropped in `OptimizeInsightsView`.

## Testing

- New `MeterBarTests/DashboardLayoutTests.swift` (written first, per TDD policy): sidebar-group invariants (all non-settings sections reachable, no duplicates, ordering), both `DashboardCard` trailing variants build, and a height regression test asserting the cost card renders under 220pt.
- Full `swift test` suite passes; `swift build` and `swiftlint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)