### PR TITLE
fix(wake): use OAuth usage source for default-account wake quota gate

### DIFF
--- a/MeterBar/Services/ClaudeCodeLocalService.swift
+++ b/MeterBar/Services/ClaudeCodeLocalService.swift
@@ -8,8 +8,13 @@ class ClaudeCodeLocalService: ObservableObject {
     // reference the singleton (methods keep their own isolation).
     nonisolated static let shared = ClaudeCodeLocalService()
 
-    // Working endpoint (discovered via testing)
-    private let usageEndpoint = "https://api.anthropic.com/api/oauth/usage"
+    /// Authenticated Claude Code usage endpoint — the same data Claude Code's
+    /// own `/usage` screen reads. `nonisolated static` so the side-effect-free
+    /// fetch (used by the background session-wake quota gate) can reach it
+    /// without touching main-actor state.
+    nonisolated static let defaultUsageEndpoint = "https://api.anthropic.com/api/oauth/usage"
+
+    private let usageEndpoint = ClaudeCodeLocalService.defaultUsageEndpoint
 
     private let keychainService = "Claude Code-credentials"
     private let cliUsageService = ClaudeCodeCLIUsageService.shared
@@ -139,44 +144,29 @@ class ClaudeCodeLocalService: ObservableObject {
     }
 
     /// Fetches usage from the OAuth `/api/oauth/usage` endpoint for the default
-    /// account. Returns `nil` when there is no usable Keychain token (missing or
-    /// expired) so the caller can fall back to the CLI.
+    /// account and updates the app's `@Published` auth/error state. Returns
+    /// `nil` when there is no usable Keychain token (missing or expired) so the
+    /// caller can fall back to the CLI. The actual request/decode is delegated
+    /// to the pure `fetchOAuthMetrics(token:)`; this wrapper adds only the UI
+    /// side effects.
     private func fetchUsageViaOAuth() async throws -> UsageMetrics? {
         // Keychain read — off the main actor (it can raise a blocking approval
         // dialog, and the app target runs async bodies on the main actor).
+        // `getOAuthToken()` also refreshes `subscriptionType`/`hasAccess`.
         let token = await Task.detached(priority: .userInitiated) { [self] in
             getOAuthToken()
         }.value
 
         guard let token else { return nil }
 
-        guard let url = URL(string: usageEndpoint) else {
-            throw ServiceError.invalidURL
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
-        request.timeoutInterval = 30.0
-
         do {
-            let (data, response) = try await urlSession.data(for: request)
-            try ServiceSupport.validate(response, data: data)
-
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            let usageResponse = try decoder.decode(ClaudeCodeUsageResponse.self, from: data)
-
+            let metrics = try await Self.fetchOAuthMetrics(token: token, session: urlSession)
             await MainActor.run {
                 self.lastError = nil
                 self.hasAccess = true
                 self.authState = .connected(.oauth)
             }
-
-            return Self.metrics(from: usageResponse)
+            return metrics
         } catch {
             let serviceError = ServiceSupport.serviceError(from: error)
             await MainActor.run {
@@ -190,6 +180,72 @@ class ClaudeCodeLocalService: ObservableObject {
             }
             throw serviceError
         }
+    }
+
+    /// Pure, side-effect-free fetch of Claude Code usage from `/api/oauth/usage`.
+    ///
+    /// Reads no `@Published` state and performs no `MainActor` mutation, so it
+    /// is safe to call from a nonisolated background context — e.g. the
+    /// session-wake quota gate, which must not couple UI state into background
+    /// polls. The caller supplies the bearer token; this builds the request,
+    /// validates the response, decodes it, and maps it onto `UsageMetrics`,
+    /// mapping any failure onto `ServiceError` (fail fast — never returns a
+    /// partial reading).
+    nonisolated static func fetchOAuthMetrics(
+        token: String,
+        endpoint: String = defaultUsageEndpoint,
+        session: URLSession = ServiceSupport.session
+    ) async throws -> UsageMetrics {
+        guard let url = URL(string: endpoint), !endpoint.isEmpty else {
+            throw ServiceError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+        request.timeoutInterval = 30.0
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            try ServiceSupport.validate(response, data: data)
+
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let usageResponse = try decoder.decode(ClaudeCodeUsageResponse.self, from: data)
+            return metrics(from: usageResponse)
+        } catch {
+            throw ServiceSupport.serviceError(from: error)
+        }
+    }
+
+    /// Reads a non-expired Claude Code OAuth access token from the Keychain
+    /// *without* mutating any `@Published` state. Returns `nil` when the
+    /// credential is missing or expired. The UI-facing `getOAuthToken()`
+    /// additionally refreshes published subscription/access state; background
+    /// callers (the wake quota gate) must not, so they use this instead.
+    nonisolated func nonMutatingOAuthToken() -> String? {
+        guard let credentials = getCredentials(),
+              !OAuthTokenExpiry.isExpired(unixTimestamp: credentials.claudeAiOauth.expiresAt) else {
+            return nil
+        }
+        return credentials.claudeAiOauth.accessToken
+    }
+
+    /// Side-effect-free OAuth usage fetch for background callers (the
+    /// session-wake quota gate). Reads a non-expired Keychain token off the main
+    /// actor and, when present, fetches `/api/oauth/usage` — mutating NO
+    /// `@Published`/`MainActor` state. Returns `nil` when there is no usable
+    /// token so the caller can fall back to the CLI; throws when a token was in
+    /// hand but the request/decode failed (fail closed).
+    nonisolated static func oauthMetricsWithoutSideEffects() async throws -> UsageMetrics? {
+        let token = await Task.detached(priority: .userInitiated) {
+            shared.nonMutatingOAuthToken()
+        }.value
+        guard let token else { return nil }
+        return try await fetchOAuthMetrics(token: token)
     }
 
     /// Fallback source: shells out to `claude /usage` and parses the terminal

--- a/MeterBar/SessionWake/WakeQuotaAuthority.swift
+++ b/MeterBar/SessionWake/WakeQuotaAuthority.swift
@@ -8,11 +8,50 @@ nonisolated protocol WakeQuotaProviding: Sendable {
     func fetchMetrics(account: ClaudeCodeAccount) async throws -> UsageMetrics
 }
 
-/// Default provider: the same `claude /usage` service the app and CLI already
-/// use, scoped to the selected account's `CLAUDE_CONFIG_DIR`.
+/// Default provider. For the default account it prefers the authenticated
+/// `/api/oauth/usage` endpoint — the same source the usage card adopted in
+/// PR #175 — because `claude /usage` no longer renders in a headless (non-TTY)
+/// spawn and its parse fails. It falls back to the `claude /usage` CLI for
+/// custom accounts (which have no Keychain token), a missing/expired token, or
+/// an OAuth opt-out. The OAuth path is side-effect-free: unlike the usage
+/// card's `ClaudeCodeLocalService.fetchUsageMetrics`, it never mutates
+/// `@Published` UI state, so background wake polls stay decoupled from the UI.
 nonisolated struct LiveWakeQuotaProvider: WakeQuotaProviding {
+    /// Fetches usage via OAuth without UI side effects; `nil` ⇒ no usable
+    /// Keychain token, so fall back to the CLI. A throw ⇒ a token was in hand
+    /// but the request failed — surface it (fail closed) rather than retry the
+    /// headless-broken CLI.
+    private let oauthMetrics: @Sendable () async throws -> UsageMetrics?
+    /// Fallback: shells out to `claude /usage` for the given account.
+    private let cliMetrics: @Sendable (ClaudeCodeAccount) async throws -> UsageMetrics
+    /// Whether the OAuth source is enabled (user opt-out honored).
+    private let oauthEnabled: @Sendable () -> Bool
+
+    init(
+        oauthMetrics: @escaping @Sendable () async throws -> UsageMetrics? = {
+            try await ClaudeCodeLocalService.oauthMetricsWithoutSideEffects()
+        },
+        cliMetrics: @escaping @Sendable (ClaudeCodeAccount) async throws -> UsageMetrics = { account in
+            try await ClaudeCodeCLIUsageService.shared.fetchUsageMetrics(account: account)
+        },
+        oauthEnabled: @escaping @Sendable () -> Bool = {
+            ClaudeCodeLocalService.isOAuthUsageEnabled()
+        }
+    ) {
+        self.oauthMetrics = oauthMetrics
+        self.cliMetrics = cliMetrics
+        self.oauthEnabled = oauthEnabled
+    }
+
     func fetchMetrics(account: ClaudeCodeAccount) async throws -> UsageMetrics {
-        try await ClaudeCodeCLIUsageService.shared.fetchUsageMetrics(account: account)
+        if ClaudeCodeLocalService.prefersOAuth(account: account, oauthEnabled: oauthEnabled()) {
+            // `nil` ⇒ no usable token: fall through to the CLI. A throw
+            // propagates so the authority fails closed to `.unknown`.
+            if let metrics = try await oauthMetrics() {
+                return metrics
+            }
+        }
+        return try await cliMetrics(account)
     }
 }
 

--- a/MeterBarTests/ClaudeCodeOAuthUsageTests.swift
+++ b/MeterBarTests/ClaudeCodeOAuthUsageTests.swift
@@ -60,6 +60,23 @@ final class ClaudeCodeOAuthUsageTests: XCTestCase {
         XCTAssertFalse(ClaudeCodeLocalService.prefersOAuth(account: custom, oauthEnabled: false))
     }
 
+    // MARK: - Pure OAuth fetch (side-effect-free)
+
+    func testOAuthFetchThrowsInvalidURLForEmptyEndpoint() async {
+        // The pure fetch validates the endpoint before touching the network, so
+        // this exercises it without a request. It also proves the fetch is a
+        // plain `static` callable from a nonisolated (background) context — the
+        // property the session-wake path depends on.
+        do {
+            _ = try await ClaudeCodeLocalService.fetchOAuthMetrics(token: "token", endpoint: "")
+            XCTFail("An empty endpoint must throw before any network call")
+        } catch ServiceError.invalidURL {
+            // expected
+        } catch {
+            XCTFail("Expected ServiceError.invalidURL, got \(error)")
+        }
+    }
+
     // MARK: - Enabled-by-default flag
 
     func testOAuthUsageEnabledDefaultsTrueWhenUnset() throws {

--- a/MeterBarTests/WakeQuotaProviderSelectionTests.swift
+++ b/MeterBarTests/WakeQuotaProviderSelectionTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import MeterBar
+@testable import MeterBarShared
+
+/// Extends PR #175's OAuth-primary usage source to the session-wake quota gate.
+///
+/// `LiveWakeQuotaProvider` must prefer the side-effect-free OAuth fetch for the
+/// default account (whose token lives in the Keychain) and fall back to the CLI
+/// for custom accounts, a missing token, or an OAuth opt-out — matching the
+/// selection policy the usage card already uses, and without any UI side
+/// effects or network. The injected closures exercise that selection in
+/// isolation.
+final class WakeQuotaProviderSelectionTests: XCTestCase {
+    private func metrics(session used: Double) -> UsageMetrics {
+        UsageMetrics(
+            service: .claudeCode,
+            sessionLimit: UsageLimit(used: used, total: 100, resetTime: nil)
+        )
+    }
+
+    /// Thread-safe recorder for which source path a fetch took. The provider's
+    /// closures are `@Sendable`, so mutation must be isolated.
+    private actor CallRecorder {
+        private(set) var oauthCalls = 0
+        private(set) var cliAccounts: [ClaudeCodeAccount] = []
+        func recordOAuth() { oauthCalls += 1 }
+        func recordCLI(_ account: ClaudeCodeAccount) { cliAccounts.append(account) }
+    }
+
+    func testDefaultAccountPrefersOAuthWhenTokenPresent() async throws {
+        let recorder = CallRecorder()
+        let provider = LiveWakeQuotaProvider(
+            oauthMetrics: { await recorder.recordOAuth(); return self.metrics(session: 42) },
+            cliMetrics: { account in await recorder.recordCLI(account); return self.metrics(session: 99) },
+            oauthEnabled: { true }
+        )
+
+        let result = try await provider.fetchMetrics(account: .defaultAccount)
+
+        XCTAssertEqual(try XCTUnwrap(result.sessionLimit).percentage, 42, accuracy: 0.01)
+        let oauthCalls = await recorder.oauthCalls
+        let cliAccounts = await recorder.cliAccounts
+        XCTAssertEqual(oauthCalls, 1)
+        XCTAssertTrue(cliAccounts.isEmpty, "OAuth success must not also hit the CLI")
+    }
+
+    func testDefaultAccountFallsBackToCLIWhenNoToken() async throws {
+        let recorder = CallRecorder()
+        let provider = LiveWakeQuotaProvider(
+            oauthMetrics: { await recorder.recordOAuth(); return nil }, // no usable Keychain token
+            cliMetrics: { account in await recorder.recordCLI(account); return self.metrics(session: 7) },
+            oauthEnabled: { true }
+        )
+
+        let result = try await provider.fetchMetrics(account: .defaultAccount)
+
+        XCTAssertEqual(try XCTUnwrap(result.sessionLimit).percentage, 7, accuracy: 0.01)
+        let oauthCalls = await recorder.oauthCalls
+        let cliAccounts = await recorder.cliAccounts
+        XCTAssertEqual(oauthCalls, 1)
+        XCTAssertEqual(cliAccounts, [.defaultAccount])
+    }
+
+    func testDefaultAccountUsesCLIWhenOAuthDisabled() async throws {
+        let recorder = CallRecorder()
+        let provider = LiveWakeQuotaProvider(
+            oauthMetrics: { await recorder.recordOAuth(); return self.metrics(session: 1) },
+            cliMetrics: { account in await recorder.recordCLI(account); return self.metrics(session: 55) },
+            oauthEnabled: { false }
+        )
+
+        let result = try await provider.fetchMetrics(account: .defaultAccount)
+
+        XCTAssertEqual(try XCTUnwrap(result.sessionLimit).percentage, 55, accuracy: 0.01)
+        let oauthCalls = await recorder.oauthCalls
+        let cliAccounts = await recorder.cliAccounts
+        XCTAssertEqual(oauthCalls, 0, "An OAuth opt-out must skip the OAuth path entirely")
+        XCTAssertEqual(cliAccounts, [.defaultAccount])
+    }
+
+    func testCustomAccountAlwaysUsesCLI() async throws {
+        let recorder = CallRecorder()
+        let custom = ClaudeCodeAccount(id: UUID(), name: "Work", configDirectory: "/tmp/work")
+        let provider = LiveWakeQuotaProvider(
+            oauthMetrics: { await recorder.recordOAuth(); return self.metrics(session: 1) },
+            cliMetrics: { account in await recorder.recordCLI(account); return self.metrics(session: 33) },
+            oauthEnabled: { true }
+        )
+
+        let result = try await provider.fetchMetrics(account: custom)
+
+        XCTAssertEqual(try XCTUnwrap(result.sessionLimit).percentage, 33, accuracy: 0.01)
+        let oauthCalls = await recorder.oauthCalls
+        let cliAccounts = await recorder.cliAccounts
+        XCTAssertEqual(oauthCalls, 0, "Custom accounts have no Keychain token; never hit OAuth")
+        XCTAssertEqual(cliAccounts, [custom])
+    }
+
+    func testOAuthFailurePropagatesAndDoesNotFallBackToCLI() async {
+        struct Boom: Error {}
+        let recorder = CallRecorder()
+        let provider = LiveWakeQuotaProvider(
+            oauthMetrics: { await recorder.recordOAuth(); throw Boom() },
+            cliMetrics: { account in await recorder.recordCLI(account); return self.metrics(session: 5) },
+            oauthEnabled: { true }
+        )
+
+        do {
+            _ = try await provider.fetchMetrics(account: .defaultAccount)
+            XCTFail("A token-present OAuth failure must propagate, not silently fall back")
+        } catch {
+            // expected — fail closed
+        }
+
+        let cliAccounts = await recorder.cliAccounts
+        XCTAssertTrue(cliAccounts.isEmpty, "OAuth error must fail closed, not retry the headless-broken CLI")
+    }
+}


### PR DESCRIPTION
## What

Extends **#175** to the session-wake path.

PR #175 promoted the authenticated `/api/oauth/usage` endpoint to the primary Claude Code usage source for the default account (because `claude /usage` no longer renders in a headless spawn — it prints a session cost summary, so parsing fails). But the **session-wake subsystem bypassed that fix**: `LiveWakeQuotaProvider.fetchMetrics(account:)` called `ClaudeCodeCLIUsageService.shared.fetchUsageMetrics` **directly** (the raw CLI parser). So for the default account the wake quota gate was still broken headlessly.

It wasn't fixed in #175 because `ClaudeCodeLocalService.fetchUsageMetrics` mutates `@Published` UI state (`hasAccess`, `authState`, `lastError`) as a side effect, and `WakeQuotaAuthority` is `nonisolated` / used in background wake decisions — routing it through the local service would couple UI state into background quota polls.

## How

- **Extract a pure, side-effect-free OAuth fetch** on `ClaudeCodeLocalService`:
  - `fetchOAuthMetrics(token:endpoint:session:)` — `nonisolated static`; builds the request, `ServiceSupport.validate`, decodes `ClaudeCodeUsageResponse`, returns `metrics(from:)`. **No `@Published`/`MainActor` mutation.**
  - `nonMutatingOAuthToken()` — reads a non-expired Keychain token without touching published state (the UI-facing `getOAuthToken()` still refreshes subscription/access state).
  - `oauthMetricsWithoutSideEffects()` — combines the two for background callers; `nil` ⇒ no usable token (fall back to CLI), throws ⇒ token in hand but request failed (fail closed).
  - `fetchUsageViaOAuth` now **delegates** to the pure fetch and keeps its existing UI-state updates intact.
- **`LiveWakeQuotaProvider`** now prefers OAuth for the **default account** (reusing the existing `prefersOAuth` / `isOAuthUsageEnabled` helpers) and falls back to `ClaudeCodeCLIUsageService` for **custom (`CLAUDE_CONFIG_DIR`) accounts**, a missing/expired token, or an OAuth opt-out. A token-present OAuth failure propagates, so the authority fails closed to `.unknown`. The three dependencies are injected (defaulted) so the selection is testable without network/Keychain.

## Tests (TDD — written first)

- **`WakeQuotaProviderSelectionTests`** (new): default→OAuth when token present (no CLI), default→CLI fallback when no token, default→CLI when OAuth disabled, custom account→always CLI, and OAuth-failure→propagates without CLI fallback. Uses the injectable provider closures — no network.
- **`ClaudeCodeOAuthUsageTests`**: adds a pure `invalidURL` check for `fetchOAuthMetrics` (validates the endpoint before any request).

## Verification

Per repo policy, relying on **PR CI** (macos-26: `swift test --enable-code-coverage` + xcodebuild build + SwiftLint) — not run locally. SwiftLint passed locally on the changed files.