### PR TITLE
fix(claude-cli): augment spawned CLI PATH + parse Fable weekly window

### DIFF
--- a/.agents/SESSIONS/2026-07-12.md
+++ b/.agents/SESSIONS/2026-07-12.md
@@ -1,0 +1,67 @@
+# 2026-07-12
+
+## Session 1: First-run onboarding scoping → issue #127 (v1.7.1)
+
+**Duration:** ~15 min
+**Status:** Complete (planning only — implementation deferred until after v1.7 release is monitored)
+
+**What was done:**
+- Audited the current first-run experience: popover already has an empty-state tile ("No sources enabled") and the auto-collapsing "Finish setup" readiness checklist (`MenuBarView.swift`, `ReadinessComponents.swift`, `ProviderReadinessInspector`), but no real onboarding flow.
+- Identified three gaps: (1) empty-state tile and checklist recovery hints are styled text, not actionable buttons; (2) no welcome moment — app just appears in the menu bar and first-time users may never notice the icon; (3) no launch-at-login offer, despite `LaunchAtLoginStore` (SMAppService) existing with a Settings toggle.
+- Decision: do NOT default launch-at-login ON (macOS posts a "background items added" notification; reads as sneaky for an unsigned brew-distributed app; HIG expects consent). Instead: one-time "Start MeterBar at login?" ask at first launch, Rectangle/Ice/Stats pattern.
+- Created milestone **v1.7.1** and filed issue **#127** with full scope: `hasCompletedFirstRun` flag, auto-open popover on first launch, actionable empty state + recovery rows, prompt-once launch-at-login callout.
+
+**Next steps:**
+- User is deploying v1.7 and monitoring the release; implement #127 after that settles (TDD: flag/prompt-once logic first, then UI seam).
+
+## Session 2: Roadmap planning — dashboard audit, CodexBar gap analysis, milestones v1.7.1/v1.8/v1.9
+
+**Duration:** ~30 min
+**Status:** Complete (planning only)
+
+**What was done:**
+- Audited the current feature surface against source (v1.6.1 → v1.7.0 shipping): 5 providers (Claude Code, Codex, Cursor, Claude/OpenAI admin APIs), full dashboard (Overview/Limits/Status/Costs/Optimize/Diagnostics/Share/Settings), threshold notifications, widget, bundled CLI, Session Wake fully shipped (Claude-only, app-running-only).
+- Audited GitHub tracker: v1.5.1 milestone fully closed (now closed the milestone itself), epic #94 complete (all children #95–#99 closed; #94 closed with follow-up cross-links).
+- Gap analysis vs steipete/CodexBar issues + README. Key demand signals: multi-account per provider (their #1 request), auto-updates, lifetime cost view, spend charts. Their 57-provider sprawl is their main pain source — staying narrow confirmed as strategy.
+- Internal gaps found: no auto-update mechanism (unblocked by signing), heuristic numbers presented as facts (Cursor 500-req quota, admin 1.5× limits), pricing table duplicated app/CLI, dead `SessionWakeFeatureEnabled` flag, no parse-health detection for silent provider breakage.
+- User decisions (interview): Sparkle in v1.7.1; providers = Grok + OpenRouter only; Session Wake next = background persistence; Codex multi-account pulled into v1.8.
+
+**Created:**
+- Milestones: v1.7.1 (due 2026-07-24, extended with roadmap scope), v1.8 "Wake 2 + accounts", v1.9 "Providers".
+- v1.7.1: #128 Sparkle auto-update (P0), #129 label heuristic numbers as estimates (P1), #130 single-source pricing table (P1), #131 wire/remove dead Session Wake flag (P2), #132 provider parse-health diagnostics (P1). Plus pre-existing #127 onboarding.
+- v1.8: #133 Session Wake background persistence, #134 Codex multi-account.
+- v1.9: #135 Grok provider, #136 OpenRouter provider.
+- Backlog (deferred label, no milestone): #137 lifetime cost view, #138 spend charts, #139 Codex wake, #140 wake event hooks.
+
+**Next steps:**
+- v1.7.1 work starts next week once the v1.7.0 signed release settles; #128 Sparkle is the P0.
+
+### Session 2 addendum: second steal pass from CodexBar tracker
+- User asked what else is worth stealing beyond auto-update + multi-account. Filed three approved items:
+  - #141 codex: one-click reset-credit action (v1.8; their #1502, unbuilt there; we already parse resetCreditsAvailable)
+  - #142 ui: menu bar display options — pin metric/label style/reset format (v1.8; consolidates their #1920/#1777/#1856; scheduled with #134 since both rework StatusItemLimitSelector)
+  - #143 cli: --json output for third-party integrations (backlog; flag-only, no serve mode)
+- Explicitly rejected: confetti (their misfire bug tail), localization, Linux builds, iOS companion. Icon-dim-on-stale already covered by #132.
+
+## Session 3: Claude CLI PATH gap + Fable window parsing (v1.7.1 candidates)
+
+**Duration:** ~45 min
+**Status:** Complete (implemented, tests green; not yet committed)
+
+**Root cause found (user report: "Could not parse Claude CLI usage: No Claude usage windows found"):**
+- A GUI-launched MeterBar inherits launchd's bare PATH (no `/opt/homebrew/bin`). `CLIBinaryLocator` still finds `claude` via its fallback list, but the *spawned* CLI inherits the bare PATH and can't find `node` — it prints a session cost summary (with a `node: command not found` hook error) instead of the usage screen, so the parser finds no windows. Reproduced with `env -i PATH=/usr/bin:/bin claude /usage`; adding node's dir to PATH restores the usage output.
+- Same gap existed in `WakeCommandBuilder` — Session Wake resumes would fail identically from a Finder-launched app.
+- Second bug found while testing: CLI 2.1.205 renamed the model-specific window to "Current week (Fable)"; parser only matched "Sonnet only", so `codeReviewLimit` silently dropped to nil.
+
+**What was done (TDD — tests written first):**
+- `CLIBinaryLocator`: extracted `fallbackDirectories(home:)` and added `augmentedPATH(environment:home:)` — appends the known CLI install dirs to the inherited PATH (existing entries keep priority, deduped). Mirrors the reconnect script's `export PATH` list.
+- `ClaudeCodeCLIUsageService.processEnvironment`: now sets the augmented PATH; made internal with injectable `base` env for testability.
+- `WakeCommandBuilder.build`: same PATH augmentation for resumed sessions.
+- Parser: `sonnetLimit` label prefixes now include `current week (fable)` / `fable`.
+- New tests: `CLIBinaryLocatorTests` (3), `ClaudeCodeCLIUsageServiceTests` (2), `WakeRunnerTests.testBuildAugmentsPATHWithCLIInstallDirectories`, `ClaudeCodeCLIUsageParserTests.testParsesFableWeeklyWindow`. Full suite 533/533 green; SwiftLint clean.
+
+**Also this session:** upgraded local install via brew (1.6.1 → 1.7.0 signed build) after the tap caught up; settings-UI audit delivered (account row alignment, default-path readonly rationale, per-profile disable, API-key progressive disclosure, Session Wake checkbox→switch + prerequisite ordering, settings-in-sidebar navigation proposal) — not yet filed as issues.
+
+**Next steps:**
+- Commit as two `fix(...)` commits or one PR for v1.7.1.
+- Decide whether to file the settings-UI audit items as issues.

--- a/MeterBar/Services/CLIBinaryLocator.swift
+++ b/MeterBar/Services/CLIBinaryLocator.swift
@@ -7,17 +7,45 @@ import Foundation
 /// out so provider-readiness diagnostics can ask "is `codex` / `claude` on
 /// PATH?" without re-deriving the same fallback list.
 nonisolated enum CLIBinaryLocator {
+    /// The install directories the fallbacks draw from, in priority order.
+    /// Kept in sync with the reconnect script's `export PATH` list.
+    static func fallbackDirectories(home: String) -> [String] {
+        [
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "\(home)/.local/bin",
+            "\(home)/.npm-global/bin",
+            "\(home)/.yarn/bin",
+            "\(home)/.bun/bin",
+            "\(home)/.volta/bin",
+        ]
+    }
+
     /// The install-location fallbacks checked after `PATH`, for `command`.
     private static func fallbackCandidates(for command: String, home: String) -> [String] {
-        [
-            "/opt/homebrew/bin/\(command)",
-            "/usr/local/bin/\(command)",
-            "\(home)/.local/bin/\(command)",
-            "\(home)/.npm-global/bin/\(command)",
-            "\(home)/.yarn/bin/\(command)",
-            "\(home)/.bun/bin/\(command)",
-            "\(home)/.volta/bin/\(command)",
-        ]
+        fallbackDirectories(home: home).map { "\($0)/\(command)" }
+    }
+
+    /// `PATH` from `environment` with the fallback install directories appended
+    /// (existing entries keep priority; duplicates are dropped).
+    ///
+    /// GUI apps inherit launchd's bare PATH, so even when MeterBar resolves a
+    /// CLI binary via the fallbacks, the *spawned* CLI can fail to find its own
+    /// runtime — `claude` needs `node`, typically in `/opt/homebrew/bin`.
+    /// Spawn child processes with this PATH instead of the inherited one.
+    static func augmentedPATH(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        home: String = ServiceSupport.realHomeDirectory()
+    ) -> String {
+        let existing = (environment["PATH"] ?? "")
+            .split(separator: ":")
+            .map(String.init)
+        var seen = Set(existing)
+        var entries = existing
+        for directory in fallbackDirectories(home: home) where seen.insert(directory).inserted {
+            entries.append(directory)
+        }
+        return entries.joined(separator: ":")
     }
 
     /// The resolved absolute path to `command`, or nil if it isn't found.

--- a/MeterBar/Services/ClaudeCodeCLIUsageService.swift
+++ b/MeterBar/Services/ClaudeCodeCLIUsageService.swift
@@ -93,8 +93,16 @@ nonisolated final class ClaudeCodeCLIUsageService: Sendable {
         return output
     }
 
-    private func processEnvironment(account: ClaudeCodeAccount) -> [String: String] {
-        var environment = ProcessInfo.processInfo.environment
+    /// Internal (not private) so tests can verify the spawned environment.
+    func processEnvironment(
+        account: ClaudeCodeAccount,
+        base: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [String: String] {
+        var environment = base
+        // launchd's bare GUI PATH lacks the dirs the CLI's own runtime lives in
+        // (e.g. node under /opt/homebrew/bin); without this the CLI prints a
+        // cost summary instead of the usage screen and parsing fails.
+        environment["PATH"] = CLIBinaryLocator.augmentedPATH(environment: base)
         environment["NO_COLOR"] = "1"
         environment["FORCE_COLOR"] = "0"
         environment["TERM"] = "dumb"
@@ -124,9 +132,11 @@ nonisolated enum ClaudeCodeCLIUsageParser {
             labelPrefixes: ["current week (all models)", "current week"],
             windowMinutes: 7 * 24 * 60,
             now: now)
+        // The CLI's model-specific window label has changed over time
+        // ("Sonnet only" → "Fable", observed claude 2.1.205); match all knowns.
         let sonnetLimit = parseLimit(
             from: lines,
-            labelPrefixes: ["current week (sonnet only)", "sonnet"],
+            labelPrefixes: ["current week (sonnet only)", "current week (fable)", "sonnet", "fable"],
             windowMinutes: 7 * 24 * 60,
             now: now)
 

--- a/MeterBar/SessionWake/WakeCommand.swift
+++ b/MeterBar/SessionWake/WakeCommand.swift
@@ -60,6 +60,9 @@ nonisolated enum WakeCommandBuilder {
         }
 
         var environment = baseEnvironment
+        // Same PATH gap as ClaudeCodeCLIUsageService: a GUI-launched MeterBar
+        // inherits launchd's bare PATH, and the resumed `claude` needs `node`.
+        environment["PATH"] = CLIBinaryLocator.augmentedPATH(environment: baseEnvironment)
         environment["NO_COLOR"] = "1"
         environment["FORCE_COLOR"] = "0"
         environment["TERM"] = "dumb"

--- a/MeterBarTests/CLIBinaryLocatorTests.swift
+++ b/MeterBarTests/CLIBinaryLocatorTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import MeterBar
+
+final class CLIBinaryLocatorTests: XCTestCase {
+    // MARK: - augmentedPATH
+
+    /// GUI apps inherit launchd's bare PATH; the spawned CLI must still be able
+    /// to find its runtime (e.g. `node` in /opt/homebrew/bin).
+    func testAugmentedPATHAppendsFallbackDirectoriesAfterExistingEntries() {
+        let path = CLIBinaryLocator.augmentedPATH(
+            environment: ["PATH": "/usr/bin:/bin"],
+            home: "/Users/tester"
+        )
+
+        XCTAssertTrue(path.hasPrefix("/usr/bin:/bin:"), "Existing PATH entries must keep priority")
+        let entries = path.split(separator: ":").map(String.init)
+        XCTAssertTrue(entries.contains("/opt/homebrew/bin"))
+        XCTAssertTrue(entries.contains("/usr/local/bin"))
+        XCTAssertTrue(entries.contains("/Users/tester/.local/bin"))
+    }
+
+    func testAugmentedPATHDoesNotDuplicateEntriesAlreadyOnPATH() {
+        let path = CLIBinaryLocator.augmentedPATH(
+            environment: ["PATH": "/opt/homebrew/bin:/usr/bin"],
+            home: "/Users/tester"
+        )
+
+        let entries = path.split(separator: ":").map(String.init)
+        XCTAssertEqual(entries.filter { $0 == "/opt/homebrew/bin" }.count, 1)
+        XCTAssertEqual(entries.first, "/opt/homebrew/bin", "User-chosen ordering must be preserved")
+    }
+
+    func testAugmentedPATHWithEmptyEnvironmentReturnsFallbackDirectories() {
+        let path = CLIBinaryLocator.augmentedPATH(environment: [:], home: "/Users/tester")
+
+        let entries = path.split(separator: ":").map(String.init)
+        XCTAssertFalse(entries.isEmpty)
+        XCTAssertEqual(entries.first, "/opt/homebrew/bin")
+        XCTAssertFalse(entries.contains(""), "No empty segments from a missing PATH")
+    }
+}

--- a/MeterBarTests/ClaudeCodeCLIUsageParserTests.swift
+++ b/MeterBarTests/ClaudeCodeCLIUsageParserTests.swift
@@ -42,6 +42,32 @@ final class ClaudeCodeCLIUsageParserTests: XCTestCase {
         XCTAssertEqual(weeklyLimit.percentage, 75, accuracy: 0.01)
     }
 
+    /// The CLI renamed the model-specific window from "Sonnet only" to "Fable"
+    /// (observed 2026-07, claude 2.1.205); both labels must keep parsing.
+    func testParsesFableWeeklyWindow() throws {
+        let output = """
+        You are currently using your subscription to power your Claude Code usage
+
+        Current session: 13% used · resets Jul 12 at 4pm (Europe/Malta)
+        Current week (all models): 23% used · resets Jul 17 at 10pm (Europe/Malta)
+        Current week (Fable): 32% used · resets Jul 17 at 10pm (Europe/Malta)
+
+        What's contributing to your limits usage?
+        Approximate, based on local sessions on this machine.
+        """
+
+        let metrics = try ClaudeCodeCLIUsageParser.parseMetrics(
+            from: output,
+            now: Date(timeIntervalSince1970: 1_781_154_000))
+
+        let sessionLimit = try XCTUnwrap(metrics.sessionLimit)
+        let weeklyLimit = try XCTUnwrap(metrics.weeklyLimit)
+        let modelLimit = try XCTUnwrap(metrics.codeReviewLimit)
+        XCTAssertEqual(sessionLimit.percentage, 13, accuracy: 0.01)
+        XCTAssertEqual(weeklyLimit.percentage, 23, accuracy: 0.01)
+        XCTAssertEqual(modelLimit.percentage, 32, accuracy: 0.01)
+    }
+
     func testThrowsWhenNoUsageWindowsArePresent() {
         XCTAssertThrowsError(try ClaudeCodeCLIUsageParser.parseMetrics(from: "No usage data"))
     }

--- a/MeterBarTests/ClaudeCodeCLIUsageServiceTests.swift
+++ b/MeterBarTests/ClaudeCodeCLIUsageServiceTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import MeterBar
+
+final class ClaudeCodeCLIUsageServiceTests: XCTestCase {
+    /// The spawned `claude` must get an augmented PATH: under launchd's bare
+    /// GUI PATH the CLI itself launches but cannot find `node`, prints a cost
+    /// summary instead of the usage screen, and parsing fails with
+    /// "No Claude usage windows found".
+    func testProcessEnvironmentAugmentsPATH() {
+        let environment = ClaudeCodeCLIUsageService.shared.processEnvironment(
+            account: .defaultAccount,
+            base: ["PATH": "/usr/bin:/bin"]
+        )
+
+        let path = environment["PATH"] ?? ""
+        XCTAssertTrue(path.hasPrefix("/usr/bin:/bin"), "Inherited PATH entries must keep priority")
+        XCTAssertTrue(path.contains("/opt/homebrew/bin"), "Homebrew bin dir must be reachable for node")
+    }
+
+    func testProcessEnvironmentSetsPlainTerminalAndConfigDirectory() {
+        let account = ClaudeCodeAccount(id: UUID(), name: "alt", configDirectory: "/tmp/claude-alt")
+        let environment = ClaudeCodeCLIUsageService.shared.processEnvironment(
+            account: account,
+            base: [:]
+        )
+
+        XCTAssertEqual(environment["NO_COLOR"], "1")
+        XCTAssertEqual(environment["TERM"], "dumb")
+        XCTAssertEqual(environment["CLAUDE_CONFIG_DIR"], "/tmp/claude-alt")
+    }
+}

--- a/MeterBarTests/WakeRunnerTests.swift
+++ b/MeterBarTests/WakeRunnerTests.swift
@@ -102,6 +102,18 @@ final class WakeRunnerTests: XCTestCase {
         XCTAssertTrue(acknowledged.arguments.contains("--dangerously-skip-permissions"))
     }
 
+    /// GUI launches inherit launchd's bare PATH; without augmentation the
+    /// resumed `claude` cannot find `node` and the wake silently fails.
+    func testBuildAugmentsPATHWithCLIInstallDirectories() {
+        let command = WakeCommandBuilder.build(
+            executable: "/bin/claude", candidate: candidate(cwd: tempDir.path), account: account(),
+            bounds: .default, baseEnvironment: ["PATH": "/usr/bin:/bin"]
+        )
+        let path = command.environment["PATH"] ?? ""
+        XCTAssertTrue(path.hasPrefix("/usr/bin:/bin"), "Inherited PATH entries must keep priority")
+        XCTAssertTrue(path.contains("/opt/homebrew/bin"), "Homebrew bin dir must be reachable for node")
+    }
+
     func testMaxTurnsAndSessionArgs() {
         let command = WakeCommandBuilder.build(
             executable: "/bin/claude", candidate: candidate(sessionID: "abc", cwd: tempDir.path),


### PR DESCRIPTION
## Summary

Fixes the "Needs Attention / Could not parse Claude CLI usage: No Claude usage windows found" failure, plus a silently-dropped limit.

### 1. PATH gap (hits every Homebrew-node user)
A GUI-launched MeterBar inherits launchd's bare PATH. `CLIBinaryLocator` still finds `claude` via fallbacks, but the **spawned** CLI can't find `node` (`/opt/homebrew/bin` missing) — it prints a session cost summary instead of the usage screen, so parsing finds no windows.

- New `CLIBinaryLocator.augmentedPATH(environment:home:)`: appends the known CLI install dirs (deduped; inherited entries keep priority; mirrors the reconnect script's `export PATH` list).
- Wired into `ClaudeCodeCLIUsageService.processEnvironment` **and** `WakeCommandBuilder.build` — Session Wake resumes had the identical gap.

### 2. Fable weekly window
claude 2.1.205 renamed the model-specific window to `Current week (Fable)`; the parser only matched "Sonnet only", so `codeReviewLimit` silently dropped to nil. Parser now matches both label generations.

#132 (parse-health diagnostics) is the detection net for this failure class going forward.

## Verification
- Repro confirmed: `env -i HOME=$HOME PATH=/usr/bin:/bin claude /usage` → cost summary, no windows; with node's dir on PATH → windows return.
- TDD: 7 new tests (`CLIBinaryLocatorTests`, `ClaudeCodeCLIUsageServiceTests`, `WakeRunnerTests` PATH test, Fable parser fixture) written first.
- Full suite: 533/533 green. SwiftLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line tool discovery when the app is launched from a GUI or resumed with a limited environment.
  * Fixed resumed sessions that could not locate required tools such as Node.
  * Improved recognition of usage limits reported under updated model labels, including Fable.

* **Tests**
  * Added coverage for environment setup, command resumption, executable discovery, and updated usage output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->