### PR TITLE
fix(session-wake): wire master feature gate

### DIFF
--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -33,7 +33,8 @@ nonisolated enum StorageKeys {
 
     // MARK: - Session Wake (#98)
 
-    /// Master enablement for the Session Wake feature (Bool, default off).
+    /// Master enablement for Session Wake. Missing stays on for v1.7 compatibility;
+    /// an explicit false is the emergency kill-switch shared with the CLI.
     static let sessionWakeFeatureEnabled = "SessionWakeFeatureEnabled"
     /// Runtime intent for the watcher, distinct from feature enablement (Bool).
     static let sessionWakeWatcherArmed = "SessionWakeWatcherArmed"

--- a/MeterBar/SessionWake/SessionWakeCLI.swift
+++ b/MeterBar/SessionWake/SessionWakeCLI.swift
@@ -7,6 +7,9 @@ import MeterBarShared
 /// CLI stays a thin wrapper over the same native discovery / quota / runner /
 /// ledger the app uses, and MeterBar's public surface doesn't balloon.
 public enum SessionWakeCLI {
+    /// Shared app-group key used by both the app and bundled CLI.
+    public static let sharedFeatureEnabledKey = "SessionWakeFeatureEnabled"
+
     /// Everything the command needs to render output and set an exit code.
     public struct Result: Sendable {
         /// The versioned JSON response (stdout when `--json`).
@@ -58,6 +61,19 @@ public enum SessionWakeCLI {
 
     /// Run a one-shot wake. `dryRun` performs no subprocess and no mutation.
     public static func run(_ request: Request) async -> Result {
+        guard isFeatureEnabled() else {
+            let message = "Session Wake is disabled by MeterBar's master feature switch."
+            let response = WakeCLIResponse.from(
+                candidates: [],
+                outcome: .validationFailure,
+                provider: request.provider,
+                dryRun: request.dryRun,
+                account: request.configDirectory,
+                message: message
+            )
+            return result(from: response)
+        }
+
         let account = resolveAccount(configDirectory: request.configDirectory)
         let mode: WakePermissionMode = (request.permissionMode.lowercased() == "bypass") ? .bypass : .safe
         let engine = WakeCLIEngine(
@@ -77,17 +93,16 @@ public enum SessionWakeCLI {
             dryRun: request.dryRun,
             limit: request.limit
         )
-        let json = (try? response.jsonData())
-            .flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
-        let summary = "Session Wake: \(response.outcome.rawValue) · eligible \(response.eligibleCount)"
-            + " · resumed \(response.summary.resumed) · failed \(response.summary.failed)"
+        return result(from: response)
+    }
 
-        return Result(
-            jsonOutput: json,
-            summaryLine: summary,
-            message: response.message,
-            exitCode: response.outcome.exitCode
-        )
+    /// Missing means enabled for compatibility with v1.7.0 installs. Only an
+    /// explicit false activates the kill-switch.
+    public static func isFeatureEnabled(userDefaults: UserDefaults? = nil) -> Bool {
+        let defaults = userDefaults ?? UserDefaults(suiteName: SharedMetricsStore.appGroupIdentifier)
+        guard let defaults else { return true }
+        guard defaults.object(forKey: sharedFeatureEnabledKey) != nil else { return true }
+        return defaults.bool(forKey: sharedFeatureEnabledKey)
     }
 
     /// The wake account config directory the app shares via the app-group
@@ -102,6 +117,20 @@ public enum SessionWakeCLI {
 
     /// The app-group key the app writes the selected wake account's config dir to.
     public static let sharedAccountConfigKey = "SessionWakeAccountConfigDir"
+
+    private static func result(from response: WakeCLIResponse) -> Result {
+        let json = (try? response.jsonData())
+            .flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
+        let summary = "Session Wake: \(response.outcome.rawValue) · eligible \(response.eligibleCount)"
+            + " · resumed \(response.summary.resumed) · failed \(response.summary.failed)"
+
+        return Result(
+            jsonOutput: json,
+            summaryLine: summary,
+            message: response.message,
+            exitCode: response.outcome.exitCode
+        )
+    }
 
     private static func resolveAccount(configDirectory: String?) -> ClaudeCodeAccount {
         let explicit = configDirectory?.trimmingCharacters(in: .whitespaces)

--- a/MeterBar/SessionWake/SessionWakeSettingsStore.swift
+++ b/MeterBar/SessionWake/SessionWakeSettingsStore.swift
@@ -1,7 +1,9 @@
 import Combine
 import Foundation
+import MeterBarShared
 
-/// Persists Session Wake preferences behind a single ON/OFF switch.
+/// Persists Session Wake preferences behind a user ON/OFF switch and a master
+/// feature kill-switch.
 ///
 /// `isOn` is the one control: when on, the watcher polls the selected account's
 /// session limits and resumes blocked sessions after reset; when off, nothing
@@ -12,6 +14,7 @@ import Foundation
 final class SessionWakeSettingsStore: ObservableObject {
     static let shared = SessionWakeSettingsStore()
 
+    @Published private(set) var featureEnabled: Bool
     @Published private(set) var isOn: Bool
     @Published private(set) var wakeAccountID: UUID?
     @Published private(set) var firstRunAcknowledged: Bool
@@ -26,6 +29,14 @@ final class SessionWakeSettingsStore: ObservableObject {
 
     init(userDefaults: UserDefaults = .standard) {
         self.userDefaults = userDefaults
+        if userDefaults.object(forKey: StorageKeys.sessionWakeFeatureEnabled) == nil {
+            // Session Wake shipped before this key was wired. Preserve that
+            // behavior for existing installs; an explicit false is the master
+            // emergency-off switch.
+            featureEnabled = true
+        } else {
+            featureEnabled = userDefaults.bool(forKey: StorageKeys.sessionWakeFeatureEnabled)
+        }
         isOn = userDefaults.bool(forKey: StorageKeys.sessionWakeWatcherArmed)
         wakeAccountID = userDefaults.string(forKey: StorageKeys.sessionWakeAccountID).flatMap(UUID.init(uuidString:))
         firstRunAcknowledged = userDefaults.bool(forKey: StorageKeys.sessionWakeFirstEnableAcknowledged)
@@ -43,10 +54,15 @@ final class SessionWakeSettingsStore: ObservableObject {
         let storedTurns = userDefaults.object(forKey: StorageKeys.sessionWakeMaxTurns) as? Int
         maxTurns = storedTurns ?? WakeBounds.default.maxTurns
 
-        // Invariant: never persist "on" without the preconditions still holding.
+        // Invariant: never persist "on" while the master switch is off or
+        // without the remaining preconditions still holding.
         if isOn && !canTurnOn {
             isOn = false
             userDefaults.set(false, forKey: StorageKeys.sessionWakeWatcherArmed)
+        }
+
+        if userDefaults === UserDefaults.standard {
+            syncSharedFeatureFlag()
         }
     }
 
@@ -66,7 +82,7 @@ final class SessionWakeSettingsStore: ObservableObject {
     /// Whether the switch may be turned on right now: an explicit account and,
     /// for bypass mode, its separate acknowledgement.
     var canTurnOn: Bool {
-        wakeAccountID != nil && (permissionMode == .safe || bypassAcknowledged)
+        featureEnabled && wakeAccountID != nil && (permissionMode == .safe || bypassAcknowledged)
     }
 
     /// True when turning on should first show the one-time confirmation.
@@ -75,6 +91,20 @@ final class SessionWakeSettingsStore: ObservableObject {
     }
 
     // MARK: - Mutations
+
+    /// The master kill-switch. Disabling the feature immediately clears live
+    /// watcher intent and is mirrored to the app-group domain used by the CLI.
+    func setFeatureEnabled(_ enabled: Bool) {
+        guard enabled != featureEnabled else { return }
+        featureEnabled = enabled
+        userDefaults.set(enabled, forKey: StorageKeys.sessionWakeFeatureEnabled)
+        if userDefaults === UserDefaults.standard {
+            syncSharedFeatureFlag()
+        }
+        if !enabled {
+            forceOff()
+        }
+    }
 
     /// Turn the watcher on or off. Turning on is refused unless `canTurnOn` and
     /// the first-run confirmation has been acknowledged; turning off always
@@ -157,5 +187,10 @@ final class SessionWakeSettingsStore: ObservableObject {
         guard isOn else { return }
         isOn = false
         userDefaults.set(false, forKey: StorageKeys.sessionWakeWatcherArmed)
+    }
+
+    private func syncSharedFeatureFlag() {
+        UserDefaults(suiteName: SharedMetricsStore.appGroupIdentifier)?
+            .set(featureEnabled, forKey: SessionWakeCLI.sharedFeatureEnabledKey)
     }
 }

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -80,6 +80,7 @@ struct MenuBarView: View {
           )
 
           if SessionWakeMenuControl.shouldShow(
+            featureEnabled: sessionWakeStore.featureEnabled,
             isOn: sessionWakeStore.isOn,
             canTurnOn: sessionWakeStore.canTurnOn
           ) {

--- a/MeterBar/Views/SessionWakeMenuControl.swift
+++ b/MeterBar/Views/SessionWakeMenuControl.swift
@@ -41,8 +41,8 @@ struct SessionWakeMenuControl: View {
     /// always one click away — or when it is ready to be armed (a wake account is
     /// configured). Hidden when unconfigured, so users who never touch Session
     /// Wake (e.g. Codex-only) don't see an inert row.
-    static func shouldShow(isOn: Bool, canTurnOn: Bool) -> Bool {
-        isOn || canTurnOn
+    static func shouldShow(featureEnabled: Bool, isOn: Bool, canTurnOn: Bool) -> Bool {
+        featureEnabled && (isOn || canTurnOn)
     }
 
     private var label: SessionWakeStatusLabel {

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -179,6 +179,7 @@ struct SettingsView: View {
     @StateObject private var launchAtLogin = LaunchAtLoginStore.shared
     @StateObject private var authManager = AuthenticationManager.shared
     @StateObject private var apiUsageStore = ApiUsageStore.shared
+    @StateObject private var sessionWakeStore = SessionWakeSettingsStore.shared
 
     @State private var isAddingClaudeAccount = false
     @State private var claudeReconnectError: String?
@@ -207,6 +208,10 @@ struct SettingsView: View {
 
     private var enabledProviderCount: Int {
         ServiceType.allCases.filter { providerVisibility.isEnabled($0) }.count
+    }
+
+    private var visibleAppPanes: [SettingsPane] {
+        SettingsPane.appPanes.filter { $0 != .automation || sessionWakeStore.featureEnabled }
     }
 
     private var providerSnapshots: [ProviderSnapshot] {
@@ -286,7 +291,7 @@ struct SettingsView: View {
                     SettingsSidebarSectionHeader(title: "Settings")
 
                     VStack(spacing: 3) {
-                        ForEach(SettingsPane.appPanes) { pane in
+                        ForEach(visibleAppPanes) { pane in
                             SettingsSidebarRow(
                                 pane: pane,
                                 isSelected: selectedPane == pane,
@@ -363,6 +368,9 @@ struct SettingsView: View {
         .onChange(of: providerVisibility.enabledServices) {
             keepSelectedPaneValid()
         }
+        .onChange(of: sessionWakeStore.featureEnabled) {
+            keepSelectedPaneValid()
+        }
     }
 
     private var settingsDetailHeader: some View {
@@ -403,7 +411,9 @@ struct SettingsView: View {
             costTrackingSection
             refreshSection
             notificationsSection
-            automationSection
+            if sessionWakeStore.featureEnabled {
+                automationSection
+            }
             generalSection
         }
         .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -1094,6 +1104,10 @@ struct SettingsView: View {
     }
 
     private func keepSelectedPaneValid() {
+        if selectedPane == .automation, !sessionWakeStore.featureEnabled {
+            selectedPane = .general
+            return
+        }
         guard case let .provider(service) = selectedPane else {
             return
         }

--- a/MeterBarTests/SessionWakeSettingsTests.swift
+++ b/MeterBarTests/SessionWakeSettingsTests.swift
@@ -23,10 +23,35 @@ final class SessionWakeSettingsTests: XCTestCase {
 
     func testDefaultsAreOff() {
         let store = makeStore()
+        XCTAssertTrue(store.featureEnabled)
         XCTAssertFalse(store.isOn)
         XCTAssertNil(store.wakeAccountID)
         XCTAssertFalse(store.canTurnOn)
         XCTAssertTrue(store.needsFirstRunConfirmation)
+    }
+
+    func testMasterFeatureFlagOffForcesWatcherOffAndPreventsArming() {
+        let store = makeStore()
+        store.setWakeAccountID(UUID())
+        store.acknowledgeFirstRunAndTurnOn()
+        XCTAssertTrue(store.isOn)
+
+        store.setFeatureEnabled(false)
+
+        XCTAssertFalse(store.featureEnabled)
+        XCTAssertFalse(store.isOn)
+        XCTAssertFalse(store.canTurnOn)
+        store.setOn(true)
+        XCTAssertFalse(store.isOn)
+    }
+
+    func testExplicitlyDisabledFeatureStaysDisabledAcrossRelaunch() {
+        defaults.set(false, forKey: StorageKeys.sessionWakeFeatureEnabled)
+
+        let store = makeStore()
+
+        XCTAssertFalse(store.featureEnabled)
+        XCTAssertFalse(store.isOn)
     }
 
     func testCannotTurnOnWithoutAccount() {

--- a/MeterBarTests/SessionWakeStatusTests.swift
+++ b/MeterBarTests/SessionWakeStatusTests.swift
@@ -97,11 +97,13 @@ final class SessionWakeStatusTests: XCTestCase {
 
     func testMenuControlVisibility() {
         // On ⇒ shown (kill switch must stay reachable), even mid-run.
-        XCTAssertTrue(SessionWakeMenuControl.shouldShow(isOn: true, canTurnOn: false))
+        XCTAssertTrue(SessionWakeMenuControl.shouldShow(featureEnabled: true, isOn: true, canTurnOn: false))
         // Off but armable (account configured) ⇒ shown for quick access.
-        XCTAssertTrue(SessionWakeMenuControl.shouldShow(isOn: false, canTurnOn: true))
+        XCTAssertTrue(SessionWakeMenuControl.shouldShow(featureEnabled: true, isOn: false, canTurnOn: true))
         // Off and unconfigured ⇒ hidden, no inert row.
-        XCTAssertFalse(SessionWakeMenuControl.shouldShow(isOn: false, canTurnOn: false))
+        XCTAssertFalse(SessionWakeMenuControl.shouldShow(featureEnabled: true, isOn: false, canTurnOn: false))
+        // The master flag hides the control even if stale watcher intent exists.
+        XCTAssertFalse(SessionWakeMenuControl.shouldShow(featureEnabled: false, isOn: true, canTurnOn: true))
     }
 
     func testMenuControlHosts() {

--- a/MeterBarTests/WakeCLIEngineTests.swift
+++ b/MeterBarTests/WakeCLIEngineTests.swift
@@ -18,6 +18,18 @@ final class WakeCLIEngineTests: XCTestCase {
         try? FileManager.default.removeItem(at: tempDir)
     }
 
+    func testSharedFeatureFlagDefaultsOnButExplicitOffBlocksCLI() {
+        let suite = "WakeFeatureGateTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            return XCTFail("test defaults should be available")
+        }
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertTrue(SessionWakeCLI.isFeatureEnabled(userDefaults: defaults))
+        defaults.set(false, forKey: SessionWakeCLI.sharedFeatureEnabledKey)
+        XCTAssertFalse(SessionWakeCLI.isFeatureEnabled(userDefaults: defaults))
+    }
+
     private func writeBlockedSession(_ id: String = "s0") throws {
         let projects = tempDir.appendingPathComponent("projects").appendingPathComponent("-proj")
         try FileManager.default.createDirectory(at: projects, withIntermediateDirectories: true)


### PR DESCRIPTION
## Summary

- restore `SessionWakeFeatureEnabled` as a real master kill-switch while preserving enabled behavior when the key is absent
- force watcher intent off and prevent re-arming when explicitly disabled
- hide Automation and menu-bar Session Wake controls while disabled
- mirror the gate to the app group and reject `meterbar wake` with a stable validation failure

## Why

The storage key existed but was never read, leaving the intended emergency-off path inert across the app and CLI.

## Verification

- `swift test` — 536 tests passed
- `swiftlint lint --strict` — 0 violations
- `swift build --package-path MeterBarCLI` — succeeded
- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug CODE_SIGNING_ALLOWED=NO build` — succeeded
- `git diff --check` — clean

Closes #131