### PR TITLE
feat(onboarding): add first-run setup flow

### DIFF
--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -80,6 +80,8 @@ meterbar/
 
 `@main` SwiftUI `App` with `Settings` scene + `NSApplicationDelegateAdaptor`. The delegate creates a manual `NSStatusItem` (not `MenuBarExtra`) with an `NSPopover` hosting `MenuBarView`; right-click opens a native status menu (Dock toggle / dashboard / quit). `LSUIElement = true`; Dock icon toggled at runtime via activation policy. A 5-minute `Task.sleep` loop checks limits and posts local notifications at 90%/100% with stable identifiers and re-arm-on-drop semantics.
 
+On the first launch, `FirstRunOnboardingStore` auto-opens the menu panel and shows a one-time launch-at-login choice. Enablement remains explicit through `SMAppService`; choosing either option or dismissing the panel persists `HasCompletedFirstRun` so onboarding does not reappear.
+
 ## Widget & CLI data contract
 
 The app, widget, and CLI consume the canonical `ServiceType`, `UsageLimit`, and `UsageMetrics` definitions from `Packages/MeterBarShared`. The app-group JSON contract is locked by `CachedMetricsContractTests` and `CachedMetricsReplicaContractTests` so fields and date encoding cannot silently drift across targets.

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -82,8 +82,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             },
             onDismiss: {
                 MeterBarMenuDetailPanel.shared.dismiss()
+                FirstRunOnboardingStore.shared.dismiss()
             }
         )
+
+        if FirstRunOnboardingStore.shared.shouldPresent {
+            // Defer one run-loop turn so the status-item window is ready before
+            // positioning the panel. This is the first-launch welcome moment.
+            DispatchQueue.main.async { [weak self] in
+                self?.menuPanel?.show()
+            }
+        }
 
         Task { @MainActor in
             observeUsageMetrics()

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -16,6 +16,8 @@ nonisolated enum StorageKeys {
     static let hiddenProviderServices = "HiddenProviderServices"
     /// Whether the Dock icon is shown (menu bar item is unaffected).
     static let showInDock = "ShowMeterBarInDock"
+    /// Whether the one-time first-launch popover has been completed or dismissed.
+    static let hasCompletedFirstRun = "HasCompletedFirstRun"
     /// Enables the legacy Claude Code OAuth fallback when the CLI is unavailable.
     static let claudeCodeOAuthFallback = "ClaudeCodeEnableOAuthFallback"
     /// Extra Claude Code account profiles (JSON-encoded [ClaudeCodeAccount]).

--- a/MeterBar/Services/FirstRunOnboardingStore.swift
+++ b/MeterBar/Services/FirstRunOnboardingStore.swift
@@ -17,7 +17,33 @@ final class FirstRunOnboardingStore: ObservableObject {
     ) {
         self.userDefaults = userDefaults
         self.launchAtLogin = launchAtLogin
-        hasCompletedFirstRun = userDefaults.bool(forKey: StorageKeys.hasCompletedFirstRun)
+        if userDefaults.bool(forKey: StorageKeys.hasCompletedFirstRun) {
+            hasCompletedFirstRun = true
+        } else if Self.hasEvidenceOfPriorUse(in: userDefaults) {
+            // Upgrades: installs that predate this flag already have other
+            // MeterBar state persisted. Adopt the flag silently so long-time
+            // users are never greeted with first-run onboarding.
+            hasCompletedFirstRun = true
+            userDefaults.set(true, forKey: StorageKeys.hasCompletedFirstRun)
+        } else {
+            hasCompletedFirstRun = false
+        }
+    }
+
+    /// Keys a pre-onboarding install would have written during normal use.
+    /// `cachedUsageMetrics` is persisted on every successful refresh, so any
+    /// real install carries at least that one.
+    private static let priorUseSentinelKeys: [String] = [
+        StorageKeys.cachedUsageMetrics,
+        StorageKeys.refreshInterval,
+        StorageKeys.hiddenProviderServices,
+        StorageKeys.notificationsEnabled,
+        StorageKeys.claudeCodeCustomAccounts,
+        StorageKeys.showInDock
+    ]
+
+    private static func hasEvidenceOfPriorUse(in userDefaults: UserDefaults) -> Bool {
+        priorUseSentinelKeys.contains { userDefaults.object(forKey: $0) != nil }
     }
 
     var shouldPresent: Bool { !hasCompletedFirstRun }

--- a/MeterBar/Services/FirstRunOnboardingStore.swift
+++ b/MeterBar/Services/FirstRunOnboardingStore.swift
@@ -1,0 +1,43 @@
+import Combine
+import Foundation
+
+/// Owns the single prompt-once flag for MeterBar's first-launch experience.
+/// Launch-at-login remains opt-in and is only registered after an explicit tap.
+final class FirstRunOnboardingStore: ObservableObject {
+    static let shared = FirstRunOnboardingStore()
+
+    @Published private(set) var hasCompletedFirstRun: Bool
+
+    private let userDefaults: UserDefaults
+    private let launchAtLogin: LaunchAtLoginStore
+
+    init(
+        userDefaults: UserDefaults = .standard,
+        launchAtLogin: LaunchAtLoginStore = .shared
+    ) {
+        self.userDefaults = userDefaults
+        self.launchAtLogin = launchAtLogin
+        hasCompletedFirstRun = userDefaults.bool(forKey: StorageKeys.hasCompletedFirstRun)
+    }
+
+    var shouldPresent: Bool { !hasCompletedFirstRun }
+
+    func chooseLaunchAtLogin(_ enabled: Bool) {
+        if enabled {
+            launchAtLogin.setEnabled(true)
+        }
+        complete()
+    }
+
+    /// Clicking away is also a dismissal choice; onboarding must never nag on
+    /// a later launch after the user has seen and dismissed it.
+    func dismiss() {
+        complete()
+    }
+
+    private func complete() {
+        guard !hasCompletedFirstRun else { return }
+        hasCompletedFirstRun = true
+        userDefaults.set(true, forKey: StorageKeys.hasCompletedFirstRun)
+    }
+}

--- a/MeterBar/Views/Components/ReadinessComponents.swift
+++ b/MeterBar/Views/Components/ReadinessComponents.swift
@@ -39,6 +39,7 @@ extension ReadinessLevel {
 struct ReadinessCheckRow: View {
   let check: ReadinessCheck
   var compact: Bool = false
+  var recoveryAction: (() -> Void)?
 
   var body: some View {
     HStack(alignment: .top, spacing: 8) {
@@ -57,12 +58,20 @@ struct ReadinessCheckRow: View {
           .fixedSize(horizontal: false, vertical: true)
 
         if let recovery = check.recovery {
-          Text(recovery)
-            .font(compact ? .caption2 : .caption)
-            .fontWeight(.medium)
-            .foregroundStyle(check.level.tint)
-            .fixedSize(horizontal: false, vertical: true)
-            .padding(.top, 1)
+          if let recoveryAction {
+            Button(action: recoveryAction) {
+              HStack(spacing: 4) {
+                Text(recovery)
+                Image(systemName: "arrow.up.forward.app")
+              }
+            }
+            .buttonStyle(.plain)
+            .accessibilityHint("Open MeterBar Settings")
+            .recoveryStyle(compact: compact, tint: check.level.tint)
+          } else {
+            Text(recovery)
+              .recoveryStyle(compact: compact, tint: check.level.tint)
+          }
         }
       }
       Spacer(minLength: 0)
@@ -75,6 +84,7 @@ struct ReadinessCheckRow: View {
 struct ReadinessProviderCard: View {
   let report: ProviderReadiness
   var compact: Bool = false
+  var recoveryAction: (() -> Void)?
 
   var body: some View {
     DashboardTile(padding: compact ? 11 : 14) {
@@ -94,7 +104,7 @@ struct ReadinessProviderCard: View {
 
         VStack(alignment: .leading, spacing: compact ? 7 : 9) {
           ForEach(report.checks) { check in
-            ReadinessCheckRow(check: check, compact: compact)
+            ReadinessCheckRow(check: check, compact: compact, recoveryAction: recoveryAction)
           }
         }
       }
@@ -150,12 +160,23 @@ enum DiagnosticsReportText {
 struct ReadinessChecklist: View {
   let reports: [ProviderReadiness]
   var compact: Bool = false
+  var recoveryAction: (() -> Void)?
 
   var body: some View {
     VStack(alignment: .leading, spacing: compact ? 8 : 12) {
       ForEach(reports) { report in
-        ReadinessProviderCard(report: report, compact: compact)
+        ReadinessProviderCard(report: report, compact: compact, recoveryAction: recoveryAction)
       }
     }
+  }
+}
+
+private extension View {
+  func recoveryStyle(compact: Bool, tint: Color) -> some View {
+    font(compact ? .caption2 : .caption)
+      .fontWeight(.medium)
+      .foregroundStyle(tint)
+      .fixedSize(horizontal: false, vertical: true)
+      .padding(.top, 1)
   }
 }

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -228,6 +228,9 @@ struct PopoverOverviewPanel: View {
   let openProviderOverview: (ProviderSnapshot) -> Void
 
   @State private var setupReports: [ProviderReadiness] = []
+  @StateObject private var onboarding = FirstRunOnboardingStore.shared
+  @Environment(\.openSettings)
+  private var openSettings
 
   /// The enabled providers currently shown in the popover.
   private var enabledProviders: Set<ServiceType> {
@@ -242,23 +245,33 @@ struct PopoverOverviewPanel: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 10) {
+      if onboarding.shouldPresent {
+        firstRunCallout
+      }
+
       if snapshots.isEmpty {
         DashboardTile(padding: 12) {
-          HStack(alignment: .center, spacing: 10) {
-            Image(systemName: "clock.fill")
-              .font(.system(size: 17, weight: .bold))
-              .foregroundStyle(.secondary)
-              .frame(width: 34, height: 34)
+          VStack(alignment: .leading, spacing: 9) {
+            HStack(alignment: .center, spacing: 10) {
+              Image(systemName: "clock.fill")
+                .font(.system(size: 17, weight: .bold))
+                .foregroundStyle(.secondary)
+                .frame(width: 34, height: 34)
 
-            VStack(alignment: .leading, spacing: 2) {
-              Text("No sources enabled")
-                .font(.headline)
-                .fontWeight(.semibold)
-              Text("Enable a provider in Settings.")
-                .font(.caption)
-                .foregroundColor(.secondary)
+              VStack(alignment: .leading, spacing: 2) {
+                Text("No sources enabled")
+                  .font(.headline)
+                  .fontWeight(.semibold)
+                Text("Enable a provider in Settings.")
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+              }
+              Spacer(minLength: 0)
             }
-            Spacer(minLength: 0)
+
+            Button("Open Settings") { openSettings() }
+              .buttonStyle(.borderedProminent)
+              .controlSize(.small)
           }
         }
       }
@@ -298,7 +311,39 @@ struct PopoverOverviewPanel: View {
           .fontWeight(.semibold)
         Spacer(minLength: 0)
       }
-      ReadinessChecklist(reports: providersNeedingSetup, compact: true)
+      ReadinessChecklist(
+        reports: providersNeedingSetup,
+        compact: true,
+        recoveryAction: { openSettings() }
+      )
+    }
+  }
+
+  private var firstRunCallout: some View {
+    DashboardTile(padding: 12) {
+      VStack(alignment: .leading, spacing: 9) {
+        HStack(spacing: 8) {
+          Image(systemName: "sparkles")
+            .foregroundStyle(MeterBarTheme.appAccent)
+          Text("Welcome to MeterBar")
+            .font(.headline)
+            .fontWeight(.semibold)
+        }
+
+        Text("Your usage lives in the menu bar. Start MeterBar automatically when you log in?")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+
+        HStack(spacing: 8) {
+          Button("Enable") { onboarding.chooseLaunchAtLogin(true) }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+          Button("Not Now") { onboarding.chooseLaunchAtLogin(false) }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+      }
     }
   }
 

--- a/MeterBarTests/FirstRunOnboardingTests.swift
+++ b/MeterBarTests/FirstRunOnboardingTests.swift
@@ -26,6 +26,31 @@ final class FirstRunOnboardingTests: XCTestCase {
         defaults.removePersistentDomain(forName: suiteName)
     }
 
+    func testUpgradingExistingInstallDoesNotPresentOnboarding() {
+        // An install that predates the onboarding flag has other MeterBar
+        // state in defaults; it must be treated as already onboarded.
+        defaults.set(true, forKey: StorageKeys.notificationsEnabled)
+
+        let store = FirstRunOnboardingStore(
+            userDefaults: defaults,
+            launchAtLogin: LaunchAtLoginStore(controller: FakeLaunchController())
+        )
+
+        XCTAssertFalse(store.shouldPresent)
+        XCTAssertTrue(defaults.bool(forKey: StorageKeys.hasCompletedFirstRun))
+    }
+
+    func testUpgradeMigrationRecognizesCachedMetricsSentinel() {
+        defaults.set(Data("{}".utf8), forKey: StorageKeys.cachedUsageMetrics)
+
+        let store = FirstRunOnboardingStore(
+            userDefaults: defaults,
+            launchAtLogin: LaunchAtLoginStore(controller: FakeLaunchController())
+        )
+
+        XCTAssertFalse(store.shouldPresent)
+    }
+
     func testFreshInstallPresentsAndDismissPersistsOnce() {
         let store = FirstRunOnboardingStore(
             userDefaults: defaults,

--- a/MeterBarTests/FirstRunOnboardingTests.swift
+++ b/MeterBarTests/FirstRunOnboardingTests.swift
@@ -1,0 +1,70 @@
+@testable import MeterBar
+import XCTest
+
+final class FirstRunOnboardingTests: XCTestCase {
+    private final class FakeLaunchController: LaunchAtLoginControlling {
+        var status: LaunchAtLoginStatus = .notRegistered
+        private(set) var registerCallCount = 0
+
+        func currentStatus() -> LaunchAtLoginStatus { status }
+        func register() throws {
+            registerCallCount += 1
+            status = .enabled
+        }
+        func unregister() throws { status = .notRegistered }
+    }
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUpWithError() throws {
+        suiteName = "FirstRunOnboardingTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    func testFreshInstallPresentsAndDismissPersistsOnce() {
+        let store = FirstRunOnboardingStore(
+            userDefaults: defaults,
+            launchAtLogin: LaunchAtLoginStore(controller: FakeLaunchController())
+        )
+        XCTAssertTrue(store.shouldPresent)
+
+        store.dismiss()
+
+        XCTAssertFalse(store.shouldPresent)
+        let reloaded = FirstRunOnboardingStore(
+            userDefaults: defaults,
+            launchAtLogin: LaunchAtLoginStore(controller: FakeLaunchController())
+        )
+        XCTAssertFalse(reloaded.shouldPresent)
+    }
+
+    func testEnableLaunchAtLoginRegistersAndCompletesOnboarding() {
+        let controller = FakeLaunchController()
+        let launchAtLogin = LaunchAtLoginStore(controller: controller)
+        let store = FirstRunOnboardingStore(userDefaults: defaults, launchAtLogin: launchAtLogin)
+
+        store.chooseLaunchAtLogin(true)
+
+        XCTAssertEqual(controller.registerCallCount, 1)
+        XCTAssertTrue(launchAtLogin.isEnabled)
+        XCTAssertFalse(store.shouldPresent)
+    }
+
+    func testNotNowCompletesWithoutRegistering() {
+        let controller = FakeLaunchController()
+        let store = FirstRunOnboardingStore(
+            userDefaults: defaults,
+            launchAtLogin: LaunchAtLoginStore(controller: controller)
+        )
+
+        store.chooseLaunchAtLogin(false)
+
+        XCTAssertEqual(controller.registerCallCount, 0)
+        XCTAssertFalse(store.shouldPresent)
+    }
+}


### PR DESCRIPTION
## Summary

- add a single prompt-once `HasCompletedFirstRun` state store
- auto-open the menu panel on first launch so the menu-bar app is discoverable
- offer an explicit Enable / Not Now launch-at-login choice without silent registration
- persist completion after either choice or panel dismissal
- make the empty state and readiness recovery rows open Settings
- document the implemented first-launch lifecycle

## Why

MeterBar had setup diagnostics but no welcome moment or actionable path into Settings, and launch at login was only discoverable later in preferences.

## Verification

- `swift test` — 536 tests passed
- `swiftlint lint --strict` — 0 violations
- `swift build --package-path MeterBarCLI` — succeeded
- Xcode Debug app/widget build — succeeded
- `git diff --check` — clean

Closes #127