### PR TITLE
feat(session-wake): add Codex provider support

### DIFF
--- a/MeterBar/SessionWake/ClaudeWakeRuntime.swift
+++ b/MeterBar/SessionWake/ClaudeWakeRuntime.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// `WakeProviderRuntime` for Claude Code — a thin adapter binding the existing
+/// Claude discovery, quota authority, and process-runner factory to one
+/// selected account so the shared orchestration never sees `ClaudeCodeAccount`.
+nonisolated struct ClaudeWakeRuntime: WakeProviderRuntime {
+    let account: ClaudeCodeAccount
+    private let discovery: SessionDiscovery
+    private let authority: WakeQuotaAuthority
+    private let makeRunnerForAccount: @Sendable (ClaudeCodeAccount) -> WakeExecuting
+
+    init(
+        account: ClaudeCodeAccount,
+        discovery: SessionDiscovery = SessionDiscovery(),
+        authority: WakeQuotaAuthority = WakeQuotaAuthority(),
+        makeRunner: @escaping @Sendable (ClaudeCodeAccount) -> WakeExecuting
+    ) {
+        self.account = account
+        self.discovery = discovery
+        self.authority = authority
+        self.makeRunnerForAccount = makeRunner
+    }
+
+    var provider: WakeProvider { .claude }
+    var accountLabel: String? { account.configDirectory }
+
+    func discover(ledger: ReplayLedger) async -> [WakeSessionCandidate] {
+        await discovery.discover(configDirectory: account.configDirectory, ledger: ledger)
+    }
+
+    func freshQuota() async -> WakeQuota {
+        await authority.freshQuota(account: account)
+    }
+
+    func makeRunner() -> WakeExecuting {
+        makeRunnerForAccount(account)
+    }
+}

--- a/MeterBar/SessionWake/CodexRollout.swift
+++ b/MeterBar/SessionWake/CodexRollout.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+/// The terminal state of a Codex session rollout, mirroring the Claude
+/// `TranscriptState` vocabulary so both providers feed the same candidate model.
+nonisolated enum CodexRolloutState: Equatable, Sendable {
+    /// The session hit a usage window and did not recover afterwards.
+    case blocked(reason: WakeBlockReason, blockedAt: Date, resetHint: TranscriptResetParser.Result?)
+    /// The session completed or is otherwise not blocked on a usage limit.
+    case active
+    /// No decisive signal (empty/garbled tail, or no rate-limit data).
+    case indeterminate
+}
+
+/// What discovery needs from one Codex rollout file.
+nonisolated struct CodexRolloutSummary: Equatable, Sendable {
+    let sessionID: String
+    /// The working directory recorded in `session_meta`, if any.
+    let cwd: String?
+    /// The `session_meta.source` ("exec", "tui", …), if present.
+    let source: String?
+    let state: CodexRolloutState
+}
+
+/// Classifies a Codex `~/.codex/sessions/**/*.jsonl` rollout into a wake state.
+///
+/// Codex records usage against structured windows on every `token_count` event:
+/// `payload.rate_limits.rate_limit_reached_type` is `null` in normal operation
+/// and non-null exactly when a window was hit. That field — not free-text prose
+/// (which would false-positive on any session that merely *discusses* rate
+/// limits) — is the block signal. A `task_complete` emitted after the hit means
+/// the session recovered and is not a wake target, so the classifier clears the
+/// blocked state on a later completion, exactly like the Claude classifier
+/// clears on successful activity.
+nonisolated enum CodexRolloutClassifier {
+    /// Mutable state threaded through the linear pass over rollout lines.
+    private struct Accumulator {
+        var sessionID: String
+        var cwd: String?
+        var source: String?
+        var blocked: (reason: WakeBlockReason, blockedAt: Date, resetHint: TranscriptResetParser.Result?)?
+        var sawCompletion = false
+    }
+
+    static func classify(fallbackID: String, lines: [String]) -> CodexRolloutSummary {
+        var accumulator = Accumulator(sessionID: fallbackID)
+        for line in lines {
+            guard let object = jsonObject(from: line) else { continue }
+            apply(object: object, to: &accumulator)
+        }
+
+        let state: CodexRolloutState
+        if let blocked = accumulator.blocked, !accumulator.sawCompletion {
+            state = .blocked(reason: blocked.reason, blockedAt: blocked.blockedAt, resetHint: blocked.resetHint)
+        } else if accumulator.sawCompletion {
+            state = .active
+        } else {
+            state = .indeterminate
+        }
+
+        return CodexRolloutSummary(
+            sessionID: accumulator.sessionID,
+            cwd: accumulator.cwd,
+            source: accumulator.source,
+            state: state
+        )
+    }
+
+    /// Fold one decoded rollout line into the accumulator.
+    private static func apply(object: [String: Any], to accumulator: inout Accumulator) {
+        guard let type = object["type"] as? String else { return }
+        let payload = object["payload"] as? [String: Any]
+
+        switch type {
+        case "session_meta":
+            applyMeta(payload: payload, to: &accumulator)
+        case "event_msg":
+            applyEvent(payload: payload, timestamp: object["timestamp"] as? String, to: &accumulator)
+        default:
+            break
+        }
+    }
+
+    private static func applyMeta(payload: [String: Any]?, to accumulator: inout Accumulator) {
+        guard let payload else { return }
+        if let id = (payload["id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !id.isEmpty {
+            accumulator.sessionID = id
+        }
+        if let recordedCwd = (payload["cwd"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !recordedCwd.isEmpty {
+            accumulator.cwd = recordedCwd
+        }
+        accumulator.source = payload["source"] as? String
+    }
+
+    private static func applyEvent(payload: [String: Any]?, timestamp: String?, to accumulator: inout Accumulator) {
+        guard let payload, let eventType = payload["type"] as? String else { return }
+        switch eventType {
+        case "token_count":
+            if let hit = rateLimitHit(rateLimits: payload["rate_limits"] as? [String: Any], eventTimestamp: timestamp) {
+                accumulator.blocked = hit
+                accumulator.sawCompletion = false
+            }
+        case "task_complete":
+            // A completed turn after the last recorded hit means the session is
+            // no longer stuck on a window.
+            accumulator.sawCompletion = true
+        default:
+            break
+        }
+    }
+
+    // MARK: - Rate-limit extraction
+
+    /// Interpret a `rate_limits` object. Returns a block only when
+    /// `rate_limit_reached_type` is a non-empty string; the window it names
+    /// selects both the typed reason and the reset instant.
+    private static func rateLimitHit(
+        rateLimits: [String: Any]?,
+        eventTimestamp: String?
+    ) -> (reason: WakeBlockReason, blockedAt: Date, resetHint: TranscriptResetParser.Result?)? {
+        guard let rateLimits else { return nil }
+        guard let reached = (rateLimits["rate_limit_reached_type"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !reached.isEmpty else {
+            return nil
+        }
+
+        // "secondary" is Codex's long (weekly) window; anything else is treated
+        // as the short/primary session window.
+        let isSecondary = reached.lowercased().contains("secondary")
+        let windowKey = isSecondary ? "secondary" : "primary"
+        let reason: WakeBlockReason = isSecondary ? .weeklyLimit : .sessionLimit
+
+        let blockedAt = Self.parseTimestamp(eventTimestamp) ?? Date()
+        var resetHint: TranscriptResetParser.Result?
+        if let window = rateLimits[windowKey] as? [String: Any],
+           let resetsAt = Self.epochSeconds(window["resets_at"]) {
+            resetHint = TranscriptResetParser.Result(
+                resetAt: Date(timeIntervalSince1970: resetsAt),
+                timeZoneIdentifier: nil
+            )
+        }
+        return (reason, blockedAt, resetHint)
+    }
+
+    // MARK: - Parsing helpers
+
+    private static func jsonObject(from line: String) -> [String: Any]? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let data = trimmed.data(using: .utf8) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+
+    /// Accepts Int/Double/String epoch encodings (rollouts use a bare number).
+    private static func epochSeconds(_ value: Any?) -> TimeInterval? {
+        switch value {
+        case let int as Int: return TimeInterval(int)
+        case let double as Double: return double
+        case let number as NSNumber: return number.doubleValue
+        case let string as String: return TimeInterval(string)
+        default: return nil
+        }
+    }
+
+    private static let fractionalFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let plainFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    static func parseTimestamp(_ raw: String?) -> Date? {
+        guard let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else { return nil }
+        return fractionalFormatter.date(from: raw) ?? plainFormatter.date(from: raw)
+    }
+}

--- a/MeterBar/SessionWake/CodexSessionDiscovery.swift
+++ b/MeterBar/SessionWake/CodexSessionDiscovery.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+/// Read-only discovery of blocked Codex sessions for the selected CODEX_HOME.
+///
+/// Mirrors `SessionDiscovery` (bounded newest-first enumeration, tail reads, no
+/// mutation) but over Codex's rollout layout: `<CODEX_HOME>/sessions/YYYY/MM/DD/
+/// rollout-<iso>-<uuid>.jsonl`. Classification is delegated to
+/// `CodexRolloutClassifier`, which keys the block signal on the structured
+/// `rate_limits.rate_limit_reached_type` field rather than any prose.
+actor CodexSessionDiscovery {
+    struct Configuration {
+        var maxTailBytes: Int = 64 * 1024
+        var maxTranscriptAge: TimeInterval = 14 * 24 * 3600
+        var maxTranscripts: Int = 400
+        var fileManager: FileManager = .default
+
+        init(
+            maxTailBytes: Int = 64 * 1024,
+            maxTranscriptAge: TimeInterval = 14 * 24 * 3600,
+            maxTranscripts: Int = 400,
+            fileManager: FileManager = .default
+        ) {
+            self.maxTailBytes = maxTailBytes
+            self.maxTranscriptAge = maxTranscriptAge
+            self.maxTranscripts = maxTranscripts
+            self.fileManager = fileManager
+        }
+    }
+
+    private let configuration: Configuration
+
+    init(configuration: Configuration = Configuration()) {
+        self.configuration = configuration
+    }
+
+    /// The `sessions` root for a CODEX_HOME, honoring an explicit override and
+    /// otherwise `~/.codex`.
+    static func sessionsDirectory(codexHome: String?) -> URL {
+        let trimmed = codexHome?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let base: String
+        if let trimmed, !trimmed.isEmpty {
+            base = (trimmed as NSString).standardizingPath
+        } else {
+            base = "\(ServiceSupport.realHomeDirectory())/.codex"
+        }
+        return URL(fileURLWithPath: base, isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+    }
+
+    /// Discover blocked Codex sessions under `codexHome`, consulting `ledger` to
+    /// flag already-handled blocks.
+    func discover(
+        codexHome: String?,
+        ledger: ReplayLedger,
+        now: Date = Date()
+    ) async -> [WakeSessionCandidate] {
+        let sessions = CodexSessionDiscovery.sessionsDirectory(codexHome: codexHome)
+        let rollouts = rolloutURLs(under: sessions, now: now)
+
+        var bySession: [String: WakeSessionCandidate] = [:]
+
+        for url in rollouts {
+            guard let lines = readTail(of: url) else { continue }
+            let fallbackID = url.deletingPathExtension().lastPathComponent
+            let summary = CodexRolloutClassifier.classify(fallbackID: fallbackID, lines: lines)
+
+            guard case let .blocked(reason, blockedAt, resetHint) = summary.state else { continue }
+
+            let fingerprint = BlockFingerprint(
+                sessionID: summary.sessionID,
+                blockedAt: blockedAt,
+                reason: reason,
+                provider: .codex
+            )
+            let (canonicalCwd, cwdSkip) = resolveWorkingDirectory(summary.cwd)
+            let alreadyHandled = await ledger.contains(fingerprint)
+            let skip: WakeSkipReason? = alreadyHandled ? .alreadyHandled : cwdSkip
+
+            let candidate = WakeSessionCandidate(
+                sessionID: summary.sessionID,
+                transcriptPath: url.path,
+                workingDirectory: canonicalCwd,
+                gitBranch: nil,
+                reason: reason,
+                blockedAt: blockedAt,
+                resetHint: resetHint,
+                fingerprint: fingerprint,
+                skipReason: skip,
+                provider: .codex
+            )
+
+            if let existing = bySession[summary.sessionID], !supersedes(candidate, existing) {
+                continue
+            }
+            bySession[summary.sessionID] = candidate
+        }
+
+        return bySession.values.sorted(by: supersedes)
+    }
+
+    private func supersedes(_ candidate: WakeSessionCandidate, _ existing: WakeSessionCandidate) -> Bool {
+        if candidate.blockedAt != existing.blockedAt {
+            return candidate.blockedAt > existing.blockedAt
+        }
+        return candidate.transcriptPath < existing.transcriptPath
+    }
+
+    // MARK: - Filesystem
+
+    private func rolloutURLs(under sessions: URL, now: Date) -> [URL] {
+        guard let enumerator = configuration.fileManager.enumerator(
+            at: sessions,
+            includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+        let oldestAllowed = now.addingTimeInterval(-configuration.maxTranscriptAge)
+        var found: [(url: URL, modified: Date)] = []
+        for case let url as URL in enumerator {
+            guard url.pathExtension == "jsonl",
+                  let values = try? url.resourceValues(
+                      forKeys: [.isRegularFileKey, .contentModificationDateKey]
+                  ),
+                  values.isRegularFile == true,
+                  let modified = values.contentModificationDate,
+                  modified >= oldestAllowed else {
+                continue
+            }
+            found.append((url, modified))
+        }
+        return found
+            .sorted {
+                if $0.modified != $1.modified {
+                    return $0.modified > $1.modified
+                }
+                return $0.url.path < $1.url.path
+            }
+            .prefix(configuration.maxTranscripts)
+            .map(\.url)
+    }
+
+    private func readTail(of url: URL) -> [String]? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+
+        let size = (try? handle.seekToEnd()) ?? 0
+        let start = size > UInt64(configuration.maxTailBytes)
+            ? size - UInt64(configuration.maxTailBytes)
+            : 0
+        try? handle.seek(toOffset: start)
+        let data = (try? handle.readToEnd()) ?? Data()
+        // Lossy decode for the same reason SessionDiscovery uses it: a bounded
+        // tail can split a multibyte character and strict decoding would drop
+        // the whole buffer.
+        // swiftlint:disable:next optional_data_string_conversion
+        let string = String(decoding: data, as: UTF8.self)
+        return string.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+    }
+
+    private func resolveWorkingDirectory(_ raw: String?) -> (String?, WakeSkipReason?) {
+        guard let raw, !raw.isEmpty else { return (nil, .unknownWorkingDirectory) }
+        let canonical = URL(fileURLWithPath: raw).resolvingSymlinksInPath().path
+        var isDirectory: ObjCBool = false
+        let exists = configuration.fileManager.fileExists(atPath: canonical, isDirectory: &isDirectory)
+        if !exists || !isDirectory.boolValue {
+            return (canonical, .missingWorkingDirectory)
+        }
+        return (canonical, nil)
+    }
+}

--- a/MeterBar/SessionWake/CodexWakeCommand.swift
+++ b/MeterBar/SessionWake/CodexWakeCommand.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Builds the `codex exec resume` invocation for a blocked Codex candidate.
+///
+/// Only flags confirmed present on the `codex exec resume` subcommand are used:
+/// the positional `SESSION_ID` and `PROMPT`, `-c key=value` config overrides,
+/// and `--dangerously-bypass-approvals-and-sandbox`. The posture mapping mirrors
+/// the Claude builder's intent:
+///
+/// - `.safe` pins an explicit, self-contained sandbox: `sandbox_mode` =
+///   `workspace-write` (edit the project, no network/system escape) and
+///   `approval_policy` = `never` (headless: never block on an approval that
+///   cannot be answered — anything needing escalation simply fails closed).
+/// - `.bypass` maps to `--dangerously-bypass-approvals-and-sandbox`, and — like
+///   the Claude builder — is only emitted when separately acknowledged; an
+///   unacknowledged bypass request is silently downgraded to `.safe`.
+nonisolated enum CodexWakeCommandBuilder {
+    static func build(
+        executable: String,
+        candidate: WakeSessionCandidate,
+        account: CodexAccount,
+        bounds: WakeBounds,
+        prompt: String = WakeCommandBuilder.defaultPrompt,
+        permissionMode: WakePermissionMode = .safe,
+        bypassAcknowledged: Bool = false,
+        baseEnvironment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> WakeCommand {
+        var arguments = ["exec", "resume", candidate.sessionID, prompt]
+
+        let effectiveMode: WakePermissionMode = (permissionMode == .bypass && bypassAcknowledged) ? .bypass : .safe
+        switch effectiveMode {
+        case .safe:
+            // TOML-quoted values: `"workspace-write"` parses as a TOML string.
+            arguments.append(contentsOf: ["-c", "sandbox_mode=\"workspace-write\""])
+            arguments.append(contentsOf: ["-c", "approval_policy=\"never\""])
+        case .bypass:
+            arguments.append("--dangerously-bypass-approvals-and-sandbox")
+        }
+
+        var environment = baseEnvironment
+        // Same PATH gap as the Claude runner: a GUI-launched MeterBar inherits
+        // launchd's bare PATH, and the resumed `codex` needs `node`/tooling.
+        environment["PATH"] = CLIBinaryLocator.augmentedPATH(environment: baseEnvironment)
+        environment["NO_COLOR"] = "1"
+        environment["FORCE_COLOR"] = "0"
+        environment["TERM"] = "dumb"
+        if let home = account.homeDirectory?.trimmingCharacters(in: .whitespacesAndNewlines), !home.isEmpty {
+            environment["CODEX_HOME"] = (home as NSString).standardizingPath
+        }
+
+        let workingDirectory = candidate.workingDirectory
+            ?? account.homeDirectory
+            ?? FileManager.default.currentDirectoryPath
+        return WakeCommand(
+            executable: executable,
+            arguments: arguments,
+            environment: environment,
+            workingDirectory: workingDirectory
+        )
+    }
+}

--- a/MeterBar/SessionWake/CodexWakeProcessRunner.swift
+++ b/MeterBar/SessionWake/CodexWakeProcessRunner.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+/// The native process runner for Codex resumes — the Codex sibling of
+/// `WakeProcessRunner`.
+///
+/// Same discipline: revalidate the target cwd immediately before exec, take the
+/// shared lock only when actually ready, spawn `codex` with an argument array
+/// (never a shell), enforce a timeout with process-tree cleanup, honor
+/// structured cancellation, and record a metadata-only log line. Codex `.safe`
+/// runs cannot escalate (approval_policy=never), so a non-zero exit is a plain
+/// failure — there is no permission-denial gate to classify as with Claude.
+nonisolated struct CodexWakeProcessRunner: WakeExecuting {
+    /// Explicit executable path; when nil the `codex` binary is resolved.
+    let executable: String?
+    let permissionMode: WakePermissionMode
+    let bypassAcknowledged: Bool
+    let prompt: String
+    let account: CodexAccount
+    private let baseEnvironment: [String: String]
+    private let lockFactory: @Sendable () -> WakeLock
+    private let logger: WakeRunLogger
+    private let now: @Sendable () -> Date
+
+    init(
+        account: CodexAccount,
+        executable: String? = nil,
+        permissionMode: WakePermissionMode = .safe,
+        bypassAcknowledged: Bool = false,
+        prompt: String = WakeCommandBuilder.defaultPrompt,
+        baseEnvironment: [String: String] = ProcessInfo.processInfo.environment,
+        lockFactory: @escaping @Sendable () -> WakeLock = { WakeLock() },
+        logger: WakeRunLogger = WakeRunLogger(),
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.account = account
+        self.executable = executable
+        self.permissionMode = permissionMode
+        self.bypassAcknowledged = bypassAcknowledged
+        self.prompt = prompt
+        self.baseEnvironment = baseEnvironment
+        self.lockFactory = lockFactory
+        self.logger = logger
+        self.now = now
+    }
+
+    func run(_ candidate: WakeSessionCandidate, bounds: WakeBounds) async -> WakeRunOutcome {
+        guard let cwd = candidate.workingDirectory, isDirectory(cwd) else {
+            record(candidate: candidate, outcome: .skipped(reason: .missingWorkingDirectory), result: nil, start: now())
+            return .skipped(reason: .missingWorkingDirectory)
+        }
+
+        let codexPath = executable ?? CLIBinaryLocator.resolve(command: "codex", overrideEnvVar: "CODEX_CLI_PATH")
+        guard let resolved = codexPath else {
+            record(candidate: candidate, outcome: .failed(reason: "codex binary not found"), result: nil, start: now())
+            return .failed(reason: "codex binary not found")
+        }
+
+        let lock = lockFactory()
+        switch lock.acquire() {
+        case .acquired:
+            break
+        case let .contended(holder):
+            let suffix = holder.map { " (\($0.shortDescription))" } ?? ""
+            let outcome = WakeRunOutcome.failed(reason: "another Session Wake holder is active\(suffix)")
+            record(candidate: candidate, outcome: outcome, result: nil, start: now())
+            return outcome
+        case let .legacyHeld(guidance):
+            let outcome = WakeRunOutcome.failed(reason: guidance)
+            record(candidate: candidate, outcome: outcome, result: nil, start: now())
+            return outcome
+        case let .unavailable(reason):
+            let outcome = WakeRunOutcome.failed(reason: "wake lock unavailable: \(reason)")
+            record(candidate: candidate, outcome: outcome, result: nil, start: now())
+            return outcome
+        }
+        defer { lock.release() }
+
+        let command = CodexWakeCommandBuilder.build(
+            executable: resolved,
+            candidate: candidate,
+            account: account,
+            bounds: bounds,
+            prompt: prompt,
+            permissionMode: permissionMode,
+            bypassAcknowledged: bypassAcknowledged,
+            baseEnvironment: baseEnvironment
+        )
+        let validated = WakeCommand(
+            executable: command.executable,
+            arguments: command.arguments,
+            environment: command.environment,
+            workingDirectory: cwd
+        )
+
+        let start = now()
+        let cancellation = ManagedProcess.Cancellation()
+        let result = await withTaskCancellationHandler {
+            await spawn(validated, timeout: bounds.perSessionTimeout, cancellation: cancellation)
+        } onCancel: {
+            cancellation.cancel()
+        }
+
+        let outcome = Self.mapOutcome(result)
+        record(candidate: candidate, outcome: outcome, result: result, start: start)
+        return outcome
+    }
+
+    // MARK: - Helpers
+
+    private func spawn(
+        _ command: WakeCommand,
+        timeout: TimeInterval,
+        cancellation: ManagedProcess.Cancellation
+    ) async -> ManagedProcess.Result {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let result = ManagedProcess.run(
+                    executable: command.executable,
+                    arguments: command.arguments,
+                    environment: command.environment,
+                    workingDirectory: command.workingDirectory,
+                    timeout: timeout,
+                    cancellation: cancellation
+                )
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
+    private func isDirectory(_ path: String) -> Bool {
+        var isDirectory: ObjCBool = false
+        return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue
+    }
+
+    static func mapOutcome(_ result: ManagedProcess.Result) -> WakeRunOutcome {
+        switch result.termination {
+        case .exited(0):
+            return .succeeded
+        case let .exited(code):
+            return .failed(reason: "codex exited with status \(code)")
+        case let .signalled(signal):
+            return .failed(reason: "codex terminated by signal \(signal)")
+        case .timedOut:
+            return .failed(reason: "session timed out")
+        case .cancelled:
+            return .cancelled
+        case let .launchFailed(message):
+            return .failed(reason: message)
+        }
+    }
+
+    private func record(
+        candidate: WakeSessionCandidate,
+        outcome: WakeRunOutcome,
+        result: ManagedProcess.Result?,
+        start: Date
+    ) {
+        let exitCode: Int32?
+        switch result?.termination {
+        case let .exited(code): exitCode = code
+        default: exitCode = nil
+        }
+        logger.append(WakeRunLogger.Record(
+            timestamp: start,
+            event: "resume",
+            sessionID: candidate.sessionID,
+            reason: candidate.reason.rawValue,
+            outcome: outcome.logLabel,
+            exitCode: exitCode,
+            durationMilliseconds: Int(now().timeIntervalSince(start) * 1000),
+            stdoutBytes: result?.stdoutByteCount,
+            stderrBytes: result?.stderrByteCount
+        ))
+    }
+}

--- a/MeterBar/SessionWake/CodexWakeQuotaAuthority.swift
+++ b/MeterBar/SessionWake/CodexWakeQuotaAuthority.swift
@@ -1,0 +1,52 @@
+import Foundation
+import MeterBarShared
+
+/// Source of *fresh* Codex quota, scoped to a selected `CodexAccount`
+/// (CODEX_HOME). Mirrors `WakeQuotaProviding` but over the Codex account type;
+/// cached UI metrics are never accepted as launch authority.
+nonisolated protocol CodexWakeQuotaProviding: Sendable {
+    func fetchMetrics(account: CodexAccount) async throws -> UsageMetrics
+}
+
+/// Default provider: the same Codex usage service the app and menu bar use,
+/// scoped to the account's CODEX_HOME.
+nonisolated struct LiveCodexWakeQuotaProvider: CodexWakeQuotaProviding {
+    func fetchMetrics(account: CodexAccount) async throws -> UsageMetrics {
+        try await CodexCliLocalService.shared.fetchUsageMetrics(account: account)
+    }
+}
+
+/// Resolves a fresh Codex quota decision, failing closed on any error,
+/// staleness, or ambiguity — the same contract as the Claude authority. The
+/// classification itself is provider-agnostic (`WakeQuota.classify` reads only
+/// the shared `UsageMetrics`), so Codex's primary (5h) window maps onto the
+/// session limit and its secondary (weekly) window onto the weekly limit with
+/// no change to the gate.
+nonisolated struct CodexWakeQuotaAuthority: Sendable {
+    private let provider: CodexWakeQuotaProviding
+    private let maxAge: TimeInterval
+    private let now: @Sendable () -> Date
+
+    init(
+        provider: CodexWakeQuotaProviding = LiveCodexWakeQuotaProvider(),
+        maxAge: TimeInterval = 120,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.provider = provider
+        self.maxAge = maxAge
+        self.now = now
+    }
+
+    func freshQuota(account: CodexAccount) async -> WakeQuota {
+        let metrics: UsageMetrics
+        do {
+            metrics = try await provider.fetchMetrics(account: account)
+        } catch {
+            return .unknown(reason: "quota fetch failed: \(error.localizedDescription)")
+        }
+        if now().timeIntervalSince(metrics.lastUpdated) > maxAge {
+            return .unknown(reason: "quota reading is stale")
+        }
+        return WakeQuota.classify(metrics)
+    }
+}

--- a/MeterBar/SessionWake/CodexWakeRuntime.swift
+++ b/MeterBar/SessionWake/CodexWakeRuntime.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// `WakeProviderRuntime` for Codex — binds Codex discovery, the Codex quota
+/// authority, and the Codex process-runner factory to one selected account
+/// (CODEX_HOME) so the shared orchestration never sees `CodexAccount`.
+nonisolated struct CodexWakeRuntime: WakeProviderRuntime {
+    let account: CodexAccount
+    private let discovery: CodexSessionDiscovery
+    private let authority: CodexWakeQuotaAuthority
+    private let makeRunnerForAccount: @Sendable (CodexAccount) -> WakeExecuting
+
+    init(
+        account: CodexAccount,
+        discovery: CodexSessionDiscovery = CodexSessionDiscovery(),
+        authority: CodexWakeQuotaAuthority = CodexWakeQuotaAuthority(),
+        makeRunner: @escaping @Sendable (CodexAccount) -> WakeExecuting
+    ) {
+        self.account = account
+        self.discovery = discovery
+        self.authority = authority
+        self.makeRunnerForAccount = makeRunner
+    }
+
+    var provider: WakeProvider { .codex }
+    var accountLabel: String? { account.homeDirectory }
+
+    func discover(ledger: ReplayLedger) async -> [WakeSessionCandidate] {
+        await discovery.discover(codexHome: account.homeDirectory, ledger: ledger)
+    }
+
+    func freshQuota() async -> WakeQuota {
+        await authority.freshQuota(account: account)
+    }
+
+    func makeRunner() -> WakeExecuting {
+        makeRunnerForAccount(account)
+    }
+}

--- a/MeterBar/SessionWake/SessionWakeCLI.swift
+++ b/MeterBar/SessionWake/SessionWakeCLI.swift
@@ -74,26 +74,59 @@ public enum SessionWakeCLI {
             return result(from: response)
         }
 
-        let account = resolveAccount(configDirectory: request.configDirectory)
+        guard let provider = WakeProvider.parse(request.provider) else {
+            let response = WakeCLIResponse.from(
+                candidates: [],
+                outcome: .validationFailure,
+                provider: request.provider.lowercased(),
+                dryRun: request.dryRun,
+                account: request.configDirectory,
+                message: "Unsupported provider '\(request.provider)'. Use 'claude' or 'codex'."
+            )
+            return result(from: response)
+        }
+
         let mode: WakePermissionMode = (request.permissionMode.lowercased() == "bypass") ? .bypass : .safe
-        let engine = WakeCLIEngine(
-            makeRunner: { runnerAccount in
+        let engine = WakeCLIEngine(shouldCancel: request.shouldCancel)
+        let runtime = makeRuntime(
+            provider: provider,
+            configDirectory: request.configDirectory,
+            mode: mode,
+            bypassAcknowledged: request.bypassAcknowledged
+        )
+
+        let response = await engine.run(runtime: runtime, dryRun: request.dryRun, limit: request.limit)
+        return result(from: response)
+    }
+
+    /// Build the provider-specific runtime the engine drives. For Codex the
+    /// `configDirectory` request field is reinterpreted as CODEX_HOME.
+    private static func makeRuntime(
+        provider: WakeProvider,
+        configDirectory: String?,
+        mode: WakePermissionMode,
+        bypassAcknowledged: Bool
+    ) -> WakeProviderRuntime {
+        switch provider {
+        case .claude:
+            let account = resolveAccount(configDirectory: configDirectory)
+            return ClaudeWakeRuntime(account: account) { runnerAccount in
                 WakeProcessRunner(
                     account: runnerAccount,
                     permissionMode: mode,
-                    bypassAcknowledged: request.bypassAcknowledged
+                    bypassAcknowledged: bypassAcknowledged
                 )
-            },
-            shouldCancel: request.shouldCancel
-        )
-
-        let response = await engine.run(
-            provider: request.provider,
-            account: account,
-            dryRun: request.dryRun,
-            limit: request.limit
-        )
-        return result(from: response)
+            }
+        case .codex:
+            let account = resolveCodexAccount(homeDirectory: configDirectory)
+            return CodexWakeRuntime(account: account) { runnerAccount in
+                CodexWakeProcessRunner(
+                    account: runnerAccount,
+                    permissionMode: mode,
+                    bypassAcknowledged: bypassAcknowledged
+                )
+            }
+        }
     }
 
     /// Missing means enabled for compatibility with v1.7.0 installs. Only an
@@ -139,6 +172,33 @@ public enum SessionWakeCLI {
         }
         if let shared = sharedAccountConfigDirectory() {
             return ClaudeCodeAccount(id: UUID(), name: "shared", configDirectory: shared)
+        }
+        return .defaultAccount
+    }
+
+    /// The app-group key the app writes the selected Codex wake account's
+    /// CODEX_HOME to. Read-only from the CLI.
+    public static let sharedCodexHomeKey = "SessionWakeCodexHomeDir"
+
+    /// The Codex CODEX_HOME the app shares via the app-group domain.
+    public static func sharedCodexHomeDirectory() -> String? {
+        guard let shared = UserDefaults(suiteName: SharedMetricsStore.appGroupIdentifier) else {
+            return nil
+        }
+        let value = shared.string(forKey: sharedCodexHomeKey)?.trimmingCharacters(in: .whitespaces)
+        return (value?.isEmpty == false) ? value : nil
+    }
+
+    /// Resolve the Codex wake account. An explicit `--config-dir` is treated as
+    /// CODEX_HOME; otherwise the app-group value the app shares, then the
+    /// default profile (`CODEX_HOME` env / `~/.codex`).
+    private static func resolveCodexAccount(homeDirectory: String?) -> CodexAccount {
+        let explicit = homeDirectory?.trimmingCharacters(in: .whitespaces)
+        if let explicit, !explicit.isEmpty {
+            return CodexAccount(id: UUID(), name: "cli", homeDirectory: explicit)
+        }
+        if let shared = sharedCodexHomeDirectory() {
+            return CodexAccount(id: UUID(), name: "shared", homeDirectory: shared)
         }
         return .defaultAccount
     }

--- a/MeterBar/SessionWake/WakeCLIEngine.swift
+++ b/MeterBar/SessionWake/WakeCLIEngine.swift
@@ -2,9 +2,14 @@ import Foundation
 
 /// The engine behind `meterbar wake`: a thin one-shot orchestration over the
 /// same discovery, quota, runner, and ledger the app uses. It never invokes a
-/// Claude process or mutates anything on `dryRun`, emits a distinguishable
-/// outcome for every terminal state, and refuses non-Claude providers (Codex is
-/// not exposed in v1).
+/// provider process or mutates anything on `dryRun`, and emits a
+/// distinguishable outcome for every terminal state.
+///
+/// The orchestration is provider-agnostic: it drives a `WakeProviderRuntime`
+/// (Claude or Codex) via `run(runtime:dryRun:limit:)`. The legacy
+/// `run(provider:account:dryRun:limit:)` is retained as a Claude-only facade
+/// that builds a `ClaudeWakeRuntime` and delegates to the same body — so the
+/// caller that already speaks `ClaudeCodeAccount` keeps working unchanged.
 struct WakeCLIEngine {
     private let discovery: SessionDiscovery
     private let authority: WakeQuotaAuthority
@@ -17,7 +22,7 @@ struct WakeCLIEngine {
     init(
         discovery: SessionDiscovery = SessionDiscovery(),
         authority: WakeQuotaAuthority = WakeQuotaAuthority(),
-        makeRunner: @escaping @Sendable (ClaudeCodeAccount) -> WakeExecuting,
+        makeRunner: @escaping @Sendable (ClaudeCodeAccount) -> WakeExecuting = { WakeProcessRunner(account: $0) },
         ledgerFactory: @escaping @Sendable () -> ReplayLedger = { ReplayLedger() },
         lock: WakeLock = WakeLock(holderKind: .cli),
         bounds: WakeBounds = .default,
@@ -32,22 +37,39 @@ struct WakeCLIEngine {
         self.shouldCancel = shouldCancel
     }
 
+    /// Legacy Claude-only entry point. Preserved so existing callers and tests
+    /// that pass a `ClaudeCodeAccount` and a provider string keep their exact
+    /// behavior; a non-Claude provider string here is still a validation
+    /// failure (Codex is reached through `run(runtime:)`, not this method).
     func run(provider: String, account: ClaudeCodeAccount, dryRun: Bool, limit: Int?) async -> WakeCLIResponse {
         let normalizedProvider = provider.lowercased()
         guard normalizedProvider == "claude" else {
-            // Codex is intentionally not exposed in v1.
             return .from(
                 candidates: [],
                 outcome: .validationFailure,
                 provider: normalizedProvider,
                 dryRun: dryRun,
                 account: account.configDirectory,
-                message: "Only the 'claude' provider is supported in this version."
+                message: "Only the 'claude' provider is supported on this entry point."
             )
         }
+        let runtime = ClaudeWakeRuntime(
+            account: account,
+            discovery: discovery,
+            authority: authority,
+            makeRunner: makeRunner
+        )
+        return await run(runtime: runtime, dryRun: dryRun, limit: limit)
+    }
+
+    /// Provider-agnostic one-shot wake. `dryRun` performs no subprocess and no
+    /// mutation.
+    func run(runtime: WakeProviderRuntime, dryRun: Bool, limit: Int?) async -> WakeCLIResponse {
+        let providerToken = runtime.provider.rawValue
+        let accountLabel = runtime.accountLabel
 
         let ledger = ledgerFactory()
-        let candidates = await discovery.discover(configDirectory: account.configDirectory, ledger: ledger)
+        let candidates = await runtime.discover(ledger: ledger)
 
         // Dry-run / preview: strictly read-only. No lock, no quota fetch, no
         // subprocess, no mutation.
@@ -55,9 +77,9 @@ struct WakeCLIEngine {
             return .from(
                 candidates: candidates,
                 outcome: .success,
-                provider: normalizedProvider,
+                provider: providerToken,
                 dryRun: true,
-                account: account.configDirectory
+                account: accountLabel
             )
         }
 
@@ -76,42 +98,42 @@ struct WakeCLIEngine {
             return .from(
                 candidates: candidates,
                 outcome: .validationFailure,
-                provider: normalizedProvider,
+                provider: providerToken,
                 dryRun: false,
-                account: account.configDirectory,
+                account: accountLabel,
                 message: "Another Session Wake holder\(who) is already running."
             )
         case let .legacyHeld(guidance):
             return .from(
                 candidates: candidates,
                 outcome: .validationFailure,
-                provider: normalizedProvider,
+                provider: providerToken,
                 dryRun: false,
-                account: account.configDirectory,
+                account: accountLabel,
                 message: guidance
             )
         case let .unavailable(reason):
             return .from(
                 candidates: candidates,
                 outcome: .validationFailure,
-                provider: normalizedProvider,
+                provider: providerToken,
                 dryRun: false,
-                account: account.configDirectory,
+                account: accountLabel,
                 message: "Session Wake lock unavailable: \(reason)"
             )
         }
         defer { lock.release() }
 
         // Fresh quota before any launch.
-        let quota = await authority.freshQuota(account: account)
+        let quota = await runtime.freshQuota()
         switch quota {
         case let .unknown(reason):
             return .from(
                 candidates: candidates,
                 outcome: .quotaUnknown,
-                provider: normalizedProvider,
+                provider: providerToken,
                 dryRun: false,
-                account: account.configDirectory,
+                account: accountLabel,
                 message: reason
             )
         case let .blocked(until, reason):
@@ -119,30 +141,31 @@ struct WakeCLIEngine {
             return .from(
                 candidates: candidates,
                 outcome: .blockedWithoutWait,
-                provider: normalizedProvider,
+                provider: providerToken,
                 dryRun: false,
-                account: account.configDirectory,
+                account: accountLabel,
                 message: detail
             )
         case .available:
             return await resume(
                 candidates: candidates,
-                account: account,
+                runner: runtime.makeRunner(),
                 ledger: ledger,
                 limit: limit,
-                provider: normalizedProvider
+                provider: providerToken,
+                accountLabel: accountLabel
             )
         }
     }
 
     private func resume(
         candidates: [WakeSessionCandidate],
-        account: ClaudeCodeAccount,
+        runner: WakeExecuting,
         ledger: ReplayLedger,
         limit: Int?,
-        provider: String
+        provider: String,
+        accountLabel: String?
     ) async -> WakeCLIResponse {
-        let runner = makeRunner(account)
         let cap = min(limit ?? bounds.maxSessionsPerRun, bounds.maxSessionsPerRun)
         let queue = Array(candidates.filter(\.isExecutable).prefix(cap))
 
@@ -184,7 +207,7 @@ struct WakeCLIEngine {
             outcome: outcome,
             provider: provider,
             dryRun: false,
-            account: account.configDirectory,
+            account: accountLabel,
             summary: summary
         )
     }

--- a/MeterBar/SessionWake/WakeProvider.swift
+++ b/MeterBar/SessionWake/WakeProvider.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// The AI coding assistant a Session Wake run targets.
+///
+/// Session Wake shipped Claude-only (#95–#99). Codex is the second provider
+/// (#… this change). The `rawValue` is the stable, lowercase token used on the
+/// `meterbar wake --provider` flag, in the versioned CLI JSON response, and in
+/// persisted settings — never localize it.
+nonisolated enum WakeProvider: String, Codable, Equatable, Sendable, CaseIterable {
+    case claude
+    case codex
+
+    /// User-facing name for menus, notifications, and status copy.
+    var displayName: String {
+        switch self {
+        case .claude: return "Claude Code"
+        case .codex: return "Codex"
+        }
+    }
+
+    /// Parse a provider token (case-insensitive). Returns nil for anything not
+    /// in the closed set so the CLI can fail closed with a validation error
+    /// rather than silently defaulting.
+    static func parse(_ raw: String) -> WakeProvider? {
+        WakeProvider(rawValue: raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased())
+    }
+}
+
+/// The provider-specific behaviors the one-shot engine and the continuous
+/// coordinator drive, bundled behind one seam so the orchestration stays a
+/// single implementation regardless of provider.
+///
+/// A runtime is constructed already bound to its selected account, so callers
+/// never thread a provider-typed account (`ClaudeCodeAccount` vs `CodexAccount`)
+/// through the shared orchestration — they hand it a runtime and ask it to
+/// discover, gate, and run.
+nonisolated protocol WakeProviderRuntime: Sendable {
+    /// Which provider this runtime speaks for (tags the response + candidates).
+    var provider: WakeProvider { get }
+
+    /// A short label identifying the bound account for the CLI JSON response's
+    /// `account` field (a config directory or CODEX_HOME). Never a secret.
+    var accountLabel: String? { get }
+
+    /// Read-only discovery of blocked sessions for the bound account, flagging
+    /// already-handled blocks via `ledger`.
+    func discover(ledger: ReplayLedger) async -> [WakeSessionCandidate]
+
+    /// A fresh, fail-closed quota decision for the bound account.
+    func freshQuota() async -> WakeQuota
+
+    /// The execution seam used to resume one session at a time.
+    func makeRunner() -> WakeExecuting
+}

--- a/MeterBar/SessionWake/WakeSession.swift
+++ b/MeterBar/SessionWake/WakeSession.swift
@@ -10,10 +10,17 @@ import Foundation
 nonisolated struct BlockFingerprint: Codable, Equatable, Hashable, Sendable {
     let value: String
 
-    init(sessionID: String, blockedAt: Date, reason: WakeBlockReason) {
+    init(sessionID: String, blockedAt: Date, reason: WakeBlockReason, provider: WakeProvider = .claude) {
         // Second precision: the same event re-read must hash identically.
         let epochSecond = Int(blockedAt.timeIntervalSince1970.rounded())
-        let seed = "\(sessionID)|\(epochSecond)|\(reason.rawValue)"
+        // Claude's seed is kept byte-identical so existing ledger entries keep
+        // matching across the upgrade that added a provider dimension; only
+        // non-Claude providers namespace the seed, which also prevents a Claude
+        // and a Codex session that share an id/instant/reason from colliding on
+        // one ledger entry.
+        let seed = (provider == .claude)
+            ? "\(sessionID)|\(epochSecond)|\(reason.rawValue)"
+            : "\(provider.rawValue)|\(sessionID)|\(epochSecond)|\(reason.rawValue)"
         let digest = SHA256.hash(data: Data(seed.utf8))
         self.value = digest.map { String(format: "%02x", $0) }.joined()
     }
@@ -38,6 +45,10 @@ nonisolated enum WakeSkipReason: String, Codable, Equatable, Sendable {
 /// reason rather than silently dropping the candidate so the UI/CLI can explain
 /// why a visible blocked session was not resumed.
 nonisolated struct WakeSessionCandidate: Equatable, Sendable, Identifiable {
+    /// Which assistant this session belongs to. Defaulted to `.claude` so every
+    /// existing construction site (and test) keeps compiling unchanged; Codex
+    /// discovery passes `.codex` explicitly.
+    let provider: WakeProvider
     let sessionID: String
     let transcriptPath: String
     /// Canonicalized (symlinks resolved) working directory, if resolvable.
@@ -49,6 +60,30 @@ nonisolated struct WakeSessionCandidate: Equatable, Sendable, Identifiable {
     let resetHint: TranscriptResetParser.Result?
     let fingerprint: BlockFingerprint
     let skipReason: WakeSkipReason?
+
+    init(
+        sessionID: String,
+        transcriptPath: String,
+        workingDirectory: String?,
+        gitBranch: String?,
+        reason: WakeBlockReason,
+        blockedAt: Date,
+        resetHint: TranscriptResetParser.Result?,
+        fingerprint: BlockFingerprint,
+        skipReason: WakeSkipReason?,
+        provider: WakeProvider = .claude
+    ) {
+        self.provider = provider
+        self.sessionID = sessionID
+        self.transcriptPath = transcriptPath
+        self.workingDirectory = workingDirectory
+        self.gitBranch = gitBranch
+        self.reason = reason
+        self.blockedAt = blockedAt
+        self.resetHint = resetHint
+        self.fingerprint = fingerprint
+        self.skipReason = skipReason
+    }
 
     var id: String { fingerprint.value }
 

--- a/MeterBarCLI/Sources/Wake.swift
+++ b/MeterBarCLI/Sources/Wake.swift
@@ -16,10 +16,11 @@ import MeterBar
 /// - SIGINT releases the shared lock and leaves no child process.
 /// - Configuration comes from explicit flags or the shared app-group domain,
 ///   never the CLI process's own `UserDefaults.standard`.
-/// - Codex is not exposed.
+/// - Both `claude` and `codex` providers are supported; each resumes only its
+///   own blocked sessions, gated by that account's fresh usage quota.
 struct Wake: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
-        abstract: "Resume Claude Code sessions blocked on usage limits"
+        abstract: "Resume Claude Code or Codex sessions blocked on usage limits"
     )
 
     @Flag(name: .long, help: "Preview resumable sessions without launching anything.")
@@ -28,10 +29,10 @@ struct Wake: AsyncParsableCommand {
     @Flag(name: .shortAndLong, help: "Emit only the versioned JSON response on stdout.")
     var json: Bool = false
 
-    @Option(name: .shortAndLong, help: "Provider (only 'claude' is supported).")
+    @Option(name: .shortAndLong, help: "Provider: 'claude' (default) or 'codex'.")
     var provider: String = "claude"
 
-    @Option(name: .long, help: "Explicit CLAUDE_CONFIG_DIR for the wake account.")
+    @Option(name: .long, help: "Explicit config dir for the wake account (CLAUDE_CONFIG_DIR for claude, CODEX_HOME for codex).")
     var configDir: String?
 
     @Option(name: .shortAndLong, help: "Maximum sessions to resume this run.")

--- a/MeterBarTests/CodexRolloutClassifierTests.swift
+++ b/MeterBarTests/CodexRolloutClassifierTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+@testable import MeterBar
+
+/// Coverage for the Codex rollout classifier: the block signal is the
+/// structured `rate_limit_reached_type`, never prose; a later `task_complete`
+/// clears it; the reached window selects the reason and reset instant.
+final class CodexRolloutClassifierTests: XCTestCase {
+    // MARK: - Fixtures
+
+    private func line(_ object: [String: Any]) -> String {
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private func meta(id: String = "sess-1", cwd: String? = "/tmp/work", source: String = "exec") -> String {
+        var payload: [String: Any] = ["id": id, "source": source]
+        if let cwd { payload["cwd"] = cwd }
+        return line(["type": "session_meta", "timestamp": "2026-07-13T09:00:00.000Z", "payload": payload])
+    }
+
+    private func tokenCount(
+        timestamp: String = "2026-07-13T09:05:00.000Z",
+        reached: Any = NSNull(),
+        primaryResetsAt: Int? = 1_900_000_000,
+        secondaryResetsAt: Int? = 1_900_500_000
+    ) -> String {
+        var rateLimits: [String: Any] = ["rate_limit_reached_type": reached]
+        if let primaryResetsAt {
+            rateLimits["primary"] = ["used_percent": 100.0, "window_minutes": 300, "resets_at": primaryResetsAt]
+        }
+        if let secondaryResetsAt {
+            rateLimits["secondary"] = ["used_percent": 100.0, "window_minutes": 10080, "resets_at": secondaryResetsAt]
+        }
+        return line([
+            "type": "event_msg", "timestamp": timestamp,
+            "payload": ["type": "token_count", "rate_limits": rateLimits]
+        ])
+    }
+
+    private func taskComplete(timestamp: String = "2026-07-13T09:10:00.000Z") -> String {
+        line(["type": "event_msg", "timestamp": timestamp, "payload": ["type": "task_complete"]])
+    }
+
+    // MARK: - Blocked signal
+
+    func testPrimaryHitIsSessionLimitBlockedWithResetInstant() {
+        let lines = [meta(), tokenCount(reached: "primary")]
+        let summary = CodexRolloutClassifier.classify(fallbackID: "fallback", lines: lines)
+
+        XCTAssertEqual(summary.sessionID, "sess-1")
+        XCTAssertEqual(summary.cwd, "/tmp/work")
+        guard case let .blocked(reason, blockedAt, resetHint) = summary.state else {
+            return XCTFail("expected blocked, got \(summary.state)")
+        }
+        XCTAssertEqual(reason, .sessionLimit)
+        XCTAssertEqual(blockedAt, CodexRolloutClassifier.parseTimestamp("2026-07-13T09:05:00.000Z"))
+        XCTAssertEqual(resetHint?.resetAt, Date(timeIntervalSince1970: 1_900_000_000))
+    }
+
+    func testSecondaryHitIsWeeklyLimitWithSecondaryReset() {
+        let lines = [meta(), tokenCount(reached: "secondary")]
+        let summary = CodexRolloutClassifier.classify(fallbackID: "f", lines: lines)
+        guard case let .blocked(reason, _, resetHint) = summary.state else {
+            return XCTFail("expected blocked, got \(summary.state)")
+        }
+        XCTAssertEqual(reason, .weeklyLimit)
+        XCTAssertEqual(resetHint?.resetAt, Date(timeIntervalSince1970: 1_900_500_000))
+    }
+
+    // MARK: - Recovery clears the block
+
+    func testCompletionAfterHitClearsBlocked() {
+        let lines = [meta(), tokenCount(reached: "primary"), taskComplete()]
+        let summary = CodexRolloutClassifier.classify(fallbackID: "f", lines: lines)
+        XCTAssertEqual(summary.state, .active, "a completed turn after the hit means it recovered")
+    }
+
+    func testHitAfterEarlierCompletionStaysBlocked() {
+        // Completed an early turn, then a later turn hit the wall: still blocked.
+        let lines = [
+            meta(),
+            tokenCount(timestamp: "2026-07-13T09:01:00.000Z", reached: NSNull()),
+            taskComplete(timestamp: "2026-07-13T09:02:00.000Z"),
+            tokenCount(timestamp: "2026-07-13T09:09:00.000Z", reached: "primary")
+        ]
+        let summary = CodexRolloutClassifier.classify(fallbackID: "f", lines: lines)
+        guard case .blocked = summary.state else {
+            return XCTFail("expected blocked after a later hit, got \(summary.state)")
+        }
+    }
+
+    // MARK: - False-positive guards
+
+    func testNullReachedTypeIsNotBlocked() {
+        let lines = [meta(), tokenCount(reached: NSNull())]
+        let summary = CodexRolloutClassifier.classify(fallbackID: "f", lines: lines)
+        XCTAssertEqual(summary.state, .indeterminate, "normal usage (null reached type) is never a block")
+    }
+
+    func testRateLimitWordsInMessageContentDoNotBlock() {
+        // A session that merely *discusses* rate limits must not read as blocked.
+        let chatter = line([
+            "type": "response_item", "timestamp": "2026-07-13T09:05:00.000Z",
+            "payload": [
+                "type": "message", "role": "assistant",
+                "content": [["type": "output_text", "text": "You hit a 429 rate limit; usage limit reached, resets soon."]]
+            ]
+        ])
+        let summary = CodexRolloutClassifier.classify(fallbackID: "f", lines: [meta(), chatter])
+        XCTAssertEqual(summary.state, .indeterminate, "prose about limits is not a structured hit")
+    }
+
+    func testEmptyReachedStringIsNotBlocked() {
+        let lines = [meta(), tokenCount(reached: "")]
+        let summary = CodexRolloutClassifier.classify(fallbackID: "f", lines: lines)
+        XCTAssertEqual(summary.state, .indeterminate)
+    }
+
+    // MARK: - Robustness
+
+    func testGarbledAndTruncatedLinesDoNotCrash() {
+        let lines = [
+            "{ this is not json",
+            String("{\"type\":\"session_meta\",\"payload\":{\"id\":\"sess-9\"".dropLast(4)), // truncated tail
+            meta(id: "sess-9"),
+            tokenCount(reached: "primary")
+        ]
+        let summary = CodexRolloutClassifier.classify(fallbackID: "fallback", lines: lines)
+        XCTAssertEqual(summary.sessionID, "sess-9")
+        guard case .blocked = summary.state else { return XCTFail("expected blocked despite garbled lines") }
+    }
+
+    func testFallbackIDUsedWhenNoSessionMeta() {
+        let summary = CodexRolloutClassifier.classify(fallbackID: "on-disk-id", lines: [tokenCount(reached: "primary")])
+        XCTAssertEqual(summary.sessionID, "on-disk-id")
+    }
+
+    func testMissingResetWindowStillBlocksWithoutHint() {
+        // reached=primary but no primary window object: blocked, nil resetHint.
+        let lines = [meta(), tokenCount(reached: "primary", primaryResetsAt: nil)]
+        let summary = CodexRolloutClassifier.classify(fallbackID: "f", lines: lines)
+        guard case let .blocked(reason, _, resetHint) = summary.state else {
+            return XCTFail("expected blocked, got \(summary.state)")
+        }
+        XCTAssertEqual(reason, .sessionLimit)
+        XCTAssertNil(resetHint)
+    }
+}

--- a/MeterBarTests/CodexSessionDiscoveryTests.swift
+++ b/MeterBarTests/CodexSessionDiscoveryTests.swift
@@ -1,0 +1,185 @@
+import XCTest
+@testable import MeterBar
+@testable import MeterBarShared
+
+/// End-to-end Codex discovery over a synthetic `~/.codex/sessions` tree, plus
+/// the engine driving a `CodexWakeRuntime` through to a resume.
+final class CodexSessionDiscoveryTests: XCTestCase {
+    private var home: URL!
+
+    override func setUpWithError() throws {
+        home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexWake-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        home = home.resolvingSymlinksInPath()
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: home)
+    }
+
+    // MARK: - Fixture writing
+
+    private func jsonl(_ objects: [[String: Any]]) -> String {
+        objects.map { String(decoding: try! JSONSerialization.data(withJSONObject: $0), as: UTF8.self) }
+            .joined(separator: "\n")
+    }
+
+    @discardableResult
+    private func writeRollout(
+        id: String,
+        cwd: String?,
+        reached: Any = "primary",
+        day: String = "2026/07/13",
+        completed: Bool = false
+    ) throws -> URL {
+        let dir = home.appendingPathComponent("sessions/\(day)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        var meta: [String: Any] = ["id": id, "source": "exec"]
+        if let cwd { meta["cwd"] = cwd }
+        var objects: [[String: Any]] = [
+            ["type": "session_meta", "timestamp": "2026-07-13T09:00:00.000Z", "payload": meta],
+            ["type": "event_msg", "timestamp": "2026-07-13T09:05:00.000Z",
+             "payload": ["type": "token_count",
+                         "rate_limits": ["rate_limit_reached_type": reached,
+                                         "primary": ["resets_at": 1_900_000_000]]]]
+        ]
+        if completed {
+            objects.append(["type": "event_msg", "timestamp": "2026-07-13T09:06:00.000Z",
+                            "payload": ["type": "task_complete"]])
+        }
+        let url = dir.appendingPathComponent("rollout-2026-07-13T09-00-00-\(id).jsonl")
+        try jsonl(objects).write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private func ledger() -> ReplayLedger {
+        ReplayLedger(fileURL: home.appendingPathComponent("ledger.json"))
+    }
+
+    // MARK: - Discovery
+
+    func testDiscoversExecutableBlockedSession() async throws {
+        try writeRollout(id: "s-exec", cwd: home.path)
+        let candidates = await CodexSessionDiscovery().discover(codexHome: home.path, ledger: ledger())
+        XCTAssertEqual(candidates.count, 1)
+        let candidate = try XCTUnwrap(candidates.first)
+        XCTAssertEqual(candidate.provider, .codex)
+        XCTAssertEqual(candidate.sessionID, "s-exec")
+        XCTAssertEqual(candidate.reason, .sessionLimit)
+        XCTAssertTrue(candidate.isExecutable)
+        XCTAssertEqual(candidate.resetHint?.resetAt, Date(timeIntervalSince1970: 1_900_000_000))
+    }
+
+    func testMissingWorkingDirectoryIsSkipNotDrop() async throws {
+        try writeRollout(id: "s-dead", cwd: "/no/such/dir/\(UUID().uuidString)")
+        let candidates = await CodexSessionDiscovery().discover(codexHome: home.path, ledger: ledger())
+        XCTAssertEqual(candidates.first?.skipReason, .missingWorkingDirectory)
+        XCTAssertFalse(candidates.first?.isExecutable ?? true)
+    }
+
+    func testCompletedSessionIsNotDiscovered() async throws {
+        try writeRollout(id: "s-done", cwd: home.path, completed: true)
+        let candidates = await CodexSessionDiscovery().discover(codexHome: home.path, ledger: ledger())
+        XCTAssertTrue(candidates.isEmpty, "a recovered session is not a wake target")
+    }
+
+    func testNormalUsageSessionIsNotDiscovered() async throws {
+        try writeRollout(id: "s-ok", cwd: home.path, reached: NSNull())
+        let candidates = await CodexSessionDiscovery().discover(codexHome: home.path, ledger: ledger())
+        XCTAssertTrue(candidates.isEmpty)
+    }
+
+    func testAlreadyHandledBlockIsFlaggedAcrossRescan() async throws {
+        try writeRollout(id: "s-dup", cwd: home.path)
+        let led = ledger()
+        let first = await CodexSessionDiscovery().discover(codexHome: home.path, ledger: led)
+        let fingerprint = try XCTUnwrap(first.first?.fingerprint)
+        await led.record(fingerprint)
+
+        let rescan = await CodexSessionDiscovery().discover(codexHome: home.path, ledger: led)
+        XCTAssertEqual(rescan.first?.skipReason, .alreadyHandled)
+    }
+
+    func testDiscoveryIsScopedToTheSelectedHome() async throws {
+        // A blocked rollout under a DIFFERENT home must never be seen.
+        let other = home.appendingPathComponent("other-home")
+        try FileManager.default.createDirectory(at: other, withIntermediateDirectories: true)
+        let dir = other.appendingPathComponent("sessions/2026/07/13")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try jsonl([["type": "session_meta", "timestamp": "2026-07-13T09:00:00.000Z",
+                    "payload": ["id": "elsewhere", "cwd": home.path]],
+                   ["type": "event_msg", "timestamp": "2026-07-13T09:05:00.000Z",
+                    "payload": ["type": "token_count", "rate_limits": ["rate_limit_reached_type": "primary"]]]])
+            .write(to: dir.appendingPathComponent("rollout-x.jsonl"), atomically: true, encoding: .utf8)
+
+        let candidates = await CodexSessionDiscovery().discover(codexHome: home.path, ledger: ledger())
+        XCTAssertTrue(candidates.isEmpty, "discovery must only read the selected CODEX_HOME")
+    }
+
+    // MARK: - Engine integration through the runtime
+
+    func testEngineResumesCodexSessionWhenQuotaAvailable() async throws {
+        try writeRollout(id: "s-run", cwd: home.path)
+        let runner = CodexRecordingRunner(outcome: .succeeded)
+        let runtime = CodexWakeRuntime(
+            account: CodexAccount(id: UUID(), name: "a", homeDirectory: home.path),
+            discovery: CodexSessionDiscovery(),
+            authority: CodexWakeQuotaAuthority(provider: OpenCodexProvider(), maxAge: 3600, now: { Date() }),
+            makeRunner: { _ in runner }
+        )
+        let engine = WakeCLIEngine(
+            ledgerFactory: { self.ledger() },
+            lock: WakeLock(lockURL: home.appendingPathComponent("wake.lock"), legacyLockURLs: [])
+        )
+        let response = await engine.run(runtime: runtime, dryRun: false, limit: nil)
+        XCTAssertEqual(response.outcome, .success)
+        XCTAssertEqual(response.provider, "codex")
+        XCTAssertEqual(response.summary.resumed, 1)
+        let ran = await runner.ran
+        XCTAssertEqual(ran, ["s-run"])
+    }
+
+    func testEngineDryRunForCodexLaunchesNothing() async throws {
+        try writeRollout(id: "s-dry", cwd: home.path)
+        let runner = CodexRecordingRunner(outcome: .succeeded)
+        let runtime = CodexWakeRuntime(
+            account: CodexAccount(id: UUID(), name: "a", homeDirectory: home.path),
+            authority: CodexWakeQuotaAuthority(provider: ThrowingCodexProvider2()),
+            makeRunner: { _ in runner }
+        )
+        let engine = WakeCLIEngine(
+            ledgerFactory: { self.ledger() },
+            lock: WakeLock(lockURL: home.appendingPathComponent("wake.lock"), legacyLockURLs: [])
+        )
+        let response = await engine.run(runtime: runtime, dryRun: true, limit: nil)
+        XCTAssertEqual(response.outcome, .success)
+        XCTAssertTrue(response.dryRun)
+        XCTAssertEqual(response.eligibleCount, 1)
+        let ran = await runner.ran
+        XCTAssertTrue(ran.isEmpty, "dry-run must launch nothing and never consult quota")
+    }
+}
+
+// MARK: - Doubles
+
+private actor CodexRecordingRunner: WakeExecuting {
+    private(set) var ran: [String] = []
+    private let outcome: WakeRunOutcome
+    init(outcome: WakeRunOutcome = .succeeded) { self.outcome = outcome }
+    func run(_ candidate: WakeSessionCandidate, bounds: WakeBounds) async -> WakeRunOutcome {
+        ran.append(candidate.sessionID)
+        return outcome
+    }
+}
+
+private struct OpenCodexProvider: CodexWakeQuotaProviding {
+    func fetchMetrics(account: CodexAccount) async throws -> UsageMetrics {
+        UsageMetrics(service: .codexCli, sessionLimit: UsageLimit(used: 5, total: 100, resetTime: nil), lastUpdated: Date())
+    }
+}
+
+private struct ThrowingCodexProvider2: CodexWakeQuotaProviding {
+    struct Boom: Error {}
+    func fetchMetrics(account: CodexAccount) async throws -> UsageMetrics { throw Boom() }
+}

--- a/MeterBarTests/CodexWakeCommandTests.swift
+++ b/MeterBarTests/CodexWakeCommandTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import MeterBar
+
+/// Coverage for the `codex exec resume` invocation builder: exact argv shape,
+/// the safe/bypass posture mapping, the bypass acknowledgement gate, and
+/// CODEX_HOME injection.
+final class CodexWakeCommandTests: XCTestCase {
+    private func candidate(sessionID: String = "sess-1", cwd: String? = "/tmp/work") -> WakeSessionCandidate {
+        WakeSessionCandidate(
+            sessionID: sessionID,
+            transcriptPath: "/tmp/rollout.jsonl",
+            workingDirectory: cwd,
+            gitBranch: nil,
+            reason: .sessionLimit,
+            blockedAt: Date(timeIntervalSince1970: 1_000),
+            resetHint: nil,
+            fingerprint: BlockFingerprint(sessionID: sessionID, blockedAt: Date(timeIntervalSince1970: 1_000), reason: .sessionLimit, provider: .codex),
+            skipReason: nil,
+            provider: .codex
+        )
+    }
+
+    private func account(home: String? = "/custom/codex") -> CodexAccount {
+        CodexAccount(id: UUID(), name: "acct", homeDirectory: home)
+    }
+
+    func testResumeArgvShapeAndPrompt() {
+        let command = CodexWakeCommandBuilder.build(
+            executable: "/bin/codex",
+            candidate: candidate(),
+            account: account(),
+            bounds: .default,
+            prompt: "keep going",
+            baseEnvironment: ["PATH": "/usr/bin"]
+        )
+        XCTAssertEqual(command.executable, "/bin/codex")
+        // Positional subcommand + session id + prompt come first.
+        XCTAssertEqual(Array(command.arguments.prefix(4)), ["exec", "resume", "sess-1", "keep going"])
+    }
+
+    func testSafeModeSetsSandboxAndApprovalOverrides() {
+        let command = CodexWakeCommandBuilder.build(
+            executable: "/bin/codex",
+            candidate: candidate(),
+            account: account(),
+            bounds: .default,
+            permissionMode: .safe,
+            baseEnvironment: ["PATH": "/usr/bin"]
+        )
+        XCTAssertTrue(command.arguments.contains("sandbox_mode=\"workspace-write\""))
+        XCTAssertTrue(command.arguments.contains("approval_policy=\"never\""))
+        XCTAssertFalse(command.arguments.contains("--dangerously-bypass-approvals-and-sandbox"))
+    }
+
+    func testBypassRequiresAcknowledgement() {
+        let unacked = CodexWakeCommandBuilder.build(
+            executable: "/bin/codex", candidate: candidate(), account: account(), bounds: .default,
+            permissionMode: .bypass, bypassAcknowledged: false, baseEnvironment: ["PATH": "/usr/bin"]
+        )
+        XCTAssertFalse(unacked.arguments.contains("--dangerously-bypass-approvals-and-sandbox"),
+                       "unacknowledged bypass must downgrade to safe")
+        XCTAssertTrue(unacked.arguments.contains("sandbox_mode=\"workspace-write\""))
+
+        let acked = CodexWakeCommandBuilder.build(
+            executable: "/bin/codex", candidate: candidate(), account: account(), bounds: .default,
+            permissionMode: .bypass, bypassAcknowledged: true, baseEnvironment: ["PATH": "/usr/bin"]
+        )
+        XCTAssertTrue(acked.arguments.contains("--dangerously-bypass-approvals-and-sandbox"))
+        XCTAssertFalse(acked.arguments.contains("sandbox_mode=\"workspace-write\""))
+    }
+
+    func testCodexHomeInjectedWhenAccountHasHome() {
+        let command = CodexWakeCommandBuilder.build(
+            executable: "/bin/codex", candidate: candidate(), account: account(home: "/custom/codex"),
+            bounds: .default, baseEnvironment: ["PATH": "/usr/bin"]
+        )
+        XCTAssertEqual(command.environment["CODEX_HOME"], "/custom/codex")
+        XCTAssertEqual(command.environment["NO_COLOR"], "1")
+        XCTAssertEqual(command.workingDirectory, "/tmp/work")
+    }
+
+    func testDefaultAccountOmitsCodexHome() {
+        let command = CodexWakeCommandBuilder.build(
+            executable: "/bin/codex", candidate: candidate(), account: account(home: nil),
+            bounds: .default, baseEnvironment: ["PATH": "/usr/bin"]
+        )
+        XCTAssertNil(command.environment["CODEX_HOME"], "default profile inherits the ambient CODEX_HOME")
+    }
+}

--- a/MeterBarTests/CodexWakeQuotaTests.swift
+++ b/MeterBarTests/CodexWakeQuotaTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import MeterBar
+@testable import MeterBarShared
+
+/// The Codex quota authority must fail closed exactly like the Claude one:
+/// fetch error or stale reading ⇒ `.unknown`, fresh metrics classify normally.
+final class CodexWakeQuotaTests: XCTestCase {
+    private func account() -> CodexAccount { CodexAccount(id: UUID(), name: "a", homeDirectory: nil) }
+
+    func testFetchFailureIsUnknown() async {
+        let authority = CodexWakeQuotaAuthority(provider: ThrowingCodexProvider(), maxAge: 3600, now: { Date() })
+        let quota = await authority.freshQuota(account: account())
+        guard case .unknown = quota else { return XCTFail("fetch failure must fail closed, got \(quota)") }
+    }
+
+    func testStaleMetricsAreUnknownNotAuthority() async {
+        let stale = Date(timeIntervalSince1970: 0)
+        let authority = CodexWakeQuotaAuthority(
+            provider: FixedCodexProvider(.open, lastUpdated: stale), maxAge: 120, now: { Date() }
+        )
+        let quota = await authority.freshQuota(account: account())
+        guard case .unknown = quota else { return XCTFail("stale metrics must fail closed, got \(quota)") }
+    }
+
+    func testFreshOpenMetricsAreAvailable() async {
+        let authority = CodexWakeQuotaAuthority(provider: FixedCodexProvider(.open), maxAge: 3600, now: { Date() })
+        let quota = await authority.freshQuota(account: account())
+        XCTAssertEqual(quota, .available)
+    }
+
+    func testFreshBlockedMetricsAreBlocked() async {
+        let authority = CodexWakeQuotaAuthority(provider: FixedCodexProvider(.blocked), maxAge: 3600, now: { Date() })
+        let quota = await authority.freshQuota(account: account())
+        guard case .blocked = quota else { return XCTFail("maxed session window must block, got \(quota)") }
+    }
+}
+
+// MARK: - Doubles
+
+private struct ThrowingCodexProvider: CodexWakeQuotaProviding {
+    struct Boom: Error {}
+    func fetchMetrics(account: CodexAccount) async throws -> UsageMetrics { throw Boom() }
+}
+
+private struct FixedCodexProvider: CodexWakeQuotaProviding {
+    enum Kind { case open, blocked }
+    let kind: Kind
+    let lastUpdated: Date
+    init(_ kind: Kind, lastUpdated: Date = Date()) { self.kind = kind; self.lastUpdated = lastUpdated }
+    func fetchMetrics(account: CodexAccount) async throws -> UsageMetrics {
+        let limit = kind == .open
+            ? UsageLimit(used: 10, total: 100, resetTime: nil)
+            : UsageLimit(used: 100, total: 100, resetTime: Date(timeIntervalSince1970: 9_999))
+        return UsageMetrics(service: .codexCli, sessionLimit: limit, lastUpdated: lastUpdated)
+    }
+}


### PR DESCRIPTION
## Summary

Session Wake shipped **Claude-only** (#95–#99). This adds **Codex** as a second provider behind a new `WakeProviderRuntime` seam, so the engine orchestration stays a single implementation for both providers.

`meterbar wake --provider codex` now works end to end: discover blocked Codex sessions → fail-closed fresh-quota gate → `codex exec resume`.

## Why it's feasible (the DEFERRED note was wrong about the blocker)

The prior "Codex intentionally not exposed in v1" deferral assumed there was no reliable reset signal. There is: every rollout `token_count` event embeds structured `rate_limits`:

```json
"rate_limits":{"primary":{"used_percent":100,"window_minutes":10080,"resets_at":1784488477},"rate_limit_reached_type":"primary"}
```

`rate_limit_reached_type` is `null` in normal operation and non-null exactly when a window was hit — a clean structured block signal (not prose), plus `resets_at` for the reset instant.

## Three pieces (mirroring Claude's discovery + authority + command)

| Piece | Codex implementation |
|---|---|
| **Discovery** | `CodexSessionDiscovery` walks `<CODEX_HOME>/sessions/**/*.jsonl`; `CodexRolloutClassifier` blocks on `rate_limit_reached_type != null`, cleared by a later `task_complete`. |
| **Quota** | `CodexWakeQuotaAuthority` → existing `CodexCliLocalService`; shared `WakeQuota.classify` maps primary→session, secondary→weekly. Same fail-closed contract. |
| **Resume** | `CodexWakeCommandBuilder` → `codex exec resume <id> <prompt>`; safe = `-c sandbox_mode="workspace-write" -c approval_policy="never"`, bypass = `--dangerously-bypass-approvals-and-sandbox` (acknowledgement-gated). `CODEX_HOME` injected per account. |

## Design notes

- **`WakeProviderRuntime`** is the seam; `WakeCLIEngine` orchestration is now provider-agnostic (`run(runtime:)`), with the legacy Claude `run(provider:account:)` facade delegating to it (existing engine tests unchanged).
- **`BlockFingerprint`** namespaces non-Claude seeds, so existing Claude ledger entries stay byte-identical across the upgrade and Claude/Codex sessions can't collide.
- **Safe-posture mapping** is a deliberate product call (documented in `CodexWakeCommandBuilder`): `workspace-write` + `approval_policy=never` lets a resumed session make progress while sandboxed, failing closed on anything needing escalation.
- **Lock** stays a single global lock (serializes all wake activity across providers) — simplest and avoids concurrent Claude+Codex resume contention.

## Tests

Classifier (block signal, recovery clears, **prose false-positive guard**, reason/reset mapping, truncated-line robustness), discovery (executable / missing-cwd / completed / already-handled / home-scoped), command builder (argv, posture, bypass gate, `CODEX_HOME`), quota fail-closed, and engine-through-runtime resume + dry-run. `swiftlint --strict` clean.

## Scope / follow-up

This PR delivers the complete **CLI** path (the testable mechanism). The **app-watcher continuous mode + Settings provider picker** ride on the same `WakeProviderRuntime` seam and are the immediate next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)