### PR TITLE
feat: surface provider parse health

### DIFF
--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -62,7 +62,7 @@ meterbar/
 
 ## Services (all `.shared` singletons)
 
-- **UsageDataManager** (`@MainActor`, ObservableObject) — orchestrates refresh across providers, caches to UserDefaults (`cached_usage_metrics`), mirrors to the app group via SharedDataStore, drives a `Timer` auto-refresh (default 15 min; `RefreshInterval` supports 1/2/5/15/30 min + manual).
+- **UsageDataManager** (`@MainActor`, ObservableObject) — orchestrates refresh across providers, caches to UserDefaults (`cached_usage_metrics`), mirrors to the app group via SharedDataStore, records per-provider refresh outcomes in `ProviderParseHealthStore`, and drives a `Timer` auto-refresh (default 15 min; `RefreshInterval` supports 1/2/5/15/30 min + manual).
 - **ClaudeCodeCLIUsageService** — resolves the `claude` binary (`CLAUDE_CLI_PATH`, `$PATH`, 7 fallback paths), runs `claude /usage` (12 s timeout, dedicated GCD queue bridged to async), parses output with `ClaudeCodeCLIUsageParser`. Multi-account via `CLAUDE_CONFIG_DIR` env injection.
 - **ClaudeCodeLocalService** — CLI-first wrapper; legacy OAuth fallback + best-effort "extra usage" probe against `api.anthropic.com/api/oauth/usage`.
 - **CodexCliLocalService** — Codex auth file + wham/usage endpoint; maps credits/spend to `ExtraUsageStatus` (safety-biased: never false "Off").
@@ -71,6 +71,7 @@ meterbar/
 - **CostTracker** (1,029 lines) — JSONL/SQLite log scanning, per-model pricing table, per-day/model/origin breakdowns, cache at `~/Library/Application Support/MeterBar/cost-summary-v1.json`.
 - **AuthenticationManager + KeychainManager** — the two admin keys, stored in keychain service `dev.meterbar.app`. Reads migrate the older `dev.shipshit.meterbar` (v1.6.x) and `com.agenticindiedev.quotaguard` (v1.0-v1.6) services into the current one, and removals delete all three so a legacy key cannot reappear.
 - **SharedDataStore** — app-group JSON file (`cached_usage_metrics.json`), atomic writes on a serial queue, `WidgetCenter.reloadTimelines` after save.
+- **ProviderParseHealthStore** — app-group `UserDefaults` records of each provider's last successful parse, last attempt, consecutive failures, and format-mismatch state. Diagnostics and `meterbar doctor` share the same records; successful data warns after 2 hours, while format mismatches or 3 consecutive failures need attention and dim the menu bar item.
 - **ProviderVisibilityStore / DockVisibilityStore / ClaudeCodeAccountStore** — UserDefaults-backed preference stores.
 - **OAuthTokenExpiry** — JWT/unix-timestamp expiry checks (60 s grace; unparseable ⇒ not-expired by design).
 - **ServiceSupport** — shared URLSession config, secret-safe HTTP/URLError mapping, real (non-container) home dir via `getpwuid`.

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -569,6 +569,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
             .store(in: &cancellables)
 
+        ProviderParseHealthStore.shared.$records
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    self?.updateStatusItem(metrics: UsageDataManager.shared.metrics)
+                }
+            }
+            .store(in: &cancellables)
+
         updateStatusItem(metrics: UsageDataManager.shared.metrics)
     }
 
@@ -621,6 +629,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             button.title = ""
             button.imagePosition = .imageOnly
             button.toolTip = "MeterBar"
+            applyParseHealthAppearance(to: button)
             return
         }
 
@@ -630,6 +639,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         button.title = " \(percent)%"
         button.toolTip = "MeterBar: \(percent)% left on \(selection.displayName)"
         button.setAccessibilityLabel("MeterBar \(percent)% left on \(selection.displayName)")
+        applyParseHealthAppearance(to: button)
+    }
+
+    @MainActor
+    private func applyParseHealthAppearance(to button: NSStatusBarButton) {
+        let now = Date()
+        let hasAttention = providerVisibilityStore.enabledServices.contains { service in
+            ProviderParseHealthStore.shared.records[service]?.needsAttention(now: now) == true
+        }
+        button.alphaValue = hasAttention ? 0.55 : 1
+        if hasAttention {
+            button.toolTip = "\(button.toolTip ?? "MeterBar") · Provider data needs attention"
+        }
     }
 
     /// Every enabled account/provider quota that may own the menu bar title,

--- a/MeterBar/Services/ProviderParseHealthStore.swift
+++ b/MeterBar/Services/ProviderParseHealthStore.swift
@@ -1,0 +1,111 @@
+import Combine
+import Foundation
+import MeterBarShared
+
+/// Persisted fetch/parse health for one reverse-engineered provider integration.
+nonisolated public struct ProviderParseHealthRecord: Codable, Equatable, Sendable {
+    static let staleAfter: TimeInterval = 2 * 60 * 60
+    static let sustainedFailureCount = 3
+
+    public let provider: ServiceType
+    public let lastSuccess: Date?
+    public let lastAttempt: Date
+    public let consecutiveFailures: Int
+    public let lastFailureWasShapeMismatch: Bool
+
+    public init(
+        provider: ServiceType,
+        lastSuccess: Date?,
+        lastAttempt: Date,
+        consecutiveFailures: Int,
+        lastFailureWasShapeMismatch: Bool
+    ) {
+        self.provider = provider
+        self.lastSuccess = lastSuccess
+        self.lastAttempt = lastAttempt
+        self.consecutiveFailures = consecutiveFailures
+        self.lastFailureWasShapeMismatch = lastFailureWasShapeMismatch
+    }
+
+    static func success(provider: ServiceType = .claudeCode, at date: Date) -> Self {
+        Self(
+            provider: provider,
+            lastSuccess: date,
+            lastAttempt: date,
+            consecutiveFailures: 0,
+            lastFailureWasShapeMismatch: false
+        )
+    }
+
+    func needsAttention(now: Date = Date()) -> Bool {
+        if lastFailureWasShapeMismatch || consecutiveFailures >= Self.sustainedFailureCount {
+            return true
+        }
+        guard let lastSuccess else { return false }
+        return now.timeIntervalSince(lastSuccess) > Self.staleAfter
+    }
+}
+
+/// Records provider outcomes in the app-group domain so the GUI and bundled
+/// `meterbar doctor` process read the same diagnostic state.
+final class ProviderParseHealthStore: ObservableObject {
+    static let shared = ProviderParseHealthStore()
+    nonisolated static let storageKey = "ProviderParseHealthV1"
+
+    @Published private(set) var records: [ServiceType: ProviderParseHealthRecord]
+
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults? = nil) {
+        let resolved = userDefaults
+            ?? UserDefaults(suiteName: SharedMetricsStore.appGroupIdentifier)
+            ?? .standard
+        self.userDefaults = resolved
+        records = Self.persistedRecords(from: resolved)
+    }
+
+    func recordSuccess(_ provider: ServiceType, at date: Date = Date()) {
+        records[provider] = .success(provider: provider, at: date)
+        persist()
+    }
+
+    func recordFailure(_ provider: ServiceType, error: Error, at date: Date = Date()) {
+        let previous = records[provider]
+        records[provider] = ProviderParseHealthRecord(
+            provider: provider,
+            lastSuccess: previous?.lastSuccess,
+            lastAttempt: date,
+            consecutiveFailures: (previous?.consecutiveFailures ?? 0) + 1,
+            lastFailureWasShapeMismatch: Self.isShapeMismatch(error)
+        )
+        persist()
+    }
+
+    nonisolated static func persistedRecords(from userDefaults: UserDefaults) -> [ServiceType: ProviderParseHealthRecord] {
+        guard let data = userDefaults.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode([ProviderParseHealthRecord].self, from: data) else {
+            return [:]
+        }
+        return Dictionary(uniqueKeysWithValues: decoded.map { ($0.provider, $0) })
+    }
+
+    nonisolated static func sharedRecords() -> [ServiceType: ProviderParseHealthRecord] {
+        guard let defaults = UserDefaults(suiteName: SharedMetricsStore.appGroupIdentifier) else { return [:] }
+        return persistedRecords(from: defaults)
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(Array(records.values)) else { return }
+        userDefaults.set(data, forKey: Self.storageKey)
+    }
+
+    nonisolated private static func isShapeMismatch(_ error: Error) -> Bool {
+        if let serviceError = error as? ServiceError,
+           case .parsingError = serviceError {
+            return true
+        }
+        if error is DecodingError { return true }
+        let message = error.localizedDescription.lowercased()
+        return message.contains("parse") || message.contains("decode") || message.contains("format")
+    }
+}

--- a/MeterBar/Services/ProviderParseHealthStore.swift
+++ b/MeterBar/Services/ProviderParseHealthStore.swift
@@ -6,25 +6,45 @@ import MeterBarShared
 nonisolated public struct ProviderParseHealthRecord: Codable, Equatable, Sendable {
     static let staleAfter: TimeInterval = 2 * 60 * 60
     static let sustainedFailureCount = 3
+    /// Genuine schema drift fails on every refresh, so two consecutive
+    /// mismatches are the earliest reliable drift signal; a single decode
+    /// failure can be a truncated body from a flaky connection.
+    static let sustainedShapeMismatchCount = 2
 
     public let provider: ServiceType
     public let lastSuccess: Date?
     public let lastAttempt: Date
     public let consecutiveFailures: Int
     public let lastFailureWasShapeMismatch: Bool
+    public let consecutiveShapeMismatches: Int
 
     public init(
         provider: ServiceType,
         lastSuccess: Date?,
         lastAttempt: Date,
         consecutiveFailures: Int,
-        lastFailureWasShapeMismatch: Bool
+        lastFailureWasShapeMismatch: Bool,
+        consecutiveShapeMismatches: Int = 0
     ) {
         self.provider = provider
         self.lastSuccess = lastSuccess
         self.lastAttempt = lastAttempt
         self.consecutiveFailures = consecutiveFailures
         self.lastFailureWasShapeMismatch = lastFailureWasShapeMismatch
+        self.consecutiveShapeMismatches = consecutiveShapeMismatches
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        provider = try container.decode(ServiceType.self, forKey: .provider)
+        lastSuccess = try container.decodeIfPresent(Date.self, forKey: .lastSuccess)
+        lastAttempt = try container.decode(Date.self, forKey: .lastAttempt)
+        consecutiveFailures = try container.decode(Int.self, forKey: .consecutiveFailures)
+        lastFailureWasShapeMismatch = try container.decode(Bool.self, forKey: .lastFailureWasShapeMismatch)
+        // Records persisted before this field existed used a one-shot
+        // mismatch flag; carry that meaning forward conservatively.
+        consecutiveShapeMismatches = try container.decodeIfPresent(Int.self, forKey: .consecutiveShapeMismatches)
+            ?? (lastFailureWasShapeMismatch ? Self.sustainedShapeMismatchCount : 0)
     }
 
     static func success(provider: ServiceType = .claudeCode, at date: Date) -> Self {
@@ -33,12 +53,14 @@ nonisolated public struct ProviderParseHealthRecord: Codable, Equatable, Sendabl
             lastSuccess: date,
             lastAttempt: date,
             consecutiveFailures: 0,
-            lastFailureWasShapeMismatch: false
+            lastFailureWasShapeMismatch: false,
+            consecutiveShapeMismatches: 0
         )
     }
 
     func needsAttention(now: Date = Date()) -> Bool {
-        if lastFailureWasShapeMismatch || consecutiveFailures >= Self.sustainedFailureCount {
+        if consecutiveShapeMismatches >= Self.sustainedShapeMismatchCount
+            || consecutiveFailures >= Self.sustainedFailureCount {
             return true
         }
         guard let lastSuccess else { return false }
@@ -71,12 +93,16 @@ final class ProviderParseHealthStore: ObservableObject {
 
     func recordFailure(_ provider: ServiceType, error: Error, at date: Date = Date()) {
         let previous = records[provider]
+        let isShapeMismatch = Self.isShapeMismatch(error)
         records[provider] = ProviderParseHealthRecord(
             provider: provider,
             lastSuccess: previous?.lastSuccess,
             lastAttempt: date,
             consecutiveFailures: (previous?.consecutiveFailures ?? 0) + 1,
-            lastFailureWasShapeMismatch: Self.isShapeMismatch(error)
+            lastFailureWasShapeMismatch: isShapeMismatch,
+            consecutiveShapeMismatches: isShapeMismatch
+                ? (previous?.consecutiveShapeMismatches ?? 0) + 1
+                : 0
         )
         persist()
     }

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -22,9 +22,10 @@ nonisolated public enum ProviderReadinessInspector {
     public static func reports(
         providers: Set<ServiceType> = Set(ServiceType.allCases),
         refreshErrors: [ServiceType: ServiceError] = [:],
-        now: Date = Date()
+        now: Date = Date(),
+        parseHealth: [ServiceType: ProviderParseHealthRecord]? = nil
     ) -> [ProviderReadiness] {
-        reports(
+        let baseReports = reports(
             providers: providers,
             refreshErrors: refreshErrors,
             now: now,
@@ -32,6 +33,13 @@ nonisolated public enum ProviderReadinessInspector {
             codexReport: { codexReport(refreshError: $0, now: $1) },
             cursorReport: { cursorReport(refreshError: $0, now: $1) }
         )
+        let health = parseHealth ?? ProviderParseHealthStore.sharedRecords()
+        return baseReports.map { report in
+            ProviderReadiness(
+                provider: report.provider,
+                checks: report.checks + [parseHealthCheck(health[report.provider], now: now)]
+            )
+        }
     }
 
     /// Injectable routing seam used to prove that disabled providers perform no
@@ -139,6 +147,61 @@ nonisolated public enum ProviderReadinessInspector {
     }
 
     // MARK: - Helpers
+
+    private static func parseHealthCheck(_ record: ProviderParseHealthRecord?, now: Date) -> ReadinessCheck {
+        let threshold = "Data is considered stale after 2 hours."
+        guard let record else {
+            return ReadinessCheck(
+                id: ReadinessCheckID.parseHealth,
+                title: "Provider format health",
+                level: .warn,
+                detail: "No refresh outcome has been recorded yet. \(threshold)"
+            )
+        }
+
+        if record.lastFailureWasShapeMismatch {
+            return ReadinessCheck(
+                id: ReadinessCheckID.parseHealth,
+                title: "Provider format health",
+                level: .fail,
+                detail: "The last refresh detected an upstream format mismatch. \(threshold)",
+                recovery: "Refresh once more, then copy this Diagnostics report if it persists."
+            )
+        }
+        if record.consecutiveFailures >= ProviderParseHealthRecord.sustainedFailureCount {
+            return ReadinessCheck(
+                id: ReadinessCheckID.parseHealth,
+                title: "Provider format health",
+                level: .fail,
+                detail: "\(record.consecutiveFailures) consecutive refreshes failed. \(threshold)",
+                recovery: "Check the provider connection and refresh again."
+            )
+        }
+        if record.consecutiveFailures > 0 {
+            return ReadinessCheck(
+                id: ReadinessCheckID.parseHealth,
+                title: "Provider format health",
+                level: .warn,
+                detail: "The latest refresh failed; \(record.consecutiveFailures) failure recorded. \(threshold)"
+            )
+        }
+        if let lastSuccess = record.lastSuccess,
+           now.timeIntervalSince(lastSuccess) > ProviderParseHealthRecord.staleAfter {
+            return ReadinessCheck(
+                id: ReadinessCheckID.parseHealth,
+                title: "Provider format health",
+                level: .warn,
+                detail: "Usage data is older than the 2-hour staleness threshold.",
+                recovery: "Refresh the provider and review any new error."
+            )
+        }
+        return ReadinessCheck(
+            id: ReadinessCheckID.parseHealth,
+            title: "Provider format health",
+            level: .pass,
+            detail: "The most recent provider response parsed successfully. \(threshold)"
+        )
+    }
 
     private static func cursorAppPresent() -> Bool {
         let fileManager = FileManager.default

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -42,6 +42,7 @@ class UsageDataManager: ObservableObject {
     private let codexCliService: SimpleUsageProviding
     private let claudeCodeAccountStore: ClaudeCodeAccountStore
     private let providerVisibilityStore: ProviderVisibilityStore
+    private let parseHealthStore: ProviderParseHealthStore
 
     private var refreshTimer: Timer?
     private let cacheKey = StorageKeys.cachedUsageMetrics
@@ -62,6 +63,7 @@ class UsageDataManager: ObservableObject {
         providerVisibilityStore: ProviderVisibilityStore? = nil,
         sharedStore: SharedDataStore = .shared,
         cacheDefaults: UserDefaults = .standard,
+        parseHealthStore: ProviderParseHealthStore? = nil,
         schedulesAutoRefresh: Bool = true
     ) {
         self.codexCliService = codexCliService
@@ -71,6 +73,7 @@ class UsageDataManager: ObservableObject {
         self.providerVisibilityStore = providerVisibilityStore ?? .shared
         self.sharedStore = sharedStore
         self.cacheDefaults = cacheDefaults
+        self.parseHealthStore = parseHealthStore ?? .shared
         loadCachedData()
         if schedulesAutoRefresh {
             setupAutoRefresh()
@@ -232,16 +235,26 @@ class UsageDataManager: ObservableObject {
 
     private func fetchClaudeCodeAccountMetrics() async -> [UUID: UsageMetrics] {
         var refreshedMetrics: [UUID: UsageMetrics] = [:]
+        var firstFailure: Error?
+        var successCount = 0
 
         for account in claudeCodeAccountStore.accounts {
             do {
                 refreshedMetrics[account.id] = try await claudeCodeService.fetchUsageMetrics(account: account)
+                successCount += 1
             } catch {
+                if firstFailure == nil { firstFailure = error }
                 lastError = error
                 if let cachedMetrics = claudeCodeAccountMetrics[account.id] {
                     refreshedMetrics[account.id] = cachedMetrics
                 }
             }
+        }
+
+        if let firstFailure {
+            parseHealthStore.recordFailure(.claudeCode, error: firstFailure)
+        } else if successCount > 0 {
+            parseHealthStore.recordSuccess(.claudeCode)
         }
 
         return refreshedMetrics
@@ -267,13 +280,21 @@ class UsageDataManager: ObservableObject {
     /// Fetch for the providers without multi-account handling (Claude Code has
     /// its own account-aware path).
     private func fetchSimpleProviderMetrics(_ service: ServiceType) async throws -> UsageMetrics {
-        switch service {
-        case .codexCli:
-            return try await codexCliService.fetchUsageMetrics()
-        case .cursor:
-            return try await cursorService.fetchUsageMetrics()
-        case .claudeCode:
-            preconditionFailure("Claude Code uses the account-aware fetch path")
+        do {
+            let result: UsageMetrics
+            switch service {
+            case .codexCli:
+                result = try await codexCliService.fetchUsageMetrics()
+            case .cursor:
+                result = try await cursorService.fetchUsageMetrics()
+            case .claudeCode:
+                preconditionFailure("Claude Code uses the account-aware fetch path")
+            }
+            parseHealthStore.recordSuccess(service)
+            return result
+        } catch {
+            parseHealthStore.recordFailure(service, error: error)
+            throw error
         }
     }
 }

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -251,10 +251,13 @@ class UsageDataManager: ObservableObject {
             }
         }
 
-        if let firstFailure {
-            parseHealthStore.recordFailure(.claudeCode, error: firstFailure)
-        } else if successCount > 0 {
+        // Parse health tracks integration health, not per-account health:
+        // if any account parses, the format contract still holds, so one
+        // failing account must not dim the whole provider.
+        if successCount > 0 {
             parseHealthStore.recordSuccess(.claudeCode)
+        } else if let firstFailure {
+            parseHealthStore.recordFailure(.claudeCode, error: firstFailure)
         }
 
         return refreshedMetrics

--- a/MeterBarTests/ProviderParseHealthTests.swift
+++ b/MeterBarTests/ProviderParseHealthTests.swift
@@ -1,0 +1,55 @@
+import MeterBarShared
+@testable import MeterBar
+import XCTest
+
+final class ProviderParseHealthTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUpWithError() throws {
+        suiteName = "ProviderParseHealthTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    func testParseMismatchNeedsAttentionAfterOneFailureAndPersists() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let store = ProviderParseHealthStore(userDefaults: defaults)
+
+        store.recordFailure(.claudeCode, error: ServiceError.parsingError, at: now)
+
+        let record = store.records[.claudeCode]
+        XCTAssertEqual(record?.consecutiveFailures, 1)
+        XCTAssertTrue(record?.lastFailureWasShapeMismatch ?? false)
+        XCTAssertTrue(record?.needsAttention(now: now) ?? false)
+        XCTAssertEqual(ProviderParseHealthStore.persistedRecords(from: defaults)[.claudeCode], record)
+    }
+
+    func testOrdinaryFailureNeedsThreeAttemptsAndSuccessResetsCounter() {
+        let now = Date(timeIntervalSince1970: 20_000)
+        let store = ProviderParseHealthStore(userDefaults: defaults)
+        for offset in 0..<2 {
+            store.recordFailure(.cursor, error: ServiceError.apiError("Request timed out"), at: now + Double(offset))
+        }
+        XCTAssertFalse(store.records[.cursor]?.needsAttention(now: now + 2) ?? true)
+
+        store.recordFailure(.cursor, error: ServiceError.apiError("Request timed out"), at: now + 2)
+        XCTAssertTrue(store.records[.cursor]?.needsAttention(now: now + 2) ?? false)
+
+        store.recordSuccess(.cursor, at: now + 3)
+        XCTAssertEqual(store.records[.cursor]?.consecutiveFailures, 0)
+        XCTAssertFalse(store.records[.cursor]?.needsAttention(now: now + 3) ?? true)
+    }
+
+    func testSuccessfulDataBecomesStaleAfterPublishedThreshold() {
+        let now = Date(timeIntervalSince1970: 30_000)
+        let record = ProviderParseHealthRecord.success(at: now)
+
+        XCTAssertFalse(record.needsAttention(now: now + ProviderParseHealthRecord.staleAfter - 1))
+        XCTAssertTrue(record.needsAttention(now: now + ProviderParseHealthRecord.staleAfter + 1))
+        XCTAssertEqual(ProviderParseHealthRecord.staleAfter, 2 * 60 * 60)
+    }
+}

--- a/MeterBarTests/ProviderParseHealthTests.swift
+++ b/MeterBarTests/ProviderParseHealthTests.swift
@@ -15,17 +15,56 @@ final class ProviderParseHealthTests: XCTestCase {
         defaults.removePersistentDomain(forName: suiteName)
     }
 
-    func testParseMismatchNeedsAttentionAfterOneFailureAndPersists() {
+    func testParseMismatchNeedsAttentionOnlyAfterConsecutiveMismatchesAndPersists() {
         let now = Date(timeIntervalSince1970: 10_000)
         let store = ProviderParseHealthStore(userDefaults: defaults)
 
+        // One decode failure can be a truncated body from a flaky connection;
+        // it must not one-shot the provider into "needs attention".
         store.recordFailure(.claudeCode, error: ServiceError.parsingError, at: now)
-
-        let record = store.records[.claudeCode]
+        var record = store.records[.claudeCode]
         XCTAssertEqual(record?.consecutiveFailures, 1)
         XCTAssertTrue(record?.lastFailureWasShapeMismatch ?? false)
-        XCTAssertTrue(record?.needsAttention(now: now) ?? false)
+        XCTAssertFalse(record?.needsAttention(now: now) ?? true)
+
+        // Genuine schema drift fails every refresh; the second consecutive
+        // mismatch is the earliest reliable drift signal.
+        store.recordFailure(.claudeCode, error: ServiceError.parsingError, at: now + 1)
+        record = store.records[.claudeCode]
+        XCTAssertTrue(record?.needsAttention(now: now + 1) ?? false)
         XCTAssertEqual(ProviderParseHealthStore.persistedRecords(from: defaults)[.claudeCode], record)
+    }
+
+    func testTransientDecodeFailureThenSuccessStaysHealthy() {
+        let now = Date(timeIntervalSince1970: 15_000)
+        let store = ProviderParseHealthStore(userDefaults: defaults)
+        let decodeError = DecodingError.dataCorrupted(
+            DecodingError.Context(codingPath: [], debugDescription: "truncated body")
+        )
+
+        store.recordFailure(.claudeCode, error: decodeError, at: now)
+        XCTAssertFalse(store.records[.claudeCode]?.needsAttention(now: now) ?? true)
+
+        store.recordSuccess(.claudeCode, at: now + 1)
+        XCTAssertFalse(store.records[.claudeCode]?.needsAttention(now: now + 1) ?? true)
+
+        // A later isolated mismatch after recovery must start counting from zero.
+        store.recordFailure(.claudeCode, error: decodeError, at: now + 2)
+        XCTAssertFalse(store.records[.claudeCode]?.needsAttention(now: now + 2) ?? true)
+    }
+
+    func testMixedFailureKindsDoNotAccumulateMismatchCount() {
+        let now = Date(timeIntervalSince1970: 17_000)
+        let store = ProviderParseHealthStore(userDefaults: defaults)
+
+        store.recordFailure(.cursor, error: ServiceError.parsingError, at: now)
+        store.recordFailure(.cursor, error: ServiceError.apiError("Request timed out"), at: now + 1)
+        store.recordFailure(.cursor, error: ServiceError.parsingError, at: now + 2)
+
+        // parse, api, parse: never two consecutive mismatches, and only
+        // three total failures reach the ordinary sustained threshold.
+        XCTAssertTrue(store.records[.cursor]?.needsAttention(now: now + 2) ?? false)
+        XCTAssertEqual(store.records[.cursor]?.consecutiveFailures, 3)
     }
 
     func testOrdinaryFailureNeedsThreeAttemptsAndSuccessResetsCounter() {

--- a/MeterBarTests/ProviderReadinessInspectorTests.swift
+++ b/MeterBarTests/ProviderReadinessInspectorTests.swift
@@ -113,6 +113,28 @@ final class ProviderReadinessInspectorTests: XCTestCase {
         XCTAssertNil(ProviderReadinessInspector.sanitize(nil))
     }
 
+    func testParseHealthAddsImmediateFormatMismatchCheckWithStalenessThreshold() {
+        let now = Date(timeIntervalSince1970: 40_000)
+        let record = ProviderParseHealthRecord(
+            provider: .codexCli,
+            lastSuccess: now.addingTimeInterval(-60),
+            lastAttempt: now,
+            consecutiveFailures: 1,
+            lastFailureWasShapeMismatch: true
+        )
+
+        let reports = ProviderReadinessInspector.reports(
+            providers: [.codexCli],
+            now: now,
+            parseHealth: [.codexCli: record]
+        )
+        let check = reports.first?.check(ReadinessCheckID.parseHealth)
+
+        XCTAssertEqual(check?.level, .fail)
+        XCTAssertTrue(check?.detail.contains("format") ?? false)
+        XCTAssertTrue(check?.detail.contains("2 hours") ?? false)
+    }
+
     func testHttpStatusExtraction() {
         XCTAssertEqual(ProviderReadinessInspector.httpStatus(in: "HTTP 404: not found"), 404)
         XCTAssertNil(ProviderReadinessInspector.httpStatus(in: "no status here"))

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -60,7 +60,8 @@ final class UsageDataManagerTests: XCTestCase {
         codex: StubProvider,
         cursor: StubProvider,
         hidden: Set<ServiceType> = [],
-        preload: [ServiceType: UsageMetrics] = [:]
+        preload: [ServiceType: UsageMetrics] = [:],
+        parseHealthStore: ProviderParseHealthStore? = nil
     ) -> (manager: UsageDataManager, sharedStore: SharedDataStore) {
         let suiteName = "UsageDataManagerTests-\(UUID().uuidString)"
         createdSuiteNames.append(contentsOf: [suiteName, "\(suiteName)-vis"])
@@ -83,9 +84,25 @@ final class UsageDataManagerTests: XCTestCase {
             providerVisibilityStore: visibility,
             sharedStore: sharedStore,
             cacheDefaults: cacheDefaults,
+            parseHealthStore: parseHealthStore,
             schedulesAutoRefresh: false
         )
         return (manager, sharedStore)
+    }
+
+    func testRefreshRecordsSuccessAndFailureHealth() async {
+        let healthSuite = "UsageDataManagerHealthTests-\(UUID().uuidString)"
+        createdSuiteNames.append(healthSuite)
+        let health = ProviderParseHealthStore(userDefaults: UserDefaults(suiteName: healthSuite)!)
+        let codex = StubProvider(hasAccess: true, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: true, result: .failure(ServiceError.parsingError))
+        let (manager, _) = makeManager(codex: codex, cursor: cursor, parseHealthStore: health)
+
+        await manager.refreshAll()
+
+        XCTAssertEqual(health.records[.codexCli]?.consecutiveFailures, 0)
+        XCTAssertEqual(health.records[.cursor]?.consecutiveFailures, 1)
+        XCTAssertTrue(health.records[.cursor]?.lastFailureWasShapeMismatch ?? false)
     }
 
     func testRefreshAllMergesBothEnabledProviders() async {

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
@@ -39,6 +39,7 @@ public enum ReadinessCheckID {
     public static let auth = "auth"
     public static let data = "data"
     public static let refresh = "refresh"
+    public static let parseHealth = "parse-health"
 }
 
 /// One evaluated check: a pass/warn/fail plus a redacted, plain-language detail


### PR DESCRIPTION
## Summary
- persist per-provider parse outcomes in the shared app-group domain
- surface shape mismatches, sustained failures, and stale data in Diagnostics and `meterbar doctor`
- dim the menu bar item when an enabled provider needs attention

## Validation
- `swift test` (538 tests)
- `swiftlint lint --strict --quiet`
- `swift build --package-path MeterBarCLI`
- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO build`

Closes #132