### PR TITLE
Session Wake hardening: ADR-010, cancellation test, isFinite guard, WakeLock lock

### DIFF
--- a/.agents/SESSIONS/2026-07-11.md
+++ b/.agents/SESSIONS/2026-07-11.md
@@ -111,3 +111,36 @@ warnings for the same mismatches; the SwiftPM build showed none.
 - `MeterBarCLI` (`swift build` in `MeterBarCLI/`): clean — the CLI consumes the
   library with the new isolation and the shared types are now explicitly
   `nonisolated` in every target that compiles them.
+
+---
+
+## Session 2: Session Wake hardening (ADR-010, cancellation test, isFinite guard, WakeLock lock)
+
+**Duration:** ~30 min
+**Status:** Complete
+
+**What was done (TDD-first):**
+- **ADR-010** ported into `.agents/SYSTEM/architecture/DECISIONS.md` (was ending at
+  ADR-009) from closed-candidate PR #106, updated for #112's continuous watcher:
+  app-running-only lifetime (no launchd/XPC helper), active-child cancellation
+  policy (cooperative-cancel / preserve candidate / never record to the replay
+  ledger), and rejected alternatives.
+- **Coordinator cancellation test** added to `WakeCoordinatorTests` —
+  `testActiveChildCancellationPreservesCandidateAndDoesNotRecord` (adapted to
+  master's `WakeExecuting`/`WakeRunOutcome.cancelled` API). A `CancellingRunner`
+  blocks until the structured task is cancelled, returns `.cancelled`; stopping
+  the watcher mid-child must settle to `.off` and must NOT write the block
+  fingerprint to the ledger, so re-discovery still sees the candidate executable
+  (retryable). Locks in the existing-but-untested `.cancelled → break` behavior.
+- **`WakeBounds.clamped(to:)` isFinite guard**: added a `FloatingPoint` overload
+  that maps NaN/±∞ to the range's lower (narrowest) bound so a non-finite
+  preference can never survive to trap in `UInt64(seconds * 1e9)`. New
+  `WakeBoundsTests` covers finite/NaN/∞ clamping and non-finite construction.
+- **`WakeLock` data-race fix** (from PR #116 CodeRabbit review, deferred): the
+  `@unchecked Sendable` class mutated `fileDescriptor` in
+  `acquire()`/`release()`/`deinit` without synchronization. Added an `NSLock`
+  (`stateLock`) guarding every read/write of the descriptor.
+
+**Verification:**
+- `swift test`: 463/463 pass (0 failures), new tests confirmed executing.
+- `swiftlint --strict`: clean (exit 0).

--- a/.agents/SYSTEM/architecture/DECISIONS.md
+++ b/.agents/SYSTEM/architecture/DECISIONS.md
@@ -284,4 +284,90 @@ Cache usage metrics in UserDefaults:
 
 ---
 
+### ADR-010: Session Wake watcher lifetime and active-child cancellation (v1)
+
+**Date:** 2026-07-10
+**Status:** Accepted
+**Issue:** #96 (cancellable watcher state machine); refined by #112 (single
+ON/OFF toggle wired to a live continuous watcher)
+
+#### Context
+
+Session Wake needs a long-lived component that waits for a quota reset and then
+resumes blocked Claude Code sessions. #96 requires an explicit, tested decision
+for the watcher's lifetime (app-running-only vs. a managed background helper)
+covering sleep/wake, app quit, crash, and relaunch — plus what happens to a
+child `claude` session that is mid-run when the user turns the watcher off.
+
+#### Decision
+
+**Lifetime: app-running-only. No managed helper (no launchd/XPC daemon) in v1.**
+
+Each watch *pass* is a single cancellable structured `Task` owned by the
+`WakeCoordinator` actor, driving scan → (wait | quota-unknown) → run → re-check.
+Since #112 the watcher is *continuous*: `SessionWakeController` runs a
+`WakeCoordinator` pass, and when a pass settles it re-scans after a fixed
+interval so the watcher keeps watching for the *next* limit hit rather than
+stopping after one resume. The whole thing is tied to the app process lifetime:
+
+- **Quit / crash:** the watch task dies with the app. Nothing resumes while
+  MeterBar is not running. This is intentional — a background daemon that
+  resumes agent sessions unattended is a larger security/permissions surface
+  than v1 accepts (permission bypass, private logging, and the mutual-exclusion
+  protocol are #97 concerns). The legacy launchd watcher stays paused; it is not
+  replaced by a new daemon here.
+- **Relaunch:** the coordinator starts in `.off`. Re-arming is driven by the
+  persisted single ON/OFF toggle (#98/#112 settings store): if the toggle was
+  left on, the controller reconciles and re-arms on launch. #95's replay ledger
+  guarantees a block already handled before the quit is not resumed again after
+  relaunch.
+- **Sleep / wake:** waits are driven in poll-interval-bounded chunks against a
+  wall-clock deadline, and **every** launch is gated on a *fresh* quota fetch.
+  A timer that is paused across system sleep therefore costs at most one extra
+  poll cycle; the watcher never launches on a stale timer — it re-proves quota
+  on wake.
+
+**Active-child cancellation: cooperative-cancel, preserve, never record.**
+
+When the watcher is turned off (toggle off, wake account removed, or app
+teardown) while a child session is running:
+
+- The structured task is cancelled; the runner (#97) receives cooperative
+  cancellation via its task-cancellation handler, terminates the child within a
+  bounded grace, and returns `WakeRunOutcome.cancelled`.
+- A `.cancelled` outcome is **not** recorded: only `.succeeded` writes the
+  candidate's block fingerprint to the replay ledger, so the interrupted block
+  stays retryable on a later armed run. The in-flight candidate has already been
+  removed from the local queue for the attempt, but because nothing was recorded
+  a subsequent re-scan rediscovers it.
+- `stop()` awaits the task's full unwind before reporting `.off`, so "watcher
+  off" is deterministic rather than best-effort.
+
+#### Consequences
+
+- **Easier:** no signing/entitlement surface for a helper; no daemon lifecycle
+  to manage; cancellation is deterministic and unit-testable with fakes.
+- **Easier:** fail-closed by construction — missing/stale/ambiguous quota and a
+  passed reset all launch nothing.
+- **More difficult:** no overnight resume when the Mac is fully asleep or the
+  app is quit. Documented as a v1 limitation; a managed helper is a possible
+  v2 follow-up.
+- **More difficult:** interrupting a child mid-turn may leave that session's
+  work partially done; it is retried from its last transcript state, not from a
+  checkpoint.
+
+#### Alternatives Considered
+
+- **launchd/XPC managed helper (rejected for v1):** enables resume while the app
+  is closed, but multiplies the signing, permission-bypass, and private-logging
+  surface the epic defers to later issues; the legacy launchd watcher is being
+  retired, not re-created.
+- **Let the active child finish on watcher-off (rejected):** makes "off" mean
+  "off after the current session," which is surprising for a kill switch and
+  leaves a subprocess running unbounded after the user opted out.
+- **Force-kill without preserving the candidate (rejected):** would either drop
+  the work or, if recorded as handled, silently skip it on the next run.
+
+---
+
 <!-- Add new ADRs above this line -->

--- a/.agents/SYSTEM/architecture/DECISIONS.md
+++ b/.agents/SYSTEM/architecture/DECISIONS.md
@@ -321,11 +321,11 @@ stopping after one resume. The whole thing is tied to the app process lifetime:
   left on, the controller reconciles and re-arms on launch. #95's replay ledger
   guarantees a block already handled before the quit is not resumed again after
   relaunch.
-- **Sleep / wake:** waits are driven in poll-interval-bounded chunks against a
-  wall-clock deadline, and **every** launch is gated on a *fresh* quota fetch.
-  A timer that is paused across system sleep therefore costs at most one extra
-  poll cycle; the watcher never launches on a stale timer — it re-proves quota
-  on wake.
+- **Sleep / wake:** a known reset waits in a single bounded sleep until that
+  instant (an unknown reset polls in interval-sized steps), and **every**
+  launch is gated on a *fresh* quota fetch. A sleep that overshoots after the
+  machine wakes therefore costs only latency, never correctness; the watcher
+  never launches on a stale timer — it re-proves quota on wake.
 
 **Active-child cancellation: cooperative-cancel, preserve, never record.**
 
@@ -340,8 +340,10 @@ teardown) while a child session is running:
   stays retryable on a later armed run. The in-flight candidate has already been
   removed from the local queue for the attempt, but because nothing was recorded
   a subsequent re-scan rediscovers it.
-- `stop()` awaits the task's full unwind before reporting `.off`, so "watcher
-  off" is deterministic rather than best-effort.
+- `stop()` requests cancellation and returns; the run loop — not `stop()` —
+  owns the final transition, and the coordinator only enters `.off` after the
+  task fully unwinds (observable via `waitUntilFinished()`), so "watcher off"
+  is deterministic rather than best-effort.
 
 #### Consequences
 

--- a/MeterBar/SessionWake/WakeBounds.swift
+++ b/MeterBar/SessionWake/WakeBounds.swift
@@ -67,3 +67,14 @@ nonisolated extension Comparable {
         min(max(self, range.lowerBound), range.upperBound)
     }
 }
+
+nonisolated extension FloatingPoint {
+    /// Clamp a floating-point value into a closed range, failing safe on a
+    /// non-finite input: NaN and ±∞ map to the range's lower (narrowest) bound
+    /// rather than passing through, so an invalid preference can never survive
+    /// as NaN/∞ and trap later in e.g. `UInt64(seconds * 1e9)`.
+    func clamped(to range: ClosedRange<Self>) -> Self {
+        guard isFinite else { return range.lowerBound }
+        return Swift.min(Swift.max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/MeterBar/SessionWake/WakeLock.swift
+++ b/MeterBar/SessionWake/WakeLock.swift
@@ -53,14 +53,23 @@ nonisolated final class WakeLock: @unchecked Sendable {
             return .contended
         }
 
-        let descriptor = open(lockURL.path, O_CREAT | O_RDWR, 0o600)
-        guard descriptor >= 0 else { return .contended }
-        if flock(descriptor, LOCK_EX | LOCK_NB) != 0 {
-            close(descriptor)
-            return .contended
+        // The whole open/flock/store sequence runs under `stateLock` so a
+        // concurrent `release()` can't slip between a successful `flock` and
+        // the descriptor store (which would leak the held lock), and a second
+        // `acquire()` can't overwrite an already-held descriptor. `LOCK_NB`
+        // keeps the critical section non-blocking.
+        let acquired: Bool = stateLock.withLock {
+            guard fileDescriptor < 0 else { return true }
+            let descriptor = open(lockURL.path, O_CREAT | O_RDWR, 0o600)
+            guard descriptor >= 0 else { return false }
+            if flock(descriptor, LOCK_EX | LOCK_NB) != 0 {
+                close(descriptor)
+                return false
+            }
+            fileDescriptor = descriptor
+            return true
         }
-        stateLock.withLock { fileDescriptor = descriptor }
-        return .acquired
+        return acquired ? .acquired : .contended
     }
 
     /// Release the lock and remove the descriptor. Safe to call repeatedly.

--- a/MeterBar/SessionWake/WakeLock.swift
+++ b/MeterBar/SessionWake/WakeLock.swift
@@ -20,6 +20,10 @@ nonisolated final class WakeLock: @unchecked Sendable {
 
     private let lockURL: URL
     private let legacyLockURLs: [URL]
+    /// Guards `fileDescriptor`: the class is `@unchecked Sendable` and its
+    /// descriptor may be touched from `acquire()`, `release()`, and `deinit` on
+    /// different threads, so every read/write of it goes through this lock.
+    private let stateLock = NSLock()
     private var fileDescriptor: Int32 = -1
 
     init(lockURL: URL? = nil, legacyLockURLs: [URL]? = nil) {
@@ -55,16 +59,18 @@ nonisolated final class WakeLock: @unchecked Sendable {
             close(descriptor)
             return .contended
         }
-        fileDescriptor = descriptor
+        stateLock.withLock { fileDescriptor = descriptor }
         return .acquired
     }
 
     /// Release the lock and remove the descriptor. Safe to call repeatedly.
     func release() {
-        guard fileDescriptor >= 0 else { return }
-        flock(fileDescriptor, LOCK_UN)
-        close(fileDescriptor)
-        fileDescriptor = -1
+        stateLock.withLock {
+            guard fileDescriptor >= 0 else { return }
+            flock(fileDescriptor, LOCK_UN)
+            close(fileDescriptor)
+            fileDescriptor = -1
+        }
     }
 
     /// Whether any known legacy lock file is currently `flock`-held by another

--- a/MeterBarTests/WakeBoundsTests.swift
+++ b/MeterBarTests/WakeBoundsTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import MeterBar
+
+/// Coverage for `WakeBounds` clamping — in particular that a non-finite
+/// preference (NaN or ±∞) can never survive construction and later trap in
+/// `UInt64(seconds * 1e9)` when a wait is scheduled.
+final class WakeBoundsTests: XCTestCase {
+    // MARK: - clamped(to:) numeric guard
+
+    func testClampedKeepsFiniteValueInsideRange() {
+        XCTAssertEqual((5.0).clamped(to: 0...10), 5.0)
+        XCTAssertEqual((-3.0).clamped(to: 0...10), 0.0)
+        XCTAssertEqual((42.0).clamped(to: 0...10), 10.0)
+        XCTAssertEqual(7.clamped(to: 1...5), 5)
+    }
+
+    func testClampedMapsNaNToLowerBound() {
+        let clamped = Double.nan.clamped(to: 15...900)
+        XCTAssertTrue(clamped.isFinite, "NaN must not survive clamping")
+        XCTAssertEqual(clamped, 15)
+    }
+
+    func testClampedMapsInfinitiesToFiniteBounds() {
+        XCTAssertEqual(Double.infinity.clamped(to: 15...900), 15)
+        XCTAssertEqual((-Double.infinity).clamped(to: 15...900), 15)
+    }
+
+    // MARK: - Construction is fail-safe against non-finite input
+
+    func testInitClampsNonFinitePreferencesToFiniteBounds() {
+        let bounds = WakeBounds(
+            pollInterval: .nan,
+            bufferAfterReset: .infinity,
+            gapBetweenSessions: -.infinity,
+            perSessionTimeout: .nan,
+            maxTurns: 40,
+            maxSessionsPerRun: 5,
+            maxUnknownPolls: 30
+        )
+        // Non-finite input fails safe to the narrowest (lower) bound, never
+        // survives as NaN/∞ to trap later in `UInt64(seconds * 1e9)`.
+        XCTAssertTrue(bounds.pollInterval.isFinite)
+        XCTAssertTrue(bounds.bufferAfterReset.isFinite)
+        XCTAssertTrue(bounds.gapBetweenSessions.isFinite)
+        XCTAssertTrue(bounds.perSessionTimeout.isFinite)
+        XCTAssertEqual(bounds.pollInterval, WakeBounds.pollIntervalRange.lowerBound)
+        XCTAssertEqual(bounds.bufferAfterReset, WakeBounds.bufferRange.lowerBound)
+        XCTAssertEqual(bounds.gapBetweenSessions, WakeBounds.gapRange.lowerBound)
+        XCTAssertEqual(bounds.perSessionTimeout, WakeBounds.timeoutRange.lowerBound)
+    }
+}

--- a/MeterBarTests/WakeCoordinatorTests.swift
+++ b/MeterBarTests/WakeCoordinatorTests.swift
@@ -188,6 +188,44 @@ final class WakeCoordinatorTests: XCTestCase {
         XCTAssertTrue(ran.isEmpty, "No session should launch while blocked")
     }
 
+    func testActiveChildCancellationPreservesCandidateAndDoesNotRecord() async throws {
+        try writeBlockedSessions(1)
+        let runner = CancellingRunner()
+        let provider = SequencedProvider(repeating: .open)
+        // Real sleep so cancellation must actually unwind the running child.
+        let coordinator = makeCoordinator(
+            provider: provider,
+            runner: runner,
+            sleep: { seconds in try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000)) }
+        )
+
+        await coordinator.start(account: account())
+
+        // Wait until the child is actually running before we stop the watcher.
+        var running = false
+        for _ in 0..<200 {
+            if case .running = await coordinator.state { running = true; break }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        XCTAssertTrue(running, "A session should be running before we cancel")
+
+        await coordinator.stop()
+        await coordinator.waitUntilFinished()
+
+        let ran = await runner.ran
+        XCTAssertEqual(ran, ["s0"], "The candidate should have been attempted exactly once")
+        let finalState = await coordinator.state
+        XCTAssertEqual(finalState, .off, "Cancelling mid-child settles the watcher to off")
+
+        // The interrupted block must NOT be recorded, so a later run rediscovers
+        // it as an executable candidate rather than skipping it as handled.
+        let ledger = ReplayLedger(fileURL: ledgerURL)
+        let candidates = await SessionDiscovery().discover(configDirectory: accountDir.path, ledger: ledger)
+        XCTAssertEqual(candidates.first?.sessionID, "s0")
+        XCTAssertNil(candidates.first?.skipReason, "Interrupted candidate must stay retryable")
+        XCTAssertTrue(candidates.first?.isExecutable ?? false)
+    }
+
     func testSuccessfulResumeIsRecordedInLedger() async throws {
         try writeBlockedSessions(1)
         let runner = RecordingRunner(outcome: .succeeded)
@@ -213,6 +251,20 @@ private actor RecordingRunner: WakeExecuting {
     func run(_ candidate: WakeSessionCandidate, bounds: WakeBounds) async -> WakeRunOutcome {
         ran.append(candidate.sessionID)
         return outcome
+    }
+}
+
+/// Blocks inside `run` until the surrounding structured task is cancelled, then
+/// reports `.cancelled` — mirroring a real child that honors cooperative
+/// cancellation when the watcher is stopped mid-run.
+private actor CancellingRunner: WakeExecuting {
+    private(set) var ran: [String] = []
+    func run(_ candidate: WakeSessionCandidate, bounds: WakeBounds) async -> WakeRunOutcome {
+        ran.append(candidate.sessionID)
+        while !Task.isCancelled {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        return .cancelled
     }
 }
 

--- a/MeterBarTests/WakeRunnerTests.swift
+++ b/MeterBarTests/WakeRunnerTests.swift
@@ -161,6 +161,19 @@ final class WakeRunnerTests: XCTestCase {
         second.release()
     }
 
+    func testReacquireWhileHeldIsIdempotent() {
+        let url = tempDir.appendingPathComponent("reacquire.lock")
+        let lock = WakeLock(lockURL: url, legacyLockURLs: [])
+        XCTAssertEqual(lock.acquire(), .acquired)
+        // A second acquire must not open a new descriptor over the held one.
+        XCTAssertEqual(lock.acquire(), .acquired)
+        lock.release()
+        // One release fully releases: another holder can take the lock.
+        let other = WakeLock(lockURL: url, legacyLockURLs: [])
+        XCTAssertEqual(other.acquire(), .acquired)
+        other.release()
+    }
+
     func testLegacyWatcherContentionIsReported() {
         let legacy = tempDir.appendingPathComponent("legacy.lock")
         FileManager.default.createFile(atPath: legacy.path, contents: nil)


### PR DESCRIPTION
Three small TDD-first hardening items for Session Wake, salvaged from closed-candidate PRs.

## 1. ADR-010 ported into `DECISIONS.md`
Ports ADR-010 (was ending at ADR-009) from closed-candidate PR #106 (branch `claude/busy-gauss-143645`), updated lightly for #112's continuous watcher. Documents:
- **Lifetime:** app-running-only — no launchd/XPC helper in v1 (each pass is a cancellable structured `Task` in `WakeCoordinator`; `SessionWakeController` runs passes continuously, re-arming on launch if the toggle was left on).
- **Active-child cancellation:** cooperative-cancel / preserve candidate / never record to the replay ledger, so an interrupted block stays retryable.
- Rejected alternatives (managed helper, let-child-finish, force-kill-without-preserve).

## 2. Coordinator cancellation test + `isFinite` guard
- **`testActiveChildCancellationPreservesCandidateAndDoesNotRecord`** (adapted from PR #106 to master's `WakeExecuting`/`WakeRunOutcome.cancelled` API): a `CancellingRunner` blocks until the structured task is cancelled and returns `.cancelled`; stopping the watcher mid-child must settle to `.off` and must **not** write the block fingerprint to the ledger — verified by re-discovering the candidate as still executable. Locks in master's existing-but-untested `.cancelled → break` behavior.
- **`WakeBounds.clamped(to:)`**: added a `FloatingPoint` overload that maps NaN/±∞ to the range's lower (narrowest) bound, so a non-finite preference can never survive to trap in `UInt64(seconds * 1e9)`. Covered by new `WakeBoundsTests`.

## 3. `WakeLock` data race (PR #116 CodeRabbit review, deferred to unblock merge)
`WakeLock` is `nonisolated @unchecked Sendable` but mutated `fileDescriptor` in `acquire()`/`release()`/`deinit` without synchronization. Now guarded by an `NSLock` (`stateLock`) around every read/write of the descriptor.

## Verification
- `swift test`: **463/463 pass** (0 failures); new tests confirmed executing.
- `swiftlint --strict`: clean (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session Wake now follows documented app-lifetime behavior and refreshes quotas after sleep or wake.
  * Stopping Session Wake during an active session safely cancels the session while keeping it available for retry.

* **Bug Fixes**
  * Invalid wake timing values are safely normalized to valid limits.
  * Improved wake-lock reliability when operations occur concurrently.

* **Documentation**
  * Added architecture guidance describing Session Wake behavior and cancellation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->