### PR TITLE
Release v1.7.0

### DIFF
--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -288,7 +288,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -333,7 +333,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -498,7 +498,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -544,7 +544,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
Bumps `MARKETING_VERSION` to **1.7** across all four build configs.

Once merged, `/release` tags `v1.7` → CI builds the signed/notarized app, publishes the GitHub Release, and bumps the Homebrew cask.

### Headline: Session Wake (epic #94)
Native, quota-blocked-session auto-resume for Claude Code — discovery, fail-closed quota gate, safe process runner, settings/status UI, single ON/OFF toggle, and the `meterbar wake` CLI. Epic closed with full acceptance-criteria verification.

### Also in 1.7 (this session)
- Main-thread freeze fix (blocking I/O off the main actor) + SwiftPM/Xcode MainActor isolation parity
- Dashboard layout audit, popover status card, aligned detail panels
- CI signing migrated to canonical credential names; shared Xcode scheme committed
- Salvage hardening: `ManagedProcess` drain-hang guard + graceful timeout, permission-denial classification, lock-holder identity, `WakeLock` thread-safety + `O_CLOEXEC`, weekly/legacy reset parsing, bounded discovery enumeration, ledger pruning, and the `meterbar wake` self-contention fix

526 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)