### PR TITLE
fix(session-wake): month/day resets, UTF-8 tail decode, sidechain classification

### DIFF
--- a/.agents/SESSIONS/2026-07-11.md
+++ b/.agents/SESSIONS/2026-07-11.md
@@ -111,3 +111,59 @@ warnings for the same mismatches; the SwiftPM build showed none.
 - `MeterBarCLI` (`swift build` in `MeterBarCLI/`): clean — the CLI consumes the
   library with the new isolation and the shared types are now explicitly
   `nonisolated` in every target that compiles them.
+
+---
+
+## Session Wake: port discovery/parser fixes from closed PR #102
+
+Salvaged three correctness fixes from the superseded PR #102
+(`claude/nostalgic-mcnulty-90f66b`, old `MeterBar/Services/SessionWake/*` layout)
+into master's current `MeterBar/SessionWake/*` value layer. PR #102 used a wholly
+different architecture (`ClaudeTranscriptTailClassifier`, `SessionWakeDiscovery`,
+`SessionWakeModels`, `SessionWakeReplayLedger`), so the fixes were re-implemented
+against master's types (`TranscriptResetParser`, `SessionDiscovery`,
+`TranscriptClassifier`), TDD-first (tests written and confirmed red before code).
+
+### Fixes
+1. **`TranscriptResetParser` — explicit month/day(/year) resets.** The old regex
+   required a digit right after "resets", so weekly-limit text like
+   `resets Jul 15 at 10pm (Europe/Malta)` returned `nil`. Added a named-group
+   regex with an optional `<month><day>(,<year>)? at ` prefix. Month/day resolve
+   to the stated calendar date; an inferred (non-stated) year rolls forward a
+   whole year when it lands before the block event (December → January window).
+   Bare clock times keep master's existing nearest-occurrence semantics (#96).
+   Refactored into `explicitDate` / `nearestOccurrence` helpers to stay under the
+   cyclomatic-complexity/nesting limits.
+2. **`SessionDiscovery.readTail` — lossy UTF-8 decode.** A bounded tail read can
+   begin mid-multibyte-character; the failable `String(data:encoding:.utf8)`
+   returned `nil` and dropped the *entire* transcript (including its decisive
+   block event). Switched to `String(decoding:as: UTF8.self)` — the split leading
+   bytes become U+FFFD on a partial line that JSON-decode skips. Needed a
+   `// swiftlint:disable:next optional_data_string_conversion` (the default rule
+   prefers exactly the nil-dropping initializer being removed).
+3. **`TranscriptClassifier` — sidechain handling.** Previously *any* sidechain
+   line both marked the whole transcript `isSidechain` and still fed the mainline
+   decisive-state machine — so a blocked mainline session that had merely spawned
+   a subagent was a false-negative exclusion, and a sidechain block could
+   mis-classify the mainline. Now sidechain event lines are counted but skipped
+   for classification and metadata, and a transcript is flagged subagent only
+   when *every* event line is sidechain.
+
+Also ported two low-risk extras from the same PR: deterministic dedupe tie-break
+(equal block instants → lexicographically first transcript path, independent of
+enumeration order) and a zero-filesystem-mutation regression test proving
+discovery is a pure preview. Deferred (not ported): legacy pipe-epoch reset
+extraction, 14-day/400-file enumeration bounds, and ReplayLedger 500-entry
+pruning (the last needs a storage-format change to master's `[String]` ledger).
+
+### Verification
+- `swift test`: **466/466 pass** (was 445; +21 net incl. new SessionWake cases).
+- `swiftlint --strict`: 0 violations across 86 files.
+- New/updated tests in `SessionWakeDiscoveryTests.swift`: `testMonthDayResetForm`,
+  `testMonthDayResetRollsToNextYearWhenBeforeEvent`,
+  `testWeeklyMonthDayMessageClassifiesBlockedWithReset`,
+  `testTailReadSplittingMultibyteCharStillDiscoversBlock`,
+  `testSidechainLinesAreIgnoredForClassification`,
+  `testAllSidechainTranscriptIsFlaggedSubagent`,
+  `testDuplicateSessionTieBreaksOnLexicographicallyFirstPath`,
+  `testDiscoveryPerformsZeroFilesystemMutations` (+ `snapshot(of:)` helper).

--- a/MeterBar/SessionWake/SessionDiscovery.swift
+++ b/MeterBar/SessionWake/SessionDiscovery.swift
@@ -85,13 +85,28 @@ actor SessionDiscovery {
                 skipReason: skip
             )
 
-            if let existing = bySession[summary.sessionID], existing.blockedAt >= blockedAt {
+            if let existing = bySession[summary.sessionID], !supersedes(candidate, existing) {
                 continue
             }
             bySession[summary.sessionID] = candidate
         }
 
-        return bySession.values.sorted { $0.blockedAt > $1.blockedAt }
+        return bySession.values.sorted { lhs, rhs in
+            if lhs.blockedAt != rhs.blockedAt {
+                return lhs.blockedAt > rhs.blockedAt
+            }
+            return lhs.transcriptPath < rhs.transcriptPath
+        }
+    }
+
+    /// Deterministic dedupe: the latest block wins; equal block instants
+    /// tie-break on the lexicographically first transcript path so the winner
+    /// never depends on filesystem enumeration order.
+    private func supersedes(_ candidate: WakeSessionCandidate, _ existing: WakeSessionCandidate) -> Bool {
+        if candidate.blockedAt != existing.blockedAt {
+            return candidate.blockedAt > existing.blockedAt
+        }
+        return candidate.transcriptPath < existing.transcriptPath
     }
 
     // MARK: - Filesystem
@@ -123,7 +138,15 @@ actor SessionDiscovery {
             : 0
         try? handle.seek(toOffset: start)
         let data = (try? handle.readToEnd()) ?? Data()
-        guard let string = String(data: data, encoding: .utf8) else { return [] }
+        // A bounded tail read can begin mid-multibyte-character. A failable
+        // String(data:encoding:) would reject the whole buffer and silently
+        // drop the transcript's decisive event; lossy decoding turns only the
+        // split leading bytes into U+FFFD (that partial line is skipped as
+        // malformed JSON) and keeps every complete line intact. The lint rule
+        // prefers the failable initializer — exactly the nil-dropping behavior
+        // this fix removes — so it is disabled here deliberately.
+        // swiftlint:disable:next optional_data_string_conversion
+        let string = String(decoding: data, as: UTF8.self)
         return string.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
     }
 

--- a/MeterBar/SessionWake/SessionDiscovery.swift
+++ b/MeterBar/SessionWake/SessionDiscovery.swift
@@ -91,12 +91,9 @@ actor SessionDiscovery {
             bySession[summary.sessionID] = candidate
         }
 
-        return bySession.values.sorted { lhs, rhs in
-            if lhs.blockedAt != rhs.blockedAt {
-                return lhs.blockedAt > rhs.blockedAt
-            }
-            return lhs.transcriptPath < rhs.transcriptPath
-        }
+        // `supersedes` is a strict total order over (blockedAt desc, path asc);
+        // reusing it keeps the dedupe winner and the output order one rule.
+        return bySession.values.sorted(by: supersedes)
     }
 
     /// Deterministic dedupe: the latest block wins; equal block instants

--- a/MeterBar/SessionWake/TranscriptClassifier.swift
+++ b/MeterBar/SessionWake/TranscriptClassifier.swift
@@ -86,7 +86,8 @@ nonisolated enum TranscriptClassifier {
         var resolvedSessionID: String?
         var cwd: String?
         var gitBranch: String?
-        var sawSidechain = false
+        var eventCount = 0
+        var sidechainEventCount = 0
 
         var lastDecisiveState: TranscriptState = .indeterminate
 
@@ -100,10 +101,20 @@ nonisolated enum TranscriptClassifier {
                 continue
             }
 
+            let isEvent = isEventRecord(record)
+            if isEvent { eventCount += 1 }
+
+            // A subagent (sidechain) line describes a child agent, not this
+            // session: it never sets the mainline terminal state and never
+            // contributes this session's metadata.
+            if record.isSidechain {
+                if isEvent { sidechainEventCount += 1 }
+                continue
+            }
+
             resolvedSessionID = resolvedSessionID ?? record.sessionID
             if let recordCwd = record.cwd, !recordCwd.isEmpty { cwd = recordCwd }
             if let branch = record.gitBranch, !branch.isEmpty { gitBranch = branch }
-            if record.isSidechain { sawSidechain = true }
 
             guard let timestamp = record.timestamp else { continue }
 
@@ -119,13 +130,28 @@ nonisolated enum TranscriptClassifier {
             }
         }
 
+        // A transcript is a subagent transcript only when *every* event line is
+        // sidechain. A mainline session that merely spawned subagents keeps its
+        // own terminal state and stays discoverable.
+        let isSubagent = eventCount > 0 && sidechainEventCount == eventCount
         return TranscriptSummary(
             sessionID: resolvedSessionID ?? fallbackID,
             cwd: cwd,
             gitBranch: gitBranch,
-            isSidechain: sawSidechain,
-            state: lastDecisiveState
+            isSidechain: isSubagent,
+            state: isSubagent ? .indeterminate : lastDecisiveState
         )
+    }
+
+    /// Lines that carry conversational activity — the population the
+    /// all-sidechain test is measured against.
+    private static func isEventRecord(_ record: Record) -> Bool {
+        switch record.type {
+        case "assistant", "user", "tool_result":
+            return true
+        default:
+            return false
+        }
     }
 
     /// A 429/limit assistant error is the only kind of blocking event.

--- a/MeterBar/SessionWake/TranscriptClassifier.swift
+++ b/MeterBar/SessionWake/TranscriptClassifier.swift
@@ -20,7 +20,9 @@ nonisolated struct TranscriptSummary: Equatable, Sendable {
     let sessionID: String
     let cwd: String?
     let gitBranch: String?
-    /// True when any decisive entry was a subagent/sidechain entry.
+    /// True when every event line is a subagent/sidechain entry — the whole
+    /// transcript belongs to a subagent run (individual sidechain lines are
+    /// skipped for classification, not disqualifying).
     let isSidechain: Bool
     let state: TranscriptState
 }

--- a/MeterBar/SessionWake/TranscriptResetParser.swift
+++ b/MeterBar/SessionWake/TranscriptResetParser.swift
@@ -25,15 +25,24 @@ nonisolated enum TranscriptResetParser {
         }
     }
 
-    // "resets 7:30am (Europe/Malta)" / "resets 2:10am" / "resets **2:10am ...**"
+    // Two accepted shapes, both anchored to the event:
+    //   Time-of-day: "resets 7:30am (Europe/Malta)" / "resets 2:10am" /
+    //                "resets **2:10am ...**" / "resets 19:00"
+    //   Explicit date (weekly limits): "resets Jul 15 at 10pm (Europe/Malta)" /
+    //                "resets Jan 2, 2027 at 9am"
     private static let pattern = try? NSRegularExpression(
-        pattern: #"resets\s*\**\s*(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*\**\s*(?:\(([^)]+)\))?"#,
+        pattern: #"resets\s*\**\s*"# +
+            #"(?:(?<month>jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s+"# +
+            #"(?<day>\d{1,2})(?:,\s*(?<year>\d{4}))?\s+at\s+)?"# +
+            #"(?<hour>\d{1,2})(?::(?<minute>\d{2}))?\s*(?<ampm>am|pm)?\s*\**\s*"# +
+            #"(?:\((?<zone>[^)]+)\))?"#,
         options: [.caseInsensitive]
     )
 
-    /// Parse `messageText`, anchoring the clock time to `eventTimestamp`.
+    /// Parse `messageText`, anchoring the reset to `eventTimestamp`.
     ///
-    /// - Returns: the nearest absolute occurrence of the stated clock time, or
+    /// - Returns: the absolute reset instant — the nearest occurrence of a bare
+    ///   clock time, or the stated calendar date for an explicit month/day — or
     ///   nil when no reset hint is present.
     static func parse(messageText: String, eventTimestamp: Date) -> Result? {
         guard let pattern else { return nil }
@@ -42,20 +51,20 @@ nonisolated enum TranscriptResetParser {
             return nil
         }
 
-        func group(_ index: Int) -> String? {
-            guard match.numberOfRanges > index,
-                  let r = Range(match.range(at: index), in: messageText) else {
+        func group(_ name: String) -> String? {
+            let r = match.range(withName: name)
+            guard r.location != NSNotFound, let swiftRange = Range(r, in: messageText) else {
                 return nil
             }
-            return String(messageText[r])
+            return String(messageText[swiftRange])
         }
 
-        guard let hourString = group(1), let rawHour = Int(hourString) else {
+        guard let hourString = group("hour"), let rawHour = Int(hourString) else {
             return nil
         }
-        let minute = group(2).flatMap(Int.init) ?? 0
-        let meridiem = group(3)?.lowercased()
-        let tzIdentifier = group(4)?.trimmingCharacters(in: .whitespaces)
+        let minute = group("minute").flatMap(Int.init) ?? 0
+        let meridiem = group("ampm")?.lowercased()
+        let tzIdentifier = group("zone")?.trimmingCharacters(in: .whitespaces)
 
         var hour = rawHour
         if let meridiem {
@@ -70,23 +79,76 @@ nonisolated enum TranscriptResetParser {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = timeZone
 
-        // Build the clock time on the event's calendar day, then pick whichever
-        // of {yesterday, today, tomorrow} lands closest to the event instant.
         var components = calendar.dateComponents([.year, .month, .day], from: eventTimestamp)
         components.hour = hour
         components.minute = minute
         components.second = 0
-        guard let sameDay = calendar.date(from: components) else { return nil }
 
+        // A weekly limit names a calendar date; a session limit names only a
+        // clock time. They resolve differently, so dispatch on the month group.
+        let resetAt: Date?
+        if let month = group("month").flatMap(Self.monthNumber(fromAbbreviation:)) {
+            resetAt = explicitDate(
+                month: month,
+                day: group("day").flatMap(Int.init),
+                explicitYear: group("year").flatMap(Int.init),
+                base: components,
+                calendar: calendar,
+                eventTimestamp: eventTimestamp
+            )
+        } else {
+            resetAt = nearestOccurrence(of: components, calendar: calendar, eventTimestamp: eventTimestamp)
+        }
+
+        guard let resetAt else { return nil }
+        return Result(resetAt: resetAt, timeZoneIdentifier: tzIdentifier)
+    }
+
+    /// Resolve an explicit month/day(/year) reset. With no stated year the date
+    /// is anchored to the event's year and rolled forward a *whole year* when it
+    /// lands before the event — a December block whose reset reads "Jan 2" is
+    /// next January, never this year's elapsed one.
+    private static func explicitDate(
+        month: Int,
+        day: Int?,
+        explicitYear: Int?,
+        base: DateComponents,
+        calendar: Calendar,
+        eventTimestamp: Date
+    ) -> Date? {
+        var components = base
+        components.month = month
+        if let day { components.day = day }
+        if let explicitYear { components.year = explicitYear }
+        guard let resolved = calendar.date(from: components) else { return nil }
+        // A stated year is authoritative; only an inferred year rolls forward.
+        guard explicitYear == nil, resolved < eventTimestamp else { return resolved }
+        return calendar.date(byAdding: .year, value: 1, to: resolved)
+    }
+
+    /// Resolve a bare clock time to whichever of {yesterday, today, tomorrow}
+    /// lands closest to the event instant. Choosing the nearest occurrence —
+    /// rather than always rolling forward — keeps a "02:10 reset read at 02:15"
+    /// from being mistaken for tomorrow (#96).
+    private static func nearestOccurrence(
+        of components: DateComponents,
+        calendar: Calendar,
+        eventTimestamp: Date
+    ) -> Date? {
+        guard let sameDay = calendar.date(from: components) else { return nil }
         let candidates = [-1, 0, 1].compactMap {
             calendar.date(byAdding: .day, value: $0, to: sameDay)
         }
-        guard let nearest = candidates.min(by: {
+        return candidates.min(by: {
             abs($0.timeIntervalSince(eventTimestamp)) < abs($1.timeIntervalSince(eventTimestamp))
-        }) else {
+        })
+    }
+
+    private static func monthNumber(fromAbbreviation value: String) -> Int? {
+        let months = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"]
+        guard let index = months.firstIndex(of: String(value.lowercased().prefix(3))) else {
             return nil
         }
-
-        return Result(resetAt: nearest, timeZoneIdentifier: tzIdentifier)
+        return index + 1
     }
 }

--- a/MeterBar/SessionWake/TranscriptResetParser.swift
+++ b/MeterBar/SessionWake/TranscriptResetParser.swift
@@ -106,8 +106,8 @@ nonisolated enum TranscriptResetParser {
 
     /// Resolve an explicit month/day(/year) reset. With no stated year the date
     /// is anchored to the event's year and rolled forward a *whole year* when it
-    /// lands before the event — a December block whose reset reads "Jan 2" is
-    /// next January, never this year's elapsed one.
+    /// lands well before the event — a December block whose reset reads "Jan 2"
+    /// is next January, never this year's elapsed one.
     private static func explicitDate(
         month: Int,
         day: Int?,
@@ -118,13 +118,27 @@ nonisolated enum TranscriptResetParser {
     ) -> Date? {
         var components = base
         components.month = month
-        if let day { components.day = day }
+        if let day {
+            // Calendar.date(from:) silently normalizes overflow ("Jul 32" →
+            // Aug 1); reject impossible days like the hour/minute guards do.
+            guard (1...31).contains(day) else { return nil }
+            components.day = day
+        }
         if let explicitYear { components.year = explicitYear }
         guard let resolved = calendar.date(from: components) else { return nil }
-        // A stated year is authoritative; only an inferred year rolls forward.
-        guard explicitYear == nil, resolved < eventTimestamp else { return resolved }
+        // A stated year is authoritative; only an inferred year rolls forward,
+        // and only when the shortfall exceeds what display rounding or a
+        // timezone-fallback skew could explain. Within the tolerance the past
+        // instant is returned as-is — the contract treats an elapsed reset as
+        // "re-check now", which is safe; a +1-year instant is not.
+        guard explicitYear == nil,
+              resolved < eventTimestamp - rolloverSkewTolerance else { return resolved }
         return calendar.date(byAdding: .year, value: 1, to: resolved)
     }
+
+    /// How far in the past an inferred-year month/day reset may land before we
+    /// assume it means *next* year rather than clock/display skew (2 days).
+    private static let rolloverSkewTolerance: TimeInterval = 2 * 86_400
 
     /// Resolve a bare clock time to whichever of {yesterday, today, tomorrow}
     /// lands closest to the event instant. Choosing the nearest occurrence —

--- a/MeterBarTests/SessionWakeDiscoveryTests.swift
+++ b/MeterBarTests/SessionWakeDiscoveryTests.swift
@@ -333,4 +333,162 @@ final class SessionWakeDiscoveryTests: XCTestCase {
         let contained = await ledger.contains(fingerprint)
         XCTAssertFalse(contained)
     }
+
+    // MARK: - Reset parser: explicit month/day (weekly limits)
+
+    func testMonthDayResetForm() throws {
+        // Weekly limits state a calendar date, not just a clock time.
+        let event = ISO8601DateFormatter().date(from: "2026-07-10T04:14:15Z")!
+        let result = try XCTUnwrap(TranscriptResetParser.parse(
+            messageText: "You've hit your weekly limit · resets Jul 15 at 10pm (Europe/Malta)",
+            eventTimestamp: event
+        ))
+        // 10pm Malta (UTC+2 in July) on Jul 15 == 20:00Z.
+        XCTAssertEqual(result.resetAt, ISO8601DateFormatter().date(from: "2026-07-15T20:00:00Z"))
+        XCTAssertEqual(result.timeZoneIdentifier, "Europe/Malta")
+    }
+
+    func testMonthDayResetRollsToNextYearWhenBeforeEvent() throws {
+        // A December block whose reset reads "Jan 2" is next January, not this
+        // year's already-elapsed January (December → January window).
+        let event = ISO8601DateFormatter().date(from: "2026-12-30T12:00:00Z")!
+        let result = try XCTUnwrap(TranscriptResetParser.parse(
+            messageText: "You've hit your weekly limit · resets Jan 2 at 9am (UTC)",
+            eventTimestamp: event
+        ))
+        XCTAssertEqual(result.resetAt, ISO8601DateFormatter().date(from: "2027-01-02T09:00:00Z"))
+    }
+
+    func testWeeklyMonthDayMessageClassifiesBlockedWithReset() throws {
+        let cwd = tempDir.path
+        let lines = [
+            rateLimit(
+                "You've hit your weekly limit · resets Jul 15 at 10pm (Europe/Malta)",
+                timestamp: "2026-07-10T04:00:00.000Z",
+                cwd: cwd
+            )
+        ]
+        let summary = TranscriptClassifier.classify(sessionID: "s", lines: lines)
+        guard case let .blocked(reason, _, resetHint) = summary.state else {
+            return XCTFail("Expected blocked, got \(summary.state)")
+        }
+        XCTAssertEqual(reason, .weeklyLimit)
+        XCTAssertEqual(resetHint?.resetAt, ISO8601DateFormatter().date(from: "2026-07-15T20:00:00Z"))
+    }
+
+    // MARK: - Tail read: multi-byte UTF-8 boundary
+
+    func testTailReadSplittingMultibyteCharStillDiscoversBlock() async throws {
+        let cwd = tempDir.path
+        let block = rateLimit(
+            "session limit resets 2:10am (UTC)",
+            timestamp: "2026-07-10T02:00:00.000Z",
+            cwd: cwd
+        )
+        // Prefix ends with a 2-byte character ("é") and the tail window is sized
+        // so the read begins on its continuation byte. A failable
+        // String(data:encoding:) would reject the whole buffer and drop the
+        // transcript's decisive event; lossy decoding must keep the block line.
+        let content = "Xé\n" + block
+        let dir = tempDir
+            .appendingPathComponent("acct")
+            .appendingPathComponent("projects")
+            .appendingPathComponent("-Users-me-proj")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try content.write(to: dir.appendingPathComponent("session-a.jsonl"), atomically: true, encoding: .utf8)
+
+        let discovery = SessionDiscovery(
+            configuration: .init(maxTailBytes: block.utf8.count + 2)
+        )
+        let ledger = ReplayLedger(fileURL: tempDir.appendingPathComponent("ledger.json"))
+        let candidates = await discovery.discover(configDirectory: accountConfigDir(), ledger: ledger)
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertEqual(candidates.first?.reason, .sessionLimit)
+    }
+
+    // MARK: - Classifier: sidechain lines only exclude all-subagent transcripts
+
+    func testSidechainLinesAreIgnoredForClassification() {
+        // A mainline session that finished after spawning a subagent (whose
+        // transcript tail is a sidechain block) is active, not a subagent.
+        let cwd = tempDir.path
+        let lines = [
+            assistantText("Resumed and finished the task.", timestamp: "2026-07-10T03:00:00.000Z", cwd: cwd),
+            rateLimit("session limit resets 2:10am (UTC)", timestamp: "2026-07-10T04:00:00.000Z", cwd: cwd, sidechain: true)
+        ]
+        let summary = TranscriptClassifier.classify(sessionID: "s", lines: lines)
+        XCTAssertFalse(summary.isSidechain, "a mainline session with subagent lines is not a subagent transcript")
+        if case .active = summary.state {} else {
+            XCTFail("A sidechain block must not classify the mainline session, got \(summary.state)")
+        }
+    }
+
+    func testAllSidechainTranscriptIsFlaggedSubagent() {
+        let cwd = tempDir.path
+        let lines = [
+            assistantText("subagent working", timestamp: "2026-07-10T03:00:00.000Z", cwd: cwd, sidechain: true),
+            rateLimit("session limit resets 2:10am (UTC)", timestamp: "2026-07-10T04:00:00.000Z", cwd: cwd, sidechain: true)
+        ]
+        let summary = TranscriptClassifier.classify(sessionID: "s", lines: lines)
+        XCTAssertTrue(summary.isSidechain)
+        if case .indeterminate = summary.state {} else {
+            XCTFail("An all-sidechain transcript has no mainline terminal state, got \(summary.state)")
+        }
+    }
+
+    // MARK: - Deterministic dedupe & read-only preview
+
+    func testDuplicateSessionTieBreaksOnLexicographicallyFirstPath() async throws {
+        let cwd = tempDir.path
+        // Same session and same block instant across two project directories:
+        // the winner must be deterministic regardless of enumeration order.
+        try writeTranscript(project: "-proj-b", lines: [
+            rateLimit("session limit resets 2:10am (UTC)", timestamp: "2026-07-10T02:00:00.000Z", cwd: cwd)
+        ])
+        try writeTranscript(project: "-proj-a", lines: [
+            rateLimit("session limit resets 2:10am (UTC)", timestamp: "2026-07-10T02:00:00.000Z", cwd: cwd)
+        ])
+        let discovery = SessionDiscovery()
+        let ledger = ReplayLedger(fileURL: tempDir.appendingPathComponent("ledger.json"))
+        let candidates = await discovery.discover(configDirectory: accountConfigDir(), ledger: ledger)
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertTrue(
+            candidates.first?.transcriptPath.contains("-proj-a") == true,
+            "equal-timestamp duplicates must tie-break on the lexicographically first path"
+        )
+    }
+
+    func testDiscoveryPerformsZeroFilesystemMutations() async throws {
+        let cwd = tempDir.path
+        try writeTranscript(lines: [
+            rateLimit("session limit resets 2:10am (UTC)", timestamp: "2026-07-10T02:00:00.000Z", cwd: cwd)
+        ])
+        let ledgerURL = tempDir.appendingPathComponent("ledger.json")
+
+        let before = try snapshot(of: tempDir)
+        let discovery = SessionDiscovery()
+        _ = await discovery.discover(configDirectory: accountConfigDir(), ledger: ReplayLedger(fileURL: ledgerURL))
+        let after = try snapshot(of: tempDir)
+
+        XCTAssertEqual(before, after, "discovery is a preview and must not create, modify, or delete any file")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: ledgerURL.path),
+            "discovery must not write the replay ledger"
+        )
+    }
+
+    /// Recursive path → "size|modification-date" map used to prove read-only behavior.
+    private func snapshot(of root: URL) throws -> [String: String] {
+        var result: [String: String] = [:]
+        let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey]
+        )
+        while let url = enumerator?.nextObject() as? URL {
+            let values = try url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
+            let stamp = values.contentModificationDate.map { String($0.timeIntervalSinceReferenceDate) } ?? "-"
+            result[url.path] = "\(values.fileSize ?? -1)|\(stamp)"
+        }
+        return result
+    }
 }

--- a/MeterBarTests/SessionWakeDiscoveryTests.swift
+++ b/MeterBarTests/SessionWakeDiscoveryTests.swift
@@ -359,6 +359,38 @@ final class SessionWakeDiscoveryTests: XCTestCase {
         XCTAssertEqual(result.resetAt, ISO8601DateFormatter().date(from: "2027-01-02T09:00:00Z"))
     }
 
+    func testSlightlyElapsedMonthDayResetStaysPastInsteadOfRollingAYear() throws {
+        // Display rounding or a timezone fallback can put the resolved reset
+        // minutes before the event; that must read as "already elapsed,
+        // re-check now" — not as next year's reset.
+        let event = ISO8601DateFormatter().date(from: "2026-07-10T09:05:00Z")!
+        let result = try XCTUnwrap(TranscriptResetParser.parse(
+            messageText: "You've hit your weekly limit · resets Jul 10 at 9am (UTC)",
+            eventTimestamp: event
+        ))
+        XCTAssertEqual(result.resetAt, ISO8601DateFormatter().date(from: "2026-07-10T09:00:00Z"))
+    }
+
+    func testStatedYearIsAuthoritativeEvenWhenPast() throws {
+        // An explicit year never rolls forward, even if it is long elapsed.
+        let event = ISO8601DateFormatter().date(from: "2026-07-10T04:14:15Z")!
+        let result = try XCTUnwrap(TranscriptResetParser.parse(
+            messageText: "You've hit your weekly limit · resets Jan 2, 2026 at 9am (UTC)",
+            eventTimestamp: event
+        ))
+        XCTAssertEqual(result.resetAt, ISO8601DateFormatter().date(from: "2026-01-02T09:00:00Z"))
+    }
+
+    func testImpossibleDayOfMonthIsRejected() {
+        // Calendar would silently normalize "Jul 32" to Aug 1; the parser must
+        // refuse instead of inventing a date the message never stated.
+        let event = ISO8601DateFormatter().date(from: "2026-07-10T04:14:15Z")!
+        XCTAssertNil(TranscriptResetParser.parse(
+            messageText: "You've hit your weekly limit · resets Jul 32 at 9am (UTC)",
+            eventTimestamp: event
+        ))
+    }
+
     func testWeeklyMonthDayMessageClassifiesBlockedWithReset() throws {
         let cwd = tempDir.path
         let lines = [


### PR DESCRIPTION
Salvages three correctness fixes from the superseded PR #102
(`claude/nostalgic-mcnulty-90f66b`) into master's current
`MeterBar/SessionWake/*` value layer. That PR used a wholly different
architecture (`ClaudeTranscriptTailClassifier` / `SessionWakeDiscovery` /
`SessionWakeModels` / `SessionWakeReplayLedger`), so each fix is
re-implemented against master's types (`TranscriptResetParser`,
`SessionDiscovery`, `TranscriptClassifier`), **TDD-first** — every test was
written and confirmed red before the corresponding fix.

## Fixes

1. **`TranscriptResetParser` — explicit month/day(/year) resets.** The old
   regex required a digit immediately after `resets`, so weekly-limit text like
   `resets Jul 15 at 10pm (Europe/Malta)` returned `nil`. Added a named-group
   regex with an optional `<month> <day>(, <year>)? at ` prefix. Month/day
   resolve to the stated calendar date; an *inferred* (non-stated) year rolls
   forward a whole year when it lands before the block event — a December block
   whose reset reads "Jan 2" is next January (December → January window). Bare
   clock times keep master's existing nearest-occurrence semantics (#96).

2. **`SessionDiscovery.readTail` — lossy UTF-8 decode.** A bounded tail read can
   begin mid-multibyte-character; the failable `String(data:encoding:.utf8)`
   returned `nil` and dropped the **entire** transcript, decisive block event
   included. Switched to `String(decoding:as: UTF8.self)`; the split leading
   bytes become U+FFFD on a partial line that JSON-decode already skips.

3. **`TranscriptClassifier` — sidechain handling.** Previously *any* sidechain
   line both marked the whole transcript `isSidechain` and still drove the
   mainline decisive-state machine — so a blocked mainline session that had
   merely spawned a subagent was a false-negative exclusion, and a sidechain
   block could mis-classify the mainline. Now sidechain event lines are counted
   but skipped for classification/metadata, and a transcript is flagged subagent
   only when *every* event line is sidechain.

## Extras (also from #102)

- Deterministic dedupe tie-break: equal block instants resolve to the
  lexicographically first transcript path, independent of enumeration order.
- Zero-filesystem-mutation regression test proving discovery is a pure preview.

**Deferred** (not ported): legacy pipe-epoch reset extraction, 14-day/400-file
enumeration bounds, and ReplayLedger 500-entry pruning (the last needs a
storage-format change to master's `[String]` ledger).

## Verification

- `swift test`: **466/466 pass**.
- `swiftlint --strict`: **0 violations** across 86 files.

New/updated `SessionWakeDiscoveryTests` cases: `testMonthDayResetForm`,
`testMonthDayResetRollsToNextYearWhenBeforeEvent`,
`testWeeklyMonthDayMessageClassifiesBlockedWithReset`,
`testTailReadSplittingMultibyteCharStillDiscoversBlock`,
`testSidechainLinesAreIgnoredForClassification`,
`testAllSidechainTranscriptIsFlaggedSubagent`,
`testDuplicateSessionTieBreaksOnLexicographicallyFirstPath`,
`testDiscoveryPerformsZeroFilesystemMutations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)