### PR TITLE
feat(a11y): consistent VoiceOver labels + Dynamic Type across usage UI

### DIFF
--- a/.agents/SESSIONS/2026-07-14.md
+++ b/.agents/SESSIONS/2026-07-14.md
@@ -47,3 +47,50 @@ Claude Code ▸ "Claude Code OAuth usage" (dev builds re-prompt per rebuild).
 `WakeQuotaAuthority`/`LiveWakeQuotaProvider` still call the raw CLI service; the
 session-wake default-account quota gate would also benefit from OAuth, but needs a
 **side-effect-free** OAuth fetch to avoid coupling UI `@Published` state into wake decisions.
+
+---
+
+# 2026-07-14 — Accessibility labeling + Dynamic Type pass
+
+## Problem
+VoiceOver labeling was sparse/inconsistent. Only `ProviderOverviewStatusCard`
+had the full `.accessibilityElement(children:.combine)` + label(+hint) treatment.
+The popover provider row had a hint but no label; the popover status card,
+summary card, every limit row (3 impls), stat stacks, icon-only glass header
+buttons, ApiUsageCard, and the Session Wake controls read as fragmented subview
+trees. Below-legible-minimum fixed fonts (8pt "Estimated" ×3, 9pt metric label)
+bypassed Dynamic Type; the 34/28pt cost headlines were frozen in pixels.
+
+## Change
+- **Pure, testable a11y helpers** on `SnapshotLimit` and `ProviderSnapshot`
+  (`accessibilityLabel`/`accessibilityValue`), mirroring visible row copy and
+  following the existing `DailyUsageDay.chartAccessibilityLabel` pattern. One
+  source of truth so the three limit-row renderers and both provider-card
+  branches can't drift.
+- **Applied combine+label(+value/hint)** to: popover `PopoverProviderStatusCard`
+  (both branches now identical via shared helper; hint only on the actionable
+  one), `PopoverProviderStatusSummaryCard`, all three limit rows
+  (`DashboardLimitRow`, `MenuBarProviderLimitDetailRow`, `PopoverLimitRow`),
+  `DashboardMetricTile`, `CostMetric`, `UsageDetailMetric`, and `ApiUsageCard`
+  (header + per-model rows).
+- **Icon-only glass header buttons** labeled "Open Dashboard" / "Refresh"
+  (inner SF Symbols marked `.accessibilityHidden(true)`); decorative
+  "No sources" clock and summary chevron hidden.
+- **Session Wake controls**: empty-string `Toggle`/`Picker`/`Stepper` labels
+  filled in (kept `.labelsHidden()` — no visual change) so VoiceOver names them;
+  menu toggle folds status into `.accessibilityValue`.
+- **`SettingsRowView`**: title+detail combined into one element centrally
+  (benefits every Settings row; trailing control stays separately actuable).
+- **Dynamic Type**: 8pt "Estimated" tags → `.caption2`; 9pt `UsageDetailMetric`
+  label → `.caption2`; cost headlines → `@ScaledMetric(relativeTo:)` (34/28 at
+  default, scales up; `minimumScaleFactor`+`lineLimit(1)` guard overflow).
+  Chart 8pt axis date labels intentionally left (dense axis, cited good ref).
+
+## Tests (TDD-first)
+`AccessibilityLabelTests` — label/value composition across estimated, currency,
+exhausted, empty, and multi-window cases on both types. Pure-helper style,
+auto-discovered by `swift test` (path-based test target; xcodebuild only builds).
+
+## Scope
+Accessibility + Dynamic Type only; no visual redesign. SF-Symbol `.system(size:)`
+icon sizing left as-is (not text legibility).

--- a/MeterBar/Views/ApiUsageCard.swift
+++ b/MeterBar/Views/ApiUsageCard.swift
@@ -166,6 +166,9 @@ struct ApiUsageCard: View {
             .monospacedDigit()
             .foregroundColor(accent)
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(provider.displayName)
+        .accessibilityValue("Estimated \(UsageFormat.cost(usage?.estimatedCostUSD ?? 0))")
 
         if isLoading, usage == nil {
           Text("Loading usage…")
@@ -191,6 +194,11 @@ struct ApiUsageCard: View {
                 .foregroundColor(.secondary)
                 .monospacedDigit()
             }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(model.model)
+            .accessibilityValue(
+              "\(UsageFormat.tokens(model.totalTokens)) tokens, \(UsageFormat.cost(model.estimatedCostUSD))"
+            )
           }
         } else {
           Text("No API usage in this window.")

--- a/MeterBar/Views/DashboardCard.swift
+++ b/MeterBar/Views/DashboardCard.swift
@@ -194,5 +194,8 @@ struct DashboardMetricTile: View {
       }
       .frame(maxWidth: .infinity, alignment: .leading)
     }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(title)
+    .accessibilityValue("\(value), \(caption)")
   }
 }

--- a/MeterBar/Views/DashboardCostCards.swift
+++ b/MeterBar/Views/DashboardCostCards.swift
@@ -10,6 +10,13 @@ struct CostOverviewStatusCard: View {
   let isRefreshingMissingDays: Bool
   let formattedTokens: String
 
+  // Headline sizes scale with Dynamic Type (from their default 34/28pt) instead
+  // of being frozen in pixels, so the cost figure grows for larger accessibility
+  // text sizes. `minimumScaleFactor` + `lineLimit(1)` below keep the tile from
+  // breaking when it does.
+  @ScaledMetric(relativeTo: .largeTitle) private var headlineSize: CGFloat = 34
+  @ScaledMetric(relativeTo: .title) private var scanningHeadlineSize: CGFloat = 28
+
   private var subtitle: String {
     if isScanning { return "Scanning local logs" }
     if isRefreshingMissingDays { return "Updating…" }
@@ -36,7 +43,7 @@ struct CostOverviewStatusCard: View {
 
         if let formattedTotalCost = summary?.formattedTotalCost {
           Text(formattedTotalCost)
-            .font(.system(size: 34, weight: .bold))
+            .font(.system(size: headlineSize, weight: .bold))
             .foregroundColor(.primary)
             .lineLimit(1)
             .minimumScaleFactor(0.75)
@@ -45,14 +52,14 @@ struct CostOverviewStatusCard: View {
             ProgressView()
               .controlSize(.small)
             Text("Scanning...")
-              .font(.system(size: 28, weight: .bold))
+              .font(.system(size: scanningHeadlineSize, weight: .bold))
               .foregroundColor(.primary)
               .lineLimit(1)
               .minimumScaleFactor(0.75)
           }
         } else {
           Text("Scan needed")
-            .font(.system(size: 34, weight: .bold))
+            .font(.system(size: headlineSize, weight: .bold))
             .foregroundColor(.primary)
             .lineLimit(1)
             .minimumScaleFactor(0.75)
@@ -308,6 +315,9 @@ struct CostMetric: View {
         .minimumScaleFactor(0.75)
     }
     .frame(maxWidth: .infinity, alignment: .leading)
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(label)
+    .accessibilityValue(value)
   }
 }
 
@@ -318,7 +328,8 @@ struct UsageDetailMetric: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 1) {
       Text(label)
-        .font(.system(size: 9, weight: .medium))
+        .font(.caption2)
+        .fontWeight(.medium)
         .foregroundColor(.secondary)
       Text(value)
         .font(.caption)
@@ -327,5 +338,8 @@ struct UsageDetailMetric: View {
         .minimumScaleFactor(0.75)
     }
     .frame(width: 58, alignment: .leading)
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(label)
+    .accessibilityValue(value)
   }
 }

--- a/MeterBar/Views/DashboardProviderCards.swift
+++ b/MeterBar/Views/DashboardProviderCards.swift
@@ -230,6 +230,9 @@ struct DashboardLimitRow: View {
         }
       }
     }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(limit.accessibilityLabel)
+    .accessibilityValue(limit.accessibilityValue)
   }
 
   private var trailingValue: String {

--- a/MeterBar/Views/MenuBarDetailPanel.swift
+++ b/MeterBar/Views/MenuBarDetailPanel.swift
@@ -226,7 +226,8 @@ private struct MenuBarProviderLimitDetailRow: View {
           .fontWeight(.semibold)
         if limit.usageLimit.isEstimated {
           Text("Estimated")
-            .font(.system(size: 8, weight: .semibold))
+            .font(.caption2)
+            .fontWeight(.semibold)
             .foregroundColor(.secondary)
         }
         Spacer(minLength: 4)
@@ -269,6 +270,9 @@ private struct MenuBarProviderLimitDetailRow: View {
     }
     .padding(10)
     .meterBarCardSurface(cornerRadius: 10)
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(limit.accessibilityLabel)
+    .accessibilityValue(limit.accessibilityValue)
   }
 
   private func paceLabelColor(_ pace: UsagePace) -> Color {

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -146,18 +146,23 @@ struct MenuBarView: View {
           Button(action: openDashboard) {
             Image(systemName: MenuBarOverlayIcons.dashboard)
               .font(.system(size: 12, weight: .semibold))
+              .accessibilityHidden(true)
           }
           .meterBarGlassIconButton()
           .help("Open Usage Dashboard")
+          .accessibilityLabel("Open Dashboard")
 
           Button {
             Task { await dataManager.refreshAll() }
           } label: {
             RefreshingIcon(isRefreshing: dataManager.isLoading)
               .font(.system(size: 12, weight: .semibold))
+              .accessibilityHidden(true)
           }
           .meterBarGlassIconButton()
           .help(dataManager.isLoading ? "Refreshing usage" : "Refresh usage")
+          .accessibilityLabel("Refresh")
+          .accessibilityValue(dataManager.isLoading ? "Refreshing" : "")
           .disabled(dataManager.isLoading)
         }
       }
@@ -271,6 +276,7 @@ struct PopoverOverviewPanel: View {
                 .font(.system(size: 17, weight: .bold))
                 .foregroundStyle(.secondary)
                 .frame(width: 34, height: 34)
+                .accessibilityHidden(true)
 
               VStack(alignment: .leading, spacing: 2) {
                 Text("No sources enabled")
@@ -391,9 +397,15 @@ private struct PopoverProviderStatusCard: View {
           cardContent
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(snapshot.accessibilityLabel)
+        .accessibilityValue(snapshot.accessibilityValue)
         .accessibilityHint("Open \(snapshot.title) provider details")
       } else {
         cardContent
+          .accessibilityElement(children: .combine)
+          .accessibilityLabel(snapshot.accessibilityLabel)
+          .accessibilityValue(snapshot.accessibilityValue)
       }
     }
   }
@@ -528,7 +540,8 @@ private struct PopoverLimitRow: View {
           .lineLimit(1)
         if limit.usageLimit.isEstimated {
           Text("Estimated")
-            .font(.system(size: 8, weight: .semibold))
+            .font(.caption2)
+            .fontWeight(.semibold)
             .foregroundColor(.secondary)
         }
         Spacer(minLength: 4)
@@ -556,6 +569,9 @@ private struct PopoverLimitRow: View {
         )
       }
     }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(limit.accessibilityLabel)
+    .accessibilityValue(limit.accessibilityValue)
   }
 }
 

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -85,6 +85,28 @@ struct ProviderSnapshot: Identifiable {
         guard hasExhaustedWeeklyLimit else { return limits }
         return limits.filter { $0.kind != .session }
     }
+
+    // MARK: - Accessibility
+
+    /// VoiceOver label for a provider card: provider name, severity band, and
+    /// freshness — the same three facts the card renders in its header. Kept as
+    /// a pure computed property (like `DailyUsageDay.chartAccessibilityLabel`)
+    /// so the popover and dashboard cards can't drift and the composition is
+    /// unit-testable without the network or a rendered view.
+    var accessibilityLabel: String {
+        "\(title), \(band?.shortLabel ?? "No data"), \(updatedText)"
+    }
+
+    /// VoiceOver value for a provider card: each quota window's reading spoken
+    /// in order, so a `children: .combine` card announces as one coherent
+    /// summary instead of a fragmented subview tree. Falls back to the card's
+    /// empty-state copy when no windows are reported.
+    var accessibilityValue: String {
+        guard !limits.isEmpty else { return emptyDetail }
+        return limits
+            .map { "\($0.accessibilityLabel), \($0.accessibilityValue)" }
+            .joined(separator: ", ")
+    }
 }
 
 enum ExtraUsageDisplayPolicy {
@@ -135,6 +157,30 @@ struct SnapshotLimit: Identifiable {
     /// Derived from the limit's kind, not by string-matching the display title.
     var paceContext: PaceLabelContext {
         kind == .weekly ? .weekly : .session
+    }
+
+    // MARK: - Accessibility
+
+    private var isOut: Bool { percentLeft <= 0 }
+
+    /// VoiceOver label naming this quota window, appending "estimated" when the
+    /// total was derived rather than provider-reported (the visual "Estimated"
+    /// tag). Shared by all three limit-row renderers so they read identically.
+    var accessibilityLabel: String {
+        usageLimit.isEstimated ? "\(title), estimated" : title
+    }
+
+    /// VoiceOver value for a quota window: how much is left and how much is
+    /// used/spent, mirroring the trailing value + used-value copy the rows
+    /// render. Currency-style limits (OpenRouter key/credit balances) speak
+    /// dollars; quota-style limits speak percentages.
+    var accessibilityValue: String {
+        if valueStyle == .currency {
+            let left = UsageFormat.cost(max(0, usageLimit.total - usageLimit.used))
+            return "\(left) left, \(UsageFormat.cost(usageLimit.used)) spent"
+        }
+        let trailing = (isOut && !usageLimit.isEstimated) ? "Out" : usageLimit.percentLeftText
+        return "\(trailing), \(usageLimit.usedPercentageText)"
     }
 }
 

--- a/MeterBar/Views/ProviderStatusViews.swift
+++ b/MeterBar/Views/ProviderStatusViews.swift
@@ -324,10 +324,15 @@ struct PopoverProviderStatusSummaryCard: View {
                     Image(systemName: "chevron.right")
                         .font(.system(size: 10, weight: .semibold))
                         .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
                 }
             }
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Provider Status")
+        .accessibilityValue(summaryText)
+        .accessibilityHint("Show provider status details")
         .task {
             await statusMonitor.refreshAllIfNeeded()
         }

--- a/MeterBar/Views/SessionWakeMenuControl.swift
+++ b/MeterBar/Views/SessionWakeMenuControl.swift
@@ -26,9 +26,14 @@ struct SessionWakeMenuControl: View {
             Text(label.title)
                 .font(.caption)
                 .foregroundStyle(label.isAttention ? .orange : .secondary)
-            Toggle("", isOn: watcherBinding)
+                .accessibilityHidden(true)
+            // Real label kept but hidden visually so VoiceOver announces
+            // "Session Wake, <on/off>" instead of an unnamed switch; the status
+            // text above is folded in as the accessibility value.
+            Toggle("Session Wake", isOn: watcherBinding)
                 .labelsHidden()
                 .toggleStyle(.switch)
+                .accessibilityValue(label.title)
                 // The one-time first-run confirmation happens in Settings, so
                 // the menu toggle is a quick kill-switch once enabled there.
                 .disabled(!store.isOn && (!store.canTurnOn || store.needsFirstRunConfirmation))

--- a/MeterBar/Views/SessionWakeSettingsView.swift
+++ b/MeterBar/Views/SessionWakeSettingsView.swift
@@ -65,7 +65,7 @@ struct SessionWakeSettingsView: View {
                     ? "Choose a wake account above to enable Session Wake."
                     : "Automatically resume blocked Claude Code sessions after a limit resets."
             ) {
-                Toggle("", isOn: onBinding)
+                Toggle("Session Wake", isOn: onBinding)
                     .labelsHidden()
                     .toggleStyle(.switch)
                     .disabled(!store.canTurnOn && !store.isOn)
@@ -81,7 +81,7 @@ struct SessionWakeSettingsView: View {
     private var accountSection: some View {
         SettingsPanelSection(title: "Wake account", systemImage: "person.crop.circle", color: MeterBarTheme.appAccent) {
             SettingsRowView(title: "Account") {
-                Picker("", selection: accountBinding) {
+                Picker("Wake account", selection: accountBinding) {
                     Text("None selected").tag(UUID?.none)
                     ForEach(accounts.enabledAccounts) { account in
                         Text(account.name).tag(UUID?.some(account.id))
@@ -137,20 +137,22 @@ struct SessionWakeSettingsView: View {
         SettingsPanelSection(title: "Limits", systemImage: "slider.horizontal.3", color: MeterBarTheme.appAccent) {
             SettingsRowView(title: "Max sessions per run", detail: "\(store.maxSessionsPerRun)") {
                 Stepper(
-                    "",
+                    "Max sessions per run",
                     value: binding(store.maxSessionsPerRun, store.setMaxSessionsPerRun),
                     in: WakeBounds.sessionsRange
                 )
                 .labelsHidden()
+                .accessibilityValue("\(store.maxSessionsPerRun)")
             }
 
             SettingsRowView(title: "Max turns per session", detail: "\(store.maxTurns)") {
                 Stepper(
-                    "",
+                    "Max turns per session",
                     value: binding(store.maxTurns, store.setMaxTurns),
                     in: WakeBounds.maxTurnsRange
                 )
                 .labelsHidden()
+                .accessibilityValue("\(store.maxTurns)")
             }
 
             SettingsRowView(title: "Resume prompt") {
@@ -164,7 +166,7 @@ struct SessionWakeSettingsView: View {
     private var permissionSection: some View {
         SettingsPanelSection(title: "Permissions", systemImage: "lock.shield", color: MeterBarTheme.appAccent) {
             SettingsRowView(title: "Permission mode") {
-                Picker("", selection: binding(store.permissionMode, store.setPermissionMode)) {
+                Picker("Permission mode", selection: binding(store.permissionMode, store.setPermissionMode)) {
                     Text("Safe").tag(WakePermissionMode.safe)
                     Text("Bypass").tag(WakePermissionMode.bypass)
                 }
@@ -178,7 +180,7 @@ struct SessionWakeSettingsView: View {
                     title: "Acknowledge risk",
                     detail: "Bypassing permission prompts lets resumed sessions run without confirmation."
                 ) {
-                    Toggle("", isOn: binding(store.bypassAcknowledged, store.setBypassAcknowledged))
+                    Toggle("Acknowledge risk", isOn: binding(store.bypassAcknowledged, store.setBypassAcknowledged))
                         .labelsHidden()
                         .toggleStyle(.switch)
                 }
@@ -192,7 +194,7 @@ struct SessionWakeSettingsView: View {
                 title: "Notify when a run completes",
                 detail: "Post a notification after Session Wake finishes resuming sessions."
             ) {
-                Toggle("", isOn: $store.notifyOnCompletion)
+                Toggle("Notify when a run completes", isOn: $store.notifyOnCompletion)
                     .labelsHidden()
                     .toggleStyle(.switch)
             }

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -1351,6 +1351,10 @@ struct SettingsRowView<Content: View>: View {
                 }
             }
             .frame(width: SettingsRowViewMetrics.labelWidth, alignment: .leading)
+            // Read the title and its explanatory detail as one VoiceOver element
+            // rather than two adjacent fragments. The trailing control stays a
+            // separate focusable element so its own label/actuation are intact.
+            .accessibilityElement(children: .combine)
 
             content
                 .frame(maxWidth: .infinity, alignment: .trailing)

--- a/MeterBarTests/AccessibilityLabelTests.swift
+++ b/MeterBarTests/AccessibilityLabelTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+@testable import MeterBar
+import MeterBarShared
+
+/// Covers the pure VoiceOver label/value composition on `SnapshotLimit` and
+/// `ProviderSnapshot`. These strings are what the popover, dashboard, and
+/// detail-panel cards feed into `.accessibilityLabel`/`.accessibilityValue`, so
+/// asserting them here guarantees the three limit-row renderers and both
+/// provider-card branches speak identically without a rendered-view harness.
+final class AccessibilityLabelTests: XCTestCase {
+    private func limit(
+        used: Double,
+        total: Double = 100,
+        resetIn seconds: TimeInterval? = nil,
+        isEstimated: Bool = false
+    ) -> UsageLimit {
+        UsageLimit(
+            used: used,
+            total: total,
+            resetTime: seconds.map { Date().addingTimeInterval($0) },
+            isEstimated: isEstimated
+        )
+    }
+
+    private func snapshotLimit(
+        kind: SnapshotLimit.Kind = .session,
+        title: String = "Session",
+        limit: UsageLimit,
+        valueStyle: SnapshotLimit.ValueStyle = .quota
+    ) -> SnapshotLimit {
+        SnapshotLimit(id: title, kind: kind, title: title, usageLimit: limit, valueStyle: valueStyle)
+    }
+
+    // MARK: - SnapshotLimit label
+
+    func testLimitLabelIsTitleWhenReported() {
+        let row = snapshotLimit(limit: limit(used: 40))
+        XCTAssertEqual(row.accessibilityLabel, "Session")
+    }
+
+    func testLimitLabelAppendsEstimatedWhenDerived() {
+        let row = snapshotLimit(limit: limit(used: 40, isEstimated: true))
+        XCTAssertEqual(row.accessibilityLabel, "Session, estimated")
+    }
+
+    // MARK: - SnapshotLimit value
+
+    func testQuotaLimitValueSpeaksLeftAndUsedPercent() {
+        let row = snapshotLimit(limit: limit(used: 40))
+        // 40% used -> 60% left.
+        XCTAssertEqual(row.accessibilityValue, "60% left, 40% used")
+    }
+
+    func testEstimatedLimitValueCarriesApproximationMark() {
+        let row = snapshotLimit(limit: limit(used: 40, isEstimated: true))
+        XCTAssertEqual(row.accessibilityValue, "~60% left, ~40% used")
+    }
+
+    func testExhaustedQuotaLimitValueSaysOut() {
+        let row = snapshotLimit(limit: limit(used: 100))
+        XCTAssertTrue(row.accessibilityValue.hasPrefix("Out, "), row.accessibilityValue)
+    }
+
+    func testExhaustedEstimatedLimitDoesNotSayOut() {
+        // Estimated totals are never presented as a hard "Out".
+        let row = snapshotLimit(limit: limit(used: 100, isEstimated: true))
+        XCTAssertFalse(row.accessibilityValue.hasPrefix("Out"), row.accessibilityValue)
+    }
+
+    func testCurrencyLimitValueSpeaksDollars() {
+        let row = snapshotLimit(
+            kind: .session,
+            title: "Key limit",
+            limit: limit(used: 3, total: 10),
+            valueStyle: .currency
+        )
+        // $7.00 left, $3.00 spent (exact formatting comes from UsageFormat.cost).
+        XCTAssertTrue(row.accessibilityValue.contains("left"), row.accessibilityValue)
+        XCTAssertTrue(row.accessibilityValue.contains("spent"), row.accessibilityValue)
+    }
+
+    // MARK: - ProviderSnapshot label
+
+    func testProviderLabelIncludesTitleBandAndFreshness() {
+        let snapshot = ProviderSnapshot(
+            id: "codex",
+            title: "Codex",
+            service: .codexCli,
+            updatedAt: nil,
+            limits: [snapshotLimit(limit: limit(used: 10))],
+            emptyDetail: "Waiting for refresh",
+            extraUsage: nil,
+            resetCreditsAvailable: nil
+        )
+        // 10% used -> healthy band, no updatedAt -> "No data" freshness.
+        XCTAssertEqual(snapshot.accessibilityLabel, "Codex, Healthy, No data")
+    }
+
+    func testProviderLabelReportsExhaustedBand() {
+        let snapshot = ProviderSnapshot(
+            id: "claude",
+            title: "Claude",
+            service: .claudeCode,
+            updatedAt: nil,
+            limits: [snapshotLimit(kind: .weekly, title: "Weekly", limit: limit(used: 100))],
+            emptyDetail: "Waiting for refresh",
+            extraUsage: nil,
+            resetCreditsAvailable: nil
+        )
+        XCTAssertTrue(snapshot.accessibilityLabel.contains("Out"), snapshot.accessibilityLabel)
+    }
+
+    // MARK: - ProviderSnapshot value
+
+    func testProviderValueEnumeratesEveryWindow() {
+        let snapshot = ProviderSnapshot(
+            id: "codex",
+            title: "Codex",
+            service: .codexCli,
+            updatedAt: nil,
+            limits: [
+                snapshotLimit(kind: .session, title: "Session", limit: limit(used: 40)),
+                snapshotLimit(kind: .weekly, title: "Weekly", limit: limit(used: 20))
+            ],
+            emptyDetail: "Waiting for refresh",
+            extraUsage: nil,
+            resetCreditsAvailable: nil
+        )
+        let value = snapshot.accessibilityValue
+        XCTAssertTrue(value.contains("Session"), value)
+        XCTAssertTrue(value.contains("Weekly"), value)
+        XCTAssertTrue(value.contains("60% left"), value)
+        XCTAssertTrue(value.contains("80% left"), value)
+    }
+
+    func testProviderValueFallsBackToEmptyDetail() {
+        let snapshot = ProviderSnapshot(
+            id: "cursor",
+            title: "Cursor",
+            service: .cursor,
+            updatedAt: nil,
+            limits: [],
+            emptyDetail: "Log in to Cursor",
+            extraUsage: nil,
+            resetCreditsAvailable: nil
+        )
+        XCTAssertEqual(snapshot.accessibilityValue, "Log in to Cursor")
+    }
+}


### PR DESCRIPTION
## Problem

Accessibility labeling was sparse and inconsistent. Only `ProviderOverviewStatusCard` had the full `.accessibilityElement(children: .combine)` + label(+hint) treatment (and its two branches even disagreed). The popover status/summary/provider cards, every limit row (three implementations), the dashboard stat stacks, the icon-only glass header buttons, `ApiUsageCard`, and the Session Wake controls all read as fragmented subview trees under VoiceOver. Several fixed fonts sat below Apple's legible minimum (an 8pt "Estimated" tag ×3, a 9pt metric label) and the 34/28pt cost headlines were frozen in pixels, bypassing Dynamic Type.

## Change

**Single source of truth for labels.** New pure, unit-testable `accessibilityLabel`/`accessibilityValue` computed properties on `SnapshotLimit` and `ProviderSnapshot`, mirroring the visible row copy and following the existing `DailyUsageDay.chartAccessibilityLabel` pattern — so the three limit-row renderers and both provider-card branches can't drift.

**Applied `combine`+label(+value/hint) to:**
- `PopoverProviderStatusCard` — both branches now identical via the shared helper; hint only on the actionable one.
- `PopoverProviderStatusSummaryCard`, and all three limit rows (`DashboardLimitRow`, `MenuBarProviderLimitDetailRow`, `PopoverLimitRow`).
- `DashboardMetricTile`, `CostMetric`, `UsageDetailMetric` stat stacks, and `ApiUsageCard` (header + per-model rows).

**Icons & controls:**
- Icon-only glass header buttons labeled **"Open Dashboard"** / **"Refresh"** (inner SF Symbols `.accessibilityHidden(true)`); decorative "No sources" clock and summary chevron hidden.
- Session Wake empty-string `Toggle`/`Picker`/`Stepper` labels filled in (kept `.labelsHidden()` — **no visual change**) so VoiceOver names them; menu toggle folds status into `.accessibilityValue`.
- `SettingsRowView` title+detail combined centrally (benefits every Settings row; trailing control stays separately actuable).

**Dynamic Type:**
- 8pt "Estimated" tags and the 9pt `UsageDetailMetric` label → semantic `.caption2`.
- Cost headlines → `@ScaledMetric(relativeTo:)` (34/28 at default, scale up; `minimumScaleFactor` + `lineLimit(1)` guard overflow).
- Chart 8pt axis date labels intentionally left (dense axis; cited as the good reference). SF-Symbol `.system(size:)` icon sizing left as-is (not text legibility).

## Tests

`AccessibilityLabelTests` (TDD-first) asserts label/value composition across estimated, currency, exhausted, empty, and multi-window cases on both types. Pure-helper style; auto-discovered by the `swift test` coverage gate (path-based test target — the xcodebuild CI steps only build).

## Scope

Accessibility + Dynamic Type only. No visual redesign beyond what legibility required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)