### PR TITLE
feat: add signed Sparkle updates

### DIFF
--- a/.agents/SESSIONS/2026-07-13.md
+++ b/.agents/SESSIONS/2026-07-13.md
@@ -7,7 +7,7 @@
 | Issue | Delivery |
 |---|---|
 | #127 first-run onboarding | `codex/127-onboarding`, PR #155 |
-| #128 Sparkle auto-update | `codex/128-sparkle-auto-update` |
+| #128 Sparkle auto-update | `codex/128-sparkle-auto-update`, PR #159 |
 | #129 honest estimated-limit labels | Existing branch `codex/129-label-estimated-limits`, PR #152 |
 | #130 shared pricing source | `codex/130-shared-pricing`, PR #154 |
 | #131 Session Wake master feature gate | `codex/131-session-wake-feature-gate`, PR #153 |

--- a/.agents/SESSIONS/2026-07-13.md
+++ b/.agents/SESSIONS/2026-07-13.md
@@ -1,0 +1,47 @@
+# 2026-07-13
+
+## Session: v1.7.1 milestone implementation
+
+**Summary:** Implemented the six fixes originally planned for v1.7.1, with one isolated worktree, branch, commit, and ready PR per issue. The milestone itself had been closed empty and the issues had moved to the `2026-W29 · Weekly Release` milestone, so delivery followed issues #127–#132.
+
+| Issue | Delivery |
+|---|---|
+| #127 first-run onboarding | `codex/127-onboarding`, PR #155 |
+| #128 Sparkle auto-update | `codex/128-sparkle-auto-update` |
+| #129 honest estimated-limit labels | Existing branch `codex/129-label-estimated-limits`, PR #152 |
+| #130 shared pricing source | `codex/130-shared-pricing`, PR #154 |
+| #131 Session Wake master feature gate | `codex/131-session-wake-feature-gate`, PR #153 |
+| #132 provider parse health | `codex/132-provider-parse-health`, PR #156 |
+
+### Sparkle release flow
+
+```mermaid
+flowchart LR
+    Tag["Canonical release tag"] --> Preflight["Developer ID, notarization, and EdDSA preflight"]
+    Preflight --> Build["Universal app, widget, and CLI"]
+    Build --> Sign["Sign Sparkle helpers, app; notarize and staple"]
+    Sign --> Zip["Create final release ZIP"]
+    Zip --> Appcast["generate_appcast via private key on stdin"]
+    Appcast --> Verify["Validate version, URL, length, and EdDSA signature"]
+    Verify --> Release["Publish ZIP, SHA-256, and appcast.xml"]
+    Release --> Client["Opted-in Sparkle clients read latest/download/appcast.xml"]
+```
+
+### Decisions and constraints
+
+- Pinned Sparkle 2.9.4 in the Xcode project; the standalone CLI deliberately does not link Sparkle.
+- Automatic checks default off in Info.plist. The Settings toggle is explicit consent; **Check Now** is manual.
+- `CFBundleVersion` now tracks the three-part marketing version because Sparkle compares the build version, not only the display version.
+- Release CI consumes `SPARKLE_PUBLIC_ED_KEY` as an Actions variable and `SPARKLE_ED_PRIVATE_KEY` as a secret. Missing values fail before build work.
+- The custom signer follows Sparkle's helper-specific signing order and preserves Downloader XPC entitlements.
+- v1.7.0 as already shipped does not contain Sparkle, so it cannot discover v1.7.1 automatically. It requires one manual/Homebrew upgrade; v1.7.1 establishes the future automatic path.
+- The first worktree creation loop used zsh's reserved `path` variable and temporarily changed that subprocess's command lookup. No repository state changed; the loop was rerun with `worktree_dir`.
+
+### Verification
+
+- Every issue branch: `swift test`, strict SwiftLint, standalone CLI build, and Xcode app/widget build.
+- #128: 536 Swift tests; Sparkle configuration/appcast/version tests; `actionlint`; `shellcheck`; Info.plist validation; universal arm64+x86_64 app/widget/CLI; CLI confirmed not linked to Sparkle; helper-aware ad-hoc release signing and deep verification; embedded Session Wake dry-run.
+
+### External release prerequisite
+
+Before tagging v1.7.1, configure the Actions variable and secret described in `docs/sparkle-updates.md`. The workflow will intentionally reject a release without them.

--- a/.agents/SESSIONS/2026-07-13.md
+++ b/.agents/SESSIONS/2026-07-13.md
@@ -32,7 +32,7 @@ flowchart LR
 - Pinned Sparkle 2.9.4 in the Xcode project; the standalone CLI deliberately does not link Sparkle.
 - Automatic checks default off in Info.plist. The Settings toggle is explicit consent; **Check Now** is manual.
 - `CFBundleVersion` now tracks the three-part marketing version because Sparkle compares the build version, not only the display version.
-- Release CI consumes `SPARKLE_PUBLIC_ED_KEY` as an Actions variable and `SPARKLE_ED_PRIVATE_KEY` as a secret. Missing values fail before build work.
+- Release CI consumes `SPARKLE_PUBLIC_ED_KEY` as a variable and `SPARKLE_PRIVATE_ED_KEY` as a secret from the `release` environment. Missing values fail before build work.
 - The custom signer follows Sparkle's helper-specific signing order and preserves Downloader XPC entitlements.
 - v1.7.0 as already shipped does not contain Sparkle, so it cannot discover v1.7.1 automatically. It requires one manual/Homebrew upgrade; v1.7.1 establishes the future automatic path.
 - The first worktree creation loop used zsh's reserved `path` variable and temporarily changed that subprocess's command lookup. No repository state changed; the loop was rerun with `worktree_dir`.

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -75,6 +75,7 @@ meterbar/
 - **OAuthTokenExpiry** — JWT/unix-timestamp expiry checks (60 s grace; unparseable ⇒ not-expired by design).
 - **ServiceSupport** — shared URLSession config, secret-safe HTTP/URLError mapping, real (non-container) home dir via `getpwuid`.
 - **AppLog** — `os.Logger` categories: app, usage, cost, network, storage. This is the only observability; there is no crash reporting or analytics.
+- **SoftwareUpdateController** — owns Sparkle 2's standard updater. The General settings pane binds directly to Sparkle's automatic-check preference (default off until consent) and exposes a manual check action. Release builds embed the GitHub Releases appcast URL and an Actions-provided EdDSA public key.
 
 ## App lifecycle
 
@@ -91,7 +92,7 @@ Dates in the shared JSON use `JSONEncoder`/`JSONDecoder` **default** strategies 
 ## CI / release
 
 - `ci.yml` (push/PR to master, macos-26 + Xcode 26.2): the branch-protection-required `build` job waits for tests/coverage and SwiftLint, fails explicitly unless both pass, then compiles and verifies universal app, widget, and CLI artifacts. Branch protection also requires the test, lint, and secret-scan contexts directly.
-- `release.yml` (canonical `vMAJOR.MINOR.PATCH` tag): builds universal arm64+x86_64 app/widget/CLI artifacts, checks tag/app/CLI version agreement, signs nested code inside-out with an ad-hoc hardened-runtime signature, verifies source entitlements and bundle integrity, zips via `ditto`, publishes GitHub Release, then calls `update-homebrew.yml`. Developer ID signing, authorized provisioning, and notarization remain pending credentials.
+- `release.yml` (canonical `vMAJOR.MINOR.PATCH` tag): preflights Developer ID, notarization, and Sparkle EdDSA credentials; builds universal arm64+x86_64 app/widget/CLI artifacts; checks tag/app/CLI version agreement; signs, notarizes, and staples nested code; generates and validates an EdDSA-signed Sparkle appcast; publishes all assets to GitHub Releases; then calls `update-homebrew.yml`.
 - `secret-scan.yml`: gitleaks (pinned + checksum-verified) over full history.
 
 ## Known architectural risks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     runs-on: macos-26
     timeout-minutes: 60
+    environment: release
     permissions:
       contents: write
     env:
@@ -72,7 +73,7 @@ jobs:
           APPLE_API_PRIVATE_KEY_P8_BASE64: ${{ secrets.APPLE_API_PRIVATE_KEY_P8_BASE64 }}
           APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ vars.APPLE_API_ISSUER_ID }}
-          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+          SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
         run: |
           set -euo pipefail
           missing=()
@@ -81,7 +82,7 @@ jobs:
           # runtime, not stored.
           for name in DEVELOPER_ID_P12_BASE64 DEVELOPER_ID_P12_PASSWORD \
                       APPLE_API_PRIVATE_KEY_P8_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER_ID \
-                      SPARKLE_ED_PRIVATE_KEY SPARKLE_PUBLIC_ED_KEY; do
+                      SPARKLE_PRIVATE_ED_KEY SPARKLE_PUBLIC_ED_KEY; do
             # Indirect expansion reads the env var named in $name without echoing its value.
             if [ -z "${!name:-}" ]; then
               missing+=("$name")
@@ -325,7 +326,7 @@ jobs:
           RELEASE_TAG: ${{ steps.version.outputs.tag }}
           RELEASE_VERSION: ${{ steps.version.outputs.version }}
           ZIP_NAME: ${{ steps.package.outputs.zip_name }}
-          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+          SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
         run: |
           set -euo pipefail
           APPCAST_DIR="$RUNNER_TEMP/sparkle-appcast"
@@ -339,7 +340,7 @@ jobs:
 
           mkdir -p "$APPCAST_DIR"
           cp "$GITHUB_WORKSPACE/$ZIP_NAME" "$APPCAST_DIR/$ZIP_NAME"
-          printf '%s' "$SPARKLE_ED_PRIVATE_KEY" | "$GENERATE_APPCAST" \
+          printf '%s' "$SPARKLE_PRIVATE_ED_KEY" | "$GENERATE_APPCAST" \
             --ed-key-file - \
             --download-url-prefix "$DOWNLOAD_PREFIX" \
             "$APPCAST_DIR"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       APP_PATH: ${{ github.workspace }}/build/Build/Products/Release/MeterBar.app
       # Context values enter shell code only through environment variables.
       REF_NAME: ${{ github.ref_name }}
+      SPARKLE_PUBLIC_ED_KEY: ${{ vars.SPARKLE_PUBLIC_ED_KEY }}
       # notarytool keychain-profile name (stored in the temp keychain at runtime).
       NOTARY_PROFILE: asc-profile
 
@@ -71,6 +72,7 @@ jobs:
           APPLE_API_PRIVATE_KEY_P8_BASE64: ${{ secrets.APPLE_API_PRIVATE_KEY_P8_BASE64 }}
           APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ vars.APPLE_API_ISSUER_ID }}
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
         run: |
           set -euo pipefail
           missing=()
@@ -78,7 +80,8 @@ jobs:
           # required. KEYCHAIN_PASSWORD is intentionally absent — it is generated at
           # runtime, not stored.
           for name in DEVELOPER_ID_P12_BASE64 DEVELOPER_ID_P12_PASSWORD \
-                      APPLE_API_PRIVATE_KEY_P8_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER_ID; do
+                      APPLE_API_PRIVATE_KEY_P8_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER_ID \
+                      SPARKLE_ED_PRIVATE_KEY SPARKLE_PUBLIC_ED_KEY; do
             # Indirect expansion reads the env var named in $name without echoing its value.
             if [ -z "${!name:-}" ]; then
               missing+=("$name")
@@ -86,7 +89,7 @@ jobs:
           done
           if [ "${#missing[@]}" -ne 0 ]; then
             echo "::error::Missing required signing credential(s): ${missing[*]}" >&2
-            echo "Set secrets DEVELOPER_ID_P12_BASE64 / DEVELOPER_ID_P12_PASSWORD / APPLE_API_PRIVATE_KEY_P8_BASE64 and variables APPLE_API_KEY_ID / APPLE_API_ISSUER_ID under Settings > Secrets and variables > Actions, then re-run." >&2
+            echo "Set the required Developer ID, notarization, and Sparkle EdDSA secrets/variables under Settings > Secrets and variables > Actions, then re-run." >&2
             exit 1
           fi
           echo "All required signing credentials are present."
@@ -110,6 +113,7 @@ jobs:
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
+            SPARKLE_PUBLIC_ED_KEY="$SPARKLE_PUBLIC_ED_KEY" \
             build
 
       - name: Build and inject universal CLI
@@ -315,12 +319,44 @@ jobs:
             echo "sha_name=$SHA_NAME"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Generate and verify Sparkle appcast
+        id: appcast
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          ZIP_NAME: ${{ steps.package.outputs.zip_name }}
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          APPCAST_DIR="$RUNNER_TEMP/sparkle-appcast"
+          GENERATE_APPCAST="$GITHUB_WORKSPACE/build/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_appcast"
+          DOWNLOAD_PREFIX="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/"
+
+          if [ ! -x "$GENERATE_APPCAST" ]; then
+            echo "::error::Sparkle generate_appcast was not resolved at $GENERATE_APPCAST" >&2
+            exit 1
+          fi
+
+          mkdir -p "$APPCAST_DIR"
+          cp "$GITHUB_WORKSPACE/$ZIP_NAME" "$APPCAST_DIR/$ZIP_NAME"
+          printf '%s' "$SPARKLE_ED_PRIVATE_KEY" | "$GENERATE_APPCAST" \
+            --ed-key-file - \
+            --download-url-prefix "$DOWNLOAD_PREFIX" \
+            "$APPCAST_DIR"
+
+          APPCAST_PATH="$APPCAST_DIR/appcast.xml"
+          scripts/verify-appcast.sh \
+            "$APPCAST_PATH" "$RELEASE_VERSION" "$ZIP_NAME" "$DOWNLOAD_PREFIX"
+          cp "$APPCAST_PATH" "$GITHUB_WORKSPACE/appcast.xml"
+          echo "name=appcast.xml" >> "$GITHUB_OUTPUT"
+
       - name: Create Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: |
             ${{ steps.package.outputs.zip_name }}
             ${{ steps.package.outputs.sha_name }}
+            ${{ steps.appcast.outputs.name }}
           draft: false
           prerelease: false
           generate_release_notes: true
@@ -337,6 +373,7 @@ jobs:
             echo ""
             echo "**Tag:** \`$RELEASE_TAG\`"
             echo "**SHA256:** \`$RELEASE_SHA256\`"
+            echo "**Sparkle feed:** \`appcast.xml\` (EdDSA signed archive)"
             echo ""
             echo "Universal arm64+x86_64, Developer ID signed, notarized, and stapled."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		5259E44F2F032E78001001CF /* MeterBarWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 5259E43D2F032E77001001CF /* MeterBarWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		52ABC1022F0400010036036C /* MeterBarShared in Frameworks */ = {isa = PBXBuildFile; productRef = 52ABC1012F0400010036036C /* MeterBarShared */; };
 		52ABC1042F0400010036036C /* MeterBarShared in Frameworks */ = {isa = PBXBuildFile; productRef = 52ABC1032F0400010036036C /* MeterBarShared */; };
+		52ABC1072F0400010036036C /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 52ABC1062F0400010036036C /* Sparkle */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,6 +47,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		52ABC1082F0400010036036C /* Exceptions for "MeterBar" folder in "MeterBar" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 52CFA4FF2F0323EF0036036C /* MeterBar */;
+		};
 		5259E4502F032E78001001CF /* Exceptions for "MeterBarWidget" folder in "MeterBarWidgetExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -66,6 +74,9 @@
 		};
 		52CFA5022F0323EF0036036C /* MeterBar */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				52ABC1082F0400010036036C /* Exceptions for "MeterBar" folder in "MeterBar" target */,
+			);
 			path = MeterBar;
 			sourceTree = "<group>";
 		};
@@ -86,6 +97,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				52ABC1072F0400010036036C /* Sparkle in Frameworks */,
 				52ABC1022F0400010036036C /* MeterBarShared in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -167,6 +179,7 @@
 			name = MeterBar;
 			packageProductDependencies = (
 				52ABC1012F0400010036036C /* MeterBarShared */,
+				52ABC1062F0400010036036C /* Sparkle */,
 			);
 			productName = MeterBar;
 			productReference = 52CFA5002F0323EF0036036C /* MeterBar.app */;
@@ -201,6 +214,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				52ABC1002F0400010036036C /* XCLocalSwiftPackageReference "Packages/MeterBarShared" */,
+				52ABC1052F0400010036036C /* XCRemoteSwiftPackageReference "Sparkle" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 52CFA5012F0323EF0036036C /* Products */;
@@ -263,7 +277,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = MeterBarWidget/MeterBarWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
 				DEVELOPMENT_TEAM = C76R5DRH64;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -308,7 +322,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = MeterBarWidget/MeterBarWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
 				DEVELOPMENT_TEAM = C76R5DRH64;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -475,7 +489,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
 				DEVELOPMENT_TEAM = C76R5DRH64;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -491,8 +505,8 @@
 				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
 				ENABLE_RESOURCE_ACCESS_USB = NO;
 				ENABLE_USER_SELECTED_FILES = readonly;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = MeterBar/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -521,7 +535,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
 				DEVELOPMENT_TEAM = C76R5DRH64;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -537,8 +551,8 @@
 				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
 				ENABLE_RESOURCE_ACCESS_USB = NO;
 				ENABLE_USER_SELECTED_FILES = readonly;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = MeterBar/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -597,6 +611,17 @@
 		};
 /* End XCLocalSwiftPackageReference section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		52ABC1052F0400010036036C /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = exactVersion;
+				version = 2.9.4;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		52ABC1012F0400010036036C /* MeterBarShared */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -605,6 +630,11 @@
 		52ABC1032F0400010036036C /* MeterBarShared */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = MeterBarShared;
+		};
+		52ABC1062F0400010036036C /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 52ABC1052F0400010036036C /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/MeterBar.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MeterBar.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "f3cee4d5706decc7a44194a51ee825677d3a8dedbd1a5e481858477f2b02be3c",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -52,6 +52,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         AppLog.app.info("MeterBar finished launching")
+        SoftwareUpdateController.shared.refreshState()
 
         // Keep Dock visibility in sync with the user's preference.
         observeDockVisibility()

--- a/MeterBar/Info.plist
+++ b/MeterBar/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconName</key>
+	<string>AppIcon</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>SUEnableAutomaticChecks</key>
+	<false/>
+	<key>SUFeedURL</key>
+	<string>https://github.com/VincentShipsIt/meterbar.dev/releases/latest/download/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>$(SPARKLE_PUBLIC_ED_KEY)</string>
+</dict>
+</plist>

--- a/MeterBar/Services/SoftwareUpdateController.swift
+++ b/MeterBar/Services/SoftwareUpdateController.swift
@@ -13,13 +13,23 @@ final class SoftwareUpdateController: ObservableObject {
     @Published private(set) var canCheckForUpdates = false
     @Published private(set) var configurationError: String?
 
+    /// True only for a plausible Ed25519 public key. Debug and PR-gate builds
+    /// carry the unsubstituted `$(SPARKLE_PUBLIC_ED_KEY)` build variable in
+    /// their Info.plist, which the empty-string check alone would let through.
+    nonisolated static func isUsableEDPublicKey(_ rawValue: String) -> Bool {
+        let key = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !key.isEmpty, !key.hasPrefix("$("), !key.hasPrefix("${") else { return false }
+        guard let decoded = Data(base64Encoded: key) else { return false }
+        return decoded.count == 32
+    }
+
 #if canImport(Sparkle)
     private let controller: SPUStandardUpdaterController?
     private var cancellables = Set<AnyCancellable>()
 
     init(bundle: Bundle = .main) {
         guard let publicKey = bundle.object(forInfoDictionaryKey: "SUPublicEDKey") as? String,
-              !publicKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+              Self.isUsableEDPublicKey(publicKey) else {
             controller = nil
             configurationError = "Software updates are unavailable in this build."
             return

--- a/MeterBar/Services/SoftwareUpdateController.swift
+++ b/MeterBar/Services/SoftwareUpdateController.swift
@@ -1,0 +1,85 @@
+import Combine
+import Foundation
+#if canImport(Sparkle)
+import Sparkle
+#endif
+
+/// Owns Sparkle's standard updater and exposes only user-controlled update actions.
+/// Automatic network checks remain off until the user explicitly enables them.
+final class SoftwareUpdateController: ObservableObject {
+    static let shared = SoftwareUpdateController()
+
+    @Published private(set) var automaticallyChecksForUpdates = false
+    @Published private(set) var canCheckForUpdates = false
+    @Published private(set) var configurationError: String?
+
+#if canImport(Sparkle)
+    private let controller: SPUStandardUpdaterController?
+    private var cancellables = Set<AnyCancellable>()
+
+    init(bundle: Bundle = .main) {
+        guard let publicKey = bundle.object(forInfoDictionaryKey: "SUPublicEDKey") as? String,
+              !publicKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            controller = nil
+            configurationError = "Software updates are unavailable in this build."
+            return
+        }
+
+        let controller = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+        self.controller = controller
+        controller.updater.publisher(for: \.automaticallyChecksForUpdates, options: [.initial, .new])
+            .sink { [weak self] enabled in
+                self?.automaticallyChecksForUpdates = enabled
+            }
+            .store(in: &cancellables)
+        controller.updater.publisher(for: \.canCheckForUpdates, options: [.initial, .new])
+            .sink { [weak self] canCheck in
+                self?.canCheckForUpdates = canCheck
+            }
+            .store(in: &cancellables)
+        refreshState()
+    }
+
+    func setAutomaticallyChecksForUpdates(_ enabled: Bool) {
+        guard let updater = controller?.updater else { return }
+        updater.automaticallyChecksForUpdates = enabled
+        refreshState()
+    }
+
+    func checkForUpdates() {
+        controller?.checkForUpdates(nil)
+        refreshState()
+    }
+
+    func refreshState() {
+        guard let updater = controller?.updater else {
+            automaticallyChecksForUpdates = false
+            canCheckForUpdates = false
+            return
+        }
+        automaticallyChecksForUpdates = updater.automaticallyChecksForUpdates
+        canCheckForUpdates = updater.canCheckForUpdates
+    }
+#else
+    init(bundle: Bundle = .main) {
+        _ = bundle
+        configurationError = "Software updates are available in the app build."
+    }
+
+    func setAutomaticallyChecksForUpdates(_ enabled: Bool) {
+        _ = enabled
+    }
+
+    func checkForUpdates() {
+        // The standalone Swift package intentionally has no updater framework.
+    }
+
+    func refreshState() {
+        // The standalone Swift package intentionally has no updater framework.
+    }
+#endif
+}

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -177,6 +177,7 @@ struct SettingsView: View {
     @StateObject private var dockVisibility = DockVisibilityStore.shared
     @StateObject private var notificationPreferences = NotificationPreferencesStore.shared
     @StateObject private var launchAtLogin = LaunchAtLoginStore.shared
+    @StateObject private var softwareUpdates = SoftwareUpdateController.shared
     @StateObject private var authManager = AuthenticationManager.shared
     @StateObject private var apiUsageStore = ApiUsageStore.shared
 
@@ -538,11 +539,38 @@ struct SettingsView: View {
                 .labelsHidden()
                 .toggleStyle(.switch)
             }
+
+            SettingsDivider()
+
+            SettingsRowView(
+                title: "Check for updates automatically",
+                detail: "Allow MeterBar to check GitHub Releases for signed updates. Off until you opt in."
+            ) {
+                Toggle("", isOn: Binding(
+                    get: { softwareUpdates.automaticallyChecksForUpdates },
+                    set: { softwareUpdates.setAutomaticallyChecksForUpdates($0) }
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .disabled(softwareUpdates.configurationError != nil)
+            }
+
+            SettingsRowView(
+                title: "Software Update",
+                detail: softwareUpdates.configurationError ?? "Check for a new signed MeterBar release now."
+            ) {
+                Button("Check Now") {
+                    softwareUpdates.checkForUpdates()
+                }
+                .buttonStyle(.bordered)
+                .disabled(!softwareUpdates.canCheckForUpdates)
+            }
         }
         .onAppear {
             // The login-item status can change behind the app's back in System
             // Settings, so re-read it whenever settings is shown.
             launchAtLogin.refreshStatus()
+            softwareUpdates.refreshState()
         }
     }
 

--- a/MeterBarTests/SparkleUpdateTests.swift
+++ b/MeterBarTests/SparkleUpdateTests.swift
@@ -1,7 +1,30 @@
 import Foundation
+@testable import MeterBar
 import XCTest
 
 final class SparkleUpdateTests: XCTestCase {
+    func testKeyValidatorRejectsUnsubstitutedBuildVariable() {
+        // Debug and PR-gate builds never substitute the build setting, so the
+        // literal variable is exactly what ships in their Info.plist.
+        XCTAssertFalse(SoftwareUpdateController.isUsableEDPublicKey("$(SPARKLE_PUBLIC_ED_KEY)"))
+        XCTAssertFalse(SoftwareUpdateController.isUsableEDPublicKey("${SPARKLE_PUBLIC_ED_KEY}"))
+    }
+
+    func testKeyValidatorRejectsEmptyAndMalformedKeys() {
+        XCTAssertFalse(SoftwareUpdateController.isUsableEDPublicKey(""))
+        XCTAssertFalse(SoftwareUpdateController.isUsableEDPublicKey("   "))
+        XCTAssertFalse(SoftwareUpdateController.isUsableEDPublicKey("not base64!!"))
+        // Valid base64 of the wrong length is not an Ed25519 public key.
+        let shortKey = Data(repeating: 7, count: 16).base64EncodedString()
+        XCTAssertFalse(SoftwareUpdateController.isUsableEDPublicKey(shortKey))
+    }
+
+    func testKeyValidatorAcceptsWellFormedEd25519Key() {
+        let key = Data(repeating: 7, count: 32).base64EncodedString()
+        XCTAssertTrue(SoftwareUpdateController.isUsableEDPublicKey(key))
+        XCTAssertTrue(SoftwareUpdateController.isUsableEDPublicKey(" \(key) "))
+    }
+
     func testCheckedInConfigurationRequiresAutomaticCheckConsent() throws {
         let repositoryRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()

--- a/MeterBarTests/SparkleUpdateTests.swift
+++ b/MeterBarTests/SparkleUpdateTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import XCTest
+
+final class SparkleUpdateTests: XCTestCase {
+    func testCheckedInConfigurationRequiresAutomaticCheckConsent() throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let infoURL = repositoryRoot.appendingPathComponent("MeterBar/Info.plist")
+        let data = try Data(contentsOf: infoURL)
+        let plist = try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        )
+
+        XCTAssertEqual(plist["SUEnableAutomaticChecks"] as? Bool, false)
+        XCTAssertEqual(
+            plist["SUFeedURL"] as? String,
+            "https://github.com/VincentShipsIt/meterbar.dev/releases/latest/download/appcast.xml"
+        )
+        XCTAssertEqual(plist["SUPublicEDKey"] as? String, "$(SPARKLE_PUBLIC_ED_KEY)")
+    }
+
+    func testVersionComparatorOffers171To170() {
+        XCTAssertEqual("1.7.1".compare("1.7.0", options: .numeric), .orderedDescending)
+        XCTAssertEqual("1.7.0".compare("1.7.1", options: .numeric), .orderedAscending)
+        XCTAssertEqual("1.7.1".compare("1.7.1", options: .numeric), .orderedSame)
+    }
+
+    func testAppcastContractCarriesSignedReleaseArchive() throws {
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel>
+            <item>
+              <title>Version 1.7.1</title>
+              <sparkle:version>1.7.1</sparkle:version>
+              <sparkle:shortVersionString>1.7.1</sparkle:shortVersionString>
+              <enclosure
+                url="https://github.com/VincentShipsIt/meterbar.dev/releases/download/v1.7.1/MeterBar-v1.7.1.zip"
+                sparkle:edSignature="signed-update"
+                length="1234"
+                type="application/octet-stream" />
+            </item>
+          </channel>
+        </rss>
+        """
+
+        let document = try XMLDocument(xmlString: xml)
+        let enclosure = try XCTUnwrap(document.nodes(forXPath: "/rss/channel/item/enclosure").first as? XMLElement)
+        let item = try XCTUnwrap(document.nodes(forXPath: "/rss/channel/item").first as? XMLElement)
+
+        XCTAssertEqual(enclosure.attribute(forName: "url")?.stringValue?.hasSuffix("MeterBar-v1.7.1.zip"), true)
+        let namespace = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+        XCTAssertEqual(item.elements(forLocalName: "version", uri: namespace).first?.stringValue, "1.7.1")
+        XCTAssertEqual(item.elements(forLocalName: "shortVersionString", uri: namespace).first?.stringValue, "1.7.1")
+        XCTAssertFalse(try XCTUnwrap(enclosure.attributes?.first { $0.localName == "edSignature" }).stringValue?.isEmpty ?? true)
+
+        let temporaryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("meterbar-appcast-\(UUID().uuidString).xml")
+        try xml.write(to: temporaryURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: temporaryURL) }
+
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let verifier = repositoryRoot.appendingPathComponent("scripts/verify-appcast.sh")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [
+            verifier.path,
+            temporaryURL.path,
+            "1.7.1",
+            "MeterBar-v1.7.1.zip",
+            "https://github.com/VincentShipsIt/meterbar.dev/releases/download/v1.7.1/"
+        ]
+        try process.run()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
             path: "MeterBar",
             exclude: [
                 "App/MeterBarApp.swift",
+                "Info.plist",
                 "MeterBar.entitlements",
                 "Assets.xcassets",
                 "Resources"

--- a/README.md
+++ b/README.md
@@ -73,11 +73,17 @@ To update:
 brew upgrade --cask VincentShipsIt/tap/meterbar
 ```
 
+Homebrew installations continue to update through Homebrew. Direct-download builds from v1.7.1 onward can also use **Settings → General → Software Update**. Automatic checks are disabled until you explicitly opt in; **Check Now** always performs a one-time manual check.
+
 ### Manual Download
 
 Download the latest release from [meterbar.dev](https://meterbar.dev).
 
 Releases after v1.6.1 are Developer ID signed and notarized, so direct downloads open without Gatekeeper warnings. For v1.6.1 and earlier (ad-hoc signed only), right-click and select "Open" the first time, or run `xattr -cr /Applications/MeterBar.app`.
+
+Starting with v1.7.1, direct-download releases include Sparkle 2 and consume an EdDSA-signed `appcast.xml` published with each GitHub Release. Older versions without Sparkle cannot discover v1.7.1 automatically and must be upgraded once manually.
+
+Maintainer setup and release verification are documented in [docs/sparkle-updates.md](docs/sparkle-updates.md).
 
 ### Build from Source
 

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -1,0 +1,39 @@
+# Sparkle Update Setup
+
+MeterBar direct-download builds use Sparkle 2.9.4. Homebrew remains a supported, independent update path.
+
+## One-time signing setup
+
+1. Resolve the Xcode package and locate Sparkle's tools under the Derived Data `SourcePackages/artifacts/sparkle/Sparkle/bin/` directory.
+2. Run `generate_keys -x /secure/path/meterbar-sparkle-private-key`. Back up that private key outside the repository.
+3. Add the printed base64 public key as the GitHub Actions variable `SPARKLE_PUBLIC_ED_KEY`.
+4. Add the exported private-key contents as the GitHub Actions secret `SPARKLE_ED_PRIVATE_KEY`.
+
+The release workflow fails before building if either value is absent. Never commit the private key or pass it as a command-line argument; CI pipes the secret to `generate_appcast --ed-key-file -` over standard input.
+
+## Release behavior
+
+For a canonical `vMAJOR.MINOR.PATCH` tag, `.github/workflows/release.yml`:
+
+1. embeds the public key and stable GitHub Releases feed URL in `MeterBar.app`;
+2. signs, notarizes, and staples the universal app;
+3. creates the final ZIP;
+4. uses Sparkle's `generate_appcast` to add the ZIP's EdDSA signature;
+5. validates the version, archive URL, length, and signature; and
+6. publishes the ZIP, SHA-256 file, and `appcast.xml` in the same GitHub Release.
+
+The app reads the feed from `https://github.com/VincentShipsIt/meterbar.dev/releases/latest/download/appcast.xml`. Automatic checks default off and begin only after explicit consent in Settings. A manual **Check Now** remains available.
+
+## Verification
+
+Before tagging, run:
+
+```bash
+swift test --filter SparkleUpdateTests
+shellcheck scripts/verify-appcast.sh scripts/sign-and-verify-release.sh
+actionlint .github/workflows/release.yml
+```
+
+After publishing, install the prior Sparkle-enabled release, choose **Settings → General → Check Now**, and complete the update. Versions before v1.7.1 do not contain Sparkle and require one manual upgrade.
+
+Treat key rotation as a release migration. Follow Sparkle's official key-rotation procedure and never change the app bundle identifier (`dev.meterbar.app`).

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -5,9 +5,9 @@ MeterBar direct-download builds use Sparkle 2.9.4. Homebrew remains a supported,
 ## One-time signing setup
 
 1. Resolve the Xcode package and locate Sparkle's tools under the Derived Data `SourcePackages/artifacts/sparkle/Sparkle/bin/` directory.
-2. Run `generate_keys -x /secure/path/meterbar-sparkle-private-key`. Back up that private key outside the repository.
-3. Add the printed base64 public key as the GitHub Actions variable `SPARKLE_PUBLIC_ED_KEY`.
-4. Add the exported private-key contents as the GitHub Actions secret `SPARKLE_ED_PRIVATE_KEY`.
+2. Run `generate_keys --account meterbar` once, then export it with `generate_keys --account meterbar -x /secure/path/meterbar-sparkle-private-key`. Back up that private key outside the repository.
+3. Add the printed base64 public key to the `release` GitHub environment as the Actions variable `SPARKLE_PUBLIC_ED_KEY`.
+4. Add the exported private-key contents to the `release` GitHub environment as the Actions secret `SPARKLE_PRIVATE_ED_KEY`.
 
 The release workflow fails before building if either value is absent. Never commit the private key or pass it as a command-line argument; CI pipes the secret to `generate_appcast --ed-key-file -` over standard input.
 

--- a/scripts/sign-and-verify-release.sh
+++ b/scripts/sign-and-verify-release.sh
@@ -63,14 +63,20 @@ verify_universal_binary "$widget_binary" "Widget"
 verify_universal_binary "$cli_binary" "CLI"
 
 app_version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$app_path/Contents/Info.plist")
+app_build_version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$app_path/Contents/Info.plist")
 cli_version=$("$cli_binary" --version)
 
 echo "Tag version: $expected_version"
 echo "App version: $app_version"
+echo "App build version: $app_build_version"
 echo "CLI version: $cli_version"
 
 if [ "$app_version" != "$expected_version" ]; then
   echo "App version $app_version does not match release version $expected_version." >&2
+  exit 1
+fi
+if [ "$app_build_version" != "$expected_version" ]; then
+  echo "App build version $app_build_version does not match release version $expected_version." >&2
   exit 1
 fi
 if [ "$cli_version" != "$expected_version" ]; then
@@ -110,13 +116,42 @@ sign_code() {
   fi
 }
 
+# Sparkle's helpers have distinct signing requirements. In particular, the
+# Downloader XPC service carries an entitlement that must survive re-signing.
+# Sign these leaves explicitly before sealing Sparkle.framework; `--deep` would
+# incorrectly apply one entitlement set to every nested executable.
+sparkle_framework="$app_path/Contents/Frameworks/Sparkle.framework"
+if [ -d "$sparkle_framework" ]; then
+  sparkle_version="$sparkle_framework/Versions/B"
+  for helper in \
+    "$sparkle_version/XPCServices/Installer.xpc" \
+    "$sparkle_version/Autoupdate" \
+    "$sparkle_version/Updater.app"; do
+    if [ -e "$helper" ]; then
+      echo "Signing Sparkle helper: $helper"
+      sign_code "$helper"
+    fi
+  done
+
+  sparkle_downloader="$sparkle_version/XPCServices/Downloader.xpc"
+  if [ -e "$sparkle_downloader" ]; then
+    echo "Signing Sparkle helper with preserved entitlements: $sparkle_downloader"
+    sign_code "$sparkle_downloader" --preserve-metadata=entitlements
+  fi
+
+  echo "Signing Sparkle framework: $sparkle_framework"
+  sign_code "$sparkle_framework"
+fi
+
 # Sign leaf code first so each containing bundle is sealed only after its
-# contents are final. Framework directories are currently absent, but handling
-# them here prevents a future embedded dependency from silently invalidating the
-# outer signature.
+# contents are final. Sparkle is handled above because its helpers need
+# entitlement-aware signing.
 for frameworks_path in "$widget_path/Contents/Frameworks" "$app_path/Contents/Frameworks"; do
   if [ -d "$frameworks_path" ]; then
     while IFS= read -r -d '' nested_code; do
+      if [ "$nested_code" = "$sparkle_framework" ]; then
+        continue
+      fi
       echo "Signing nested code: $nested_code"
       sign_code "$nested_code"
     done < <(find "$frameworks_path" -depth \( -name '*.framework' -o -name '*.dylib' \) -print0)
@@ -130,6 +165,9 @@ sign_code "$app_path" --entitlements "$app_entitlements"
 codesign --verify --strict --verbose=2 "$cli_binary"
 codesign --verify --strict --verbose=2 "$widget_path"
 codesign --verify --deep --strict --verbose=2 "$app_path"
+if [ -d "$sparkle_framework" ]; then
+  codesign --verify --deep --strict --verbose=2 "$sparkle_framework"
+fi
 
 temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/meterbar-release-entitlements.XXXXXX")
 trap 'rm -rf "$temporary_directory"' EXIT

--- a/scripts/verify-appcast.sh
+++ b/scripts/verify-appcast.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "usage: $0 <appcast.xml> <version> <archive-name> <download-url-prefix>" >&2
+  exit 64
+fi
+
+APPCAST=$1
+VERSION=$2
+ARCHIVE_NAME=$3
+DOWNLOAD_URL_PREFIX=${4%/}/
+
+xpath_string() {
+  xmllint --xpath "string((//*[local-name()='enclosure'])[1]/@$1)" "$APPCAST"
+}
+
+xpath_namespaced_attribute() {
+  xmllint --xpath "string((//*[local-name()='enclosure'])[1]/@*[local-name()='$1'])" "$APPCAST"
+}
+
+xpath_item_element() {
+  xmllint --xpath "string((//*[local-name()='item'])[1]/*[local-name()='$1'][1])" "$APPCAST"
+}
+
+ACTUAL_VERSION=$(xpath_item_element version)
+ACTUAL_SHORT_VERSION=$(xpath_item_element shortVersionString)
+ACTUAL_SIGNATURE=$(xpath_namespaced_attribute edSignature)
+ACTUAL_LENGTH=$(xpath_string length)
+ACTUAL_URL=$(xpath_string url)
+
+if [ "$ACTUAL_VERSION" != "$VERSION" ] || [ "$ACTUAL_SHORT_VERSION" != "$VERSION" ]; then
+  echo "appcast version mismatch: expected $VERSION, got $ACTUAL_VERSION / $ACTUAL_SHORT_VERSION" >&2
+  exit 1
+fi
+
+if [ -z "$ACTUAL_SIGNATURE" ]; then
+  echo "appcast enclosure is missing sparkle:edSignature" >&2
+  exit 1
+fi
+
+if ! [[ "$ACTUAL_LENGTH" =~ ^[1-9][0-9]*$ ]]; then
+  echo "appcast enclosure has invalid length: $ACTUAL_LENGTH" >&2
+  exit 1
+fi
+
+if [ "$ACTUAL_URL" != "${DOWNLOAD_URL_PREFIX}${ARCHIVE_NAME}" ]; then
+  echo "appcast URL mismatch: expected ${DOWNLOAD_URL_PREFIX}${ARCHIVE_NAME}, got $ACTUAL_URL" >&2
+  exit 1
+fi
+
+echo "Sparkle appcast verified for $VERSION ($ARCHIVE_NAME)."


### PR DESCRIPTION
## Summary
- integrate Sparkle 2.9.4 with opt-in automatic checks and a manual Check Now action
- embed the stable GitHub Releases feed and Actions-provided EdDSA public key
- generate and validate `appcast.xml` from the final notarized ZIP during release
- sign Sparkle helpers with their required entitlement handling
- document key setup, release behavior, Homebrew coexistence, and the one-time pre-Sparkle upgrade

## Validation
- `swift test` (536 tests)
- Sparkle appcast/configuration/version contract tests
- `swiftlint lint --strict --quiet`
- `shellcheck scripts/verify-appcast.sh scripts/sign-and-verify-release.sh`
- `actionlint .github/workflows/release.yml`
- standalone CLI build and `otool` verification that it does not link Sparkle
- Xcode app/widget build with embedded feed/key and automatic checks disabled
- universal arm64+x86_64 release-like app/widget/CLI build
- helper-aware ad-hoc signing, deep signature verification, entitlement comparison, and embedded Session Wake dry-run

## Release setup
The `release` environment now has `SPARKLE_PUBLIC_ED_KEY` and `SPARKLE_PRIVATE_ED_KEY` configured. The private seed also has a local macOS Keychain backup under service `dev.meterbar.sparkle` and account `meterbar`. Release preflight intentionally fails if either value is absent.

The already-shipped v1.7.0 has no Sparkle runtime, so it cannot self-discover v1.7.1; users need one manual/Homebrew upgrade. v1.7.1 establishes the update path for subsequent releases.

Closes #128


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added software update support for direct-download installations through Settings → General → Software Update.
  * Added an option to enable automatic update checks, which are disabled by default.
  * Added signed update feeds and release verification for safer upgrades.

* **Documentation**
  * Updated installation guidance, including the one-time manual upgrade required for versions before 1.7.1.
  * Added setup and release verification documentation for software updates.

* **Bug Fixes**
  * Improved release validation, signing, and version consistency checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->