### PR TITLE
fix(session-wake): probe-release the CLI wake lock (drop assumesExternalLock footgun)

### DIFF
--- a/.agents/SESSIONS/2026-07-11.md
+++ b/.agents/SESSIONS/2026-07-11.md
@@ -360,3 +360,27 @@ architecture against master's `MeterBar/SessionWake/` layout. TDD: tests written
 ### Verification
 - `swift test`: 509/509 pass (15 new tests).
 - `swiftlint lint --strict` on the 7 changed/new `MeterBar/` files: 0 violations.
+
+## Session: Adopt probe-release for the CLI wake lock (supersedes #124 approach)
+
+The `meterbar wake` self-contention fix that shipped in #123 (`assumesExternalLock`)
+worked but was a footgun: it kept the engine holding the shared lock across the
+whole pass and required every runner caller to remember `assumesExternalLock: true`,
+or the runner would self-contend again. PR #124 proposed a cleaner design; adopted
+it here on master.
+
+- `WakeCLIEngine.run`: the engine's `lock.acquire()` is now a **pre-flight probe
+  only** — it surfaces the distinct `contended (holder)` / `legacyHeld` / `unavailable`
+  message before the quota fetch, then releases immediately. It no longer holds the
+  lock across `resume()`.
+- `WakeProcessRunner`: reverted `assumesExternalLock`; the runner is once again the
+  **sole owner** of the shared lock, taken only when a launch is ready and released
+  after — matching the app watcher path (`WakeCoordinator`), where the runner (not the
+  coordinator) owns the lock, and honoring `WakeLock`'s documented "never held across a
+  long quota wait."
+- Tests: replaced the footgun-shaped runner test with `testRunnerReleasesLockSo
+  SequentialRunsSucceed`, and added `testRealRunnerResumesWithoutSelfContendingOn
+  SharedLock` (from #124) — drives the real engine + real `WakeProcessRunner` + two
+  separate `WakeLock` instances on one file, exactly as production wires it. RED under
+  the held-lock design, GREEN under probe-release.
+- 526 tests pass; SwiftLint strict clean.

--- a/MeterBar/SessionWake/SessionWakeCLI.swift
+++ b/MeterBar/SessionWake/SessionWakeCLI.swift
@@ -65,11 +65,7 @@ public enum SessionWakeCLI {
                 WakeProcessRunner(
                     account: runnerAccount,
                     permissionMode: mode,
-                    bypassAcknowledged: request.bypassAcknowledged,
-                    // The engine holds the shared lock for the whole pass; a
-                    // second same-process flock would self-contend (fd-level
-                    // holders), failing every real resume.
-                    assumesExternalLock: true
+                    bypassAcknowledged: request.bypassAcknowledged
                 )
             },
             shouldCancel: request.shouldCancel

--- a/MeterBar/SessionWake/WakeCLIEngine.swift
+++ b/MeterBar/SessionWake/WakeCLIEngine.swift
@@ -61,10 +61,16 @@ struct WakeCLIEngine {
             )
         }
 
-        // Detect legacy watcher / another holder before doing anything live.
+        // Pre-flight probe only: detect a legacy watcher / another live holder
+        // for a distinct, actionable message before the quota fetch — then
+        // release at once. The per-run runner takes the shared lock when a
+        // launch is actually ready (matching the app watcher, where the runner,
+        // not the coordinator, owns the lock). Holding this engine lock across
+        // resume() would self-contend: flock via a second descriptor in the
+        // same process is denied on macOS, so every real resume would fail.
         switch lock.acquire() {
         case .acquired:
-            break
+            lock.release()
         case let .contended(holder):
             let who = holder.map { " (\($0.shortDescription))" } ?? " (app or CLI)"
             return .from(

--- a/MeterBar/SessionWake/WakeProcessRunner.swift
+++ b/MeterBar/SessionWake/WakeProcessRunner.swift
@@ -16,11 +16,6 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
     let account: ClaudeCodeAccount
     private let baseEnvironment: [String: String]
     private let lockFactory: @Sendable () -> WakeLock
-    /// True when the caller (the CLI engine) already holds the shared wake
-    /// lock for the whole pass. flock treats a second descriptor in the SAME
-    /// process as a distinct holder, so re-acquiring here would self-contend
-    /// and fail every real CLI resume — skip locking entirely instead.
-    private let assumesExternalLock: Bool
     private let logger: WakeRunLogger
     private let now: @Sendable () -> Date
 
@@ -32,7 +27,6 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
         prompt: String = WakeCommandBuilder.defaultPrompt,
         baseEnvironment: [String: String] = ProcessInfo.processInfo.environment,
         lockFactory: @escaping @Sendable () -> WakeLock = { WakeLock() },
-        assumesExternalLock: Bool = false,
         logger: WakeRunLogger = WakeRunLogger(),
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
@@ -43,7 +37,6 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
         self.prompt = prompt
         self.baseEnvironment = baseEnvironment
         self.lockFactory = lockFactory
-        self.assumesExternalLock = assumesExternalLock
         self.logger = logger
         self.now = now
     }
@@ -62,10 +55,11 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
             return .failed(reason: "claude binary not found")
         }
 
-        // Take the shared lock only now, when we are actually ready to launch
-        // — unless the caller already holds it for the whole pass.
-        let lock = assumesExternalLock ? nil : lockFactory()
-        switch lock?.acquire() ?? .acquired {
+        // Take the shared lock only now, when we are actually ready to launch.
+        // The runner is the sole owner of the lock across app and CLI paths, so
+        // the caller must not hold it (the CLI engine only probe-releases).
+        let lock = lockFactory()
+        switch lock.acquire() {
         case .acquired:
             break
         case let .contended(holder):
@@ -82,7 +76,7 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
             record(candidate: candidate, outcome: outcome, result: nil, start: now())
             return outcome
         }
-        defer { lock?.release() }
+        defer { lock.release() }
 
         let command = WakeCommandBuilder.build(
             executable: resolved,

--- a/MeterBarTests/WakeCLIEngineTests.swift
+++ b/MeterBarTests/WakeCLIEngineTests.swift
@@ -35,6 +35,49 @@ final class WakeCLIEngineTests: XCTestCase {
         ClaudeCodeAccount(id: UUID(), name: "acct", configDirectory: tempDir.path)
     }
 
+    private func makeFakeClaude(exitCode: Int32) throws -> String {
+        let script = """
+        #!/bin/bash
+        exit \(exitCode)
+        """
+        let url = tempDir.appendingPathComponent("fake-claude.sh")
+        try script.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url.path
+    }
+
+    /// The real production wiring: the engine holds a `.cli` lock instance and
+    /// the runner it makes holds a *separate* lock instance on the SAME file.
+    /// If the engine held its lock across `resume()`, the runner's acquire would
+    /// self-contend (same-process flock) and every real resume would fail. The
+    /// engine must probe-and-release so the runner is the sole lock owner.
+    func testRealRunnerResumesWithoutSelfContendingOnSharedLock() async throws {
+        try writeBlockedSession()
+        let fake = try makeFakeClaude(exitCode: 0)
+        let sharedLockURL = tempDir.appendingPathComponent("wake.lock")
+        let engine = WakeCLIEngine(
+            discovery: SessionDiscovery(),
+            authority: WakeQuotaAuthority(provider: FixedProvider(.open), maxAge: 3600, now: { Date() }),
+            makeRunner: { runnerAccount in
+                WakeProcessRunner(
+                    account: runnerAccount,
+                    executable: fake,
+                    baseEnvironment: ["PATH": "/usr/bin:/bin"],
+                    lockFactory: { WakeLock(lockURL: sharedLockURL, legacyLockURLs: [], holderKind: .app) },
+                    logger: WakeRunLogger(directory: self.tempDir.appendingPathComponent("logs"))
+                )
+            },
+            ledgerFactory: { ReplayLedger(fileURL: self.tempDir.appendingPathComponent("l.json")) },
+            lock: WakeLock(lockURL: sharedLockURL, legacyLockURLs: [], holderKind: .cli),
+            bounds: .default
+        )
+
+        let response = await engine.run(provider: "claude", account: account(), dryRun: false, limit: nil)
+        XCTAssertEqual(response.outcome, .success, "Real resume must not self-contend on the shared wake lock")
+        XCTAssertEqual(response.summary.resumed, 1)
+        XCTAssertEqual(response.summary.failed, 0)
+    }
+
     private func makeEngine(
         provider: WakeQuotaProviding,
         runner: WakeExecuting,

--- a/MeterBarTests/WakeRunnerTests.swift
+++ b/MeterBarTests/WakeRunnerTests.swift
@@ -275,35 +275,20 @@ final class WakeRunnerTests: XCTestCase {
         second.release()
     }
 
-    func testExternallyLockedRunnerDoesNotSelfContend() async throws {
-        // The CLI engine holds the shared lock for its whole pass; a runner it
-        // creates must not open a second descriptor on the same file — flock
-        // treats same-process descriptors as distinct holders, so re-acquiring
-        // would fail every real `meterbar wake` resume.
+    func testRunnerReleasesLockSoSequentialRunsSucceed() async throws {
+        // The runner is the sole owner of the shared lock: it acquires when
+        // ready and releases after. A second runner on the same file (the next
+        // queued session) must then acquire cleanly — proving the lock is not
+        // leaked across runs.
+        // makeRunner pins one shared lock file, so two runners here contend on
+        // the same lock exactly as sequential queued sessions do in production.
         let fake = try makeFake()
-        let out = tempDir.appendingPathComponent("out.txt")
-        let lockURL = tempDir.appendingPathComponent("wake.lock")
-        let engineLock = WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .cli)
-        guard case .acquired = engineLock.acquire() else {
-            return XCTFail("engine lock must acquire")
-        }
-        defer { engineLock.release() }
-
-        var env = ["WAKE_TEST_OUT": out.path]
-        env["PATH"] = "/usr/bin:/bin"
-        let runner = WakeProcessRunner(
-            account: account(),
-            executable: fake,
-            baseEnvironment: env,
-            lockFactory: {
-                XCTFail("externally locked runner must not consult the lock factory")
-                return WakeLock(lockURL: lockURL, legacyLockURLs: [])
-            },
-            assumesExternalLock: true,
-            logger: WakeRunLogger(directory: self.tempDir.appendingPathComponent("logs"))
-        )
-        let outcome = await runner.run(candidate(cwd: tempDir.path), bounds: .default)
-        XCTAssertEqual(outcome, .succeeded, "runner must not self-contend with the engine's held lock")
+        let first = await makeRunner(fake: fake, env: [:])
+            .run(candidate(sessionID: "a", cwd: tempDir.path), bounds: .default)
+        XCTAssertEqual(first, .succeeded)
+        let second = await makeRunner(fake: fake, env: [:])
+            .run(candidate(sessionID: "b", cwd: tempDir.path), bounds: .default)
+        XCTAssertEqual(second, .succeeded, "runner must release its lock so the next queued run acquires")
     }
 
     func testLockHolderCarriesCLIKind() {


### PR DESCRIPTION
## Problem

The `meterbar wake` self-contention fix that shipped in #123 (`assumesExternalLock`) worked, but was a footgun: the engine held the shared lock across the whole pass, and the runner only avoided a second `flock` on the same file (denied same-process on macOS) because every caller remembered to pass `assumesExternalLock: true`. Any runner wired without it — including the natural production-style wiring — would self-contend again and fail every real resume.

## Fix (adopts #124's design)

- **`WakeCLIEngine.run`**: the engine's `lock.acquire()` is now a **pre-flight probe only** — it surfaces the distinct `contended (holder)` / `legacyHeld` / `unavailable` message before the quota fetch, then releases immediately. It no longer holds the lock across `resume()`.
- **`WakeProcessRunner`**: reverted `assumesExternalLock`; the runner is once again the **sole owner** of the shared lock, taken only when a launch is ready and released after — matching the app watcher (`WakeCoordinator`, where the runner owns the lock) and honoring `WakeLock`'s documented *"never held across a long quota wait."*
- **`SessionWakeCLI`**: dropped the now-unnecessary wiring flag.

`WakeLock`'s atomic-acquire + idempotent-reacquire + `O_CLOEXEC` invariants (from #123) are untouched.

## Tests

- `testRealRunnerResumesWithoutSelfContendingOnSharedLock` (from #124): drives the **real** engine + **real** `WakeProcessRunner` + two **separate** `WakeLock` instances on one file — exactly how production wires it. RED under the held-lock design, GREEN under probe-release.
- Replaced the footgun-shaped runner test with `testRunnerReleasesLockSoSequentialRunsSucceed` (two sequential runners on one lock file both succeed).
- **526 tests pass**; SwiftLint strict clean.

Supersedes #124 (same fix, reconciled onto master which already had #123's `assumesExternalLock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)