### PR TITLE
feat(updates): in-app Nightly channel + reusable signed-build workflow

### DIFF
--- a/.agents/SESSIONS/2026-07-13.md
+++ b/.agents/SESSIONS/2026-07-13.md
@@ -23,3 +23,30 @@
 
 - OpenRouter is disabled by default because it requires an explicitly supplied API key.
 - Account credits use the shared weekly slot and per-key caps use the shared session slot, with currency-specific labels on every user-facing surface.
+
+## Session 2: Nightly / master update channel
+
+**Status:** Complete
+
+### What was done
+
+- Added an in-app **Update channel** (Stable / Nightly) so one installed MeterBar can update itself to master builds without a tagged release. Nightly = Sparkle feed swap, not a side-by-side app.
+- `SoftwareUpdateController`: `UpdateChannel` enum + pure `resolvedFeedURLString(for:)` / channel persistence helpers (outside the Sparkle gate, so the no-Sparkle test target covers them); a retained `ChannelUpdaterDelegate` implementing `feedURLString(for:)` now passed as `updaterDelegate` (was `nil`). Nightly feed = rolling `nightly` pre-release.
+- `SettingsView`: Stable/Nightly picker row in the software-update section.
+- Extracted the entire signed build+notarize+publish pipeline into a reusable `_build-signed.yml` (`workflow_call`); `release.yml` is now a thin caller and new `nightly.yml` runs daily (07:09 UTC) + on dispatch, publishing a rolling `nightly` pre-release with fixed `MeterBar-nightly.zip` / `appcast-nightly.xml` names.
+- Generalized `sign-and-verify-release.sh` (short vs build version pair) and `verify-appcast.sh` (optional short-version arg) for the decoupled nightly version scheme; stable callers unchanged.
+
+### Verification
+
+- `actionlint` on `_build-signed.yml`, `release.yml`, `nightly.yml` — passed.
+- `bash -n` on both changed scripts — passed; 2-arg `sign-and-verify` (ci.yml) and 4-arg `verify-appcast` (test) contracts preserved.
+- `swiftlint --quiet` on changed Swift — no new violations.
+- Full `swift test` / Xcode build deferred to CI (MacBook local-verification policy).
+
+### Decisions
+
+- **Version scheme decouples the two fields:** nightly `CFBundleVersion` = `<latest-stable>.<commits>` (e.g. `1.7.1.42`, Sparkle ordering key); `CFBundleShortVersionString` = `<latest-stable>-nightly.<N>+<sha>` (display). Sorts `1.7.1 < 1.7.1.42 < 1.7.2`, so a newer nightly always wins and the next stable overtakes any nightly — switching back to Stable auto-updates cleanly once the next tag ships.
+- **Feed swap, not Sparkle channels:** the nightly feed holds only nightly items, so `feedURLString(for:)` alone suffices — avoids the `allowedChannels` "filtered → nothing offered" failure mode.
+- **Reusable workflow injects `MARKETING_VERSION`/`CURRENT_PROJECT_VERSION` explicitly**, removing stable's prior hidden dependency on a pre-tag pbxproj bump (robustness win). Behaviour to watch: the next real `v*` tag must still cut an identical stable release through the refactored pipeline.
+- Homebrew tracks stable only; the `update-homebrew` job stays in `release.yml`.
+- Nightly reuses the same Developer ID + EdDSA key; no new secrets. The `release` GitHub environment must permit the scheduled nightly run (no required reviewers, or add the nightly workflow).

--- a/.github/workflows/_build-signed.yml
+++ b/.github/workflows/_build-signed.yml
@@ -1,0 +1,453 @@
+name: Build signed release
+
+# Reusable build+sign+notarize+publish pipeline shared by the stable Release
+# workflow (tag-triggered) and the Nightly workflow (schedule/dispatch). The two
+# channels differ only in the version scheme, feed/archive names, and whether the
+# publish rolls a moving tag — everything below is identical, so it lives here
+# once instead of being duplicated and drifting.
+on:
+  workflow_call:
+    inputs:
+      short_version:
+        description: 'CFBundleShortVersionString (display). e.g. 1.7.1 or 1.7.1-nightly.42+a1b2c3d'
+        required: true
+        type: string
+      build_version:
+        description: 'CFBundleVersion (Sparkle ordering key). e.g. 1.7.1 or 1.7.1.42'
+        required: true
+        type: string
+      release_tag:
+        description: 'Git tag / GitHub Release to publish under. e.g. v1.7.1 or nightly'
+        required: true
+        type: string
+      download_prefix:
+        description: 'Download URL prefix for the appcast enclosure (trailing slash).'
+        required: true
+        type: string
+      appcast_name:
+        description: 'Published appcast filename. e.g. appcast.xml or appcast-nightly.xml'
+        required: true
+        type: string
+      zip_name:
+        description: 'Published archive filename. e.g. MeterBar-v1.7.1.zip or MeterBar-nightly.zip'
+        required: true
+        type: string
+      prerelease:
+        description: 'Mark the GitHub Release as a pre-release.'
+        required: false
+        type: boolean
+        default: false
+      rolling:
+        description: 'Move the tag to HEAD and replace assets (nightly). Deletes the prior release+tag first.'
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      release_tag:
+        description: 'The tag the release was published under.'
+        value: ${{ inputs.release_tag }}
+      sha256:
+        description: 'SHA256 of the published archive.'
+        value: ${{ jobs.build.outputs.sha256 }}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: macos-26
+    timeout-minutes: 60
+    environment: release
+    permissions:
+      contents: write
+    env:
+      APP_PATH: ${{ github.workspace }}/build/Build/Products/Release/MeterBar.app
+      SPARKLE_PUBLIC_ED_KEY: ${{ vars.SPARKLE_PUBLIC_ED_KEY }}
+      # notarytool keychain-profile name (stored in the temp keychain at runtime).
+      NOTARY_PROFILE: asc-profile
+      # Inputs surfaced as env so shell code never interpolates untrusted context.
+      SHORT_VERSION: ${{ inputs.short_version }}
+      BUILD_VERSION: ${{ inputs.build_version }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      DOWNLOAD_PREFIX: ${{ inputs.download_prefix }}
+      APPCAST_NAME: ${{ inputs.appcast_name }}
+      ZIP_NAME: ${{ inputs.zip_name }}
+
+    outputs:
+      sha256: ${{ steps.package.outputs.sha256 }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      # Resolve ephemeral file paths under RUNNER_TEMP (outside the workspace) and
+      # export them for later steps. The `runner` context is NOT available in
+      # job-level `env:`, so these are computed here where $RUNNER_TEMP is a real
+      # shell variable, then written fully-resolved into $GITHUB_ENV.
+      - name: Configure signing paths
+        run: |
+          set -euo pipefail
+          # KEYCHAIN_PASSWORD is a DISPOSABLE password for the temp keychain created
+          # below and destroyed in cleanup — it is generated at runtime, never stored
+          # as a secret. Mask it so it is redacted from all step logs, then persist it
+          # via $GITHUB_ENV so later steps can unlock the same keychain.
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+          echo "::add-mask::$KEYCHAIN_PASSWORD"
+          {
+            echo "CERT_PATH=$RUNNER_TEMP/build_certificate.p12"
+            echo "ASC_KEY_PATH=$RUNNER_TEMP/asc_api_key.p8"
+            echo "KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db"
+            echo "KEYCHAIN_LIST_BACKUP=$RUNNER_TEMP/original-keychains.list"
+            echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD"
+          } >> "$GITHUB_ENV"
+
+      # Fail FAST (before any build work) if any required signing credential is
+      # missing. Releases must be signed + notarized, so an absent secret/variable
+      # is fatal. Only presence is checked (non-empty); values are never printed.
+      - name: Preflight - require signing credentials
+        env:
+          DEVELOPER_ID_P12_BASE64: ${{ secrets.DEVELOPER_ID_P12_BASE64 }}
+          DEVELOPER_ID_P12_PASSWORD: ${{ secrets.DEVELOPER_ID_P12_PASSWORD }}
+          APPLE_API_PRIVATE_KEY_P8_BASE64: ${{ secrets.APPLE_API_PRIVATE_KEY_P8_BASE64 }}
+          APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ vars.APPLE_API_ISSUER_ID }}
+          SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
+        run: |
+          set -euo pipefail
+          missing=()
+          # Secrets (key material) and variables (non-sensitive identifiers) are all
+          # required. KEYCHAIN_PASSWORD is intentionally absent — it is generated at
+          # runtime, not stored.
+          for name in DEVELOPER_ID_P12_BASE64 DEVELOPER_ID_P12_PASSWORD \
+                      APPLE_API_PRIVATE_KEY_P8_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER_ID \
+                      SPARKLE_PRIVATE_ED_KEY SPARKLE_PUBLIC_ED_KEY; do
+            # Indirect expansion reads the env var named in $name without echoing its value.
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "::error::Missing required signing credential(s): ${missing[*]}" >&2
+            echo "Set the required Developer ID, notarization, and Sparkle EdDSA secrets/variables under Settings > Secrets and variables > Actions, then re-run." >&2
+            exit 1
+          fi
+          echo "All required signing credentials are present."
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      # Version is injected explicitly (not read from the pbxproj) so both channels
+      # get exactly the CFBundleShortVersionString + CFBundleVersion the caller
+      # computed. This also removes stable's hidden dependency on a pre-tag pbxproj
+      # bump: the tag alone now determines the shipped version.
+      - name: Build universal app and widget
+        run: |
+          set -euo pipefail
+          xcodebuild -project MeterBar.xcodeproj \
+            -scheme MeterBar \
+            -configuration Release \
+            -derivedDataPath build \
+            -destination 'generic/platform=macOS' \
+            ARCHS="arm64 x86_64" \
+            ONLY_ACTIVE_ARCH=NO \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            MARKETING_VERSION="$SHORT_VERSION" \
+            CURRENT_PROJECT_VERSION="$BUILD_VERSION" \
+            SPARKLE_PUBLIC_ED_KEY="$SPARKLE_PUBLIC_ED_KEY" \
+            build
+
+      - name: Build and inject universal CLI
+        run: |
+          set -euo pipefail
+          scripts/build-universal-cli.sh \
+            "$APP_PATH/Contents/Helpers/meterbar" \
+            "$RUNNER_TEMP/meterbar-cli-build"
+
+      # Import the Developer ID cert + private key into a DEDICATED temporary
+      # keychain, and store the notarization API key profile in that same
+      # keychain. Everything created here is removed by the always() cleanup step.
+      - name: Import signing assets
+        id: identity
+        env:
+          # KEYCHAIN_PASSWORD is inherited from $GITHUB_ENV (generated in the paths step).
+          DEVELOPER_ID_P12_BASE64: ${{ secrets.DEVELOPER_ID_P12_BASE64 }}
+          DEVELOPER_ID_P12_PASSWORD: ${{ secrets.DEVELOPER_ID_P12_PASSWORD }}
+          APPLE_API_PRIVATE_KEY_P8_BASE64: ${{ secrets.APPLE_API_PRIVATE_KEY_P8_BASE64 }}
+          APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ vars.APPLE_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+
+          # Decode straight to disk; -o avoids piping secret bytes through stdout/logs.
+          # macOS base64 does not line-wrap by default, so single-line blobs decode cleanly.
+          echo -n "$DEVELOPER_ID_P12_BASE64"         | base64 --decode -o "$CERT_PATH"
+          echo -n "$APPLE_API_PRIVATE_KEY_P8_BASE64" | base64 --decode -o "$ASC_KEY_PATH"
+
+          # Capture the ORIGINAL user keychain search list so cleanup can restore it
+          # exactly, rather than assuming a hardcoded default that might differ on
+          # this runner image.
+          security list-keychains -d user | tr -d '"' | sed 's/^[[:space:]]*//' > "$KEYCHAIN_LIST_BACKUP"
+
+          # DEDICATED temporary keychain.
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          # -l lock on sleep, -u lock on timeout, -t 21600 = 6h. Bounds key reachability.
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import the identity (cert + private key) from the .p12. Do NOT pass -t cert:
+          # that would import only the certificate and drop the private key, leaving an
+          # unusable identity. -T whitelists codesign/security to use the key headlessly.
+          security import "$CERT_PATH" \
+            -P "$DEVELOPER_ID_P12_PASSWORD" \
+            -f pkcs12 \
+            -k "$KEYCHAIN_PATH" \
+            -T /usr/bin/codesign -T /usr/bin/security
+
+          # Add temp keychain to the USER search list WITHOUT clobbering login.keychain.
+          # Word-splitting of the existing list into separate args is intentional.
+          # shellcheck disable=SC2046
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+          # CRITICAL: authorize non-interactive key access. Without this, codesign on a
+          # headless runner triggers the keychain ACL GUI prompt -> errSecInternalComponent
+          # or an indefinite hang. -T on import alone is NOT sufficient.
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # HARD GATE: exactly ONE Developer ID Application identity must be present in
+          # the temp keychain. Zero -> nothing to sign with. More than one -> ambiguous
+          # .p12, codesign could silently pick the wrong cert. Fail fast either way.
+          COUNT=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | grep -c "Developer ID Application" || true)
+          echo "Developer ID Application identities found: $COUNT"
+          if [ "$COUNT" -ne 1 ]; then
+            echo "::error::Expected exactly 1 Developer ID Application identity in the temp keychain, found $COUNT." >&2
+            security find-identity -v -p codesigning "$KEYCHAIN_PATH" >&2 || true
+            exit 1
+          fi
+
+          # Resolve the exact identity by its SHA-1 hash from OUR keychain ONLY
+          # (codesign accepts a hash), so it can never match a same-named cert
+          # from another keychain and no CN is hardcoded.
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | grep "Developer ID Application" | head -1 | awk '{print $2}')
+          echo "Using signing identity (SHA-1): $IDENTITY"
+          echo "hash=$IDENTITY" >> "$GITHUB_OUTPUT"
+
+          # Store notarization creds in the disposable keychain (validates them
+          # immediately, and they vanish when the keychain is deleted in cleanup).
+          # Non-interactive when all of --key/--key-id/--issuer are supplied.
+          xcrun notarytool store-credentials "$NOTARY_PROFILE" \
+            --key "$ASC_KEY_PATH" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --keychain "$KEYCHAIN_PATH"
+
+      # Inside-out Developer ID signing with hardened runtime, plus the
+      # universal-architecture, version-agreement, and entitlement-split
+      # verification shared with CI (which runs the same script ad-hoc). The two
+      # version args let a nightly build carry a display short version distinct
+      # from its Sparkle ordering (build) version.
+      - name: Sign and verify universal artifact
+        env:
+          # KEYCHAIN_PASSWORD is inherited from $GITHUB_ENV (generated in the paths step).
+          SIGNING_IDENTITY: ${{ steps.identity.outputs.hash }}
+        run: |
+          set -euo pipefail
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          SIGNING_KEYCHAIN="$KEYCHAIN_PATH" \
+            scripts/sign-and-verify-release.sh "$APP_PATH" "$SHORT_VERSION" "$BUILD_VERSION"
+
+      # Notarize the signed app, then staple the ticket onto the .app bundle.
+      # notarytool submit --wait blocks on Apple's servers. The inner
+      # '--timeout 40m' bounds the wait so an Apple-side backlog fails clearly
+      # (with a poll-able submission id) instead of silently consuming the whole
+      # 60-min job timeout.
+      - name: Notarize and staple
+        # KEYCHAIN_PASSWORD is inherited from $GITHUB_ENV (generated in the paths step).
+        run: |
+          set -euo pipefail
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          SUBMIT_ZIP="$RUNNER_TEMP/MeterBar-notarize.zip"
+
+          # A bare .app must be zipped with ditto for a ticket-compatible archive.
+          ditto -c -k --keepParent "$APP_PATH" "$SUBMIT_ZIP"
+
+          # Submit and block until Apple finishes; capture JSON to read id/status.
+          set +e
+          SUBMIT_OUT=$(xcrun notarytool submit "$SUBMIT_ZIP" \
+            --keychain-profile "$NOTARY_PROFILE" \
+            --keychain "$KEYCHAIN_PATH" \
+            --timeout 40m \
+            --wait --output-format json)
+          SUBMIT_RC=$?
+          set -e
+          echo "$SUBMIT_OUT"
+
+          SUBID=$(echo "$SUBMIT_OUT" | /usr/bin/python3 -c 'import sys,json;print(json.load(sys.stdin).get("id",""))' 2>/dev/null || true)
+          STATUS=$(echo "$SUBMIT_OUT" | /usr/bin/python3 -c 'import sys,json;print(json.load(sys.stdin).get("status",""))' 2>/dev/null || true)
+          echo "Notarization id=$SUBID status=$STATUS rc=$SUBMIT_RC"
+
+          if [ "$STATUS" != "Accepted" ] || [ "$SUBMIT_RC" -ne 0 ]; then
+            echo "::error::Notarization did not succeed (status=$STATUS rc=$SUBMIT_RC). Pulling detailed log." >&2
+            if [ -n "${SUBID:-}" ]; then
+              xcrun notarytool log "$SUBID" \
+                --keychain-profile "$NOTARY_PROFILE" \
+                --keychain "$KEYCHAIN_PATH" \
+                "$RUNNER_TEMP/developer_log.json" || true
+              cat "$RUNNER_TEMP/developer_log.json" || true
+            fi
+            exit 1
+          fi
+
+          # Staple the ticket onto the bundle (cannot staple a .zip).
+          xcrun stapler staple "$APP_PATH"
+
+      # Gatekeeper acceptance + signature integrity + stapled ticket. Fail on error.
+      - name: Verify signature, Gatekeeper, and staple
+        run: |
+          set -euo pipefail
+
+          echo "::group::spctl assessment (type execute)"
+          spctl --assess --type execute --verbose=4 "$APP_PATH"
+          echo "::endgroup::"
+
+          echo "::group::codesign --verify --deep --strict"
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          echo "::endgroup::"
+
+          echo "::group::stapler validate"
+          xcrun stapler validate "$APP_PATH"
+          echo "::endgroup::"
+
+          # Session Wake: exercise the embedded CLI wake path on the FINAL
+          # notarized + stapled artifact. Hardened runtime and Gatekeeper can
+          # gate process spawning differently than an ad-hoc build, so launch
+          # the real signed binary. --dry-run spawns no claude process.
+          echo "::group::embedded CLI Session Wake (stapled artifact)"
+          WAKE_CFG="$(mktemp -d)/claude"
+          mkdir -p "$WAKE_CFG/projects"
+          WAKE_JSON="$("$APP_PATH/Contents/Helpers/meterbar" wake --dry-run --json --config-dir "$WAKE_CFG")"
+          printf '%s' "$WAKE_JSON" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['schemaVersion']==1 and d['dryRun'] is True and d['outcome']=='success', d; print('Session Wake dry-run OK on stapled artifact')"
+          echo "::endgroup::"
+
+      # Zip the STAPLED bundle and compute the SHA256 on that FINAL artifact
+      # (this is what the Homebrew cask consumes via <zip>.sha256). The pre-staple
+      # notarization zip differs byte-for-byte, so the SHA must be computed here,
+      # after stapling.
+      - name: Create release package
+        id: package
+        run: |
+          set -euo pipefail
+          ZIP_PATH="$GITHUB_WORKSPACE/$ZIP_NAME"
+          SHA_NAME="${ZIP_NAME}.sha256"
+          SHA_PATH="$GITHUB_WORKSPACE/$SHA_NAME"
+
+          ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH"
+
+          SHA256=$(shasum -a 256 "$ZIP_PATH" | cut -d ' ' -f 1)
+          echo "SHA256: $SHA256"
+          echo "$SHA256" > "$SHA_PATH"
+
+          {
+            echo "sha256=$SHA256"
+            echo "sha_name=$SHA_NAME"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate and verify Sparkle appcast
+        id: appcast
+        env:
+          SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
+        run: |
+          set -euo pipefail
+          APPCAST_DIR="$RUNNER_TEMP/sparkle-appcast"
+          GENERATE_APPCAST="$GITHUB_WORKSPACE/build/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_appcast"
+
+          if [ ! -x "$GENERATE_APPCAST" ]; then
+            echo "::error::Sparkle generate_appcast was not resolved at $GENERATE_APPCAST" >&2
+            exit 1
+          fi
+
+          mkdir -p "$APPCAST_DIR"
+          cp "$GITHUB_WORKSPACE/$ZIP_NAME" "$APPCAST_DIR/$ZIP_NAME"
+          printf '%s' "$SPARKLE_PRIVATE_ED_KEY" | "$GENERATE_APPCAST" \
+            --ed-key-file - \
+            --download-url-prefix "$DOWNLOAD_PREFIX" \
+            "$APPCAST_DIR"
+
+          # generate_appcast always writes appcast.xml; publish it under the
+          # channel's filename (appcast.xml for stable, appcast-nightly.xml for nightly).
+          APPCAST_PATH="$APPCAST_DIR/appcast.xml"
+          scripts/verify-appcast.sh \
+            "$APPCAST_PATH" "$BUILD_VERSION" "$ZIP_NAME" "$DOWNLOAD_PREFIX" "$SHORT_VERSION"
+          cp "$APPCAST_PATH" "$GITHUB_WORKSPACE/$APPCAST_NAME"
+          echo "name=$APPCAST_NAME" >> "$GITHUB_OUTPUT"
+
+      # Rolling channel (nightly): the tag moves to each new build, so drop the
+      # prior release + tag first. The publish step then recreates both at HEAD
+      # with the fixed asset names, keeping the feed/download URLs permanent.
+      - name: Roll release tag
+        if: ${{ inputs.rolling }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release delete "$RELEASE_TAG" --cleanup-tag --yes || true
+
+      - name: Create Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        with:
+          tag_name: ${{ inputs.release_tag }}
+          target_commitish: ${{ github.sha }}
+          files: |
+            ${{ inputs.zip_name }}
+            ${{ steps.package.outputs.sha_name }}
+            ${{ steps.appcast.outputs.name }}
+          draft: false
+          prerelease: ${{ inputs.prerelease }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Output summary
+        env:
+          RELEASE_SHA256: ${{ steps.package.outputs.sha256 }}
+        run: |
+          {
+            echo "### Release Artifacts"
+            echo ""
+            echo "**Tag:** \`$RELEASE_TAG\`"
+            echo "**Short version:** \`$SHORT_VERSION\`"
+            echo "**Build version:** \`$BUILD_VERSION\`"
+            echo "**SHA256:** \`$RELEASE_SHA256\`"
+            echo "**Sparkle feed:** \`$APPCAST_NAME\` (EdDSA signed archive)"
+            echo ""
+            echo "Universal arm64+x86_64, Developer ID signed, notarized, and stapled."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Cleanup - ALWAYS, even on failure. Remove the temp keychain + decoded
+      # secrets, restore the ORIGINAL captured user keychain search list.
+      - name: Clean up keychain and secret files
+        if: ${{ always() }}
+        run: |
+          security delete-keychain "$KEYCHAIN_PATH" || true
+          # Restore the exact original user search list captured before it was modified.
+          if [ -f "$KEYCHAIN_LIST_BACKUP" ] && [ -s "$KEYCHAIN_LIST_BACKUP" ]; then
+            # shellcheck disable=SC2046
+            security list-keychains -d user -s $(cat "$KEYCHAIN_LIST_BACKUP") || true
+          else
+            security list-keychains -d user -s login.keychain-db || true
+          fi
+          rm -f "$CERT_PATH" "$ASC_KEY_PATH" \
+                "$RUNNER_TEMP/MeterBar-notarize.zip" \
+                "$RUNNER_TEMP/developer_log.json" \
+                "$KEYCHAIN_LIST_BACKUP" || true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,67 @@
+name: Nightly
+
+# Build a signed, notarized nightly from master so testers can flip MeterBar's
+# in-app Update channel to Nightly and update in place — no tag, no full release.
+# Publishes to a rolling `nightly` pre-release with fixed asset names, so the
+# feed (appcast-nightly.xml) and download (MeterBar-nightly.zip) URLs are stable.
+on:
+  schedule:
+    # Daily at 09:07 UTC. Off the :00 mark to avoid the top-of-hour scheduler surge.
+    - cron: '7 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Never let two nightlies race on the rolling tag; the newest wins.
+concurrency:
+  group: nightly
+  cancel-in-progress: true
+
+jobs:
+  # Derive a version pair that orders correctly in Sparkle:
+  #   build  = <latest-stable>.<commits-since-tag>   e.g. 1.7.1.42   (CFBundleVersion, ordering key)
+  #   short  = <latest-stable>-nightly.<N>+<sha>     e.g. 1.7.1-nightly.42+a1b2c3d (display)
+  # `1.7.1 < 1.7.1.42 < 1.7.2`, so a newer nightly always wins, and the next
+  # tagged stable overtakes any nightly — a switch back to Stable auto-updates.
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      short: ${{ steps.version.outputs.short }}
+      build: ${{ steps.version.outputs.build }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+          # Full history + tags so `git describe` / `rev-list --count` work.
+          fetch-depth: 0
+
+      - name: Derive nightly version
+        id: version
+        run: |
+          set -euo pipefail
+          BASE_TAG=$(git describe --tags --abbrev=0 --match 'v*')
+          BASE=${BASE_TAG#v}
+          COUNT=$(git rev-list --count "${BASE_TAG}..HEAD")
+          SHA=$(git rev-parse --short HEAD)
+          {
+            echo "short=${BASE}-nightly.${COUNT}+${SHA}"
+            echo "build=${BASE}.${COUNT}"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: version
+    permissions:
+      contents: write
+    uses: ./.github/workflows/_build-signed.yml
+    with:
+      short_version: ${{ needs.version.outputs.short }}
+      build_version: ${{ needs.version.outputs.build }}
+      release_tag: nightly
+      download_prefix: https://github.com/${{ github.repository }}/releases/download/nightly/
+      appcast_name: appcast-nightly.xml
+      zip_name: MeterBar-nightly.zip
+      prerelease: true
+      rolling: true
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,23 +9,13 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    runs-on: macos-26
-    timeout-minutes: 60
-    environment: release
-    permissions:
-      contents: write
-    env:
-      APP_PATH: ${{ github.workspace }}/build/Build/Products/Release/MeterBar.app
-      # Context values enter shell code only through environment variables.
-      REF_NAME: ${{ github.ref_name }}
-      SPARKLE_PUBLIC_ED_KEY: ${{ vars.SPARKLE_PUBLIC_ED_KEY }}
-      # notarytool keychain-profile name (stored in the temp keychain at runtime).
-      NOTARY_PROFILE: asc-profile
-
+  # Derive the release version from the tag (cheap, on Linux) so the signed build
+  # job receives it as an input. Stable ships identical short/build versions.
+  version:
+    runs-on: ubuntu-latest
     outputs:
-      release_tag: ${{ steps.version.outputs.tag }}
-
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -34,6 +24,8 @@ jobs:
 
       - name: Validate release tag
         id: version
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           RELEASE_VERSION=$(scripts/validate-release-tag.sh "$REF_NAME")
@@ -42,364 +34,26 @@ jobs:
             echo "version=$RELEASE_VERSION"
           } >> "$GITHUB_OUTPUT"
 
-      # Resolve ephemeral file paths under RUNNER_TEMP (outside the workspace) and
-      # export them for later steps. The `runner` context is NOT available in
-      # job-level `env:`, so these are computed here where $RUNNER_TEMP is a real
-      # shell variable, then written fully-resolved into $GITHUB_ENV.
-      - name: Configure signing paths
-        run: |
-          set -euo pipefail
-          # KEYCHAIN_PASSWORD is a DISPOSABLE password for the temp keychain created
-          # below and destroyed in cleanup — it is generated at runtime, never stored
-          # as a secret. Mask it so it is redacted from all step logs, then persist it
-          # via $GITHUB_ENV so later steps can unlock the same keychain.
-          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
-          echo "::add-mask::$KEYCHAIN_PASSWORD"
-          {
-            echo "CERT_PATH=$RUNNER_TEMP/build_certificate.p12"
-            echo "ASC_KEY_PATH=$RUNNER_TEMP/asc_api_key.p8"
-            echo "KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db"
-            echo "KEYCHAIN_LIST_BACKUP=$RUNNER_TEMP/original-keychains.list"
-            echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD"
-          } >> "$GITHUB_ENV"
-
-      # Fail FAST (before any build work) if any required signing credential is
-      # missing. Releases must be signed + notarized, so an absent secret/variable
-      # is fatal. Only presence is checked (non-empty); values are never printed.
-      - name: Preflight - require signing credentials
-        env:
-          DEVELOPER_ID_P12_BASE64: ${{ secrets.DEVELOPER_ID_P12_BASE64 }}
-          DEVELOPER_ID_P12_PASSWORD: ${{ secrets.DEVELOPER_ID_P12_PASSWORD }}
-          APPLE_API_PRIVATE_KEY_P8_BASE64: ${{ secrets.APPLE_API_PRIVATE_KEY_P8_BASE64 }}
-          APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER_ID: ${{ vars.APPLE_API_ISSUER_ID }}
-          SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
-        run: |
-          set -euo pipefail
-          missing=()
-          # Secrets (key material) and variables (non-sensitive identifiers) are all
-          # required. KEYCHAIN_PASSWORD is intentionally absent — it is generated at
-          # runtime, not stored.
-          for name in DEVELOPER_ID_P12_BASE64 DEVELOPER_ID_P12_PASSWORD \
-                      APPLE_API_PRIVATE_KEY_P8_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER_ID \
-                      SPARKLE_PRIVATE_ED_KEY SPARKLE_PUBLIC_ED_KEY; do
-            # Indirect expansion reads the env var named in $name without echoing its value.
-            if [ -z "${!name:-}" ]; then
-              missing+=("$name")
-            fi
-          done
-          if [ "${#missing[@]}" -ne 0 ]; then
-            echo "::error::Missing required signing credential(s): ${missing[*]}" >&2
-            echo "Set the required Developer ID, notarization, and Sparkle EdDSA secrets/variables under Settings > Secrets and variables > Actions, then re-run." >&2
-            exit 1
-          fi
-          echo "All required signing credentials are present."
-
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
-
-      - name: Show Xcode version
-        run: xcodebuild -version
-
-      - name: Build universal app and widget
-        run: |
-          set -euo pipefail
-          xcodebuild -project MeterBar.xcodeproj \
-            -scheme MeterBar \
-            -configuration Release \
-            -derivedDataPath build \
-            -destination 'generic/platform=macOS' \
-            ARCHS="arm64 x86_64" \
-            ONLY_ACTIVE_ARCH=NO \
-            CODE_SIGN_IDENTITY="-" \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO \
-            SPARKLE_PUBLIC_ED_KEY="$SPARKLE_PUBLIC_ED_KEY" \
-            build
-
-      - name: Build and inject universal CLI
-        run: |
-          set -euo pipefail
-          scripts/build-universal-cli.sh \
-            "$APP_PATH/Contents/Helpers/meterbar" \
-            "$RUNNER_TEMP/meterbar-cli-build"
-
-      # Import the Developer ID cert + private key into a DEDICATED temporary
-      # keychain, and store the notarization API key profile in that same
-      # keychain. Everything created here is removed by the always() cleanup step.
-      - name: Import signing assets
-        id: identity
-        env:
-          # KEYCHAIN_PASSWORD is inherited from $GITHUB_ENV (generated in the paths step).
-          DEVELOPER_ID_P12_BASE64: ${{ secrets.DEVELOPER_ID_P12_BASE64 }}
-          DEVELOPER_ID_P12_PASSWORD: ${{ secrets.DEVELOPER_ID_P12_PASSWORD }}
-          APPLE_API_PRIVATE_KEY_P8_BASE64: ${{ secrets.APPLE_API_PRIVATE_KEY_P8_BASE64 }}
-          APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER_ID: ${{ vars.APPLE_API_ISSUER_ID }}
-        run: |
-          set -euo pipefail
-
-          # Decode straight to disk; -o avoids piping secret bytes through stdout/logs.
-          # macOS base64 does not line-wrap by default, so single-line blobs decode cleanly.
-          echo -n "$DEVELOPER_ID_P12_BASE64"         | base64 --decode -o "$CERT_PATH"
-          echo -n "$APPLE_API_PRIVATE_KEY_P8_BASE64" | base64 --decode -o "$ASC_KEY_PATH"
-
-          # Capture the ORIGINAL user keychain search list so cleanup can restore it
-          # exactly, rather than assuming a hardcoded default that might differ on
-          # this runner image.
-          security list-keychains -d user | tr -d '"' | sed 's/^[[:space:]]*//' > "$KEYCHAIN_LIST_BACKUP"
-
-          # DEDICATED temporary keychain.
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          # -l lock on sleep, -u lock on timeout, -t 21600 = 6h. Bounds key reachability.
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          # Import the identity (cert + private key) from the .p12. Do NOT pass -t cert:
-          # that would import only the certificate and drop the private key, leaving an
-          # unusable identity. -T whitelists codesign/security to use the key headlessly.
-          security import "$CERT_PATH" \
-            -P "$DEVELOPER_ID_P12_PASSWORD" \
-            -f pkcs12 \
-            -k "$KEYCHAIN_PATH" \
-            -T /usr/bin/codesign -T /usr/bin/security
-
-          # Add temp keychain to the USER search list WITHOUT clobbering login.keychain.
-          # Word-splitting of the existing list into separate args is intentional.
-          # shellcheck disable=SC2046
-          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
-
-          # CRITICAL: authorize non-interactive key access. Without this, codesign on a
-          # headless runner triggers the keychain ACL GUI prompt -> errSecInternalComponent
-          # or an indefinite hang. -T on import alone is NOT sufficient.
-          security set-key-partition-list \
-            -S apple-tool:,apple:,codesign: \
-            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          # HARD GATE: exactly ONE Developer ID Application identity must be present in
-          # the temp keychain. Zero -> nothing to sign with. More than one -> ambiguous
-          # .p12, codesign could silently pick the wrong cert. Fail fast either way.
-          COUNT=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
-            | grep -c "Developer ID Application" || true)
-          echo "Developer ID Application identities found: $COUNT"
-          if [ "$COUNT" -ne 1 ]; then
-            echo "::error::Expected exactly 1 Developer ID Application identity in the temp keychain, found $COUNT." >&2
-            security find-identity -v -p codesigning "$KEYCHAIN_PATH" >&2 || true
-            exit 1
-          fi
-
-          # Resolve the exact identity by its SHA-1 hash from OUR keychain ONLY
-          # (codesign accepts a hash), so it can never match a same-named cert
-          # from another keychain and no CN is hardcoded.
-          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
-            | grep "Developer ID Application" | head -1 | awk '{print $2}')
-          echo "Using signing identity (SHA-1): $IDENTITY"
-          echo "hash=$IDENTITY" >> "$GITHUB_OUTPUT"
-
-          # Store notarization creds in the disposable keychain (validates them
-          # immediately, and they vanish when the keychain is deleted in cleanup).
-          # Non-interactive when all of --key/--key-id/--issuer are supplied.
-          xcrun notarytool store-credentials "$NOTARY_PROFILE" \
-            --key "$ASC_KEY_PATH" \
-            --key-id "$APPLE_API_KEY_ID" \
-            --issuer "$APPLE_API_ISSUER_ID" \
-            --keychain "$KEYCHAIN_PATH"
-
-      # Inside-out Developer ID signing with hardened runtime, plus the
-      # universal-architecture, version-agreement, and entitlement-split
-      # verification shared with CI (which runs the same script ad-hoc).
-      - name: Sign and verify universal artifact
-        env:
-          # KEYCHAIN_PASSWORD is inherited from $GITHUB_ENV (generated in the paths step).
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-          SIGNING_IDENTITY: ${{ steps.identity.outputs.hash }}
-        run: |
-          set -euo pipefail
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          SIGNING_KEYCHAIN="$KEYCHAIN_PATH" \
-            scripts/sign-and-verify-release.sh "$APP_PATH" "$RELEASE_VERSION"
-
-      # Notarize the signed app, then staple the ticket onto the .app bundle.
-      # notarytool submit --wait blocks on Apple's servers. The inner
-      # '--timeout 40m' bounds the wait so an Apple-side backlog fails clearly
-      # (with a poll-able submission id) instead of silently consuming the whole
-      # 60-min job timeout.
-      - name: Notarize and staple
-        # KEYCHAIN_PASSWORD is inherited from $GITHUB_ENV (generated in the paths step).
-        run: |
-          set -euo pipefail
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          SUBMIT_ZIP="$RUNNER_TEMP/MeterBar-notarize.zip"
-
-          # A bare .app must be zipped with ditto for a ticket-compatible archive.
-          ditto -c -k --keepParent "$APP_PATH" "$SUBMIT_ZIP"
-
-          # Submit and block until Apple finishes; capture JSON to read id/status.
-          set +e
-          SUBMIT_OUT=$(xcrun notarytool submit "$SUBMIT_ZIP" \
-            --keychain-profile "$NOTARY_PROFILE" \
-            --keychain "$KEYCHAIN_PATH" \
-            --timeout 40m \
-            --wait --output-format json)
-          SUBMIT_RC=$?
-          set -e
-          echo "$SUBMIT_OUT"
-
-          SUBID=$(echo "$SUBMIT_OUT" | /usr/bin/python3 -c 'import sys,json;print(json.load(sys.stdin).get("id",""))' 2>/dev/null || true)
-          STATUS=$(echo "$SUBMIT_OUT" | /usr/bin/python3 -c 'import sys,json;print(json.load(sys.stdin).get("status",""))' 2>/dev/null || true)
-          echo "Notarization id=$SUBID status=$STATUS rc=$SUBMIT_RC"
-
-          if [ "$STATUS" != "Accepted" ] || [ "$SUBMIT_RC" -ne 0 ]; then
-            echo "::error::Notarization did not succeed (status=$STATUS rc=$SUBMIT_RC). Pulling detailed log." >&2
-            if [ -n "${SUBID:-}" ]; then
-              xcrun notarytool log "$SUBID" \
-                --keychain-profile "$NOTARY_PROFILE" \
-                --keychain "$KEYCHAIN_PATH" \
-                "$RUNNER_TEMP/developer_log.json" || true
-              cat "$RUNNER_TEMP/developer_log.json" || true
-            fi
-            exit 1
-          fi
-
-          # Staple the ticket onto the bundle (cannot staple a .zip).
-          xcrun stapler staple "$APP_PATH"
-
-      # Gatekeeper acceptance + signature integrity + stapled ticket. Fail on error.
-      - name: Verify signature, Gatekeeper, and staple
-        run: |
-          set -euo pipefail
-
-          echo "::group::spctl assessment (type execute)"
-          spctl --assess --type execute --verbose=4 "$APP_PATH"
-          echo "::endgroup::"
-
-          echo "::group::codesign --verify --deep --strict"
-          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
-          echo "::endgroup::"
-
-          echo "::group::stapler validate"
-          xcrun stapler validate "$APP_PATH"
-          echo "::endgroup::"
-
-          # Session Wake: exercise the embedded CLI wake path on the FINAL
-          # notarized + stapled artifact. Hardened runtime and Gatekeeper can
-          # gate process spawning differently than an ad-hoc build, so launch
-          # the real signed binary. --dry-run spawns no claude process.
-          echo "::group::embedded CLI Session Wake (stapled artifact)"
-          WAKE_CFG="$(mktemp -d)/claude"
-          mkdir -p "$WAKE_CFG/projects"
-          WAKE_JSON="$("$APP_PATH/Contents/Helpers/meterbar" wake --dry-run --json --config-dir "$WAKE_CFG")"
-          printf '%s' "$WAKE_JSON" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['schemaVersion']==1 and d['dryRun'] is True and d['outcome']=='success', d; print('Session Wake dry-run OK on stapled artifact')"
-          echo "::endgroup::"
-
-      # Zip the STAPLED bundle and compute the SHA256 on that FINAL artifact
-      # (this is what the Homebrew cask consumes via MeterBar-<version>.zip.sha256).
-      # The pre-staple notarization zip differs byte-for-byte, so the SHA must be
-      # computed here, after stapling.
-      - name: Create release package
-        id: package
-        env:
-          RELEASE_TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          set -euo pipefail
-          ZIP_NAME="MeterBar-${RELEASE_TAG}.zip"
-          ZIP_PATH="$GITHUB_WORKSPACE/$ZIP_NAME"
-          SHA_NAME="${ZIP_NAME}.sha256"
-          SHA_PATH="$GITHUB_WORKSPACE/$SHA_NAME"
-
-          ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH"
-
-          SHA256=$(shasum -a 256 "$ZIP_PATH" | cut -d ' ' -f 1)
-          echo "SHA256: $SHA256"
-          echo "$SHA256" > "$SHA_PATH"
-
-          {
-            echo "sha256=$SHA256"
-            echo "zip_name=$ZIP_NAME"
-            echo "sha_name=$SHA_NAME"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Generate and verify Sparkle appcast
-        id: appcast
-        env:
-          RELEASE_TAG: ${{ steps.version.outputs.tag }}
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-          ZIP_NAME: ${{ steps.package.outputs.zip_name }}
-          SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
-        run: |
-          set -euo pipefail
-          APPCAST_DIR="$RUNNER_TEMP/sparkle-appcast"
-          GENERATE_APPCAST="$GITHUB_WORKSPACE/build/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_appcast"
-          DOWNLOAD_PREFIX="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/"
-
-          if [ ! -x "$GENERATE_APPCAST" ]; then
-            echo "::error::Sparkle generate_appcast was not resolved at $GENERATE_APPCAST" >&2
-            exit 1
-          fi
-
-          mkdir -p "$APPCAST_DIR"
-          cp "$GITHUB_WORKSPACE/$ZIP_NAME" "$APPCAST_DIR/$ZIP_NAME"
-          printf '%s' "$SPARKLE_PRIVATE_ED_KEY" | "$GENERATE_APPCAST" \
-            --ed-key-file - \
-            --download-url-prefix "$DOWNLOAD_PREFIX" \
-            "$APPCAST_DIR"
-
-          APPCAST_PATH="$APPCAST_DIR/appcast.xml"
-          scripts/verify-appcast.sh \
-            "$APPCAST_PATH" "$RELEASE_VERSION" "$ZIP_NAME" "$DOWNLOAD_PREFIX"
-          cp "$APPCAST_PATH" "$GITHUB_WORKSPACE/appcast.xml"
-          echo "name=appcast.xml" >> "$GITHUB_OUTPUT"
-
-      - name: Create Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
-        with:
-          files: |
-            ${{ steps.package.outputs.zip_name }}
-            ${{ steps.package.outputs.sha_name }}
-            ${{ steps.appcast.outputs.name }}
-          draft: false
-          prerelease: false
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Output SHA256
-        env:
-          RELEASE_TAG: ${{ steps.version.outputs.tag }}
-          RELEASE_SHA256: ${{ steps.package.outputs.sha256 }}
-        run: |
-          {
-            echo "### Release Artifacts"
-            echo ""
-            echo "**Tag:** \`$RELEASE_TAG\`"
-            echo "**SHA256:** \`$RELEASE_SHA256\`"
-            echo "**Sparkle feed:** \`appcast.xml\` (EdDSA signed archive)"
-            echo ""
-            echo "Universal arm64+x86_64, Developer ID signed, notarized, and stapled."
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      # Cleanup - ALWAYS, even on failure. Remove the temp keychain + decoded
-      # secrets, restore the ORIGINAL captured user keychain search list.
-      - name: Clean up keychain and secret files
-        if: ${{ always() }}
-        run: |
-          security delete-keychain "$KEYCHAIN_PATH" || true
-          # Restore the exact original user search list captured before it was modified.
-          if [ -f "$KEYCHAIN_LIST_BACKUP" ] && [ -s "$KEYCHAIN_LIST_BACKUP" ]; then
-            # shellcheck disable=SC2046
-            security list-keychains -d user -s $(cat "$KEYCHAIN_LIST_BACKUP") || true
-          else
-            security list-keychains -d user -s login.keychain-db || true
-          fi
-          rm -f "$CERT_PATH" "$ASC_KEY_PATH" \
-                "$RUNNER_TEMP/MeterBar-notarize.zip" \
-                "$RUNNER_TEMP/developer_log.json" \
-                "$KEYCHAIN_LIST_BACKUP" || true
+  build:
+    needs: version
+    permissions:
+      contents: write
+    uses: ./.github/workflows/_build-signed.yml
+    with:
+      short_version: ${{ needs.version.outputs.version }}
+      build_version: ${{ needs.version.outputs.version }}
+      release_tag: ${{ needs.version.outputs.tag }}
+      download_prefix: https://github.com/${{ github.repository }}/releases/download/${{ needs.version.outputs.tag }}/
+      appcast_name: appcast.xml
+      zip_name: MeterBar-${{ needs.version.outputs.tag }}.zip
+      prerelease: false
+      rolling: false
+    secrets: inherit
 
   # After the release is published, bump the Homebrew cask in VincentShipsIt/homebrew-tap.
   # Called directly (not via `release: published`) because GITHUB_TOKEN-created releases
   # do not cascade-trigger workflows — so this guarantees the tap always tracks the release.
+  # Stable only: Homebrew never tracks nightly.
   update-homebrew:
     needs: build
     uses: ./.github/workflows/update-homebrew.yml

--- a/MeterBar/Services/SoftwareUpdateController.swift
+++ b/MeterBar/Services/SoftwareUpdateController.swift
@@ -4,6 +4,24 @@ import Foundation
 import Sparkle
 #endif
 
+/// Release channel the updater points Sparkle at. Stable uses the feed baked
+/// into Info.plist (`SUFeedURL`); Nightly swaps to the rolling master feed at
+/// runtime via the updater delegate, so one installed app can test master
+/// builds without a full release.
+enum UpdateChannel: String, CaseIterable, Identifiable {
+    case stable
+    case nightly
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .stable: "Stable"
+        case .nightly: "Nightly"
+        }
+    }
+}
+
 /// Owns Sparkle's standard updater and exposes only user-controlled update actions.
 /// Automatic network checks remain off until the user explicitly enables them.
 final class SoftwareUpdateController: ObservableObject {
@@ -12,6 +30,39 @@ final class SoftwareUpdateController: ObservableObject {
     @Published private(set) var automaticallyChecksForUpdates = false
     @Published private(set) var canCheckForUpdates = false
     @Published private(set) var configurationError: String?
+    /// Currently selected release channel. Persisted across launches.
+    @Published private(set) var channel: UpdateChannel = .stable
+
+    /// UserDefaults key holding the persisted `UpdateChannel.rawValue`.
+    static let channelStorageKey = "MeterBarUpdateChannel"
+
+    /// Rolling nightly feed. Uses the fixed `nightly` pre-release tag (not
+    /// `/latest/`, which resolves only to non-prerelease releases) so the URL is
+    /// permanent. Signed with the same EdDSA key as stable.
+    static let nightlyFeedURLString =
+        "https://github.com/VincentShipsIt/meterbar.dev/releases/download/nightly/appcast-nightly.xml"
+
+    /// Feed override for a channel. `nil` means "use the Info.plist `SUFeedURL`"
+    /// (the stable feed), which is exactly what Sparkle expects from
+    /// `feedURLString(for:)` when no override applies.
+    static func resolvedFeedURLString(for channel: UpdateChannel) -> String? {
+        switch channel {
+        case .stable: nil
+        case .nightly: nightlyFeedURLString
+        }
+    }
+
+    static func loadChannel(from defaults: UserDefaults) -> UpdateChannel {
+        guard let raw = defaults.string(forKey: channelStorageKey),
+              let channel = UpdateChannel(rawValue: raw) else {
+            return .stable
+        }
+        return channel
+    }
+
+    static func persistChannel(_ channel: UpdateChannel, to defaults: UserDefaults) {
+        defaults.set(channel.rawValue, forKey: channelStorageKey)
+    }
 
     /// True only for a plausible Ed25519 public key. Debug and PR-gate builds
     /// carry the unsubstituted `$(SPARKLE_PUBLIC_ED_KEY)` build variable in
@@ -23,11 +74,23 @@ final class SoftwareUpdateController: ObservableObject {
         return decoded.count == 32
     }
 
+    private let userDefaults: UserDefaults
+
 #if canImport(Sparkle)
     private let controller: SPUStandardUpdaterController?
+    private let channelDelegate: ChannelUpdaterDelegate
     private var cancellables = Set<AnyCancellable>()
 
-    init(bundle: Bundle = .main) {
+    init(bundle: Bundle = .main, defaults: UserDefaults = .standard) {
+        userDefaults = defaults
+        let channel = Self.loadChannel(from: defaults)
+        self.channel = channel
+        // Sparkle references the updater delegate weakly, so the controller must
+        // retain it. Created before the guard so every stored property is set on
+        // the unusable-key early return too.
+        let delegate = ChannelUpdaterDelegate(channel: channel)
+        channelDelegate = delegate
+
         guard let publicKey = bundle.object(forInfoDictionaryKey: "SUPublicEDKey") as? String,
               Self.isUsableEDPublicKey(publicKey) else {
             controller = nil
@@ -37,7 +100,7 @@ final class SoftwareUpdateController: ObservableObject {
 
         let controller = SPUStandardUpdaterController(
             startingUpdater: true,
-            updaterDelegate: nil,
+            updaterDelegate: delegate,
             userDriverDelegate: nil
         )
         self.controller = controller
@@ -60,6 +123,20 @@ final class SoftwareUpdateController: ObservableObject {
         refreshState()
     }
 
+    /// Switch release channel: persist it, repoint the updater's feed, then look
+    /// for a build on the new channel immediately (Sparkle re-queries the
+    /// delegate on each check, so the swapped feed takes effect right away).
+    func setChannel(_ channel: UpdateChannel) {
+        guard channel != self.channel else { return }
+        self.channel = channel
+        Self.persistChannel(channel, to: userDefaults)
+        channelDelegate.channel = channel
+        refreshState()
+        if canCheckForUpdates {
+            checkForUpdates()
+        }
+    }
+
     func checkForUpdates() {
         controller?.checkForUpdates(nil)
         refreshState()
@@ -74,14 +151,36 @@ final class SoftwareUpdateController: ObservableObject {
         automaticallyChecksForUpdates = updater.automaticallyChecksForUpdates
         canCheckForUpdates = updater.canCheckForUpdates
     }
+
+    /// Retains Sparkle's updater delegate and overrides the feed per channel.
+    /// `channel` is mutated by `setChannel` so a live channel switch is picked up
+    /// on the next update check without recreating the updater.
+    private final class ChannelUpdaterDelegate: NSObject, SPUUpdaterDelegate {
+        var channel: UpdateChannel
+
+        init(channel: UpdateChannel) {
+            self.channel = channel
+        }
+
+        func feedURLString(for updater: SPUUpdater) -> String? {
+            SoftwareUpdateController.resolvedFeedURLString(for: channel)
+        }
+    }
 #else
-    init(bundle: Bundle = .main) {
+    init(bundle: Bundle = .main, defaults: UserDefaults = .standard) {
         _ = bundle
+        userDefaults = defaults
+        channel = Self.loadChannel(from: defaults)
         configurationError = "Software updates are available in the app build."
     }
 
     func setAutomaticallyChecksForUpdates(_ enabled: Bool) {
         _ = enabled
+    }
+
+    func setChannel(_ channel: UpdateChannel) {
+        self.channel = channel
+        Self.persistChannel(channel, to: userDefaults)
     }
 
     func checkForUpdates() {

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -561,6 +561,25 @@ struct SettingsView: View {
             SettingsDivider()
 
             SettingsRowView(
+                title: "Update channel",
+                detail: "Nightly tracks master builds for testing — expect pre-release bugs. "
+                    + "Stable is the default and updates only on tagged releases."
+            ) {
+                Picker("", selection: Binding(
+                    get: { softwareUpdates.channel },
+                    set: { softwareUpdates.setChannel($0) }
+                )) {
+                    ForEach(UpdateChannel.allCases) { channel in
+                        Text(channel.displayName).tag(channel)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .frame(width: 240)
+                .disabled(softwareUpdates.configurationError != nil)
+            }
+
+            SettingsRowView(
                 title: "Check for updates automatically",
                 detail: "Allow MeterBar to check GitHub Releases for signed updates. Off until you opt in."
             ) {

--- a/MeterBarTests/SparkleUpdateTests.swift
+++ b/MeterBarTests/SparkleUpdateTests.swift
@@ -100,4 +100,72 @@ final class SparkleUpdateTests: XCTestCase {
         process.waitUntilExit()
         XCTAssertEqual(process.terminationStatus, 0)
     }
+
+    // MARK: - Update channel
+
+    private func makeIsolatedDefaults() throws -> (UserDefaults, String) {
+        let suiteName = "meterbar-channel-tests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        return (defaults, suiteName)
+    }
+
+    func testChannelDefaultsToStableWhenUnsetOrInvalid() throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertEqual(SoftwareUpdateController.loadChannel(from: defaults), .stable)
+
+        defaults.set("not-a-channel", forKey: SoftwareUpdateController.channelStorageKey)
+        XCTAssertEqual(SoftwareUpdateController.loadChannel(from: defaults), .stable)
+    }
+
+    func testChannelPersistenceRoundTrips() throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        SoftwareUpdateController.persistChannel(.nightly, to: defaults)
+        XCTAssertEqual(
+            defaults.string(forKey: SoftwareUpdateController.channelStorageKey),
+            UpdateChannel.nightly.rawValue
+        )
+        XCTAssertEqual(SoftwareUpdateController.loadChannel(from: defaults), .nightly)
+
+        SoftwareUpdateController.persistChannel(.stable, to: defaults)
+        XCTAssertEqual(SoftwareUpdateController.loadChannel(from: defaults), .stable)
+    }
+
+    func testStableChannelFallsBackToInfoPlistFeed() {
+        // nil tells Sparkle to use the Info.plist SUFeedURL (the stable feed).
+        XCTAssertNil(SoftwareUpdateController.resolvedFeedURLString(for: .stable))
+    }
+
+    func testNightlyChannelResolvesToRollingNightlyFeed() throws {
+        let feed = try XCTUnwrap(SoftwareUpdateController.resolvedFeedURLString(for: .nightly))
+        XCTAssertEqual(feed, SoftwareUpdateController.nightlyFeedURLString)
+        XCTAssertTrue(feed.hasPrefix("https://"))
+        // Fixed `nightly` tag path — never `/latest/`, which excludes prereleases.
+        XCTAssertTrue(feed.contains("/releases/download/nightly/"))
+        XCTAssertTrue(feed.hasSuffix("/appcast-nightly.xml"))
+        XCTAssertNotNil(URL(string: feed))
+    }
+
+    // MARK: - Nightly version ordering
+
+    // Nightly CFBundleVersion is `<latest-stable>.<commits>` (e.g. 1.7.1.5) so
+    // Sparkle's numeric comparator ranks a newer nightly above an older one,
+    // above the last stable, and BELOW the next stable — letting a switch back
+    // to Stable auto-update cleanly once the next tagged release ships.
+    func testNightlyBuildOutranksBaseStable() {
+        XCTAssertEqual("1.7.1.5".compare("1.7.1", options: .numeric), .orderedDescending)
+    }
+
+    func testLaterNightlyOutranksEarlierNightly() {
+        XCTAssertEqual("1.7.1.6".compare("1.7.1.5", options: .numeric), .orderedDescending)
+    }
+
+    func testNextStableOutranksNightly() {
+        XCTAssertEqual("1.7.2".compare("1.7.1.5", options: .numeric), .orderedDescending)
+        // Even a high nightly build number cannot beat the next stable minor.
+        XCTAssertEqual("1.7.2".compare("1.7.1.9999", options: .numeric), .orderedDescending)
+    }
 }

--- a/scripts/sign-and-verify-release.sh
+++ b/scripts/sign-and-verify-release.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 2 ]; then
-  echo "Usage: $0 APP_PATH EXPECTED_VERSION" >&2
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+  echo "Usage: $0 APP_PATH EXPECTED_SHORT_VERSION [EXPECTED_BUILD_VERSION]" >&2
+  echo "EXPECTED_BUILD_VERSION defaults to EXPECTED_SHORT_VERSION (stable, where" >&2
+  echo "CFBundleShortVersionString == CFBundleVersion). Pass both to verify a" >&2
+  echo "nightly build whose display and ordering versions differ." >&2
   echo "Signs ad-hoc by default; set SIGNING_IDENTITY (and optionally" >&2
   echo "SIGNING_KEYCHAIN) to sign with a Developer ID identity instead." >&2
   exit 64
@@ -20,7 +23,11 @@ fi
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repository_root=$(cd "$script_dir/.." && pwd)
 app_path="$1"
-expected_version="$2"
+# Short version is the human/display string (CFBundleShortVersionString, and what
+# the embedded CLI reports). Build version is Sparkle's ordering key
+# (CFBundleVersion). For stable they are identical; for nightly they differ.
+expected_short="$2"
+expected_build="${3:-$2}"
 widget_path="$app_path/Contents/PlugIns/MeterBarWidgetExtension.appex"
 app_binary="$app_path/Contents/MacOS/MeterBar"
 widget_binary="$widget_path/Contents/MacOS/MeterBarWidgetExtension"
@@ -28,9 +35,24 @@ cli_binary="$app_path/Contents/Helpers/meterbar"
 app_entitlements="$repository_root/MeterBar/MeterBar.entitlements"
 widget_entitlements="$repository_root/MeterBarWidget/MeterBarWidget.entitlements"
 
-if [[ ! "$expected_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-  echo "Expected version must match canonical MAJOR.MINOR.PATCH syntax." >&2
-  exit 64
+# Keep every version value free of shell metacharacters (they flow into echo and
+# string comparisons downstream). Stable stays strictly canonical; nightly allows
+# the decoupled forms: a dotted-integer build (e.g. 1.7.1.42) and a display short
+# version drawn from a limited charset (e.g. 1.7.1-nightly.42+a1b2c3d).
+if [ "$expected_build" = "$expected_short" ]; then
+  if [[ ! "$expected_short" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+    echo "Expected version must match canonical MAJOR.MINOR.PATCH syntax." >&2
+    exit 64
+  fi
+else
+  if [[ ! "$expected_build" =~ ^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))+$ ]]; then
+    echo "Nightly build version must be dotted integers (e.g. 1.7.1.42)." >&2
+    exit 64
+  fi
+  if [[ ! "$expected_short" =~ ^[0-9A-Za-z.+-]+$ ]]; then
+    echo "Nightly short version has unexpected characters: $expected_short" >&2
+    exit 64
+  fi
 fi
 
 for directory in "$app_path" "$widget_path"; do
@@ -66,21 +88,23 @@ app_version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$a
 app_build_version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$app_path/Contents/Info.plist")
 cli_version=$("$cli_binary" --version)
 
-echo "Tag version: $expected_version"
+echo "Expected short version: $expected_short"
+echo "Expected build version: $expected_build"
 echo "App version: $app_version"
 echo "App build version: $app_build_version"
 echo "CLI version: $cli_version"
 
-if [ "$app_version" != "$expected_version" ]; then
-  echo "App version $app_version does not match release version $expected_version." >&2
+if [ "$app_version" != "$expected_short" ]; then
+  echo "App version $app_version does not match expected short version $expected_short." >&2
   exit 1
 fi
-if [ "$app_build_version" != "$expected_version" ]; then
-  echo "App build version $app_build_version does not match release version $expected_version." >&2
+if [ "$app_build_version" != "$expected_build" ]; then
+  echo "App build version $app_build_version does not match expected build version $expected_build." >&2
   exit 1
 fi
-if [ "$cli_version" != "$expected_version" ]; then
-  echo "CLI version $cli_version does not match release version $expected_version." >&2
+# The embedded CLI reports CFBundleShortVersionString, so it must equal the short version.
+if [ "$cli_version" != "$expected_short" ]; then
+  echo "CLI version $cli_version does not match expected short version $expected_short." >&2
   exit 1
 fi
 

--- a/scripts/verify-appcast.sh
+++ b/scripts/verify-appcast.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 4 ]; then
-  echo "usage: $0 <appcast.xml> <version> <archive-name> <download-url-prefix>" >&2
+if [ "$#" -lt 4 ] || [ "$#" -gt 5 ]; then
+  echo "usage: $0 <appcast.xml> <version> <archive-name> <download-url-prefix> [short-version]" >&2
   exit 64
 fi
 
 APPCAST=$1
+# VERSION is Sparkle's ordering key (sparkle:version / CFBundleVersion).
+# SHORT_VERSION is the display string (sparkle:shortVersionString). They match on
+# stable, so SHORT_VERSION defaults to VERSION and existing 4-arg callers are unaffected.
 VERSION=$2
 ARCHIVE_NAME=$3
 DOWNLOAD_URL_PREFIX=${4%/}/
+SHORT_VERSION=${5:-$2}
 
 xpath_string() {
   xmllint --xpath "string((//*[local-name()='enclosure'])[1]/@$1)" "$APPCAST"
@@ -29,8 +33,8 @@ ACTUAL_SIGNATURE=$(xpath_namespaced_attribute edSignature)
 ACTUAL_LENGTH=$(xpath_string length)
 ACTUAL_URL=$(xpath_string url)
 
-if [ "$ACTUAL_VERSION" != "$VERSION" ] || [ "$ACTUAL_SHORT_VERSION" != "$VERSION" ]; then
-  echo "appcast version mismatch: expected $VERSION, got $ACTUAL_VERSION / $ACTUAL_SHORT_VERSION" >&2
+if [ "$ACTUAL_VERSION" != "$VERSION" ] || [ "$ACTUAL_SHORT_VERSION" != "$SHORT_VERSION" ]; then
+  echo "appcast version mismatch: expected version=$VERSION short=$SHORT_VERSION, got $ACTUAL_VERSION / $ACTUAL_SHORT_VERSION" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## What & why

Adds an in-app **Update channel** (Stable / Nightly) so one installed MeterBar can update itself to master builds **without cutting a tagged release** — flip the switch, Sparkle picks up the nightly feed. This is an in-place feed swap (`feedURLString(for:)`), **one app**, not a side-by-side "MeterBar Nightly.app".

MeterBar was already a Sparkle app, so this is the Sparkle-native pattern (not t3code's Electron `electron-updater`).

## App

- **`SoftwareUpdateController`** — `UpdateChannel` enum + pure `resolvedFeedURLString(for:)` / channel-persistence helpers (kept **outside** the `#if canImport(Sparkle)` gate so the no-Sparkle test target covers them, mirroring `isUsableEDPublicKey`). A retained `ChannelUpdaterDelegate` implementing `feedURLString(for:)` is now passed as `updaterDelegate` (was `nil`). Stable returns `nil` → falls back to the Info.plist `SUFeedURL`; Nightly returns the rolling `nightly` feed.
- **`SettingsView`** — Stable/Nightly picker row in the software-update section, disabled when updates are unavailable.
- **Tests** — channel persistence round-trip, feed-URL resolution, and the nightly version-ordering invariants.

## CI

- **`_build-signed.yml`** (new, `workflow_call`) — the entire signed build → notarize → staple → appcast → publish pipeline, extracted once. `release.yml` is now a thin caller; **`nightly.yml`** (new) runs daily (07:09 UTC) + on dispatch and publishes a **rolling `nightly` pre-release** with fixed `MeterBar-nightly.zip` / `appcast-nightly.xml` so the feed/download URLs are permanent.
- Versions are injected at build (`MARKETING_VERSION` / `CURRENT_PROJECT_VERSION`), which also **removes stable's prior hidden dependency on a pre-tag pbxproj bump** — the tag alone now determines the shipped version.

## Scripts

- `sign-and-verify-release.sh` takes a **short/build version pair**; `verify-appcast.sh` takes an optional short-version arg. Existing stable + `ci.yml` callers are unchanged (build defaults to short → canonical path preserved byte-for-byte).

## Version scheme (ordering-critical)

Nightly decouples the two version fields:
- `CFBundleVersion` (Sparkle ordering key) = `<latest-stable>.<commits-since-tag>` — e.g. `1.7.1.42`
- `CFBundleShortVersionString` (display) = `<latest-stable>-nightly.<N>+<sha>`

Sorts `1.7.1 < 1.7.1.42 < 1.7.2`: newer nightly always wins, **and the next stable overtakes any nightly**, so flipping back to Stable auto-updates cleanly once the next tag ships.

## Notes / things to watch

- **Same** Developer ID + EdDSA key; no new secrets. Nightly is signed + notarized like stable.
- The `release` GitHub environment must permit the scheduled nightly run (no required reviewers, or allow the nightly workflow), else scheduled runs block on approval.
- **Regression to watch:** the next real `v*` tag must still cut an identical signed/notarized stable release through the refactored reusable workflow.

## Verification

- `actionlint` on all three workflows — passed.
- `bash -n` on both scripts — passed; 2-arg / 4-arg legacy contracts preserved.
- `swiftlint --quiet` on changed Swift — no new violations.
- Full `swift test` / Xcode build run in CI per the repo's MacBook local-verification policy.