### PR TITLE
feat(codex): add multi-account support

### DIFF
--- a/.agents/SESSIONS/2026-07-13.md
+++ b/.agents/SESSIONS/2026-07-13.md
@@ -1,0 +1,69 @@
+# Sessions: 2026-07-13
+
+**Summary:** Codex multi-account usage tracking
+
+---
+
+## Session 1: Add Codex Multi-Account Support
+
+**Duration:** ~1 hour
+**Status:** Complete
+
+### System flow
+
+```mermaid
+flowchart LR
+    A["Codex account profiles"] --> B["Per-home auth reader"]
+    B --> C["UsageDataManager account refresh"]
+    C --> D["Popover and dashboard cards"]
+    C --> E["Menu bar selector and notifications"]
+    C --> F["Shared account cache"]
+    F --> G["Widget account rows"]
+```
+
+### Affected components
+
+- Codex account configuration and OAuth-file resolution
+- Usage refresh, cache, notifications, and status-item selection
+- Popover, dashboard, Settings, and widget presentation
+- Shared app-group data contract and focused tests
+
+### What was done
+
+- [x] Added zero-config default and persistent custom `CODEX_HOME` profiles
+- [x] Fetched and preserved independent usage metrics per Codex account
+- [x] Added labeled account cards, menu selection, notifications, and widget rows
+- [x] Added Settings controls for account labels and home directories
+- [x] Added account-store, service, orchestration, snapshot, notification, selector, and shared-cache tests
+- [x] Updated implemented architecture documentation
+
+### Key decisions
+
+- Preserve the existing provider-level metrics cache as the compatibility representative while adding a separate labeled account cache for multi-row surfaces.
+- Keep auth-file reads off the main actor for every account.
+- Use deterministic account IDs and account-scoped notification keys so identical providers cannot collide.
+
+### Files changed
+
+- `MeterBar/Models/CodexAccount.swift` - Codex profile model and persistent store
+- `MeterBar/Services/CodexCliLocalService.swift` - Account-aware auth and usage fetch
+- `MeterBar/Services/UsageDataManager.swift` - Per-account orchestration and caching
+- `MeterBar/App/MeterBarApp.swift` - Account-aware notifications and status selection
+- `MeterBar/Views/` - Labeled Codex account presentation and settings
+- `MeterBarWidget/UsageWidget.swift` - Account-aware widget rows
+- `Packages/MeterBarShared/` - Shared labeled account snapshot contract
+- `MeterBarTests/` - Focused multi-account regression coverage
+- `.agents/SYSTEM/ARCHITECTURE.md` - Current multi-account architecture
+
+### Mistakes and fixes
+
+- Initial notification changes were inserted at the wrong matching loop; moved them into the notification evaluator before verification.
+- The first Settings refresh gate depended on the default account; changed it to refresh all configured profiles.
+
+### Next steps
+
+- [ ] Review and merge the pull request after CI passes
+
+---
+
+**Total sessions today:** 1

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture - MeterBar
 
 **Purpose:** Document what IS implemented (not what WILL BE).
-**Last Updated:** 2026-07-09 (rewritten from a full-repo audit; see `docs/audits/00-repo-map.md`)
+**Last Updated:** 2026-07-13 (rewritten from a full-repo audit; see `docs/audits/00-repo-map.md`)
 
 ---
 
@@ -14,7 +14,7 @@ Providers tracked:
 | Provider | `ServiceType` case | Data source |
 |---|---|---|
 | Claude Code | `.claudeCode` | Shells out to `claude /usage`, regex-parses terminal output. Legacy OAuth fallback (keychain item `Claude Code-credentials`) behind the `ClaudeCodeEnableOAuthFallback` UserDefaults flag |
-| OpenAI Codex CLI | `.codexCli` | Reads `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`), calls `https://chatgpt.com/backend-api/wham/usage` |
+| OpenAI Codex CLI | `.codexCli` | Reads one or more Codex homes (`$CODEX_HOME` / configured profiles), calls `https://chatgpt.com/backend-api/wham/usage` per account |
 | Cursor | `.cursor` | Reads session JWT from Cursor's `state.vscdb` SQLite, calls `https://cursor.com/api/usage-summary` |
 | Claude (admin) | `.claude` | Anthropic Admin API key (user-provided, stored in our keychain), `/v1/organizations/usage_report/messages` |
 | OpenAI (admin) | `.openai` | OpenAI Admin API key (user-provided, stored in our keychain), `/v1/organization/usage/completions` |
@@ -65,12 +65,12 @@ meterbar/
 - **UsageDataManager** (`@MainActor`, ObservableObject) — orchestrates refresh across providers, caches to UserDefaults (`cached_usage_metrics`), mirrors to the app group via SharedDataStore, drives a `Timer` auto-refresh (default 15 min; `RefreshInterval` supports 1/2/5/15/30 min + manual).
 - **ClaudeCodeCLIUsageService** — resolves the `claude` binary (`CLAUDE_CLI_PATH`, `$PATH`, 7 fallback paths), runs `claude /usage` (12 s timeout, dedicated GCD queue bridged to async), parses output with `ClaudeCodeCLIUsageParser`. Multi-account via `CLAUDE_CONFIG_DIR` env injection.
 - **ClaudeCodeLocalService** — CLI-first wrapper; legacy OAuth fallback + best-effort "extra usage" probe against `api.anthropic.com/api/oauth/usage`.
-- **CodexCliLocalService** — Codex auth file + wham/usage endpoint; maps credits/spend to `ExtraUsageStatus` (safety-biased: never false "Off").
+- **CodexCliLocalService** — account-aware Codex auth-file + wham/usage client; maps credits/spend to `ExtraUsageStatus` (safety-biased: never false "Off"). `CodexAccountStore` persists labels and additional `CODEX_HOME` profiles while the default profile retains zero-config behavior.
 - **CursorLocalService** — SQLite token extraction + usage-summary endpoint; assumed 500-request default quota when API omits totals.
 - **ClaudeService / OpenAIService** — admin-key usage reports (paginated, 50-page cap) via `ServiceSupport.fetchDecoded`.
 - **CostTracker** (1,029 lines) — JSONL/SQLite log scanning, per-model pricing table, per-day/model/origin breakdowns, cache at `~/Library/Application Support/MeterBar/cost-summary-v1.json`.
 - **AuthenticationManager + KeychainManager** — the two admin keys, stored in keychain service `dev.meterbar.app`. Reads migrate the older `dev.shipshit.meterbar` (v1.6.x) and `com.agenticindiedev.quotaguard` (v1.0-v1.6) services into the current one, and removals delete all three so a legacy key cannot reappear.
-- **SharedDataStore** — app-group JSON file (`cached_usage_metrics.json`), atomic writes on a serial queue, `WidgetCenter.reloadTimelines` after save.
+- **SharedDataStore** — app-group JSON files for provider summaries (`cached_usage_metrics.json`) and labeled per-account usage (`cached_usage_account_metrics.json`), atomic writes on a serial queue, `WidgetCenter.reloadTimelines` after save.
 - **ProviderVisibilityStore / DockVisibilityStore / ClaudeCodeAccountStore** — UserDefaults-backed preference stores.
 - **OAuthTokenExpiry** — JWT/unix-timestamp expiry checks (60 s grace; unparseable ⇒ not-expired by design).
 - **ServiceSupport** — shared URLSession config, secret-safe HTTP/URLError mapping, real (non-container) home dir via `getpwuid`.

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -206,7 +206,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             item.submenu = makeProviderStatusSubmenu(for: service)
             menu.addItem(item)
         }
-
         menu.addItem(.separator())
 
         let refreshItem = NSMenuItem(
@@ -466,7 +465,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         var keys = notifiedLimitKeys
         let currentMetrics = UsageDataManager.shared.metrics
 
-        for service in ServiceType.allCases {
+        for service in ServiceType.allCases where service != .claudeCode && service != .codexCli {
             // Disabled providers are removed from UsageDataManager. Evaluate an
             // empty snapshot so their stale band keys are cleared instead of
             // suppressing a future crossing after the provider is re-enabled.
@@ -483,7 +482,77 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        keys = evaluateAccountNotifications(
+            AccountNotificationInput(
+                service: .claudeCode,
+                accounts: ClaudeCodeAccountStore.shared.accounts.map { ($0.id, $0.name) },
+                accountMetrics: UsageDataManager.shared.claudeCodeAccountMetrics,
+                fallbackMetrics: currentMetrics[.claudeCode]
+            ),
+            decider: decider,
+            keys: keys,
+            now: now
+        )
+        keys = evaluateAccountNotifications(
+            AccountNotificationInput(
+                service: .codexCli,
+                accounts: CodexAccountStore.shared.accounts.map { ($0.id, $0.name) },
+                accountMetrics: UsageDataManager.shared.codexAccountMetrics,
+                fallbackMetrics: currentMetrics[.codexCli]
+            ),
+            decider: decider,
+            keys: keys,
+            now: now
+        )
+
         notifiedLimitKeys = keys
+    }
+
+    private struct AccountNotificationInput {
+        let service: ServiceType
+        let accounts: [(id: UUID, name: String)]
+        let accountMetrics: [UUID: UsageMetrics]
+        let fallbackMetrics: UsageMetrics?
+    }
+
+    private func evaluateAccountNotifications(
+        _ input: AccountNotificationInput,
+        decider: NotificationDecider,
+        keys: Set<String>,
+        now: Date
+    ) -> Set<String> {
+        var updatedKeys = keys
+        let available = input.accounts.compactMap { account -> (UUID, String, UsageMetrics)? in
+            guard let metrics = input.accountMetrics[account.id] else { return nil }
+            return (account.id, account.name, metrics)
+        }
+
+        if available.isEmpty {
+            let metrics = input.fallbackMetrics ?? UsageMetrics(service: input.service, lastUpdated: now)
+            let evaluation = decider.evaluate(
+                metrics: metrics,
+                providerEnabled: providerVisibilityStore.isEnabled(input.service),
+                alreadyNotified: updatedKeys,
+                now: now
+            )
+            updatedKeys = evaluation.notifiedKeys
+            evaluation.notifications.forEach(postNotification)
+            return updatedKeys
+        }
+
+        for (id, name, metrics) in available {
+            let evaluation = decider.evaluate(
+                metrics: metrics,
+                providerEnabled: providerVisibilityStore.isEnabled(input.service),
+                alreadyNotified: updatedKeys,
+                accountKey: id.uuidString,
+                serviceDisplayName: "\(name) (\(input.service.displayName))",
+                now: now
+            )
+            updatedKeys = evaluation.notifiedKeys
+            evaluation.notifications.forEach(postNotification)
+        }
+        return updatedKeys
     }
 
     private func postNotification(_ fired: FiredNotification) {
@@ -553,7 +622,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
             .store(in: &cancellables)
 
+        UsageDataManager.shared.$codexAccountMetrics
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    self?.updateStatusItem(metrics: UsageDataManager.shared.metrics)
+                }
+            }
+            .store(in: &cancellables)
+
         ClaudeCodeAccountStore.shared.$customAccounts
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    self?.updateStatusItem(metrics: UsageDataManager.shared.metrics)
+                }
+            }
+            .store(in: &cancellables)
+
+        CodexAccountStore.shared.$customAccounts
             .sink { [weak self] _ in
                 Task { @MainActor in
                     self?.updateStatusItem(metrics: UsageDataManager.shared.metrics)
@@ -651,13 +736,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 ))
             }
         }
-        if providerVisibilityStore.isEnabled(.codexCli), let codexLimit = metrics[.codexCli]?.sessionLimit {
-            requests.append(StatusLimitProbeRequest(
-                key: "codex",
-                displayName: ServiceType.codexCli.displayName,
-                limit: codexLimit,
-                probe: { AccountActivityInspector.codexCliActivity() }
-            ))
+        if providerVisibilityStore.isEnabled(.codexCli) {
+            for account in CodexAccountStore.shared.accounts {
+                let accountMetrics = UsageDataManager.shared.codexAccountMetrics[account.id]
+                    ?? (account.isDefault ? metrics[.codexCli] : nil)
+                guard let limit = accountMetrics?.sessionLimit else { continue }
+                let homeDirectory = account.homeDirectory
+                requests.append(StatusLimitProbeRequest(
+                    key: "codex:\(account.id.uuidString)",
+                    displayName: "\(account.name) (\(ServiceType.codexCli.displayName))",
+                    limit: limit,
+                    probe: { AccountActivityInspector.codexCliActivity(homeDirectory: homeDirectory) }
+                ))
+            }
         }
         if providerVisibilityStore.isEnabled(.cursor), let cursorLimit = metrics[.cursor]?.weeklyLimit {
             requests.append(StatusLimitProbeRequest(

--- a/MeterBar/Models/CodexAccount.swift
+++ b/MeterBar/Models/CodexAccount.swift
@@ -1,0 +1,157 @@
+import Combine
+import Foundation
+
+nonisolated struct CodexAccount: Codable, Equatable, Identifiable, Sendable {
+    static let defaultName = "Default CLI Profile"
+    static let defaultID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2))
+
+    static let defaultAccount = CodexAccount(
+        id: Self.defaultID,
+        name: Self.defaultName,
+        homeDirectory: nil
+    )
+
+    let id: UUID
+    var name: String
+    var homeDirectory: String?
+
+    var isDefault: Bool { id == Self.defaultID }
+}
+
+final class CodexAccountStore: ObservableObject {
+    static let shared = CodexAccountStore()
+
+    @Published private(set) var customAccounts: [CodexAccount] = []
+    @Published private(set) var defaultAccountName = CodexAccount.defaultName
+    @Published private(set) var accountOrder: [UUID] = []
+
+    private let userDefaults: UserDefaults
+
+    var accounts: [CodexAccount] {
+        orderedAccounts(from: [
+            CodexAccount(id: CodexAccount.defaultID, name: defaultAccountName, homeDirectory: nil)
+        ] + customAccounts)
+    }
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        load()
+    }
+
+    func addAccount(name: String, homeDirectory: String) {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedDirectory = homeDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty, !trimmedDirectory.isEmpty else { return }
+
+        let account = CodexAccount(
+            id: UUID(),
+            name: trimmedName,
+            homeDirectory: (trimmedDirectory as NSString).standardizingPath
+        )
+        customAccounts.append(account)
+        if !accountOrder.isEmpty {
+            accountOrder.append(account.id)
+            saveAccountOrder()
+        }
+        saveCustomAccounts()
+    }
+
+    func updateAccount(id: UUID, name: String, homeDirectory: String?) {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { return }
+
+        if id == CodexAccount.defaultID {
+            guard trimmedName != defaultAccountName else { return }
+            defaultAccountName = trimmedName
+            saveDefaultAccountName()
+            return
+        }
+
+        guard let index = customAccounts.firstIndex(where: { $0.id == id }), let homeDirectory else { return }
+        let trimmedDirectory = homeDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedDirectory.isEmpty else { return }
+
+        var updated = customAccounts[index]
+        updated.name = trimmedName
+        updated.homeDirectory = (trimmedDirectory as NSString).standardizingPath
+        guard updated != customAccounts[index] else { return }
+        var updatedAccounts = customAccounts
+        updatedAccounts[index] = updated
+        customAccounts = updatedAccounts
+        saveCustomAccounts()
+    }
+
+    func removeAccount(id: UUID) {
+        guard id != CodexAccount.defaultID else { return }
+        customAccounts.removeAll { $0.id == id }
+        accountOrder.removeAll { $0 == id }
+        saveAccountOrder()
+        saveCustomAccounts()
+    }
+
+    func moveAccounts(fromOffsets source: IndexSet, toOffset destination: Int) {
+        var ordered = accounts
+        let movingIndexes = source.sorted()
+        guard movingIndexes.allSatisfy({ ordered.indices.contains($0) }) else { return }
+
+        let movingAccounts = movingIndexes.map { ordered[$0] }
+        for index in movingIndexes.reversed() { ordered.remove(at: index) }
+        let removedBeforeDestination = movingIndexes.filter { $0 < destination }.count
+        let adjustedDestination = max(0, min(destination - removedBeforeDestination, ordered.count))
+        ordered.insert(contentsOf: movingAccounts, at: adjustedDestination)
+        accountOrder = ordered.map(\.id)
+        saveAccountOrder()
+    }
+
+    private func load() {
+        if let name = userDefaults.string(forKey: StorageKeys.codexDefaultAccountName)?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
+            defaultAccountName = name
+        }
+        accountOrder = userDefaults.stringArray(forKey: StorageKeys.codexAccountOrder)?
+            .compactMap(UUID.init(uuidString:)) ?? []
+        if let data = userDefaults.data(forKey: StorageKeys.codexCustomAccounts),
+           let decoded = try? JSONDecoder().decode([CodexAccount].self, from: data) {
+            customAccounts = decoded.filter { !$0.isDefault }
+        }
+        pruneAccountOrder()
+    }
+
+    private func saveCustomAccounts() {
+        guard let data = try? JSONEncoder().encode(customAccounts) else { return }
+        userDefaults.set(data, forKey: StorageKeys.codexCustomAccounts)
+    }
+
+    private func saveDefaultAccountName() {
+        if defaultAccountName == CodexAccount.defaultName {
+            userDefaults.removeObject(forKey: StorageKeys.codexDefaultAccountName)
+        } else {
+            userDefaults.set(defaultAccountName, forKey: StorageKeys.codexDefaultAccountName)
+        }
+    }
+
+    private func saveAccountOrder() {
+        if accountOrder.isEmpty {
+            userDefaults.removeObject(forKey: StorageKeys.codexAccountOrder)
+        } else {
+            userDefaults.set(accountOrder.map(\.uuidString), forKey: StorageKeys.codexAccountOrder)
+        }
+    }
+
+    private func orderedAccounts(from unordered: [CodexAccount]) -> [CodexAccount] {
+        guard !accountOrder.isEmpty else { return unordered }
+        let byID = Dictionary(uniqueKeysWithValues: unordered.map { ($0.id, $0) })
+        let ordered = accountOrder.compactMap { byID[$0] }
+        let orderedIDs = Set(ordered.map(\.id))
+        return ordered + unordered.filter { !orderedIDs.contains($0.id) }
+    }
+
+    private func pruneAccountOrder() {
+        guard !accountOrder.isEmpty else { return }
+        let validIDs = Set([CodexAccount.defaultID] + customAccounts.map(\.id))
+        let pruned = accountOrder.filter { validIDs.contains($0) }
+        guard pruned != accountOrder else { return }
+        accountOrder = pruned
+        saveAccountOrder()
+    }
+}

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -24,6 +24,14 @@ nonisolated enum StorageKeys {
     static let claudeCodeDefaultAccountName = "ClaudeCodeDefaultAccountName"
     /// Persisted account display order (array of UUID strings).
     static let claudeCodeAccountOrder = "ClaudeCodeAccountOrder"
+    /// Extra Codex CLI account profiles (JSON-encoded [CodexAccount]).
+    static let codexCustomAccounts = "CodexCustomAccounts"
+    /// User-chosen display name for the default Codex CLI profile.
+    static let codexDefaultAccountName = "CodexDefaultAccountName"
+    /// Persisted Codex account display order (array of UUID strings).
+    static let codexAccountOrder = "CodexAccountOrder"
+    /// Cached per-account Codex metrics (JSON-encoded [UUID: UsageMetrics]).
+    static let cachedCodexAccountMetrics = "CachedCodexAccountMetrics"
     /// Global on/off switch for usage notifications.
     static let notificationsEnabled = "NotificationsEnabled"
     /// Raw value of the `NotificationThreshold` at which a warning notifies.

--- a/MeterBar/Services/AccountActivityInspector.swift
+++ b/MeterBar/Services/AccountActivityInspector.swift
@@ -61,6 +61,15 @@ nonisolated enum AccountActivityInspector {
         ))
     }
 
+    static func codexCliActivity(homeDirectory: String?) -> Date? {
+        let account = CodexAccount(
+            id: CodexAccount.defaultID,
+            name: CodexAccount.defaultName,
+            homeDirectory: homeDirectory
+        )
+        return lastActivity(inDirectory: CodexHomeDirectory.path(for: account))
+    }
+
     /// Cursor continuously checkpoints its state database while running; the
     /// WAL sibling is the hottest file. Mirrors the candidate paths used by
     /// `CursorLocalService.getCursorDatabasePath`.

--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -26,7 +26,7 @@ class CodexCliLocalService: ObservableObject {
     /// fixture without a real credential file on disk (the auth file never
     /// exists on CI). Defaults to reading the real path. `@Sendable` because the
     /// read is disk I/O and must be callable off the main actor.
-    nonisolated private let authFileDataProvider: @Sendable () -> Data?
+    nonisolated private let authFileDataProvider: @Sendable (CodexAccount) -> Data?
 
     @Published private(set) var hasAccess: Bool = false
     @Published private(set) var lastError: ServiceError?
@@ -34,15 +34,26 @@ class CodexCliLocalService: ObservableObject {
 
     /// Defaults reproduce the production singleton; tests inject a fixture
     /// auth-file provider.
-    init(authFileDataProvider: (@Sendable () -> Data?)? = nil) {
-        self.authFileDataProvider = authFileDataProvider ?? { CodexCliLocalService.defaultAuthFileDataProvider() }
+    init(
+        authFileDataProvider: (@Sendable () -> Data?)? = nil,
+        accountAuthFileDataProvider: (@Sendable (CodexAccount) -> Data?)? = nil
+    ) {
+        if let accountAuthFileDataProvider {
+            self.authFileDataProvider = accountAuthFileDataProvider
+        } else if let authFileDataProvider {
+            self.authFileDataProvider = { _ in authFileDataProvider() }
+        } else {
+            self.authFileDataProvider = { account in
+                Self.defaultAuthFileDataProvider(account: account)
+            }
+        }
         Task.detached(priority: .utility) { [weak self] in self?.checkAccess() }
     }
 
     /// Reads `CODEX_HOME/auth.json` using the same resolver as readiness,
     /// activity, and cost scans.
-    nonisolated private static func defaultAuthFileDataProvider() -> Data? {
-        let path = CodexHomeDirectory.authFilePath()
+    nonisolated private static func defaultAuthFileDataProvider(account: CodexAccount) -> Data? {
+        let path = CodexHomeDirectory.authFilePath(for: account)
         guard FileManager.default.fileExists(atPath: path) else { return nil }
         return FileManager.default.contents(atPath: path)
     }
@@ -52,8 +63,8 @@ class CodexCliLocalService: ObservableObject {
     /// Read OAuth access token from `CODEX_HOME/auth.json`.
     /// This file is created and maintained by the Codex CLI when user logs in.
     /// `nonisolated`: disk I/O — never call this synchronously from the main actor.
-    nonisolated func getAuthToken() -> String? {
-        guard let token = readAuthFile()?.tokens?.accessToken else {
+    nonisolated func getAuthToken(account: CodexAccount = .defaultAccount) -> String? {
+        guard let token = readAuthFile(account: account)?.tokens?.accessToken else {
             return nil
         }
 
@@ -66,13 +77,23 @@ class CodexCliLocalService: ObservableObject {
 
     /// Read account ID from `CODEX_HOME/auth.json`.
     /// Required for the ChatGPT-Account-Id header to get team/workspace data
-    nonisolated func getAccountId() -> String? {
-        readAuthFile()?.tokens?.accountId
+    nonisolated func getAccountId(account: CodexAccount = .defaultAccount) -> String? {
+        readAuthFile(account: account)?.tokens?.accountId
     }
 
-    nonisolated private func readAuthFile() -> CodexAuthFile? {
-        guard let data = authFileDataProvider() else { return nil }
+    nonisolated private func readAuthFile(account: CodexAccount) -> CodexAuthFile? {
+        guard let data = authFileDataProvider(account) else { return nil }
         return try? JSONDecoder().decode(CodexAuthFile.self, from: data)
+    }
+
+    nonisolated func hasAccess(account: CodexAccount) -> Bool {
+        getAuthToken(account: account) != nil
+    }
+
+    func canAccess(account: CodexAccount) async -> Bool {
+        await Task.detached(priority: .userInitiated) { [self] in
+            hasAccess(account: account)
+        }.value
     }
 
     /// Check and update access status
@@ -87,18 +108,18 @@ class CodexCliLocalService: ObservableObject {
 
     // MARK: - Usage Fetching
 
-    func fetchUsageMetrics() async throws -> UsageMetrics {
+    func fetchUsageMetrics(account: CodexAccount = .defaultAccount) async throws -> UsageMetrics {
         // Auth-file read is disk I/O; the app target runs async bodies on the
         // main actor (default MainActor isolation), so hop off explicitly.
         let auth = await Task.detached(priority: .userInitiated) { [self] in
-            (token: getAuthToken(), accountId: getAccountId())
+            (token: getAuthToken(account: account), accountId: getAccountId(account: account))
         }.value
 
         guard let token = auth.token else {
             let error = ServiceError.notAuthenticated
             await MainActor.run {
                 self.lastError = error
-                self.hasAccess = false
+                if account.isDefault { self.hasAccess = false }
             }
             throw error
         }
@@ -138,8 +159,10 @@ class CodexCliLocalService: ObservableObject {
 
             await MainActor.run {
                 self.lastError = nil
-                self.hasAccess = true
-                self.subscriptionType = usageResponse.planType
+                if account.isDefault {
+                    self.hasAccess = true
+                    self.subscriptionType = usageResponse.planType
+                }
             }
 
             // Pure response→UsageMetrics mapping (window math, code-review limit,
@@ -151,7 +174,7 @@ class CodexCliLocalService: ObservableObject {
             AppLog.usage.error("Codex usage fetch failed: \(serviceError.localizedDescription)")
             await MainActor.run {
                 self.lastError = serviceError
-                if case .notAuthenticated = serviceError {
+                if account.isDefault, case .notAuthenticated = serviceError {
                     self.hasAccess = false
                 }
             }

--- a/MeterBar/Services/CodexHomeDirectory.swift
+++ b/MeterBar/Services/CodexHomeDirectory.swift
@@ -33,6 +33,18 @@ nonisolated enum CodexHomeDirectory {
             .appendingPathComponent("auth.json")
     }
 
+    static func path(for account: CodexAccount) -> String {
+        guard let homeDirectory = account.homeDirectory?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !homeDirectory.isEmpty else {
+            return path()
+        }
+        return (homeDirectory as NSString).standardizingPath
+    }
+
+    static func authFilePath(for account: CodexAccount) -> String {
+        (path(for: account) as NSString).appendingPathComponent("auth.json")
+    }
+
     /// The resolved auth-file path for user-facing copy, compacting paths under
     /// the real home directory back to `~/...` while retaining absolute custom
     /// `CODEX_HOME` paths outside it.

--- a/MeterBar/Services/NotificationDecider.swift
+++ b/MeterBar/Services/NotificationDecider.swift
@@ -91,6 +91,8 @@ struct NotificationDecider {
         metrics: UsageMetrics,
         providerEnabled: Bool,
         alreadyNotified: Set<String>,
+        accountKey: String? = nil,
+        serviceDisplayName: String? = nil,
         now: Date = Date()
     ) -> NotificationEvaluation {
         // Delivery gates suppress banners, not state transitions. Continuing to
@@ -114,7 +116,9 @@ struct NotificationDecider {
         let criticalRank = Self.severityRank(preferences.criticalThreshold.band)
 
         for (limit, quotaKind) in limits {
-            let baseKey = "\(metrics.service.rawValue)-\(quotaKind.rawValue)"
+            let baseKey = [metrics.service.rawValue, accountKey, quotaKind.rawValue]
+                .compactMap { $0 }
+                .joined(separator: "-")
             let warnKey = "\(baseKey)-warn"
             let criticalKey = "\(baseKey)-critical"
 
@@ -138,7 +142,7 @@ struct NotificationDecider {
                     fired.append(FiredNotification(
                         key: criticalKey,
                         level: .critical,
-                        serviceDisplayName: metrics.service.displayName,
+                        serviceDisplayName: serviceDisplayName ?? metrics.service.displayName,
                         quotaDisplayName: quotaDisplayName,
                         blocksProvider: blocksProvider,
                         percentUsed: Int(limit.percentage),
@@ -154,7 +158,7 @@ struct NotificationDecider {
                     fired.append(FiredNotification(
                         key: warnKey,
                         level: .warning,
-                        serviceDisplayName: metrics.service.displayName,
+                        serviceDisplayName: serviceDisplayName ?? metrics.service.displayName,
                         quotaDisplayName: quotaDisplayName,
                         blocksProvider: blocksProvider,
                         percentUsed: Int(limit.percentage),

--- a/MeterBar/Services/SharedDataStore.swift
+++ b/MeterBar/Services/SharedDataStore.swift
@@ -36,6 +36,13 @@ nonisolated public final class SharedDataStore: @unchecked Sendable {
         return SharedMetricsStore.metricsFileURL
     }
 
+    private var accountMetricsFileURL: URL? {
+        if let directoryOverride {
+            return directoryOverride.appendingPathComponent("\(SharedMetricsStore.accountMetricsKey).json")
+        }
+        return SharedMetricsStore.accountMetricsFileURL
+    }
+
     /// Defaults reproduce the production singleton exactly; tests inject a
     /// directory + write spy.
     init(directoryOverride: URL? = nil, didWrite: (() -> Void)? = nil) {
@@ -66,6 +73,25 @@ nonisolated public final class SharedDataStore: @unchecked Sendable {
         }
     }
 
+    func saveAccountMetrics(_ snapshots: [AccountUsageSnapshot]) {
+        guard let fileURL = accountMetricsFileURL,
+              let data = try? JSONEncoder().encode(snapshots) else {
+            AppLog.storage.error("Failed to prepare shared account metrics")
+            return
+        }
+
+        ioQueue.async { [weak self] in
+            do {
+                try data.write(to: fileURL, options: [.atomic])
+                self?.didWrite()
+            } catch {
+                AppLog.storage.error(
+                    "Failed to save shared account metrics: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+    }
+
     /// Reads through the shared reader so the app, widget, and CLI decode the
     /// same file the same way. The test override reads the same file name from
     /// the injected directory.
@@ -76,6 +102,16 @@ nonisolated public final class SharedDataStore: @unchecked Sendable {
             return MetricsCodec.decode(data)
         }
         return SharedMetricsStore.loadMetrics()
+    }
+
+    public func loadAccountMetrics() -> [AccountUsageSnapshot] {
+        guard directoryOverride == nil else {
+            guard let fileURL = accountMetricsFileURL,
+                  let data = try? Data(contentsOf: fileURL),
+                  let decoded = try? JSONDecoder().decode([AccountUsageSnapshot].self, from: data) else { return [] }
+            return decoded
+        }
+        return SharedMetricsStore.loadAccountMetrics()
     }
 
     /// Blocks until any in-flight async write has completed. Test-only: lets a

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -4,8 +4,8 @@ import os
 import Combine
 import SwiftUI
 
-/// The single-account provider surface `UsageDataManager` orchestrates (Codex,
-/// Cursor). Behind a protocol so the manager's merge / graceful-degradation
+/// The single-account provider surface `UsageDataManager` orchestrates (Cursor).
+/// Behind a protocol so the manager's merge / graceful-degradation
 /// logic can be tested with stub providers instead of the real network + local
 /// credential files. Claude Code has its own account-aware path and is not part
 /// of this seam.
@@ -14,8 +14,14 @@ protocol SimpleUsageProviding: AnyObject {
     func fetchUsageMetrics() async throws -> UsageMetrics
 }
 
-extension CodexCliLocalService: SimpleUsageProviding {}
 extension CursorLocalService: SimpleUsageProviding {}
+
+protocol CodexUsageProviding: AnyObject {
+    func canAccess(account: CodexAccount) async -> Bool
+    func fetchUsageMetrics(account: CodexAccount) async throws -> UsageMetrics
+}
+
+extension CodexCliLocalService: CodexUsageProviding {}
 
 @MainActor
 class UsageDataManager: ObservableObject {
@@ -23,6 +29,7 @@ class UsageDataManager: ObservableObject {
 
     @Published var metrics: [ServiceType: UsageMetrics] = [:]
     @Published var claudeCodeAccountMetrics: [UUID: UsageMetrics] = [:]
+    @Published var codexAccountMetrics: [UUID: UsageMetrics] = [:]
     @Published var isLoading: Bool = false
     @Published var lastError: Error?
 
@@ -39,8 +46,9 @@ class UsageDataManager: ObservableObject {
 
     private let claudeCodeService: ClaudeCodeLocalService
     private let cursorService: SimpleUsageProviding
-    private let codexCliService: SimpleUsageProviding
+    private let codexCliService: CodexUsageProviding
     private let claudeCodeAccountStore: ClaudeCodeAccountStore
+    private let codexAccountStore: CodexAccountStore
     private let providerVisibilityStore: ProviderVisibilityStore
 
     private var refreshTimer: Timer?
@@ -55,23 +63,26 @@ class UsageDataManager: ObservableObject {
     /// MainActor-isolated singletons cannot appear in (nonisolated) default
     /// argument position.
     init(
-        codexCliService: SimpleUsageProviding = CodexCliLocalService.shared,
+        codexCliService: CodexUsageProviding? = nil,
         cursorService: SimpleUsageProviding = CursorLocalService.shared,
         claudeCodeService: ClaudeCodeLocalService = .shared,
         claudeCodeAccountStore: ClaudeCodeAccountStore? = nil,
+        codexAccountStore: CodexAccountStore? = nil,
         providerVisibilityStore: ProviderVisibilityStore? = nil,
         sharedStore: SharedDataStore = .shared,
         cacheDefaults: UserDefaults = .standard,
         schedulesAutoRefresh: Bool = true
     ) {
-        self.codexCliService = codexCliService
+        self.codexCliService = codexCliService ?? CodexCliLocalService.shared
         self.cursorService = cursorService
         self.claudeCodeService = claudeCodeService
         self.claudeCodeAccountStore = claudeCodeAccountStore ?? .shared
+        self.codexAccountStore = codexAccountStore ?? .shared
         self.providerVisibilityStore = providerVisibilityStore ?? .shared
         self.sharedStore = sharedStore
         self.cacheDefaults = cacheDefaults
         loadCachedData()
+        loadCachedCodexAccountMetrics()
         if schedulesAutoRefresh {
             setupAutoRefresh()
         }
@@ -97,9 +108,21 @@ class UsageDataManager: ObservableObject {
             claudeCodeAccountMetrics = [:]
         }
 
+        if providerVisibilityStore.isEnabled(.codexCli) {
+            let accountMetrics = await fetchCodexAccountMetrics()
+            codexAccountMetrics = accountMetrics
+            if let representative = representativeCodexMetrics(from: accountMetrics) {
+                newMetrics[.codexCli] = representative
+            } else if let cachedMetrics = self.metrics[.codexCli] {
+                newMetrics[.codexCli] = cachedMetrics
+            }
+        } else {
+            codexAccountMetrics = [:]
+        }
+
         // Fetch the simple (single-account) providers. On failure the final
         // merge loop below preserves any cached metrics (graceful degradation).
-        for service in [ServiceType.codexCli, .cursor]
+        for service in [ServiceType.cursor]
         where providerVisibilityStore.isEnabled(service) && hasProviderAccess(service) {
             do {
                 newMetrics[service] = try await fetchSimpleProviderMetrics(service)
@@ -120,7 +143,8 @@ class UsageDataManager: ObservableObject {
 
         metrics = newMetrics
         saveCachedData()
-        sharedStore.saveMetrics(newMetrics)
+        saveCachedCodexAccountMetrics()
+        saveSharedData(newMetrics)
         isLoading = false
     }
 
@@ -132,53 +156,23 @@ class UsageDataManager: ObservableObject {
             metrics.removeValue(forKey: service)
             if service == .claudeCode {
                 claudeCodeAccountMetrics = [:]
+            } else if service == .codexCli {
+                codexAccountMetrics = [:]
             }
             saveCachedData()
-            sharedStore.saveMetrics(metrics)
+            saveCachedCodexAccountMetrics()
+            saveSharedData(metrics)
             isLoading = false
             return
         }
 
         do {
-            let newMetrics: UsageMetrics
-
-            switch service {
-            case .claudeCode:
-                guard claudeCodeService.hasAccess else {
-                    throw ServiceError.notAuthenticated
-                }
-                let accountMetrics = await fetchClaudeCodeAccountMetrics()
-                claudeCodeAccountMetrics = accountMetrics
-                if let representativeMetrics = representativeClaudeCodeMetrics(from: accountMetrics) {
-                    newMetrics = representativeMetrics
-                } else if let cachedMetric = metrics[service] {
-                    newMetrics = cachedMetric
-                } else {
-                    // No representative account metrics and nothing cached. Throw a
-                    // specific error rather than the shared `lastError`, which may
-                    // hold a stale error from an unrelated provider/account.
-                    throw ServiceError.notAuthenticated
-                }
-            case .codexCli, .cursor:
-                guard hasProviderAccess(service) else {
-                    throw ServiceError.notAuthenticated
-                }
-                do {
-                    newMetrics = try await fetchSimpleProviderMetrics(service)
-                } catch {
-                    // On individual refresh, preserve cached data if fetch fails
-                    if let cachedMetric = metrics[service] {
-                        newMetrics = cachedMetric
-                        lastError = error
-                    } else {
-                        throw error
-                    }
-                }
-            }
+            let newMetrics = try await refreshedMetrics(for: service)
 
             metrics[service] = newMetrics
             saveCachedData()
-            sharedStore.saveMetrics(metrics)
+            saveCachedCodexAccountMetrics()
+            saveSharedData(metrics)
         } catch {
             if lastError == nil {
                 lastError = error
@@ -192,6 +186,34 @@ class UsageDataManager: ObservableObject {
         }
 
         isLoading = false
+    }
+
+    private func refreshedMetrics(for service: ServiceType) async throws -> UsageMetrics {
+        switch service {
+        case .claudeCode:
+            guard claudeCodeService.hasAccess else { throw ServiceError.notAuthenticated }
+            let accountMetrics = await fetchClaudeCodeAccountMetrics()
+            claudeCodeAccountMetrics = accountMetrics
+            if let representative = representativeClaudeCodeMetrics(from: accountMetrics) { return representative }
+        case .codexCli:
+            let accountMetrics = await fetchCodexAccountMetrics()
+            codexAccountMetrics = accountMetrics
+            if let representative = representativeCodexMetrics(from: accountMetrics) { return representative }
+        case .cursor:
+            guard hasProviderAccess(service) else { throw ServiceError.notAuthenticated }
+            do {
+                return try await fetchSimpleProviderMetrics(service)
+            } catch {
+                if let cachedMetric = metrics[service] {
+                    lastError = error
+                    return cachedMetric
+                }
+                throw error
+            }
+        }
+
+        if let cachedMetric = metrics[service] { return cachedMetric }
+        throw ServiceError.notAuthenticated
     }
 
     private func loadCachedData() {
@@ -213,6 +235,26 @@ class UsageDataManager: ObservableObject {
         if let data = MetricsCodec.encode(metrics) {
             cacheDefaults.set(data, forKey: cacheKey)
         }
+    }
+
+    private func loadCachedCodexAccountMetrics() {
+        guard let data = cacheDefaults.data(forKey: StorageKeys.cachedCodexAccountMetrics),
+              let decoded = try? JSONDecoder().decode([UUID: UsageMetrics].self, from: data) else { return }
+        codexAccountMetrics = decoded
+    }
+
+    private func saveCachedCodexAccountMetrics() {
+        guard let data = try? JSONEncoder().encode(codexAccountMetrics) else { return }
+        cacheDefaults.set(data, forKey: StorageKeys.cachedCodexAccountMetrics)
+    }
+
+    private func saveSharedData(_ metrics: [ServiceType: UsageMetrics]) {
+        sharedStore.saveMetrics(metrics)
+        let accountSnapshots = codexAccountStore.accounts.compactMap { account -> AccountUsageSnapshot? in
+            guard let metrics = codexAccountMetrics[account.id] else { return nil }
+            return AccountUsageSnapshot(id: account.id, name: account.name, metrics: metrics)
+        }
+        sharedStore.saveAccountMetrics(accountSnapshots)
     }
 
     private func setupAutoRefresh() {
@@ -251,6 +293,27 @@ class UsageDataManager: ObservableObject {
         accountMetrics[ClaudeCodeAccount.defaultID] ?? accountMetrics.values.first
     }
 
+    private func fetchCodexAccountMetrics() async -> [UUID: UsageMetrics] {
+        var refreshedMetrics: [UUID: UsageMetrics] = [:]
+        for account in codexAccountStore.accounts {
+            guard await codexCliService.canAccess(account: account) else { continue }
+            do {
+                refreshedMetrics[account.id] = try await codexCliService.fetchUsageMetrics(account: account)
+            } catch {
+                lastError = error
+                if let cachedMetrics = codexAccountMetrics[account.id] {
+                    refreshedMetrics[account.id] = cachedMetrics
+                }
+            }
+        }
+        return refreshedMetrics
+    }
+
+    private func representativeCodexMetrics(from accountMetrics: [UUID: UsageMetrics]) -> UsageMetrics? {
+        accountMetrics[CodexAccount.defaultID]
+            ?? codexAccountStore.accounts.lazy.compactMap { accountMetrics[$0.id] }.first
+    }
+
     // MARK: - Provider strategy
 
     private func hasProviderAccess(_ service: ServiceType) -> Bool {
@@ -258,7 +321,7 @@ class UsageDataManager: ObservableObject {
         case .claudeCode:
             return claudeCodeService.hasAccess
         case .codexCli:
-            return codexCliService.hasAccess
+            return false
         case .cursor:
             return cursorService.hasAccess
         }
@@ -268,12 +331,10 @@ class UsageDataManager: ObservableObject {
     /// its own account-aware path).
     private func fetchSimpleProviderMetrics(_ service: ServiceType) async throws -> UsageMetrics {
         switch service {
-        case .codexCli:
-            return try await codexCliService.fetchUsageMetrics()
         case .cursor:
             return try await cursorService.fetchUsageMetrics()
-        case .claudeCode:
-            preconditionFailure("Claude Code uses the account-aware fetch path")
+        case .claudeCode, .codexCli:
+            preconditionFailure("Account-aware providers use dedicated fetch paths")
         }
     }
 }

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -13,6 +13,7 @@ struct MenuBarView: View {
   @StateObject private var dataManager = UsageDataManager.shared
   @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
   @StateObject private var codexCliService = CodexCliLocalService.shared
+  @StateObject private var codexAccountStore = CodexAccountStore.shared
   @StateObject private var cursorService = CursorLocalService.shared
   @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
   @StateObject private var providerVisibility = ProviderVisibilityStore.shared
@@ -67,6 +68,8 @@ struct MenuBarView: View {
             snapshots: ProviderSnapshotBuilder.snapshots(
               ProviderSnapshotBuilder.Input(
                 metrics: dataManager.metrics,
+                codexAccounts: codexAccountStore.accounts,
+                codexAccountMetrics: dataManager.codexAccountMetrics,
                 claudeAccounts: claudeAccountStore.accounts,
                 claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
                 enabledServices: providerVisibility.enabledServices,

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -125,6 +125,8 @@ struct SnapshotLimit: Identifiable {
 enum ProviderSnapshotBuilder {
     struct Input {
         var metrics: [ServiceType: UsageMetrics]
+        var codexAccounts: [CodexAccount] = [.defaultAccount]
+        var codexAccountMetrics: [UUID: UsageMetrics] = [:]
         var claudeAccounts: [ClaudeCodeAccount]
         var claudeAccountMetrics: [UUID: UsageMetrics]
         var enabledServices: Set<ServiceType>
@@ -141,12 +143,25 @@ enum ProviderSnapshotBuilder {
         var result: [ProviderSnapshot] = []
 
         if input.enabledServices.contains(.codexCli) {
-            result.append(snapshot(
-                title: "Codex",
-                service: .codexCli,
-                metrics: input.metrics[.codexCli],
-                emptyDetail: input.codexCliHasAccess ? "Waiting for refresh" : "Run codex login"
-            ))
+            if !input.codexAccountMetrics.isEmpty {
+                for account in input.codexAccounts {
+                    let title = account.isDefault && input.codexAccounts.count == 1 ? "Codex" : account.name
+                    result.append(snapshot(
+                        title: title,
+                        service: .codexCli,
+                        metrics: input.codexAccountMetrics[account.id],
+                        emptyDetail: account.isDefault ? "Waiting for refresh" : "Run codex login",
+                        accountID: account.id
+                    ))
+                }
+            } else {
+                result.append(snapshot(
+                    title: "Codex",
+                    service: .codexCli,
+                    metrics: input.metrics[.codexCli],
+                    emptyDetail: input.codexCliHasAccess ? "Waiting for refresh" : "Run codex login"
+                ))
+            }
         }
 
         if input.enabledServices.contains(.claudeCode) {

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -163,6 +163,13 @@ struct SettingsView: View {
                 isAddingClaudeAccount = false
             }
         }
+        .sheet(isPresented: $isAddingCodexAccount) {
+            AddCodexAccountSheet { name, homeDirectory in
+                codexAccountStore.addAccount(name: name, homeDirectory: homeDirectory)
+                isAddingCodexAccount = false
+                Task { await dataManager.refreshAll() }
+            }
+        }
     }
 
     // MARK: Private
@@ -170,6 +177,7 @@ struct SettingsView: View {
     @StateObject private var dataManager = UsageDataManager.shared
     @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
     @StateObject private var codexCliService = CodexCliLocalService.shared
+    @StateObject private var codexAccountStore = CodexAccountStore.shared
     @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
     @StateObject private var cursorService = CursorLocalService.shared
     @StateObject private var costTracker = CostTracker.shared
@@ -181,6 +189,7 @@ struct SettingsView: View {
     @StateObject private var apiUsageStore = ApiUsageStore.shared
 
     @State private var isAddingClaudeAccount = false
+    @State private var isAddingCodexAccount = false
     @State private var claudeReconnectError: String?
     @State private var claudeAdminKeyDraft = ""
     @State private var openaiAdminKeyDraft = ""
@@ -213,6 +222,8 @@ struct SettingsView: View {
         ProviderSnapshotBuilder.snapshots(
             ProviderSnapshotBuilder.Input(
                 metrics: dataManager.metrics,
+                codexAccounts: codexAccountStore.accounts,
+                codexAccountMetrics: dataManager.codexAccountMetrics,
                 claudeAccounts: claudeAccountStore.accounts,
                 claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
                 enabledServices: providerVisibility.enabledServices,
@@ -420,7 +431,7 @@ struct SettingsView: View {
     private var codexCliSection: some View {
         SettingsPanelSection(title: "OpenAI Codex", logoKind: .codex, color: MeterBarTheme.codexAccent) {
             SettingsRowView(
-                title: "Connection",
+                title: "Default connection",
                 detail: "Reads the OAuth session from \(codexAuthFileDisplayPath)."
             ) {
                 HStack(spacing: 8) {
@@ -435,9 +446,7 @@ struct SettingsView: View {
                         Task {
                             let service = codexCliService
                             await Task.detached(priority: .userInitiated) { service.checkAccess() }.value
-                            if codexCliService.hasAccess {
-                                await dataManager.refresh(service: .codexCli)
-                            }
+                            await dataManager.refresh(service: .codexCli)
                         }
                     }
                     .buttonStyle(.bordered)
@@ -452,6 +461,46 @@ struct SettingsView: View {
                 }
             } else if !codexCliService.hasAccess {
                 SettingsNotice(text: "Run codex login, then check again.", color: MeterBarTheme.warning)
+            }
+
+            SettingsDivider()
+
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Text("Codex Accounts")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                    Spacer()
+                    Button {
+                        isAddingCodexAccount = true
+                    } label: {
+                        Label("Add Account", systemImage: "plus")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                }
+
+                VStack(spacing: 0) {
+                    ForEach(Array(codexAccountStore.accounts.enumerated()), id: \.element.id) { index, account in
+                        if index > 0 { SettingsDivider() }
+                        CodexAccountProfileRow(
+                            account: account,
+                            isConnected: dataManager.codexAccountMetrics[account.id] != nil,
+                            onSave: { name, homeDirectory in
+                                codexAccountStore.updateAccount(
+                                    id: account.id,
+                                    name: name,
+                                    homeDirectory: homeDirectory
+                                )
+                                Task { await dataManager.refreshAll() }
+                            },
+                            onRemove: {
+                                codexAccountStore.removeAccount(id: account.id)
+                                Task { await dataManager.refreshAll() }
+                            }
+                        )
+                    }
+                }
             }
         }
     }
@@ -1650,6 +1699,71 @@ private struct AdminKeySettingsRow: View {
 
 // MARK: - AddClaudeAccountSheet
 
+private struct AddCodexAccountSheet: View {
+    let onAdd: (String, String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(spacing: 10) {
+                ProviderLogoView(kind: .codex, size: 18, foregroundColor: MeterBarTheme.codexAccent)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Add Codex Account").font(.headline)
+                    Text("Use a separate CODEX_HOME containing its own auth.json.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 12) {
+                TextField("Account name", text: $accountName).settingsInput()
+                HStack(spacing: 8) {
+                    TextField("Codex home directory", text: $homeDirectory).settingsInput()
+                    Button("Choose", action: chooseHomeDirectory).buttonStyle(.bordered)
+                }
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }.keyboardShortcut(.cancelAction)
+                Button("Add Account") {
+                    onAdd(trimmedName, trimmedHomeDirectory)
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(!canAdd)
+            }
+        }
+        .padding(22)
+        .frame(width: 520)
+    }
+
+    @Environment(\.dismiss)
+    private var dismiss
+    @State private var accountName = ""
+    @State private var homeDirectory = ""
+
+    private var trimmedName: String { accountName.trimmingCharacters(in: .whitespacesAndNewlines) }
+    private var trimmedHomeDirectory: String {
+        homeDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    private var canAdd: Bool { !trimmedName.isEmpty && !trimmedHomeDirectory.isEmpty }
+
+    private func chooseHomeDirectory() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Use"
+        if panel.runModal() == .OK, let url = panel.url {
+            homeDirectory = url.path
+            if trimmedName.isEmpty { accountName = url.lastPathComponent }
+        }
+    }
+}
+
+// MARK: - AddClaudeAccountSheet
+
 private struct AddClaudeAccountSheet: View {
     // MARK: Internal
 
@@ -1907,6 +2021,102 @@ private struct AccountProfileRow: View {
         if panel.runModal() == .OK, let url = panel.url {
             configDirectoryDraft = url.path
         }
+    }
+}
+
+private struct CodexAccountProfileRow: View {
+    init(
+        account: CodexAccount,
+        isConnected: Bool,
+        onSave: @escaping (String, String?) -> Void,
+        onRemove: @escaping () -> Void
+    ) {
+        self.account = account
+        self.isConnected = isConnected
+        self.onSave = onSave
+        self.onRemove = onRemove
+        _nameDraft = State(initialValue: account.name)
+        _homeDirectoryDraft = State(initialValue: account.homeDirectory ?? "")
+    }
+
+    let account: CodexAccount
+    let isConnected: Bool
+    let onSave: (String, String?) -> Void
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: account.isDefault ? "person.crop.circle" : "person.crop.circle.badge.plus")
+                .foregroundStyle(MeterBarTheme.codexAccent)
+                .frame(width: 18)
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    TextField("Account label", text: $nameDraft)
+                        .settingsInput(width: 240)
+                        .onSubmit(saveChanges)
+                    Text(account.isDefault ? "Default" : "Profile")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(account.isDefault ? MeterBarTheme.appAccent : MeterBarTheme.codexAccent)
+                    StatusPill(title: isConnected ? "Connected" : "Not Connected", isConnected: isConnected)
+                        .font(.caption)
+                }
+
+                HStack(spacing: 8) {
+                    Text("CODEX_HOME")
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 126, alignment: .leading)
+                    if account.isDefault {
+                        SettingsReadonlyField(text: CodexHomeDirectory.path(for: account))
+                    } else {
+                        TextField("Codex home directory", text: $homeDirectoryDraft)
+                            .settingsInput(width: 280)
+                            .onSubmit(saveChanges)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            HStack(spacing: 8) {
+                Button(action: saveChanges) { Image(systemName: "checkmark") }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(!hasChanges || !canSave)
+                    .help("Save account changes")
+                if !account.isDefault {
+                    Button(role: .destructive, action: onRemove) { Image(systemName: "trash") }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .help("Delete account")
+                }
+            }
+            .frame(minWidth: 80, alignment: .trailing)
+        }
+        .padding(.vertical, 10)
+        .onChange(of: account) { _, updated in
+            nameDraft = updated.name
+            homeDirectoryDraft = updated.homeDirectory ?? ""
+        }
+    }
+
+    @State private var nameDraft: String
+    @State private var homeDirectoryDraft: String
+
+    private var trimmedName: String { nameDraft.trimmingCharacters(in: .whitespacesAndNewlines) }
+    private var trimmedHomeDirectory: String {
+        homeDirectoryDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    private var hasChanges: Bool {
+        trimmedName != account.name || (!account.isDefault && trimmedHomeDirectory != account.homeDirectory)
+    }
+    private var canSave: Bool { !trimmedName.isEmpty && (account.isDefault || !trimmedHomeDirectory.isEmpty) }
+
+    private func saveChanges() {
+        guard hasChanges, canSave else { return }
+        onSave(trimmedName, account.isDefault ? nil : trimmedHomeDirectory)
     }
 }
 

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -1697,7 +1697,7 @@ private struct AdminKeySettingsRow: View {
     }
 }
 
-// MARK: - AddClaudeAccountSheet
+// MARK: - AddCodexAccountSheet
 
 private struct AddCodexAccountSheet: View {
     let onAdd: (String, String) -> Void

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -170,6 +170,7 @@ struct UsageDashboardView: View {
     @StateObject private var dataManager = UsageDataManager.shared
     @StateObject private var costTracker = CostTracker.shared
     @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
+    @StateObject private var codexAccountStore = CodexAccountStore.shared
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
     @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
     @StateObject private var codexCliService = CodexCliLocalService.shared
@@ -600,6 +601,8 @@ struct UsageDashboardView: View {
         // that have reported metrics.
         ProviderSnapshotBuilder.snapshots(ProviderSnapshotBuilder.Input(
             metrics: dataManager.metrics,
+            codexAccounts: codexAccountStore.accounts,
+            codexAccountMetrics: dataManager.codexAccountMetrics,
             claudeAccounts: claudeAccountStore.accounts,
             claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
             enabledServices: providerVisibility.enabledServices,

--- a/MeterBarTests/CodexAccountStoreTests.swift
+++ b/MeterBarTests/CodexAccountStoreTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import MeterBar
+
+final class CodexAccountStoreTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "CodexAccountStoreTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testDefaultProfileNeedsNoConfigurationAndLabelPersists() {
+        let store = CodexAccountStore(userDefaults: defaults)
+        XCTAssertEqual(store.accounts, [.defaultAccount])
+
+        store.updateAccount(id: CodexAccount.defaultID, name: "Personal", homeDirectory: nil)
+
+        let reloaded = CodexAccountStore(userDefaults: defaults)
+        XCTAssertEqual(reloaded.accounts.first?.name, "Personal")
+        XCTAssertNil(reloaded.accounts.first?.homeDirectory)
+    }
+
+    func testCustomProfilesPersistIndependentHomesAndOrder() {
+        let store = CodexAccountStore(userDefaults: defaults)
+        store.addAccount(name: "Work", homeDirectory: "/tmp/codex-work")
+        store.addAccount(name: "Personal", homeDirectory: "/tmp/codex-personal")
+
+        store.moveAccounts(fromOffsets: IndexSet(integer: 2), toOffset: 0)
+
+        let reloaded = CodexAccountStore(userDefaults: defaults)
+        XCTAssertEqual(reloaded.accounts.map(\.name), ["Personal", CodexAccount.defaultName, "Work"])
+        XCTAssertEqual(reloaded.customAccounts.map(\.homeDirectory), ["/tmp/codex-work", "/tmp/codex-personal"])
+    }
+
+    func testCustomProfileCanBeEditedAndRemovedWithoutRemovingDefault() {
+        let store = CodexAccountStore(userDefaults: defaults)
+        store.addAccount(name: "Work", homeDirectory: "/tmp/old")
+        let account = store.customAccounts[0]
+
+        store.updateAccount(id: account.id, name: "Team", homeDirectory: "/tmp/new")
+        XCTAssertEqual(store.customAccounts[0].name, "Team")
+        XCTAssertEqual(store.customAccounts[0].homeDirectory, "/tmp/new")
+
+        store.removeAccount(id: account.id)
+        store.removeAccount(id: CodexAccount.defaultID)
+        XCTAssertEqual(store.accounts.map(\.id), [CodexAccount.defaultID])
+    }
+}

--- a/MeterBarTests/CodexCliLocalServiceTests.swift
+++ b/MeterBarTests/CodexCliLocalServiceTests.swift
@@ -173,6 +173,23 @@ final class CodexCliLocalServiceTests: XCTestCase {
         XCTAssertNil(service.getAuthToken())
     }
 
+    func testAccountAuthProviderReadsEachCodexHomeIndependently() {
+        let defaultToken = makeJWT(exp: futureExp, accountId: "default")
+        let workToken = makeJWT(exp: futureExp, accountId: "work")
+        let work = CodexAccount(id: UUID(), name: "Work", homeDirectory: "/tmp/codex-work")
+        let service = CodexCliLocalService(accountAuthFileDataProvider: { account in
+            if account.id == work.id {
+                return self.authFileJSON(accessToken: workToken, accountId: "work")
+            }
+            return self.authFileJSON(accessToken: defaultToken, accountId: "default")
+        })
+
+        XCTAssertEqual(service.getAuthToken(account: .defaultAccount), defaultToken)
+        XCTAssertEqual(service.getAccountId(account: .defaultAccount), "default")
+        XCTAssertEqual(service.getAuthToken(account: work), workToken)
+        XCTAssertEqual(service.getAccountId(account: work), "work")
+    }
+
     // MARK: - Main-thread hygiene
 
     /// The auth-file read is disk I/O and must never run on the main thread when

--- a/MeterBarTests/MenuBarSmokeTests.swift
+++ b/MeterBarTests/MenuBarSmokeTests.swift
@@ -16,7 +16,7 @@ import XCTest
 final class MenuBarSmokeTests: XCTestCase {
 
     /// Controllable single-account provider (Codex / Cursor stand-in).
-    private final class StubUsageProvider: SimpleUsageProviding {
+    private final class StubUsageProvider: SimpleUsageProviding, CodexUsageProviding {
         var hasAccess: Bool
         private let metrics: UsageMetrics
         init(hasAccess: Bool, metrics: UsageMetrics) {
@@ -24,6 +24,8 @@ final class MenuBarSmokeTests: XCTestCase {
             self.metrics = metrics
         }
         func fetchUsageMetrics() async throws -> UsageMetrics { metrics }
+        func canAccess(account: CodexAccount) async -> Bool { hasAccess }
+        func fetchUsageMetrics(account: CodexAccount) async throws -> UsageMetrics { metrics }
     }
 
     private var tempDirectory: URL!

--- a/MeterBarTests/NotificationDeciderTests.swift
+++ b/MeterBarTests/NotificationDeciderTests.swift
@@ -386,4 +386,18 @@ final class NotificationDeciderTests: XCTestCase {
             "Claude Code-codeReview-critical"
         ])
     }
+
+    func testAccountIdentityScopesKeysAndLabelsNotification() {
+        let result = decider().evaluate(
+            metrics: metrics(service: .codexCli, session: exhaustedLimit()),
+            providerEnabled: true,
+            alreadyNotified: [],
+            accountKey: "work-account",
+            serviceDisplayName: "Work (OpenAI Codex)",
+            now: now
+        )
+
+        XCTAssertEqual(result.notifications.first?.key, "Codex CLI-work-account-session-critical")
+        XCTAssertEqual(result.notifications.first?.title, "Work (OpenAI Codex) Session Limit Reached")
+    }
 }

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -100,6 +100,25 @@ final class ProviderSnapshotTests: XCTestCase {
         XCTAssertEqual(Set(snapshots.map(\.id)).count, snapshots.count)
     }
 
+    func testMultipleCodexAccountsUseIndependentMetricsAndAccountNames() {
+        let work = CodexAccount(id: UUID(), name: "Work", homeDirectory: "/tmp/codex-work")
+        let snapshots = ProviderSnapshotBuilder.snapshots(ProviderSnapshotBuilder.Input(
+            metrics: [:],
+            codexAccounts: [.defaultAccount, work],
+            codexAccountMetrics: [
+                CodexAccount.defaultID: makeMetrics(service: .codexCli, weekly: 25),
+                work.id: makeMetrics(service: .codexCli, weekly: 75)
+            ],
+            claudeAccounts: [.defaultAccount],
+            claudeAccountMetrics: [:],
+            enabledServices: [.codexCli]
+        ))
+
+        XCTAssertEqual(snapshots.map(\.title), [CodexAccount.defaultName, "Work"])
+        XCTAssertEqual(snapshots.map { $0.primaryLimit?.usedPercent }, [25, 75])
+        XCTAssertEqual(Set(snapshots.map(\.id)).count, 2)
+    }
+
     // MARK: - Limits
 
     func testThirdLimitLabelIsSonnetForClaudeAndCodeReviewForCodex() {

--- a/MeterBarTests/SharedDataStoreTests.swift
+++ b/MeterBarTests/SharedDataStoreTests.swift
@@ -71,4 +71,23 @@ final class SharedDataStoreTests: XCTestCase {
         XCTAssertEqual(Set(loaded.keys), [.cursor])
         XCTAssertEqual(loaded[.cursor]?.weeklyLimit?.used, 400)
     }
+
+    func testAccountMetricsRoundTripPreservesLabelsAndIndependentUsage() {
+        let store = SharedDataStore(directoryOverride: tempDirectory) {}
+        let snapshots = [
+            AccountUsageSnapshot(id: CodexAccount.defaultID, name: "Personal", metrics: MetricsFixtures.codexCli()),
+            AccountUsageSnapshot(
+                id: UUID(),
+                name: "Work",
+                metrics: MetricsFixtures.codexCli(sessionUsedPercent: 90, weeklyUsedPercent: 70)
+            )
+        ]
+
+        store.saveAccountMetrics(snapshots)
+        store.flushPendingWrites()
+
+        let loaded = store.loadAccountMetrics()
+        XCTAssertEqual(loaded.map(\.name), ["Personal", "Work"])
+        XCTAssertEqual(loaded.map { $0.metrics.sessionLimit?.used }, [30, 90])
+    }
 }

--- a/MeterBarTests/StatusItemLimitSelectorTests.swift
+++ b/MeterBarTests/StatusItemLimitSelectorTests.swift
@@ -115,4 +115,11 @@ final class StatusItemLimitSelectorTests: XCTestCase {
         XCTAssertEqual(select([b, a])?.key, "claude:a")
         XCTAssertEqual(select([a, b])?.key, "claude:a")
     }
+
+    func testCodexAccountsCompeteIndependentlyByActivity() {
+        let idle = candidate(key: "codex:personal", percentUsed: 95)
+        let active = candidate(key: "codex:work", percentUsed: 45, activeMinutesAgo: 2)
+
+        XCTAssertEqual(select([idle, active])?.key, "codex:work")
+    }
 }

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -12,7 +12,7 @@ import XCTest
 final class UsageDataManagerTests: XCTestCase {
 
     /// Stub provider whose access flag and fetch result are fully controlled.
-    private final class StubProvider: SimpleUsageProviding {
+    private final class StubProvider: SimpleUsageProviding, CodexUsageProviding {
         var hasAccess: Bool
         var result: Result<UsageMetrics, Error>
         private(set) var fetchCount = 0
@@ -26,9 +26,31 @@ final class UsageDataManagerTests: XCTestCase {
             fetchCount += 1
             return try result.get()
         }
+
+        func canAccess(account: CodexAccount) async -> Bool { hasAccess }
+        func fetchUsageMetrics(account: CodexAccount) async throws -> UsageMetrics {
+            try await fetchUsageMetrics()
+        }
     }
 
     private enum StubError: Error { case fetchFailed }
+
+    private final class MultiAccountCodexProvider: CodexUsageProviding {
+        let metricsByAccount: [UUID: UsageMetrics]
+
+        init(metricsByAccount: [UUID: UsageMetrics]) {
+            self.metricsByAccount = metricsByAccount
+        }
+
+        func canAccess(account: CodexAccount) async -> Bool {
+            metricsByAccount[account.id] != nil
+        }
+
+        func fetchUsageMetrics(account: CodexAccount) async throws -> UsageMetrics {
+            guard let metrics = metricsByAccount[account.id] else { throw StubError.fetchFailed }
+            return metrics
+        }
+    }
 
     private var tempDirectory: URL!
     private var createdSuiteNames: [String] = []
@@ -57,8 +79,9 @@ final class UsageDataManagerTests: XCTestCase {
     /// `.claudeCode`; `preload` seeds the on-disk cache before construction so
     /// graceful-degradation paths have something to preserve.
     private func makeManager(
-        codex: StubProvider,
+        codex: CodexUsageProviding,
         cursor: StubProvider,
+        codexAccountStore: CodexAccountStore? = nil,
         hidden: Set<ServiceType> = [],
         preload: [ServiceType: UsageMetrics] = [:]
     ) -> (manager: UsageDataManager, sharedStore: SharedDataStore) {
@@ -80,6 +103,7 @@ final class UsageDataManagerTests: XCTestCase {
         let manager = UsageDataManager(
             codexCliService: codex,
             cursorService: cursor,
+            codexAccountStore: codexAccountStore,
             providerVisibilityStore: visibility,
             sharedStore: sharedStore,
             cacheDefaults: cacheDefaults,
@@ -161,5 +185,32 @@ final class UsageDataManagerTests: XCTestCase {
         XCTAssertNil(manager.metrics[.cursor])
         sharedStore.flushPendingWrites()
         XCTAssertNil(sharedStore.loadMetrics()[.cursor])
+    }
+
+    func testRefreshAllFetchesIndependentCodexAccountsAndBridgesLabels() async throws {
+        let accountSuite = "UsageDataManagerTests-accounts-\(UUID().uuidString)"
+        createdSuiteNames.append(accountSuite)
+        let accountDefaults = try XCTUnwrap(UserDefaults(suiteName: accountSuite))
+        let accountStore = CodexAccountStore(userDefaults: accountDefaults)
+        accountStore.addAccount(name: "Work", homeDirectory: "/tmp/codex-work")
+        let work = try XCTUnwrap(accountStore.customAccounts.first)
+        let provider = MultiAccountCodexProvider(metricsByAccount: [
+            CodexAccount.defaultID: MetricsFixtures.codexCli(sessionUsedPercent: 20),
+            work.id: MetricsFixtures.codexCli(sessionUsedPercent: 80)
+        ])
+        let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+        let (manager, sharedStore) = makeManager(
+            codex: provider,
+            cursor: cursor,
+            codexAccountStore: accountStore
+        )
+
+        await manager.refreshAll()
+
+        XCTAssertEqual(manager.codexAccountMetrics[CodexAccount.defaultID]?.sessionLimit?.used, 20)
+        XCTAssertEqual(manager.codexAccountMetrics[work.id]?.sessionLimit?.used, 80)
+        XCTAssertEqual(manager.metrics[.codexCli]?.sessionLimit?.used, 20)
+        sharedStore.flushPendingWrites()
+        XCTAssertEqual(sharedStore.loadAccountMetrics().map(\.name), [CodexAccount.defaultName, "Work"])
     }
 }

--- a/MeterBarWidget/UsageWidget.swift
+++ b/MeterBarWidget/UsageWidget.swift
@@ -32,10 +32,26 @@ struct UsageWidget: Widget {
 struct UsageWidgetEntry: TimelineEntry {
     let date: Date
     let metrics: [ServiceType: UsageMetrics]
+    let accountMetrics: [AccountUsageSnapshot]
 
-    var sortedServices: [ServiceType] {
-        metrics.keys.sorted { $0.sortOrder < $1.sortOrder }
+    var rows: [WidgetUsageRow] {
+        let accountServices = Set(accountMetrics.map { $0.metrics.service })
+        let accountRows = accountMetrics.map {
+            WidgetUsageRow(id: $0.id.uuidString, name: $0.name, metrics: $0.metrics)
+        }
+        let providerRows = metrics
+            .filter { !accountServices.contains($0.key) }
+            .map { WidgetUsageRow(id: $0.key.rawValue, name: $0.key.displayName, metrics: $0.value) }
+        return (accountRows + providerRows).sorted {
+            ($0.metrics.service.sortOrder, $0.name) < ($1.metrics.service.sortOrder, $1.name)
+        }
     }
+}
+
+struct WidgetUsageRow: Identifiable {
+    let id: String
+    let name: String
+    let metrics: UsageMetrics
 }
 
 struct UsageWidgetProvider: TimelineProvider {
@@ -55,14 +71,16 @@ struct UsageWidgetProvider: TimelineProvider {
                     service: .claudeCode,
                     weeklyLimit: UsageLimit(used: 90, total: 100, resetTime: nil)
                 )
-            ]
+            ],
+            accountMetrics: []
         )
     }
 
     func getSnapshot(in context: Context, completion: @escaping (UsageWidgetEntry) -> Void) {
         let entry = UsageWidgetEntry(
             date: Date(),
-            metrics: SharedMetricsStore.loadMetrics()
+            metrics: SharedMetricsStore.loadMetrics(),
+            accountMetrics: SharedMetricsStore.loadAccountMetrics()
         )
         completion(entry)
     }
@@ -71,7 +89,8 @@ struct UsageWidgetProvider: TimelineProvider {
         let cachedMetrics = SharedMetricsStore.loadMetrics()
         let entry = UsageWidgetEntry(
             date: Date(),
-            metrics: cachedMetrics
+            metrics: cachedMetrics,
+            accountMetrics: SharedMetricsStore.loadAccountMetrics()
         )
 
         let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: Date()) ?? Date()
@@ -103,15 +122,13 @@ struct SmallWidgetView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            if entry.metrics.isEmpty {
+            if entry.rows.isEmpty {
                 Text("No data")
                     .font(.caption)
                     .foregroundColor(.secondary)
             } else {
-                ForEach(entry.sortedServices.prefix(3), id: \.self) { service in
-                    if let metrics = entry.metrics[service] {
-                        ServiceMiniView(metrics: metrics)
-                    }
+                ForEach(Array(entry.rows.prefix(3))) { row in
+                    ServiceMiniView(row: row)
                 }
             }
         }
@@ -122,16 +139,20 @@ struct SmallWidgetView: View {
 }
 
 struct ServiceMiniView: View {
-    let metrics: UsageMetrics
+    let row: WidgetUsageRow
 
     var body: some View {
         HStack(spacing: 6) {
-            Image(metrics.service.assetName)
+            Image(row.metrics.service.assetName)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 14, height: 14)
 
-            if let weeklyLimit = metrics.weeklyLimit {
+            Text(row.name)
+                .font(.caption2)
+                .lineLimit(1)
+
+            if let weeklyLimit = row.metrics.weeklyLimit {
                 ProgressView(value: weeklyLimit.clampedUsed, total: weeklyLimit.clampedTotal)
                     .tint(weeklyLimit.statusColor.color)
                 Text("\(Int(weeklyLimit.percentage))%")
@@ -139,7 +160,7 @@ struct ServiceMiniView: View {
                     .foregroundColor(.secondary)
             }
 
-            WidgetStatusIndicator(status: metrics.overallStatus)
+            WidgetStatusIndicator(status: row.metrics.overallStatus)
         }
     }
 }
@@ -149,15 +170,13 @@ struct MediumWidgetView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            if entry.metrics.isEmpty {
+            if entry.rows.isEmpty {
                 Text("No services connected")
                     .font(.caption)
                     .foregroundColor(.secondary)
             } else {
-                ForEach(entry.sortedServices, id: \.self) { service in
-                    if let metrics = entry.metrics[service] {
-                        ServiceCompactView(metrics: metrics)
-                    }
+                ForEach(entry.rows) { row in
+                    ServiceCompactView(row: row)
                 }
             }
         }
@@ -172,7 +191,7 @@ struct LargeWidgetView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if entry.metrics.isEmpty {
+            if entry.rows.isEmpty {
                 VStack {
                     Image(systemName: "exclamationmark.triangle")
                         .font(.largeTitle)
@@ -183,13 +202,11 @@ struct LargeWidgetView: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                let services = Array(entry.sortedServices.prefix(7))
-                ForEach(Array(services.enumerated()), id: \.element) { index, service in
-                    if let metrics = entry.metrics[service] {
-                        ServiceCompactView(metrics: metrics)
-                        if index < services.count - 1 {
-                            Spacer()
-                        }
+                let rows = Array(entry.rows.prefix(7))
+                ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                    ServiceCompactView(row: row)
+                    if index < rows.count - 1 {
+                        Spacer()
                     }
                 }
             }
@@ -201,23 +218,23 @@ struct LargeWidgetView: View {
 }
 
 struct ServiceCompactView: View {
-    let metrics: UsageMetrics
+    let row: WidgetUsageRow
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
-                Image(metrics.service.assetName)
+                Image(row.metrics.service.assetName)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 18, height: 18)
-                Text(metrics.service.displayName)
+                Text(row.name)
                     .font(.subheadline)
                     .bold()
                 Spacer()
-                WidgetStatusIndicator(status: metrics.overallStatus)
+                WidgetStatusIndicator(status: row.metrics.overallStatus)
             }
 
-            if let weeklyLimit = metrics.weeklyLimit {
+            if let weeklyLimit = row.metrics.weeklyLimit {
                 HStack {
                     ProgressView(value: weeklyLimit.clampedUsed, total: weeklyLimit.clampedTotal)
                         .tint(weeklyLimit.statusColor.color)

--- a/Packages/MeterBarShared/Sources/MeterBarShared/AccountUsageSnapshot.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/AccountUsageSnapshot.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// A labeled provider account for surfaces that can render more than one
+/// account per service, such as the widget.
+public struct AccountUsageSnapshot: Codable, Identifiable, Sendable {
+    public let id: UUID
+    public let name: String
+    public let metrics: UsageMetrics
+
+    public init(id: UUID, name: String, metrics: UsageMetrics) {
+        self.id = id
+        self.name = name
+        self.metrics = metrics
+    }
+}

--- a/Packages/MeterBarShared/Sources/MeterBarShared/SharedMetricsStore.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/SharedMetricsStore.swift
@@ -18,6 +18,7 @@ public enum SharedMetricsStore {
     /// Base name (no extension) of the cached-metrics blob. Also the app's
     /// in-process UserDefaults cache key (see `StorageKeys.cachedUsageMetrics`).
     public static let metricsKey = "cached_usage_metrics"
+    public static let accountMetricsKey = "cached_usage_account_metrics"
 
     /// The shared App Group container, or `nil` when App Groups aren't
     /// provisioned for the running target.
@@ -30,6 +31,10 @@ public enum SharedMetricsStore {
         containerURL?.appendingPathComponent("\(metricsKey).json")
     }
 
+    public static var accountMetricsFileURL: URL? {
+        containerURL?.appendingPathComponent("\(accountMetricsKey).json")
+    }
+
     /// Decode the cached metrics, tolerating a missing file or malformed entries
     /// (an unknown service key drops that entry, not the whole cache — see
     /// `MetricsCodec.decode`). Returns an empty map when nothing is readable.
@@ -39,5 +44,14 @@ public enum SharedMetricsStore {
             return [:]
         }
         return MetricsCodec.decode(data)
+    }
+
+    public static func loadAccountMetrics() -> [AccountUsageSnapshot] {
+        guard let accountMetricsFileURL,
+              let data = try? Data(contentsOf: accountMetricsFileURL),
+              let decoded = try? JSONDecoder().decode([AccountUsageSnapshot].self, from: data) else {
+            return []
+        }
+        return decoded
     }
 }


### PR DESCRIPTION
## Summary

- add zero-config default and persistent custom `CODEX_HOME` profiles with account labels
- fetch, cache, and display independent Codex usage across the popover, dashboard, menu bar, notifications, and widget
- add Settings account management plus account-aware shared widget data
- add focused account-store, auth, orchestration, selector, notification, snapshot, and cache coverage

## Verification

- `swift test --filter 'CodexAccountStoreTests|CodexCliLocalServiceTests|UsageDataManagerTests|ProviderSnapshotTests|StatusItemLimitSelectorTests|SharedDataStoreTests|NotificationDeciderTests'` — 87 tests passed\n- `COVERAGE_THRESHOLD=19 bash scripts/check-coverage.sh` — 542 tests passed; 42.4% line coverage\n- `swiftlint lint --strict --quiet` — passed\n- `swift build --package-path MeterBarCLI` — passed\n- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug CODE_SIGNING_ALLOWED=NO build` — app and widget passed\n- `git diff --check` — passed\n- final correctness and security review — approved with no findings\n\n## Skipped checks / residual risk\n\n- Standalone SwiftFormat is unavailable locally; SwiftLint and compiler formatting checks passed.\n- Live two-account API validation was not possible without a second Codex credential; injected auth fixtures and per-account orchestration tests cover independent homes and metrics.\n- Native visual interaction was compiled but not manually exercised; account labels and Settings layout retain low visual risk.\n- Existing Session Wake Swift 6 actor-isolation warnings in the standalone CLI remain unchanged and outside this issue.\n\nCloses #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking usage across multiple OpenAI Codex accounts and profiles.
  * Added Codex account management in Settings, including adding, editing, reordering, and removing profiles.
  * Displayed independent usage metrics and account labels throughout the dashboard, menu bar, and widget.
  * Added account-specific notifications and status-limit monitoring.

* **Bug Fixes**
  * Improved Codex authentication and usage refresh behavior for separate account profiles.

* **Tests**
  * Added coverage for account persistence, independent metrics, notifications, widgets, and refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->