### PR TITLE
fix(settings): polish settings interactions

### DIFF
--- a/.agents/SESSIONS/2026-07-13.md
+++ b/.agents/SESSIONS/2026-07-13.md
@@ -1,0 +1,66 @@
+# Sessions: 2026-07-13
+
+**Summary:** Settings polish for issue #146
+
+---
+
+## Session 1: Settings polish pass
+
+**Duration:** ~30 minutes
+**Status:** Complete
+
+### System Flow
+
+```mermaid
+flowchart LR
+    A[Settings account row] --> B[Shared label and field columns]
+    B --> C[Stable three-slot actions]
+    A --> D[Resolved default Claude config]
+    D --> E[Reveal in Finder]
+    F[Wake account picker] --> G[Session Wake switch]
+    H[Admin key state] --> I{Connected?}
+    I -->|No| J[Key field, Save, Help]
+    I -->|Yes| K[Masked key, Remove]
+```
+
+### Affected components
+
+| Layer | Components |
+|---|---|
+| Settings UI | Claude account rows, API key rows, Session Wake pane |
+| Model utility | Default Claude config-directory resolution |
+| Tests | Claude config-directory resolution fixtures |
+
+### What was done
+
+- [x] Aligned Claude account name/config columns and fixed action slots.
+- [x] Added default-config explanatory copy and Finder reveal action.
+- [x] Moved the wake-account prerequisite above an explicit switch-style toggle.
+- [x] Added connected/disconnected progressive disclosure for admin keys.
+- [x] Added focused path-resolution tests and passed strict SwiftLint/diff checks.
+
+### Files changed
+
+- `MeterBar/Models/ClaudeCodeAccount.swift` - resolves the effective default Claude config directory.
+- `MeterBar/Views/SettingsView.swift` - account-row and admin-key UI polish.
+- `MeterBar/Views/SessionWakeSettingsView.swift` - prerequisite ordering and switch style.
+- `MeterBarTests/ClaudeCodeAccountStoreTests.swift` - default-path resolution coverage.
+
+### Key decisions
+
+- **Decision:** Match the existing `CodexHomeDirectory` injectable resolver pattern inside the existing Claude account model.
+  - **Rationale:** Keeps environment handling deterministic and testable without introducing another service.
+- **Decision:** Reserve the unavailable default-profile delete action with an accessibility-hidden layout slot.
+  - **Rationale:** All visible actions remain aligned without exposing an inert control.
+
+### Mistakes and fixes
+
+_None._
+
+### Next steps
+
+- [ ] Let pull-request CI run tests, coverage, and Xcode builds under the workstation safety policy.
+
+---
+
+**Total sessions today:** 1

--- a/MeterBar/Models/ClaudeCodeAccount.swift
+++ b/MeterBar/Models/ClaudeCodeAccount.swift
@@ -24,6 +24,27 @@ nonisolated struct ClaudeCodeAccount: Codable, Equatable, Identifiable, Sendable
     var isDefault: Bool {
         id == Self.defaultID
     }
+
+    /// Resolves the default Claude CLI profile directory for user-facing paths
+    /// and Finder actions without mutating the process environment in tests.
+    static func defaultConfigDirectory(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        realHomeDirectory: String = ServiceSupport.realHomeDirectory()
+    ) -> String {
+        guard let rawValue = environment["CLAUDE_CONFIG_DIR"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !rawValue.isEmpty else {
+            return (realHomeDirectory as NSString).appendingPathComponent(".claude")
+        }
+
+        if rawValue == "~" {
+            return realHomeDirectory
+        }
+        if rawValue.hasPrefix("~/") {
+            return (realHomeDirectory as NSString).appendingPathComponent(String(rawValue.dropFirst(2)))
+        }
+        return (rawValue as NSString).standardizingPath
+    }
 }
 
 // MARK: - ClaudeCodeAccountStore

--- a/MeterBar/Views/SessionWakeSettingsView.swift
+++ b/MeterBar/Views/SessionWakeSettingsView.swift
@@ -68,8 +68,8 @@ struct SessionWakeSettingsView: View {
     }
 
     @ViewBuilder private var sections: some View {
-        switchSection
         accountSection
+        switchSection
         previewSection
         limitsSection
         permissionSection
@@ -82,8 +82,9 @@ struct SessionWakeSettingsView: View {
         Section("Session Wake") {
             Toggle("Session Wake", isOn: onBinding)
                 .disabled(!store.canTurnOn && !store.isOn)
+                .toggleStyle(.switch)
             if store.wakeAccountID == nil {
-                Text("Choose a wake account below to enable Session Wake.")
+                Text("Choose a wake account above to enable Session Wake.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -1618,20 +1618,26 @@ private struct AdminKeySettingsRow: View {
             }
 
             HStack(spacing: 8) {
-                SecureField(placeholder, text: $draft)
-                    .settingsInput()
-                    .frame(minWidth: 220, maxWidth: 340)
+                if connected {
+                    SettingsReadonlyField(text: "••••••••••••••••")
 
-                Button("Save", action: onSave)
-                    .buttonStyle(.borderedProminent)
-                    .disabled(trimmedDraft.isEmpty)
+                    Button("Remove", role: .destructive, action: onRemove)
+                        .buttonStyle(.bordered)
+                } else {
+                    SecureField(placeholder, text: $draft)
+                        .settingsInput()
+                        .frame(minWidth: 220, maxWidth: 340)
 
-                Button("Remove", action: onRemove)
+                    Button("Save", action: onSave)
+                        .buttonStyle(.borderedProminent)
+                        .disabled(trimmedDraft.isEmpty)
+
+                    Button(action: onHelp) {
+                        Image(systemName: "questionmark.circle")
+                    }
                     .buttonStyle(.bordered)
-                    .disabled(!connected)
-
-                Button("Help", action: onHelp)
-                    .buttonStyle(.bordered)
+                    .help("Where to create this admin API key")
+                }
             }
         }
         .padding(.vertical, 6)
@@ -1753,6 +1759,12 @@ private struct AddClaudeAccountSheet: View {
 
 // MARK: - AccountProfileRow
 
+private enum AccountProfileRowMetrics {
+    static let labelWidth: CGFloat = 126
+    static let fieldWidth: CGFloat = 280
+    static let actionWidth: CGFloat = 28
+}
+
 private struct AccountProfileRow: View {
     // MARK: Lifecycle
 
@@ -1785,8 +1797,10 @@ private struct AccountProfileRow: View {
 
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 8) {
+                    accountFieldLabel("Account name")
+
                     TextField("Account label", text: $nameDraft)
-                        .settingsInput(width: 240)
+                        .settingsInput(width: AccountProfileRowMetrics.fieldWidth)
                         .onSubmit(saveChanges)
 
                     Text(account.isDefault ? "Default" : "Profile")
@@ -1801,18 +1815,22 @@ private struct AccountProfileRow: View {
                 }
 
                 HStack(spacing: 8) {
-                    Text(account.isDefault ? "Default config directory" : "Config directory")
-                        .font(.caption2)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(.secondary)
-                        .frame(width: 126, alignment: .leading)
+                    accountFieldLabel(account.isDefault ? "Default config directory" : "Config directory")
 
                     if account.isDefault {
                         SettingsReadonlyField(text: displayConfigDirectory)
+
+                        Button {
+                            revealDefaultConfigDirectory()
+                        } label: {
+                            Image(systemName: "folder")
+                        }
+                        .buttonStyle(.bordered)
+                        .help("Reveal config directory in Finder")
                     } else {
                         HStack(spacing: 8) {
                             TextField("Config directory", text: $configDirectoryDraft)
-                                .settingsInput(width: 280)
+                                .settingsInput(width: AccountProfileRowMetrics.fieldWidth)
                                 .onSubmit(saveChanges)
 
                             Button {
@@ -1825,6 +1843,13 @@ private struct AccountProfileRow: View {
                         }
                     }
                 }
+
+                if account.isDefault {
+                    Text("Mirrors the Claude CLI default (~/.claude, or $CLAUDE_CONFIG_DIR)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .padding(.leading, AccountProfileRowMetrics.labelWidth + 8)
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -1834,6 +1859,7 @@ private struct AccountProfileRow: View {
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
+                .frame(width: AccountProfileRowMetrics.actionWidth)
                 .help("Reconnect Claude profile")
 
                 Button(action: saveChanges) {
@@ -1841,6 +1867,7 @@ private struct AccountProfileRow: View {
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
+                .frame(width: AccountProfileRowMetrics.actionWidth)
                 .disabled(!hasChanges || !canSave)
                 .help("Save account changes")
 
@@ -1850,10 +1877,15 @@ private struct AccountProfileRow: View {
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
+                    .frame(width: AccountProfileRowMetrics.actionWidth)
                     .help("Delete account")
+                } else {
+                    Color.clear
+                        .frame(width: AccountProfileRowMetrics.actionWidth, height: 1)
+                        .accessibilityHidden(true)
                 }
             }
-            .frame(minWidth: 116, alignment: .trailing)
+            .fixedSize()
         }
         .padding(.vertical, 10)
         .onChange(of: account) { _, updatedAccount in
@@ -1878,7 +1910,7 @@ private struct AccountProfileRow: View {
     private var displayConfigDirectory: String {
         account.configDirectory?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
             ? account.configDirectory ?? ""
-            : "\(ServiceSupport.realHomeDirectory())/.claude"
+            : ClaudeCodeAccount.defaultConfigDirectory()
     }
 
     private var hasChanges: Bool {
@@ -1895,6 +1927,20 @@ private struct AccountProfileRow: View {
             return
         }
         onSave(trimmedName, account.isDefault ? nil : trimmedConfigDirectory)
+    }
+
+    private func accountFieldLabel(_ title: String) -> some View {
+        Text(title)
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .foregroundStyle(.secondary)
+            .frame(width: AccountProfileRowMetrics.labelWidth, alignment: .leading)
+    }
+
+    private func revealDefaultConfigDirectory() {
+        NSWorkspace.shared.activateFileViewerSelecting([
+            URL(fileURLWithPath: ClaudeCodeAccount.defaultConfigDirectory(), isDirectory: true)
+        ])
     }
 
     private func chooseConfigDirectory() {

--- a/MeterBarTests/ClaudeCodeAccountStoreTests.swift
+++ b/MeterBarTests/ClaudeCodeAccountStoreTests.swift
@@ -33,6 +33,30 @@ final class ClaudeCodeAccountStoreTests: XCTestCase {
         XCTAssertEqual(reloaded.accounts.first?.name, "shipshitdev")
     }
 
+    func testDefaultConfigDirectoryFallsBackToClaudeUnderRealHome() {
+        XCTAssertEqual(
+            ClaudeCodeAccount.defaultConfigDirectory(environment: [:], realHomeDirectory: "/Users/tester"),
+            "/Users/tester/.claude"
+        )
+    }
+
+    func testDefaultConfigDirectoryHonorsAndExpandsEnvironmentOverride() {
+        XCTAssertEqual(
+            ClaudeCodeAccount.defaultConfigDirectory(
+                environment: ["CLAUDE_CONFIG_DIR": "~/.claude-work"],
+                realHomeDirectory: "/Users/tester"
+            ),
+            "/Users/tester/.claude-work"
+        )
+        XCTAssertEqual(
+            ClaudeCodeAccount.defaultConfigDirectory(
+                environment: ["CLAUDE_CONFIG_DIR": " /Volumes/config/claude "],
+                realHomeDirectory: "/Users/tester"
+            ),
+            "/Volumes/config/claude"
+        )
+    }
+
     func testCustomProfileCanBeEditedAndPersists() {
         let store = ClaudeCodeAccountStore(userDefaults: defaults)
         store.addAccount(name: "genfeed.ai", configDirectory: "/tmp/old-claude-profile")


### PR DESCRIPTION
## Summary

- align Claude account labels, fields, and fixed three-slot action columns
- explain and reveal the resolved default Claude config directory
- place the Session Wake account prerequisite before an explicit switch control
- progressively disclose admin-key actions for connected and disconnected states

## Verification

- PR CI tests + coverage — 535 tests, 3 credential-gated skips, 0 failures; 41.7% coverage (19% threshold)
- PR CI universal app/widget/CLI build and nested-bundle verification — passed
- PR CI SwiftLint and secret scan — passed
- CodeRabbit and final correctness/security/regression review — approved with no findings
- local `swiftlint lint --strict --quiet` — passed
- local `git diff --check` — passed

## Skipped checks / residual risk

- Local tests, coverage, SwiftPM/Xcode builds, and user-facing launch checks were not run under the workstation safety policy; equivalent broad PR CI gates passed.
- Credential-backed Claude, Codex, and Cursor integration checks were skipped in CI because credentials are intentionally unavailable.
- Native visual alignment carries low residual visual risk until reviewed in a running Settings window.

Closes #146
