### PR TITLE
chore: harmonize PR issue linking

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,10 @@
 
 Brief description of what this PR does.
 
+## Related issue
+
+<!-- Use `Closes #123` only when this PR fully resolves the issue. Use `Refs #123` otherwise. A closing keyword takes effect when the PR merges into the repository's default branch. -->
+
 ## Type of Change
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
@@ -35,4 +39,3 @@ Add screenshots to help explain your changes.
 ## Additional Notes
 
 Any additional information that reviewers should know.
-


### PR DESCRIPTION
## Summary

- add the shared Related issue contract to the repository PR template
- use `Closes #123` only for fully resolved issues and `Refs #123` otherwise
- document that the closing keyword takes effect when the PR merges into the default branch

## Verification

- `git diff --check`
- documentation-only GitHub PR-template change

## Impact

Fully resolving PRs can consistently close their linked issue on merge. The GitHub Project Item closed workflow remains responsible for moving the closed issue to Done.