### PR TITLE
feat(session-wake): persist watcher after app quit

### DIFF
--- a/.agents/SESSIONS/2026-07-14.md
+++ b/.agents/SESSIONS/2026-07-14.md
@@ -47,3 +47,34 @@ Claude Code ▸ "Claude Code OAuth usage" (dev builds re-prompt per rebuild).
 `WakeQuotaAuthority`/`LiveWakeQuotaProvider` still call the raw CLI service; the
 session-wake default-account quota gate would also benefit from OAuth, but needs a
 **side-effect-free** OAuth fetch to avoid coupling UI `@Published` state into wake decisions.
+
+---
+
+# 2026-07-14 (pt 2) — Session Wake managed background persistence (#133)
+
+## Implementation
+
+- Added an `SMAppService.agent` launch agent backed by the already-bundled
+  `Contents/Helpers/meterbar wake-agent` executable; no second wake engine or
+  helper target.
+- Added versioned app-group configuration plus metadata-only status/heartbeat
+  so the agent survives GUI quit and Settings can show the live background state.
+- Moved continuous app/agent ownership onto the existing `wake.lock` for the
+  watcher lifetime. One-shot CLI runs still use the same lock, so app, agent,
+  and CLI cannot run concurrently.
+- Disarm and master-feature-off update the shared agent configuration
+  synchronously before ServiceManagement unregisters, then cooperatively cancel
+  the coordinator and any active child.
+- Added launchd lifecycle packaging/verification, completion notifications from
+  the agent, Login Items approval UI, ADR-011, and migration/architecture updates.
+
+## Tests and verification
+
+- Added `SessionWakeAgentTests` for configuration/status round trips,
+  fail-closed bypass, synchronous disarm, restart-sensitive configuration, and
+  lifetime-lock contention.
+- Extended `SessionWakeControllerTests` for agent registration, no duplicate
+  in-app watcher, shared armed state, and unregister-on-disarm.
+- `swiftlint lint --strict`, plist validation, shell syntax, and diff whitespace
+  checks pass locally. Builds/tests intentionally deferred to PR CI per the
+  MacBook verification rule.

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -81,6 +81,7 @@ meterbar/
 - **ServiceSupport** — shared URLSession config, secret-safe HTTP/URLError mapping, real (non-container) home dir via `getpwuid`.
 - **AppLog** — `os.Logger` categories: app, usage, cost, network, storage. This is the only observability; there is no crash reporting or analytics.
 - **SoftwareUpdateController** — owns Sparkle 2's standard updater. The General settings pane binds directly to Sparkle's automatic-check preference (default off until consent) and exposes a manual check action. Release builds embed the GitHub Releases appcast URL and an Actions-provided EdDSA public key.
+- **SessionWakeController + managed agent** — signed release bundles register `Contents/Helpers/meterbar wake-agent` through `SMAppService.agent`. The launch agent owns the shared wake lock for its lifetime, reads versioned configuration/status through the app group, and keeps the native coordinator alive after the GUI quits. Debug builds without the injected CLI retain the in-process fallback.
 
 ## App lifecycle
 

--- a/.agents/SYSTEM/architecture/DECISIONS.md
+++ b/.agents/SYSTEM/architecture/DECISIONS.md
@@ -372,4 +372,57 @@ teardown) while a child session is running:
 
 ---
 
+### ADR-011: Managed Session Wake launch agent (v1.8)
+
+**Date:** 2026-07-14
+**Status:** Accepted
+**Issue:** #133
+
+#### Context
+
+ADR-010 deliberately kept Session Wake inside the GUI for v1, so quitting
+MeterBar also stopped overnight reset handling. The safety-critical discovery,
+fresh-quota gate, replay ledger, bounded runner, and advisory lock are now
+shared native code and the release is Developer ID signed/notarized. The next
+step is persistence without reviving the retired Python/shell watcher.
+
+#### Decision
+
+Register a per-user `SMAppService` launch agent whose plist lives at
+`Contents/Library/LaunchAgents/dev.meterbar.app.session-wake.plist`. The agent
+runs the already-bundled, already-signed `Contents/Helpers/meterbar wake-agent`
+entry point; there is no second engine or helper target.
+
+- The app writes a versioned configuration snapshot and metadata-only live
+  status/heartbeat through the existing app-group domain. Turning Session Wake
+  off writes `isArmed = false` before unregistering, so cancellation does not
+  depend solely on ServiceManagement succeeding.
+- The agent owns the existing `wake.lock` for its full lifetime. Development
+  builds without the embedded CLI retain the in-app watcher, which takes the
+  same lifetime lock. One-shot CLI work probes the same lock, making app,
+  launch agent, and CLI mutually exclusive.
+- The agent recreates the provider runtime from fresh shared configuration for
+  every scan. Every launch still goes through the existing fresh quota gate,
+  cwd revalidation, bounded runner, and replay ledger. Sleep overshoot only
+  delays a fresh quota check; it never authorizes a launch.
+- `SIGTERM`, the shared armed flag, or feature kill-switch cancels the
+  coordinator and active child cooperatively before releasing the lifetime
+  lock. `launchd` restarts unexpected non-zero exits and bootstraps the agent on
+  subsequent logins; a deliberate disarm exits successfully and unregisters.
+- Completion banners are emitted by the agent using metadata-only summary copy,
+  so notification delivery does not depend on the GUI process being alive.
+
+#### Consequences
+
+- **Easier:** overnight wake survives GUI quit, crash recovery, sleep/wake, and
+  logout/login without installing files outside the signed app bundle.
+- **Easier:** the same lock and native engine enforce one automation owner and
+  preserve every existing fail-closed invariant.
+- **More difficult:** first registration can require approval in System
+  Settings › General › Login Items; Settings surfaces that state explicitly.
+- **More difficult:** debug builds use the in-process fallback because CI injects
+  the universal CLI after the Xcode app build.
+
+---
+
 <!-- Add new ADRs above this line -->

--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
+				Resources/dev.meterbar.app.session-wake.plist,
 			);
 			target = 52CFA4FF2F0323EF0036036C /* MeterBar */;
 		};
@@ -166,6 +167,7 @@
 				52CFA4FC2F0323EF0036036C /* Sources */,
 				52CFA4FD2F0323EF0036036C /* Frameworks */,
 				52CFA4FE2F0323EF0036036C /* Resources */,
+				52B0A0012F1400010036036C /* Embed Session Wake Launch Agent */,
 				5259E4542F032E78001001CF /* Embed Foundation Extensions */,
 			);
 			buildRules = (
@@ -243,6 +245,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		52B0A0012F1400010036036C /* Embed Session Wake Launch Agent */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 0;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/MeterBar/Resources/dev.meterbar.app.session-wake.plist",
+			);
+			name = "Embed Session Wake Launch Agent";
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(CONTENTS_FOLDER_PATH)/Library/LaunchAgents/dev.meterbar.app.session-wake.plist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\nsource_plist=\"${SRCROOT}/MeterBar/Resources/dev.meterbar.app.session-wake.plist\"\ndestination_dir=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Library/LaunchAgents\"\n/bin/mkdir -p \"${destination_dir}\"\n/bin/cp \"${source_plist}\" \"${destination_dir}/dev.meterbar.app.session-wake.plist\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		5259E4392F032E77001001CF /* Sources */ = {

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -100,9 +100,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             // Bring the Session Wake watcher online: it re-arms if the toggle was
             // left on and starts/stops as the user flips it.
             SessionWakeController.shared.activate()
-            // Surface a banner when a wake run finishes (gated by the global,
-            // provider, and Session Wake notification switches).
-            observeSessionWakeCompletion()
+            // The managed agent owns completion banners while it is available,
+            // including when the GUI is quit. Development builds without the
+            // embedded helper retain the in-app notification observer.
+            if !SessionWakeController.shared.usesBackgroundAgent {
+                observeSessionWakeCompletion()
+            }
         }
 
         // Setup notifications (also handles initial data refresh)

--- a/MeterBar/Resources/dev.meterbar.app.session-wake.plist
+++ b/MeterBar/Resources/dev.meterbar.app.session-wake.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>dev.meterbar.app.session-wake</string>
+    <key>BundleProgram</key>
+    <string>Contents/Helpers/meterbar</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>meterbar</string>
+        <string>wake-agent</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+</dict>
+</plist>

--- a/MeterBar/SessionWake/CodexWakeProcessRunner.swift
+++ b/MeterBar/SessionWake/CodexWakeProcessRunner.swift
@@ -18,6 +18,7 @@ nonisolated struct CodexWakeProcessRunner: WakeExecuting {
     let account: CodexAccount
     private let baseEnvironment: [String: String]
     private let lockFactory: @Sendable () -> WakeLock
+    private let lockMode: WakeExecutionLockMode
     private let logger: WakeRunLogger
     private let now: @Sendable () -> Date
 
@@ -29,6 +30,7 @@ nonisolated struct CodexWakeProcessRunner: WakeExecuting {
         prompt: String = WakeCommandBuilder.defaultPrompt,
         baseEnvironment: [String: String] = ProcessInfo.processInfo.environment,
         lockFactory: @escaping @Sendable () -> WakeLock = { WakeLock() },
+        lockMode: WakeExecutionLockMode = .acquirePerRun,
         logger: WakeRunLogger = WakeRunLogger(),
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
@@ -39,6 +41,7 @@ nonisolated struct CodexWakeProcessRunner: WakeExecuting {
         self.prompt = prompt
         self.baseEnvironment = baseEnvironment
         self.lockFactory = lockFactory
+        self.lockMode = lockMode
         self.logger = logger
         self.now = now
     }
@@ -55,25 +58,27 @@ nonisolated struct CodexWakeProcessRunner: WakeExecuting {
             return .failed(reason: "codex binary not found")
         }
 
-        let lock = lockFactory()
-        switch lock.acquire() {
-        case .acquired:
-            break
-        case let .contended(holder):
-            let suffix = holder.map { " (\($0.shortDescription))" } ?? ""
-            let outcome = WakeRunOutcome.failed(reason: "another Session Wake holder is active\(suffix)")
-            record(candidate: candidate, outcome: outcome, result: nil, start: now())
-            return outcome
-        case let .legacyHeld(guidance):
-            let outcome = WakeRunOutcome.failed(reason: guidance)
-            record(candidate: candidate, outcome: outcome, result: nil, start: now())
-            return outcome
-        case let .unavailable(reason):
-            let outcome = WakeRunOutcome.failed(reason: "wake lock unavailable: \(reason)")
-            record(candidate: candidate, outcome: outcome, result: nil, start: now())
-            return outcome
+        let lock = lockMode == .acquirePerRun ? lockFactory() : nil
+        if let lock {
+            switch lock.acquire() {
+            case .acquired:
+                break
+            case let .contended(holder):
+                let suffix = holder.map { " (\($0.shortDescription))" } ?? ""
+                let outcome = WakeRunOutcome.failed(reason: "another Session Wake holder is active\(suffix)")
+                record(candidate: candidate, outcome: outcome, result: nil, start: now())
+                return outcome
+            case let .legacyHeld(guidance):
+                let outcome = WakeRunOutcome.failed(reason: guidance)
+                record(candidate: candidate, outcome: outcome, result: nil, start: now())
+                return outcome
+            case let .unavailable(reason):
+                let outcome = WakeRunOutcome.failed(reason: "wake lock unavailable: \(reason)")
+                record(candidate: candidate, outcome: outcome, result: nil, start: now())
+                return outcome
+            }
         }
-        defer { lock.release() }
+        defer { lock?.release() }
 
         let command = CodexWakeCommandBuilder.build(
             executable: resolved,

--- a/MeterBar/SessionWake/SessionWakeAgent.swift
+++ b/MeterBar/SessionWake/SessionWakeAgent.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+/// Long-lived worker executed by the managed launch agent through the bundled
+/// `meterbar wake-agent` command. One process-lifetime lock excludes the GUI's
+/// fallback watcher and every one-shot CLI run; each launch still revalidates
+/// its cwd and proves fresh quota through the existing coordinator/runtime.
+public enum SessionWakeAgent {
+    public static func run(shouldCancel: @escaping @Sendable () -> Bool) async -> Int32 {
+        let stateStore = SessionWakeAgentStateStore()
+        let lock = WakeLock(holderKind: .agent)
+
+        switch lock.acquire() {
+        case .acquired:
+            break
+        case let .contended(holder):
+            let suffix = holder.map { " (\($0.shortDescription))" } ?? ""
+            stateStore.saveStatus(.init(state: .failed(reason: "Another Session Wake holder is active\(suffix).")))
+            return 75
+        case let .legacyHeld(guidance):
+            stateStore.saveStatus(.init(state: .failed(reason: guidance)))
+            return 75
+        case let .unavailable(reason):
+            stateStore.saveStatus(.init(state: .failed(reason: "Wake lock unavailable: \(reason)")))
+            return 75
+        }
+        defer {
+            stateStore.saveStatus(.init(state: .off))
+            lock.release()
+        }
+
+        while !shouldCancel() {
+            guard let configuration = stateStore.loadConfiguration(), configuration.canRun else {
+                return 0
+            }
+
+            let runtime = makeRuntime(configuration: configuration)
+            let coordinator = WakeCoordinator(
+                runner: runtime.makeRunner(),
+                bounds: configuration.bounds,
+                onState: { state in
+                    stateStore.saveStatus(.init(state: state))
+                }
+            )
+
+            let completed = await runPass(
+                coordinator: coordinator,
+                runtime: runtime,
+                configuration: configuration,
+                stateStore: stateStore,
+                shouldCancel: shouldCancel
+            )
+            if !completed {
+                if !shouldCancel(), stateStore.loadConfiguration()?.canRun == true {
+                    continue
+                }
+                return 0
+            }
+
+            if let latestConfiguration = stateStore.loadConfiguration(),
+               let status = stateStore.loadStatus(),
+               case let .completed(summary) = status.watcherState,
+               latestConfiguration.notifyOnCompletion {
+                postCompletionNotification(summary: summary, provider: latestConfiguration.provider)
+            }
+
+            guard await waitForRescan(
+                seconds: 300,
+                stateStore: stateStore,
+                shouldCancel: shouldCancel
+            ) else { return 0 }
+        }
+        return 0
+    }
+
+    private static func makeRuntime(configuration: SessionWakeAgentConfiguration) -> WakeProviderRuntime {
+        switch configuration.provider {
+        case .claude:
+            let account = ClaudeCodeAccount(
+                id: UUID(),
+                name: "background",
+                configDirectory: configuration.accountDirectory
+            )
+            return ClaudeWakeRuntime(account: account) { runnerAccount in
+                WakeProcessRunner(
+                    account: runnerAccount,
+                    permissionMode: configuration.permissionMode,
+                    bypassAcknowledged: configuration.bypassAcknowledged,
+                    prompt: configuration.prompt,
+                    lockMode: .externallyOwned
+                )
+            }
+        case .codex:
+            let account = CodexAccount(
+                id: UUID(),
+                name: "background",
+                homeDirectory: configuration.accountDirectory
+            )
+            return CodexWakeRuntime(account: account) { runnerAccount in
+                CodexWakeProcessRunner(
+                    account: runnerAccount,
+                    permissionMode: configuration.permissionMode,
+                    bypassAcknowledged: configuration.bypassAcknowledged,
+                    prompt: configuration.prompt,
+                    lockMode: .externallyOwned
+                )
+            }
+        }
+    }
+
+    /// Race one coordinator pass against disarm, app unregister, or SIGTERM.
+    /// The monitor also refreshes the heartbeat so the reopened app can
+    /// distinguish a live waiting worker from stale state after a crash.
+    private static func runPass(
+        coordinator: WakeCoordinator,
+        runtime: WakeProviderRuntime,
+        configuration: SessionWakeAgentConfiguration,
+        stateStore: SessionWakeAgentStateStore,
+        shouldCancel: @escaping @Sendable () -> Bool
+    ) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                await coordinator.start(runtime: runtime)
+                await coordinator.waitUntilFinished()
+                return true
+            }
+            group.addTask {
+                while !Task.isCancelled {
+                    guard let latest = stateStore.loadConfiguration(), latest.canRun else {
+                        return false
+                    }
+                    if shouldCancel() || latest.requiresRuntimeRestart(comparedTo: configuration) { return false }
+                    stateStore.refreshHeartbeat()
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                }
+                return false
+            }
+
+            let completed = await group.next() ?? false
+            if !completed {
+                await coordinator.stop()
+                await coordinator.waitUntilFinished()
+            }
+            group.cancelAll()
+            return completed
+        }
+    }
+
+    private static func waitForRescan(
+        seconds: TimeInterval,
+        stateStore: SessionWakeAgentStateStore,
+        shouldCancel: @escaping @Sendable () -> Bool
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline {
+            if shouldCancel() || stateStore.loadConfiguration()?.canRun != true { return false }
+            stateStore.refreshHeartbeat()
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+        }
+        return true
+    }
+
+    /// A launch-agent executable has no independent app UI. Use a direct
+    /// `osascript` process (argument array, never a shell) for the completion
+    /// banner so delivery still works while MeterBar itself is quit.
+    private static func postCompletionNotification(summary: WakeRunSummary, provider: WakeProvider) {
+        let attempted = summary.attempted
+        guard attempted > 0 || summary.remaining > 0 else { return }
+
+        var body = "Resumed \(summary.resumed) of \(attempted) \(provider.displayName) sessions."
+        if summary.failed > 0 { body += " \(summary.failed) failed." }
+        if summary.remaining > 0 { body += " \(summary.remaining) still queued." }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = [
+            "-e",
+            "display notification \"\(appleScriptEscaped(body))\" with title \"Session Wake — Run Complete\""
+        ]
+        try? process.run()
+    }
+
+    private static func appleScriptEscaped(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}

--- a/MeterBar/SessionWake/SessionWakeAgentService.swift
+++ b/MeterBar/SessionWake/SessionWakeAgentService.swift
@@ -1,0 +1,58 @@
+import Foundation
+import ServiceManagement
+
+enum SessionWakeAgentRegistrationStatus: Equatable, Sendable {
+    case enabled
+    case notRegistered
+    case requiresApproval
+    case notFound
+    case unknown
+}
+
+/// ServiceManagement seam for the managed launch agent. The concrete service
+/// points at the plist embedded in MeterBar.app; controller tests use a fake so
+/// they never mutate the user's login-item database.
+protocol SessionWakeAgentControlling {
+    var isAvailable: Bool { get }
+    func currentStatus() -> SessionWakeAgentRegistrationStatus
+    func register() throws
+    func unregister() throws
+}
+
+struct SMAppServiceSessionWakeAgent: SessionWakeAgentControlling {
+    static let plistName = "dev.meterbar.app.session-wake.plist"
+
+    private var service: SMAppService {
+        SMAppService.agent(plistName: Self.plistName)
+    }
+
+    var isAvailable: Bool {
+        let contents = Bundle.main.bundleURL.appendingPathComponent("Contents", isDirectory: true)
+        let executable = contents.appendingPathComponent("Helpers/meterbar")
+        let plist = contents.appendingPathComponent("Library/LaunchAgents/\(Self.plistName)")
+        return FileManager.default.isExecutableFile(atPath: executable.path)
+            && FileManager.default.fileExists(atPath: plist.path)
+    }
+
+    func currentStatus() -> SessionWakeAgentRegistrationStatus {
+        switch service.status {
+        case .enabled: return .enabled
+        case .notRegistered: return .notRegistered
+        case .requiresApproval: return .requiresApproval
+        case .notFound: return .notFound
+        @unknown default: return .unknown
+        }
+    }
+
+    func register() throws {
+        try service.register()
+    }
+
+    func unregister() throws {
+        try service.unregister()
+    }
+
+    static func openSystemSettings() {
+        SMAppService.openSystemSettingsLoginItems()
+    }
+}

--- a/MeterBar/SessionWake/SessionWakeAgentState.swift
+++ b/MeterBar/SessionWake/SessionWakeAgentState.swift
@@ -1,0 +1,243 @@
+import Darwin
+import Foundation
+import MeterBarShared
+
+/// Durable configuration handed from the GUI to the managed Session Wake
+/// launch agent. The agent reads a fresh snapshot before every scan, so changing
+/// the kill switch, account, permission posture, or bounds never relies on an
+/// already-running app process.
+nonisolated struct SessionWakeAgentConfiguration: Codable, Equatable, Sendable {
+    let featureEnabled: Bool
+    let isArmed: Bool
+    let provider: WakeProvider
+    let accountDirectory: String?
+    let permissionMode: WakePermissionMode
+    let bypassAcknowledged: Bool
+    let prompt: String
+    let notifyOnCompletion: Bool
+    let maxSessionsPerRun: Int
+    let maxTurns: Int
+
+    var canRun: Bool {
+        featureEnabled
+            && isArmed
+            && (permissionMode == .safe || bypassAcknowledged)
+    }
+
+    var bounds: WakeBounds {
+        WakeBounds(
+            pollInterval: WakeBounds.default.pollInterval,
+            bufferAfterReset: WakeBounds.default.bufferAfterReset,
+            gapBetweenSessions: WakeBounds.default.gapBetweenSessions,
+            perSessionTimeout: WakeBounds.default.perSessionTimeout,
+            maxTurns: maxTurns,
+            maxSessionsPerRun: maxSessionsPerRun,
+            maxUnknownPolls: WakeBounds.default.maxUnknownPolls
+        )
+    }
+
+    func withControlFlags(featureEnabled: Bool, isArmed: Bool) -> Self {
+        Self(
+            featureEnabled: featureEnabled,
+            isArmed: isArmed,
+            provider: provider,
+            accountDirectory: accountDirectory,
+            permissionMode: permissionMode,
+            bypassAcknowledged: bypassAcknowledged,
+            prompt: prompt,
+            notifyOnCompletion: notifyOnCompletion,
+            maxSessionsPerRun: maxSessionsPerRun,
+            maxTurns: maxTurns
+        )
+    }
+
+    func requiresRuntimeRestart(comparedTo other: Self) -> Bool {
+        provider != other.provider
+            || accountDirectory != other.accountDirectory
+            || permissionMode != other.permissionMode
+            || bypassAcknowledged != other.bypassAcknowledged
+            || prompt != other.prompt
+            || maxSessionsPerRun != other.maxSessionsPerRun
+            || maxTurns != other.maxTurns
+    }
+}
+
+/// Codable representation of the associated-value watcher state. It is kept
+/// intentionally metadata-only: no prompt, transcript, command output, or
+/// credential material crosses the process boundary.
+nonisolated struct SessionWakeAgentStatusRecord: Codable, Equatable, Sendable {
+    enum Phase: String, Codable, Equatable, Sendable {
+        case off
+        case idle
+        case scanning
+        case waiting
+        case quotaUnknown
+        case running
+        case stopping
+        case completed
+        case failed
+    }
+
+    let phase: Phase
+    let processID: Int32
+    let heartbeat: Date
+    let resetTime: Date?
+    let sessionID: String?
+    let reason: String?
+    let summary: WakeRunSummaryRecord?
+
+    init(
+        state: WakeWatcherState,
+        processID: Int32 = getpid(),
+        heartbeat: Date = Date()
+    ) {
+        self.processID = processID
+        self.heartbeat = heartbeat
+        resetTime = state.resetTime
+        sessionID = state.sessionID
+        reason = state.failureReason
+        summary = state.summary.map(WakeRunSummaryRecord.init)
+        phase = state.agentPhase
+    }
+
+    func refreshingHeartbeat(at date: Date = Date()) -> Self {
+        Self(
+            phase: phase,
+            processID: processID,
+            heartbeat: date,
+            resetTime: resetTime,
+            sessionID: sessionID,
+            reason: reason,
+            summary: summary
+        )
+    }
+
+    var watcherState: WakeWatcherState {
+        switch phase {
+        case .off: return .off
+        case .idle: return .idle
+        case .scanning: return .scanning
+        case .waiting: return .waiting(until: resetTime)
+        case .quotaUnknown: return .quotaUnknown(reason: reason ?? "Fresh quota unavailable")
+        case .running: return .running(sessionID: sessionID ?? "unknown")
+        case .stopping: return .stopping
+        case .completed: return .completed(summary: summary?.wakeSummary ?? WakeRunSummary())
+        case .failed: return .failed(reason: reason ?? "Background watcher failed")
+        }
+    }
+
+    private init(
+        phase: Phase,
+        processID: Int32,
+        heartbeat: Date,
+        resetTime: Date?,
+        sessionID: String?,
+        reason: String?,
+        summary: WakeRunSummaryRecord?
+    ) {
+        self.phase = phase
+        self.processID = processID
+        self.heartbeat = heartbeat
+        self.resetTime = resetTime
+        self.sessionID = sessionID
+        self.reason = reason
+        self.summary = summary
+    }
+}
+
+nonisolated struct WakeRunSummaryRecord: Codable, Equatable, Sendable {
+    let resumed: Int
+    let failed: Int
+    let skipped: Int
+    let remaining: Int
+
+    init(_ summary: WakeRunSummary) {
+        resumed = summary.resumed
+        failed = summary.failed
+        skipped = summary.skipped
+        remaining = summary.remaining
+    }
+
+    var wakeSummary: WakeRunSummary {
+        WakeRunSummary(resumed: resumed, failed: failed, skipped: skipped, remaining: remaining)
+    }
+}
+
+/// App-group-backed process boundary for agent configuration and live status.
+/// UserDefaults is thread-safe; instances are immutable wrappers around one
+/// suite and therefore safe to use from the agent's background tasks.
+nonisolated final class SessionWakeAgentStateStore: @unchecked Sendable {
+    static let configurationKey = "SessionWakeAgentConfigurationV1"
+    static let statusKey = "SessionWakeAgentStatusV1"
+
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults? = nil) {
+        self.userDefaults = userDefaults
+            ?? UserDefaults(suiteName: SharedMetricsStore.appGroupIdentifier)
+            ?? .standard
+    }
+
+    func saveConfiguration(_ configuration: SessionWakeAgentConfiguration) {
+        guard let data = try? JSONEncoder().encode(configuration) else { return }
+        userDefaults.set(data, forKey: Self.configurationKey)
+    }
+
+    func loadConfiguration() -> SessionWakeAgentConfiguration? {
+        guard let data = userDefaults.data(forKey: Self.configurationKey) else { return nil }
+        return try? JSONDecoder().decode(SessionWakeAgentConfiguration.self, from: data)
+    }
+
+    func saveStatus(_ status: SessionWakeAgentStatusRecord) {
+        guard let data = try? JSONEncoder().encode(status) else { return }
+        userDefaults.set(data, forKey: Self.statusKey)
+    }
+
+    func loadStatus() -> SessionWakeAgentStatusRecord? {
+        guard let data = userDefaults.data(forKey: Self.statusKey) else { return nil }
+        return try? JSONDecoder().decode(SessionWakeAgentStatusRecord.self, from: data)
+    }
+
+    func refreshHeartbeat(at date: Date = Date()) {
+        guard let status = loadStatus() else { return }
+        saveStatus(status.refreshingHeartbeat(at: date))
+    }
+}
+
+nonisolated private extension WakeWatcherState {
+    var agentPhase: SessionWakeAgentStatusRecord.Phase {
+        switch self {
+        case .off: return .off
+        case .idle: return .idle
+        case .scanning: return .scanning
+        case .waiting: return .waiting
+        case .quotaUnknown: return .quotaUnknown
+        case .running: return .running
+        case .stopping: return .stopping
+        case .completed: return .completed
+        case .failed: return .failed
+        }
+    }
+
+    var resetTime: Date? {
+        guard case let .waiting(until) = self else { return nil }
+        return until
+    }
+
+    var sessionID: String? {
+        guard case let .running(sessionID) = self else { return nil }
+        return sessionID
+    }
+
+    var failureReason: String? {
+        switch self {
+        case let .quotaUnknown(reason), let .failed(reason): return reason
+        default: return nil
+        }
+    }
+
+    var summary: WakeRunSummary? {
+        guard case let .completed(summary) = self else { return nil }
+        return summary
+    }
+}

--- a/MeterBar/SessionWake/SessionWakeController.swift
+++ b/MeterBar/SessionWake/SessionWakeController.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import MeterBarShared
 
 /// The lifecycle abstraction the controller drives. `WakeCoordinator` is the
 /// production conformer; tests substitute a fake to assert start/stop without

--- a/MeterBar/SessionWake/SessionWakeController.swift
+++ b/MeterBar/SessionWake/SessionWakeController.swift
@@ -21,13 +21,11 @@ typealias WakeWatcherFactory = @Sendable (
 
 /// Bridges the single ON/OFF toggle to a live, continuous watcher.
 ///
-/// While `isOn`, it runs a `WakeCoordinator` pass (scan → wait for quota →
-/// resume), and when a pass settles it re-scans after `rescanInterval` so the
-/// watcher keeps watching for the *next* time a session hits its limit — rather
-/// than stopping after one resume. Turning the toggle off, or removing the wake
-/// account, tears the watcher down deterministically. v1 lifetime is
-/// app-running-only: the watcher lives with the process and re-arms on launch
-/// if the toggle was left on.
+/// Signed release bundles register the embedded `meterbar wake-agent` launch
+/// agent so the watcher survives app quit and relaunch. Development/SwiftPM
+/// builds do not contain that helper and retain the in-process watcher as a
+/// deterministic fallback. Both modes hold the same lifetime lock, so app,
+/// agent, and one-shot CLI work are mutually exclusive.
 @MainActor
 final class SessionWakeController: ObservableObject {
     static let shared = SessionWakeController()
@@ -35,11 +33,18 @@ final class SessionWakeController: ObservableObject {
     private let store: SessionWakeSettingsStore
     private let status: SessionWakeStatus
     private let accounts: ClaudeCodeAccountStore
+    private let notificationPreferences: NotificationPreferencesStore
+    private let providerVisibility: ProviderVisibilityStore
+    private let agent: SessionWakeAgentControlling
+    private let agentStateStore: SessionWakeAgentStateStore
     private let rescanInterval: TimeInterval
     private let makeWatcher: WakeWatcherFactory
+    private let makeLifetimeLock: @Sendable () -> WakeLock
 
     private var cancellables = Set<AnyCancellable>()
     private var watchTask: Task<Void, Never>?
+    private var localLifetimeLock: WakeLock?
+    private var agentMonitorTask: Task<Void, Never>?
     private var started = false
 
     /// The store defaults are `nil` sentinels resolved in the body because the
@@ -49,16 +54,26 @@ final class SessionWakeController: ObservableObject {
         store: SessionWakeSettingsStore? = nil,
         status: SessionWakeStatus? = nil,
         accounts: ClaudeCodeAccountStore? = nil,
+        notificationPreferences: NotificationPreferencesStore? = nil,
+        providerVisibility: ProviderVisibilityStore? = nil,
+        agent: SessionWakeAgentControlling? = nil,
+        agentStateStore: SessionWakeAgentStateStore? = nil,
         rescanInterval: TimeInterval = 300,
         makeWatcher: @escaping WakeWatcherFactory = { runner, bounds, onState in
             WakeCoordinator(runner: runner, bounds: bounds, onState: onState)
-        }
+        },
+        makeLifetimeLock: @escaping @Sendable () -> WakeLock = { WakeLock(holderKind: .app) }
     ) {
         self.store = store ?? .shared
         self.status = status ?? .shared
         self.accounts = accounts ?? .shared
+        self.notificationPreferences = notificationPreferences ?? .shared
+        self.providerVisibility = providerVisibility ?? .shared
+        self.agent = agent ?? SMAppServiceSessionWakeAgent()
+        self.agentStateStore = agentStateStore ?? SessionWakeAgentStateStore()
         self.rescanInterval = rescanInterval
         self.makeWatcher = makeWatcher
+        self.makeLifetimeLock = makeLifetimeLock
     }
 
     /// Begin observing the toggle and re-arm if it was left on. Idempotent;
@@ -70,15 +85,28 @@ final class SessionWakeController: ObservableObject {
         // Any change that affects whether/where we should watch triggers a
         // reconcile: the toggle, the selected account, the permission posture,
         // and the account list (a removed account disarms via the store).
-        Publishers.Merge4(
-            store.$isOn.map { _ in () },
-            store.$wakeAccountID.map { _ in () },
-            store.$permissionMode.map { _ in () },
-            store.$bypassAcknowledged.map { _ in () }
-        )
+        Publishers.MergeMany([
+            store.$featureEnabled.map { _ in () }.eraseToAnyPublisher(),
+            store.$isOn.map { _ in () }.eraseToAnyPublisher(),
+            store.$wakeAccountID.map { _ in () }.eraseToAnyPublisher(),
+            store.$permissionMode.map { _ in () }.eraseToAnyPublisher(),
+            store.$bypassAcknowledged.map { _ in () }.eraseToAnyPublisher(),
+            store.$prompt.map { _ in () }.eraseToAnyPublisher(),
+            store.$notifyOnCompletion.map { _ in () }.eraseToAnyPublisher(),
+            store.$maxSessionsPerRun.map { _ in () }.eraseToAnyPublisher(),
+            store.$maxTurns.map { _ in () }.eraseToAnyPublisher()
+        ])
         .receive(on: RunLoop.main)
         .sink { [weak self] in self?.reconcile() }
         .store(in: &cancellables)
+
+        Publishers.Merge(
+            notificationPreferences.$isEnabled.map { _ in () },
+            providerVisibility.$hiddenServices.map { _ in () }
+        )
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.reconcile() }
+            .store(in: &cancellables)
 
         Publishers.Merge(
             accounts.$customAccounts.map { _ in () },
@@ -93,18 +121,33 @@ final class SessionWakeController: ObservableObject {
             .store(in: &cancellables)
 
         reconcile()
+        startAgentMonitorIfNeeded()
     }
 
     /// Whether the controller currently has a live watch task (test hook).
     var isWatching: Bool { watchTask != nil }
 
+    /// Whether this installed bundle can hand the watcher to launchd. Debug
+    /// builds without the injected CLI remain in-process.
+    var usesBackgroundAgent: Bool { agent.isAvailable }
+
     // MARK: - Reconciliation
 
     private func reconcile() {
-        if store.isOn, let account = selectedAccount() {
-            startWatching(account: account)
+        let account = selectedAccount()
+        saveAgentConfiguration(account: account)
+
+        if store.isOn, let account {
+            if usesBackgroundAgent {
+                stopWatching()
+                registerAgentIfNeeded()
+            } else {
+                unregisterAgentIfNeeded()
+                startWatching(account: account)
+            }
         } else {
             stopWatching()
+            unregisterAgentIfNeeded()
         }
     }
 
@@ -115,20 +158,39 @@ final class SessionWakeController: ObservableObject {
 
     private func startWatching(account: ClaudeCodeAccount) {
         guard watchTask == nil else { return }
+        let lifetimeLock = makeLifetimeLock()
+        switch lifetimeLock.acquire() {
+        case .acquired:
+            localLifetimeLock = lifetimeLock
+        case let .contended(holder):
+            let suffix = holder.map { " (\($0.shortDescription))" } ?? ""
+            status.update(state: .failed(reason: "Another Session Wake holder is active\(suffix)."))
+            return
+        case let .legacyHeld(guidance):
+            status.update(state: .failed(reason: guidance))
+            return
+        case let .unavailable(reason):
+            status.update(state: .failed(reason: "Wake lock unavailable: \(reason)"))
+            return
+        }
+
+        status.updateBackgroundExecution(.inApp)
         let bounds = store.bounds
         let runner = WakeProcessRunner(
             account: account,
             permissionMode: store.permissionMode,
             bypassAcknowledged: store.bypassAcknowledged,
-            prompt: store.prompt
+            prompt: store.prompt,
+            lockMode: .externallyOwned
         )
         let interval = rescanInterval
         let make = makeWatcher
+        let publishedStatus = status
 
         watchTask = Task {
             while !Task.isCancelled {
                 let watcher = make(runner, bounds) { state in
-                    Task { @MainActor in SessionWakeStatus.shared.update(state: state) }
+                    Task { @MainActor in publishedStatus.update(state: state) }
                 }
                 await watcher.start(account: account)
                 // A cancel (toggle off) reliably stops the coordinator via the
@@ -147,8 +209,106 @@ final class SessionWakeController: ObservableObject {
 
     private func stopWatching() {
         guard watchTask != nil else { return }
-        watchTask?.cancel()
+        let task = watchTask
+        let lifetimeLock = localLifetimeLock
+        task?.cancel()
         watchTask = nil
-        status.update(state: .off)
+        localLifetimeLock = nil
+        Task { [weak self] in
+            await task?.value
+            lifetimeLock?.release()
+            self?.status.update(state: .off)
+        }
+    }
+
+    // MARK: - Managed background agent
+
+    private func saveAgentConfiguration(account: ClaudeCodeAccount?) {
+        let notificationsAllowed = store.notifyOnCompletion
+            && notificationPreferences.isEnabled
+            && providerVisibility.isEnabled(.claudeCode)
+        agentStateStore.saveConfiguration(
+            SessionWakeAgentConfiguration(
+                featureEnabled: store.featureEnabled,
+                isArmed: store.isOn && account != nil,
+                provider: .claude,
+                accountDirectory: account?.configDirectory,
+                permissionMode: store.permissionMode,
+                bypassAcknowledged: store.bypassAcknowledged,
+                prompt: store.prompt,
+                notifyOnCompletion: notificationsAllowed,
+                maxSessionsPerRun: store.maxSessionsPerRun,
+                maxTurns: store.maxTurns
+            )
+        )
+    }
+
+    private func registerAgentIfNeeded() {
+        switch agent.currentStatus() {
+        case .enabled:
+            status.updateBackgroundExecution(.active)
+        case .requiresApproval:
+            status.updateBackgroundExecution(.requiresApproval)
+        case .notRegistered, .notFound, .unknown:
+            do {
+                try agent.register()
+                refreshAgentRegistrationStatus()
+            } catch {
+                status.updateBackgroundExecution(.failed("Couldn't start the background watcher."))
+                status.update(
+                    state: .failed(reason: "Background watcher registration failed: \(error.localizedDescription)")
+                )
+                store.setOn(false)
+                saveAgentConfiguration(account: selectedAccount())
+            }
+        }
+    }
+
+    private func unregisterAgentIfNeeded() {
+        guard usesBackgroundAgent else { return }
+        switch agent.currentStatus() {
+        case .notRegistered, .notFound:
+            status.updateBackgroundExecution(.inactive)
+        case .enabled, .requiresApproval, .unknown:
+            do {
+                try agent.unregister()
+                status.updateBackgroundExecution(.inactive)
+            } catch {
+                // The shared `isArmed = false` configuration is the immediate
+                // kill switch even when ServiceManagement cannot unregister.
+                status.updateBackgroundExecution(.failed("Background registration could not be removed."))
+            }
+        }
+    }
+
+    private func startAgentMonitorIfNeeded() {
+        guard usesBackgroundAgent, agentMonitorTask == nil else { return }
+        agentMonitorTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard self != nil else { return }
+                self?.refreshAgentRegistrationStatus()
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+            }
+        }
+    }
+
+    private func refreshAgentRegistrationStatus() {
+        guard usesBackgroundAgent else { return }
+        switch agent.currentStatus() {
+        case .enabled:
+            if let record = agentStateStore.loadStatus(),
+               Date().timeIntervalSince(record.heartbeat) < 10 {
+                status.update(state: record.watcherState)
+                status.updateBackgroundExecution(.active)
+            } else {
+                status.updateBackgroundExecution(store.isOn ? .starting : .inactive)
+            }
+        case .requiresApproval:
+            status.updateBackgroundExecution(.requiresApproval)
+        case .notRegistered, .notFound:
+            status.updateBackgroundExecution(.inactive)
+        case .unknown:
+            status.updateBackgroundExecution(.failed("Background watcher status is unavailable."))
+        }
     }
 }

--- a/MeterBar/SessionWake/SessionWakeSettingsStore.swift
+++ b/MeterBar/SessionWake/SessionWakeSettingsStore.swift
@@ -26,9 +26,15 @@ final class SessionWakeSettingsStore: ObservableObject {
     @Published private(set) var maxTurns: Int
 
     private let userDefaults: UserDefaults
+    private let agentStateStore: SessionWakeAgentStateStore?
 
-    init(userDefaults: UserDefaults = .standard) {
+    init(
+        userDefaults: UserDefaults = .standard,
+        agentStateStore: SessionWakeAgentStateStore? = nil
+    ) {
         self.userDefaults = userDefaults
+        self.agentStateStore = agentStateStore
+            ?? (userDefaults === UserDefaults.standard ? SessionWakeAgentStateStore() : nil)
         if userDefaults.object(forKey: StorageKeys.sessionWakeFeatureEnabled) == nil {
             // Session Wake shipped before this key was wired. Preserve that
             // behavior for existing installs; an explicit false is the master
@@ -63,6 +69,7 @@ final class SessionWakeSettingsStore: ObservableObject {
 
         if userDefaults === UserDefaults.standard {
             syncSharedFeatureFlag()
+            syncAgentControlFlags()
         }
     }
 
@@ -104,6 +111,7 @@ final class SessionWakeSettingsStore: ObservableObject {
         if !enabled {
             forceOff()
         }
+        syncAgentControlFlags()
     }
 
     /// Turn the watcher on or off. Turning on is refused unless `canTurnOn` and
@@ -116,6 +124,7 @@ final class SessionWakeSettingsStore: ObservableObject {
         guard on != isOn else { return }
         isOn = on
         userDefaults.set(on, forKey: StorageKeys.sessionWakeWatcherArmed)
+        syncAgentControlFlags()
     }
 
     /// Complete the one-time confirmation and turn on in a single step (what the
@@ -187,10 +196,23 @@ final class SessionWakeSettingsStore: ObservableObject {
         guard isOn else { return }
         isOn = false
         userDefaults.set(false, forKey: StorageKeys.sessionWakeWatcherArmed)
+        syncAgentControlFlags()
     }
 
     private func syncSharedFeatureFlag() {
         UserDefaults(suiteName: SharedMetricsStore.appGroupIdentifier)?
             .set(featureEnabled, forKey: SessionWakeCLI.sharedFeatureEnabledKey)
+    }
+
+    /// Synchronous kill-switch propagation. The controller writes the complete
+    /// configuration, but turning Session Wake off must reach an already-running
+    /// agent before the next Combine/run-loop reconciliation (including an
+    /// immediate app quit).
+    private func syncAgentControlFlags() {
+        guard let agentStateStore,
+              let configuration = agentStateStore.loadConfiguration() else { return }
+        agentStateStore.saveConfiguration(
+            configuration.withControlFlags(featureEnabled: featureEnabled, isArmed: isOn)
+        )
     }
 }

--- a/MeterBar/SessionWake/SessionWakeStatus.swift
+++ b/MeterBar/SessionWake/SessionWakeStatus.swift
@@ -1,6 +1,31 @@
 import Combine
 import Foundation
 
+enum SessionWakeBackgroundExecution: Equatable, Sendable {
+    case inactive
+    case starting
+    case active
+    case requiresApproval
+    case inApp
+    case failed(String)
+
+    var title: String {
+        switch self {
+        case .inactive: return "Inactive"
+        case .starting: return "Starting in background"
+        case .active: return "Background · survives app quit"
+        case .requiresApproval: return "Approval required in Login Items"
+        case .inApp: return "In app · development fallback"
+        case .failed: return "Needs attention"
+        }
+    }
+
+    var detail: String? {
+        guard case let .failed(message) = self else { return nil }
+        return message
+    }
+}
+
 /// Pure mapping from watcher state to the user-facing status surface.
 ///
 /// Real states are surfaced distinctly (Running / Stopping / Quota Unknown /
@@ -62,6 +87,7 @@ final class SessionWakeStatus: ObservableObject {
     @Published private(set) var previewCandidates: [WakeSessionCandidate] = []
     @Published private(set) var isPreviewing = false
     @Published private(set) var lastSummary: WakeRunSummary?
+    @Published private(set) var backgroundExecution: SessionWakeBackgroundExecution = .inactive
 
     private let discovery: SessionDiscovery
     private let ledgerFactory: @Sendable () -> ReplayLedger
@@ -98,6 +124,10 @@ final class SessionWakeStatus: ObservableObject {
         if case let .completed(summary) = state {
             lastSummary = summary
         }
+    }
+
+    func updateBackgroundExecution(_ execution: SessionWakeBackgroundExecution) {
+        backgroundExecution = execution
     }
 
     func label(isOn: Bool) -> SessionWakeStatusLabel {

--- a/MeterBar/SessionWake/WakeCLIEngine.swift
+++ b/MeterBar/SessionWake/WakeCLIEngine.swift
@@ -85,11 +85,11 @@ struct WakeCLIEngine {
 
         // Pre-flight probe only: detect a legacy watcher / another live holder
         // for a distinct, actionable message before the quota fetch — then
-        // release at once. The per-run runner takes the shared lock when a
-        // launch is actually ready (matching the app watcher, where the runner,
-        // not the coordinator, owns the lock). Holding this engine lock across
-        // resume() would self-contend: flock via a second descriptor in the
-        // same process is denied on macOS, so every real resume would fail.
+        // release at once. A managed app/agent watcher holds this lock for its
+        // whole lifetime, so this probe excludes one-shot CLI work. If no
+        // watcher owns it, the per-run runner takes the lock when launch-ready.
+        // Holding this engine instance across resume() would self-contend via
+        // the runner's second descriptor, so the probe is released first.
         switch lock.acquire() {
         case .acquired:
             lock.release()

--- a/MeterBar/SessionWake/WakeCoordinator.swift
+++ b/MeterBar/SessionWake/WakeCoordinator.swift
@@ -8,9 +8,8 @@ import Foundation
 /// re-exhausts the window stops the queue and preserves the remaining work
 /// instead of hammering a blocked account.
 ///
-/// v1 lifetime is **app-running-only**: the watcher lives with the process.
-/// There is no managed launchd helper in v1; sleep/wake and quit simply end the
-/// watcher, and it is re-armed on next launch by the settings layer (#98).
+/// The same actor runs in the GUI fallback and in the managed launch agent. Its
+/// structured cancellation semantics are identical in both processes.
 actor WakeCoordinator {
     private let discovery: SessionDiscovery
     private let authority: WakeQuotaAuthority
@@ -50,8 +49,23 @@ actor WakeCoordinator {
     /// Arm the watcher for `account`. No-op if already running.
     func start(account: ClaudeCodeAccount) {
         guard runTask == nil else { return }
+        let legacyRunner = runner
+        let runtime = ClaudeWakeRuntime(
+            account: account,
+            discovery: discovery,
+            authority: authority,
+            makeRunner: { _ in legacyRunner }
+        )
+        start(runtime: runtime)
+    }
+
+    /// Provider-agnostic entry point used by the managed agent and Codex-aware
+    /// callers. The legacy Claude entry point above remains for existing tests
+    /// and app wiring.
+    func start(runtime: WakeProviderRuntime) {
+        guard runTask == nil else { return }
         runTask = Task { [weak self] in
-            await self?.runLoop(account: account)
+            await self?.runLoop(runtime: runtime)
         }
     }
 
@@ -85,10 +99,11 @@ actor WakeCoordinator {
 
     private var unknownPolls = 0
 
-    private func runLoop(account: ClaudeCodeAccount) async {
+    private func runLoop(runtime: WakeProviderRuntime) async {
         transition(.scanning)
-        let discovered = await discovery.discover(configDirectory: account.configDirectory, ledger: ledger)
+        let discovered = await runtime.discover(ledger: ledger)
         var queue = Array(discovered.filter(\.isExecutable).prefix(bounds.maxSessionsPerRun))
+        let runtimeRunner = runtime.makeRunner()
 
         var summary = WakeRunSummary()
         summary.skipped = discovered.count - queue.count
@@ -96,8 +111,14 @@ actor WakeCoordinator {
 
         loop: while !queue.isEmpty && !Task.isCancelled {
             // Fresh quota before EVERY launch.
-            let quota = await authority.freshQuota(account: account)
-            let step = await handle(quota: quota, account: account, queue: &queue, summary: &summary)
+            let quota = await runtime.freshQuota()
+            let step = await handle(
+                quota: quota,
+                runtime: runtime,
+                runner: runtimeRunner,
+                queue: &queue,
+                summary: &summary
+            )
             switch step {
             case .keepGoing:
                 continue
@@ -122,14 +143,15 @@ actor WakeCoordinator {
 
     private func handle(
         quota: WakeQuota,
-        account: ClaudeCodeAccount,
+        runtime: WakeProviderRuntime,
+        runner: WakeExecuting,
         queue: inout [WakeSessionCandidate],
         summary: inout WakeRunSummary
     ) async -> LoopStep {
         switch quota {
         case .available:
             unknownPolls = 0
-            return await launchNext(account: account, queue: &queue, summary: &summary)
+            return await launchNext(runtime: runtime, runner: runner, queue: &queue, summary: &summary)
         case let .blocked(until, _):
             summary.remaining = queue.count
             transition(.waiting(until: until))
@@ -145,7 +167,8 @@ actor WakeCoordinator {
     }
 
     private func launchNext(
-        account: ClaudeCodeAccount,
+        runtime: WakeProviderRuntime,
+        runner: WakeExecuting,
         queue: inout [WakeSessionCandidate],
         summary: inout WakeRunSummary
     ) async -> LoopStep {
@@ -158,7 +181,7 @@ actor WakeCoordinator {
 
         // Re-fetch AFTER the attempt; a re-maxed window stops the queue and
         // preserves the remaining work.
-        let post = await authority.freshQuota(account: account)
+        let post = await runtime.freshQuota()
         if case let .blocked(until, _) = post {
             summary.remaining = queue.count
             transition(.waiting(until: until))

--- a/MeterBar/SessionWake/WakeLock.swift
+++ b/MeterBar/SessionWake/WakeLock.swift
@@ -7,6 +7,7 @@ nonisolated struct WakeLockHolder: Codable, Equatable, Sendable {
     /// Who is holding the shared lock.
     enum Kind: String, Codable, Equatable, Sendable {
         case app
+        case agent
         case cli
     }
 
@@ -28,10 +29,10 @@ nonisolated struct WakeLockHolder: Codable, Equatable, Sendable {
 /// legacy watcher during migration.
 ///
 /// Uses `flock(LOCK_EX|LOCK_NB)` on a fixed lock file so any two holders — the
-/// app and the CLI, or either and a still-loaded legacy job — mutually exclude.
-/// The lock is acquired only when a run is actually ready, never held across a
-/// long quota wait. The holder writes a JSON descriptor into the lock file so a
-/// contender can say who is running.
+/// app, managed agent, CLI, or a still-loaded legacy job — mutually exclude.
+/// Continuous watchers hold it for their process/task lifetime; one-shot CLI
+/// runs probe it before quota work and their runner owns it across execution.
+/// The holder writes a JSON descriptor so a contender can say who is running.
 nonisolated final class WakeLock: @unchecked Sendable {
     /// The outcome of trying to acquire the shared lock.
     enum Acquisition: Equatable {

--- a/MeterBar/SessionWake/WakeProcessRunner.swift
+++ b/MeterBar/SessionWake/WakeProcessRunner.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+/// Whether the runner takes the shared Session Wake lock itself or runs under
+/// a process-lifetime lock already held by the continuous app/agent watcher.
+nonisolated enum WakeExecutionLockMode: Equatable, Sendable {
+    case acquirePerRun
+    case externallyOwned
+}
+
 /// The one native process runner shared by MeterBar and its CLI.
 ///
 /// Responsibilities: revalidate the target immediately before exec, take the
@@ -16,6 +23,7 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
     let account: ClaudeCodeAccount
     private let baseEnvironment: [String: String]
     private let lockFactory: @Sendable () -> WakeLock
+    private let lockMode: WakeExecutionLockMode
     private let logger: WakeRunLogger
     private let now: @Sendable () -> Date
 
@@ -27,6 +35,7 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
         prompt: String = WakeCommandBuilder.defaultPrompt,
         baseEnvironment: [String: String] = ProcessInfo.processInfo.environment,
         lockFactory: @escaping @Sendable () -> WakeLock = { WakeLock() },
+        lockMode: WakeExecutionLockMode = .acquirePerRun,
         logger: WakeRunLogger = WakeRunLogger(),
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
@@ -37,6 +46,7 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
         self.prompt = prompt
         self.baseEnvironment = baseEnvironment
         self.lockFactory = lockFactory
+        self.lockMode = lockMode
         self.logger = logger
         self.now = now
     }
@@ -55,28 +65,30 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
             return .failed(reason: "claude binary not found")
         }
 
-        // Take the shared lock only now, when we are actually ready to launch.
-        // The runner is the sole owner of the lock across app and CLI paths, so
-        // the caller must not hold it (the CLI engine only probe-releases).
-        let lock = lockFactory()
-        switch lock.acquire() {
-        case .acquired:
-            break
-        case let .contended(holder):
-            let suffix = holder.map { " (\($0.shortDescription))" } ?? ""
-            let outcome = WakeRunOutcome.failed(reason: "another Session Wake holder is active\(suffix)")
-            record(candidate: candidate, outcome: outcome, result: nil, start: now())
-            return outcome
-        case let .legacyHeld(guidance):
-            let outcome = WakeRunOutcome.failed(reason: guidance)
-            record(candidate: candidate, outcome: outcome, result: nil, start: now())
-            return outcome
-        case let .unavailable(reason):
-            let outcome = WakeRunOutcome.failed(reason: "wake lock unavailable: \(reason)")
-            record(candidate: candidate, outcome: outcome, result: nil, start: now())
-            return outcome
+        let lock = lockMode == .acquirePerRun ? lockFactory() : nil
+        if let lock {
+            // One-shot CLI runs take the shared lock only when ready to launch.
+            // Continuous app/agent watchers pass `.externallyOwned` because they
+            // hold the same lock for their whole lifetime.
+            switch lock.acquire() {
+            case .acquired:
+                break
+            case let .contended(holder):
+                let suffix = holder.map { " (\($0.shortDescription))" } ?? ""
+                let outcome = WakeRunOutcome.failed(reason: "another Session Wake holder is active\(suffix)")
+                record(candidate: candidate, outcome: outcome, result: nil, start: now())
+                return outcome
+            case let .legacyHeld(guidance):
+                let outcome = WakeRunOutcome.failed(reason: guidance)
+                record(candidate: candidate, outcome: outcome, result: nil, start: now())
+                return outcome
+            case let .unavailable(reason):
+                let outcome = WakeRunOutcome.failed(reason: "wake lock unavailable: \(reason)")
+                record(candidate: candidate, outcome: outcome, result: nil, start: now())
+                return outcome
+            }
         }
-        defer { lock.release() }
+        defer { lock?.release() }
 
         let command = WakeCommandBuilder.build(
             executable: resolved,

--- a/MeterBar/Views/SessionWakeSettingsView.swift
+++ b/MeterBar/Views/SessionWakeSettingsView.swift
@@ -36,7 +36,7 @@ struct SessionWakeSettingsView: View {
             Text("""
             While on, MeterBar watches this account's usage limits and, after a \
             limit resets, automatically resumes your blocked Claude Code sessions \
-            one at a time. It only runs while MeterBar is open.
+            one at a time. The background watcher keeps running after MeterBar quits.
             """)
         }
     }
@@ -74,6 +74,21 @@ struct SessionWakeSettingsView: View {
             SettingsRowView(title: "Status") {
                 Text(status.label(isOn: store.isOn).title)
                     .foregroundStyle(.secondary)
+            }
+
+            SettingsRowView(
+                title: "Execution",
+                detail: status.backgroundExecution.detail
+            ) {
+                if status.backgroundExecution == .requiresApproval {
+                    Button("Open Login Items") {
+                        SMAppServiceSessionWakeAgent.openSystemSettings()
+                    }
+                    .buttonStyle(.bordered)
+                } else {
+                    Text(status.backgroundExecution.title)
+                        .foregroundStyle(.secondary)
+                }
             }
         }
     }

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -10,7 +10,7 @@ struct MeterBarCLI: AsyncParsableCommand {
         commandName: "meterbar",
         abstract: "Track AI coding assistant usage from the command line",
         version: MeterBarCLIVersion.current,
-        subcommands: [Usage.self, Cost.self, Doctor.self, Wake.self],
+        subcommands: [Usage.self, Cost.self, Doctor.self, Wake.self, WakeAgent.self],
         defaultSubcommand: Usage.self
     )
 }

--- a/MeterBarCLI/Sources/WakeAgent.swift
+++ b/MeterBarCLI/Sources/WakeAgent.swift
@@ -1,0 +1,53 @@
+import ArgumentParser
+import Darwin
+import Dispatch
+import Foundation
+import MeterBar
+
+/// Private launchd entry point. Users control it through MeterBar's Session
+/// Wake switch; it is intentionally hidden from the normal CLI help surface.
+struct WakeAgent: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "wake-agent",
+        abstract: "Run MeterBar's managed Session Wake background agent",
+        shouldDisplay: false
+    )
+
+    func run() async throws {
+        let cancellation = AgentCancellation()
+        let signalSources = installSignalHandlers(cancellation)
+        defer { signalSources.forEach { $0.cancel() } }
+
+        let exitCode = await SessionWakeAgent.run(shouldCancel: { cancellation.isCancelled })
+        if exitCode != 0 {
+            throw ExitCode(exitCode)
+        }
+    }
+
+    private func installSignalHandlers(_ cancellation: AgentCancellation) -> [DispatchSourceSignal] {
+        [SIGINT, SIGTERM].map { signalNumber in
+            signal(signalNumber, SIG_IGN)
+            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global())
+            source.setEventHandler { cancellation.cancel() }
+            source.resume()
+            return source
+        }
+    }
+}
+
+private final class AgentCancellation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+}

--- a/MeterBarTests/SessionWakeAgentTests.swift
+++ b/MeterBarTests/SessionWakeAgentTests.swift
@@ -1,0 +1,166 @@
+@testable import MeterBar
+import XCTest
+
+final class SessionWakeAgentTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUpWithError() throws {
+        suiteName = "SessionWakeAgentTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    func testConfigurationRoundTripsAndClampsBounds() throws {
+        let store = SessionWakeAgentStateStore(userDefaults: defaults)
+        let configuration = SessionWakeAgentConfiguration(
+            featureEnabled: true,
+            isArmed: true,
+            provider: .claude,
+            accountDirectory: "/tmp/claude-profile",
+            permissionMode: .safe,
+            bypassAcknowledged: false,
+            prompt: "continue",
+            notifyOnCompletion: true,
+            maxSessionsPerRun: 9_999,
+            maxTurns: 0
+        )
+
+        store.saveConfiguration(configuration)
+
+        let restored = try XCTUnwrap(store.loadConfiguration())
+        XCTAssertEqual(restored, configuration)
+        XCTAssertTrue(restored.canRun)
+        XCTAssertEqual(restored.bounds.maxSessionsPerRun, WakeBounds.sessionsRange.upperBound)
+        XCTAssertEqual(restored.bounds.maxTurns, WakeBounds.maxTurnsRange.lowerBound)
+    }
+
+    func testBypassWithoutAcknowledgementFailsClosed() {
+        let configuration = SessionWakeAgentConfiguration(
+            featureEnabled: true,
+            isArmed: true,
+            provider: .claude,
+            accountDirectory: nil,
+            permissionMode: .bypass,
+            bypassAcknowledged: false,
+            prompt: "continue",
+            notifyOnCompletion: true,
+            maxSessionsPerRun: 5,
+            maxTurns: 40
+        )
+
+        XCTAssertFalse(configuration.canRun)
+    }
+
+    func testDisarmSynchronouslyUpdatesRunningAgentConfiguration() throws {
+        let agentState = SessionWakeAgentStateStore(userDefaults: defaults)
+        agentState.saveConfiguration(
+            SessionWakeAgentConfiguration(
+                featureEnabled: true,
+                isArmed: true,
+                provider: .claude,
+                accountDirectory: nil,
+                permissionMode: .safe,
+                bypassAcknowledged: false,
+                prompt: "continue",
+                notifyOnCompletion: true,
+                maxSessionsPerRun: 5,
+                maxTurns: 40
+            )
+        )
+        let settings = SessionWakeSettingsStore(userDefaults: defaults, agentStateStore: agentState)
+        settings.setWakeAccountID(UUID())
+        settings.acknowledgeFirstRunAndTurnOn()
+        XCTAssertTrue(settings.isOn)
+
+        settings.setOn(false)
+
+        XCTAssertFalse(try XCTUnwrap(agentState.loadConfiguration()).isArmed)
+    }
+
+    func testExecutionChangesRestartButNotificationOnlyChangeDoesNot() {
+        let baseline = SessionWakeAgentConfiguration(
+            featureEnabled: true,
+            isArmed: true,
+            provider: .claude,
+            accountDirectory: nil,
+            permissionMode: .safe,
+            bypassAcknowledged: false,
+            prompt: "continue",
+            notifyOnCompletion: true,
+            maxSessionsPerRun: 5,
+            maxTurns: 40
+        )
+        let notificationOnly = SessionWakeAgentConfiguration(
+            featureEnabled: true,
+            isArmed: true,
+            provider: .claude,
+            accountDirectory: nil,
+            permissionMode: .safe,
+            bypassAcknowledged: false,
+            prompt: "continue",
+            notifyOnCompletion: false,
+            maxSessionsPerRun: 5,
+            maxTurns: 40
+        )
+        let saferPermission = SessionWakeAgentConfiguration(
+            featureEnabled: true,
+            isArmed: true,
+            provider: .claude,
+            accountDirectory: nil,
+            permissionMode: .safe,
+            bypassAcknowledged: false,
+            prompt: "continue safely",
+            notifyOnCompletion: true,
+            maxSessionsPerRun: 5,
+            maxTurns: 40
+        )
+
+        XCTAssertFalse(notificationOnly.requiresRuntimeRestart(comparedTo: baseline))
+        XCTAssertTrue(saferPermission.requiresRuntimeRestart(comparedTo: baseline))
+    }
+
+    func testStatusRoundTripsEveryAssociatedValue() throws {
+        let store = SessionWakeAgentStateStore(userDefaults: defaults)
+        let summary = WakeRunSummary(resumed: 2, failed: 1, skipped: 3, remaining: 4)
+        let states: [WakeWatcherState] = [
+            .off,
+            .idle,
+            .scanning,
+            .waiting(until: Date(timeIntervalSince1970: 123)),
+            .quotaUnknown(reason: "missing token"),
+            .running(sessionID: "session-1"),
+            .stopping,
+            .completed(summary: summary),
+            .failed(reason: "boom")
+        ]
+
+        for state in states {
+            store.saveStatus(.init(state: state, processID: 42, heartbeat: Date(timeIntervalSince1970: 456)))
+            let restored = try XCTUnwrap(store.loadStatus())
+            XCTAssertEqual(restored.watcherState, state)
+            XCTAssertEqual(restored.processID, 42)
+        }
+    }
+
+    func testAgentLifetimeLockExcludesAppAndCLIHolders() {
+        let lockURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SessionWakeAgentLock-\(UUID().uuidString)")
+        let agent = WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .agent)
+        let cli = WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .cli)
+
+        XCTAssertEqual(agent.acquire(), .acquired)
+        guard case let .contended(holder) = cli.acquire() else {
+            agent.release()
+            return XCTFail("CLI must contend while the managed watcher owns the lifetime lock")
+        }
+        XCTAssertEqual(holder?.kind, .agent)
+
+        agent.release()
+        XCTAssertEqual(cli.acquire(), .acquired)
+        cli.release()
+    }
+}

--- a/MeterBarTests/SessionWakeControllerTests.swift
+++ b/MeterBarTests/SessionWakeControllerTests.swift
@@ -17,6 +17,9 @@ final class SessionWakeControllerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         defaults.removePersistentDomain(forName: suiteName)
+        try? FileManager.default.removeItem(
+            at: FileManager.default.temporaryDirectory.appendingPathComponent("\(suiteName ?? "")-watcher.lock")
+        )
     }
 
     private func pump(_ seconds: TimeInterval = 0.1) {
@@ -39,6 +42,12 @@ final class SessionWakeControllerTests: XCTestCase {
         return store
     }
 
+    private func lifetimeLockFactory() -> @Sendable () -> WakeLock {
+        let lockURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(suiteName ?? UUID().uuidString)-watcher.lock")
+        return { WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .app) }
+    }
+
     func testWatcherReArmsOnLaunchWhenToggleWasLeftOn() {
         let store = armedStore()
         XCTAssertTrue(store.isOn)
@@ -49,7 +58,8 @@ final class SessionWakeControllerTests: XCTestCase {
             status: SessionWakeStatus(),
             accounts: ClaudeCodeAccountStore(userDefaults: defaults),
             rescanInterval: 3_600,
-            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
         )
 
         controller.activate() // initial reconcile re-arms
@@ -66,7 +76,8 @@ final class SessionWakeControllerTests: XCTestCase {
             status: SessionWakeStatus(),
             accounts: ClaudeCodeAccountStore(userDefaults: defaults),
             rescanInterval: 3_600,
-            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
         )
         controller.activate()
         XCTAssertTrue(controller.isWatching)
@@ -100,7 +111,8 @@ final class SessionWakeControllerTests: XCTestCase {
             status: SessionWakeStatus(),
             accounts: accounts,
             rescanInterval: 3_600,
-            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
         )
         controller.activate()
         XCTAssertTrue(controller.isWatching)
@@ -127,7 +139,8 @@ final class SessionWakeControllerTests: XCTestCase {
             status: SessionWakeStatus(),
             accounts: accounts,
             rescanInterval: 3_600,
-            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
         )
         controller.activate()
         poll { recorder.startCount >= 1 }
@@ -150,11 +163,48 @@ final class SessionWakeControllerTests: XCTestCase {
             status: SessionWakeStatus(),
             accounts: ClaudeCodeAccountStore(userDefaults: defaults),
             rescanInterval: 3_600,
-            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
         )
         controller.activate()
         XCTAssertFalse(controller.isWatching)
         XCTAssertEqual(recorder.startCount, 0)
+    }
+
+    func testReleaseBundleHandsWatchingToManagedAgentAndDisarmUnregisters() {
+        let store = armedStore()
+        let recorder = WatchRecorder()
+        let fakeAgent = FakeSessionWakeAgent()
+        let agentSuite = "SessionWakeControllerAgent-\(UUID().uuidString)"
+        let agentDefaults = UserDefaults(suiteName: agentSuite)
+        guard let agentDefaults else { return XCTFail("agent defaults should be available") }
+        defer { agentDefaults.removePersistentDomain(forName: agentSuite) }
+        let agentState = SessionWakeAgentStateStore(userDefaults: agentDefaults)
+        agentState.saveStatus(.init(state: .idle))
+        let sessionStatus = SessionWakeStatus()
+        let controller = SessionWakeController(
+            store: store,
+            status: sessionStatus,
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            agent: fakeAgent,
+            agentStateStore: agentState,
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
+        )
+
+        controller.activate()
+
+        XCTAssertEqual(fakeAgent.registerCount, 1)
+        XCTAssertEqual(recorder.startCount, 0, "managed bundles must not start a second in-app watcher")
+        XCTAssertEqual(sessionStatus.backgroundExecution, .active)
+        XCTAssertTrue(agentState.loadConfiguration()?.canRun == true)
+
+        store.setOn(false)
+        pump()
+
+        XCTAssertEqual(fakeAgent.unregisterCount, 1)
+        XCTAssertFalse(agentState.loadConfiguration()?.isArmed ?? true)
     }
 }
 
@@ -191,5 +241,24 @@ nonisolated private struct FakeWatcher: WakeWatching {
         while !Task.isCancelled {
             try? await Task.sleep(nanoseconds: 20_000_000)
         }
+    }
+}
+
+private final class FakeSessionWakeAgent: SessionWakeAgentControlling {
+    var isAvailable = true
+    private(set) var status: SessionWakeAgentRegistrationStatus = .notRegistered
+    private(set) var registerCount = 0
+    private(set) var unregisterCount = 0
+
+    func currentStatus() -> SessionWakeAgentRegistrationStatus { status }
+
+    func register() throws {
+        registerCount += 1
+        status = .enabled
+    }
+
+    func unregister() throws {
+        unregisterCount += 1
+        status = .notRegistered
     }
 }

--- a/docs/audits/00-repo-map.md
+++ b/docs/audits/00-repo-map.md
@@ -59,7 +59,7 @@ Three build systems coexist in one repo (see risk R6):
 - **No code signing identity, no notarization** anywhere in the pipeline; README instructs users to `xattr -cr` the quarantine flag (`README.md:80-83`). Version currently `MARKETING_VERSION = 1.6` (pbxproj:282 etc.), while `MeterBar/Info.plist:22` pins `CFBundleShortVersionString` to `1.0` — the plist value appears overridden by build settings, but the checked-in `1.0` is misleading.
 - README badge claims "macOS 13.0+" and "Swift 5.9" (`README.md:12-13`) — both false against the project files (macOS 26, Swift 5 mode / tools 6.2).
 
-**Scheduling/cron analog:** in-process `Timer` (refresh) + `Task.sleep` loop (notifications) + WidgetKit timeline `.after(nextUpdate)` (`MeterBarWidget/UsageWidget.swift:225-233`). No launchd agents, no background daemons.
+**Scheduling/cron analog:** in-process `Timer` (refresh) + `Task.sleep` loop (notifications) + WidgetKit timeline `.after(nextUpdate)` (`MeterBarWidget/UsageWidget.swift:225-233`). Session Wake additionally registers the bundled `meterbar wake-agent` as a per-user `SMAppService` launch agent while armed.
 
 **Observability:** `os.Logger` only, via `AppLog` with 5 categories (`MeterBar/Services/AppLog.swift`). No crash reporting, no analytics, no telemetry (grep for Sentry/Crashlytics/analytics: zero hits in Swift sources). For a distributed app, the only failure signal is user reports.
 

--- a/docs/session-wake-migration.md
+++ b/docs/session-wake-migration.md
@@ -92,6 +92,7 @@ Only after steps 1–3 pass:
   the selected account directory directly; there is no session-sync step.
 - **Codex is not covered by v1.** Its subagent filtering and CLI-compatibility
   preflight are deferred to a separate follow-up issue.
-- **v1 watcher lifetime is app-running-only.** There is no managed launchd
-  helper; the watcher lives with the MeterBar process and re-arms on next launch
-  per your Automation settings.
+- **v1.8+ watcher lifetime is managed.** Enabling Session Wake registers the
+  signed `meterbar wake-agent` launch agent bundled inside MeterBar.app. It
+  survives GUI quit and subsequent logins; turning the Session Wake switch off
+  writes the kill-switch first and then unregisters the agent.

--- a/scripts/sign-and-verify-release.sh
+++ b/scripts/sign-and-verify-release.sh
@@ -25,6 +25,7 @@ widget_path="$app_path/Contents/PlugIns/MeterBarWidgetExtension.appex"
 app_binary="$app_path/Contents/MacOS/MeterBar"
 widget_binary="$widget_path/Contents/MacOS/MeterBarWidgetExtension"
 cli_binary="$app_path/Contents/Helpers/meterbar"
+session_wake_agent_plist="$app_path/Contents/Library/LaunchAgents/dev.meterbar.app.session-wake.plist"
 app_entitlements="$repository_root/MeterBar/MeterBar.entitlements"
 widget_entitlements="$repository_root/MeterBarWidget/MeterBarWidget.entitlements"
 
@@ -40,12 +41,31 @@ for directory in "$app_path" "$widget_path"; do
   fi
 done
 
-for file in "$app_binary" "$widget_binary" "$cli_binary" "$app_entitlements" "$widget_entitlements"; do
+for file in \
+  "$app_binary" \
+  "$widget_binary" \
+  "$cli_binary" \
+  "$session_wake_agent_plist" \
+  "$app_entitlements" \
+  "$widget_entitlements"; do
   if [ ! -f "$file" ]; then
     echo "Required release input not found: $file" >&2
     exit 1
   fi
 done
+
+plutil -lint "$session_wake_agent_plist"
+agent_program=$(/usr/libexec/PlistBuddy -c "Print :BundleProgram" "$session_wake_agent_plist")
+agent_command=$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments:1" "$session_wake_agent_plist")
+agent_run_at_load=$(/usr/libexec/PlistBuddy -c "Print :RunAtLoad" "$session_wake_agent_plist")
+agent_restart_on_failure=$(/usr/libexec/PlistBuddy -c "Print :KeepAlive:SuccessfulExit" "$session_wake_agent_plist")
+if [ "$agent_program" != "Contents/Helpers/meterbar" ] \
+  || [ "$agent_command" != "wake-agent" ] \
+  || [ "$agent_run_at_load" != "true" ] \
+  || [ "$agent_restart_on_failure" != "false" ]; then
+  echo "Session Wake launch-agent plist has an invalid command or lifecycle policy." >&2
+  exit 1
+fi
 
 verify_universal_binary() {
   local binary="$1"


### PR DESCRIPTION
## Summary

- register a per-user `SMAppService` launch agent that runs the already-bundled `meterbar wake-agent` executable
- share versioned configuration plus metadata-only status/heartbeat across the app and agent
- hold the existing wake lock for the continuous watcher lifetime, excluding app, agent, and one-shot CLI overlap
- synchronously propagate disarm before unregistering, cooperatively cancelling the coordinator and active child
- surface background/approval state in Settings and deliver completion notifications while the GUI is closed
- embed and validate the launch-agent plist in CI/release artifacts; document the lifecycle in ADR-011

Implements #133.

## Verification

- `swiftlint lint --strict` — passed, 0 violations
- `bash -n scripts/sign-and-verify-release.sh` — passed
- `plutil -lint MeterBar/Resources/dev.meterbar.app.session-wake.plist MeterBar.xcodeproj/project.pbxproj` — passed
- launch-agent copy script and plist lifecycle keys (`BundleProgram`, `wake-agent`, `RunAtLoad`, restart-on-failure) — statically verified
- `git diff --check` — passed
- local builds/tests intentionally skipped per repository machine policy; PR CI owns Swift tests + coverage, Debug/Release Xcode builds, universal CLI injection, and signed nested-bundle verification

## Residual risk / blockers

- The current default branch still has the separately tracked headless Claude quota-source bug; PR #177 fixes that path. This change preserves fail-closed quota behavior and does not duplicate #177's scope.
- Register/unregister, app quit/relaunch, and logout/login require a signed installed app and therefore were not exercised locally. The release verifier now fails if the managed-agent plist or embedded command/lifecycle contract drifts.
- Open PR #178 also evolves Session Wake provider/runtime wiring and may require a small merge-order conflict resolution, but it does not implement background persistence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session Wake can now continue running in the background after MeterBar quits.
  * Added background execution status and Login Items approval guidance in settings.
  * Added support for safe handoff between the app, background service, and command-line actions.
  * Completion notifications can be delivered independently of the app interface.

* **Documentation**
  * Updated architecture, migration, release, and deployment documentation for background Session Wake behavior.

* **Tests**
  * Expanded coverage for persistence, disarming, locking, registration, status reporting, and background-agent handoff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->