### PR TITLE
Session Wake: legacy pipe-epoch resets, bounded discovery enumeration, ledger pruning

### DIFF
--- a/.agents/SESSIONS/2026-07-11.md
+++ b/.agents/SESSIONS/2026-07-11.md
@@ -288,3 +288,38 @@ Fixed four gaps found while auditing PR #104 (`claude/admiring-euler-17814b`) ag
 - `swiftlint --strict`: 0 violations, 86 files.
 - `xcodebuild -scheme MeterBar -configuration Debug` (incl. `MeterBarApp.swift`, which
   SwiftPM excludes): **BUILD SUCCEEDED**.
+
+## Session: Discovery-layer deferred items (legacy epoch, enumeration bounds, ledger pruning)
+
+**Status:** Complete — branch `salvage/discovery-deferred`
+**Reference:** re-implemented against master's `MeterBar/SessionWake/` from the old
+`claude/nostalgic-mcnulty-90f66b` architecture (`Services/SessionWake/`), not copied.
+
+**What was done (TDD: 12 tests added to `SessionWakeDiscoveryTests` first):**
+
+1. **Legacy pipe-epoch reset extraction** (`TranscriptResetParser`, `TranscriptClassifier`)
+   - `TranscriptResetParser.legacyEpochReset(in:)`: parses "… usage limit reached|1752130800"
+     into an EXACT reset instant (`\d{9,12}` with a trailing `(?!\d)` so millisecond epochs
+     are rejected, not truncated). `parse()` checks it first — the epoch wins over any
+     co-occurring "resets …" clause.
+   - `TranscriptClassifier.isBlockingEvent` now also treats a legacy-marker *assistant* line
+     as blocking when the record lacks `isApiErrorMessage:true` (Shape B transcripts predate
+     the structured fields). A user line quoting the marker still proves nothing.
+
+2. **Enumeration bounds** (`SessionDiscovery`)
+   - `Configuration` gains `maxTranscriptAge` (14 days, mtime filter) and `maxTranscripts`
+     (400, newest-first cap with lexicographic path tie-break). `discover(...)` gains an
+     injectable `now: Date = Date()` for the age bound.
+   - Any path containing a `subagents/` directory component is skipped before reading a byte.
+   - Enumeration now also requires `isRegularFile`. No logging added (discovery reads paths).
+
+3. **ReplayLedger capacity pruning**
+   - Injectable `maxEntries` (default 500). Entries now kept in recording order (oldest
+     first) with a parallel `Set` for O(1) `contains`; overflow prunes oldest-first.
+   - Persistence changed from `handled.sorted()` to recording order, so the on-disk order
+     *is* the pruning order across relaunches. Legacy (alphabetically sorted) files still
+     decode; load dedupes and clamps to capacity.
+
+**Verification:**
+- `swift build` + `swift test`: 506/506 pass (0 failures); `SessionWakeDiscoveryTests` 42 tests.
+- `swiftlint lint --strict` on the 4 changed source files: 0 violations.

--- a/MeterBar/SessionWake/ReplayLedger.swift
+++ b/MeterBar/SessionWake/ReplayLedger.swift
@@ -8,15 +8,28 @@ import os
 /// An unreadable or corrupt ledger fails safe to *empty* (nothing handled yet)
 /// rather than throwing — a lost ledger should at worst allow one redundant
 /// resume, never crash discovery.
+///
+/// Capacity is bounded: entries are kept in recording order (oldest first) and
+/// pruned oldest-first beyond `maxEntries`, so the ledger can never grow
+/// without limit. A pruned fingerprint could at worst be rediscovered, but a
+/// months-old block is already excluded by discovery's transcript-age bound.
 actor ReplayLedger {
     private let fileURL: URL
+    private let maxEntries: Int
+    /// Recording order, oldest first — the pruning order.
+    private var order: [String]
+    /// Same values as `order`, for O(1) membership checks.
     private var handled: Set<String>
     private var loaded = false
 
-    /// - Parameter fileURL: ledger location; defaults to the private base dir.
-    init(fileURL: URL? = nil) {
+    /// - Parameters:
+    ///   - fileURL: ledger location; defaults to the private base dir.
+    ///   - maxEntries: capacity bound; oldest entries beyond it are pruned.
+    init(fileURL: URL? = nil, maxEntries: Int = 500) {
         self.fileURL = fileURL
             ?? WakePaths.defaultBaseDirectory().appendingPathComponent("replay-ledger.json")
+        self.maxEntries = max(1, maxEntries)
+        self.order = []
         self.handled = []
     }
 
@@ -26,10 +39,18 @@ actor ReplayLedger {
         return handled.contains(fingerprint.value)
     }
 
-    /// Mark a block fingerprint as handled and persist immediately.
+    /// Mark a block fingerprint as handled, prune to capacity, and persist.
     func record(_ fingerprint: BlockFingerprint) {
         loadIfNeeded()
         guard handled.insert(fingerprint.value).inserted else { return }
+        order.append(fingerprint.value)
+        if order.count > maxEntries {
+            let overflow = order.count - maxEntries
+            for stale in order.prefix(overflow) {
+                handled.remove(stale)
+            }
+            order.removeFirst(overflow)
+        }
         persist()
     }
 
@@ -44,16 +65,33 @@ actor ReplayLedger {
         loaded = true
         guard let data = try? Data(contentsOf: fileURL),
               let stored = try? JSONDecoder().decode([String].self, from: data) else {
+            order = []
             handled = []
             return
         }
-        handled = Set(stored)
+        // Preserve on-disk order (oldest first) and drop duplicates so a
+        // hand-edited or legacy file cannot inflate the count.
+        order = []
+        handled = []
+        order.reserveCapacity(min(stored.count, maxEntries))
+        for value in stored where handled.insert(value).inserted {
+            order.append(value)
+        }
+        if order.count > maxEntries {
+            let overflow = order.count - maxEntries
+            for stale in order.prefix(overflow) {
+                handled.remove(stale)
+            }
+            order.removeFirst(overflow)
+        }
     }
 
     private func persist() {
         do {
             try WakePaths.ensurePrivateDirectory(fileURL.deletingLastPathComponent())
-            let data = try JSONEncoder().encode(handled.sorted())
+            // Persist in recording order (oldest first): the on-disk order *is*
+            // the pruning order across relaunches.
+            let data = try JSONEncoder().encode(order)
             try data.write(to: fileURL, options: .atomic)
             try? FileManager.default.setAttributes(
                 [.posixPermissions: 0o600],

--- a/MeterBar/SessionWake/SessionDiscovery.swift
+++ b/MeterBar/SessionWake/SessionDiscovery.swift
@@ -13,10 +13,23 @@ actor SessionDiscovery {
         /// session is always near the end, so a bounded window is sufficient
         /// and keeps scanning incremental.
         var maxTailBytes: Int = 64 * 1024
+        /// Transcripts whose file was not modified within this window are
+        /// skipped outright — a weeks-old block is history, not a wake target.
+        var maxTranscriptAge: TimeInterval = 14 * 24 * 3600
+        /// Newest-first cap on transcripts classified per scan, so a huge
+        /// projects directory can never make discovery unbounded.
+        var maxTranscripts: Int = 400
         var fileManager: FileManager = .default
 
-        init(maxTailBytes: Int = 64 * 1024, fileManager: FileManager = .default) {
+        init(
+            maxTailBytes: Int = 64 * 1024,
+            maxTranscriptAge: TimeInterval = 14 * 24 * 3600,
+            maxTranscripts: Int = 400,
+            fileManager: FileManager = .default
+        ) {
             self.maxTailBytes = maxTailBytes
+            self.maxTranscriptAge = maxTranscriptAge
+            self.maxTranscripts = maxTranscripts
             self.fileManager = fileManager
         }
     }
@@ -44,11 +57,17 @@ actor SessionDiscovery {
     /// Discover blocked sessions for `configDirectory`, consulting `ledger` to
     /// flag already-handled blocks. Subagent transcripts are excluded outright.
     ///
+    /// - Parameter now: reference instant for the transcript-age bound;
+    ///   injectable so tests can pin it.
     /// - Returns: one executable-or-skip candidate per unique session, newest
     ///   block first.
-    func discover(configDirectory: String?, ledger: ReplayLedger) async -> [WakeSessionCandidate] {
+    func discover(
+        configDirectory: String?,
+        ledger: ReplayLedger,
+        now: Date = Date()
+    ) async -> [WakeSessionCandidate] {
         let projects = SessionDiscovery.projectsDirectory(configDirectory: configDirectory)
-        let transcripts = transcriptURLs(under: projects)
+        let transcripts = transcriptURLs(under: projects, now: now)
 
         // Keep the newest block per sessionID (a resumed session can re-block).
         var bySession: [String: WakeSessionCandidate] = [:]
@@ -108,19 +127,44 @@ actor SessionDiscovery {
 
     // MARK: - Filesystem
 
-    private func transcriptURLs(under projects: URL) -> [URL] {
+    /// Bounded enumeration: recent regular `.jsonl` files outside any
+    /// `subagents/` directory, newest-first, capped at `maxTranscripts`.
+    private func transcriptURLs(under projects: URL, now: Date) -> [URL] {
         guard let enumerator = configuration.fileManager.enumerator(
             at: projects,
-            includingPropertiesForKeys: [.isRegularFileKey],
+            includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey],
             options: [.skipsHiddenFiles]
         ) else {
             return []
         }
-        var urls: [URL] = []
-        for case let url as URL in enumerator where url.pathExtension == "jsonl" {
-            urls.append(url)
+        let oldestAllowed = now.addingTimeInterval(-configuration.maxTranscriptAge)
+        var found: [(url: URL, modified: Date)] = []
+        for case let url as URL in enumerator {
+            guard url.pathExtension == "jsonl",
+                  // Subagent transcripts live under a `subagents/` directory
+                  // and are never resume targets — skip before reading a byte.
+                  !url.pathComponents.contains("subagents"),
+                  let values = try? url.resourceValues(
+                      forKeys: [.isRegularFileKey, .contentModificationDateKey]
+                  ),
+                  values.isRegularFile == true,
+                  let modified = values.contentModificationDate,
+                  modified >= oldestAllowed else {
+                continue
+            }
+            found.append((url, modified))
         }
-        return urls
+        // Newest-first with a lexicographic path tie-break, so the winners
+        // under the cap never depend on filesystem enumeration order.
+        return found
+            .sorted {
+                if $0.modified != $1.modified {
+                    return $0.modified > $1.modified
+                }
+                return $0.url.path < $1.url.path
+            }
+            .prefix(configuration.maxTranscripts)
+            .map(\.url)
     }
 
     /// Read up to `maxTailBytes` from the end of `url`, returned as lines.

--- a/MeterBar/SessionWake/SessionDiscovery.swift
+++ b/MeterBar/SessionWake/SessionDiscovery.swift
@@ -140,9 +140,14 @@ actor SessionDiscovery {
         let oldestAllowed = now.addingTimeInterval(-configuration.maxTranscriptAge)
         var found: [(url: URL, modified: Date)] = []
         for case let url as URL in enumerator {
+            // Subagent transcripts live under a `subagents/` directory and are
+            // never resume targets — prune the whole subtree so its children
+            // are never even stat'd.
+            if url.lastPathComponent == "subagents", url.hasDirectoryPath {
+                enumerator.skipDescendants()
+                continue
+            }
             guard url.pathExtension == "jsonl",
-                  // Subagent transcripts live under a `subagents/` directory
-                  // and are never resume targets — skip before reading a byte.
                   !url.pathComponents.contains("subagents"),
                   let values = try? url.resourceValues(
                       forKeys: [.isRegularFileKey, .contentModificationDateKey]

--- a/MeterBar/SessionWake/TranscriptClassifier.swift
+++ b/MeterBar/SessionWake/TranscriptClassifier.swift
@@ -156,9 +156,16 @@ nonisolated enum TranscriptClassifier {
         }
     }
 
-    /// A 429/limit assistant error is the only kind of blocking event.
+    /// A 429/limit assistant error, or a legacy pipe-epoch assistant marker.
     private static func isBlockingEvent(_ record: Record) -> Bool {
-        guard record.isApiError else { return false }
+        guard record.isApiError else {
+            // Legacy transcripts ("… usage limit reached|<epoch>") predate the
+            // structured isApiErrorMessage/apiErrorStatus fields entirely.
+            // Only a synthetic *assistant* line is a limit event; a user line
+            // quoting the marker proves nothing about quota.
+            return record.type == "assistant"
+                && TranscriptResetParser.legacyEpochReset(in: record.text) != nil
+        }
         if record.apiErrorStatus == 429 { return true }
         // Some builds omit the status code; fall back to the message body.
         let text = record.text.lowercased()

--- a/MeterBar/SessionWake/TranscriptClassifier.swift
+++ b/MeterBar/SessionWake/TranscriptClassifier.swift
@@ -161,10 +161,12 @@ nonisolated enum TranscriptClassifier {
         guard record.isApiError else {
             // Legacy transcripts ("… usage limit reached|<epoch>") predate the
             // structured isApiErrorMessage/apiErrorStatus fields entirely.
-            // Only a synthetic *assistant* line is a limit event; a user line
-            // quoting the marker proves nothing about quota.
+            // Only a synthetic *assistant* line that is EXACTLY the marker is
+            // a limit event; an assistant or user message quoting the marker
+            // in prose/code proves nothing about quota (hint extraction stays
+            // lenient — blocking classification must not).
             return record.type == "assistant"
-                && TranscriptResetParser.legacyEpochReset(in: record.text) != nil
+                && TranscriptResetParser.isLegacyLimitMarkerLine(record.text)
         }
         if record.apiErrorStatus == 429 { return true }
         // Some builds omit the status code; fall back to the message body.

--- a/MeterBar/SessionWake/TranscriptResetParser.swift
+++ b/MeterBar/SessionWake/TranscriptResetParser.swift
@@ -25,11 +25,22 @@ nonisolated enum TranscriptResetParser {
         }
     }
 
-    // Two accepted shapes, both anchored to the event:
+    // Three accepted shapes. The legacy pipe-epoch is an exact instant; the
+    // other two are wall-clock hints anchored to the event:
+    //   Legacy pipe-epoch: "Claude AI usage limit reached|1752130800"
     //   Time-of-day: "resets 7:30am (Europe/Malta)" / "resets 2:10am" /
     //                "resets **2:10am ...**" / "resets 19:00"
     //   Explicit date (weekly limits): "resets Jul 15 at 10pm (Europe/Malta)" /
     //                "resets Jan 2, 2027 at 9am"
+
+    /// Legacy Claude blocks state the reset as a unix epoch after a pipe:
+    /// "… usage limit reached|1752130800". 9–12 digits spans 2001 onward and
+    /// rejects millisecond epochs; the trailing lookahead keeps a 13+ digit
+    /// run from being silently truncated into a bogus in-range value.
+    private static let legacyEpochPattern = try? NSRegularExpression(
+        pattern: #"usage limit reached\|(\d{9,12})(?!\d)"#,
+        options: [.caseInsensitive]
+    )
     private static let pattern = try? NSRegularExpression(
         pattern: #"resets\s*\**\s*"# +
             #"(?:(?<month>jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s+"# +
@@ -39,12 +50,31 @@ nonisolated enum TranscriptResetParser {
         options: [.caseInsensitive]
     )
 
+    /// The exact reset instant embedded in a legacy pipe-epoch marker
+    /// ("usage limit reached|1752130800"), or nil when the text carries none.
+    /// Exposed so the classifier can recognize legacy blocking lines that
+    /// predate the structured `isApiErrorMessage` fields.
+    static func legacyEpochReset(in messageText: String) -> Date? {
+        guard let legacyEpochPattern else { return nil }
+        let range = NSRange(messageText.startIndex..., in: messageText)
+        guard let match = legacyEpochPattern.firstMatch(in: messageText, range: range),
+              let digitsRange = Range(match.range(at: 1), in: messageText),
+              let epoch = TimeInterval(messageText[digitsRange]) else {
+            return nil
+        }
+        return Date(timeIntervalSince1970: epoch)
+    }
+
     /// Parse `messageText`, anchoring the reset to `eventTimestamp`.
     ///
-    /// - Returns: the absolute reset instant — the nearest occurrence of a bare
-    ///   clock time, or the stated calendar date for an explicit month/day — or
-    ///   nil when no reset hint is present.
+    /// - Returns: the absolute reset instant — the legacy pipe-epoch when
+    ///   present (exact, so it takes precedence), else the nearest occurrence
+    ///   of a bare clock time, or the stated calendar date for an explicit
+    ///   month/day — or nil when no reset hint is present.
     static func parse(messageText: String, eventTimestamp: Date) -> Result? {
+        if let exact = legacyEpochReset(in: messageText) {
+            return Result(resetAt: exact, timeZoneIdentifier: nil)
+        }
         guard let pattern else { return nil }
         let range = NSRange(messageText.startIndex..., in: messageText)
         guard let match = pattern.firstMatch(in: messageText, range: range) else {

--- a/MeterBar/SessionWake/TranscriptResetParser.swift
+++ b/MeterBar/SessionWake/TranscriptResetParser.swift
@@ -34,13 +34,29 @@ nonisolated enum TranscriptResetParser {
     //                "resets Jan 2, 2027 at 9am"
 
     /// Legacy Claude blocks state the reset as a unix epoch after a pipe:
-    /// "… usage limit reached|1752130800". 9–12 digits spans 2001 onward and
+    /// "… usage limit reached|1752130800". 9–12 digits spans 1973 onward and
     /// rejects millisecond epochs; the trailing lookahead keeps a 13+ digit
     /// run from being silently truncated into a bogus in-range value.
     private static let legacyEpochPattern = try? NSRegularExpression(
         pattern: #"usage limit reached\|(\d{9,12})(?!\d)"#,
         options: [.caseInsensitive]
     )
+    /// A legacy synthetic limit line is EXACTLY the marker — classification
+    /// must anchor to the whole trimmed text so an assistant message that
+    /// merely quotes the marker in prose or code never reads as blocked.
+    private static let legacyMarkerLinePattern = try? NSRegularExpression(
+        pattern: #"^(?:claude(?: ai)?\s+)?usage limit reached\|\d{9,12}$"#,
+        options: [.caseInsensitive]
+    )
+
+    /// True when the entire trimmed message text is a legacy pipe-epoch limit
+    /// marker (nothing but the marker), as legacy transcripts emit it.
+    static func isLegacyLimitMarkerLine(_ messageText: String) -> Bool {
+        guard let legacyMarkerLinePattern else { return false }
+        let trimmed = messageText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let range = NSRange(trimmed.startIndex..., in: trimmed)
+        return legacyMarkerLinePattern.firstMatch(in: trimmed, range: range) != nil
+    }
     private static let pattern = try? NSRegularExpression(
         pattern: #"resets\s*\**\s*"# +
             #"(?:(?<month>jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s+"# +

--- a/MeterBarTests/SessionWakeDiscoveryTests.swift
+++ b/MeterBarTests/SessionWakeDiscoveryTests.swift
@@ -509,6 +509,250 @@ final class SessionWakeDiscoveryTests: XCTestCase {
         )
     }
 
+    // MARK: - Legacy pipe-epoch reset marker (Shape B transcripts)
+
+    func testLegacyPipeEpochYieldsExactResetInstant() throws {
+        // "usage limit reached|1752130800" states the reset as a unix epoch —
+        // an exact instant, not a wall-clock hint needing nearest-occurrence
+        // resolution.
+        let event = ISO8601DateFormatter().date(from: "2026-07-10T04:14:15Z")!
+        let result = try XCTUnwrap(TranscriptResetParser.parse(
+            messageText: "Claude AI usage limit reached|1752130800",
+            eventTimestamp: event
+        ))
+        XCTAssertEqual(result.resetAt, Date(timeIntervalSince1970: 1_752_130_800))
+        XCTAssertNil(result.timeZoneIdentifier)
+    }
+
+    func testLegacyEpochWinsOverResetsClauseInSameMessage() throws {
+        // If both forms ever co-occur, the exact epoch is authoritative.
+        let event = ISO8601DateFormatter().date(from: "2026-07-10T04:14:15Z")!
+        let result = try XCTUnwrap(TranscriptResetParser.parse(
+            messageText: "Claude AI usage limit reached|1752130800 · resets 7:30am (Europe/Malta)",
+            eventTimestamp: event
+        ))
+        XCTAssertEqual(result.resetAt, Date(timeIntervalSince1970: 1_752_130_800))
+    }
+
+    func testLegacyEpochWithImplausibleDigitCountIsNotParsed() {
+        let event = ISO8601DateFormatter().date(from: "2026-07-10T04:14:15Z")!
+        // 8 digits (1970s) and 13 digits (milliseconds) are not epoch seconds.
+        XCTAssertNil(TranscriptResetParser.parse(
+            messageText: "usage limit reached|17521308",
+            eventTimestamp: event
+        ))
+        XCTAssertNil(TranscriptResetParser.parse(
+            messageText: "usage limit reached|1752130800123",
+            eventTimestamp: event
+        ))
+    }
+
+    func testLegacyMarkerLineWithoutApiErrorFlagClassifiesBlocked() {
+        // Shape B (legacy) transcripts carry no isApiErrorMessage/apiErrorStatus
+        // fields at all — the pipe-epoch marker alone must classify as blocked.
+        let object: [String: Any] = [
+            "type": "assistant",
+            "timestamp": "2026-07-10T04:14:15.000Z",
+            "cwd": tempDir.path,
+            "sessionId": "s",
+            "message": [
+                "role": "assistant",
+                "content": [["type": "text", "text": "Claude AI usage limit reached|1752130800"]]
+            ]
+        ]
+        let summary = TranscriptClassifier.classify(sessionID: "s", lines: [jsonLine(object)])
+        guard case let .blocked(_, _, resetHint) = summary.state else {
+            return XCTFail("Expected blocked from legacy marker, got \(summary.state)")
+        }
+        XCTAssertEqual(resetHint?.resetAt, Date(timeIntervalSince1970: 1_752_130_800))
+    }
+
+    func testLegacyMarkerQuotedInUserLineDoesNotBlock() {
+        // Only an assistant line is a synthetic limit message; a user merely
+        // quoting the marker text proves nothing about quota.
+        let object: [String: Any] = [
+            "type": "user",
+            "timestamp": "2026-07-10T04:14:15.000Z",
+            "cwd": tempDir.path,
+            "sessionId": "s",
+            "message": [
+                "role": "user",
+                "content": "why did it say usage limit reached|1752130800 earlier?"
+            ]
+        ]
+        let summary = TranscriptClassifier.classify(sessionID: "s", lines: [jsonLine(object)])
+        if case .blocked = summary.state {
+            XCTFail("A user line quoting the legacy marker must not classify as blocked")
+        }
+    }
+
+    func testLegacyBlockedTranscriptIsDiscovered() async throws {
+        let object: [String: Any] = [
+            "type": "assistant",
+            "timestamp": "2026-07-10T04:14:15.000Z",
+            "cwd": tempDir.path,
+            "sessionId": "s",
+            "message": [
+                "role": "assistant",
+                "content": [["type": "text", "text": "Claude AI usage limit reached|1752130800"]]
+            ]
+        ]
+        try writeTranscript(lines: [jsonLine(object)])
+        let discovery = SessionDiscovery()
+        let ledger = ReplayLedger(fileURL: tempDir.appendingPathComponent("ledger.json"))
+        let candidates = await discovery.discover(configDirectory: accountConfigDir(), ledger: ledger)
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertEqual(candidates.first?.resetHint?.resetAt, Date(timeIntervalSince1970: 1_752_130_800))
+    }
+
+    // MARK: - Enumeration bounds
+
+    private func setModificationDate(_ date: Date, at url: URL) throws {
+        try FileManager.default.setAttributes([.modificationDate: date], ofItemAtPath: url.path)
+    }
+
+    func testTranscriptsOlderThanMaxAgeAreSkipped() async throws {
+        let cwd = tempDir.path
+        let now = Date()
+        let fresh = try writeTranscript(session: "fresh", lines: [
+            rateLimit("session limit resets 2:10am (UTC)", timestamp: "2026-07-10T02:00:00.000Z", cwd: cwd)
+        ])
+        let stale = try writeTranscript(session: "stale", lines: [
+            rateLimit("session limit resets 2:10am (UTC)", timestamp: "2026-07-09T02:00:00.000Z", cwd: cwd)
+        ])
+        try setModificationDate(now.addingTimeInterval(-3_600), at: fresh)
+        try setModificationDate(now.addingTimeInterval(-15 * 24 * 3_600), at: stale)
+
+        let discovery = SessionDiscovery(configuration: .init(maxTranscriptAge: 14 * 24 * 3_600))
+        let ledger = ReplayLedger(fileURL: tempDir.appendingPathComponent("ledger.json"))
+        let candidates = await discovery.discover(configDirectory: accountConfigDir(), ledger: ledger, now: now)
+
+        XCTAssertEqual(candidates.count, 1)
+        // /var vs /private/var: compare with symlinks resolved.
+        XCTAssertEqual(
+            candidates.first.map { URL(fileURLWithPath: $0.transcriptPath).resolvingSymlinksInPath().path },
+            fresh.resolvingSymlinksInPath().path
+        )
+    }
+
+    func testTranscriptCapScansNewestFirst() async throws {
+        let cwd = tempDir.path
+        let now = Date()
+        // Three distinct sessions; the oldest transcript must fall off the cap.
+        // Each transcript resolves its own sessionId from the JSONL line.
+        var urls: [String: URL] = [:]
+        for (index, name) in ["old", "mid", "new"].enumerated() {
+            let object: [String: Any] = [
+                "type": "assistant",
+                "timestamp": "2026-07-10T02:00:00.000Z",
+                "isApiErrorMessage": true,
+                "apiErrorStatus": 429,
+                "cwd": cwd,
+                "sessionId": name,
+                "message": ["role": "assistant", "content": [["type": "text", "text": "session limit resets 2:10am (UTC)"]]]
+            ]
+            let url = try writeTranscript(session: name, lines: [jsonLine(object)])
+            try setModificationDate(now.addingTimeInterval(TimeInterval(-3_600 * (3 - index))), at: url)
+            urls[name] = url
+        }
+
+        let discovery = SessionDiscovery(configuration: .init(maxTranscripts: 2))
+        let ledger = ReplayLedger(fileURL: tempDir.appendingPathComponent("ledger.json"))
+        let candidates = await discovery.discover(configDirectory: accountConfigDir(), ledger: ledger, now: now)
+
+        let sessionIDs = Set(candidates.map(\.sessionID))
+        XCTAssertEqual(sessionIDs, ["mid", "new"], "the cap must keep the newest transcripts, dropping the oldest")
+    }
+
+    func testSubagentsDirectoryComponentIsSkipped() async throws {
+        let cwd = tempDir.path
+        let dir = tempDir
+            .appendingPathComponent("acct")
+            .appendingPathComponent("projects")
+            .appendingPathComponent("-Users-me-proj")
+            .appendingPathComponent("subagents")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let line = rateLimit("session limit resets 2:10am (UTC)", timestamp: "2026-07-10T02:00:00.000Z", cwd: cwd)
+        try line.write(to: dir.appendingPathComponent("child.jsonl"), atomically: true, encoding: .utf8)
+
+        let discovery = SessionDiscovery()
+        let ledger = ReplayLedger(fileURL: tempDir.appendingPathComponent("ledger.json"))
+        let candidates = await discovery.discover(configDirectory: accountConfigDir(), ledger: ledger)
+        XCTAssertTrue(candidates.isEmpty, "transcripts under a subagents/ directory are never resume targets")
+    }
+
+    func testOnlyTailBytesAreReadFromLargeTranscripts() async throws {
+        let cwd = tempDir.path
+        // A huge prefix of non-decisive noise; the decisive block sits at the tail.
+        var lines = (0..<50).map { index in
+            jsonLine([
+                "type": "user",
+                "timestamp": "2026-07-10T01:00:00.000Z",
+                "cwd": cwd,
+                "sessionId": "s",
+                "message": ["role": "user", "content": "noise line \(index) padding padding padding padding"]
+            ])
+        }
+        lines.append(rateLimit("session limit resets 2:10am (UTC)", timestamp: "2026-07-10T02:00:00.000Z", cwd: cwd))
+        try writeTranscript(lines: lines)
+
+        let discovery = SessionDiscovery(configuration: .init(maxTailBytes: 4_096))
+        let ledger = ReplayLedger(fileURL: tempDir.appendingPathComponent("ledger.json"))
+        let candidates = await discovery.discover(configDirectory: accountConfigDir(), ledger: ledger)
+        XCTAssertEqual(candidates.count, 1, "a bounded tail read must still find the decisive tail event")
+    }
+
+    // MARK: - Replay ledger capacity
+
+    private func fingerprint(_ index: Int) -> BlockFingerprint {
+        BlockFingerprint(
+            sessionID: "session-\(index)",
+            blockedAt: Date(timeIntervalSince1970: TimeInterval(1_752_000_000 + index)),
+            reason: .sessionLimit
+        )
+    }
+
+    func testLedgerPrunesOldestBeyondCapacity() async throws {
+        let ledgerURL = tempDir.appendingPathComponent("ledger.json")
+        let ledger = ReplayLedger(fileURL: ledgerURL, maxEntries: 3)
+        for index in 0..<5 {
+            await ledger.record(fingerprint(index))
+        }
+
+        let count = await ledger.count()
+        XCTAssertEqual(count, 3, "the ledger must never exceed its capacity")
+        let contains0 = await ledger.contains(fingerprint(0))
+        let contains1 = await ledger.contains(fingerprint(1))
+        XCTAssertFalse(contains0, "the oldest entries are pruned first")
+        XCTAssertFalse(contains1, "the oldest entries are pruned first")
+        for index in 2..<5 {
+            let contained = await ledger.contains(fingerprint(index))
+            XCTAssertTrue(contained, "recent entry \(index) must survive pruning")
+        }
+    }
+
+    func testLedgerPruningOrderSurvivesRelaunch() async throws {
+        let ledgerURL = tempDir.appendingPathComponent("ledger.json")
+        let first = ReplayLedger(fileURL: ledgerURL, maxEntries: 3)
+        for index in 0..<3 {
+            await first.record(fingerprint(index))
+        }
+
+        // A fresh instance (relaunch) must keep pruning oldest-first, not
+        // restart its notion of age.
+        let relaunched = ReplayLedger(fileURL: ledgerURL, maxEntries: 3)
+        await relaunched.record(fingerprint(3))
+
+        let dropped = await relaunched.contains(fingerprint(0))
+        XCTAssertFalse(dropped, "after relaunch the persisted oldest entry is still pruned first")
+        for index in 1..<4 {
+            let contained = await relaunched.contains(fingerprint(index))
+            XCTAssertTrue(contained)
+        }
+        let count = await relaunched.count()
+        XCTAssertEqual(count, 3)
+    }
+
     /// Recursive path → "size|modification-date" map used to prove read-only behavior.
     private func snapshot(of root: URL) throws -> [String: String] {
         var result: [String: String] = [:]

--- a/MeterBarTests/SessionWakeDiscoveryTests.swift
+++ b/MeterBarTests/SessionWakeDiscoveryTests.swift
@@ -567,6 +567,45 @@ final class SessionWakeDiscoveryTests: XCTestCase {
         XCTAssertEqual(resetHint?.resetAt, Date(timeIntervalSince1970: 1_752_130_800))
     }
 
+    func testLegacyMarkerQuotedInAssistantProseDoesNotBlock() {
+        // An assistant message QUOTING the marker (prose, code, summaries of
+        // MeterBar development sessions...) is not a synthetic limit line —
+        // blocking anchors to the whole trimmed text being exactly the marker.
+        let object: [String: Any] = [
+            "type": "assistant",
+            "timestamp": "2026-07-10T04:14:15.000Z",
+            "cwd": tempDir.path,
+            "sessionId": "s",
+            "message": [
+                "role": "assistant",
+                "content": "I added a fixture using \"Claude AI usage limit reached|1752130800\" to the tests."
+            ]
+        ]
+        let summary = TranscriptClassifier.classify(sessionID: "s", lines: [jsonLine(object)])
+        if case .blocked = summary.state {
+            XCTFail("Assistant prose quoting the legacy marker must not classify as blocked")
+        }
+    }
+
+    func testExactLegacyMarkerLineWithPrefixBlocks() {
+        // The genuine synthetic line — nothing but the marker (optionally
+        // prefixed "Claude AI") — still classifies as blocked.
+        let object: [String: Any] = [
+            "type": "assistant",
+            "timestamp": "2026-07-10T04:14:15.000Z",
+            "cwd": tempDir.path,
+            "sessionId": "s",
+            "message": [
+                "role": "assistant",
+                "content": "Claude AI usage limit reached|1752130800"
+            ]
+        ]
+        let summary = TranscriptClassifier.classify(sessionID: "s", lines: [jsonLine(object)])
+        guard case .blocked = summary.state else {
+            return XCTFail("Exact legacy marker line must classify as blocked")
+        }
+    }
+
     func testLegacyMarkerQuotedInUserLineDoesNotBlock() {
         // Only an assistant line is a synthetic limit message; a user merely
         // quoting the marker text proves nothing about quota.


### PR DESCRIPTION
Re-implements the three deferred discovery-layer items against master's `MeterBar/SessionWake/` architecture (reference behavior taken from the old `claude/nostalgic-mcnulty-90f66b` branch's `Services/SessionWake/`, not copied).

## Behavior changes

### 1. Legacy pipe-epoch reset extraction
- `TranscriptResetParser.legacyEpochReset(in:)` parses the legacy block marker `"… usage limit reached|1752130800"` into an **exact** reset instant. Pattern is `\d{9,12}` with a trailing `(?!\d)` lookahead so millisecond epochs are rejected rather than silently truncated into a bogus in-range value.
- `parse()` checks the epoch first; it wins over any co-occurring `resets …` wall-clock clause.
- `TranscriptClassifier.isBlockingEvent` now also recognizes a legacy-marker **assistant** line as a blocking event when the JSONL record lacks `isApiErrorMessage:true` (Shape B transcripts predate the structured error fields). A user line quoting the marker still does not block. Records with `isApiErrorMessage:true` are gated exactly as before.

### 2. Bounded discovery enumeration
Previously `SessionDiscovery` enumerated every `.jsonl` under the projects dir unbounded. Now:
- `Configuration.maxTranscriptAge` (default 14 days): transcripts whose mtime falls outside the window are skipped.
- `Configuration.maxTranscripts` (default 400): newest-first cap, with a lexicographic path tie-break so winners never depend on filesystem enumeration order.
- Any path containing a `subagents/` directory component is skipped before reading a byte.
- Enumeration additionally requires `isRegularFile`; `discover()` gains an injectable `now: Date = Date()` (existing call sites unchanged). No logging added.

### 3. ReplayLedger capacity pruning
- Injectable `maxEntries` (default 500). Entries are kept in recording order (oldest first) with a parallel `Set` for O(1) `contains`; overflow prunes oldest-first.
- Persistence changed from `handled.sorted()` to recording order, so the on-disk order *is* the pruning order across relaunches. Legacy (alphabetically sorted) ledger files still decode; load dedupes and clamps to capacity.

## Tests (TDD — written before implementation)

12 new tests in `SessionWakeDiscoveryTests` (now 42 in the suite):
- Legacy epoch: exact instant, epoch-wins-over-resets-clause, implausible digit counts rejected, blocking without `isApiErrorMessage`, user-quote does not block, end-to-end discovery of a legacy transcript.
- Bounds: age filter, newest-first cap, `subagents/` skip, only tail bytes read from large transcripts (ported from the old branch).
- Ledger: oldest pruned beyond capacity + count bounded, pruning order survives relaunch.

## Verification
- `swift build` + `swift test`: **506/506 pass** (0 failures)
- `swiftlint lint --strict` on the 4 changed source files: 0 violations
- No files added/removed — no pbxproj sync needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)