### PR TITLE
Runner deferred items: permission-denial classification + lock-holder identity

### DIFF
--- a/.agents/SESSIONS/2026-07-11.md
+++ b/.agents/SESSIONS/2026-07-11.md
@@ -288,3 +288,40 @@ Fixed four gaps found while auditing PR #104 (`claude/admiring-euler-17814b`) ag
 - `swiftlint --strict`: 0 violations, 86 files.
 - `xcodebuild -scheme MeterBar -configuration Debug` (incl. `MeterBarApp.swift`, which
   SwiftPM excludes): **BUILD SUCCEEDED**.
+
+## Session: Runner-layer deferred items — permission-denial classification + lock-holder identity
+
+**Status:** Complete (branch `salvage/runner-deferred`)
+
+Re-implemented the two runner items deferred from the old `claude/eager-rubin-4e1ab8`
+architecture against master's `MeterBar/SessionWake/` layout. TDD: tests written first.
+
+1. **Permission-denial classification.** `ManagedProcess`'s `StreamCounter` became a
+   `BoundedSink`: it still counts every drained byte (pipe never blocks) but now retains
+   the leading `maxCaptureBytes` (64 KiB default) in memory — the buffer can never grow
+   past the cap. `ManagedProcess.Result` gains `stdoutCapture`/`stderrCapture` (classification
+   only; documented never-logged). New `PermissionDenialDetector` (conservative case-insensitive
+   phrase heuristics). `WakeProcessRunner.mapOutcome` now takes the full `Result` and, on
+   non-zero exit whose capture reads as an approval-gate stop, returns the new
+   `WakeRunOutcome.permissionDenied` (log label `permission-denied`). Denials tally as
+   failures in `WakeCoordinator`/`WakeCLIEngine` and are never ledger-recorded (retryable),
+   and there is still no path that escalates to `--dangerously-skip-permissions`.
+   Privacy pinned by test: captured content never reaches `WakeRunLogger` files.
+
+2. **Lock-holder identification.** `WakeLock.acquire()` now writes a JSON
+   `WakeLockHolder` descriptor (kind app|cli, pid, host, startedAtEpoch) into the lock
+   file inside the same `stateLock` critical section as open/flock/store (atomicity +
+   idempotent-reacquire invariants preserved). On contention the descriptor is read back:
+   `Acquisition.contended(holder: WakeLockHolder?)`. Directory-creation/open/flock
+   failures are now a distinct `.unavailable(reason:)` instead of masquerading as
+   contention. `release()` truncates the descriptor so a freed lock is never misattributed.
+   `WakeCLIEngine` defaults to a `.cli`-kind lock and its contention message (and the
+   runner's failure reason) now name the holder ("cli, pid N on host").
+
+**Files:** `ManagedProcess.swift`, `PermissionDenialDetector.swift` (new), `WakeLock.swift`,
+`WakeProcessRunner.swift`, `WakeCLIEngine.swift`, `WakeCoordinator.swift`,
+`WakeWatcherState.swift`; tests in `ManagedProcessTests`, `WakeRunnerTests`, `WakeCLIEngineTests`.
+
+### Verification
+- `swift test`: 509/509 pass (15 new tests).
+- `swiftlint lint --strict` on the 7 changed/new `MeterBar/` files: 0 violations.

--- a/MeterBar/SessionWake/ManagedProcess.swift
+++ b/MeterBar/SessionWake/ManagedProcess.swift
@@ -33,10 +33,30 @@ nonisolated enum ManagedProcess {
         /// counted but discarded, so a caller knows the capture is incomplete).
         let stdoutTruncated: Bool
         let stderrTruncated: Bool
+        /// The leading `maxCaptureBytes` of each stream, retained in memory for
+        /// the caller to *classify* the run (e.g. permission-denial detection).
+        /// PRIVACY: this content must never be written to logs or persisted —
+        /// only metadata (byte counts, truncation flags, outcome labels) may be
+        /// recorded. It lives exactly as long as this `Result` value.
+        let stdoutCapture: Data
+        let stderrCapture: Data
 
         var isSuccess: Bool {
             if case .exited(0) = termination { return true }
             return false
+        }
+
+        /// A content-free result for failures before any stream existed.
+        fileprivate static func empty(_ termination: Termination) -> Result {
+            Result(
+                termination: termination,
+                stdoutByteCount: 0,
+                stderrByteCount: 0,
+                stdoutTruncated: false,
+                stderrTruncated: false,
+                stdoutCapture: Data(),
+                stderrCapture: Data()
+            )
         }
     }
 
@@ -97,13 +117,7 @@ nonisolated enum ManagedProcess {
         let errPipe = UnsafeMutablePointer<Int32>.allocate(capacity: 2)
         defer { outPipe.deallocate(); errPipe.deallocate() }
         guard pipe(outPipe) == 0, pipe(errPipe) == 0 else {
-            return Result(
-                termination: .launchFailed("pipe() failed"),
-                stdoutByteCount: 0,
-                stderrByteCount: 0,
-                stdoutTruncated: false,
-                stderrTruncated: false
-            )
+            return .empty(.launchFailed("pipe() failed"))
         }
 
         // Child: stdin from /dev/null, stdout/stderr to the pipe write ends.
@@ -149,22 +163,16 @@ nonisolated enum ManagedProcess {
         close(outPipe[1]); close(errPipe[1])
         guard spawnResult == 0 else {
             close(outPipe[0]); close(errPipe[0])
-            return Result(
-                termination: .launchFailed("posix_spawn failed (\(spawnResult))"),
-                stdoutByteCount: 0,
-                stderrByteCount: 0,
-                stdoutTruncated: false,
-                stderrTruncated: false
-            )
+            return .empty(.launchFailed("posix_spawn failed (\(spawnResult))"))
         }
 
         cancellation.attach(pgid: pid)
 
-        let outCounter = StreamCounter(cap: maxCaptureBytes)
-        let errCounter = StreamCounter(cap: maxCaptureBytes)
+        let outSink = BoundedSink(cap: maxCaptureBytes)
+        let errSink = BoundedSink(cap: maxCaptureBytes)
         let drains = DispatchGroup()
-        drain(fd: outPipe[0], into: outCounter, group: drains)
-        drain(fd: errPipe[0], into: errCounter, group: drains)
+        drain(fd: outPipe[0], into: outSink, group: drains)
+        drain(fd: errPipe[0], into: errSink, group: drains)
 
         let termination = wait(pid: pid, timeout: timeout, cancellation: cancellation)
 
@@ -184,28 +192,36 @@ nonisolated enum ManagedProcess {
 
         return Result(
             termination: termination,
-            stdoutByteCount: outCounter.count,
-            stderrByteCount: errCounter.count,
-            stdoutTruncated: outCounter.truncated,
-            stderrTruncated: errCounter.truncated
+            stdoutByteCount: outSink.count,
+            stderrByteCount: errSink.count,
+            stdoutTruncated: outSink.truncated,
+            stderrTruncated: errSink.truncated,
+            stdoutCapture: outSink.capturedData,
+            stderrCapture: errSink.capturedData
         )
     }
 
     // MARK: - Draining
 
-    /// Thread-safe byte tally for one drained stream. Every byte read is counted
-    /// so the caller learns the true stream size; `cap` bounds only what is
-    /// conceptually retained, and `truncated` reports whether the stream exceeded
-    /// it.
-    private final class StreamCounter: @unchecked Sendable {
+    /// Thread-safe bounded collector for one drained stream. Every byte read is
+    /// counted so the caller learns the true stream size, but only the leading
+    /// `cap` bytes are retained — the buffer can never grow past the cap, so a
+    /// runaway child cannot exhaust memory. Draining always continues past the
+    /// cap (excess is counted and discarded, never blocking the pipe).
+    private final class BoundedSink: @unchecked Sendable {
         private let lock = NSLock()
         private let cap: Int
         private var total = 0
+        private var storage = Data()
 
-        init(cap: Int) { self.cap = cap }
+        init(cap: Int) { self.cap = max(0, cap) }
 
-        func add(_ count: Int) {
-            lock.lock(); total += count; lock.unlock()
+        func append(_ buffer: [UInt8], count: Int) {
+            lock.lock(); defer { lock.unlock() }
+            total += count
+            let remaining = cap - storage.count
+            guard remaining > 0 else { return }
+            storage.append(contentsOf: buffer[0..<min(remaining, count)])
         }
 
         var count: Int {
@@ -215,11 +231,16 @@ nonisolated enum ManagedProcess {
 
         var truncated: Bool {
             lock.lock(); defer { lock.unlock() }
-            return total > cap
+            return total > storage.count
+        }
+
+        var capturedData: Data {
+            lock.lock(); defer { lock.unlock() }
+            return storage
         }
     }
 
-    private static func drain(fd: Int32, into counter: StreamCounter, group: DispatchGroup) {
+    private static func drain(fd: Int32, into sink: BoundedSink, group: DispatchGroup) {
         let queue = DispatchQueue(label: "dev.meterbar.app.wake.drain.\(fd)")
         group.enter()
         queue.async {
@@ -228,8 +249,8 @@ nonisolated enum ManagedProcess {
             while true {
                 let n = read(fd, &buffer, buffer.count)
                 if n > 0 {
-                    // Count everything; only the cap bounds memory pressure.
-                    counter.add(n)
+                    // Retain up to the cap; count everything past it.
+                    sink.append(buffer, count: n)
                 } else if n == 0 {
                     break
                 } else if errno == EINTR {

--- a/MeterBar/SessionWake/PermissionDenialDetector.swift
+++ b/MeterBar/SessionWake/PermissionDenialDetector.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Recognises a Claude run that ended because it was blocked at the permission
+/// approval gate, so the runner can report a *structured* `permissionDenied`
+/// outcome instead of a generic failure.
+///
+/// Detection never triggers a retry with bypass: a denied session is reported
+/// and left for the user to act on. There is deliberately no code path anywhere
+/// that upgrades a safe run to `--dangerously-skip-permissions` on failure.
+///
+/// PRIVACY: the input is the bounded in-memory stdout/stderr capture from
+/// `ManagedProcess.Result`. It is inspected here and nowhere else — never
+/// logged, never persisted.
+nonisolated enum PermissionDenialDetector {
+    /// Conservative markers that indicate an approval gate stopped the run.
+    /// Kept small and matched case-insensitively so unrelated failures are not
+    /// misclassified as permission denials.
+    private static let markers: [String] = [
+        "permission denied",
+        "requires permission",
+        "requires approval",
+        "needs approval",
+        "permission to use",
+        "permission_denied",
+        "--dangerously-skip-permissions"
+    ]
+
+    /// Whether `output` (a bounded capture, never logged) reads as a permission
+    /// denial.
+    static func indicatesDenial(in output: String) -> Bool {
+        guard !output.isEmpty else { return false }
+        let haystack = output.lowercased()
+        return markers.contains { haystack.contains($0) }
+    }
+}

--- a/MeterBar/SessionWake/SessionWakeCLI.swift
+++ b/MeterBar/SessionWake/SessionWakeCLI.swift
@@ -65,7 +65,11 @@ public enum SessionWakeCLI {
                 WakeProcessRunner(
                     account: runnerAccount,
                     permissionMode: mode,
-                    bypassAcknowledged: request.bypassAcknowledged
+                    bypassAcknowledged: request.bypassAcknowledged,
+                    // The engine holds the shared lock for the whole pass; a
+                    // second same-process flock would self-contend (fd-level
+                    // holders), failing every real resume.
+                    assumesExternalLock: true
                 )
             },
             shouldCancel: request.shouldCancel

--- a/MeterBar/SessionWake/WakeCLIEngine.swift
+++ b/MeterBar/SessionWake/WakeCLIEngine.swift
@@ -19,7 +19,7 @@ struct WakeCLIEngine {
         authority: WakeQuotaAuthority = WakeQuotaAuthority(),
         makeRunner: @escaping @Sendable (ClaudeCodeAccount) -> WakeExecuting,
         ledgerFactory: @escaping @Sendable () -> ReplayLedger = { ReplayLedger() },
-        lock: WakeLock = WakeLock(),
+        lock: WakeLock = WakeLock(holderKind: .cli),
         bounds: WakeBounds = .default,
         shouldCancel: @escaping @Sendable () -> Bool = { false }
     ) {
@@ -65,14 +65,15 @@ struct WakeCLIEngine {
         switch lock.acquire() {
         case .acquired:
             break
-        case .contended:
+        case let .contended(holder):
+            let who = holder.map { " (\($0.shortDescription))" } ?? " (app or CLI)"
             return .from(
                 candidates: candidates,
                 outcome: .validationFailure,
                 provider: normalizedProvider,
                 dryRun: false,
                 account: account.configDirectory,
-                message: "Another Session Wake holder (app or CLI) is already running."
+                message: "Another Session Wake holder\(who) is already running."
             )
         case let .legacyHeld(guidance):
             return .from(
@@ -82,6 +83,15 @@ struct WakeCLIEngine {
                 dryRun: false,
                 account: account.configDirectory,
                 message: guidance
+            )
+        case let .unavailable(reason):
+            return .from(
+                candidates: candidates,
+                outcome: .validationFailure,
+                provider: normalizedProvider,
+                dryRun: false,
+                account: account.configDirectory,
+                message: "Session Wake lock unavailable: \(reason)"
             )
         }
         defer { lock.release() }
@@ -141,7 +151,9 @@ struct WakeCLIEngine {
             case .succeeded:
                 summary.resumed += 1
                 await ledger.record(candidate.fingerprint)
-            case .failed:
+            case .failed, .permissionDenied:
+                // A denial is a failure for tally purposes; the ledger is not
+                // written, so the session stays retryable once the user acts.
                 summary.failed += 1
             case .skipped:
                 summary.skipped += 1

--- a/MeterBar/SessionWake/WakeCoordinator.swift
+++ b/MeterBar/SessionWake/WakeCoordinator.swift
@@ -178,7 +178,9 @@ actor WakeCoordinator {
             // Only a real resume marks the block handled, so a failed attempt
             // can be retried on a later run.
             await ledger.record(candidate.fingerprint)
-        case .failed:
+        case .failed, .permissionDenied:
+            // A permission denial tallies as a failure and is NOT recorded in
+            // the ledger, so the session stays retryable once the user acts.
             summary.failed += 1
         case .skipped:
             summary.skipped += 1

--- a/MeterBar/SessionWake/WakeLock.swift
+++ b/MeterBar/SessionWake/WakeLock.swift
@@ -55,6 +55,10 @@ nonisolated final class WakeLock: @unchecked Sendable {
     private let stateLock = NSLock()
     private var fileDescriptor: Int32 = -1
 
+    /// Resolved once — `hostName` can trigger reverse-DNS and stall, which we
+    /// never want inside `acquire()`'s critical section.
+    private static let cachedHostName = ProcessInfo.processInfo.hostName
+
     init(lockURL: URL? = nil, legacyLockURLs: [URL]? = nil, holderKind: WakeLockHolder.Kind = .app) {
         self.lockURL = lockURL
             ?? WakePaths.defaultBaseDirectory().appendingPathComponent("wake.lock")
@@ -90,7 +94,10 @@ nonisolated final class WakeLock: @unchecked Sendable {
         // descriptor. `LOCK_NB` keeps the critical section non-blocking.
         return stateLock.withLock {
             guard fileDescriptor < 0 else { return .acquired }
-            let descriptor = open(lockURL.path, O_CREAT | O_RDWR, 0o600)
+            // O_CLOEXEC so the spawned `claude` child does not inherit the
+            // held flock fd — otherwise a parent that dies mid-run leaves the
+            // child holding the lock with a dead pid in the descriptor.
+            let descriptor = open(lockURL.path, O_CREAT | O_RDWR | O_CLOEXEC, 0o600)
             guard descriptor >= 0 else {
                 return .unavailable(reason: "open lock: \(String(cString: strerror(errno)))")
             }
@@ -132,10 +139,12 @@ nonisolated final class WakeLock: @unchecked Sendable {
     /// Write our descriptor into the freshly-locked file for contenders to read.
     /// Best-effort: a failed write degrades a contender's message, never the lock.
     private func writeHolder(to descriptor: Int32) {
+        // hostName can stall on reverse-DNS; resolve it before we are called
+        // (inside the stateLock critical section) — see cachedHostName.
         let holder = WakeLockHolder(
             kind: holderKind,
             pid: getpid(),
-            host: ProcessInfo.processInfo.hostName,
+            host: WakeLock.cachedHostName,
             startedAtEpoch: Date().timeIntervalSince1970
         )
         guard let data = try? JSONEncoder().encode(holder) else { return }

--- a/MeterBar/SessionWake/WakeLock.swift
+++ b/MeterBar/SessionWake/WakeLock.swift
@@ -1,34 +1,64 @@
 import Darwin
 import Foundation
 
+/// The descriptor the current holder writes into the lock file so a contender
+/// can report *who* holds it instead of a bare "contended".
+nonisolated struct WakeLockHolder: Codable, Equatable, Sendable {
+    /// Who is holding the shared lock.
+    enum Kind: String, Codable, Equatable, Sendable {
+        case app
+        case cli
+    }
+
+    let kind: Kind
+    let pid: Int32
+    let host: String
+    let startedAtEpoch: Double
+
+    var startedAt: Date { Date(timeIntervalSince1970: startedAtEpoch) }
+
+    /// A compact, log-safe label ("cli, pid 123 on host") for user-facing
+    /// contention messages.
+    var shortDescription: String {
+        "\(kind.rawValue), pid \(pid) on \(host)"
+    }
+}
+
 /// One advisory-lock protocol shared by MeterBar, `meterbar wake`, and the
 /// legacy watcher during migration.
 ///
 /// Uses `flock(LOCK_EX|LOCK_NB)` on a fixed lock file so any two holders — the
 /// app and the CLI, or either and a still-loaded legacy job — mutually exclude.
 /// The lock is acquired only when a run is actually ready, never held across a
-/// long quota wait.
+/// long quota wait. The holder writes a JSON descriptor into the lock file so a
+/// contender can say who is running.
 nonisolated final class WakeLock: @unchecked Sendable {
     /// The outcome of trying to acquire the shared lock.
     enum Acquisition: Equatable {
         case acquired
-        /// Held by another MeterBar/CLI holder.
-        case contended
+        /// Held by another MeterBar/CLI holder; `holder` is present when its
+        /// descriptor could be read from the lock file.
+        case contended(holder: WakeLockHolder?)
         /// A known legacy watcher lock is present — actionable guidance.
         case legacyHeld(guidance: String)
+        /// The lock file or its directory could not be created/opened at all —
+        /// an environment failure, distinct from another holder being active.
+        case unavailable(reason: String)
     }
 
     private let lockURL: URL
     private let legacyLockURLs: [URL]
+    private let holderKind: WakeLockHolder.Kind
     /// Guards `fileDescriptor`: the class is `@unchecked Sendable` and its
     /// descriptor may be touched from `acquire()`, `release()`, and `deinit` on
     /// different threads, so every read/write of it goes through this lock.
     private let stateLock = NSLock()
     private var fileDescriptor: Int32 = -1
 
-    init(lockURL: URL? = nil, legacyLockURLs: [URL]? = nil) {
+    init(lockURL: URL? = nil, legacyLockURLs: [URL]? = nil, holderKind: WakeLockHolder.Kind = .app) {
         self.lockURL = lockURL
             ?? WakePaths.defaultBaseDirectory().appendingPathComponent("wake.lock")
+        self.holderKind = holderKind
         // Conventional legacy watcher lock locations from the Python/launchd era.
         self.legacyLockURLs = legacyLockURLs ?? [
             URL(fileURLWithPath: "\(ServiceSupport.realHomeDirectory())/.claude/wake-watcher.lock"),
@@ -50,35 +80,80 @@ nonisolated final class WakeLock: @unchecked Sendable {
         do {
             try WakePaths.ensurePrivateDirectory(lockURL.deletingLastPathComponent())
         } catch {
-            return .contended
+            return .unavailable(reason: "lock directory: \(error.localizedDescription)")
         }
 
-        // The whole open/flock/store sequence runs under `stateLock` so a
-        // concurrent `release()` can't slip between a successful `flock` and
-        // the descriptor store (which would leak the held lock), and a second
-        // `acquire()` can't overwrite an already-held descriptor. `LOCK_NB`
-        // keeps the critical section non-blocking.
-        let acquired: Bool = stateLock.withLock {
-            guard fileDescriptor < 0 else { return true }
+        // The whole open/flock/write-holder/store sequence runs under
+        // `stateLock` so a concurrent `release()` can't slip between a
+        // successful `flock` and the descriptor store (which would leak the
+        // held lock), and a second `acquire()` can't overwrite an already-held
+        // descriptor. `LOCK_NB` keeps the critical section non-blocking.
+        return stateLock.withLock {
+            guard fileDescriptor < 0 else { return .acquired }
             let descriptor = open(lockURL.path, O_CREAT | O_RDWR, 0o600)
-            guard descriptor >= 0 else { return false }
-            if flock(descriptor, LOCK_EX | LOCK_NB) != 0 {
-                close(descriptor)
-                return false
+            guard descriptor >= 0 else {
+                return .unavailable(reason: "open lock: \(String(cString: strerror(errno)))")
             }
+            if flock(descriptor, LOCK_EX | LOCK_NB) != 0 {
+                let blocked = errno == EWOULDBLOCK
+                close(descriptor)
+                return blocked
+                    ? .contended(holder: readHolder())
+                    : .unavailable(reason: "flock: \(String(cString: strerror(errno)))")
+            }
+            writeHolder(to: descriptor)
             fileDescriptor = descriptor
-            return true
+            return .acquired
         }
-        return acquired ? .acquired : .contended
     }
 
-    /// Release the lock and remove the descriptor. Safe to call repeatedly.
+    /// Release the lock, clearing the holder descriptor so a later contender
+    /// does not attribute the (now free) lock to us. Safe to call repeatedly.
     func release() {
         stateLock.withLock {
             guard fileDescriptor >= 0 else { return }
+            ftruncate(fileDescriptor, 0)
             flock(fileDescriptor, LOCK_UN)
             close(fileDescriptor)
             fileDescriptor = -1
+        }
+    }
+
+    // MARK: - Holder descriptor
+
+    /// Read the current holder's descriptor without taking the lock. `nil` when
+    /// the file is empty (released, or a holder that has not written yet) or
+    /// does not decode.
+    private func readHolder() -> WakeLockHolder? {
+        guard let data = try? Data(contentsOf: lockURL), !data.isEmpty else { return nil }
+        return try? JSONDecoder().decode(WakeLockHolder.self, from: data)
+    }
+
+    /// Write our descriptor into the freshly-locked file for contenders to read.
+    /// Best-effort: a failed write degrades a contender's message, never the lock.
+    private func writeHolder(to descriptor: Int32) {
+        let holder = WakeLockHolder(
+            kind: holderKind,
+            pid: getpid(),
+            host: ProcessInfo.processInfo.hostName,
+            startedAtEpoch: Date().timeIntervalSince1970
+        )
+        guard let data = try? JSONEncoder().encode(holder) else { return }
+        ftruncate(descriptor, 0)
+        lseek(descriptor, 0, SEEK_SET)
+        data.withUnsafeBytes { raw in
+            guard let base = raw.baseAddress else { return }
+            var written = 0
+            while written < raw.count {
+                let count = write(descriptor, base + written, raw.count - written)
+                if count > 0 {
+                    written += count
+                } else if count == -1 && errno == EINTR {
+                    continue
+                } else {
+                    break
+                }
+            }
         }
     }
 

--- a/MeterBar/SessionWake/WakeProcessRunner.swift
+++ b/MeterBar/SessionWake/WakeProcessRunner.swift
@@ -16,6 +16,11 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
     let account: ClaudeCodeAccount
     private let baseEnvironment: [String: String]
     private let lockFactory: @Sendable () -> WakeLock
+    /// True when the caller (the CLI engine) already holds the shared wake
+    /// lock for the whole pass. flock treats a second descriptor in the SAME
+    /// process as a distinct holder, so re-acquiring here would self-contend
+    /// and fail every real CLI resume — skip locking entirely instead.
+    private let assumesExternalLock: Bool
     private let logger: WakeRunLogger
     private let now: @Sendable () -> Date
 
@@ -27,6 +32,7 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
         prompt: String = WakeCommandBuilder.defaultPrompt,
         baseEnvironment: [String: String] = ProcessInfo.processInfo.environment,
         lockFactory: @escaping @Sendable () -> WakeLock = { WakeLock() },
+        assumesExternalLock: Bool = false,
         logger: WakeRunLogger = WakeRunLogger(),
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
@@ -37,6 +43,7 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
         self.prompt = prompt
         self.baseEnvironment = baseEnvironment
         self.lockFactory = lockFactory
+        self.assumesExternalLock = assumesExternalLock
         self.logger = logger
         self.now = now
     }
@@ -55,9 +62,10 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
             return .failed(reason: "claude binary not found")
         }
 
-        // Take the shared lock only now, when we are actually ready to launch.
-        let lock = lockFactory()
-        switch lock.acquire() {
+        // Take the shared lock only now, when we are actually ready to launch
+        // — unless the caller already holds it for the whole pass.
+        let lock = assumesExternalLock ? nil : lockFactory()
+        switch lock?.acquire() ?? .acquired {
         case .acquired:
             break
         case let .contended(holder):
@@ -74,7 +82,7 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
             record(candidate: candidate, outcome: outcome, result: nil, start: now())
             return outcome
         }
-        defer { lock.release() }
+        defer { lock?.release() }
 
         let command = WakeCommandBuilder.build(
             executable: resolved,
@@ -102,7 +110,7 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
             cancellation.cancel()
         }
 
-        let outcome = Self.mapOutcome(result)
+        let outcome = Self.mapOutcome(result, permissionMode: permissionMode)
         record(candidate: candidate, outcome: outcome, result: result, start: start)
         return outcome
     }
@@ -134,14 +142,15 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
         return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue
     }
 
-    static func mapOutcome(_ result: ManagedProcess.Result) -> WakeRunOutcome {
+    static func mapOutcome(_ result: ManagedProcess.Result, permissionMode: WakePermissionMode) -> WakeRunOutcome {
         switch result.termination {
         case .exited(0):
             return .succeeded
         case let .exited(code):
             // Classification only — the bounded capture is inspected here and
-            // never logged or retained beyond this call.
-            if indicatesPermissionDenial(result) {
+            // never logged or retained beyond this call. Bypass runs skip the
+            // permission gate entirely, so a denial label can't apply there.
+            if permissionMode != .bypass, indicatesPermissionDenial(result) {
                 return .permissionDenied
             }
             return .failed(reason: "claude exited with status \(code)")
@@ -160,9 +169,15 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
     /// The captured output exists only in memory on `result`; nothing here (or
     /// downstream) writes it anywhere.
     private static func indicatesPermissionDenial(_ result: ManagedProcess.Result) -> Bool {
-        let combined = (String(data: result.stdoutCapture, encoding: .utf8) ?? "")
+        // Lossy decode: a capture truncated at the byte cap can split a
+        // multibyte character, and strict decoding would drop the WHOLE
+        // capture — disabling classification in exactly the long-output case
+        // the bounded sink exists for.
+        // swiftlint:disable optional_data_string_conversion
+        let combined = String(decoding: result.stdoutCapture, as: UTF8.self)
             + "\n"
-            + (String(data: result.stderrCapture, encoding: .utf8) ?? "")
+            + String(decoding: result.stderrCapture, as: UTF8.self)
+        // swiftlint:enable optional_data_string_conversion
         return PermissionDenialDetector.indicatesDenial(in: combined)
     }
 

--- a/MeterBar/SessionWake/WakeProcessRunner.swift
+++ b/MeterBar/SessionWake/WakeProcessRunner.swift
@@ -60,12 +60,17 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
         switch lock.acquire() {
         case .acquired:
             break
-        case .contended:
-            let outcome = WakeRunOutcome.failed(reason: "another Session Wake holder is active")
+        case let .contended(holder):
+            let suffix = holder.map { " (\($0.shortDescription))" } ?? ""
+            let outcome = WakeRunOutcome.failed(reason: "another Session Wake holder is active\(suffix)")
             record(candidate: candidate, outcome: outcome, result: nil, start: now())
             return outcome
         case let .legacyHeld(guidance):
             let outcome = WakeRunOutcome.failed(reason: guidance)
+            record(candidate: candidate, outcome: outcome, result: nil, start: now())
+            return outcome
+        case let .unavailable(reason):
+            let outcome = WakeRunOutcome.failed(reason: "wake lock unavailable: \(reason)")
             record(candidate: candidate, outcome: outcome, result: nil, start: now())
             return outcome
         }
@@ -97,7 +102,7 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
             cancellation.cancel()
         }
 
-        let outcome = Self.mapOutcome(result.termination)
+        let outcome = Self.mapOutcome(result)
         record(candidate: candidate, outcome: outcome, result: result, start: start)
         return outcome
     }
@@ -129,11 +134,16 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
         return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue
     }
 
-    static func mapOutcome(_ termination: ManagedProcess.Result.Termination) -> WakeRunOutcome {
-        switch termination {
+    static func mapOutcome(_ result: ManagedProcess.Result) -> WakeRunOutcome {
+        switch result.termination {
         case .exited(0):
             return .succeeded
         case let .exited(code):
+            // Classification only — the bounded capture is inspected here and
+            // never logged or retained beyond this call.
+            if indicatesPermissionDenial(result) {
+                return .permissionDenied
+            }
             return .failed(reason: "claude exited with status \(code)")
         case let .signalled(signal):
             return .failed(reason: "claude terminated by signal \(signal)")
@@ -144,6 +154,16 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
         case let .launchFailed(message):
             return .failed(reason: message)
         }
+    }
+
+    /// Whether a non-zero exit reads as a stop at the permission-approval gate.
+    /// The captured output exists only in memory on `result`; nothing here (or
+    /// downstream) writes it anywhere.
+    private static func indicatesPermissionDenial(_ result: ManagedProcess.Result) -> Bool {
+        let combined = (String(data: result.stdoutCapture, encoding: .utf8) ?? "")
+            + "\n"
+            + (String(data: result.stderrCapture, encoding: .utf8) ?? "")
+        return PermissionDenialDetector.indicatesDenial(in: combined)
     }
 
     private func record(
@@ -179,6 +199,7 @@ nonisolated extension WakeRunOutcome {
         case .failed: return "failed"
         case .skipped: return "skipped"
         case .cancelled: return "cancelled"
+        case .permissionDenied: return "permission-denied"
         }
     }
 }

--- a/MeterBar/SessionWake/WakeWatcherState.swift
+++ b/MeterBar/SessionWake/WakeWatcherState.swift
@@ -44,6 +44,11 @@ nonisolated enum WakeRunOutcome: Equatable, Sendable {
     case failed(reason: String)
     case skipped(reason: WakeSkipReason)
     case cancelled
+    /// The run was stopped at Claude's permission-approval gate (a tool needed
+    /// interactive approval and the headless run failed closed). Reported as a
+    /// distinct outcome so the user can act on it — never auto-escalated to
+    /// `--dangerously-skip-permissions`.
+    case permissionDenied
 }
 
 /// The execution seam the coordinator drives. #96 owns orchestration and state;

--- a/MeterBarTests/ManagedProcessTests.swift
+++ b/MeterBarTests/ManagedProcessTests.swift
@@ -26,6 +26,8 @@ final class ManagedProcessTests: XCTestCase {
         if [ -n "$WAKE_TEST_OUT" ]; then
           { echo "ARGS:$*"; echo "PWD:$(pwd)"; echo "CFG:${CLAUDE_CONFIG_DIR}"; echo "TERM:${TERM}"; } >> "$WAKE_TEST_OUT"
         fi
+        if [ -n "$WAKE_STDOUT_MSG" ]; then echo "$WAKE_STDOUT_MSG"; fi
+        if [ -n "$WAKE_STDERR_MSG" ]; then echo "$WAKE_STDERR_MSG" >&2; fi
         if [ -n "$WAKE_SPAWN_CHILD" ]; then
           sleep 30 &
           echo $! > "$WAKE_CHILD_PID"
@@ -139,6 +141,46 @@ final class ManagedProcessTests: XCTestCase {
         // …while the stream is reported as truncated past the capture cap.
         XCTAssertTrue(result.stdoutTruncated, "stream beyond the cap must report truncation")
         XCTAssertFalse(result.stderrTruncated)
+        // The retained capture never grows past the cap, no matter the stream size.
+        XCTAssertLessThanOrEqual(result.stdoutCapture.count, 64 * 1024,
+                                 "bounded capture must never exceed maxCaptureBytes")
+        XCTAssertEqual(result.stderrCapture.count, 0)
+    }
+
+    func testBoundedCaptureRetainsStreamContent() async throws {
+        let fake = try makeFake()
+        let result = await run(
+            fake,
+            env: [
+                "WAKE_STDOUT_MSG": "resuming session sid",
+                "WAKE_STDERR_MSG": "this tool requires approval before running",
+                "WAKE_EXIT": "1"
+            ],
+            timeout: 10
+        )
+        XCTAssertEqual(result.termination, .exited(code: 1))
+        let stdout = String(data: result.stdoutCapture, encoding: .utf8) ?? ""
+        let stderr = String(data: result.stderrCapture, encoding: .utf8) ?? ""
+        XCTAssertTrue(stdout.contains("resuming session sid"), "stdout capture missing: \(stdout)")
+        XCTAssertTrue(stderr.contains("requires approval"), "stderr capture missing: \(stderr)")
+        XCTAssertFalse(result.stdoutTruncated)
+        XCTAssertFalse(result.stderrTruncated)
+    }
+
+    func testCaptureRetainsLeadingBytesWhenTruncated() async throws {
+        let fake = try makeFake()
+        // A marker printed *before* the flood must survive: the sink keeps the
+        // leading bytes and discards everything past the cap.
+        let result = await run(
+            fake,
+            env: ["WAKE_STDOUT_MSG": "MARKER-HEAD", "WAKE_STDOUT_BYTES": "500000"],
+            timeout: 20
+        )
+        XCTAssertEqual(result.termination, .exited(code: 0))
+        XCTAssertTrue(result.stdoutTruncated)
+        XCTAssertLessThanOrEqual(result.stdoutCapture.count, 64 * 1024)
+        let head = String(data: result.stdoutCapture.prefix(64), encoding: .utf8) ?? ""
+        XCTAssertTrue(head.contains("MARKER-HEAD"), "leading bytes must be retained, got: \(head)")
     }
 
     func testDrainDoesNotHangWhenGrandchildHoldsStdoutOpen() async throws {

--- a/MeterBarTests/WakeCLIEngineTests.swift
+++ b/MeterBarTests/WakeCLIEngineTests.swift
@@ -119,6 +119,43 @@ final class WakeCLIEngineTests: XCTestCase {
         XCTAssertEqual(response.summary.failed, 1)
     }
 
+    func testPermissionDenialCountsAsFailureNotSuccess() async throws {
+        try writeBlockedSession()
+        let runner = RecordingRunner(outcome: .permissionDenied)
+        let engine = makeEngine(provider: FixedProvider(.open), runner: runner)
+        let response = await engine.run(provider: "claude", account: account(), dryRun: false, limit: nil)
+        XCTAssertEqual(response.outcome, .partialFailure)
+        XCTAssertEqual(response.summary.failed, 1)
+        XCTAssertEqual(response.summary.resumed, 0)
+
+        // A denied session was never resumed — it must stay retryable.
+        let ledger = ReplayLedger(fileURL: tempDir.appendingPathComponent("l.json"))
+        let rescan = await SessionDiscovery().discover(configDirectory: tempDir.path, ledger: ledger)
+        XCTAssertNil(rescan.first?.skipReason, "denied session must not be marked handled")
+    }
+
+    func testLockContentionNamesTheHolder() async throws {
+        try writeBlockedSession()
+        // Pre-hold the engine's lock file as a CLI-kind holder.
+        let holder = WakeLock(
+            lockURL: tempDir.appendingPathComponent("wake.lock"),
+            legacyLockURLs: [],
+            holderKind: .cli
+        )
+        XCTAssertEqual(holder.acquire(), .acquired)
+        defer { holder.release() }
+
+        let runner = RecordingRunner()
+        let engine = makeEngine(provider: FixedProvider(.open), runner: runner)
+        let response = await engine.run(provider: "claude", account: account(), dryRun: false, limit: nil)
+        XCTAssertEqual(response.outcome, .validationFailure)
+        let message = try XCTUnwrap(response.message)
+        XCTAssertTrue(message.contains("cli"), "message should name the holder kind: \(message)")
+        XCTAssertTrue(message.contains("\(getpid())"), "message should name the holder pid: \(message)")
+        let ran = await runner.ran
+        XCTAssertTrue(ran.isEmpty)
+    }
+
     // MARK: - Outcome + JSON contract
 
     func testExitCodesAreDistinct() {

--- a/MeterBarTests/WakeRunnerTests.swift
+++ b/MeterBarTests/WakeRunnerTests.swift
@@ -162,6 +162,31 @@ final class WakeRunnerTests: XCTestCase {
                        "A non-zero exit whose output signals the approval gate must classify as permissionDenied")
     }
 
+    func testPermissionDenialSurvivesCaptureTruncatedMidMultibyte() async throws {
+        // The bounded capture keeps the leading 64 KiB; when that boundary
+        // splits a multibyte character, a STRICT utf8 decode returns nil and
+        // would drop the whole capture — losing the denial phrase in exactly
+        // the long-output case the sink exists for. Lossy decoding must retain
+        // it. The fake emits the phrase, then enough 3-byte characters that the
+        // 65536-byte boundary lands one byte into the final character.
+        let denialFake = tempDir.appendingPathComponent("denial-fill.sh")
+        // Raw string so `\n` and `\x{597d}` reach bash/perl literally, not the
+        // Swift compiler. 18-byte phrase + 21840×3-byte chars = 65538 bytes;
+        // the retained leading 65536 ends one byte into the final character.
+        let script = #"""
+        #!/bin/bash
+        { printf 'requires approval\n'; perl -e 'print "\x{597d}" x 21840'; } >&2
+        exit 1
+        """#
+        try script.write(to: denialFake, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: denialFake.path)
+
+        let runner = makeRunner(fake: denialFake.path, env: [:])
+        let outcome = await runner.run(candidate(cwd: tempDir.path), bounds: .default)
+        XCTAssertEqual(outcome, .permissionDenied,
+                       "A denial phrase must classify even when the capture is truncated mid-character")
+    }
+
     func testDenialPhrasesOnSuccessfulExitStaySuccess() async throws {
         let fake = try makeFake()
         // A run that *mentions* permissions but exits 0 succeeded — classification
@@ -248,6 +273,37 @@ final class WakeRunnerTests: XCTestCase {
         first.release()
         XCTAssertEqual(second.acquire(), .acquired)
         second.release()
+    }
+
+    func testExternallyLockedRunnerDoesNotSelfContend() async throws {
+        // The CLI engine holds the shared lock for its whole pass; a runner it
+        // creates must not open a second descriptor on the same file — flock
+        // treats same-process descriptors as distinct holders, so re-acquiring
+        // would fail every real `meterbar wake` resume.
+        let fake = try makeFake()
+        let out = tempDir.appendingPathComponent("out.txt")
+        let lockURL = tempDir.appendingPathComponent("wake.lock")
+        let engineLock = WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .cli)
+        guard case .acquired = engineLock.acquire() else {
+            return XCTFail("engine lock must acquire")
+        }
+        defer { engineLock.release() }
+
+        var env = ["WAKE_TEST_OUT": out.path]
+        env["PATH"] = "/usr/bin:/bin"
+        let runner = WakeProcessRunner(
+            account: account(),
+            executable: fake,
+            baseEnvironment: env,
+            lockFactory: {
+                XCTFail("externally locked runner must not consult the lock factory")
+                return WakeLock(lockURL: lockURL, legacyLockURLs: [])
+            },
+            assumesExternalLock: true,
+            logger: WakeRunLogger(directory: self.tempDir.appendingPathComponent("logs"))
+        )
+        let outcome = await runner.run(candidate(cwd: tempDir.path), bounds: .default)
+        XCTAssertEqual(outcome, .succeeded, "runner must not self-contend with the engine's held lock")
     }
 
     func testLockHolderCarriesCLIKind() {

--- a/MeterBarTests/WakeRunnerTests.swift
+++ b/MeterBarTests/WakeRunnerTests.swift
@@ -23,6 +23,7 @@ final class WakeRunnerTests: XCTestCase {
         if [ -n "$WAKE_TEST_OUT" ]; then
           { echo "ARGS:$*"; echo "PWD:$(pwd)"; echo "CFG:${CLAUDE_CONFIG_DIR}"; } >> "$WAKE_TEST_OUT"
         fi
+        if [ -n "$WAKE_STDERR_MSG" ]; then echo "$WAKE_STDERR_MSG" >&2; fi
         exit "${WAKE_EXIT:-0}"
         """
         let url = tempDir.appendingPathComponent("fake.sh")
@@ -148,17 +149,170 @@ final class WakeRunnerTests: XCTestCase {
         XCTAssertFalse(recorded.contains("--dangerously-skip-permissions"))
     }
 
+    // MARK: - Permission-denial classification
+
+    func testPermissionDenialOnNonZeroExitIsStructuredOutcome() async throws {
+        let fake = try makeFake()
+        let runner = makeRunner(
+            fake: fake,
+            env: ["WAKE_STDERR_MSG": "Bash requires approval before it can run", "WAKE_EXIT": "1"]
+        )
+        let outcome = await runner.run(candidate(cwd: tempDir.path), bounds: .default)
+        XCTAssertEqual(outcome, .permissionDenied,
+                       "A non-zero exit whose output signals the approval gate must classify as permissionDenied")
+    }
+
+    func testDenialPhrasesOnSuccessfulExitStaySuccess() async throws {
+        let fake = try makeFake()
+        // A run that *mentions* permissions but exits 0 succeeded — classification
+        // only applies to non-zero exits.
+        let runner = makeRunner(
+            fake: fake,
+            env: ["WAKE_STDERR_MSG": "permission denied earlier, but recovered", "WAKE_EXIT": "0"]
+        )
+        let outcome = await runner.run(candidate(cwd: tempDir.path), bounds: .default)
+        XCTAssertEqual(outcome, .succeeded)
+    }
+
+    func testNonDenialFailureStaysGenericFailure() async throws {
+        let fake = try makeFake()
+        let runner = makeRunner(
+            fake: fake,
+            env: ["WAKE_STDERR_MSG": "fatal: repository not found", "WAKE_EXIT": "5"]
+        )
+        let outcome = await runner.run(candidate(cwd: tempDir.path), bounds: .default)
+        if case .failed = outcome {} else {
+            XCTFail("Unrelated failure must not classify as permissionDenied, got \(outcome)")
+        }
+    }
+
+    func testPermissionDenialContentNeverReachesLogs() async throws {
+        let fake = try makeFake()
+        let logDir = tempDir.appendingPathComponent("denial-logs")
+        let runner = makeRunner(
+            fake: fake,
+            env: ["WAKE_STDERR_MSG": "SecretToolName requires approval", "WAKE_EXIT": "1"],
+            logDir: logDir
+        )
+        let outcome = await runner.run(candidate(sessionID: "sid-denied", cwd: tempDir.path), bounds: .default)
+        XCTAssertEqual(outcome, .permissionDenied)
+
+        let logFile = try XCTUnwrap(FileManager.default
+            .contentsOfDirectory(at: logDir, includingPropertiesForKeys: nil)
+            .first(where: { $0.pathExtension == "log" }))
+        let contents = try String(contentsOf: logFile, encoding: .utf8)
+        // The structured label is logged; the captured output never is.
+        XCTAssertTrue(contents.contains("\"outcome\":\"permission-denied\""), "log missing label: \(contents)")
+        XCTAssertFalse(contents.contains("SecretToolName"), "raw output leaked into the log")
+        XCTAssertFalse(contents.contains("requires approval"), "raw output leaked into the log")
+    }
+
+    func testDetectorMatchesApprovalGatePhrases() {
+        for phrase in [
+            "Error: Permission Denied while running Bash",
+            "This tool requires approval",
+            "the command needs approval before continuing",
+            "run with --dangerously-skip-permissions to skip",
+            "status: PERMISSION_DENIED",
+            "Claude requires permission to use Write"
+        ] {
+            XCTAssertTrue(PermissionDenialDetector.indicatesDenial(in: phrase), "should match: \(phrase)")
+        }
+    }
+
+    func testDetectorIgnoresUnrelatedFailures() {
+        for phrase in [
+            "",
+            "fatal: repository not found",
+            "error: ENOENT no such file or directory",
+            "session limit reached, resets 3:00am"
+        ] {
+            XCTAssertFalse(PermissionDenialDetector.indicatesDenial(in: phrase), "should not match: \(phrase)")
+        }
+    }
+
     // MARK: - Lock
 
-    func testSharedLockRejectsContention() {
+    func testSharedLockRejectsContentionAndReportsHolder() {
         let url = tempDir.appendingPathComponent("shared.lock")
         let first = WakeLock(lockURL: url, legacyLockURLs: [])
         let second = WakeLock(lockURL: url, legacyLockURLs: [])
         XCTAssertEqual(first.acquire(), .acquired)
-        XCTAssertEqual(second.acquire(), .contended)
+        guard case let .contended(holder) = second.acquire() else {
+            return XCTFail("Expected contention while first holds the lock")
+        }
+        // The holder descriptor written by `first` is readable by the contender.
+        XCTAssertEqual(holder?.kind, .app)
+        XCTAssertEqual(holder?.pid, getpid())
+        XCTAssertEqual(holder?.host.isEmpty, false)
         first.release()
         XCTAssertEqual(second.acquire(), .acquired)
         second.release()
+    }
+
+    func testLockHolderCarriesCLIKind() {
+        let url = tempDir.appendingPathComponent("cli.lock")
+        let cli = WakeLock(lockURL: url, legacyLockURLs: [], holderKind: .cli)
+        XCTAssertEqual(cli.acquire(), .acquired)
+        defer { cli.release() }
+        let contender = WakeLock(lockURL: url, legacyLockURLs: [])
+        guard case let .contended(holder) = contender.acquire() else {
+            return XCTFail("Expected contention")
+        }
+        XCTAssertEqual(holder?.kind, .cli)
+    }
+
+    func testReleaseClearsHolderDescriptor() throws {
+        let url = tempDir.appendingPathComponent("clear.lock")
+        let lock = WakeLock(lockURL: url, legacyLockURLs: [])
+        XCTAssertEqual(lock.acquire(), .acquired)
+        lock.release()
+        // A released lock must not leave a stale descriptor that a later
+        // contender would misattribute the (now free) lock to.
+        let data = try Data(contentsOf: url)
+        XCTAssertTrue(data.isEmpty, "released lock left a stale holder descriptor")
+    }
+
+    func testLockDirectoryCreationFailureIsUnavailableNotContended() {
+        // The lock's parent path runs through a regular file, so the private
+        // directory cannot be created. That is an environment failure, not
+        // another holder.
+        let blocker = tempDir.appendingPathComponent("blocker-file")
+        FileManager.default.createFile(atPath: blocker.path, contents: nil)
+        let lock = WakeLock(
+            lockURL: blocker.appendingPathComponent("sub").appendingPathComponent("wake.lock"),
+            legacyLockURLs: []
+        )
+        guard case .unavailable = lock.acquire() else {
+            return XCTFail("Directory-creation failure must be .unavailable, not contention")
+        }
+    }
+
+    func testUnopenableLockFileIsUnavailableNotContended() throws {
+        // The lock path itself is a directory: open(O_RDWR) fails outright.
+        let dir = tempDir.appendingPathComponent("lock-is-a-dir", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let lock = WakeLock(lockURL: dir, legacyLockURLs: [])
+        guard case .unavailable = lock.acquire() else {
+            return XCTFail("Open failure must be .unavailable, not contention")
+        }
+    }
+
+    func testRunnerContentionFailureNamesTheHolder() async throws {
+        let fake = try makeFake()
+        // Pre-hold the exact lock the runner uses, as a CLI-kind holder.
+        let lockURL = tempDir.appendingPathComponent("wake.lock")
+        let holder = WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .cli)
+        XCTAssertEqual(holder.acquire(), .acquired)
+        defer { holder.release() }
+
+        let runner = makeRunner(fake: fake, env: [:])
+        let outcome = await runner.run(candidate(cwd: tempDir.path), bounds: .default)
+        guard case let .failed(reason) = outcome else {
+            return XCTFail("Expected structured failure on contention, got \(outcome)")
+        }
+        XCTAssertTrue(reason.contains("cli"), "reason should name the holder kind: \(reason)")
+        XCTAssertTrue(reason.contains("\(getpid())"), "reason should name the holder pid: \(reason)")
     }
 
     func testReacquireWhileHeldIsIdempotent() {


### PR DESCRIPTION
Re-implements the two runner-layer items deferred from the old `claude/eager-rubin-4e1ab8` architecture, built against master's `MeterBar/SessionWake/` layout (not a port of the old file structure). TDD-first.

## 1. Permission-denial classification

A wake run blocked at Claude's permission-approval gate previously surfaced as a generic `failed(reason: "claude exited with status N")`.

- **`ManagedProcess`**: the `StreamCounter` byte tally became a `BoundedSink` — it still counts every drained byte (a chatty child can never fill a pipe) but now retains the leading `maxCaptureBytes` (64 KiB default) in memory; the buffer can never grow past the cap. `Result` gains `stdoutCapture`/`stderrCapture`.
- **`PermissionDenialDetector`** (new): conservative, case-insensitive phrase heuristics ("requires approval", "permission denied", `--dangerously-skip-permissions`, …).
- **`WakeProcessRunner.mapOutcome`** now takes the full `Result`; a non-zero exit whose capture reads as an approval-gate stop maps to the new **`WakeRunOutcome.permissionDenied`** (log label `permission-denied`). Zero-exit runs are never re-classified.
- Denials tally as failures in `WakeCoordinator` and `WakeCLIEngine`, are **never ledger-recorded** (the session stays retryable), and there is still no path that escalates to bypass.
- **Privacy**: captured content is used only for the in-memory classification call and never reaches `WakeRunLogger` — the existing no-raw-output-in-logs test still passes, plus a new test pinning that denial phrases don't leak while the `permission-denied` label is logged.

All prior `ManagedProcess` hardening is preserved unchanged: SIGTERM→SIGKILL escalation, bounded drain waits with group kill, bounded second drain wait, EINTR retries.

## 2. Lock-holder identification

`WakeLock.acquire()` previously returned a bare `.contended`, and conflated directory/open failures with contention.

- After a successful `flock`, the holder writes a JSON **`WakeLockHolder`** descriptor (kind `app`|`cli`, pid, host, startedAtEpoch) into the lock file — inside the same `stateLock` critical section as open/flock/store, preserving the atomic-acquire and idempotent-reacquire invariants exactly.
- On contention the descriptor is read back: **`Acquisition.contended(holder: WakeLockHolder?)`**.
- Directory-creation, open, and non-EWOULDBLOCK flock failures now return a distinct **`.unavailable(reason:)`** instead of masquerading as contention.
- `release()` truncates the descriptor so a freed lock is never misattributed.
- `WakeCLIEngine` locks as `.cli` by default; its contention message and the runner's failure reason now name the holder ("cli, pid N on host").

## Tests

- `swift test`: **509/509 pass** (15 new: 2 in `ManagedProcessTests`, 11 in `WakeRunnerTests`, 2 in `WakeCLIEngineTests`).
- `swiftlint lint --strict` on the 7 changed/new `MeterBar/` files: 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)