### PR TITLE
Fix Session Wake gaps found auditing PR #104

### DIFF
--- a/.agents/SESSIONS/2026-07-11.md
+++ b/.agents/SESSIONS/2026-07-11.md
@@ -111,3 +111,42 @@ warnings for the same mismatches; the SwiftPM build showed none.
 - `MeterBarCLI` (`swift build` in `MeterBarCLI/`): clean — the CLI consumes the
   library with the new isolation and the shared types are now explicitly
   `nonisolated` in every target that compiles them.
+
+## Session: Session Wake gap fixes (audit of closed-candidate PR #104)
+
+**Status:** Complete
+**Branch:** claude/charming-goldstine-c09e11 → PR to master
+
+Fixed four gaps found while auditing PR #104 (`claude/admiring-euler-17814b`) against master. TDD-first per policy: failing tests written before each fix.
+
+1. **BUG — account switch left the live watcher bound to the OLD account.**
+   `SessionWakeSettingsStore.setWakeAccountID` only force-disarmed on `nil`; on an
+   account→account change it kept `isOn` true, and `SessionWakeController.startWatching`
+   guards `watchTask == nil`, so `reconcile()` never rebound. Fix: `setWakeAccountID`
+   now `forceOff()`s on *any* change — switching the wake target disarms; re-arm is one
+   toggle (never silently retarget). Tests: `SessionWakeSettingsTests.testSwitchingAccountWhileArmedDisarms`
+   / `testReselectingSameAccountWhileArmedStaysOn`; `SessionWakeControllerTests.testSwitchingAccountWhileArmedStopsTheWatcher`
+   (two real accounts, A→B while armed → watcher torn down).
+
+2. **Dead code — `SessionWakeMenuControl` never embedded.** Added `SessionWakeMenuControl.shouldShow(isOn:canTurnOn:)`
+   and embedded the control at the foot of the popover scroll content in `MenuBarView`
+   (shown when on — kill switch reachable — or armable). Test: `SessionWakeStatusTests.testMenuControlVisibility`.
+
+3. **Dashboard settings couldn't reach Session Wake.** `SettingsView`'s embedded
+   `settingsStack` omitted it. Added `SessionWakeSettingsView(embeddedInDashboard:)` —
+   embedded mode drops the grouped `Form` (a nested scroll container inside the dashboard
+   ScrollView would collapse) for a plain stack — wrapped in an "Automation" `SettingsPanelSection`.
+   Test: `SessionWakeStatusTests.testSettingsPaneHostsEmbeddedInDashboard`.
+
+4. **"Notify on completion" toggle was inert.** Extended `SessionWakeNotificationDecider`
+   with `FiredWakeNotification` + `completionNotification(summary:context:)` (stable
+   replace-don't-stack key, pluralized copy, failure + still-queued counts), adapting PR
+   #104's payload design to master's `WakeRunSummary`. Wired `AppDelegate` to observe
+   `SessionWakeStatus.$watcherState` and post on `.completed` (gated by global/provider/wake
+   switches). Tests: `SessionWakeNotificationDeciderTests` (6 cases).
+
+### Verification
+- `swift test`: 469/469 pass (0 failures).
+- `swiftlint --strict`: 0 violations, 86 files.
+- `xcodebuild -scheme MeterBar -configuration Debug` (incl. `MeterBarApp.swift`, which
+  SwiftPM excludes): **BUILD SUCCEEDED**.

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -90,6 +90,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             // Bring the Session Wake watcher online: it re-arms if the toggle was
             // left on and starts/stops as the user flips it.
             SessionWakeController.shared.activate()
+            // Surface a banner when a wake run finishes (gated by the global,
+            // provider, and Session Wake notification switches).
+            observeSessionWakeCompletion()
         }
 
         // Setup notifications (also handles initial data refresh)
@@ -484,6 +487,34 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func postNotification(_ fired: FiredNotification) {
+        sendNotification(identifier: fired.key, title: fired.title, body: fired.body)
+    }
+
+    /// Observes the shared Session Wake status and posts a completion banner each
+    /// time a run settles. The decision (gates + copy) lives in the pure,
+    /// unit-tested `SessionWakeNotificationDecider`; this only turns a fired
+    /// decision into a banner, mirroring `checkAndNotify`.
+    @MainActor
+    private func observeSessionWakeCompletion() {
+        SessionWakeStatus.shared.$watcherState
+            .sink { [weak self] state in
+                guard case let .completed(summary) = state else { return }
+                self?.postSessionWakeCompletion(summary: summary)
+            }
+            .store(in: &cancellables)
+    }
+
+    @MainActor
+    private func postSessionWakeCompletion(summary: WakeRunSummary) {
+        let context = SessionWakeNotificationContext(
+            globalNotificationsEnabled: notificationPreferences.isEnabled,
+            claudeProviderEnabled: providerVisibilityStore.isEnabled(.claudeCode),
+            notifyOnCompletion: SessionWakeSettingsStore.shared.notifyOnCompletion
+        )
+        guard let fired = SessionWakeNotificationDecider.completionNotification(
+            summary: summary,
+            context: context
+        ) else { return }
         sendNotification(identifier: fired.key, title: fired.title, body: fired.body)
     }
 

--- a/MeterBar/SessionWake/SessionWakeNotificationDecider.swift
+++ b/MeterBar/SessionWake/SessionWakeNotificationDecider.swift
@@ -11,11 +11,27 @@ struct SessionWakeNotificationContext: Equatable, Sendable {
     let notifyOnCompletion: Bool
 }
 
+/// A Session Wake notification the decider decided should be posted.
+///
+/// Mirrors `FiredNotification` (the quota-crossing analogue): the decider stays
+/// pure and the app delegate owns the `UNUserNotificationCenter` interaction.
+/// The `key` is stable so re-posting replaces the pending banner rather than
+/// stacking a duplicate.
+struct FiredWakeNotification: Equatable, Sendable {
+    let key: String
+    let title: String
+    let body: String
+}
+
 /// Decides whether Session Wake may post a notification. A wake notification is
 /// suppressed unless the global switch, the Claude provider, and the Session
 /// Wake preference all allow it — Session Wake never overrides the user's global
 /// or provider-level choices.
 enum SessionWakeNotificationDecider {
+    /// Stable identifier for the completion banner. Re-posting the same id
+    /// replaces the pending request instead of stacking a new banner every run.
+    static let completionKey = "session-wake-completion"
+
     static func shouldNotifyOnCompletion(_ context: SessionWakeNotificationContext) -> Bool {
         context.globalNotificationsEnabled
             && context.claudeProviderEnabled
@@ -26,5 +42,32 @@ enum SessionWakeNotificationDecider {
     /// notifications are informational and never bypass the global/provider gate.
     static func shouldNotifyOnWatchStart(_ context: SessionWakeNotificationContext) -> Bool {
         shouldNotifyOnCompletion(context)
+    }
+
+    /// The completion notification for a finished run, or `nil` when any gate is
+    /// closed. Copy is pluralized and surfaces failure and still-queued counts so
+    /// the banner reads honestly whether the run fully drained the queue or the
+    /// quota re-exhausted partway through.
+    static func completionNotification(
+        summary: WakeRunSummary,
+        context: SessionWakeNotificationContext
+    ) -> FiredWakeNotification? {
+        guard shouldNotifyOnCompletion(context) else { return nil }
+
+        let sessionNoun = summary.attempted == 1 ? "session" : "sessions"
+        var body = "Resumed \(summary.resumed) of \(summary.attempted) Claude \(sessionNoun)."
+        if summary.failed > 0 {
+            let failureNoun = summary.failed == 1 ? "failure" : "failures"
+            body += " \(summary.failed) \(failureNoun)."
+        }
+        if summary.remaining > 0 {
+            body += " \(summary.remaining) still queued."
+        }
+
+        return FiredWakeNotification(
+            key: completionKey,
+            title: "Session Wake — Run Complete",
+            body: body
+        )
     }
 }

--- a/MeterBar/SessionWake/SessionWakeNotificationDecider.swift
+++ b/MeterBar/SessionWake/SessionWakeNotificationDecider.swift
@@ -53,6 +53,11 @@ enum SessionWakeNotificationDecider {
         context: SessionWakeNotificationContext
     ) -> FiredWakeNotification? {
         guard shouldNotifyOnCompletion(context) else { return nil }
+        // The continuous watcher ends EVERY rescan pass in .completed, and an
+        // idle pass produces an all-zero summary — without this gate an armed
+        // watcher with nothing to do would post (and replace any meaningful
+        // banner with) "Resumed 0 of 0" every rescan interval, with sound.
+        guard summary.attempted > 0 || summary.remaining > 0 else { return nil }
 
         let sessionNoun = summary.attempted == 1 ? "session" : "sessions"
         var body = "Resumed \(summary.resumed) of \(summary.attempted) Claude \(sessionNoun)."

--- a/MeterBar/SessionWake/SessionWakeSettingsStore.swift
+++ b/MeterBar/SessionWake/SessionWakeSettingsStore.swift
@@ -105,8 +105,13 @@ final class SessionWakeSettingsStore: ObservableObject {
             userDefaults.set(id.uuidString, forKey: StorageKeys.sessionWakeAccountID)
         } else {
             userDefaults.removeObject(forKey: StorageKeys.sessionWakeAccountID)
-            forceOff()
         }
+        // Any change of the wake target disarms the watcher. Otherwise a live
+        // watcher would stay bound to the *old* account (the controller only
+        // starts a watch when none is running), and automation must never keep
+        // running against — or silently retarget to — an account the user did
+        // not just explicitly arm. Re-arming with the new account is one toggle.
+        forceOff()
     }
 
     func setPermissionMode(_ mode: WakePermissionMode) {

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -16,6 +16,7 @@ struct MenuBarView: View {
   @StateObject private var cursorService = CursorLocalService.shared
   @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
   @StateObject private var providerVisibility = ProviderVisibilityStore.shared
+  @StateObject private var sessionWakeStore = SessionWakeSettingsStore.shared
 
   @State private var contentHeight: CGFloat = 320
   @State private var expandedDetailID: String?
@@ -61,21 +62,31 @@ struct MenuBarView: View {
       Divider()
 
       ScrollView {
-        PopoverOverviewPanel(
-          snapshots: ProviderSnapshotBuilder.snapshots(
-            ProviderSnapshotBuilder.Input(
-              metrics: dataManager.metrics,
-              claudeAccounts: claudeAccountStore.accounts,
-              claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
-              enabledServices: providerVisibility.enabledServices,
-              claudeCodeHasAccess: claudeCodeService.hasAccess,
-              codexCliHasAccess: codexCliService.hasAccess,
-              cursorHasAccess: cursorService.hasAccess
-            )),
-          openDashboard: openDashboard,
-          openStatusDetail: openStatusDetail,
-          openProviderOverview: openProviderDetail
-        )
+        VStack(spacing: 10) {
+          PopoverOverviewPanel(
+            snapshots: ProviderSnapshotBuilder.snapshots(
+              ProviderSnapshotBuilder.Input(
+                metrics: dataManager.metrics,
+                claudeAccounts: claudeAccountStore.accounts,
+                claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
+                enabledServices: providerVisibility.enabledServices,
+                claudeCodeHasAccess: claudeCodeService.hasAccess,
+                codexCliHasAccess: codexCliService.hasAccess,
+                cursorHasAccess: cursorService.hasAccess
+              )),
+            openDashboard: openDashboard,
+            openStatusDetail: openStatusDetail,
+            openProviderOverview: openProviderDetail
+          )
+
+          if SessionWakeMenuControl.shouldShow(
+            isOn: sessionWakeStore.isOn,
+            canTurnOn: sessionWakeStore.canTurnOn
+          ) {
+            Divider()
+            SessionWakeMenuControl()
+          }
+        }
         .padding(10)
         .background(
           GeometryReader { proxy in

--- a/MeterBar/Views/SessionWakeMenuControl.swift
+++ b/MeterBar/Views/SessionWakeMenuControl.swift
@@ -35,6 +35,16 @@ struct SessionWakeMenuControl: View {
         }
     }
 
+    /// Whether the compact control belongs in the menu-bar popover right now.
+    ///
+    /// Shown when the watcher is on — so the stop-the-watcher kill switch is
+    /// always one click away — or when it is ready to be armed (a wake account is
+    /// configured). Hidden when unconfigured, so users who never touch Session
+    /// Wake (e.g. Codex-only) don't see an inert row.
+    static func shouldShow(isOn: Bool, canTurnOn: Bool) -> Bool {
+        isOn || canTurnOn
+    }
+
     private var label: SessionWakeStatusLabel {
         status.label(isOn: store.isOn)
     }

--- a/MeterBar/Views/SessionWakeSettingsView.swift
+++ b/MeterBar/Views/SessionWakeSettingsView.swift
@@ -99,6 +99,11 @@ struct SessionWakeSettingsView: View {
                     Text(account.name).tag(UUID?.some(account.id))
                 }
             }
+            if store.isOn {
+                Text("Changing the wake account turns Session Wake off.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
         }
     }
 

--- a/MeterBar/Views/SessionWakeSettingsView.swift
+++ b/MeterBar/Views/SessionWakeSettingsView.swift
@@ -12,27 +12,27 @@ struct SessionWakeSettingsView: View {
     @ObservedObject private var accounts: ClaudeCodeAccountStore
     @State private var showingFirstRunConfirmation = false
 
+    /// When embedded in the dashboard settings stack (itself inside a ScrollView)
+    /// the grouped `Form` — a nested scroll container — must be dropped for a
+    /// plain vertical layout, or the sections collapse. The standalone Settings
+    /// pane keeps the `Form` styling.
+    private let embeddedInDashboard: Bool
+
     @MainActor
     init(
+        embeddedInDashboard: Bool = false,
         store: SessionWakeSettingsStore? = nil,
         status: SessionWakeStatus? = nil,
         accounts: ClaudeCodeAccountStore? = nil
     ) {
+        self.embeddedInDashboard = embeddedInDashboard
         self.store = store ?? .shared
         self.status = status ?? .shared
         self.accounts = accounts ?? .shared
     }
 
     var body: some View {
-        Form {
-            switchSection
-            accountSection
-            previewSection
-            limitsSection
-            permissionSection
-            notificationSection
-        }
-        .formStyle(.grouped)
+        layout
         .confirmationDialog(
             "Turn on Session Wake?",
             isPresented: $showingFirstRunConfirmation,
@@ -47,6 +47,33 @@ struct SessionWakeSettingsView: View {
             one at a time. It only runs while MeterBar is open.
             """)
         }
+    }
+
+    // MARK: - Layout
+
+    /// Grouped `Form` when standalone; a plain stack when embedded in the
+    /// dashboard's own ScrollView (a nested Form would collapse there).
+    @ViewBuilder private var layout: some View {
+        if embeddedInDashboard {
+            VStack(alignment: .leading, spacing: 12) {
+                sections
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            Form {
+                sections
+            }
+            .formStyle(.grouped)
+        }
+    }
+
+    @ViewBuilder private var sections: some View {
+        switchSection
+        accountSection
+        previewSection
+        limitsSection
+        permissionSection
+        notificationSection
     }
 
     // MARK: - Sections

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -403,9 +403,18 @@ struct SettingsView: View {
             costTrackingSection
             refreshSection
             notificationsSection
+            automationSection
             generalSection
         }
         .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    /// Session Wake automation. Mirrors the standalone `.automation` pane (always
+    /// available) so the dashboard settings surface can reach it too.
+    private var automationSection: some View {
+        SettingsPanelSection(title: "Automation", systemImage: "moon.zzz", color: MeterBarTheme.appAccent) {
+            SessionWakeSettingsView(embeddedInDashboard: true)
+        }
     }
 
     private var codexCliSection: some View {

--- a/MeterBarTests/SessionWakeControllerTests.swift
+++ b/MeterBarTests/SessionWakeControllerTests.swift
@@ -80,6 +80,44 @@ final class SessionWakeControllerTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(recorder.stopCount, 1)
     }
 
+    func testSwitchingAccountWhileArmedStopsTheWatcher() {
+        // Two real, resolvable accounts: the always-present default (A) plus a
+        // custom one (B), so the controller can start a watch against either.
+        let accounts = ClaudeCodeAccountStore(userDefaults: defaults)
+        accounts.addAccount(name: "Second", configDirectory: "/tmp/session-wake-second")
+        guard let accountB = accounts.customAccounts.first?.id else {
+            return XCTFail("adding a custom account should yield a resolvable id")
+        }
+
+        let store = SessionWakeSettingsStore(userDefaults: defaults)
+        store.setWakeAccountID(ClaudeCodeAccount.defaultID) // account A
+        store.acknowledgeFirstRunAndTurnOn()
+        XCTAssertTrue(store.isOn)
+
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: SessionWakeStatus(),
+            accounts: accounts,
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+        )
+        controller.activate()
+        XCTAssertTrue(controller.isWatching)
+        poll { recorder.startCount >= 1 } // watch against A is genuinely in-flight
+        XCTAssertGreaterThanOrEqual(recorder.startCount, 1)
+
+        // Switch the wake account while the watcher is ON. The live watcher must
+        // not stay bound to the old account: the store disarms and the controller
+        // tears the watch down.
+        store.setWakeAccountID(accountB)
+        poll { !controller.isWatching }
+        XCTAssertFalse(controller.isWatching)
+        XCTAssertFalse(store.isOn)
+        poll { recorder.stopCount >= 1 }
+        XCTAssertGreaterThanOrEqual(recorder.stopCount, 1)
+    }
+
     func testStaysOffWhenToggleOff() {
         let store = SessionWakeSettingsStore(userDefaults: defaults) // off
         let recorder = WatchRecorder()

--- a/MeterBarTests/SessionWakeNotificationDeciderTests.swift
+++ b/MeterBarTests/SessionWakeNotificationDeciderTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import MeterBar
+
+/// Coverage for the Session Wake completion notification the decider emits.
+///
+/// The decider stays pure — it returns a `FiredWakeNotification` value (stable
+/// key, composed copy) or `nil` when any gate is closed — and the app delegate
+/// owns the actual `UNUserNotificationCenter` interaction. These tests pin the
+/// three gates plus the pluralization / failure-count copy.
+final class SessionWakeNotificationDeciderTests: XCTestCase {
+    private func allowingContext(notifyOnCompletion: Bool = true) -> SessionWakeNotificationContext {
+        SessionWakeNotificationContext(
+            globalNotificationsEnabled: true,
+            claudeProviderEnabled: true,
+            notifyOnCompletion: notifyOnCompletion
+        )
+    }
+
+    func testCompletionSuppressedWhenAnyGateClosed() {
+        let summary = WakeRunSummary(resumed: 1)
+        let closed = [
+            SessionWakeNotificationContext(globalNotificationsEnabled: false, claudeProviderEnabled: true, notifyOnCompletion: true),
+            SessionWakeNotificationContext(globalNotificationsEnabled: true, claudeProviderEnabled: false, notifyOnCompletion: true),
+            SessionWakeNotificationContext(globalNotificationsEnabled: true, claudeProviderEnabled: true, notifyOnCompletion: false)
+        ]
+        for context in closed {
+            XCTAssertNil(SessionWakeNotificationDecider.completionNotification(summary: summary, context: context))
+        }
+    }
+
+    func testCompletionSingularCopy() {
+        let summary = WakeRunSummary(resumed: 1)
+        let fired = SessionWakeNotificationDecider.completionNotification(summary: summary, context: allowingContext())
+        XCTAssertEqual(fired?.key, "session-wake-completion")
+        XCTAssertEqual(fired?.title, "Session Wake — Run Complete")
+        XCTAssertEqual(fired?.body, "Resumed 1 of 1 Claude session.")
+    }
+
+    func testCompletionPluralWithSingleFailure() {
+        // resumed 2 + failed 1 ⇒ attempted 3.
+        let summary = WakeRunSummary(resumed: 2, failed: 1)
+        let fired = SessionWakeNotificationDecider.completionNotification(summary: summary, context: allowingContext())
+        XCTAssertEqual(fired?.body, "Resumed 2 of 3 Claude sessions. 1 failure.")
+    }
+
+    func testCompletionPluralFailures() {
+        let summary = WakeRunSummary(resumed: 0, failed: 2)
+        let fired = SessionWakeNotificationDecider.completionNotification(summary: summary, context: allowingContext())
+        XCTAssertEqual(fired?.body, "Resumed 0 of 2 Claude sessions. 2 failures.")
+    }
+
+    func testCompletionMentionsRemainingWhenRequeued() {
+        // Quota re-exhausted mid-run: some resumed, some still queued.
+        let summary = WakeRunSummary(resumed: 1, failed: 0, skipped: 0, remaining: 2)
+        let fired = SessionWakeNotificationDecider.completionNotification(summary: summary, context: allowingContext())
+        XCTAssertEqual(fired?.body, "Resumed 1 of 1 Claude session. 2 still queued.")
+    }
+
+    func testCompletionKeyIsStableAcrossDifferentCounts() {
+        // A stable key means re-posting replaces the banner rather than stacking.
+        let first = SessionWakeNotificationDecider.completionNotification(
+            summary: WakeRunSummary(resumed: 1), context: allowingContext()
+        )
+        let second = SessionWakeNotificationDecider.completionNotification(
+            summary: WakeRunSummary(resumed: 5, failed: 3), context: allowingContext()
+        )
+        XCTAssertEqual(first?.key, second?.key)
+    }
+}

--- a/MeterBarTests/SessionWakeNotificationDeciderTests.swift
+++ b/MeterBarTests/SessionWakeNotificationDeciderTests.swift
@@ -28,6 +28,26 @@ final class SessionWakeNotificationDeciderTests: XCTestCase {
         }
     }
 
+    func testIdlePassSummaryIsSuppressed() {
+        // The continuous watcher ends every rescan pass in .completed; an idle
+        // pass (nothing attempted, nothing queued) must not post "0 of 0".
+        let fired = SessionWakeNotificationDecider.completionNotification(
+            summary: WakeRunSummary(),
+            context: allowingContext()
+        )
+        XCTAssertNil(fired)
+    }
+
+    func testRequeuedOnlySummaryStillNotifies() {
+        // Quota re-exhausted before anything launched: attempted 0 but work
+        // remains queued — that is worth telling the user about.
+        let fired = SessionWakeNotificationDecider.completionNotification(
+            summary: WakeRunSummary(remaining: 2),
+            context: allowingContext()
+        )
+        XCTAssertEqual(fired?.body, "Resumed 0 of 0 Claude sessions. 2 still queued.")
+    }
+
     func testCompletionSingularCopy() {
         let summary = WakeRunSummary(resumed: 1)
         let fired = SessionWakeNotificationDecider.completionNotification(summary: summary, context: allowingContext())

--- a/MeterBarTests/SessionWakeSettingsTests.swift
+++ b/MeterBarTests/SessionWakeSettingsTests.swift
@@ -98,6 +98,38 @@ final class SessionWakeSettingsTests: XCTestCase {
         XCTAssertFalse(store.isOn)
     }
 
+    func testSwitchingAccountWhileArmedDisarms() {
+        let accountA = UUID()
+        let accountB = UUID()
+        let store = makeStore()
+        store.setWakeAccountID(accountA)
+        store.acknowledgeFirstRunAndTurnOn()
+        XCTAssertTrue(store.isOn)
+
+        // Switching the wake target while armed must disarm: automation may never
+        // keep running against the old account, nor silently retarget the new one.
+        store.setWakeAccountID(accountB)
+        XCTAssertEqual(store.wakeAccountID, accountB)
+        XCTAssertFalse(store.isOn)
+
+        // The persisted flag is off too, so a relaunch stays off until re-armed.
+        let reloaded = SessionWakeSettingsStore(userDefaults: defaults)
+        XCTAssertFalse(reloaded.isOn)
+        XCTAssertEqual(reloaded.wakeAccountID, accountB)
+    }
+
+    func testReselectingSameAccountWhileArmedStaysOn() {
+        let account = UUID()
+        let store = makeStore()
+        store.setWakeAccountID(account)
+        store.acknowledgeFirstRunAndTurnOn()
+        XCTAssertTrue(store.isOn)
+
+        // A no-op re-selection of the already-selected account must not disarm.
+        store.setWakeAccountID(account)
+        XCTAssertTrue(store.isOn)
+    }
+
     func testStaleOnWithoutAccountIsCorrectedAtLoad() {
         // Simulate a persisted "on" with no account (should not stay on).
         defaults.set(true, forKey: StorageKeys.sessionWakeWatcherArmed)

--- a/MeterBarTests/SessionWakeStatusTests.swift
+++ b/MeterBarTests/SessionWakeStatusTests.swift
@@ -76,6 +76,34 @@ final class SessionWakeStatusTests: XCTestCase {
         XCTAssertGreaterThan(host.fittingSize.height, 100)
     }
 
+    func testSettingsPaneHostsEmbeddedInDashboard() {
+        // The dashboard embeds the settings inside its own ScrollView, so the
+        // embedded variant must render without the grouped Form's nested scroll.
+        let defaults = UserDefaults(suiteName: "hosting-\(UUID().uuidString)")!
+        let store = SessionWakeSettingsStore(userDefaults: defaults)
+        store.setWakeAccountID(UUID())
+        store.acknowledgeFirstRunAndTurnOn()
+        let view = SessionWakeSettingsView(
+            embeddedInDashboard: true,
+            store: store,
+            status: SessionWakeStatus(),
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults)
+        )
+        let host = NSHostingView(rootView: view)
+        host.frame = NSRect(x: 0, y: 0, width: 520, height: 700)
+        host.layoutSubtreeIfNeeded()
+        XCTAssertGreaterThan(host.fittingSize.height, 100)
+    }
+
+    func testMenuControlVisibility() {
+        // On ⇒ shown (kill switch must stay reachable), even mid-run.
+        XCTAssertTrue(SessionWakeMenuControl.shouldShow(isOn: true, canTurnOn: false))
+        // Off but armable (account configured) ⇒ shown for quick access.
+        XCTAssertTrue(SessionWakeMenuControl.shouldShow(isOn: false, canTurnOn: true))
+        // Off and unconfigured ⇒ hidden, no inert row.
+        XCTAssertFalse(SessionWakeMenuControl.shouldShow(isOn: false, canTurnOn: false))
+    }
+
     func testMenuControlHosts() {
         let defaults = UserDefaults(suiteName: "hosting-\(UUID().uuidString)")!
         let view = SessionWakeMenuControl(


### PR DESCRIPTION
Fixes four gaps surfaced while auditing closed-candidate PR #104 (`claude/admiring-euler-17814b`) against `master`. Each fix is TDD-first (failing test written before the change).

## 1. BUG — switching the wake account while armed left the watcher bound to the OLD account
`SessionWakeSettingsStore.setWakeAccountID` only force-disarmed on `nil`. On an account→account change it kept `isOn` true, and `SessionWakeController.startWatching` guards `watchTask == nil`, so `reconcile()` never rebound — the live watcher kept running against the *previous* account.

**Fix:** `setWakeAccountID` now `forceOff()`s on **any** change. Switching the wake target disarms; re-arming with the new account is one toggle. This honors the existing invariant that automation is never silently retargeted to an account the user didn't just explicitly arm.

**Tests:** `SessionWakeSettingsTests.testSwitchingAccountWhileArmedDisarms` / `testReselectingSameAccountWhileArmedStaysOn`; `SessionWakeControllerTests.testSwitchingAccountWhileArmedStopsTheWatcher` (two real accounts, A→B while armed → live watcher torn down).

## 2. `SessionWakeMenuControl` was dead code
Referenced only by its own test — never embedded in `MenuBarView`, so the menu-bar stop-the-watcher affordance never shipped.

**Fix:** added `SessionWakeMenuControl.shouldShow(isOn:canTurnOn:)` and embedded the control at the foot of the popover (shown when on — kill switch reachable — or when armable; hidden when unconfigured). **Test:** `SessionWakeStatusTests.testMenuControlVisibility`.

## 3. Session Wake settings unreachable from the dashboard
`SettingsView`'s embedded `settingsStack` (`embeddedInDashboard: true`) omitted `SessionWakeSettingsView`.

**Fix:** added an `embeddedInDashboard` mode to `SessionWakeSettingsView` that drops the grouped `Form` (a nested scroll container would collapse inside the dashboard's `ScrollView`) for a plain stack of the same controls, surfaced as an "Automation" section — mirroring the always-available standalone `.automation` pane. **Test:** `SessionWakeStatusTests.testSettingsPaneHostsEmbeddedInDashboard`.

## 4. "Notify on completion" toggle was inert
`SessionWakeNotificationDecider` had zero production callers.

**Fix:** extended it with `FiredWakeNotification` + `completionNotification(summary:context:)` — stable replace-don't-stack key, pluralized copy, failure and still-queued counts — adapting PR #104's payload design to master's `WakeRunSummary`. Wired `AppDelegate` to observe `SessionWakeStatus.$watcherState` and post on `.completed`, gated by the global / provider / Session-Wake switches (mirrors the existing `checkAndNotify` pattern; decider stays pure, delegate owns `UNUserNotificationCenter`). **Tests:** `SessionWakeNotificationDeciderTests` (6 cases).

## Verification
- `swift test`: **469/469 pass**
- `swiftlint --strict`: **0 violations** (86 files)
- `xcodebuild -scheme MeterBar -configuration Debug` (compiles `MeterBarApp.swift`, which SwiftPM excludes): **BUILD SUCCEEDED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)