### PR TITLE
Fix main-thread freeze during data load: move blocking I/O off the main actor

### DIFF
--- a/.agents/SESSIONS/2026-07-11.md
+++ b/.agents/SESSIONS/2026-07-11.md
@@ -1,0 +1,36 @@
+# 2026-07-11
+
+## Session 1: Fix app freeze (beachball) during data load
+
+**Status:** Complete
+**Branch:** `claude/app-freeze-data-load-d0c100`
+
+**Root cause:**
+The Xcode app target builds with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` + `SWIFT_APPROACHABLE_CONCURRENCY = YES`, so every unannotated type/function is implicitly `@MainActor` and async function bodies run on the main actor's executor. All the "async, therefore off-main" fetch code was executing its synchronous I/O on the main thread: Cursor `state.vscdb` SQLite reads (plus a recursive scan of the whole Cursor app-support tree on a miss), Claude keychain reads (`SecItemCopyMatching` can raise a blocking approval dialog), Codex `auth.json` reads, and the `AccountActivityInspector` directory scans fired by four Combine sinks per metrics publish. `Task { }` wrappers didn't help (they inherit the main actor). The SwiftPM build (`swift test`) does **not** set that flag, so tests genuinely ran the same code off-main and never caught it. The loading spinner (`UsageDataManager.isLoading` → `RefreshingIcon`) was already wired up — it simply couldn't render while main was frozen.
+
+**What was done:**
+- Marked blocking/pure helpers `nonisolated` and hopped their invocations off the main actor with `await Task.detached { … }.value` (the async bodies stay main-actor; only the blocking work hops):
+  - `CursorLocalService` — DB path scan, recursive finder, `getAccessTokenFromDatabase`, `probeReadinessDatabase`, `checkAccess`; token read in `fetchUsageMetrics` now detached.
+  - `ClaudeCodeLocalService` — `getOAuthToken`, `getCredentials`, `credentialsData`, `checkAccess`; keychain reads in `fetchUsageMetrics`/`fetchExtraUsageStatus` now detached. Singleton `shared` is `nonisolated`.
+  - `CodexCliLocalService` — `getAuthToken`, `getAccountId`, `readAuthFile`, `checkAccess`; auth-file read in `fetchUsageMetrics` now detached; `authFileDataProvider` is `@Sendable`.
+  - `ClaudeCodeCLIUsageService` — whole class `nonisolated` (already bridged its subprocess via a GCD queue; now explicit).
+  - `AccountActivityInspector` — enum `nonisolated`; `AppDelegate.updateStatusItem` now gathers main-actor inputs, runs the activity probes in a detached task, and applies the selection back on main behind a generation counter so stale probes can't overwrite newer ones.
+  - `CostTracker` — all static scan/parse helpers and value types `nonisolated` so the detached cost scan is guaranteed off-main in both build systems.
+  - `SettingsView` — the five direct `checkAccess()` button/toggle call sites now run the check in `Task.detached` before reading `hasAccess` (safe: `applyOnMain`'s main-queue block is enqueued before the awaiting task's continuation).
+  - `ServiceSupport.applyOnMain` now takes a `@MainActor` closure (via `MainActor.assumeIsolated`), letting nonisolated service code mutate `@Published` state warning-free.
+  - Pure data/helper types marked `nonisolated`: `AppLog`, `FlexibleISO8601`, `StorageKeys`, `UsageFormat`, `CLIBinaryLocator`, `ServiceSupport`, `CodexHomeDirectory`, `ProviderReadinessInspector`, `SharedDataStore` (now `final … @unchecked Sendable`, queue-confined), `ClaudeCodeAccount`, `TokenCost.swift` structs, `CostSummaryStore`, provider response models.
+
+**Files changed:**
+- `MeterBar/Services/` — `CursorLocalService.swift`, `ClaudeCodeLocalService.swift`, `CodexCliLocalService.swift`, `ClaudeCodeCLIUsageService.swift`, `AccountActivityInspector.swift`, `CostTracker.swift`, `ServiceSupport.swift`, `SharedDataStore.swift`, `AppLog.swift`, `CLIBinaryLocator.swift`, `CodexHomeDirectory.swift`, `ProviderReadinessInspector.swift`
+- `MeterBar/App/MeterBarApp.swift` — off-main status-item activity probes with generation-counter coalescing
+- `MeterBar/Views/SettingsView.swift` — detached access checks
+- `MeterBar/Models/` — `TokenCost.swift`, `CostSummaryStore.swift`, `ClaudeCodeAccount.swift`, `StorageKeys.swift`, `FlexibleISO8601.swift`, `UsageFormatting.swift`
+- `MeterBarTests/CodexCliLocalServiceTests.swift` — new test pinning that `fetchUsageMetrics` reads the auth file off the main thread (written first, TDD)
+
+**Verification:**
+- `swift test`: 446 tests, 0 failures (1 credential-dependent skip), including the new off-main contract test.
+- `xcodebuild … clean build` (the build where the bug exists): **BUILD SUCCEEDED**, zero new warnings vs a clean-tree baseline, 16 pre-existing isolation warnings eliminated.
+- Ran the built app through its initial `refreshAll()`: four consecutive 1s `sample` captures during the load window show the main thread idle in the run loop (no SQLite/FS/keychain frames on main); app quit cleanly.
+
+**Deferred / follow-up:**
+- Add `.defaultIsolation(MainActor.self)` to `Package.swift` so `swift test` compiles with the same isolation as the app and catches this class of regression at test time (may surface unrelated compile errors; deliberately not coupled to this fix).

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -40,6 +40,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// sticky selection so concurrent Claude + Codex use doesn't flip the title.
     private var shownStatusItemKey: String?
 
+    /// Monotonic stamp for status-item updates: activity probes run off the
+    /// main actor, so a stale in-flight result must not overwrite a newer one.
+    private var statusItemUpdateGeneration = 0
+
     func applicationWillFinishLaunching(_ notification: Notification) {
         // Apply the persisted Dock visibility as early as possible so users who
         // hide MeterBar from the Dock don't see a brief Dock-icon flash.
@@ -537,12 +541,49 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         updateStatusItem(metrics: UsageDataManager.shared.metrics)
     }
 
+    /// One menu-bar-title candidate whose on-disk activity probe has not run
+    /// yet. The probe is a `@Sendable` closure so the filesystem scan can run
+    /// off the main actor (it previously ran inline here and stalled the UI).
+    private struct StatusLimitProbeRequest: Sendable {
+        let key: String
+        let displayName: String
+        let limit: UsageLimit
+        let probe: @Sendable () -> Date?
+    }
+
     @MainActor
     private func updateStatusItem(metrics: [ServiceType: UsageMetrics]) {
+        guard statusItem?.button != nil else { return }
+
+        // Gather the cheap main-actor inputs now; run the activity probes
+        // (directory scans) off the main actor; apply on return. A generation
+        // counter lets a newer update supersede an in-flight probe.
+        let requests = statusLimitProbeRequests(in: metrics)
+        statusItemUpdateGeneration += 1
+        let generation = statusItemUpdateGeneration
+
+        Task { [weak self] in
+            let candidates = await Task.detached(priority: .userInitiated) {
+                requests.map { request in
+                    StatusLimitCandidate(
+                        key: request.key,
+                        displayName: request.displayName,
+                        limit: request.limit,
+                        lastActivity: request.probe()
+                    )
+                }
+            }.value
+            guard let self, generation == self.statusItemUpdateGeneration else { return }
+            self.applyStatusItemSelection(candidates: candidates)
+        }
+    }
+
+    @MainActor
+    private func applyStatusItemSelection(candidates: [StatusLimitCandidate]) {
         guard let button = statusItem?.button else { return }
 
         guard let selection = StatusItemLimitSelector.select(
-            candidates: statusLimitCandidates(in: metrics),
+            candidates: candidates,
             previousKey: shownStatusItemKey
         ) else {
             shownStatusItemKey = nil
@@ -561,43 +602,42 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// Every enabled account/provider quota that may own the menu bar title,
-    /// tagged with its latest on-disk activity so `StatusItemLimitSelector`
-    /// can follow the accounts actually in use.
+    /// each carrying a deferred probe for its latest on-disk activity so
+    /// `StatusItemLimitSelector` can follow the accounts actually in use.
     @MainActor
-    private func statusLimitCandidates(in metrics: [ServiceType: UsageMetrics]) -> [StatusLimitCandidate] {
-        var candidates: [StatusLimitCandidate] = []
+    private func statusLimitProbeRequests(in metrics: [ServiceType: UsageMetrics]) -> [StatusLimitProbeRequest] {
+        var requests: [StatusLimitProbeRequest] = []
 
         if providerVisibilityStore.isEnabled(.claudeCode) {
             for account in ClaudeCodeAccountStore.shared.accounts {
                 guard let limit = claudeMetrics(for: account, metrics: metrics)?.sessionLimit else { continue }
-                candidates.append(StatusLimitCandidate(
+                let configDirectory = account.configDirectory
+                requests.append(StatusLimitProbeRequest(
                     key: "claude:\(account.id.uuidString)",
                     displayName: "\(account.name) (\(ServiceType.claudeCode.displayName))",
                     limit: limit,
-                    lastActivity: AccountActivityInspector.claudeCodeActivity(
-                        configDirectory: account.configDirectory
-                    )
+                    probe: { AccountActivityInspector.claudeCodeActivity(configDirectory: configDirectory) }
                 ))
             }
         }
         if providerVisibilityStore.isEnabled(.codexCli), let codexLimit = metrics[.codexCli]?.sessionLimit {
-            candidates.append(StatusLimitCandidate(
+            requests.append(StatusLimitProbeRequest(
                 key: "codex",
                 displayName: ServiceType.codexCli.displayName,
                 limit: codexLimit,
-                lastActivity: AccountActivityInspector.codexCliActivity()
+                probe: { AccountActivityInspector.codexCliActivity() }
             ))
         }
         if providerVisibilityStore.isEnabled(.cursor), let cursorLimit = metrics[.cursor]?.weeklyLimit {
-            candidates.append(StatusLimitCandidate(
+            requests.append(StatusLimitProbeRequest(
                 key: "cursor",
                 displayName: ServiceType.cursor.displayName,
                 limit: cursorLimit,
-                lastActivity: AccountActivityInspector.cursorActivity()
+                probe: { AccountActivityInspector.cursorActivity() }
             ))
         }
 
-        return candidates
+        return requests
     }
 
     @MainActor

--- a/MeterBar/Models/ClaudeCodeAccount.swift
+++ b/MeterBar/Models/ClaudeCodeAccount.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // MARK: - ClaudeCodeAccount
 
-struct ClaudeCodeAccount: Codable, Equatable, Identifiable, Sendable {
+nonisolated struct ClaudeCodeAccount: Codable, Equatable, Identifiable, Sendable {
     static let defaultName = "Default CLI Profile"
 
     /// Fixed sentinel id for the default CLI profile. Built from raw bytes

--- a/MeterBar/Models/CostSummaryStore.swift
+++ b/MeterBar/Models/CostSummaryStore.swift
@@ -4,7 +4,7 @@ import Foundation
 /// CostTracker after each scan; read back by the app on launch and by
 /// `meterbar cost` (which reports the app's scan instead of re-implementing
 /// a divergent one).
-public struct CostSummaryCache: Codable, Sendable {
+nonisolated public struct CostSummaryCache: Codable, Sendable {
     public let summary: CostSummary
     public let lastScanDate: Date
 
@@ -16,7 +16,7 @@ public struct CostSummaryCache: Codable, Sendable {
 
 /// Single owner of the cost-summary cache location and encoding
 /// (`~/Library/Application Support/MeterBar/cost-summary-v1.json`).
-public enum CostSummaryStore {
+nonisolated public enum CostSummaryStore {
     static let cacheFileName = "cost-summary-v1.json"
 
     public static var cacheURL: URL? {

--- a/MeterBar/Models/FlexibleISO8601.swift
+++ b/MeterBar/Models/FlexibleISO8601.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Shared by the hot scan paths (CostTracker parses tens of thousands of log
 /// lines) and CursorLocalService, which previously each maintained their own
 /// identical formatter pair. `ISO8601DateFormatter` is thread-safe to share.
-enum FlexibleISO8601 {
+nonisolated enum FlexibleISO8601 {
     static let fractional: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -5,7 +5,7 @@ import MeterBarShared
 ///
 /// These were previously inline string literals scattered across six files —
 /// a typo in any one of them silently reads/writes the wrong key.
-enum StorageKeys {
+nonisolated enum StorageKeys {
     /// Cached `[ServiceType: UsageMetrics]` blob (also the app-group file's
     /// base name — see SharedDataStore). Single-sourced from `MeterBarShared`
     /// so the app, widget, and CLI can't drift on the key.

--- a/MeterBar/Models/TokenCost.swift
+++ b/MeterBar/Models/TokenCost.swift
@@ -3,7 +3,7 @@ import MeterBarShared
 
 // Public: part of the MeterBar library's API surface consumed by the
 // meterbar CLI (`meterbar cost` reads the app's cached CostSummary).
-public struct TokenCost: Codable, Identifiable, Sendable {
+nonisolated public struct TokenCost: Codable, Identifiable, Sendable {
     public var id: String { provider.rawValue }
 
     public let provider: ServiceType
@@ -57,7 +57,7 @@ public struct TokenCost: Codable, Identifiable, Sendable {
     }
 }
 
-public struct TokenUsageBreakdown: Codable, Identifiable, Sendable {
+nonisolated public struct TokenUsageBreakdown: Codable, Identifiable, Sendable {
     public var id: String { "\(provider.rawValue)-\(name)" }
 
     public let provider: ServiceType
@@ -102,7 +102,7 @@ public struct TokenUsageBreakdown: Codable, Identifiable, Sendable {
     }
 }
 
-public struct DailyTokenUsage: Codable, Identifiable, Sendable {
+nonisolated public struct DailyTokenUsage: Codable, Identifiable, Sendable {
     public var id: String { "\(provider.rawValue)-\(Self.dayFormatter.string(from: date))" }
 
     public let date: Date
@@ -140,7 +140,7 @@ public struct DailyTokenUsage: Codable, Identifiable, Sendable {
     }()
 }
 
-public struct CostSummary: Codable, Sendable {
+nonisolated public struct CostSummary: Codable, Sendable {
     public let costs: [TokenCost]
     public let totalCostUSD: Double
     public let totalTokens: Int
@@ -284,7 +284,7 @@ public struct CostSummary: Codable, Sendable {
 /// Per-provider token/cost totals summed over a day window (see
 /// `CostSummary.dailyCostWindow`). Public: part of the `meterbar cost --days`
 /// output surface.
-public struct ProviderDailyTotal: Codable, Sendable, Identifiable {
+nonisolated public struct ProviderDailyTotal: Codable, Sendable, Identifiable {
     public var id: String { provider.rawValue }
 
     public let provider: ServiceType
@@ -320,7 +320,7 @@ public struct ProviderDailyTotal: Codable, Sendable, Identifiable {
 /// Result of windowing the cached daily cost rows to the last N days
 /// (`CostSummary.dailyCostWindow`). Codable so `meterbar cost --days N --json`
 /// can emit it directly.
-public struct DailyCostWindow: Codable, Sendable {
+nonisolated public struct DailyCostWindow: Codable, Sendable {
     /// Days requested via `--days N` (clamped to ≥ 1).
     public let requestedDays: Int
     /// Days the cache can actually cover: the requested window clamped to both

--- a/MeterBar/Models/UsageFormatting.swift
+++ b/MeterBar/Models/UsageFormatting.swift
@@ -7,7 +7,7 @@ import Foundation
 /// formatting, currency formatting, and a cached `RelativeDateTimeFormatter`.
 /// The formatters are created once and reused so hot UI/scan paths don't
 /// reallocate a `NumberFormatter`/`RelativeDateTimeFormatter` on every call.
-public enum UsageFormat {
+nonisolated public enum UsageFormat {
     private static let groupedInteger: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")

--- a/MeterBar/Services/AccountActivityInspector.swift
+++ b/MeterBar/Services/AccountActivityInspector.swift
@@ -7,7 +7,10 @@ import Foundation
 /// children) — Claude Code and Codex both touch top-level entries constantly
 /// while a session runs (`sessions/`, `session-env/`, sqlite WAL files), so a
 /// depth-1 scan is a reliable and cheap activity signal.
-enum AccountActivityInspector {
+/// `nonisolated`: pure filesystem probing with no shared state — opts out of
+/// the app target's default MainActor isolation so callers can (and must)
+/// run the scans off the main actor.
+nonisolated enum AccountActivityInspector {
     /// Newest modification date among a directory and its top-level entries,
     /// or nil when the directory doesn't exist.
     static func lastActivity(inDirectory path: String) -> Date? {

--- a/MeterBar/Services/AppLog.swift
+++ b/MeterBar/Services/AppLog.swift
@@ -7,7 +7,7 @@ import os
 /// SwiftLint rule) with the unified logging system. Using `Logger` keeps diagnostics
 /// out of release stdout, lets the OS apply privacy redaction, and avoids logging
 /// raw API response bodies or token-bearing strings to the console.
-enum AppLog {
+nonisolated enum AppLog {
     private static let subsystem = Bundle.main.bundleIdentifier ?? "dev.meterbar.app"
 
     static let app = Logger(subsystem: subsystem, category: "app")

--- a/MeterBar/Services/CLIBinaryLocator.swift
+++ b/MeterBar/Services/CLIBinaryLocator.swift
@@ -6,7 +6,7 @@ import Foundation
 /// This was previously private to `ClaudeCodeCLIUsageService`; it is factored
 /// out so provider-readiness diagnostics can ask "is `codex` / `claude` on
 /// PATH?" without re-deriving the same fallback list.
-enum CLIBinaryLocator {
+nonisolated enum CLIBinaryLocator {
     /// The install-location fallbacks checked after `PATH`, for `command`.
     private static func fallbackCandidates(for command: String, home: String) -> [String] {
         [

--- a/MeterBar/Services/ClaudeCodeCLIUsageService.swift
+++ b/MeterBar/Services/ClaudeCodeCLIUsageService.swift
@@ -1,7 +1,10 @@
 import Foundation
 import MeterBarShared
 
-final class ClaudeCodeCLIUsageService: Sendable {
+/// `nonisolated`: opts the whole class out of the app target's default
+/// MainActor isolation — it owns no UI state and does blocking process I/O
+/// that must stay off the main actor (bridged via `processQueue`).
+nonisolated final class ClaudeCodeCLIUsageService: Sendable {
     static let shared = ClaudeCodeCLIUsageService()
 
     private let commandTimeout: TimeInterval = 12
@@ -103,7 +106,7 @@ final class ClaudeCodeCLIUsageService: Sendable {
     }
 }
 
-enum ClaudeCodeCLIUsageParser {
+nonisolated enum ClaudeCodeCLIUsageParser {
     static func parseMetrics(from text: String, now: Date = Date()) throws -> UsageMetrics {
         let sanitized = stripANSICodes(from: text)
         let lines = sanitized
@@ -261,7 +264,7 @@ enum ClaudeCodeCLIUsageError: LocalizedError {
     }
 }
 
-private extension Array where Element == String {
+nonisolated private extension Array where Element == String {
     subscript(safe index: Int) -> String? {
         indices.contains(index) ? self[index] : nil
     }

--- a/MeterBar/Services/ClaudeCodeLocalService.swift
+++ b/MeterBar/Services/ClaudeCodeLocalService.swift
@@ -57,7 +57,7 @@ class ClaudeCodeLocalService: ObservableObject {
         return credentials.claudeAiOauth.accessToken
     }
 
-    private nonisolated func getCredentials() -> ClaudeCodeCredentials? {
+    nonisolated private func getCredentials() -> ClaudeCodeCredentials? {
         guard let data = credentialsData() else { return nil }
         return try? JSONDecoder().decode(ClaudeCodeCredentials.self, from: data)
     }
@@ -284,7 +284,7 @@ class ClaudeCodeLocalService: ObservableObject {
         }
     }
 
-    private nonisolated var isOAuthFallbackEnabled: Bool {
+    nonisolated private var isOAuthFallbackEnabled: Bool {
         UserDefaults.standard.bool(forKey: oauthFallbackUserDefaultsKey)
     }
 

--- a/MeterBar/Services/ClaudeCodeLocalService.swift
+++ b/MeterBar/Services/ClaudeCodeLocalService.swift
@@ -4,7 +4,9 @@ import AppKit
 import Combine
 
 class ClaudeCodeLocalService: ObservableObject {
-    static let shared = ClaudeCodeLocalService()
+    // nonisolated: lets nonisolated code such as the readiness inspector
+    // reference the singleton (methods keep their own isolation).
+    nonisolated static let shared = ClaudeCodeLocalService()
 
     // Working endpoint (discovered via testing)
     private let usageEndpoint = "https://api.anthropic.com/api/oauth/usage"
@@ -29,14 +31,16 @@ class ClaudeCodeLocalService: ObservableObject {
 
     // MARK: - Keychain Access
 
-    /// Get OAuth token from Claude Code's keychain storage
-    func getOAuthToken() -> String? {
+    /// Get OAuth token from Claude Code's keychain storage.
+    /// `nonisolated`: a keychain read can raise a blocking approval dialog —
+    /// never call synchronously from the main actor.
+    nonisolated func getOAuthToken() -> String? {
         guard let credentials = getCredentials() else {
             return nil
         }
 
         guard !OAuthTokenExpiry.isExpired(unixTimestamp: credentials.claudeAiOauth.expiresAt) else {
-            DispatchQueue.main.async {
+            ServiceSupport.applyOnMain {
                 self.subscriptionType = credentials.claudeAiOauth.subscriptionType
                 self.rateLimitTier = credentials.claudeAiOauth.rateLimitTier
                 self.hasAccess = false
@@ -44,7 +48,7 @@ class ClaudeCodeLocalService: ObservableObject {
             return nil
         }
 
-        DispatchQueue.main.async {
+        ServiceSupport.applyOnMain {
             self.subscriptionType = credentials.claudeAiOauth.subscriptionType
             self.rateLimitTier = credentials.claudeAiOauth.rateLimitTier
             self.hasAccess = true
@@ -53,7 +57,7 @@ class ClaudeCodeLocalService: ObservableObject {
         return credentials.claudeAiOauth.accessToken
     }
 
-    private func getCredentials() -> ClaudeCodeCredentials? {
+    private nonisolated func getCredentials() -> ClaudeCodeCredentials? {
         guard let data = credentialsData() else { return nil }
         return try? JSONDecoder().decode(ClaudeCodeCredentials.self, from: data)
     }
@@ -63,7 +67,7 @@ class ClaudeCodeLocalService: ObservableObject {
     /// Exposed for provider-readiness diagnostics, which pass the bytes to the
     /// pure readiness core (it reads only the expiry claim — never surfaces the
     /// token). Reading the raw blob here keeps the keychain query in one place.
-    func credentialsData() -> Data? {
+    nonisolated func credentialsData() -> Data? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: keychainService,
@@ -81,18 +85,22 @@ class ClaudeCodeLocalService: ObservableObject {
         return data
     }
 
-    /// Check and update access status
-    func checkAccess() {
+    /// Check and update access status.
+    /// `nonisolated`: file stats + (with the OAuth fallback) a keychain read —
+    /// call from a detached task.
+    nonisolated func checkAccess() {
         let newHasAccess: Bool
         let newAuthState: ClaudeCodeAuthState
-        var clearsSubscription = false
+        let clearsSubscription: Bool
 
         if cliUsageService.isAvailable() {
             newHasAccess = true
             newAuthState = .cliAvailable
+            clearsSubscription = false
         } else if isOAuthFallbackEnabled, getOAuthToken() != nil {
             newHasAccess = true
             newAuthState = .connected(.legacyOAuth)
+            clearsSubscription = false
         } else {
             newHasAccess = false
             newAuthState = .unavailable
@@ -142,7 +150,13 @@ class ClaudeCodeLocalService: ObservableObject {
             }
         }
 
-        guard let token = getOAuthToken() else {
+        // Keychain read — off the main actor (it can raise a blocking approval
+        // dialog, and the app target runs async bodies on the main actor).
+        let fallbackToken = await Task.detached(priority: .userInitiated) { [self] in
+            getOAuthToken()
+        }.value
+
+        guard let token = fallbackToken else {
             let error = ServiceError.notAuthenticated
             await MainActor.run {
                 self.lastError = error
@@ -235,7 +249,11 @@ class ClaudeCodeLocalService: ObservableObject {
     private func fetchExtraUsageStatus(account: ClaudeCodeAccount) async -> ExtraUsageStatus {
         guard isOAuthFallbackEnabled else { return .unknown }
         guard account.isDefault else { return .unknown }
-        guard let credentials = getCredentials(),
+        // Keychain read — off the main actor, same as the fallback-token path.
+        let storedCredentials = await Task.detached(priority: .utility) { [self] in
+            getCredentials()
+        }.value
+        guard let credentials = storedCredentials,
               !OAuthTokenExpiry.isExpired(unixTimestamp: credentials.claudeAiOauth.expiresAt) else {
             return .unknown
         }
@@ -266,7 +284,7 @@ class ClaudeCodeLocalService: ObservableObject {
         }
     }
 
-    private var isOAuthFallbackEnabled: Bool {
+    private nonisolated var isOAuthFallbackEnabled: Bool {
         UserDefaults.standard.bool(forKey: oauthFallbackUserDefaultsKey)
     }
 
@@ -356,11 +374,11 @@ enum ClaudeCodeAuthState: Equatable {
 
 // MARK: - Response Models
 
-struct ClaudeCodeCredentials: Codable {
+nonisolated struct ClaudeCodeCredentials: Codable {
     let claudeAiOauth: ClaudeAiOAuth
 }
 
-struct ClaudeAiOAuth: Codable {
+nonisolated struct ClaudeAiOAuth: Codable {
     let accessToken: String
     let refreshToken: String
     let expiresAt: Int64
@@ -369,7 +387,7 @@ struct ClaudeAiOAuth: Codable {
     let rateLimitTier: String?
 }
 
-struct ClaudeCodeUsageResponse: Codable {
+nonisolated struct ClaudeCodeUsageResponse: Codable {
     let fiveHour: UsageWindow
     let sevenDay: UsageWindow
     let sevenDaySonnet: UsageWindow?
@@ -420,7 +438,7 @@ struct ClaudeCodeUsageResponse: Codable {
 }
 
 /// Claude `extra_usage` object from `/api/oauth/usage`.
-struct ClaudeExtraUsage: Codable {
+nonisolated struct ClaudeExtraUsage: Codable {
     let isEnabled: Bool
     let monthlyLimit: Double?
     let usedCredits: Double?
@@ -439,7 +457,7 @@ struct ClaudeExtraUsage: Codable {
 }
 
 /// Claude `spend` object from `/api/oauth/usage`.
-struct ClaudeSpend: Codable {
+nonisolated struct ClaudeSpend: Codable {
     let used: ClaudeMoney?
     let limit: ClaudeMoney?
     let percent: Double?
@@ -456,7 +474,7 @@ struct ClaudeSpend: Codable {
 }
 
 /// Minor-unit money amount (e.g. `amount_minor: 500, exponent: 2` → $5.00).
-struct ClaudeMoney: Codable {
+nonisolated struct ClaudeMoney: Codable {
     let amountMinor: Int?
     let currency: String?
     let exponent: Int?
@@ -475,7 +493,7 @@ struct ClaudeMoney: Codable {
     }
 }
 
-struct UsageWindow: Codable {
+nonisolated struct UsageWindow: Codable {
     let utilization: Double
     let resetsAt: Date
 

--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -26,7 +26,7 @@ class CodexCliLocalService: ObservableObject {
     /// fixture without a real credential file on disk (the auth file never
     /// exists on CI). Defaults to reading the real path. `@Sendable` because the
     /// read is disk I/O and must be callable off the main actor.
-    private nonisolated let authFileDataProvider: @Sendable () -> Data?
+    nonisolated private let authFileDataProvider: @Sendable () -> Data?
 
     @Published private(set) var hasAccess: Bool = false
     @Published private(set) var lastError: ServiceError?
@@ -41,7 +41,7 @@ class CodexCliLocalService: ObservableObject {
 
     /// Reads `CODEX_HOME/auth.json` using the same resolver as readiness,
     /// activity, and cost scans.
-    private nonisolated static func defaultAuthFileDataProvider() -> Data? {
+    nonisolated private static func defaultAuthFileDataProvider() -> Data? {
         let path = CodexHomeDirectory.authFilePath()
         guard FileManager.default.fileExists(atPath: path) else { return nil }
         return FileManager.default.contents(atPath: path)
@@ -70,7 +70,7 @@ class CodexCliLocalService: ObservableObject {
         readAuthFile()?.tokens?.accountId
     }
 
-    private nonisolated func readAuthFile() -> CodexAuthFile? {
+    nonisolated private func readAuthFile() -> CodexAuthFile? {
         guard let data = authFileDataProvider() else { return nil }
         return try? JSONDecoder().decode(CodexAuthFile.self, from: data)
     }

--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -24,8 +24,9 @@ class CodexCliLocalService: ObservableObject {
 
     /// Raw bytes of `CODEX_HOME/auth.json`, behind a closure so tests can supply a
     /// fixture without a real credential file on disk (the auth file never
-    /// exists on CI). Defaults to reading the real path.
-    private let authFileDataProvider: () -> Data?
+    /// exists on CI). Defaults to reading the real path. `@Sendable` because the
+    /// read is disk I/O and must be callable off the main actor.
+    private nonisolated let authFileDataProvider: @Sendable () -> Data?
 
     @Published private(set) var hasAccess: Bool = false
     @Published private(set) var lastError: ServiceError?
@@ -33,14 +34,14 @@ class CodexCliLocalService: ObservableObject {
 
     /// Defaults reproduce the production singleton; tests inject a fixture
     /// auth-file provider.
-    init(authFileDataProvider: (() -> Data?)? = nil) {
-        self.authFileDataProvider = authFileDataProvider ?? CodexCliLocalService.defaultAuthFileDataProvider
+    init(authFileDataProvider: (@Sendable () -> Data?)? = nil) {
+        self.authFileDataProvider = authFileDataProvider ?? { CodexCliLocalService.defaultAuthFileDataProvider() }
         Task.detached(priority: .utility) { [weak self] in self?.checkAccess() }
     }
 
     /// Reads `CODEX_HOME/auth.json` using the same resolver as readiness,
     /// activity, and cost scans.
-    private static func defaultAuthFileDataProvider() -> Data? {
+    private nonisolated static func defaultAuthFileDataProvider() -> Data? {
         let path = CodexHomeDirectory.authFilePath()
         guard FileManager.default.fileExists(atPath: path) else { return nil }
         return FileManager.default.contents(atPath: path)
@@ -49,8 +50,9 @@ class CodexCliLocalService: ObservableObject {
     // MARK: - Auth File Access
 
     /// Read OAuth access token from `CODEX_HOME/auth.json`.
-    /// This file is created and maintained by the Codex CLI when user logs in
-    func getAuthToken() -> String? {
+    /// This file is created and maintained by the Codex CLI when user logs in.
+    /// `nonisolated`: disk I/O — never call this synchronously from the main actor.
+    nonisolated func getAuthToken() -> String? {
         guard let token = readAuthFile()?.tokens?.accessToken else {
             return nil
         }
@@ -64,17 +66,17 @@ class CodexCliLocalService: ObservableObject {
 
     /// Read account ID from `CODEX_HOME/auth.json`.
     /// Required for the ChatGPT-Account-Id header to get team/workspace data
-    func getAccountId() -> String? {
+    nonisolated func getAccountId() -> String? {
         readAuthFile()?.tokens?.accountId
     }
 
-    private func readAuthFile() -> CodexAuthFile? {
+    private nonisolated func readAuthFile() -> CodexAuthFile? {
         guard let data = authFileDataProvider() else { return nil }
         return try? JSONDecoder().decode(CodexAuthFile.self, from: data)
     }
 
     /// Check and update access status
-    func checkAccess() {
+    nonisolated func checkAccess() {
         let hasToken = getAuthToken() != nil
         ServiceSupport.applyOnMain { [weak self] in
             guard let self else { return }
@@ -86,7 +88,13 @@ class CodexCliLocalService: ObservableObject {
     // MARK: - Usage Fetching
 
     func fetchUsageMetrics() async throws -> UsageMetrics {
-        guard let token = getAuthToken() else {
+        // Auth-file read is disk I/O; the app target runs async bodies on the
+        // main actor (default MainActor isolation), so hop off explicitly.
+        let auth = await Task.detached(priority: .userInitiated) { [self] in
+            (token: getAuthToken(), accountId: getAccountId())
+        }.value
+
+        guard let token = auth.token else {
             let error = ServiceError.notAuthenticated
             await MainActor.run {
                 self.lastError = error
@@ -107,7 +115,7 @@ class CodexCliLocalService: ObservableObject {
 
         // CRITICAL: Include ChatGPT-Account-Id header to get team/workspace data
         // Without this header, API returns free plan data even for team accounts
-        if let accountId = getAccountId() {
+        if let accountId = auth.accountId {
             request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
         }
 
@@ -165,7 +173,7 @@ class CodexCliLocalService: ObservableObject {
 // MARK: - Response Models
 
 /// Response structure for Codex CLI usage API from https://chatgpt.com/backend-api/wham/usage
-struct CodexCliUsageResponse: Codable {
+nonisolated struct CodexCliUsageResponse: Codable {
     let planType: String
     let rateLimit: RateLimit?  // Can be null for free accounts
     let codeReviewRateLimit: CodeReviewRateLimit?
@@ -308,7 +316,7 @@ extension CodexCliUsageResponse {
 }
 
 /// Optional per-account spending cap returned by the Codex usage API.
-struct SpendControl: Codable {
+nonisolated struct SpendControl: Codable {
     let reached: Bool
     let individualLimit: Double?
 
@@ -338,7 +346,7 @@ struct SpendControl: Codable {
 }
 
 /// Banked rate-limit resets the account can trigger on demand, from the Codex usage API.
-struct RateLimitResetCredits: Codable {
+nonisolated struct RateLimitResetCredits: Codable {
     /// How many resets are currently available to use. `nil` if absent/null.
     let availableCount: Int?
 
@@ -347,7 +355,7 @@ struct RateLimitResetCredits: Codable {
     }
 }
 
-struct RateLimit: Codable {
+nonisolated struct RateLimit: Codable {
     let allowed: Bool
     let limitReached: Bool
     let primaryWindow: LimitWindow
@@ -363,7 +371,7 @@ struct RateLimit: Codable {
 
 typealias CodeReviewRateLimit = RateLimit
 
-struct LimitWindow: Codable {
+nonisolated struct LimitWindow: Codable {
     let usedPercent: Double
     let limitWindowSeconds: Int
     let resetAfterSeconds: Int
@@ -377,7 +385,7 @@ struct LimitWindow: Codable {
     }
 }
 
-struct Credits: Codable {
+nonisolated struct Credits: Codable {
     let hasCredits: Bool
     let unlimited: Bool
     let overageLimitReached: Bool
@@ -439,7 +447,7 @@ struct Credits: Codable {
 // MARK: - Auth File Models
 
 /// Structure of `CODEX_HOME/auth.json`.
-struct CodexAuthFile: Codable {
+nonisolated struct CodexAuthFile: Codable {
     let openaiApiKey: String?
     let tokens: CodexTokens?
     let lastRefresh: String?
@@ -451,7 +459,7 @@ struct CodexAuthFile: Codable {
     }
 }
 
-struct CodexTokens: Codable {
+nonisolated struct CodexTokens: Codable {
     let idToken: String?
     let accessToken: String?
     let refreshToken: String?

--- a/MeterBar/Services/CodexHomeDirectory.swift
+++ b/MeterBar/Services/CodexHomeDirectory.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Codex honors `CODEX_HOME`; MeterBar must therefore use the same directory for
 /// activity, auth, readiness, and cost scans. Keeping this path logic pure also
 /// lets tests exercise custom homes without mutating the process environment.
-enum CodexHomeDirectory {
+nonisolated enum CodexHomeDirectory {
     static func path(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         realHomeDirectory: String = ServiceSupport.realHomeDirectory()

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -25,7 +25,7 @@ class CostTracker: ObservableObject {
     // NOTE: MeterBarCLI/Sources/MeterBarCLI.swift carries a simplified copy of the
     // "claude-sonnet" entry; keep the two in sync until a shared package exists
     // (.agents/docs/DEFERRED_WORK.md §1).
-    private static let pricing: [String: TokenPricing] = [
+    private nonisolated static let pricing: [String: TokenPricing] = [
         "claude-sonnet": TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30),
         "claude-opus": TokenPricing(input: 15.0, output: 75.0, cacheCreation: 18.75, cacheRead: 1.50),
         "claude-haiku": TokenPricing(input: 0.25, output: 1.25, cacheCreation: 0.30, cacheRead: 0.03),
@@ -51,7 +51,7 @@ class CostTracker: ObservableObject {
 
     /// Non-optional fallback so pricing lookups never need a force-unwrap of
     /// `pricing["default"]`. Mirrors the `"default"` entry above.
-    private static let defaultPricing = TokenPricing(
+    private nonisolated static let defaultPricing = TokenPricing(
         input: 3.0,
         output: 15.0,
         cacheCreation: 3.75,
@@ -61,7 +61,7 @@ class CostTracker: ObservableObject {
     // Cached regexes. The scan parses tens of thousands of log lines, so
     // allocating an NSRegularExpression per call was a measurable hot-path
     // cost. Date parsing shares the cached FlexibleISO8601 formatters.
-    private static let codexLogValueRegexes: [String: NSRegularExpression] = {
+    private nonisolated static let codexLogValueRegexes: [String: NSRegularExpression] = {
         let keys = [
             "event.timestamp", "input_token_count", "output_token_count",
             "cached_token_count", "reasoning_token_count", "conversation.id",
@@ -138,7 +138,7 @@ class CostTracker: ObservableObject {
         }.value
     }
 
-    private static func buildCostSummary(
+    private nonisolated static func buildCostSummary(
         days: Int,
         includeClaudeCode: Bool,
         includeCodexCli: Bool,
@@ -193,7 +193,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private static func scanClaudeCodeSessions(
+    private nonisolated static func scanClaudeCodeSessions(
         since cutoffDate: Date,
         claudeAccounts: [ClaudeCodeAccount]
     ) -> (TokenCost, [DailyTokenUsage])? {
@@ -282,7 +282,7 @@ class CostTracker: ObservableObject {
         ), Self.makeDailyUsage(from: dailyTotals, provider: .claudeCode, pricing: pricing))
     }
 
-    private static func claudeProjectRoots(accounts: [ClaudeCodeAccount]) -> [URL] {
+    private nonisolated static func claudeProjectRoots(accounts: [ClaudeCodeAccount]) -> [URL] {
         let fileManager = FileManager.default
         // realHomeDirectory, not homeDirectoryForCurrentUser: in sandboxed
         // builds the latter is the app container, and the scan would silently
@@ -327,7 +327,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private static func claudeProjectsURL(forConfigPath rawPath: String) -> URL {
+    private nonisolated static func claudeProjectsURL(forConfigPath rawPath: String) -> URL {
         let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
         let url = URL(fileURLWithPath: (trimmed as NSString).standardizingPath)
         if url.lastPathComponent == "projects" {
@@ -336,7 +336,7 @@ class CostTracker: ObservableObject {
         return url.appendingPathComponent("projects", isDirectory: true)
     }
 
-    static func parseSessionFile(
+    nonisolated static func parseSessionFile(
         at url: URL,
         since cutoffDate: Date
     ) -> (
@@ -451,14 +451,14 @@ class CostTracker: ObservableObject {
                 dates, dailyTotals, modelTotals, originTotals)
     }
 
-    private static func claudeOneHourCacheCreationTokens(in usage: [String: Any]) -> Int {
+    private nonisolated static func claudeOneHourCacheCreationTokens(in usage: [String: Any]) -> Int {
         guard let cacheCreation = usage["cache_creation"] as? [String: Any] else { return 0 }
         let total = intValue(usage["cache_creation_input_tokens"])
         let oneHour = intValue(cacheCreation["ephemeral_1h_input_tokens"])
         return min(total, max(0, oneHour))
     }
 
-    static func claudePricing(for model: String?) -> TokenPricing {
+    nonisolated static func claudePricing(for model: String?) -> TokenPricing {
         guard let model else {
             return Self.pricing["claude-sonnet"] ?? Self.defaultPricing
         }
@@ -494,7 +494,7 @@ class CostTracker: ObservableObject {
         return Self.defaultPricing
     }
 
-    static func normalizeClaudeModel(_ raw: String) -> String {
+    nonisolated static func normalizeClaudeModel(_ raw: String) -> String {
         var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.hasPrefix("anthropic.") {
             trimmed = String(trimmed.dropFirst("anthropic.".count))
@@ -519,7 +519,7 @@ class CostTracker: ObservableObject {
         return trimmed
     }
 
-    private static func scanCodexSessions(since cutoffDate: Date) -> (TokenCost, [DailyTokenUsage])? {
+    private nonisolated static func scanCodexSessions(since cutoffDate: Date) -> (TokenCost, [DailyTokenUsage])? {
         let codexDir = URL(fileURLWithPath: CodexHomeDirectory.path(), isDirectory: true)
         let archivedDir = codexDir.appendingPathComponent("archived_sessions")
         let logsDatabase = codexDir.appendingPathComponent("logs_2.sqlite")
@@ -560,7 +560,7 @@ class CostTracker: ObservableObject {
     /// Internal (not private) so the archived-session parsing — the Codex
     /// counterpart to `parseSessionFile`, and where CLI-vs-app cost divergence
     /// hides — can be fixture-tested against a temp directory.
-    static func scanCodexArchivedSessions(
+    nonisolated static func scanCodexArchivedSessions(
         directory: URL,
         since cutoffDate: Date,
         context: inout CodexScanContext
@@ -611,7 +611,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private static func isLocalDirectory(_ url: URL) -> Bool {
+    private nonisolated static func isLocalDirectory(_ url: URL) -> Bool {
         let standardized = url.standardizedFileURL
         var isDirectory: ObjCBool = false
 
@@ -626,7 +626,7 @@ class CostTracker: ObservableObject {
         return values?.volumeIsLocal != false
     }
 
-    private static func scanCodexSQLiteLogs(
+    private nonisolated static func scanCodexSQLiteLogs(
         database: URL,
         since cutoffDate: Date,
         context: inout CodexScanContext
@@ -672,7 +672,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private static func addCodexUsage(
+    private nonisolated static func addCodexUsage(
         _ usage: [String: Any],
         timestamp: Date,
         sessionID: String,
@@ -718,7 +718,7 @@ class CostTracker: ObservableObject {
         if timestamp > context.latestDate { context.latestDate = timestamp }
     }
 
-    private static func makeDailyUsage(
+    private nonisolated static func makeDailyUsage(
         from dailyTotals: [Date: TokenAccumulator],
         provider: ServiceType,
         pricing: TokenPricing
@@ -745,7 +745,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private static func makeBreakdowns(
+    private nonisolated static func makeBreakdowns(
         from totals: [String: TokenAccumulator],
         provider: ServiceType,
         pricing: TokenPricing
@@ -781,7 +781,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private static func mergeDailyTotals(
+    private nonisolated static func mergeDailyTotals(
         _ target: inout [Date: TokenAccumulator],
         with source: [Date: TokenAccumulator]
     ) {
@@ -790,7 +790,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private static func mergeNamedTotals(
+    private nonisolated static func mergeNamedTotals(
         _ target: inout [String: TokenAccumulator],
         with source: [String: TokenAccumulator]
     ) {
@@ -799,7 +799,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private static func claudeUsageOrigin(json: [String: Any], message: [String: Any], url: URL) -> String {
+    private nonisolated static func claudeUsageOrigin(json: [String: Any], message: [String: Any], url: URL) -> String {
         if url.path.contains("/subagents/") || (json["isSidechain"] as? Bool == true) {
             return "Agents"
         }
@@ -821,7 +821,7 @@ class CostTracker: ObservableObject {
         return "Main chat"
     }
 
-    private static func toolUseNames(in message: [String: Any]) -> [String] {
+    private nonisolated static func toolUseNames(in message: [String: Any]) -> [String] {
         guard let content = message["content"] as? [[String: Any]] else { return [] }
         return content.compactMap { item in
             guard item["type"] as? String == "tool_use" else { return nil }
@@ -829,19 +829,19 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private static func codexModelName(from info: [String: Any], payload: [String: Any]) -> String? {
+    private nonisolated static func codexModelName(from info: [String: Any], payload: [String: Any]) -> String? {
         (info["model"] as? String)
             ?? (info["slug"] as? String)
             ?? (payload["model"] as? String)
             ?? (payload["slug"] as? String)
     }
 
-    private static func displayModelName(_ raw: String?) -> String {
+    private nonisolated static func displayModelName(_ raw: String?) -> String {
         let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return trimmed.isEmpty ? "Unknown model" : Self.normalizeClaudeModel(trimmed)
     }
 
-    private static func displayOriginName(_ raw: String?) -> String {
+    private nonisolated static func displayOriginName(_ raw: String?) -> String {
         let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !trimmed.isEmpty else { return "Unknown origin" }
         return trimmed
@@ -857,7 +857,7 @@ class CostTracker: ObservableObject {
     /// Cost without a one-hour cache tier — delegates to `calculateClaudeCost`
     /// so there is exactly one pricing formula. (These were near-duplicates
     /// that had drifted: only the Claude variant clamped negative inputs.)
-    static func calculateCost(
+    nonisolated static func calculateCost(
         input: Int,
         output: Int,
         cacheCreation: Int,
@@ -874,7 +874,7 @@ class CostTracker: ObservableObject {
         )
     }
 
-    static func calculateClaudeCost(
+    nonisolated static func calculateClaudeCost(
         input: Int,
         output: Int,
         cacheCreation: Int,
@@ -894,7 +894,7 @@ class CostTracker: ObservableObject {
         return inputCost + outputCost + cacheCreationCost + oneHourCacheCreationCost + cacheReadCost
     }
 
-    private static func intValue(_ value: Any?) -> Int {
+    private nonisolated static func intValue(_ value: Any?) -> Int {
         if let value = value as? Int { return value }
         if let value = value as? Int64 { return Int(value) }
         if let value = value as? Double { return Int(value) }
@@ -902,17 +902,17 @@ class CostTracker: ObservableObject {
         return 0
     }
 
-    private static func codexLogDate(in text: String) -> Date? {
+    private nonisolated static func codexLogDate(in text: String) -> Date? {
         guard let value = Self.codexLogValue("event.timestamp", in: text) else { return nil }
         return FlexibleISO8601.date(from: value)
     }
 
-    private static func codexLogInt(_ key: String, in text: String) -> Int {
+    private nonisolated static func codexLogInt(_ key: String, in text: String) -> Int {
         guard let value = Self.codexLogValue(key, in: text) else { return 0 }
         return Int(value) ?? 0
     }
 
-    private static func codexLogValue(_ key: String, in text: String) -> String? {
+    private nonisolated static func codexLogValue(_ key: String, in text: String) -> String? {
         let regex: NSRegularExpression
         if let cached = Self.codexLogValueRegexes[key] {
             regex = cached
@@ -936,7 +936,7 @@ class CostTracker: ObservableObject {
 /// a single `inout` argument.
 ///
 /// Internal (not private) so `scanCodexArchivedSessions` can be fixture-tested.
-struct CodexScanContext: Sendable {
+nonisolated struct CodexScanContext: Sendable {
     var totals = TokenAccumulator()
     var dailyTotals: [Date: TokenAccumulator] = [:]
     var modelTotals: [String: TokenAccumulator] = [:]
@@ -947,7 +947,7 @@ struct CodexScanContext: Sendable {
     var latestDate: Date
 }
 
-struct TokenPricing: Sendable {
+nonisolated struct TokenPricing: Sendable {
     let input: Double      // per million tokens
     let output: Double     // per million tokens
     let cacheCreation: Double
@@ -969,7 +969,7 @@ struct TokenPricing: Sendable {
     }
 }
 
-struct TokenAccumulator: Sendable {
+nonisolated struct TokenAccumulator: Sendable {
     var input = 0
     var output = 0
     var cacheCreation = 0
@@ -1009,7 +1009,7 @@ struct TokenAccumulator: Sendable {
     }
 }
 
-private struct ClaudeUsageEvent: Sendable {
+private nonisolated struct ClaudeUsageEvent: Sendable {
     let timestamp: Date
     let model: String?
     let messageID: String?

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -25,7 +25,7 @@ class CostTracker: ObservableObject {
     // NOTE: MeterBarCLI/Sources/MeterBarCLI.swift carries a simplified copy of the
     // "claude-sonnet" entry; keep the two in sync until a shared package exists
     // (.agents/docs/DEFERRED_WORK.md §1).
-    private nonisolated static let pricing: [String: TokenPricing] = [
+    nonisolated private static let pricing: [String: TokenPricing] = [
         "claude-sonnet": TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30),
         "claude-opus": TokenPricing(input: 15.0, output: 75.0, cacheCreation: 18.75, cacheRead: 1.50),
         "claude-haiku": TokenPricing(input: 0.25, output: 1.25, cacheCreation: 0.30, cacheRead: 0.03),
@@ -51,7 +51,7 @@ class CostTracker: ObservableObject {
 
     /// Non-optional fallback so pricing lookups never need a force-unwrap of
     /// `pricing["default"]`. Mirrors the `"default"` entry above.
-    private nonisolated static let defaultPricing = TokenPricing(
+    nonisolated private static let defaultPricing = TokenPricing(
         input: 3.0,
         output: 15.0,
         cacheCreation: 3.75,
@@ -61,7 +61,7 @@ class CostTracker: ObservableObject {
     // Cached regexes. The scan parses tens of thousands of log lines, so
     // allocating an NSRegularExpression per call was a measurable hot-path
     // cost. Date parsing shares the cached FlexibleISO8601 formatters.
-    private nonisolated static let codexLogValueRegexes: [String: NSRegularExpression] = {
+    nonisolated private static let codexLogValueRegexes: [String: NSRegularExpression] = {
         let keys = [
             "event.timestamp", "input_token_count", "output_token_count",
             "cached_token_count", "reasoning_token_count", "conversation.id",
@@ -138,7 +138,7 @@ class CostTracker: ObservableObject {
         }.value
     }
 
-    private nonisolated static func buildCostSummary(
+    nonisolated private static func buildCostSummary(
         days: Int,
         includeClaudeCode: Bool,
         includeCodexCli: Bool,
@@ -193,7 +193,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private nonisolated static func scanClaudeCodeSessions(
+    nonisolated private static func scanClaudeCodeSessions(
         since cutoffDate: Date,
         claudeAccounts: [ClaudeCodeAccount]
     ) -> (TokenCost, [DailyTokenUsage])? {
@@ -282,7 +282,7 @@ class CostTracker: ObservableObject {
         ), Self.makeDailyUsage(from: dailyTotals, provider: .claudeCode, pricing: pricing))
     }
 
-    private nonisolated static func claudeProjectRoots(accounts: [ClaudeCodeAccount]) -> [URL] {
+    nonisolated private static func claudeProjectRoots(accounts: [ClaudeCodeAccount]) -> [URL] {
         let fileManager = FileManager.default
         // realHomeDirectory, not homeDirectoryForCurrentUser: in sandboxed
         // builds the latter is the app container, and the scan would silently
@@ -327,7 +327,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private nonisolated static func claudeProjectsURL(forConfigPath rawPath: String) -> URL {
+    nonisolated private static func claudeProjectsURL(forConfigPath rawPath: String) -> URL {
         let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
         let url = URL(fileURLWithPath: (trimmed as NSString).standardizingPath)
         if url.lastPathComponent == "projects" {
@@ -451,7 +451,7 @@ class CostTracker: ObservableObject {
                 dates, dailyTotals, modelTotals, originTotals)
     }
 
-    private nonisolated static func claudeOneHourCacheCreationTokens(in usage: [String: Any]) -> Int {
+    nonisolated private static func claudeOneHourCacheCreationTokens(in usage: [String: Any]) -> Int {
         guard let cacheCreation = usage["cache_creation"] as? [String: Any] else { return 0 }
         let total = intValue(usage["cache_creation_input_tokens"])
         let oneHour = intValue(cacheCreation["ephemeral_1h_input_tokens"])
@@ -519,7 +519,7 @@ class CostTracker: ObservableObject {
         return trimmed
     }
 
-    private nonisolated static func scanCodexSessions(since cutoffDate: Date) -> (TokenCost, [DailyTokenUsage])? {
+    nonisolated private static func scanCodexSessions(since cutoffDate: Date) -> (TokenCost, [DailyTokenUsage])? {
         let codexDir = URL(fileURLWithPath: CodexHomeDirectory.path(), isDirectory: true)
         let archivedDir = codexDir.appendingPathComponent("archived_sessions")
         let logsDatabase = codexDir.appendingPathComponent("logs_2.sqlite")
@@ -611,7 +611,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private nonisolated static func isLocalDirectory(_ url: URL) -> Bool {
+    nonisolated private static func isLocalDirectory(_ url: URL) -> Bool {
         let standardized = url.standardizedFileURL
         var isDirectory: ObjCBool = false
 
@@ -626,7 +626,7 @@ class CostTracker: ObservableObject {
         return values?.volumeIsLocal != false
     }
 
-    private nonisolated static func scanCodexSQLiteLogs(
+    nonisolated private static func scanCodexSQLiteLogs(
         database: URL,
         since cutoffDate: Date,
         context: inout CodexScanContext
@@ -672,7 +672,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private nonisolated static func addCodexUsage(
+    nonisolated private static func addCodexUsage(
         _ usage: [String: Any],
         timestamp: Date,
         sessionID: String,
@@ -718,7 +718,7 @@ class CostTracker: ObservableObject {
         if timestamp > context.latestDate { context.latestDate = timestamp }
     }
 
-    private nonisolated static func makeDailyUsage(
+    nonisolated private static func makeDailyUsage(
         from dailyTotals: [Date: TokenAccumulator],
         provider: ServiceType,
         pricing: TokenPricing
@@ -745,7 +745,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private nonisolated static func makeBreakdowns(
+    nonisolated private static func makeBreakdowns(
         from totals: [String: TokenAccumulator],
         provider: ServiceType,
         pricing: TokenPricing
@@ -781,7 +781,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private nonisolated static func mergeDailyTotals(
+    nonisolated private static func mergeDailyTotals(
         _ target: inout [Date: TokenAccumulator],
         with source: [Date: TokenAccumulator]
     ) {
@@ -790,7 +790,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private nonisolated static func mergeNamedTotals(
+    nonisolated private static func mergeNamedTotals(
         _ target: inout [String: TokenAccumulator],
         with source: [String: TokenAccumulator]
     ) {
@@ -799,7 +799,7 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private nonisolated static func claudeUsageOrigin(json: [String: Any], message: [String: Any], url: URL) -> String {
+    nonisolated private static func claudeUsageOrigin(json: [String: Any], message: [String: Any], url: URL) -> String {
         if url.path.contains("/subagents/") || (json["isSidechain"] as? Bool == true) {
             return "Agents"
         }
@@ -821,7 +821,7 @@ class CostTracker: ObservableObject {
         return "Main chat"
     }
 
-    private nonisolated static func toolUseNames(in message: [String: Any]) -> [String] {
+    nonisolated private static func toolUseNames(in message: [String: Any]) -> [String] {
         guard let content = message["content"] as? [[String: Any]] else { return [] }
         return content.compactMap { item in
             guard item["type"] as? String == "tool_use" else { return nil }
@@ -829,19 +829,19 @@ class CostTracker: ObservableObject {
         }
     }
 
-    private nonisolated static func codexModelName(from info: [String: Any], payload: [String: Any]) -> String? {
+    nonisolated private static func codexModelName(from info: [String: Any], payload: [String: Any]) -> String? {
         (info["model"] as? String)
             ?? (info["slug"] as? String)
             ?? (payload["model"] as? String)
             ?? (payload["slug"] as? String)
     }
 
-    private nonisolated static func displayModelName(_ raw: String?) -> String {
+    nonisolated private static func displayModelName(_ raw: String?) -> String {
         let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return trimmed.isEmpty ? "Unknown model" : Self.normalizeClaudeModel(trimmed)
     }
 
-    private nonisolated static func displayOriginName(_ raw: String?) -> String {
+    nonisolated private static func displayOriginName(_ raw: String?) -> String {
         let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !trimmed.isEmpty else { return "Unknown origin" }
         return trimmed
@@ -894,7 +894,7 @@ class CostTracker: ObservableObject {
         return inputCost + outputCost + cacheCreationCost + oneHourCacheCreationCost + cacheReadCost
     }
 
-    private nonisolated static func intValue(_ value: Any?) -> Int {
+    nonisolated private static func intValue(_ value: Any?) -> Int {
         if let value = value as? Int { return value }
         if let value = value as? Int64 { return Int(value) }
         if let value = value as? Double { return Int(value) }
@@ -902,17 +902,17 @@ class CostTracker: ObservableObject {
         return 0
     }
 
-    private nonisolated static func codexLogDate(in text: String) -> Date? {
+    nonisolated private static func codexLogDate(in text: String) -> Date? {
         guard let value = Self.codexLogValue("event.timestamp", in: text) else { return nil }
         return FlexibleISO8601.date(from: value)
     }
 
-    private nonisolated static func codexLogInt(_ key: String, in text: String) -> Int {
+    nonisolated private static func codexLogInt(_ key: String, in text: String) -> Int {
         guard let value = Self.codexLogValue(key, in: text) else { return 0 }
         return Int(value) ?? 0
     }
 
-    private nonisolated static func codexLogValue(_ key: String, in text: String) -> String? {
+    nonisolated private static func codexLogValue(_ key: String, in text: String) -> String? {
         let regex: NSRegularExpression
         if let cached = Self.codexLogValueRegexes[key] {
             regex = cached
@@ -1009,7 +1009,7 @@ nonisolated struct TokenAccumulator: Sendable {
     }
 }
 
-private nonisolated struct ClaudeUsageEvent: Sendable {
+nonisolated private struct ClaudeUsageEvent: Sendable {
     let timestamp: Date
     let model: String?
     let messageID: String?

--- a/MeterBar/Services/CursorLocalService.swift
+++ b/MeterBar/Services/CursorLocalService.swift
@@ -10,7 +10,9 @@ import SQLite3
 /// Reads authentication token from Cursor's local SQLite database and calls dashboard APIs.
 /// Based on: https://github.com/darzhang/cursor-stats-lite
 class CursorLocalService: ObservableObject {
-    static let shared = CursorLocalService()
+    // nonisolated: lets the nonisolated readiness inspector reference the
+    // singleton (methods keep their own isolation).
+    nonisolated static let shared = CursorLocalService()
 
     // API endpoint (from Vibeviewer: https://github.com/MarveleE/Vibeviewer)
     private let usageSummaryEndpoint = "https://cursor.com/api/usage-summary"
@@ -37,8 +39,10 @@ class CursorLocalService: ObservableObject {
     // MARK: - Database Access (cursor-stats approach)
 
     /// Get the path to Cursor's state database
-    /// Scans multiple possible locations and optionally searches recursively
-    private func getCursorDatabasePath(forceRescan: Bool = false) -> String? {
+    /// Scans multiple possible locations and optionally searches recursively.
+    /// `nonisolated`: filesystem I/O (recursive when rescanning) — never call
+    /// synchronously from the main actor.
+    private nonisolated func getCursorDatabasePath(forceRescan: Bool = false) -> String? {
         let homeDir = ServiceSupport.realHomeDirectory()
         let fileManager = FileManager.default
 
@@ -75,7 +79,7 @@ class CursorLocalService: ObservableObject {
     }
 
     /// Recursively search for a database file in a directory
-    private func findDatabaseRecursively(in directory: String, filename: String) -> String? {
+    private nonisolated func findDatabaseRecursively(in directory: String, filename: String) -> String? {
         let fileManager = FileManager.default
 
         guard fileManager.fileExists(atPath: directory),
@@ -93,9 +97,11 @@ class CursorLocalService: ObservableObject {
         return nil
     }
 
-    /// Read access token from Cursor's SQLite database
+    /// Read access token from Cursor's SQLite database.
+    /// `nonisolated`: opens and queries `state.vscdb` (often large and actively
+    /// WAL-written by Cursor) — never call synchronously from the main actor.
     /// - Parameter forceRescan: If true, will recursively search for database if not found in primary paths
-    func getAccessTokenFromDatabase(forceRescan: Bool = false) -> (userId: String, token: String)? {
+    nonisolated func getAccessTokenFromDatabase(forceRescan: Bool = false) -> (userId: String, token: String)? {
         guard let dbPath = getCursorDatabasePath(forceRescan: forceRescan) else {
             // Database not found - Cursor may not be installed, which is okay
             return nil
@@ -151,7 +157,7 @@ class CursorLocalService: ObservableObject {
     /// Uses the same path scan and read-only open as `getAccessTokenFromDatabase`,
     /// but reports *why* auth is unavailable (not found / unreadable / no token)
     /// instead of just a token, and never returns the token value itself.
-    func probeReadinessDatabase() -> CursorDatabaseProbe {
+    nonisolated func probeReadinessDatabase() -> CursorDatabaseProbe {
         guard let dbPath = getCursorDatabasePath(forceRescan: false)
             ?? getCursorDatabasePath(forceRescan: true) else {
             return .notFound
@@ -185,7 +191,7 @@ class CursorLocalService: ObservableObject {
 
     /// Extract userId from JWT token's 'sub' claim.
     /// Static + internal so it is unit-testable without a Cursor DB or network.
-    static func extractUserIdFromJWT(_ token: String) -> String? {
+    nonisolated static func extractUserIdFromJWT(_ token: String) -> String? {
         guard let sub = JWT.claimString("sub", in: token) else { return nil }
 
         // Extract userId from sub claim
@@ -203,9 +209,11 @@ class CursorLocalService: ObservableObject {
         "\(userId)%3A%3A\(token)"
     }
 
-    /// Check and update access status
+    /// Check and update access status.
+    /// `nonisolated`: reads the Cursor SQLite DB (and recursively scans the
+    /// Cursor directory when `forceRescan`) — call from a detached task.
     /// - Parameter forceRescan: If true, will recursively search for database if not found in primary paths
-    func checkAccess(forceRescan: Bool = false) {
+    nonisolated func checkAccess(forceRescan: Bool = false) {
         let hasToken = getAccessTokenFromDatabase(forceRescan: forceRescan) != nil
         ServiceSupport.applyOnMain { [weak self] in
             guard let self else { return }
@@ -217,9 +225,16 @@ class CursorLocalService: ObservableObject {
     // MARK: - Usage Fetching
 
     func fetchUsageMetrics() async throws -> UsageMetrics {
-        // Try without rescan first (faster), then with rescan if needed
-        guard let (userId, token) = getAccessTokenFromDatabase(forceRescan: false)
-            ?? getAccessTokenFromDatabase(forceRescan: true) else {
+        // SQLite read (plus a recursive directory scan on a miss) is blocking
+        // I/O; the app target runs async bodies on the main actor (default
+        // MainActor isolation), so hop off explicitly. Try without rescan first
+        // (faster), then with rescan if needed.
+        let credentials = await Task.detached(priority: .userInitiated) { [self] in
+            getAccessTokenFromDatabase(forceRescan: false)
+                ?? getAccessTokenFromDatabase(forceRescan: true)
+        }.value
+
+        guard let (userId, token) = credentials else {
             let error = ServiceError.notAuthenticated
             await MainActor.run {
                 self.lastError = error
@@ -341,7 +356,7 @@ class CursorLocalService: ObservableObject {
 
 /// Response from https://cursor.com/api/usage-summary
 /// Based on Vibeviewer implementation
-struct CursorUsageSummaryResponse: Decodable {
+nonisolated struct CursorUsageSummaryResponse: Decodable {
     let billingCycleStart: String?
     let billingCycleEnd: String?
     let membershipType: String?
@@ -350,12 +365,12 @@ struct CursorUsageSummaryResponse: Decodable {
     let teamUsage: CursorTeamUsage?
 }
 
-struct CursorIndividualUsage: Decodable {
+nonisolated struct CursorIndividualUsage: Decodable {
     let plan: CursorPlanUsage?
     let onDemand: CursorOnDemandUsage?
 }
 
-struct CursorPlanUsage: Decodable {
+nonisolated struct CursorPlanUsage: Decodable {
     let used: Int?
     let limit: Int?
     let remaining: Int?
@@ -364,14 +379,14 @@ struct CursorPlanUsage: Decodable {
     let total: Int?
 }
 
-struct CursorOnDemandUsage: Decodable {
+nonisolated struct CursorOnDemandUsage: Decodable {
     let used: Int?
     let limit: Int?
     let remaining: Int?
     let enabled: Bool?
 }
 
-struct CursorTeamUsage: Decodable {
+nonisolated struct CursorTeamUsage: Decodable {
     let plan: CursorPlanUsage?
     let onDemand: CursorOnDemandUsage?
 }

--- a/MeterBar/Services/CursorLocalService.swift
+++ b/MeterBar/Services/CursorLocalService.swift
@@ -42,7 +42,7 @@ class CursorLocalService: ObservableObject {
     /// Scans multiple possible locations and optionally searches recursively.
     /// `nonisolated`: filesystem I/O (recursive when rescanning) — never call
     /// synchronously from the main actor.
-    private nonisolated func getCursorDatabasePath(forceRescan: Bool = false) -> String? {
+    nonisolated private func getCursorDatabasePath(forceRescan: Bool = false) -> String? {
         let homeDir = ServiceSupport.realHomeDirectory()
         let fileManager = FileManager.default
 
@@ -79,7 +79,7 @@ class CursorLocalService: ObservableObject {
     }
 
     /// Recursively search for a database file in a directory
-    private nonisolated func findDatabaseRecursively(in directory: String, filename: String) -> String? {
+    nonisolated private func findDatabaseRecursively(in directory: String, filename: String) -> String? {
         let fileManager = FileManager.default
 
         guard fileManager.fileExists(atPath: directory),

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -13,7 +13,7 @@ import MeterBarShared
 ///
 /// All provider error text is sanitized here (`sanitize`) so nothing that could
 /// contain a token, account id, or raw response body reaches a pasteable report.
-public enum ProviderReadinessInspector {
+nonisolated public enum ProviderReadinessInspector {
     /// Readiness reports for the requested providers, in stable display order.
     ///
     /// - Parameter refreshErrors: each provider's live last-refresh error. The app

--- a/MeterBar/Services/ServiceSupport.swift
+++ b/MeterBar/Services/ServiceSupport.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Centralizes the URLSession configuration, HTTP response validation, error
 /// mapping, browser-spoof headers, main-thread state application, and the real
 /// (non-sandboxed) home directory lookup so all services behave consistently.
-enum ServiceSupport {
+nonisolated enum ServiceSupport {
     /// The one `URLSession` all usage requests share, configured with the
     /// standard MeterBar timeouts. Previously each service built its own
     /// session — and some code paths silently used `URLSession.shared`,
@@ -140,11 +140,15 @@ enum ServiceSupport {
     /// Runs `block` on the main thread — synchronously when already there, so
     /// callers on the main thread observe the state change immediately
     /// (SettingsView reads `hasAccess` right after calling `checkAccess()`).
-    static func applyOnMain(_ block: @escaping () -> Void) {
+    /// `@MainActor` on the closure lets nonisolated service code mutate
+    /// main-actor `@Published` state through here without isolation warnings.
+    static func applyOnMain(_ block: @escaping @MainActor () -> Void) {
         if Thread.isMainThread {
-            block()
+            MainActor.assumeIsolated(block)
         } else {
-            DispatchQueue.main.async(execute: block)
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated(block)
+            }
         }
     }
 

--- a/MeterBar/Services/SharedDataStore.swift
+++ b/MeterBar/Services/SharedDataStore.swift
@@ -8,7 +8,9 @@ import WidgetKit
 /// Shared data store using App Groups for Widget extension access.
 /// Public so the meterbar CLI reads the same file through the same code path
 /// instead of maintaining its own copy of the location and decode logic.
-public class SharedDataStore {
+/// `@unchecked Sendable`: all stored properties are immutable and disk writes
+/// are serialized on `ioQueue`, so instances are safe to use from any actor.
+nonisolated public final class SharedDataStore: @unchecked Sendable {
     public static let shared = SharedDataStore()
 
     /// Serial queue for off-main disk writes so callers on the MainActor don't

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -421,9 +421,12 @@ struct SettingsView: View {
                     )
 
                     Button(codexCliService.hasAccess ? "Refresh" : "Check Again") {
-                        codexCliService.checkAccess()
-                        if codexCliService.hasAccess {
-                            Task {
+                        // checkAccess does disk I/O — run it off the main actor
+                        // (a plain Task would inherit MainActor and block the UI).
+                        Task {
+                            let service = codexCliService
+                            await Task.detached(priority: .userInitiated) { service.checkAccess() }.value
+                            if codexCliService.hasAccess {
                                 await dataManager.refresh(service: .codexCli)
                             }
                         }
@@ -621,9 +624,12 @@ struct SettingsView: View {
                     StatusPill(title: claudeCodeService.authState.statusText, isConnected: claudeCodeService.hasAccess)
 
                     Button(claudeCodeService.hasAccess ? "Refresh" : "Check Again") {
-                        claudeCodeService.checkAccess()
-                        if claudeCodeService.hasAccess {
-                            Task {
+                        // checkAccess can hit the keychain (blocking approval
+                        // dialog) — run it off the main actor.
+                        Task {
+                            let service = claudeCodeService
+                            await Task.detached(priority: .userInitiated) { service.checkAccess() }.value
+                            if claudeCodeService.hasAccess {
                                 await dataManager.refreshAll()
                             }
                         }
@@ -667,7 +673,9 @@ struct SettingsView: View {
                     get: { oauthFallbackEnabled },
                     set: { enabled in
                         oauthFallbackEnabled = enabled
-                        claudeCodeService.checkAccess()
+                        // Keychain/file I/O — keep it off the main actor.
+                        let service = claudeCodeService
+                        Task.detached(priority: .userInitiated) { service.checkAccess() }
                     }
                 ))
                 .labelsHidden()
@@ -725,9 +733,14 @@ struct SettingsView: View {
                     )
 
                     Button(cursorService.hasAccess ? "Refresh" : "Check Again") {
-                        cursorService.checkAccess(forceRescan: true)
-                        if cursorService.hasAccess {
-                            Task {
+                        // forceRescan walks the whole Cursor directory tree —
+                        // the worst main-thread stall in the app; run detached.
+                        Task {
+                            let service = cursorService
+                            await Task.detached(priority: .userInitiated) {
+                                service.checkAccess(forceRescan: true)
+                            }.value
+                            if cursorService.hasAccess {
                                 await dataManager.refreshAll()
                             }
                         }
@@ -1094,14 +1107,21 @@ struct SettingsView: View {
 
     private func refreshProvider(_ service: ServiceType) {
         Task {
-            switch service {
-            case .claudeCode:
-                claudeCodeService.checkAccess()
-            case .codexCli:
-                codexCliService.checkAccess()
-            case .cursor:
-                cursorService.checkAccess(forceRescan: true)
-            }
+            // Access checks do disk/keychain I/O; a plain Task inherits the
+            // main actor here, so hop to a detached task for the check itself.
+            let claudeCode = claudeCodeService
+            let codexCli = codexCliService
+            let cursor = cursorService
+            await Task.detached(priority: .userInitiated) {
+                switch service {
+                case .claudeCode:
+                    claudeCode.checkAccess()
+                case .codexCli:
+                    codexCli.checkAccess()
+                case .cursor:
+                    cursor.checkAccess(forceRescan: true)
+                }
+            }.value
             await dataManager.refresh(service: service)
         }
     }

--- a/MeterBarTests/CodexCliLocalServiceTests.swift
+++ b/MeterBarTests/CodexCliLocalServiceTests.swift
@@ -172,4 +172,59 @@ final class CodexCliLocalServiceTests: XCTestCase {
         let service = CodexCliLocalService(authFileDataProvider: { Data("not json".utf8) })
         XCTAssertNil(service.getAuthToken())
     }
+
+    // MARK: - Main-thread hygiene
+
+    /// The auth-file read is disk I/O and must never run on the main thread when
+    /// triggered through the async fetch path. The Xcode app target builds with
+    /// default MainActor isolation, where an un-hopped read would land on main
+    /// and beachball the UI (the SwiftPM test build is laxer — this pins the
+    /// contract so the explicit off-main hop is not reverted).
+    @MainActor
+    func testFetchUsageMetricsReadsAuthFileOffMainThread() async {
+        final class ThreadRecorder: @unchecked Sendable {
+            private let lock = NSLock()
+            private var sawMainThread = false
+            private var callCount = 0
+            func record() {
+                lock.lock()
+                defer { lock.unlock() }
+                if Thread.isMainThread { sawMainThread = true }
+                callCount += 1
+            }
+            var wasCalledOnMainThread: Bool {
+                lock.lock()
+                defer { lock.unlock() }
+                return sawMainThread
+            }
+            var wasCalled: Bool {
+                lock.lock()
+                defer { lock.unlock() }
+                return callCount > 0
+            }
+        }
+
+        let recorder = ThreadRecorder()
+        // No auth file → fetch throws notAuthenticated before any network call,
+        // but only after consulting the provider (the part under test).
+        let service = CodexCliLocalService(authFileDataProvider: {
+            recorder.record()
+            return nil
+        })
+
+        await Task.yield() // let the init-time detached checkAccess drain first
+
+        do {
+            _ = try await service.fetchUsageMetrics()
+            XCTFail("Expected notAuthenticated")
+        } catch {
+            // expected
+        }
+
+        XCTAssertTrue(recorder.wasCalled, "fetch must consult the auth file")
+        XCTAssertFalse(
+            recorder.wasCalledOnMainThread,
+            "auth-file read ran on the main thread — blocking I/O must hop off main"
+        )
+    }
 }


### PR DESCRIPTION
## Problem

The app beachballs when it loads usage data. The loading spinner already exists (`UsageDataManager.isLoading` → `RefreshingIcon`) but couldn't render — the main thread itself was doing the load.

**Root cause:** the app target builds with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` (+ `SWIFT_APPROACHABLE_CONCURRENCY`), so every unannotated service is implicitly `@MainActor` and async fetch bodies run on the main actor's executor. All the "async, therefore off-main" code ran its synchronous I/O on the UI thread:

- `CursorLocalService` — SQLite reads of `state.vscdb` (often 100+ MB, actively WAL-written), falling back to a **recursive scan of the whole `~/Library/Application Support/Cursor` tree** on a miss
- `ClaudeCodeLocalService` — keychain `SecItemCopyMatching` (can raise a blocking approval dialog)
- `CodexCliLocalService` — `auth.json` read + JWT decode
- `AccountActivityInspector` — directory scans fired by four Combine sinks on every metrics publish
- `SettingsView` — direct `checkAccess()` calls in button/toggle handlers (incl. `forceRescan: true`)

`Task { }` wrappers didn't help — they inherit the main actor. `swift test` never caught it because `Package.swift` builds **without** default isolation, so the same code genuinely runs off-main under tests (follow-up to align: separate task).

## Fix

Make isolation explicit so both build systems behave identically:

- Mark blocking/pure helpers `nonisolated`; hop their invocations off the main actor with `await Task.detached { … }.value` inside the fetch paths (`@Published` mutations already went through `MainActor.run`/`applyOnMain`)
- Menu-bar activity probes now run detached, with a generation counter so a stale in-flight probe can't overwrite a newer selection
- SettingsView access checks run detached before reading `hasAccess` (safe: the `applyOnMain` main-queue block is enqueued before the awaiting continuation)
- `ServiceSupport.applyOnMain` takes a `@MainActor` closure (`MainActor.assumeIsolated`) so nonisolated services mutate published state warning-free
- `CostTracker` scan statics + shared value/helper types (`AppLog`, `FlexibleISO8601`, `StorageKeys`, `UsageFormat`, `ServiceSupport`, `CLIBinaryLocator`, `CodexHomeDirectory`, `ProviderReadinessInspector`, `SharedDataStore`, response models) explicitly `nonisolated`

## Verification

- `swift test`: 446 tests, 0 failures — including a new TDD test pinning that `fetchUsageMetrics` reads credentials off the main thread
- `xcodebuild clean build` (the build where the bug exists): succeeds with **zero new warnings** vs a clean-tree baseline, and eliminates 16 pre-existing isolation warnings
- Ran the built app through its initial `refreshAll()`: four consecutive `sample` captures during the load window show the main thread idle in the run loop (no SQLite/FS/keychain frames on main); UI stays responsive, spinner renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)