### PR TITLE
fix(xcode): isolate Debug app identity

### DIFF
--- a/.agents/SESSIONS/2026-07-13.md
+++ b/.agents/SESSIONS/2026-07-13.md
@@ -1,0 +1,31 @@
+# 2026-07-13
+
+## Session 1: Isolate Debug app identity
+
+**Duration:** ~1 hour
+**Status:** Complete
+
+**What was done:**
+- Claimed project issue #149 and separated Debug app/widget identities from the shipped Release identities.
+- Renamed the Debug app product and display name to `MeterBar Dev` so LaunchServices cannot resolve it as the installed release.
+- Added a CI contract check for the effective Debug and Release bundle identifiers, product names, and display names.
+
+**Files changed:**
+- `MeterBar.xcodeproj/project.pbxproj` - Debug-only app/widget identity settings.
+- `scripts/verify-build-identities.sh` - Effective Xcode build-setting assertions.
+- `.github/workflows/ci.yml` - Run the identity contract and compile the Debug product before the universal Release gate.
+- `.agents/SYSTEM/ARCHITECTURE.md` - Document configuration-specific identities.
+
+**Verification:**
+- `scripts/verify-build-identities.sh`: Debug and Release identities verified.
+- `bash -n scripts/verify-build-identities.sh`: passed.
+- `shellcheck scripts/verify-build-identities.sh`: passed.
+- `swiftlint lint --strict`: passed.
+- `git diff --check`: passed.
+- Local tests and builds intentionally skipped under the workstation policy; PR CI is the broad validation gate.
+
+**Decisions:**
+- Preserve the production app group across configurations so Debug builds can exercise shared-cache behavior while retaining distinct LaunchServices, signing, and widget identities.
+
+**Next steps:**
+- [ ] Review and merge the pull request for issue #149 after CI passes.

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -34,7 +34,9 @@ Three build systems coexist (see `docs/audits/00-repo-map.md` §2):
 Key settings (from `MeterBar.xcodeproj/project.pbxproj`):
 - `MACOSX_DEPLOYMENT_TARGET = 26.0` (Liquid Glass APIs), `SWIFT_VERSION = 5.0` (Swift 5 language mode)
 - App: `ENABLE_APP_SANDBOX = NO` (the app must read other tools' credential/log files and spawn the `claude` binary). Widget: sandboxed. Hardened runtime on for both.
-- Bundle ids `dev.meterbar.app` / `dev.meterbar.app.Widget`; app group `group.dev.meterbar.app`.
+- Release bundle ids `dev.meterbar.app` / `dev.meterbar.app.Widget`; Debug uses
+  `dev.meterbar.app.debug` / `dev.meterbar.app.debug.Widget` and the app product name `MeterBar Dev` so
+  local builds cannot shadow the installed release. Both configurations use app group `group.dev.meterbar.app`.
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,27 @@ jobs:
       - name: Show Xcode version
         run: xcodebuild -version
 
+      - name: Verify Debug and Release identities
+        run: scripts/verify-build-identities.sh
+
       - name: Test release tag validation
         run: scripts/test-release-tag.sh
 
       - name: Build library (SwiftPM)
         run: swift build
+
+      - name: Build Debug app and widget (Xcode)
+        run: |
+          set -euo pipefail
+          xcodebuild -project MeterBar.xcodeproj \
+            -scheme MeterBar \
+            -configuration Debug \
+            -derivedDataPath "$RUNNER_TEMP/MeterBarDebugDerivedData" \
+            -destination 'generic/platform=macOS' \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            build
 
       - name: Build universal app and widget (Xcode)
         run: |

--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -280,7 +280,7 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MeterBarWidget/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = MeterBarWidget;
+				INFOPLIST_KEY_CFBundleDisplayName = "MeterBarWidget Dev";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -289,7 +289,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.7.0;
-				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.Widget;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SKIP_INSTALL = YES;
@@ -492,6 +492,7 @@
 				ENABLE_RESOURCE_ACCESS_USB = NO;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "MeterBar Dev";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -499,8 +500,8 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.7.0;
-				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug;
+				PRODUCT_NAME = "MeterBar Dev";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				REGISTER_APP_GROUPS = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/scripts/verify-build-identities.sh
+++ b/scripts/verify-build-identities.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repository_root=$(cd "$script_dir/.." && pwd)
+project="$repository_root/MeterBar.xcodeproj"
+temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/meterbar-build-identities.XXXXXX")
+trap 'rm -rf "$temporary_directory"' EXIT
+
+read_setting() {
+  local settings_file="$1"
+  local key="$2"
+
+  plutil -extract "0.buildSettings.$key" raw -o - "$settings_file"
+}
+
+assert_setting() {
+  local settings_file="$1"
+  local key="$2"
+  local expected="$3"
+  local actual
+
+  actual=$(read_setting "$settings_file" "$key")
+  if [ "$actual" != "$expected" ]; then
+    echo "$key mismatch: expected '$expected', got '$actual'." >&2
+    exit 1
+  fi
+}
+
+verify_target() {
+  local target="$1"
+  local configuration="$2"
+  local expected_bundle_identifier="$3"
+  local expected_product_name="$4"
+  local expected_full_product_name="$5"
+  local expected_display_name="${6:-}"
+  local settings_file="$temporary_directory/${target}-${configuration}.json"
+
+  xcodebuild \
+    -project "$project" \
+    -scheme "$target" \
+    -configuration "$configuration" \
+    -destination 'generic/platform=macOS' \
+    -showBuildSettings \
+    -json > "$settings_file"
+
+  assert_setting "$settings_file" PRODUCT_BUNDLE_IDENTIFIER "$expected_bundle_identifier"
+  assert_setting "$settings_file" PRODUCT_NAME "$expected_product_name"
+  assert_setting "$settings_file" FULL_PRODUCT_NAME "$expected_full_product_name"
+  if [ -n "$expected_display_name" ]; then
+    assert_setting "$settings_file" INFOPLIST_KEY_CFBundleDisplayName "$expected_display_name"
+  fi
+}
+
+verify_target MeterBar Debug dev.meterbar.app.debug "MeterBar Dev" "MeterBar Dev.app" "MeterBar Dev"
+verify_target MeterBarWidgetExtension Debug \
+  dev.meterbar.app.debug.Widget MeterBarWidgetExtension MeterBarWidgetExtension.appex "MeterBarWidget Dev"
+verify_target MeterBar Release dev.meterbar.app MeterBar MeterBar.app
+verify_target MeterBarWidgetExtension Release \
+  dev.meterbar.app.Widget MeterBarWidgetExtension MeterBarWidgetExtension.appex MeterBarWidget
+
+echo "Debug and Release app/widget identities verified."


### PR DESCRIPTION
## Summary

- give Debug builds the distinct `MeterBar Dev` product/display name and `dev.meterbar.app.debug` bundle identifier
- give the Debug widget the matching `dev.meterbar.app.debug.Widget` identity while preserving all Release identifiers
- add an effective-build-settings contract and a real Debug app/widget build to PR CI

## Why

LaunchServices could register stale DerivedData Debug products as `MeterBar.app` with the production bundle identifier, causing name-based launches to open an old development build instead of `/Applications/MeterBar.app`.

## Verification

- `scripts/verify-build-identities.sh` — Debug and Release app/widget identities verified
- `bash -n scripts/verify-build-identities.sh` — passed
- `shellcheck scripts/verify-build-identities.sh` — passed
- `actionlint .github/workflows/ci.yml` — passed
- `swiftlint lint --strict --quiet` — passed
- `git diff --check` — passed
- code review — approved with no findings

## Skipped checks / residual risk

- Local tests and builds were not run under the workstation safety policy. PR CI remains the broad gate and now compiles the affected Debug scheme before the existing universal Release build.
- The shared app-group identifier remains unchanged intentionally so Debug builds can exercise the production-shaped shared-cache contract; LaunchServices, signing, TCC, and WidgetKit identities are separated by bundle identifier.

Closes #149
