### PR TITLE
fix(claude): read usage from /api/oauth/usage instead of broken CLI parse

### DIFF
--- a/.agents/SESSIONS/2026-07-14.md
+++ b/.agents/SESSIONS/2026-07-14.md
@@ -1,0 +1,49 @@
+# 2026-07-14 — Fix broken Claude Code usage (OAuth primary)
+
+## Problem
+`claude /usage` (CLI 2.1.208) only renders the usage screen in an interactive TTY.
+Every headless spawn a GUI app can make returns a session **cost summary**
+(`Total cost: $0.0000 …`), so `ClaudeCodeCLIUsageParser` found no usage windows →
+`parsingFailed("No Claude usage windows found.")` → the card showed "Refresh failed".
+#156's parse-health surfaced it; #145 fixed only a separate PATH hook error.
+
+## Research (option 1 — authenticated API)
+- Confirmed the live source Claude Code's own `/usage` screen reads:
+  `GET https://api.anthropic.com/api/oauth/usage` with the `Claude Code-credentials`
+  Keychain OAuth token (`Authorization: Bearer`, `anthropic-beta: oauth-2025-04-20`).
+  Response: `five_hour` / `seven_day` / `seven_day_sonnet` windows (`utilization`,
+  `resets_at`) + `extra_usage`.
+- Verified dead-ends from the brief: no `usage`/`status` subcommand;
+  `-p "/usage" --output-format json` runs an empty session; PTY makes `claude` hang.
+- **Key finding:** MeterBar already implemented this exact endpoint in
+  `ClaudeCodeLocalService` — but gated behind the opt-in `ClaudeCodeEnableOAuthFallback`
+  flag and only tried *after* the (broken) CLI path failed.
+
+## Fix
+Promoted OAuth from "legacy fallback" to the **primary** source:
+- `ClaudeCodeLocalService.fetchUsageMetrics` now tries `/api/oauth/usage` first for
+  the **default account** (`fetchUsageViaOAuth` returns `nil` ⇒ CLI fallback; throws
+  on a real network/decode error rather than retrying the headless-broken CLI).
+  Custom (`CLAUDE_CONFIG_DIR`) accounts stay CLI-only (no Keychain token).
+- Extracted pure, tested helpers: `metrics(from:)`, `prefersOAuth(account:oauthEnabled:)`,
+  `isOAuthUsageEnabled(defaults:)` — single source of truth for the flag, now **on by
+  default** (`object(forKey:) as? Bool ?? true`), routed through the two other call
+  sites (`ProviderSnapshot`, `ProviderReadinessInspector`).
+- Renamed `ClaudeCodeUsageSource.legacyOAuth` → `.oauth`; refreshed Settings copy.
+- Option 3 as a bonus: `ClaudeCodeCLIUsageParser` now detects the cost-summary shape
+  and throws a legible error instead of the vague "No usage windows found."
+
+## Tests (TDD-first)
+- `ClaudeCodeOAuthUsageTests` — mapping, source policy, enabled-by-default flag.
+- `ClaudeCodeCLIUsageParserTests.testDetectsCostSummaryInsteadOfUsageScreen`.
+- Existing decode contract tests already cover the wire model.
+
+## Tradeoff
+Enabling OAuth by default means one **one-time macOS Keychain prompt** on first launch
+of a signed release (the grant persists across Sparkle updates). Opt out via Settings ▸
+Claude Code ▸ "Claude Code OAuth usage" (dev builds re-prompt per rebuild).
+
+## Follow-up (out of scope)
+`WakeQuotaAuthority`/`LiveWakeQuotaProvider` still call the raw CLI service; the
+session-wake default-account quota gate would also benefit from OAuth, but needs a
+**side-effect-free** OAuth fetch to avoid coupling UI `@Published` state into wake decisions.

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -13,7 +13,7 @@ Providers tracked:
 
 | Provider | `ServiceType` case | Data source |
 |---|---|---|
-| Claude Code | `.claudeCode` | Shells out to `claude /usage`, regex-parses terminal output. Legacy OAuth fallback (keychain item `Claude Code-credentials`) behind the `ClaudeCodeEnableOAuthFallback` UserDefaults flag |
+| Claude Code | `.claudeCode` | Default account: calls the authenticated `https://api.anthropic.com/api/oauth/usage` endpoint with the `Claude Code-credentials` Keychain OAuth token (primary; on by default via the `ClaudeCodeEnableOAuthFallback` flag). Falls back to shelling out to `claude /usage` and regex-parsing terminal output when no token is available. Custom (`CLAUDE_CONFIG_DIR`) accounts use the CLI, since `claude /usage` no longer renders in a headless spawn |
 | OpenAI Codex CLI | `.codexCli` | Reads `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`), calls `https://chatgpt.com/backend-api/wham/usage` |
 | Cursor | `.cursor` | Reads session JWT from Cursor's `state.vscdb` SQLite, calls `https://cursor.com/api/usage-summary` |
 | OpenRouter | `.openRouter` | User-provided API key in Keychain; calls documented `/api/v1/credits` and `/api/v1/key` endpoints |
@@ -66,8 +66,8 @@ meterbar/
 ## Services (all `.shared` singletons)
 
 - **UsageDataManager** (`@MainActor`, ObservableObject) — orchestrates refresh across providers, caches to UserDefaults (`cached_usage_metrics`), mirrors to the app group via SharedDataStore, records per-provider refresh outcomes in `ProviderParseHealthStore`, and drives a `Timer` auto-refresh (default 15 min; `RefreshInterval` supports 1/2/5/15/30 min + manual).
-- **ClaudeCodeCLIUsageService** — resolves the `claude` binary (`CLAUDE_CLI_PATH`, `$PATH`, 7 fallback paths), runs `claude /usage` (12 s timeout, dedicated GCD queue bridged to async), parses output with `ClaudeCodeCLIUsageParser`. Multi-account via `CLAUDE_CONFIG_DIR` env injection.
-- **ClaudeCodeLocalService** — CLI-first wrapper; legacy OAuth fallback + best-effort "extra usage" probe against `api.anthropic.com/api/oauth/usage`.
+- **ClaudeCodeCLIUsageService** — fallback source. Resolves the `claude` binary (`CLAUDE_CLI_PATH`, `$PATH`, 7 fallback paths), runs `claude /usage` (12 s timeout, dedicated GCD queue bridged to async), parses output with `ClaudeCodeCLIUsageParser`. `/usage` no longer renders in a headless spawn (it prints a session cost summary), so the parser detects that shape and throws a legible error. Multi-account via `CLAUDE_CONFIG_DIR` env injection.
+- **ClaudeCodeLocalService** — OAuth-primary wrapper. For the default account it reads `api.anthropic.com/api/oauth/usage` with the Keychain token (`metrics(from:)` maps windows + extra-usage), falling back to the CLI parser only when no token is available; custom accounts use the CLI. `prefersOAuth`/`isOAuthUsageEnabled` are the pure source-selection helpers.
 - **CodexCliLocalService** — Codex auth file + wham/usage endpoint; maps credits/spend to `ExtraUsageStatus` (safety-biased: never false "Off").
 - **CursorLocalService** — SQLite token extraction + usage-summary endpoint; assumed 500-request default quota when API omits totals.
 - **OpenRouterService** — opt-in API-key provider; maps account credits/spend and optional per-key caps into shared metrics.

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -20,7 +20,9 @@ nonisolated enum StorageKeys {
     static let showInDock = "ShowMeterBarInDock"
     /// Whether the one-time first-launch popover has been completed or dismissed.
     static let hasCompletedFirstRun = "HasCompletedFirstRun"
-    /// Enables the legacy Claude Code OAuth fallback when the CLI is unavailable.
+    /// Enables the Claude Code OAuth usage source (`/api/oauth/usage`), the
+    /// primary reader for the default account. On by default; off forces the CLI
+    /// output fallback. Legacy key name kept to preserve existing user settings.
     static let claudeCodeOAuthFallback = "ClaudeCodeEnableOAuthFallback"
     /// Extra Claude Code account profiles (JSON-encoded [ClaudeCodeAccount]).
     static let claudeCodeCustomAccounts = "ClaudeCodeCustomAccounts"

--- a/MeterBar/Services/ClaudeCodeCLIUsageService.swift
+++ b/MeterBar/Services/ClaudeCodeCLIUsageService.swift
@@ -141,6 +141,15 @@ nonisolated enum ClaudeCodeCLIUsageParser {
             now: now)
 
         guard sessionLimit != nil || weeklyLimit != nil || sonnetLimit != nil else {
+            // A headless (non-TTY) spawn of `claude /usage` renders a session
+            // cost summary instead of the usage screen, so no windows parse.
+            // Surface that specifically — the OAuth endpoint is the fix.
+            if looksLikeCostSummary(sanitized) {
+                throw ClaudeCodeCLIUsageError.parsingFailed(
+                    "Claude CLI returned a session cost summary instead of the usage screen; "
+                        + "`claude /usage` no longer renders headlessly. "
+                        + "Connect Claude Code via its OAuth login in Settings.")
+            }
             throw ClaudeCodeCLIUsageError.parsingFailed("No Claude usage windows found.")
         }
 
@@ -221,6 +230,13 @@ nonisolated enum ClaudeCodeCLIUsageParser {
         }
 
         return nil
+    }
+
+    /// The session cost summary a headless `claude /usage` prints leads with a
+    /// "Total cost:" line — a reliable, version-stable marker distinct from the
+    /// usage screen's window labels.
+    private static func looksLikeCostSummary(_ text: String) -> Bool {
+        text.range(of: "total cost", options: .caseInsensitive) != nil
     }
 
     private static func stripANSICodes(from text: String) -> String {

--- a/MeterBar/Services/ClaudeCodeLocalService.swift
+++ b/MeterBar/Services/ClaudeCodeLocalService.swift
@@ -13,7 +13,6 @@ class ClaudeCodeLocalService: ObservableObject {
 
     private let keychainService = "Claude Code-credentials"
     private let cliUsageService = ClaudeCodeCLIUsageService.shared
-    private let oauthFallbackUserDefaultsKey = StorageKeys.claudeCodeOAuthFallback
 
     private let urlSession = ServiceSupport.session
 
@@ -99,7 +98,7 @@ class ClaudeCodeLocalService: ObservableObject {
             clearsSubscription = false
         } else if isOAuthFallbackEnabled, getOAuthToken() != nil {
             newHasAccess = true
-            newAuthState = .connected(.legacyOAuth)
+            newAuthState = .connected(.oauth)
             clearsSubscription = false
         } else {
             newHasAccess = false
@@ -121,50 +120,35 @@ class ClaudeCodeLocalService: ObservableObject {
     // MARK: - Usage Fetching
 
     func fetchUsageMetrics(account: ClaudeCodeAccount = .defaultAccount) async throws -> UsageMetrics {
-        do {
-            let metrics = try await cliUsageService.fetchUsageMetrics(account: account)
-            await MainActor.run {
-                self.lastError = nil
-                self.hasAccess = true
-                if account.isDefault || self.authState == .unavailable {
-                    self.authState = .connected(.cli)
-                }
-            }
-            // The CLI output does not expose the "extra usage" toggle. Only read
-            // Claude's OAuth keychain item when the user explicitly enables the
-            // legacy OAuth fallback; ad-hoc local installs otherwise trigger a
-            // keychain approval prompt on every rebuilt binary.
-            let extraUsage = await fetchExtraUsageStatus(account: account)
-            return metrics.withExtraUsage(extraUsage)
-        } catch {
-            if !account.isDefault || !isOAuthFallbackEnabled {
-                let serviceError = serviceError(from: error)
-                await MainActor.run {
-                    self.lastError = serviceError
-                    if account.isDefault {
-                        self.hasAccess = false
-                        self.authState = authState(from: error)
-                    }
-                }
-                throw serviceError
+        // Primary source: the authenticated `/api/oauth/usage` endpoint — the
+        // same data Claude Code's own `/usage` screen reads. `claude /usage` no
+        // longer renders in a headless (non-TTY) spawn (it prints a session cost
+        // summary instead), so the CLI parser is now a fallback. Only the
+        // default account has a Keychain OAuth token; custom accounts
+        // (`CLAUDE_CONFIG_DIR`) have none and go straight to the CLI.
+        if Self.prefersOAuth(account: account, oauthEnabled: isOAuthFallbackEnabled) {
+            // `nil` ⇒ no usable Keychain token; fall back to the CLI. A thrown
+            // error means a token was in hand but the request/decode failed —
+            // surface it rather than retry the headless-broken CLI.
+            if let metrics = try await fetchUsageViaOAuth() {
+                return metrics
             }
         }
 
+        return try await fetchUsageViaCLI(account: account)
+    }
+
+    /// Fetches usage from the OAuth `/api/oauth/usage` endpoint for the default
+    /// account. Returns `nil` when there is no usable Keychain token (missing or
+    /// expired) so the caller can fall back to the CLI.
+    private func fetchUsageViaOAuth() async throws -> UsageMetrics? {
         // Keychain read — off the main actor (it can raise a blocking approval
         // dialog, and the app target runs async bodies on the main actor).
-        let fallbackToken = await Task.detached(priority: .userInitiated) { [self] in
+        let token = await Task.detached(priority: .userInitiated) { [self] in
             getOAuthToken()
         }.value
 
-        guard let token = fallbackToken else {
-            let error = ServiceError.notAuthenticated
-            await MainActor.run {
-                self.lastError = error
-                self.hasAccess = false
-                self.authState = .needsLogin
-            }
-            throw error
-        }
+        guard let token else { return nil }
 
         guard let url = URL(string: usageEndpoint) else {
             throw ServiceError.invalidURL
@@ -189,43 +173,10 @@ class ClaudeCodeLocalService: ObservableObject {
             await MainActor.run {
                 self.lastError = nil
                 self.hasAccess = true
-                self.authState = .connected(.legacyOAuth)
+                self.authState = .connected(.oauth)
             }
 
-            // Session limit = 5-hour window
-            let sessionLimit = UsageLimit(
-                used: usageResponse.fiveHour.utilization,
-                total: 100.0,
-                resetTime: usageResponse.fiveHour.resetsAt,
-                windowSeconds: 5 * 60 * 60
-            )
-
-            // Weekly limit = 7-day window (all models)
-            let weeklyLimit = UsageLimit(
-                used: usageResponse.sevenDay.utilization,
-                total: 100.0,
-                resetTime: usageResponse.sevenDay.resetsAt,
-                windowSeconds: 7 * 24 * 60 * 60
-            )
-
-            // Sonnet-only weekly limit (if available)
-            var sonnetLimit: UsageLimit?
-            if let sonnet = usageResponse.sevenDaySonnet {
-                sonnetLimit = UsageLimit(
-                    used: sonnet.utilization,
-                    total: 100.0,
-                    resetTime: sonnet.resetsAt,
-                    windowSeconds: 7 * 24 * 60 * 60
-                )
-            }
-
-            return UsageMetrics(
-                service: .claudeCode,
-                sessionLimit: sessionLimit,
-                weeklyLimit: weeklyLimit,
-                codeReviewLimit: sonnetLimit,
-                extraUsage: usageResponse.extraUsageStatus
-            )
+            return Self.metrics(from: usageResponse)
         } catch {
             let serviceError = ServiceSupport.serviceError(from: error)
             await MainActor.run {
@@ -239,6 +190,88 @@ class ClaudeCodeLocalService: ObservableObject {
             }
             throw serviceError
         }
+    }
+
+    /// Fallback source: shells out to `claude /usage` and parses the terminal
+    /// output. Used for custom accounts and when no OAuth token is available.
+    private func fetchUsageViaCLI(account: ClaudeCodeAccount) async throws -> UsageMetrics {
+        do {
+            let metrics = try await cliUsageService.fetchUsageMetrics(account: account)
+            await MainActor.run {
+                self.lastError = nil
+                self.hasAccess = true
+                if account.isDefault || self.authState == .unavailable {
+                    self.authState = .connected(.cli)
+                }
+            }
+            // The CLI output does not expose the "extra usage" toggle. Only read
+            // Claude's OAuth keychain item when OAuth is enabled; ad-hoc local
+            // installs otherwise trigger a keychain approval prompt on every
+            // rebuilt binary.
+            let extraUsage = await fetchExtraUsageStatus(account: account)
+            return metrics.withExtraUsage(extraUsage)
+        } catch {
+            let serviceError = serviceError(from: error)
+            await MainActor.run {
+                self.lastError = serviceError
+                if account.isDefault {
+                    self.hasAccess = false
+                    self.authState = authState(from: error)
+                }
+            }
+            throw serviceError
+        }
+    }
+
+    /// OAuth (`/api/oauth/usage`) is the primary Claude Code usage source and is
+    /// enabled by default. Users opt out — e.g. unsigned dev builds that
+    /// re-prompt for Keychain access on every rebuild — by setting the flag
+    /// false. Single source of truth for the three call sites that read it.
+    nonisolated static func isOAuthUsageEnabled(defaults: UserDefaults = .standard) -> Bool {
+        (defaults.object(forKey: StorageKeys.claudeCodeOAuthFallback) as? Bool) ?? true
+    }
+
+    /// OAuth is preferred only for the default account (whose token lives in the
+    /// Keychain) and only when enabled.
+    nonisolated static func prefersOAuth(account: ClaudeCodeAccount, oauthEnabled: Bool) -> Bool {
+        account.isDefault && oauthEnabled
+    }
+
+    /// Maps an `/api/oauth/usage` response onto the shared `UsageMetrics`.
+    /// Session = 5-hour window, weekly = 7-day (all models), code-review =
+    /// per-model weekly window (Sonnet/Fable) when the server emits one.
+    nonisolated static func metrics(from response: ClaudeCodeUsageResponse) -> UsageMetrics {
+        let sessionLimit = UsageLimit(
+            used: response.fiveHour.utilization,
+            total: 100.0,
+            resetTime: response.fiveHour.resetsAt,
+            windowSeconds: 5 * 60 * 60
+        )
+
+        let weeklyLimit = UsageLimit(
+            used: response.sevenDay.utilization,
+            total: 100.0,
+            resetTime: response.sevenDay.resetsAt,
+            windowSeconds: 7 * 24 * 60 * 60
+        )
+
+        var codeReviewLimit: UsageLimit?
+        if let sonnet = response.sevenDaySonnet {
+            codeReviewLimit = UsageLimit(
+                used: sonnet.utilization,
+                total: 100.0,
+                resetTime: sonnet.resetsAt,
+                windowSeconds: 7 * 24 * 60 * 60
+            )
+        }
+
+        return UsageMetrics(
+            service: .claudeCode,
+            sessionLimit: sessionLimit,
+            weeklyLimit: weeklyLimit,
+            codeReviewLimit: codeReviewLimit,
+            extraUsage: response.extraUsageStatus
+        )
     }
 
     /// Best-effort fetch of the Claude "extra usage" on/off state from the OAuth usage endpoint.
@@ -285,7 +318,7 @@ class ClaudeCodeLocalService: ObservableObject {
     }
 
     nonisolated private var isOAuthFallbackEnabled: Bool {
-        UserDefaults.standard.bool(forKey: oauthFallbackUserDefaultsKey)
+        Self.isOAuthUsageEnabled()
     }
 
     private func serviceError(from error: Error) -> ServiceError {
@@ -329,7 +362,7 @@ class ClaudeCodeLocalService: ObservableObject {
 
 enum ClaudeCodeUsageSource: String {
     case cli = "Claude CLI"
-    case legacyOAuth = "Legacy OAuth"
+    case oauth = "OAuth"
 }
 
 enum ClaudeCodeAuthState: Equatable {
@@ -359,11 +392,11 @@ enum ClaudeCodeAuthState: Equatable {
         case .unavailable:
             return "Install Claude Code and run 'claude login'."
         case .cliAvailable:
-            return "Using Claude CLI usage output; refresh to update."
+            return "Ready. MeterBar reads usage from your Claude Code login; refresh to update."
         case .connected(.cli):
             return "Using Claude CLI usage output."
-        case .connected(.legacyOAuth):
-            return "Using legacy OAuth fallback."
+        case .connected(.oauth):
+            return "Using Claude Code's OAuth usage endpoint."
         case .needsLogin:
             return "Run 'claude login' again."
         case let .error(message):

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -84,7 +84,7 @@ nonisolated public enum ProviderReadinessInspector {
         now: Date = Date(),
         cachedMetrics: UsageMetrics? = SharedDataStore.shared.loadMetrics()[.claudeCode],
         isOAuthFallbackEnabled: () -> Bool = {
-            UserDefaults.standard.bool(forKey: StorageKeys.claudeCodeOAuthFallback)
+            ClaudeCodeLocalService.isOAuthUsageEnabled()
         },
         credentialsData: () -> Data? = { ClaudeCodeLocalService.shared.credentialsData() }
     ) -> ProviderReadiness {

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -93,7 +93,7 @@ enum ExtraUsageDisplayPolicy {
         guard service == .claudeCode, status.state == .unknown else {
             return status
         }
-        return UserDefaults.standard.bool(forKey: StorageKeys.claudeCodeOAuthFallback) ? status : nil
+        return ClaudeCodeLocalService.isOAuthUsageEnabled() ? status : nil
     }
 }
 

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -66,11 +66,11 @@ struct SettingsView: View {
     @State private var openRouterKeyDraft = ""
     @State private var selectedProviderTab: ServiceType = .claudeCode
 
-    /// Same key ClaudeCodeLocalService reads. Previously this flag was only
-    /// settable via `defaults write`; exposing it here makes the legacy OAuth
-    /// fallback discoverable instead of a hidden switch.
+    /// Same key ClaudeCodeLocalService reads. OAuth (`/api/oauth/usage`) is the
+    /// primary Claude Code usage source and is on by default; turning this off
+    /// forces the CLI-output fallback (which no longer renders headlessly).
     @AppStorage(StorageKeys.claudeCodeOAuthFallback)
-    private var oauthFallbackEnabled = false
+    private var oauthFallbackEnabled = true
 
     private var providerSnapshots: [ProviderSnapshot] {
         ProviderSnapshotBuilder.snapshots(
@@ -556,14 +556,15 @@ struct SettingsView: View {
                     color: .secondary
                 )
                 SettingsNotice(
-                    text: "MeterBar reads Claude CLI usage output before any legacy OAuth fallback.",
+                    text: "MeterBar reads usage from Claude Code's OAuth login; the CLI output is a fallback.",
                     color: MeterBarTheme.warning
                 )
             }
 
             SettingsRowView(
-                title: "Legacy OAuth fallback",
-                detail: "When the Claude CLI is unavailable, read usage via Claude Code's OAuth token."
+                title: "Claude Code OAuth usage",
+                detail: "Read usage from Claude Code's Keychain login (the primary source). "
+                    + "Off = use only the CLI's `claude /usage` output, which no longer renders headlessly."
             ) {
                 Toggle("", isOn: Binding(
                     get: { oauthFallbackEnabled },

--- a/MeterBarTests/ClaudeCodeCLIUsageParserTests.swift
+++ b/MeterBarTests/ClaudeCodeCLIUsageParserTests.swift
@@ -71,4 +71,28 @@ final class ClaudeCodeCLIUsageParserTests: XCTestCase {
     func testThrowsWhenNoUsageWindowsArePresent() {
         XCTAssertThrowsError(try ClaudeCodeCLIUsageParser.parseMetrics(from: "No usage data"))
     }
+
+    /// Headless (non-TTY) spawns of `claude /usage` no longer render the usage
+    /// screen — the CLI prints a session cost summary instead. The parser must
+    /// recognise that shape and throw a legible, actionable error rather than a
+    /// vague "No Claude usage windows found."
+    func testDetectsCostSummaryInsteadOfUsageScreen() {
+        let output = """
+        Total cost:            $0.0000
+        Total duration (API):  0s
+        Total duration (wall): 1.2s
+        Total code changes:    0 lines added, 0 lines removed
+        Usage by model:
+            claude-opus:  0 input, 0 output
+        """
+
+        XCTAssertThrowsError(try ClaudeCodeCLIUsageParser.parseMetrics(from: output)) { error in
+            guard case let ClaudeCodeCLIUsageError.parsingFailed(message) = error else {
+                return XCTFail("Expected parsingFailed, got \(error)")
+            }
+            XCTAssertTrue(
+                message.lowercased().contains("cost summary"),
+                "Message should call out the cost-summary shape, got: \(message)")
+        }
+    }
 }

--- a/MeterBarTests/ClaudeCodeOAuthUsageTests.swift
+++ b/MeterBarTests/ClaudeCodeOAuthUsageTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import MeterBar
+@testable import MeterBarShared
+
+/// Covers the OAuth-primary path for Claude Code usage: the pure response→metrics
+/// mapping, the source-selection policy, and the enabled-by-default flag. The
+/// network/Keychain fetch itself is exercised by CI/integration, not here.
+final class ClaudeCodeOAuthUsageTests: XCTestCase {
+    // MARK: - Response → UsageMetrics mapping
+
+    func testMetricsMapsAllWindowsAndExtraUsage() throws {
+        let response = try decodeUsage(#"""
+        {
+          "five_hour": {"utilization": 61.5, "resets_at": "2026-07-02T14:00:00Z"},
+          "seven_day": {"utilization": 30.0, "resets_at": "2026-07-08T00:00:00Z"},
+          "seven_day_sonnet": {"utilization": 12.0, "resets_at": "2026-07-08T00:00:00Z"},
+          "extra_usage": {"is_enabled": true, "monthly_limit": 50.0, "currency": "USD"}
+        }
+        """#)
+
+        let metrics = ClaudeCodeLocalService.metrics(from: response)
+
+        XCTAssertEqual(metrics.service, .claudeCode)
+        let session = try XCTUnwrap(metrics.sessionLimit)
+        let weekly = try XCTUnwrap(metrics.weeklyLimit)
+        let sonnet = try XCTUnwrap(metrics.codeReviewLimit)
+        XCTAssertEqual(session.percentage, 61.5, accuracy: 0.01)
+        XCTAssertEqual(session.windowSeconds, 5 * 60 * 60)
+        XCTAssertEqual(weekly.percentage, 30.0, accuracy: 0.01)
+        XCTAssertEqual(weekly.windowSeconds, 7 * 24 * 60 * 60)
+        XCTAssertEqual(sonnet.percentage, 12.0, accuracy: 0.01)
+        XCTAssertEqual(sonnet.windowSeconds, 7 * 24 * 60 * 60)
+        XCTAssertNotNil(session.resetTime)
+        XCTAssertEqual(metrics.extraUsage?.state, .on)
+    }
+
+    func testMetricsOmitsModelWindowWhenAbsent() throws {
+        let response = try decodeUsage(#"""
+        {
+          "five_hour": {"utilization": 5.0, "resets_at": "2026-07-02T14:00:00Z"},
+          "seven_day": {"utilization": 10.0, "resets_at": "2026-07-08T00:00:00Z"}
+        }
+        """#)
+
+        let metrics = ClaudeCodeLocalService.metrics(from: response)
+
+        XCTAssertNotNil(metrics.sessionLimit)
+        XCTAssertNotNil(metrics.weeklyLimit)
+        XCTAssertNil(metrics.codeReviewLimit)
+    }
+
+    // MARK: - Source-selection policy
+
+    func testPrefersOAuthOnlyForDefaultAccountWhenEnabled() {
+        XCTAssertTrue(ClaudeCodeLocalService.prefersOAuth(account: .defaultAccount, oauthEnabled: true))
+        XCTAssertFalse(ClaudeCodeLocalService.prefersOAuth(account: .defaultAccount, oauthEnabled: false))
+
+        let custom = ClaudeCodeAccount(id: UUID(), name: "Work", configDirectory: "/tmp/work")
+        XCTAssertFalse(ClaudeCodeLocalService.prefersOAuth(account: custom, oauthEnabled: true))
+        XCTAssertFalse(ClaudeCodeLocalService.prefersOAuth(account: custom, oauthEnabled: false))
+    }
+
+    // MARK: - Enabled-by-default flag
+
+    func testOAuthUsageEnabledDefaultsTrueWhenUnset() throws {
+        let defaults = try makeEmptyDefaults()
+        XCTAssertTrue(ClaudeCodeLocalService.isOAuthUsageEnabled(defaults: defaults))
+    }
+
+    func testOAuthUsageRespectsExplicitOptOut() throws {
+        let defaults = try makeEmptyDefaults()
+        defaults.set(false, forKey: StorageKeys.claudeCodeOAuthFallback)
+        XCTAssertFalse(ClaudeCodeLocalService.isOAuthUsageEnabled(defaults: defaults))
+
+        defaults.set(true, forKey: StorageKeys.claudeCodeOAuthFallback)
+        XCTAssertTrue(ClaudeCodeLocalService.isOAuthUsageEnabled(defaults: defaults))
+    }
+
+    // MARK: - Helpers
+
+    private func decodeUsage(_ json: String) throws -> ClaudeCodeUsageResponse {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        return try decoder.decode(ClaudeCodeUsageResponse.self, from: data)
+    }
+
+    private func makeEmptyDefaults() throws -> UserDefaults {
+        let suite = "ClaudeCodeOAuthUsageTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        addTeardownBlock { defaults.removePersistentDomain(forName: suite) }
+        return defaults
+    }
+}

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A lightweight macOS menu bar app that monitors Claude Code, Codex CLI, and Curso
 
 | Service | Auth Method | Metrics Tracked |
 |---------|-------------|-----------------|
-| **Claude Code** | Claude CLI `/usage` output | 5h session, 7-day all models, 7-day Sonnet |
+| **Claude Code** | Keychain OAuth token (`/api/oauth/usage`); CLI `/usage` fallback | 5h session, 7-day all models, 7-day Sonnet |
 | **Codex CLI** | OAuth token from `codex login` | 5h limit, weekly limit, code review |
 | **Cursor** | Local SQLite database | Monthly usage |
 
@@ -104,8 +104,8 @@ open MeterBar.xcodeproj
 
 1. Install Claude Code CLI: `npm install -g @anthropic-ai/claude-code`
 2. Log in: `claude login`
-3. The app runs `claude /usage` and parses the CLI usage output
-4. Add extra Claude accounts in Settings by pointing each one at a separate `CLAUDE_CONFIG_DIR`
+3. The app reads usage from Claude Code's authenticated `/api/oauth/usage` endpoint using its Keychain login (first launch shows a one-time Keychain access prompt); if no token is available it falls back to parsing `claude /usage` output
+4. Add extra Claude accounts in Settings by pointing each one at a separate `CLAUDE_CONFIG_DIR` (custom accounts use the CLI, since only the default account has a Keychain token)
 
 ### Codex CLI
 
@@ -174,22 +174,22 @@ The CLI is automatically installed when using Homebrew. For manual installs, it'
 MeterBar reads usage data from local CLI output, local credential stores, and provider APIs:
 
 ```
-claude /usage            # Claude Code usage
-macOS Keychain           # Legacy Claude Code OAuth fallback only
+macOS Keychain           # Claude Code OAuth token (Claude Code-credentials)
+claude /usage            # Claude Code usage fallback (CLI output)
 ~/.claude/               # Claude Code account metadata and local sessions
 $CODEX_HOME/auth.json    # Codex CLI OAuth token (defaults to ~/.codex/auth.json)
 ~/Library/Application Support/Cursor/  # Cursor local DB
 ```
 
 It then uses the respective local source or API to fetch current usage data:
-- Claude Code (legacy OAuth fallback only): `https://api.anthropic.com/api/oauth/usage`
+- Claude Code (primary): `https://api.anthropic.com/api/oauth/usage`, using the `Claude Code-credentials` Keychain OAuth token
 - Codex: `https://chatgpt.com/backend-api/wham/usage`
 
-Claude Code usage uses `claude /usage` first so MeterBar does not need to read Claude Code's OAuth token during normal operation. A legacy OAuth fallback can be enabled in Settings under Claude Code.
-- Additional Claude accounts are tracked by running `claude /usage` with each account's configured `CLAUDE_CONFIG_DIR`.
+Claude Code usage reads the authenticated `/api/oauth/usage` endpoint — the same data Claude Code's own `/usage` screen shows — because `claude /usage` no longer renders in a headless (non-interactive) spawn. Parsing the CLI output is kept as a fallback and can be forced by turning off "Claude Code OAuth usage" in Settings.
+- Additional Claude accounts are tracked by running `claude /usage` with each account's configured `CLAUDE_CONFIG_DIR` (they have no Keychain token of their own).
 - Cursor: Local SQLite queries
 
-**No provider API keys are required for CLI-backed services** - the app uses local CLI/session data where possible and does not read Claude Code's OAuth token during normal operation.
+**No provider API keys are required for CLI-backed services** - the app uses the local Claude Code login and CLI/session data. The default Claude Code account's Keychain OAuth token is read to fetch usage (a one-time macOS Keychain prompt on first launch).
 
 ## Privacy & Security
 


### PR DESCRIPTION
## Problem

MeterBar's Claude Code card shows **"Refresh failed" / parse error**. Root cause: `claude /usage` (CLI 2.1.208) only renders the usage screen in an interactive TTY. Every headless spawn a GUI app can make returns a session **cost summary** (`Total cost: $0.0000 …`), so `ClaudeCodeCLIUsageParser` finds no usage windows → `parsingFailed("No Claude usage windows found.")`. #156's parse-health correctly surfaced this; #145 fixed only a separate PATH-hook error.

Verified dead-ends: no `usage`/`status`/`limits` subcommand; `-p "/usage" --output-format json` runs an empty session and returns the same cost summary; forcing a PTY makes `claude` go interactive and hang; no local usage cache file exists.

## Fix (option 1 — authenticated API, the most robust path)

The data Claude Code's own `/usage` screen shows comes from an authenticated endpoint:

```
GET https://api.anthropic.com/api/oauth/usage
Authorization: Bearer <Claude Code-credentials Keychain OAuth token>
anthropic-beta: oauth-2025-04-20
```

**MeterBar already implemented this endpoint** — but gated behind the opt-in `ClaudeCodeEnableOAuthFallback` flag and only tried *after* the (broken, ~12 s) CLI spawn failed. This PR promotes it to the **primary** source:

- `ClaudeCodeLocalService.fetchUsageMetrics` now tries OAuth **first** for the default account. `fetchUsageViaOAuth` returns `nil` when there's no usable Keychain token (⇒ CLI fallback), and throws on a genuine network/decode error rather than retrying the headless-broken CLI. Custom (`CLAUDE_CONFIG_DIR`) accounts stay CLI-only — they have no Keychain token.
- Extracted pure, unit-tested helpers: `metrics(from:)`, `prefersOAuth(account:oauthEnabled:)`, `isOAuthUsageEnabled(defaults:)` — the single source of truth for the flag, now **on by default** (`object(forKey:) as? Bool ?? true`), routed through the two other call sites (`ProviderSnapshot`, `ProviderReadinessInspector`) so they agree.
- Renamed `ClaudeCodeUsageSource.legacyOAuth` → `.oauth`; refreshed the Settings toggle/notice copy.
- **Bonus (option 3):** `ClaudeCodeCLIUsageParser` now detects the cost-summary shape and throws a legible, actionable error instead of the vague "No usage windows found." — so the CLI fallback fails clearly too.

## Tradeoff

Enabling OAuth by default means **one one-time macOS Keychain prompt** on first launch of a signed release (the grant persists across Sparkle updates). Users can opt out via **Settings ▸ Claude Code ▸ "Claude Code OAuth usage"** (also the escape hatch for unsigned dev builds that re-prompt per rebuild).

## Tests (TDD-first)

- `MeterBarTests/ClaudeCodeOAuthUsageTests.swift` — response→`UsageMetrics` mapping, source-selection policy, enabled-by-default flag (isolated `UserDefaults` suite).
- `MeterBarTests/ClaudeCodeCLIUsageParserTests.swift` — cost-summary detection.
- Existing `ProviderResponseContractTests` already lock the `/api/oauth/usage` decode.

Ran research + edits only; relied on PR CI for `swift test` + build (per machine policy).

## Follow-up (out of scope)

`WakeQuotaAuthority`/`LiveWakeQuotaProvider` still call the raw CLI service. The session-wake default-account quota gate would also benefit from OAuth, but needs a **side-effect-free** OAuth fetch to avoid coupling UI `@Published` state into wake decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude Code usage is now fetched through OAuth by default for the primary account, with CLI parsing retained as a fallback.
  * Added clearer usage-source status and settings guidance.
  * Custom Claude Code accounts continue using CLI-based usage retrieval.

* **Bug Fixes**
  * Improved handling of headless CLI output that previously caused usage refresh failures.
  * Added a more specific message when cost-summary output is detected.
  * Improved usage mapping and extra-usage display behavior.

* **Documentation**
  * Updated setup and architecture guidance to describe OAuth usage, fallback behavior, and the initial Keychain prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->