### PR TITLE
Port #103 runner hardening into ManagedProcess: drain-hang guard + graceful timeout

### DIFF
--- a/.agents/SESSIONS/2026-07-11.md
+++ b/.agents/SESSIONS/2026-07-11.md
@@ -111,3 +111,54 @@ warnings for the same mismatches; the SwiftPM build showed none.
 - `MeterBarCLI` (`swift build` in `MeterBarCLI/`): clean — the CLI consumes the
   library with the new isolation and the shared types are now explicitly
   `nonisolated` in every target that compiles them.
+
+## Session 3: Port #103 runner hardening into `ManagedProcess` (drain-hang + graceful timeout)
+
+**Status:** Complete — TDD-first.
+
+Ported two runner behaviors from the closed-candidate PR #103
+(`MeterBar/Services/SessionWake/ProcessRunner.swift`) into master's
+`MeterBar/SessionWake/ManagedProcess.swift`, plus the tests PR #103 had that
+master lacked.
+
+**Behaviors ported**
+- **Drain-hang protection.** After reaping the child, `run()` waited
+  *unconditionally* on the pipe-drain counters. A backgrounded grandchild that
+  inherits the stdout/stderr write fd keeps the pipe open, so the drain never
+  EOFs and `run()` would hang forever. Now the two drains share a `DispatchGroup`
+  and `run()` waits at most `drainGrace` (2 s); on timeout it `SIGKILL`s the
+  process group to force the inherited fds closed, then waits for the drains.
+- **Graceful timeout escalation.** On timeout the launcher went straight to
+  `SIGKILL`. It now sends `SIGTERM` to the process group, waits `terminationGrace`
+  (2 s) for the child to flush and exit, then escalates to `SIGKILL`. `killGroup`
+  gained a `signal:` parameter (default `SIGKILL`).
+
+**Latent bug found & fixed (blocked signal mask).** Wiring up graceful `SIGTERM`
+surfaced a real defect: `ManagedProcess.run` is invoked from a libdispatch worker
+thread whose signal mask blocks `SIGTERM`, and `posix_spawn` inherited that mask,
+so the child could never *receive* `SIGTERM` — only the unblockable `SIGKILL` got
+through (which is why the old SIGKILL-only path masked it). The spawn now resets
+the child's signal state via `POSIX_SPAWN_SETSIGMASK` (empty mask) +
+`POSIX_SPAWN_SETSIGDEF` (all dispositions to `SIG_DFL`). Confirmed the diagnosis
+with a `fork`/`setpgid`/`execv` repro that blocks `SIGTERM` before spawning.
+Bonus: `testTimeoutKillsProcessTree` now reaps in ~1 s instead of ~3 s because the
+tree dies on `SIGTERM` rather than waiting out the SIGKILL escalation.
+
+**Also exposed** `stdoutTruncated`/`stderrTruncated` on `ManagedProcess.Result`
+(counter tracks total vs. `maxCaptureBytes`) so truncation is observable; drain
+reads now handle `EINTR` by retrying.
+
+**Files changed**
+- `MeterBar/SessionWake/ManagedProcess.swift` — bounded drain wait, `SIGTERM`→
+  `SIGKILL` escalation, signal-mask/disposition reset, truncation flags, `EINTR`
+  handling, `StreamCounter` (replaces per-fd `DrainHandle`).
+- `MeterBarTests/ManagedProcessTests.swift` — new: parent-env-does-not-leak,
+  4 MiB drain stress w/ truncation assertion, drain-hang (grandchild holds stdout),
+  `SIGTERM`-before-`SIGKILL` (trap writes a marker a bare `SIGKILL` can't).
+- `MeterBarTests/WakeRunnerTests.swift` — new: lock-file `0600` permission assert,
+  `WakeRunLogger.pruneOldLogs` retention test (injected clock).
+
+**Verification**
+- `swift test`: **464/464 pass** (was 445; +19 = 6 new here + others since).
+- `swiftlint --strict`: 0 violations (config lints `MeterBar/` only; tests match
+  the surrounding per-line arg style).

--- a/MeterBar/SessionWake/ManagedProcess.swift
+++ b/MeterBar/SessionWake/ManagedProcess.swift
@@ -175,7 +175,11 @@ nonisolated enum ManagedProcess {
         // whole group to force the inherited fds closed, then wait for the drains.
         if drains.wait(timeout: .now() + drainGrace) == .timedOut {
             Cancellation.killGroup(pid, signal: SIGKILL)
-            drains.wait()
+            // The group kill can't reach a descendant that re-sessioned via
+            // setsid(); if it still holds a write end, bound this wait too and
+            // return with the bytes counted so far — one leaked drain block is
+            // better than run() never returning.
+            _ = drains.wait(timeout: .now() + drainGrace)
         }
 
         return Result(
@@ -270,12 +274,26 @@ nonisolated enum ManagedProcess {
         Cancellation.killGroup(pid, signal: SIGTERM)
         let graceDeadline = Date().addingTimeInterval(terminationGrace)
         var status: Int32 = 0
+        var reaped = false
         while Date() < graceDeadline {
-            if waitpid(pid, &status, WNOHANG) == pid { return }
+            if waitpid(pid, &status, WNOHANG) == pid {
+                reaped = true
+                break
+            }
             usleep(20_000)
         }
+        // SIGKILL the group even when the leader reaped within the grace: a
+        // grandchild that traps SIGTERM would otherwise outlive the timeout,
+        // losing the class's tree-cleanup guarantee. While any group member
+        // survives, POSIX forbids recycling the pid as another group's pgid,
+        // so this cannot target an unrelated tree; on an empty group it is a
+        // harmless ESRCH.
         Cancellation.killGroup(pid, signal: SIGKILL)
-        _ = waitpid(pid, &status, 0)
+        if !reaped {
+            while waitpid(pid, &status, 0) == -1 && errno == EINTR {
+                continue
+            }
+        }
     }
 
     private static func _WSTATUS(_ status: Int32) -> Int32 { status & 0x7F }

--- a/MeterBar/SessionWake/ManagedProcess.swift
+++ b/MeterBar/SessionWake/ManagedProcess.swift
@@ -11,6 +11,12 @@ import Foundation
 /// drains both pipes on background queues with a byte cap so a chatty child can
 /// never fill a pipe buffer and hang.
 nonisolated enum ManagedProcess {
+    /// How long to wait for the pipe drains to finish after the child is reaped
+    /// before force-killing the group to unstick an inherited-fd hang.
+    private static let drainGrace: TimeInterval = 2
+    /// How long a timed-out child is given to exit on `SIGTERM` before `SIGKILL`.
+    private static let terminationGrace: TimeInterval = 2
+
     struct Result: Sendable {
         enum Termination: Equatable, Sendable {
             case exited(code: Int32)
@@ -23,6 +29,10 @@ nonisolated enum ManagedProcess {
         /// Bounded stdout capture (diagnostic only; never persisted verbatim).
         let stdoutByteCount: Int
         let stderrByteCount: Int
+        /// Whether the stream exceeded `maxCaptureBytes` (content past the cap is
+        /// counted but discarded, so a caller knows the capture is incomplete).
+        let stdoutTruncated: Bool
+        let stderrTruncated: Bool
 
         var isSuccess: Bool {
             if case .exited(0) = termination { return true }
@@ -61,9 +71,9 @@ nonisolated enum ManagedProcess {
             return cancelled
         }
 
-        fileprivate static func killGroup(_ pgid: pid_t) {
+        fileprivate static func killGroup(_ pgid: pid_t, signal: Int32 = SIGKILL) {
             // Negative pid targets the whole process group.
-            _ = kill(-pgid, SIGKILL)
+            _ = kill(-pgid, signal)
         }
     }
 
@@ -87,7 +97,13 @@ nonisolated enum ManagedProcess {
         let errPipe = UnsafeMutablePointer<Int32>.allocate(capacity: 2)
         defer { outPipe.deallocate(); errPipe.deallocate() }
         guard pipe(outPipe) == 0, pipe(errPipe) == 0 else {
-            return Result(termination: .launchFailed("pipe() failed"), stdoutByteCount: 0, stderrByteCount: 0)
+            return Result(
+                termination: .launchFailed("pipe() failed"),
+                stdoutByteCount: 0,
+                stderrByteCount: 0,
+                stdoutTruncated: false,
+                stderrTruncated: false
+            )
         }
 
         // Child: stdin from /dev/null, stdout/stderr to the pipe write ends.
@@ -101,9 +117,24 @@ nonisolated enum ManagedProcess {
         var attributes: posix_spawnattr_t?
         posix_spawnattr_init(&attributes)
         defer { posix_spawnattr_destroy(&attributes) }
+        // Reset the child's signal state to a clean default. We spawn from a
+        // libdispatch worker thread, whose signal mask may block signals such as
+        // SIGTERM; without this the child would inherit that blocked mask and be
+        // unable to receive the graceful SIGTERM we send on timeout (only the
+        // unblockable SIGKILL would get through). Empty the mask and restore
+        // every disposition to SIG_DFL so the child behaves like a normal process.
+        var emptyMask = sigset_t()
+        sigemptyset(&emptyMask)
+        posix_spawnattr_setsigmask(&attributes, &emptyMask)
+        var defaultSignals = sigset_t()
+        sigfillset(&defaultSignals)
+        posix_spawnattr_setsigdefault(&attributes, &defaultSignals)
         // New process group with the child as leader ⇒ kill(-pgid) hits the tree.
-        posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETPGROUP))
         posix_spawnattr_setpgroup(&attributes, 0)
+        posix_spawnattr_setflags(
+            &attributes,
+            Int16(POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSIGDEF)
+        )
 
         let argv = ([executable] + arguments).map { strdup($0) } + [nil]
         let envp = environment.map { strdup("\($0.key)=\($0.value)") } + [nil]
@@ -121,55 +152,89 @@ nonisolated enum ManagedProcess {
             return Result(
                 termination: .launchFailed("posix_spawn failed (\(spawnResult))"),
                 stdoutByteCount: 0,
-                stderrByteCount: 0
+                stderrByteCount: 0,
+                stdoutTruncated: false,
+                stderrTruncated: false
             )
         }
 
         cancellation.attach(pgid: pid)
 
-        let outCounter = drain(fd: outPipe[0], cap: maxCaptureBytes)
-        let errCounter = drain(fd: errPipe[0], cap: maxCaptureBytes)
+        let outCounter = StreamCounter(cap: maxCaptureBytes)
+        let errCounter = StreamCounter(cap: maxCaptureBytes)
+        let drains = DispatchGroup()
+        drain(fd: outPipe[0], into: outCounter, group: drains)
+        drain(fd: errPipe[0], into: errCounter, group: drains)
 
         let termination = wait(pid: pid, timeout: timeout, cancellation: cancellation)
 
-        // Ensure drains finish and fds close.
-        let outBytes = outCounter.wait()
-        let errBytes = errCounter.wait()
+        // Drain-hang protection. The main child is reaped, but a backgrounded
+        // grandchild that inherited a pipe's write end keeps it open, so the drain
+        // reads never observe EOF and an unconditional wait would block forever.
+        // Wait only a bounded grace; if the drains have not finished, SIGKILL the
+        // whole group to force the inherited fds closed, then wait for the drains.
+        if drains.wait(timeout: .now() + drainGrace) == .timedOut {
+            Cancellation.killGroup(pid, signal: SIGKILL)
+            drains.wait()
+        }
 
-        return Result(termination: termination, stdoutByteCount: outBytes, stderrByteCount: errBytes)
+        return Result(
+            termination: termination,
+            stdoutByteCount: outCounter.count,
+            stderrByteCount: errCounter.count,
+            stdoutTruncated: outCounter.truncated,
+            stderrTruncated: errCounter.truncated
+        )
     }
 
     // MARK: - Draining
 
-    private final class DrainHandle: @unchecked Sendable {
-        private let queue: DispatchQueue
-        private var bytes = 0
-        private let group = DispatchGroup()
+    /// Thread-safe byte tally for one drained stream. Every byte read is counted
+    /// so the caller learns the true stream size; `cap` bounds only what is
+    /// conceptually retained, and `truncated` reports whether the stream exceeded
+    /// it.
+    private final class StreamCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private let cap: Int
+        private var total = 0
 
-        init(fd: Int32, cap: Int) {
-            queue = DispatchQueue(label: "dev.meterbar.app.wake.drain.\(fd)")
-            group.enter()
-            queue.async { [self] in
-                defer { close(fd); self.group.leave() }
-                var buffer = [UInt8](repeating: 0, count: 16 * 1024)
-                while true {
-                    let n = read(fd, &buffer, buffer.count)
-                    if n <= 0 { break }
-                    // Count everything, but only the cap bounds memory pressure.
-                    bytes += n
-                    if bytes > cap { /* keep reading to drain, discard content */ }
-                }
-            }
+        init(cap: Int) { self.cap = cap }
+
+        func add(_ count: Int) {
+            lock.lock(); total += count; lock.unlock()
         }
 
-        func wait() -> Int {
-            group.wait()
-            return bytes
+        var count: Int {
+            lock.lock(); defer { lock.unlock() }
+            return total
+        }
+
+        var truncated: Bool {
+            lock.lock(); defer { lock.unlock() }
+            return total > cap
         }
     }
 
-    private static func drain(fd: Int32, cap: Int) -> DrainHandle {
-        DrainHandle(fd: fd, cap: cap)
+    private static func drain(fd: Int32, into counter: StreamCounter, group: DispatchGroup) {
+        let queue = DispatchQueue(label: "dev.meterbar.app.wake.drain.\(fd)")
+        group.enter()
+        queue.async {
+            defer { close(fd); group.leave() }
+            var buffer = [UInt8](repeating: 0, count: 16 * 1024)
+            while true {
+                let n = read(fd, &buffer, buffer.count)
+                if n > 0 {
+                    // Count everything; only the cap bounds memory pressure.
+                    counter.add(n)
+                } else if n == 0 {
+                    break
+                } else if errno == EINTR {
+                    continue
+                } else {
+                    break
+                }
+            }
+        }
     }
 
     // MARK: - Waiting
@@ -190,12 +255,27 @@ nonisolated enum ManagedProcess {
                 return .launchFailed("waitpid failed")
             }
             if Date() >= deadline {
-                Cancellation.killGroup(pid)
-                _ = waitpid(pid, &status, 0)
+                escalateTimeout(pid: pid)
                 return .timedOut
             }
             usleep(20_000) // 20ms poll
         }
+    }
+
+    /// Graceful timeout escalation: first `SIGTERM` the process group so a
+    /// well-behaved child can flush and exit, wait a bounded grace for it to
+    /// reap, then `SIGKILL` the group and block until it is gone. Going straight
+    /// to `SIGKILL` would deny the child any chance to clean up.
+    private static func escalateTimeout(pid: pid_t) {
+        Cancellation.killGroup(pid, signal: SIGTERM)
+        let graceDeadline = Date().addingTimeInterval(terminationGrace)
+        var status: Int32 = 0
+        while Date() < graceDeadline {
+            if waitpid(pid, &status, WNOHANG) == pid { return }
+            usleep(20_000)
+        }
+        Cancellation.killGroup(pid, signal: SIGKILL)
+        _ = waitpid(pid, &status, 0)
     }
 
     private static func _WSTATUS(_ status: Int32) -> Int32 { status & 0x7F }

--- a/MeterBarTests/ManagedProcessTests.swift
+++ b/MeterBarTests/ManagedProcessTests.swift
@@ -178,7 +178,9 @@ final class ManagedProcessTests: XCTestCase {
         try script.write(to: url, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
 
-        let result = await run(url.path, env: ["WAKE_TERM_MARKER": marker.path], timeout: 1)
+        // Generous timeout so a slow CI runner has installed the trap before
+        // SIGTERM lands; the default disposition would kill bash markerless.
+        let result = await run(url.path, env: ["WAKE_TERM_MARKER": marker.path], timeout: 2.5)
         XCTAssertEqual(result.termination, .timedOut)
         let recorded = try String(contentsOf: marker, encoding: .utf8)
         XCTAssertTrue(recorded.contains("TERMED"), "child did not receive SIGTERM before SIGKILL")

--- a/MeterBarTests/ManagedProcessTests.swift
+++ b/MeterBarTests/ManagedProcessTests.swift
@@ -109,6 +109,81 @@ final class ManagedProcessTests: XCTestCase {
         XCTAssertFalse(processAlive(childPid), "Child process leaked after timeout")
     }
 
+    func testParentEnvironmentDoesNotLeakToChild() async throws {
+        // A variable present only in the parent must NOT reach the child: the
+        // launcher builds envp solely from the provided environment, verbatim.
+        setenv("WAKE_SHOULD_NOT_LEAK", "leaked", 1)
+        defer { unsetenv("WAKE_SHOULD_NOT_LEAK") }
+
+        let marker = tempDir.appendingPathComponent("env.txt")
+        let script = """
+        #!/bin/bash
+        printf '%s' "${WAKE_SHOULD_NOT_LEAK:-ABSENT}" > "$WAKE_ENV_OUT"
+        """
+        let url = tempDir.appendingPathComponent("env.sh")
+        try script.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+
+        let result = await run(url.path, env: ["WAKE_ENV_OUT": marker.path], timeout: 10)
+        XCTAssertEqual(result.termination, .exited(code: 0))
+        XCTAssertEqual(try String(contentsOf: marker, encoding: .utf8), "ABSENT")
+    }
+
+    func testLargeOutputTruncatesCaptureWithoutDeadlock() async throws {
+        let fake = try makeFake()
+        // 4 MiB ≫ the 16 KiB read buffer and the 64 KiB capture cap.
+        let result = await run(fake, env: ["WAKE_STDOUT_BYTES": "4194304"], timeout: 20)
+        XCTAssertEqual(result.termination, .exited(code: 0))
+        // Every byte is drained (proving no pipe-buffer deadlock)…
+        XCTAssertGreaterThan(result.stdoutByteCount, 4_000_000)
+        // …while the stream is reported as truncated past the capture cap.
+        XCTAssertTrue(result.stdoutTruncated, "stream beyond the cap must report truncation")
+        XCTAssertFalse(result.stderrTruncated)
+    }
+
+    func testDrainDoesNotHangWhenGrandchildHoldsStdoutOpen() async throws {
+        let fake = try makeFake()
+        let childPidFile = tempDir.appendingPathComponent("child.pid")
+        // The child spawns `sleep 30 &` (which inherits the stdout pipe) and exits
+        // 0 immediately without waiting. The reaped child is gone, but the
+        // grandchild keeps the pipe's write end open, so the drain never sees EOF.
+        // run() must fall back to a bounded drain wait, then SIGKILL the group.
+        let started = Date()
+        let result = await run(
+            fake,
+            env: ["WAKE_SPAWN_CHILD": "1", "WAKE_CHILD_PID": childPidFile.path],
+            timeout: 30
+        )
+        XCTAssertEqual(result.termination, .exited(code: 0))
+        XCTAssertLessThan(Date().timeIntervalSince(started), 15, "run() hung on the inherited-fd drain")
+
+        // The bounded-drain fallback SIGKILLs the whole group, reaping the leaked
+        // grandchild that was holding the pipe open.
+        let childPid = try pid(from: childPidFile)
+        try await waitForProcessGone(childPid)
+        XCTAssertFalse(processAlive(childPid), "grandchild holding stdout open was not cleaned up")
+    }
+
+    func testTimeoutSendsSIGTERMBeforeSIGKILL() async throws {
+        let marker = tempDir.appendingPathComponent("term.marker")
+        // Trap SIGTERM, record it, and exit. A straight SIGKILL cannot be trapped,
+        // so a written marker proves graceful escalation delivered SIGTERM first.
+        let script = """
+        #!/bin/bash
+        trap 'echo TERMED > "$WAKE_TERM_MARKER"; exit 42' TERM
+        sleep 120 &
+        wait
+        """
+        let url = tempDir.appendingPathComponent("trap.sh")
+        try script.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+
+        let result = await run(url.path, env: ["WAKE_TERM_MARKER": marker.path], timeout: 1)
+        XCTAssertEqual(result.termination, .timedOut)
+        let recorded = try String(contentsOf: marker, encoding: .utf8)
+        XCTAssertTrue(recorded.contains("TERMED"), "child did not receive SIGTERM before SIGKILL")
+    }
+
     func testCancellationKillsGroupAndReportsCancelled() async throws {
         let fake = try makeFake()
         let childPidFile = tempDir.appendingPathComponent("child.pid")

--- a/MeterBarTests/WakeRunnerTests.swift
+++ b/MeterBarTests/WakeRunnerTests.swift
@@ -161,6 +161,15 @@ final class WakeRunnerTests: XCTestCase {
         second.release()
     }
 
+    func testLockFileIsCreatedWithPrivatePermissions() throws {
+        let url = tempDir.appendingPathComponent("perm.lock")
+        let lock = WakeLock(lockURL: url, legacyLockURLs: [])
+        XCTAssertEqual(lock.acquire(), .acquired)
+        defer { lock.release() }
+        let perms = try FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions] as? Int
+        XCTAssertEqual(perms, 0o600, "Lock file must be owner-only (0600)")
+    }
+
     func testLegacyWatcherContentionIsReported() {
         let legacy = tempDir.appendingPathComponent("legacy.lock")
         FileManager.default.createFile(atPath: legacy.path, contents: nil)
@@ -199,5 +208,33 @@ final class WakeRunnerTests: XCTestCase {
         // No prompt, no raw output tails.
         XCTAssertFalse(contents.contains("continue"))
         XCTAssertFalse(contents.lowercased().contains("stdout\":\""))
+    }
+
+    func testPruneOldLogsRemovesFilesBeyondRetention() throws {
+        let logDir = tempDir.appendingPathComponent("prune-logs")
+        try FileManager.default.createDirectory(at: logDir, withIntermediateDirectories: true)
+        let fixedNow = Date(timeIntervalSince1970: 1_700_000_000)
+        let fileManager = FileManager.default
+
+        // One log aged past the 14-day window, one comfortably inside it. Pruning
+        // keys off file modification time, so set those explicitly.
+        let expired = logDir.appendingPathComponent("session-wake-old.log")
+        let fresh = logDir.appendingPathComponent("session-wake-new.log")
+        fileManager.createFile(atPath: expired.path, contents: Data("x".utf8))
+        fileManager.createFile(atPath: fresh.path, contents: Data("y".utf8))
+        try fileManager.setAttributes(
+            [.modificationDate: fixedNow.addingTimeInterval(-30 * 86_400)], ofItemAtPath: expired.path)
+        try fileManager.setAttributes(
+            [.modificationDate: fixedNow.addingTimeInterval(-1 * 86_400)], ofItemAtPath: fresh.path)
+
+        // Appending triggers pruneOldLogs against the injected clock.
+        let logger = WakeRunLogger(directory: logDir, retentionDays: 14, now: { fixedNow })
+        logger.append(WakeRunLogger.Record(
+            timestamp: fixedNow, event: "wake", sessionID: "sid", reason: "sessionLimit",
+            outcome: "succeeded", exitCode: 0, durationMilliseconds: 10, stdoutBytes: 1, stderrBytes: 0
+        ))
+
+        XCTAssertFalse(fileManager.fileExists(atPath: expired.path), "Log older than retention must be pruned")
+        XCTAssertTrue(fileManager.fileExists(atPath: fresh.path), "Log within retention must be kept")
     }
 }


### PR DESCRIPTION
Ports two SessionWake runner behaviors from the closed-candidate PR #103 (`MeterBar/Services/SessionWake/ProcessRunner.swift`) into master's `MeterBar/SessionWake/ManagedProcess.swift`, TDD-first per `CLAUDE.md`, plus the tests PR #103 had that master lacked.

## Behaviors ported

**1. Drain-hang protection.** After reaping the child, `run()` waited *unconditionally* on the pipe-drain counters. If a backgrounded grandchild inherits the stdout/stderr write fd, the drain never sees EOF and `run()` hangs forever. The two drains now share a `DispatchGroup`; `run()` waits at most `drainGrace` (~2s), then `SIGKILL`s the process group to force the inherited fds closed before waiting again.

**2. Graceful timeout escalation.** On timeout the launcher went straight to `SIGKILL`. It now sends `SIGTERM` to the process group, waits `terminationGrace` (~2s) for the child to flush and exit, then escalates to `SIGKILL`. `killGroup` gained a `signal:` parameter (default `SIGKILL`).

## Latent bug found & fixed (blocked signal mask)

Wiring up graceful `SIGTERM` surfaced a real defect: `ManagedProcess.run` is invoked from a libdispatch worker thread whose signal mask blocks `SIGTERM`, and `posix_spawn` inherited that mask — so the child could never *receive* `SIGTERM`; only the unblockable `SIGKILL` got through (which is exactly why the old SIGKILL-only path never hit this). The spawn now resets the child's signal state via `POSIX_SPAWN_SETSIGMASK` (empty mask) + `POSIX_SPAWN_SETSIGDEF` (all dispositions → `SIG_DFL`). Diagnosis confirmed with a `fork`/`setpgid`/`execv` repro that blocks `SIGTERM` before spawning.

Side benefit: `testTimeoutKillsProcessTree` now reaps in ~1s instead of ~3s, since the tree dies on `SIGTERM` rather than waiting out the escalation.

## Also

- Exposes `stdoutTruncated`/`stderrTruncated` on `ManagedProcess.Result` so truncation past `maxCaptureBytes` is observable.
- Drain reads now retry on `EINTR`.
- `StreamCounter` replaces the per-fd `DrainHandle` so both drains can share one group.

## Tests ported (were missing on master)

- `ManagedProcessTests`: parent-env-does-not-leak, 4 MiB drain stress **with truncation assertion**, drain-hang (grandchild holds stdout open), `SIGTERM`-before-`SIGKILL` (a trap writes a marker a bare `SIGKILL` couldn't).
- `WakeRunnerTests`: lock-file `0600` permission assert, `WakeRunLogger.pruneOldLogs` retention (injected clock).

## Verification

- `swift test`: **464/464 pass**.
- `swiftlint --strict`: **0 violations**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)