### PR TITLE
feat(openrouter): add provider support

### DIFF
--- a/.agents/SESSIONS/2026-07-13.md
+++ b/.agents/SESSIONS/2026-07-13.md
@@ -1,0 +1,25 @@
+# Sessions: 2026-07-13
+
+## Session 1: OpenRouter Provider
+
+**Status:** Complete
+
+### What was done
+
+- Added opt-in OpenRouter tracking through the documented credits and key endpoints.
+- Stored the API key in Keychain and added settings validation/error recovery.
+- Added app, popover, dashboard, widget, CLI, notification, doctor, and provider-status coverage.
+- Added fixture-driven response mapping and provider visibility/readiness tests.
+
+### Verification
+
+- `COVERAGE_THRESHOLD=19 bash scripts/check-coverage.sh` — 540 tests passed; 42.6% line coverage.
+- Focused Keychain, OpenRouter, readiness, visibility, and provider-status tests — passed.
+- `swiftlint lint --strict --quiet` — passed.
+- `swift build --package-path MeterBarCLI` — passed.
+- Debug app/widget Xcode build with code signing disabled — passed.
+
+### Decisions
+
+- OpenRouter is disabled by default because it requires an explicitly supplied API key.
+- Account credits use the shared weekly slot and per-key caps use the shared session slot, with currency-specific labels on every user-facing surface.

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -16,6 +16,7 @@ Providers tracked:
 | Claude Code | `.claudeCode` | Shells out to `claude /usage`, regex-parses terminal output. Legacy OAuth fallback (keychain item `Claude Code-credentials`) behind the `ClaudeCodeEnableOAuthFallback` UserDefaults flag |
 | OpenAI Codex CLI | `.codexCli` | Reads `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`), calls `https://chatgpt.com/backend-api/wham/usage` |
 | Cursor | `.cursor` | Reads session JWT from Cursor's `state.vscdb` SQLite, calls `https://cursor.com/api/usage-summary` |
+| OpenRouter | `.openRouter` | User-provided API key in Keychain; calls documented `/api/v1/credits` and `/api/v1/key` endpoints |
 | Claude (admin) | `.claude` | Anthropic Admin API key (user-provided, stored in our keychain), `/v1/organizations/usage_report/messages` |
 | OpenAI (admin) | `.openai` | OpenAI Admin API key (user-provided, stored in our keychain), `/v1/organization/usage/completions` |
 
@@ -67,6 +68,7 @@ meterbar/
 - **ClaudeCodeLocalService** — CLI-first wrapper; legacy OAuth fallback + best-effort "extra usage" probe against `api.anthropic.com/api/oauth/usage`.
 - **CodexCliLocalService** — Codex auth file + wham/usage endpoint; maps credits/spend to `ExtraUsageStatus` (safety-biased: never false "Off").
 - **CursorLocalService** — SQLite token extraction + usage-summary endpoint; assumed 500-request default quota when API omits totals.
+- **OpenRouterService** — opt-in API-key provider; maps account credits/spend and optional per-key caps into shared metrics.
 - **ClaudeService / OpenAIService** — admin-key usage reports (paginated, 50-page cap) via `ServiceSupport.fetchDecoded`.
 - **CostTracker** (1,029 lines) — JSONL/SQLite log scanning, per-model pricing table, per-day/model/origin breakdowns, cache at `~/Library/Application Support/MeterBar/cost-summary-v1.json`.
 - **AuthenticationManager + KeychainManager** — the two admin keys, stored in keychain service `dev.meterbar.app`. Reads migrate the older `dev.shipshit.meterbar` (v1.6.x) and `com.agenticindiedev.quotaguard` (v1.0-v1.6) services into the current one, and removals delete all three so a legacy key cannot reappear.

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -14,6 +14,8 @@ nonisolated enum StorageKeys {
     static let refreshInterval = "refreshInterval"
     /// Raw values of ServiceTypes the user has hidden.
     static let hiddenProviderServices = "HiddenProviderServices"
+    /// OpenRouter is API-key backed and must be explicitly enabled.
+    static let openRouterProviderEnabled = "OpenRouterProviderEnabled"
     /// Whether the Dock icon is shown (menu bar item is unaffected).
     static let showInDock = "ShowMeterBarInDock"
     /// Enables the legacy Claude Code OAuth fallback when the CLI is unavailable.

--- a/MeterBar/Services/KeychainManager.swift
+++ b/MeterBar/Services/KeychainManager.swift
@@ -6,7 +6,7 @@ import Security
 /// fake instead of the real login keychain (which is unavailable / prompts on
 /// CI runners). Signatures mirror the C API 1:1 so the production backend is a
 /// thin pass-through.
-protocol KeychainBackend {
+nonisolated protocol KeychainBackend {
     func update(query: [String: Any], attributes: [String: Any]) -> OSStatus
     func add(query: [String: Any]) -> OSStatus
     func copyMatching(query: [String: Any], result: inout AnyObject?) -> OSStatus
@@ -14,7 +14,7 @@ protocol KeychainBackend {
 }
 
 /// Production backend: forwards straight to the Security framework.
-struct SecItemKeychainBackend: KeychainBackend {
+nonisolated struct SecItemKeychainBackend: KeychainBackend {
     func update(query: [String: Any], attributes: [String: Any]) -> OSStatus {
         SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
     }
@@ -33,7 +33,7 @@ struct SecItemKeychainBackend: KeychainBackend {
 }
 
 /// Minimal Keychain wrapper for the org API admin keys entered in Settings.
-final class KeychainManager {
+nonisolated final class KeychainManager {
     static let shared = KeychainManager()
 
     private let currentService: String

--- a/MeterBar/Services/NotificationDecider.swift
+++ b/MeterBar/Services/NotificationDecider.swift
@@ -194,9 +194,9 @@ struct NotificationDecider {
         func displayName(for service: ServiceType) -> String {
             switch self {
             case .session:
-                return "Session"
+                return service == .openRouter ? "Key Limit" : "Session"
             case .weekly:
-                return "Weekly"
+                return service == .openRouter ? "Account Credits" : "Weekly"
             case .codeReview:
                 return service == .claudeCode ? "Sonnet" : "Code Review"
             }

--- a/MeterBar/Services/OpenRouterService.swift
+++ b/MeterBar/Services/OpenRouterService.swift
@@ -1,0 +1,190 @@
+import Combine
+import Foundation
+import MeterBarShared
+
+/// Fetches OpenRouter account credits and optional per-key spending limits.
+/// The API key is stored in MeterBar's Keychain service and is only sent to
+/// OpenRouter's documented `/api/v1/credits` and `/api/v1/key` endpoints.
+final class OpenRouterService: ObservableObject {
+    nonisolated static let shared = OpenRouterService()
+    nonisolated static let keychainKey = "openRouterAPIKey"
+
+    @Published private(set) var hasAccess: Bool
+    @Published private(set) var lastError: ServiceError?
+
+    private let keychain: KeychainManager
+    private let fetchData: (URLRequest) async throws -> Data
+
+    init(
+        keychain: KeychainManager = .shared,
+        fetchData: ((URLRequest) async throws -> Data)? = nil
+    ) {
+        self.keychain = keychain
+        self.fetchData = fetchData ?? Self.fetch
+        hasAccess = keychain.hasKey(key: Self.keychainKey)
+    }
+
+    @discardableResult
+    func saveAPIKey(_ value: String) -> Bool {
+        let key = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !key.isEmpty, keychain.save(key: Self.keychainKey, value: key) else {
+            return false
+        }
+        hasAccess = true
+        lastError = nil
+        return true
+    }
+
+    @discardableResult
+    func removeAPIKey() -> Bool {
+        let deleted = keychain.delete(key: Self.keychainKey)
+        hasAccess = keychain.hasKey(key: Self.keychainKey)
+        if !hasAccess {
+            lastError = nil
+        }
+        return deleted
+    }
+
+    func fetchUsageMetrics() async throws -> UsageMetrics {
+        guard let apiKey = keychain.get(key: Self.keychainKey) else {
+            let error = ServiceError.notAuthenticated
+            lastError = error
+            hasAccess = false
+            throw error
+        }
+
+        do {
+            async let creditsData = fetchData(try Self.request(path: "credits", apiKey: apiKey))
+            async let keyData = fetchData(try Self.request(path: "key", apiKey: apiKey))
+            let decoder = JSONDecoder()
+            let credits = try decoder.decode(OpenRouterCreditsResponse.self, from: await creditsData)
+            let key = try decoder.decode(OpenRouterKeyResponse.self, from: await keyData)
+            let metrics = Self.map(credits: credits.data, key: key.data)
+            hasAccess = true
+            lastError = nil
+            return metrics
+        } catch {
+            let serviceError = ServiceSupport.serviceError(from: error)
+            lastError = serviceError
+            if case .notAuthenticated = serviceError {
+                hasAccess = false
+            }
+            throw serviceError
+        }
+    }
+
+    static func map(
+        credits: OpenRouterCredits,
+        key: OpenRouterKey,
+        now: Date = Date(),
+        calendar: Calendar = Calendar(identifier: .gregorian)
+    ) -> UsageMetrics {
+        let accountCredits = UsageLimit(
+            used: credits.totalUsage,
+            total: credits.totalCredits,
+            resetTime: nil
+        )
+
+        let keyLimit: UsageLimit? = {
+            guard let limit = key.limit, limit > 0 else { return nil }
+            let used = key.limitRemaining.map { max(0, limit - $0) } ?? min(key.usage, limit)
+            let reset = resetWindow(key.limitReset, now: now, calendar: calendar)
+            return UsageLimit(
+                used: used,
+                total: limit,
+                resetTime: reset.date,
+                windowSeconds: reset.windowSeconds
+            )
+        }()
+
+        return UsageMetrics(
+            service: .openRouter,
+            sessionLimit: keyLimit,
+            weeklyLimit: accountCredits,
+            lastUpdated: now
+        )
+    }
+
+    private static func request(path: String, apiKey: String) throws -> URLRequest {
+        guard let url = URL(string: "https://openrouter.ai/api/v1/\(path)") else {
+            throw ServiceError.invalidURL
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        return request
+    }
+
+    private static func fetch(_ request: URLRequest) async throws -> Data {
+        let (data, response) = try await ServiceSupport.session.data(for: request)
+        try ServiceSupport.validate(response, data: data)
+        return data
+    }
+
+    private static func resetWindow(
+        _ rawValue: String?,
+        now: Date,
+        calendar: Calendar
+    ) -> (date: Date?, windowSeconds: TimeInterval?) {
+        guard let rawValue else { return (nil, nil) }
+        var utc = calendar
+        utc.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+
+        switch rawValue.lowercased() {
+        case "daily":
+            let start = utc.startOfDay(for: now)
+            return (utc.date(byAdding: .day, value: 1, to: start), 86_400)
+        case "weekly":
+            let start = utc.dateInterval(of: .weekOfYear, for: now)?.start
+            return (start.flatMap { utc.date(byAdding: .weekOfYear, value: 1, to: $0) }, 604_800)
+        case "monthly":
+            let start = utc.dateInterval(of: .month, for: now)?.start
+            return (start.flatMap { utc.date(byAdding: .month, value: 1, to: $0) }, nil)
+        default:
+            return (nil, nil)
+        }
+    }
+}
+
+struct OpenRouterCreditsResponse: Codable {
+    let data: OpenRouterCredits
+}
+
+struct OpenRouterCredits: Codable {
+    let totalCredits: Double
+    let totalUsage: Double
+
+    enum CodingKeys: String, CodingKey {
+        case totalCredits = "total_credits"
+        case totalUsage = "total_usage"
+    }
+}
+
+struct OpenRouterKeyResponse: Codable {
+    let data: OpenRouterKey
+}
+
+struct OpenRouterKey: Codable {
+    let label: String?
+    let limit: Double?
+    let limitReset: String?
+    let limitRemaining: Double?
+    let usage: Double
+    let usageDaily: Double?
+    let usageWeekly: Double?
+    let usageMonthly: Double?
+    let isFreeTier: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case label
+        case limit
+        case limitReset = "limit_reset"
+        case limitRemaining = "limit_remaining"
+        case usage
+        case usageDaily = "usage_daily"
+        case usageWeekly = "usage_weekly"
+        case usageMonthly = "usage_monthly"
+        case isFreeTier = "is_free_tier"
+    }
+}

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -30,7 +30,8 @@ nonisolated public enum ProviderReadinessInspector {
             now: now,
             claudeReport: { claudeReport(refreshError: $0, now: $1) },
             codexReport: { codexReport(refreshError: $0, now: $1) },
-            cursorReport: { cursorReport(refreshError: $0, now: $1) }
+            cursorReport: { cursorReport(refreshError: $0, now: $1) },
+            openRouterReport: { error, _ in openRouterReport(refreshError: error) }
         )
     }
 
@@ -43,7 +44,10 @@ nonisolated public enum ProviderReadinessInspector {
         now: Date,
         claudeReport: (ServiceError?, Date) -> ProviderReadiness,
         codexReport: (ServiceError?, Date) -> ProviderReadiness,
-        cursorReport: (ServiceError?, Date) -> ProviderReadiness
+        cursorReport: (ServiceError?, Date) -> ProviderReadiness,
+        openRouterReport: (ServiceError?, Date) -> ProviderReadiness = { error, _ in
+            ProviderReadinessInspector.openRouterReport(refreshError: error)
+        }
     ) -> [ProviderReadiness] {
         ServiceType.allCases.compactMap { provider in
             guard providers.contains(provider) else { return nil }
@@ -54,6 +58,8 @@ nonisolated public enum ProviderReadinessInspector {
                 return codexReport(refreshErrors[provider], now)
             case .cursor:
                 return cursorReport(refreshErrors[provider], now)
+            case .openRouter:
+                return openRouterReport(refreshErrors[provider], now)
             }
         }
     }
@@ -136,6 +142,18 @@ nonisolated public enum ProviderReadinessInspector {
             now: now
         )
         return ProviderReadinessEvaluator.cursor(input)
+    }
+
+    static func openRouterReport(
+        refreshError: ServiceError? = nil,
+        hasAPIKey: () -> Bool = { KeychainManager.shared.hasKey(key: OpenRouterService.keychainKey) }
+    ) -> ProviderReadiness {
+        ProviderReadinessEvaluator.openRouter(
+            OpenRouterReadinessInput(
+                hasAPIKey: hasAPIKey(),
+                refreshError: sanitize(refreshError)
+            )
+        )
     }
 
     // MARK: - Helpers

--- a/MeterBar/Services/ProviderStatusMonitor.swift
+++ b/MeterBar/Services/ProviderStatusMonitor.swift
@@ -144,6 +144,8 @@ extension ServiceType {
             return "OpenAI"
         case .cursor:
             return "Cursor"
+        case .openRouter:
+            return "OpenRouter"
         }
     }
 
@@ -155,6 +157,8 @@ extension ServiceType {
             return "https://status.openai.com/"
         case .cursor:
             return "https://status.cursor.com/"
+        case .openRouter:
+            return "https://status.openrouter.ai/"
         }
     }
 
@@ -277,6 +281,9 @@ struct ProviderStatusClient {
     let session: URLSession
 
     func fetchReport(for service: ServiceType) async throws -> ProviderStatusReport {
+        if service == .openRouter {
+            return try await fetchOpenRouterReport()
+        }
         guard let baseURL = service.statusPageURL else {
             throw ServiceError.invalidURL
         }
@@ -289,6 +296,30 @@ struct ProviderStatusClient {
             pageURL: baseURL,
             summary: parsedStatus.summary,
             components: components,
+            fetchedAt: Date()
+        )
+    }
+
+    private func fetchOpenRouterReport() async throws -> ProviderStatusReport {
+        guard let url = ServiceType.openRouter.statusPageURL else {
+            throw ServiceError.invalidURL
+        }
+        let (data, response) = try await session.data(from: url)
+        try ServiceSupport.validate(response, data: data)
+        guard let html = String(data: data, encoding: .utf8) else {
+            throw ServiceError.parsingError
+        }
+        let operational = html.localizedCaseInsensitiveContains("All Systems Operational")
+        return ProviderStatusReport(
+            service: .openRouter,
+            pageName: "OpenRouter",
+            pageURL: url,
+            summary: ProviderStatusSummary(
+                indicator: operational ? .none : .unknown,
+                description: operational ? "All Systems Operational" : "Check the OpenRouter status page",
+                updatedAt: nil
+            ),
+            components: [],
             fetchedAt: Date()
         )
     }

--- a/MeterBar/Services/ProviderVisibilityStore.swift
+++ b/MeterBar/Services/ProviderVisibilityStore.swift
@@ -36,12 +36,18 @@ final class ProviderVisibilityStore: ObservableObject {
 
         guard nextHiddenServices != hiddenServices else { return }
         hiddenServices = nextHiddenServices
+        if service == .openRouter {
+            userDefaults.set(enabled, forKey: StorageKeys.openRouterProviderEnabled)
+        }
         save()
     }
 
     private func load() {
         let rawValues = userDefaults.stringArray(forKey: storageKey) ?? []
         hiddenServices = Set(rawValues.compactMap(ServiceType.init(rawValue:)))
+        if !userDefaults.bool(forKey: StorageKeys.openRouterProviderEnabled) {
+            hiddenServices.insert(.openRouter)
+        }
     }
 
     private func save() {

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -16,6 +16,7 @@ protocol SimpleUsageProviding: AnyObject {
 
 extension CodexCliLocalService: SimpleUsageProviding {}
 extension CursorLocalService: SimpleUsageProviding {}
+extension OpenRouterService: SimpleUsageProviding {}
 
 @MainActor
 class UsageDataManager: ObservableObject {
@@ -40,6 +41,7 @@ class UsageDataManager: ObservableObject {
     private let claudeCodeService: ClaudeCodeLocalService
     private let cursorService: SimpleUsageProviding
     private let codexCliService: SimpleUsageProviding
+    private let openRouterService: SimpleUsageProviding
     private let claudeCodeAccountStore: ClaudeCodeAccountStore
     private let providerVisibilityStore: ProviderVisibilityStore
 
@@ -57,6 +59,7 @@ class UsageDataManager: ObservableObject {
     init(
         codexCliService: SimpleUsageProviding = CodexCliLocalService.shared,
         cursorService: SimpleUsageProviding = CursorLocalService.shared,
+        openRouterService: SimpleUsageProviding = OpenRouterService.shared,
         claudeCodeService: ClaudeCodeLocalService = .shared,
         claudeCodeAccountStore: ClaudeCodeAccountStore? = nil,
         providerVisibilityStore: ProviderVisibilityStore? = nil,
@@ -66,6 +69,7 @@ class UsageDataManager: ObservableObject {
     ) {
         self.codexCliService = codexCliService
         self.cursorService = cursorService
+        self.openRouterService = openRouterService
         self.claudeCodeService = claudeCodeService
         self.claudeCodeAccountStore = claudeCodeAccountStore ?? .shared
         self.providerVisibilityStore = providerVisibilityStore ?? .shared
@@ -99,7 +103,7 @@ class UsageDataManager: ObservableObject {
 
         // Fetch the simple (single-account) providers. On failure the final
         // merge loop below preserves any cached metrics (graceful degradation).
-        for service in [ServiceType.codexCli, .cursor]
+        for service in [ServiceType.codexCli, .cursor, .openRouter]
         where providerVisibilityStore.isEnabled(service) && hasProviderAccess(service) {
             do {
                 newMetrics[service] = try await fetchSimpleProviderMetrics(service)
@@ -159,7 +163,7 @@ class UsageDataManager: ObservableObject {
                     // hold a stale error from an unrelated provider/account.
                     throw ServiceError.notAuthenticated
                 }
-            case .codexCli, .cursor:
+            case .codexCli, .cursor, .openRouter:
                 guard hasProviderAccess(service) else {
                     throw ServiceError.notAuthenticated
                 }
@@ -261,6 +265,8 @@ class UsageDataManager: ObservableObject {
             return codexCliService.hasAccess
         case .cursor:
             return cursorService.hasAccess
+        case .openRouter:
+            return openRouterService.hasAccess
         }
     }
 
@@ -272,6 +278,8 @@ class UsageDataManager: ObservableObject {
             return try await codexCliService.fetchUsageMetrics()
         case .cursor:
             return try await cursorService.fetchUsageMetrics()
+        case .openRouter:
+            return try await openRouterService.fetchUsageMetrics()
         case .claudeCode:
             preconditionFailure("Claude Code uses the account-aware fetch path")
         }

--- a/MeterBar/Views/Components/ProviderComponents.swift
+++ b/MeterBar/Views/Components/ProviderComponents.swift
@@ -12,6 +12,7 @@ enum ProviderLogoKind: Equatable {
     case claude
     case cursor
     case openai
+    case openRouter
 
     static func forService(_ service: ServiceType) -> ProviderLogoKind {
         switch service {
@@ -21,6 +22,8 @@ enum ProviderLogoKind: Equatable {
             return .claude
         case .cursor:
             return .cursor
+        case .openRouter:
+            return .openRouter
         }
     }
 
@@ -45,6 +48,8 @@ enum ProviderLogoKind: Equatable {
             return "ProviderIcon-cursor"
         case .openai:
             return "ProviderIcon-openai"
+        case .openRouter:
+            return nil
         }
     }
 
@@ -60,6 +65,8 @@ enum ProviderLogoKind: Equatable {
             return ServiceType.cursor.iconName
         case .openai:
             return "brain"
+        case .openRouter:
+            return ServiceType.openRouter.iconName
         }
     }
 }

--- a/MeterBar/Views/DailyUsageChart.swift
+++ b/MeterBar/Views/DailyUsageChart.swift
@@ -559,6 +559,8 @@ struct DailyProviderUsageSummaryRow: View {
       return "Codex"
     case .cursor:
       return "Cursor"
+    case .openRouter:
+      return "OpenRouter"
     }
   }
 }

--- a/MeterBar/Views/DashboardProviderCards.swift
+++ b/MeterBar/Views/DashboardProviderCards.swift
@@ -190,7 +190,7 @@ struct DashboardLimitRow: View {
           .font(.subheadline)
           .bold()
         Spacer()
-        Text(isOut ? "Out" : "\(limit.percentLeft)% left")
+        Text(trailingValue)
           .font(.subheadline)
           .bold()
           .foregroundColor(isOut ? MeterBarTheme.danger : .primary)
@@ -204,7 +204,7 @@ struct DashboardLimitRow: View {
       )
 
       HStack {
-        Text("\(Int(limit.usedPercent.rounded()))% used")
+        Text(usedValue)
           .font(.caption)
           .foregroundColor(.secondary)
         if let pace = limit.usageLimit.pace() {
@@ -224,6 +224,20 @@ struct DashboardLimitRow: View {
         }
       }
     }
+  }
+
+  private var trailingValue: String {
+    if limit.valueStyle == .currency {
+      return "\(UsageFormat.cost(max(0, limit.usageLimit.total - limit.usageLimit.used))) left"
+    }
+    return isOut ? "Out" : "\(limit.percentLeft)% left"
+  }
+
+  private var usedValue: String {
+    if limit.valueStyle == .currency {
+      return "\(UsageFormat.cost(limit.usageLimit.used)) spent"
+    }
+    return "\(Int(limit.usedPercent.rounded()))% used"
   }
 
   private func paceLabelColor(_ pace: UsagePace) -> Color {

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -14,6 +14,7 @@ struct MenuBarView: View {
   @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
   @StateObject private var codexCliService = CodexCliLocalService.shared
   @StateObject private var cursorService = CursorLocalService.shared
+  @StateObject private var openRouterService = OpenRouterService.shared
   @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
   @StateObject private var providerVisibility = ProviderVisibilityStore.shared
   @StateObject private var sessionWakeStore = SessionWakeSettingsStore.shared
@@ -72,7 +73,8 @@ struct MenuBarView: View {
                 enabledServices: providerVisibility.enabledServices,
                 claudeCodeHasAccess: claudeCodeService.hasAccess,
                 codexCliHasAccess: codexCliService.hasAccess,
-                cursorHasAccess: cursorService.hasAccess
+                cursorHasAccess: cursorService.hasAccess,
+                openRouterHasAccess: openRouterService.hasAccess
               )),
             openDashboard: openDashboard,
             openStatusDetail: openStatusDetail,

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -30,6 +30,10 @@ enum MeterBarTheme {
     light: NSColor(srgbRed: 16 / 255, green: 163 / 255, blue: 127 / 255, alpha: 1),
     dark: NSColor(srgbRed: 106 / 255, green: 216 / 255, blue: 185 / 255, alpha: 1)
   )
+  static let openRouterAccent = Color.adaptive(
+    light: NSColor(srgbRed: 105 / 255, green: 82 / 255, blue: 188 / 255, alpha: 1),
+    dark: NSColor(srgbRed: 177 / 255, green: 159 / 255, blue: 255 / 255, alpha: 1)
+  )
 
   /// The app's own accent. Follows the user's system accent color.
   static let appAccent = Color.accentColor
@@ -78,6 +82,8 @@ enum MeterBarTheme {
       return codexAccent
     case .cursor:
       return cursorAccent
+    case .openRouter:
+      return openRouterAccent
     }
   }
 

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -106,6 +106,20 @@ struct SnapshotLimit: Identifiable {
     let kind: Kind
     let title: String
     let usageLimit: UsageLimit
+    let valueStyle: ValueStyle
+
+    enum ValueStyle: Equatable {
+        case quota
+        case currency
+    }
+
+    init(id: String, kind: Kind, title: String, usageLimit: UsageLimit, valueStyle: ValueStyle = .quota) {
+        self.id = id
+        self.kind = kind
+        self.title = title
+        self.usageLimit = usageLimit
+        self.valueStyle = valueStyle
+    }
 
     var usedPercent: Double {
         usageLimit.rawPercentage
@@ -131,6 +145,7 @@ enum ProviderSnapshotBuilder {
         var claudeCodeHasAccess: Bool = false
         var codexCliHasAccess: Bool = false
         var cursorHasAccess: Bool = false
+        var openRouterHasAccess: Bool = false
     }
 
     /// Builds the provider cards in display order (Codex, Claude accounts,
@@ -181,6 +196,15 @@ enum ProviderSnapshotBuilder {
             ))
         }
 
+        if input.enabledServices.contains(.openRouter) {
+            result.append(snapshot(
+                title: "OpenRouter",
+                service: .openRouter,
+                metrics: input.metrics[.openRouter],
+                emptyDetail: input.openRouterHasAccess ? "Waiting for refresh" : "Add an OpenRouter API key"
+            ))
+        }
+
         return result
     }
 
@@ -211,10 +235,22 @@ enum ProviderSnapshotBuilder {
 
         var result: [SnapshotLimit] = []
         if let session = metrics.sessionLimit {
-            result.append(SnapshotLimit(id: "session", kind: .session, title: "Session", usageLimit: session))
+            result.append(SnapshotLimit(
+                id: "session",
+                kind: .session,
+                title: service == .openRouter ? "Key limit" : "Session",
+                usageLimit: session,
+                valueStyle: service == .openRouter ? .currency : .quota
+            ))
         }
         if let weekly = metrics.weeklyLimit {
-            result.append(SnapshotLimit(id: "weekly", kind: .weekly, title: "Weekly", usageLimit: weekly))
+            result.append(SnapshotLimit(
+                id: "weekly",
+                kind: .weekly,
+                title: service == .openRouter ? "Account credits" : "Weekly",
+                usageLimit: weekly,
+                valueStyle: service == .openRouter ? .currency : .quota
+            ))
         }
         if let codeReview = metrics.codeReviewLimit {
             // Claude's third window is the Sonnet-only weekly quota; Codex's is

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -70,6 +70,8 @@ private enum SettingsPane: Hashable, Identifiable {
                 "Codex CLI OAuth"
             case .cursor:
                 "Cursor local state"
+            case .openRouter:
+                "OpenRouter API key"
             }
         }
     }
@@ -172,6 +174,7 @@ struct SettingsView: View {
     @StateObject private var codexCliService = CodexCliLocalService.shared
     @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
     @StateObject private var cursorService = CursorLocalService.shared
+    @StateObject private var openRouterService = OpenRouterService.shared
     @StateObject private var costTracker = CostTracker.shared
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
     @StateObject private var dockVisibility = DockVisibilityStore.shared
@@ -184,6 +187,7 @@ struct SettingsView: View {
     @State private var claudeReconnectError: String?
     @State private var claudeAdminKeyDraft = ""
     @State private var openaiAdminKeyDraft = ""
+    @State private var openRouterKeyDraft = ""
     @State private var selectedPane: SettingsPane = .general
     @State private var providerSearchText = ""
 
@@ -218,7 +222,8 @@ struct SettingsView: View {
                 enabledServices: providerVisibility.enabledServices,
                 claudeCodeHasAccess: claudeCodeService.hasAccess,
                 codexCliHasAccess: codexCliService.hasAccess,
-                cursorHasAccess: cursorService.hasAccess
+                cursorHasAccess: cursorService.hasAccess,
+                openRouterHasAccess: openRouterService.hasAccess
             )
         )
     }
@@ -623,6 +628,11 @@ struct SettingsView: View {
                 detail: "Track Cursor quota from local Cursor state.",
                 service: .cursor
             )
+            providerToggleRow(
+                title: "OpenRouter",
+                detail: "Track credit balance, spend, and per-key limits.",
+                service: .openRouter
+            )
         }
     }
 
@@ -770,6 +780,63 @@ struct SettingsView: View {
                     color: .secondary
                 )
                 SettingsNotice(text: "Log in to Cursor IDE first, then check again.", color: MeterBarTheme.warning)
+            }
+        }
+    }
+
+    private var openRouterSection: some View {
+        SettingsPanelSection(title: "OpenRouter", logoKind: .openRouter, color: MeterBarTheme.openRouterAccent) {
+            SettingsNotice(
+                text: "The key is stored in macOS Keychain and sent only to OpenRouter's credits and key APIs.",
+                color: .secondary
+            )
+
+            SettingsRowView(
+                title: "API key",
+                detail: openRouterService.hasAccess
+                    ? "Configured. Refresh validates access and updates credits."
+                    : "Create a key at openrouter.ai/settings/keys."
+            ) {
+                HStack(spacing: 8) {
+                    if openRouterService.hasAccess {
+                        StatusPill(title: "Configured", isConnected: true)
+                        Button("Remove", role: .destructive) {
+                            openRouterService.removeAPIKey()
+                            Task { await dataManager.refresh(service: .openRouter) }
+                        }
+                        .buttonStyle(.bordered)
+                    } else {
+                        SecureField("sk-or-v1-...", text: $openRouterKeyDraft)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 260)
+
+                        Button("Save & Validate") {
+                            guard openRouterService.saveAPIKey(openRouterKeyDraft) else { return }
+                            openRouterKeyDraft = ""
+                            providerVisibility.set(.openRouter, isEnabled: true)
+                            Task { await dataManager.refresh(service: .openRouter) }
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(openRouterKeyDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+
+                    Button("Get Key") {
+                        if let url = URL(string: "https://openrouter.ai/settings/keys") {
+                            NSWorkspace.shared.open(url)
+                        }
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+
+            if let error = openRouterService.lastError {
+                let detail = switch error {
+                case .notAuthenticated:
+                    "OpenRouter rejected this key. Remove it and add a valid API key."
+                default:
+                    error.localizedDescription
+                }
+                SettingsNotice(text: detail, color: MeterBarTheme.warning)
             }
         }
     }
@@ -1001,6 +1068,8 @@ struct SettingsView: View {
             providerExtraUsageSection(for: service)
         case .cursor:
             cursorSection
+        case .openRouter:
+            openRouterSection
         }
     }
 
@@ -1026,6 +1095,8 @@ struct SettingsView: View {
                 )
             }
         case .cursor:
+            EmptyView()
+        case .openRouter:
             EmptyView()
         }
     }
@@ -1129,6 +1200,8 @@ struct SettingsView: View {
                     codexCli.checkAccess()
                 case .cursor:
                     cursor.checkAccess(forceRescan: true)
+                case .openRouter:
+                    break
                 }
             }.value
             await dataManager.refresh(service: service)
@@ -1143,6 +1216,8 @@ struct SettingsView: View {
             "\(codexAuthFileDisplayPath) + ChatGPT usage API"
         case .cursor:
             "Cursor local state + usage API"
+        case .openRouter:
+            "OpenRouter credits + key APIs"
         }
     }
 
@@ -1201,6 +1276,8 @@ struct SettingsView: View {
             return codexCliService.subscriptionType?.capitalized.nilIfEmpty
         case .cursor:
             return cursorService.subscriptionType?.capitalized.nilIfEmpty
+        case .openRouter:
+            return nil
         }
     }
 
@@ -1212,6 +1289,8 @@ struct SettingsView: View {
             codexCliService.hasAccess
         case .cursor:
             cursorService.hasAccess
+        case .openRouter:
+            openRouterService.hasAccess
         }
     }
 
@@ -1223,6 +1302,8 @@ struct SettingsView: View {
             codexCliService.lastError?.localizedDescription
         case .cursor:
             cursorService.lastError?.localizedDescription
+        case .openRouter:
+            openRouterService.lastError?.localizedDescription
         }
     }
 

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -174,6 +174,7 @@ struct UsageDashboardView: View {
     @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
     @StateObject private var codexCliService = CodexCliLocalService.shared
     @StateObject private var cursorService = CursorLocalService.shared
+    @StateObject private var openRouterService = OpenRouterService.shared
     @StateObject private var apiUsageStore = ApiUsageStore.shared
     @StateObject private var providerStatusMonitor = ProviderStatusMonitor.shared
     @StateObject private var navigation = DashboardNavigationStore.shared
@@ -605,7 +606,8 @@ struct UsageDashboardView: View {
             enabledServices: providerVisibility.enabledServices,
             claudeCodeHasAccess: claudeCodeService.hasAccess,
             codexCliHasAccess: codexCliService.hasAccess,
-            cursorHasAccess: cursorService.hasAccess
+            cursorHasAccess: cursorService.hasAccess,
+            openRouterHasAccess: openRouterService.hasAccess
         ))
         .filter(\.hasMetrics)
     }

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -64,7 +64,7 @@ struct Usage: ParsableCommand {
     @Flag(name: .shortAndLong, help: "Output as JSON")
     var json: Bool = false
 
-    @Option(name: .shortAndLong, help: "Filter by provider (claude, codex, cursor)")
+    @Option(name: .shortAndLong, help: "Filter by provider (claude, codex, cursor, openrouter)")
     var provider: String?
 
     func run() throws {
@@ -120,10 +120,18 @@ struct Usage: ParsableCommand {
             print("▸ \(service.displayName)")
 
             if let session = metric.sessionLimit {
-                printLimit("  Session", session)
+                printLimit(
+                    service == .openRouter ? "  Key limit" : "  Session",
+                    session,
+                    currency: service == .openRouter
+                )
             }
             if let weekly = metric.weeklyLimit {
-                printLimit("  Weekly", weekly)
+                printLimit(
+                    service == .openRouter ? "  Account credits" : "  Weekly",
+                    weekly,
+                    currency: service == .openRouter
+                )
             }
             if let codeReview = metric.codeReviewLimit {
                 printLimit(service == .claudeCode ? "  Sonnet" : "  Code Review", codeReview)
@@ -132,13 +140,17 @@ struct Usage: ParsableCommand {
         }
     }
 
-    private func printLimit(_ label: String, _ limit: UsageLimit) {
+    private func printLimit(_ label: String, _ limit: UsageLimit, currency: Bool = false) {
         let percent = limit.percentage
         let bar = progressBar(percent: percent, width: 20)
         let status = statusEmoji(for: limit)
 
         print("\(label): \(bar) \(String(format: "%.0f%%", percent)) \(status)")
-        print("    \(Int(limit.used))/\(Int(limit.total)) used")
+        if currency {
+            print("    \(UsageFormat.cost(limit.used)) spent / \(UsageFormat.cost(limit.total)) credits")
+        } else {
+            print("    \(Int(limit.used))/\(Int(limit.total)) used")
+        }
         if let reset = limit.resetTime {
             print("    Resets: \(UsageFormat.relative(reset))")
         }
@@ -307,7 +319,7 @@ struct Doctor: ParsableCommand {
     @Flag(name: .shortAndLong, help: "Output as JSON")
     var json: Bool = false
 
-    @Option(name: .shortAndLong, help: "Filter by provider (claude, codex, cursor)")
+    @Option(name: .shortAndLong, help: "Filter by provider (claude, codex, cursor, openrouter)")
     var provider: String?
 
     func run() throws {

--- a/MeterBarTests/KeychainManagerTests.swift
+++ b/MeterBarTests/KeychainManagerTests.swift
@@ -15,7 +15,7 @@ final class KeychainManagerTests: XCTestCase {
     /// and account. Mirrors the real semantics the manager relies on: update on
     /// a missing item returns `errSecItemNotFound`, copy on a missing item
     /// returns `errSecItemNotFound`, and delete is idempotent at the manager.
-    private final class InMemoryKeychainBackend: KeychainBackend {
+    nonisolated private final class InMemoryKeychainBackend: KeychainBackend {
         private struct ItemKey: Hashable {
             let service: String
             let account: String

--- a/MeterBarTests/OpenRouterServiceTests.swift
+++ b/MeterBarTests/OpenRouterServiceTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+final class OpenRouterServiceTests: XCTestCase {
+    func testOfficialCreditAndKeyFixturesMapToCurrencyLimits() throws {
+        let credits = try decodeCredits(#"{"data":{"total_credits":100.5,"total_usage":25.75}}"#)
+        let key = try decodeKey(
+            #"{"data":{"label":"MeterBar","limit":40,"limit_reset":"monthly","limit_remaining":12.5,"usage":27.5,"usage_daily":1.25,"usage_weekly":8,"usage_monthly":20,"is_free_tier":false}}"#
+        )
+        let now = date(2026, 7, 13)
+
+        let metrics = OpenRouterService.map(credits: credits.data, key: key.data, now: now)
+
+        XCTAssertEqual(metrics.service, .openRouter)
+        XCTAssertEqual(metrics.weeklyLimit?.used, 25.75)
+        XCTAssertEqual(metrics.weeklyLimit?.total, 100.5)
+        XCTAssertEqual(metrics.sessionLimit?.used, 27.5)
+        XCTAssertEqual(metrics.sessionLimit?.total, 40)
+        XCTAssertEqual(metrics.sessionLimit?.resetTime, date(2026, 8, 1))
+        XCTAssertNil(metrics.sessionLimit?.windowSeconds)
+    }
+
+    func testUnlimitedKeyOmitsKeyLimitButKeepsAccountCredits() throws {
+        let credits = try decodeCredits(#"{"data":{"total_credits":10,"total_usage":4}}"#)
+        let key = try decodeKey(
+            #"{"data":{"label":"Unlimited","limit":null,"limit_reset":null,"limit_remaining":null,"usage":4,"is_free_tier":false}}"#
+        )
+
+        let metrics = OpenRouterService.map(credits: credits.data, key: key.data)
+
+        XCTAssertNil(metrics.sessionLimit)
+        XCTAssertEqual(metrics.weeklyLimit?.used, 4)
+        XCTAssertEqual(metrics.weeklyLimit?.total, 10)
+    }
+
+    func testZeroBalanceStillProducesVisibleAccountCredits() throws {
+        let credits = try decodeCredits(#"{"data":{"total_credits":0,"total_usage":0}}"#)
+        let key = try decodeKey(
+            #"{"data":{"limit":null,"limit_reset":null,"limit_remaining":null,"usage":0,"is_free_tier":true}}"#
+        )
+
+        let metrics = OpenRouterService.map(credits: credits.data, key: key.data)
+
+        XCTAssertNotNil(metrics.weeklyLimit)
+        XCTAssertEqual(metrics.weeklyLimit?.used, 0)
+        XCTAssertEqual(metrics.weeklyLimit?.total, 0)
+    }
+
+    func testDailyKeyLimitMapsToNextUTCReset() throws {
+        let credits = try decodeCredits(#"{"data":{"total_credits":20,"total_usage":5}}"#)
+        let key = try decodeKey(
+            #"{"data":{"limit":5,"limit_reset":"daily","limit_remaining":2,"usage":3,"is_free_tier":true}}"#
+        )
+
+        let metrics = OpenRouterService.map(
+            credits: credits.data,
+            key: key.data,
+            now: date(2026, 7, 13, 16)
+        )
+
+        XCTAssertEqual(metrics.sessionLimit?.resetTime, date(2026, 7, 14))
+        XCTAssertEqual(metrics.sessionLimit?.windowSeconds, 86_400)
+    }
+
+    private func decodeCredits(_ json: String) throws -> OpenRouterCreditsResponse {
+        try JSONDecoder().decode(OpenRouterCreditsResponse.self, from: Data(json.utf8))
+    }
+
+    private func decodeKey(_ json: String) throws -> OpenRouterKeyResponse {
+        try JSONDecoder().decode(OpenRouterKeyResponse.self, from: Data(json.utf8))
+    }
+
+    private func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int = 0) -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+        return calendar.date(from: DateComponents(year: year, month: month, day: day, hour: hour)) ?? .distantPast
+    }
+}

--- a/MeterBarTests/ProviderReadinessTests.swift
+++ b/MeterBarTests/ProviderReadinessTests.swift
@@ -14,6 +14,20 @@ final class ProviderReadinessTests: XCTestCase {
     // A token value that must never appear in user-facing output.
     private let secret = "SECRET-TOKEN-DO-NOT-LEAK-abc123"
 
+    func testOpenRouterRequiresKeyAndSurfacesSanitizedRefreshFailure() {
+        let missing = ProviderReadinessEvaluator.openRouter(OpenRouterReadinessInput(hasAPIKey: false))
+        XCTAssertEqual(missing.provider, .openRouter)
+        XCTAssertEqual(missing.check("auth")?.level, .fail)
+        XCTAssertTrue((missing.check("auth")?.recovery ?? "").contains("Settings"))
+
+        let configured = ProviderReadinessEvaluator.openRouter(
+            OpenRouterReadinessInput(hasAPIKey: true, refreshError: "API error (HTTP 401)")
+        )
+        XCTAssertEqual(configured.check("auth")?.level, .pass)
+        XCTAssertEqual(configured.check("refresh")?.level, .fail)
+        XCTAssertFalse(configured.isHealthy)
+    }
+
     // MARK: - Claude Code
 
     func testClaudeHealthy() {

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -35,17 +35,18 @@ final class ProviderSnapshotTests: XCTestCase {
 
     // MARK: - Ordering and inclusion
 
-    func testDisplayOrderIsCodexClaudeCursor() {
+    func testDisplayOrderIsCodexClaudeCursorOpenRouter() {
         let snapshots = ProviderSnapshotBuilder.snapshots(makeInput(
             metrics: [
                 .codexCli: makeMetrics(service: .codexCli, weekly: 10),
                 .claudeCode: makeMetrics(service: .claudeCode, weekly: 20),
-                .cursor: makeMetrics(service: .cursor, weekly: 30)
+                .cursor: makeMetrics(service: .cursor, weekly: 30),
+                .openRouter: makeMetrics(service: .openRouter, weekly: 40)
             ]
         ))
 
-        XCTAssertEqual(snapshots.map(\.service), [.codexCli, .claudeCode, .cursor])
-        XCTAssertEqual(snapshots.map(\.title), ["Codex", "Claude", "Cursor"])
+        XCTAssertEqual(snapshots.map(\.service), [.codexCli, .claudeCode, .cursor, .openRouter])
+        XCTAssertEqual(snapshots.map(\.title), ["Codex", "Claude", "Cursor", "OpenRouter"])
     }
 
     func testDisabledProvidersAreExcluded() {
@@ -62,8 +63,8 @@ final class ProviderSnapshotTests: XCTestCase {
             metrics: [.cursor: makeMetrics(service: .cursor, weekly: 30)]
         ))
 
-        // Popover shows all three (Codex/Claude as empty-state cards)…
-        XCTAssertEqual(snapshots.count, 3)
+        // Popover shows all enabled providers (Codex/Claude/OpenRouter as empty-state cards)…
+        XCTAssertEqual(snapshots.count, 4)
         XCTAssertFalse(snapshots[0].hasMetrics)
         // …the dashboard filters to providers with data.
         XCTAssertEqual(snapshots.filter(\.hasMetrics).map(\.service), [.cursor])
@@ -114,6 +115,16 @@ final class ProviderSnapshotTests: XCTestCase {
 
         XCTAssertEqual(claudeLimits.map(\.title), ["Sonnet"])
         XCTAssertEqual(codexLimits.map(\.title), ["Code Review"])
+    }
+
+    func testOpenRouterUsesCurrencyCreditLabels() {
+        let limits = ProviderSnapshotBuilder.limits(
+            for: makeMetrics(service: .openRouter, session: 10, weekly: 20),
+            service: .openRouter
+        )
+
+        XCTAssertEqual(limits.map(\.title), ["Key limit", "Account credits"])
+        XCTAssertTrue(limits.allSatisfy { $0.valueStyle == .currency })
     }
 
     func testPaceContextComesFromKindNotTitle() {

--- a/MeterBarTests/ProviderStatusMonitorTests.swift
+++ b/MeterBarTests/ProviderStatusMonitorTests.swift
@@ -107,10 +107,35 @@ final class ProviderStatusMonitorTests: XCTestCase {
         XCTAssertEqual(ServiceType.claudeCode.statusPageDisplayName, "Claude")
         XCTAssertEqual(ServiceType.codexCli.statusPageDisplayName, "OpenAI")
         XCTAssertEqual(ServiceType.cursor.statusPageDisplayName, "Cursor")
+        XCTAssertEqual(ServiceType.openRouter.statusPageDisplayName, "OpenRouter")
 
         XCTAssertEqual(try XCTUnwrap(ServiceType.claudeCode.statusPageURL).absoluteString, "https://status.claude.com/")
         XCTAssertEqual(try XCTUnwrap(ServiceType.codexCli.statusPageURL).absoluteString, "https://status.openai.com/")
         XCTAssertEqual(try XCTUnwrap(ServiceType.cursor.statusPageURL).absoluteString, "https://status.cursor.com/")
+        XCTAssertEqual(
+            try XCTUnwrap(ServiceType.openRouter.statusPageURL).absoluteString,
+            "https://status.openrouter.ai/"
+        )
+    }
+
+    func testOpenRouterStatusPageMapsOperationalHTML() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        let client = ProviderStatusClient(session: URLSession(configuration: configuration))
+
+        StubURLProtocol.handler = { request in
+            let url = try XCTUnwrap(request.url)
+            let response = try XCTUnwrap(
+                HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+            )
+            return (response, Data("<h1>All Systems Operational</h1>".utf8))
+        }
+
+        let report = try await client.fetchReport(for: .openRouter)
+
+        XCTAssertEqual(report.service, .openRouter)
+        XCTAssertEqual(report.summary.indicator, .none)
+        XCTAssertFalse(report.hasIssue)
     }
 
     @MainActor

--- a/MeterBarTests/ProviderVisibilityStoreTests.swift
+++ b/MeterBarTests/ProviderVisibilityStoreTests.swift
@@ -1,0 +1,22 @@
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+final class ProviderVisibilityStoreTests: XCTestCase {
+    func testOpenRouterRequiresExplicitOptInAndPersistsEnablement() {
+        let suiteName = "ProviderVisibilityStoreTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Could not create isolated defaults")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let initial = ProviderVisibilityStore(userDefaults: defaults)
+        XCTAssertFalse(initial.isEnabled(.openRouter))
+        XCTAssertTrue(initial.isEnabled(.claudeCode))
+
+        initial.set(.openRouter, isEnabled: true)
+        let reloaded = ProviderVisibilityStore(userDefaults: defaults)
+
+        XCTAssertTrue(reloaded.isEnabled(.openRouter))
+    }
+}

--- a/MeterBarTests/ServiceTypeTests.swift
+++ b/MeterBarTests/ServiceTypeTests.swift
@@ -7,28 +7,32 @@ final class ServiceTypeTests: XCTestCase {
         XCTAssertEqual(ServiceType.claudeCode.rawValue, "Claude Code")
         XCTAssertEqual(ServiceType.codexCli.rawValue, "Codex CLI")
         XCTAssertEqual(ServiceType.cursor.rawValue, "Cursor")
+        XCTAssertEqual(ServiceType.openRouter.rawValue, "OpenRouter")
     }
 
     func testDisplayNames() {
         XCTAssertEqual(ServiceType.claudeCode.displayName, "Claude Code")
         XCTAssertEqual(ServiceType.codexCli.displayName, "OpenAI Codex")
         XCTAssertEqual(ServiceType.cursor.displayName, "Cursor")
+        XCTAssertEqual(ServiceType.openRouter.displayName, "OpenRouter")
     }
 
     func testIconNames() {
         XCTAssertEqual(ServiceType.claudeCode.iconName, "terminal")
         XCTAssertEqual(ServiceType.codexCli.iconName, "terminal.fill")
         XCTAssertEqual(ServiceType.cursor.iconName, "cursorarrow.click")
+        XCTAssertEqual(ServiceType.openRouter.iconName, "point.3.connected.trianglepath.dotted")
     }
 
     func testIdProperty() {
         XCTAssertEqual(ServiceType.claudeCode.id, "Claude Code")
         XCTAssertEqual(ServiceType.codexCli.id, "Codex CLI")
         XCTAssertEqual(ServiceType.cursor.id, "Cursor")
+        XCTAssertEqual(ServiceType.openRouter.id, "OpenRouter")
     }
 
     func testAllCasesCount() {
-        XCTAssertEqual(ServiceType.allCases.count, 3)
+        XCTAssertEqual(ServiceType.allCases.count, 4)
     }
 
     func testCodable() throws {

--- a/MeterBarWidget/UsageWidget.swift
+++ b/MeterBarWidget/UsageWidget.swift
@@ -126,21 +126,25 @@ struct ServiceMiniView: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            Image(metrics.service.assetName)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 14, height: 14)
+            WidgetProviderIcon(service: metrics.service, size: 14)
 
             if let weeklyLimit = metrics.weeklyLimit {
                 ProgressView(value: weeklyLimit.clampedUsed, total: weeklyLimit.clampedTotal)
                     .tint(weeklyLimit.statusColor.color)
-                Text("\(Int(weeklyLimit.percentage))%")
+                Text(limitSummary(weeklyLimit))
                     .font(.caption2)
                     .foregroundColor(.secondary)
             }
 
             WidgetStatusIndicator(status: metrics.overallStatus)
         }
+    }
+
+    private func limitSummary(_ limit: UsageLimit) -> String {
+        if metrics.service == .openRouter {
+            return String(format: "$%.2f", max(0, limit.total - limit.used))
+        }
+        return "\(Int(limit.percentage))%"
     }
 }
 
@@ -206,10 +210,7 @@ struct ServiceCompactView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
-                Image(metrics.service.assetName)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 18, height: 18)
+                WidgetProviderIcon(service: metrics.service, size: 18)
                 Text(metrics.service.displayName)
                     .font(.subheadline)
                     .bold()
@@ -221,11 +222,18 @@ struct ServiceCompactView: View {
                 HStack {
                     ProgressView(value: weeklyLimit.clampedUsed, total: weeklyLimit.clampedTotal)
                         .tint(weeklyLimit.statusColor.color)
-                    Text("\(Int(weeklyLimit.percentage))%")
+                    Text(limitSummary(weeklyLimit))
                         .font(.caption)
                 }
             }
         }
+    }
+
+    private func limitSummary(_ limit: UsageLimit) -> String {
+        if metrics.service == .openRouter {
+            return String(format: "$%.2f left", max(0, limit.total - limit.used))
+        }
+        return "\(Int(limit.percentage))%"
     }
 }
 
@@ -235,10 +243,7 @@ struct ServiceDetailView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
-                Image(metrics.service.assetName)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 20, height: 20)
+                WidgetProviderIcon(service: metrics.service, size: 20)
                 Text(metrics.service.displayName)
                     .font(.headline)
                 Spacer()
@@ -246,11 +251,19 @@ struct ServiceDetailView: View {
             }
 
             if let sessionLimit = metrics.sessionLimit {
-                LimitDetailView(title: "Session", limit: sessionLimit)
+                LimitDetailView(
+                    title: metrics.service == .openRouter ? "Key limit" : "Session",
+                    limit: sessionLimit,
+                    currency: metrics.service == .openRouter
+                )
             }
 
             if let weeklyLimit = metrics.weeklyLimit {
-                LimitDetailView(title: "Weekly", limit: weeklyLimit)
+                LimitDetailView(
+                    title: metrics.service == .openRouter ? "Account credits" : "Weekly",
+                    limit: weeklyLimit,
+                    currency: metrics.service == .openRouter
+                )
             }
 
             if let codeReviewLimit = metrics.codeReviewLimit {
@@ -266,6 +279,7 @@ struct ServiceDetailView: View {
 struct LimitDetailView: View {
     let title: String
     let limit: UsageLimit
+    var currency = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -281,10 +295,14 @@ struct LimitDetailView: View {
             ProgressView(value: limit.clampedUsed, total: limit.clampedTotal)
                 .tint(limit.statusColor.color)
 
-            Text("\(formatNumber(limit.used)) / \(formatNumber(limit.total))")
+            Text(currency ? currencyText : "\(formatNumber(limit.used)) / \(formatNumber(limit.total))")
                 .font(.caption2)
                 .foregroundColor(.secondary)
         }
+    }
+
+    private var currencyText: String {
+        "$\(String(format: "%.2f", limit.used)) spent / $\(String(format: "%.2f", limit.total))"
     }
 
     private func formatNumber(_ value: Double) -> String {
@@ -292,6 +310,24 @@ struct LimitDetailView: View {
             return String(format: "%.1fk", value / 1000)
         }
         return String(format: "%.0f", value)
+    }
+}
+
+struct WidgetProviderIcon: View {
+    let service: ServiceType
+    let size: CGFloat
+
+    var body: some View {
+        if service == .openRouter {
+            Image(systemName: service.iconName)
+                .font(.system(size: size, weight: .semibold))
+                .frame(width: size, height: size)
+        } else {
+            Image(service.assetName)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: size, height: size)
+        }
     }
 }
 

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
@@ -206,6 +206,17 @@ public struct CursorReadinessInput: Sendable {
     }
 }
 
+/// Fixture-able facts for the API-key-backed OpenRouter provider.
+public struct OpenRouterReadinessInput: Sendable {
+    public var hasAPIKey: Bool
+    public var refreshError: String?
+
+    public init(hasAPIKey: Bool, refreshError: String? = nil) {
+        self.hasAPIKey = hasAPIKey
+        self.refreshError = refreshError
+    }
+}
+
 // MARK: - Evaluator
 
 public enum ProviderReadinessEvaluator {
@@ -477,6 +488,36 @@ public enum ProviderReadinessEvaluator {
                 recovery: "Quit Cursor (its database locks while running), then rescan."
             )
         }
+    }
+
+    // MARK: OpenRouter
+
+    public static func openRouter(_ input: OpenRouterReadinessInput) -> ProviderReadiness {
+        let installed = ReadinessCheck(
+            id: ReadinessCheckID.installed,
+            title: "App required",
+            level: .pass,
+            detail: "No local OpenRouter app or CLI is required."
+        )
+        let auth = ReadinessCheck(
+            id: ReadinessCheckID.auth,
+            title: "API key",
+            level: input.hasAPIKey ? .pass : .fail,
+            detail: input.hasAPIKey ? "OpenRouter API key is configured." : "OpenRouter API key is missing.",
+            recovery: input.hasAPIKey ? nil : "Add an API key in MeterBar Settings."
+        )
+        let data = ReadinessCheck(
+            id: ReadinessCheckID.data,
+            title: "Usage readable",
+            level: input.hasAPIKey ? .pass : .warn,
+            detail: input.hasAPIKey
+                ? "Credits and per-key limits can be fetched from OpenRouter."
+                : "Usage becomes readable after an API key is configured."
+        )
+        return ProviderReadiness(
+            provider: .openRouter,
+            checks: [installed, auth, data, refreshCheck(input.refreshError)]
+        )
     }
 
     // MARK: Shared

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ServiceType.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ServiceType.swift
@@ -7,6 +7,7 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
     case claudeCode = "Claude Code"
     case codexCli = "Codex CLI"
     case cursor = "Cursor"
+    case openRouter = "OpenRouter"
 
     public var id: String { rawValue }
 
@@ -15,6 +16,7 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
         case .claudeCode: return "Claude Code"
         case .codexCli: return "OpenAI Codex"
         case .cursor: return "Cursor"
+        case .openRouter: return "OpenRouter"
         }
     }
 
@@ -24,6 +26,7 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
         case .claudeCode: return "terminal"
         case .codexCli: return "terminal.fill"
         case .cursor: return "cursorarrow.click"
+        case .openRouter: return "point.3.connected.trianglepath.dotted"
         }
     }
 
@@ -34,6 +37,7 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
         case .claudeCode: return "ClaudeIcon"
         case .codexCli: return "CodexIcon"
         case .cursor: return "CursorIcon"
+        case .openRouter: return "OpenRouterIcon"
         }
     }
 
@@ -43,6 +47,7 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
         case .claudeCode: return 0
         case .codexCli: return 1
         case .cursor: return 2
+        case .openRouter: return 3
         }
     }
 }


### PR DESCRIPTION
## Summary

- add opt-in OpenRouter tracking through the documented credits and key endpoints
- store the API key in macOS Keychain with clear validation and recovery states
- surface currency-aware credit and key-limit data across the popover, dashboard, Settings, widget, CLI, notifications, doctor, and provider status
- add fixture-driven response, readiness, visibility, rendering, and status tests

## Verification

- `COVERAGE_THRESHOLD=19 bash scripts/check-coverage.sh` — 540 tests passed; 42.6% line coverage
- focused Keychain, OpenRouter, readiness, visibility, and provider-status tests — passed
- `swiftlint lint --strict --quiet` — passed
- `swift build --package-path MeterBarCLI` — passed
- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug CODE_SIGNING_ALLOWED=NO build` — passed for app and widget
- `git diff --check` — passed
- final correctness/security/QA review — approved

## Skipped checks / residual risk

- Live OpenRouter API validation was not run because no OpenRouter credential is available; official response fixtures cover `/api/v1/credits` and `/api/v1/key`.
- Existing Swift actor-isolation warnings in `UsageDataManager` and the CLI wake path remain unchanged and are outside this issue.
- Standalone SwiftFormat is unavailable locally; SwiftLint and compiler formatting checks passed.

Closes #136