### PR TITLE
Unify empty/error states and remove fabricated share-card data

### DIFF
--- a/.agents/SESSIONS/2026-07-14.md
+++ b/.agents/SESSIONS/2026-07-14.md
@@ -47,3 +47,51 @@ Claude Code ▸ "Claude Code OAuth usage" (dev builds re-prompt per rebuild).
 `WakeQuotaAuthority`/`LiveWakeQuotaProvider` still call the raw CLI service; the
 session-wake default-account quota gate would also benefit from OAuth, but needs a
 **side-effect-free** OAuth fetch to avoid coupling UI `@Published` state into wake decisions.
+
+---
+
+# 2026-07-14 (session 2) — Unify empty/error states + kill fabricated share-card data
+
+## Problem
+Empty/loading/error states were inconsistent across surfaces and one surface showed
+fabricated data:
+- Provider "not connected" notices differed per provider (Claude Code stacked **two**
+  `SettingsNotice`s, Codex one, Cursor two, OpenRouter notice+inline-error), all worded
+  differently.
+- Cost/usage sections invented near-duplicate empty strings ("No cost data for enabled
+  providers" vs "No cost data loaded yet"; "No usage data yet…" vs "Provider is disabled.").
+- **Fake data:** `SocialShareTokenChart` substituted a hardcoded `[4,7,5,10,8,…]` array at
+  reduced opacity ("waiting for scan") instead of an honest empty state — the only surface
+  rendering synthetic-looking numbers.
+
+## Fix
+- **New `EmptyStateCard`** (`MeterBar/Views/Components/EmptyStateCard.swift`): one shape —
+  icon + title + one-line message + optional action button; `.neutral` / `.warning` tone.
+  Renders inline (no tile of its own) so it drops into `SettingsPanelSection`.
+- **Migrated every settings empty/not-connected/error state** to it: one notice per provider
+  with unified "Not connected" framing (kept provider-specific recovery text — "Run codex
+  login" vs "Log in to Cursor IDE"). Collapsed the cost/usage duplicates to one card each,
+  keyed on the genuinely distinct condition (never-scanned vs scanned-but-empty;
+  no-usage-yet vs provider-disabled).
+- **Killed the fabricated chart data:** removed the hardcoded array. Added
+  `SocialShareCardContent.hasDailyChartData` as the single honest signal; when false the card
+  renders a "scan needed" placeholder (dashed baseline + caption), never fake bars. Kept the
+  card's intentional fixed-palette export geometry.
+- **Differentiated the two cost-scan loaders** via doc comments: `CostScanLoadingChart` =
+  first/empty scan (full takeover) vs `CostScanProgressBadge` = refresh over existing data
+  (corner overlay).
+
+## Tests
+- `EmptyStateCardTests` — tone→tint mapping + hosting render smoke (with/without action).
+- `SocialShareCardContentTests` — `hasDailyChartData` reflects real totals (empty/zero ⇒ false),
+  plus a render-smoke asserting the card builds its honest empty state with no scan.
+- `SettingsViewSmokeTests` — added an EmptyStateCard-in-`SettingsPanelSection` layout smoke.
+
+## Mistake and fix
+- **Mistake:** Initial edits landed in the **main checkout** (`master`) instead of this
+  worktree, on top of another live session's in-progress "R-settings split" refactor.
+- **Fix:** Re-applied all edits to the worktree against the clean base via an exact
+  match-count script; reverse-applied only my blocks in main (content-preserving, leaving the
+  other session's work intact) and removed the stray file there. Verified main retains none of
+  my distinctive copy.
+- **Prevention:** Edit via worktree-relative paths; never absolute paths into the parent repo.

--- a/MeterBar/Models/SocialShareCardContent.swift
+++ b/MeterBar/Models/SocialShareCardContent.swift
@@ -45,6 +45,13 @@ struct SocialShareCardContent: Equatable {
         tokenTotal != nil
     }
 
+    /// Whether the 30-day chart has any real usage to draw. When this is false
+    /// the share card must render an honest empty state — never fabricated bars.
+    /// This is the single source of truth the chart view keys its empty state on.
+    var hasDailyChartData: Bool {
+        dailyTokenTotals.contains { $0 > 0 }
+    }
+
     var tokenHeroValue: String {
         guard let tokenTotal else {
             return "Scan needed"

--- a/MeterBar/Views/Components/EmptyStateCard.swift
+++ b/MeterBar/Views/Components/EmptyStateCard.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+/// The single empty/not-connected/error placeholder used across MeterBar's
+/// settings and dashboard surfaces.
+///
+/// Before this existed, each surface hand-rolled its own treatment: providers
+/// stacked two differently-worded `SettingsNotice`s, the cost and usage sections
+/// invented near-duplicate "no data" strings, and the social share card even
+/// faked a chart. `EmptyStateCard` gives all of them one shape — icon, title,
+/// one-line explanation, and an optional recovery button — and one copy tone
+/// (short, action-oriented). Callers only supply the words that genuinely
+/// differ (e.g. "Run `codex login`" vs "Log in to Cursor IDE").
+///
+/// It renders as lightweight inline content (no tile of its own) so it drops
+/// straight into a `SettingsPanelSection`, which already provides the card
+/// surface.
+struct EmptyStateCard: View {
+    // MARK: Internal
+
+    /// Visual weight of the state. `.neutral` reads as informational (nothing is
+    /// wrong — just no data yet); `.warning` signals the user must act to
+    /// proceed (sign in, enable a provider, fix a key).
+    enum Tone {
+        case neutral
+        case warning
+
+        var tint: Color {
+            switch self {
+            case .neutral:
+                .secondary
+            case .warning:
+                MeterBarTheme.warning
+            }
+        }
+    }
+
+    let systemImage: String
+    let title: String
+    let message: String
+    var tone: Tone = .neutral
+    var actionTitle: String?
+    var action: (() -> Void)?
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: systemImage)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(tone.tint)
+                .frame(width: 18)
+                .padding(.top, 1)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.primary)
+
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let actionTitle, let action {
+                    Button(actionTitle, action: action)
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .padding(.top, 2)
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/MeterBar/Views/DashboardCostCards.swift
+++ b/MeterBar/Views/DashboardCostCards.swift
@@ -92,6 +92,11 @@ struct CostOverviewStatusCard: View {
   }
 }
 
+/// Full-area loading treatment for the **first** scan, when there is no cost
+/// data to show yet. It replaces the entire chart with an animated shimmer so
+/// the empty slot reads as "working on it" rather than "nothing here." Contrast
+/// with `CostScanProgressBadge`, which is a small overlay used when a scan
+/// refreshes data that is *already* on screen.
 struct CostScanLoadingChart: View {
   let compact: Bool
 
@@ -176,6 +181,10 @@ struct CostScanLoadingChart: View {
   }
 }
 
+/// Small overlay badge shown when a scan runs **on top of** data that is
+/// already displayed — the chart stays visible (dimmed) and this badge signals
+/// the in-progress refresh in a corner. Contrast with `CostScanLoadingChart`,
+/// which takes over the whole area when there is nothing to show yet.
 struct CostScanProgressBadge: View {
   let compact: Bool
 

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -266,7 +266,12 @@ struct SettingsView: View {
                         .fontWeight(.semibold)
                 }
             } else if !codexCliService.hasAccess {
-                SettingsNotice(text: "Run codex login, then check again.", color: MeterBarTheme.warning)
+                EmptyStateCard(
+                    systemImage: "person.crop.circle.badge.exclamationmark",
+                    title: "Not connected",
+                    message: "Run codex login, then Check Again.",
+                    tone: .warning
+                )
             }
 
             SettingsDivider()
@@ -551,13 +556,11 @@ struct SettingsView: View {
                     }
                 }
             } else {
-                SettingsNotice(
-                    text: claudeCodeService.authState.guidanceText,
-                    color: .secondary
-                )
-                SettingsNotice(
-                    text: "MeterBar reads usage from Claude Code's OAuth login; the CLI output is a fallback.",
-                    color: MeterBarTheme.warning
+                EmptyStateCard(
+                    systemImage: "person.crop.circle.badge.exclamationmark",
+                    title: "Not connected",
+                    message: claudeCodeService.authState.guidanceText,
+                    tone: .warning
                 )
             }
 
@@ -660,11 +663,12 @@ struct SettingsView: View {
                         .fontWeight(.semibold)
                 }
             } else if !cursorService.hasAccess {
-                SettingsNotice(
-                    text: "Reads Cursor IDE credentials from Cursor's local state database.",
-                    color: .secondary
+                EmptyStateCard(
+                    systemImage: "person.crop.circle.badge.exclamationmark",
+                    title: "Not connected",
+                    message: "Log in to Cursor IDE, then Check Again.",
+                    tone: .warning
                 )
-                SettingsNotice(text: "Log in to Cursor IDE first, then check again.", color: MeterBarTheme.warning)
             }
         }
     }
@@ -721,7 +725,12 @@ struct SettingsView: View {
                 default:
                     error.localizedDescription
                 }
-                SettingsNotice(text: detail, color: MeterBarTheme.warning)
+                EmptyStateCard(
+                    systemImage: "exclamationmark.triangle.fill",
+                    title: "Not connected",
+                    message: detail,
+                    tone: .warning
+                )
             }
         }
     }
@@ -766,15 +775,27 @@ struct SettingsView: View {
                     SettingsNotice(text: "Last scanned \(formatDate(lastScan)) ago.", color: .secondary)
                 }
             } else if costTracker.costSummary != nil {
-                SettingsNotice(text: "No cost data for enabled providers.", color: .secondary)
+                // Scanned, but nothing landed for the providers that are enabled.
+                EmptyStateCard(
+                    systemImage: "tray",
+                    title: "No cost data",
+                    message: "Enabled providers logged no local tokens in the last 30 days."
+                )
             } else {
-                SettingsNotice(text: "No cost data loaded yet.", color: .secondary)
+                // Never scanned this session — the button below kicks off the first scan.
+                EmptyStateCard(
+                    systemImage: "magnifyingglass",
+                    title: "No scan yet",
+                    message: "Scan 30 days to estimate local token cost."
+                )
             }
 
             if !canScanCosts {
-                SettingsNotice(
-                    text: "Enable Claude Code or OpenAI Codex to scan local token logs.",
-                    color: MeterBarTheme.warning
+                EmptyStateCard(
+                    systemImage: "exclamationmark.triangle.fill",
+                    title: "Nothing to scan",
+                    message: "Enable Claude Code or OpenAI Codex to scan local token logs.",
+                    tone: .warning
                 )
             }
 
@@ -906,11 +927,19 @@ struct SettingsView: View {
         ) {
             let snapshots = providerSnapshots(for: service).filter(\.hasMetrics)
             if snapshots.isEmpty {
-                SettingsNotice(
-                    text: providerVisibility
-                        .isEnabled(service) ? "No usage data yet. Refresh after signing in." : "Provider is disabled.",
-                    color: .secondary
-                )
+                if providerVisibility.isEnabled(service) {
+                    EmptyStateCard(
+                        systemImage: "chart.bar",
+                        title: "No usage yet",
+                        message: "Refresh after signing in to see \(service.displayName) usage."
+                    )
+                } else {
+                    EmptyStateCard(
+                        systemImage: "eye.slash",
+                        title: "Provider disabled",
+                        message: "Enable \(service.displayName) to track its usage."
+                    )
+                }
             } else {
                 ForEach(snapshots) { snapshot in
                     VStack(alignment: .leading, spacing: 10) {
@@ -924,7 +953,11 @@ struct SettingsView: View {
                         }
 
                         if snapshot.detailLimits.isEmpty {
-                            SettingsNotice(text: "No quota windows reported.", color: .secondary)
+                            EmptyStateCard(
+                                systemImage: "clock.badge.questionmark",
+                                title: "No quota windows",
+                                message: "This provider didn't report any limit windows."
+                            )
                         } else {
                             ForEach(snapshot.detailLimits) { limit in
                                 DashboardLimitRow(limit: limit, accentColor: snapshot.accentColor)

--- a/MeterBar/Views/SocialShareCard.swift
+++ b/MeterBar/Views/SocialShareCard.swift
@@ -58,6 +58,7 @@ struct SocialShareCard: View {
                         Spacer(minLength: 16 * scale)
                         SocialShareTokenChart(
                             values: content.dailyTokenTotals,
+                            hasData: content.hasDailyChartData,
                             accent: MeterBarTheme.codexAccent,
                             scale: scale
                         )
@@ -258,26 +259,25 @@ private struct SocialShareMetricPill: View {
 ///
 /// Deliberately kept separate from the interactive `DailyUsageChart`: this one
 /// renders a fixed-size marketing bitmap (dark gradient palette, `scale`-driven
-/// geometry, sample bars when no scan has run yet, no legend/axis/tooltips),
-/// whereas `DailyUsageChart` is a live, system-themed, `DailyTokenUsage`-bound
-/// view with `.help()` tooltips that are meaningless in a flattened PNG. The two
-/// consume different inputs (`[Int]` daily totals vs. `[DailyTokenUsage]` rows)
-/// and share no rendering requirements, so composing them would mean bolting an
-/// alternate palette and placeholder mode onto the interactive chart.
+/// geometry, no legend/axis/tooltips), whereas `DailyUsageChart` is a live,
+/// system-themed, `DailyTokenUsage`-bound view with `.help()` tooltips that are
+/// meaningless in a flattened PNG. The two consume different inputs (`[Int]`
+/// daily totals vs. `[DailyTokenUsage]` rows) and share no rendering
+/// requirements, so composing them would mean bolting an alternate palette and
+/// placeholder mode onto the interactive chart.
+///
+/// When there is no real usage (`hasData == false`) the chart renders an honest
+/// "scan needed" placeholder — a flat dashed baseline, no bars. It never
+/// fabricates plausible-looking numbers, so a screenshot can't misrepresent a
+/// user who hasn't run a scan.
 private struct SocialShareTokenChart: View {
     let values: [Int]
+    let hasData: Bool
     let accent: Color
     let scale: CGFloat
 
-    private var chartValues: [Int] {
-        if values.contains(where: { $0 > 0 }) {
-            return values
-        }
-        return [4, 7, 5, 10, 8, 14, 9, 17, 13, 20, 12, 18, 24, 16, 28]
-    }
-
     private var maxValue: Int {
-        max(chartValues.max() ?? 1, 1)
+        max(values.max() ?? 1, 1)
     }
 
     var body: some View {
@@ -287,7 +287,7 @@ private struct SocialShareTokenChart: View {
                     Text("30d local tokens")
                         .font(.system(size: 17 * scale, weight: .bold))
                         .foregroundStyle(.white)
-                    Text(values.contains(where: { $0 > 0 }) ? "tracked history" : "waiting for scan")
+                    Text(hasData ? "tracked history" : "scan needed")
                         .font(.system(size: 12 * scale, weight: .semibold))
                         .foregroundStyle(.white.opacity(0.54))
                 }
@@ -297,35 +297,10 @@ private struct SocialShareTokenChart: View {
                     .foregroundStyle(accent)
             }
 
-            GeometryReader { proxy in
-                let spacing = max(3 * scale, 2)
-                let barWidth = max(
-                    4 * scale,
-                    (proxy.size.width - CGFloat(max(0, chartValues.count - 1)) * spacing)
-                        / CGFloat(max(1, chartValues.count))
-                )
-
-                HStack(alignment: .bottom, spacing: spacing) {
-                    ForEach(chartValues.indices, id: \.self) { index in
-                        let value = chartValues[index]
-                        let percent = CGFloat(value) / CGFloat(maxValue)
-                        let opacity = values.contains(where: { $0 > 0 }) ? 0.92 : 0.38
-
-                        RoundedRectangle(cornerRadius: 4 * scale, style: .continuous)
-                            .fill(
-                                LinearGradient(
-                                    colors: [
-                                        accent.opacity(opacity),
-                                        MeterBarTheme.cursorAccent.opacity(max(0.18, opacity - 0.18))
-                                    ],
-                                    startPoint: .bottom,
-                                    endPoint: .top
-                                )
-                            )
-                            .frame(width: barWidth, height: max(6 * scale, proxy.size.height * percent))
-                    }
-                }
-                .frame(width: proxy.size.width, height: proxy.size.height, alignment: .bottomLeading)
+            if hasData {
+                bars
+            } else {
+                emptyPlaceholder
             }
         }
         .padding(16 * scale)
@@ -333,6 +308,68 @@ private struct SocialShareTokenChart: View {
         .overlay {
             RoundedRectangle(cornerRadius: 18 * scale, style: .continuous)
                 .stroke(Color.white.opacity(0.12), lineWidth: max(0.5, scale))
+        }
+    }
+
+    private var bars: some View {
+        GeometryReader { proxy in
+            let spacing = max(3 * scale, 2)
+            let barWidth = max(
+                4 * scale,
+                (proxy.size.width - CGFloat(max(0, values.count - 1)) * spacing)
+                    / CGFloat(max(1, values.count))
+            )
+
+            HStack(alignment: .bottom, spacing: spacing) {
+                ForEach(values.indices, id: \.self) { index in
+                    let percent = CGFloat(values[index]) / CGFloat(maxValue)
+
+                    RoundedRectangle(cornerRadius: 4 * scale, style: .continuous)
+                        .fill(
+                            LinearGradient(
+                                colors: [
+                                    accent.opacity(0.92),
+                                    MeterBarTheme.cursorAccent.opacity(0.74)
+                                ],
+                                startPoint: .bottom,
+                                endPoint: .top
+                            )
+                        )
+                        .frame(width: barWidth, height: max(6 * scale, proxy.size.height * percent))
+                }
+            }
+            .frame(width: proxy.size.width, height: proxy.size.height, alignment: .bottomLeading)
+        }
+    }
+
+    /// Honest "no data yet" state: a dashed baseline with a short caption, drawn
+    /// in place of bars so the card reads as empty rather than populated.
+    private var emptyPlaceholder: some View {
+        GeometryReader { proxy in
+            ZStack {
+                RoundedRectangle(cornerRadius: 8 * scale, style: .continuous)
+                    .fill(Color.white.opacity(0.03))
+
+                VStack(spacing: 8 * scale) {
+                    Image(systemName: "chart.bar.xaxis")
+                        .font(.system(size: 26 * scale, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.32))
+                    Text("Run a cost scan to fill this in")
+                        .font(.system(size: 13 * scale, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.46))
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                Path { path in
+                    let y = proxy.size.height - max(2, scale)
+                    path.move(to: CGPoint(x: 0, y: y))
+                    path.addLine(to: CGPoint(x: proxy.size.width, y: y))
+                }
+                .stroke(
+                    Color.white.opacity(0.22),
+                    style: StrokeStyle(lineWidth: max(1, scale), dash: [6 * scale, 5 * scale])
+                )
+            }
         }
     }
 }

--- a/MeterBarTests/EmptyStateCardTests.swift
+++ b/MeterBarTests/EmptyStateCardTests.swift
@@ -1,0 +1,48 @@
+import AppKit
+@testable import MeterBar
+import SwiftUI
+import XCTest
+
+@MainActor
+final class EmptyStateCardTests: XCTestCase {
+    func testToneTintUsesSemanticColors() {
+        // Neutral is informational (secondary); warning routes through the shared
+        // theme token. The two must be visually distinct so a "needs action"
+        // state never reads like a passive "no data yet" one.
+        XCTAssertEqual(EmptyStateCard.Tone.warning.tint, MeterBarTheme.warning)
+        XCTAssertEqual(EmptyStateCard.Tone.neutral.tint, Color.secondary)
+        XCTAssertNotEqual(EmptyStateCard.Tone.neutral.tint, EmptyStateCard.Tone.warning.tint)
+    }
+
+    func testNeutralCardWithoutActionRenders() {
+        let view = EmptyStateCard(
+            systemImage: "tray",
+            title: "No cost data",
+            message: "Enabled providers logged no local tokens in the last 30 days."
+        )
+        XCTAssertGreaterThan(renderedHeight(of: view), 0)
+    }
+
+    func testWarningCardWithActionRendersWithoutFiringAction() {
+        var tapped = false
+        let view = EmptyStateCard(
+            systemImage: "exclamationmark.triangle.fill",
+            title: "Not connected",
+            message: "Run codex login, then Check Again.",
+            tone: .warning,
+            actionTitle: "Check Again",
+            action: { tapped = true }
+        )
+        XCTAssertGreaterThan(renderedHeight(of: view), 0)
+        // Building the view must never invoke the recovery action itself.
+        XCTAssertFalse(tapped)
+    }
+
+    // MARK: Private
+
+    private func renderedHeight(of view: EmptyStateCard) -> CGFloat {
+        let host = NSHostingView(rootView: view.frame(width: 320))
+        host.layoutSubtreeIfNeeded()
+        return host.fittingSize.height
+    }
+}

--- a/MeterBarTests/SettingsViewSmokeTests.swift
+++ b/MeterBarTests/SettingsViewSmokeTests.swift
@@ -15,4 +15,27 @@ final class SettingsViewSmokeTests: XCTestCase {
         XCTAssertLessThanOrEqual(hostingView.fittingSize.width, 820)
         XCTAssertGreaterThanOrEqual(hostingView.fittingSize.height, 560)
     }
+
+    func testProviderNotConnectedEmptyStateRendersInSettingsSection() {
+        // Mirrors the real composition: the unified EmptyStateCard nested inside
+        // a SettingsPanelSection tile, at the settings column width. Guards that
+        // the migrated not-connected notices lay out where the old stacked
+        // SettingsNotices used to.
+        let section = SettingsPanelSection(
+            title: "Cursor",
+            systemImage: "person.crop.circle",
+            color: MeterBarTheme.cursorAccent
+        ) {
+            EmptyStateCard(
+                systemImage: "person.crop.circle.badge.exclamationmark",
+                title: "Not connected",
+                message: "Log in to Cursor IDE, then Check Again.",
+                tone: .warning
+            )
+        }
+
+        let hostingView = NSHostingView(rootView: section.frame(width: 720))
+        hostingView.layoutSubtreeIfNeeded()
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+    }
 }

--- a/MeterBarTests/SocialShareCardContentTests.swift
+++ b/MeterBarTests/SocialShareCardContentTests.swift
@@ -1,5 +1,7 @@
-import XCTest
+import AppKit
 @testable import MeterBar
+import SwiftUI
+import XCTest
 
 final class SocialShareCardContentTests: XCTestCase {
     func testPublicInstallMetadataMatchesReadme() {
@@ -100,6 +102,36 @@ final class SocialShareCardContentTests: XCTestCase {
         )
     }
 
+    func testHasDailyChartDataReflectsRealTotalsNotFabricatedBars() {
+        // The share chart used to substitute a hardcoded [4,7,5,...] array when
+        // no scan had run. It no longer does — the honest signal is
+        // `hasDailyChartData`, which is false unless a real total is present.
+        let noHistory = makeContent(dailyTokenTotals: [])
+        XCTAssertFalse(noHistory.hasDailyChartData)
+
+        let allZero = makeContent(dailyTokenTotals: [0, 0, 0, 0])
+        XCTAssertFalse(allZero.hasDailyChartData)
+
+        let withUsage = makeContent(dailyTokenTotals: [0, 0, 3, 0])
+        XCTAssertTrue(withUsage.hasDailyChartData)
+    }
+
+    @MainActor
+    func testShareCardRendersHonestEmptyStateWhenNoScan() {
+        let content = makeContent(tokenTotal: nil, dailyTokenTotals: [])
+        XCTAssertFalse(content.hasDailyChartData)
+
+        // The card must still render its fixed export geometry with no real data,
+        // falling back to the "scan needed" placeholder rather than fake bars.
+        let host = NSHostingView(
+            rootView: SocialShareCard(content: content)
+                .frame(width: 1_200, height: 675)
+        )
+        host.layoutSubtreeIfNeeded()
+        XCTAssertGreaterThan(host.fittingSize.width, 0)
+        XCTAssertGreaterThan(host.fittingSize.height, 0)
+    }
+
     func testDefaultFilenameUsesGeneratedTimestamp() {
         let content = SocialShareCardContent(
             tokenTotal: 1,
@@ -115,5 +147,23 @@ final class SocialShareCardContentTests: XCTestCase {
         XCTAssertEqual(content.providerNames, ["Codex"])
         XCTAssertEqual(content.dailyTokenTotals.count, 30)
         XCTAssertEqual(content.defaultFilename, "meterbar-token-card-19700101-010000.png")
+    }
+
+    // MARK: Private
+
+    private func makeContent(
+        tokenTotal: Int? = 1_000,
+        dailyTokenTotals: [Int]
+    ) -> SocialShareCardContent {
+        SocialShareCardContent(
+            tokenTotal: tokenTotal,
+            estimatedCostUSD: nil,
+            sourceCount: 1,
+            providerNames: ["Claude Code"],
+            tightestLimitTitle: nil,
+            tightestPercentLeft: nil,
+            dailyTokenTotals: dailyTokenTotals,
+            generatedAt: Date(timeIntervalSince1970: 0)
+        )
     }
 }


### PR DESCRIPTION
## Problem

Empty / loading / error states were inconsistent across surfaces, and one surface rendered **fabricated data**:

- Provider "not connected" notices differed per provider — Claude Code stacked **two** `SettingsNotice`s, Codex one, Cursor two, OpenRouter notice + inline error — all worded differently.
- Cost / usage sections invented near-duplicate empty strings ("No cost data for enabled providers" vs "No cost data loaded yet"; "No usage data yet…" vs "Provider is disabled.").
- **Fake data:** `SocialShareTokenChart` substituted a hardcoded `[4,7,5,10,8,…]` array at reduced opacity ("waiting for scan") instead of an honest empty state — the only surface rendering synthetic-looking numbers.

## Changes

- **New `EmptyStateCard`** (`MeterBar/Views/Components/EmptyStateCard.swift`): one shape — icon + title + one-line message + optional action button, `.neutral` / `.warning` tone. Renders inline (no tile of its own) so it composes inside `SettingsPanelSection`.
- **Migrated every settings empty/not-connected/error state** to it: one card per provider under a unified **"Not connected"** framing, keeping the genuinely provider-specific recovery text ("Run codex login" vs "Log in to Cursor IDE"). Collapsed the cost/usage duplicates to **one card each, keyed on the distinct condition** (never-scanned vs scanned-but-empty; no-usage-yet vs provider-disabled).
- **Removed the fabricated chart data.** Added `SocialShareCardContent.hasDailyChartData` as the single honest signal; when false the share card draws a "scan needed" placeholder (dashed baseline + caption) instead of fake bars. The card's intentional fixed-palette export geometry is unchanged.
- **Differentiated the two cost-scan loaders** via doc comments: `CostScanLoadingChart` (first/empty scan — full takeover) vs `CostScanProgressBadge` (refresh over existing data — corner overlay).

## Tests

- `EmptyStateCardTests` — tone→tint mapping + hosting render smoke (with / without action).
- `SocialShareCardContentTests` — `hasDailyChartData` reflects real totals (empty/zero ⇒ false); render-smoke asserting the card builds its honest empty state with no scan.
- `SettingsViewSmokeTests` — added an `EmptyStateCard`-in-`SettingsPanelSection` layout smoke.

Scope: empty/error-state unification + fake-data fix only. No motion/token/split work. SwiftLint clean on all changed files; `swift test` deferred to CI.