### PR TITLE
docs: refresh README product screenshot

### DIFF
--- a/.agents/SESSIONS/2026-07-12.md
+++ b/.agents/SESSIONS/2026-07-12.md
@@ -65,3 +65,74 @@
 **Next steps:**
 - Commit as two `fix(...)` commits or one PR for v1.7.1.
 - Decide whether to file the settings-UI audit items as issues.
+
+## Session 4: Rename GitHub Repository
+
+**Duration:** ~10 minutes
+**Status:** Complete
+
+### Affected components
+
+- GitHub repository identity and metadata
+- Local Git `origin` remote
+
+### What was done
+
+- [x] Renamed `VincentShipsIt/meterbar.app` to `VincentShipsIt/meterbar.dev`
+- [x] Set the GitHub description and homepage URL
+- [x] Updated and verified the local `origin` URL
+
+### Files changed
+
+- `.agents/SESSIONS/2026-07-12.md` - Track repository administration work
+
+### Key decisions
+
+- Preserve the existing README-aligned description: “Track your AI coding assistant usage limits from the macOS menu bar.”
+- Use `https://meterbar.dev` as the GitHub homepage URL.
+
+### Mistakes and fixes
+
+_None._
+
+### Next steps
+
+_None._
+
+## Session 5: Refresh README Screenshot
+
+**Duration:** ~10 minutes
+**Status:** Complete
+
+### Affected components
+
+- README product presentation
+- Live MeterBar website asset
+
+### What was done
+
+- [x] Audited all committed screenshot assets and their history
+- [x] Confirmed the existing README images still showed the obsolete “Quota Guard” UI
+- [x] Replaced both stale mock screenshots with the current MeterBar overview image from the official website
+
+### Files changed
+
+- `README.md` - Use the current MeterBar dashboard overview image
+- `.agents/SESSIONS/2026-07-12.md` - Track screenshot audit and README update
+
+### Key decisions
+
+- Use the official `https://meterbar.dev/product/overview.png` asset because it accurately shows the current dashboard, providers, pace markers, costs, and navigation.
+- Stop presenting the hand-maintained screenshot renderer output because the repository audit already identifies it as a stale replica of the real UI.
+
+### Mistakes and fixes
+
+_None._
+
+### Next steps
+
+- [ ] Consider deleting or replacing the now-unused stale files in `docs/screenshots/` and retiring the replica screenshot renderer in a separate cleanup
+
+---
+
+**Total sessions today:** 5

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ A lightweight macOS menu bar app that monitors Claude Code, Codex CLI, and Curso
 ## Screenshots
 
 <p align="center">
-  <img src="docs/screenshots/menubar.png" alt="Menu Bar" width="300">
-  &nbsp;&nbsp;&nbsp;
-  <img src="docs/screenshots/widget-medium.png" alt="Widget" width="300">
+  <img
+    src="https://meterbar.dev/product/overview.png"
+    alt="MeterBar overview window tracking Codex, Claude, and Cursor usage limits"
+    width="800"
+  >
 </p>
 
 ## Features


### PR DESCRIPTION
## Summary

- Refresh the README product screenshot to the current app UI.

## Verification

- Documentation-only change; `git diff --check` clean.

## Impact

- README displays an up-to-date product screenshot. No code paths affected.