### PR TITLE
feat(ui): add menu bar display options

### DIFF
--- a/.agents/SESSIONS/2026-07-14.md
+++ b/.agents/SESSIONS/2026-07-14.md
@@ -47,3 +47,49 @@ Claude Code ▸ "Claude Code OAuth usage" (dev builds re-prompt per rebuild).
 `WakeQuotaAuthority`/`LiveWakeQuotaProvider` still call the raw CLI service; the
 session-wake default-account quota gate would also benefit from OAuth, but needs a
 **side-effect-free** OAuth fetch to avoid coupling UI `@Published` state into wake decisions.
+
+---
+
+# 2026-07-14 (pt 2) — Menu bar display preferences (#142)
+
+## System flow
+
+```mermaid
+flowchart LR
+    A[Settings preference] --> B[UserDefaults-backed display store]
+    B --> C[Status-item candidate selector]
+    C --> D[Pinned window or unchanged Auto heuristic]
+    B --> E[Popover reset formatter]
+    E --> F[Countdown or local clock time]
+```
+
+## What was done
+
+- Added persistent Auto/pinned provider-account-window selection with stable pin keys.
+- Preserved the legacy Auto candidate keys and selector pool so default behavior and tie-breaks do not change.
+- Added percentage-left, percentage-used, icon-only, compact, and regular status-item presentation options.
+- Added countdown/local-clock reset formatting across normal, detail, and exhausted popover cards.
+- Added focused tests for persistence, selector precedence/fallback, stable option keys, labels, and reset formatters.
+
+## Key decisions
+
+- Unavailable pins remain persisted but temporarily fall back to Auto, so disabling a provider does not erase intent.
+- Compact percentage-left plus countdown remains the default and renders the same status title, tooltip, and selector behavior as before.
+- Activity probes still run once per account off-main; their result is shared across that account's pin-capable windows.
+
+## Verification
+
+- `swiftlint lint --strict --quiet` — passed.
+- `git diff --check` — passed.
+- Local tests/builds skipped by the MacBook verification rule; PR CI is the execution gate.
+- `swiftformat --version` — blocked because SwiftFormat is not installed.
+
+## Mistakes and fixes
+
+- The first fetch refspec used an unbraced zsh variable before `:refs`; corrected it with `${DEFAULT_BRANCH}` before any fetch occurred.
+- A read-only shell loop used zsh's special `path` variable; renamed it and reran successfully with no repository changes.
+- Initial pin keys would have changed Auto's equal-quota tie-break; separated persistent pin identity from the legacy sticky key.
+
+## Next steps
+
+- [ ] Let PR CI run tests, coverage, app/widget/CLI builds, lint, and secret scan.

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -28,6 +28,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private let providerVisibilityStore = ProviderVisibilityStore.shared
     private let dockVisibilityStore = DockVisibilityStore.shared
     private let notificationPreferences = NotificationPreferencesStore.shared
+    private let menuBarDisplayPreferences = MenuBarDisplayPreferencesStore.shared
     private var cancellables = Set<AnyCancellable>()
     private var monitorTask: Task<Void, Never>?
 
@@ -675,17 +676,45 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
             .store(in: &cancellables)
 
+        Publishers.Merge3(
+            menuBarDisplayPreferences.$pinnedCandidateKey.map { _ in () },
+            menuBarDisplayPreferences.$labelMetric.map { _ in () },
+            menuBarDisplayPreferences.$labelSize.map { _ in () }
+        )
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    self?.updateStatusItem(metrics: UsageDataManager.shared.metrics)
+                }
+            }
+            .store(in: &cancellables)
+
         updateStatusItem(metrics: UsageDataManager.shared.metrics)
     }
 
     /// One menu-bar-title candidate whose on-disk activity probe has not run
     /// yet. The probe is a `@Sendable` closure so the filesystem scan can run
     /// off the main actor (it previously ran inline here and stalled the UI).
-    private struct StatusLimitProbeRequest: Sendable {
+    private struct StatusLimitCandidateSeed: Sendable {
         let key: String
+        let pinKey: String
         let displayName: String
+        let windowName: String
         let limit: UsageLimit
+        let isAutoSelectable: Bool
+    }
+
+    private struct StatusLimitProbeRequest: Sendable {
+        let seeds: [StatusLimitCandidateSeed]
         let probe: @Sendable () -> Date?
+    }
+
+    private struct StatusLimitSource {
+        let service: ServiceType
+        let accountID: UUID?
+        let autoSelectionKey: String?
+        let displayName: String
+        let metrics: UsageMetrics
+        let autoWindowID: String?
     }
 
     @MainActor
@@ -701,13 +730,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         Task { [weak self] in
             let candidates = await Task.detached(priority: .userInitiated) {
-                requests.map { request in
-                    StatusLimitCandidate(
-                        key: request.key,
-                        displayName: request.displayName,
-                        limit: request.limit,
-                        lastActivity: request.probe()
-                    )
+                requests.flatMap { request in
+                    let lastActivity = request.probe()
+                    return request.seeds.map { seed in
+                        StatusLimitCandidate(
+                            key: seed.key,
+                            pinKey: seed.pinKey,
+                            displayName: seed.displayName,
+                            windowName: seed.windowName,
+                            limit: seed.limit,
+                            lastActivity: lastActivity,
+                            isAutoSelectable: seed.isAutoSelectable
+                        )
+                    }
                 }
             }.value
             guard let self, generation == self.statusItemUpdateGeneration else { return }
@@ -721,22 +756,42 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         guard let selection = StatusItemLimitSelector.select(
             candidates: candidates,
-            previousKey: shownStatusItemKey
+            previousKey: shownStatusItemKey,
+            pinnedKey: menuBarDisplayPreferences.pinnedCandidateKey
         ) else {
             shownStatusItemKey = nil
             button.title = ""
             button.imagePosition = .imageOnly
             button.toolTip = "MeterBar"
+            button.setAccessibilityLabel("MeterBar")
             applyParseHealthAppearance(to: button)
             return
         }
 
         shownStatusItemKey = selection.key
-        let percent = percentLeft(for: selection.limit)
-        button.imagePosition = .imageLeft
-        button.title = " \(percent)%"
-        button.toolTip = "MeterBar: \(percent)% left on \(selection.displayName)"
-        button.setAccessibilityLabel("MeterBar \(percent)% left on \(selection.displayName)")
+        let isPinned = menuBarDisplayPreferences.pinnedCandidateKey == selection.pinKey
+        let selectionName = isPinned
+            ? "\(selection.displayName) · \(selection.windowName)"
+            : selection.displayName
+        let title = StatusItemLabelFormatter.title(
+            for: selection.limit,
+            metric: menuBarDisplayPreferences.labelMetric,
+            size: menuBarDisplayPreferences.labelSize
+        )
+        let spokenValue = StatusItemLabelFormatter.spokenValue(
+            for: selection.limit,
+            metric: menuBarDisplayPreferences.labelMetric
+        )
+
+        button.imagePosition = title == nil ? .imageOnly : .imageLeft
+        button.title = title.map { " \($0)" } ?? ""
+        if let spokenValue {
+            button.toolTip = "MeterBar: \(spokenValue) on \(selectionName)"
+            button.setAccessibilityLabel("MeterBar \(spokenValue) on \(selectionName)")
+        } else {
+            button.toolTip = "MeterBar: \(selectionName)"
+            button.setAccessibilityLabel("MeterBar \(selectionName)")
+        }
         applyParseHealthAppearance(to: button)
     }
 
@@ -761,12 +816,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         if providerVisibilityStore.isEnabled(.claudeCode) {
             for account in ClaudeCodeAccountStore.shared.enabledAccounts {
-                guard let limit = claudeMetrics(for: account, metrics: metrics)?.sessionLimit else { continue }
+                guard let accountMetrics = claudeMetrics(for: account, metrics: metrics) else { continue }
                 let configDirectory = account.configDirectory
-                requests.append(StatusLimitProbeRequest(
-                    key: "claude:\(account.id.uuidString)",
+                let source = StatusLimitSource(
+                    service: .claudeCode,
+                    accountID: account.id,
+                    autoSelectionKey: "claude:\(account.id.uuidString)",
                     displayName: "\(account.name) (\(ServiceType.claudeCode.displayName))",
-                    limit: limit,
+                    metrics: accountMetrics,
+                    autoWindowID: "session"
+                )
+                requests.append(statusLimitProbeRequest(
+                    source: source,
                     probe: { AccountActivityInspector.claudeCodeActivity(configDirectory: configDirectory) }
                 ))
             }
@@ -775,38 +836,79 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             for account in CodexAccountStore.shared.accounts {
                 let accountMetrics = UsageDataManager.shared.codexAccountMetrics[account.id]
                     ?? (account.isDefault ? metrics[.codexCli] : nil)
-                guard let limit = accountMetrics?.sessionLimit else { continue }
+                guard let accountMetrics else { continue }
                 let homeDirectory = account.homeDirectory
-                requests.append(StatusLimitProbeRequest(
-                    key: "codex:\(account.id.uuidString)",
+                let source = StatusLimitSource(
+                    service: .codexCli,
+                    accountID: account.id,
+                    autoSelectionKey: "codex:\(account.id.uuidString)",
                     displayName: "\(account.name) (\(ServiceType.codexCli.displayName))",
-                    limit: limit,
+                    metrics: accountMetrics,
+                    autoWindowID: "session"
+                )
+                requests.append(statusLimitProbeRequest(
+                    source: source,
                     probe: { AccountActivityInspector.codexCliActivity(homeDirectory: homeDirectory) }
                 ))
             }
         }
-        if providerVisibilityStore.isEnabled(.cursor), let cursorLimit = metrics[.cursor]?.weeklyLimit {
-            requests.append(StatusLimitProbeRequest(
-                key: "cursor",
+        if providerVisibilityStore.isEnabled(.cursor), let cursorMetrics = metrics[.cursor] {
+            let source = StatusLimitSource(
+                service: .cursor,
+                accountID: nil,
+                autoSelectionKey: "cursor",
                 displayName: ServiceType.cursor.displayName,
-                limit: cursorLimit,
+                metrics: cursorMetrics,
+                autoWindowID: "weekly"
+            )
+            requests.append(statusLimitProbeRequest(
+                source: source,
                 probe: { AccountActivityInspector.cursorActivity() }
+            ))
+        }
+        if providerVisibilityStore.isEnabled(.openRouter), let openRouterMetrics = metrics[.openRouter] {
+            let source = StatusLimitSource(
+                service: .openRouter,
+                accountID: nil,
+                autoSelectionKey: nil,
+                displayName: ServiceType.openRouter.displayName,
+                metrics: openRouterMetrics,
+                autoWindowID: nil
+            )
+            requests.append(statusLimitProbeRequest(
+                source: source,
+                probe: { nil }
             ))
         }
 
         return requests
     }
 
+    private func statusLimitProbeRequest(
+        source: StatusLimitSource,
+        probe: @escaping @Sendable () -> Date?
+    ) -> StatusLimitProbeRequest {
+        let seeds = ProviderSnapshotBuilder.limits(for: source.metrics, service: source.service).map { limit in
+            let pinKey = StatusItemPinKey.make(
+                service: source.service,
+                accountID: source.accountID,
+                windowID: limit.id
+            )
+            return StatusLimitCandidateSeed(
+                key: limit.id == source.autoWindowID ? source.autoSelectionKey ?? pinKey : pinKey,
+                pinKey: pinKey,
+                displayName: source.displayName,
+                windowName: limit.title,
+                limit: limit.usageLimit,
+                isAutoSelectable: limit.id == source.autoWindowID
+            )
+        }
+        return StatusLimitProbeRequest(seeds: seeds, probe: probe)
+    }
+
     @MainActor
     private func claudeMetrics(for account: ClaudeCodeAccount, metrics: [ServiceType: UsageMetrics]) -> UsageMetrics? {
         UsageDataManager.shared.claudeCodeAccountMetrics[account.id] ?? (account.isDefault ? metrics[.claudeCode] : nil)
-    }
-
-    private func percentLeft(for limit: UsageLimit) -> Int {
-        // Shared math so the menu-bar title always agrees with the popover and
-        // dashboard (the previous copy rounded instead of ceiling and could
-        // disagree by 1%).
-        QuotaMath.percentLeft(for: limit)
     }
 
     private func createMenuBarIcon() -> NSImage {

--- a/MeterBar/Models/StatusItemLimitSelector.swift
+++ b/MeterBar/Models/StatusItemLimitSelector.swift
@@ -2,15 +2,34 @@ import Foundation
 import MeterBarShared
 
 /// One account/provider quota competing for the menu bar percentage slot.
-struct StatusLimitCandidate: Equatable {
-    /// Stable identity across refreshes (e.g. "claude:<uuid>", "codex", "cursor")
-    /// so the sticky selection can recognize the previously shown account.
+struct StatusLimitCandidate: Equatable, Sendable {
+    /// Legacy Auto identity (e.g. "claude:<uuid>", "codex:<uuid>", "cursor")
+    /// retained byte-for-byte so sticky selection and equal-quota tie-breaks do
+    /// not change when the user leaves the new preference set to Auto.
     let key: String
+    /// Stable provider/account/window identity persisted for explicit pins.
+    let pinKey: String
     /// Human-readable label for the status item tooltip.
     let displayName: String
+    /// Provider-specific quota-window label (Session, Weekly, Sonnet, etc.).
+    let windowName: String
     let limit: UsageLimit
     /// Most recent on-disk activity for the account, nil when undetectable.
     let lastActivity: Date?
+    /// Only the same session/weekly windows used before #142 participate in
+    /// Auto. Other windows exist solely so the user can pin them explicitly.
+    let isAutoSelectable: Bool
+}
+
+nonisolated enum StatusItemPinKey {
+    static func make(service: ServiceType, accountID: UUID?, windowID: String) -> String {
+        "\(service.rawValue):\(accountID?.uuidString ?? "default"):\(windowID)"
+    }
+}
+
+struct StatusItemPinOption: Identifiable, Equatable {
+    let id: String
+    let title: String
 }
 
 /// Picks which quota the menu bar title shows.
@@ -31,20 +50,26 @@ enum StatusItemLimitSelector {
     static func select(
         candidates: [StatusLimitCandidate],
         previousKey: String?,
+        pinnedKey: String? = nil,
         now: Date = Date(),
         activityWindow: TimeInterval = Self.activityWindow,
         hysteresisPoints: Int = Self.hysteresisPoints
     ) -> StatusLimitCandidate? {
-        guard !candidates.isEmpty else { return nil }
+        if let pinnedKey, let pinned = candidates.first(where: { $0.pinKey == pinnedKey }) {
+            return pinned
+        }
 
-        let active = candidates.filter { candidate in
+        let autoCandidates = candidates.filter(\.isAutoSelectable)
+        guard !autoCandidates.isEmpty else { return nil }
+
+        let active = autoCandidates.filter { candidate in
             guard let lastActivity = candidate.lastActivity else { return false }
             return now.timeIntervalSince(lastActivity) <= activityWindow
         }
 
         // No detectable activity anywhere: fall back to the old behavior and
         // let every enabled account compete.
-        let pool = active.isEmpty ? candidates : active
+        let pool = active.isEmpty ? autoCandidates : active
 
         guard let tightest = pool.min(by: { lhs, rhs in
             let lhsLeft = QuotaMath.percentLeft(for: lhs.limit)

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -18,6 +18,14 @@ nonisolated enum StorageKeys {
     static let openRouterProviderEnabled = "OpenRouterProviderEnabled"
     /// Whether the Dock icon is shown (menu bar item is unaffected).
     static let showInDock = "ShowMeterBarInDock"
+    /// Stable provider/account/window key pinned into the menu bar title. Missing means Auto.
+    static let statusItemPinnedCandidate = "StatusItemPinnedCandidate"
+    /// `StatusItemLabelMetric` raw value (percent left, percent used, or icon only).
+    static let statusItemLabelMetric = "StatusItemLabelMetric"
+    /// `StatusItemLabelSize` raw value (compact or regular).
+    static let statusItemLabelSize = "StatusItemLabelSize"
+    /// `ResetTimeFormat` raw value for reset labels in popover cards.
+    static let popoverResetTimeFormat = "PopoverResetTimeFormat"
     /// Whether the one-time first-launch popover has been completed or dismissed.
     static let hasCompletedFirstRun = "HasCompletedFirstRun"
     /// Enables the Claude Code OAuth usage source (`/api/oauth/usage`), the

--- a/MeterBar/Services/MenuBarDisplayPreferencesStore.swift
+++ b/MeterBar/Services/MenuBarDisplayPreferencesStore.swift
@@ -1,0 +1,130 @@
+import Combine
+import Foundation
+import MeterBarShared
+
+nonisolated enum StatusItemLabelMetric: String, CaseIterable, Identifiable {
+    case percentLeft
+    case percentUsed
+    case iconOnly
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .percentLeft: return "Percentage Left"
+        case .percentUsed: return "Percentage Used"
+        case .iconOnly: return "Icon Only"
+        }
+    }
+}
+
+nonisolated enum StatusItemLabelSize: String, CaseIterable, Identifiable {
+    case compact
+    case regular
+
+    var id: String { rawValue }
+
+    var displayName: String { rawValue.capitalized }
+}
+
+nonisolated enum ResetTimeFormat: String, CaseIterable, Identifiable {
+    case countdown
+    case clock
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .countdown: return "Countdown"
+        case .clock: return "Clock Time"
+        }
+    }
+}
+
+/// Persists the status-item and popover-label choices introduced by issue #142.
+/// Defaults preserve the exact pre-feature presentation: Auto selection, a
+/// compact percentage-left label, and reset countdowns.
+final class MenuBarDisplayPreferencesStore: ObservableObject {
+    static let shared = MenuBarDisplayPreferencesStore()
+
+    @Published private(set) var pinnedCandidateKey: String?
+    @Published private(set) var labelMetric: StatusItemLabelMetric
+    @Published private(set) var labelSize: StatusItemLabelSize
+    @Published private(set) var resetTimeFormat: ResetTimeFormat
+
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        pinnedCandidateKey = userDefaults.string(forKey: StorageKeys.statusItemPinnedCandidate)
+            .flatMap(Self.normalizedPin)
+        labelMetric = userDefaults.string(forKey: StorageKeys.statusItemLabelMetric)
+            .flatMap(StatusItemLabelMetric.init(rawValue:)) ?? .percentLeft
+        labelSize = userDefaults.string(forKey: StorageKeys.statusItemLabelSize)
+            .flatMap(StatusItemLabelSize.init(rawValue:)) ?? .compact
+        resetTimeFormat = userDefaults.string(forKey: StorageKeys.popoverResetTimeFormat)
+            .flatMap(ResetTimeFormat.init(rawValue:)) ?? .countdown
+    }
+
+    func setPinnedCandidateKey(_ key: String?) {
+        let normalized = key.flatMap(Self.normalizedPin)
+        guard normalized != pinnedCandidateKey else { return }
+        pinnedCandidateKey = normalized
+        if let normalized {
+            userDefaults.set(normalized, forKey: StorageKeys.statusItemPinnedCandidate)
+        } else {
+            userDefaults.removeObject(forKey: StorageKeys.statusItemPinnedCandidate)
+        }
+    }
+
+    func setLabelMetric(_ metric: StatusItemLabelMetric) {
+        guard metric != labelMetric else { return }
+        labelMetric = metric
+        userDefaults.set(metric.rawValue, forKey: StorageKeys.statusItemLabelMetric)
+    }
+
+    func setLabelSize(_ size: StatusItemLabelSize) {
+        guard size != labelSize else { return }
+        labelSize = size
+        userDefaults.set(size.rawValue, forKey: StorageKeys.statusItemLabelSize)
+    }
+
+    func setResetTimeFormat(_ format: ResetTimeFormat) {
+        guard format != resetTimeFormat else { return }
+        resetTimeFormat = format
+        userDefaults.set(format.rawValue, forKey: StorageKeys.popoverResetTimeFormat)
+    }
+
+    nonisolated private static func normalizedPin(_ key: String) -> String? {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+nonisolated enum StatusItemLabelFormatter {
+    static func title(
+        for limit: UsageLimit,
+        metric: StatusItemLabelMetric,
+        size: StatusItemLabelSize
+    ) -> String? {
+        guard let value = value(for: limit, metric: metric) else { return nil }
+        guard size == .regular else { return "\(value)%" }
+        return "\(value)% \(metric == .percentLeft ? "left" : "used")"
+    }
+
+    static func spokenValue(for limit: UsageLimit, metric: StatusItemLabelMetric) -> String? {
+        guard let value = value(for: limit, metric: metric) else { return nil }
+        return "\(value)% \(metric == .percentLeft ? "left" : "used")"
+    }
+
+    private static func value(for limit: UsageLimit, metric: StatusItemLabelMetric) -> Int? {
+        switch metric {
+        case .percentLeft:
+            return QuotaMath.percentLeft(for: limit)
+        case .percentUsed:
+            return Int(limit.percentage.rounded())
+        case .iconOnly:
+            return nil
+        }
+    }
+}

--- a/MeterBar/Views/Components/ResetCountdowns.swift
+++ b/MeterBar/Views/Components/ResetCountdowns.swift
@@ -22,14 +22,40 @@ enum ResetCountdownSchedule {
 struct ResetCountdownLabel: View {
     let title: String?
     let limit: UsageLimit
-    var font: Font = .caption
-    var foregroundColor: Color = .secondary
-    var iconSize: CGFloat = 10
+    let font: Font
+    let foregroundColor: Color
+    let iconSize: CGFloat
+    let usesPopoverPreference: Bool
+
+    @ObservedObject private var preferences: MenuBarDisplayPreferencesStore
+
+    init(
+        title: String?,
+        limit: UsageLimit,
+        font: Font = .caption,
+        foregroundColor: Color = .secondary,
+        iconSize: CGFloat = 10,
+        usesPopoverPreference: Bool = false,
+        preferences: MenuBarDisplayPreferencesStore? = nil
+    ) {
+        self.title = title
+        self.limit = limit
+        self.font = font
+        self.foregroundColor = foregroundColor
+        self.iconSize = iconSize
+        self.usesPopoverPreference = usesPopoverPreference
+        _preferences = ObservedObject(wrappedValue: preferences ?? .shared)
+    }
 
     var body: some View {
         TimelineView(.periodic(from: ResetCountdownSchedule.anchor, by: ResetCountdownSchedule.interval)) { timeline in
             Group {
-                if let text = Self.counterText(title: title, limit: limit, now: timeline.date) {
+                if let text = Self.counterText(
+                    title: title,
+                    limit: limit,
+                    format: usesPopoverPreference ? preferences.resetTimeFormat : .countdown,
+                    now: timeline.date
+                ) {
                     HStack(spacing: 4) {
                         Image(systemName: "clock")
                             .font(.system(size: iconSize, weight: .semibold))
@@ -45,12 +71,36 @@ struct ResetCountdownLabel: View {
         }
     }
 
-    static func counterText(title: String?, limit: UsageLimit, now: Date) -> String? {
-        guard let countdown = limit.resetCountdownText(now: now) else { return nil }
+    static func counterText(
+        title: String?,
+        limit: UsageLimit,
+        format: ResetTimeFormat = .countdown,
+        now: Date,
+        locale: Locale = .current,
+        timeZone: TimeZone = .current
+    ) -> String? {
+        guard let resetTime = limit.resetTime,
+              let countdown = limit.resetCountdownText(now: now) else { return nil }
         if countdown == "now" {
             return title.map { "\($0) reset due" } ?? "Reset due"
         }
-        return title.map { "\($0) reset in \(countdown)" } ?? "Resets in \(countdown)"
+
+        switch format {
+        case .countdown:
+            return title.map { "\($0) reset in \(countdown)" } ?? "Resets in \(countdown)"
+        case .clock:
+            let clock = formattedClockTime(resetTime, locale: locale, timeZone: timeZone)
+            return title.map { "\($0) resets at \(clock)" } ?? "Resets at \(clock)"
+        }
+    }
+
+    static func formattedClockTime(_ date: Date, locale: Locale, timeZone: TimeZone) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.timeZone = timeZone
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
     }
 }
 
@@ -121,12 +171,13 @@ struct NextResetCountdownLabel: View {
 struct BlockingLimitResetCounter: View {
     let windows: [ResetCountdownWindow]
     let accentColor: Color
+    var format: ResetTimeFormat = .countdown
 
     var body: some View {
         TimelineView(.periodic(from: ResetCountdownSchedule.anchor, by: ResetCountdownSchedule.interval)) { timeline in
             let blockingWindow = Self.selectBlockingWindow(windows, now: timeline.date)
             let title = Self.titleText(for: blockingWindow, in: windows)
-            let counter = Self.counterText(for: blockingWindow, now: timeline.date)
+            let counter = Self.counterText(for: blockingWindow, now: timeline.date, format: format)
             let detail = Self.detailText(for: blockingWindow, in: windows)
 
             HStack(alignment: .center, spacing: 9) {
@@ -204,13 +255,29 @@ struct BlockingLimitResetCounter: View {
         return exhaustedCount > 1 ? "Limits exhausted" : "Limit exhausted"
     }
 
-    static func counterText(for window: ResetCountdownWindow?, now: Date) -> String {
+    static func counterText(
+        for window: ResetCountdownWindow?,
+        now: Date,
+        format: ResetTimeFormat = .countdown,
+        locale: Locale = .current,
+        timeZone: TimeZone = .current
+    ) -> String {
         guard let window,
               let countdown = window.limit.resetCountdownText(now: now) else {
             return "Reset time unavailable"
         }
 
-        return countdown == "now" ? "due now" : "in \(countdown)"
+        if countdown == "now" {
+            return "due now"
+        }
+
+        switch format {
+        case .countdown:
+            return "in \(countdown)"
+        case .clock:
+            guard let resetTime = window.limit.resetTime else { return "Reset time unavailable" }
+            return "at \(ResetCountdownLabel.formattedClockTime(resetTime, locale: locale, timeZone: timeZone))"
+        }
     }
 
     static func detailText(for window: ResetCountdownWindow?, in windows: [ResetCountdownWindow]) -> String {

--- a/MeterBar/Views/MenuBarDetailPanel.swift
+++ b/MeterBar/Views/MenuBarDetailPanel.swift
@@ -114,6 +114,12 @@ enum MeterBarMenuDetailPanelLayout {
 struct MenuBarProviderDetailContent: View {
   let snapshot: ProviderSnapshot
 
+  @ObservedObject private var menuBarDisplayPreferences = MenuBarDisplayPreferencesStore.shared
+
+  init(snapshot: ProviderSnapshot) {
+    self.snapshot = snapshot
+  }
+
   private var detailLimits: [SnapshotLimit] {
     snapshot.detailLimits
   }
@@ -162,7 +168,8 @@ struct MenuBarProviderDetailContent: View {
         if snapshot.hasExhaustedLimit {
           BlockingLimitResetCounter(
             windows: snapshot.resetWindows,
-            accentColor: snapshot.accentColor
+            accentColor: snapshot.accentColor,
+            format: menuBarDisplayPreferences.resetTimeFormat
           )
           .padding(10)
           .meterBarCardSurface(cornerRadius: 10)
@@ -262,7 +269,8 @@ private struct MenuBarProviderLimitDetailRow: View {
             limit: limit.usageLimit,
             font: .caption2,
             foregroundColor: .secondary,
-            iconSize: 9
+            iconSize: 9,
+            usesPopoverPreference: true
           )
         }
       }

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -376,6 +376,13 @@ private struct PopoverProviderStatusCard: View {
   let snapshot: ProviderSnapshot
   var onSelect: (() -> Void)?
 
+  @ObservedObject private var menuBarDisplayPreferences = MenuBarDisplayPreferencesStore.shared
+
+  init(snapshot: ProviderSnapshot, onSelect: (() -> Void)? = nil) {
+    self.snapshot = snapshot
+    self.onSelect = onSelect
+  }
+
   private var statusColor: Color {
     snapshot.band?.color ?? .secondary
   }
@@ -418,7 +425,11 @@ private struct PopoverProviderStatusCard: View {
             now: timeline.date
           )
           let title = BlockingLimitResetCounter.titleText(for: blockingWindow, in: snapshot.resetWindows)
-          let counter = BlockingLimitResetCounter.counterText(for: blockingWindow, now: timeline.date)
+          let counter = BlockingLimitResetCounter.counterText(
+            for: blockingWindow,
+            now: timeline.date,
+            format: menuBarDisplayPreferences.resetTimeFormat
+          )
 
           HStack(alignment: .center, spacing: 9) {
             ProviderLogoView(kind: snapshot.logoKind, size: 17, foregroundColor: snapshot.accentColor)
@@ -552,7 +563,8 @@ private struct PopoverLimitRow: View {
           limit: limit.usageLimit,
           font: .caption2,
           foregroundColor: .secondary,
-          iconSize: 9
+          iconSize: 9,
+          usesPopoverPreference: true
         )
       }
     }

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -12,6 +12,7 @@ struct ProviderSnapshot: Identifiable {
     let id: String
     let title: String
     let service: ServiceType
+    let accountID: UUID?
     let updatedAt: Date?
     let limits: [SnapshotLimit]
     let emptyDetail: String
@@ -176,7 +177,8 @@ enum ProviderSnapshotBuilder {
                     title: "Codex",
                     service: .codexCli,
                     metrics: input.metrics[.codexCli],
-                    emptyDetail: input.codexCliHasAccess ? "Waiting for refresh" : "Run codex login"
+                    emptyDetail: input.codexCliHasAccess ? "Waiting for refresh" : "Run codex login",
+                    accountID: CodexAccount.defaultID
                 ))
             }
         }
@@ -236,6 +238,7 @@ enum ProviderSnapshotBuilder {
             id: "\(service.rawValue)-\(title)-\(accountID?.uuidString ?? "default")",
             title: title,
             service: service,
+            accountID: accountID,
             updatedAt: metrics?.lastUpdated,
             limits: limits(for: metrics, service: service),
             emptyDetail: emptyDetail,
@@ -274,6 +277,23 @@ enum ProviderSnapshotBuilder {
             result.append(SnapshotLimit(id: "codeReview", kind: .codeReview, title: title, usageLimit: codeReview))
         }
         return result
+    }
+}
+
+extension Array where Element == ProviderSnapshot {
+    var statusItemPinOptions: [StatusItemPinOption] {
+        flatMap { snapshot in
+            snapshot.limits.map { limit in
+                StatusItemPinOption(
+                    id: StatusItemPinKey.make(
+                        service: snapshot.service,
+                        accountID: snapshot.accountID,
+                        windowID: limit.id
+                    ),
+                    title: "\(snapshot.title) · \(limit.title)"
+                )
+            }
+        }
     }
 }
 

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -51,6 +51,7 @@ struct SettingsView: View {
     @StateObject private var costTracker = CostTracker.shared
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
     @StateObject private var dockVisibility = DockVisibilityStore.shared
+    @StateObject private var menuBarDisplayPreferences = MenuBarDisplayPreferencesStore.shared
     @StateObject private var notificationPreferences = NotificationPreferencesStore.shared
     @StateObject private var launchAtLogin = LaunchAtLoginStore.shared
     @StateObject private var softwareUpdates = SoftwareUpdateController.shared
@@ -94,6 +95,10 @@ struct SettingsView: View {
             || providerVisibility.isEnabled(.codexCli)
     }
 
+    private var statusItemPinOptions: [StatusItemPinOption] {
+        providerSnapshots.statusItemPinOptions
+    }
+
     private var claudeExtraUsageStatus: ExtraUsageStatus? {
         ExtraUsageDisplayPolicy.visibleStatus(
             for: .claudeCode,
@@ -122,6 +127,7 @@ struct SettingsView: View {
             settingsTab {
                 trackedProvidersSection
                 refreshSection
+                menuBarDisplaySection
                 notificationsSection
                 generalSection
             }
@@ -425,6 +431,88 @@ struct SettingsView: View {
             // Settings, so re-read it whenever settings is shown.
             launchAtLogin.refreshStatus()
             softwareUpdates.refreshState()
+        }
+    }
+
+    private var menuBarDisplaySection: some View {
+        SettingsPanelSection(
+            title: "Menu Bar & Popover",
+            systemImage: "menubar.rectangle",
+            color: MeterBarTheme.appAccent
+        ) {
+            SettingsRowView(
+                title: "Menu bar shows",
+                detail: "Auto follows recent activity. Pinning keeps one provider, account, and quota window visible."
+            ) {
+                Picker("", selection: Binding(
+                    get: { menuBarDisplayPreferences.pinnedCandidateKey },
+                    set: { menuBarDisplayPreferences.setPinnedCandidateKey($0) }
+                )) {
+                    Text("Auto").tag(String?.none)
+                    ForEach(statusItemPinOptions) { option in
+                        Text(option.title).tag(String?.some(option.id))
+                    }
+                    if let pinned = menuBarDisplayPreferences.pinnedCandidateKey,
+                       !statusItemPinOptions.contains(where: { $0.id == pinned }) {
+                        Text("Pinned metric unavailable").tag(String?.some(pinned))
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .frame(width: 240)
+            }
+
+            SettingsRowView(
+                title: "Label metric",
+                detail: "Icon Only keeps the status item minimal while preserving details in its tooltip."
+            ) {
+                Picker("", selection: Binding(
+                    get: { menuBarDisplayPreferences.labelMetric },
+                    set: { menuBarDisplayPreferences.setLabelMetric($0) }
+                )) {
+                    ForEach(StatusItemLabelMetric.allCases) { metric in
+                        Text(metric.displayName).tag(metric)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .frame(width: 180)
+            }
+
+            SettingsRowView(
+                title: "Label width",
+                detail: "Regular adds “left” or “used”; Compact keeps today’s number-only label."
+            ) {
+                Picker("", selection: Binding(
+                    get: { menuBarDisplayPreferences.labelSize },
+                    set: { menuBarDisplayPreferences.setLabelSize($0) }
+                )) {
+                    ForEach(StatusItemLabelSize.allCases) { size in
+                        Text(size.displayName).tag(size)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .frame(width: 180)
+                .disabled(menuBarDisplayPreferences.labelMetric == .iconOnly)
+            }
+
+            SettingsRowView(
+                title: "Reset times",
+                detail: "Choose countdowns or local clock times on popover quota cards."
+            ) {
+                Picker("", selection: Binding(
+                    get: { menuBarDisplayPreferences.resetTimeFormat },
+                    set: { menuBarDisplayPreferences.setResetTimeFormat($0) }
+                )) {
+                    ForEach(ResetTimeFormat.allCases) { format in
+                        Text(format.displayName).tag(format)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .frame(width: 180)
+            }
         }
     }
 

--- a/MeterBarTests/MenuBarDisplayPreferencesStoreTests.swift
+++ b/MeterBarTests/MenuBarDisplayPreferencesStoreTests.swift
@@ -1,0 +1,89 @@
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+final class MenuBarDisplayPreferencesStoreTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "MenuBarDisplayPreferencesStoreTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testDefaultsPreserveCurrentPresentation() {
+        let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+
+        XCTAssertNil(store.pinnedCandidateKey)
+        XCTAssertEqual(store.labelMetric, .percentLeft)
+        XCTAssertEqual(store.labelSize, .compact)
+        XCTAssertEqual(store.resetTimeFormat, .countdown)
+    }
+
+    func testPreferencesPersistAcrossRelaunch() {
+        let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+        store.setPinnedCandidateKey("codex:account-id:weekly")
+        store.setLabelMetric(.percentUsed)
+        store.setLabelSize(.regular)
+        store.setResetTimeFormat(.clock)
+
+        let reloaded = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+
+        XCTAssertEqual(reloaded.pinnedCandidateKey, "codex:account-id:weekly")
+        XCTAssertEqual(reloaded.labelMetric, .percentUsed)
+        XCTAssertEqual(reloaded.labelSize, .regular)
+        XCTAssertEqual(reloaded.resetTimeFormat, .clock)
+    }
+
+    func testInvalidPersistedValuesFallBackToExistingDefaults() {
+        defaults.set("invalid", forKey: StorageKeys.statusItemLabelMetric)
+        defaults.set("invalid", forKey: StorageKeys.statusItemLabelSize)
+        defaults.set("invalid", forKey: StorageKeys.popoverResetTimeFormat)
+
+        let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+
+        XCTAssertEqual(store.labelMetric, .percentLeft)
+        XCTAssertEqual(store.labelSize, .compact)
+        XCTAssertEqual(store.resetTimeFormat, .countdown)
+    }
+
+    func testBlankPinRestoresAutoAndRemovesPersistence() {
+        let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+        store.setPinnedCandidateKey("codex:account-id:weekly")
+
+        store.setPinnedCandidateKey("   ")
+
+        XCTAssertNil(store.pinnedCandidateKey)
+        XCTAssertNil(defaults.string(forKey: StorageKeys.statusItemPinnedCandidate))
+    }
+
+    func testLabelFormatterCoversMetricAndDensityOptions() {
+        let limit = UsageLimit(used: 42.4, total: 100, resetTime: nil)
+
+        XCTAssertEqual(
+            StatusItemLabelFormatter.title(for: limit, metric: .percentLeft, size: .compact),
+            "58%"
+        )
+        XCTAssertEqual(
+            StatusItemLabelFormatter.title(for: limit, metric: .percentLeft, size: .regular),
+            "58% left"
+        )
+        XCTAssertEqual(
+            StatusItemLabelFormatter.title(for: limit, metric: .percentUsed, size: .compact),
+            "42%"
+        )
+        XCTAssertEqual(
+            StatusItemLabelFormatter.title(for: limit, metric: .percentUsed, size: .regular),
+            "42% used"
+        )
+        XCTAssertNil(StatusItemLabelFormatter.title(for: limit, metric: .iconOnly, size: .regular))
+    }
+}

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -160,6 +160,34 @@ final class ProviderSnapshotTests: XCTestCase {
         XCTAssertEqual(Set(snapshots.map(\.id)).count, 2)
     }
 
+    func testStatusItemPinOptionsUseStableProviderAccountWindowKeys() {
+        let work = CodexAccount(id: UUID(), name: "Work", homeDirectory: "/tmp/codex-work")
+        let snapshots = ProviderSnapshotBuilder.snapshots(ProviderSnapshotBuilder.Input(
+            metrics: [:],
+            codexAccounts: [work],
+            codexAccountMetrics: [
+                work.id: makeMetrics(service: .codexCli, session: 25, weekly: 75)
+            ],
+            claudeAccounts: [.defaultAccount],
+            claudeAccountMetrics: [:],
+            enabledServices: [.codexCli]
+        ))
+
+        XCTAssertEqual(
+            snapshots.statusItemPinOptions,
+            [
+                StatusItemPinOption(
+                    id: StatusItemPinKey.make(service: .codexCli, accountID: work.id, windowID: "session"),
+                    title: "Work · Session"
+                ),
+                StatusItemPinOption(
+                    id: StatusItemPinKey.make(service: .codexCli, accountID: work.id, windowID: "weekly"),
+                    title: "Work · Weekly"
+                )
+            ]
+        )
+    }
+
     // MARK: - Limits
 
     func testThirdLimitLabelIsSonnetForClaudeAndCodeReviewForCodex() {

--- a/MeterBarTests/ResetCountdownTests.swift
+++ b/MeterBarTests/ResetCountdownTests.swift
@@ -75,6 +75,54 @@ final class ResetCountdownTests: XCTestCase {
         XCTAssertNil(ResetCountdownLabel.counterText(title: "Weekly", limit: limit(resetIn: nil), now: epoch))
     }
 
+    func testCounterTextClockFormatUsesInjectedLocaleAndTimeZone() {
+        let locale = Locale(identifier: "en_GB")
+        let timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+
+        XCTAssertEqual(
+            ResetCountdownLabel.counterText(
+                title: "Weekly",
+                limit: limit(resetIn: 3_660),
+                format: .clock,
+                now: epoch,
+                locale: locale,
+                timeZone: timeZone
+            ),
+            "Weekly resets at 01:01"
+        )
+        XCTAssertEqual(
+            ResetCountdownLabel.counterText(
+                title: nil,
+                limit: limit(resetIn: 3_660),
+                format: .clock,
+                now: epoch,
+                locale: locale,
+                timeZone: timeZone
+            ),
+            "Resets at 01:01"
+        )
+    }
+
+    func testClockFormatKeepsResetDueAndMissingTimeBehavior() {
+        XCTAssertEqual(
+            ResetCountdownLabel.counterText(
+                title: "Session",
+                limit: limit(resetIn: -1),
+                format: .clock,
+                now: epoch
+            ),
+            "Session reset due"
+        )
+        XCTAssertNil(
+            ResetCountdownLabel.counterText(
+                title: nil,
+                limit: limit(resetIn: nil),
+                format: .clock,
+                now: epoch
+            )
+        )
+    }
+
     // MARK: - NextResetCountdownLabel.selectNextWindow
 
     func testSelectNextWindowPicksSoonestFuture() {
@@ -157,6 +205,16 @@ final class ResetCountdownTests: XCTestCase {
         XCTAssertEqual(
             BlockingLimitResetCounter.counterText(for: weekly, now: epoch),
             "in 1d 1h"
+        )
+        XCTAssertEqual(
+            BlockingLimitResetCounter.counterText(
+                for: weekly,
+                now: epoch,
+                format: .clock,
+                locale: Locale(identifier: "en_GB"),
+                timeZone: TimeZone(secondsFromGMT: 0) ?? .current
+            ),
+            "at 01:00"
         )
     }
 }

--- a/MeterBarTests/StatusItemLimitSelectorTests.swift
+++ b/MeterBarTests/StatusItemLimitSelectorTests.swift
@@ -9,21 +9,33 @@ final class StatusItemLimitSelectorTests: XCTestCase {
         key: String,
         percentUsed: Double,
         activeMinutesAgo: Double? = nil,
-        displayName: String? = nil
+        displayName: String? = nil,
+        pinKey: String? = nil,
+        windowName: String = "Session",
+        isAutoSelectable: Bool = true
     ) -> StatusLimitCandidate {
         StatusLimitCandidate(
             key: key,
+            pinKey: pinKey ?? key,
             displayName: displayName ?? key,
+            windowName: windowName,
             limit: UsageLimit(used: percentUsed, total: 100, resetTime: nil),
-            lastActivity: activeMinutesAgo.map { now.addingTimeInterval(-$0 * 60) }
+            lastActivity: activeMinutesAgo.map { now.addingTimeInterval(-$0 * 60) },
+            isAutoSelectable: isAutoSelectable
         )
     }
 
     private func select(
         _ candidates: [StatusLimitCandidate],
-        previousKey: String? = nil
+        previousKey: String? = nil,
+        pinnedKey: String? = nil
     ) -> StatusLimitCandidate? {
-        StatusItemLimitSelector.select(candidates: candidates, previousKey: previousKey, now: now)
+        StatusItemLimitSelector.select(
+            candidates: candidates,
+            previousKey: previousKey,
+            pinnedKey: pinnedKey,
+            now: now
+        )
     }
 
     // MARK: - Basics
@@ -121,5 +133,60 @@ final class StatusItemLimitSelectorTests: XCTestCase {
         let active = candidate(key: "codex:work", percentUsed: 45, activeMinutesAgo: 2)
 
         XCTAssertEqual(select([idle, active])?.key, "codex:work")
+    }
+
+    // MARK: - Pinned selection
+
+    func testPinnedWindowWinsOverAutoHeuristic() {
+        let automatic = candidate(key: "codex:work:session", percentUsed: 90, activeMinutesAgo: 1)
+        let pinned = candidate(
+            key: "claude:personal:weekly",
+            percentUsed: 20,
+            windowName: "Weekly",
+            isAutoSelectable: false
+        )
+
+        XCTAssertEqual(
+            select([automatic, pinned], pinnedKey: pinned.key)?.key,
+            pinned.key
+        )
+    }
+
+    func testPinnedAutoWindowMatchesPersistentPinKeyWithoutChangingLegacyAutoKey() {
+        let claude = candidate(key: "claude:work", percentUsed: 90, activeMinutesAgo: 1)
+        let codex = candidate(
+            key: "codex:work",
+            percentUsed: 20,
+            activeMinutesAgo: 1,
+            pinKey: "codexCli:account-id:session"
+        )
+
+        let selection = select([claude, codex], pinnedKey: "codexCli:account-id:session")
+
+        XCTAssertEqual(selection?.key, "codex:work")
+        XCTAssertEqual(selection?.pinKey, "codexCli:account-id:session")
+    }
+
+    func testUnavailablePinFallsBackToByteCompatibleAutoSelection() {
+        let claude = candidate(key: "claude:work:session", percentUsed: 40, activeMinutesAgo: 2)
+        let codex = candidate(key: "codex:work:session", percentUsed: 70, activeMinutesAgo: 1)
+
+        XCTAssertEqual(
+            select([claude, codex], pinnedKey: "cursor:default:weekly")?.key,
+            "codex:work:session"
+        )
+    }
+
+    func testPinOnlyWindowsDoNotChangeAutoSelection() {
+        let session = candidate(key: "codex:work:session", percentUsed: 40, activeMinutesAgo: 1)
+        let weekly = candidate(
+            key: "codex:work:weekly",
+            percentUsed: 95,
+            activeMinutesAgo: 1,
+            windowName: "Weekly",
+            isAutoSelectable: false
+        )
+
+        XCTAssertEqual(select([session, weekly])?.key, session.key)
     }
 }


### PR DESCRIPTION
## Summary
- persist Auto or pinned provider/account/quota-window selection while preserving the existing Auto heuristic and tie-break keys
- add percentage-left, percentage-used, icon-only, compact, and regular status-item label options
- add countdown or local clock-time formatting across normal, detail, and exhausted popover cards
- cover preference persistence, stable pin keys, pin precedence/fallback, labels, and reset formatting

## Verification
- `swiftlint lint --strict --quiet` — passed
- `git diff --check` — passed
- Local tests, coverage, app/widget/CLI builds, and user-facing app checks — not run per the repository MacBook verification rule; PR CI is the execution gate
- `swiftformat --version` — blocked because SwiftFormat is not installed

## Residual risk
- Clock labels intentionally follow the Mac’s current locale and time zone.
- Open PR #192 restructures `SettingsView`; if it lands first, this PR may need a mechanical conflict resolution in that view.

Closes #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Menu Bar & Popover settings for pinning usage windows, choosing label metrics and sizes, and selecting countdown or clock-time reset formats.
  * Added support for displaying selected usage limits and customizable status-item labels in the menu bar.
  * Added stable usage-window options for selecting specific provider limits.

* **Bug Fixes**
  * Improved automatic limit selection to prioritize active session windows and gracefully handle unavailable pinned limits.
  * Reset indicators now correctly support both countdown and clock-time formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->