### PR TITLE
Integrate v1.7.1 batch: 11 reviewed PRs (#152,#155-164)

### DIFF
--- a/.agents/SESSIONS/2026-07-13.md
+++ b/.agents/SESSIONS/2026-07-13.md
@@ -1,0 +1,59 @@
+# Sessions: 2026-07-13
+
+**Summary:** Consolidate app settings into the native macOS Settings scene
+
+---
+
+## Session 1: Remove Embedded Dashboard Settings
+
+**Duration:** ~20 minutes
+**Status:** Complete
+
+### Affected components
+
+- Usage dashboard navigation and toolbar
+- Settings window layout
+- Session Wake settings layout
+- Dashboard and Settings smoke tests
+
+### What was done
+
+- [x] Removed Settings as a dashboard content section and removed the dashboard gear destination
+- [x] Kept `MeterBar > Settings…` as the single app-settings entry and the SwiftUI `Settings` scene as the canonical surface
+- [x] Removed the alternate embedded `SettingsView` layout and its aggregate settings stack
+- [x] Removed the now-dead embedded Session Wake layout
+- [x] Updated layout and smoke tests to cover the consolidated navigation model
+- [x] Cleaned pre-existing lint violations in the touched Session Wake test file
+
+### Files changed
+
+- `MeterBar/Views/UsageDashboardView.swift` - Remove the Settings section, toolbar gear, and embedded settings content
+- `MeterBar/Views/SettingsView.swift` - Keep only the standalone Settings window layout
+- `MeterBar/Views/SessionWakeSettingsView.swift` - Keep only the grouped Settings-pane layout
+- `MeterBarTests/DashboardLayoutTests.swift` - Assert that all dashboard sections are real sidebar destinations
+- `MeterBarTests/SettingsViewSmokeTests.swift` - Remove obsolete embedded-settings coverage
+- `MeterBarTests/SessionWakeStatusTests.swift` - Remove obsolete embedded-layout coverage and satisfy strict lint
+
+### Verification
+
+- `swiftlint lint --strict` on all touched Swift files: 0 violations
+- `swift test`: 524 tests passed
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug build CODE_SIGNING_ALLOWED=NO`: succeeded
+
+### Key decisions
+
+- Settings is app-level configuration, not dashboard content. The native macOS Settings scene is the only Settings surface.
+- The dashboard keeps only monitoring, health, and utility destinations; its toolbar keeps only Refresh.
+
+### Mistakes and fixes
+
+- `swiftformat` is not installed in the environment; formatting was checked with strict SwiftLint and `git diff --check` instead.
+- Strict lint surfaced existing violations in the touched Session Wake test file; those were corrected while preserving test behavior.
+
+### Next steps
+
+_None._
+
+---
+
+**Total sessions today:** 1

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -35,7 +35,9 @@ Three build systems coexist (see `docs/audits/00-repo-map.md` §2):
 Key settings (from `MeterBar.xcodeproj/project.pbxproj`):
 - `MACOSX_DEPLOYMENT_TARGET = 26.0` (Liquid Glass APIs), `SWIFT_VERSION = 5.0` (Swift 5 language mode)
 - App: `ENABLE_APP_SANDBOX = NO` (the app must read other tools' credential/log files and spawn the `claude` binary). Widget: sandboxed. Hardened runtime on for both.
-- Bundle ids `dev.meterbar.app` / `dev.meterbar.app.Widget`; app group `group.dev.meterbar.app`.
+- Release bundle ids `dev.meterbar.app` / `dev.meterbar.app.Widget`; Debug uses
+  `dev.meterbar.app.debug` / `dev.meterbar.app.debug.Widget` and the app product name `MeterBar Dev` so
+  local builds cannot shadow the installed release. Both configurations use app group `group.dev.meterbar.app`.
 
 ---
 

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -83,6 +83,8 @@ meterbar/
 
 `@main` SwiftUI `App` with `Settings` scene + `NSApplicationDelegateAdaptor`. The delegate creates a manual `NSStatusItem` (not `MenuBarExtra`) with an `NSPopover` hosting `MenuBarView`; right-click opens a native status menu (Dock toggle / dashboard / quit). `LSUIElement = true`; Dock icon toggled at runtime via activation policy. A 5-minute `Task.sleep` loop checks limits and posts local notifications at 90%/100% with stable identifiers and re-arm-on-drop semantics.
 
+On the first launch, `FirstRunOnboardingStore` auto-opens the menu panel and shows a one-time launch-at-login choice. Enablement remains explicit through `SMAppService`; choosing either option or dismissing the panel persists `HasCompletedFirstRun` so onboarding does not reappear.
+
 ## Widget & CLI data contract
 
 The app, widget, and CLI consume the canonical `ServiceType`, `UsageLimit`, and `UsageMetrics` definitions from `Packages/MeterBarShared`. The app-group JSON contract is locked by `CachedMetricsContractTests` and `CachedMetricsReplicaContractTests` so fields and date encoding cannot silently drift across targets.

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -80,6 +80,7 @@ meterbar/
 - **OAuthTokenExpiry** — JWT/unix-timestamp expiry checks (60 s grace; unparseable ⇒ not-expired by design).
 - **ServiceSupport** — shared URLSession config, secret-safe HTTP/URLError mapping, real (non-container) home dir via `getpwuid`.
 - **AppLog** — `os.Logger` categories: app, usage, cost, network, storage. This is the only observability; there is no crash reporting or analytics.
+- **SoftwareUpdateController** — owns Sparkle 2's standard updater. The General settings pane binds directly to Sparkle's automatic-check preference (default off until consent) and exposes a manual check action. Release builds embed the GitHub Releases appcast URL and an Actions-provided EdDSA public key.
 
 ## App lifecycle
 
@@ -98,7 +99,7 @@ Dates in the shared JSON use `JSONEncoder`/`JSONDecoder` **default** strategies 
 ## CI / release
 
 - `ci.yml` (push/PR to master, macos-26 + Xcode 26.2): the branch-protection-required `build` job waits for tests/coverage and SwiftLint, fails explicitly unless both pass, then compiles and verifies universal app, widget, and CLI artifacts. Branch protection also requires the test, lint, and secret-scan contexts directly.
-- `release.yml` (canonical `vMAJOR.MINOR.PATCH` tag): builds universal arm64+x86_64 app/widget/CLI artifacts, checks tag/app/CLI version agreement, signs nested code inside-out with an ad-hoc hardened-runtime signature, verifies source entitlements and bundle integrity, zips via `ditto`, publishes GitHub Release, then calls `update-homebrew.yml`. Developer ID signing, authorized provisioning, and notarization remain pending credentials.
+- `release.yml` (canonical `vMAJOR.MINOR.PATCH` tag): preflights Developer ID, notarization, and Sparkle EdDSA credentials; builds universal arm64+x86_64 app/widget/CLI artifacts; checks tag/app/CLI version agreement; signs, notarizes, and staples nested code; generates and validates an EdDSA-signed Sparkle appcast; publishes all assets to GitHub Releases; then calls `update-homebrew.yml`.
 - `secret-scan.yml`: gitleaks (pinned + checksum-verified) over full history.
 
 ## Known architectural risks

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -16,6 +16,7 @@ Providers tracked:
 | Claude Code | `.claudeCode` | Shells out to `claude /usage`, regex-parses terminal output. Legacy OAuth fallback (keychain item `Claude Code-credentials`) behind the `ClaudeCodeEnableOAuthFallback` UserDefaults flag |
 | OpenAI Codex CLI | `.codexCli` | Reads `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`), calls `https://chatgpt.com/backend-api/wham/usage` |
 | Cursor | `.cursor` | Reads session JWT from Cursor's `state.vscdb` SQLite, calls `https://cursor.com/api/usage-summary` |
+| OpenRouter | `.openRouter` | User-provided API key in Keychain; calls documented `/api/v1/credits` and `/api/v1/key` endpoints |
 | Claude (admin) | `.claude` | Anthropic Admin API key (user-provided, stored in our keychain), `/v1/organizations/usage_report/messages` |
 | OpenAI (admin) | `.openai` | OpenAI Admin API key (user-provided, stored in our keychain), `/v1/organization/usage/completions` |
 
@@ -67,6 +68,7 @@ meterbar/
 - **ClaudeCodeLocalService** — CLI-first wrapper; legacy OAuth fallback + best-effort "extra usage" probe against `api.anthropic.com/api/oauth/usage`.
 - **CodexCliLocalService** — Codex auth file + wham/usage endpoint; maps credits/spend to `ExtraUsageStatus` (safety-biased: never false "Off").
 - **CursorLocalService** — SQLite token extraction + usage-summary endpoint; assumed 500-request default quota when API omits totals.
+- **OpenRouterService** — opt-in API-key provider; maps account credits/spend and optional per-key caps into shared metrics.
 - **ClaudeService / OpenAIService** — admin-key usage reports (paginated, 50-page cap) via `ServiceSupport.fetchDecoded`.
 - **CostTracker** — JSONL/SQLite log scanning, per-day/model/origin breakdowns, cache at `~/Library/Application Support/MeterBar/cost-summary-v1.json`. API-rate estimates come from the versioned `ModelPricing` table in `MeterBarShared`, which is shared with the CLI.
 - **AuthenticationManager + KeychainManager** — the two admin keys, stored in keychain service `dev.meterbar.app`. Reads migrate the older `dev.shipshit.meterbar` (v1.6.x) and `com.agenticindiedev.quotaguard` (v1.0-v1.6) services into the current one, and removals delete all three so a legacy key cannot reappear.

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -63,7 +63,7 @@ meterbar/
 
 ## Services (all `.shared` singletons)
 
-- **UsageDataManager** (`@MainActor`, ObservableObject) — orchestrates refresh across providers, caches to UserDefaults (`cached_usage_metrics`), mirrors to the app group via SharedDataStore, drives a `Timer` auto-refresh (default 15 min; `RefreshInterval` supports 1/2/5/15/30 min + manual).
+- **UsageDataManager** (`@MainActor`, ObservableObject) — orchestrates refresh across providers, caches to UserDefaults (`cached_usage_metrics`), mirrors to the app group via SharedDataStore, records per-provider refresh outcomes in `ProviderParseHealthStore`, and drives a `Timer` auto-refresh (default 15 min; `RefreshInterval` supports 1/2/5/15/30 min + manual).
 - **ClaudeCodeCLIUsageService** — resolves the `claude` binary (`CLAUDE_CLI_PATH`, `$PATH`, 7 fallback paths), runs `claude /usage` (12 s timeout, dedicated GCD queue bridged to async), parses output with `ClaudeCodeCLIUsageParser`. Multi-account via `CLAUDE_CONFIG_DIR` env injection.
 - **ClaudeCodeLocalService** — CLI-first wrapper; legacy OAuth fallback + best-effort "extra usage" probe against `api.anthropic.com/api/oauth/usage`.
 - **CodexCliLocalService** — Codex auth file + wham/usage endpoint; maps credits/spend to `ExtraUsageStatus` (safety-biased: never false "Off").
@@ -73,6 +73,7 @@ meterbar/
 - **CostTracker** — JSONL/SQLite log scanning, per-day/model/origin breakdowns, cache at `~/Library/Application Support/MeterBar/cost-summary-v1.json`. API-rate estimates come from the versioned `ModelPricing` table in `MeterBarShared`, which is shared with the CLI.
 - **AuthenticationManager + KeychainManager** — the two admin keys, stored in keychain service `dev.meterbar.app`. Reads migrate the older `dev.shipshit.meterbar` (v1.6.x) and `com.agenticindiedev.quotaguard` (v1.0-v1.6) services into the current one, and removals delete all three so a legacy key cannot reappear.
 - **SharedDataStore** — app-group JSON file (`cached_usage_metrics.json`), atomic writes on a serial queue, `WidgetCenter.reloadTimelines` after save.
+- **ProviderParseHealthStore** — app-group `UserDefaults` records of each provider's last successful parse, last attempt, consecutive failures, and format-mismatch state. Diagnostics and `meterbar doctor` share the same records; successful data warns after 2 hours, while format mismatches or 3 consecutive failures need attention and dim the menu bar item.
 - **ProviderVisibilityStore / DockVisibilityStore / ClaudeCodeAccountStore** — UserDefaults-backed preference stores.
 - **OAuthTokenExpiry** — JWT/unix-timestamp expiry checks (60 s grace; unparseable ⇒ not-expired by design).
 - **ServiceSupport** — shared URLSession config, secret-safe HTTP/URLError mapping, real (non-container) home dir via `getpwuid`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,27 @@ jobs:
       - name: Show Xcode version
         run: xcodebuild -version
 
+      - name: Verify Debug and Release identities
+        run: scripts/verify-build-identities.sh
+
       - name: Test release tag validation
         run: scripts/test-release-tag.sh
 
       - name: Build library (SwiftPM)
         run: swift build
+
+      - name: Build Debug app and widget (Xcode)
+        run: |
+          set -euo pipefail
+          xcodebuild -project MeterBar.xcodeproj \
+            -scheme MeterBar \
+            -configuration Debug \
+            -derivedDataPath "$RUNNER_TEMP/MeterBarDebugDerivedData" \
+            -destination 'generic/platform=macOS' \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            build
 
       - name: Build universal app and widget (Xcode)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,14 @@ jobs:
   build:
     runs-on: macos-26
     timeout-minutes: 60
+    environment: release
     permissions:
       contents: write
     env:
       APP_PATH: ${{ github.workspace }}/build/Build/Products/Release/MeterBar.app
       # Context values enter shell code only through environment variables.
       REF_NAME: ${{ github.ref_name }}
+      SPARKLE_PUBLIC_ED_KEY: ${{ vars.SPARKLE_PUBLIC_ED_KEY }}
       # notarytool keychain-profile name (stored in the temp keychain at runtime).
       NOTARY_PROFILE: asc-profile
 
@@ -71,6 +73,7 @@ jobs:
           APPLE_API_PRIVATE_KEY_P8_BASE64: ${{ secrets.APPLE_API_PRIVATE_KEY_P8_BASE64 }}
           APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ vars.APPLE_API_ISSUER_ID }}
+          SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
         run: |
           set -euo pipefail
           missing=()
@@ -78,7 +81,8 @@ jobs:
           # required. KEYCHAIN_PASSWORD is intentionally absent — it is generated at
           # runtime, not stored.
           for name in DEVELOPER_ID_P12_BASE64 DEVELOPER_ID_P12_PASSWORD \
-                      APPLE_API_PRIVATE_KEY_P8_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER_ID; do
+                      APPLE_API_PRIVATE_KEY_P8_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER_ID \
+                      SPARKLE_PRIVATE_ED_KEY SPARKLE_PUBLIC_ED_KEY; do
             # Indirect expansion reads the env var named in $name without echoing its value.
             if [ -z "${!name:-}" ]; then
               missing+=("$name")
@@ -86,7 +90,7 @@ jobs:
           done
           if [ "${#missing[@]}" -ne 0 ]; then
             echo "::error::Missing required signing credential(s): ${missing[*]}" >&2
-            echo "Set secrets DEVELOPER_ID_P12_BASE64 / DEVELOPER_ID_P12_PASSWORD / APPLE_API_PRIVATE_KEY_P8_BASE64 and variables APPLE_API_KEY_ID / APPLE_API_ISSUER_ID under Settings > Secrets and variables > Actions, then re-run." >&2
+            echo "Set the required Developer ID, notarization, and Sparkle EdDSA secrets/variables under Settings > Secrets and variables > Actions, then re-run." >&2
             exit 1
           fi
           echo "All required signing credentials are present."
@@ -110,6 +114,7 @@ jobs:
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
+            SPARKLE_PUBLIC_ED_KEY="$SPARKLE_PUBLIC_ED_KEY" \
             build
 
       - name: Build and inject universal CLI
@@ -315,12 +320,44 @@ jobs:
             echo "sha_name=$SHA_NAME"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Generate and verify Sparkle appcast
+        id: appcast
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          ZIP_NAME: ${{ steps.package.outputs.zip_name }}
+          SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
+        run: |
+          set -euo pipefail
+          APPCAST_DIR="$RUNNER_TEMP/sparkle-appcast"
+          GENERATE_APPCAST="$GITHUB_WORKSPACE/build/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_appcast"
+          DOWNLOAD_PREFIX="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/"
+
+          if [ ! -x "$GENERATE_APPCAST" ]; then
+            echo "::error::Sparkle generate_appcast was not resolved at $GENERATE_APPCAST" >&2
+            exit 1
+          fi
+
+          mkdir -p "$APPCAST_DIR"
+          cp "$GITHUB_WORKSPACE/$ZIP_NAME" "$APPCAST_DIR/$ZIP_NAME"
+          printf '%s' "$SPARKLE_PRIVATE_ED_KEY" | "$GENERATE_APPCAST" \
+            --ed-key-file - \
+            --download-url-prefix "$DOWNLOAD_PREFIX" \
+            "$APPCAST_DIR"
+
+          APPCAST_PATH="$APPCAST_DIR/appcast.xml"
+          scripts/verify-appcast.sh \
+            "$APPCAST_PATH" "$RELEASE_VERSION" "$ZIP_NAME" "$DOWNLOAD_PREFIX"
+          cp "$APPCAST_PATH" "$GITHUB_WORKSPACE/appcast.xml"
+          echo "name=appcast.xml" >> "$GITHUB_OUTPUT"
+
       - name: Create Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: |
             ${{ steps.package.outputs.zip_name }}
             ${{ steps.package.outputs.sha_name }}
+            ${{ steps.appcast.outputs.name }}
           draft: false
           prerelease: false
           generate_release_notes: true
@@ -337,6 +374,7 @@ jobs:
             echo ""
             echo "**Tag:** \`$RELEASE_TAG\`"
             echo "**SHA256:** \`$RELEASE_SHA256\`"
+            echo "**Sparkle feed:** \`appcast.xml\` (EdDSA signed archive)"
             echo ""
             echo "Universal arm64+x86_64, Developer ID signed, notarized, and stapled."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -280,7 +280,7 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MeterBarWidget/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = MeterBarWidget;
+				INFOPLIST_KEY_CFBundleDisplayName = "MeterBarWidget Dev";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -289,7 +289,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.7.0;
-				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.Widget;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SKIP_INSTALL = YES;
@@ -492,6 +492,7 @@
 				ENABLE_RESOURCE_ACCESS_USB = NO;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "MeterBar Dev";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -499,8 +500,8 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.7.0;
-				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug;
+				PRODUCT_NAME = "MeterBar Dev";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				REGISTER_APP_GROUPS = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		5259E44F2F032E78001001CF /* MeterBarWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 5259E43D2F032E77001001CF /* MeterBarWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		52ABC1022F0400010036036C /* MeterBarShared in Frameworks */ = {isa = PBXBuildFile; productRef = 52ABC1012F0400010036036C /* MeterBarShared */; };
 		52ABC1042F0400010036036C /* MeterBarShared in Frameworks */ = {isa = PBXBuildFile; productRef = 52ABC1032F0400010036036C /* MeterBarShared */; };
+		52ABC1072F0400010036036C /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 52ABC1062F0400010036036C /* Sparkle */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,6 +47,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		52ABC1082F0400010036036C /* Exceptions for "MeterBar" folder in "MeterBar" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 52CFA4FF2F0323EF0036036C /* MeterBar */;
+		};
 		5259E4502F032E78001001CF /* Exceptions for "MeterBarWidget" folder in "MeterBarWidgetExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -66,6 +74,9 @@
 		};
 		52CFA5022F0323EF0036036C /* MeterBar */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				52ABC1082F0400010036036C /* Exceptions for "MeterBar" folder in "MeterBar" target */,
+			);
 			path = MeterBar;
 			sourceTree = "<group>";
 		};
@@ -86,6 +97,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				52ABC1072F0400010036036C /* Sparkle in Frameworks */,
 				52ABC1022F0400010036036C /* MeterBarShared in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -167,6 +179,7 @@
 			name = MeterBar;
 			packageProductDependencies = (
 				52ABC1012F0400010036036C /* MeterBarShared */,
+				52ABC1062F0400010036036C /* Sparkle */,
 			);
 			productName = MeterBar;
 			productReference = 52CFA5002F0323EF0036036C /* MeterBar.app */;
@@ -201,6 +214,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				52ABC1002F0400010036036C /* XCLocalSwiftPackageReference "Packages/MeterBarShared" */,
+				52ABC1052F0400010036036C /* XCRemoteSwiftPackageReference "Sparkle" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 52CFA5012F0323EF0036036C /* Products */;
@@ -263,7 +277,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = MeterBarWidget/MeterBarWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
 				DEVELOPMENT_TEAM = C76R5DRH64;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -308,7 +322,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = MeterBarWidget/MeterBarWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
 				DEVELOPMENT_TEAM = C76R5DRH64;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -475,7 +489,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
 				DEVELOPMENT_TEAM = C76R5DRH64;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -491,9 +505,8 @@
 				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
 				ENABLE_RESOURCE_ACCESS_USB = NO;
 				ENABLE_USER_SELECTED_FILES = readonly;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = "MeterBar Dev";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = MeterBar/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -522,7 +535,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
 				DEVELOPMENT_TEAM = C76R5DRH64;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -538,8 +551,8 @@
 				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
 				ENABLE_RESOURCE_ACCESS_USB = NO;
 				ENABLE_USER_SELECTED_FILES = readonly;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = MeterBar/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -598,6 +611,17 @@
 		};
 /* End XCLocalSwiftPackageReference section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		52ABC1052F0400010036036C /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = exactVersion;
+				version = 2.9.4;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		52ABC1012F0400010036036C /* MeterBarShared */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -606,6 +630,11 @@
 		52ABC1032F0400010036036C /* MeterBarShared */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = MeterBarShared;
+		};
+		52ABC1062F0400010036036C /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 52ABC1052F0400010036036C /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/MeterBar.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MeterBar.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "f3cee4d5706decc7a44194a51ee825677d3a8dedbd1a5e481858477f2b02be3c",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -562,7 +562,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
             .store(in: &cancellables)
 
-        ClaudeCodeAccountStore.shared.$customAccounts
+        Publishers.Merge(
+            ClaudeCodeAccountStore.shared.$customAccounts.map { _ in () },
+            ClaudeCodeAccountStore.shared.$defaultAccountIsEnabled.map { _ in () }
+        )
             .sink { [weak self] _ in
                 Task { @MainActor in
                     self?.updateStatusItem(metrics: UsageDataManager.shared.metrics)
@@ -671,7 +674,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         var requests: [StatusLimitProbeRequest] = []
 
         if providerVisibilityStore.isEnabled(.claudeCode) {
-            for account in ClaudeCodeAccountStore.shared.accounts {
+            for account in ClaudeCodeAccountStore.shared.enabledAccounts {
                 guard let limit = claudeMetrics(for: account, metrics: metrics)?.sessionLimit else { continue }
                 let configDirectory = account.configDirectory
                 requests.append(StatusLimitProbeRequest(

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -569,6 +569,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
             .store(in: &cancellables)
 
+        ProviderParseHealthStore.shared.$records
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    self?.updateStatusItem(metrics: UsageDataManager.shared.metrics)
+                }
+            }
+            .store(in: &cancellables)
+
         updateStatusItem(metrics: UsageDataManager.shared.metrics)
     }
 
@@ -621,6 +629,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             button.title = ""
             button.imagePosition = .imageOnly
             button.toolTip = "MeterBar"
+            applyParseHealthAppearance(to: button)
             return
         }
 
@@ -630,6 +639,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         button.title = " \(percent)%"
         button.toolTip = "MeterBar: \(percent)% left on \(selection.displayName)"
         button.setAccessibilityLabel("MeterBar \(percent)% left on \(selection.displayName)")
+        applyParseHealthAppearance(to: button)
+    }
+
+    @MainActor
+    private func applyParseHealthAppearance(to button: NSStatusBarButton) {
+        let now = Date()
+        let hasAttention = providerVisibilityStore.enabledServices.contains { service in
+            ProviderParseHealthStore.shared.records[service]?.needsAttention(now: now) == true
+        }
+        button.alphaValue = hasAttention ? 0.55 : 1
+        if hasAttention {
+            button.toolTip = "\(button.toolTip ?? "MeterBar") · Provider data needs attention"
+        }
     }
 
     /// Every enabled account/provider quota that may own the menu bar title,

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -82,8 +82,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             },
             onDismiss: {
                 MeterBarMenuDetailPanel.shared.dismiss()
+                FirstRunOnboardingStore.shared.dismiss()
             }
         )
+
+        if FirstRunOnboardingStore.shared.shouldPresent {
+            // Defer one run-loop turn so the status-item window is ready before
+            // positioning the panel. This is the first-launch welcome moment.
+            DispatchQueue.main.async { [weak self] in
+                self?.menuPanel?.show()
+            }
+        }
 
         Task { @MainActor in
             observeUsageMetrics()

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -52,6 +52,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         AppLog.app.info("MeterBar finished launching")
+        SoftwareUpdateController.shared.refreshState()
 
         // Keep Dock visibility in sync with the user's preference.
         observeDockVisibility()

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -215,7 +215,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             item.submenu = makeProviderStatusSubmenu(for: service)
             menu.addItem(item)
         }
-
         menu.addItem(.separator())
 
         let refreshItem = NSMenuItem(
@@ -475,7 +474,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         var keys = notifiedLimitKeys
         let currentMetrics = UsageDataManager.shared.metrics
 
-        for service in ServiceType.allCases {
+        for service in ServiceType.allCases where service != .claudeCode && service != .codexCli {
             // Disabled providers are removed from UsageDataManager. Evaluate an
             // empty snapshot so their stale band keys are cleared instead of
             // suppressing a future crossing after the provider is re-enabled.
@@ -492,7 +491,77 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        keys = evaluateAccountNotifications(
+            AccountNotificationInput(
+                service: .claudeCode,
+                accounts: ClaudeCodeAccountStore.shared.accounts.map { ($0.id, $0.name) },
+                accountMetrics: UsageDataManager.shared.claudeCodeAccountMetrics,
+                fallbackMetrics: currentMetrics[.claudeCode]
+            ),
+            decider: decider,
+            keys: keys,
+            now: now
+        )
+        keys = evaluateAccountNotifications(
+            AccountNotificationInput(
+                service: .codexCli,
+                accounts: CodexAccountStore.shared.accounts.map { ($0.id, $0.name) },
+                accountMetrics: UsageDataManager.shared.codexAccountMetrics,
+                fallbackMetrics: currentMetrics[.codexCli]
+            ),
+            decider: decider,
+            keys: keys,
+            now: now
+        )
+
         notifiedLimitKeys = keys
+    }
+
+    private struct AccountNotificationInput {
+        let service: ServiceType
+        let accounts: [(id: UUID, name: String)]
+        let accountMetrics: [UUID: UsageMetrics]
+        let fallbackMetrics: UsageMetrics?
+    }
+
+    private func evaluateAccountNotifications(
+        _ input: AccountNotificationInput,
+        decider: NotificationDecider,
+        keys: Set<String>,
+        now: Date
+    ) -> Set<String> {
+        var updatedKeys = keys
+        let available = input.accounts.compactMap { account -> (UUID, String, UsageMetrics)? in
+            guard let metrics = input.accountMetrics[account.id] else { return nil }
+            return (account.id, account.name, metrics)
+        }
+
+        if available.isEmpty {
+            let metrics = input.fallbackMetrics ?? UsageMetrics(service: input.service, lastUpdated: now)
+            let evaluation = decider.evaluate(
+                metrics: metrics,
+                providerEnabled: providerVisibilityStore.isEnabled(input.service),
+                alreadyNotified: updatedKeys,
+                now: now
+            )
+            updatedKeys = evaluation.notifiedKeys
+            evaluation.notifications.forEach(postNotification)
+            return updatedKeys
+        }
+
+        for (id, name, metrics) in available {
+            let evaluation = decider.evaluate(
+                metrics: metrics,
+                providerEnabled: providerVisibilityStore.isEnabled(input.service),
+                alreadyNotified: updatedKeys,
+                accountKey: id.uuidString,
+                serviceDisplayName: "\(name) (\(input.service.displayName))",
+                now: now
+            )
+            updatedKeys = evaluation.notifiedKeys
+            evaluation.notifications.forEach(postNotification)
+        }
+        return updatedKeys
     }
 
     private func postNotification(_ fired: FiredNotification) {
@@ -562,10 +631,26 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
             .store(in: &cancellables)
 
+        UsageDataManager.shared.$codexAccountMetrics
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    self?.updateStatusItem(metrics: UsageDataManager.shared.metrics)
+                }
+            }
+            .store(in: &cancellables)
+
         Publishers.Merge(
             ClaudeCodeAccountStore.shared.$customAccounts.map { _ in () },
             ClaudeCodeAccountStore.shared.$defaultAccountIsEnabled.map { _ in () }
         )
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    self?.updateStatusItem(metrics: UsageDataManager.shared.metrics)
+                }
+            }
+            .store(in: &cancellables)
+
+        CodexAccountStore.shared.$customAccounts
             .sink { [weak self] _ in
                 Task { @MainActor in
                     self?.updateStatusItem(metrics: UsageDataManager.shared.metrics)
@@ -685,13 +770,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 ))
             }
         }
-        if providerVisibilityStore.isEnabled(.codexCli), let codexLimit = metrics[.codexCli]?.sessionLimit {
-            requests.append(StatusLimitProbeRequest(
-                key: "codex",
-                displayName: ServiceType.codexCli.displayName,
-                limit: codexLimit,
-                probe: { AccountActivityInspector.codexCliActivity() }
-            ))
+        if providerVisibilityStore.isEnabled(.codexCli) {
+            for account in CodexAccountStore.shared.accounts {
+                let accountMetrics = UsageDataManager.shared.codexAccountMetrics[account.id]
+                    ?? (account.isDefault ? metrics[.codexCli] : nil)
+                guard let limit = accountMetrics?.sessionLimit else { continue }
+                let homeDirectory = account.homeDirectory
+                requests.append(StatusLimitProbeRequest(
+                    key: "codex:\(account.id.uuidString)",
+                    displayName: "\(account.name) (\(ServiceType.codexCli.displayName))",
+                    limit: limit,
+                    probe: { AccountActivityInspector.codexCliActivity(homeDirectory: homeDirectory) }
+                ))
+            }
         }
         if providerVisibilityStore.isEnabled(.cursor), let cursorLimit = metrics[.cursor]?.weeklyLimit {
             requests.append(StatusLimitProbeRequest(

--- a/MeterBar/App/MeterBarMenuPanelController.swift
+++ b/MeterBar/App/MeterBarMenuPanelController.swift
@@ -1,6 +1,10 @@
 import AppKit
 import SwiftUI
 
+final class KeyableMenuPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+}
+
 @MainActor
 final class MeterBarMenuPanelController {
     private let statusButtonProvider: () -> NSStatusBarButton?
@@ -27,7 +31,7 @@ final class MeterBarMenuPanelController {
         guard let button = statusButtonProvider() else { return }
         let panel = ensurePanel()
         position(panel, anchoredTo: button, size: contentSize)
-        panel.orderFrontRegardless()
+        panel.makeKeyAndOrderFront(nil)
         startEventMonitoring()
     }
 
@@ -46,7 +50,7 @@ final class MeterBarMenuPanelController {
     private func ensurePanel() -> NSPanel {
         if let panel { return panel }
 
-        let panel = NSPanel(
+        let panel = KeyableMenuPanel(
             contentRect: NSRect(origin: .zero, size: contentSize),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,

--- a/MeterBar/Info.plist
+++ b/MeterBar/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconName</key>
+	<string>AppIcon</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>SUEnableAutomaticChecks</key>
+	<false/>
+	<key>SUFeedURL</key>
+	<string>https://github.com/VincentShipsIt/meterbar.dev/releases/latest/download/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>$(SPARKLE_PUBLIC_ED_KEY)</string>
+</dict>
+</plist>

--- a/MeterBar/Models/ClaudeCodeAccount.swift
+++ b/MeterBar/Models/ClaudeCodeAccount.swift
@@ -24,6 +24,27 @@ nonisolated struct ClaudeCodeAccount: Codable, Equatable, Identifiable, Sendable
     var isDefault: Bool {
         id == Self.defaultID
     }
+
+    /// Resolves the default Claude CLI profile directory for user-facing paths
+    /// and Finder actions without mutating the process environment in tests.
+    static func defaultConfigDirectory(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        realHomeDirectory: String = ServiceSupport.realHomeDirectory()
+    ) -> String {
+        guard let rawValue = environment["CLAUDE_CONFIG_DIR"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !rawValue.isEmpty else {
+            return (realHomeDirectory as NSString).appendingPathComponent(".claude")
+        }
+
+        if rawValue == "~" {
+            return realHomeDirectory
+        }
+        if rawValue.hasPrefix("~/") {
+            return (realHomeDirectory as NSString).appendingPathComponent(String(rawValue.dropFirst(2)))
+        }
+        return (rawValue as NSString).standardizingPath
+    }
 }
 
 // MARK: - ClaudeCodeAccountStore

--- a/MeterBar/Models/ClaudeCodeAccount.swift
+++ b/MeterBar/Models/ClaudeCodeAccount.swift
@@ -20,6 +20,22 @@ nonisolated struct ClaudeCodeAccount: Codable, Equatable, Identifiable, Sendable
     let id: UUID
     var name: String
     var configDirectory: String?
+    var isEnabled: Bool
+
+    init(id: UUID, name: String, configDirectory: String?, isEnabled: Bool = true) {
+        self.id = id
+        self.name = name
+        self.configDirectory = configDirectory
+        self.isEnabled = isEnabled
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        configDirectory = try container.decodeIfPresent(String.self, forKey: .configDirectory)
+        isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
+    }
 
     var isDefault: Bool {
         id == Self.defaultID
@@ -54,11 +70,13 @@ final class ClaudeCodeAccountStore: ObservableObject {
 
     @Published private(set) var customAccounts: [ClaudeCodeAccount] = []
     @Published private(set) var defaultAccountName = ClaudeCodeAccount.defaultName
+    @Published private(set) var defaultAccountIsEnabled = true
     @Published private(set) var accountOrder: [UUID] = []
 
     private let userDefaults: UserDefaults
     private let storageKey = StorageKeys.claudeCodeCustomAccounts
     private let defaultNameStorageKey = StorageKeys.claudeCodeDefaultAccountName
+    private let defaultEnabledStorageKey = StorageKeys.claudeCodeDefaultAccountEnabled
     private let accountOrderStorageKey = StorageKeys.claudeCodeAccountOrder
 
     var accounts: [ClaudeCodeAccount] {
@@ -66,9 +84,14 @@ final class ClaudeCodeAccountStore: ObservableObject {
             ClaudeCodeAccount(
                 id: ClaudeCodeAccount.defaultID,
                 name: defaultAccountName,
-                configDirectory: nil
+                configDirectory: nil,
+                isEnabled: defaultAccountIsEnabled
             )
         ] + customAccounts)
+    }
+
+    var enabledAccounts: [ClaudeCodeAccount] {
+        accounts.filter(\.isEnabled)
     }
 
     init(userDefaults: UserDefaults = .standard) {
@@ -131,6 +154,24 @@ final class ClaudeCodeAccountStore: ObservableObject {
         saveCustomAccounts()
     }
 
+    func setEnabled(_ enabled: Bool, for id: UUID) {
+        if id == ClaudeCodeAccount.defaultID {
+            guard enabled != defaultAccountIsEnabled else { return }
+            defaultAccountIsEnabled = enabled
+            saveDefaultAccountEnabled()
+            return
+        }
+
+        guard let index = customAccounts.firstIndex(where: { $0.id == id }),
+              customAccounts[index].isEnabled != enabled else {
+            return
+        }
+        var updatedAccounts = customAccounts
+        updatedAccounts[index].isEnabled = enabled
+        customAccounts = updatedAccounts
+        saveCustomAccounts()
+    }
+
     func moveAccounts(fromOffsets source: IndexSet, toOffset destination: Int) {
         var ordered = accounts
         guard !ordered.isEmpty else { return }
@@ -158,6 +199,10 @@ final class ClaudeCodeAccountStore: ObservableObject {
             defaultAccountName = storedDefaultName
         }
 
+        if userDefaults.object(forKey: defaultEnabledStorageKey) != nil {
+            defaultAccountIsEnabled = userDefaults.bool(forKey: defaultEnabledStorageKey)
+        }
+
         accountOrder = userDefaults.stringArray(forKey: accountOrderStorageKey)?
             .compactMap(UUID.init(uuidString:)) ?? []
 
@@ -180,6 +225,14 @@ final class ClaudeCodeAccountStore: ObservableObject {
             userDefaults.removeObject(forKey: defaultNameStorageKey)
         } else {
             userDefaults.set(defaultAccountName, forKey: defaultNameStorageKey)
+        }
+    }
+
+    private func saveDefaultAccountEnabled() {
+        if defaultAccountIsEnabled {
+            userDefaults.removeObject(forKey: defaultEnabledStorageKey)
+        } else {
+            userDefaults.set(false, forKey: defaultEnabledStorageKey)
         }
     }
 

--- a/MeterBar/Models/CodexAccount.swift
+++ b/MeterBar/Models/CodexAccount.swift
@@ -1,0 +1,157 @@
+import Combine
+import Foundation
+
+nonisolated struct CodexAccount: Codable, Equatable, Identifiable, Sendable {
+    static let defaultName = "Default CLI Profile"
+    static let defaultID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2))
+
+    static let defaultAccount = CodexAccount(
+        id: Self.defaultID,
+        name: Self.defaultName,
+        homeDirectory: nil
+    )
+
+    let id: UUID
+    var name: String
+    var homeDirectory: String?
+
+    var isDefault: Bool { id == Self.defaultID }
+}
+
+final class CodexAccountStore: ObservableObject {
+    static let shared = CodexAccountStore()
+
+    @Published private(set) var customAccounts: [CodexAccount] = []
+    @Published private(set) var defaultAccountName = CodexAccount.defaultName
+    @Published private(set) var accountOrder: [UUID] = []
+
+    private let userDefaults: UserDefaults
+
+    var accounts: [CodexAccount] {
+        orderedAccounts(from: [
+            CodexAccount(id: CodexAccount.defaultID, name: defaultAccountName, homeDirectory: nil)
+        ] + customAccounts)
+    }
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        load()
+    }
+
+    func addAccount(name: String, homeDirectory: String) {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedDirectory = homeDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty, !trimmedDirectory.isEmpty else { return }
+
+        let account = CodexAccount(
+            id: UUID(),
+            name: trimmedName,
+            homeDirectory: (trimmedDirectory as NSString).standardizingPath
+        )
+        customAccounts.append(account)
+        if !accountOrder.isEmpty {
+            accountOrder.append(account.id)
+            saveAccountOrder()
+        }
+        saveCustomAccounts()
+    }
+
+    func updateAccount(id: UUID, name: String, homeDirectory: String?) {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { return }
+
+        if id == CodexAccount.defaultID {
+            guard trimmedName != defaultAccountName else { return }
+            defaultAccountName = trimmedName
+            saveDefaultAccountName()
+            return
+        }
+
+        guard let index = customAccounts.firstIndex(where: { $0.id == id }), let homeDirectory else { return }
+        let trimmedDirectory = homeDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedDirectory.isEmpty else { return }
+
+        var updated = customAccounts[index]
+        updated.name = trimmedName
+        updated.homeDirectory = (trimmedDirectory as NSString).standardizingPath
+        guard updated != customAccounts[index] else { return }
+        var updatedAccounts = customAccounts
+        updatedAccounts[index] = updated
+        customAccounts = updatedAccounts
+        saveCustomAccounts()
+    }
+
+    func removeAccount(id: UUID) {
+        guard id != CodexAccount.defaultID else { return }
+        customAccounts.removeAll { $0.id == id }
+        accountOrder.removeAll { $0 == id }
+        saveAccountOrder()
+        saveCustomAccounts()
+    }
+
+    func moveAccounts(fromOffsets source: IndexSet, toOffset destination: Int) {
+        var ordered = accounts
+        let movingIndexes = source.sorted()
+        guard movingIndexes.allSatisfy({ ordered.indices.contains($0) }) else { return }
+
+        let movingAccounts = movingIndexes.map { ordered[$0] }
+        for index in movingIndexes.reversed() { ordered.remove(at: index) }
+        let removedBeforeDestination = movingIndexes.filter { $0 < destination }.count
+        let adjustedDestination = max(0, min(destination - removedBeforeDestination, ordered.count))
+        ordered.insert(contentsOf: movingAccounts, at: adjustedDestination)
+        accountOrder = ordered.map(\.id)
+        saveAccountOrder()
+    }
+
+    private func load() {
+        if let name = userDefaults.string(forKey: StorageKeys.codexDefaultAccountName)?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
+            defaultAccountName = name
+        }
+        accountOrder = userDefaults.stringArray(forKey: StorageKeys.codexAccountOrder)?
+            .compactMap(UUID.init(uuidString:)) ?? []
+        if let data = userDefaults.data(forKey: StorageKeys.codexCustomAccounts),
+           let decoded = try? JSONDecoder().decode([CodexAccount].self, from: data) {
+            customAccounts = decoded.filter { !$0.isDefault }
+        }
+        pruneAccountOrder()
+    }
+
+    private func saveCustomAccounts() {
+        guard let data = try? JSONEncoder().encode(customAccounts) else { return }
+        userDefaults.set(data, forKey: StorageKeys.codexCustomAccounts)
+    }
+
+    private func saveDefaultAccountName() {
+        if defaultAccountName == CodexAccount.defaultName {
+            userDefaults.removeObject(forKey: StorageKeys.codexDefaultAccountName)
+        } else {
+            userDefaults.set(defaultAccountName, forKey: StorageKeys.codexDefaultAccountName)
+        }
+    }
+
+    private func saveAccountOrder() {
+        if accountOrder.isEmpty {
+            userDefaults.removeObject(forKey: StorageKeys.codexAccountOrder)
+        } else {
+            userDefaults.set(accountOrder.map(\.uuidString), forKey: StorageKeys.codexAccountOrder)
+        }
+    }
+
+    private func orderedAccounts(from unordered: [CodexAccount]) -> [CodexAccount] {
+        guard !accountOrder.isEmpty else { return unordered }
+        let byID = Dictionary(uniqueKeysWithValues: unordered.map { ($0.id, $0) })
+        let ordered = accountOrder.compactMap { byID[$0] }
+        let orderedIDs = Set(ordered.map(\.id))
+        return ordered + unordered.filter { !orderedIDs.contains($0.id) }
+    }
+
+    private func pruneAccountOrder() {
+        guard !accountOrder.isEmpty else { return }
+        let validIDs = Set([CodexAccount.defaultID] + customAccounts.map(\.id))
+        let pruned = accountOrder.filter { validIDs.contains($0) }
+        guard pruned != accountOrder else { return }
+        accountOrder = pruned
+        saveAccountOrder()
+    }
+}

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -14,6 +14,8 @@ nonisolated enum StorageKeys {
     static let refreshInterval = "refreshInterval"
     /// Raw values of ServiceTypes the user has hidden.
     static let hiddenProviderServices = "HiddenProviderServices"
+    /// OpenRouter is API-key backed and must be explicitly enabled.
+    static let openRouterProviderEnabled = "OpenRouterProviderEnabled"
     /// Whether the Dock icon is shown (menu bar item is unaffected).
     static let showInDock = "ShowMeterBarInDock"
     /// Enables the legacy Claude Code OAuth fallback when the CLI is unavailable.

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -30,6 +30,14 @@ nonisolated enum StorageKeys {
     static let claudeCodeDefaultAccountEnabled = "ClaudeCodeDefaultAccountEnabled"
     /// Persisted account display order (array of UUID strings).
     static let claudeCodeAccountOrder = "ClaudeCodeAccountOrder"
+    /// Extra Codex CLI account profiles (JSON-encoded [CodexAccount]).
+    static let codexCustomAccounts = "CodexCustomAccounts"
+    /// User-chosen display name for the default Codex CLI profile.
+    static let codexDefaultAccountName = "CodexDefaultAccountName"
+    /// Persisted Codex account display order (array of UUID strings).
+    static let codexAccountOrder = "CodexAccountOrder"
+    /// Cached per-account Codex metrics (JSON-encoded [UUID: UsageMetrics]).
+    static let cachedCodexAccountMetrics = "CachedCodexAccountMetrics"
     /// Global on/off switch for usage notifications.
     static let notificationsEnabled = "NotificationsEnabled"
     /// Raw value of the `NotificationThreshold` at which a warning notifies.

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -18,6 +18,8 @@ nonisolated enum StorageKeys {
     static let openRouterProviderEnabled = "OpenRouterProviderEnabled"
     /// Whether the Dock icon is shown (menu bar item is unaffected).
     static let showInDock = "ShowMeterBarInDock"
+    /// Whether the one-time first-launch popover has been completed or dismissed.
+    static let hasCompletedFirstRun = "HasCompletedFirstRun"
     /// Enables the legacy Claude Code OAuth fallback when the CLI is unavailable.
     static let claudeCodeOAuthFallback = "ClaudeCodeEnableOAuthFallback"
     /// Extra Claude Code account profiles (JSON-encoded [ClaudeCodeAccount]).

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -26,6 +26,8 @@ nonisolated enum StorageKeys {
     static let claudeCodeCustomAccounts = "ClaudeCodeCustomAccounts"
     /// User-chosen display name for the default Claude Code CLI profile.
     static let claudeCodeDefaultAccountName = "ClaudeCodeDefaultAccountName"
+    /// Whether the synthesized default Claude Code CLI profile participates in tracking.
+    static let claudeCodeDefaultAccountEnabled = "ClaudeCodeDefaultAccountEnabled"
     /// Persisted account display order (array of UUID strings).
     static let claudeCodeAccountOrder = "ClaudeCodeAccountOrder"
     /// Global on/off switch for usage notifications.

--- a/MeterBar/Services/AccountActivityInspector.swift
+++ b/MeterBar/Services/AccountActivityInspector.swift
@@ -61,6 +61,15 @@ nonisolated enum AccountActivityInspector {
         ))
     }
 
+    static func codexCliActivity(homeDirectory: String?) -> Date? {
+        let account = CodexAccount(
+            id: CodexAccount.defaultID,
+            name: CodexAccount.defaultName,
+            homeDirectory: homeDirectory
+        )
+        return lastActivity(inDirectory: CodexHomeDirectory.path(for: account))
+    }
+
     /// Cursor continuously checkpoints its state database while running; the
     /// WAL sibling is the hottest file. Mirrors the candidate paths used by
     /// `CursorLocalService.getCursorDatabasePath`.

--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -26,7 +26,7 @@ class CodexCliLocalService: ObservableObject {
     /// fixture without a real credential file on disk (the auth file never
     /// exists on CI). Defaults to reading the real path. `@Sendable` because the
     /// read is disk I/O and must be callable off the main actor.
-    nonisolated private let authFileDataProvider: @Sendable () -> Data?
+    nonisolated private let authFileDataProvider: @Sendable (CodexAccount) -> Data?
 
     @Published private(set) var hasAccess: Bool = false
     @Published private(set) var lastError: ServiceError?
@@ -34,15 +34,26 @@ class CodexCliLocalService: ObservableObject {
 
     /// Defaults reproduce the production singleton; tests inject a fixture
     /// auth-file provider.
-    init(authFileDataProvider: (@Sendable () -> Data?)? = nil) {
-        self.authFileDataProvider = authFileDataProvider ?? { CodexCliLocalService.defaultAuthFileDataProvider() }
+    init(
+        authFileDataProvider: (@Sendable () -> Data?)? = nil,
+        accountAuthFileDataProvider: (@Sendable (CodexAccount) -> Data?)? = nil
+    ) {
+        if let accountAuthFileDataProvider {
+            self.authFileDataProvider = accountAuthFileDataProvider
+        } else if let authFileDataProvider {
+            self.authFileDataProvider = { _ in authFileDataProvider() }
+        } else {
+            self.authFileDataProvider = { account in
+                Self.defaultAuthFileDataProvider(account: account)
+            }
+        }
         Task.detached(priority: .utility) { [weak self] in self?.checkAccess() }
     }
 
     /// Reads `CODEX_HOME/auth.json` using the same resolver as readiness,
     /// activity, and cost scans.
-    nonisolated private static func defaultAuthFileDataProvider() -> Data? {
-        let path = CodexHomeDirectory.authFilePath()
+    nonisolated private static func defaultAuthFileDataProvider(account: CodexAccount) -> Data? {
+        let path = CodexHomeDirectory.authFilePath(for: account)
         guard FileManager.default.fileExists(atPath: path) else { return nil }
         return FileManager.default.contents(atPath: path)
     }
@@ -52,8 +63,8 @@ class CodexCliLocalService: ObservableObject {
     /// Read OAuth access token from `CODEX_HOME/auth.json`.
     /// This file is created and maintained by the Codex CLI when user logs in.
     /// `nonisolated`: disk I/O — never call this synchronously from the main actor.
-    nonisolated func getAuthToken() -> String? {
-        guard let token = readAuthFile()?.tokens?.accessToken else {
+    nonisolated func getAuthToken(account: CodexAccount = .defaultAccount) -> String? {
+        guard let token = readAuthFile(account: account)?.tokens?.accessToken else {
             return nil
         }
 
@@ -66,13 +77,23 @@ class CodexCliLocalService: ObservableObject {
 
     /// Read account ID from `CODEX_HOME/auth.json`.
     /// Required for the ChatGPT-Account-Id header to get team/workspace data
-    nonisolated func getAccountId() -> String? {
-        readAuthFile()?.tokens?.accountId
+    nonisolated func getAccountId(account: CodexAccount = .defaultAccount) -> String? {
+        readAuthFile(account: account)?.tokens?.accountId
     }
 
-    nonisolated private func readAuthFile() -> CodexAuthFile? {
-        guard let data = authFileDataProvider() else { return nil }
+    nonisolated private func readAuthFile(account: CodexAccount) -> CodexAuthFile? {
+        guard let data = authFileDataProvider(account) else { return nil }
         return try? JSONDecoder().decode(CodexAuthFile.self, from: data)
+    }
+
+    nonisolated func hasAccess(account: CodexAccount) -> Bool {
+        getAuthToken(account: account) != nil
+    }
+
+    func canAccess(account: CodexAccount) async -> Bool {
+        await Task.detached(priority: .userInitiated) { [self] in
+            hasAccess(account: account)
+        }.value
     }
 
     /// Check and update access status
@@ -87,18 +108,18 @@ class CodexCliLocalService: ObservableObject {
 
     // MARK: - Usage Fetching
 
-    func fetchUsageMetrics() async throws -> UsageMetrics {
+    func fetchUsageMetrics(account: CodexAccount = .defaultAccount) async throws -> UsageMetrics {
         // Auth-file read is disk I/O; the app target runs async bodies on the
         // main actor (default MainActor isolation), so hop off explicitly.
         let auth = await Task.detached(priority: .userInitiated) { [self] in
-            (token: getAuthToken(), accountId: getAccountId())
+            (token: getAuthToken(account: account), accountId: getAccountId(account: account))
         }.value
 
         guard let token = auth.token else {
             let error = ServiceError.notAuthenticated
             await MainActor.run {
                 self.lastError = error
-                self.hasAccess = false
+                if account.isDefault { self.hasAccess = false }
             }
             throw error
         }
@@ -138,8 +159,10 @@ class CodexCliLocalService: ObservableObject {
 
             await MainActor.run {
                 self.lastError = nil
-                self.hasAccess = true
-                self.subscriptionType = usageResponse.planType
+                if account.isDefault {
+                    self.hasAccess = true
+                    self.subscriptionType = usageResponse.planType
+                }
             }
 
             // Pure response→UsageMetrics mapping (window math, code-review limit,
@@ -151,7 +174,7 @@ class CodexCliLocalService: ObservableObject {
             AppLog.usage.error("Codex usage fetch failed: \(serviceError.localizedDescription)")
             await MainActor.run {
                 self.lastError = serviceError
-                if case .notAuthenticated = serviceError {
+                if account.isDefault, case .notAuthenticated = serviceError {
                     self.hasAccess = false
                 }
             }

--- a/MeterBar/Services/CodexHomeDirectory.swift
+++ b/MeterBar/Services/CodexHomeDirectory.swift
@@ -33,6 +33,18 @@ nonisolated enum CodexHomeDirectory {
             .appendingPathComponent("auth.json")
     }
 
+    static func path(for account: CodexAccount) -> String {
+        guard let homeDirectory = account.homeDirectory?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !homeDirectory.isEmpty else {
+            return path()
+        }
+        return (homeDirectory as NSString).standardizingPath
+    }
+
+    static func authFilePath(for account: CodexAccount) -> String {
+        (path(for: account) as NSString).appendingPathComponent("auth.json")
+    }
+
     /// The resolved auth-file path for user-facing copy, compacting paths under
     /// the real home directory back to `~/...` while retaining absolute custom
     /// `CODEX_HOME` paths outside it.

--- a/MeterBar/Services/CursorLocalService.swift
+++ b/MeterBar/Services/CursorLocalService.swift
@@ -273,14 +273,17 @@ class CursorLocalService: ObservableObject {
         }
 
         // Extract usage from individual plan
-        let planUsed = Double(summaryData.individualUsage?.plan?.used ?? 0)
-        let planTotal = Double(summaryData.individualUsage?.plan?.total ?? Int(defaultPlanTotal))
+        let plan = summaryData.individualUsage?.plan
+        let planUsed = Double(plan?.used ?? 0)
+        let planTotalIsEstimated = plan?.total == nil
+        let planTotal = Double(plan?.total ?? Int(defaultPlanTotal))
 
         // Create usage metrics using plan data
         let weeklyLimit = UsageLimit(
             used: planUsed,
             total: planTotal,
-            resetTime: resetTime
+            resetTime: resetTime,
+            isEstimated: planTotalIsEstimated
         )
 
         // On-demand usage as secondary metric if enabled
@@ -292,7 +295,8 @@ class CursorLocalService: ObservableObject {
                 sessionLimit = UsageLimit(
                     used: onDemandUsed,
                     total: onDemandLimit > 0 ? onDemandLimit : onDemandUsed * onDemandHeadroomMultiplier,
-                    resetTime: resetTime
+                    resetTime: resetTime,
+                    isEstimated: onDemandLimit <= 0
                 )
             }
         }

--- a/MeterBar/Services/FirstRunOnboardingStore.swift
+++ b/MeterBar/Services/FirstRunOnboardingStore.swift
@@ -1,0 +1,69 @@
+import Combine
+import Foundation
+
+/// Owns the single prompt-once flag for MeterBar's first-launch experience.
+/// Launch-at-login remains opt-in and is only registered after an explicit tap.
+final class FirstRunOnboardingStore: ObservableObject {
+    static let shared = FirstRunOnboardingStore()
+
+    @Published private(set) var hasCompletedFirstRun: Bool
+
+    private let userDefaults: UserDefaults
+    private let launchAtLogin: LaunchAtLoginStore
+
+    init(
+        userDefaults: UserDefaults = .standard,
+        launchAtLogin: LaunchAtLoginStore = .shared
+    ) {
+        self.userDefaults = userDefaults
+        self.launchAtLogin = launchAtLogin
+        if userDefaults.bool(forKey: StorageKeys.hasCompletedFirstRun) {
+            hasCompletedFirstRun = true
+        } else if Self.hasEvidenceOfPriorUse(in: userDefaults) {
+            // Upgrades: installs that predate this flag already have other
+            // MeterBar state persisted. Adopt the flag silently so long-time
+            // users are never greeted with first-run onboarding.
+            hasCompletedFirstRun = true
+            userDefaults.set(true, forKey: StorageKeys.hasCompletedFirstRun)
+        } else {
+            hasCompletedFirstRun = false
+        }
+    }
+
+    /// Keys a pre-onboarding install would have written during normal use.
+    /// `cachedUsageMetrics` is persisted on every successful refresh, so any
+    /// real install carries at least that one.
+    private static let priorUseSentinelKeys: [String] = [
+        StorageKeys.cachedUsageMetrics,
+        StorageKeys.refreshInterval,
+        StorageKeys.hiddenProviderServices,
+        StorageKeys.notificationsEnabled,
+        StorageKeys.claudeCodeCustomAccounts,
+        StorageKeys.showInDock
+    ]
+
+    private static func hasEvidenceOfPriorUse(in userDefaults: UserDefaults) -> Bool {
+        priorUseSentinelKeys.contains { userDefaults.object(forKey: $0) != nil }
+    }
+
+    var shouldPresent: Bool { !hasCompletedFirstRun }
+
+    func chooseLaunchAtLogin(_ enabled: Bool) {
+        if enabled {
+            launchAtLogin.setEnabled(true)
+        }
+        complete()
+    }
+
+    /// Clicking away is also a dismissal choice; onboarding must never nag on
+    /// a later launch after the user has seen and dismissed it.
+    func dismiss() {
+        complete()
+    }
+
+    private func complete() {
+        guard !hasCompletedFirstRun else { return }
+        hasCompletedFirstRun = true
+        userDefaults.set(true, forKey: StorageKeys.hasCompletedFirstRun)
+    }
+}

--- a/MeterBar/Services/KeychainManager.swift
+++ b/MeterBar/Services/KeychainManager.swift
@@ -6,7 +6,7 @@ import Security
 /// fake instead of the real login keychain (which is unavailable / prompts on
 /// CI runners). Signatures mirror the C API 1:1 so the production backend is a
 /// thin pass-through.
-protocol KeychainBackend {
+nonisolated protocol KeychainBackend {
     func update(query: [String: Any], attributes: [String: Any]) -> OSStatus
     func add(query: [String: Any]) -> OSStatus
     func copyMatching(query: [String: Any], result: inout AnyObject?) -> OSStatus
@@ -14,7 +14,7 @@ protocol KeychainBackend {
 }
 
 /// Production backend: forwards straight to the Security framework.
-struct SecItemKeychainBackend: KeychainBackend {
+nonisolated struct SecItemKeychainBackend: KeychainBackend {
     func update(query: [String: Any], attributes: [String: Any]) -> OSStatus {
         SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
     }
@@ -33,7 +33,7 @@ struct SecItemKeychainBackend: KeychainBackend {
 }
 
 /// Minimal Keychain wrapper for the org API admin keys entered in Settings.
-final class KeychainManager {
+nonisolated final class KeychainManager {
     static let shared = KeychainManager()
 
     private let currentService: String

--- a/MeterBar/Services/NotificationDecider.swift
+++ b/MeterBar/Services/NotificationDecider.swift
@@ -124,6 +124,15 @@ struct NotificationDecider {
                 continue
             }
 
+            // Heuristic totals can indicate UI severity, but they are not a
+            // reliable basis for a threshold alert. Clear crossing state so a
+            // later provider-reported value can notify normally.
+            guard !limit.isEstimated else {
+                keys.remove(warnKey)
+                keys.remove(criticalKey)
+                continue
+            }
+
             let band = QuotaBand.forLimit(limit)
             let bandRank = Self.severityRank(band)
             let quotaDisplayName = quotaKind.displayName(for: metrics.service)

--- a/MeterBar/Services/NotificationDecider.swift
+++ b/MeterBar/Services/NotificationDecider.swift
@@ -91,6 +91,8 @@ struct NotificationDecider {
         metrics: UsageMetrics,
         providerEnabled: Bool,
         alreadyNotified: Set<String>,
+        accountKey: String? = nil,
+        serviceDisplayName: String? = nil,
         now: Date = Date()
     ) -> NotificationEvaluation {
         // Delivery gates suppress banners, not state transitions. Continuing to
@@ -114,7 +116,9 @@ struct NotificationDecider {
         let criticalRank = Self.severityRank(preferences.criticalThreshold.band)
 
         for (limit, quotaKind) in limits {
-            let baseKey = "\(metrics.service.rawValue)-\(quotaKind.rawValue)"
+            let baseKey = [metrics.service.rawValue, accountKey, quotaKind.rawValue]
+                .compactMap { $0 }
+                .joined(separator: "-")
             let warnKey = "\(baseKey)-warn"
             let criticalKey = "\(baseKey)-critical"
 
@@ -147,7 +151,7 @@ struct NotificationDecider {
                     fired.append(FiredNotification(
                         key: criticalKey,
                         level: .critical,
-                        serviceDisplayName: metrics.service.displayName,
+                        serviceDisplayName: serviceDisplayName ?? metrics.service.displayName,
                         quotaDisplayName: quotaDisplayName,
                         blocksProvider: blocksProvider,
                         percentUsed: Int(limit.percentage),
@@ -163,7 +167,7 @@ struct NotificationDecider {
                     fired.append(FiredNotification(
                         key: warnKey,
                         level: .warning,
-                        serviceDisplayName: metrics.service.displayName,
+                        serviceDisplayName: serviceDisplayName ?? metrics.service.displayName,
                         quotaDisplayName: quotaDisplayName,
                         blocksProvider: blocksProvider,
                         percentUsed: Int(limit.percentage),

--- a/MeterBar/Services/NotificationDecider.swift
+++ b/MeterBar/Services/NotificationDecider.swift
@@ -203,9 +203,9 @@ struct NotificationDecider {
         func displayName(for service: ServiceType) -> String {
             switch self {
             case .session:
-                return "Session"
+                return service == .openRouter ? "Key Limit" : "Session"
             case .weekly:
-                return "Weekly"
+                return service == .openRouter ? "Account Credits" : "Weekly"
             case .codeReview:
                 return service == .claudeCode ? "Sonnet" : "Code Review"
             }

--- a/MeterBar/Services/OpenRouterService.swift
+++ b/MeterBar/Services/OpenRouterService.swift
@@ -1,0 +1,190 @@
+import Combine
+import Foundation
+import MeterBarShared
+
+/// Fetches OpenRouter account credits and optional per-key spending limits.
+/// The API key is stored in MeterBar's Keychain service and is only sent to
+/// OpenRouter's documented `/api/v1/credits` and `/api/v1/key` endpoints.
+final class OpenRouterService: ObservableObject {
+    nonisolated static let shared = OpenRouterService()
+    nonisolated static let keychainKey = "openRouterAPIKey"
+
+    @Published private(set) var hasAccess: Bool
+    @Published private(set) var lastError: ServiceError?
+
+    private let keychain: KeychainManager
+    private let fetchData: (URLRequest) async throws -> Data
+
+    init(
+        keychain: KeychainManager = .shared,
+        fetchData: ((URLRequest) async throws -> Data)? = nil
+    ) {
+        self.keychain = keychain
+        self.fetchData = fetchData ?? Self.fetch
+        hasAccess = keychain.hasKey(key: Self.keychainKey)
+    }
+
+    @discardableResult
+    func saveAPIKey(_ value: String) -> Bool {
+        let key = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !key.isEmpty, keychain.save(key: Self.keychainKey, value: key) else {
+            return false
+        }
+        hasAccess = true
+        lastError = nil
+        return true
+    }
+
+    @discardableResult
+    func removeAPIKey() -> Bool {
+        let deleted = keychain.delete(key: Self.keychainKey)
+        hasAccess = keychain.hasKey(key: Self.keychainKey)
+        if !hasAccess {
+            lastError = nil
+        }
+        return deleted
+    }
+
+    func fetchUsageMetrics() async throws -> UsageMetrics {
+        guard let apiKey = keychain.get(key: Self.keychainKey) else {
+            let error = ServiceError.notAuthenticated
+            lastError = error
+            hasAccess = false
+            throw error
+        }
+
+        do {
+            async let creditsData = fetchData(try Self.request(path: "credits", apiKey: apiKey))
+            async let keyData = fetchData(try Self.request(path: "key", apiKey: apiKey))
+            let decoder = JSONDecoder()
+            let credits = try decoder.decode(OpenRouterCreditsResponse.self, from: await creditsData)
+            let key = try decoder.decode(OpenRouterKeyResponse.self, from: await keyData)
+            let metrics = Self.map(credits: credits.data, key: key.data)
+            hasAccess = true
+            lastError = nil
+            return metrics
+        } catch {
+            let serviceError = ServiceSupport.serviceError(from: error)
+            lastError = serviceError
+            if case .notAuthenticated = serviceError {
+                hasAccess = false
+            }
+            throw serviceError
+        }
+    }
+
+    static func map(
+        credits: OpenRouterCredits,
+        key: OpenRouterKey,
+        now: Date = Date(),
+        calendar: Calendar = Calendar(identifier: .gregorian)
+    ) -> UsageMetrics {
+        let accountCredits = UsageLimit(
+            used: credits.totalUsage,
+            total: credits.totalCredits,
+            resetTime: nil
+        )
+
+        let keyLimit: UsageLimit? = {
+            guard let limit = key.limit, limit > 0 else { return nil }
+            let used = key.limitRemaining.map { max(0, limit - $0) } ?? min(key.usage, limit)
+            let reset = resetWindow(key.limitReset, now: now, calendar: calendar)
+            return UsageLimit(
+                used: used,
+                total: limit,
+                resetTime: reset.date,
+                windowSeconds: reset.windowSeconds
+            )
+        }()
+
+        return UsageMetrics(
+            service: .openRouter,
+            sessionLimit: keyLimit,
+            weeklyLimit: accountCredits,
+            lastUpdated: now
+        )
+    }
+
+    private static func request(path: String, apiKey: String) throws -> URLRequest {
+        guard let url = URL(string: "https://openrouter.ai/api/v1/\(path)") else {
+            throw ServiceError.invalidURL
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        return request
+    }
+
+    private static func fetch(_ request: URLRequest) async throws -> Data {
+        let (data, response) = try await ServiceSupport.session.data(for: request)
+        try ServiceSupport.validate(response, data: data)
+        return data
+    }
+
+    private static func resetWindow(
+        _ rawValue: String?,
+        now: Date,
+        calendar: Calendar
+    ) -> (date: Date?, windowSeconds: TimeInterval?) {
+        guard let rawValue else { return (nil, nil) }
+        var utc = calendar
+        utc.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+
+        switch rawValue.lowercased() {
+        case "daily":
+            let start = utc.startOfDay(for: now)
+            return (utc.date(byAdding: .day, value: 1, to: start), 86_400)
+        case "weekly":
+            let start = utc.dateInterval(of: .weekOfYear, for: now)?.start
+            return (start.flatMap { utc.date(byAdding: .weekOfYear, value: 1, to: $0) }, 604_800)
+        case "monthly":
+            let start = utc.dateInterval(of: .month, for: now)?.start
+            return (start.flatMap { utc.date(byAdding: .month, value: 1, to: $0) }, nil)
+        default:
+            return (nil, nil)
+        }
+    }
+}
+
+struct OpenRouterCreditsResponse: Codable {
+    let data: OpenRouterCredits
+}
+
+struct OpenRouterCredits: Codable {
+    let totalCredits: Double
+    let totalUsage: Double
+
+    enum CodingKeys: String, CodingKey {
+        case totalCredits = "total_credits"
+        case totalUsage = "total_usage"
+    }
+}
+
+struct OpenRouterKeyResponse: Codable {
+    let data: OpenRouterKey
+}
+
+struct OpenRouterKey: Codable {
+    let label: String?
+    let limit: Double?
+    let limitReset: String?
+    let limitRemaining: Double?
+    let usage: Double
+    let usageDaily: Double?
+    let usageWeekly: Double?
+    let usageMonthly: Double?
+    let isFreeTier: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case label
+        case limit
+        case limitReset = "limit_reset"
+        case limitRemaining = "limit_remaining"
+        case usage
+        case usageDaily = "usage_daily"
+        case usageWeekly = "usage_weekly"
+        case usageMonthly = "usage_monthly"
+        case isFreeTier = "is_free_tier"
+    }
+}

--- a/MeterBar/Services/ProviderParseHealthStore.swift
+++ b/MeterBar/Services/ProviderParseHealthStore.swift
@@ -1,0 +1,137 @@
+import Combine
+import Foundation
+import MeterBarShared
+
+/// Persisted fetch/parse health for one reverse-engineered provider integration.
+nonisolated public struct ProviderParseHealthRecord: Codable, Equatable, Sendable {
+    static let staleAfter: TimeInterval = 2 * 60 * 60
+    static let sustainedFailureCount = 3
+    /// Genuine schema drift fails on every refresh, so two consecutive
+    /// mismatches are the earliest reliable drift signal; a single decode
+    /// failure can be a truncated body from a flaky connection.
+    static let sustainedShapeMismatchCount = 2
+
+    public let provider: ServiceType
+    public let lastSuccess: Date?
+    public let lastAttempt: Date
+    public let consecutiveFailures: Int
+    public let lastFailureWasShapeMismatch: Bool
+    public let consecutiveShapeMismatches: Int
+
+    public init(
+        provider: ServiceType,
+        lastSuccess: Date?,
+        lastAttempt: Date,
+        consecutiveFailures: Int,
+        lastFailureWasShapeMismatch: Bool,
+        consecutiveShapeMismatches: Int = 0
+    ) {
+        self.provider = provider
+        self.lastSuccess = lastSuccess
+        self.lastAttempt = lastAttempt
+        self.consecutiveFailures = consecutiveFailures
+        self.lastFailureWasShapeMismatch = lastFailureWasShapeMismatch
+        self.consecutiveShapeMismatches = consecutiveShapeMismatches
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        provider = try container.decode(ServiceType.self, forKey: .provider)
+        lastSuccess = try container.decodeIfPresent(Date.self, forKey: .lastSuccess)
+        lastAttempt = try container.decode(Date.self, forKey: .lastAttempt)
+        consecutiveFailures = try container.decode(Int.self, forKey: .consecutiveFailures)
+        lastFailureWasShapeMismatch = try container.decode(Bool.self, forKey: .lastFailureWasShapeMismatch)
+        // Records persisted before this field existed used a one-shot
+        // mismatch flag; carry that meaning forward conservatively.
+        consecutiveShapeMismatches = try container.decodeIfPresent(Int.self, forKey: .consecutiveShapeMismatches)
+            ?? (lastFailureWasShapeMismatch ? Self.sustainedShapeMismatchCount : 0)
+    }
+
+    static func success(provider: ServiceType = .claudeCode, at date: Date) -> Self {
+        Self(
+            provider: provider,
+            lastSuccess: date,
+            lastAttempt: date,
+            consecutiveFailures: 0,
+            lastFailureWasShapeMismatch: false,
+            consecutiveShapeMismatches: 0
+        )
+    }
+
+    func needsAttention(now: Date = Date()) -> Bool {
+        if consecutiveShapeMismatches >= Self.sustainedShapeMismatchCount
+            || consecutiveFailures >= Self.sustainedFailureCount {
+            return true
+        }
+        guard let lastSuccess else { return false }
+        return now.timeIntervalSince(lastSuccess) > Self.staleAfter
+    }
+}
+
+/// Records provider outcomes in the app-group domain so the GUI and bundled
+/// `meterbar doctor` process read the same diagnostic state.
+final class ProviderParseHealthStore: ObservableObject {
+    static let shared = ProviderParseHealthStore()
+    nonisolated static let storageKey = "ProviderParseHealthV1"
+
+    @Published private(set) var records: [ServiceType: ProviderParseHealthRecord]
+
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults? = nil) {
+        let resolved = userDefaults
+            ?? UserDefaults(suiteName: SharedMetricsStore.appGroupIdentifier)
+            ?? .standard
+        self.userDefaults = resolved
+        records = Self.persistedRecords(from: resolved)
+    }
+
+    func recordSuccess(_ provider: ServiceType, at date: Date = Date()) {
+        records[provider] = .success(provider: provider, at: date)
+        persist()
+    }
+
+    func recordFailure(_ provider: ServiceType, error: Error, at date: Date = Date()) {
+        let previous = records[provider]
+        let isShapeMismatch = Self.isShapeMismatch(error)
+        records[provider] = ProviderParseHealthRecord(
+            provider: provider,
+            lastSuccess: previous?.lastSuccess,
+            lastAttempt: date,
+            consecutiveFailures: (previous?.consecutiveFailures ?? 0) + 1,
+            lastFailureWasShapeMismatch: isShapeMismatch,
+            consecutiveShapeMismatches: isShapeMismatch
+                ? (previous?.consecutiveShapeMismatches ?? 0) + 1
+                : 0
+        )
+        persist()
+    }
+
+    nonisolated static func persistedRecords(from userDefaults: UserDefaults) -> [ServiceType: ProviderParseHealthRecord] {
+        guard let data = userDefaults.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode([ProviderParseHealthRecord].self, from: data) else {
+            return [:]
+        }
+        return Dictionary(uniqueKeysWithValues: decoded.map { ($0.provider, $0) })
+    }
+
+    nonisolated static func sharedRecords() -> [ServiceType: ProviderParseHealthRecord] {
+        guard let defaults = UserDefaults(suiteName: SharedMetricsStore.appGroupIdentifier) else { return [:] }
+        return persistedRecords(from: defaults)
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(Array(records.values)) else { return }
+        userDefaults.set(data, forKey: Self.storageKey)
+    }
+
+    nonisolated private static func isShapeMismatch(_ error: Error) -> Bool {
+        if let serviceError = error as? ServiceError,
+           case .parsingError = serviceError {
+            return true
+        }
+        if error is DecodingError { return true }
+        let message = error.localizedDescription.lowercased()
+        return message.contains("parse") || message.contains("decode") || message.contains("format")
+    }
+}

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -30,7 +30,8 @@ nonisolated public enum ProviderReadinessInspector {
             now: now,
             claudeReport: { claudeReport(refreshError: $0, now: $1) },
             codexReport: { codexReport(refreshError: $0, now: $1) },
-            cursorReport: { cursorReport(refreshError: $0, now: $1) }
+            cursorReport: { cursorReport(refreshError: $0, now: $1) },
+            openRouterReport: { error, _ in openRouterReport(refreshError: error) }
         )
     }
 
@@ -43,7 +44,10 @@ nonisolated public enum ProviderReadinessInspector {
         now: Date,
         claudeReport: (ServiceError?, Date) -> ProviderReadiness,
         codexReport: (ServiceError?, Date) -> ProviderReadiness,
-        cursorReport: (ServiceError?, Date) -> ProviderReadiness
+        cursorReport: (ServiceError?, Date) -> ProviderReadiness,
+        openRouterReport: (ServiceError?, Date) -> ProviderReadiness = { error, _ in
+            ProviderReadinessInspector.openRouterReport(refreshError: error)
+        }
     ) -> [ProviderReadiness] {
         ServiceType.allCases.compactMap { provider in
             guard providers.contains(provider) else { return nil }
@@ -54,6 +58,8 @@ nonisolated public enum ProviderReadinessInspector {
                 return codexReport(refreshErrors[provider], now)
             case .cursor:
                 return cursorReport(refreshErrors[provider], now)
+            case .openRouter:
+                return openRouterReport(refreshErrors[provider], now)
             }
         }
     }
@@ -136,6 +142,18 @@ nonisolated public enum ProviderReadinessInspector {
             now: now
         )
         return ProviderReadinessEvaluator.cursor(input)
+    }
+
+    static func openRouterReport(
+        refreshError: ServiceError? = nil,
+        hasAPIKey: () -> Bool = { KeychainManager.shared.hasKey(key: OpenRouterService.keychainKey) }
+    ) -> ProviderReadiness {
+        ProviderReadinessEvaluator.openRouter(
+            OpenRouterReadinessInput(
+                hasAPIKey: hasAPIKey(),
+                refreshError: sanitize(refreshError)
+            )
+        )
     }
 
     // MARK: - Helpers

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -22,9 +22,10 @@ nonisolated public enum ProviderReadinessInspector {
     public static func reports(
         providers: Set<ServiceType> = Set(ServiceType.allCases),
         refreshErrors: [ServiceType: ServiceError] = [:],
-        now: Date = Date()
+        now: Date = Date(),
+        parseHealth: [ServiceType: ProviderParseHealthRecord]? = nil
     ) -> [ProviderReadiness] {
-        reports(
+        let baseReports = reports(
             providers: providers,
             refreshErrors: refreshErrors,
             now: now,
@@ -33,6 +34,13 @@ nonisolated public enum ProviderReadinessInspector {
             cursorReport: { cursorReport(refreshError: $0, now: $1) },
             openRouterReport: { error, _ in openRouterReport(refreshError: error) }
         )
+        let health = parseHealth ?? ProviderParseHealthStore.sharedRecords()
+        return baseReports.map { report in
+            ProviderReadiness(
+                provider: report.provider,
+                checks: report.checks + [parseHealthCheck(health[report.provider], now: now)]
+            )
+        }
     }
 
     /// Injectable routing seam used to prove that disabled providers perform no
@@ -157,6 +165,61 @@ nonisolated public enum ProviderReadinessInspector {
     }
 
     // MARK: - Helpers
+
+    private static func parseHealthCheck(_ record: ProviderParseHealthRecord?, now: Date) -> ReadinessCheck {
+        let threshold = "Data is considered stale after 2 hours."
+        guard let record else {
+            return ReadinessCheck(
+                id: ReadinessCheckID.parseHealth,
+                title: "Provider format health",
+                level: .warn,
+                detail: "No refresh outcome has been recorded yet. \(threshold)"
+            )
+        }
+
+        if record.lastFailureWasShapeMismatch {
+            return ReadinessCheck(
+                id: ReadinessCheckID.parseHealth,
+                title: "Provider format health",
+                level: .fail,
+                detail: "The last refresh detected an upstream format mismatch. \(threshold)",
+                recovery: "Refresh once more, then copy this Diagnostics report if it persists."
+            )
+        }
+        if record.consecutiveFailures >= ProviderParseHealthRecord.sustainedFailureCount {
+            return ReadinessCheck(
+                id: ReadinessCheckID.parseHealth,
+                title: "Provider format health",
+                level: .fail,
+                detail: "\(record.consecutiveFailures) consecutive refreshes failed. \(threshold)",
+                recovery: "Check the provider connection and refresh again."
+            )
+        }
+        if record.consecutiveFailures > 0 {
+            return ReadinessCheck(
+                id: ReadinessCheckID.parseHealth,
+                title: "Provider format health",
+                level: .warn,
+                detail: "The latest refresh failed; \(record.consecutiveFailures) failure recorded. \(threshold)"
+            )
+        }
+        if let lastSuccess = record.lastSuccess,
+           now.timeIntervalSince(lastSuccess) > ProviderParseHealthRecord.staleAfter {
+            return ReadinessCheck(
+                id: ReadinessCheckID.parseHealth,
+                title: "Provider format health",
+                level: .warn,
+                detail: "Usage data is older than the 2-hour staleness threshold.",
+                recovery: "Refresh the provider and review any new error."
+            )
+        }
+        return ReadinessCheck(
+            id: ReadinessCheckID.parseHealth,
+            title: "Provider format health",
+            level: .pass,
+            detail: "The most recent provider response parsed successfully. \(threshold)"
+        )
+    }
 
     private static func cursorAppPresent() -> Bool {
         let fileManager = FileManager.default

--- a/MeterBar/Services/ProviderStatusMonitor.swift
+++ b/MeterBar/Services/ProviderStatusMonitor.swift
@@ -144,6 +144,8 @@ extension ServiceType {
             return "OpenAI"
         case .cursor:
             return "Cursor"
+        case .openRouter:
+            return "OpenRouter"
         }
     }
 
@@ -155,6 +157,8 @@ extension ServiceType {
             return "https://status.openai.com/"
         case .cursor:
             return "https://status.cursor.com/"
+        case .openRouter:
+            return "https://status.openrouter.ai/"
         }
     }
 
@@ -277,6 +281,9 @@ struct ProviderStatusClient {
     let session: URLSession
 
     func fetchReport(for service: ServiceType) async throws -> ProviderStatusReport {
+        if service == .openRouter {
+            return try await fetchOpenRouterReport()
+        }
         guard let baseURL = service.statusPageURL else {
             throw ServiceError.invalidURL
         }
@@ -289,6 +296,30 @@ struct ProviderStatusClient {
             pageURL: baseURL,
             summary: parsedStatus.summary,
             components: components,
+            fetchedAt: Date()
+        )
+    }
+
+    private func fetchOpenRouterReport() async throws -> ProviderStatusReport {
+        guard let url = ServiceType.openRouter.statusPageURL else {
+            throw ServiceError.invalidURL
+        }
+        let (data, response) = try await session.data(from: url)
+        try ServiceSupport.validate(response, data: data)
+        guard let html = String(data: data, encoding: .utf8) else {
+            throw ServiceError.parsingError
+        }
+        let operational = html.localizedCaseInsensitiveContains("All Systems Operational")
+        return ProviderStatusReport(
+            service: .openRouter,
+            pageName: "OpenRouter",
+            pageURL: url,
+            summary: ProviderStatusSummary(
+                indicator: operational ? .none : .unknown,
+                description: operational ? "All Systems Operational" : "Check the OpenRouter status page",
+                updatedAt: nil
+            ),
+            components: [],
             fetchedAt: Date()
         )
     }

--- a/MeterBar/Services/ProviderVisibilityStore.swift
+++ b/MeterBar/Services/ProviderVisibilityStore.swift
@@ -36,12 +36,18 @@ final class ProviderVisibilityStore: ObservableObject {
 
         guard nextHiddenServices != hiddenServices else { return }
         hiddenServices = nextHiddenServices
+        if service == .openRouter {
+            userDefaults.set(enabled, forKey: StorageKeys.openRouterProviderEnabled)
+        }
         save()
     }
 
     private func load() {
         let rawValues = userDefaults.stringArray(forKey: storageKey) ?? []
         hiddenServices = Set(rawValues.compactMap(ServiceType.init(rawValue:)))
+        if !userDefaults.bool(forKey: StorageKeys.openRouterProviderEnabled) {
+            hiddenServices.insert(.openRouter)
+        }
     }
 
     private func save() {

--- a/MeterBar/Services/SharedDataStore.swift
+++ b/MeterBar/Services/SharedDataStore.swift
@@ -36,6 +36,13 @@ nonisolated public final class SharedDataStore: @unchecked Sendable {
         return SharedMetricsStore.metricsFileURL
     }
 
+    private var accountMetricsFileURL: URL? {
+        if let directoryOverride {
+            return directoryOverride.appendingPathComponent("\(SharedMetricsStore.accountMetricsKey).json")
+        }
+        return SharedMetricsStore.accountMetricsFileURL
+    }
+
     /// Defaults reproduce the production singleton exactly; tests inject a
     /// directory + write spy.
     init(directoryOverride: URL? = nil, didWrite: (() -> Void)? = nil) {
@@ -66,6 +73,25 @@ nonisolated public final class SharedDataStore: @unchecked Sendable {
         }
     }
 
+    func saveAccountMetrics(_ snapshots: [AccountUsageSnapshot]) {
+        guard let fileURL = accountMetricsFileURL,
+              let data = try? JSONEncoder().encode(snapshots) else {
+            AppLog.storage.error("Failed to prepare shared account metrics")
+            return
+        }
+
+        ioQueue.async { [weak self] in
+            do {
+                try data.write(to: fileURL, options: [.atomic])
+                self?.didWrite()
+            } catch {
+                AppLog.storage.error(
+                    "Failed to save shared account metrics: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+    }
+
     /// Reads through the shared reader so the app, widget, and CLI decode the
     /// same file the same way. The test override reads the same file name from
     /// the injected directory.
@@ -76,6 +102,16 @@ nonisolated public final class SharedDataStore: @unchecked Sendable {
             return MetricsCodec.decode(data)
         }
         return SharedMetricsStore.loadMetrics()
+    }
+
+    public func loadAccountMetrics() -> [AccountUsageSnapshot] {
+        guard directoryOverride == nil else {
+            guard let fileURL = accountMetricsFileURL,
+                  let data = try? Data(contentsOf: fileURL),
+                  let decoded = try? JSONDecoder().decode([AccountUsageSnapshot].self, from: data) else { return [] }
+            return decoded
+        }
+        return SharedMetricsStore.loadAccountMetrics()
     }
 
     /// Blocks until any in-flight async write has completed. Test-only: lets a

--- a/MeterBar/Services/SoftwareUpdateController.swift
+++ b/MeterBar/Services/SoftwareUpdateController.swift
@@ -1,0 +1,95 @@
+import Combine
+import Foundation
+#if canImport(Sparkle)
+import Sparkle
+#endif
+
+/// Owns Sparkle's standard updater and exposes only user-controlled update actions.
+/// Automatic network checks remain off until the user explicitly enables them.
+final class SoftwareUpdateController: ObservableObject {
+    static let shared = SoftwareUpdateController()
+
+    @Published private(set) var automaticallyChecksForUpdates = false
+    @Published private(set) var canCheckForUpdates = false
+    @Published private(set) var configurationError: String?
+
+    /// True only for a plausible Ed25519 public key. Debug and PR-gate builds
+    /// carry the unsubstituted `$(SPARKLE_PUBLIC_ED_KEY)` build variable in
+    /// their Info.plist, which the empty-string check alone would let through.
+    nonisolated static func isUsableEDPublicKey(_ rawValue: String) -> Bool {
+        let key = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !key.isEmpty, !key.hasPrefix("$("), !key.hasPrefix("${") else { return false }
+        guard let decoded = Data(base64Encoded: key) else { return false }
+        return decoded.count == 32
+    }
+
+#if canImport(Sparkle)
+    private let controller: SPUStandardUpdaterController?
+    private var cancellables = Set<AnyCancellable>()
+
+    init(bundle: Bundle = .main) {
+        guard let publicKey = bundle.object(forInfoDictionaryKey: "SUPublicEDKey") as? String,
+              Self.isUsableEDPublicKey(publicKey) else {
+            controller = nil
+            configurationError = "Software updates are unavailable in this build."
+            return
+        }
+
+        let controller = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+        self.controller = controller
+        controller.updater.publisher(for: \.automaticallyChecksForUpdates, options: [.initial, .new])
+            .sink { [weak self] enabled in
+                self?.automaticallyChecksForUpdates = enabled
+            }
+            .store(in: &cancellables)
+        controller.updater.publisher(for: \.canCheckForUpdates, options: [.initial, .new])
+            .sink { [weak self] canCheck in
+                self?.canCheckForUpdates = canCheck
+            }
+            .store(in: &cancellables)
+        refreshState()
+    }
+
+    func setAutomaticallyChecksForUpdates(_ enabled: Bool) {
+        guard let updater = controller?.updater else { return }
+        updater.automaticallyChecksForUpdates = enabled
+        refreshState()
+    }
+
+    func checkForUpdates() {
+        controller?.checkForUpdates(nil)
+        refreshState()
+    }
+
+    func refreshState() {
+        guard let updater = controller?.updater else {
+            automaticallyChecksForUpdates = false
+            canCheckForUpdates = false
+            return
+        }
+        automaticallyChecksForUpdates = updater.automaticallyChecksForUpdates
+        canCheckForUpdates = updater.canCheckForUpdates
+    }
+#else
+    init(bundle: Bundle = .main) {
+        _ = bundle
+        configurationError = "Software updates are available in the app build."
+    }
+
+    func setAutomaticallyChecksForUpdates(_ enabled: Bool) {
+        _ = enabled
+    }
+
+    func checkForUpdates() {
+        // The standalone Swift package intentionally has no updater framework.
+    }
+
+    func refreshState() {
+        // The standalone Swift package intentionally has no updater framework.
+    }
+#endif
+}

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -1,8 +1,7 @@
+import Combine
 import Foundation
 import MeterBarShared
 import os
-import Combine
-import SwiftUI
 
 /// The single-account provider surface `UsageDataManager` orchestrates (Codex,
 /// Cursor). Behind a protocol so the manager's merge / graceful-degradation
@@ -26,8 +25,13 @@ class UsageDataManager: ObservableObject {
     @Published var isLoading: Bool = false
     @Published var lastError: Error?
 
-    @AppStorage(StorageKeys.refreshInterval)
-    private var refreshIntervalRaw: Int = RefreshInterval.fifteenMinutes.rawValue
+    @Published private var refreshIntervalRaw: Int =
+        UserDefaults.standard.object(forKey: StorageKeys.refreshInterval) as? Int
+        ?? RefreshInterval.fifteenMinutes.rawValue {
+        didSet {
+            UserDefaults.standard.set(refreshIntervalRaw, forKey: StorageKeys.refreshInterval)
+        }
+    }
 
     var refreshInterval: RefreshInterval {
         get { RefreshInterval(rawValue: refreshIntervalRaw) ?? .fifteenMinutes }

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -15,6 +15,7 @@ protocol SimpleUsageProviding: AnyObject {
 
 extension CodexCliLocalService: SimpleUsageProviding {}
 extension CursorLocalService: SimpleUsageProviding {}
+extension OpenRouterService: SimpleUsageProviding {}
 
 @MainActor
 class UsageDataManager: ObservableObject {
@@ -44,6 +45,7 @@ class UsageDataManager: ObservableObject {
     private let claudeCodeService: ClaudeCodeLocalService
     private let cursorService: SimpleUsageProviding
     private let codexCliService: SimpleUsageProviding
+    private let openRouterService: SimpleUsageProviding
     private let claudeCodeAccountStore: ClaudeCodeAccountStore
     private let providerVisibilityStore: ProviderVisibilityStore
 
@@ -61,6 +63,7 @@ class UsageDataManager: ObservableObject {
     init(
         codexCliService: SimpleUsageProviding = CodexCliLocalService.shared,
         cursorService: SimpleUsageProviding = CursorLocalService.shared,
+        openRouterService: SimpleUsageProviding = OpenRouterService.shared,
         claudeCodeService: ClaudeCodeLocalService = .shared,
         claudeCodeAccountStore: ClaudeCodeAccountStore? = nil,
         providerVisibilityStore: ProviderVisibilityStore? = nil,
@@ -70,6 +73,7 @@ class UsageDataManager: ObservableObject {
     ) {
         self.codexCliService = codexCliService
         self.cursorService = cursorService
+        self.openRouterService = openRouterService
         self.claudeCodeService = claudeCodeService
         self.claudeCodeAccountStore = claudeCodeAccountStore ?? .shared
         self.providerVisibilityStore = providerVisibilityStore ?? .shared
@@ -103,7 +107,7 @@ class UsageDataManager: ObservableObject {
 
         // Fetch the simple (single-account) providers. On failure the final
         // merge loop below preserves any cached metrics (graceful degradation).
-        for service in [ServiceType.codexCli, .cursor]
+        for service in [ServiceType.codexCli, .cursor, .openRouter]
         where providerVisibilityStore.isEnabled(service) && hasProviderAccess(service) {
             do {
                 newMetrics[service] = try await fetchSimpleProviderMetrics(service)
@@ -163,7 +167,7 @@ class UsageDataManager: ObservableObject {
                     // hold a stale error from an unrelated provider/account.
                     throw ServiceError.notAuthenticated
                 }
-            case .codexCli, .cursor:
+            case .codexCli, .cursor, .openRouter:
                 guard hasProviderAccess(service) else {
                     throw ServiceError.notAuthenticated
                 }
@@ -265,6 +269,8 @@ class UsageDataManager: ObservableObject {
             return codexCliService.hasAccess
         case .cursor:
             return cursorService.hasAccess
+        case .openRouter:
+            return openRouterService.hasAccess
         }
     }
 
@@ -276,6 +282,8 @@ class UsageDataManager: ObservableObject {
             return try await codexCliService.fetchUsageMetrics()
         case .cursor:
             return try await cursorService.fetchUsageMetrics()
+        case .openRouter:
+            return try await openRouterService.fetchUsageMetrics()
         case .claudeCode:
             preconditionFailure("Claude Code uses the account-aware fetch path")
         }

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -95,7 +95,8 @@ class UsageDataManager: ObservableObject {
         var newMetrics: [ServiceType: UsageMetrics] = [:]
 
         // Fetch Claude Code metrics (local files)
-        if providerVisibilityStore.isEnabled(.claudeCode), claudeCodeService.hasAccess {
+        let hasEnabledClaudeAccount = !claudeCodeAccountStore.enabledAccounts.isEmpty
+        if providerVisibilityStore.isEnabled(.claudeCode), hasEnabledClaudeAccount, claudeCodeService.hasAccess {
             let accountMetrics = await fetchClaudeCodeAccountMetrics()
             claudeCodeAccountMetrics = accountMetrics
 
@@ -104,7 +105,7 @@ class UsageDataManager: ObservableObject {
             } else if let cachedMetrics = self.metrics[.claudeCode] {
                 newMetrics[.claudeCode] = cachedMetrics
             }
-        } else if !providerVisibilityStore.isEnabled(.claudeCode) {
+        } else if !providerVisibilityStore.isEnabled(.claudeCode) || !hasEnabledClaudeAccount {
             claudeCodeAccountMetrics = [:]
         }
 
@@ -124,6 +125,7 @@ class UsageDataManager: ObservableObject {
 
         // Merge new metrics with existing cached metrics for services that failed to fetch
         for service in ServiceType.allCases where providerVisibilityStore.isEnabled(service) {
+            if service == .claudeCode, !hasEnabledClaudeAccount { continue }
             if newMetrics[service] == nil, let cachedMetric = self.metrics[service] {
                 newMetrics[service] = cachedMetric
             }
@@ -155,6 +157,14 @@ class UsageDataManager: ObservableObject {
 
             switch service {
             case .claudeCode:
+                guard !claudeCodeAccountStore.enabledAccounts.isEmpty else {
+                    claudeCodeAccountMetrics = [:]
+                    metrics.removeValue(forKey: service)
+                    saveCachedData()
+                    sharedStore.saveMetrics(metrics)
+                    isLoading = false
+                    return
+                }
                 guard claudeCodeService.hasAccess else {
                     throw ServiceError.notAuthenticated
                 }
@@ -246,7 +256,7 @@ class UsageDataManager: ObservableObject {
         var firstFailure: Error?
         var successCount = 0
 
-        for account in claudeCodeAccountStore.accounts {
+        for account in claudeCodeAccountStore.enabledAccounts {
             do {
                 refreshedMetrics[account.id] = try await claudeCodeService.fetchUsageMetrics(account: account)
                 successCount += 1
@@ -272,7 +282,11 @@ class UsageDataManager: ObservableObject {
     }
 
     private func representativeClaudeCodeMetrics(from accountMetrics: [UUID: UsageMetrics]) -> UsageMetrics? {
-        accountMetrics[ClaudeCodeAccount.defaultID] ?? accountMetrics.values.first
+        if claudeCodeAccountStore.defaultAccountIsEnabled,
+           let defaultMetrics = accountMetrics[ClaudeCodeAccount.defaultID] {
+            return defaultMetrics
+        }
+        return claudeCodeAccountStore.enabledAccounts.lazy.compactMap { accountMetrics[$0.id] }.first
     }
 
     // MARK: - Provider strategy

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -48,6 +48,7 @@ class UsageDataManager: ObservableObject {
     private let openRouterService: SimpleUsageProviding
     private let claudeCodeAccountStore: ClaudeCodeAccountStore
     private let providerVisibilityStore: ProviderVisibilityStore
+    private let parseHealthStore: ProviderParseHealthStore
 
     private var refreshTimer: Timer?
     private let cacheKey = StorageKeys.cachedUsageMetrics
@@ -69,6 +70,7 @@ class UsageDataManager: ObservableObject {
         providerVisibilityStore: ProviderVisibilityStore? = nil,
         sharedStore: SharedDataStore = .shared,
         cacheDefaults: UserDefaults = .standard,
+        parseHealthStore: ProviderParseHealthStore? = nil,
         schedulesAutoRefresh: Bool = true
     ) {
         self.codexCliService = codexCliService
@@ -79,6 +81,7 @@ class UsageDataManager: ObservableObject {
         self.providerVisibilityStore = providerVisibilityStore ?? .shared
         self.sharedStore = sharedStore
         self.cacheDefaults = cacheDefaults
+        self.parseHealthStore = parseHealthStore ?? .shared
         loadCachedData()
         if schedulesAutoRefresh {
             setupAutoRefresh()
@@ -240,16 +243,29 @@ class UsageDataManager: ObservableObject {
 
     private func fetchClaudeCodeAccountMetrics() async -> [UUID: UsageMetrics] {
         var refreshedMetrics: [UUID: UsageMetrics] = [:]
+        var firstFailure: Error?
+        var successCount = 0
 
         for account in claudeCodeAccountStore.accounts {
             do {
                 refreshedMetrics[account.id] = try await claudeCodeService.fetchUsageMetrics(account: account)
+                successCount += 1
             } catch {
+                if firstFailure == nil { firstFailure = error }
                 lastError = error
                 if let cachedMetrics = claudeCodeAccountMetrics[account.id] {
                     refreshedMetrics[account.id] = cachedMetrics
                 }
             }
+        }
+
+        // Parse health tracks integration health, not per-account health:
+        // if any account parses, the format contract still holds, so one
+        // failing account must not dim the whole provider.
+        if successCount > 0 {
+            parseHealthStore.recordSuccess(.claudeCode)
+        } else if let firstFailure {
+            parseHealthStore.recordFailure(.claudeCode, error: firstFailure)
         }
 
         return refreshedMetrics
@@ -277,15 +293,23 @@ class UsageDataManager: ObservableObject {
     /// Fetch for the providers without multi-account handling (Claude Code has
     /// its own account-aware path).
     private func fetchSimpleProviderMetrics(_ service: ServiceType) async throws -> UsageMetrics {
-        switch service {
-        case .codexCli:
-            return try await codexCliService.fetchUsageMetrics()
-        case .cursor:
-            return try await cursorService.fetchUsageMetrics()
-        case .openRouter:
-            return try await openRouterService.fetchUsageMetrics()
-        case .claudeCode:
-            preconditionFailure("Claude Code uses the account-aware fetch path")
+        do {
+            let result: UsageMetrics
+            switch service {
+            case .codexCli:
+                result = try await codexCliService.fetchUsageMetrics()
+            case .cursor:
+                result = try await cursorService.fetchUsageMetrics()
+            case .openRouter:
+                result = try await openRouterService.fetchUsageMetrics()
+            case .claudeCode:
+                preconditionFailure("Claude Code uses the account-aware fetch path")
+            }
+            parseHealthStore.recordSuccess(service)
+            return result
+        } catch {
+            parseHealthStore.recordFailure(service, error: error)
+            throw error
         }
     }
 }

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -3,8 +3,8 @@ import Foundation
 import MeterBarShared
 import os
 
-/// The single-account provider surface `UsageDataManager` orchestrates (Codex,
-/// Cursor). Behind a protocol so the manager's merge / graceful-degradation
+/// The single-account provider surface `UsageDataManager` orchestrates (Cursor).
+/// Behind a protocol so the manager's merge / graceful-degradation
 /// logic can be tested with stub providers instead of the real network + local
 /// credential files. Claude Code has its own account-aware path and is not part
 /// of this seam.
@@ -13,9 +13,15 @@ protocol SimpleUsageProviding: AnyObject {
     func fetchUsageMetrics() async throws -> UsageMetrics
 }
 
-extension CodexCliLocalService: SimpleUsageProviding {}
 extension CursorLocalService: SimpleUsageProviding {}
 extension OpenRouterService: SimpleUsageProviding {}
+
+protocol CodexUsageProviding: AnyObject {
+    func canAccess(account: CodexAccount) async -> Bool
+    func fetchUsageMetrics(account: CodexAccount) async throws -> UsageMetrics
+}
+
+extension CodexCliLocalService: CodexUsageProviding {}
 
 @MainActor
 class UsageDataManager: ObservableObject {
@@ -23,6 +29,7 @@ class UsageDataManager: ObservableObject {
 
     @Published var metrics: [ServiceType: UsageMetrics] = [:]
     @Published var claudeCodeAccountMetrics: [UUID: UsageMetrics] = [:]
+    @Published var codexAccountMetrics: [UUID: UsageMetrics] = [:]
     @Published var isLoading: Bool = false
     @Published var lastError: Error?
 
@@ -44,9 +51,10 @@ class UsageDataManager: ObservableObject {
 
     private let claudeCodeService: ClaudeCodeLocalService
     private let cursorService: SimpleUsageProviding
-    private let codexCliService: SimpleUsageProviding
+    private let codexCliService: CodexUsageProviding
     private let openRouterService: SimpleUsageProviding
     private let claudeCodeAccountStore: ClaudeCodeAccountStore
+    private let codexAccountStore: CodexAccountStore
     private let providerVisibilityStore: ProviderVisibilityStore
     private let parseHealthStore: ProviderParseHealthStore
 
@@ -62,27 +70,30 @@ class UsageDataManager: ObservableObject {
     /// MainActor-isolated singletons cannot appear in (nonisolated) default
     /// argument position.
     init(
-        codexCliService: SimpleUsageProviding = CodexCliLocalService.shared,
+        codexCliService: CodexUsageProviding? = nil,
         cursorService: SimpleUsageProviding = CursorLocalService.shared,
         openRouterService: SimpleUsageProviding = OpenRouterService.shared,
         claudeCodeService: ClaudeCodeLocalService = .shared,
         claudeCodeAccountStore: ClaudeCodeAccountStore? = nil,
+        codexAccountStore: CodexAccountStore? = nil,
         providerVisibilityStore: ProviderVisibilityStore? = nil,
         sharedStore: SharedDataStore = .shared,
         cacheDefaults: UserDefaults = .standard,
         parseHealthStore: ProviderParseHealthStore? = nil,
         schedulesAutoRefresh: Bool = true
     ) {
-        self.codexCliService = codexCliService
+        self.codexCliService = codexCliService ?? CodexCliLocalService.shared
         self.cursorService = cursorService
         self.openRouterService = openRouterService
         self.claudeCodeService = claudeCodeService
         self.claudeCodeAccountStore = claudeCodeAccountStore ?? .shared
+        self.codexAccountStore = codexAccountStore ?? .shared
         self.providerVisibilityStore = providerVisibilityStore ?? .shared
         self.sharedStore = sharedStore
         self.cacheDefaults = cacheDefaults
         self.parseHealthStore = parseHealthStore ?? .shared
         loadCachedData()
+        loadCachedCodexAccountMetrics()
         if schedulesAutoRefresh {
             setupAutoRefresh()
         }
@@ -109,9 +120,21 @@ class UsageDataManager: ObservableObject {
             claudeCodeAccountMetrics = [:]
         }
 
+        if providerVisibilityStore.isEnabled(.codexCli) {
+            let accountMetrics = await fetchCodexAccountMetrics()
+            codexAccountMetrics = accountMetrics
+            if let representative = representativeCodexMetrics(from: accountMetrics) {
+                newMetrics[.codexCli] = representative
+            } else if let cachedMetrics = self.metrics[.codexCli] {
+                newMetrics[.codexCli] = cachedMetrics
+            }
+        } else {
+            codexAccountMetrics = [:]
+        }
+
         // Fetch the simple (single-account) providers. On failure the final
         // merge loop below preserves any cached metrics (graceful degradation).
-        for service in [ServiceType.codexCli, .cursor, .openRouter]
+        for service in [ServiceType.cursor, .openRouter]
         where providerVisibilityStore.isEnabled(service) && hasProviderAccess(service) {
             do {
                 newMetrics[service] = try await fetchSimpleProviderMetrics(service)
@@ -133,7 +156,8 @@ class UsageDataManager: ObservableObject {
 
         metrics = newMetrics
         saveCachedData()
-        sharedStore.saveMetrics(newMetrics)
+        saveCachedCodexAccountMetrics()
+        saveSharedData(newMetrics)
         isLoading = false
     }
 
@@ -145,61 +169,34 @@ class UsageDataManager: ObservableObject {
             metrics.removeValue(forKey: service)
             if service == .claudeCode {
                 claudeCodeAccountMetrics = [:]
+            } else if service == .codexCli {
+                codexAccountMetrics = [:]
             }
             saveCachedData()
-            sharedStore.saveMetrics(metrics)
+            saveCachedCodexAccountMetrics()
+            saveSharedData(metrics)
+            isLoading = false
+            return
+        }
+
+        if service == .claudeCode, claudeCodeAccountStore.enabledAccounts.isEmpty {
+            // All Claude accounts disabled: clear metrics without an error so the
+            // catch below does not restore stale cached data.
+            claudeCodeAccountMetrics = [:]
+            metrics.removeValue(forKey: service)
+            saveCachedData()
+            saveSharedData(metrics)
             isLoading = false
             return
         }
 
         do {
-            let newMetrics: UsageMetrics
-
-            switch service {
-            case .claudeCode:
-                guard !claudeCodeAccountStore.enabledAccounts.isEmpty else {
-                    claudeCodeAccountMetrics = [:]
-                    metrics.removeValue(forKey: service)
-                    saveCachedData()
-                    sharedStore.saveMetrics(metrics)
-                    isLoading = false
-                    return
-                }
-                guard claudeCodeService.hasAccess else {
-                    throw ServiceError.notAuthenticated
-                }
-                let accountMetrics = await fetchClaudeCodeAccountMetrics()
-                claudeCodeAccountMetrics = accountMetrics
-                if let representativeMetrics = representativeClaudeCodeMetrics(from: accountMetrics) {
-                    newMetrics = representativeMetrics
-                } else if let cachedMetric = metrics[service] {
-                    newMetrics = cachedMetric
-                } else {
-                    // No representative account metrics and nothing cached. Throw a
-                    // specific error rather than the shared `lastError`, which may
-                    // hold a stale error from an unrelated provider/account.
-                    throw ServiceError.notAuthenticated
-                }
-            case .codexCli, .cursor, .openRouter:
-                guard hasProviderAccess(service) else {
-                    throw ServiceError.notAuthenticated
-                }
-                do {
-                    newMetrics = try await fetchSimpleProviderMetrics(service)
-                } catch {
-                    // On individual refresh, preserve cached data if fetch fails
-                    if let cachedMetric = metrics[service] {
-                        newMetrics = cachedMetric
-                        lastError = error
-                    } else {
-                        throw error
-                    }
-                }
-            }
+            let newMetrics = try await refreshedMetrics(for: service)
 
             metrics[service] = newMetrics
             saveCachedData()
-            sharedStore.saveMetrics(metrics)
+            saveCachedCodexAccountMetrics()
+            saveSharedData(metrics)
         } catch {
             if lastError == nil {
                 lastError = error
@@ -213,6 +210,34 @@ class UsageDataManager: ObservableObject {
         }
 
         isLoading = false
+    }
+
+    private func refreshedMetrics(for service: ServiceType) async throws -> UsageMetrics {
+        switch service {
+        case .claudeCode:
+            guard claudeCodeService.hasAccess else { throw ServiceError.notAuthenticated }
+            let accountMetrics = await fetchClaudeCodeAccountMetrics()
+            claudeCodeAccountMetrics = accountMetrics
+            if let representative = representativeClaudeCodeMetrics(from: accountMetrics) { return representative }
+        case .codexCli:
+            let accountMetrics = await fetchCodexAccountMetrics()
+            codexAccountMetrics = accountMetrics
+            if let representative = representativeCodexMetrics(from: accountMetrics) { return representative }
+        case .cursor, .openRouter:
+            guard hasProviderAccess(service) else { throw ServiceError.notAuthenticated }
+            do {
+                return try await fetchSimpleProviderMetrics(service)
+            } catch {
+                if let cachedMetric = metrics[service] {
+                    lastError = error
+                    return cachedMetric
+                }
+                throw error
+            }
+        }
+
+        if let cachedMetric = metrics[service] { return cachedMetric }
+        throw ServiceError.notAuthenticated
     }
 
     private func loadCachedData() {
@@ -234,6 +259,26 @@ class UsageDataManager: ObservableObject {
         if let data = MetricsCodec.encode(metrics) {
             cacheDefaults.set(data, forKey: cacheKey)
         }
+    }
+
+    private func loadCachedCodexAccountMetrics() {
+        guard let data = cacheDefaults.data(forKey: StorageKeys.cachedCodexAccountMetrics),
+              let decoded = try? JSONDecoder().decode([UUID: UsageMetrics].self, from: data) else { return }
+        codexAccountMetrics = decoded
+    }
+
+    private func saveCachedCodexAccountMetrics() {
+        guard let data = try? JSONEncoder().encode(codexAccountMetrics) else { return }
+        cacheDefaults.set(data, forKey: StorageKeys.cachedCodexAccountMetrics)
+    }
+
+    private func saveSharedData(_ metrics: [ServiceType: UsageMetrics]) {
+        sharedStore.saveMetrics(metrics)
+        let accountSnapshots = codexAccountStore.accounts.compactMap { account -> AccountUsageSnapshot? in
+            guard let metrics = codexAccountMetrics[account.id] else { return nil }
+            return AccountUsageSnapshot(id: account.id, name: account.name, metrics: metrics)
+        }
+        sharedStore.saveAccountMetrics(accountSnapshots)
     }
 
     private func setupAutoRefresh() {
@@ -289,6 +334,41 @@ class UsageDataManager: ObservableObject {
         return claudeCodeAccountStore.enabledAccounts.lazy.compactMap { accountMetrics[$0.id] }.first
     }
 
+    private func fetchCodexAccountMetrics() async -> [UUID: UsageMetrics] {
+        var refreshedMetrics: [UUID: UsageMetrics] = [:]
+        var firstFailure: Error?
+        var successCount = 0
+
+        for account in codexAccountStore.accounts {
+            guard await codexCliService.canAccess(account: account) else { continue }
+            do {
+                refreshedMetrics[account.id] = try await codexCliService.fetchUsageMetrics(account: account)
+                successCount += 1
+            } catch {
+                if firstFailure == nil { firstFailure = error }
+                lastError = error
+                if let cachedMetrics = codexAccountMetrics[account.id] {
+                    refreshedMetrics[account.id] = cachedMetrics
+                }
+            }
+        }
+
+        // Parse health tracks integration health, not per-account health:
+        // if any account parses, the format contract still holds.
+        if successCount > 0 {
+            parseHealthStore.recordSuccess(.codexCli)
+        } else if let firstFailure {
+            parseHealthStore.recordFailure(.codexCli, error: firstFailure)
+        }
+
+        return refreshedMetrics
+    }
+
+    private func representativeCodexMetrics(from accountMetrics: [UUID: UsageMetrics]) -> UsageMetrics? {
+        accountMetrics[CodexAccount.defaultID]
+            ?? codexAccountStore.accounts.lazy.compactMap { accountMetrics[$0.id] }.first
+    }
+
     // MARK: - Provider strategy
 
     private func hasProviderAccess(_ service: ServiceType) -> Bool {
@@ -296,7 +376,7 @@ class UsageDataManager: ObservableObject {
         case .claudeCode:
             return claudeCodeService.hasAccess
         case .codexCli:
-            return codexCliService.hasAccess
+            return false
         case .cursor:
             return cursorService.hasAccess
         case .openRouter:
@@ -310,14 +390,12 @@ class UsageDataManager: ObservableObject {
         do {
             let result: UsageMetrics
             switch service {
-            case .codexCli:
-                result = try await codexCliService.fetchUsageMetrics()
             case .cursor:
                 result = try await cursorService.fetchUsageMetrics()
             case .openRouter:
                 result = try await openRouterService.fetchUsageMetrics()
-            case .claudeCode:
-                preconditionFailure("Claude Code uses the account-aware fetch path")
+            case .claudeCode, .codexCli:
+                preconditionFailure("Account-aware providers use dedicated fetch paths")
             }
             parseHealthStore.recordSuccess(service)
             return result

--- a/MeterBar/SessionWake/SessionWakeController.swift
+++ b/MeterBar/SessionWake/SessionWakeController.swift
@@ -80,11 +80,14 @@ final class SessionWakeController: ObservableObject {
         .sink { [weak self] in self?.reconcile() }
         .store(in: &cancellables)
 
-        accounts.$customAccounts
+        Publishers.Merge(
+            accounts.$customAccounts.map { _ in () },
+            accounts.$defaultAccountIsEnabled.map { _ in () }
+        )
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 guard let self else { return }
-                self.store.reconcileAccounts(available: self.accounts.accounts.map(\.id))
+                self.store.reconcileAccounts(available: self.accounts.enabledAccounts.map(\.id))
                 self.reconcile()
             }
             .store(in: &cancellables)
@@ -107,7 +110,7 @@ final class SessionWakeController: ObservableObject {
 
     private func selectedAccount() -> ClaudeCodeAccount? {
         guard let id = store.wakeAccountID else { return nil }
-        return accounts.accounts.first { $0.id == id }
+        return accounts.enabledAccounts.first { $0.id == id }
     }
 
     private func startWatching(account: ClaudeCodeAccount) {

--- a/MeterBar/Views/Components/ProviderComponents.swift
+++ b/MeterBar/Views/Components/ProviderComponents.swift
@@ -12,6 +12,7 @@ enum ProviderLogoKind: Equatable {
     case claude
     case cursor
     case openai
+    case openRouter
 
     static func forService(_ service: ServiceType) -> ProviderLogoKind {
         switch service {
@@ -21,6 +22,8 @@ enum ProviderLogoKind: Equatable {
             return .claude
         case .cursor:
             return .cursor
+        case .openRouter:
+            return .openRouter
         }
     }
 
@@ -45,6 +48,8 @@ enum ProviderLogoKind: Equatable {
             return "ProviderIcon-cursor"
         case .openai:
             return "ProviderIcon-openai"
+        case .openRouter:
+            return nil
         }
     }
 
@@ -60,6 +65,8 @@ enum ProviderLogoKind: Equatable {
             return ServiceType.cursor.iconName
         case .openai:
             return "brain"
+        case .openRouter:
+            return ServiceType.openRouter.iconName
         }
     }
 }

--- a/MeterBar/Views/Components/ReadinessComponents.swift
+++ b/MeterBar/Views/Components/ReadinessComponents.swift
@@ -39,6 +39,7 @@ extension ReadinessLevel {
 struct ReadinessCheckRow: View {
   let check: ReadinessCheck
   var compact: Bool = false
+  var recoveryAction: (() -> Void)?
 
   var body: some View {
     HStack(alignment: .top, spacing: 8) {
@@ -57,12 +58,20 @@ struct ReadinessCheckRow: View {
           .fixedSize(horizontal: false, vertical: true)
 
         if let recovery = check.recovery {
-          Text(recovery)
-            .font(compact ? .caption2 : .caption)
-            .fontWeight(.medium)
-            .foregroundStyle(check.level.tint)
-            .fixedSize(horizontal: false, vertical: true)
-            .padding(.top, 1)
+          if let recoveryAction {
+            Button(action: recoveryAction) {
+              HStack(spacing: 4) {
+                Text(recovery)
+                Image(systemName: "arrow.up.forward.app")
+              }
+            }
+            .buttonStyle(.plain)
+            .accessibilityHint("Open MeterBar Settings")
+            .recoveryStyle(compact: compact, tint: check.level.tint)
+          } else {
+            Text(recovery)
+              .recoveryStyle(compact: compact, tint: check.level.tint)
+          }
         }
       }
       Spacer(minLength: 0)
@@ -75,6 +84,7 @@ struct ReadinessCheckRow: View {
 struct ReadinessProviderCard: View {
   let report: ProviderReadiness
   var compact: Bool = false
+  var recoveryAction: (() -> Void)?
 
   var body: some View {
     DashboardTile(padding: compact ? 11 : 14) {
@@ -94,7 +104,7 @@ struct ReadinessProviderCard: View {
 
         VStack(alignment: .leading, spacing: compact ? 7 : 9) {
           ForEach(report.checks) { check in
-            ReadinessCheckRow(check: check, compact: compact)
+            ReadinessCheckRow(check: check, compact: compact, recoveryAction: recoveryAction)
           }
         }
       }
@@ -150,12 +160,23 @@ enum DiagnosticsReportText {
 struct ReadinessChecklist: View {
   let reports: [ProviderReadiness]
   var compact: Bool = false
+  var recoveryAction: (() -> Void)?
 
   var body: some View {
     VStack(alignment: .leading, spacing: compact ? 8 : 12) {
       ForEach(reports) { report in
-        ReadinessProviderCard(report: report, compact: compact)
+        ReadinessProviderCard(report: report, compact: compact, recoveryAction: recoveryAction)
       }
     }
+  }
+}
+
+private extension View {
+  func recoveryStyle(compact: Bool, tint: Color) -> some View {
+    font(compact ? .caption2 : .caption)
+      .fontWeight(.medium)
+      .foregroundStyle(tint)
+      .fixedSize(horizontal: false, vertical: true)
+      .padding(.top, 1)
   }
 }

--- a/MeterBar/Views/DailyUsageChart.swift
+++ b/MeterBar/Views/DailyUsageChart.swift
@@ -209,6 +209,9 @@ struct StackedDailyUsageColumn: View {
       }
     }
     .frame(width: width, height: maxHeight, alignment: .bottom)
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(day.chartAccessibilityLabel)
+    .accessibilityValue(day.chartAccessibilityValue)
     .help(helpText)
   }
 
@@ -261,6 +264,22 @@ struct DailyUsageDay: Identifiable {
 
   var totalTokens: Int {
     segments.reduce(0) { $0 + $1.tokens }
+  }
+
+  var chartAccessibilityLabel: String {
+    DashboardDateFormat.medium(date)
+  }
+
+  var chartAccessibilityValue: String {
+    var values = [
+      "\(UsageFormat.tokens(totalTokens)) tokens",
+      UsageFormat.cost(cost),
+    ]
+    values.append(contentsOf: segments.map { segment in
+      "\(segment.provider.displayName) \(UsageFormat.tokens(segment.tokens)) tokens, "
+        + UsageFormat.cost(segment.cost)
+    })
+    return values.joined(separator: ", ")
   }
 }
 

--- a/MeterBar/Views/DailyUsageChart.swift
+++ b/MeterBar/Views/DailyUsageChart.swift
@@ -578,6 +578,8 @@ struct DailyProviderUsageSummaryRow: View {
       return "Codex"
     case .cursor:
       return "Cursor"
+    case .openRouter:
+      return "OpenRouter"
     }
   }
 }

--- a/MeterBar/Views/DashboardProviderCards.swift
+++ b/MeterBar/Views/DashboardProviderCards.swift
@@ -189,8 +189,14 @@ struct DashboardLimitRow: View {
         Text(limit.title)
           .font(.subheadline)
           .bold()
+        if limit.usageLimit.isEstimated {
+          Text("Estimated")
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .foregroundColor(.secondary)
+        }
         Spacer()
-        Text(isOut ? "Out" : "\(limit.percentLeft)% left")
+        Text(isOut && !limit.usageLimit.isEstimated ? "Out" : limit.usageLimit.percentLeftText)
           .font(.subheadline)
           .bold()
           .foregroundColor(isOut ? MeterBarTheme.danger : .primary)
@@ -199,15 +205,15 @@ struct DashboardLimitRow: View {
       UsageBar(
         usedPercentage: limit.usedPercent,
         accentColor: accentColor,
-        pace: limit.usageLimit.pace(),
+        pace: limit.usageLimit.isEstimated ? nil : limit.usageLimit.pace(),
         paceContext: limit.paceContext
       )
 
       HStack {
-        Text("\(Int(limit.usedPercent.rounded()))% used")
+        Text(limit.usageLimit.usedPercentageText)
           .font(.caption)
           .foregroundColor(.secondary)
-        if let pace = limit.usageLimit.pace() {
+        if !limit.usageLimit.isEstimated, let pace = limit.usageLimit.pace() {
           Text(pace.leftLabel)
             .font(.caption)
             .foregroundColor(paceLabelColor(pace))

--- a/MeterBar/Views/DashboardProviderCards.swift
+++ b/MeterBar/Views/DashboardProviderCards.swift
@@ -196,7 +196,7 @@ struct DashboardLimitRow: View {
             .foregroundColor(.secondary)
         }
         Spacer()
-        Text(isOut && !limit.usageLimit.isEstimated ? "Out" : limit.usageLimit.percentLeftText)
+        Text(trailingValue)
           .font(.subheadline)
           .bold()
           .foregroundColor(isOut ? MeterBarTheme.danger : .primary)
@@ -210,7 +210,7 @@ struct DashboardLimitRow: View {
       )
 
       HStack {
-        Text(limit.usageLimit.usedPercentageText)
+        Text(usedValue)
           .font(.caption)
           .foregroundColor(.secondary)
         if !limit.usageLimit.isEstimated, let pace = limit.usageLimit.pace() {
@@ -230,6 +230,20 @@ struct DashboardLimitRow: View {
         }
       }
     }
+  }
+
+  private var trailingValue: String {
+    if limit.valueStyle == .currency {
+      return "\(UsageFormat.cost(max(0, limit.usageLimit.total - limit.usageLimit.used))) left"
+    }
+    return (isOut && !limit.usageLimit.isEstimated) ? "Out" : limit.usageLimit.percentLeftText
+  }
+
+  private var usedValue: String {
+    if limit.valueStyle == .currency {
+      return "\(UsageFormat.cost(limit.usageLimit.used)) spent"
+    }
+    return limit.usageLimit.usedPercentageText
   }
 
   private func paceLabelColor(_ pace: UsagePace) -> Color {

--- a/MeterBar/Views/MenuBarDetailPanel.swift
+++ b/MeterBar/Views/MenuBarDetailPanel.swift
@@ -64,7 +64,7 @@ final class MeterBarMenuDetailPanel {
 
   private func ensurePanel() -> NSPanel {
     if let panel { return panel }
-    let panel = NSPanel(
+    let panel = KeyableMenuPanel(
       contentRect: NSRect(x: 0, y: 0, width: 340, height: 360),
       styleMask: [.borderless, .nonactivatingPanel],
       backing: .buffered,

--- a/MeterBar/Views/MenuBarDetailPanel.swift
+++ b/MeterBar/Views/MenuBarDetailPanel.swift
@@ -224,8 +224,13 @@ private struct MenuBarProviderLimitDetailRow: View {
         Text(limit.title)
           .font(.caption)
           .fontWeight(.semibold)
+        if limit.usageLimit.isEstimated {
+          Text("Estimated")
+            .font(.system(size: 8, weight: .semibold))
+            .foregroundColor(.secondary)
+        }
         Spacer(minLength: 4)
-        Text(isOut ? "Out" : "\(limit.percentLeft)% left")
+        Text(isOut && !limit.usageLimit.isEstimated ? "Out" : limit.usageLimit.percentLeftText)
           .font(.caption)
           .fontWeight(.semibold)
           .foregroundColor(isOut ? MeterBarTheme.danger : .primary)
@@ -234,16 +239,16 @@ private struct MenuBarProviderLimitDetailRow: View {
       UsageBar(
         usedPercentage: limit.usedPercent,
         accentColor: accentColor,
-        pace: limit.usageLimit.pace(),
+        pace: limit.usageLimit.isEstimated ? nil : limit.usageLimit.pace(),
         paceContext: limit.paceContext
       )
 
       HStack(spacing: 6) {
-        Text("\(Int(limit.usedPercent.rounded()))% used")
+        Text(limit.usageLimit.usedPercentageText)
           .font(.caption2)
           .foregroundColor(.secondary)
 
-        if let pace = limit.usageLimit.pace() {
+        if !limit.usageLimit.isEstimated, let pace = limit.usageLimit.pace() {
           Text(pace.leftLabel)
             .font(.caption2)
             .foregroundColor(paceLabelColor(pace))

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -17,6 +17,7 @@ struct MenuBarView: View {
   @StateObject private var dataManager = UsageDataManager.shared
   @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
   @StateObject private var codexCliService = CodexCliLocalService.shared
+  @StateObject private var codexAccountStore = CodexAccountStore.shared
   @StateObject private var cursorService = CursorLocalService.shared
   @StateObject private var openRouterService = OpenRouterService.shared
   @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
@@ -72,6 +73,8 @@ struct MenuBarView: View {
             snapshots: ProviderSnapshotBuilder.snapshots(
               ProviderSnapshotBuilder.Input(
                 metrics: dataManager.metrics,
+                codexAccounts: codexAccountStore.accounts,
+                codexAccountMetrics: dataManager.codexAccountMetrics,
                 claudeAccounts: claudeAccountStore.accounts,
                 claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
                 enabledServices: providerVisibility.enabledServices,

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -18,6 +18,7 @@ struct MenuBarView: View {
   @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
   @StateObject private var codexCliService = CodexCliLocalService.shared
   @StateObject private var cursorService = CursorLocalService.shared
+  @StateObject private var openRouterService = OpenRouterService.shared
   @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
   @StateObject private var providerVisibility = ProviderVisibilityStore.shared
   @StateObject private var sessionWakeStore = SessionWakeSettingsStore.shared
@@ -76,7 +77,8 @@ struct MenuBarView: View {
                 enabledServices: providerVisibility.enabledServices,
                 claudeCodeHasAccess: claudeCodeService.hasAccess,
                 codexCliHasAccess: codexCliService.hasAccess,
-                cursorHasAccess: cursorService.hasAccess
+                cursorHasAccess: cursorService.hasAccess,
+                openRouterHasAccess: openRouterService.hasAccess
               )),
             openDashboard: openDashboard,
             openStatusDetail: openStatusDetail,

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -476,8 +476,13 @@ private struct PopoverLimitRow: View {
           .font(.caption2)
           .foregroundColor(.secondary)
           .lineLimit(1)
+        if limit.usageLimit.isEstimated {
+          Text("Estimated")
+            .font(.system(size: 8, weight: .semibold))
+            .foregroundColor(.secondary)
+        }
         Spacer(minLength: 4)
-        Text(isOut ? "Out" : "\(limit.percentLeft)% left")
+        Text(isOut && !limit.usageLimit.isEstimated ? "Out" : limit.usageLimit.percentLeftText)
           .font(.caption)
           .fontWeight(.semibold)
           .foregroundColor(isOut ? MeterBarTheme.danger : .primary)
@@ -487,7 +492,7 @@ private struct PopoverLimitRow: View {
       UsageBar(
         usedPercentage: limit.usedPercent,
         accentColor: accentColor,
-        pace: limit.usageLimit.pace(),
+        pace: limit.usageLimit.isEstimated ? nil : limit.usageLimit.pace(),
         paceContext: limit.paceContext
       )
 

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -239,6 +239,9 @@ struct PopoverOverviewPanel: View {
   let openProviderOverview: (ProviderSnapshot) -> Void
 
   @State private var setupReports: [ProviderReadiness] = []
+  @StateObject private var onboarding = FirstRunOnboardingStore.shared
+  @Environment(\.openSettings)
+  private var openSettings
 
   /// The enabled providers currently shown in the popover.
   private var enabledProviders: Set<ServiceType> {
@@ -253,23 +256,33 @@ struct PopoverOverviewPanel: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 10) {
+      if onboarding.shouldPresent {
+        firstRunCallout
+      }
+
       if snapshots.isEmpty {
         DashboardTile(padding: 12) {
-          HStack(alignment: .center, spacing: 10) {
-            Image(systemName: "clock.fill")
-              .font(.system(size: 17, weight: .bold))
-              .foregroundStyle(.secondary)
-              .frame(width: 34, height: 34)
+          VStack(alignment: .leading, spacing: 9) {
+            HStack(alignment: .center, spacing: 10) {
+              Image(systemName: "clock.fill")
+                .font(.system(size: 17, weight: .bold))
+                .foregroundStyle(.secondary)
+                .frame(width: 34, height: 34)
 
-            VStack(alignment: .leading, spacing: 2) {
-              Text("No sources enabled")
-                .font(.headline)
-                .fontWeight(.semibold)
-              Text("Enable a provider in Settings.")
-                .font(.caption)
-                .foregroundColor(.secondary)
+              VStack(alignment: .leading, spacing: 2) {
+                Text("No sources enabled")
+                  .font(.headline)
+                  .fontWeight(.semibold)
+                Text("Enable a provider in Settings.")
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+              }
+              Spacer(minLength: 0)
             }
-            Spacer(minLength: 0)
+
+            Button("Open Settings") { openSettings() }
+              .buttonStyle(.borderedProminent)
+              .controlSize(.small)
           }
         }
       }
@@ -309,7 +322,39 @@ struct PopoverOverviewPanel: View {
           .fontWeight(.semibold)
         Spacer(minLength: 0)
       }
-      ReadinessChecklist(reports: providersNeedingSetup, compact: true)
+      ReadinessChecklist(
+        reports: providersNeedingSetup,
+        compact: true,
+        recoveryAction: { openSettings() }
+      )
+    }
+  }
+
+  private var firstRunCallout: some View {
+    DashboardTile(padding: 12) {
+      VStack(alignment: .leading, spacing: 9) {
+        HStack(spacing: 8) {
+          Image(systemName: "sparkles")
+            .foregroundStyle(MeterBarTheme.appAccent)
+          Text("Welcome to MeterBar")
+            .font(.headline)
+            .fontWeight(.semibold)
+        }
+
+        Text("Your usage lives in the menu bar. Start MeterBar automatically when you log in?")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+
+        HStack(spacing: 8) {
+          Button("Enable") { onboarding.chooseLaunchAtLogin(true) }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+          Button("Not Now") { onboarding.chooseLaunchAtLogin(false) }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+      }
     }
   }
 

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -2,6 +2,10 @@ import AppKit
 import MeterBarShared
 import SwiftUI
 
+private final class CardFrameBox {
+  var frames: [String: CGRect] = [:]
+}
+
 struct MenuBarView: View {
   private let popoverWidth: CGFloat = 390
   private let minPopoverHeight: CGFloat = 180
@@ -20,7 +24,7 @@ struct MenuBarView: View {
 
   @State private var contentHeight: CGFloat = 320
   @State private var expandedDetailID: String?
-  @State private var cardFrames: [String: CGRect] = [:]
+  @State private var cardFrameBox = CardFrameBox()
   @State private var menuWindow: NSWindow?
 
   init(onContentSizeChange: @escaping (NSSize) -> Void = { _ in }) {
@@ -51,7 +55,7 @@ struct MenuBarView: View {
       notifyContentSize(height: height)
     }
     .onPreferenceChange(PopoverCardFramesPreferenceKey.self) { frames in
-      cardFrames = frames
+      cardFrameBox.frames = frames
     }
   }
 
@@ -132,22 +136,26 @@ struct MenuBarView: View {
     HStack(spacing: 8) {
       Spacer()
 
-      Button(action: openDashboard) {
-        Image(systemName: MenuBarOverlayIcons.dashboard)
-          .font(.system(size: 12, weight: .semibold))
-      }
-      .meterBarGlassIconButton()
-      .help("Open Usage Dashboard")
+      GlassEffectContainer(spacing: 8) {
+        HStack(spacing: 8) {
+          Button(action: openDashboard) {
+            Image(systemName: MenuBarOverlayIcons.dashboard)
+              .font(.system(size: 12, weight: .semibold))
+          }
+          .meterBarGlassIconButton()
+          .help("Open Usage Dashboard")
 
-      Button {
-        Task { await dataManager.refreshAll() }
-      } label: {
-        RefreshingIcon(isRefreshing: dataManager.isLoading)
-          .font(.system(size: 12, weight: .semibold))
+          Button {
+            Task { await dataManager.refreshAll() }
+          } label: {
+            RefreshingIcon(isRefreshing: dataManager.isLoading)
+              .font(.system(size: 12, weight: .semibold))
+          }
+          .meterBarGlassIconButton()
+          .help(dataManager.isLoading ? "Refreshing usage" : "Refresh usage")
+          .disabled(dataManager.isLoading)
+        }
       }
-      .meterBarGlassIconButton()
-      .help(dataManager.isLoading ? "Refreshing usage" : "Refresh usage")
-      .disabled(dataManager.isLoading)
     }
     .font(.body)
     .padding(.horizontal, 14)
@@ -195,7 +203,7 @@ struct MenuBarView: View {
   /// Converts a card's SwiftUI global frame (top-left origin, window space)
   /// into the card top's AppKit screen Y so the detail panel can align to it.
   private func screenTopY(forCardID id: String) -> CGFloat? {
-    guard let menuWindow, let frame = cardFrames[id] else { return nil }
+    guard let menuWindow, let frame = cardFrameBox.frames[id] else { return nil }
     return menuWindow.frame.maxY - frame.minY
   }
 
@@ -211,7 +219,7 @@ private extension View {
   func meterBarGlassIconButton() -> some View {
     frame(width: 30, height: 30)
       .contentShape(Circle())
-      .glassEffect(.regular, in: Circle())
+      .glassEffect(.regular.interactive(), in: .circle)
       .buttonStyle(.plain)
   }
 }

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -56,13 +56,6 @@ enum MeterBarTheme {
   static let warning = Color(nsColor: .systemOrange)
   static let danger = Color(nsColor: .systemRed)
 
-  static let glassCardTint = Color.adaptive(
-    light: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.24),
-    dark: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.07),
-    lightHighContrast: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.34),
-    darkHighContrast: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.13)
-  )
-
   static let glassCardStroke = Color.adaptive(
     light: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.05),
     dark: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.06),
@@ -135,39 +128,13 @@ struct MeterBarDetailBackground: View {
 
 struct MeterBarCompanionSurface: View {
   var radius: CGFloat = 16
-  @Environment(\.accessibilityReduceTransparency)
-  private var reduceTransparency
 
   var body: some View {
-    let shape = RoundedRectangle(cornerRadius: radius, style: .continuous)
-
-    shape
-      .fill(reduceTransparency ? Color(nsColor: .windowBackgroundColor) : Color.clear)
-      .background {
-        if !reduceTransparency {
-          shape.fill(.ultraThinMaterial)
-        }
-      }
-      .overlay {
-        if !reduceTransparency {
-          shape.fill(MeterBarTheme.companionTint)
-        }
-      }
-      .overlay(alignment: .topLeading) {
-        LinearGradient(
-          colors: [
-            MeterBarTheme.codexAccent.opacity(0.14),
-            MeterBarTheme.appAccent.opacity(0.08),
-            .clear,
-          ],
-          startPoint: .topLeading,
-          endPoint: .bottomTrailing
-        )
-        .clipShape(shape)
-      }
-      .overlay {
-        shape.stroke(MeterBarTheme.glassCardStroke, lineWidth: 0.5)
-      }
+    Color.clear
+      .glassEffect(
+        .regular.tint(MeterBarTheme.companionTint),
+        in: .rect(cornerRadius: radius, style: .continuous)
+      )
   }
 }
 
@@ -193,18 +160,7 @@ private struct MeterBarCardSurfaceModifier: ViewModifier {
     let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
 
     content
-      .background(.ultraThinMaterial, in: shape)
-      .overlay {
-        // Decorative only — filled shapes hit-test, and these sit above the
-        // card content, so they must not swallow clicks meant for buttons
-        // inside the card (e.g. the Costs daily-detail disclosure rows).
-        shape.fill(MeterBarTheme.glassCardTint)
-          .allowsHitTesting(false)
-      }
-      .overlay {
-        shape.stroke(MeterBarTheme.glassCardStroke, lineWidth: 0.5)
-          .allowsHitTesting(false)
-      }
+      .background(Color(nsColor: .controlBackgroundColor), in: shape)
   }
 }
 

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -30,6 +30,10 @@ enum MeterBarTheme {
     light: NSColor(srgbRed: 16 / 255, green: 163 / 255, blue: 127 / 255, alpha: 1),
     dark: NSColor(srgbRed: 106 / 255, green: 216 / 255, blue: 185 / 255, alpha: 1)
   )
+  static let openRouterAccent = Color.adaptive(
+    light: NSColor(srgbRed: 105 / 255, green: 82 / 255, blue: 188 / 255, alpha: 1),
+    dark: NSColor(srgbRed: 177 / 255, green: 159 / 255, blue: 255 / 255, alpha: 1)
+  )
 
   /// The app's own accent. Follows the user's system accent color.
   static let appAccent = Color.accentColor
@@ -71,6 +75,8 @@ enum MeterBarTheme {
       return codexAccent
     case .cursor:
       return cursorAccent
+    case .openRouter:
+      return openRouterAccent
     }
   }
 

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -167,25 +167,22 @@ enum ProviderSnapshotBuilder {
         }
 
         if input.enabledServices.contains(.claudeCode) {
+            let enabledAccounts = input.claudeAccounts.filter(\.isEnabled)
             let accountMetrics = input.claudeAccountMetrics
-            if !accountMetrics.isEmpty {
-                for account in input.claudeAccounts {
-                    let title = account.isDefault && input.claudeAccounts.count == 1 ? "Claude" : account.name
+            if !enabledAccounts.isEmpty {
+                for account in enabledAccounts {
+                    let title = account.isDefault && enabledAccounts.count == 1 ? "Claude" : account.name
+                    let emptyDetail = account.isDefault && input.claudeCodeHasAccess
+                        ? "Waiting for refresh"
+                        : "Run claude login"
                     result.append(snapshot(
                         title: title,
                         service: .claudeCode,
-                        metrics: accountMetrics[account.id],
-                        emptyDetail: account.isDefault ? "Waiting for refresh" : "Run claude login",
+                        metrics: accountMetrics[account.id] ?? (account.isDefault ? input.metrics[.claudeCode] : nil),
+                        emptyDetail: emptyDetail,
                         accountID: account.id
                     ))
                 }
-            } else {
-                result.append(snapshot(
-                    title: "Claude",
-                    service: .claudeCode,
-                    metrics: input.metrics[.claudeCode],
-                    emptyDetail: input.claudeCodeHasAccess ? "Waiting for refresh" : "Run claude login"
-                ))
             }
         }
 

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -50,7 +50,9 @@ struct ProviderSnapshot: Identifiable {
     var blockingLimits: [SnapshotLimit] {
         guard extraUsage?.state != .on else { return [] }
         return limits.filter {
-            ($0.kind == .session || $0.kind == .weekly) && $0.usageLimit.isAtLimit
+            ($0.kind == .session || $0.kind == .weekly)
+                && !$0.usageLimit.isEstimated
+                && $0.usageLimit.isAtLimit
         }
     }
 

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -108,6 +108,20 @@ struct SnapshotLimit: Identifiable {
     let kind: Kind
     let title: String
     let usageLimit: UsageLimit
+    let valueStyle: ValueStyle
+
+    enum ValueStyle: Equatable {
+        case quota
+        case currency
+    }
+
+    init(id: String, kind: Kind, title: String, usageLimit: UsageLimit, valueStyle: ValueStyle = .quota) {
+        self.id = id
+        self.kind = kind
+        self.title = title
+        self.usageLimit = usageLimit
+        self.valueStyle = valueStyle
+    }
 
     var usedPercent: Double {
         usageLimit.rawPercentage
@@ -133,6 +147,7 @@ enum ProviderSnapshotBuilder {
         var claudeCodeHasAccess: Bool = false
         var codexCliHasAccess: Bool = false
         var cursorHasAccess: Bool = false
+        var openRouterHasAccess: Bool = false
     }
 
     /// Builds the provider cards in display order (Codex, Claude accounts,
@@ -183,6 +198,15 @@ enum ProviderSnapshotBuilder {
             ))
         }
 
+        if input.enabledServices.contains(.openRouter) {
+            result.append(snapshot(
+                title: "OpenRouter",
+                service: .openRouter,
+                metrics: input.metrics[.openRouter],
+                emptyDetail: input.openRouterHasAccess ? "Waiting for refresh" : "Add an OpenRouter API key"
+            ))
+        }
+
         return result
     }
 
@@ -213,10 +237,22 @@ enum ProviderSnapshotBuilder {
 
         var result: [SnapshotLimit] = []
         if let session = metrics.sessionLimit {
-            result.append(SnapshotLimit(id: "session", kind: .session, title: "Session", usageLimit: session))
+            result.append(SnapshotLimit(
+                id: "session",
+                kind: .session,
+                title: service == .openRouter ? "Key limit" : "Session",
+                usageLimit: session,
+                valueStyle: service == .openRouter ? .currency : .quota
+            ))
         }
         if let weekly = metrics.weeklyLimit {
-            result.append(SnapshotLimit(id: "weekly", kind: .weekly, title: "Weekly", usageLimit: weekly))
+            result.append(SnapshotLimit(
+                id: "weekly",
+                kind: .weekly,
+                title: service == .openRouter ? "Account credits" : "Weekly",
+                usageLimit: weekly,
+                valueStyle: service == .openRouter ? .currency : .quota
+            ))
         }
         if let codeReview = metrics.codeReviewLimit {
             // Claude's third window is the Sonnet-only weekly quota; Codex's is

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -141,6 +141,8 @@ struct SnapshotLimit: Identifiable {
 enum ProviderSnapshotBuilder {
     struct Input {
         var metrics: [ServiceType: UsageMetrics]
+        var codexAccounts: [CodexAccount] = [.defaultAccount]
+        var codexAccountMetrics: [UUID: UsageMetrics] = [:]
         var claudeAccounts: [ClaudeCodeAccount]
         var claudeAccountMetrics: [UUID: UsageMetrics]
         var enabledServices: Set<ServiceType>
@@ -158,12 +160,25 @@ enum ProviderSnapshotBuilder {
         var result: [ProviderSnapshot] = []
 
         if input.enabledServices.contains(.codexCli) {
-            result.append(snapshot(
-                title: "Codex",
-                service: .codexCli,
-                metrics: input.metrics[.codexCli],
-                emptyDetail: input.codexCliHasAccess ? "Waiting for refresh" : "Run codex login"
-            ))
+            if !input.codexAccountMetrics.isEmpty {
+                for account in input.codexAccounts {
+                    let title = account.isDefault && input.codexAccounts.count == 1 ? "Codex" : account.name
+                    result.append(snapshot(
+                        title: title,
+                        service: .codexCli,
+                        metrics: input.codexAccountMetrics[account.id],
+                        emptyDetail: account.isDefault ? "Waiting for refresh" : "Run codex login",
+                        accountID: account.id
+                    ))
+                }
+            } else {
+                result.append(snapshot(
+                    title: "Codex",
+                    service: .codexCli,
+                    metrics: input.metrics[.codexCli],
+                    emptyDetail: input.codexCliHasAccess ? "Waiting for refresh" : "Run codex login"
+                ))
+            }
         }
 
         if input.enabledServices.contains(.claudeCode) {

--- a/MeterBar/Views/SessionWakeSettingsView.swift
+++ b/MeterBar/Views/SessionWakeSettingsView.swift
@@ -12,20 +12,12 @@ struct SessionWakeSettingsView: View {
     @ObservedObject private var accounts: ClaudeCodeAccountStore
     @State private var showingFirstRunConfirmation = false
 
-    /// When embedded in the dashboard settings stack (itself inside a ScrollView)
-    /// the grouped `Form` — a nested scroll container — must be dropped for a
-    /// plain vertical layout, or the sections collapse. The standalone Settings
-    /// pane keeps the `Form` styling.
-    private let embeddedInDashboard: Bool
-
     @MainActor
     init(
-        embeddedInDashboard: Bool = false,
         store: SessionWakeSettingsStore? = nil,
         status: SessionWakeStatus? = nil,
         accounts: ClaudeCodeAccountStore? = nil
     ) {
-        self.embeddedInDashboard = embeddedInDashboard
         self.store = store ?? .shared
         self.status = status ?? .shared
         self.accounts = accounts ?? .shared
@@ -51,20 +43,11 @@ struct SessionWakeSettingsView: View {
 
     // MARK: - Layout
 
-    /// Grouped `Form` when standalone; a plain stack when embedded in the
-    /// dashboard's own ScrollView (a nested Form would collapse there).
-    @ViewBuilder private var layout: some View {
-        if embeddedInDashboard {
-            VStack(alignment: .leading, spacing: 12) {
-                sections
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-        } else {
-            Form {
-                sections
-            }
-            .formStyle(.grouped)
+    private var layout: some View {
+        Form {
+            sections
         }
+        .formStyle(.grouped)
     }
 
     @ViewBuilder private var sections: some View {

--- a/MeterBar/Views/SessionWakeSettingsView.swift
+++ b/MeterBar/Views/SessionWakeSettingsView.swift
@@ -79,7 +79,7 @@ struct SessionWakeSettingsView: View {
         Section("Wake account") {
             Picker("Account", selection: accountBinding) {
                 Text("None selected").tag(UUID?.none)
-                ForEach(accounts.accounts) { account in
+                ForEach(accounts.enabledAccounts) { account in
                     Text(account.name).tag(UUID?.some(account.id))
                 }
             }
@@ -174,7 +174,7 @@ struct SessionWakeSettingsView: View {
     }
 
     private var selectedConfigDirectory: String? {
-        accounts.accounts.first(where: { $0.id == store.wakeAccountID })?.configDirectory
+        accounts.enabledAccounts.first(where: { $0.id == store.wakeAccountID })?.configDirectory
     }
 
     private func binding<Value>(_ value: Value, _ setter: @escaping (Value) -> Void) -> Binding<Value> {

--- a/MeterBar/Views/SessionWakeSettingsView.swift
+++ b/MeterBar/Views/SessionWakeSettingsView.swift
@@ -51,8 +51,8 @@ struct SessionWakeSettingsView: View {
     }
 
     @ViewBuilder private var sections: some View {
-        switchSection
         accountSection
+        switchSection
         previewSection
         limitsSection
         permissionSection
@@ -65,8 +65,9 @@ struct SessionWakeSettingsView: View {
         Section("Session Wake") {
             Toggle("Session Wake", isOn: onBinding)
                 .disabled(!store.canTurnOn && !store.isOn)
+                .toggleStyle(.switch)
             if store.wakeAccountID == nil {
-                Text("Choose a wake account below to enable Session Wake.")
+                Text("Choose a wake account above to enable Session Wake.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -70,6 +70,8 @@ private enum SettingsPane: Hashable, Identifiable {
                 "Codex CLI OAuth"
             case .cursor:
                 "Cursor local state"
+            case .openRouter:
+                "OpenRouter API key"
             }
         }
     }
@@ -158,6 +160,7 @@ struct SettingsView: View {
     @StateObject private var codexCliService = CodexCliLocalService.shared
     @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
     @StateObject private var cursorService = CursorLocalService.shared
+    @StateObject private var openRouterService = OpenRouterService.shared
     @StateObject private var costTracker = CostTracker.shared
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
     @StateObject private var dockVisibility = DockVisibilityStore.shared
@@ -171,6 +174,7 @@ struct SettingsView: View {
     @State private var claudeReconnectError: String?
     @State private var claudeAdminKeyDraft = ""
     @State private var openaiAdminKeyDraft = ""
+    @State private var openRouterKeyDraft = ""
     @State private var selectedPane: SettingsPane = .general
     @State private var providerSearchText = ""
 
@@ -209,7 +213,8 @@ struct SettingsView: View {
                 enabledServices: providerVisibility.enabledServices,
                 claudeCodeHasAccess: claudeCodeService.hasAccess,
                 codexCliHasAccess: codexCliService.hasAccess,
-                cursorHasAccess: cursorService.hasAccess
+                cursorHasAccess: cursorService.hasAccess,
+                openRouterHasAccess: openRouterService.hasAccess
             )
         )
     }
@@ -587,6 +592,11 @@ struct SettingsView: View {
                 detail: "Track Cursor quota from local Cursor state.",
                 service: .cursor
             )
+            providerToggleRow(
+                title: "OpenRouter",
+                detail: "Track credit balance, spend, and per-key limits.",
+                service: .openRouter
+            )
         }
     }
 
@@ -734,6 +744,63 @@ struct SettingsView: View {
                     color: .secondary
                 )
                 SettingsNotice(text: "Log in to Cursor IDE first, then check again.", color: MeterBarTheme.warning)
+            }
+        }
+    }
+
+    private var openRouterSection: some View {
+        SettingsPanelSection(title: "OpenRouter", logoKind: .openRouter, color: MeterBarTheme.openRouterAccent) {
+            SettingsNotice(
+                text: "The key is stored in macOS Keychain and sent only to OpenRouter's credits and key APIs.",
+                color: .secondary
+            )
+
+            SettingsRowView(
+                title: "API key",
+                detail: openRouterService.hasAccess
+                    ? "Configured. Refresh validates access and updates credits."
+                    : "Create a key at openrouter.ai/settings/keys."
+            ) {
+                HStack(spacing: 8) {
+                    if openRouterService.hasAccess {
+                        StatusPill(title: "Configured", isConnected: true)
+                        Button("Remove", role: .destructive) {
+                            openRouterService.removeAPIKey()
+                            Task { await dataManager.refresh(service: .openRouter) }
+                        }
+                        .buttonStyle(.bordered)
+                    } else {
+                        SecureField("sk-or-v1-...", text: $openRouterKeyDraft)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 260)
+
+                        Button("Save & Validate") {
+                            guard openRouterService.saveAPIKey(openRouterKeyDraft) else { return }
+                            openRouterKeyDraft = ""
+                            providerVisibility.set(.openRouter, isEnabled: true)
+                            Task { await dataManager.refresh(service: .openRouter) }
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(openRouterKeyDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+
+                    Button("Get Key") {
+                        if let url = URL(string: "https://openrouter.ai/settings/keys") {
+                            NSWorkspace.shared.open(url)
+                        }
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+
+            if let error = openRouterService.lastError {
+                let detail = switch error {
+                case .notAuthenticated:
+                    "OpenRouter rejected this key. Remove it and add a valid API key."
+                default:
+                    error.localizedDescription
+                }
+                SettingsNotice(text: detail, color: MeterBarTheme.warning)
             }
         }
     }
@@ -965,6 +1032,8 @@ struct SettingsView: View {
             providerExtraUsageSection(for: service)
         case .cursor:
             cursorSection
+        case .openRouter:
+            openRouterSection
         }
     }
 
@@ -990,6 +1059,8 @@ struct SettingsView: View {
                 )
             }
         case .cursor:
+            EmptyView()
+        case .openRouter:
             EmptyView()
         }
     }
@@ -1097,6 +1168,8 @@ struct SettingsView: View {
                     codexCli.checkAccess()
                 case .cursor:
                     cursor.checkAccess(forceRescan: true)
+                case .openRouter:
+                    break
                 }
             }.value
             await dataManager.refresh(service: service)
@@ -1111,6 +1184,8 @@ struct SettingsView: View {
             "\(codexAuthFileDisplayPath) + ChatGPT usage API"
         case .cursor:
             "Cursor local state + usage API"
+        case .openRouter:
+            "OpenRouter credits + key APIs"
         }
     }
 
@@ -1169,6 +1244,8 @@ struct SettingsView: View {
             return codexCliService.subscriptionType?.capitalized.nilIfEmpty
         case .cursor:
             return cursorService.subscriptionType?.capitalized.nilIfEmpty
+        case .openRouter:
+            return nil
         }
     }
 
@@ -1180,6 +1257,8 @@ struct SettingsView: View {
             codexCliService.hasAccess
         case .cursor:
             cursorService.hasAccess
+        case .openRouter:
+            openRouterService.hasAccess
         }
     }
 
@@ -1191,6 +1270,8 @@ struct SettingsView: View {
             codexCliService.lastError?.localizedDescription
         case .cursor:
             cursorService.lastError?.localizedDescription
+        case .openRouter:
+            openRouterService.lastError?.localizedDescription
         }
     }
 

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -1667,20 +1667,26 @@ private struct AdminKeySettingsRow: View {
             }
 
             HStack(spacing: 8) {
-                SecureField(placeholder, text: $draft)
-                    .settingsInput()
-                    .frame(minWidth: 220, maxWidth: 340)
+                if connected {
+                    SettingsReadonlyField(text: "••••••••••••••••")
 
-                Button("Save", action: onSave)
-                    .buttonStyle(.borderedProminent)
-                    .disabled(trimmedDraft.isEmpty)
+                    Button("Remove", role: .destructive, action: onRemove)
+                        .buttonStyle(.bordered)
+                } else {
+                    SecureField(placeholder, text: $draft)
+                        .settingsInput()
+                        .frame(minWidth: 220, maxWidth: 340)
 
-                Button("Remove", action: onRemove)
+                    Button("Save", action: onSave)
+                        .buttonStyle(.borderedProminent)
+                        .disabled(trimmedDraft.isEmpty)
+
+                    Button(action: onHelp) {
+                        Image(systemName: "questionmark.circle")
+                    }
                     .buttonStyle(.bordered)
-                    .disabled(!connected)
-
-                Button("Help", action: onHelp)
-                    .buttonStyle(.bordered)
+                    .help("Where to create this admin API key")
+                }
             }
         }
         .padding(.vertical, 6)
@@ -1802,6 +1808,12 @@ private struct AddClaudeAccountSheet: View {
 
 // MARK: - AccountProfileRow
 
+private enum AccountProfileRowMetrics {
+    static let labelWidth: CGFloat = 126
+    static let fieldWidth: CGFloat = 280
+    static let actionWidth: CGFloat = 28
+}
+
 private struct AccountProfileRow: View {
     // MARK: Lifecycle
 
@@ -1834,8 +1846,10 @@ private struct AccountProfileRow: View {
 
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 8) {
+                    accountFieldLabel("Account name")
+
                     TextField("Account label", text: $nameDraft)
-                        .settingsInput(width: 240)
+                        .settingsInput(width: AccountProfileRowMetrics.fieldWidth)
                         .onSubmit(saveChanges)
 
                     Text(account.isDefault ? "Default" : "Profile")
@@ -1850,18 +1864,22 @@ private struct AccountProfileRow: View {
                 }
 
                 HStack(spacing: 8) {
-                    Text(account.isDefault ? "Default config directory" : "Config directory")
-                        .font(.caption2)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(.secondary)
-                        .frame(width: 126, alignment: .leading)
+                    accountFieldLabel(account.isDefault ? "Default config directory" : "Config directory")
 
                     if account.isDefault {
                         SettingsReadonlyField(text: displayConfigDirectory)
+
+                        Button {
+                            revealDefaultConfigDirectory()
+                        } label: {
+                            Image(systemName: "folder")
+                        }
+                        .buttonStyle(.bordered)
+                        .help("Reveal config directory in Finder")
                     } else {
                         HStack(spacing: 8) {
                             TextField("Config directory", text: $configDirectoryDraft)
-                                .settingsInput(width: 280)
+                                .settingsInput(width: AccountProfileRowMetrics.fieldWidth)
                                 .onSubmit(saveChanges)
 
                             Button {
@@ -1874,6 +1892,13 @@ private struct AccountProfileRow: View {
                         }
                     }
                 }
+
+                if account.isDefault {
+                    Text("Mirrors the Claude CLI default (~/.claude, or $CLAUDE_CONFIG_DIR)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .padding(.leading, AccountProfileRowMetrics.labelWidth + 8)
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -1883,6 +1908,7 @@ private struct AccountProfileRow: View {
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
+                .frame(width: AccountProfileRowMetrics.actionWidth)
                 .help("Reconnect Claude profile")
 
                 Button(action: saveChanges) {
@@ -1890,6 +1916,7 @@ private struct AccountProfileRow: View {
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
+                .frame(width: AccountProfileRowMetrics.actionWidth)
                 .disabled(!hasChanges || !canSave)
                 .help("Save account changes")
 
@@ -1899,10 +1926,15 @@ private struct AccountProfileRow: View {
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
+                    .frame(width: AccountProfileRowMetrics.actionWidth)
                     .help("Delete account")
+                } else {
+                    Color.clear
+                        .frame(width: AccountProfileRowMetrics.actionWidth, height: 1)
+                        .accessibilityHidden(true)
                 }
             }
-            .frame(minWidth: 116, alignment: .trailing)
+            .fixedSize()
         }
         .padding(.vertical, 10)
         .onChange(of: account) { _, updatedAccount in
@@ -1927,7 +1959,7 @@ private struct AccountProfileRow: View {
     private var displayConfigDirectory: String {
         account.configDirectory?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
             ? account.configDirectory ?? ""
-            : "\(ServiceSupport.realHomeDirectory())/.claude"
+            : ClaudeCodeAccount.defaultConfigDirectory()
     }
 
     private var hasChanges: Bool {
@@ -1944,6 +1976,20 @@ private struct AccountProfileRow: View {
             return
         }
         onSave(trimmedName, account.isDefault ? nil : trimmedConfigDirectory)
+    }
+
+    private func accountFieldLabel(_ title: String) -> some View {
+        Text(title)
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .foregroundStyle(.secondary)
+            .frame(width: AccountProfileRowMetrics.labelWidth, alignment: .leading)
+    }
+
+    private func revealDefaultConfigDirectory() {
+        NSWorkspace.shared.activateFileViewerSelecting([
+            URL(fileURLWithPath: ClaudeCodeAccount.defaultConfigDirectory(), isDirectory: true)
+        ])
     }
 
     private func chooseConfigDirectory() {

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -151,6 +151,13 @@ struct SettingsView: View {
                 isAddingClaudeAccount = false
             }
         }
+        .sheet(isPresented: $isAddingCodexAccount) {
+            AddCodexAccountSheet { name, homeDirectory in
+                codexAccountStore.addAccount(name: name, homeDirectory: homeDirectory)
+                isAddingCodexAccount = false
+                Task { await dataManager.refreshAll() }
+            }
+        }
     }
 
     // MARK: Private
@@ -158,6 +165,7 @@ struct SettingsView: View {
     @StateObject private var dataManager = UsageDataManager.shared
     @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
     @StateObject private var codexCliService = CodexCliLocalService.shared
+    @StateObject private var codexAccountStore = CodexAccountStore.shared
     @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
     @StateObject private var cursorService = CursorLocalService.shared
     @StateObject private var openRouterService = OpenRouterService.shared
@@ -171,6 +179,7 @@ struct SettingsView: View {
     @StateObject private var sessionWakeStore = SessionWakeSettingsStore.shared
 
     @State private var isAddingClaudeAccount = false
+    @State private var isAddingCodexAccount = false
     @State private var claudeReconnectError: String?
     @State private var claudeAdminKeyDraft = ""
     @State private var openaiAdminKeyDraft = ""
@@ -208,6 +217,8 @@ struct SettingsView: View {
         ProviderSnapshotBuilder.snapshots(
             ProviderSnapshotBuilder.Input(
                 metrics: dataManager.metrics,
+                codexAccounts: codexAccountStore.accounts,
+                codexAccountMetrics: dataManager.codexAccountMetrics,
                 claudeAccounts: claudeAccountStore.accounts,
                 claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
                 enabledServices: providerVisibility.enabledServices,
@@ -389,7 +400,7 @@ struct SettingsView: View {
     private var codexCliSection: some View {
         SettingsPanelSection(title: "OpenAI Codex", logoKind: .codex, color: MeterBarTheme.codexAccent) {
             SettingsRowView(
-                title: "Connection",
+                title: "Default connection",
                 detail: "Reads the OAuth session from \(codexAuthFileDisplayPath)."
             ) {
                 HStack(spacing: 8) {
@@ -404,9 +415,7 @@ struct SettingsView: View {
                         Task {
                             let service = codexCliService
                             await Task.detached(priority: .userInitiated) { service.checkAccess() }.value
-                            if codexCliService.hasAccess {
-                                await dataManager.refresh(service: .codexCli)
-                            }
+                            await dataManager.refresh(service: .codexCli)
                         }
                     }
                     .buttonStyle(.bordered)
@@ -421,6 +430,46 @@ struct SettingsView: View {
                 }
             } else if !codexCliService.hasAccess {
                 SettingsNotice(text: "Run codex login, then check again.", color: MeterBarTheme.warning)
+            }
+
+            SettingsDivider()
+
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Text("Codex Accounts")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                    Spacer()
+                    Button {
+                        isAddingCodexAccount = true
+                    } label: {
+                        Label("Add Account", systemImage: "plus")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                }
+
+                VStack(spacing: 0) {
+                    ForEach(Array(codexAccountStore.accounts.enumerated()), id: \.element.id) { index, account in
+                        if index > 0 { SettingsDivider() }
+                        CodexAccountProfileRow(
+                            account: account,
+                            isConnected: dataManager.codexAccountMetrics[account.id] != nil,
+                            onSave: { name, homeDirectory in
+                                codexAccountStore.updateAccount(
+                                    id: account.id,
+                                    name: name,
+                                    homeDirectory: homeDirectory
+                                )
+                                Task { await dataManager.refreshAll() }
+                            },
+                            onRemove: {
+                                codexAccountStore.removeAccount(id: account.id)
+                                Task { await dataManager.refreshAll() }
+                            }
+                        )
+                    }
+                }
             }
         }
     }
@@ -1710,6 +1759,71 @@ private struct AdminKeySettingsRow: View {
     }
 }
 
+// MARK: - AddCodexAccountSheet
+
+private struct AddCodexAccountSheet: View {
+    let onAdd: (String, String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(spacing: 10) {
+                ProviderLogoView(kind: .codex, size: 18, foregroundColor: MeterBarTheme.codexAccent)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Add Codex Account").font(.headline)
+                    Text("Use a separate CODEX_HOME containing its own auth.json.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 12) {
+                TextField("Account name", text: $accountName).settingsInput()
+                HStack(spacing: 8) {
+                    TextField("Codex home directory", text: $homeDirectory).settingsInput()
+                    Button("Choose", action: chooseHomeDirectory).buttonStyle(.bordered)
+                }
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }.keyboardShortcut(.cancelAction)
+                Button("Add Account") {
+                    onAdd(trimmedName, trimmedHomeDirectory)
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(!canAdd)
+            }
+        }
+        .padding(22)
+        .frame(width: 520)
+    }
+
+    @Environment(\.dismiss)
+    private var dismiss
+    @State private var accountName = ""
+    @State private var homeDirectory = ""
+
+    private var trimmedName: String { accountName.trimmingCharacters(in: .whitespacesAndNewlines) }
+    private var trimmedHomeDirectory: String {
+        homeDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    private var canAdd: Bool { !trimmedName.isEmpty && !trimmedHomeDirectory.isEmpty }
+
+    private func chooseHomeDirectory() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Use"
+        if panel.runModal() == .OK, let url = panel.url {
+            homeDirectory = url.path
+            if trimmedName.isEmpty { accountName = url.lastPathComponent }
+        }
+    }
+}
+
 // MARK: - AddClaudeAccountSheet
 
 private struct AddClaudeAccountSheet: View {
@@ -2021,6 +2135,102 @@ private struct AccountProfileRow: View {
         if panel.runModal() == .OK, let url = panel.url {
             configDirectoryDraft = url.path
         }
+    }
+}
+
+private struct CodexAccountProfileRow: View {
+    init(
+        account: CodexAccount,
+        isConnected: Bool,
+        onSave: @escaping (String, String?) -> Void,
+        onRemove: @escaping () -> Void
+    ) {
+        self.account = account
+        self.isConnected = isConnected
+        self.onSave = onSave
+        self.onRemove = onRemove
+        _nameDraft = State(initialValue: account.name)
+        _homeDirectoryDraft = State(initialValue: account.homeDirectory ?? "")
+    }
+
+    let account: CodexAccount
+    let isConnected: Bool
+    let onSave: (String, String?) -> Void
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: account.isDefault ? "person.crop.circle" : "person.crop.circle.badge.plus")
+                .foregroundStyle(MeterBarTheme.codexAccent)
+                .frame(width: 18)
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    TextField("Account label", text: $nameDraft)
+                        .settingsInput(width: 240)
+                        .onSubmit(saveChanges)
+                    Text(account.isDefault ? "Default" : "Profile")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(account.isDefault ? MeterBarTheme.appAccent : MeterBarTheme.codexAccent)
+                    StatusPill(title: isConnected ? "Connected" : "Not Connected", isConnected: isConnected)
+                        .font(.caption)
+                }
+
+                HStack(spacing: 8) {
+                    Text("CODEX_HOME")
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 126, alignment: .leading)
+                    if account.isDefault {
+                        SettingsReadonlyField(text: CodexHomeDirectory.path(for: account))
+                    } else {
+                        TextField("Codex home directory", text: $homeDirectoryDraft)
+                            .settingsInput(width: 280)
+                            .onSubmit(saveChanges)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            HStack(spacing: 8) {
+                Button(action: saveChanges) { Image(systemName: "checkmark") }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(!hasChanges || !canSave)
+                    .help("Save account changes")
+                if !account.isDefault {
+                    Button(role: .destructive, action: onRemove) { Image(systemName: "trash") }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .help("Delete account")
+                }
+            }
+            .frame(minWidth: 80, alignment: .trailing)
+        }
+        .padding(.vertical, 10)
+        .onChange(of: account) { _, updated in
+            nameDraft = updated.name
+            homeDirectoryDraft = updated.homeDirectory ?? ""
+        }
+    }
+
+    @State private var nameDraft: String
+    @State private var homeDirectoryDraft: String
+
+    private var trimmedName: String { nameDraft.trimmingCharacters(in: .whitespacesAndNewlines) }
+    private var trimmedHomeDirectory: String {
+        homeDirectoryDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    private var hasChanges: Bool {
+        trimmedName != account.name || (!account.isDefault && trimmedHomeDirectory != account.homeDirectory)
+    }
+    private var canSave: Bool { !trimmedName.isEmpty && (account.isDefault || !trimmedHomeDirectory.isEmpty) }
+
+    private func saveChanges() {
+        guard hasChanges, canSave else { return }
+        onSave(trimmedName, account.isDefault ? nil : trimmedHomeDirectory)
     }
 }
 

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -691,6 +691,13 @@ struct SettingsView: View {
                         }
                         AccountProfileRow(
                             account: account,
+                            onEnabledChange: { isEnabled in
+                                claudeAccountStore.setEnabled(isEnabled, for: account.id)
+                                SessionWakeSettingsStore.shared.reconcileAccounts(
+                                    available: claudeAccountStore.enabledAccounts.map(\.id)
+                                )
+                                Task { await dataManager.refreshAll() }
+                            },
                             onSave: { name, configDirectory in
                                 updateClaudeAccount(id: account.id, name: name, configDirectory: configDirectory)
                             },
@@ -1819,11 +1826,13 @@ private struct AccountProfileRow: View {
 
     init(
         account: ClaudeCodeAccount,
+        onEnabledChange: @escaping (Bool) -> Void,
         onSave: @escaping (String, String?) -> Void,
         onReconnect: @escaping () -> Void,
         onRemove: @escaping () -> Void
     ) {
         self.account = account
+        self.onEnabledChange = onEnabledChange
         self.onSave = onSave
         self.onReconnect = onReconnect
         self.onRemove = onRemove
@@ -1834,6 +1843,7 @@ private struct AccountProfileRow: View {
     // MARK: Internal
 
     let account: ClaudeCodeAccount
+    let onEnabledChange: (Bool) -> Void
     let onSave: (String, String?) -> Void
     let onReconnect: () -> Void
     let onRemove: () -> Void
@@ -1903,6 +1913,15 @@ private struct AccountProfileRow: View {
             .frame(maxWidth: .infinity, alignment: .leading)
 
             HStack(spacing: 8) {
+                Toggle("Enabled", isOn: Binding(
+                    get: { account.isEnabled },
+                    set: onEnabledChange
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .controlSize(.small)
+                .help(account.isEnabled ? "Disable account" : "Enable account")
+
                 Button(action: onReconnect) {
                     Image(systemName: "arrow.clockwise")
                 }

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -120,27 +120,13 @@ private enum SettingsPane: Hashable, Identifiable {
 // MARK: - SettingsView
 
 struct SettingsView: View {
-    // MARK: Lifecycle
-
-    init(embeddedInDashboard: Bool = false) {
-        self.embeddedInDashboard = embeddedInDashboard
-    }
-
     // MARK: Internal
 
-    let embeddedInDashboard: Bool
-
     var body: some View {
-        Group {
-            if embeddedInDashboard {
-                settingsStack
-            } else {
-                settingsWindow
-            }
-        }
+        settingsWindow
         .frame(
-            minWidth: embeddedInDashboard ? nil : SettingsPane.windowMinWidth,
-            minHeight: embeddedInDashboard ? nil : SettingsPane.windowMinHeight
+            minWidth: SettingsPane.windowMinWidth,
+            minHeight: SettingsPane.windowMinHeight
         )
         .alert(
             "Claude Reconnect Failed",
@@ -393,38 +379,6 @@ struct SettingsView: View {
                 .foregroundStyle(.secondary)
         }
         .padding(.bottom, 2)
-    }
-
-    private var settingsStack: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            trackedProvidersSection
-            if providerVisibility.isEnabled(.claudeCode) {
-                claudeCodeSection
-            }
-            if providerVisibility.isEnabled(.cursor) {
-                cursorSection
-            }
-            if showExtraUsageSection {
-                extraUsageSection
-            }
-            apiUsageSection
-            costTrackingSection
-            refreshSection
-            notificationsSection
-            if sessionWakeStore.featureEnabled {
-                automationSection
-            }
-            generalSection
-        }
-        .frame(maxWidth: .infinity, alignment: .topLeading)
-    }
-
-    /// Session Wake automation. Mirrors the standalone `.automation` pane (always
-    /// available) so the dashboard settings surface can reach it too.
-    private var automationSection: some View {
-        SettingsPanelSection(title: "Automation", systemImage: "moon.zzz", color: MeterBarTheme.appAccent) {
-            SessionWakeSettingsView(embeddedInDashboard: true)
-        }
     }
 
     private var codexCliSection: some View {

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -174,6 +174,7 @@ struct SettingsView: View {
     @StateObject private var dockVisibility = DockVisibilityStore.shared
     @StateObject private var notificationPreferences = NotificationPreferencesStore.shared
     @StateObject private var launchAtLogin = LaunchAtLoginStore.shared
+    @StateObject private var softwareUpdates = SoftwareUpdateController.shared
     @StateObject private var authManager = AuthenticationManager.shared
     @StateObject private var apiUsageStore = ApiUsageStore.shared
     @StateObject private var sessionWakeStore = SessionWakeSettingsStore.shared
@@ -556,11 +557,38 @@ struct SettingsView: View {
                 .labelsHidden()
                 .toggleStyle(.switch)
             }
+
+            SettingsDivider()
+
+            SettingsRowView(
+                title: "Check for updates automatically",
+                detail: "Allow MeterBar to check GitHub Releases for signed updates. Off until you opt in."
+            ) {
+                Toggle("", isOn: Binding(
+                    get: { softwareUpdates.automaticallyChecksForUpdates },
+                    set: { softwareUpdates.setAutomaticallyChecksForUpdates($0) }
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .disabled(softwareUpdates.configurationError != nil)
+            }
+
+            SettingsRowView(
+                title: "Software Update",
+                detail: softwareUpdates.configurationError ?? "Check for a new signed MeterBar release now."
+            ) {
+                Button("Check Now") {
+                    softwareUpdates.checkForUpdates()
+                }
+                .buttonStyle(.bordered)
+                .disabled(!softwareUpdates.canCheckForUpdates)
+            }
         }
         .onAppear {
             // The login-item status can change behind the app's back in System
             // Settings, so re-read it whenever settings is shown.
             launchAtLogin.refreshStatus()
+            softwareUpdates.refreshState()
         }
     }
 

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -165,6 +165,7 @@ struct UsageDashboardView: View {
     @StateObject private var dataManager = UsageDataManager.shared
     @StateObject private var costTracker = CostTracker.shared
     @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
+    @StateObject private var codexAccountStore = CodexAccountStore.shared
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
     @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
     @StateObject private var codexCliService = CodexCliLocalService.shared
@@ -578,6 +579,8 @@ struct UsageDashboardView: View {
         // that have reported metrics.
         ProviderSnapshotBuilder.snapshots(ProviderSnapshotBuilder.Input(
             metrics: dataManager.metrics,
+            codexAccounts: codexAccountStore.accounts,
+            codexAccountMetrics: dataManager.codexAccountMetrics,
             claudeAccounts: claudeAccountStore.accounts,
             claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
             enabledServices: providerVisibility.enabledServices,

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -169,6 +169,7 @@ struct UsageDashboardView: View {
     @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
     @StateObject private var codexCliService = CodexCliLocalService.shared
     @StateObject private var cursorService = CursorLocalService.shared
+    @StateObject private var openRouterService = OpenRouterService.shared
     @StateObject private var apiUsageStore = ApiUsageStore.shared
     @StateObject private var providerStatusMonitor = ProviderStatusMonitor.shared
     @StateObject private var navigation = DashboardNavigationStore.shared
@@ -582,7 +583,8 @@ struct UsageDashboardView: View {
             enabledServices: providerVisibility.enabledServices,
             claudeCodeHasAccess: claudeCodeService.hasAccess,
             codexCliHasAccess: codexCliService.hasAccess,
-            cursorHasAccess: cursorService.hasAccess
+            cursorHasAccess: cursorService.hasAccess,
+            openRouterHasAccess: openRouterService.hasAccess
         ))
         .filter(\.hasMetrics)
     }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -88,7 +88,6 @@ enum DashboardSection: String, CaseIterable, Identifiable, Hashable {
     case optimize = "Optimize"
     case diagnostics = "Diagnostics"
     case share = "Share"
-    case settings = "Settings"
 
     var id: String { rawValue }
 
@@ -108,14 +107,12 @@ enum DashboardSection: String, CaseIterable, Identifiable, Hashable {
             return "stethoscope"
         case .share:
             return "square.and.arrow.up.fill"
-        case .settings:
-            return "gearshape.fill"
         }
     }
 
     /// Sidebar layout: frequency-ordered monitoring pages first, then health
-    /// checks, then utilities. Settings is reached via the toolbar gear, not
-    /// the sidebar (app-level function, not a content destination).
+    /// checks, then utilities. App settings live in the dedicated macOS
+    /// Settings scene rather than masquerading as dashboard content.
     struct SidebarGroup: Identifiable {
         let title: String?
         let sections: [DashboardSection]
@@ -145,8 +142,6 @@ enum DashboardSection: String, CaseIterable, Identifiable, Hashable {
             return "Provider setup health"
         case .share:
             return "Social card export"
-        case .settings:
-            return "Accounts, refresh, and local sources"
         }
     }
 }
@@ -231,8 +226,7 @@ struct UsageDashboardView: View {
         } detail: {
             detailContent
                 .toolbar {
-                    ToolbarItemGroup(placement: .primaryAction) {
-                        settingsToolbarButton
+                    ToolbarItem(placement: .primaryAction) {
                         refreshToolbarButton
                     }
                 }
@@ -270,16 +264,6 @@ struct UsageDashboardView: View {
         .disabled(isRefreshButtonDisabled)
     }
 
-    private var settingsToolbarButton: some View {
-        Button {
-            navigation.navigate(to: .settings)
-        } label: {
-            Image(systemName: "gearshape")
-                .symbolVariant(activeSection == .settings ? .fill : .none)
-        }
-        .help("Settings")
-    }
-
     private var detailContent: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
@@ -298,8 +282,6 @@ struct UsageDashboardView: View {
                     diagnosticsContent
                 case .share:
                     shareContent
-                case .settings:
-                    settingsContent
                 }
             }
             .padding(.horizontal, 22)
@@ -590,11 +572,6 @@ struct UsageDashboardView: View {
         .frame(height: height)
     }
 
-    private var settingsContent: some View {
-        SettingsView(embeddedInDashboard: true)
-            .frame(maxWidth: .infinity, minHeight: 520, alignment: .leading)
-    }
-
     private var providerSnapshots: [ProviderSnapshot] {
         // Same builder the popover uses; the dashboard only renders providers
         // that have reported metrics.
@@ -791,7 +768,7 @@ struct UsageDashboardView: View {
             return costTracker.isRefreshInProgress
         case .status:
             return providerStatusMonitor.isRefreshing
-        case .overview, .limits, .diagnostics, .settings:
+        case .overview, .limits, .diagnostics:
             return dataManager.isLoading
         }
     }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -650,7 +650,7 @@ struct UsageDashboardView: View {
             count += 1
         }
         if providerVisibility.isEnabled(.claudeCode) {
-            count += claudeAccountStore.accounts.count
+            count += claudeAccountStore.enabledAccounts.count
         }
         if providerVisibility.isEnabled(.cursor) {
             count += 1

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -964,7 +964,10 @@ private struct OverviewSummaryStrip: View {
     private func tightestValue(now: Date) -> String {
         guard let tightestLimit else { return "No data" }
         guard tightestLimit.usageLimit.isAtLimit else {
-            return "\(tightestLimit.percentLeft)% left"
+            return tightestLimit.usageLimit.percentLeftText
+        }
+        if tightestLimit.usageLimit.isEstimated {
+            return tightestLimit.usageLimit.percentLeftText
         }
         guard let countdown = tightestLimit.usageLimit.resetCountdownText(now: now) else {
             return "Reset unknown"

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -64,7 +64,7 @@ struct Usage: ParsableCommand {
     @Flag(name: .shortAndLong, help: "Output as JSON")
     var json: Bool = false
 
-    @Option(name: .shortAndLong, help: "Filter by provider (claude, codex, cursor)")
+    @Option(name: .shortAndLong, help: "Filter by provider (claude, codex, cursor, openrouter)")
     var provider: String?
 
     func run() throws {
@@ -120,10 +120,18 @@ struct Usage: ParsableCommand {
             print("▸ \(service.displayName)")
 
             if let session = metric.sessionLimit {
-                printLimit("  Session", session)
+                printLimit(
+                    service == .openRouter ? "  Key limit" : "  Session",
+                    session,
+                    currency: service == .openRouter
+                )
             }
             if let weekly = metric.weeklyLimit {
-                printLimit("  Weekly", weekly)
+                printLimit(
+                    service == .openRouter ? "  Account credits" : "  Weekly",
+                    weekly,
+                    currency: service == .openRouter
+                )
             }
             if let codeReview = metric.codeReviewLimit {
                 printLimit(service == .claudeCode ? "  Sonnet" : "  Code Review", codeReview)
@@ -132,14 +140,18 @@ struct Usage: ParsableCommand {
         }
     }
 
-    private func printLimit(_ label: String, _ limit: UsageLimit) {
+    private func printLimit(_ label: String, _ limit: UsageLimit, currency: Bool = false) {
         let percent = limit.percentage
         let bar = progressBar(percent: percent, width: 20)
         let status = statusEmoji(for: limit)
 
-        print("\(label): \(bar) \(limit.percentageText) \(status)")
-        let estimateDetail = limit.isEstimated ? " (estimated limit)" : ""
-        print("    \(Int(limit.used))/\(Int(limit.total)) used\(estimateDetail)")
+        print("\(label): \(bar) \(currency ? String(format: "%.0f%%", percent) : limit.percentageText) \(status)")
+        if currency {
+            print("    \(UsageFormat.cost(limit.used)) spent / \(UsageFormat.cost(limit.total)) credits")
+        } else {
+            let estimateDetail = limit.isEstimated ? " (estimated limit)" : ""
+            print("    \(Int(limit.used))/\(Int(limit.total)) used\(estimateDetail)")
+        }
         if let reset = limit.resetTime {
             print("    Resets: \(UsageFormat.relative(reset))")
         }
@@ -310,7 +322,7 @@ struct Doctor: ParsableCommand {
     @Flag(name: .shortAndLong, help: "Output as JSON")
     var json: Bool = false
 
-    @Option(name: .shortAndLong, help: "Filter by provider (claude, codex, cursor)")
+    @Option(name: .shortAndLong, help: "Filter by provider (claude, codex, cursor, openrouter)")
     var provider: String?
 
     func run() throws {

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -137,8 +137,9 @@ struct Usage: ParsableCommand {
         let bar = progressBar(percent: percent, width: 20)
         let status = statusEmoji(for: limit)
 
-        print("\(label): \(bar) \(String(format: "%.0f%%", percent)) \(status)")
-        print("    \(Int(limit.used))/\(Int(limit.total)) used")
+        print("\(label): \(bar) \(limit.percentageText) \(status)")
+        let estimateDetail = limit.isEstimated ? " (estimated limit)" : ""
+        print("    \(Int(limit.used))/\(Int(limit.total)) used\(estimateDetail)")
         if let reset = limit.resetTime {
             print("    Resets: \(UsageFormat.relative(reset))")
         }

--- a/MeterBarTests/CachedMetricsContractTests.swift
+++ b/MeterBarTests/CachedMetricsContractTests.swift
@@ -18,7 +18,8 @@ final class CachedMetricsContractTests: XCTestCase {
                 used: 42.5,
                 total: 100,
                 resetTime: Date(timeIntervalSinceReferenceDate: 700_000_000),
-                windowSeconds: 5 * 3_600
+                windowSeconds: 5 * 3_600,
+                isEstimated: true
             ),
             weeklyLimit: UsageLimit(used: 12, total: 100, resetTime: nil),
             extraUsage: ExtraUsageStatus(state: .on, detail: "$0.00 used"),
@@ -61,10 +62,11 @@ final class CachedMetricsContractTests: XCTestCase {
         }
 
         let session = try XCTUnwrap(object["sessionLimit"] as? [String: Any])
-        for key in ["used", "total", "resetTime", "windowSeconds"] {
+        for key in ["used", "total", "resetTime", "windowSeconds", "isEstimated"] {
             XCTAssertNotNil(session[key], "missing sessionLimit key '\(key)'")
         }
         XCTAssertEqual(session["used"] as? Double, 42.5)
+        XCTAssertEqual(session["isEstimated"] as? Bool, true)
 
         let extra = try XCTUnwrap(object["extraUsage"] as? [String: Any])
         XCTAssertEqual(extra["state"] as? String, "on")
@@ -98,6 +100,7 @@ final class CachedMetricsContractTests: XCTestCase {
         XCTAssertEqual(metrics.service, .codexCli)
         XCTAssertEqual(metrics.weeklyLimit?.used, 30)
         XCTAssertNil(metrics.weeklyLimit?.windowSeconds)
+        XCTAssertEqual(metrics.weeklyLimit?.isEstimated, false)
         XCTAssertNil(metrics.extraUsage)
         XCTAssertNil(metrics.resetCreditsAvailable)
     }

--- a/MeterBarTests/ClaudeCodeAccountStoreTests.swift
+++ b/MeterBarTests/ClaudeCodeAccountStoreTests.swift
@@ -80,6 +80,46 @@ final class ClaudeCodeAccountStoreTests: XCTestCase {
         XCTAssertEqual(reloaded.customAccounts.first?.configDirectory, "/tmp/genfeed-claude-profile")
     }
 
+    func testLegacyCustomProfileDefaultsToEnabled() throws {
+        let id = UUID()
+        let data = try XCTUnwrap(
+            """
+            [{"id":"\(id.uuidString)","name":"Legacy","configDirectory":"/tmp/legacy"}]
+            """.data(using: .utf8)
+        )
+        defaults.set(data, forKey: StorageKeys.claudeCodeCustomAccounts)
+
+        let store = ClaudeCodeAccountStore(userDefaults: defaults)
+
+        XCTAssertEqual(store.customAccounts.first?.id, id)
+        XCTAssertEqual(store.customAccounts.first?.isEnabled, true)
+        XCTAssertEqual(store.enabledAccounts.map(\.id), [ClaudeCodeAccount.defaultID, id])
+    }
+
+    func testDefaultAndCustomProfileEnabledStatePersists() {
+        let store = ClaudeCodeAccountStore(userDefaults: defaults)
+        store.addAccount(name: "Work", configDirectory: "/tmp/work")
+        guard let customID = store.customAccounts.first?.id else {
+            XCTFail("Expected a custom Claude account")
+            return
+        }
+
+        store.setEnabled(false, for: ClaudeCodeAccount.defaultID)
+        store.setEnabled(false, for: customID)
+
+        XCTAssertTrue(store.enabledAccounts.isEmpty)
+        XCTAssertEqual(store.accounts.map(\.isEnabled), [false, false])
+
+        let reloaded = ClaudeCodeAccountStore(userDefaults: defaults)
+        XCTAssertTrue(reloaded.enabledAccounts.isEmpty)
+        XCTAssertEqual(reloaded.accounts.map(\.isEnabled), [false, false])
+
+        reloaded.setEnabled(true, for: ClaudeCodeAccount.defaultID)
+        reloaded.setEnabled(true, for: customID)
+        let enabledReload = ClaudeCodeAccountStore(userDefaults: defaults)
+        XCTAssertEqual(enabledReload.enabledAccounts.map(\.id), [ClaudeCodeAccount.defaultID, customID])
+    }
+
     func testCustomProfileCanBeRemoved() {
         let store = ClaudeCodeAccountStore(userDefaults: defaults)
         store.addAccount(name: "genfeedai", configDirectory: "/tmp/genfeed-claude-profile")

--- a/MeterBarTests/ClaudeCodeAccountStoreTests.swift
+++ b/MeterBarTests/ClaudeCodeAccountStoreTests.swift
@@ -33,6 +33,30 @@ final class ClaudeCodeAccountStoreTests: XCTestCase {
         XCTAssertEqual(reloaded.accounts.first?.name, "shipshitdev")
     }
 
+    func testDefaultConfigDirectoryFallsBackToClaudeUnderRealHome() {
+        XCTAssertEqual(
+            ClaudeCodeAccount.defaultConfigDirectory(environment: [:], realHomeDirectory: "/Users/tester"),
+            "/Users/tester/.claude"
+        )
+    }
+
+    func testDefaultConfigDirectoryHonorsAndExpandsEnvironmentOverride() {
+        XCTAssertEqual(
+            ClaudeCodeAccount.defaultConfigDirectory(
+                environment: ["CLAUDE_CONFIG_DIR": "~/.claude-work"],
+                realHomeDirectory: "/Users/tester"
+            ),
+            "/Users/tester/.claude-work"
+        )
+        XCTAssertEqual(
+            ClaudeCodeAccount.defaultConfigDirectory(
+                environment: ["CLAUDE_CONFIG_DIR": " /Volumes/config/claude "],
+                realHomeDirectory: "/Users/tester"
+            ),
+            "/Volumes/config/claude"
+        )
+    }
+
     func testCustomProfileCanBeEditedAndPersists() {
         let store = ClaudeCodeAccountStore(userDefaults: defaults)
         store.addAccount(name: "genfeed.ai", configDirectory: "/tmp/old-claude-profile")

--- a/MeterBarTests/CodexAccountStoreTests.swift
+++ b/MeterBarTests/CodexAccountStoreTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import MeterBar
+
+final class CodexAccountStoreTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "CodexAccountStoreTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testDefaultProfileNeedsNoConfigurationAndLabelPersists() {
+        let store = CodexAccountStore(userDefaults: defaults)
+        XCTAssertEqual(store.accounts, [.defaultAccount])
+
+        store.updateAccount(id: CodexAccount.defaultID, name: "Personal", homeDirectory: nil)
+
+        let reloaded = CodexAccountStore(userDefaults: defaults)
+        XCTAssertEqual(reloaded.accounts.first?.name, "Personal")
+        XCTAssertNil(reloaded.accounts.first?.homeDirectory)
+    }
+
+    func testCustomProfilesPersistIndependentHomesAndOrder() {
+        let store = CodexAccountStore(userDefaults: defaults)
+        store.addAccount(name: "Work", homeDirectory: "/tmp/codex-work")
+        store.addAccount(name: "Personal", homeDirectory: "/tmp/codex-personal")
+
+        store.moveAccounts(fromOffsets: IndexSet(integer: 2), toOffset: 0)
+
+        let reloaded = CodexAccountStore(userDefaults: defaults)
+        XCTAssertEqual(reloaded.accounts.map(\.name), ["Personal", CodexAccount.defaultName, "Work"])
+        XCTAssertEqual(reloaded.customAccounts.map(\.homeDirectory), ["/tmp/codex-work", "/tmp/codex-personal"])
+    }
+
+    func testCustomProfileCanBeEditedAndRemovedWithoutRemovingDefault() {
+        let store = CodexAccountStore(userDefaults: defaults)
+        store.addAccount(name: "Work", homeDirectory: "/tmp/old")
+        let account = store.customAccounts[0]
+
+        store.updateAccount(id: account.id, name: "Team", homeDirectory: "/tmp/new")
+        XCTAssertEqual(store.customAccounts[0].name, "Team")
+        XCTAssertEqual(store.customAccounts[0].homeDirectory, "/tmp/new")
+
+        store.removeAccount(id: account.id)
+        store.removeAccount(id: CodexAccount.defaultID)
+        XCTAssertEqual(store.accounts.map(\.id), [CodexAccount.defaultID])
+    }
+}

--- a/MeterBarTests/CodexCliLocalServiceTests.swift
+++ b/MeterBarTests/CodexCliLocalServiceTests.swift
@@ -173,6 +173,23 @@ final class CodexCliLocalServiceTests: XCTestCase {
         XCTAssertNil(service.getAuthToken())
     }
 
+    func testAccountAuthProviderReadsEachCodexHomeIndependently() {
+        let defaultToken = makeJWT(exp: futureExp, accountId: "default")
+        let workToken = makeJWT(exp: futureExp, accountId: "work")
+        let work = CodexAccount(id: UUID(), name: "Work", homeDirectory: "/tmp/codex-work")
+        let service = CodexCliLocalService(accountAuthFileDataProvider: { account in
+            if account.id == work.id {
+                return self.authFileJSON(accessToken: workToken, accountId: "work")
+            }
+            return self.authFileJSON(accessToken: defaultToken, accountId: "default")
+        })
+
+        XCTAssertEqual(service.getAuthToken(account: .defaultAccount), defaultToken)
+        XCTAssertEqual(service.getAccountId(account: .defaultAccount), "default")
+        XCTAssertEqual(service.getAuthToken(account: work), workToken)
+        XCTAssertEqual(service.getAccountId(account: work), "work")
+    }
+
     // MARK: - Main-thread hygiene
 
     /// The auth-file read is disk I/O and must never run on the main thread when

--- a/MeterBarTests/CursorLocalServiceTests.swift
+++ b/MeterBarTests/CursorLocalServiceTests.swift
@@ -44,9 +44,11 @@ final class CursorLocalServiceTests: XCTestCase {
         XCTAssertEqual(metrics.service, .cursor)
         XCTAssertEqual(metrics.weeklyLimit?.used, 137)
         XCTAssertEqual(metrics.weeklyLimit?.total, 500)
+        XCTAssertEqual(metrics.weeklyLimit?.isEstimated, false)
         XCTAssertEqual(metrics.weeklyLimit?.resetTime, FlexibleISO8601.date(from: "2026-08-01T00:00:00Z"))
         XCTAssertEqual(metrics.sessionLimit?.used, 4)
         XCTAssertEqual(metrics.sessionLimit?.total, 20)
+        XCTAssertEqual(metrics.sessionLimit?.isEstimated, false)
     }
 
     func testMapSummarySubstitutesDefaultPlanTotalWhenMissing() throws {
@@ -57,6 +59,7 @@ final class CursorLocalServiceTests: XCTestCase {
         let metrics = CursorLocalService.mapSummary(try decodeSummary(json))
         XCTAssertEqual(metrics.weeklyLimit?.used, 50)
         XCTAssertEqual(metrics.weeklyLimit?.total, 500)
+        XCTAssertEqual(metrics.weeklyLimit?.isEstimated, true)
     }
 
     func testMapSummaryOmitsSessionLimitWhenOnDemandDisabled() throws {
@@ -85,6 +88,7 @@ final class CursorLocalServiceTests: XCTestCase {
         let metrics = CursorLocalService.mapSummary(try decodeSummary(json))
         XCTAssertEqual(metrics.sessionLimit?.used, 8)
         XCTAssertEqual(metrics.sessionLimit?.total ?? 0, 12, accuracy: 0.0001)
+        XCTAssertEqual(metrics.sessionLimit?.isEstimated, true)
     }
 
     func testMapSummaryOmitsSessionLimitWhenOnDemandAllZero() throws {

--- a/MeterBarTests/DashboardLayoutTests.swift
+++ b/MeterBarTests/DashboardLayoutTests.swift
@@ -3,21 +3,20 @@ import AppKit
 import SwiftUI
 import XCTest
 
-/// Layout-audit coverage (2026-07-11): sidebar grouping, toolbar settings
-/// entry, header-hosted card controls, and content-hugging cost card.
+/// Layout-audit coverage: sidebar grouping, header-hosted card controls,
+/// and content-hugging cost card.
 @MainActor
 final class DashboardLayoutTests: XCTestCase {
     // MARK: - Sidebar groups
 
-    func testSidebarGroupsCoverEverySectionExceptSettings() {
+    func testSidebarGroupsCoverEveryDashboardSection() {
         let flattened = DashboardSection.sidebarGroups.flatMap(\.sections)
 
         XCTAssertEqual(Set(flattened).count, flattened.count, "sidebar must not repeat a section")
-        XCTAssertFalse(flattened.contains(.settings), "settings moves to the toolbar gear")
         XCTAssertEqual(
             Set(flattened),
-            Set(DashboardSection.allCases).subtracting([.settings]),
-            "every non-settings section must stay reachable from the sidebar"
+            Set(DashboardSection.allCases),
+            "every dashboard section must stay reachable from the sidebar"
         )
     }
 

--- a/MeterBarTests/FirstRunOnboardingTests.swift
+++ b/MeterBarTests/FirstRunOnboardingTests.swift
@@ -1,0 +1,95 @@
+@testable import MeterBar
+import XCTest
+
+final class FirstRunOnboardingTests: XCTestCase {
+    private final class FakeLaunchController: LaunchAtLoginControlling {
+        var status: LaunchAtLoginStatus = .notRegistered
+        private(set) var registerCallCount = 0
+
+        func currentStatus() -> LaunchAtLoginStatus { status }
+        func register() throws {
+            registerCallCount += 1
+            status = .enabled
+        }
+        func unregister() throws { status = .notRegistered }
+    }
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUpWithError() throws {
+        suiteName = "FirstRunOnboardingTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    func testUpgradingExistingInstallDoesNotPresentOnboarding() {
+        // An install that predates the onboarding flag has other MeterBar
+        // state in defaults; it must be treated as already onboarded.
+        defaults.set(true, forKey: StorageKeys.notificationsEnabled)
+
+        let store = FirstRunOnboardingStore(
+            userDefaults: defaults,
+            launchAtLogin: LaunchAtLoginStore(controller: FakeLaunchController())
+        )
+
+        XCTAssertFalse(store.shouldPresent)
+        XCTAssertTrue(defaults.bool(forKey: StorageKeys.hasCompletedFirstRun))
+    }
+
+    func testUpgradeMigrationRecognizesCachedMetricsSentinel() {
+        defaults.set(Data("{}".utf8), forKey: StorageKeys.cachedUsageMetrics)
+
+        let store = FirstRunOnboardingStore(
+            userDefaults: defaults,
+            launchAtLogin: LaunchAtLoginStore(controller: FakeLaunchController())
+        )
+
+        XCTAssertFalse(store.shouldPresent)
+    }
+
+    func testFreshInstallPresentsAndDismissPersistsOnce() {
+        let store = FirstRunOnboardingStore(
+            userDefaults: defaults,
+            launchAtLogin: LaunchAtLoginStore(controller: FakeLaunchController())
+        )
+        XCTAssertTrue(store.shouldPresent)
+
+        store.dismiss()
+
+        XCTAssertFalse(store.shouldPresent)
+        let reloaded = FirstRunOnboardingStore(
+            userDefaults: defaults,
+            launchAtLogin: LaunchAtLoginStore(controller: FakeLaunchController())
+        )
+        XCTAssertFalse(reloaded.shouldPresent)
+    }
+
+    func testEnableLaunchAtLoginRegistersAndCompletesOnboarding() {
+        let controller = FakeLaunchController()
+        let launchAtLogin = LaunchAtLoginStore(controller: controller)
+        let store = FirstRunOnboardingStore(userDefaults: defaults, launchAtLogin: launchAtLogin)
+
+        store.chooseLaunchAtLogin(true)
+
+        XCTAssertEqual(controller.registerCallCount, 1)
+        XCTAssertTrue(launchAtLogin.isEnabled)
+        XCTAssertFalse(store.shouldPresent)
+    }
+
+    func testNotNowCompletesWithoutRegistering() {
+        let controller = FakeLaunchController()
+        let store = FirstRunOnboardingStore(
+            userDefaults: defaults,
+            launchAtLogin: LaunchAtLoginStore(controller: controller)
+        )
+
+        store.chooseLaunchAtLogin(false)
+
+        XCTAssertEqual(controller.registerCallCount, 0)
+        XCTAssertFalse(store.shouldPresent)
+    }
+}

--- a/MeterBarTests/KeychainManagerTests.swift
+++ b/MeterBarTests/KeychainManagerTests.swift
@@ -15,7 +15,7 @@ final class KeychainManagerTests: XCTestCase {
     /// and account. Mirrors the real semantics the manager relies on: update on
     /// a missing item returns `errSecItemNotFound`, copy on a missing item
     /// returns `errSecItemNotFound`, and delete is idempotent at the manager.
-    private final class InMemoryKeychainBackend: KeychainBackend {
+    nonisolated private final class InMemoryKeychainBackend: KeychainBackend {
         private struct ItemKey: Hashable {
             let service: String
             let account: String

--- a/MeterBarTests/LiquidGlassP1RegressionTests.swift
+++ b/MeterBarTests/LiquidGlassP1RegressionTests.swift
@@ -1,0 +1,35 @@
+import AppKit
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+@MainActor
+final class LiquidGlassP1RegressionTests: XCTestCase {
+    func testMenuPanelCanBecomeKey() {
+        let panel = KeyableMenuPanel(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        XCTAssertTrue(panel.canBecomeKey)
+    }
+
+    func testDailyUsageDayExposesAccessibleChartSummary() {
+        let day = DailyUsageDay(
+            date: Date(timeIntervalSinceReferenceDate: 0),
+            segments: [
+                DailyUsageProviderSegment(provider: .claudeCode, tokens: 1_200, cost: 1.25),
+                DailyUsageProviderSegment(provider: .codexCli, tokens: 800, cost: 0.75),
+            ],
+            cost: 2
+        )
+
+        XCTAssertFalse(day.chartAccessibilityLabel.isEmpty)
+        XCTAssertEqual(
+            day.chartAccessibilityValue,
+            "2.0K tokens, $2.00, Claude Code 1.2K tokens, $1.25, OpenAI Codex 800 tokens, $0.75"
+        )
+    }
+}

--- a/MeterBarTests/MenuBarSmokeTests.swift
+++ b/MeterBarTests/MenuBarSmokeTests.swift
@@ -16,7 +16,7 @@ import XCTest
 final class MenuBarSmokeTests: XCTestCase {
 
     /// Controllable single-account provider (Codex / Cursor stand-in).
-    private final class StubUsageProvider: SimpleUsageProviding {
+    private final class StubUsageProvider: SimpleUsageProviding, CodexUsageProviding {
         var hasAccess: Bool
         private let metrics: UsageMetrics
         init(hasAccess: Bool, metrics: UsageMetrics) {
@@ -24,6 +24,8 @@ final class MenuBarSmokeTests: XCTestCase {
             self.metrics = metrics
         }
         func fetchUsageMetrics() async throws -> UsageMetrics { metrics }
+        func canAccess(account: CodexAccount) async -> Bool { hasAccess }
+        func fetchUsageMetrics(account: CodexAccount) async throws -> UsageMetrics { metrics }
     }
 
     private var tempDirectory: URL!

--- a/MeterBarTests/NotificationDeciderTests.swift
+++ b/MeterBarTests/NotificationDeciderTests.swift
@@ -399,4 +399,18 @@ final class NotificationDeciderTests: XCTestCase {
             "Claude Code-codeReview-critical"
         ])
     }
+
+    func testAccountIdentityScopesKeysAndLabelsNotification() {
+        let result = decider().evaluate(
+            metrics: metrics(service: .codexCli, session: exhaustedLimit()),
+            providerEnabled: true,
+            alreadyNotified: [],
+            accountKey: "work-account",
+            serviceDisplayName: "Work (OpenAI Codex)",
+            now: now
+        )
+
+        XCTAssertEqual(result.notifications.first?.key, "Codex CLI-work-account-session-critical")
+        XCTAssertEqual(result.notifications.first?.title, "Work (OpenAI Codex) Session Limit Reached")
+    }
 }

--- a/MeterBarTests/NotificationDeciderTests.swift
+++ b/MeterBarTests/NotificationDeciderTests.swift
@@ -272,6 +272,19 @@ final class NotificationDeciderTests: XCTestCase {
         XCTAssertTrue(result.notifiedKeys.isEmpty)
     }
 
+    func testEstimatedLimitNeverNotifiesAndClearsPreviousBandState() {
+        let estimated = UsageLimit(used: 100, total: 100, resetTime: nil, isEstimated: true)
+        let result = decider().evaluate(
+            metrics: metrics(session: estimated),
+            providerEnabled: true,
+            alreadyNotified: ["Claude Code-session-warn", "Claude Code-session-critical"],
+            now: now
+        )
+
+        XCTAssertTrue(result.notifications.isEmpty)
+        XCTAssertTrue(result.notifiedKeys.isEmpty)
+    }
+
     func testExhaustedCriticalCopyClaimsLimitReached() {
         let result = decider().evaluate(
             metrics: metrics(session: exhaustedLimit()),

--- a/MeterBarTests/OpenRouterServiceTests.swift
+++ b/MeterBarTests/OpenRouterServiceTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+final class OpenRouterServiceTests: XCTestCase {
+    func testOfficialCreditAndKeyFixturesMapToCurrencyLimits() throws {
+        let credits = try decodeCredits(#"{"data":{"total_credits":100.5,"total_usage":25.75}}"#)
+        let key = try decodeKey(
+            #"{"data":{"label":"MeterBar","limit":40,"limit_reset":"monthly","limit_remaining":12.5,"usage":27.5,"usage_daily":1.25,"usage_weekly":8,"usage_monthly":20,"is_free_tier":false}}"#
+        )
+        let now = date(2026, 7, 13)
+
+        let metrics = OpenRouterService.map(credits: credits.data, key: key.data, now: now)
+
+        XCTAssertEqual(metrics.service, .openRouter)
+        XCTAssertEqual(metrics.weeklyLimit?.used, 25.75)
+        XCTAssertEqual(metrics.weeklyLimit?.total, 100.5)
+        XCTAssertEqual(metrics.sessionLimit?.used, 27.5)
+        XCTAssertEqual(metrics.sessionLimit?.total, 40)
+        XCTAssertEqual(metrics.sessionLimit?.resetTime, date(2026, 8, 1))
+        XCTAssertNil(metrics.sessionLimit?.windowSeconds)
+    }
+
+    func testUnlimitedKeyOmitsKeyLimitButKeepsAccountCredits() throws {
+        let credits = try decodeCredits(#"{"data":{"total_credits":10,"total_usage":4}}"#)
+        let key = try decodeKey(
+            #"{"data":{"label":"Unlimited","limit":null,"limit_reset":null,"limit_remaining":null,"usage":4,"is_free_tier":false}}"#
+        )
+
+        let metrics = OpenRouterService.map(credits: credits.data, key: key.data)
+
+        XCTAssertNil(metrics.sessionLimit)
+        XCTAssertEqual(metrics.weeklyLimit?.used, 4)
+        XCTAssertEqual(metrics.weeklyLimit?.total, 10)
+    }
+
+    func testZeroBalanceStillProducesVisibleAccountCredits() throws {
+        let credits = try decodeCredits(#"{"data":{"total_credits":0,"total_usage":0}}"#)
+        let key = try decodeKey(
+            #"{"data":{"limit":null,"limit_reset":null,"limit_remaining":null,"usage":0,"is_free_tier":true}}"#
+        )
+
+        let metrics = OpenRouterService.map(credits: credits.data, key: key.data)
+
+        XCTAssertNotNil(metrics.weeklyLimit)
+        XCTAssertEqual(metrics.weeklyLimit?.used, 0)
+        XCTAssertEqual(metrics.weeklyLimit?.total, 0)
+    }
+
+    func testDailyKeyLimitMapsToNextUTCReset() throws {
+        let credits = try decodeCredits(#"{"data":{"total_credits":20,"total_usage":5}}"#)
+        let key = try decodeKey(
+            #"{"data":{"limit":5,"limit_reset":"daily","limit_remaining":2,"usage":3,"is_free_tier":true}}"#
+        )
+
+        let metrics = OpenRouterService.map(
+            credits: credits.data,
+            key: key.data,
+            now: date(2026, 7, 13, 16)
+        )
+
+        XCTAssertEqual(metrics.sessionLimit?.resetTime, date(2026, 7, 14))
+        XCTAssertEqual(metrics.sessionLimit?.windowSeconds, 86_400)
+    }
+
+    private func decodeCredits(_ json: String) throws -> OpenRouterCreditsResponse {
+        try JSONDecoder().decode(OpenRouterCreditsResponse.self, from: Data(json.utf8))
+    }
+
+    private func decodeKey(_ json: String) throws -> OpenRouterKeyResponse {
+        try JSONDecoder().decode(OpenRouterKeyResponse.self, from: Data(json.utf8))
+    }
+
+    private func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int = 0) -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+        return calendar.date(from: DateComponents(year: year, month: month, day: day, hour: hour)) ?? .distantPast
+    }
+}

--- a/MeterBarTests/ProviderParseHealthTests.swift
+++ b/MeterBarTests/ProviderParseHealthTests.swift
@@ -1,0 +1,94 @@
+import MeterBarShared
+@testable import MeterBar
+import XCTest
+
+final class ProviderParseHealthTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUpWithError() throws {
+        suiteName = "ProviderParseHealthTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    func testParseMismatchNeedsAttentionOnlyAfterConsecutiveMismatchesAndPersists() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let store = ProviderParseHealthStore(userDefaults: defaults)
+
+        // One decode failure can be a truncated body from a flaky connection;
+        // it must not one-shot the provider into "needs attention".
+        store.recordFailure(.claudeCode, error: ServiceError.parsingError, at: now)
+        var record = store.records[.claudeCode]
+        XCTAssertEqual(record?.consecutiveFailures, 1)
+        XCTAssertTrue(record?.lastFailureWasShapeMismatch ?? false)
+        XCTAssertFalse(record?.needsAttention(now: now) ?? true)
+
+        // Genuine schema drift fails every refresh; the second consecutive
+        // mismatch is the earliest reliable drift signal.
+        store.recordFailure(.claudeCode, error: ServiceError.parsingError, at: now + 1)
+        record = store.records[.claudeCode]
+        XCTAssertTrue(record?.needsAttention(now: now + 1) ?? false)
+        XCTAssertEqual(ProviderParseHealthStore.persistedRecords(from: defaults)[.claudeCode], record)
+    }
+
+    func testTransientDecodeFailureThenSuccessStaysHealthy() {
+        let now = Date(timeIntervalSince1970: 15_000)
+        let store = ProviderParseHealthStore(userDefaults: defaults)
+        let decodeError = DecodingError.dataCorrupted(
+            DecodingError.Context(codingPath: [], debugDescription: "truncated body")
+        )
+
+        store.recordFailure(.claudeCode, error: decodeError, at: now)
+        XCTAssertFalse(store.records[.claudeCode]?.needsAttention(now: now) ?? true)
+
+        store.recordSuccess(.claudeCode, at: now + 1)
+        XCTAssertFalse(store.records[.claudeCode]?.needsAttention(now: now + 1) ?? true)
+
+        // A later isolated mismatch after recovery must start counting from zero.
+        store.recordFailure(.claudeCode, error: decodeError, at: now + 2)
+        XCTAssertFalse(store.records[.claudeCode]?.needsAttention(now: now + 2) ?? true)
+    }
+
+    func testMixedFailureKindsDoNotAccumulateMismatchCount() {
+        let now = Date(timeIntervalSince1970: 17_000)
+        let store = ProviderParseHealthStore(userDefaults: defaults)
+
+        store.recordFailure(.cursor, error: ServiceError.parsingError, at: now)
+        store.recordFailure(.cursor, error: ServiceError.apiError("Request timed out"), at: now + 1)
+        store.recordFailure(.cursor, error: ServiceError.parsingError, at: now + 2)
+
+        // parse, api, parse: never two consecutive mismatches, and only
+        // three total failures reach the ordinary sustained threshold.
+        XCTAssertTrue(store.records[.cursor]?.needsAttention(now: now + 2) ?? false)
+        XCTAssertEqual(store.records[.cursor]?.consecutiveFailures, 3)
+    }
+
+    func testOrdinaryFailureNeedsThreeAttemptsAndSuccessResetsCounter() {
+        let now = Date(timeIntervalSince1970: 20_000)
+        let store = ProviderParseHealthStore(userDefaults: defaults)
+        for offset in 0..<2 {
+            store.recordFailure(.cursor, error: ServiceError.apiError("Request timed out"), at: now + Double(offset))
+        }
+        XCTAssertFalse(store.records[.cursor]?.needsAttention(now: now + 2) ?? true)
+
+        store.recordFailure(.cursor, error: ServiceError.apiError("Request timed out"), at: now + 2)
+        XCTAssertTrue(store.records[.cursor]?.needsAttention(now: now + 2) ?? false)
+
+        store.recordSuccess(.cursor, at: now + 3)
+        XCTAssertEqual(store.records[.cursor]?.consecutiveFailures, 0)
+        XCTAssertFalse(store.records[.cursor]?.needsAttention(now: now + 3) ?? true)
+    }
+
+    func testSuccessfulDataBecomesStaleAfterPublishedThreshold() {
+        let now = Date(timeIntervalSince1970: 30_000)
+        let record = ProviderParseHealthRecord.success(at: now)
+
+        XCTAssertFalse(record.needsAttention(now: now + ProviderParseHealthRecord.staleAfter - 1))
+        XCTAssertTrue(record.needsAttention(now: now + ProviderParseHealthRecord.staleAfter + 1))
+        XCTAssertEqual(ProviderParseHealthRecord.staleAfter, 2 * 60 * 60)
+    }
+}

--- a/MeterBarTests/ProviderReadinessInspectorTests.swift
+++ b/MeterBarTests/ProviderReadinessInspectorTests.swift
@@ -113,6 +113,28 @@ final class ProviderReadinessInspectorTests: XCTestCase {
         XCTAssertNil(ProviderReadinessInspector.sanitize(nil))
     }
 
+    func testParseHealthAddsImmediateFormatMismatchCheckWithStalenessThreshold() {
+        let now = Date(timeIntervalSince1970: 40_000)
+        let record = ProviderParseHealthRecord(
+            provider: .codexCli,
+            lastSuccess: now.addingTimeInterval(-60),
+            lastAttempt: now,
+            consecutiveFailures: 1,
+            lastFailureWasShapeMismatch: true
+        )
+
+        let reports = ProviderReadinessInspector.reports(
+            providers: [.codexCli],
+            now: now,
+            parseHealth: [.codexCli: record]
+        )
+        let check = reports.first?.check(ReadinessCheckID.parseHealth)
+
+        XCTAssertEqual(check?.level, .fail)
+        XCTAssertTrue(check?.detail.contains("format") ?? false)
+        XCTAssertTrue(check?.detail.contains("2 hours") ?? false)
+    }
+
     func testHttpStatusExtraction() {
         XCTAssertEqual(ProviderReadinessInspector.httpStatus(in: "HTTP 404: not found"), 404)
         XCTAssertNil(ProviderReadinessInspector.httpStatus(in: "no status here"))

--- a/MeterBarTests/ProviderReadinessTests.swift
+++ b/MeterBarTests/ProviderReadinessTests.swift
@@ -14,6 +14,20 @@ final class ProviderReadinessTests: XCTestCase {
     // A token value that must never appear in user-facing output.
     private let secret = "SECRET-TOKEN-DO-NOT-LEAK-abc123"
 
+    func testOpenRouterRequiresKeyAndSurfacesSanitizedRefreshFailure() {
+        let missing = ProviderReadinessEvaluator.openRouter(OpenRouterReadinessInput(hasAPIKey: false))
+        XCTAssertEqual(missing.provider, .openRouter)
+        XCTAssertEqual(missing.check("auth")?.level, .fail)
+        XCTAssertTrue((missing.check("auth")?.recovery ?? "").contains("Settings"))
+
+        let configured = ProviderReadinessEvaluator.openRouter(
+            OpenRouterReadinessInput(hasAPIKey: true, refreshError: "API error (HTTP 401)")
+        )
+        XCTAssertEqual(configured.check("auth")?.level, .pass)
+        XCTAssertEqual(configured.check("refresh")?.level, .fail)
+        XCTAssertFalse(configured.isHealthy)
+    }
+
     // MARK: - Claude Code
 
     func testClaudeHealthy() {

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -101,6 +101,46 @@ final class ProviderSnapshotTests: XCTestCase {
         XCTAssertEqual(Set(snapshots.map(\.id)).count, snapshots.count)
     }
 
+    func testDisabledClaudeAccountsAreExcludedEvenWithCachedMetrics() {
+        let disabled = ClaudeCodeAccount(
+            id: UUID(),
+            name: "Disabled",
+            configDirectory: "/tmp/disabled",
+            isEnabled: false
+        )
+        let enabled = ClaudeCodeAccount(id: UUID(), name: "Enabled", configDirectory: "/tmp/enabled")
+        let accountMetrics = [
+            disabled.id: makeMetrics(service: .claudeCode, weekly: 80),
+            enabled.id: makeMetrics(service: .claudeCode, weekly: 20)
+        ]
+
+        let snapshots = ProviderSnapshotBuilder.snapshots(makeInput(
+            claudeAccounts: [disabled, enabled],
+            claudeAccountMetrics: accountMetrics,
+            enabledServices: [.claudeCode]
+        ))
+
+        XCTAssertEqual(snapshots.map(\.title), ["Enabled"])
+        XCTAssertEqual(snapshots.first?.limits.first?.usageLimit.used, 20)
+    }
+
+    func testClaudeProviderHasNoSnapshotWhenAllAccountsAreDisabled() {
+        let disabledDefault = ClaudeCodeAccount(
+            id: ClaudeCodeAccount.defaultID,
+            name: ClaudeCodeAccount.defaultName,
+            configDirectory: nil,
+            isEnabled: false
+        )
+
+        let snapshots = ProviderSnapshotBuilder.snapshots(makeInput(
+            metrics: [.claudeCode: makeMetrics(service: .claudeCode, weekly: 90)],
+            claudeAccounts: [disabledDefault],
+            enabledServices: [.claudeCode]
+        ))
+
+        XCTAssertTrue(snapshots.isEmpty)
+    }
+
     // MARK: - Limits
 
     func testThirdLimitLabelIsSonnetForClaudeAndCodeReviewForCodex() {

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -35,17 +35,18 @@ final class ProviderSnapshotTests: XCTestCase {
 
     // MARK: - Ordering and inclusion
 
-    func testDisplayOrderIsCodexClaudeCursor() {
+    func testDisplayOrderIsCodexClaudeCursorOpenRouter() {
         let snapshots = ProviderSnapshotBuilder.snapshots(makeInput(
             metrics: [
                 .codexCli: makeMetrics(service: .codexCli, weekly: 10),
                 .claudeCode: makeMetrics(service: .claudeCode, weekly: 20),
-                .cursor: makeMetrics(service: .cursor, weekly: 30)
+                .cursor: makeMetrics(service: .cursor, weekly: 30),
+                .openRouter: makeMetrics(service: .openRouter, weekly: 40)
             ]
         ))
 
-        XCTAssertEqual(snapshots.map(\.service), [.codexCli, .claudeCode, .cursor])
-        XCTAssertEqual(snapshots.map(\.title), ["Codex", "Claude", "Cursor"])
+        XCTAssertEqual(snapshots.map(\.service), [.codexCli, .claudeCode, .cursor, .openRouter])
+        XCTAssertEqual(snapshots.map(\.title), ["Codex", "Claude", "Cursor", "OpenRouter"])
     }
 
     func testDisabledProvidersAreExcluded() {
@@ -62,8 +63,8 @@ final class ProviderSnapshotTests: XCTestCase {
             metrics: [.cursor: makeMetrics(service: .cursor, weekly: 30)]
         ))
 
-        // Popover shows all three (Codex/Claude as empty-state cards)…
-        XCTAssertEqual(snapshots.count, 3)
+        // Popover shows all enabled providers (Codex/Claude/OpenRouter as empty-state cards)…
+        XCTAssertEqual(snapshots.count, 4)
         XCTAssertFalse(snapshots[0].hasMetrics)
         // …the dashboard filters to providers with data.
         XCTAssertEqual(snapshots.filter(\.hasMetrics).map(\.service), [.cursor])
@@ -114,6 +115,16 @@ final class ProviderSnapshotTests: XCTestCase {
 
         XCTAssertEqual(claudeLimits.map(\.title), ["Sonnet"])
         XCTAssertEqual(codexLimits.map(\.title), ["Code Review"])
+    }
+
+    func testOpenRouterUsesCurrencyCreditLabels() {
+        let limits = ProviderSnapshotBuilder.limits(
+            for: makeMetrics(service: .openRouter, session: 10, weekly: 20),
+            service: .openRouter
+        )
+
+        XCTAssertEqual(limits.map(\.title), ["Key limit", "Account credits"])
+        XCTAssertTrue(limits.allSatisfy { $0.valueStyle == .currency })
     }
 
     func testPaceContextComesFromKindNotTitle() {

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -141,6 +141,25 @@ final class ProviderSnapshotTests: XCTestCase {
         XCTAssertTrue(snapshots.isEmpty)
     }
 
+    func testMultipleCodexAccountsUseIndependentMetricsAndAccountNames() {
+        let work = CodexAccount(id: UUID(), name: "Work", homeDirectory: "/tmp/codex-work")
+        let snapshots = ProviderSnapshotBuilder.snapshots(ProviderSnapshotBuilder.Input(
+            metrics: [:],
+            codexAccounts: [.defaultAccount, work],
+            codexAccountMetrics: [
+                CodexAccount.defaultID: makeMetrics(service: .codexCli, weekly: 25),
+                work.id: makeMetrics(service: .codexCli, weekly: 75)
+            ],
+            claudeAccounts: [.defaultAccount],
+            claudeAccountMetrics: [:],
+            enabledServices: [.codexCli]
+        ))
+
+        XCTAssertEqual(snapshots.map(\.title), [CodexAccount.defaultName, "Work"])
+        XCTAssertEqual(snapshots.map { $0.primaryLimit?.usedPercent }, [25, 75])
+        XCTAssertEqual(Set(snapshots.map(\.id)).count, 2)
+    }
+
     // MARK: - Limits
 
     func testThirdLimitLabelIsSonnetForClaudeAndCodeReviewForCodex() {

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -262,6 +262,29 @@ final class ProviderSnapshotTests: XCTestCase {
         )
     }
 
+    func testEstimatedExhaustionDoesNotClaimProviderIsBlocked() {
+        let metrics = UsageMetrics(
+            service: .cursor,
+            weeklyLimit: UsageLimit(
+                used: 500,
+                total: 500,
+                resetTime: nil,
+                isEstimated: true
+            )
+        )
+        let snapshot = ProviderSnapshotBuilder.snapshot(
+            title: "Cursor",
+            service: .cursor,
+            metrics: metrics,
+            emptyDetail: ""
+        )
+
+        XCTAssertEqual(snapshot.band, .exhausted)
+        XCTAssertFalse(snapshot.hasExhaustedLimit)
+        XCTAssertFalse(snapshot.hasExhaustedWeeklyLimit)
+        XCTAssertTrue(snapshot.blockingLimits.isEmpty)
+    }
+
     func testBlockingResetWindowsExcludeSimultaneouslyExhaustedSecondaryQuota() {
         let snapshot = ProviderSnapshotBuilder.snapshot(
             title: "Claude",

--- a/MeterBarTests/ProviderStatusMonitorTests.swift
+++ b/MeterBarTests/ProviderStatusMonitorTests.swift
@@ -107,10 +107,35 @@ final class ProviderStatusMonitorTests: XCTestCase {
         XCTAssertEqual(ServiceType.claudeCode.statusPageDisplayName, "Claude")
         XCTAssertEqual(ServiceType.codexCli.statusPageDisplayName, "OpenAI")
         XCTAssertEqual(ServiceType.cursor.statusPageDisplayName, "Cursor")
+        XCTAssertEqual(ServiceType.openRouter.statusPageDisplayName, "OpenRouter")
 
         XCTAssertEqual(try XCTUnwrap(ServiceType.claudeCode.statusPageURL).absoluteString, "https://status.claude.com/")
         XCTAssertEqual(try XCTUnwrap(ServiceType.codexCli.statusPageURL).absoluteString, "https://status.openai.com/")
         XCTAssertEqual(try XCTUnwrap(ServiceType.cursor.statusPageURL).absoluteString, "https://status.cursor.com/")
+        XCTAssertEqual(
+            try XCTUnwrap(ServiceType.openRouter.statusPageURL).absoluteString,
+            "https://status.openrouter.ai/"
+        )
+    }
+
+    func testOpenRouterStatusPageMapsOperationalHTML() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        let client = ProviderStatusClient(session: URLSession(configuration: configuration))
+
+        StubURLProtocol.handler = { request in
+            let url = try XCTUnwrap(request.url)
+            let response = try XCTUnwrap(
+                HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+            )
+            return (response, Data("<h1>All Systems Operational</h1>".utf8))
+        }
+
+        let report = try await client.fetchReport(for: .openRouter)
+
+        XCTAssertEqual(report.service, .openRouter)
+        XCTAssertEqual(report.summary.indicator, .none)
+        XCTAssertFalse(report.hasIssue)
     }
 
     @MainActor

--- a/MeterBarTests/ProviderVisibilityStoreTests.swift
+++ b/MeterBarTests/ProviderVisibilityStoreTests.swift
@@ -1,0 +1,22 @@
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+final class ProviderVisibilityStoreTests: XCTestCase {
+    func testOpenRouterRequiresExplicitOptInAndPersistsEnablement() {
+        let suiteName = "ProviderVisibilityStoreTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Could not create isolated defaults")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let initial = ProviderVisibilityStore(userDefaults: defaults)
+        XCTAssertFalse(initial.isEnabled(.openRouter))
+        XCTAssertTrue(initial.isEnabled(.claudeCode))
+
+        initial.set(.openRouter, isEnabled: true)
+        let reloaded = ProviderVisibilityStore(userDefaults: defaults)
+
+        XCTAssertTrue(reloaded.isEnabled(.openRouter))
+    }
+}

--- a/MeterBarTests/ServiceTypeTests.swift
+++ b/MeterBarTests/ServiceTypeTests.swift
@@ -7,28 +7,32 @@ final class ServiceTypeTests: XCTestCase {
         XCTAssertEqual(ServiceType.claudeCode.rawValue, "Claude Code")
         XCTAssertEqual(ServiceType.codexCli.rawValue, "Codex CLI")
         XCTAssertEqual(ServiceType.cursor.rawValue, "Cursor")
+        XCTAssertEqual(ServiceType.openRouter.rawValue, "OpenRouter")
     }
 
     func testDisplayNames() {
         XCTAssertEqual(ServiceType.claudeCode.displayName, "Claude Code")
         XCTAssertEqual(ServiceType.codexCli.displayName, "OpenAI Codex")
         XCTAssertEqual(ServiceType.cursor.displayName, "Cursor")
+        XCTAssertEqual(ServiceType.openRouter.displayName, "OpenRouter")
     }
 
     func testIconNames() {
         XCTAssertEqual(ServiceType.claudeCode.iconName, "terminal")
         XCTAssertEqual(ServiceType.codexCli.iconName, "terminal.fill")
         XCTAssertEqual(ServiceType.cursor.iconName, "cursorarrow.click")
+        XCTAssertEqual(ServiceType.openRouter.iconName, "point.3.connected.trianglepath.dotted")
     }
 
     func testIdProperty() {
         XCTAssertEqual(ServiceType.claudeCode.id, "Claude Code")
         XCTAssertEqual(ServiceType.codexCli.id, "Codex CLI")
         XCTAssertEqual(ServiceType.cursor.id, "Cursor")
+        XCTAssertEqual(ServiceType.openRouter.id, "OpenRouter")
     }
 
     func testAllCasesCount() {
-        XCTAssertEqual(ServiceType.allCases.count, 3)
+        XCTAssertEqual(ServiceType.allCases.count, 4)
     }
 
     func testCodable() throws {

--- a/MeterBarTests/SessionWakeControllerTests.swift
+++ b/MeterBarTests/SessionWakeControllerTests.swift
@@ -118,6 +118,30 @@ final class SessionWakeControllerTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(recorder.stopCount, 1)
     }
 
+    func testDisablingSelectedAccountStopsWatcherAndClearsSelection() {
+        let accounts = ClaudeCodeAccountStore(userDefaults: defaults)
+        let store = armedStore()
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: SessionWakeStatus(),
+            accounts: accounts,
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+        )
+        controller.activate()
+        poll { recorder.startCount >= 1 }
+
+        accounts.setEnabled(false, for: ClaudeCodeAccount.defaultID)
+
+        poll { !controller.isWatching }
+        XCTAssertFalse(controller.isWatching)
+        XCTAssertFalse(store.isOn)
+        XCTAssertNil(store.wakeAccountID)
+        poll { recorder.stopCount >= 1 }
+        XCTAssertGreaterThanOrEqual(recorder.stopCount, 1)
+    }
+
     func testStaysOffWhenToggleOff() {
         let store = SessionWakeSettingsStore(userDefaults: defaults) // off
         let recorder = WatchRecorder()

--- a/MeterBarTests/SessionWakeSettingsTests.swift
+++ b/MeterBarTests/SessionWakeSettingsTests.swift
@@ -123,6 +123,20 @@ final class SessionWakeSettingsTests: XCTestCase {
         XCTAssertFalse(store.isOn)
     }
 
+    func testDisablingSelectedAccountClearsItAndTurnsOff() {
+        let accounts = ClaudeCodeAccountStore(userDefaults: defaults)
+        let store = makeStore()
+        store.setWakeAccountID(ClaudeCodeAccount.defaultID)
+        store.acknowledgeFirstRunAndTurnOn()
+        XCTAssertTrue(store.isOn)
+
+        accounts.setEnabled(false, for: ClaudeCodeAccount.defaultID)
+        store.reconcileAccounts(available: accounts.enabledAccounts.map(\.id))
+
+        XCTAssertNil(store.wakeAccountID)
+        XCTAssertFalse(store.isOn)
+    }
+
     func testSwitchingAccountWhileArmedDisarms() {
         let accountA = UUID()
         let accountB = UUID()

--- a/MeterBarTests/SessionWakeStatusTests.swift
+++ b/MeterBarTests/SessionWakeStatusTests.swift
@@ -52,8 +52,8 @@ final class SessionWakeStatusTests: XCTestCase {
             "message": ["role": "assistant", "content": [["type": "text", "text": "session limit resets 3:00am (UTC)"]]]
         ]
         let data = try JSONSerialization.data(withJSONObject: object)
-        try String(decoding: data, as: UTF8.self)
-            .write(to: projects.appendingPathComponent("s0.jsonl"), atomically: true, encoding: .utf8)
+        let transcript = try XCTUnwrap(String(data: data, encoding: .utf8))
+        try transcript.write(to: projects.appendingPathComponent("s0.jsonl"), atomically: true, encoding: .utf8)
 
         let ledgerURL = tempDir.appendingPathComponent("l.json")
         let status = SessionWakeStatus(ledgerFactory: { ReplayLedger(fileURL: ledgerURL) })
@@ -64,27 +64,12 @@ final class SessionWakeStatusTests: XCTestCase {
 
     // MARK: - SwiftUI hosting
 
-    func testSettingsPaneHosts() {
-        let defaults = UserDefaults(suiteName: "hosting-\(UUID().uuidString)")!
-        let store = SessionWakeSettingsStore(userDefaults: defaults)
-        store.setWakeAccountID(UUID())
-        store.acknowledgeFirstRunAndTurnOn()
-        let view = SessionWakeSettingsView(store: store, status: SessionWakeStatus(), accounts: ClaudeCodeAccountStore(userDefaults: defaults))
-        let host = NSHostingView(rootView: view)
-        host.frame = NSRect(x: 0, y: 0, width: 520, height: 700)
-        host.layoutSubtreeIfNeeded()
-        XCTAssertGreaterThan(host.fittingSize.height, 100)
-    }
-
-    func testSettingsPaneHostsEmbeddedInDashboard() {
-        // The dashboard embeds the settings inside its own ScrollView, so the
-        // embedded variant must render without the grouped Form's nested scroll.
-        let defaults = UserDefaults(suiteName: "hosting-\(UUID().uuidString)")!
+    func testSettingsPaneHosts() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: "hosting-\(UUID().uuidString)"))
         let store = SessionWakeSettingsStore(userDefaults: defaults)
         store.setWakeAccountID(UUID())
         store.acknowledgeFirstRunAndTurnOn()
         let view = SessionWakeSettingsView(
-            embeddedInDashboard: true,
             store: store,
             status: SessionWakeStatus(),
             accounts: ClaudeCodeAccountStore(userDefaults: defaults)
@@ -106,8 +91,8 @@ final class SessionWakeStatusTests: XCTestCase {
         XCTAssertFalse(SessionWakeMenuControl.shouldShow(featureEnabled: false, isOn: true, canTurnOn: true))
     }
 
-    func testMenuControlHosts() {
-        let defaults = UserDefaults(suiteName: "hosting-\(UUID().uuidString)")!
+    func testMenuControlHosts() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: "hosting-\(UUID().uuidString)"))
         let view = SessionWakeMenuControl(
             store: SessionWakeSettingsStore(userDefaults: defaults),
             status: SessionWakeStatus()

--- a/MeterBarTests/SettingsViewSmokeTests.swift
+++ b/MeterBarTests/SettingsViewSmokeTests.swift
@@ -13,13 +13,4 @@ final class SettingsViewSmokeTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(hostingView.fittingSize.width, 840)
         XCTAssertGreaterThanOrEqual(hostingView.fittingSize.height, 560)
     }
-
-    func testEmbeddedSettingsBuildsAllDashboardSections() {
-        let hostingView = NSHostingView(rootView: SettingsView(embeddedInDashboard: true))
-        hostingView.frame = NSRect(x: 0, y: 0, width: 920, height: 1_200)
-        hostingView.layoutSubtreeIfNeeded()
-
-        XCTAssertGreaterThan(hostingView.fittingSize.width, 500)
-        XCTAssertGreaterThan(hostingView.fittingSize.height, 500)
-    }
 }

--- a/MeterBarTests/SharedDataStoreTests.swift
+++ b/MeterBarTests/SharedDataStoreTests.swift
@@ -71,4 +71,23 @@ final class SharedDataStoreTests: XCTestCase {
         XCTAssertEqual(Set(loaded.keys), [.cursor])
         XCTAssertEqual(loaded[.cursor]?.weeklyLimit?.used, 400)
     }
+
+    func testAccountMetricsRoundTripPreservesLabelsAndIndependentUsage() {
+        let store = SharedDataStore(directoryOverride: tempDirectory) {}
+        let snapshots = [
+            AccountUsageSnapshot(id: CodexAccount.defaultID, name: "Personal", metrics: MetricsFixtures.codexCli()),
+            AccountUsageSnapshot(
+                id: UUID(),
+                name: "Work",
+                metrics: MetricsFixtures.codexCli(sessionUsedPercent: 90, weeklyUsedPercent: 70)
+            )
+        ]
+
+        store.saveAccountMetrics(snapshots)
+        store.flushPendingWrites()
+
+        let loaded = store.loadAccountMetrics()
+        XCTAssertEqual(loaded.map(\.name), ["Personal", "Work"])
+        XCTAssertEqual(loaded.map { $0.metrics.sessionLimit?.used }, [30, 90])
+    }
 }

--- a/MeterBarTests/SparkleUpdateTests.swift
+++ b/MeterBarTests/SparkleUpdateTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+@testable import MeterBar
+import XCTest
+
+final class SparkleUpdateTests: XCTestCase {
+    func testKeyValidatorRejectsUnsubstitutedBuildVariable() {
+        // Debug and PR-gate builds never substitute the build setting, so the
+        // literal variable is exactly what ships in their Info.plist.
+        XCTAssertFalse(SoftwareUpdateController.isUsableEDPublicKey("$(SPARKLE_PUBLIC_ED_KEY)"))
+        XCTAssertFalse(SoftwareUpdateController.isUsableEDPublicKey("${SPARKLE_PUBLIC_ED_KEY}"))
+    }
+
+    func testKeyValidatorRejectsEmptyAndMalformedKeys() {
+        XCTAssertFalse(SoftwareUpdateController.isUsableEDPublicKey(""))
+        XCTAssertFalse(SoftwareUpdateController.isUsableEDPublicKey("   "))
+        XCTAssertFalse(SoftwareUpdateController.isUsableEDPublicKey("not base64!!"))
+        // Valid base64 of the wrong length is not an Ed25519 public key.
+        let shortKey = Data(repeating: 7, count: 16).base64EncodedString()
+        XCTAssertFalse(SoftwareUpdateController.isUsableEDPublicKey(shortKey))
+    }
+
+    func testKeyValidatorAcceptsWellFormedEd25519Key() {
+        let key = Data(repeating: 7, count: 32).base64EncodedString()
+        XCTAssertTrue(SoftwareUpdateController.isUsableEDPublicKey(key))
+        XCTAssertTrue(SoftwareUpdateController.isUsableEDPublicKey(" \(key) "))
+    }
+
+    func testCheckedInConfigurationRequiresAutomaticCheckConsent() throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let infoURL = repositoryRoot.appendingPathComponent("MeterBar/Info.plist")
+        let data = try Data(contentsOf: infoURL)
+        let plist = try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        )
+
+        XCTAssertEqual(plist["SUEnableAutomaticChecks"] as? Bool, false)
+        XCTAssertEqual(
+            plist["SUFeedURL"] as? String,
+            "https://github.com/VincentShipsIt/meterbar.dev/releases/latest/download/appcast.xml"
+        )
+        XCTAssertEqual(plist["SUPublicEDKey"] as? String, "$(SPARKLE_PUBLIC_ED_KEY)")
+    }
+
+    func testVersionComparatorOffers171To170() {
+        XCTAssertEqual("1.7.1".compare("1.7.0", options: .numeric), .orderedDescending)
+        XCTAssertEqual("1.7.0".compare("1.7.1", options: .numeric), .orderedAscending)
+        XCTAssertEqual("1.7.1".compare("1.7.1", options: .numeric), .orderedSame)
+    }
+
+    func testAppcastContractCarriesSignedReleaseArchive() throws {
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel>
+            <item>
+              <title>Version 1.7.1</title>
+              <sparkle:version>1.7.1</sparkle:version>
+              <sparkle:shortVersionString>1.7.1</sparkle:shortVersionString>
+              <enclosure
+                url="https://github.com/VincentShipsIt/meterbar.dev/releases/download/v1.7.1/MeterBar-v1.7.1.zip"
+                sparkle:edSignature="signed-update"
+                length="1234"
+                type="application/octet-stream" />
+            </item>
+          </channel>
+        </rss>
+        """
+
+        let document = try XMLDocument(xmlString: xml)
+        let enclosure = try XCTUnwrap(document.nodes(forXPath: "/rss/channel/item/enclosure").first as? XMLElement)
+        let item = try XCTUnwrap(document.nodes(forXPath: "/rss/channel/item").first as? XMLElement)
+
+        XCTAssertEqual(enclosure.attribute(forName: "url")?.stringValue?.hasSuffix("MeterBar-v1.7.1.zip"), true)
+        let namespace = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+        XCTAssertEqual(item.elements(forLocalName: "version", uri: namespace).first?.stringValue, "1.7.1")
+        XCTAssertEqual(item.elements(forLocalName: "shortVersionString", uri: namespace).first?.stringValue, "1.7.1")
+        XCTAssertFalse(try XCTUnwrap(enclosure.attributes?.first { $0.localName == "edSignature" }).stringValue?.isEmpty ?? true)
+
+        let temporaryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("meterbar-appcast-\(UUID().uuidString).xml")
+        try xml.write(to: temporaryURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: temporaryURL) }
+
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let verifier = repositoryRoot.appendingPathComponent("scripts/verify-appcast.sh")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [
+            verifier.path,
+            temporaryURL.path,
+            "1.7.1",
+            "MeterBar-v1.7.1.zip",
+            "https://github.com/VincentShipsIt/meterbar.dev/releases/download/v1.7.1/"
+        ]
+        try process.run()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0)
+    }
+}

--- a/MeterBarTests/StatusItemLimitSelectorTests.swift
+++ b/MeterBarTests/StatusItemLimitSelectorTests.swift
@@ -115,4 +115,11 @@ final class StatusItemLimitSelectorTests: XCTestCase {
         XCTAssertEqual(select([b, a])?.key, "claude:a")
         XCTAssertEqual(select([a, b])?.key, "claude:a")
     }
+
+    func testCodexAccountsCompeteIndependentlyByActivity() {
+        let idle = candidate(key: "codex:personal", percentUsed: 95)
+        let active = candidate(key: "codex:work", percentUsed: 45, activeMinutesAgo: 2)
+
+        XCTAssertEqual(select([idle, active])?.key, "codex:work")
+    }
 }

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import MeterBarShared
 import XCTest
@@ -102,6 +103,29 @@ final class UsageDataManagerTests: XCTestCase {
         // The merged snapshot is mirrored to the App Group file for the widget.
         sharedStore.flushPendingWrites()
         XCTAssertEqual(Set(sharedStore.loadMetrics().keys), [.codexCli, .cursor])
+    }
+
+    func testChangingRefreshIntervalPublishesToObservers() {
+        let savedRefreshInterval = UserDefaults.standard.object(forKey: StorageKeys.refreshInterval)
+        defer {
+            if let savedRefreshInterval {
+                UserDefaults.standard.set(savedRefreshInterval, forKey: StorageKeys.refreshInterval)
+            } else {
+                UserDefaults.standard.removeObject(forKey: StorageKeys.refreshInterval)
+            }
+        }
+
+        let codex = StubProvider(hasAccess: true, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: true, result: .success(MetricsFixtures.cursor()))
+        let (manager, _) = makeManager(codex: codex, cursor: cursor)
+        var publicationCount = 0
+        let cancellable = manager.objectWillChange.sink { publicationCount += 1 }
+        let newInterval: RefreshInterval = manager.refreshInterval == .fiveMinutes ? .manual : .fiveMinutes
+
+        manager.refreshInterval = newInterval
+
+        XCTAssertEqual(publicationCount, 1)
+        withExtendedLifetime(cancellable) {}
     }
 
     func testRefreshAllPreservesCachedMetricsWhenProviderFails() async {

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -13,7 +13,7 @@ import XCTest
 final class UsageDataManagerTests: XCTestCase {
 
     /// Stub provider whose access flag and fetch result are fully controlled.
-    private final class StubProvider: SimpleUsageProviding {
+    private final class StubProvider: SimpleUsageProviding, CodexUsageProviding {
         var hasAccess: Bool
         var result: Result<UsageMetrics, Error>
         private(set) var fetchCount = 0
@@ -27,9 +27,31 @@ final class UsageDataManagerTests: XCTestCase {
             fetchCount += 1
             return try result.get()
         }
+
+        func canAccess(account: CodexAccount) async -> Bool { hasAccess }
+        func fetchUsageMetrics(account: CodexAccount) async throws -> UsageMetrics {
+            try await fetchUsageMetrics()
+        }
     }
 
     private enum StubError: Error { case fetchFailed }
+
+    private final class MultiAccountCodexProvider: CodexUsageProviding {
+        let metricsByAccount: [UUID: UsageMetrics]
+
+        init(metricsByAccount: [UUID: UsageMetrics]) {
+            self.metricsByAccount = metricsByAccount
+        }
+
+        func canAccess(account: CodexAccount) async -> Bool {
+            metricsByAccount[account.id] != nil
+        }
+
+        func fetchUsageMetrics(account: CodexAccount) async throws -> UsageMetrics {
+            guard let metrics = metricsByAccount[account.id] else { throw StubError.fetchFailed }
+            return metrics
+        }
+    }
 
     private var tempDirectory: URL!
     private var createdSuiteNames: [String] = []
@@ -58,8 +80,9 @@ final class UsageDataManagerTests: XCTestCase {
     /// `.claudeCode`; `preload` seeds the on-disk cache before construction so
     /// graceful-degradation paths have something to preserve.
     private func makeManager(
-        codex: StubProvider,
+        codex: CodexUsageProviding,
         cursor: StubProvider,
+        codexAccountStore: CodexAccountStore? = nil,
         hidden: Set<ServiceType> = [],
         preload: [ServiceType: UsageMetrics] = [:],
         parseHealthStore: ProviderParseHealthStore? = nil
@@ -82,6 +105,7 @@ final class UsageDataManagerTests: XCTestCase {
         let manager = UsageDataManager(
             codexCliService: codex,
             cursorService: cursor,
+            codexAccountStore: codexAccountStore,
             providerVisibilityStore: visibility,
             sharedStore: sharedStore,
             cacheDefaults: cacheDefaults,
@@ -202,5 +226,32 @@ final class UsageDataManagerTests: XCTestCase {
         XCTAssertNil(manager.metrics[.cursor])
         sharedStore.flushPendingWrites()
         XCTAssertNil(sharedStore.loadMetrics()[.cursor])
+    }
+
+    func testRefreshAllFetchesIndependentCodexAccountsAndBridgesLabels() async throws {
+        let accountSuite = "UsageDataManagerTests-accounts-\(UUID().uuidString)"
+        createdSuiteNames.append(accountSuite)
+        let accountDefaults = try XCTUnwrap(UserDefaults(suiteName: accountSuite))
+        let accountStore = CodexAccountStore(userDefaults: accountDefaults)
+        accountStore.addAccount(name: "Work", homeDirectory: "/tmp/codex-work")
+        let work = try XCTUnwrap(accountStore.customAccounts.first)
+        let provider = MultiAccountCodexProvider(metricsByAccount: [
+            CodexAccount.defaultID: MetricsFixtures.codexCli(sessionUsedPercent: 20),
+            work.id: MetricsFixtures.codexCli(sessionUsedPercent: 80)
+        ])
+        let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+        let (manager, sharedStore) = makeManager(
+            codex: provider,
+            cursor: cursor,
+            codexAccountStore: accountStore
+        )
+
+        await manager.refreshAll()
+
+        XCTAssertEqual(manager.codexAccountMetrics[CodexAccount.defaultID]?.sessionLimit?.used, 20)
+        XCTAssertEqual(manager.codexAccountMetrics[work.id]?.sessionLimit?.used, 80)
+        XCTAssertEqual(manager.metrics[.codexCli]?.sessionLimit?.used, 20)
+        sharedStore.flushPendingWrites()
+        XCTAssertEqual(sharedStore.loadAccountMetrics().map(\.name), [CodexAccount.defaultName, "Work"])
     }
 }

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -61,7 +61,8 @@ final class UsageDataManagerTests: XCTestCase {
         codex: StubProvider,
         cursor: StubProvider,
         hidden: Set<ServiceType> = [],
-        preload: [ServiceType: UsageMetrics] = [:]
+        preload: [ServiceType: UsageMetrics] = [:],
+        parseHealthStore: ProviderParseHealthStore? = nil
     ) -> (manager: UsageDataManager, sharedStore: SharedDataStore) {
         let suiteName = "UsageDataManagerTests-\(UUID().uuidString)"
         createdSuiteNames.append(contentsOf: [suiteName, "\(suiteName)-vis"])
@@ -84,9 +85,25 @@ final class UsageDataManagerTests: XCTestCase {
             providerVisibilityStore: visibility,
             sharedStore: sharedStore,
             cacheDefaults: cacheDefaults,
+            parseHealthStore: parseHealthStore,
             schedulesAutoRefresh: false
         )
         return (manager, sharedStore)
+    }
+
+    func testRefreshRecordsSuccessAndFailureHealth() async {
+        let healthSuite = "UsageDataManagerHealthTests-\(UUID().uuidString)"
+        createdSuiteNames.append(healthSuite)
+        let health = ProviderParseHealthStore(userDefaults: UserDefaults(suiteName: healthSuite)!)
+        let codex = StubProvider(hasAccess: true, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: true, result: .failure(ServiceError.parsingError))
+        let (manager, _) = makeManager(codex: codex, cursor: cursor, parseHealthStore: health)
+
+        await manager.refreshAll()
+
+        XCTAssertEqual(health.records[.codexCli]?.consecutiveFailures, 0)
+        XCTAssertEqual(health.records[.cursor]?.consecutiveFailures, 1)
+        XCTAssertTrue(health.records[.cursor]?.lastFailureWasShapeMismatch ?? false)
     }
 
     func testRefreshAllMergesBothEnabledProviders() async {

--- a/MeterBarTests/UsageLimitTests.swift
+++ b/MeterBarTests/UsageLimitTests.swift
@@ -3,6 +3,28 @@ import MeterBarShared
 @testable import MeterBar
 
 final class UsageLimitTests: XCTestCase {
+    func testEstimatedPresentationLabelsAreExplicit() {
+        let reported = UsageLimit(used: 25, total: 100, resetTime: nil)
+        let estimated = UsageLimit(used: 25, total: 100, resetTime: nil, isEstimated: true)
+
+        XCTAssertFalse(reported.isEstimated)
+        XCTAssertEqual(reported.percentageText, "25%")
+        XCTAssertEqual(reported.percentLeftText, "75% left")
+        XCTAssertEqual(reported.usedPercentageText, "25% used")
+
+        XCTAssertTrue(estimated.isEstimated)
+        XCTAssertEqual(estimated.percentageText, "~25%")
+        XCTAssertEqual(estimated.percentLeftText, "~75% left")
+        XCTAssertEqual(estimated.usedPercentageText, "~25% used")
+    }
+
+    func testLegacyJSONWithoutEstimatedFlagDecodesAsReported() throws {
+        let data = Data(#"{"used":25,"total":100,"resetTime":null,"windowSeconds":null}"#.utf8)
+        let limit = try JSONDecoder().decode(UsageLimit.self, from: data)
+
+        XCTAssertFalse(limit.isEstimated)
+    }
+
     func testPercentageValues() {
         let limit = UsageLimit(used: 25, total: 100, resetTime: nil)
 

--- a/MeterBarWidget/UsageWidget.swift
+++ b/MeterBarWidget/UsageWidget.swift
@@ -32,10 +32,26 @@ struct UsageWidget: Widget {
 struct UsageWidgetEntry: TimelineEntry {
     let date: Date
     let metrics: [ServiceType: UsageMetrics]
+    let accountMetrics: [AccountUsageSnapshot]
 
-    var sortedServices: [ServiceType] {
-        metrics.keys.sorted { $0.sortOrder < $1.sortOrder }
+    var rows: [WidgetUsageRow] {
+        let accountServices = Set(accountMetrics.map { $0.metrics.service })
+        let accountRows = accountMetrics.map {
+            WidgetUsageRow(id: $0.id.uuidString, name: $0.name, metrics: $0.metrics)
+        }
+        let providerRows = metrics
+            .filter { !accountServices.contains($0.key) }
+            .map { WidgetUsageRow(id: $0.key.rawValue, name: $0.key.displayName, metrics: $0.value) }
+        return (accountRows + providerRows).sorted {
+            ($0.metrics.service.sortOrder, $0.name) < ($1.metrics.service.sortOrder, $1.name)
+        }
     }
+}
+
+struct WidgetUsageRow: Identifiable {
+    let id: String
+    let name: String
+    let metrics: UsageMetrics
 }
 
 struct UsageWidgetProvider: TimelineProvider {
@@ -55,14 +71,16 @@ struct UsageWidgetProvider: TimelineProvider {
                     service: .claudeCode,
                     weeklyLimit: UsageLimit(used: 90, total: 100, resetTime: nil)
                 )
-            ]
+            ],
+            accountMetrics: []
         )
     }
 
     func getSnapshot(in context: Context, completion: @escaping (UsageWidgetEntry) -> Void) {
         let entry = UsageWidgetEntry(
             date: Date(),
-            metrics: SharedMetricsStore.loadMetrics()
+            metrics: SharedMetricsStore.loadMetrics(),
+            accountMetrics: SharedMetricsStore.loadAccountMetrics()
         )
         completion(entry)
     }
@@ -71,7 +89,8 @@ struct UsageWidgetProvider: TimelineProvider {
         let cachedMetrics = SharedMetricsStore.loadMetrics()
         let entry = UsageWidgetEntry(
             date: Date(),
-            metrics: cachedMetrics
+            metrics: cachedMetrics,
+            accountMetrics: SharedMetricsStore.loadAccountMetrics()
         )
 
         let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: Date()) ?? Date()
@@ -103,15 +122,13 @@ struct SmallWidgetView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            if entry.metrics.isEmpty {
+            if entry.rows.isEmpty {
                 Text("No data")
                     .font(.caption)
                     .foregroundColor(.secondary)
             } else {
-                ForEach(entry.sortedServices.prefix(3), id: \.self) { service in
-                    if let metrics = entry.metrics[service] {
-                        ServiceMiniView(metrics: metrics)
-                    }
+                ForEach(Array(entry.rows.prefix(3))) { row in
+                    ServiceMiniView(row: row)
                 }
             }
         }
@@ -122,13 +139,20 @@ struct SmallWidgetView: View {
 }
 
 struct ServiceMiniView: View {
-    let metrics: UsageMetrics
+    let row: WidgetUsageRow
 
     var body: some View {
         HStack(spacing: 6) {
-            WidgetProviderIcon(service: metrics.service, size: 14)
+            Image(row.metrics.service.assetName)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 14, height: 14)
 
-            if let weeklyLimit = metrics.weeklyLimit {
+            Text(row.name)
+                .font(.caption2)
+                .lineLimit(1)
+
+            if let weeklyLimit = row.metrics.weeklyLimit {
                 ProgressView(value: weeklyLimit.clampedUsed, total: weeklyLimit.clampedTotal)
                     .tint(weeklyLimit.statusColor.color)
                 Text(limitSummary(weeklyLimit))
@@ -136,12 +160,12 @@ struct ServiceMiniView: View {
                     .foregroundColor(.secondary)
             }
 
-            WidgetStatusIndicator(status: metrics.overallStatus)
+            WidgetStatusIndicator(status: row.metrics.overallStatus)
         }
     }
 
     private func limitSummary(_ limit: UsageLimit) -> String {
-        if metrics.service == .openRouter {
+        if row.metrics.service == .openRouter {
             return String(format: "$%.2f", max(0, limit.total - limit.used))
         }
         return limit.percentageText
@@ -153,15 +177,13 @@ struct MediumWidgetView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            if entry.metrics.isEmpty {
+            if entry.rows.isEmpty {
                 Text("No services connected")
                     .font(.caption)
                     .foregroundColor(.secondary)
             } else {
-                ForEach(entry.sortedServices, id: \.self) { service in
-                    if let metrics = entry.metrics[service] {
-                        ServiceCompactView(metrics: metrics)
-                    }
+                ForEach(entry.rows) { row in
+                    ServiceCompactView(row: row)
                 }
             }
         }
@@ -176,7 +198,7 @@ struct LargeWidgetView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if entry.metrics.isEmpty {
+            if entry.rows.isEmpty {
                 VStack {
                     Image(systemName: "exclamationmark.triangle")
                         .font(.largeTitle)
@@ -187,13 +209,11 @@ struct LargeWidgetView: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                let services = Array(entry.sortedServices.prefix(7))
-                ForEach(Array(services.enumerated()), id: \.element) { index, service in
-                    if let metrics = entry.metrics[service] {
-                        ServiceCompactView(metrics: metrics)
-                        if index < services.count - 1 {
-                            Spacer()
-                        }
+                let rows = Array(entry.rows.prefix(7))
+                ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                    ServiceCompactView(row: row)
+                    if index < rows.count - 1 {
+                        Spacer()
                     }
                 }
             }
@@ -205,20 +225,23 @@ struct LargeWidgetView: View {
 }
 
 struct ServiceCompactView: View {
-    let metrics: UsageMetrics
+    let row: WidgetUsageRow
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
-                WidgetProviderIcon(service: metrics.service, size: 18)
-                Text(metrics.service.displayName)
+                Image(row.metrics.service.assetName)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 18, height: 18)
+                Text(row.name)
                     .font(.subheadline)
                     .bold()
                 Spacer()
-                WidgetStatusIndicator(status: metrics.overallStatus)
+                WidgetStatusIndicator(status: row.metrics.overallStatus)
             }
 
-            if let weeklyLimit = metrics.weeklyLimit {
+            if let weeklyLimit = row.metrics.weeklyLimit {
                 HStack {
                     ProgressView(value: weeklyLimit.clampedUsed, total: weeklyLimit.clampedTotal)
                         .tint(weeklyLimit.statusColor.color)
@@ -230,7 +253,7 @@ struct ServiceCompactView: View {
     }
 
     private func limitSummary(_ limit: UsageLimit) -> String {
-        if metrics.service == .openRouter {
+        if row.metrics.service == .openRouter {
             return String(format: "$%.2f left", max(0, limit.total - limit.used))
         }
         return limit.percentageText

--- a/MeterBarWidget/UsageWidget.swift
+++ b/MeterBarWidget/UsageWidget.swift
@@ -126,21 +126,25 @@ struct ServiceMiniView: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            Image(metrics.service.assetName)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 14, height: 14)
+            WidgetProviderIcon(service: metrics.service, size: 14)
 
             if let weeklyLimit = metrics.weeklyLimit {
                 ProgressView(value: weeklyLimit.clampedUsed, total: weeklyLimit.clampedTotal)
                     .tint(weeklyLimit.statusColor.color)
-                Text(weeklyLimit.percentageText)
+                Text(limitSummary(weeklyLimit))
                     .font(.caption2)
                     .foregroundColor(.secondary)
             }
 
             WidgetStatusIndicator(status: metrics.overallStatus)
         }
+    }
+
+    private func limitSummary(_ limit: UsageLimit) -> String {
+        if metrics.service == .openRouter {
+            return String(format: "$%.2f", max(0, limit.total - limit.used))
+        }
+        return limit.percentageText
     }
 }
 
@@ -206,10 +210,7 @@ struct ServiceCompactView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
-                Image(metrics.service.assetName)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 18, height: 18)
+                WidgetProviderIcon(service: metrics.service, size: 18)
                 Text(metrics.service.displayName)
                     .font(.subheadline)
                     .bold()
@@ -221,11 +222,18 @@ struct ServiceCompactView: View {
                 HStack {
                     ProgressView(value: weeklyLimit.clampedUsed, total: weeklyLimit.clampedTotal)
                         .tint(weeklyLimit.statusColor.color)
-                    Text(weeklyLimit.percentageText)
+                    Text(limitSummary(weeklyLimit))
                         .font(.caption)
                 }
             }
         }
+    }
+
+    private func limitSummary(_ limit: UsageLimit) -> String {
+        if metrics.service == .openRouter {
+            return String(format: "$%.2f left", max(0, limit.total - limit.used))
+        }
+        return limit.percentageText
     }
 }
 
@@ -235,10 +243,7 @@ struct ServiceDetailView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
-                Image(metrics.service.assetName)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 20, height: 20)
+                WidgetProviderIcon(service: metrics.service, size: 20)
                 Text(metrics.service.displayName)
                     .font(.headline)
                 Spacer()
@@ -246,11 +251,19 @@ struct ServiceDetailView: View {
             }
 
             if let sessionLimit = metrics.sessionLimit {
-                LimitDetailView(title: "Session", limit: sessionLimit)
+                LimitDetailView(
+                    title: metrics.service == .openRouter ? "Key limit" : "Session",
+                    limit: sessionLimit,
+                    currency: metrics.service == .openRouter
+                )
             }
 
             if let weeklyLimit = metrics.weeklyLimit {
-                LimitDetailView(title: "Weekly", limit: weeklyLimit)
+                LimitDetailView(
+                    title: metrics.service == .openRouter ? "Account credits" : "Weekly",
+                    limit: weeklyLimit,
+                    currency: metrics.service == .openRouter
+                )
             }
 
             if let codeReviewLimit = metrics.codeReviewLimit {
@@ -266,6 +279,7 @@ struct ServiceDetailView: View {
 struct LimitDetailView: View {
     let title: String
     let limit: UsageLimit
+    var currency = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -281,13 +295,14 @@ struct LimitDetailView: View {
             ProgressView(value: limit.clampedUsed, total: limit.clampedTotal)
                 .tint(limit.statusColor.color)
 
-            Text(
-                "\(formatNumber(limit.used)) / "
-                    + "\(limit.isEstimated ? "~" : "")\(formatNumber(limit.total))"
-            )
+            Text(currency ? currencyText : "\(formatNumber(limit.used)) / \(limit.isEstimated ? "~" : "")\(formatNumber(limit.total))")
                 .font(.caption2)
                 .foregroundColor(.secondary)
         }
+    }
+
+    private var currencyText: String {
+        "$\(String(format: "%.2f", limit.used)) spent / $\(String(format: "%.2f", limit.total))"
     }
 
     private func formatNumber(_ value: Double) -> String {
@@ -295,6 +310,24 @@ struct LimitDetailView: View {
             return String(format: "%.1fk", value / 1000)
         }
         return String(format: "%.0f", value)
+    }
+}
+
+struct WidgetProviderIcon: View {
+    let service: ServiceType
+    let size: CGFloat
+
+    var body: some View {
+        if service == .openRouter {
+            Image(systemName: service.iconName)
+                .font(.system(size: size, weight: .semibold))
+                .frame(width: size, height: size)
+        } else {
+            Image(service.assetName)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: size, height: size)
+        }
     }
 }
 

--- a/MeterBarWidget/UsageWidget.swift
+++ b/MeterBarWidget/UsageWidget.swift
@@ -134,7 +134,7 @@ struct ServiceMiniView: View {
             if let weeklyLimit = metrics.weeklyLimit {
                 ProgressView(value: weeklyLimit.clampedUsed, total: weeklyLimit.clampedTotal)
                     .tint(weeklyLimit.statusColor.color)
-                Text("\(Int(weeklyLimit.percentage))%")
+                Text(weeklyLimit.percentageText)
                     .font(.caption2)
                     .foregroundColor(.secondary)
             }
@@ -221,7 +221,7 @@ struct ServiceCompactView: View {
                 HStack {
                     ProgressView(value: weeklyLimit.clampedUsed, total: weeklyLimit.clampedTotal)
                         .tint(weeklyLimit.statusColor.color)
-                    Text("\(Int(weeklyLimit.percentage))%")
+                    Text(weeklyLimit.percentageText)
                         .font(.caption)
                 }
             }
@@ -273,7 +273,7 @@ struct LimitDetailView: View {
                 Text(title)
                     .font(.caption)
                 Spacer()
-                Text("\(Int(limit.percentage))%")
+                Text(limit.percentageText)
                     .font(.caption)
                     .bold()
             }
@@ -281,7 +281,10 @@ struct LimitDetailView: View {
             ProgressView(value: limit.clampedUsed, total: limit.clampedTotal)
                 .tint(limit.statusColor.color)
 
-            Text("\(formatNumber(limit.used)) / \(formatNumber(limit.total))")
+            Text(
+                "\(formatNumber(limit.used)) / "
+                    + "\(limit.isEstimated ? "~" : "")\(formatNumber(limit.total))"
+            )
                 .font(.caption2)
                 .foregroundColor(.secondary)
         }

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
             path: "MeterBar",
             exclude: [
                 "App/MeterBarApp.swift",
+                "Info.plist",
                 "MeterBar.entitlements",
                 "Assets.xcassets",
                 "Resources"

--- a/Packages/MeterBarShared/Sources/MeterBarShared/AccountUsageSnapshot.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/AccountUsageSnapshot.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// A labeled provider account for surfaces that can render more than one
+/// account per service, such as the widget.
+public struct AccountUsageSnapshot: Codable, Identifiable, Sendable {
+    public let id: UUID
+    public let name: String
+    public let metrics: UsageMetrics
+
+    public init(id: UUID, name: String, metrics: UsageMetrics) {
+        self.id = id
+        self.name = name
+        self.metrics = metrics
+    }
+}

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
@@ -39,6 +39,7 @@ public enum ReadinessCheckID {
     public static let auth = "auth"
     public static let data = "data"
     public static let refresh = "refresh"
+    public static let parseHealth = "parse-health"
 }
 
 /// One evaluated check: a pass/warn/fail plus a redacted, plain-language detail

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
@@ -206,6 +206,17 @@ public struct CursorReadinessInput: Sendable {
     }
 }
 
+/// Fixture-able facts for the API-key-backed OpenRouter provider.
+public struct OpenRouterReadinessInput: Sendable {
+    public var hasAPIKey: Bool
+    public var refreshError: String?
+
+    public init(hasAPIKey: Bool, refreshError: String? = nil) {
+        self.hasAPIKey = hasAPIKey
+        self.refreshError = refreshError
+    }
+}
+
 // MARK: - Evaluator
 
 public enum ProviderReadinessEvaluator {
@@ -477,6 +488,36 @@ public enum ProviderReadinessEvaluator {
                 recovery: "Quit Cursor (its database locks while running), then rescan."
             )
         }
+    }
+
+    // MARK: OpenRouter
+
+    public static func openRouter(_ input: OpenRouterReadinessInput) -> ProviderReadiness {
+        let installed = ReadinessCheck(
+            id: ReadinessCheckID.installed,
+            title: "App required",
+            level: .pass,
+            detail: "No local OpenRouter app or CLI is required."
+        )
+        let auth = ReadinessCheck(
+            id: ReadinessCheckID.auth,
+            title: "API key",
+            level: input.hasAPIKey ? .pass : .fail,
+            detail: input.hasAPIKey ? "OpenRouter API key is configured." : "OpenRouter API key is missing.",
+            recovery: input.hasAPIKey ? nil : "Add an API key in MeterBar Settings."
+        )
+        let data = ReadinessCheck(
+            id: ReadinessCheckID.data,
+            title: "Usage readable",
+            level: input.hasAPIKey ? .pass : .warn,
+            detail: input.hasAPIKey
+                ? "Credits and per-key limits can be fetched from OpenRouter."
+                : "Usage becomes readable after an API key is configured."
+        )
+        return ProviderReadiness(
+            provider: .openRouter,
+            checks: [installed, auth, data, refreshCheck(input.refreshError)]
+        )
     }
 
     // MARK: Shared

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ServiceType.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ServiceType.swift
@@ -7,6 +7,7 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
     case claudeCode = "Claude Code"
     case codexCli = "Codex CLI"
     case cursor = "Cursor"
+    case openRouter = "OpenRouter"
 
     public var id: String { rawValue }
 
@@ -15,6 +16,7 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
         case .claudeCode: return "Claude Code"
         case .codexCli: return "OpenAI Codex"
         case .cursor: return "Cursor"
+        case .openRouter: return "OpenRouter"
         }
     }
 
@@ -24,6 +26,7 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
         case .claudeCode: return "terminal"
         case .codexCli: return "terminal.fill"
         case .cursor: return "cursorarrow.click"
+        case .openRouter: return "point.3.connected.trianglepath.dotted"
         }
     }
 
@@ -34,6 +37,7 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
         case .claudeCode: return "ClaudeIcon"
         case .codexCli: return "CodexIcon"
         case .cursor: return "CursorIcon"
+        case .openRouter: return "OpenRouterIcon"
         }
     }
 
@@ -43,6 +47,7 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
         case .claudeCode: return 0
         case .codexCli: return 1
         case .cursor: return 2
+        case .openRouter: return 3
         }
     }
 }

--- a/Packages/MeterBarShared/Sources/MeterBarShared/SharedMetricsStore.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/SharedMetricsStore.swift
@@ -18,6 +18,7 @@ public enum SharedMetricsStore {
     /// Base name (no extension) of the cached-metrics blob. Also the app's
     /// in-process UserDefaults cache key (see `StorageKeys.cachedUsageMetrics`).
     public static let metricsKey = "cached_usage_metrics"
+    public static let accountMetricsKey = "cached_usage_account_metrics"
 
     /// The shared App Group container, or `nil` when App Groups aren't
     /// provisioned for the running target.
@@ -30,6 +31,10 @@ public enum SharedMetricsStore {
         containerURL?.appendingPathComponent("\(metricsKey).json")
     }
 
+    public static var accountMetricsFileURL: URL? {
+        containerURL?.appendingPathComponent("\(accountMetricsKey).json")
+    }
+
     /// Decode the cached metrics, tolerating a missing file or malformed entries
     /// (an unknown service key drops that entry, not the whole cache — see
     /// `MetricsCodec.decode`). Returns an empty map when nothing is readable.
@@ -39,5 +44,14 @@ public enum SharedMetricsStore {
             return [:]
         }
         return MetricsCodec.decode(data)
+    }
+
+    public static func loadAccountMetrics() -> [AccountUsageSnapshot] {
+        guard let accountMetricsFileURL,
+              let data = try? Data(contentsOf: accountMetricsFileURL),
+              let decoded = try? JSONDecoder().decode([AccountUsageSnapshot].self, from: data) else {
+            return []
+        }
+        return decoded
     }
 }

--- a/Packages/MeterBarShared/Sources/MeterBarShared/UsageLimit.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/UsageLimit.swift
@@ -5,12 +5,39 @@ public struct UsageLimit: Codable, Equatable, Sendable {
     public let total: Double
     public let resetTime: Date?
     public let windowSeconds: TimeInterval?
+    /// True when MeterBar substituted or derived the quota total instead of
+    /// receiving it from the provider.
+    public let isEstimated: Bool
 
-    public init(used: Double, total: Double, resetTime: Date?, windowSeconds: TimeInterval? = nil) {
+    public init(
+        used: Double,
+        total: Double,
+        resetTime: Date?,
+        windowSeconds: TimeInterval? = nil,
+        isEstimated: Bool = false
+    ) {
         self.used = used
         self.total = total
         self.resetTime = resetTime
         self.windowSeconds = windowSeconds
+        self.isEstimated = isEstimated
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case used
+        case total
+        case resetTime
+        case windowSeconds
+        case isEstimated
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        used = try container.decode(Double.self, forKey: .used)
+        total = try container.decode(Double.self, forKey: .total)
+        resetTime = try container.decodeIfPresent(Date.self, forKey: .resetTime)
+        windowSeconds = try container.decodeIfPresent(TimeInterval.self, forKey: .windowSeconds)
+        isEstimated = try container.decodeIfPresent(Bool.self, forKey: .isEstimated) ?? false
     }
 
     public var rawPercentage: Double {
@@ -20,6 +47,25 @@ public struct UsageLimit: Codable, Equatable, Sendable {
 
     public var percentage: Double {
         return min(100, rawPercentage)
+    }
+
+    /// User-facing percentage labels shared by the app, widget, and CLI. A
+    /// leading approximation mark prevents heuristic totals from looking like
+    /// provider-reported measurements.
+    public var percentageText: String {
+        "\(estimatePrefix)\(Int(percentage.rounded()))%"
+    }
+
+    public var percentLeftText: String {
+        "\(estimatePrefix)\(QuotaMath.percentLeft(for: self))% left"
+    }
+
+    public var usedPercentageText: String {
+        "\(percentageText) used"
+    }
+
+    private var estimatePrefix: String {
+        isEstimated ? "~" : ""
     }
 
     /// `used` clamped into `0...total`, for progress bars that reject

--- a/README.md
+++ b/README.md
@@ -75,11 +75,17 @@ To update:
 brew upgrade --cask VincentShipsIt/tap/meterbar
 ```
 
+Homebrew installations continue to update through Homebrew. Direct-download builds from v1.7.1 onward can also use **Settings → General → Software Update**. Automatic checks are disabled until you explicitly opt in; **Check Now** always performs a one-time manual check.
+
 ### Manual Download
 
 Download the latest release from [meterbar.dev](https://meterbar.dev).
 
 Releases after v1.6.1 are Developer ID signed and notarized, so direct downloads open without Gatekeeper warnings. For v1.6.1 and earlier (ad-hoc signed only), right-click and select "Open" the first time, or run `xattr -cr /Applications/MeterBar.app`.
+
+Starting with v1.7.1, direct-download releases include Sparkle 2 and consume an EdDSA-signed `appcast.xml` published with each GitHub Release. Older versions without Sparkle cannot discover v1.7.1 automatically and must be upgraded once manually.
+
+Maintainer setup and release verification are documented in [docs/sparkle-updates.md](docs/sparkle-updates.md).
 
 ### Build from Source
 

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -1,0 +1,39 @@
+# Sparkle Update Setup
+
+MeterBar direct-download builds use Sparkle 2.9.4. Homebrew remains a supported, independent update path.
+
+## One-time signing setup
+
+1. Resolve the Xcode package and locate Sparkle's tools under the Derived Data `SourcePackages/artifacts/sparkle/Sparkle/bin/` directory.
+2. Run `generate_keys --account meterbar` once, then export it with `generate_keys --account meterbar -x /secure/path/meterbar-sparkle-private-key`. Back up that private key outside the repository.
+3. Add the printed base64 public key to the `release` GitHub environment as the Actions variable `SPARKLE_PUBLIC_ED_KEY`.
+4. Add the exported private-key contents to the `release` GitHub environment as the Actions secret `SPARKLE_PRIVATE_ED_KEY`.
+
+The release workflow fails before building if either value is absent. Never commit the private key or pass it as a command-line argument; CI pipes the secret to `generate_appcast --ed-key-file -` over standard input.
+
+## Release behavior
+
+For a canonical `vMAJOR.MINOR.PATCH` tag, `.github/workflows/release.yml`:
+
+1. embeds the public key and stable GitHub Releases feed URL in `MeterBar.app`;
+2. signs, notarizes, and staples the universal app;
+3. creates the final ZIP;
+4. uses Sparkle's `generate_appcast` to add the ZIP's EdDSA signature;
+5. validates the version, archive URL, length, and signature; and
+6. publishes the ZIP, SHA-256 file, and `appcast.xml` in the same GitHub Release.
+
+The app reads the feed from `https://github.com/VincentShipsIt/meterbar.dev/releases/latest/download/appcast.xml`. Automatic checks default off and begin only after explicit consent in Settings. A manual **Check Now** remains available.
+
+## Verification
+
+Before tagging, run:
+
+```bash
+swift test --filter SparkleUpdateTests
+shellcheck scripts/verify-appcast.sh scripts/sign-and-verify-release.sh
+actionlint .github/workflows/release.yml
+```
+
+After publishing, install the prior Sparkle-enabled release, choose **Settings → General → Check Now**, and complete the update. Versions before v1.7.1 do not contain Sparkle and require one manual upgrade.
+
+Treat key rotation as a release migration. Follow Sparkle's official key-rotation procedure and never change the app bundle identifier (`dev.meterbar.app`).

--- a/scripts/sign-and-verify-release.sh
+++ b/scripts/sign-and-verify-release.sh
@@ -63,14 +63,20 @@ verify_universal_binary "$widget_binary" "Widget"
 verify_universal_binary "$cli_binary" "CLI"
 
 app_version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$app_path/Contents/Info.plist")
+app_build_version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$app_path/Contents/Info.plist")
 cli_version=$("$cli_binary" --version)
 
 echo "Tag version: $expected_version"
 echo "App version: $app_version"
+echo "App build version: $app_build_version"
 echo "CLI version: $cli_version"
 
 if [ "$app_version" != "$expected_version" ]; then
   echo "App version $app_version does not match release version $expected_version." >&2
+  exit 1
+fi
+if [ "$app_build_version" != "$expected_version" ]; then
+  echo "App build version $app_build_version does not match release version $expected_version." >&2
   exit 1
 fi
 if [ "$cli_version" != "$expected_version" ]; then
@@ -110,13 +116,42 @@ sign_code() {
   fi
 }
 
+# Sparkle's helpers have distinct signing requirements. In particular, the
+# Downloader XPC service carries an entitlement that must survive re-signing.
+# Sign these leaves explicitly before sealing Sparkle.framework; `--deep` would
+# incorrectly apply one entitlement set to every nested executable.
+sparkle_framework="$app_path/Contents/Frameworks/Sparkle.framework"
+if [ -d "$sparkle_framework" ]; then
+  sparkle_version="$sparkle_framework/Versions/B"
+  for helper in \
+    "$sparkle_version/XPCServices/Installer.xpc" \
+    "$sparkle_version/Autoupdate" \
+    "$sparkle_version/Updater.app"; do
+    if [ -e "$helper" ]; then
+      echo "Signing Sparkle helper: $helper"
+      sign_code "$helper"
+    fi
+  done
+
+  sparkle_downloader="$sparkle_version/XPCServices/Downloader.xpc"
+  if [ -e "$sparkle_downloader" ]; then
+    echo "Signing Sparkle helper with preserved entitlements: $sparkle_downloader"
+    sign_code "$sparkle_downloader" --preserve-metadata=entitlements
+  fi
+
+  echo "Signing Sparkle framework: $sparkle_framework"
+  sign_code "$sparkle_framework"
+fi
+
 # Sign leaf code first so each containing bundle is sealed only after its
-# contents are final. Framework directories are currently absent, but handling
-# them here prevents a future embedded dependency from silently invalidating the
-# outer signature.
+# contents are final. Sparkle is handled above because its helpers need
+# entitlement-aware signing.
 for frameworks_path in "$widget_path/Contents/Frameworks" "$app_path/Contents/Frameworks"; do
   if [ -d "$frameworks_path" ]; then
     while IFS= read -r -d '' nested_code; do
+      if [ "$nested_code" = "$sparkle_framework" ]; then
+        continue
+      fi
       echo "Signing nested code: $nested_code"
       sign_code "$nested_code"
     done < <(find "$frameworks_path" -depth \( -name '*.framework' -o -name '*.dylib' \) -print0)
@@ -130,6 +165,9 @@ sign_code "$app_path" --entitlements "$app_entitlements"
 codesign --verify --strict --verbose=2 "$cli_binary"
 codesign --verify --strict --verbose=2 "$widget_path"
 codesign --verify --deep --strict --verbose=2 "$app_path"
+if [ -d "$sparkle_framework" ]; then
+  codesign --verify --deep --strict --verbose=2 "$sparkle_framework"
+fi
 
 temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/meterbar-release-entitlements.XXXXXX")
 trap 'rm -rf "$temporary_directory"' EXIT

--- a/scripts/verify-appcast.sh
+++ b/scripts/verify-appcast.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "usage: $0 <appcast.xml> <version> <archive-name> <download-url-prefix>" >&2
+  exit 64
+fi
+
+APPCAST=$1
+VERSION=$2
+ARCHIVE_NAME=$3
+DOWNLOAD_URL_PREFIX=${4%/}/
+
+xpath_string() {
+  xmllint --xpath "string((//*[local-name()='enclosure'])[1]/@$1)" "$APPCAST"
+}
+
+xpath_namespaced_attribute() {
+  xmllint --xpath "string((//*[local-name()='enclosure'])[1]/@*[local-name()='$1'])" "$APPCAST"
+}
+
+xpath_item_element() {
+  xmllint --xpath "string((//*[local-name()='item'])[1]/*[local-name()='$1'][1])" "$APPCAST"
+}
+
+ACTUAL_VERSION=$(xpath_item_element version)
+ACTUAL_SHORT_VERSION=$(xpath_item_element shortVersionString)
+ACTUAL_SIGNATURE=$(xpath_namespaced_attribute edSignature)
+ACTUAL_LENGTH=$(xpath_string length)
+ACTUAL_URL=$(xpath_string url)
+
+if [ "$ACTUAL_VERSION" != "$VERSION" ] || [ "$ACTUAL_SHORT_VERSION" != "$VERSION" ]; then
+  echo "appcast version mismatch: expected $VERSION, got $ACTUAL_VERSION / $ACTUAL_SHORT_VERSION" >&2
+  exit 1
+fi
+
+if [ -z "$ACTUAL_SIGNATURE" ]; then
+  echo "appcast enclosure is missing sparkle:edSignature" >&2
+  exit 1
+fi
+
+if ! [[ "$ACTUAL_LENGTH" =~ ^[1-9][0-9]*$ ]]; then
+  echo "appcast enclosure has invalid length: $ACTUAL_LENGTH" >&2
+  exit 1
+fi
+
+if [ "$ACTUAL_URL" != "${DOWNLOAD_URL_PREFIX}${ARCHIVE_NAME}" ]; then
+  echo "appcast URL mismatch: expected ${DOWNLOAD_URL_PREFIX}${ARCHIVE_NAME}, got $ACTUAL_URL" >&2
+  exit 1
+fi
+
+echo "Sparkle appcast verified for $VERSION ($ARCHIVE_NAME)."

--- a/scripts/verify-build-identities.sh
+++ b/scripts/verify-build-identities.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repository_root=$(cd "$script_dir/.." && pwd)
+project="$repository_root/MeterBar.xcodeproj"
+temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/meterbar-build-identities.XXXXXX")
+trap 'rm -rf "$temporary_directory"' EXIT
+
+read_setting() {
+  local settings_file="$1"
+  local key="$2"
+
+  plutil -extract "0.buildSettings.$key" raw -o - "$settings_file"
+}
+
+assert_setting() {
+  local settings_file="$1"
+  local key="$2"
+  local expected="$3"
+  local actual
+
+  actual=$(read_setting "$settings_file" "$key")
+  if [ "$actual" != "$expected" ]; then
+    echo "$key mismatch: expected '$expected', got '$actual'." >&2
+    exit 1
+  fi
+}
+
+verify_target() {
+  local target="$1"
+  local configuration="$2"
+  local expected_bundle_identifier="$3"
+  local expected_product_name="$4"
+  local expected_full_product_name="$5"
+  local expected_display_name="${6:-}"
+  local settings_file="$temporary_directory/${target}-${configuration}.json"
+
+  xcodebuild \
+    -project "$project" \
+    -scheme "$target" \
+    -configuration "$configuration" \
+    -destination 'generic/platform=macOS' \
+    -showBuildSettings \
+    -json > "$settings_file"
+
+  assert_setting "$settings_file" PRODUCT_BUNDLE_IDENTIFIER "$expected_bundle_identifier"
+  assert_setting "$settings_file" PRODUCT_NAME "$expected_product_name"
+  assert_setting "$settings_file" FULL_PRODUCT_NAME "$expected_full_product_name"
+  if [ -n "$expected_display_name" ]; then
+    assert_setting "$settings_file" INFOPLIST_KEY_CFBundleDisplayName "$expected_display_name"
+  fi
+}
+
+verify_target MeterBar Debug dev.meterbar.app.debug "MeterBar Dev" "MeterBar Dev.app" "MeterBar Dev"
+verify_target MeterBarWidgetExtension Debug \
+  dev.meterbar.app.debug.Widget MeterBarWidgetExtension MeterBarWidgetExtension.appex "MeterBarWidget Dev"
+verify_target MeterBar Release dev.meterbar.app MeterBar MeterBar.app
+verify_target MeterBarWidgetExtension Release \
+  dev.meterbar.app.Widget MeterBarWidgetExtension MeterBarWidgetExtension.appex MeterBarWidget
+
+echo "Debug and Release app/widget identities verified."


### PR DESCRIPTION
Batches the 11 open v1.7.1 PRs into one CI-validated, conflict-resolved, linear integration. Each was reviewed (4 parallel review agents), fixes applied, conflicts resolved holistically, and the full universal Release build + test suite pass locally.

Squash-merging this lands all of the following (originating PRs will be closed, referencing this):

- #157 consolidate native settings
- #158 Liquid Glass P1 fixes
- #152 label heuristic quota estimates
- #162 OpenRouter provider support
- #156 provider parse health  — *fix applied: require 2 consecutive shape mismatches before flagging drift*
- #155 first-run onboarding — *fix applied: never re-onboard existing installs on upgrade*
- #161 settings polish
- #163 per-profile enable controls
- #164 Codex multi-account — *fix applied: MARK label; codex parse-health recording; widget row scope*
- #160 isolate Debug app identity
- #159 signed Sparkle updates — *fix applied: reject unsubstituted key placeholder in updater guard; pbxproj static-plist reconciliation preserving Debug identity*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenRouter support, including credit, key-limit, status, readiness, CLI, widget, and dashboard integrations.
  * Added support for multiple Claude and Codex accounts, with independent enablement, usage tracking, and configuration.
  * Added first-run onboarding and improved setup guidance.
  * Added Sparkle-based software updates with an optional automatic update setting and “Check Now” control.
  * Added estimated-usage labels and improved accessibility information for charts and usage details.

* **Improvements**
  * Consolidated app settings into the native macOS Settings experience.
  * Improved account-specific notifications, activity monitoring, and provider health indicators.
  * Improved release validation and update delivery reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->