### PR TITLE
fix(usage): label heuristic quota estimates

### DIFF
--- a/.agents/SESSIONS/2026-07-13.md
+++ b/.agents/SESSIONS/2026-07-13.md
@@ -1,0 +1,36 @@
+# 2026-07-13
+
+## Session 1: Label heuristic quota estimates
+
+**Duration:** ~55 minutes
+**Status:** Complete
+
+**What was done:**
+- Claimed project issue #129 and implemented a backward-compatible `UsageLimit.isEstimated` cache field.
+- Marked Cursor's assumed 500-request total and derived on-demand headroom as estimates while preserving provider-reported totals as exact.
+- Added shared approximation formatting and surfaced it in the popover, dashboard, menu detail panel, widget, and CLI.
+- Suppressed pace projections, blocking-state claims, and threshold notifications for estimated limits.
+- Confirmed the old synthetic admin-API quota path no longer exists; current admin usage already labels approximate spend as estimated.
+
+**Files changed:**
+- `Packages/MeterBarShared/Sources/MeterBarShared/UsageLimit.swift` - Estimate metadata, legacy decoding, and shared display labels.
+- `MeterBar/Services/CursorLocalService.swift` - Propagate estimate provenance from Cursor mappings.
+- `MeterBar/Services/NotificationDecider.swift` - Suppress estimated-limit threshold notifications.
+- `MeterBar/Views/` - Show estimate badges/markers and avoid inferred pace/blocking claims.
+- `MeterBarWidget/UsageWidget.swift` - Mark estimated percentages and totals.
+- `MeterBarCLI/Sources/MeterBarCLI.swift` - Mark estimated CLI output.
+- `MeterBarTests/` - Focused model, mapping, cache, notification, and blocking-state coverage.
+
+**Verification:**
+- `swift test`: 537 tests passed after rebasing onto current `origin/master`.
+- `COVERAGE_THRESHOLD=19 bash scripts/check-coverage.sh`: 42.7% line coverage.
+- `swiftlint lint --strict`: 0 violations.
+- `swift build --package-path MeterBarCLI`: succeeded.
+- Universal Release `xcodebuild` for app + widget: succeeded.
+
+**Decisions:**
+- Old cache payloads decode missing `isEstimated` as `false`, preserving compatibility.
+- Estimated totals remain visible for orientation but cannot assert provider blocking, pace, or notification thresholds.
+
+**Next steps:**
+- [ ] Review and merge the pull request for issue #129.

--- a/MeterBar/Services/CursorLocalService.swift
+++ b/MeterBar/Services/CursorLocalService.swift
@@ -273,14 +273,17 @@ class CursorLocalService: ObservableObject {
         }
 
         // Extract usage from individual plan
-        let planUsed = Double(summaryData.individualUsage?.plan?.used ?? 0)
-        let planTotal = Double(summaryData.individualUsage?.plan?.total ?? Int(defaultPlanTotal))
+        let plan = summaryData.individualUsage?.plan
+        let planUsed = Double(plan?.used ?? 0)
+        let planTotalIsEstimated = plan?.total == nil
+        let planTotal = Double(plan?.total ?? Int(defaultPlanTotal))
 
         // Create usage metrics using plan data
         let weeklyLimit = UsageLimit(
             used: planUsed,
             total: planTotal,
-            resetTime: resetTime
+            resetTime: resetTime,
+            isEstimated: planTotalIsEstimated
         )
 
         // On-demand usage as secondary metric if enabled
@@ -292,7 +295,8 @@ class CursorLocalService: ObservableObject {
                 sessionLimit = UsageLimit(
                     used: onDemandUsed,
                     total: onDemandLimit > 0 ? onDemandLimit : onDemandUsed * onDemandHeadroomMultiplier,
-                    resetTime: resetTime
+                    resetTime: resetTime,
+                    isEstimated: onDemandLimit <= 0
                 )
             }
         }

--- a/MeterBar/Services/NotificationDecider.swift
+++ b/MeterBar/Services/NotificationDecider.swift
@@ -124,6 +124,15 @@ struct NotificationDecider {
                 continue
             }
 
+            // Heuristic totals can indicate UI severity, but they are not a
+            // reliable basis for a threshold alert. Clear crossing state so a
+            // later provider-reported value can notify normally.
+            guard !limit.isEstimated else {
+                keys.remove(warnKey)
+                keys.remove(criticalKey)
+                continue
+            }
+
             let band = QuotaBand.forLimit(limit)
             let bandRank = Self.severityRank(band)
             let quotaDisplayName = quotaKind.displayName(for: metrics.service)

--- a/MeterBar/Views/DashboardProviderCards.swift
+++ b/MeterBar/Views/DashboardProviderCards.swift
@@ -189,8 +189,14 @@ struct DashboardLimitRow: View {
         Text(limit.title)
           .font(.subheadline)
           .bold()
+        if limit.usageLimit.isEstimated {
+          Text("Estimated")
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .foregroundColor(.secondary)
+        }
         Spacer()
-        Text(isOut ? "Out" : "\(limit.percentLeft)% left")
+        Text(isOut && !limit.usageLimit.isEstimated ? "Out" : limit.usageLimit.percentLeftText)
           .font(.subheadline)
           .bold()
           .foregroundColor(isOut ? MeterBarTheme.danger : .primary)
@@ -199,15 +205,15 @@ struct DashboardLimitRow: View {
       UsageBar(
         usedPercentage: limit.usedPercent,
         accentColor: accentColor,
-        pace: limit.usageLimit.pace(),
+        pace: limit.usageLimit.isEstimated ? nil : limit.usageLimit.pace(),
         paceContext: limit.paceContext
       )
 
       HStack {
-        Text("\(Int(limit.usedPercent.rounded()))% used")
+        Text(limit.usageLimit.usedPercentageText)
           .font(.caption)
           .foregroundColor(.secondary)
-        if let pace = limit.usageLimit.pace() {
+        if !limit.usageLimit.isEstimated, let pace = limit.usageLimit.pace() {
           Text(pace.leftLabel)
             .font(.caption)
             .foregroundColor(paceLabelColor(pace))

--- a/MeterBar/Views/MenuBarDetailPanel.swift
+++ b/MeterBar/Views/MenuBarDetailPanel.swift
@@ -224,8 +224,13 @@ private struct MenuBarProviderLimitDetailRow: View {
         Text(limit.title)
           .font(.caption)
           .fontWeight(.semibold)
+        if limit.usageLimit.isEstimated {
+          Text("Estimated")
+            .font(.system(size: 8, weight: .semibold))
+            .foregroundColor(.secondary)
+        }
         Spacer(minLength: 4)
-        Text(isOut ? "Out" : "\(limit.percentLeft)% left")
+        Text(isOut && !limit.usageLimit.isEstimated ? "Out" : limit.usageLimit.percentLeftText)
           .font(.caption)
           .fontWeight(.semibold)
           .foregroundColor(isOut ? MeterBarTheme.danger : .primary)
@@ -234,16 +239,16 @@ private struct MenuBarProviderLimitDetailRow: View {
       UsageBar(
         usedPercentage: limit.usedPercent,
         accentColor: accentColor,
-        pace: limit.usageLimit.pace(),
+        pace: limit.usageLimit.isEstimated ? nil : limit.usageLimit.pace(),
         paceContext: limit.paceContext
       )
 
       HStack(spacing: 6) {
-        Text("\(Int(limit.usedPercent.rounded()))% used")
+        Text(limit.usageLimit.usedPercentageText)
           .font(.caption2)
           .foregroundColor(.secondary)
 
-        if let pace = limit.usageLimit.pace() {
+        if !limit.usageLimit.isEstimated, let pace = limit.usageLimit.pace() {
           Text(pace.leftLabel)
             .font(.caption2)
             .foregroundColor(paceLabelColor(pace))

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -467,8 +467,13 @@ private struct PopoverLimitRow: View {
           .font(.caption2)
           .foregroundColor(.secondary)
           .lineLimit(1)
+        if limit.usageLimit.isEstimated {
+          Text("Estimated")
+            .font(.system(size: 8, weight: .semibold))
+            .foregroundColor(.secondary)
+        }
         Spacer(minLength: 4)
-        Text(isOut ? "Out" : "\(limit.percentLeft)% left")
+        Text(isOut && !limit.usageLimit.isEstimated ? "Out" : limit.usageLimit.percentLeftText)
           .font(.caption)
           .fontWeight(.semibold)
           .foregroundColor(isOut ? MeterBarTheme.danger : .primary)
@@ -478,7 +483,7 @@ private struct PopoverLimitRow: View {
       UsageBar(
         usedPercentage: limit.usedPercent,
         accentColor: accentColor,
-        pace: limit.usageLimit.pace(),
+        pace: limit.usageLimit.isEstimated ? nil : limit.usageLimit.pace(),
         paceContext: limit.paceContext
       )
 

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -50,7 +50,9 @@ struct ProviderSnapshot: Identifiable {
     var blockingLimits: [SnapshotLimit] {
         guard extraUsage?.state != .on else { return [] }
         return limits.filter {
-            ($0.kind == .session || $0.kind == .weekly) && $0.usageLimit.isAtLimit
+            ($0.kind == .session || $0.kind == .weekly)
+                && !$0.usageLimit.isEstimated
+                && $0.usageLimit.isAtLimit
         }
     }
 

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -987,7 +987,10 @@ private struct OverviewSummaryStrip: View {
     private func tightestValue(now: Date) -> String {
         guard let tightestLimit else { return "No data" }
         guard tightestLimit.usageLimit.isAtLimit else {
-            return "\(tightestLimit.percentLeft)% left"
+            return tightestLimit.usageLimit.percentLeftText
+        }
+        if tightestLimit.usageLimit.isEstimated {
+            return tightestLimit.usageLimit.percentLeftText
         }
         guard let countdown = tightestLimit.usageLimit.resetCountdownText(now: now) else {
             return "Reset unknown"

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -137,8 +137,9 @@ struct Usage: ParsableCommand {
         let bar = progressBar(percent: percent, width: 20)
         let status = statusEmoji(for: limit)
 
-        print("\(label): \(bar) \(String(format: "%.0f%%", percent)) \(status)")
-        print("    \(Int(limit.used))/\(Int(limit.total)) used")
+        print("\(label): \(bar) \(limit.percentageText) \(status)")
+        let estimateDetail = limit.isEstimated ? " (estimated limit)" : ""
+        print("    \(Int(limit.used))/\(Int(limit.total)) used\(estimateDetail)")
         if let reset = limit.resetTime {
             print("    Resets: \(UsageFormat.relative(reset))")
         }

--- a/MeterBarTests/CachedMetricsContractTests.swift
+++ b/MeterBarTests/CachedMetricsContractTests.swift
@@ -18,7 +18,8 @@ final class CachedMetricsContractTests: XCTestCase {
                 used: 42.5,
                 total: 100,
                 resetTime: Date(timeIntervalSinceReferenceDate: 700_000_000),
-                windowSeconds: 5 * 3_600
+                windowSeconds: 5 * 3_600,
+                isEstimated: true
             ),
             weeklyLimit: UsageLimit(used: 12, total: 100, resetTime: nil),
             extraUsage: ExtraUsageStatus(state: .on, detail: "$0.00 used"),
@@ -61,10 +62,11 @@ final class CachedMetricsContractTests: XCTestCase {
         }
 
         let session = try XCTUnwrap(object["sessionLimit"] as? [String: Any])
-        for key in ["used", "total", "resetTime", "windowSeconds"] {
+        for key in ["used", "total", "resetTime", "windowSeconds", "isEstimated"] {
             XCTAssertNotNil(session[key], "missing sessionLimit key '\(key)'")
         }
         XCTAssertEqual(session["used"] as? Double, 42.5)
+        XCTAssertEqual(session["isEstimated"] as? Bool, true)
 
         let extra = try XCTUnwrap(object["extraUsage"] as? [String: Any])
         XCTAssertEqual(extra["state"] as? String, "on")
@@ -98,6 +100,7 @@ final class CachedMetricsContractTests: XCTestCase {
         XCTAssertEqual(metrics.service, .codexCli)
         XCTAssertEqual(metrics.weeklyLimit?.used, 30)
         XCTAssertNil(metrics.weeklyLimit?.windowSeconds)
+        XCTAssertEqual(metrics.weeklyLimit?.isEstimated, false)
         XCTAssertNil(metrics.extraUsage)
         XCTAssertNil(metrics.resetCreditsAvailable)
     }

--- a/MeterBarTests/CursorLocalServiceTests.swift
+++ b/MeterBarTests/CursorLocalServiceTests.swift
@@ -44,9 +44,11 @@ final class CursorLocalServiceTests: XCTestCase {
         XCTAssertEqual(metrics.service, .cursor)
         XCTAssertEqual(metrics.weeklyLimit?.used, 137)
         XCTAssertEqual(metrics.weeklyLimit?.total, 500)
+        XCTAssertEqual(metrics.weeklyLimit?.isEstimated, false)
         XCTAssertEqual(metrics.weeklyLimit?.resetTime, FlexibleISO8601.date(from: "2026-08-01T00:00:00Z"))
         XCTAssertEqual(metrics.sessionLimit?.used, 4)
         XCTAssertEqual(metrics.sessionLimit?.total, 20)
+        XCTAssertEqual(metrics.sessionLimit?.isEstimated, false)
     }
 
     func testMapSummarySubstitutesDefaultPlanTotalWhenMissing() throws {
@@ -57,6 +59,7 @@ final class CursorLocalServiceTests: XCTestCase {
         let metrics = CursorLocalService.mapSummary(try decodeSummary(json))
         XCTAssertEqual(metrics.weeklyLimit?.used, 50)
         XCTAssertEqual(metrics.weeklyLimit?.total, 500)
+        XCTAssertEqual(metrics.weeklyLimit?.isEstimated, true)
     }
 
     func testMapSummaryOmitsSessionLimitWhenOnDemandDisabled() throws {
@@ -85,6 +88,7 @@ final class CursorLocalServiceTests: XCTestCase {
         let metrics = CursorLocalService.mapSummary(try decodeSummary(json))
         XCTAssertEqual(metrics.sessionLimit?.used, 8)
         XCTAssertEqual(metrics.sessionLimit?.total ?? 0, 12, accuracy: 0.0001)
+        XCTAssertEqual(metrics.sessionLimit?.isEstimated, true)
     }
 
     func testMapSummaryOmitsSessionLimitWhenOnDemandAllZero() throws {

--- a/MeterBarTests/NotificationDeciderTests.swift
+++ b/MeterBarTests/NotificationDeciderTests.swift
@@ -272,6 +272,19 @@ final class NotificationDeciderTests: XCTestCase {
         XCTAssertTrue(result.notifiedKeys.isEmpty)
     }
 
+    func testEstimatedLimitNeverNotifiesAndClearsPreviousBandState() {
+        let estimated = UsageLimit(used: 100, total: 100, resetTime: nil, isEstimated: true)
+        let result = decider().evaluate(
+            metrics: metrics(session: estimated),
+            providerEnabled: true,
+            alreadyNotified: ["Claude Code-session-warn", "Claude Code-session-critical"],
+            now: now
+        )
+
+        XCTAssertTrue(result.notifications.isEmpty)
+        XCTAssertTrue(result.notifiedKeys.isEmpty)
+    }
+
     func testExhaustedCriticalCopyClaimsLimitReached() {
         let result = decider().evaluate(
             metrics: metrics(session: exhaustedLimit()),

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -262,6 +262,29 @@ final class ProviderSnapshotTests: XCTestCase {
         )
     }
 
+    func testEstimatedExhaustionDoesNotClaimProviderIsBlocked() {
+        let metrics = UsageMetrics(
+            service: .cursor,
+            weeklyLimit: UsageLimit(
+                used: 500,
+                total: 500,
+                resetTime: nil,
+                isEstimated: true
+            )
+        )
+        let snapshot = ProviderSnapshotBuilder.snapshot(
+            title: "Cursor",
+            service: .cursor,
+            metrics: metrics,
+            emptyDetail: ""
+        )
+
+        XCTAssertEqual(snapshot.band, .exhausted)
+        XCTAssertFalse(snapshot.hasExhaustedLimit)
+        XCTAssertFalse(snapshot.hasExhaustedWeeklyLimit)
+        XCTAssertTrue(snapshot.blockingLimits.isEmpty)
+    }
+
     func testBlockingResetWindowsExcludeSimultaneouslyExhaustedSecondaryQuota() {
         let snapshot = ProviderSnapshotBuilder.snapshot(
             title: "Claude",

--- a/MeterBarTests/UsageLimitTests.swift
+++ b/MeterBarTests/UsageLimitTests.swift
@@ -3,6 +3,28 @@ import MeterBarShared
 @testable import MeterBar
 
 final class UsageLimitTests: XCTestCase {
+    func testEstimatedPresentationLabelsAreExplicit() {
+        let reported = UsageLimit(used: 25, total: 100, resetTime: nil)
+        let estimated = UsageLimit(used: 25, total: 100, resetTime: nil, isEstimated: true)
+
+        XCTAssertFalse(reported.isEstimated)
+        XCTAssertEqual(reported.percentageText, "25%")
+        XCTAssertEqual(reported.percentLeftText, "75% left")
+        XCTAssertEqual(reported.usedPercentageText, "25% used")
+
+        XCTAssertTrue(estimated.isEstimated)
+        XCTAssertEqual(estimated.percentageText, "~25%")
+        XCTAssertEqual(estimated.percentLeftText, "~75% left")
+        XCTAssertEqual(estimated.usedPercentageText, "~25% used")
+    }
+
+    func testLegacyJSONWithoutEstimatedFlagDecodesAsReported() throws {
+        let data = Data(#"{"used":25,"total":100,"resetTime":null,"windowSeconds":null}"#.utf8)
+        let limit = try JSONDecoder().decode(UsageLimit.self, from: data)
+
+        XCTAssertFalse(limit.isEstimated)
+    }
+
     func testPercentageValues() {
         let limit = UsageLimit(used: 25, total: 100, resetTime: nil)
 

--- a/MeterBarWidget/UsageWidget.swift
+++ b/MeterBarWidget/UsageWidget.swift
@@ -134,7 +134,7 @@ struct ServiceMiniView: View {
             if let weeklyLimit = metrics.weeklyLimit {
                 ProgressView(value: weeklyLimit.clampedUsed, total: weeklyLimit.clampedTotal)
                     .tint(weeklyLimit.statusColor.color)
-                Text("\(Int(weeklyLimit.percentage))%")
+                Text(weeklyLimit.percentageText)
                     .font(.caption2)
                     .foregroundColor(.secondary)
             }
@@ -221,7 +221,7 @@ struct ServiceCompactView: View {
                 HStack {
                     ProgressView(value: weeklyLimit.clampedUsed, total: weeklyLimit.clampedTotal)
                         .tint(weeklyLimit.statusColor.color)
-                    Text("\(Int(weeklyLimit.percentage))%")
+                    Text(weeklyLimit.percentageText)
                         .font(.caption)
                 }
             }
@@ -273,7 +273,7 @@ struct LimitDetailView: View {
                 Text(title)
                     .font(.caption)
                 Spacer()
-                Text("\(Int(limit.percentage))%")
+                Text(limit.percentageText)
                     .font(.caption)
                     .bold()
             }
@@ -281,7 +281,10 @@ struct LimitDetailView: View {
             ProgressView(value: limit.clampedUsed, total: limit.clampedTotal)
                 .tint(limit.statusColor.color)
 
-            Text("\(formatNumber(limit.used)) / \(formatNumber(limit.total))")
+            Text(
+                "\(formatNumber(limit.used)) / "
+                    + "\(limit.isEstimated ? "~" : "")\(formatNumber(limit.total))"
+            )
                 .font(.caption2)
                 .foregroundColor(.secondary)
         }

--- a/Packages/MeterBarShared/Sources/MeterBarShared/UsageLimit.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/UsageLimit.swift
@@ -5,12 +5,39 @@ public struct UsageLimit: Codable, Equatable, Sendable {
     public let total: Double
     public let resetTime: Date?
     public let windowSeconds: TimeInterval?
+    /// True when MeterBar substituted or derived the quota total instead of
+    /// receiving it from the provider.
+    public let isEstimated: Bool
 
-    public init(used: Double, total: Double, resetTime: Date?, windowSeconds: TimeInterval? = nil) {
+    public init(
+        used: Double,
+        total: Double,
+        resetTime: Date?,
+        windowSeconds: TimeInterval? = nil,
+        isEstimated: Bool = false
+    ) {
         self.used = used
         self.total = total
         self.resetTime = resetTime
         self.windowSeconds = windowSeconds
+        self.isEstimated = isEstimated
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case used
+        case total
+        case resetTime
+        case windowSeconds
+        case isEstimated
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        used = try container.decode(Double.self, forKey: .used)
+        total = try container.decode(Double.self, forKey: .total)
+        resetTime = try container.decodeIfPresent(Date.self, forKey: .resetTime)
+        windowSeconds = try container.decodeIfPresent(TimeInterval.self, forKey: .windowSeconds)
+        isEstimated = try container.decodeIfPresent(Bool.self, forKey: .isEstimated) ?? false
     }
 
     public var rawPercentage: Double {
@@ -20,6 +47,25 @@ public struct UsageLimit: Codable, Equatable, Sendable {
 
     public var percentage: Double {
         return min(100, rawPercentage)
+    }
+
+    /// User-facing percentage labels shared by the app, widget, and CLI. A
+    /// leading approximation mark prevents heuristic totals from looking like
+    /// provider-reported measurements.
+    public var percentageText: String {
+        "\(estimatePrefix)\(Int(percentage.rounded()))%"
+    }
+
+    public var percentLeftText: String {
+        "\(estimatePrefix)\(QuotaMath.percentLeft(for: self))% left"
+    }
+
+    public var usedPercentageText: String {
+        "\(percentageText) used"
+    }
+
+    private var estimatePrefix: String {
+        isEstimated ? "~" : ""
     }
 
     /// `used` clamped into `0...total`, for progress bars that reject


### PR DESCRIPTION
## Summary

- add backward-compatible estimate provenance to shared usage limits
- mark Cursor's fallback monthly quota and derived on-demand headroom as estimates
- surface estimate markers across the popover, dashboard, widget, and CLI
- prevent estimated limits from driving pace projections, blocking-state claims, or threshold notifications

## Verification

- `swift test` — 537 tests passed
- `COVERAGE_THRESHOLD=19 bash scripts/check-coverage.sh` — 42.7% line coverage
- `swiftlint lint --strict` — 0 violations
- `swift build --package-path MeterBarCLI` — succeeded
- universal Release `xcodebuild` for app + widget — succeeded
- `git diff --check` — clean

## Skipped checks / residual risk

- `swiftformat --lint` was unavailable locally; SwiftFormat is not a repository CI gate. SwiftLint and compiler formatting checks passed.
- Existing Swift 6 actor-isolation warnings in `UsageDataManager` / CLI wake code remain unchanged and are outside this issue.
- Visual labels compile in all targets and are covered through shared formatting behavior; no screenshot automation exists for the native popover/widget states.

Closes #129
