### PR TITLE
refactor(cost): share model pricing table

### DIFF
--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -68,7 +68,7 @@ meterbar/
 - **CodexCliLocalService** — Codex auth file + wham/usage endpoint; maps credits/spend to `ExtraUsageStatus` (safety-biased: never false "Off").
 - **CursorLocalService** — SQLite token extraction + usage-summary endpoint; assumed 500-request default quota when API omits totals.
 - **ClaudeService / OpenAIService** — admin-key usage reports (paginated, 50-page cap) via `ServiceSupport.fetchDecoded`.
-- **CostTracker** (1,029 lines) — JSONL/SQLite log scanning, per-model pricing table, per-day/model/origin breakdowns, cache at `~/Library/Application Support/MeterBar/cost-summary-v1.json`.
+- **CostTracker** — JSONL/SQLite log scanning, per-day/model/origin breakdowns, cache at `~/Library/Application Support/MeterBar/cost-summary-v1.json`. API-rate estimates come from the versioned `ModelPricing` table in `MeterBarShared`, which is shared with the CLI.
 - **AuthenticationManager + KeychainManager** — the two admin keys, stored in keychain service `dev.meterbar.app`. Reads migrate the older `dev.shipshit.meterbar` (v1.6.x) and `com.agenticindiedev.quotaguard` (v1.0-v1.6) services into the current one, and removals delete all three so a legacy key cannot reappear.
 - **SharedDataStore** — app-group JSON file (`cached_usage_metrics.json`), atomic writes on a serial queue, `WidgetCenter.reloadTimelines` after save.
 - **ProviderVisibilityStore / DockVisibilityStore / ClaudeCodeAccountStore** — UserDefaults-backed preference stores.

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -19,45 +19,6 @@ class CostTracker: ObservableObject {
         isScanning || isRefreshingMissingDays
     }
 
-    // API-rate estimates per million tokens for local log usage.
-    // Prices last verified against provider pricing pages: 2026-07-02. These rot
-    // silently — re-verify when adding models or when estimates look off.
-    // NOTE: MeterBarCLI/Sources/MeterBarCLI.swift carries a simplified copy of the
-    // "claude-sonnet" entry; keep the two in sync until a shared package exists
-    // (.agents/docs/DEFERRED_WORK.md §1).
-    nonisolated private static let pricing: [String: TokenPricing] = [
-        "claude-sonnet": TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30),
-        "claude-opus": TokenPricing(input: 15.0, output: 75.0, cacheCreation: 18.75, cacheRead: 1.50),
-        "claude-haiku": TokenPricing(input: 0.25, output: 1.25, cacheCreation: 0.30, cacheRead: 0.03),
-        "claude-fable-5": TokenPricing(
-            input: 10.0, output: 50.0, cacheCreation: 12.5, cacheRead: 1.0, cacheCreationOneHour: 20.0),
-        "claude-opus-4-8": TokenPricing(
-            input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0),
-        "claude-opus-4-7": TokenPricing(
-            input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0),
-        "claude-opus-4-6": TokenPricing(
-            input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0),
-        "claude-sonnet-4-6": TokenPricing(
-            input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30, cacheCreationOneHour: 6.0),
-        "claude-sonnet-4-5": TokenPricing(
-            input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30, cacheCreationOneHour: 6.0),
-        "claude-sonnet-4": TokenPricing(
-            input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30, cacheCreationOneHour: 6.0),
-        "claude-haiku-4-5": TokenPricing(
-            input: 1.0, output: 5.0, cacheCreation: 1.25, cacheRead: 0.10, cacheCreationOneHour: 2.0),
-        "codex": TokenPricing(input: 1.25, output: 10.0, cacheCreation: 0, cacheRead: 0.125),
-        "default": TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30)
-    ]
-
-    /// Non-optional fallback so pricing lookups never need a force-unwrap of
-    /// `pricing["default"]`. Mirrors the `"default"` entry above.
-    nonisolated private static let defaultPricing = TokenPricing(
-        input: 3.0,
-        output: 15.0,
-        cacheCreation: 3.75,
-        cacheRead: 0.30
-    )
-
     // Cached regexes. The scan parses tens of thousands of log lines, so
     // allocating an NSRegularExpression per call was a measurable hot-path
     // cost. Date parsing shares the cached FlexibleISO8601 formatters.
@@ -257,7 +218,7 @@ class CostTracker: ObservableObject {
 
         guard totalInput > 0 || totalOutput > 0 || totalCacheCreation > 0 || totalCacheRead > 0 else { return nil }
 
-        let pricing = Self.pricing["claude-sonnet"] ?? Self.defaultPricing
+        let pricing = ModelPricing.claude(for: nil)
         let fallbackCost = Self.calculateCost(
             input: totalInput,
             output: totalOutput,
@@ -459,64 +420,11 @@ class CostTracker: ObservableObject {
     }
 
     nonisolated static func claudePricing(for model: String?) -> TokenPricing {
-        guard let model else {
-            return Self.pricing["claude-sonnet"] ?? Self.defaultPricing
-        }
-
-        let normalized = Self.normalizeClaudeModel(model)
-        if let exact = Self.pricing[normalized] {
-            return exact
-        }
-
-        if normalized.contains("fable") {
-            return Self.pricing["claude-fable-5"] ?? Self.defaultPricing
-        }
-        if normalized.contains("opus") {
-            let base = Self.pricing["claude-opus"] ?? Self.defaultPricing
-            if normalized.contains("4-8") { return Self.pricing["claude-opus-4-8"] ?? base }
-            if normalized.contains("4-7") { return Self.pricing["claude-opus-4-7"] ?? base }
-            if normalized.contains("4-6") { return Self.pricing["claude-opus-4-6"] ?? base }
-            return base
-        }
-        if normalized.contains("haiku") {
-            return normalized.contains("4-5")
-                ? Self.pricing["claude-haiku-4-5"] ?? (Self.pricing["claude-haiku"] ?? Self.defaultPricing)
-                : Self.pricing["claude-haiku"] ?? Self.defaultPricing
-        }
-        if normalized.contains("sonnet") {
-            let base = Self.pricing["claude-sonnet"] ?? Self.defaultPricing
-            if normalized.contains("4-6") { return Self.pricing["claude-sonnet-4-6"] ?? base }
-            if normalized.contains("4-5") { return Self.pricing["claude-sonnet-4-5"] ?? base }
-            if normalized.contains("4") { return Self.pricing["claude-sonnet-4"] ?? base }
-            return base
-        }
-
-        return Self.defaultPricing
+        ModelPricing.claude(for: model)
     }
 
     nonisolated static func normalizeClaudeModel(_ raw: String) -> String {
-        var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.hasPrefix("anthropic.") {
-            trimmed = String(trimmed.dropFirst("anthropic.".count))
-        }
-        if let lastDot = trimmed.lastIndex(of: "."),
-           trimmed.contains("claude-") {
-            let tail = String(trimmed[trimmed.index(after: lastDot)...])
-            if tail.hasPrefix("claude-") {
-                trimmed = tail
-            }
-        }
-        if let versionRange = trimmed.range(of: #"-v\d+:\d+$"#, options: .regularExpression) {
-            trimmed.removeSubrange(versionRange)
-        }
-        // Strip a trailing `-YYYYMMDD` release-date suffix so dated model ids
-        // (e.g. `claude-opus-4-8-20260101`) normalize to their base id. This keeps
-        // display names clean and lets pricing match new dated models too, not
-        // only the ones already present in the pricing table.
-        if let dateRange = trimmed.range(of: #"-\d{8}$"#, options: .regularExpression) {
-            return String(trimmed[..<dateRange.lowerBound])
-        }
-        return trimmed
+        ModelPricing.normalizeClaudeModel(raw)
     }
 
     nonisolated private static func scanCodexSessions(since cutoffDate: Date) -> (TokenCost, [DailyTokenUsage])? {
@@ -531,7 +439,7 @@ class CostTracker: ObservableObject {
         let totals = context.totals
         guard totals.input > 0 || totals.output > 0 || totals.cacheRead > 0 else { return nil }
 
-        let pricing = Self.pricing["codex"] ?? Self.defaultPricing
+        let pricing = ModelPricing.codex
         let billableInput = max(0, totals.input - totals.cacheRead)
         let output = totals.output + totals.reasoning
         let cost = Self.calculateCost(
@@ -945,28 +853,6 @@ nonisolated struct CodexScanContext: Sendable {
     var sessionIDs: Set<String> = []
     var earliestDate: Date
     var latestDate: Date
-}
-
-nonisolated struct TokenPricing: Sendable {
-    let input: Double      // per million tokens
-    let output: Double     // per million tokens
-    let cacheCreation: Double
-    let cacheRead: Double
-    let cacheCreationOneHour: Double?
-
-    init(
-        input: Double,
-        output: Double,
-        cacheCreation: Double,
-        cacheRead: Double,
-        cacheCreationOneHour: Double? = nil
-    ) {
-        self.input = input
-        self.output = output
-        self.cacheCreation = cacheCreation
-        self.cacheRead = cacheRead
-        self.cacheCreationOneHour = cacheCreationOneHour
-    }
 }
 
 nonisolated struct TokenAccumulator: Sendable {

--- a/MeterBar/Views/DashboardCostCards.swift
+++ b/MeterBar/Views/DashboardCostCards.swift
@@ -77,6 +77,15 @@ struct CostOverviewStatusCard: View {
               .font(.caption)
               .fontWeight(.semibold)
           }
+          HStack {
+            Text("Pricing")
+              .font(.caption)
+              .foregroundColor(.secondary)
+            Spacer()
+            Text(ModelPricing.revisionLabel)
+              .font(.caption)
+              .fontWeight(.semibold)
+          }
         }
       }
     }

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -238,6 +238,7 @@ struct Cost: ParsableCommand {
         print()
         print("Period: Last \(window.requestedDays) days (from cached daily data)")
         print("Scanned: \(UsageFormat.relative(cache.lastScanDate))")
+        print("Pricing: \(ModelPricing.revisionLabel)")
 
         // The cache holds fewer days than asked for — don't imply full coverage.
         if window.isTruncated {
@@ -280,6 +281,7 @@ struct Cost: ParsableCommand {
         print()
         print("Period: Last \(summary.periodDays) days")
         print("Scanned: \(UsageFormat.relative(cache.lastScanDate))")
+        print("Pricing: \(ModelPricing.revisionLabel)")
         print()
 
         for cost in summary.costs {

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import MeterBar
+import MeterBarShared
 
 /// First direct coverage for CostTracker's parsing/pricing internals — the
 /// audit found ~1,000 lines of money math with zero tests, which is exactly

--- a/MeterBarTests/ModelPricingTests.swift
+++ b/MeterBarTests/ModelPricingTests.swift
@@ -1,0 +1,35 @@
+@testable import MeterBar
+import MeterBarShared
+import XCTest
+
+final class ModelPricingTests: XCTestCase {
+    func testSharedTableOwnsRevisionAndProviderRates() {
+        XCTAssertEqual(ModelPricing.revision, "2026-07-02")
+        XCTAssertEqual(ModelPricing.claude(for: "claude-fable-5").input, 10.0)
+        XCTAssertEqual(ModelPricing.claude(for: "claude-opus-4-8-20260101").input, 5.0)
+        XCTAssertEqual(ModelPricing.claude(for: "mystery-model").input, 3.0)
+        XCTAssertEqual(ModelPricing.codex.input, 1.25)
+        XCTAssertEqual(ModelPricing.codex.cacheRead, 0.125)
+    }
+
+    func testCostTrackerUsesTheSharedLookup() {
+        let models = [nil, "claude-fable-9", "claude-opus-4-7", "claude-haiku-4-5", "unknown"]
+        for model in models {
+            XCTAssertEqual(CostTracker.claudePricing(for: model), ModelPricing.claude(for: model))
+        }
+    }
+
+    func testSharedPricingProducesStableFixtureTotal() {
+        let pricing = ModelPricing.claude(for: "claude-sonnet-4-6")
+        let total = CostTracker.calculateClaudeCost(
+            input: 1_000_000,
+            output: 2_000_000,
+            cacheCreation: 500_000,
+            cacheCreationOneHour: 100_000,
+            cacheRead: 4_000_000,
+            pricing: pricing
+        )
+
+        XCTAssertEqual(total, 36.3, accuracy: 0.000_001)
+    }
+}

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ModelPricing.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ModelPricing.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// API token prices in USD per million tokens.
+public struct TokenPricing: Equatable, Sendable {
+    public let input: Double
+    public let output: Double
+    public let cacheCreation: Double
+    public let cacheRead: Double
+    public let cacheCreationOneHour: Double?
+
+    public init(
+        input: Double,
+        output: Double,
+        cacheCreation: Double,
+        cacheRead: Double,
+        cacheCreationOneHour: Double? = nil
+    ) {
+        self.input = input
+        self.output = output
+        self.cacheCreation = cacheCreation
+        self.cacheRead = cacheRead
+        self.cacheCreationOneHour = cacheCreationOneHour
+    }
+}
+
+/// Single source of truth for the app and CLI's local-log cost estimates.
+public enum ModelPricing {
+    /// Date these rates were last checked against provider pricing pages.
+    public static let revision = "2026-07-02"
+    public static let revisionLabel = "Rates verified \(revision)"
+
+    private static let table: [String: TokenPricing] = [
+        "claude-sonnet": TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30),
+        "claude-opus": TokenPricing(input: 15.0, output: 75.0, cacheCreation: 18.75, cacheRead: 1.50),
+        "claude-haiku": TokenPricing(input: 0.25, output: 1.25, cacheCreation: 0.30, cacheRead: 0.03),
+        "claude-fable-5": TokenPricing(
+            input: 10.0, output: 50.0, cacheCreation: 12.5, cacheRead: 1.0, cacheCreationOneHour: 20.0),
+        "claude-opus-4-8": TokenPricing(
+            input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0),
+        "claude-opus-4-7": TokenPricing(
+            input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0),
+        "claude-opus-4-6": TokenPricing(
+            input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0),
+        "claude-sonnet-4-6": TokenPricing(
+            input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30, cacheCreationOneHour: 6.0),
+        "claude-sonnet-4-5": TokenPricing(
+            input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30, cacheCreationOneHour: 6.0),
+        "claude-sonnet-4": TokenPricing(
+            input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30, cacheCreationOneHour: 6.0),
+        "claude-haiku-4-5": TokenPricing(
+            input: 1.0, output: 5.0, cacheCreation: 1.25, cacheRead: 0.10, cacheCreationOneHour: 2.0),
+        "codex": TokenPricing(input: 1.25, output: 10.0, cacheCreation: 0, cacheRead: 0.125),
+        "default": TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30)
+    ]
+
+    public static var codex: TokenPricing {
+        table["codex"] ?? fallback
+    }
+
+    public static func claude(for model: String?) -> TokenPricing {
+        guard let model else { return table["claude-sonnet"] ?? fallback }
+
+        let normalized = normalizeClaudeModel(model)
+        if let exact = table[normalized] { return exact }
+        if normalized.contains("fable") { return table["claude-fable-5"] ?? fallback }
+        if normalized.contains("opus") {
+            let base = table["claude-opus"] ?? fallback
+            if normalized.contains("4-8") { return table["claude-opus-4-8"] ?? base }
+            if normalized.contains("4-7") { return table["claude-opus-4-7"] ?? base }
+            if normalized.contains("4-6") { return table["claude-opus-4-6"] ?? base }
+            return base
+        }
+        if normalized.contains("haiku") {
+            return normalized.contains("4-5")
+                ? table["claude-haiku-4-5"] ?? (table["claude-haiku"] ?? fallback)
+                : table["claude-haiku"] ?? fallback
+        }
+        if normalized.contains("sonnet") {
+            let base = table["claude-sonnet"] ?? fallback
+            if normalized.contains("4-6") { return table["claude-sonnet-4-6"] ?? base }
+            if normalized.contains("4-5") { return table["claude-sonnet-4-5"] ?? base }
+            if normalized.contains("4") { return table["claude-sonnet-4"] ?? base }
+            return base
+        }
+        return fallback
+    }
+
+    public static func normalizeClaudeModel(_ raw: String) -> String {
+        var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("anthropic.") {
+            trimmed = String(trimmed.dropFirst("anthropic.".count))
+        }
+        if let lastDot = trimmed.lastIndex(of: "."), trimmed.contains("claude-") {
+            let tail = String(trimmed[trimmed.index(after: lastDot)...])
+            if tail.hasPrefix("claude-") { trimmed = tail }
+        }
+        if let versionRange = trimmed.range(of: #"-v\d+:\d+$"#, options: .regularExpression) {
+            trimmed.removeSubrange(versionRange)
+        }
+        if let dateRange = trimmed.range(of: #"-\d{8}$"#, options: .regularExpression) {
+            return String(trimmed[..<dateRange.lowerBound])
+        }
+        return trimmed
+    }
+
+    private static let fallback = TokenPricing(
+        input: 3.0,
+        output: 15.0,
+        cacheCreation: 3.75,
+        cacheRead: 0.30
+    )
+}


### PR DESCRIPTION
## Summary

- move token rate definitions and Claude model lookup rules into `MeterBarShared.ModelPricing`
- make `CostTracker` consume the shared table for Claude and Codex calculations
- show the shared pricing revision in the Costs UI and `meterbar cost` output
- add parity and exact-total fixtures for the shared lookup
- update the implemented architecture documentation

## Why

Pricing and model matching belonged to the app target, leaving no durable shared source for the bundled CLI and no visible staleness signal. The CLI already consumes the app cached summary; it now also consumes the same table metadata.

## Verification

- `swift test` — 536 tests passed
- `swiftlint lint --strict` — 0 violations
- `swift build --package-path MeterBarCLI` — succeeded
- Xcode Debug app/widget build — succeeded
- pricing literal scan — no `TokenPricing` definitions in app or CLI
- `git diff --check` — clean

Closes #130