### PR TITLE
refactor(theme): fold MeterBarChip.Metrics onto design tokens

### DIFF
--- a/.agents/SESSIONS/2026-07-14.md
+++ b/.agents/SESSIONS/2026-07-14.md
@@ -809,3 +809,45 @@ losing the only decision onboarding asks for (launch-at-login).
 - `testEnableLaunchAtLoginRegistersAndCompletesOnboarding` /
   `testNotNowCompletesWithoutRegistering` — extended to assert the explicit choice
   persists across a reload (`hasCompletedFirstRun` true, reloaded store silent).
+
+---
+
+# 2026-07-14 — Fold MeterBarChip.Metrics onto theme tokens (deferred chip from #187)
+
+## Context
+PR #187 introduced `MeterBarChip` with a local `Metrics` scale (padding 8/3, fill
+0.14, stroke 0.18 × 1pt) and left a follow-up note: fold `Metrics` into
+`MeterBarTheme` once radius/opacity tokens exist. PR #191 then added
+`Fill.subtle = 0.14`, `Fill.hairline = 0.18`, plus `Spacing`/`Radius` scales.
+Both merged (191 @ 14:38, 187 @ 14:41); this is the deferred fold, done on a fresh
+branch off master (the original worktree branch carried an unrelated SettingsView
+commit, so a clean branch kept the change isolated).
+
+## Change (tokenizing MeterBarChip.Metrics only)
+- **`MeterBarChip.swift`** — `Metrics` now references theme tokens:
+  `horizontalPadding → Spacing.sm` (8), `iconTextSpacing → Spacing.xs` (4),
+  `fillOpacity → Fill.subtle` (0.14), `strokeOpacity → Fill.hairline` (0.18).
+  Rewrote the doc comment and **removed the follow-up note**.
+- **`verticalPadding`** — the one value with no exact token: old 3pt sits midway
+  between `xxs` (2) and `xs` (4), so it snaps up to `xs` (4) per the Spacing
+  scale's documented "exact ties round up" rule — the same convention #191's view
+  sweep applied. That **+1pt shift is the single sanctioned appearance change**;
+  every other value is preserved exactly (task point 3 permits it).
+- **`iconPointSize` (10)** and **`strokeWidth` (1)** stay literals — no matching
+  design token exists, and inventing one is out of scope.
+- **Capsule** — surface keeps a true `.capsule` (a pill, not a fixed-radius
+  `Radius` step), per the task's "or keep `.capsule`" allowance.
+
+## Tests (drift-guard updated, not weakened)
+- `testStandardizedMetricsAreSingleScale` → renamed
+  `testStandardizedMetricsDeriveFromThemeTokens`. Now asserts each Metric **equals
+  the theme token it derives from** (`Spacing.sm`/`xs`, `Fill.subtle`/`hairline`)
+  instead of magic numbers — catching both a re-hardcoded Metric and the
+  derivation detaching from the scale. Added an `iconTextSpacing` assertion.
+- Concrete token *values* stay guarded by `MeterBarThemeTests`
+  (`Spacing == [2,4,8,…]`, `Fill.subtle == 0.14`, `Fill.hairline == 0.18`), so the
+  two suites split cleanly: theme owns values, chip owns linkage.
+
+## Verification
+- SwiftLint clean on both changed files (repo `.swiftlint.yml`); longest new line
+  82 cols (< 120). `swift test` not run locally per MacBook policy — relying on PR CI.

--- a/MeterBar/Views/Components/MeterBarChip.swift
+++ b/MeterBar/Views/Components/MeterBarChip.swift
@@ -23,22 +23,24 @@ struct MeterBarChip: View {
         case glass
     }
 
-    /// One padding scale + one stroke/fill treatment for every chip.
+    /// One padding scale + one stroke/fill treatment for every chip, now sourced
+    /// from `MeterBarTheme`'s shared design tokens so chips, cards, and bars draw
+    /// from the same spacing/opacity vocabulary instead of local literals.
     ///
-    /// These are the *single* standardized values the five legacy recipes used
-    /// to disagree on. They intentionally live here rather than in
-    /// `MeterBarTheme` because no radius/opacity design token has landed yet.
-    ///
-    /// Follow-up (not yet actionable): once the radius/opacity design-token
-    /// chip lands in `MeterBarTheme`, fold these constants into it so chips and
-    /// cards share the same tokens instead of hard-coding them here.
+    /// `verticalPadding` is the one value without an exact token: the old 3pt sat
+    /// midway between `Spacing.xxs` (2) and `Spacing.xs` (4), so it snaps up to
+    /// `xs` following the Spacing scale's "exact ties round up" rule — the same
+    /// convention PR #191's view sweep applied. That +1pt shift is the single
+    /// sanctioned appearance change here; every other value is preserved exactly.
+    /// `iconPointSize` and `strokeWidth` have no design token and stay literals,
+    /// and the surface keeps a true `.capsule` (a pill, not a fixed-radius step).
     enum Metrics {
-        static let horizontalPadding: CGFloat = 8
-        static let verticalPadding: CGFloat = 3
-        static let iconTextSpacing: CGFloat = 4
+        static let horizontalPadding: CGFloat = MeterBarTheme.Spacing.sm
+        static let verticalPadding: CGFloat = MeterBarTheme.Spacing.xs
+        static let iconTextSpacing: CGFloat = MeterBarTheme.Spacing.xs
         static let iconPointSize: CGFloat = 10
-        static let fillOpacity: Double = 0.14
-        static let strokeOpacity: Double = 0.18
+        static let fillOpacity: Double = MeterBarTheme.Fill.subtle
+        static let strokeOpacity: Double = MeterBarTheme.Fill.hairline
         static let strokeWidth: CGFloat = 1
     }
 

--- a/MeterBarTests/MeterBarChipTests.swift
+++ b/MeterBarTests/MeterBarChipTests.swift
@@ -33,12 +33,19 @@ final class MeterBarChipTests: XCTestCase {
     }
 
     /// The whole point of the component: one padding scale, one fill, one
-    /// stroke. If someone re-diverges these, this test fails loudly.
-    func testStandardizedMetricsAreSingleScale() {
-        XCTAssertEqual(MeterBarChip.Metrics.horizontalPadding, 8)
-        XCTAssertEqual(MeterBarChip.Metrics.verticalPadding, 3)
-        XCTAssertEqual(MeterBarChip.Metrics.fillOpacity, 0.14, accuracy: 0.0001)
-        XCTAssertEqual(MeterBarChip.Metrics.strokeOpacity, 0.18, accuracy: 0.0001)
+    /// stroke — now derived from `MeterBarTheme`'s shared tokens rather than
+    /// local literals. Asserting against the tokens (not magic numbers, which
+    /// `MeterBarThemeTests` already guards) catches two kinds of drift: someone
+    /// re-hardcoding a Metric, and the derivation silently detaching from the
+    /// theme scale.
+    func testStandardizedMetricsDeriveFromThemeTokens() {
+        XCTAssertEqual(MeterBarChip.Metrics.horizontalPadding, MeterBarTheme.Spacing.sm)
+        // verticalPadding has no exact token (old 3pt); it snaps up to xs (4) per
+        // the Spacing scale's round-up tie-break — the one sanctioned +1pt shift.
+        XCTAssertEqual(MeterBarChip.Metrics.verticalPadding, MeterBarTheme.Spacing.xs)
+        XCTAssertEqual(MeterBarChip.Metrics.iconTextSpacing, MeterBarTheme.Spacing.xs)
+        XCTAssertEqual(MeterBarChip.Metrics.fillOpacity, MeterBarTheme.Fill.subtle, accuracy: 0.0001)
+        XCTAssertEqual(MeterBarChip.Metrics.strokeOpacity, MeterBarTheme.Fill.hairline, accuracy: 0.0001)
         XCTAssertEqual(MeterBarChip.Metrics.strokeWidth, 1)
     }
 


### PR DESCRIPTION
Deferred follow-up chip from #187, unblocked now that both prerequisites merged: **#187** (introduced `MeterBarChip` + local `Metrics`) and **#191** (added `Fill.subtle`/`Fill.hairline`, `Spacing`, `Radius` token scales).

## What
`MeterBarChip.Metrics` no longer hard-codes values — it references the shared `MeterBarTheme` tokens, so chips draw from the same spacing/opacity vocabulary as cards and bars. The follow-up note left in the file by #187 is removed.

| Metric | Was | Now |
|---|---|---|
| `horizontalPadding` | `8` | `Spacing.sm` |
| `verticalPadding` | `3` | `Spacing.xs` ⚠️ |
| `iconTextSpacing` | `4` | `Spacing.xs` |
| `fillOpacity` | `0.14` | `Fill.subtle` |
| `strokeOpacity` | `0.18` | `Fill.hairline` |
| `iconPointSize` | `10` | `10` (no token) |
| `strokeWidth` | `1` | `1` (no token) |

## The one appearance change ⚠️
`verticalPadding` was `3`, which has **no exact token** — it sits midway between `Spacing.xxs` (2) and `Spacing.xs` (4). It snaps **up to `xs` (4)** following the Spacing scale's documented *"exact ties round up"* rule — the same convention #191's view sweep applied to every other raw padding. Net effect: **+1pt** vertical padding on chips. This is the only visual change; every other value maps exactly. Sanctioned by the task's token-sweep convention (closest step, documented).

`iconPointSize` and `strokeWidth` stay literals (no matching design token; inventing one is out of scope). The surface keeps a true `.capsule` (a pill, not a fixed-radius `Radius` step).

## Tests
- Renamed the drift-guard `testStandardizedMetricsAreSingleScale` → `testStandardizedMetricsDeriveFromThemeTokens`. It now asserts each Metric **equals the theme token it derives from** rather than a magic number — catching both a re-hardcoded Metric and the derivation silently detaching from the scale. Added an `iconTextSpacing` assertion.
- Concrete token *values* remain guarded by `MeterBarThemeTests`, so the suites split cleanly: **theme owns values, chip owns linkage.**

## Verification
SwiftLint clean on both changed files. `swift test` deferred to CI per repo policy.

Scope: tokenizing `MeterBarChip.Metrics` only.