### PR TITLE
fix(ui): render one provider card layout

### DIFF
--- a/.agents/SESSIONS/2026-07-15.md
+++ b/.agents/SESSIONS/2026-07-15.md
@@ -51,3 +51,44 @@ flowchart LR
 ### Next steps
 
 - [ ] Confirm PR CI and merge when the visual review is accepted.
+
+## Session 2: Remove the second visual provider-card implementation
+
+**Status:** Complete; installed visual verification passed
+
+```mermaid
+flowchart LR
+    Snapshot[ProviderSnapshot] --> Shell[One ProviderStatusCard shell]
+    Shell --> Header[Shared provider header]
+    Shell --> Body{Blocking limit?}
+    Body -->|No| Limits[Quota limit rows]
+    Body -->|Yes| Reset[Reset-only counter]
+    Shell --> Footer[Shared badges and reset-credit action]
+```
+
+### Root cause
+
+The previous consolidation renamed the surviving Swift type but kept two full
+outer view trees: `compactExhaustedCard` and `expandedCard`. The code had one
+type while the rendered app still had two visibly different card designs.
+
+### What changed
+
+- Deleted the compact exhausted card, its duplicate header, and the glass morph
+  between card types.
+- Kept one `DashboardTile` shell for every provider and every state.
+- Limited exhausted-state branching to the middle body: a blocking reset counter
+  replaces quota rows, while the shared header, status, badges, and optional
+  Codex reset-credit footer remain unchanged.
+- Retained terminal interaction behavior: blocked cards do not open a redundant
+  detail panel.
+- Updated regression test language to describe the single-shell contract.
+
+### Verification
+
+- SwiftLint strict: zero violations on all changed Swift files.
+- Xcode Debug clean build succeeded for arm64.
+- Installed and ad-hoc signed `/Applications/MeterBar Dev.app`; deep signature
+  verification passed and the installed process launched successfully.
+- Opened the real dashboard and captured visual evidence confirming both provider
+  states now use the same card shell.

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -504,8 +504,8 @@ struct PopoverOverviewPanel: View {
   }
 }
 
-// Non-private so the Liquid Glass morph wiring can be rendered in both states
-// by `LiquidGlassP1RegressionTests`.
+// Non-private so the shared card shell can be rendered in both usage states by
+// `LiquidGlassP1RegressionTests`.
 struct ProviderStatusCard: View {
   let snapshot: ProviderSnapshot
   var onSelect: (() -> Void)?
@@ -521,14 +521,6 @@ struct ProviderStatusCard: View {
   @State private var showingResetCreditConfirmation = false
   @State private var resetCreditAlertTitle = "Couldn't use reset credit"
   @State private var resetCreditAlertMessage: String?
-
-  /// Shared identity for the exhausted↔expanded glass morph. Scoped per card
-  /// instance via `cardMorph`, so sibling provider cards never cross-morph.
-  @Namespace private var cardMorph
-  @Environment(\.accessibilityReduceMotion)
-  private var reduceMotion
-
-  private static let cardGlassID = "provider-status-card"
 
   init(
     snapshot: ProviderSnapshot,
@@ -556,41 +548,35 @@ struct ProviderStatusCard: View {
   }
 
   var body: some View {
-    Group {
-      if showsResetCreditAction {
-        compactExhaustedCardWithAction
-      } else {
-        selectableCard
+    selectableCard
+      .providerCardContextMenu(ProviderCardCommands.standard(snapshot: snapshot))
+      .task(id: snapshot.updatedAt) {
+        await refreshCodexAuthenticationState()
       }
-    }
-    .providerCardContextMenu(ProviderCardCommands.standard(snapshot: snapshot))
-    .task(id: snapshot.updatedAt) {
-      await refreshCodexAuthenticationState()
-    }
-    .confirmationDialog(
-      "Use a Codex reset credit?",
-      isPresented: $showingResetCreditConfirmation,
-      titleVisibility: .visible
-    ) {
-      Button("Use Reset Credit") { consumeResetCredit() }
-      Button("Cancel", role: .cancel) {}
-    } message: {
-      Text(
-        "This spends one of your finite Codex reset credits and resets the active blocked usage window. " +
-          "The action cannot be undone."
-      )
-    }
-    .alert(
-      resetCreditAlertTitle,
-      isPresented: Binding(
-        get: { resetCreditAlertMessage != nil },
-        set: { if !$0 { resetCreditAlertMessage = nil } }
-      )
-    ) {
-      Button("OK") { resetCreditAlertMessage = nil }
-    } message: {
-      Text(resetCreditAlertMessage ?? "")
-    }
+      .confirmationDialog(
+        "Use a Codex reset credit?",
+        isPresented: $showingResetCreditConfirmation,
+        titleVisibility: .visible
+      ) {
+        Button("Use Reset Credit") { consumeResetCredit() }
+        Button("Cancel", role: .cancel) {}
+      } message: {
+        Text(
+          "This spends one of your finite Codex reset credits and resets the active blocked usage window. " +
+            "The action cannot be undone."
+        )
+      }
+      .alert(
+        resetCreditAlertTitle,
+        isPresented: Binding(
+          get: { resetCreditAlertMessage != nil },
+          set: { if !$0 { resetCreditAlertMessage = nil } }
+        )
+      ) {
+        Button("OK") { resetCreditAlertMessage = nil }
+      } message: {
+        Text(resetCreditAlertMessage ?? "")
+      }
   }
 
   @ViewBuilder private var selectableCard: some View {
@@ -614,120 +600,8 @@ struct ProviderStatusCard: View {
     }
   }
 
-  // The exhausted (58pt) and expanded (124pt) states share one glass identity
-  // inside a container so the height change morphs instead of hard-swapping.
-  // Container spacing matches the 8pt provider-card list rhythm so the glass
-  // samples correctly (Liquid Glass docs). Reduce Motion drops the animation.
   private var cardContent: some View {
-    GlassEffectContainer(spacing: 8) {
-      Group {
-        if snapshot.hasExhaustedLimit {
-          compactExhaustedCard
-            .glassEffectID(Self.cardGlassID, in: cardMorph)
-        } else {
-          expandedCard
-            .glassEffectID(Self.cardGlassID, in: cardMorph)
-        }
-      }
-    }
-    .animation(
-      reduceMotion ? nil : MeterBarTheme.Motion.standard,
-      value: snapshot.hasExhaustedLimit
-    )
-    .contentShape(RoundedRectangle(cornerRadius: MeterBarTheme.Radius.card, style: .continuous))
-  }
-
-  private var compactExhaustedCard: some View {
     DashboardTile(padding: 11, surface: .glass) {
-      compactExhaustedContent
-    }
-  }
-
-  private var compactExhaustedCardWithAction: some View {
-    DashboardTile(padding: 11, surface: .glass) {
-      VStack(alignment: .leading, spacing: 8) {
-        compactExhaustedContent
-
-        Divider()
-
-        Button {
-          showingResetCreditConfirmation = true
-        } label: {
-          HStack(spacing: 6) {
-            if isConsumingResetCredit {
-              ProgressView()
-                .controlSize(.small)
-            } else {
-              Image(systemName: "arrow.clockwise.circle.fill")
-            }
-            Text(isConsumingResetCredit ? "Using reset credit…" : "Use reset credit")
-          }
-          .frame(maxWidth: .infinity)
-        }
-        .buttonStyle(.borderedProminent)
-        .controlSize(.small)
-        .disabled(isConsumingResetCredit)
-      }
-    }
-  }
-
-  private var compactExhaustedContent: some View {
-    VStack(alignment: .leading, spacing: 8) {
-      TimelineView(.periodic(from: ResetCountdownSchedule.anchor, by: ResetCountdownSchedule.interval)) { timeline in
-        let blockingWindow = BlockingLimitResetCounter.selectBlockingWindow(
-          snapshot.resetWindows,
-          now: timeline.date
-        )
-        let title = BlockingLimitResetCounter.titleText(for: blockingWindow, in: snapshot.resetWindows)
-        let counter = BlockingLimitResetCounter.counterText(
-          for: blockingWindow,
-          now: timeline.date,
-          format: menuBarDisplayPreferences.resetTimeFormat
-        )
-
-        HStack(alignment: .center, spacing: 9) {
-          ProviderLogoView(kind: snapshot.logoKind, size: 17, foregroundColor: snapshot.accentColor)
-
-          VStack(alignment: .leading, spacing: 1) {
-            Text(snapshot.title)
-              .font(.subheadline)
-              .fontWeight(.semibold)
-              .lineLimit(1)
-            Text(updatedText)
-              .font(.caption2)
-              .foregroundColor(.secondary)
-              .lineLimit(1)
-          }
-
-          Spacer(minLength: 8)
-
-          HStack(spacing: 5) {
-            Image(systemName: "hourglass")
-              .font(.system(size: 10, weight: .semibold))
-            Text("\(title) \(counter)")
-              .font(.caption)
-              .fontWeight(.semibold)
-              .monospacedDigit()
-              .lineLimit(1)
-              .minimumScaleFactor(0.72)
-          }
-          .foregroundColor(snapshot.accentColor)
-          .help("\(title) \(counter)")
-        }
-      }
-
-      let badges = ProviderStatusBadges(snapshot: snapshot, style: .compact)
-      if badges.hasContent {
-        badges
-      }
-    }
-  }
-
-  private var expandedCard: some View {
-    DashboardTile(
-      padding: 11,
-      surface: .glass
-    ) {
       VStack(alignment: .leading, spacing: 10) {
         HStack(spacing: 7) {
           ProviderLogoView(kind: snapshot.logoKind, size: 17, foregroundColor: snapshot.accentColor)
@@ -755,6 +629,12 @@ struct ProviderStatusCard: View {
             .font(.caption)
             .foregroundColor(.secondary)
             .frame(maxWidth: .infinity, alignment: .topLeading)
+        } else if snapshot.hasExhaustedLimit {
+          BlockingLimitResetCounter(
+            windows: snapshot.resetWindows,
+            accentColor: snapshot.accentColor,
+            format: menuBarDisplayPreferences.resetTimeFormat
+          )
         } else {
           VStack(alignment: .leading, spacing: 9) {
             ForEach(snapshot.limits) { limit in
@@ -767,8 +647,35 @@ struct ProviderStatusCard: View {
         if badges.hasContent {
           badges
         }
+
+        if showsResetCreditAction {
+          Divider()
+
+          resetCreditButton
+        }
       }
     }
+    .contentShape(RoundedRectangle(cornerRadius: MeterBarTheme.Radius.card, style: .continuous))
+  }
+
+  private var resetCreditButton: some View {
+    Button {
+      showingResetCreditConfirmation = true
+    } label: {
+      HStack(spacing: 6) {
+        if isConsumingResetCredit {
+          ProgressView()
+            .controlSize(.small)
+        } else {
+          Image(systemName: "arrow.clockwise.circle.fill")
+        }
+        Text(isConsumingResetCredit ? "Using reset credit…" : "Use reset credit")
+      }
+      .frame(maxWidth: .infinity)
+    }
+    .buttonStyle(.borderedProminent)
+    .controlSize(.small)
+    .disabled(isConsumingResetCredit)
   }
 
   private var updatedText: String {

--- a/MeterBarTests/LimitRowTests.swift
+++ b/MeterBarTests/LimitRowTests.swift
@@ -158,9 +158,8 @@ final class LimitRowTests: XCTestCase {
     }
 }
 
-/// Guards the compact/exhausted popover swap (`ProviderStatusCard`) that
-/// substitutes a countdown row for the limit list — item 4 of the unification:
-/// migrating the limit row must not break that card in either state.
+/// Guards the single `ProviderStatusCard` shell that substitutes reset-only
+/// content for the limit list without swapping to a second card design.
 @MainActor
 final class ProviderStatusCardSmokeTests: XCTestCase {
     private func snapshot(exhausted: Bool) -> ProviderSnapshot {
@@ -193,9 +192,9 @@ final class ProviderStatusCardSmokeTests: XCTestCase {
         XCTAssertGreaterThan(host.fittingSize.height, 0)
     }
 
-    func testExhaustedCardRendersCountdownVariant() {
+    func testExhaustedCardRendersResetOnlyContent() {
         let card = ProviderStatusCard(snapshot: snapshot(exhausted: true))
-        XCTAssertTrue(card.snapshot.hasExhaustedLimit, "fixture should drive the compact/exhausted swap")
+        XCTAssertTrue(card.snapshot.hasExhaustedLimit, "fixture should drive the reset-only content")
         let host = NSHostingView(rootView: card.frame(width: 360))
         host.layoutSubtreeIfNeeded()
         XCTAssertGreaterThan(host.fittingSize.height, 0)

--- a/MeterBarTests/LiquidGlassP1RegressionTests.swift
+++ b/MeterBarTests/LiquidGlassP1RegressionTests.swift
@@ -206,19 +206,17 @@ final class LiquidGlassP1RegressionTests: XCTestCase {
         XCTAssertNotEqual(MeterBarTheme.Motion.standard, MeterBarTheme.Motion.disclosure)
     }
 
-    // MARK: - Glass morph containers render in both states
+    // MARK: - Unified provider card renders in both states
 
-    /// The flagship popover card swaps its exhausted (compact) and expanded
-    /// bodies through a single `glassEffectID` inside a `GlassEffectContainer`.
-    /// Both branches must build and lay out — a broken morph identity or an
-    /// unrenderable glass surface would blank the provider card.
-    func testProviderStatusCardMorphRendersBothStates() {
+    /// Available and exhausted providers share one outer card shell; only the
+    /// inner usage content changes between limit rows and the reset counter.
+    func testProviderStatusCardSingleShellRendersBothStates() {
         let exhausted = makeSnapshot(service: .claudeCode, session: 100, weekly: 20)
-        XCTAssertTrue(exhausted.hasExhaustedLimit, "session at limit should drive the compact card")
+        XCTAssertTrue(exhausted.hasExhaustedLimit, "session at limit should drive reset-only content")
         XCTAssertGreaterThan(fittingHeight(ProviderStatusCard(snapshot: exhausted)), 0)
 
         let healthy = makeSnapshot(service: .claudeCode, session: 20, weekly: 20)
-        XCTAssertFalse(healthy.hasExhaustedLimit, "room left should drive the expanded card")
+        XCTAssertFalse(healthy.hasExhaustedLimit, "room left should render limit rows")
         XCTAssertGreaterThan(fittingHeight(ProviderStatusCard(snapshot: healthy)), 0)
     }
 


### PR DESCRIPTION
## Summary

- Removes the separate `compactExhaustedCard` and `expandedCard` outer view trees.
- Renders every provider and every quota state through one `DashboardTile` shell with one header and one badge/action footer.
- When a blocking limit is exhausted, only the middle body changes from quota rows to the blocking reset counter.
- Keeps exhausted cards terminal, so they cannot open the redundant secondary detail panel.
- Preserves the actionable Codex reset-credit button inside the shared footer.

## Related issue

No-Issue — correction to PR #207 after installed visual verification showed that one Swift type still rendered two card designs.

## Scope

- SwiftUI presentation only.
- No provider data, API, persistence, cache, widget, or CLI contract changes.
- No fixed-height card floor is reintroduced.

## Verification

- SwiftLint strict passed with zero violations on all changed Swift files.
- `git diff --check` passed.
- Clean arm64 Debug Xcode build succeeded.
- Installed, ad-hoc signed, and deep-signature verified `/Applications/MeterBar Dev.app`.
- Launched the installed app and visually verified the real Overview dashboard.

## Screenshots

Visual verification captured locally at `/tmp/meterbar-unified-card-dashboard.png`: the active and exhausted providers now share the same card shell; the exhausted middle body contains only its weekly reset.

## Checklist

- [x] I reviewed the final diff for unrelated changes.
- [x] I ran the relevant focused checks.
- [x] I updated the session documentation.
- [x] Migrations, release steps, and external configuration changes are not applicable.
- [x] I did not include secrets, credentials, personal data, customer data, or generated build output.
