### PR TITLE
feat(accounts): add per-profile enable controls

### DIFF
--- a/.agents/SESSIONS/2026-07-13.md
+++ b/.agents/SESSIONS/2026-07-13.md
@@ -1,0 +1,40 @@
+# Sessions: 2026-07-13
+
+**Summary:** Per-profile enable and disable controls
+
+---
+
+## Session 1: Add account enablement
+
+**Duration:** ~30 minutes
+**Status:** Complete
+
+### What was done
+
+- Added backward-compatible enabled state for Claude Code account profiles.
+- Skipped disabled accounts during refresh and hid them from usage surfaces.
+- Disarmed Session Wake when its selected account is disabled.
+- Added focused persistence, snapshot-filtering, and wake-safety tests.
+
+### Files changed
+
+- `MeterBar/Models/ClaudeCodeAccount.swift` - Persist account enablement and expose enabled accounts.
+- `MeterBar/Services/UsageDataManager.swift` - Refresh enabled profiles only.
+- `MeterBar/Views/SettingsView.swift` - Add per-profile switches.
+- `MeterBar/SessionWake/` - Exclude disabled wake accounts and fail safe.
+- `MeterBarTests/` - Cover compatibility, persistence, display filtering, and wake safety.
+
+### Decisions
+
+- **Decision:** Missing `isEnabled` values decode as enabled.
+  - **Rationale:** Existing profile JSON must remain compatible and preserve current behavior after upgrading.
+- **Decision:** Disabling the selected wake profile clears the selection and turns Session Wake off.
+  - **Rationale:** Automation must not continue against an account the user explicitly disabled.
+
+### Next steps
+
+- [ ] Validate tests and builds in pull request CI.
+
+---
+
+**Total sessions today:** 1

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -71,7 +71,8 @@ meterbar/
 - **CostTracker** (1,029 lines) — JSONL/SQLite log scanning, per-model pricing table, per-day/model/origin breakdowns, cache at `~/Library/Application Support/MeterBar/cost-summary-v1.json`.
 - **AuthenticationManager + KeychainManager** — the two admin keys, stored in keychain service `dev.meterbar.app`. Reads migrate the older `dev.shipshit.meterbar` (v1.6.x) and `com.agenticindiedev.quotaguard` (v1.0-v1.6) services into the current one, and removals delete all three so a legacy key cannot reappear.
 - **SharedDataStore** — app-group JSON file (`cached_usage_metrics.json`), atomic writes on a serial queue, `WidgetCenter.reloadTimelines` after save.
-- **ProviderVisibilityStore / DockVisibilityStore / ClaudeCodeAccountStore** — UserDefaults-backed preference stores.
+- **ProviderVisibilityStore / DockVisibilityStore / ClaudeCodeAccountStore** — UserDefaults-backed preference stores;
+  Claude profiles can be disabled without deletion and disabled profiles are excluded from quota refresh and display.
 - **OAuthTokenExpiry** — JWT/unix-timestamp expiry checks (60 s grace; unparseable ⇒ not-expired by design).
 - **ServiceSupport** — shared URLSession config, secret-safe HTTP/URLError mapping, real (non-container) home dir via `getpwuid`.
 - **AppLog** — `os.Logger` categories: app, usage, cost, network, storage. This is the only observability; there is no crash reporting or analytics.

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -553,7 +553,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
             .store(in: &cancellables)
 
-        ClaudeCodeAccountStore.shared.$customAccounts
+        Publishers.Merge(
+            ClaudeCodeAccountStore.shared.$customAccounts.map { _ in () },
+            ClaudeCodeAccountStore.shared.$defaultAccountIsEnabled.map { _ in () }
+        )
             .sink { [weak self] _ in
                 Task { @MainActor in
                     self?.updateStatusItem(metrics: UsageDataManager.shared.metrics)
@@ -640,7 +643,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         var requests: [StatusLimitProbeRequest] = []
 
         if providerVisibilityStore.isEnabled(.claudeCode) {
-            for account in ClaudeCodeAccountStore.shared.accounts {
+            for account in ClaudeCodeAccountStore.shared.enabledAccounts {
                 guard let limit = claudeMetrics(for: account, metrics: metrics)?.sessionLimit else { continue }
                 let configDirectory = account.configDirectory
                 requests.append(StatusLimitProbeRequest(

--- a/MeterBar/Models/ClaudeCodeAccount.swift
+++ b/MeterBar/Models/ClaudeCodeAccount.swift
@@ -20,6 +20,22 @@ nonisolated struct ClaudeCodeAccount: Codable, Equatable, Identifiable, Sendable
     let id: UUID
     var name: String
     var configDirectory: String?
+    var isEnabled: Bool
+
+    init(id: UUID, name: String, configDirectory: String?, isEnabled: Bool = true) {
+        self.id = id
+        self.name = name
+        self.configDirectory = configDirectory
+        self.isEnabled = isEnabled
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        configDirectory = try container.decodeIfPresent(String.self, forKey: .configDirectory)
+        isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
+    }
 
     var isDefault: Bool {
         id == Self.defaultID
@@ -33,11 +49,13 @@ final class ClaudeCodeAccountStore: ObservableObject {
 
     @Published private(set) var customAccounts: [ClaudeCodeAccount] = []
     @Published private(set) var defaultAccountName = ClaudeCodeAccount.defaultName
+    @Published private(set) var defaultAccountIsEnabled = true
     @Published private(set) var accountOrder: [UUID] = []
 
     private let userDefaults: UserDefaults
     private let storageKey = StorageKeys.claudeCodeCustomAccounts
     private let defaultNameStorageKey = StorageKeys.claudeCodeDefaultAccountName
+    private let defaultEnabledStorageKey = StorageKeys.claudeCodeDefaultAccountEnabled
     private let accountOrderStorageKey = StorageKeys.claudeCodeAccountOrder
 
     var accounts: [ClaudeCodeAccount] {
@@ -45,9 +63,14 @@ final class ClaudeCodeAccountStore: ObservableObject {
             ClaudeCodeAccount(
                 id: ClaudeCodeAccount.defaultID,
                 name: defaultAccountName,
-                configDirectory: nil
+                configDirectory: nil,
+                isEnabled: defaultAccountIsEnabled
             )
         ] + customAccounts)
+    }
+
+    var enabledAccounts: [ClaudeCodeAccount] {
+        accounts.filter(\.isEnabled)
     }
 
     init(userDefaults: UserDefaults = .standard) {
@@ -110,6 +133,24 @@ final class ClaudeCodeAccountStore: ObservableObject {
         saveCustomAccounts()
     }
 
+    func setEnabled(_ enabled: Bool, for id: UUID) {
+        if id == ClaudeCodeAccount.defaultID {
+            guard enabled != defaultAccountIsEnabled else { return }
+            defaultAccountIsEnabled = enabled
+            saveDefaultAccountEnabled()
+            return
+        }
+
+        guard let index = customAccounts.firstIndex(where: { $0.id == id }),
+              customAccounts[index].isEnabled != enabled else {
+            return
+        }
+        var updatedAccounts = customAccounts
+        updatedAccounts[index].isEnabled = enabled
+        customAccounts = updatedAccounts
+        saveCustomAccounts()
+    }
+
     func moveAccounts(fromOffsets source: IndexSet, toOffset destination: Int) {
         var ordered = accounts
         guard !ordered.isEmpty else { return }
@@ -137,6 +178,10 @@ final class ClaudeCodeAccountStore: ObservableObject {
             defaultAccountName = storedDefaultName
         }
 
+        if userDefaults.object(forKey: defaultEnabledStorageKey) != nil {
+            defaultAccountIsEnabled = userDefaults.bool(forKey: defaultEnabledStorageKey)
+        }
+
         accountOrder = userDefaults.stringArray(forKey: accountOrderStorageKey)?
             .compactMap(UUID.init(uuidString:)) ?? []
 
@@ -159,6 +204,14 @@ final class ClaudeCodeAccountStore: ObservableObject {
             userDefaults.removeObject(forKey: defaultNameStorageKey)
         } else {
             userDefaults.set(defaultAccountName, forKey: defaultNameStorageKey)
+        }
+    }
+
+    private func saveDefaultAccountEnabled() {
+        if defaultAccountIsEnabled {
+            userDefaults.removeObject(forKey: defaultEnabledStorageKey)
+        } else {
+            userDefaults.set(false, forKey: defaultEnabledStorageKey)
         }
     }
 

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -22,6 +22,8 @@ nonisolated enum StorageKeys {
     static let claudeCodeCustomAccounts = "ClaudeCodeCustomAccounts"
     /// User-chosen display name for the default Claude Code CLI profile.
     static let claudeCodeDefaultAccountName = "ClaudeCodeDefaultAccountName"
+    /// Whether the synthesized default Claude Code CLI profile participates in tracking.
+    static let claudeCodeDefaultAccountEnabled = "ClaudeCodeDefaultAccountEnabled"
     /// Persisted account display order (array of UUID strings).
     static let claudeCodeAccountOrder = "ClaudeCodeAccountOrder"
     /// Global on/off switch for usage notifications.

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -84,7 +84,8 @@ class UsageDataManager: ObservableObject {
         var newMetrics: [ServiceType: UsageMetrics] = [:]
 
         // Fetch Claude Code metrics (local files)
-        if providerVisibilityStore.isEnabled(.claudeCode), claudeCodeService.hasAccess {
+        let hasEnabledClaudeAccount = !claudeCodeAccountStore.enabledAccounts.isEmpty
+        if providerVisibilityStore.isEnabled(.claudeCode), hasEnabledClaudeAccount, claudeCodeService.hasAccess {
             let accountMetrics = await fetchClaudeCodeAccountMetrics()
             claudeCodeAccountMetrics = accountMetrics
 
@@ -93,7 +94,7 @@ class UsageDataManager: ObservableObject {
             } else if let cachedMetrics = self.metrics[.claudeCode] {
                 newMetrics[.claudeCode] = cachedMetrics
             }
-        } else if !providerVisibilityStore.isEnabled(.claudeCode) {
+        } else if !providerVisibilityStore.isEnabled(.claudeCode) || !hasEnabledClaudeAccount {
             claudeCodeAccountMetrics = [:]
         }
 
@@ -113,6 +114,7 @@ class UsageDataManager: ObservableObject {
 
         // Merge new metrics with existing cached metrics for services that failed to fetch
         for service in ServiceType.allCases where providerVisibilityStore.isEnabled(service) {
+            if service == .claudeCode, !hasEnabledClaudeAccount { continue }
             if newMetrics[service] == nil, let cachedMetric = self.metrics[service] {
                 newMetrics[service] = cachedMetric
             }
@@ -144,6 +146,14 @@ class UsageDataManager: ObservableObject {
 
             switch service {
             case .claudeCode:
+                guard !claudeCodeAccountStore.enabledAccounts.isEmpty else {
+                    claudeCodeAccountMetrics = [:]
+                    metrics.removeValue(forKey: service)
+                    saveCachedData()
+                    sharedStore.saveMetrics(metrics)
+                    isLoading = false
+                    return
+                }
                 guard claudeCodeService.hasAccess else {
                     throw ServiceError.notAuthenticated
                 }
@@ -233,7 +243,7 @@ class UsageDataManager: ObservableObject {
     private func fetchClaudeCodeAccountMetrics() async -> [UUID: UsageMetrics] {
         var refreshedMetrics: [UUID: UsageMetrics] = [:]
 
-        for account in claudeCodeAccountStore.accounts {
+        for account in claudeCodeAccountStore.enabledAccounts {
             do {
                 refreshedMetrics[account.id] = try await claudeCodeService.fetchUsageMetrics(account: account)
             } catch {
@@ -248,7 +258,11 @@ class UsageDataManager: ObservableObject {
     }
 
     private func representativeClaudeCodeMetrics(from accountMetrics: [UUID: UsageMetrics]) -> UsageMetrics? {
-        accountMetrics[ClaudeCodeAccount.defaultID] ?? accountMetrics.values.first
+        if claudeCodeAccountStore.defaultAccountIsEnabled,
+           let defaultMetrics = accountMetrics[ClaudeCodeAccount.defaultID] {
+            return defaultMetrics
+        }
+        return claudeCodeAccountStore.enabledAccounts.lazy.compactMap { accountMetrics[$0.id] }.first
     }
 
     // MARK: - Provider strategy

--- a/MeterBar/SessionWake/SessionWakeController.swift
+++ b/MeterBar/SessionWake/SessionWakeController.swift
@@ -80,11 +80,14 @@ final class SessionWakeController: ObservableObject {
         .sink { [weak self] in self?.reconcile() }
         .store(in: &cancellables)
 
-        accounts.$customAccounts
+        Publishers.Merge(
+            accounts.$customAccounts.map { _ in () },
+            accounts.$defaultAccountIsEnabled.map { _ in () }
+        )
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 guard let self else { return }
-                self.store.reconcileAccounts(available: self.accounts.accounts.map(\.id))
+                self.store.reconcileAccounts(available: self.accounts.enabledAccounts.map(\.id))
                 self.reconcile()
             }
             .store(in: &cancellables)
@@ -107,7 +110,7 @@ final class SessionWakeController: ObservableObject {
 
     private func selectedAccount() -> ClaudeCodeAccount? {
         guard let id = store.wakeAccountID else { return nil }
-        return accounts.accounts.first { $0.id == id }
+        return accounts.enabledAccounts.first { $0.id == id }
     }
 
     private func startWatching(account: ClaudeCodeAccount) {

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -150,25 +150,22 @@ enum ProviderSnapshotBuilder {
         }
 
         if input.enabledServices.contains(.claudeCode) {
+            let enabledAccounts = input.claudeAccounts.filter(\.isEnabled)
             let accountMetrics = input.claudeAccountMetrics
-            if !accountMetrics.isEmpty {
-                for account in input.claudeAccounts {
-                    let title = account.isDefault && input.claudeAccounts.count == 1 ? "Claude" : account.name
+            if !enabledAccounts.isEmpty {
+                for account in enabledAccounts {
+                    let title = account.isDefault && enabledAccounts.count == 1 ? "Claude" : account.name
+                    let emptyDetail = account.isDefault && input.claudeCodeHasAccess
+                        ? "Waiting for refresh"
+                        : "Run claude login"
                     result.append(snapshot(
                         title: title,
                         service: .claudeCode,
-                        metrics: accountMetrics[account.id],
-                        emptyDetail: account.isDefault ? "Waiting for refresh" : "Run claude login",
+                        metrics: accountMetrics[account.id] ?? (account.isDefault ? input.metrics[.claudeCode] : nil),
+                        emptyDetail: emptyDetail,
                         accountID: account.id
                     ))
                 }
-            } else {
-                result.append(snapshot(
-                    title: "Claude",
-                    service: .claudeCode,
-                    metrics: input.metrics[.claudeCode],
-                    emptyDetail: input.claudeCodeHasAccess ? "Waiting for refresh" : "Run claude login"
-                ))
             }
         }
 

--- a/MeterBar/Views/SessionWakeSettingsView.swift
+++ b/MeterBar/Views/SessionWakeSettingsView.swift
@@ -95,7 +95,7 @@ struct SessionWakeSettingsView: View {
         Section("Wake account") {
             Picker("Account", selection: accountBinding) {
                 Text("None selected").tag(UUID?.none)
-                ForEach(accounts.accounts) { account in
+                ForEach(accounts.enabledAccounts) { account in
                     Text(account.name).tag(UUID?.some(account.id))
                 }
             }
@@ -190,7 +190,7 @@ struct SessionWakeSettingsView: View {
     }
 
     private var selectedConfigDirectory: String? {
-        accounts.accounts.first(where: { $0.id == store.wakeAccountID })?.configDirectory
+        accounts.enabledAccounts.first(where: { $0.id == store.wakeAccountID })?.configDirectory
     }
 
     private func binding<Value>(_ value: Value, _ setter: @escaping (Value) -> Void) -> Binding<Value> {

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -717,6 +717,13 @@ struct SettingsView: View {
                         }
                         AccountProfileRow(
                             account: account,
+                            onEnabledChange: { isEnabled in
+                                claudeAccountStore.setEnabled(isEnabled, for: account.id)
+                                SessionWakeSettingsStore.shared.reconcileAccounts(
+                                    available: claudeAccountStore.enabledAccounts.map(\.id)
+                                )
+                                Task { await dataManager.refreshAll() }
+                            },
                             onSave: { name, configDirectory in
                                 updateClaudeAccount(id: account.id, name: name, configDirectory: configDirectory)
                             },
@@ -1758,11 +1765,13 @@ private struct AccountProfileRow: View {
 
     init(
         account: ClaudeCodeAccount,
+        onEnabledChange: @escaping (Bool) -> Void,
         onSave: @escaping (String, String?) -> Void,
         onReconnect: @escaping () -> Void,
         onRemove: @escaping () -> Void
     ) {
         self.account = account
+        self.onEnabledChange = onEnabledChange
         self.onSave = onSave
         self.onReconnect = onReconnect
         self.onRemove = onRemove
@@ -1773,6 +1782,7 @@ private struct AccountProfileRow: View {
     // MARK: Internal
 
     let account: ClaudeCodeAccount
+    let onEnabledChange: (Bool) -> Void
     let onSave: (String, String?) -> Void
     let onReconnect: () -> Void
     let onRemove: () -> Void
@@ -1829,6 +1839,15 @@ private struct AccountProfileRow: View {
             .frame(maxWidth: .infinity, alignment: .leading)
 
             HStack(spacing: 8) {
+                Toggle("Enabled", isOn: Binding(
+                    get: { account.isEnabled },
+                    set: onEnabledChange
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .controlSize(.small)
+                .help(account.isEnabled ? "Disable account" : "Enable account")
+
                 Button(action: onReconnect) {
                     Image(systemName: "arrow.clockwise")
                 }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -671,7 +671,7 @@ struct UsageDashboardView: View {
             count += 1
         }
         if providerVisibility.isEnabled(.claudeCode) {
-            count += claudeAccountStore.accounts.count
+            count += claudeAccountStore.enabledAccounts.count
         }
         if providerVisibility.isEnabled(.cursor) {
             count += 1

--- a/MeterBarTests/ClaudeCodeAccountStoreTests.swift
+++ b/MeterBarTests/ClaudeCodeAccountStoreTests.swift
@@ -56,6 +56,46 @@ final class ClaudeCodeAccountStoreTests: XCTestCase {
         XCTAssertEqual(reloaded.customAccounts.first?.configDirectory, "/tmp/genfeed-claude-profile")
     }
 
+    func testLegacyCustomProfileDefaultsToEnabled() throws {
+        let id = UUID()
+        let data = try XCTUnwrap(
+            """
+            [{"id":"\(id.uuidString)","name":"Legacy","configDirectory":"/tmp/legacy"}]
+            """.data(using: .utf8)
+        )
+        defaults.set(data, forKey: StorageKeys.claudeCodeCustomAccounts)
+
+        let store = ClaudeCodeAccountStore(userDefaults: defaults)
+
+        XCTAssertEqual(store.customAccounts.first?.id, id)
+        XCTAssertEqual(store.customAccounts.first?.isEnabled, true)
+        XCTAssertEqual(store.enabledAccounts.map(\.id), [ClaudeCodeAccount.defaultID, id])
+    }
+
+    func testDefaultAndCustomProfileEnabledStatePersists() {
+        let store = ClaudeCodeAccountStore(userDefaults: defaults)
+        store.addAccount(name: "Work", configDirectory: "/tmp/work")
+        guard let customID = store.customAccounts.first?.id else {
+            XCTFail("Expected a custom Claude account")
+            return
+        }
+
+        store.setEnabled(false, for: ClaudeCodeAccount.defaultID)
+        store.setEnabled(false, for: customID)
+
+        XCTAssertTrue(store.enabledAccounts.isEmpty)
+        XCTAssertEqual(store.accounts.map(\.isEnabled), [false, false])
+
+        let reloaded = ClaudeCodeAccountStore(userDefaults: defaults)
+        XCTAssertTrue(reloaded.enabledAccounts.isEmpty)
+        XCTAssertEqual(reloaded.accounts.map(\.isEnabled), [false, false])
+
+        reloaded.setEnabled(true, for: ClaudeCodeAccount.defaultID)
+        reloaded.setEnabled(true, for: customID)
+        let enabledReload = ClaudeCodeAccountStore(userDefaults: defaults)
+        XCTAssertEqual(enabledReload.enabledAccounts.map(\.id), [ClaudeCodeAccount.defaultID, customID])
+    }
+
     func testCustomProfileCanBeRemoved() {
         let store = ClaudeCodeAccountStore(userDefaults: defaults)
         store.addAccount(name: "genfeedai", configDirectory: "/tmp/genfeed-claude-profile")

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -100,6 +100,46 @@ final class ProviderSnapshotTests: XCTestCase {
         XCTAssertEqual(Set(snapshots.map(\.id)).count, snapshots.count)
     }
 
+    func testDisabledClaudeAccountsAreExcludedEvenWithCachedMetrics() {
+        let disabled = ClaudeCodeAccount(
+            id: UUID(),
+            name: "Disabled",
+            configDirectory: "/tmp/disabled",
+            isEnabled: false
+        )
+        let enabled = ClaudeCodeAccount(id: UUID(), name: "Enabled", configDirectory: "/tmp/enabled")
+        let accountMetrics = [
+            disabled.id: makeMetrics(service: .claudeCode, weekly: 80),
+            enabled.id: makeMetrics(service: .claudeCode, weekly: 20)
+        ]
+
+        let snapshots = ProviderSnapshotBuilder.snapshots(makeInput(
+            claudeAccounts: [disabled, enabled],
+            claudeAccountMetrics: accountMetrics,
+            enabledServices: [.claudeCode]
+        ))
+
+        XCTAssertEqual(snapshots.map(\.title), ["Enabled"])
+        XCTAssertEqual(snapshots.first?.limits.first?.usageLimit.used, 20)
+    }
+
+    func testClaudeProviderHasNoSnapshotWhenAllAccountsAreDisabled() {
+        let disabledDefault = ClaudeCodeAccount(
+            id: ClaudeCodeAccount.defaultID,
+            name: ClaudeCodeAccount.defaultName,
+            configDirectory: nil,
+            isEnabled: false
+        )
+
+        let snapshots = ProviderSnapshotBuilder.snapshots(makeInput(
+            metrics: [.claudeCode: makeMetrics(service: .claudeCode, weekly: 90)],
+            claudeAccounts: [disabledDefault],
+            enabledServices: [.claudeCode]
+        ))
+
+        XCTAssertTrue(snapshots.isEmpty)
+    }
+
     // MARK: - Limits
 
     func testThirdLimitLabelIsSonnetForClaudeAndCodeReviewForCodex() {

--- a/MeterBarTests/SessionWakeControllerTests.swift
+++ b/MeterBarTests/SessionWakeControllerTests.swift
@@ -118,6 +118,30 @@ final class SessionWakeControllerTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(recorder.stopCount, 1)
     }
 
+    func testDisablingSelectedAccountStopsWatcherAndClearsSelection() {
+        let accounts = ClaudeCodeAccountStore(userDefaults: defaults)
+        let store = armedStore()
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: SessionWakeStatus(),
+            accounts: accounts,
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+        )
+        controller.activate()
+        poll { recorder.startCount >= 1 }
+
+        accounts.setEnabled(false, for: ClaudeCodeAccount.defaultID)
+
+        poll { !controller.isWatching }
+        XCTAssertFalse(controller.isWatching)
+        XCTAssertFalse(store.isOn)
+        XCTAssertNil(store.wakeAccountID)
+        poll { recorder.stopCount >= 1 }
+        XCTAssertGreaterThanOrEqual(recorder.stopCount, 1)
+    }
+
     func testStaysOffWhenToggleOff() {
         let store = SessionWakeSettingsStore(userDefaults: defaults) // off
         let recorder = WatchRecorder()

--- a/MeterBarTests/SessionWakeSettingsTests.swift
+++ b/MeterBarTests/SessionWakeSettingsTests.swift
@@ -98,6 +98,20 @@ final class SessionWakeSettingsTests: XCTestCase {
         XCTAssertFalse(store.isOn)
     }
 
+    func testDisablingSelectedAccountClearsItAndTurnsOff() {
+        let accounts = ClaudeCodeAccountStore(userDefaults: defaults)
+        let store = makeStore()
+        store.setWakeAccountID(ClaudeCodeAccount.defaultID)
+        store.acknowledgeFirstRunAndTurnOn()
+        XCTAssertTrue(store.isOn)
+
+        accounts.setEnabled(false, for: ClaudeCodeAccount.defaultID)
+        store.reconcileAccounts(available: accounts.enabledAccounts.map(\.id))
+
+        XCTAssertNil(store.wakeAccountID)
+        XCTAssertFalse(store.isOn)
+    }
+
     func testSwitchingAccountWhileArmedDisarms() {
         let accountA = UUID()
         let accountB = UUID()


### PR DESCRIPTION
## Summary

- add backward-compatible enabled state and persistent switches for Claude Code profiles
- skip disabled profiles during quota refresh and exclude them from popover, dashboard, widget-cache, and menu-bar selection
- clear and disarm Session Wake when its selected profile is disabled
- add focused compatibility, persistence, display-filtering, and live watcher-safety tests

## Verification

- `swiftlint lint --strict --quiet` — passed
- `git diff --check` — passed
- structured correctness, security, regression, and scope review — approved

## Skipped checks / residual risk

- Local tests, coverage, SwiftPM/Xcode builds, and native UI checks were skipped under the workstation safety policy. PR CI is the required validation gate.
- Standalone SwiftFormat is unavailable locally; SwiftLint is clean.
- Native switch layout retains low visual risk until CI compilation and review in a running Settings window.

Closes #147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-profile enable/disable controls for Claude Code accounts.
  * Disabled profiles are excluded from usage tracking, refreshes, dashboards, and status updates.
  * Enabled-state preferences persist across app launches, with legacy profiles remaining enabled by default.
  * Session Wake now lists only enabled profiles and automatically stops if its selected profile is disabled.
* **Bug Fixes**
  * Improved account usage and snapshot selection when profiles are disabled.
* **Tests**
  * Added coverage for persistence, filtering, dashboard snapshots, and Session Wake safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->