### PR TITLE
feat(session-wake): app-watcher + Settings Codex support

### DIFF
--- a/.agents/SESSIONS/2026-07-14.md
+++ b/.agents/SESSIONS/2026-07-14.md
@@ -47,3 +47,77 @@ Claude Code ▸ "Claude Code OAuth usage" (dev builds re-prompt per rebuild).
 `WakeQuotaAuthority`/`LiveWakeQuotaProvider` still call the raw CLI service; the
 session-wake default-account quota gate would also benefit from OAuth, but needs a
 **side-effect-free** OAuth fetch to avoid coupling UI `@Published` state into wake decisions.
+
+---
+
+# Session 2 — Session Wake: app watcher + Settings Codex support
+
+## Goal
+PR #174 (`5ca2844`) landed the Codex **mechanism** (`WakeProvider`,
+`WakeProviderRuntime`, `Claude`/`CodexWakeRuntime`, Codex discovery/quota/runner,
+provider-agnostic `WakeCLIEngine`). This session wires that mechanism into the
+**app UI + continuous watcher** so the in-app toggle can watch Codex, not just the CLI.
+
+## Flow
+```
+Settings picker (Claude|Codex) ─▶ SessionWakeSettingsStore
+   wakeProvider + wakeAccountID/wakeCodexAccountID (each provider its own selection)
+        │  (Combine publishers)
+        ▼
+SessionWakeController.reconcile()
+   ├─ resolvedRuntime() → Claude|Codex runtime bound to selected enabled account
+   │        └─ WakeCoordinator.start(runtime:)  (runtime-driven loop)
+   └─ store.syncSharedWakeTarget(dir) → app-group key the bundled CLI reads
+             Claude→SessionWakeAccountConfigDir · Codex→SessionWakeCodexHomeDir
+```
+
+## What was done
+- **WakeCoordinator** — runtime-driven (`start(runtime:)`; `runLoop`/`handle`/
+  `launchNext` drive `WakeProviderRuntime`, one `makeRunner()` per loop). Kept
+  `start(account:)` as a Claude facade wrapping the stored discovery/authority/runner
+  into a `ClaudeWakeRuntime` — `WakeCoordinatorTests` stay green.
+- **SessionWakeController** — provider-aware. `WakeWatching` now `start(runtime:)`;
+  injects `CodexAccountStore`; reconcile reads `store.wakeProvider`, builds the matching
+  runtime (Claude→`WakeProcessRunner`, Codex→`CodexWakeProcessRunner`), and mirrors the
+  active account dir to the app group. Added `$wakeProvider`/`$wakeCodexAccountID` +
+  Codex account-store publishers.
+- **SessionWakeSettingsStore + StorageKeys** — added `wakeProvider` (`SessionWakeProvider`,
+  default `.claude`) and `wakeCodexAccountID` (`SessionWakeCodexAccountID`). `canTurnOn`/
+  `activeAccountID` are provider-scoped; changing provider or either account `forceOff()`s.
+  New `syncSharedWakeTarget(directory:)` writes the active provider's app-group key (and
+  clears the inactive one), guarded to the production standard suite like the feature flag.
+- **CodexAccount** — `isEnabled` (decode default `true`) + store `enabledAccounts` /
+  `setEnabled(_:for:)` / `defaultAccountIsEnabled` + `CodexDefaultAccountEnabled` key,
+  mirroring `ClaudeCodeAccount`.
+- **SessionWakeSettingsView** — provider segmented `Picker`; account picker lists the
+  selected provider's `enabledAccounts` (via a small provider-agnostic `AccountChoice`);
+  confirmation-dialog + switch prose use `wakeProvider.displayName`.
+- **SessionWakeNotificationDecider** — `claudeProviderEnabled` → `providerEnabled`,
+  added `providerDisplayName`; completion copy uses it. App delegate passes the active
+  provider's visibility (`.claudeCode`/`.codexCli`) + display name.
+
+## Key decisions
+- **Single active provider** (picker), **single global `WakeLock`** — no per-provider
+  locks, keeps the one-toggle model (as speced).
+- **App-group write lives in the controller→store seam**, not just the store: the store
+  owns the keys/guard, the controller (sole account resolver) supplies the directory.
+  Root-causes a pre-existing gap — the app never actually wrote `SessionWakeAccountConfigDir`
+  before, so the CLI always fell back to the default account. Now both providers mirror.
+- **Completion copy uses `displayName`** ("Claude Code"/"Codex"), a deliberate change
+  from the old hardcoded "Claude"; decider tests updated to match.
+
+## Tests (TDD)
+- `WakeCoordinatorTests` — added explicit `start(runtime:)` path; facade tests unchanged.
+- `SessionWakeControllerTests` — `FakeWatcher.start(runtime:)`, provider tracking, Codex
+  watcher path + switch-provider-disarms.
+- `SessionWakeSettingsTests` — provider default/persistence, per-provider `canTurnOn`,
+  provider/codex-account disarm, `reconcileCodexAccounts`, stale-on correction.
+- `CodexAccountStoreTests` — enablement + legacy decode.
+- `SessionWakeNotificationDeciderTests` — new fields + provider-name copy.
+
+## Constraints
+- Vincent's MacBook: no local `swift build`/`test`/`xcodebuild`. `swiftlint --strict` on
+  the 8 changed sources → **0 violations**. Build/test via PR CI.
+
+## Files changed
+8 sources + 5 test files (see PR diff).

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -585,9 +585,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @MainActor
     private func postSessionWakeCompletion(summary: WakeRunSummary) {
+        let provider = SessionWakeSettingsStore.shared.wakeProvider
+        let providerService: ServiceType = provider == .codex ? .codexCli : .claudeCode
         let context = SessionWakeNotificationContext(
             globalNotificationsEnabled: notificationPreferences.isEnabled,
-            claudeProviderEnabled: providerVisibilityStore.isEnabled(.claudeCode),
+            providerEnabled: providerVisibilityStore.isEnabled(providerService),
+            providerDisplayName: provider.displayName,
             notifyOnCompletion: SessionWakeSettingsStore.shared.notifyOnCompletion
         )
         guard let fired = SessionWakeNotificationDecider.completionNotification(

--- a/MeterBar/Models/CodexAccount.swift
+++ b/MeterBar/Models/CodexAccount.swift
@@ -14,6 +14,24 @@ nonisolated struct CodexAccount: Codable, Equatable, Identifiable, Sendable {
     let id: UUID
     var name: String
     var homeDirectory: String?
+    var isEnabled: Bool
+
+    init(id: UUID, name: String, homeDirectory: String?, isEnabled: Bool = true) {
+        self.id = id
+        self.name = name
+        self.homeDirectory = homeDirectory
+        self.isEnabled = isEnabled
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        homeDirectory = try container.decodeIfPresent(String.self, forKey: .homeDirectory)
+        // Backward-compat: profiles persisted before the enable/disable flag
+        // existed decode as enabled.
+        isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
+    }
 
     var isDefault: Bool { id == Self.defaultID }
 }
@@ -23,14 +41,24 @@ final class CodexAccountStore: ObservableObject {
 
     @Published private(set) var customAccounts: [CodexAccount] = []
     @Published private(set) var defaultAccountName = CodexAccount.defaultName
+    @Published private(set) var defaultAccountIsEnabled = true
     @Published private(set) var accountOrder: [UUID] = []
 
     private let userDefaults: UserDefaults
 
     var accounts: [CodexAccount] {
         orderedAccounts(from: [
-            CodexAccount(id: CodexAccount.defaultID, name: defaultAccountName, homeDirectory: nil)
+            CodexAccount(
+                id: CodexAccount.defaultID,
+                name: defaultAccountName,
+                homeDirectory: nil,
+                isEnabled: defaultAccountIsEnabled
+            )
         ] + customAccounts)
+    }
+
+    var enabledAccounts: [CodexAccount] {
+        accounts.filter(\.isEnabled)
     }
 
     init(userDefaults: UserDefaults = .standard) {
@@ -89,6 +117,24 @@ final class CodexAccountStore: ObservableObject {
         saveCustomAccounts()
     }
 
+    func setEnabled(_ enabled: Bool, for id: UUID) {
+        if id == CodexAccount.defaultID {
+            guard enabled != defaultAccountIsEnabled else { return }
+            defaultAccountIsEnabled = enabled
+            saveDefaultAccountEnabled()
+            return
+        }
+
+        guard let index = customAccounts.firstIndex(where: { $0.id == id }),
+              customAccounts[index].isEnabled != enabled else {
+            return
+        }
+        var updatedAccounts = customAccounts
+        updatedAccounts[index].isEnabled = enabled
+        customAccounts = updatedAccounts
+        saveCustomAccounts()
+    }
+
     func moveAccounts(fromOffsets source: IndexSet, toOffset destination: Int) {
         var ordered = accounts
         let movingIndexes = source.sorted()
@@ -107,6 +153,9 @@ final class CodexAccountStore: ObservableObject {
         if let name = userDefaults.string(forKey: StorageKeys.codexDefaultAccountName)?
             .trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
             defaultAccountName = name
+        }
+        if userDefaults.object(forKey: StorageKeys.codexDefaultAccountEnabled) != nil {
+            defaultAccountIsEnabled = userDefaults.bool(forKey: StorageKeys.codexDefaultAccountEnabled)
         }
         accountOrder = userDefaults.stringArray(forKey: StorageKeys.codexAccountOrder)?
             .compactMap(UUID.init(uuidString:)) ?? []
@@ -127,6 +176,14 @@ final class CodexAccountStore: ObservableObject {
             userDefaults.removeObject(forKey: StorageKeys.codexDefaultAccountName)
         } else {
             userDefaults.set(defaultAccountName, forKey: StorageKeys.codexDefaultAccountName)
+        }
+    }
+
+    private func saveDefaultAccountEnabled() {
+        if defaultAccountIsEnabled {
+            userDefaults.removeObject(forKey: StorageKeys.codexDefaultAccountEnabled)
+        } else {
+            userDefaults.set(false, forKey: StorageKeys.codexDefaultAccountEnabled)
         }
     }
 

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -36,6 +36,8 @@ nonisolated enum StorageKeys {
     static let codexCustomAccounts = "CodexCustomAccounts"
     /// User-chosen display name for the default Codex CLI profile.
     static let codexDefaultAccountName = "CodexDefaultAccountName"
+    /// Whether the synthesized default Codex CLI profile participates in tracking.
+    static let codexDefaultAccountEnabled = "CodexDefaultAccountEnabled"
     /// Persisted Codex account display order (array of UUID strings).
     static let codexAccountOrder = "CodexAccountOrder"
     /// Cached per-account Codex metrics (JSON-encoded [UUID: UsageMetrics]).
@@ -54,8 +56,12 @@ nonisolated enum StorageKeys {
     static let sessionWakeFeatureEnabled = "SessionWakeFeatureEnabled"
     /// Runtime intent for the watcher, distinct from feature enablement (Bool).
     static let sessionWakeWatcherArmed = "SessionWakeWatcherArmed"
-    /// Explicitly selected wake account id (UUID string). Never inferred.
+    /// The active wake provider raw value (`WakeProvider`, default `.claude`).
+    static let sessionWakeProvider = "SessionWakeProvider"
+    /// Explicitly selected Claude wake account id (UUID string). Never inferred.
     static let sessionWakeAccountID = "SessionWakeAccountID"
+    /// Explicitly selected Codex wake account id (UUID string). Never inferred.
+    static let sessionWakeCodexAccountID = "SessionWakeCodexAccountID"
     /// Whether the user completed the first-enable safety acknowledgement (Bool).
     static let sessionWakeFirstEnableAcknowledged = "SessionWakeFirstEnableAcknowledged"
     /// Whether the user separately acknowledged permission-bypass mode (Bool).

--- a/MeterBar/SessionWake/SessionWakeController.swift
+++ b/MeterBar/SessionWake/SessionWakeController.swift
@@ -4,8 +4,13 @@ import Foundation
 /// The lifecycle abstraction the controller drives. `WakeCoordinator` is the
 /// production conformer; tests substitute a fake to assert start/stop without
 /// spawning a subprocess.
+///
+/// The watcher is armed with a provider `runtime` (Claude or Codex), so the
+/// controller stays provider-agnostic. `WakeCoordinator` still offers a concrete
+/// `start(account:)` convenience for the legacy Claude path, but it is not part
+/// of this protocol.
 nonisolated protocol WakeWatching: Sendable {
-    func start(account: ClaudeCodeAccount) async
+    func start(runtime: WakeProviderRuntime) async
     func stop() async
     func waitUntilFinished() async
 }
@@ -35,6 +40,7 @@ final class SessionWakeController: ObservableObject {
     private let store: SessionWakeSettingsStore
     private let status: SessionWakeStatus
     private let accounts: ClaudeCodeAccountStore
+    private let codexAccounts: CodexAccountStore
     private let rescanInterval: TimeInterval
     private let makeWatcher: WakeWatcherFactory
 
@@ -49,6 +55,7 @@ final class SessionWakeController: ObservableObject {
         store: SessionWakeSettingsStore? = nil,
         status: SessionWakeStatus? = nil,
         accounts: ClaudeCodeAccountStore? = nil,
+        codexAccounts: CodexAccountStore? = nil,
         rescanInterval: TimeInterval = 300,
         makeWatcher: @escaping WakeWatcherFactory = { runner, bounds, onState in
             WakeCoordinator(runner: runner, bounds: bounds, onState: onState)
@@ -57,6 +64,7 @@ final class SessionWakeController: ObservableObject {
         self.store = store ?? .shared
         self.status = status ?? .shared
         self.accounts = accounts ?? .shared
+        self.codexAccounts = codexAccounts ?? .shared
         self.rescanInterval = rescanInterval
         self.makeWatcher = makeWatcher
     }
@@ -68,17 +76,21 @@ final class SessionWakeController: ObservableObject {
         started = true
 
         // Any change that affects whether/where we should watch triggers a
-        // reconcile: the toggle, the selected account, the permission posture,
-        // and the account list (a removed account disarms via the store).
-        Publishers.Merge4(
-            store.$isOn.map { _ in () },
-            store.$wakeAccountID.map { _ in () },
-            store.$permissionMode.map { _ in () },
-            store.$bypassAcknowledged.map { _ in () }
-        )
-        .receive(on: RunLoop.main)
-        .sink { [weak self] in self?.reconcile() }
-        .store(in: &cancellables)
+        // reconcile: the toggle, the active provider, either provider's selected
+        // account, and the permission posture. A removed account disarms via the
+        // store's account reconcilers below.
+        let triggers: [AnyPublisher<Void, Never>] = [
+            store.$isOn.map { _ in () }.eraseToAnyPublisher(),
+            store.$wakeProvider.map { _ in () }.eraseToAnyPublisher(),
+            store.$wakeAccountID.map { _ in () }.eraseToAnyPublisher(),
+            store.$wakeCodexAccountID.map { _ in () }.eraseToAnyPublisher(),
+            store.$permissionMode.map { _ in () }.eraseToAnyPublisher(),
+            store.$bypassAcknowledged.map { _ in () }.eraseToAnyPublisher()
+        ]
+        Publishers.MergeMany(triggers)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] in self?.reconcile() }
+            .store(in: &cancellables)
 
         Publishers.Merge(
             accounts.$customAccounts.map { _ in () },
@@ -92,6 +104,18 @@ final class SessionWakeController: ObservableObject {
             }
             .store(in: &cancellables)
 
+        Publishers.Merge(
+            codexAccounts.$customAccounts.map { _ in () },
+            codexAccounts.$defaultAccountIsEnabled.map { _ in () }
+        )
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.store.reconcileCodexAccounts(available: self.codexAccounts.enabledAccounts.map(\.id))
+                self.reconcile()
+            }
+            .store(in: &cancellables)
+
         reconcile()
     }
 
@@ -101,27 +125,72 @@ final class SessionWakeController: ObservableObject {
     // MARK: - Reconciliation
 
     private func reconcile() {
-        if store.isOn, let account = selectedAccount() {
-            startWatching(account: account)
+        if store.isOn, let runtime = resolvedRuntime() {
+            startWatching(runtime: runtime)
         } else {
             stopWatching()
         }
+        // Keep the app-group target the bundled CLI reads in step with the
+        // active provider's selection, independent of the app watcher toggle —
+        // `meterbar wake` may run from cron even when the watcher is off.
+        store.syncSharedWakeTarget(directory: activeAccountDirectory())
     }
 
-    private func selectedAccount() -> ClaudeCodeAccount? {
-        guard let id = store.wakeAccountID else { return nil }
-        return accounts.enabledAccounts.first { $0.id == id }
+    /// Build the runtime for the active provider bound to its selected, enabled
+    /// account, or `nil` when no such account exists. Runner construction mirrors
+    /// `SessionWakeCLI.makeRuntime` so the app watcher and the CLI behave the
+    /// same. `permissionMode`/`bypassAcknowledged`/`prompt` are captured by value
+    /// (they are `Sendable`) to keep the `@Sendable` runner factory clean.
+    private func resolvedRuntime() -> WakeProviderRuntime? {
+        let mode = store.permissionMode
+        let bypass = store.bypassAcknowledged
+        let prompt = store.prompt
+
+        switch store.wakeProvider {
+        case .claude:
+            guard let id = store.wakeAccountID,
+                  let account = accounts.enabledAccounts.first(where: { $0.id == id }) else { return nil }
+            return ClaudeWakeRuntime(account: account) { runnerAccount in
+                WakeProcessRunner(
+                    account: runnerAccount,
+                    permissionMode: mode,
+                    bypassAcknowledged: bypass,
+                    prompt: prompt
+                )
+            }
+        case .codex:
+            guard let id = store.wakeCodexAccountID,
+                  let account = codexAccounts.enabledAccounts.first(where: { $0.id == id }) else { return nil }
+            return CodexWakeRuntime(account: account) { runnerAccount in
+                CodexWakeProcessRunner(
+                    account: runnerAccount,
+                    permissionMode: mode,
+                    bypassAcknowledged: bypass,
+                    prompt: prompt
+                )
+            }
+        }
     }
 
-    private func startWatching(account: ClaudeCodeAccount) {
+    /// The active provider's selected-account directory (Claude config dir or
+    /// Codex CODEX_HOME), or `nil` when nothing enabled is selected.
+    private func activeAccountDirectory() -> String? {
+        switch store.wakeProvider {
+        case .claude:
+            guard let id = store.wakeAccountID else { return nil }
+            return accounts.enabledAccounts.first(where: { $0.id == id })?.configDirectory
+        case .codex:
+            guard let id = store.wakeCodexAccountID else { return nil }
+            return codexAccounts.enabledAccounts.first(where: { $0.id == id })?.homeDirectory
+        }
+    }
+
+    private func startWatching(runtime: WakeProviderRuntime) {
         guard watchTask == nil else { return }
         let bounds = store.bounds
-        let runner = WakeProcessRunner(
-            account: account,
-            permissionMode: store.permissionMode,
-            bypassAcknowledged: store.bypassAcknowledged,
-            prompt: store.prompt
-        )
+        // The factory seam still takes a runner (used by the concrete coordinator
+        // init); the runtime supplies the real per-launch runner via makeRunner.
+        let runner = runtime.makeRunner()
         let interval = rescanInterval
         let make = makeWatcher
 
@@ -130,7 +199,7 @@ final class SessionWakeController: ObservableObject {
                 let watcher = make(runner, bounds) { state in
                     Task { @MainActor in SessionWakeStatus.shared.update(state: state) }
                 }
-                await watcher.start(account: account)
+                await watcher.start(runtime: runtime)
                 // A cancel (toggle off) reliably stops the coordinator via the
                 // cancellation handler, regardless of where the pass is.
                 await withTaskCancellationHandler {

--- a/MeterBar/SessionWake/SessionWakeNotificationDecider.swift
+++ b/MeterBar/SessionWake/SessionWakeNotificationDecider.swift
@@ -5,8 +5,10 @@ import Foundation
 struct SessionWakeNotificationContext: Equatable, Sendable {
     /// The global notifications master switch (NotificationPreferencesStore).
     let globalNotificationsEnabled: Bool
-    /// Whether the Claude provider is visible/enabled (ProviderVisibilityStore).
-    let claudeProviderEnabled: Bool
+    /// Whether the active wake provider is visible/enabled (ProviderVisibilityStore).
+    let providerEnabled: Bool
+    /// The active wake provider's user-facing name, used in the completion copy.
+    let providerDisplayName: String
     /// The Session Wake "notify on completion" preference.
     let notifyOnCompletion: Bool
 }
@@ -24,7 +26,7 @@ struct FiredWakeNotification: Equatable, Sendable {
 }
 
 /// Decides whether Session Wake may post a notification. A wake notification is
-/// suppressed unless the global switch, the Claude provider, and the Session
+/// suppressed unless the global switch, the active provider, and the Session
 /// Wake preference all allow it — Session Wake never overrides the user's global
 /// or provider-level choices.
 enum SessionWakeNotificationDecider {
@@ -34,7 +36,7 @@ enum SessionWakeNotificationDecider {
 
     static func shouldNotifyOnCompletion(_ context: SessionWakeNotificationContext) -> Bool {
         context.globalNotificationsEnabled
-            && context.claudeProviderEnabled
+            && context.providerEnabled
             && context.notifyOnCompletion
     }
 
@@ -60,7 +62,7 @@ enum SessionWakeNotificationDecider {
         guard summary.attempted > 0 || summary.remaining > 0 else { return nil }
 
         let sessionNoun = summary.attempted == 1 ? "session" : "sessions"
-        var body = "Resumed \(summary.resumed) of \(summary.attempted) Claude \(sessionNoun)."
+        var body = "Resumed \(summary.resumed) of \(summary.attempted) \(context.providerDisplayName) \(sessionNoun)."
         if summary.failed > 0 {
             let failureNoun = summary.failed == 1 ? "failure" : "failures"
             body += " \(summary.failed) \(failureNoun)."

--- a/MeterBar/SessionWake/SessionWakeSettingsStore.swift
+++ b/MeterBar/SessionWake/SessionWakeSettingsStore.swift
@@ -16,7 +16,9 @@ final class SessionWakeSettingsStore: ObservableObject {
 
     @Published private(set) var featureEnabled: Bool
     @Published private(set) var isOn: Bool
+    @Published private(set) var wakeProvider: WakeProvider
     @Published private(set) var wakeAccountID: UUID?
+    @Published private(set) var wakeCodexAccountID: UUID?
     @Published private(set) var firstRunAcknowledged: Bool
     @Published private(set) var bypassAcknowledged: Bool
     @Published private(set) var permissionMode: WakePermissionMode
@@ -38,7 +40,11 @@ final class SessionWakeSettingsStore: ObservableObject {
             featureEnabled = userDefaults.bool(forKey: StorageKeys.sessionWakeFeatureEnabled)
         }
         isOn = userDefaults.bool(forKey: StorageKeys.sessionWakeWatcherArmed)
+        wakeProvider = userDefaults.string(forKey: StorageKeys.sessionWakeProvider)
+            .flatMap(WakeProvider.init(rawValue:)) ?? .claude
         wakeAccountID = userDefaults.string(forKey: StorageKeys.sessionWakeAccountID).flatMap(UUID.init(uuidString:))
+        wakeCodexAccountID = userDefaults.string(forKey: StorageKeys.sessionWakeCodexAccountID)
+            .flatMap(UUID.init(uuidString:))
         firstRunAcknowledged = userDefaults.bool(forKey: StorageKeys.sessionWakeFirstEnableAcknowledged)
         bypassAcknowledged = userDefaults.bool(forKey: StorageKeys.sessionWakeBypassAcknowledged)
         permissionMode = userDefaults.string(forKey: StorageKeys.sessionWakePermissionMode)
@@ -79,10 +85,20 @@ final class SessionWakeSettingsStore: ObservableObject {
         )
     }
 
-    /// Whether the switch may be turned on right now: an explicit account and,
-    /// for bypass mode, its separate acknowledgement.
+    /// The explicitly selected account id for the active provider. Session Wake
+    /// keeps one selection per provider so switching providers never silently
+    /// retargets automation at whatever account the other provider had.
+    var activeAccountID: UUID? {
+        switch wakeProvider {
+        case .claude: return wakeAccountID
+        case .codex: return wakeCodexAccountID
+        }
+    }
+
+    /// Whether the switch may be turned on right now: an explicit account for the
+    /// active provider and, for bypass mode, its separate acknowledgement.
     var canTurnOn: Bool {
-        featureEnabled && wakeAccountID != nil && (permissionMode == .safe || bypassAcknowledged)
+        featureEnabled && activeAccountID != nil && (permissionMode == .safe || bypassAcknowledged)
     }
 
     /// True when turning on should first show the one-time confirmation.
@@ -128,6 +144,16 @@ final class SessionWakeSettingsStore: ObservableObject {
         setOn(true)
     }
 
+    /// Switch the active wake provider. Only one provider watches at a time (the
+    /// single-toggle model); flipping it disarms so automation never keeps
+    /// running against the previously selected provider/account pair.
+    func setWakeProvider(_ provider: WakeProvider) {
+        guard provider != wakeProvider else { return }
+        wakeProvider = provider
+        userDefaults.set(provider.rawValue, forKey: StorageKeys.sessionWakeProvider)
+        forceOff()
+    }
+
     func setWakeAccountID(_ id: UUID?) {
         guard id != wakeAccountID else { return }
         wakeAccountID = id
@@ -141,6 +167,19 @@ final class SessionWakeSettingsStore: ObservableObject {
         // starts a watch when none is running), and automation must never keep
         // running against — or silently retarget to — an account the user did
         // not just explicitly arm. Re-arming with the new account is one toggle.
+        forceOff()
+    }
+
+    /// The Codex analogue of `setWakeAccountID`. Same disarm invariant: changing
+    /// the Codex wake target turns the watcher off.
+    func setWakeCodexAccountID(_ id: UUID?) {
+        guard id != wakeCodexAccountID else { return }
+        wakeCodexAccountID = id
+        if let id {
+            userDefaults.set(id.uuidString, forKey: StorageKeys.sessionWakeCodexAccountID)
+        } else {
+            userDefaults.removeObject(forKey: StorageKeys.sessionWakeCodexAccountID)
+        }
         forceOff()
     }
 
@@ -173,14 +212,58 @@ final class SessionWakeSettingsStore: ObservableObject {
         userDefaults.set(clamped, forKey: StorageKeys.sessionWakeMaxTurns)
     }
 
-    /// Reconcile with the currently available accounts. If the selected wake
-    /// account disappeared, clear it and turn off — automation must never
-    /// silently retarget another account.
+    /// Reconcile with the currently available Claude accounts. If the selected
+    /// Claude wake account disappeared, clear it and turn off — automation must
+    /// never silently retarget another account.
     func reconcileAccounts(available ids: [UUID]) {
         guard let selected = wakeAccountID else { return }
         if !ids.contains(selected) {
             setWakeAccountID(nil) // also forces off
         }
+    }
+
+    /// The Codex analogue of `reconcileAccounts`.
+    func reconcileCodexAccounts(available ids: [UUID]) {
+        guard let selected = wakeCodexAccountID else { return }
+        if !ids.contains(selected) {
+            setWakeCodexAccountID(nil) // also forces off
+        }
+    }
+
+    /// Mirror the active provider's selected account location to the app-group
+    /// domain the bundled `meterbar wake` CLI reads, so the CLI targets the same
+    /// account the app watches — Claude's config dir under
+    /// `SessionWakeAccountConfigDir`, Codex's CODEX_HOME under
+    /// `SessionWakeCodexHomeDir`. The inactive provider's key is cleared so a
+    /// stale value never leaks across a provider switch. A `nil`/empty directory
+    /// (e.g. the default profile) clears the key and lets the CLI fall back to
+    /// its own default resolution.
+    ///
+    /// Only the production standard-suite store mirrors; test suites stay
+    /// isolated (same guard as `syncSharedFeatureFlag`) so unit tests never
+    /// write into the real app group.
+    func syncSharedWakeTarget(directory: String?) {
+        guard userDefaults === UserDefaults.standard,
+              let shared = UserDefaults(suiteName: SharedMetricsStore.appGroupIdentifier) else {
+            return
+        }
+        let activeKey: String
+        let inactiveKey: String
+        switch wakeProvider {
+        case .claude:
+            activeKey = SessionWakeCLI.sharedAccountConfigKey
+            inactiveKey = SessionWakeCLI.sharedCodexHomeKey
+        case .codex:
+            activeKey = SessionWakeCLI.sharedCodexHomeKey
+            inactiveKey = SessionWakeCLI.sharedAccountConfigKey
+        }
+        let trimmed = directory?.trimmingCharacters(in: .whitespaces)
+        if let trimmed, !trimmed.isEmpty {
+            shared.set(trimmed, forKey: activeKey)
+        } else {
+            shared.removeObject(forKey: activeKey)
+        }
+        shared.removeObject(forKey: inactiveKey)
     }
 
     private func forceOff() {

--- a/MeterBar/SessionWake/WakeCoordinator.swift
+++ b/MeterBar/SessionWake/WakeCoordinator.swift
@@ -47,12 +47,29 @@ actor WakeCoordinator {
         self.onState = onState
     }
 
-    /// Arm the watcher for `account`. No-op if already running.
-    func start(account: ClaudeCodeAccount) {
+    /// Arm the watcher for a provider runtime (Claude or Codex). No-op if already
+    /// running. This is the provider-agnostic entry point the controller drives.
+    func start(runtime: WakeProviderRuntime) {
         guard runTask == nil else { return }
         runTask = Task { [weak self] in
-            await self?.runLoop(account: account)
+            await self?.runLoop(runtime: runtime)
         }
+    }
+
+    /// Legacy Claude-only convenience. Wraps the stored discovery/authority/runner
+    /// into a `ClaudeWakeRuntime` and delegates to `start(runtime:)`, so callers
+    /// and tests that already speak `ClaudeCodeAccount` keep working unchanged.
+    /// The stored single runner is reused for every launch (the runtime hands the
+    /// same instance back from `makeRunner()`), preserving the original behavior.
+    func start(account: ClaudeCodeAccount) {
+        let runner = self.runner
+        let runtime = ClaudeWakeRuntime(
+            account: account,
+            discovery: discovery,
+            authority: authority,
+            makeRunner: { _ in runner }
+        )
+        start(runtime: runtime)
     }
 
     /// Cancel any in-flight watch deterministically. Cancels pending sleep/poll
@@ -85,19 +102,29 @@ actor WakeCoordinator {
 
     private var unknownPolls = 0
 
-    private func runLoop(account: ClaudeCodeAccount) async {
+    private func runLoop(runtime: WakeProviderRuntime) async {
         transition(.scanning)
-        let discovered = await discovery.discover(configDirectory: account.configDirectory, ledger: ledger)
+        let discovered = await runtime.discover(ledger: ledger)
         var queue = Array(discovered.filter(\.isExecutable).prefix(bounds.maxSessionsPerRun))
 
         var summary = WakeRunSummary()
         summary.skipped = discovered.count - queue.count
         unknownPolls = 0
 
+        // One runner per loop, shared across every launch in this pass (matches
+        // the one-shot engine and the pre-runtime coordinator's single runner).
+        let runner = runtime.makeRunner()
+
         loop: while !queue.isEmpty && !Task.isCancelled {
             // Fresh quota before EVERY launch.
-            let quota = await authority.freshQuota(account: account)
-            let step = await handle(quota: quota, account: account, queue: &queue, summary: &summary)
+            let quota = await runtime.freshQuota()
+            let step = await handle(
+                quota: quota,
+                runtime: runtime,
+                runner: runner,
+                queue: &queue,
+                summary: &summary
+            )
             switch step {
             case .keepGoing:
                 continue
@@ -122,14 +149,15 @@ actor WakeCoordinator {
 
     private func handle(
         quota: WakeQuota,
-        account: ClaudeCodeAccount,
+        runtime: WakeProviderRuntime,
+        runner: WakeExecuting,
         queue: inout [WakeSessionCandidate],
         summary: inout WakeRunSummary
     ) async -> LoopStep {
         switch quota {
         case .available:
             unknownPolls = 0
-            return await launchNext(account: account, queue: &queue, summary: &summary)
+            return await launchNext(runtime: runtime, runner: runner, queue: &queue, summary: &summary)
         case let .blocked(until, _):
             summary.remaining = queue.count
             transition(.waiting(until: until))
@@ -145,7 +173,8 @@ actor WakeCoordinator {
     }
 
     private func launchNext(
-        account: ClaudeCodeAccount,
+        runtime: WakeProviderRuntime,
+        runner: WakeExecuting,
         queue: inout [WakeSessionCandidate],
         summary: inout WakeRunSummary
     ) async -> LoopStep {
@@ -158,7 +187,7 @@ actor WakeCoordinator {
 
         // Re-fetch AFTER the attempt; a re-maxed window stops the queue and
         // preserves the remaining work.
-        let post = await authority.freshQuota(account: account)
+        let post = await runtime.freshQuota()
         if case let .blocked(until, _) = post {
             summary.remaining = queue.count
             transition(.waiting(until: until))

--- a/MeterBar/Views/SessionWakeSettingsView.swift
+++ b/MeterBar/Views/SessionWakeSettingsView.swift
@@ -10,17 +10,20 @@ struct SessionWakeSettingsView: View {
     @ObservedObject private var store: SessionWakeSettingsStore
     @ObservedObject private var status: SessionWakeStatus
     @ObservedObject private var accounts: ClaudeCodeAccountStore
+    @ObservedObject private var codexAccounts: CodexAccountStore
     @State private var showingFirstRunConfirmation = false
 
     @MainActor
     init(
         store: SessionWakeSettingsStore? = nil,
         status: SessionWakeStatus? = nil,
-        accounts: ClaudeCodeAccountStore? = nil
+        accounts: ClaudeCodeAccountStore? = nil,
+        codexAccounts: CodexAccountStore? = nil
     ) {
         self.store = store ?? .shared
         self.status = status ?? .shared
         self.accounts = accounts ?? .shared
+        self.codexAccounts = codexAccounts ?? .shared
     }
 
     var body: some View {
@@ -35,8 +38,9 @@ struct SessionWakeSettingsView: View {
         } message: {
             Text("""
             While on, MeterBar watches this account's usage limits and, after a \
-            limit resets, automatically resumes your blocked Claude Code sessions \
-            one at a time. It only runs while MeterBar is open.
+            limit resets, automatically resumes your blocked \
+            \(store.wakeProvider.displayName) sessions one at a time. It only \
+            runs while MeterBar is open.
             """)
         }
     }
@@ -61,9 +65,9 @@ struct SessionWakeSettingsView: View {
         SettingsPanelSection(title: "Session Wake", systemImage: "moon.zzz", color: MeterBarTheme.appAccent) {
             SettingsRowView(
                 title: "Session Wake",
-                detail: store.wakeAccountID == nil
+                detail: store.activeAccountID == nil
                     ? "Choose a wake account above to enable Session Wake."
-                    : "Automatically resume blocked Claude Code sessions after a limit resets."
+                    : "Automatically resume blocked \(store.wakeProvider.displayName) sessions after a limit resets."
             ) {
                 Toggle("", isOn: onBinding)
                     .labelsHidden()
@@ -80,10 +84,21 @@ struct SessionWakeSettingsView: View {
 
     private var accountSection: some View {
         SettingsPanelSection(title: "Wake account", systemImage: "person.crop.circle", color: MeterBarTheme.appAccent) {
+            SettingsRowView(title: "Provider") {
+                Picker("", selection: providerBinding) {
+                    ForEach(WakeProvider.allCases, id: \.self) { provider in
+                        Text(provider.displayName).tag(provider)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .frame(maxWidth: 220)
+            }
+
             SettingsRowView(title: "Account") {
                 Picker("", selection: accountBinding) {
                     Text("None selected").tag(UUID?.none)
-                    ForEach(accounts.enabledAccounts) { account in
+                    ForEach(providerAccounts) { account in
                         Text(account.name).tag(UUID?.some(account.id))
                     }
                 }
@@ -92,8 +107,21 @@ struct SessionWakeSettingsView: View {
             }
 
             if store.isOn {
-                SettingsNotice(text: "Changing the wake account turns Session Wake off.", color: .secondary)
+                SettingsNotice(
+                    text: "Changing the provider or wake account turns Session Wake off.",
+                    color: .secondary
+                )
             }
+        }
+    }
+
+    /// Name + id pairs for the currently selected provider's enabled accounts.
+    private var providerAccounts: [AccountChoice] {
+        switch store.wakeProvider {
+        case .claude:
+            return accounts.enabledAccounts.map { AccountChoice(id: $0.id, name: $0.name) }
+        case .codex:
+            return codexAccounts.enabledAccounts.map { AccountChoice(id: $0.id, name: $0.name) }
         }
     }
 
@@ -220,15 +248,39 @@ struct SessionWakeSettingsView: View {
         )
     }
 
-    private var accountBinding: Binding<UUID?> {
-        Binding(get: { store.wakeAccountID }, set: { store.setWakeAccountID($0) })
+    private var providerBinding: Binding<WakeProvider> {
+        Binding(get: { store.wakeProvider }, set: { store.setWakeProvider($0) })
     }
 
+    /// Routes the account picker to the active provider's selection so each
+    /// provider keeps its own explicitly chosen account.
+    private var accountBinding: Binding<UUID?> {
+        Binding(
+            get: { store.activeAccountID },
+            set: { newValue in
+                switch store.wakeProvider {
+                case .claude: store.setWakeAccountID(newValue)
+                case .codex: store.setWakeCodexAccountID(newValue)
+                }
+            }
+        )
+    }
+
+    /// The Claude config directory to preview against. Preview uses Claude
+    /// session discovery, so it is only meaningful for the Claude provider.
     private var selectedConfigDirectory: String? {
-        accounts.enabledAccounts.first(where: { $0.id == store.wakeAccountID })?.configDirectory
+        guard store.wakeProvider == .claude else { return nil }
+        return accounts.enabledAccounts.first(where: { $0.id == store.wakeAccountID })?.configDirectory
     }
 
     private func binding<Value>(_ value: Value, _ setter: @escaping (Value) -> Void) -> Binding<Value> {
         Binding(get: { value }, set: { setter($0) })
     }
+}
+
+/// A provider-agnostic account row for the wake account picker, so the picker
+/// can list either `ClaudeCodeAccount`s or `CodexAccount`s uniformly.
+private struct AccountChoice: Identifiable {
+    let id: UUID
+    let name: String
 }

--- a/MeterBarTests/CodexAccountStoreTests.swift
+++ b/MeterBarTests/CodexAccountStoreTests.swift
@@ -54,4 +54,46 @@ final class CodexAccountStoreTests: XCTestCase {
         store.removeAccount(id: CodexAccount.defaultID)
         XCTAssertEqual(store.accounts.map(\.id), [CodexAccount.defaultID])
     }
+
+    // MARK: - Enablement (mirrors ClaudeCodeAccountStore)
+
+    func testAccountsAreEnabledByDefault() {
+        let store = CodexAccountStore(userDefaults: defaults)
+        store.addAccount(name: "Work", homeDirectory: "/tmp/codex-work")
+        XCTAssertTrue(store.defaultAccountIsEnabled)
+        XCTAssertEqual(store.enabledAccounts.map(\.id), store.accounts.map(\.id))
+    }
+
+    func testDisablingDefaultProfilePersistsAndFiltersEnabled() {
+        let store = CodexAccountStore(userDefaults: defaults)
+        store.setEnabled(false, for: CodexAccount.defaultID)
+        XCTAssertFalse(store.defaultAccountIsEnabled)
+        XCTAssertFalse(store.enabledAccounts.contains { $0.id == CodexAccount.defaultID })
+
+        let reloaded = CodexAccountStore(userDefaults: defaults)
+        XCTAssertFalse(reloaded.defaultAccountIsEnabled)
+    }
+
+    func testDisablingCustomProfilePersistsAndFiltersEnabled() {
+        let store = CodexAccountStore(userDefaults: defaults)
+        store.addAccount(name: "Work", homeDirectory: "/tmp/codex-work")
+        let account = store.customAccounts[0]
+
+        store.setEnabled(false, for: account.id)
+        XCTAssertFalse(store.enabledAccounts.contains { $0.id == account.id })
+
+        let reloaded = CodexAccountStore(userDefaults: defaults)
+        XCTAssertFalse(reloaded.customAccounts[0].isEnabled)
+        XCTAssertFalse(reloaded.enabledAccounts.contains { $0.id == account.id })
+    }
+
+    func testLegacyCustomProfilesDecodeAsEnabled() {
+        // A profile persisted before `isEnabled` existed (no key) decodes enabled.
+        let legacy = #"[{"id":"\#(UUID().uuidString)","name":"Legacy","homeDirectory":"/tmp/legacy"}]"#
+        defaults.set(Data(legacy.utf8), forKey: StorageKeys.codexCustomAccounts)
+
+        let store = CodexAccountStore(userDefaults: defaults)
+        XCTAssertEqual(store.customAccounts.count, 1)
+        XCTAssertTrue(store.customAccounts[0].isEnabled)
+    }
 }

--- a/MeterBarTests/SessionWakeControllerTests.swift
+++ b/MeterBarTests/SessionWakeControllerTests.swift
@@ -149,12 +149,80 @@ final class SessionWakeControllerTests: XCTestCase {
             store: store,
             status: SessionWakeStatus(),
             accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            codexAccounts: CodexAccountStore(userDefaults: defaults),
             rescanInterval: 3_600,
             makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
         )
         controller.activate()
         XCTAssertFalse(controller.isWatching)
         XCTAssertEqual(recorder.startCount, 0)
+    }
+
+    func testDefaultProviderStartsClaudeRuntime() {
+        // The default provider is Claude; the watcher is armed with a Claude
+        // runtime (the existing behavior, now asserted explicitly).
+        let store = armedStore()
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: SessionWakeStatus(),
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            codexAccounts: CodexAccountStore(userDefaults: defaults),
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+        )
+        controller.activate()
+        poll { recorder.startCount >= 1 }
+        XCTAssertEqual(recorder.startedProviders.first, .claude)
+    }
+
+    func testCodexProviderStartsCodexRuntime() {
+        // Selecting the Codex provider + a Codex account arms the watcher with a
+        // Codex runtime — the app-watcher Codex path this change adds.
+        let codexAccounts = CodexAccountStore(userDefaults: defaults)
+        let store = SessionWakeSettingsStore(userDefaults: defaults)
+        store.setWakeProvider(.codex)
+        store.setWakeCodexAccountID(CodexAccount.defaultID)
+        store.acknowledgeFirstRunAndTurnOn()
+        XCTAssertTrue(store.isOn)
+
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: SessionWakeStatus(),
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            codexAccounts: codexAccounts,
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+        )
+        controller.activate()
+        XCTAssertTrue(controller.isWatching)
+        poll { recorder.startCount >= 1 }
+        XCTAssertEqual(recorder.startedProviders.first, .codex)
+    }
+
+    func testSwitchingProviderWhileArmedStopsTheWatcher() {
+        let store = armedStore() // Claude, armed
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: SessionWakeStatus(),
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            codexAccounts: CodexAccountStore(userDefaults: defaults),
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+        )
+        controller.activate()
+        poll { recorder.startCount >= 1 }
+        XCTAssertGreaterThanOrEqual(recorder.startCount, 1)
+
+        // Switching the provider disarms (store.forceOff) ⇒ watcher tears down.
+        store.setWakeProvider(.codex)
+        poll { !controller.isWatching }
+        XCTAssertFalse(controller.isWatching)
+        XCTAssertFalse(store.isOn)
+        poll { recorder.stopCount >= 1 }
+        XCTAssertGreaterThanOrEqual(recorder.stopCount, 1)
     }
 }
 
@@ -164,9 +232,13 @@ nonisolated private final class WatchRecorder: @unchecked Sendable {
     private let lock = NSLock()
     private var starts = 0
     private var stops = 0
+    private var providers: [WakeProvider] = []
     var startCount: Int { lock.lock(); defer { lock.unlock() }; return starts }
     var stopCount: Int { lock.lock(); defer { lock.unlock() }; return stops }
-    func recordStart() { lock.lock(); starts += 1; lock.unlock() }
+    var startedProviders: [WakeProvider] { lock.lock(); defer { lock.unlock() }; return providers }
+    func recordStart(provider: WakeProvider) {
+        lock.lock(); starts += 1; providers.append(provider); lock.unlock()
+    }
     func recordStop() { lock.lock(); stops += 1; lock.unlock() }
 }
 
@@ -174,8 +246,8 @@ nonisolated private struct FakeWatcher: WakeWatching {
     let recorder: WatchRecorder
     let onState: @Sendable (WakeWatcherState) -> Void
 
-    func start(account: ClaudeCodeAccount) async {
-        recorder.recordStart()
+    func start(runtime: WakeProviderRuntime) async {
+        recorder.recordStart(provider: runtime.provider)
         onState(.scanning)
     }
 

--- a/MeterBarTests/SessionWakeNotificationDeciderTests.swift
+++ b/MeterBarTests/SessionWakeNotificationDeciderTests.swift
@@ -8,10 +8,14 @@ import XCTest
 /// owns the actual `UNUserNotificationCenter` interaction. These tests pin the
 /// three gates plus the pluralization / failure-count copy.
 final class SessionWakeNotificationDeciderTests: XCTestCase {
-    private func allowingContext(notifyOnCompletion: Bool = true) -> SessionWakeNotificationContext {
+    private func allowingContext(
+        notifyOnCompletion: Bool = true,
+        providerDisplayName: String = "Claude Code"
+    ) -> SessionWakeNotificationContext {
         SessionWakeNotificationContext(
             globalNotificationsEnabled: true,
-            claudeProviderEnabled: true,
+            providerEnabled: true,
+            providerDisplayName: providerDisplayName,
             notifyOnCompletion: notifyOnCompletion
         )
     }
@@ -19,9 +23,18 @@ final class SessionWakeNotificationDeciderTests: XCTestCase {
     func testCompletionSuppressedWhenAnyGateClosed() {
         let summary = WakeRunSummary(resumed: 1)
         let closed = [
-            SessionWakeNotificationContext(globalNotificationsEnabled: false, claudeProviderEnabled: true, notifyOnCompletion: true),
-            SessionWakeNotificationContext(globalNotificationsEnabled: true, claudeProviderEnabled: false, notifyOnCompletion: true),
-            SessionWakeNotificationContext(globalNotificationsEnabled: true, claudeProviderEnabled: true, notifyOnCompletion: false)
+            SessionWakeNotificationContext(
+                globalNotificationsEnabled: false, providerEnabled: true,
+                providerDisplayName: "Claude Code", notifyOnCompletion: true
+            ),
+            SessionWakeNotificationContext(
+                globalNotificationsEnabled: true, providerEnabled: false,
+                providerDisplayName: "Claude Code", notifyOnCompletion: true
+            ),
+            SessionWakeNotificationContext(
+                globalNotificationsEnabled: true, providerEnabled: true,
+                providerDisplayName: "Claude Code", notifyOnCompletion: false
+            )
         ]
         for context in closed {
             XCTAssertNil(SessionWakeNotificationDecider.completionNotification(summary: summary, context: context))
@@ -45,7 +58,7 @@ final class SessionWakeNotificationDeciderTests: XCTestCase {
             summary: WakeRunSummary(remaining: 2),
             context: allowingContext()
         )
-        XCTAssertEqual(fired?.body, "Resumed 0 of 0 Claude sessions. 2 still queued.")
+        XCTAssertEqual(fired?.body, "Resumed 0 of 0 Claude Code sessions. 2 still queued.")
     }
 
     func testCompletionSingularCopy() {
@@ -53,27 +66,37 @@ final class SessionWakeNotificationDeciderTests: XCTestCase {
         let fired = SessionWakeNotificationDecider.completionNotification(summary: summary, context: allowingContext())
         XCTAssertEqual(fired?.key, "session-wake-completion")
         XCTAssertEqual(fired?.title, "Session Wake — Run Complete")
-        XCTAssertEqual(fired?.body, "Resumed 1 of 1 Claude session.")
+        XCTAssertEqual(fired?.body, "Resumed 1 of 1 Claude Code session.")
     }
 
     func testCompletionPluralWithSingleFailure() {
         // resumed 2 + failed 1 ⇒ attempted 3.
         let summary = WakeRunSummary(resumed: 2, failed: 1)
         let fired = SessionWakeNotificationDecider.completionNotification(summary: summary, context: allowingContext())
-        XCTAssertEqual(fired?.body, "Resumed 2 of 3 Claude sessions. 1 failure.")
+        XCTAssertEqual(fired?.body, "Resumed 2 of 3 Claude Code sessions. 1 failure.")
     }
 
     func testCompletionPluralFailures() {
         let summary = WakeRunSummary(resumed: 0, failed: 2)
         let fired = SessionWakeNotificationDecider.completionNotification(summary: summary, context: allowingContext())
-        XCTAssertEqual(fired?.body, "Resumed 0 of 2 Claude sessions. 2 failures.")
+        XCTAssertEqual(fired?.body, "Resumed 0 of 2 Claude Code sessions. 2 failures.")
     }
 
     func testCompletionMentionsRemainingWhenRequeued() {
         // Quota re-exhausted mid-run: some resumed, some still queued.
         let summary = WakeRunSummary(resumed: 1, failed: 0, skipped: 0, remaining: 2)
         let fired = SessionWakeNotificationDecider.completionNotification(summary: summary, context: allowingContext())
-        XCTAssertEqual(fired?.body, "Resumed 1 of 1 Claude session. 2 still queued.")
+        XCTAssertEqual(fired?.body, "Resumed 1 of 1 Claude Code session. 2 still queued.")
+    }
+
+    func testCompletionCopyUsesProviderDisplayName() {
+        // Codex runs surface the Codex provider name, not a hardcoded "Claude".
+        let summary = WakeRunSummary(resumed: 2, failed: 1)
+        let fired = SessionWakeNotificationDecider.completionNotification(
+            summary: summary,
+            context: allowingContext(providerDisplayName: "Codex")
+        )
+        XCTAssertEqual(fired?.body, "Resumed 2 of 3 Codex sessions. 1 failure.")
     }
 
     func testCompletionKeyIsStableAcrossDifferentCounts() {

--- a/MeterBarTests/SessionWakeSettingsTests.swift
+++ b/MeterBarTests/SessionWakeSettingsTests.swift
@@ -189,12 +189,114 @@ final class SessionWakeSettingsTests: XCTestCase {
     func testNotificationRequiresGlobalProviderAndWakePreference() {
         func decide(_ global: Bool, _ provider: Bool, _ wake: Bool) -> Bool {
             SessionWakeNotificationDecider.shouldNotifyOnCompletion(
-                .init(globalNotificationsEnabled: global, claudeProviderEnabled: provider, notifyOnCompletion: wake)
+                .init(
+                    globalNotificationsEnabled: global,
+                    providerEnabled: provider,
+                    providerDisplayName: "Claude Code",
+                    notifyOnCompletion: wake
+                )
             )
         }
         XCTAssertTrue(decide(true, true, true))
         XCTAssertFalse(decide(false, true, true))
         XCTAssertFalse(decide(true, false, true))
         XCTAssertFalse(decide(true, true, false))
+    }
+
+    // MARK: - Provider dimension
+
+    func testDefaultProviderIsClaude() {
+        let store = makeStore()
+        XCTAssertEqual(store.wakeProvider, .claude)
+        XCTAssertNil(store.wakeCodexAccountID)
+        XCTAssertNil(store.activeAccountID)
+    }
+
+    func testActiveAccountIDFollowsProvider() {
+        let claudeID = UUID()
+        let codexID = UUID()
+        let store = makeStore()
+        store.setWakeAccountID(claudeID)
+        store.setWakeCodexAccountID(codexID)
+
+        XCTAssertEqual(store.activeAccountID, claudeID)
+        store.setWakeProvider(.codex)
+        XCTAssertEqual(store.activeAccountID, codexID)
+    }
+
+    func testCanTurnOnConsidersSelectedProviderAccount() {
+        let store = makeStore()
+        // Claude account selected, but the active provider is Codex ⇒ cannot arm.
+        store.setWakeAccountID(UUID())
+        store.setWakeProvider(.codex)
+        XCTAssertFalse(store.canTurnOn)
+
+        // Selecting a Codex account enables it.
+        store.setWakeCodexAccountID(UUID())
+        XCTAssertTrue(store.canTurnOn)
+    }
+
+    func testSwitchingProviderWhileArmedDisarms() {
+        let store = makeStore()
+        store.setWakeAccountID(UUID())
+        store.acknowledgeFirstRunAndTurnOn()
+        XCTAssertTrue(store.isOn)
+
+        store.setWakeProvider(.codex)
+        XCTAssertEqual(store.wakeProvider, .codex)
+        XCTAssertFalse(store.isOn)
+
+        let reloaded = SessionWakeSettingsStore(userDefaults: defaults)
+        XCTAssertEqual(reloaded.wakeProvider, .codex)
+        XCTAssertFalse(reloaded.isOn)
+    }
+
+    func testSwitchingCodexAccountWhileArmedDisarms() {
+        let accountA = UUID()
+        let accountB = UUID()
+        let store = makeStore()
+        store.setWakeProvider(.codex)
+        store.setWakeCodexAccountID(accountA)
+        store.acknowledgeFirstRunAndTurnOn()
+        XCTAssertTrue(store.isOn)
+
+        store.setWakeCodexAccountID(accountB)
+        XCTAssertEqual(store.wakeCodexAccountID, accountB)
+        XCTAssertFalse(store.isOn)
+    }
+
+    func testReconcileCodexAccountsClearsMissingSelection() {
+        let store = makeStore()
+        store.setWakeProvider(.codex)
+        store.setWakeCodexAccountID(UUID())
+        store.acknowledgeFirstRunAndTurnOn()
+        XCTAssertTrue(store.isOn)
+
+        store.reconcileCodexAccounts(available: [UUID(), UUID()]) // selected id gone
+        XCTAssertNil(store.wakeCodexAccountID)
+        XCTAssertFalse(store.isOn)
+    }
+
+    func testProviderAndCodexAccountPersistAcrossRelaunch() {
+        let codexID = UUID()
+        let store = makeStore()
+        store.setWakeProvider(.codex)
+        store.setWakeCodexAccountID(codexID)
+        store.acknowledgeFirstRunAndTurnOn()
+        XCTAssertTrue(store.isOn)
+
+        let reloaded = SessionWakeSettingsStore(userDefaults: defaults)
+        XCTAssertEqual(reloaded.wakeProvider, .codex)
+        XCTAssertEqual(reloaded.wakeCodexAccountID, codexID)
+        XCTAssertTrue(reloaded.isOn)
+    }
+
+    func testStaleOnWithoutCodexAccountIsCorrectedAtLoad() {
+        // Persisted "on" for Codex with no Codex account selected must not arm.
+        defaults.set(WakeProvider.codex.rawValue, forKey: StorageKeys.sessionWakeProvider)
+        defaults.set(true, forKey: StorageKeys.sessionWakeWatcherArmed)
+        defaults.set(true, forKey: StorageKeys.sessionWakeFirstEnableAcknowledged)
+        let store = SessionWakeSettingsStore(userDefaults: defaults)
+        XCTAssertFalse(store.isOn)
     }
 }

--- a/MeterBarTests/WakeCoordinatorTests.swift
+++ b/MeterBarTests/WakeCoordinatorTests.swift
@@ -90,6 +90,34 @@ final class WakeCoordinatorTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(calls, 3)
     }
 
+    func testStartWithRuntimeDrivesTheWholeQueue() async throws {
+        // The provider-agnostic entry point: arm with an explicit runtime rather
+        // than the Claude `start(account:)` facade. Same lifecycle, driven off
+        // `WakeProviderRuntime` (discover / freshQuota / makeRunner).
+        try writeBlockedSessions(2)
+        let runner = RecordingRunner()
+        let provider = SequencedProvider(repeating: .open)
+        let coordinator = makeCoordinator(provider: provider, runner: runner, sleep: immediateSleep)
+        let runtime = ClaudeWakeRuntime(
+            account: account(),
+            discovery: SessionDiscovery(),
+            authority: WakeQuotaAuthority(provider: provider, maxAge: 3600, now: { Date() }),
+            makeRunner: { _ in runner }
+        )
+
+        await coordinator.start(runtime: runtime)
+        await coordinator.waitUntilFinished()
+
+        let ran = await runner.ran
+        XCTAssertEqual(Set(ran), ["s0", "s1"])
+        if case let .completed(summary) = await coordinator.state {
+            XCTAssertEqual(summary.resumed, 2)
+            XCTAssertEqual(summary.remaining, 0)
+        } else {
+            XCTFail("Expected completed state")
+        }
+    }
+
     func testUnknownQuotaLaunchesNothing() async throws {
         try writeBlockedSessions(1)
         let runner = RecordingRunner()


### PR DESCRIPTION
## Summary

Extends Session Wake so the **app's Settings toggle + continuous watcher** support **Codex**, not just the bundled `meterbar wake` CLI. The Codex *mechanism* landed in #174 (`WakeProvider`, `WakeProviderRuntime`, `Claude`/`CodexWakeRuntime`, Codex discovery/quota/runner, provider-agnostic `WakeCLIEngine`); this PR wires that mechanism into the app UI and the live watcher.

## What changed

- **`WakeCoordinator`** — runtime-driven. New `start(runtime:)`; `runLoop`/`handle`/`launchNext` drive a `WakeProviderRuntime` (one `makeRunner()` per loop). `start(account:)` retained as a Claude facade that wraps the stored discovery/authority/runner into a `ClaudeWakeRuntime` — existing `WakeCoordinatorTests` unchanged.
- **`SessionWakeController`** — provider-aware. `WakeWatching` becomes `start(runtime:)`; injects `CodexAccountStore`; `reconcile()` reads `store.wakeProvider`, resolves the selected enabled account, and builds the matching runtime (Claude→`WakeProcessRunner`, Codex→`CodexWakeProcessRunner`). Subscribes to `$wakeProvider`/`$wakeCodexAccountID` and the Codex account store.
- **`SessionWakeSettingsStore` + `StorageKeys`** — add `wakeProvider` (`SessionWakeProvider`, default `.claude`) and `wakeCodexAccountID` (`SessionWakeCodexAccountID`); each provider keeps its own selection. `canTurnOn`/`activeAccountID` are provider-scoped; changing provider or either account `forceOff()`s. New `syncSharedWakeTarget(directory:)` mirrors the active provider's selected account to the app-group key the CLI reads (`SessionWakeAccountConfigDir` / `SessionWakeCodexHomeDir`), clearing the inactive one — guarded to the production standard suite like the feature flag.
- **`CodexAccount`** — `isEnabled` (backward-compat decode default `true`) + `CodexAccountStore.enabledAccounts` / `setEnabled(_:for:)` / `defaultAccountIsEnabled` + `CodexDefaultAccountEnabled` key, mirroring `ClaudeCodeAccount`.
- **`SessionWakeSettingsView`** — provider segmented `Picker`; account picker lists the selected provider's `enabledAccounts`; confirmation-dialog + switch prose use `wakeProvider.displayName`.
- **`SessionWakeNotificationDecider`** — `claudeProviderEnabled` → `providerEnabled` + `providerDisplayName`; completion copy uses the provider name. App delegate passes the active provider's visibility (`.claudeCode`/`.codexCli`) and display name.

## Product decisions (unchanged)

- **Single active wake provider** at a time (picker), keeping the single-toggle model.
- **Single global `WakeLock`** across providers — no per-provider locks.
- Codex safe/bypass posture (`CodexWakeCommandBuilder`) untouched.

## Note

The app never actually wrote `SessionWakeAccountConfigDir` before this PR, so the CLI always fell back to the default account. `syncSharedWakeTarget` now mirrors the app-selected account for **both** providers — a genuine fix, matching the spec's "just as Claude writes `SessionWakeAccountConfigDir`".

## Tests (TDD)

- `WakeCoordinatorTests` — explicit `start(runtime:)` path; facade tests unchanged.
- `SessionWakeControllerTests` — `FakeWatcher.start(runtime:)`, provider tracking, Codex watcher path, switch-provider-disarms.
- `SessionWakeSettingsTests` — provider default/persistence, per-provider `canTurnOn`, provider/codex-account disarm, `reconcileCodexAccounts`, stale-on correction.
- `CodexAccountStoreTests` — enablement + legacy decode.
- `SessionWakeNotificationDeciderTests` — new fields + provider-name copy.

## Verification

Per repo policy this was **not** built/tested locally (Vincent's MacBook). `swiftlint lint --strict` on the 8 changed sources → **0 violations**. Build + `xcodebuild` app/tests + `swift test` coverage gate run in **CI**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)