### PR TITLE
fix(onboarding): don't dismiss first-run on incidental popover close

### DIFF
--- a/.agents/SESSIONS/2026-07-14.md
+++ b/.agents/SESSIONS/2026-07-14.md
@@ -47,3 +47,46 @@ Claude Code ▸ "Claude Code OAuth usage" (dev builds re-prompt per rebuild).
 `WakeQuotaAuthority`/`LiveWakeQuotaProvider` still call the raw CLI service; the
 session-wake default-account quota gate would also benefit from OAuth, but needs a
 **side-effect-free** OAuth fetch to avoid coupling UI `@Published` state into wake decisions.
+
+---
+
+# 2026-07-14 (2) — Fix first-run onboarding dismissed on any popover close
+
+## Problem
+First-run onboarding was marked complete whenever the popover closed for **any**
+reason, not just when the user chose. `MeterBarApp.swift` wired the panel
+controller's `onDismiss` to unconditionally call `FirstRunOnboardingStore.shared.dismiss()`.
+A new user whose popover auto-opens on first launch and who clicks away / presses
+Escape without touching the "Welcome to MeterBar" callout never saw it again —
+losing the only decision onboarding asks for (launch-at-login).
+
+## Fix (root-cause)
+- **`MeterBarApp.swift`** — removed the `FirstRunOnboardingStore.shared.dismiss()`
+  call from `onDismiss`; kept `MeterBarMenuDetailPanel.shared.dismiss()`. Popover
+  close now only tears down the transient detail panel.
+- **`FirstRunOnboardingStore.swift`** — deleted the `dismiss()` method entirely.
+  After unwiring it was dead code, and its "clicking away completes onboarding"
+  semantics *was* the bug. Onboarding now completes **only** via
+  `chooseLaunchAtLogin(_:)`, driven by the callout's Enable / Not Now buttons.
+- The welcome callout (`MenuBarView.firstRunCallout`, gated on
+  `onboarding.shouldPresent`) now keeps reappearing at the top of the popover
+  until the user acts.
+
+## Unchanged (verified)
+- Silent upgrade detection (`priorUseSentinelKeys` / `hasEvidenceOfPriorUse`) and
+  `shouldPresent` are untouched — existing users still never see onboarding.
+  Covered by `testUpgradingExistingInstallDoesNotPresentOnboarding` /
+  `testUpgradeMigrationRecognizesCachedMetricsSentinel`.
+- Auto-open-on-first-launch (`shouldPresent` → `menuPanel.show()`) left as-is;
+  only the persistence bug was in scope.
+
+## Tests (TDD)
+`FirstRunOnboardingTests`:
+- `testIncidentalDismissDoesNotCompleteOnboarding` — a popover close that invokes
+  nothing on the store leaves `hasCompletedFirstRun` false; a reloaded store still
+  presents. (Replaces the old `testFreshInstallPresentsAndDismissPersistsOnce`,
+  which asserted the now-removed dismiss-completes behavior.)
+- `testFreshInstallPresents` — fresh install presents.
+- `testEnableLaunchAtLoginRegistersAndCompletesOnboarding` /
+  `testNotNowCompletesWithoutRegistering` — extended to assert the explicit choice
+  persists across a reload (`hasCompletedFirstRun` true, reloaded store silent).

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -82,8 +82,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.statusItem?.button
             },
             onDismiss: {
+                // Closing the popover only tears down the transient detail
+                // panel. First-run onboarding is NOT dismissed here: an
+                // incidental close (click-away / Escape) must leave the welcome
+                // callout to reappear until the user acts on Enable / Not Now.
                 MeterBarMenuDetailPanel.shared.dismiss()
-                FirstRunOnboardingStore.shared.dismiss()
             }
         )
 

--- a/MeterBar/Services/FirstRunOnboardingStore.swift
+++ b/MeterBar/Services/FirstRunOnboardingStore.swift
@@ -48,16 +48,14 @@ final class FirstRunOnboardingStore: ObservableObject {
 
     var shouldPresent: Bool { !hasCompletedFirstRun }
 
+    /// The only way to complete onboarding: the user explicitly acts on the
+    /// welcome callout's Enable / Not Now buttons. An incidental popover close
+    /// (click-away / Escape) deliberately does nothing, so the callout keeps
+    /// reappearing until a real choice is made.
     func chooseLaunchAtLogin(_ enabled: Bool) {
         if enabled {
             launchAtLogin.setEnabled(true)
         }
-        complete()
-    }
-
-    /// Clicking away is also a dismissal choice; onboarding must never nag on
-    /// a later launch after the user has seen and dismissed it.
-    func dismiss() {
         complete()
     }
 

--- a/MeterBarTests/FirstRunOnboardingTests.swift
+++ b/MeterBarTests/FirstRunOnboardingTests.swift
@@ -51,21 +51,35 @@ final class FirstRunOnboardingTests: XCTestCase {
         XCTAssertFalse(store.shouldPresent)
     }
 
-    func testFreshInstallPresentsAndDismissPersistsOnce() {
+    func testFreshInstallPresents() {
+        let store = FirstRunOnboardingStore(
+            userDefaults: defaults,
+            launchAtLogin: LaunchAtLoginStore(controller: FakeLaunchController())
+        )
+
+        XCTAssertTrue(store.shouldPresent)
+    }
+
+    /// The core of this bug: an incidental popover close (click-away / Escape)
+    /// must NOT complete onboarding. The callout keeps reappearing on the next
+    /// launch until the user acts on Enable / Not Now.
+    func testIncidentalDismissDoesNotCompleteOnboarding() {
         let store = FirstRunOnboardingStore(
             userDefaults: defaults,
             launchAtLogin: LaunchAtLoginStore(controller: FakeLaunchController())
         )
         XCTAssertTrue(store.shouldPresent)
 
-        store.dismiss()
-
-        XCTAssertFalse(store.shouldPresent)
+        // Simulate the popover closing without the user touching the callout:
+        // nothing is invoked on the onboarding store. Persistence must be
+        // untouched, so a freshly reloaded store still presents the callout.
         let reloaded = FirstRunOnboardingStore(
             userDefaults: defaults,
             launchAtLogin: LaunchAtLoginStore(controller: FakeLaunchController())
         )
-        XCTAssertFalse(reloaded.shouldPresent)
+
+        XCTAssertTrue(reloaded.shouldPresent)
+        XCTAssertFalse(defaults.bool(forKey: StorageKeys.hasCompletedFirstRun))
     }
 
     func testEnableLaunchAtLoginRegistersAndCompletesOnboarding() {
@@ -78,6 +92,14 @@ final class FirstRunOnboardingTests: XCTestCase {
         XCTAssertEqual(controller.registerCallCount, 1)
         XCTAssertTrue(launchAtLogin.isEnabled)
         XCTAssertFalse(store.shouldPresent)
+
+        // The choice persists: a later launch does not re-present onboarding.
+        XCTAssertTrue(defaults.bool(forKey: StorageKeys.hasCompletedFirstRun))
+        let reloaded = FirstRunOnboardingStore(
+            userDefaults: defaults,
+            launchAtLogin: LaunchAtLoginStore(controller: FakeLaunchController())
+        )
+        XCTAssertFalse(reloaded.shouldPresent)
     }
 
     func testNotNowCompletesWithoutRegistering() {
@@ -91,5 +113,13 @@ final class FirstRunOnboardingTests: XCTestCase {
 
         XCTAssertEqual(controller.registerCallCount, 0)
         XCTAssertFalse(store.shouldPresent)
+
+        // "Not Now" is still an explicit choice and persists across launches.
+        XCTAssertTrue(defaults.bool(forKey: StorageKeys.hasCompletedFirstRun))
+        let reloaded = FirstRunOnboardingStore(
+            userDefaults: defaults,
+            launchAtLogin: LaunchAtLoginStore(controller: FakeLaunchController())
+        )
+        XCTAssertFalse(reloaded.shouldPresent)
     }
 }


### PR DESCRIPTION
## Problem

First-run onboarding was marked complete whenever the popover closed for **any** reason, not just when the user chose. `MeterBarApp` wired the panel controller's `onDismiss` to unconditionally call `FirstRunOnboardingStore.shared.dismiss()`.

A new user whose popover **auto-opens on first launch** and who clicks away / presses Escape without touching the "Welcome to MeterBar" callout never sees it again — losing the only decision onboarding asks for (launch-at-login).

## Fix (root-cause)

- **`MeterBarApp.swift`** — removed the `FirstRunOnboardingStore.shared.dismiss()` call from `onDismiss`; kept `MeterBarMenuDetailPanel.shared.dismiss()`. Popover close now only tears down the transient detail panel.
- **`FirstRunOnboardingStore.swift`** — deleted the `dismiss()` method entirely. After unwiring it was dead code, and its "clicking away completes onboarding" semantics *was* the bug. Onboarding now completes **only** via `chooseLaunchAtLogin(_:)`, driven by the callout's **Enable / Not Now** buttons.
- The welcome callout (`MenuBarView.firstRunCallout`, gated on `onboarding.shouldPresent`) keeps reappearing at the top of the popover until the user acts.

## Unchanged (verified)

- Silent upgrade detection (`priorUseSentinelKeys` / `hasEvidenceOfPriorUse`) and `shouldPresent` are untouched — **existing users still never see onboarding** (covered by the existing upgrade-migration tests).
- **Auto-open-on-first-launch** (`shouldPresent` → `menuPanel.show()`) is intentionally left as-is. It's correct behavior — the bug was purely the premature persistence, not the auto-open. Only the persistence bug was in scope.

## Tests (TDD)

`FirstRunOnboardingTests`:
- `testIncidentalDismissDoesNotCompleteOnboarding` — a popover close that invokes nothing on the store leaves `hasCompletedFirstRun` false; a reloaded store still presents. Replaces the old `testFreshInstallPresentsAndDismissPersistsOnce`, which asserted the now-removed dismiss-completes behavior.
- `testFreshInstallPresents` — fresh install presents.
- `testEnableLaunchAtLoginRegistersAndCompletesOnboarding` / `testNotNowCompletesWithoutRegistering` — extended to assert the explicit choice **persists across a reload**.

_Not run locally (MacBook verification constraint / no full Xcode for `swift test`); relying on PR CI._