### PR TITLE
chore: commit shared MeterBar Xcode scheme

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/MeterBar.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/MeterBar.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2660"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "MeterBar"
+               BuildableName = "MeterBar"
+               BlueprintName = "MeterBar"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "MeterBarTests"
+               BuildableName = "MeterBarTests"
+               BlueprintName = "MeterBarTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      queueDebuggingEnableBacktraceRecording = "Yes">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "MeterBar"
+            BuildableName = "MeterBar"
+            BlueprintName = "MeterBar"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## What

Commits the shared `MeterBar.xcscheme` (`.swiftpm/xcode/xcshareddata/xcschemes/`) that was sitting untracked in the working tree.

## Why

- It's a **shared** scheme (`xcshareddata/`), the version Apple intends to be checked in — not a throwaway per-user scheme (`xcuserdata/`, which stays gitignored).
- It wires the `MeterBarTests` target into the Test action (`shouldAutocreateTestPlan = YES`, `Testables → MeterBarTests`), so Xcode and CI get an identical build/test/profile/archive setup.
- Backs the repo's TDD / `swift test` policy — without a shared scheme each machine silently falls back to its own generated one.

## Notes

- No source changes; single file addition.
- The sibling `.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata` was already tracked, so `.swiftpm/` is only partially in git — this closes that gap for the scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an Xcode scheme for MeterBar with configured build, test, launch, profile, analyze, and archive actions.
  * Enabled Debug and Release workflows for the app and its test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->