### PR TITLE
fix(settings): make default Claude config editable

### DIFF
--- a/.agents/SESSIONS/2026-07-15.md
+++ b/.agents/SESSIONS/2026-07-15.md
@@ -241,3 +241,31 @@ Settings.
 - Live dashboard verification showed `genfeedai` corrected from the shared
   `shipshitdev` countdown to its own approximately 2d 11h reset.
 - Tests were updated but not run locally per MacBook policy.
+
+## Session 7: Make the default Claude config directory editable
+
+**Status:** Implementation complete; CI verification pending
+
+### Root cause
+
+The settings row explicitly rendered the default account path as a read-only
+field, and `ClaudeCodeAccountStore.updateAccount` discarded every directory
+change for the default account. The displayed path came only from `~/.claude`
+or the app process's `CLAUDE_CONFIG_DIR`, so it could not be managed like a
+secondary profile.
+
+### What changed
+
+- Made the default Claude row use the same editable path field and directory
+  picker as secondary rows.
+- Persisted a default-account config override and routed usage refreshes,
+  reconnects, activity probes, and Session Wake through the saved path.
+- Kept global Keychain OAuth limited to an unscoped default account. A saved
+  directory selects that profile's CLI instead, preventing cross-account quota
+  contamination.
+- Added account-store persistence and OAuth source-selection regression
+  coverage.
+
+### Verification
+
+- Local tests/build intentionally not run per MacBook policy; use PR CI.

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -13,7 +13,7 @@ Providers tracked:
 
 | Provider | `ServiceType` case | Data source |
 |---|---|---|
-| Claude Code | `.claudeCode` | Default account: calls the authenticated `https://api.anthropic.com/api/oauth/usage` endpoint with the `Claude Code-credentials` Keychain OAuth token (primary; on by default via the `ClaudeCodeEnableOAuthFallback` flag). Falls back to shelling out to `claude /usage` and regex-parsing terminal output when no token is available. Custom (`CLAUDE_CONFIG_DIR`) accounts use the CLI, since `claude /usage` no longer renders in a headless spawn |
+| Claude Code | `.claudeCode` | Unscoped default account: calls the authenticated `https://api.anthropic.com/api/oauth/usage` endpoint with the global `Claude Code-credentials` Keychain OAuth token (primary; on by default via the `ClaudeCodeEnableOAuthFallback` flag). Falls back to shelling out to `claude /usage` and regex-parsing terminal output when no token is available. Any account with an explicit `CLAUDE_CONFIG_DIR`, including the editable default row, uses the CLI so credentials cannot cross-contaminate profiles. |
 | OpenAI Codex CLI | `.codexCli` | Reads `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`), calls `https://chatgpt.com/backend-api/wham/usage`; exhausted accounts can consume a banked reset credit through the authenticated reset-credit endpoints after explicit confirmation |
 | Cursor | `.cursor` | Reads session JWT from Cursor's `state.vscdb` SQLite, calls `https://cursor.com/api/usage-summary` |
 | OpenRouter | `.openRouter` | User-provided API key in Keychain; calls documented `/api/v1/credits` and `/api/v1/key` endpoints |

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -664,8 +664,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
             .store(in: &cancellables)
 
-        Publishers.Merge(
+        Publishers.Merge3(
             ClaudeCodeAccountStore.shared.$customAccounts.map { _ in () },
+            ClaudeCodeAccountStore.shared.$defaultAccountConfigDirectory.map { _ in () },
             ClaudeCodeAccountStore.shared.$defaultAccountIsEnabled.map { _ in () }
         )
             .sink { [weak self] _ in

--- a/MeterBar/Models/ClaudeCodeAccount.swift
+++ b/MeterBar/Models/ClaudeCodeAccount.swift
@@ -70,12 +70,14 @@ final class ClaudeCodeAccountStore: ObservableObject {
 
     @Published private(set) var customAccounts: [ClaudeCodeAccount] = []
     @Published private(set) var defaultAccountName = ClaudeCodeAccount.defaultName
+    @Published private(set) var defaultAccountConfigDirectory: String?
     @Published private(set) var defaultAccountIsEnabled = true
     @Published private(set) var accountOrder: [UUID] = []
 
     private let userDefaults: UserDefaults
     private let storageKey = StorageKeys.claudeCodeCustomAccounts
     private let defaultNameStorageKey = StorageKeys.claudeCodeDefaultAccountName
+    private let defaultConfigDirectoryStorageKey = StorageKeys.claudeCodeDefaultConfigDirectory
     private let defaultEnabledStorageKey = StorageKeys.claudeCodeDefaultAccountEnabled
     private let accountOrderStorageKey = StorageKeys.claudeCodeAccountOrder
 
@@ -84,7 +86,7 @@ final class ClaudeCodeAccountStore: ObservableObject {
             ClaudeCodeAccount(
                 id: ClaudeCodeAccount.defaultID,
                 name: defaultAccountName,
-                configDirectory: nil,
+                configDirectory: defaultAccountConfigDirectory,
                 isEnabled: defaultAccountIsEnabled
             )
         ] + customAccounts)
@@ -121,10 +123,24 @@ final class ClaudeCodeAccountStore: ObservableObject {
         let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedName.isEmpty else { return }
 
+        let standardizedDirectory: String?
+        if let configDirectory {
+            let trimmedDirectory = configDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedDirectory.isEmpty else { return }
+            standardizedDirectory = (trimmedDirectory as NSString).standardizingPath
+        } else {
+            standardizedDirectory = nil
+        }
+
         if id == ClaudeCodeAccount.defaultID {
-            guard trimmedName != defaultAccountName else { return }
-            defaultAccountName = trimmedName
-            saveDefaultAccountName()
+            if trimmedName != defaultAccountName {
+                defaultAccountName = trimmedName
+                saveDefaultAccountName()
+            }
+            if let standardizedDirectory, standardizedDirectory != defaultAccountConfigDirectory {
+                defaultAccountConfigDirectory = standardizedDirectory
+                saveDefaultAccountConfigDirectory()
+            }
             return
         }
 
@@ -133,10 +149,8 @@ final class ClaudeCodeAccountStore: ObservableObject {
         var updatedAccount = customAccounts[index]
         updatedAccount.name = trimmedName
 
-        if let configDirectory {
-            let trimmedDirectory = configDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmedDirectory.isEmpty else { return }
-            updatedAccount.configDirectory = (trimmedDirectory as NSString).standardizingPath
+        if let standardizedDirectory {
+            updatedAccount.configDirectory = standardizedDirectory
         }
 
         guard updatedAccount != customAccounts[index] else { return }
@@ -199,6 +213,12 @@ final class ClaudeCodeAccountStore: ObservableObject {
             defaultAccountName = storedDefaultName
         }
 
+        if let storedDefaultConfigDirectory = userDefaults.string(forKey: defaultConfigDirectoryStorageKey)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !storedDefaultConfigDirectory.isEmpty {
+            defaultAccountConfigDirectory = (storedDefaultConfigDirectory as NSString).standardizingPath
+        }
+
         if userDefaults.object(forKey: defaultEnabledStorageKey) != nil {
             defaultAccountIsEnabled = userDefaults.bool(forKey: defaultEnabledStorageKey)
         }
@@ -225,6 +245,14 @@ final class ClaudeCodeAccountStore: ObservableObject {
             userDefaults.removeObject(forKey: defaultNameStorageKey)
         } else {
             userDefaults.set(defaultAccountName, forKey: defaultNameStorageKey)
+        }
+    }
+
+    private func saveDefaultAccountConfigDirectory() {
+        if let defaultAccountConfigDirectory {
+            userDefaults.set(defaultAccountConfigDirectory, forKey: defaultConfigDirectoryStorageKey)
+        } else {
+            userDefaults.removeObject(forKey: defaultConfigDirectoryStorageKey)
         }
     }
 

--- a/MeterBar/Models/ClaudeCodeAccount.swift
+++ b/MeterBar/Models/ClaudeCodeAccount.swift
@@ -123,6 +123,24 @@ final class ClaudeCodeAccountStore: ObservableObject {
         let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedName.isEmpty else { return }
 
+        if id == ClaudeCodeAccount.defaultID {
+            if trimmedName != defaultAccountName {
+                defaultAccountName = trimmedName
+                saveDefaultAccountName()
+            }
+            if let configDirectory {
+                let trimmedDirectory = configDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+                let updatedDirectory = trimmedDirectory.isEmpty
+                    ? nil
+                    : (trimmedDirectory as NSString).standardizingPath
+                if updatedDirectory != defaultAccountConfigDirectory {
+                    defaultAccountConfigDirectory = updatedDirectory
+                    saveDefaultAccountConfigDirectory()
+                }
+            }
+            return
+        }
+
         let standardizedDirectory: String?
         if let configDirectory {
             let trimmedDirectory = configDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -130,18 +148,6 @@ final class ClaudeCodeAccountStore: ObservableObject {
             standardizedDirectory = (trimmedDirectory as NSString).standardizingPath
         } else {
             standardizedDirectory = nil
-        }
-
-        if id == ClaudeCodeAccount.defaultID {
-            if trimmedName != defaultAccountName {
-                defaultAccountName = trimmedName
-                saveDefaultAccountName()
-            }
-            if let standardizedDirectory, standardizedDirectory != defaultAccountConfigDirectory {
-                defaultAccountConfigDirectory = standardizedDirectory
-                saveDefaultAccountConfigDirectory()
-            }
-            return
         }
 
         guard let index = customAccounts.firstIndex(where: { $0.id == id }) else { return }

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -38,6 +38,8 @@ nonisolated enum StorageKeys {
     static let claudeCodeCustomAccounts = "ClaudeCodeCustomAccounts"
     /// User-chosen display name for the default Claude Code CLI profile.
     static let claudeCodeDefaultAccountName = "ClaudeCodeDefaultAccountName"
+    /// User-chosen config directory for the default Claude Code CLI profile.
+    static let claudeCodeDefaultConfigDirectory = "ClaudeCodeDefaultConfigDirectory"
     /// Whether the synthesized default Claude Code CLI profile participates in tracking.
     static let claudeCodeDefaultAccountEnabled = "ClaudeCodeDefaultAccountEnabled"
     /// Persisted account display order (array of UUID strings).

--- a/MeterBar/Services/ClaudeCodeLocalService.swift
+++ b/MeterBar/Services/ClaudeCodeLocalService.swift
@@ -129,8 +129,8 @@ class ClaudeCodeLocalService: ObservableObject {
         // same data Claude Code's own `/usage` screen reads. `claude /usage` no
         // longer renders in a headless (non-TTY) spawn (it prints a session cost
         // summary instead), so the CLI parser is now a fallback. Only the
-        // default account has a Keychain OAuth token; custom accounts
-        // (`CLAUDE_CONFIG_DIR`) have none and go straight to the CLI.
+        // unscoped default account can safely use the global Keychain token;
+        // accounts with an explicit `CLAUDE_CONFIG_DIR` go straight to the CLI.
         if Self.prefersOAuth(account: account, oauthEnabled: isOAuthFallbackEnabled) {
             // `nil` ⇒ no usable Keychain token; fall back to the CLI. A thrown
             // error means a token was in hand but the request/decode failed —
@@ -300,6 +300,11 @@ class ClaudeCodeLocalService: ObservableObject {
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Bool {
         guard account.isDefault, oauthEnabled else { return false }
+        if let accountConfigDirectory = account.configDirectory?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !accountConfigDirectory.isEmpty {
+            return false
+        }
         let configDirectory = environment["CLAUDE_CONFIG_DIR"]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return configDirectory?.isEmpty != false
@@ -351,12 +356,11 @@ class ClaudeCodeLocalService: ObservableObject {
 
     /// Best-effort fetch of the Claude "extra usage" on/off state from the OAuth usage endpoint.
     ///
-    /// Only the default account is supported, since its OAuth token lives in the Keychain.
+    /// Only the unscoped default account is supported, since its OAuth token lives in the Keychain.
     /// Reads credentials without mutating published state and never throws — any missing token,
     /// expired token, network failure, or decode failure resolves to `.unknown`.
     private func fetchExtraUsageStatus(account: ClaudeCodeAccount) async -> ExtraUsageStatus {
-        guard isOAuthFallbackEnabled else { return .unknown }
-        guard account.isDefault else { return .unknown }
+        guard Self.prefersOAuth(account: account, oauthEnabled: isOAuthFallbackEnabled) else { return .unknown }
         // Keychain read — off the main actor, same as the fallback-token path.
         let storedCredentials = await Task.detached(priority: .utility) { [self] in
             getCredentials()

--- a/MeterBar/SessionWake/SessionWakeController.swift
+++ b/MeterBar/SessionWake/SessionWakeController.swift
@@ -121,8 +121,9 @@ final class SessionWakeController: ObservableObject {
             .sink { [weak self] _ in self?.reconcile() }
             .store(in: &cancellables)
 
-        Publishers.Merge(
+        Publishers.Merge3(
             accounts.$customAccounts.map { _ in () },
+            accounts.$defaultAccountConfigDirectory.map { _ in () },
             accounts.$defaultAccountIsEnabled.map { _ in () }
         )
             .receive(on: RunLoop.main)

--- a/MeterBar/Views/Settings/ClaudeAccountProfileRow.swift
+++ b/MeterBar/Views/Settings/ClaudeAccountProfileRow.swift
@@ -84,7 +84,7 @@ struct AccountProfileRow: View {
                 }
 
                 if account.isDefault {
-                    Text("Defaults to ~/.claude or $CLAUDE_CONFIG_DIR; a saved path overrides it in MeterBar.")
+                    Text("Defaults to ~/.claude or $CLAUDE_CONFIG_DIR; clear the field to restore that default.")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                         .padding(.leading, AccountProfileRowMetrics.labelWidth + 8)
@@ -165,7 +165,7 @@ struct AccountProfileRow: View {
     }
 
     private var canSave: Bool {
-        !trimmedName.isEmpty && !trimmedConfigDirectory.isEmpty
+        !trimmedName.isEmpty && (account.isDefault || !trimmedConfigDirectory.isEmpty)
     }
 
     private func saveChanges() {

--- a/MeterBar/Views/Settings/ClaudeAccountProfileRow.swift
+++ b/MeterBar/Views/Settings/ClaudeAccountProfileRow.swift
@@ -14,8 +14,7 @@ enum AccountProfileRowMetrics {
 
 /// One editable Claude Code account row (name + config directory + enable /
 /// reconnect / save / delete). Extracted verbatim from the SettingsView
-/// monolith. The default profile is read-only for its config directory and
-/// cannot be removed.
+/// monolith. The default profile cannot be removed.
 struct AccountProfileRow: View {
     // MARK: Lifecycle
 
@@ -32,7 +31,7 @@ struct AccountProfileRow: View {
         self.onReconnect = onReconnect
         self.onRemove = onRemove
         _nameDraft = State(initialValue: account.name)
-        _configDirectoryDraft = State(initialValue: account.configDirectory ?? "")
+        _configDirectoryDraft = State(initialValue: Self.resolvedConfigDirectory(for: account))
     }
 
     // MARK: Internal
@@ -69,37 +68,23 @@ struct AccountProfileRow: View {
                 }
 
                 HStack(spacing: 8) {
-                    accountFieldLabel(account.isDefault ? "Default config directory" : "Config directory")
+                    accountFieldLabel("Config directory")
 
-                    if account.isDefault {
-                        SettingsReadonlyField(text: displayConfigDirectory)
+                    TextField("Config directory", text: $configDirectoryDraft)
+                        .settingsInput(width: AccountProfileRowMetrics.fieldWidth)
+                        .onSubmit(saveChanges)
 
-                        Button {
-                            revealDefaultConfigDirectory()
-                        } label: {
-                            Image(systemName: "folder")
-                        }
-                        .buttonStyle(.bordered)
-                        .help("Reveal config directory in Finder")
-                    } else {
-                        HStack(spacing: 8) {
-                            TextField("Config directory", text: $configDirectoryDraft)
-                                .settingsInput(width: AccountProfileRowMetrics.fieldWidth)
-                                .onSubmit(saveChanges)
-
-                            Button {
-                                chooseConfigDirectory()
-                            } label: {
-                                Image(systemName: "folder")
-                            }
-                            .buttonStyle(.bordered)
-                            .help("Choose config directory")
-                        }
+                    Button {
+                        chooseConfigDirectory()
+                    } label: {
+                        Image(systemName: "folder")
                     }
+                    .buttonStyle(.bordered)
+                    .help("Choose config directory")
                 }
 
                 if account.isDefault {
-                    Text("Mirrors the Claude CLI default (~/.claude, or $CLAUDE_CONFIG_DIR)")
+                    Text("Defaults to ~/.claude or $CLAUDE_CONFIG_DIR; a saved path overrides it in MeterBar.")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                         .padding(.leading, AccountProfileRowMetrics.labelWidth + 8)
@@ -153,7 +138,7 @@ struct AccountProfileRow: View {
         .padding(.vertical, MeterBarTheme.Spacing.md)
         .onChange(of: account) { _, updatedAccount in
             nameDraft = updatedAccount.name
-            configDirectoryDraft = updatedAccount.configDirectory ?? ""
+            configDirectoryDraft = Self.resolvedConfigDirectory(for: updatedAccount)
         }
     }
 
@@ -170,26 +155,27 @@ struct AccountProfileRow: View {
         configDirectoryDraft.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private var displayConfigDirectory: String {
-        account.configDirectory?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
-            ? account.configDirectory ?? ""
-            : ClaudeCodeAccount.defaultConfigDirectory()
+    private var resolvedConfigDirectory: String {
+        Self.resolvedConfigDirectory(for: account)
     }
 
     private var hasChanges: Bool {
         trimmedName != account.name ||
-            (!account.isDefault && trimmedConfigDirectory != (account.configDirectory ?? ""))
+            trimmedConfigDirectory != resolvedConfigDirectory
     }
 
     private var canSave: Bool {
-        !trimmedName.isEmpty && (account.isDefault || !trimmedConfigDirectory.isEmpty)
+        !trimmedName.isEmpty && !trimmedConfigDirectory.isEmpty
     }
 
     private func saveChanges() {
         guard hasChanges, canSave else {
             return
         }
-        onSave(trimmedName, account.isDefault ? nil : trimmedConfigDirectory)
+        let changedConfigDirectory = trimmedConfigDirectory == resolvedConfigDirectory
+            ? nil
+            : trimmedConfigDirectory
+        onSave(trimmedName, changedConfigDirectory)
     }
 
     private func accountFieldLabel(_ title: String) -> some View {
@@ -200,10 +186,8 @@ struct AccountProfileRow: View {
             .frame(width: AccountProfileRowMetrics.labelWidth, alignment: .leading)
     }
 
-    private func revealDefaultConfigDirectory() {
-        NSWorkspace.shared.activateFileViewerSelecting([
-            URL(fileURLWithPath: ClaudeCodeAccount.defaultConfigDirectory(), isDirectory: true)
-        ])
+    private static func resolvedConfigDirectory(for account: ClaudeCodeAccount) -> String {
+        account.configDirectory ?? (account.isDefault ? ClaudeCodeAccount.defaultConfigDirectory() : "")
     }
 
     private func chooseConfigDirectory() {

--- a/MeterBarTests/ClaudeCodeAccountStoreTests.swift
+++ b/MeterBarTests/ClaudeCodeAccountStoreTests.swift
@@ -2,7 +2,6 @@ import XCTest
 @testable import MeterBar
 
 final class ClaudeCodeAccountStoreTests: XCTestCase {
-
     // MARK: Internal
 
     override func setUp() {
@@ -31,6 +30,24 @@ final class ClaudeCodeAccountStoreTests: XCTestCase {
 
         let reloaded = ClaudeCodeAccountStore(userDefaults: defaults)
         XCTAssertEqual(reloaded.accounts.first?.name, "shipshitdev")
+        XCTAssertNil(reloaded.accounts.first?.configDirectory)
+    }
+
+    func testDefaultProfileConfigDirectoryCanBeEditedAndPersists() {
+        let store = ClaudeCodeAccountStore(userDefaults: defaults)
+
+        store.updateAccount(
+            id: ClaudeCodeAccount.defaultID,
+            name: "genfeedai",
+            configDirectory: "/tmp/old/../claude-genfeedai"
+        )
+
+        XCTAssertEqual(store.accounts.first?.name, "genfeedai")
+        XCTAssertEqual(store.accounts.first?.configDirectory, "/tmp/claude-genfeedai")
+
+        let reloaded = ClaudeCodeAccountStore(userDefaults: defaults)
+        XCTAssertEqual(reloaded.accounts.first?.name, "genfeedai")
+        XCTAssertEqual(reloaded.accounts.first?.configDirectory, "/tmp/claude-genfeedai")
     }
 
     func testDefaultConfigDirectoryFallsBackToClaudeUnderRealHome() {
@@ -80,13 +97,11 @@ final class ClaudeCodeAccountStoreTests: XCTestCase {
         XCTAssertEqual(reloaded.customAccounts.first?.configDirectory, "/tmp/genfeed-claude-profile")
     }
 
-    func testLegacyCustomProfileDefaultsToEnabled() throws {
+    func testLegacyCustomProfileDefaultsToEnabled() {
         let id = UUID()
-        let data = try XCTUnwrap(
-            """
-            [{"id":"\(id.uuidString)","name":"Legacy","configDirectory":"/tmp/legacy"}]
-            """.data(using: .utf8)
-        )
+        let data = Data("""
+        [{"id":"\(id.uuidString)","name":"Legacy","configDirectory":"/tmp/legacy"}]
+        """.utf8)
         defaults.set(data, forKey: StorageKeys.claudeCodeCustomAccounts)
 
         let store = ClaudeCodeAccountStore(userDefaults: defaults)
@@ -202,5 +217,4 @@ final class ClaudeCodeAccountStoreTests: XCTestCase {
 
     private var suiteName: String!
     private var defaults: UserDefaults!
-
 }

--- a/MeterBarTests/ClaudeCodeAccountStoreTests.swift
+++ b/MeterBarTests/ClaudeCodeAccountStoreTests.swift
@@ -50,6 +50,33 @@ final class ClaudeCodeAccountStoreTests: XCTestCase {
         XCTAssertEqual(reloaded.accounts.first?.configDirectory, "/tmp/claude-genfeedai")
     }
 
+    func testDefaultProfileConfigDirectoryCanBeClearedAndRestoresOAuth() throws {
+        let store = ClaudeCodeAccountStore(userDefaults: defaults)
+        store.updateAccount(
+            id: ClaudeCodeAccount.defaultID,
+            name: "genfeedai",
+            configDirectory: "/tmp/claude-genfeedai"
+        )
+
+        store.updateAccount(
+            id: ClaudeCodeAccount.defaultID,
+            name: "genfeedai",
+            configDirectory: "   "
+        )
+
+        XCTAssertNil(store.accounts.first?.configDirectory)
+        XCTAssertNil(defaults.object(forKey: StorageKeys.claudeCodeDefaultConfigDirectory))
+
+        let reloaded = ClaudeCodeAccountStore(userDefaults: defaults)
+        let defaultAccount = try XCTUnwrap(reloaded.accounts.first)
+        XCTAssertNil(defaultAccount.configDirectory)
+        XCTAssertTrue(ClaudeCodeLocalService.prefersOAuth(
+            account: defaultAccount,
+            oauthEnabled: true,
+            environment: [:]
+        ))
+    }
+
     func testDefaultConfigDirectoryFallsBackToClaudeUnderRealHome() {
         XCTAssertEqual(
             ClaudeCodeAccount.defaultConfigDirectory(environment: [:], realHomeDirectory: "/Users/tester"),

--- a/MeterBarTests/ClaudeCodeOAuthUsageTests.swift
+++ b/MeterBarTests/ClaudeCodeOAuthUsageTests.swift
@@ -82,6 +82,17 @@ final class ClaudeCodeOAuthUsageTests: XCTestCase {
             oauthEnabled: true,
             environment: ["CLAUDE_CONFIG_DIR": "/tmp/.claude-genfeedai"]
         ))
+
+        let savedDefault = ClaudeCodeAccount(
+            id: ClaudeCodeAccount.defaultID,
+            name: "genfeedai",
+            configDirectory: "/tmp/.claude-genfeedai"
+        )
+        XCTAssertFalse(ClaudeCodeLocalService.prefersOAuth(
+            account: savedDefault,
+            oauthEnabled: true,
+            environment: [:]
+        ))
     }
 
     func testOnlyDefaultAccountPublishesProviderWideConnectionState() {

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ open MeterBar.xcodeproj
 1. Install Claude Code CLI: `npm install -g @anthropic-ai/claude-code`
 2. Log in: `claude login`
 3. The app reads usage from Claude Code's authenticated `/api/oauth/usage` endpoint using its Keychain login (first launch shows a one-time Keychain access prompt); if no token is available it falls back to parsing `claude /usage` output
-4. Add extra Claude accounts in Settings by pointing each one at a separate `CLAUDE_CONFIG_DIR` (custom accounts use the CLI, since only the default account has a Keychain token)
+4. Configure each Claude account in Settings with its own `CLAUDE_CONFIG_DIR`. The unscoped default account can use the global Keychain token; any explicitly scoped account uses the CLI.
 
 ### Codex CLI
 
@@ -198,10 +198,10 @@ It then uses the respective local source or API to fetch current usage data:
 - Grok: official `grok agent --no-leader stdio` ACP billing response
 
 Claude Code usage reads the authenticated `/api/oauth/usage` endpoint — the same data Claude Code's own `/usage` screen shows — because `claude /usage` no longer renders in a headless (non-interactive) spawn. Parsing the CLI output is kept as a fallback and can be forced by turning off "Claude Code OAuth usage" in Settings.
-- Additional Claude accounts are tracked by running `claude /usage` with each account's configured `CLAUDE_CONFIG_DIR` (they have no Keychain token of their own).
+- Explicitly scoped Claude accounts are tracked by running `claude /usage` with each account's configured `CLAUDE_CONFIG_DIR` (they have no profile-specific Keychain token of their own).
 - Cursor: Local SQLite queries
 
-**No provider API keys are required for CLI-backed services** - the app reuses local Claude Code, Codex, and Grok sign-ins. The default Claude Code account's Keychain OAuth token is read to fetch usage (a one-time macOS Keychain prompt on first launch); Grok authentication remains inside the official CLI process.
+**No provider API keys are required for CLI-backed services** - the app reuses local Claude Code, Codex, and Grok sign-ins. The unscoped default Claude Code account's Keychain OAuth token is read to fetch usage (a one-time macOS Keychain prompt on first launch); Grok authentication remains inside the official CLI process.
 
 ## Privacy & Security
 


### PR DESCRIPTION
## What changed

- make the default Claude account config directory editable with the same field and picker as secondary profiles
- persist the selected default-account directory and propagate it through refreshes, reconnects, activity probes, and Session Wake
- keep global Keychain OAuth limited to an unscoped default account so explicitly scoped profiles use their own CLI context
- add persistence and source-selection regression coverage and update the account documentation

## Root cause

The settings row hard-coded the default account path as read-only, while `ClaudeCodeAccountStore.updateAccount` discarded any directory supplied for the default account. The displayed value came only from `~/.claude` or the app process's `CLAUDE_CONFIG_DIR`, so users could not manage it like a secondary profile.

## User impact

The default Claude profile can now be pointed at any config directory directly in MeterBar. Saved paths remain account-scoped and no longer risk reading quota from a different identity's global Keychain token.

## Validation

- `swiftlint lint --strict --quiet` on all changed Swift files
- `git diff --check`
- local tests/build intentionally skipped per repository MacBook policy; PR CI is the execution gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an editable configuration directory for the default Claude Code profile.
  * Default profile directory changes are saved and restored automatically.
  * Refreshes, reconnects, activity checks, and Session Wake now honor the saved directory.

* **Bug Fixes**
  * Improved account-specific usage tracking to prevent credential and quota cross-contamination.
  * Updated status displays when the default profile directory changes.

* **Documentation**
  * Clarified how default and explicitly configured Claude Code profiles retrieve usage data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->