### PR TITLE
feat: add Grok CLI usage provider

### DIFF
--- a/.agents/SESSIONS/2026-07-14.md
+++ b/.agents/SESSIONS/2026-07-14.md
@@ -93,6 +93,8 @@ flowchart LR
 - Local Swift tests, typechecks, and builds were intentionally not run under the
   workstation safety policy; GitHub Actions is the authoritative verification.
 - SwiftFormat was unavailable locally.
+- The first Xcode CI build caught a missing `import os` for privacy-aware logger
+  interpolation; the scoped import fix was pushed for a fresh CI run.
 
 ## Note
 The first manual research probe omitted `--no-auto-update`, allowing the locally

--- a/.agents/SESSIONS/2026-07-14.md
+++ b/.agents/SESSIONS/2026-07-14.md
@@ -47,3 +47,54 @@ Claude Code ▸ "Claude Code OAuth usage" (dev builds re-prompt per rebuild).
 `WakeQuotaAuthority`/`LiveWakeQuotaProvider` still call the raw CLI service; the
 session-wake default-account quota gate would also benefit from OAuth, but needs a
 **side-effect-free** OAuth fetch to avoid coupling UI `@Published` state into wake decisions.
+
+---
+
+# 2026-07-14 — Grok Build provider (#135)
+
+## Goal
+Add an opt-in Grok provider with the same quota surfaces as existing providers,
+without browser-cookie scraping or password/API-key entry.
+
+## Research and decision
+- Verified the official Grok Build CLI exposes an ACP stdio agent and owns its
+  cached authentication through `grok login`.
+- Sequenced ACP `initialize` → `authenticate` (`cached_token`) → `_x.ai/billing`.
+- Chose the CLI boundary so MeterBar only checks whether `~/.grok/auth.json`
+  exists/readable; it never opens, decodes, logs, or persists credential contents.
+- Disabled CLI auto-update for MeterBar-launched probes and discarded stderr,
+  which may contain account metadata.
+
+```mermaid
+flowchart LR
+    A["Grok enabled in Settings"] --> B["UsageDataManager refresh"]
+    B --> C["GrokCLIUsageService"]
+    C --> D["Official Grok ACP process"]
+    D --> E["Billing response"]
+    E --> F["UsageMetrics + reset + credits"]
+    F --> G["Popover / dashboard / widget / CLI"]
+    F --> H["Threshold notifications"]
+    C --> I["Parse-health + doctor diagnostics"]
+```
+
+## Implementation
+- Added `ServiceType.grok`, adaptive presentation, opt-in persistence, Grok
+  settings, and shared snapshot/cache/widget/CLI wiring.
+- Added `GrokCLIUsageService` with a line-buffered, timeout-bounded ACP transport
+  and fixture-tested mapping for weekly usage, reset windows, prepaid balance,
+  and on-demand caps.
+- Added readiness checks and provider-status metadata; the existing generic
+  parse-health and notification pipelines now include Grok automatically.
+- Updated README setup/privacy guidance and architecture documentation.
+
+## Verification
+- `swiftlint lint --strict --quiet` passed.
+- `git diff --check` passed.
+- Local Swift tests, typechecks, and builds were intentionally not run under the
+  workstation safety policy; GitHub Actions is the authoritative verification.
+- SwiftFormat was unavailable locally.
+
+## Note
+The first manual research probe omitted `--no-auto-update`, allowing the locally
+installed Grok CLI to update itself. The production process arguments explicitly
+include `--no-auto-update`, preventing MeterBar from repeating that side effect.

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture - MeterBar
 
 **Purpose:** Document what IS implemented (not what WILL BE).
-**Last Updated:** 2026-07-09 (rewritten from a full-repo audit; see `docs/audits/00-repo-map.md`)
+**Last Updated:** 2026-07-14 (rewritten from a full-repo audit; see `docs/audits/00-repo-map.md`)
 
 ---
 
@@ -17,6 +17,7 @@ Providers tracked:
 | OpenAI Codex CLI | `.codexCli` | Reads `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`), calls `https://chatgpt.com/backend-api/wham/usage` |
 | Cursor | `.cursor` | Reads session JWT from Cursor's `state.vscdb` SQLite, calls `https://cursor.com/api/usage-summary` |
 | OpenRouter | `.openRouter` | User-provided API key in Keychain; calls documented `/api/v1/credits` and `/api/v1/key` endpoints |
+| Grok | `.grok` | Opt-in. Runs the official Grok Build CLI's ACP stdio agent with its cached login and maps `_x.ai/billing` into the shared weekly quota/credit model; MeterBar checks login-file presence but never reads token contents |
 | Claude (admin) | `.claude` | Anthropic Admin API key (user-provided, stored in our keychain), `/v1/organizations/usage_report/messages` |
 | OpenAI (admin) | `.openai` | OpenAI Admin API key (user-provided, stored in our keychain), `/v1/organization/usage/completions` |
 
@@ -71,6 +72,7 @@ meterbar/
 - **CodexCliLocalService** — Codex auth file + wham/usage endpoint; maps credits/spend to `ExtraUsageStatus` (safety-biased: never false "Off").
 - **CursorLocalService** — SQLite token extraction + usage-summary endpoint; assumed 500-request default quota when API omits totals.
 - **OpenRouterService** — opt-in API-key provider; maps account credits/spend and optional per-key caps into shared metrics.
+- **GrokCLIUsageService** — opt-in CLI provider; resolves `grok`, authenticates the official ACP process with `cached_token`, and maps weekly usage, reset time, prepaid balance, and on-demand credit limits. The process runs with auto-update disabled and discards stderr to avoid account metadata in logs.
 - **ClaudeService / OpenAIService** — admin-key usage reports (paginated, 50-page cap) via `ServiceSupport.fetchDecoded`.
 - **CostTracker** — JSONL/SQLite log scanning, per-day/model/origin breakdowns, cache at `~/Library/Application Support/MeterBar/cost-summary-v1.json`. API-rate estimates come from the versioned `ModelPricing` table in `MeterBarShared`, which is shared with the CLI.
 - **AuthenticationManager + KeychainManager** — the two admin keys, stored in keychain service `dev.meterbar.app`. Reads migrate the older `dev.shipshit.meterbar` (v1.6.x) and `com.agenticindiedev.quotaguard` (v1.0-v1.6) services into the current one, and removals delete all three so a legacy key cannot reappear.

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -16,6 +16,8 @@ nonisolated enum StorageKeys {
     static let hiddenProviderServices = "HiddenProviderServices"
     /// OpenRouter is API-key backed and must be explicitly enabled.
     static let openRouterProviderEnabled = "OpenRouterProviderEnabled"
+    /// Grok Build is CLI-backed but opt-in while its ACP billing method is in beta.
+    static let grokProviderEnabled = "GrokProviderEnabled"
     /// Whether the Dock icon is shown (menu bar item is unaffected).
     static let showInDock = "ShowMeterBarInDock"
     /// Whether the one-time first-launch popover has been completed or dismissed.

--- a/MeterBar/Services/CLIBinaryLocator.swift
+++ b/MeterBar/Services/CLIBinaryLocator.swift
@@ -4,7 +4,7 @@ import Foundation
 /// locations MeterBar runs from (Homebrew, npm-global, yarn, bun, volta, etc.).
 ///
 /// This was previously private to `ClaudeCodeCLIUsageService`; it is factored
-/// out so provider-readiness diagnostics can ask "is `codex` / `claude` on
+/// out so provider-readiness diagnostics can ask "is `codex` / `claude` / `grok` on
 /// PATH?" without re-deriving the same fallback list.
 nonisolated enum CLIBinaryLocator {
     /// The install directories the fallbacks draw from, in priority order.

--- a/MeterBar/Services/GrokCLIUsageService.swift
+++ b/MeterBar/Services/GrokCLIUsageService.swift
@@ -1,6 +1,7 @@
 import Combine
 import Foundation
 import MeterBarShared
+import os
 
 /// Reads Grok Build subscription usage through the CLI's official ACP stdio
 /// extension. MeterBar asks the CLI to authenticate with its cached login and

--- a/MeterBar/Services/GrokCLIUsageService.swift
+++ b/MeterBar/Services/GrokCLIUsageService.swift
@@ -1,0 +1,421 @@
+import Combine
+import Foundation
+import MeterBarShared
+
+/// Reads Grok Build subscription usage through the CLI's official ACP stdio
+/// extension. MeterBar asks the CLI to authenticate with its cached login and
+/// never opens, decodes, logs, or persists `~/.grok/auth.json`.
+final class GrokCLIUsageService: ObservableObject {
+    nonisolated static let shared = GrokCLIUsageService()
+
+    @Published private(set) var hasAccess = false
+    @Published private(set) var lastError: ServiceError?
+    @Published private(set) var subscriptionType: String?
+
+    nonisolated private let binaryPathProvider: @Sendable () -> String?
+    nonisolated private let authAvailableProvider: @Sendable () -> Bool
+    nonisolated private let billingResultProvider: @Sendable (String) async throws -> GrokBillingResult
+
+    init(
+        binaryPathProvider: @escaping @Sendable () -> String? = {
+            CLIBinaryLocator.resolve(command: "grok", overrideEnvVar: "GROK_CLI_PATH")
+        },
+        authAvailableProvider: @escaping @Sendable () -> Bool = {
+            let path = GrokCLIUsageService.authFilePath()
+            return FileManager.default.fileExists(atPath: path)
+                && FileManager.default.isReadableFile(atPath: path)
+        },
+        billingResultProvider: @escaping @Sendable (String) async throws -> GrokBillingResult = {
+            try await GrokBillingRPC.fetch(binaryPath: $0)
+        }
+    ) {
+        self.binaryPathProvider = binaryPathProvider
+        self.authAvailableProvider = authAvailableProvider
+        self.billingResultProvider = billingResultProvider
+        Task.detached(priority: .utility) { [weak self] in
+            self?.checkAccess()
+        }
+    }
+
+    nonisolated static func authFilePath(home: String = ServiceSupport.realHomeDirectory()) -> String {
+        "\(home)/.grok/auth.json"
+    }
+
+    nonisolated func checkAccess() {
+        let available = binaryPathProvider() != nil && authAvailableProvider()
+        ServiceSupport.applyOnMain { [weak self] in
+            guard let self else { return }
+            self.hasAccess = available
+            if !available {
+                self.subscriptionType = nil
+            }
+        }
+    }
+
+    func fetchUsageMetrics() async throws -> UsageMetrics {
+        guard let binaryPath = binaryPathProvider(), authAvailableProvider() else {
+            let error = ServiceError.notAuthenticated
+            hasAccess = false
+            lastError = error
+            throw error
+        }
+
+        do {
+            let result = try await billingResultProvider(binaryPath)
+            let metrics = Self.map(result)
+            hasAccess = true
+            subscriptionType = result.subscriptionTier
+            lastError = nil
+            return metrics
+        } catch {
+            let serviceError = Self.serviceError(from: error)
+            lastError = serviceError
+            if case .notAuthenticated = serviceError {
+                hasAccess = false
+                subscriptionType = nil
+            }
+            AppLog.usage.error("Grok usage fetch failed: \(serviceError.localizedDescription, privacy: .public)")
+            throw serviceError
+        }
+    }
+
+    static func map(_ result: GrokBillingResult, now: Date = Date()) -> UsageMetrics {
+        let periodStart = result.config.currentPeriod?.startDate ?? result.config.billingPeriodStartDate
+        let periodEnd = result.config.currentPeriod?.endDate ?? result.config.billingPeriodEndDate
+        let windowSeconds: TimeInterval? = {
+            guard let periodStart, let periodEnd else { return nil }
+            let duration = periodEnd.timeIntervalSince(periodStart)
+            return duration > 0 ? duration : nil
+        }()
+        let weeklyLimit = UsageLimit(
+            used: max(0, result.config.creditUsagePercent),
+            total: 100,
+            resetTime: periodEnd,
+            windowSeconds: windowSeconds
+        )
+
+        return UsageMetrics(
+            service: .grok,
+            weeklyLimit: weeklyLimit,
+            extraUsage: result.config.extraUsageStatus,
+            lastUpdated: now
+        )
+    }
+
+    private static func serviceError(from error: Error) -> ServiceError {
+        guard let error = error as? GrokBillingRPC.Error else {
+            if error is DecodingError {
+                return .parsingError
+            }
+            return ServiceSupport.serviceError(from: error)
+        }
+        switch error {
+        case .notAuthenticated:
+            return .notAuthenticated
+        case .invalidResponse:
+            return .parsingError
+        case .timedOut:
+            return .apiError("Grok billing request timed out")
+        case .launchFailed:
+            return .apiError("Could not launch the Grok CLI")
+        case .commandFailed:
+            return .apiError("Grok billing request failed")
+        }
+    }
+}
+
+// MARK: - Billing response
+
+nonisolated struct GrokBillingResult: Decodable, Sendable {
+    let config: GrokBillingConfig
+    let subscriptionTier: String?
+
+    enum CodingKeys: String, CodingKey {
+        case config
+        case subscriptionTier = "subscription_tier"
+    }
+}
+
+nonisolated struct GrokBillingConfig: Decodable, Sendable {
+    struct Period: Decodable, Sendable {
+        let type: String?
+        let start: String?
+        let end: String?
+
+        var startDate: Date? { start.flatMap(FlexibleISO8601.date(from:)) }
+        var endDate: Date? { end.flatMap(FlexibleISO8601.date(from:)) }
+    }
+
+    struct Amount: Decodable, Sendable {
+        let val: Double
+    }
+
+    let creditUsagePercent: Double
+    let currentPeriod: Period?
+    let onDemandCap: Amount?
+    let onDemandUsed: Amount?
+    let prepaidBalance: Amount?
+    let isUnifiedBillingUser: Bool?
+    let billingPeriodStart: String?
+    let billingPeriodEnd: String?
+
+    var billingPeriodStartDate: Date? { billingPeriodStart.flatMap(FlexibleISO8601.date(from:)) }
+    var billingPeriodEndDate: Date? { billingPeriodEnd.flatMap(FlexibleISO8601.date(from:)) }
+
+    var extraUsageStatus: ExtraUsageStatus {
+        guard onDemandCap != nil || onDemandUsed != nil || prepaidBalance != nil else {
+            return .unknown
+        }
+
+        let cap = max(0, onDemandCap?.val ?? 0)
+        let used = max(0, onDemandUsed?.val ?? 0)
+        let balance = max(0, prepaidBalance?.val ?? 0)
+        guard cap > 0 || used > 0 || balance > 0 else {
+            return ExtraUsageStatus(state: .off)
+        }
+
+        var details: [String] = []
+        if balance > 0 {
+            details.append("\(ExtraUsageStatus.formatAmount(balance)) credits")
+        }
+        if cap > 0 || used > 0 {
+            details.append(
+                "\(ExtraUsageStatus.formatAmount(used)) / \(ExtraUsageStatus.formatAmount(cap)) on demand"
+            )
+        }
+        return ExtraUsageStatus(state: .on, detail: details.joined(separator: " · "))
+    }
+}
+
+// MARK: - ACP transport
+
+nonisolated enum GrokBillingRPC {
+    struct Request: Sendable {
+        let id: Int
+        let method: String
+        let data: Data
+        private let strings: [String: String]
+        private let nestedStrings: [String: [String: String]]
+
+        init(
+            id: Int,
+            method: String,
+            parameters: [String: Any],
+            strings: [String: String] = [:],
+            nestedStrings: [String: [String: String]] = [:]
+        ) {
+            self.id = id
+            self.method = method
+            self.strings = strings
+            self.nestedStrings = nestedStrings
+            let object: [String: Any] = [
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": method,
+                "params": parameters
+            ]
+            data = (try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])) ?? Data()
+        }
+
+        func stringParameter(_ key: String) -> String? {
+            strings[key]
+        }
+
+        func nestedStringParameter(_ object: String, key: String) -> String? {
+            nestedStrings[object]?[key]
+        }
+    }
+
+    enum Error: Swift.Error {
+        case notAuthenticated
+        case invalidResponse
+        case timedOut
+        case launchFailed
+        case commandFailed
+    }
+
+    private static let timeout: TimeInterval = 12
+    private static let queue = DispatchQueue(label: "dev.meterbar.app.GrokBillingRPC", qos: .userInitiated)
+
+    static func requests(clientVersion: String) -> [Request] {
+        [
+            Request(
+                id: 1,
+                method: "initialize",
+                parameters: [
+                    "protocolVersion": 1,
+                    "clientCapabilities": [String: Any](),
+                    "clientInfo": ["name": "MeterBar", "version": clientVersion]
+                ],
+                nestedStrings: ["clientInfo": ["name": "MeterBar", "version": clientVersion]]
+            ),
+            Request(
+                id: 2,
+                method: "authenticate",
+                parameters: ["methodId": "cached_token", "_meta": ["headless": true]],
+                strings: ["methodId": "cached_token"]
+            ),
+            Request(id: 3, method: "_x.ai/billing", parameters: [:])
+        ]
+    }
+
+    static func fetch(binaryPath: String) async throws -> GrokBillingResult {
+        try await withCheckedThrowingContinuation { continuation in
+            queue.async {
+                do {
+                    continuation.resume(returning: try fetchBlocking(binaryPath: binaryPath))
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    private static func fetchBlocking(binaryPath: String) throws -> GrokBillingResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binaryPath)
+        process.arguments = ["--no-auto-update", "agent", "--no-leader", "stdio"]
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = CLIBinaryLocator.augmentedPATH(environment: environment)
+        environment["NO_COLOR"] = "1"
+        environment["FORCE_COLOR"] = "0"
+        environment["TERM"] = "dumb"
+        process.environment = environment
+
+        let input = Pipe()
+        let output = Pipe()
+        let errorOutput = Pipe()
+        process.standardInput = input
+        process.standardOutput = output
+        process.standardError = errorOutput
+
+        let lines = LineBuffer()
+        output.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                lines.finish()
+                handle.readabilityHandler = nil
+            } else {
+                lines.append(data)
+            }
+        }
+        // Drain stderr concurrently, but intentionally discard it: the CLI can
+        // include account metadata in diagnostics and MeterBar must never log it.
+        errorOutput.fileHandleForReading.readabilityHandler = { handle in
+            if handle.availableData.isEmpty {
+                handle.readabilityHandler = nil
+            }
+        }
+
+        do {
+            try process.run()
+        } catch {
+            throw Error.launchFailed
+        }
+
+        defer {
+            output.fileHandleForReading.readabilityHandler = nil
+            errorOutput.fileHandleForReading.readabilityHandler = nil
+            try? input.fileHandleForWriting.close()
+            if process.isRunning {
+                process.terminate()
+            }
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        let clientVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+            ?? "development"
+        let requestSequence = requests(clientVersion: clientVersion)
+
+        try send(requestSequence[0], to: input.fileHandleForWriting)
+        _ = try response(id: 1, from: lines, deadline: deadline)
+
+        try send(requestSequence[1], to: input.fileHandleForWriting)
+        _ = try response(id: 2, from: lines, deadline: deadline, authenticationResponse: true)
+
+        try send(requestSequence[2], to: input.fileHandleForWriting)
+        let billingLine = try response(id: 3, from: lines, deadline: deadline)
+        return try decodeBillingResult(from: billingLine)
+    }
+
+    private static func send(_ request: Request, to handle: FileHandle) throws {
+        guard !request.data.isEmpty else { throw Error.invalidResponse }
+        var line = request.data
+        line.append(0x0A)
+        do {
+            try handle.write(contentsOf: line)
+        } catch {
+            throw Error.commandFailed
+        }
+    }
+
+    private static func response(
+        id: Int,
+        from lines: LineBuffer,
+        deadline: Date,
+        authenticationResponse: Bool = false
+    ) throws -> Data {
+        while let line = lines.nextLine(until: deadline) {
+            guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
+                  object["id"] as? Int == id else {
+                continue
+            }
+            if object["error"] != nil {
+                throw authenticationResponse ? Error.notAuthenticated : Error.commandFailed
+            }
+            guard object["result"] != nil else { throw Error.invalidResponse }
+            return line
+        }
+        throw Error.timedOut
+    }
+
+    private static func decodeBillingResult(from line: Data) throws -> GrokBillingResult {
+        struct Envelope: Decodable {
+            let result: GrokBillingResult
+        }
+        do {
+            return try JSONDecoder().decode(Envelope.self, from: line).result
+        } catch {
+            throw Error.invalidResponse
+        }
+    }
+
+    private final class LineBuffer: @unchecked Sendable {
+        private let condition = NSCondition()
+        private var pending = Data()
+        private var lines: [Data] = []
+        private var isFinished = false
+
+        func append(_ data: Data) {
+            condition.lock()
+            pending.append(data)
+            while let newline = pending.firstIndex(of: 0x0A) {
+                lines.append(Data(pending[..<newline]))
+                pending.removeSubrange(...newline)
+            }
+            condition.broadcast()
+            condition.unlock()
+        }
+
+        func finish() {
+            condition.lock()
+            if !pending.isEmpty {
+                lines.append(pending)
+                pending.removeAll(keepingCapacity: false)
+            }
+            isFinished = true
+            condition.broadcast()
+            condition.unlock()
+        }
+
+        func nextLine(until deadline: Date) -> Data? {
+            condition.lock()
+            defer { condition.unlock() }
+            while lines.isEmpty, !isFinished, Date() < deadline {
+                _ = condition.wait(until: deadline)
+            }
+            guard !lines.isEmpty else { return nil }
+            return lines.removeFirst()
+        }
+    }
+}

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -32,7 +32,8 @@ nonisolated public enum ProviderReadinessInspector {
             claudeReport: { claudeReport(refreshError: $0, now: $1) },
             codexReport: { codexReport(refreshError: $0, now: $1) },
             cursorReport: { cursorReport(refreshError: $0, now: $1) },
-            openRouterReport: { error, _ in openRouterReport(refreshError: error) }
+            openRouterReport: { error, _ in openRouterReport(refreshError: error) },
+            grokReport: { error, _ in grokReport(refreshError: error) }
         )
         let health = parseHealth ?? ProviderParseHealthStore.sharedRecords()
         return baseReports.map { report in
@@ -55,6 +56,9 @@ nonisolated public enum ProviderReadinessInspector {
         cursorReport: (ServiceError?, Date) -> ProviderReadiness,
         openRouterReport: (ServiceError?, Date) -> ProviderReadiness = { error, _ in
             ProviderReadinessInspector.openRouterReport(refreshError: error)
+        },
+        grokReport: (ServiceError?, Date) -> ProviderReadiness = { error, _ in
+            ProviderReadinessInspector.grokReport(refreshError: error)
         }
     ) -> [ProviderReadiness] {
         ServiceType.allCases.compactMap { provider in
@@ -68,6 +72,8 @@ nonisolated public enum ProviderReadinessInspector {
                 return cursorReport(refreshErrors[provider], now)
             case .openRouter:
                 return openRouterReport(refreshErrors[provider], now)
+            case .grok:
+                return grokReport(refreshErrors[provider], now)
             }
         }
     }
@@ -159,6 +165,20 @@ nonisolated public enum ProviderReadinessInspector {
         ProviderReadinessEvaluator.openRouter(
             OpenRouterReadinessInput(
                 hasAPIKey: hasAPIKey(),
+                refreshError: sanitize(refreshError)
+            )
+        )
+    }
+
+    static func grokReport(refreshError: ServiceError? = nil) -> ProviderReadiness {
+        let fileManager = FileManager.default
+        let authPath = GrokCLIUsageService.authFilePath()
+        let authExists = fileManager.fileExists(atPath: authPath)
+        return ProviderReadinessEvaluator.grok(
+            GrokReadinessInput(
+                isCLIInstalled: CLIBinaryLocator.isAvailable(command: "grok", overrideEnvVar: "GROK_CLI_PATH"),
+                authFileExists: authExists,
+                authFileReadable: authExists && fileManager.isReadableFile(atPath: authPath),
                 refreshError: sanitize(refreshError)
             )
         )

--- a/MeterBar/Services/ProviderStatusMonitor.swift
+++ b/MeterBar/Services/ProviderStatusMonitor.swift
@@ -146,6 +146,8 @@ extension ServiceType {
             return "Cursor"
         case .openRouter:
             return "OpenRouter"
+        case .grok:
+            return "Grok"
         }
     }
 
@@ -159,6 +161,8 @@ extension ServiceType {
             return "https://status.cursor.com/"
         case .openRouter:
             return "https://status.openrouter.ai/"
+        case .grok:
+            return "https://status.x.ai/"
         }
     }
 

--- a/MeterBar/Services/ProviderVisibilityStore.swift
+++ b/MeterBar/Services/ProviderVisibilityStore.swift
@@ -36,8 +36,13 @@ final class ProviderVisibilityStore: ObservableObject {
 
         guard nextHiddenServices != hiddenServices else { return }
         hiddenServices = nextHiddenServices
-        if service == .openRouter {
+        switch service {
+        case .openRouter:
             userDefaults.set(enabled, forKey: StorageKeys.openRouterProviderEnabled)
+        case .grok:
+            userDefaults.set(enabled, forKey: StorageKeys.grokProviderEnabled)
+        case .claudeCode, .codexCli, .cursor:
+            break
         }
         save()
     }
@@ -47,6 +52,9 @@ final class ProviderVisibilityStore: ObservableObject {
         hiddenServices = Set(rawValues.compactMap(ServiceType.init(rawValue:)))
         if !userDefaults.bool(forKey: StorageKeys.openRouterProviderEnabled) {
             hiddenServices.insert(.openRouter)
+        }
+        if !userDefaults.bool(forKey: StorageKeys.grokProviderEnabled) {
+            hiddenServices.insert(.grok)
         }
     }
 

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -15,6 +15,7 @@ protocol SimpleUsageProviding: AnyObject {
 
 extension CursorLocalService: SimpleUsageProviding {}
 extension OpenRouterService: SimpleUsageProviding {}
+extension GrokCLIUsageService: SimpleUsageProviding {}
 
 protocol CodexUsageProviding: AnyObject {
     func canAccess(account: CodexAccount) async -> Bool
@@ -53,6 +54,7 @@ class UsageDataManager: ObservableObject {
     private let cursorService: SimpleUsageProviding
     private let codexCliService: CodexUsageProviding
     private let openRouterService: SimpleUsageProviding
+    private let grokService: SimpleUsageProviding
     private let claudeCodeAccountStore: ClaudeCodeAccountStore
     private let codexAccountStore: CodexAccountStore
     private let providerVisibilityStore: ProviderVisibilityStore
@@ -73,6 +75,7 @@ class UsageDataManager: ObservableObject {
         codexCliService: CodexUsageProviding? = nil,
         cursorService: SimpleUsageProviding = CursorLocalService.shared,
         openRouterService: SimpleUsageProviding = OpenRouterService.shared,
+        grokService: SimpleUsageProviding = GrokCLIUsageService.shared,
         claudeCodeService: ClaudeCodeLocalService = .shared,
         claudeCodeAccountStore: ClaudeCodeAccountStore? = nil,
         codexAccountStore: CodexAccountStore? = nil,
@@ -85,6 +88,7 @@ class UsageDataManager: ObservableObject {
         self.codexCliService = codexCliService ?? CodexCliLocalService.shared
         self.cursorService = cursorService
         self.openRouterService = openRouterService
+        self.grokService = grokService
         self.claudeCodeService = claudeCodeService
         self.claudeCodeAccountStore = claudeCodeAccountStore ?? .shared
         self.codexAccountStore = codexAccountStore ?? .shared
@@ -134,7 +138,7 @@ class UsageDataManager: ObservableObject {
 
         // Fetch the simple (single-account) providers. On failure the final
         // merge loop below preserves any cached metrics (graceful degradation).
-        for service in [ServiceType.cursor, .openRouter]
+        for service in [ServiceType.cursor, .openRouter, .grok]
         where providerVisibilityStore.isEnabled(service) && hasProviderAccess(service) {
             do {
                 newMetrics[service] = try await fetchSimpleProviderMetrics(service)
@@ -221,7 +225,7 @@ class UsageDataManager: ObservableObject {
             let accountMetrics = await fetchCodexAccountMetrics()
             codexAccountMetrics = accountMetrics
             if let representative = representativeCodexMetrics(from: accountMetrics) { return representative }
-        case .cursor, .openRouter:
+        case .cursor, .openRouter, .grok:
             guard hasProviderAccess(service) else { throw ServiceError.notAuthenticated }
             do {
                 return try await fetchSimpleProviderMetrics(service)
@@ -377,6 +381,8 @@ class UsageDataManager: ObservableObject {
             return cursorService.hasAccess
         case .openRouter:
             return openRouterService.hasAccess
+        case .grok:
+            return grokService.hasAccess
         }
     }
 
@@ -390,6 +396,8 @@ class UsageDataManager: ObservableObject {
                 result = try await cursorService.fetchUsageMetrics()
             case .openRouter:
                 result = try await openRouterService.fetchUsageMetrics()
+            case .grok:
+                result = try await grokService.fetchUsageMetrics()
             case .claudeCode, .codexCli:
                 preconditionFailure("Account-aware providers use dedicated fetch paths")
             }

--- a/MeterBar/Views/Components/ProviderComponents.swift
+++ b/MeterBar/Views/Components/ProviderComponents.swift
@@ -13,6 +13,7 @@ enum ProviderLogoKind: Equatable {
     case cursor
     case openai
     case openRouter
+    case grok
 
     static func forService(_ service: ServiceType) -> ProviderLogoKind {
         switch service {
@@ -24,6 +25,8 @@ enum ProviderLogoKind: Equatable {
             return .cursor
         case .openRouter:
             return .openRouter
+        case .grok:
+            return .grok
         }
     }
 
@@ -50,6 +53,8 @@ enum ProviderLogoKind: Equatable {
             return "ProviderIcon-openai"
         case .openRouter:
             return nil
+        case .grok:
+            return nil
         }
     }
 
@@ -67,6 +72,8 @@ enum ProviderLogoKind: Equatable {
             return "brain"
         case .openRouter:
             return ServiceType.openRouter.iconName
+        case .grok:
+            return ServiceType.grok.iconName
         }
     }
 }

--- a/MeterBar/Views/DailyUsageChart.swift
+++ b/MeterBar/Views/DailyUsageChart.swift
@@ -580,6 +580,8 @@ struct DailyProviderUsageSummaryRow: View {
       return "Cursor"
     case .openRouter:
       return "OpenRouter"
+    case .grok:
+      return "Grok"
     }
   }
 }

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -20,6 +20,7 @@ struct MenuBarView: View {
   @StateObject private var codexAccountStore = CodexAccountStore.shared
   @StateObject private var cursorService = CursorLocalService.shared
   @StateObject private var openRouterService = OpenRouterService.shared
+  @StateObject private var grokService = GrokCLIUsageService.shared
   @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
   @StateObject private var providerVisibility = ProviderVisibilityStore.shared
   @StateObject private var sessionWakeStore = SessionWakeSettingsStore.shared
@@ -81,7 +82,8 @@ struct MenuBarView: View {
                 claudeCodeHasAccess: claudeCodeService.hasAccess,
                 codexCliHasAccess: codexCliService.hasAccess,
                 cursorHasAccess: cursorService.hasAccess,
-                openRouterHasAccess: openRouterService.hasAccess
+                openRouterHasAccess: openRouterService.hasAccess,
+                grokHasAccess: grokService.hasAccess
               )),
             openDashboard: openDashboard,
             openStatusDetail: openStatusDetail,

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -34,6 +34,10 @@ enum MeterBarTheme {
     light: NSColor(srgbRed: 105 / 255, green: 82 / 255, blue: 188 / 255, alpha: 1),
     dark: NSColor(srgbRed: 177 / 255, green: 159 / 255, blue: 255 / 255, alpha: 1)
   )
+  static let grokAccent = Color.adaptive(
+    light: NSColor(srgbRed: 33 / 255, green: 103 / 255, blue: 209 / 255, alpha: 1),
+    dark: NSColor(srgbRed: 108 / 255, green: 170 / 255, blue: 255 / 255, alpha: 1)
+  )
 
   /// The app's own accent. Follows the user's system accent color.
   static let appAccent = Color.accentColor
@@ -77,6 +81,8 @@ enum MeterBarTheme {
       return cursorAccent
     case .openRouter:
       return openRouterAccent
+    case .grok:
+      return grokAccent
     }
   }
 

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -150,10 +150,11 @@ enum ProviderSnapshotBuilder {
         var codexCliHasAccess: Bool = false
         var cursorHasAccess: Bool = false
         var openRouterHasAccess: Bool = false
+        var grokHasAccess: Bool = false
     }
 
     /// Builds the provider cards in display order (Codex, Claude accounts,
-    /// Cursor). Providers without metrics are included with an empty-state
+    /// Cursor, OpenRouter, Grok). Providers without metrics are included with an empty-state
     /// detail so the popover can render a "waiting / log in" card; the
     /// dashboard filters those out via `hasMetrics`.
     static func snapshots(_ input: Input) -> [ProviderSnapshot] {
@@ -216,6 +217,15 @@ enum ProviderSnapshotBuilder {
                 service: .openRouter,
                 metrics: input.metrics[.openRouter],
                 emptyDetail: input.openRouterHasAccess ? "Waiting for refresh" : "Add an OpenRouter API key"
+            ))
+        }
+
+        if input.enabledServices.contains(.grok) {
+            result.append(snapshot(
+                title: "Grok",
+                service: .grok,
+                metrics: input.metrics[.grok],
+                emptyDetail: input.grokHasAccess ? "Waiting for refresh" : "Run grok login"
             ))
         }
 

--- a/MeterBar/Views/SettingsView.swift
+++ b/MeterBar/Views/SettingsView.swift
@@ -48,6 +48,7 @@ struct SettingsView: View {
     @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
     @StateObject private var cursorService = CursorLocalService.shared
     @StateObject private var openRouterService = OpenRouterService.shared
+    @StateObject private var grokService = GrokCLIUsageService.shared
     @StateObject private var costTracker = CostTracker.shared
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
     @StateObject private var dockVisibility = DockVisibilityStore.shared
@@ -84,7 +85,8 @@ struct SettingsView: View {
                 claudeCodeHasAccess: claudeCodeService.hasAccess,
                 codexCliHasAccess: codexCliService.hasAccess,
                 cursorHasAccess: cursorService.hasAccess,
-                openRouterHasAccess: openRouterService.hasAccess
+                openRouterHasAccess: openRouterService.hasAccess,
+                grokHasAccess: grokService.hasAccess
             )
         )
     }
@@ -92,6 +94,7 @@ struct SettingsView: View {
     private var showExtraUsageSection: Bool {
         (providerVisibility.isEnabled(.claudeCode) && claudeExtraUsageStatus != nil)
             || providerVisibility.isEnabled(.codexCli)
+            || providerVisibility.isEnabled(.grok)
     }
 
     private var claudeExtraUsageStatus: ExtraUsageStatus? {
@@ -431,7 +434,7 @@ struct SettingsView: View {
     private var extraUsageSection: some View {
         SettingsPanelSection(title: "Extra Usage", systemImage: "creditcard", color: MeterBarTheme.warning) {
             SettingsNotice(
-                text: "Extra usage (Claude) and credits (Codex) let a provider bill overage beyond your "
+                text: "Extra usage and credits let a provider bill overage beyond your "
                     + "plan once your quota is exhausted. \"Off\" means usage is capped at your subscription.",
                 color: .secondary
             )
@@ -451,6 +454,14 @@ struct SettingsView: View {
                     title: "OpenAI Codex",
                     status: dataManager.metrics[.codexCli]?.extraUsage,
                     manageURL: "https://chatgpt.com"
+                )
+            }
+
+            if providerVisibility.isEnabled(.grok) {
+                extraUsageRow(
+                    title: "Grok",
+                    status: dataManager.metrics[.grok]?.extraUsage,
+                    manageURL: "https://grok.com/?_s=usage"
                 )
             }
         }
@@ -509,6 +520,11 @@ struct SettingsView: View {
                 title: "OpenRouter",
                 detail: "Track credit balance, spend, and per-key limits.",
                 service: .openRouter
+            )
+            providerToggleRow(
+                title: "Grok",
+                detail: "Track Grok Build weekly quota from its cached CLI login.",
+                service: .grok
             )
         }
     }
@@ -722,6 +738,62 @@ struct SettingsView: View {
                     error.localizedDescription
                 }
                 SettingsNotice(text: detail, color: MeterBarTheme.warning)
+            }
+        }
+    }
+
+    private var grokSection: some View {
+        SettingsPanelSection(title: "Grok Build", logoKind: .grok, color: MeterBarTheme.grokAccent) {
+            SettingsNotice(
+                text: "MeterBar asks the official Grok CLI for billing data over ACP. "
+                    + "The CLI owns authentication; MeterBar never reads or stores the cached token.",
+                color: .secondary
+            )
+
+            SettingsRowView(title: "Connection") {
+                HStack(spacing: 8) {
+                    StatusPill(
+                        title: grokService.hasAccess ? "Connected" : "Not Connected",
+                        isConnected: grokService.hasAccess
+                    )
+
+                    Button(grokService.hasAccess ? "Refresh" : "Check Again") {
+                        Task {
+                            let service = grokService
+                            await Task.detached(priority: .userInitiated) {
+                                service.checkAccess()
+                            }.value
+                            if grokService.hasAccess {
+                                await dataManager.refresh(service: .grok)
+                            }
+                        }
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button("Install / Sign In") {
+                        if let url = URL(string: "https://x.ai/cli") {
+                            NSWorkspace.shared.open(url)
+                        }
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+
+            if let subscriptionType = grokService.subscriptionType, grokService.hasAccess {
+                SettingsRowView(title: "Plan") {
+                    Text(subscriptionType)
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                }
+            } else if !grokService.hasAccess {
+                SettingsNotice(
+                    text: "Install Grok Build and run `grok login`; no password or API key is entered in MeterBar.",
+                    color: MeterBarTheme.warning
+                )
+            }
+
+            if let error = grokService.lastError {
+                SettingsNotice(text: error.localizedDescription, color: MeterBarTheme.warning)
             }
         }
     }
@@ -955,6 +1027,9 @@ struct SettingsView: View {
             cursorSection
         case .openRouter:
             openRouterSection
+        case .grok:
+            grokSection
+            providerExtraUsageSection(for: service)
         }
     }
 
@@ -983,6 +1058,14 @@ struct SettingsView: View {
             EmptyView()
         case .openRouter:
             EmptyView()
+        case .grok:
+            SettingsPanelSection(title: "Extra Usage", systemImage: "creditcard", color: MeterBarTheme.warning) {
+                extraUsageRow(
+                    title: "Grok",
+                    status: dataManager.metrics[.grok]?.extraUsage,
+                    manageURL: "https://grok.com/?_s=usage"
+                )
+            }
         }
     }
 
@@ -1068,6 +1151,7 @@ struct SettingsView: View {
             let claudeCode = claudeCodeService
             let codexCli = codexCliService
             let cursor = cursorService
+            let grok = grokService
             await Task.detached(priority: .userInitiated) {
                 switch service {
                 case .claudeCode:
@@ -1078,6 +1162,8 @@ struct SettingsView: View {
                     cursor.checkAccess(forceRescan: true)
                 case .openRouter:
                     break
+                case .grok:
+                    grok.checkAccess()
                 }
             }.value
             await dataManager.refresh(service: service)
@@ -1094,6 +1180,8 @@ struct SettingsView: View {
             "Cursor local state + usage API"
         case .openRouter:
             "OpenRouter credits + key APIs"
+        case .grok:
+            "Grok Build ACP billing"
         }
     }
 
@@ -1147,6 +1235,8 @@ struct SettingsView: View {
             return cursorService.subscriptionType?.capitalized.nilIfEmpty
         case .openRouter:
             return nil
+        case .grok:
+            return grokService.subscriptionType?.nilIfEmpty
         }
     }
 
@@ -1160,6 +1250,8 @@ struct SettingsView: View {
             cursorService.hasAccess
         case .openRouter:
             openRouterService.hasAccess
+        case .grok:
+            grokService.hasAccess
         }
     }
 
@@ -1173,6 +1265,8 @@ struct SettingsView: View {
             cursorService.lastError?.localizedDescription
         case .openRouter:
             openRouterService.lastError?.localizedDescription
+        case .grok:
+            grokService.lastError?.localizedDescription
         }
     }
 

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -171,6 +171,7 @@ struct UsageDashboardView: View {
     @StateObject private var codexCliService = CodexCliLocalService.shared
     @StateObject private var cursorService = CursorLocalService.shared
     @StateObject private var openRouterService = OpenRouterService.shared
+    @StateObject private var grokService = GrokCLIUsageService.shared
     @StateObject private var apiUsageStore = ApiUsageStore.shared
     @StateObject private var providerStatusMonitor = ProviderStatusMonitor.shared
     @StateObject private var navigation = DashboardNavigationStore.shared
@@ -587,7 +588,8 @@ struct UsageDashboardView: View {
             claudeCodeHasAccess: claudeCodeService.hasAccess,
             codexCliHasAccess: codexCliService.hasAccess,
             cursorHasAccess: cursorService.hasAccess,
-            openRouterHasAccess: openRouterService.hasAccess
+            openRouterHasAccess: openRouterService.hasAccess,
+            grokHasAccess: grokService.hasAccess
         ))
         .filter(\.hasMetrics)
     }
@@ -742,6 +744,8 @@ struct UsageDashboardView: View {
         if let error = claudeCodeService.lastError { result[.claudeCode] = error }
         if let error = codexCliService.lastError { result[.codexCli] = error }
         if let error = cursorService.lastError { result[.cursor] = error }
+        if let error = openRouterService.lastError { result[.openRouter] = error }
+        if let error = grokService.lastError { result[.grok] = error }
         return result
     }
 

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -64,7 +64,7 @@ struct Usage: ParsableCommand {
     @Flag(name: .shortAndLong, help: "Output as JSON")
     var json: Bool = false
 
-    @Option(name: .shortAndLong, help: "Filter by provider (claude, codex, cursor, openrouter)")
+    @Option(name: .shortAndLong, help: "Filter by provider (claude, codex, cursor, openrouter, grok)")
     var provider: String?
 
     func run() throws {
@@ -322,7 +322,7 @@ struct Doctor: ParsableCommand {
     @Flag(name: .shortAndLong, help: "Output as JSON")
     var json: Bool = false
 
-    @Option(name: .shortAndLong, help: "Filter by provider (claude, codex, cursor, openrouter)")
+    @Option(name: .shortAndLong, help: "Filter by provider (claude, codex, cursor, openrouter, grok)")
     var provider: String?
 
     func run() throws {

--- a/MeterBarTests/GrokCLIUsageServiceTests.swift
+++ b/MeterBarTests/GrokCLIUsageServiceTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+final class GrokCLIUsageServiceTests: XCTestCase {
+    func testBillingFixtureMapsWeeklyUsageResetAndCredits() throws {
+        let result = try decodeResult(
+            """
+            {
+              "config": {
+                "creditUsagePercent": 73.5,
+                "currentPeriod": {
+                  "type": "USAGE_PERIOD_TYPE_WEEKLY",
+                  "start": "2026-07-08T15:05:27.877598+00:00",
+                  "end": "2026-07-15T15:05:27.877598+00:00"
+                },
+                "onDemandCap": { "val": 50 },
+                "onDemandUsed": { "val": 12.25 },
+                "prepaidBalance": { "val": 8.5 },
+                "isUnifiedBillingUser": true
+              },
+              "subscription_tier": "SuperGrok Heavy"
+            }
+            """
+        )
+
+        let metrics = GrokCLIUsageService.map(result, now: Date(timeIntervalSince1970: 1_000))
+
+        XCTAssertEqual(metrics.service, .grok)
+        XCTAssertNil(metrics.sessionLimit)
+        XCTAssertEqual(metrics.weeklyLimit?.used, 73.5)
+        XCTAssertEqual(metrics.weeklyLimit?.total, 100)
+        XCTAssertEqual(metrics.weeklyLimit?.windowSeconds, 7 * 24 * 60 * 60)
+        XCTAssertEqual(
+            metrics.weeklyLimit?.resetTime,
+            FlexibleISO8601.date(from: "2026-07-15T15:05:27.877598+00:00")
+        )
+        XCTAssertEqual(metrics.extraUsage?.state, .on)
+        XCTAssertEqual(metrics.extraUsage?.detail, "$8.50 credits · $12.25 / $50.00 on demand")
+    }
+
+    func testZeroCreditFixtureMapsExtraUsageOff() throws {
+        let result = try decodeResult(
+            """
+            {
+              "config": {
+                "creditUsagePercent": 30,
+                "currentPeriod": {
+                  "type": "USAGE_PERIOD_TYPE_WEEKLY",
+                  "start": "2026-07-08T15:05:27Z",
+                  "end": "2026-07-15T15:05:27Z"
+                },
+                "onDemandCap": { "val": 0 },
+                "onDemandUsed": { "val": 0 },
+                "prepaidBalance": { "val": 0 },
+                "isUnifiedBillingUser": true
+              },
+              "subscription_tier": "X Premium"
+            }
+            """
+        )
+
+        let metrics = GrokCLIUsageService.map(result)
+
+        XCTAssertEqual(metrics.extraUsage?.state, .off)
+        XCTAssertNil(metrics.extraUsage?.detail)
+    }
+
+    func testMissingCreditFieldsMapsExtraUsageUnknown() throws {
+        let result = try decodeResult(
+            """
+            {
+              "config": {
+                "creditUsagePercent": 10,
+                "billingPeriodStart": "2026-07-08T15:05:27Z",
+                "billingPeriodEnd": "2026-07-15T15:05:27Z"
+              },
+              "subscription_tier": "Free"
+            }
+            """
+        )
+
+        let metrics = GrokCLIUsageService.map(result)
+
+        XCTAssertEqual(metrics.weeklyLimit?.used, 10)
+        XCTAssertNotNil(metrics.weeklyLimit?.resetTime)
+        XCTAssertEqual(metrics.extraUsage?.state, .unknown)
+    }
+
+    func testACPRequestSequenceUsesCachedLoginAndPrivateBillingMethod() throws {
+        let requests = GrokBillingRPC.requests(clientVersion: "1.2.3")
+
+        XCTAssertEqual(requests.map(\.id), [1, 2, 3])
+        XCTAssertEqual(requests.map(\.method), ["initialize", "authenticate", "_x.ai/billing"])
+        XCTAssertEqual(requests[1].stringParameter("methodId"), "cached_token")
+        XCTAssertEqual(requests[0].nestedStringParameter("clientInfo", key: "version"), "1.2.3")
+    }
+
+    private func decodeResult(_ json: String) throws -> GrokBillingResult {
+        try JSONDecoder().decode(GrokBillingResult.self, from: Data(json.utf8))
+    }
+}

--- a/MeterBarTests/MetricsFixtures.swift
+++ b/MeterBarTests/MetricsFixtures.swift
@@ -87,6 +87,20 @@ enum MetricsFixtures {
         )
     }
 
+    static func grok(weeklyUsedPercent: Double = 64) -> UsageMetrics {
+        UsageMetrics(
+            service: .grok,
+            weeklyLimit: UsageLimit(
+                used: weeklyUsedPercent,
+                total: 100,
+                resetTime: referenceDate.addingTimeInterval(7 * 24 * 3_600),
+                windowSeconds: 7 * 24 * 3_600
+            ),
+            extraUsage: ExtraUsageStatus(state: .on, detail: "$10.00 credits"),
+            lastUpdated: referenceDate
+        )
+    }
+
     /// One populated metric per provider, keyed by `ServiceType`.
     static func allProviders() -> [ServiceType: UsageMetrics] {
         [

--- a/MeterBarTests/ProviderReadinessTests.swift
+++ b/MeterBarTests/ProviderReadinessTests.swift
@@ -28,6 +28,22 @@ final class ProviderReadinessTests: XCTestCase {
         XCTAssertFalse(configured.isHealthy)
     }
 
+    func testGrokRequiresCLIAndCachedLogin() {
+        let missing = ProviderReadinessEvaluator.grok(
+            GrokReadinessInput(isCLIInstalled: false, authFileExists: false, authFileReadable: false)
+        )
+        XCTAssertEqual(missing.provider, .grok)
+        XCTAssertEqual(missing.check("installed")?.level, .fail)
+        XCTAssertEqual(missing.check("auth")?.level, .fail)
+        XCTAssertTrue((missing.check("auth")?.recovery ?? "").contains("grok login"))
+
+        let ready = ProviderReadinessEvaluator.grok(
+            GrokReadinessInput(isCLIInstalled: true, authFileExists: true, authFileReadable: true)
+        )
+        XCTAssertEqual(ready.overall, .pass)
+        XCTAssertEqual(ready.check("data")?.level, .pass)
+    }
+
     // MARK: - Claude Code
 
     func testClaudeHealthy() {

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -35,18 +35,19 @@ final class ProviderSnapshotTests: XCTestCase {
 
     // MARK: - Ordering and inclusion
 
-    func testDisplayOrderIsCodexClaudeCursorOpenRouter() {
+    func testDisplayOrderIsCodexClaudeCursorOpenRouterGrok() {
         let snapshots = ProviderSnapshotBuilder.snapshots(makeInput(
             metrics: [
                 .codexCli: makeMetrics(service: .codexCli, weekly: 10),
                 .claudeCode: makeMetrics(service: .claudeCode, weekly: 20),
                 .cursor: makeMetrics(service: .cursor, weekly: 30),
-                .openRouter: makeMetrics(service: .openRouter, weekly: 40)
+                .openRouter: makeMetrics(service: .openRouter, weekly: 40),
+                .grok: makeMetrics(service: .grok, weekly: 50)
             ]
         ))
 
-        XCTAssertEqual(snapshots.map(\.service), [.codexCli, .claudeCode, .cursor, .openRouter])
-        XCTAssertEqual(snapshots.map(\.title), ["Codex", "Claude", "Cursor", "OpenRouter"])
+        XCTAssertEqual(snapshots.map(\.service), [.codexCli, .claudeCode, .cursor, .openRouter, .grok])
+        XCTAssertEqual(snapshots.map(\.title), ["Codex", "Claude", "Cursor", "OpenRouter", "Grok"])
     }
 
     func testDisabledProvidersAreExcluded() {
@@ -63,8 +64,8 @@ final class ProviderSnapshotTests: XCTestCase {
             metrics: [.cursor: makeMetrics(service: .cursor, weekly: 30)]
         ))
 
-        // Popover shows all enabled providers (Codex/Claude/OpenRouter as empty-state cards)…
-        XCTAssertEqual(snapshots.count, 4)
+        // Popover shows all enabled providers (Codex/Claude/OpenRouter/Grok as empty-state cards)…
+        XCTAssertEqual(snapshots.count, 5)
         XCTAssertFalse(snapshots[0].hasMetrics)
         // …the dashboard filters to providers with data.
         XCTAssertEqual(snapshots.filter(\.hasMetrics).map(\.service), [.cursor])

--- a/MeterBarTests/ProviderStatusMonitorTests.swift
+++ b/MeterBarTests/ProviderStatusMonitorTests.swift
@@ -108,6 +108,7 @@ final class ProviderStatusMonitorTests: XCTestCase {
         XCTAssertEqual(ServiceType.codexCli.statusPageDisplayName, "OpenAI")
         XCTAssertEqual(ServiceType.cursor.statusPageDisplayName, "Cursor")
         XCTAssertEqual(ServiceType.openRouter.statusPageDisplayName, "OpenRouter")
+        XCTAssertEqual(ServiceType.grok.statusPageDisplayName, "Grok")
 
         XCTAssertEqual(try XCTUnwrap(ServiceType.claudeCode.statusPageURL).absoluteString, "https://status.claude.com/")
         XCTAssertEqual(try XCTUnwrap(ServiceType.codexCli.statusPageURL).absoluteString, "https://status.openai.com/")
@@ -116,6 +117,7 @@ final class ProviderStatusMonitorTests: XCTestCase {
             try XCTUnwrap(ServiceType.openRouter.statusPageURL).absoluteString,
             "https://status.openrouter.ai/"
         )
+        XCTAssertEqual(try XCTUnwrap(ServiceType.grok.statusPageURL).absoluteString, "https://status.x.ai/")
     }
 
     func testOpenRouterStatusPageMapsOperationalHTML() async throws {

--- a/MeterBarTests/ProviderVisibilityStoreTests.swift
+++ b/MeterBarTests/ProviderVisibilityStoreTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import MeterBar
 
 final class ProviderVisibilityStoreTests: XCTestCase {
-    func testOpenRouterRequiresExplicitOptInAndPersistsEnablement() {
+    func testOptInProvidersRequireExplicitEnablementAndPersistIt() {
         let suiteName = "ProviderVisibilityStoreTests-\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             return XCTFail("Could not create isolated defaults")
@@ -12,11 +12,14 @@ final class ProviderVisibilityStoreTests: XCTestCase {
 
         let initial = ProviderVisibilityStore(userDefaults: defaults)
         XCTAssertFalse(initial.isEnabled(.openRouter))
+        XCTAssertFalse(initial.isEnabled(.grok))
         XCTAssertTrue(initial.isEnabled(.claudeCode))
 
         initial.set(.openRouter, isEnabled: true)
+        initial.set(.grok, isEnabled: true)
         let reloaded = ProviderVisibilityStore(userDefaults: defaults)
 
         XCTAssertTrue(reloaded.isEnabled(.openRouter))
+        XCTAssertTrue(reloaded.isEnabled(.grok))
     }
 }

--- a/MeterBarTests/ServiceTypeTests.swift
+++ b/MeterBarTests/ServiceTypeTests.swift
@@ -8,6 +8,7 @@ final class ServiceTypeTests: XCTestCase {
         XCTAssertEqual(ServiceType.codexCli.rawValue, "Codex CLI")
         XCTAssertEqual(ServiceType.cursor.rawValue, "Cursor")
         XCTAssertEqual(ServiceType.openRouter.rawValue, "OpenRouter")
+        XCTAssertEqual(ServiceType.grok.rawValue, "Grok")
     }
 
     func testDisplayNames() {
@@ -15,6 +16,7 @@ final class ServiceTypeTests: XCTestCase {
         XCTAssertEqual(ServiceType.codexCli.displayName, "OpenAI Codex")
         XCTAssertEqual(ServiceType.cursor.displayName, "Cursor")
         XCTAssertEqual(ServiceType.openRouter.displayName, "OpenRouter")
+        XCTAssertEqual(ServiceType.grok.displayName, "Grok")
     }
 
     func testIconNames() {
@@ -22,6 +24,7 @@ final class ServiceTypeTests: XCTestCase {
         XCTAssertEqual(ServiceType.codexCli.iconName, "terminal.fill")
         XCTAssertEqual(ServiceType.cursor.iconName, "cursorarrow.click")
         XCTAssertEqual(ServiceType.openRouter.iconName, "point.3.connected.trianglepath.dotted")
+        XCTAssertEqual(ServiceType.grok.iconName, "bolt.fill")
     }
 
     func testIdProperty() {
@@ -29,10 +32,11 @@ final class ServiceTypeTests: XCTestCase {
         XCTAssertEqual(ServiceType.codexCli.id, "Codex CLI")
         XCTAssertEqual(ServiceType.cursor.id, "Cursor")
         XCTAssertEqual(ServiceType.openRouter.id, "OpenRouter")
+        XCTAssertEqual(ServiceType.grok.id, "Grok")
     }
 
     func testAllCasesCount() {
-        XCTAssertEqual(ServiceType.allCases.count, 4)
+        XCTAssertEqual(ServiceType.allCases.count, 5)
     }
 
     func testCodable() throws {

--- a/MeterBarTests/WidgetRenderingTests.swift
+++ b/MeterBarTests/WidgetRenderingTests.swift
@@ -95,12 +95,12 @@ final class WidgetRenderingTests: XCTestCase {
     }
 
     func testEachProviderRendersIndividually() {
-        // Claude Code, OpenAI Codex, and Cursor each render a populated row on
-        // their own (the acceptance criterion names all three providers).
+        // Every CLI-backed provider renders a populated row on its own.
         let cases: [(ServiceType, UsageMetrics)] = [
             (.claudeCode, MetricsFixtures.claudeCode()),
             (.codexCli, MetricsFixtures.codexCli()),
-            (.cursor, MetricsFixtures.cursor())
+            (.cursor, MetricsFixtures.cursor()),
+            (.grok, MetricsFixtures.grok())
         ]
         for (service, metrics) in cases {
             for family in WidgetFamily.allCases {

--- a/MeterBarWidget/UsageWidget.swift
+++ b/MeterBarWidget/UsageWidget.swift
@@ -143,10 +143,7 @@ struct ServiceMiniView: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            Image(row.metrics.service.assetName)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 14, height: 14)
+            WidgetProviderIcon(service: row.metrics.service, size: 14)
 
             Text(row.name)
                 .font(.caption2)
@@ -230,10 +227,7 @@ struct ServiceCompactView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
-                Image(row.metrics.service.assetName)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 18, height: 18)
+                WidgetProviderIcon(service: row.metrics.service, size: 18)
                 Text(row.name)
                     .font(.subheadline)
                     .bold()
@@ -341,7 +335,7 @@ struct WidgetProviderIcon: View {
     let size: CGFloat
 
     var body: some View {
-        if service == .openRouter {
+        if service == .openRouter || service == .grok {
             Image(systemName: service.iconName)
                 .font(.system(size: size, weight: .semibold))
                 .frame(width: size, height: size)

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
@@ -218,6 +218,28 @@ public struct OpenRouterReadinessInput: Sendable {
     }
 }
 
+/// Fixture-able facts for the Grok Build CLI-backed provider. The inspector
+/// checks only file existence/readability; credential contents stay private to
+/// the official CLI process.
+public struct GrokReadinessInput: Sendable {
+    public var isCLIInstalled: Bool
+    public var authFileExists: Bool
+    public var authFileReadable: Bool
+    public var refreshError: String?
+
+    public init(
+        isCLIInstalled: Bool,
+        authFileExists: Bool,
+        authFileReadable: Bool,
+        refreshError: String? = nil
+    ) {
+        self.isCLIInstalled = isCLIInstalled
+        self.authFileExists = authFileExists
+        self.authFileReadable = authFileReadable
+        self.refreshError = refreshError
+    }
+}
+
 // MARK: - Evaluator
 
 public enum ProviderReadinessEvaluator {
@@ -517,6 +539,43 @@ public enum ProviderReadinessEvaluator {
         )
         return ProviderReadiness(
             provider: .openRouter,
+            checks: [installed, auth, data, refreshCheck(input.refreshError)]
+        )
+    }
+
+    // MARK: Grok
+
+    public static func grok(_ input: GrokReadinessInput) -> ProviderReadiness {
+        let installed = ReadinessCheck(
+            id: ReadinessCheckID.installed,
+            title: "CLI installed",
+            level: input.isCLIInstalled ? .pass : .fail,
+            detail: input.isCLIInstalled ? "Grok Build CLI found on PATH." : "Grok Build CLI not found on PATH.",
+            recovery: input.isCLIInstalled ? nil : "Install Grok Build, then run `grok login`."
+        )
+        let authLevel: ReadinessLevel = input.authFileReadable ? .pass : .fail
+        let auth = ReadinessCheck(
+            id: ReadinessCheckID.auth,
+            title: "Signed in",
+            level: authLevel,
+            detail: input.authFileReadable
+                ? "A readable Grok Build cached login is available."
+                : input.authFileExists
+                    ? "Grok Build cached login exists but could not be read."
+                    : "Not signed in — no Grok Build cached login found.",
+            recovery: input.authFileReadable ? nil : "Run `grok login`."
+        )
+        let dataReady = input.isCLIInstalled && input.authFileReadable
+        let data = ReadinessCheck(
+            id: ReadinessCheckID.data,
+            title: "Usage readable",
+            level: dataReady ? .pass : .warn,
+            detail: dataReady
+                ? "Weekly usage is readable through the Grok Build ACP billing method."
+                : "Usage becomes readable once Grok Build is installed and signed in."
+        )
+        return ProviderReadiness(
+            provider: .grok,
             checks: [installed, auth, data, refreshCheck(input.refreshError)]
         )
     }

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ServiceType.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ServiceType.swift
@@ -8,6 +8,7 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
     case codexCli = "Codex CLI"
     case cursor = "Cursor"
     case openRouter = "OpenRouter"
+    case grok = "Grok"
 
     public var id: String { rawValue }
 
@@ -17,6 +18,7 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
         case .codexCli: return "OpenAI Codex"
         case .cursor: return "Cursor"
         case .openRouter: return "OpenRouter"
+        case .grok: return "Grok"
         }
     }
 
@@ -27,6 +29,7 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
         case .codexCli: return "terminal.fill"
         case .cursor: return "cursorarrow.click"
         case .openRouter: return "point.3.connected.trianglepath.dotted"
+        case .grok: return "bolt.fill"
         }
     }
 
@@ -38,6 +41,7 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
         case .codexCli: return "CodexIcon"
         case .cursor: return "CursorIcon"
         case .openRouter: return "OpenRouterIcon"
+        case .grok: return "GrokIcon"
         }
     }
 
@@ -48,6 +52,7 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
         case .codexCli: return 1
         case .cursor: return 2
         case .openRouter: return 3
+        case .grok: return 4
         }
     }
 }

--- a/Packages/MeterBarShared/Sources/MeterBarShared/UsageMetrics.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/UsageMetrics.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Whether paid "extra usage" / overage credits are enabled for a service.
 ///
-/// Both Claude Code ("extra usage") and Codex ("credits") let an account spend
+/// Claude Code and Grok ("extra usage") plus Codex ("credits") let an account spend
 /// beyond its subscription quota once exhausted. Surfacing this lets users confirm
 /// at a glance whether they can be billed for overage, or whether usage is hard-capped.
 public struct ExtraUsageStatus: Codable, Equatable, Sendable {

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 > **Note**: MeterBar is currently in active development. The app is not yet available on the Mac App Store but will be published soon. For now, you can build from source or download pre-built binaries from the Releases page.
 
-A lightweight macOS menu bar app that monitors Claude Code, Codex CLI, and Cursor usage at a glance.
+A lightweight macOS menu bar app that monitors Claude Code, Codex CLI, Cursor, OpenRouter, and Grok usage at a glance.
 
 ## Screenshots
 
@@ -39,8 +39,8 @@ A lightweight macOS menu bar app that monitors Claude Code, Codex CLI, and Curso
 
 - **Menu Bar App**: Quick access to usage data from your menu bar
 - **Widget Support**: macOS widget for at-a-glance monitoring
-- **Multi-Service Support**: Track Claude Code, Codex CLI, and Cursor
-- **Zero Configuration**: Automatically reads credentials from CLI tools (no API keys needed)
+- **Multi-Service Support**: Track Claude Code, Codex CLI, Cursor, OpenRouter, and Grok
+- **Zero Configuration for CLI Providers**: Reuses local CLI sign-ins without password entry
 - **Real-time Updates**: Background refresh every 15 minutes
 - **Pace-aware Bars**: Usage bars show quota left with an expected-pace marker and burn-rate projection
 - **Color-coded Status**: Green (healthy), Orange (tight), Red (critical/exhausted)
@@ -52,6 +52,8 @@ A lightweight macOS menu bar app that monitors Claude Code, Codex CLI, and Curso
 | **Claude Code** | Keychain OAuth token (`/api/oauth/usage`); CLI `/usage` fallback | 5h session, 7-day all models, 7-day Sonnet |
 | **Codex CLI** | OAuth token from `codex login` | 5h limit, weekly limit, code review |
 | **Cursor** | Local SQLite database | Monthly usage |
+| **OpenRouter** | User-provided API key stored in Keychain | Account credits, spend, per-key limits |
+| **Grok** | Cached `grok login` session, accessed by the official CLI | Weekly quota, reset time, extra credits |
 
 ## Installation
 
@@ -119,6 +121,13 @@ open MeterBar.xcodeproj
 1. Install and log into Cursor IDE
 2. The app automatically reads from Cursor's local database
 
+### Grok
+
+1. Install [Grok Build](https://x.ai/cli)
+2. Log in: `grok login`
+3. Enable Grok under **Settings → General → Tracked Providers**
+4. MeterBar asks the official CLI for billing data over ACP; it does not read or store the cached token
+
 ## Usage
 
 1. **Launch the app** - It appears in your menu bar with the tightest quota's percent left
@@ -151,7 +160,7 @@ meterbar usage
 # JSON output for scripts
 meterbar usage --json
 
-# Filter by provider (claude, codex, cursor)
+# Filter by provider (claude, codex, cursor, openrouter, grok)
 meterbar usage --provider claude
 
 # Show token costs from the app's last local scan
@@ -179,24 +188,26 @@ claude /usage            # Claude Code usage fallback (CLI output)
 ~/.claude/               # Claude Code account metadata and local sessions
 $CODEX_HOME/auth.json    # Codex CLI OAuth token (defaults to ~/.codex/auth.json)
 ~/Library/Application Support/Cursor/  # Cursor local DB
+~/.grok/auth.json        # Grok CLI login presence only; token contents stay inside the CLI
 ```
 
 It then uses the respective local source or API to fetch current usage data:
 - Claude Code (primary): `https://api.anthropic.com/api/oauth/usage`, using the `Claude Code-credentials` Keychain OAuth token
 - Codex: `https://chatgpt.com/backend-api/wham/usage`
+- Grok: official `grok agent --no-leader stdio` ACP billing response
 
 Claude Code usage reads the authenticated `/api/oauth/usage` endpoint — the same data Claude Code's own `/usage` screen shows — because `claude /usage` no longer renders in a headless (non-interactive) spawn. Parsing the CLI output is kept as a fallback and can be forced by turning off "Claude Code OAuth usage" in Settings.
 - Additional Claude accounts are tracked by running `claude /usage` with each account's configured `CLAUDE_CONFIG_DIR` (they have no Keychain token of their own).
 - Cursor: Local SQLite queries
 
-**No provider API keys are required for CLI-backed services** - the app uses the local Claude Code login and CLI/session data. The default Claude Code account's Keychain OAuth token is read to fetch usage (a one-time macOS Keychain prompt on first launch).
+**No provider API keys are required for CLI-backed services** - the app reuses local Claude Code, Codex, and Grok sign-ins. The default Claude Code account's Keychain OAuth token is read to fetch usage (a one-time macOS Keychain prompt on first launch); Grok authentication remains inside the official CLI process.
 
 ## Privacy & Security
 
 - All credentials remain in their original locations (managed by CLI tools)
 - No data sent to external servers (only calls to the providers' own usage endpoints)
 - The main app is **not** sandboxed — it must read other tools' credential/log files
-  (`~/.claude`, `~/.codex`, Cursor's local database) and run the `claude` binary. The
+  (`~/.claude`, `~/.codex`, Cursor's local database) and run the `claude` and `grok` binaries. The
   widget extension is sandboxed. Hardened runtime is enabled for both.
 - No analytics, telemetry, or crash reporting
 - Open source for full transparency
@@ -217,6 +228,7 @@ Make sure you're logged into the CLI tool:
 ```bash
 claude login   # For Claude Code
 codex login    # For Codex CLI
+grok login     # For Grok Build
 ```
 
 If the app still shows "Not Connected" or "Not configured", re-run the login command. MeterBar treats expired local OAuth tokens as disconnected so it does not keep making failing usage requests.
@@ -227,7 +239,7 @@ Run `codex logout && codex login` and select your team workspace when prompted.
 
 ### App can't read credentials
 
-The app reads CLI credential files from `$CODEX_HOME/auth.json` (`~/.codex/auth.json` by default) and Cursor's local database. If you built from source with App Sandbox enabled, those reads will fail — the shipped configuration keeps the main app un-sandboxed for this reason.
+The app reads CLI credential files from `$CODEX_HOME/auth.json` (`~/.codex/auth.json` by default), checks for the Grok CLI login, and reads Cursor's local database. If you built from source with App Sandbox enabled, those accesses will fail — the shipped configuration keeps the main app un-sandboxed for this reason.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- add an opt-in Grok Build provider backed by the official CLI ACP billing response
- map weekly quota, reset timing, prepaid credits, and on-demand limits into shared MeterBar metrics
- wire popover, dashboard, widget, CLI, notifications, parse-health, and doctor diagnostics
- keep Grok authentication inside the CLI with no password/API-key entry or token-file parsing

## Verification
- GitHub Actions tests + coverage gate — passed
- GitHub Actions SwiftLint — passed
- GitHub Actions Debug/Release app + widget, universal CLI, and bundle verification — passed
- GitHub Actions secret scan — passed
- `swiftlint lint --strict --quiet` — passed locally
- `git diff --check` — passed locally
- SwiftFormat unavailable locally

## Residual risk
- the Grok ACP billing extension is provider-owned but not part of the public stable ACP surface; parse-health diagnostics will flag response-shape drift

Closes #135
