### PR TITLE
fix(session-wake): preserve registration failure status

### DIFF
--- a/MeterBar/SessionWake/SessionWakeController.swift
+++ b/MeterBar/SessionWake/SessionWakeController.swift
@@ -52,6 +52,7 @@ final class SessionWakeController: ObservableObject {
     private var watchTask: Task<Void, Never>?
     private var localLifetimeLock: WakeLock?
     private var agentMonitorTask: Task<Void, Never>?
+    private var failedRegistrationStatus: SessionWakeAgentRegistrationStatus?
     private var started = false
 
     /// The store defaults are `nil` sentinels resolved in the body because the
@@ -322,18 +323,30 @@ final class SessionWakeController: ObservableObject {
     private func registerAgentIfNeeded() {
         switch agent.currentStatus() {
         case .enabled:
-            status.updateBackgroundExecution(.active)
+            clearRegistrationFailure()
+            refreshAgentRegistrationStatus()
         case .requiresApproval:
+            clearRegistrationFailure()
             status.updateBackgroundExecution(.requiresApproval)
         case .notRegistered, .notFound, .unknown:
+            // Reaching this path while armed is an explicit retry.
+            clearRegistrationFailure()
             do {
                 try agent.register()
                 refreshAgentRegistrationStatus()
             } catch {
-                status.updateBackgroundExecution(.failed("Couldn't start the background watcher."))
-                status.update(
-                    state: .failed(reason: "Background watcher registration failed: \(error.localizedDescription)")
-                )
+                let registrationStatus = agent.currentStatus()
+                failedRegistrationStatus = registrationStatus
+                if registrationStatus == .requiresApproval {
+                    status.update(state: .off)
+                    status.updateBackgroundExecution(.requiresApproval)
+                } else {
+                    let reason = error.localizedDescription
+                    status.updateBackgroundExecution(.failed("Couldn't start the background watcher: \(reason)"))
+                    status.update(
+                        state: .failed(reason: "Background watcher registration failed: \(reason)")
+                    )
+                }
                 store.setOn(false)
                 saveAgentConfiguration(account: selectedAccount())
             }
@@ -342,7 +355,9 @@ final class SessionWakeController: ObservableObject {
 
     private func unregisterAgentIfNeeded() {
         guard usesBackgroundAgent else { return }
-        switch agent.currentStatus() {
+        let registrationStatus = agent.currentStatus()
+        guard !reconcileRegistrationFailure(with: registrationStatus) else { return }
+        switch registrationStatus {
         case .notRegistered, .notFound:
             status.updateBackgroundExecution(.inactive)
         case .enabled, .requiresApproval, .unknown:
@@ -370,7 +385,9 @@ final class SessionWakeController: ObservableObject {
 
     private func refreshAgentRegistrationStatus() {
         guard usesBackgroundAgent else { return }
-        switch agent.currentStatus() {
+        let registrationStatus = agent.currentStatus()
+        guard !reconcileRegistrationFailure(with: registrationStatus) else { return }
+        switch registrationStatus {
         case .enabled:
             if let record = agentStateStore.loadStatus(),
                Date().timeIntervalSince(record.heartbeat) < 10 {
@@ -385,6 +402,28 @@ final class SessionWakeController: ObservableObject {
             status.updateBackgroundExecution(.inactive)
         case .unknown:
             status.updateBackgroundExecution(.failed("Background watcher status is unavailable."))
+        }
+    }
+
+    /// Registration failure disarms the store, which immediately triggers both
+    /// an off-state reconcile and the agent monitor. Preserve only that exact
+    /// failure while ServiceManagement reports the same registration state.
+    private func reconcileRegistrationFailure(
+        with registrationStatus: SessionWakeAgentRegistrationStatus
+    ) -> Bool {
+        guard let failedRegistrationStatus else { return false }
+        guard failedRegistrationStatus != registrationStatus else { return true }
+        clearRegistrationFailure()
+        return false
+    }
+
+    /// A retry or external registration-state transition supersedes the prior
+    /// registration failure and restores the normal status lifecycle.
+    private func clearRegistrationFailure() {
+        guard failedRegistrationStatus != nil else { return }
+        failedRegistrationStatus = nil
+        if case .failed = status.watcherState {
+            status.update(state: .off)
         }
     }
 }

--- a/MeterBarTests/SessionWakeControllerTests.swift
+++ b/MeterBarTests/SessionWakeControllerTests.swift
@@ -273,6 +273,70 @@ final class SessionWakeControllerTests: XCTestCase {
 
         XCTAssertEqual(fakeAgent.unregisterCount, 1)
         XCTAssertFalse(agentState.loadConfiguration()?.isArmed ?? true)
+        XCTAssertEqual(sessionStatus.backgroundExecution, .inactive)
+    }
+
+    func testRegistrationFailureRemainsVisibleUntilSuccessfulRetry() {
+        let store = armedStore()
+        let fakeAgent = FakeSessionWakeAgent()
+        fakeAgent.registerError = FakeSessionWakeAgentError.registrationDenied
+        let agentState = SessionWakeAgentStateStore(userDefaults: defaults)
+        agentState.saveStatus(.init(state: .idle))
+        let sessionStatus = SessionWakeStatus()
+        let controller = SessionWakeController(
+            store: store,
+            status: sessionStatus,
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            agent: fakeAgent,
+            agentStateStore: agentState
+        )
+
+        controller.activate()
+        // Deliver the automatic off-state reconcile and the monitor's first
+        // registration-status refresh; neither may erase the failure.
+        pump(0.2)
+
+        XCTAssertEqual(fakeAgent.registerCount, 1)
+        XCTAssertFalse(store.isOn)
+        XCTAssertEqual(
+            sessionStatus.backgroundExecution,
+            .failed("Couldn't start the background watcher: operation not permitted")
+        )
+        guard case let .failed(reason) = sessionStatus.watcherState else {
+            return XCTFail("registration failure should remain visible in the watcher status")
+        }
+        XCTAssertTrue(reason.contains("operation not permitted"))
+
+        fakeAgent.registerError = nil
+        store.setOn(true)
+        pump(0.2)
+
+        XCTAssertEqual(fakeAgent.registerCount, 2)
+        XCTAssertTrue(store.isOn)
+        XCTAssertEqual(sessionStatus.backgroundExecution, .active)
+        XCTAssertEqual(sessionStatus.watcherState, .idle)
+    }
+
+    func testRegistrationFailureThatRequiresApprovalShowsLoginItemsState() {
+        let store = armedStore()
+        let fakeAgent = FakeSessionWakeAgent()
+        fakeAgent.registerError = FakeSessionWakeAgentError.registrationDenied
+        fakeAgent.registerFailureStatus = .requiresApproval
+        let sessionStatus = SessionWakeStatus()
+        let controller = SessionWakeController(
+            store: store,
+            status: sessionStatus,
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            agent: fakeAgent
+        )
+
+        controller.activate()
+        pump(0.2)
+
+        XCTAssertEqual(fakeAgent.registerCount, 1)
+        XCTAssertFalse(store.isOn)
+        XCTAssertEqual(sessionStatus.backgroundExecution, .requiresApproval)
+        XCTAssertEqual(sessionStatus.watcherState, .off)
     }
 }
 
@@ -316,9 +380,17 @@ nonisolated private struct FakeWatcher: WakeWatching {
     }
 }
 
+private enum FakeSessionWakeAgentError: LocalizedError {
+    case registrationDenied
+
+    var errorDescription: String? { "operation not permitted" }
+}
+
 private final class FakeSessionWakeAgent: SessionWakeAgentControlling {
     var isAvailable = true
     private(set) var status: SessionWakeAgentRegistrationStatus = .notRegistered
+    var registerError: Error?
+    var registerFailureStatus: SessionWakeAgentRegistrationStatus?
     private(set) var registerCount = 0
     private(set) var unregisterCount = 0
 
@@ -326,6 +398,12 @@ private final class FakeSessionWakeAgent: SessionWakeAgentControlling {
 
     func register() throws {
         registerCount += 1
+        if let registerError {
+            if let registerFailureStatus {
+                status = registerFailureStatus
+            }
+            throw registerError
+        }
         status = .enabled
     }
 


### PR DESCRIPTION
## Summary

- preserve a failed Session Wake registration through the automatic disarm reconcile and agent monitor poll
- keep macOS `requiresApproval` actionable so the Login Items recovery button remains available
- surface the localized ServiceManagement failure reason and clear it on retry or external status transition
- add controller regression coverage for failure persistence, successful retry, approval-required registration, and normal disable

## Verification

- `swiftlint lint --strict --quiet MeterBar/SessionWake/SessionWakeController.swift MeterBarTests/SessionWakeControllerTests.swift`
- `git diff --check`
- Claude Opus 4.8 high-effort review: final verdict `No findings.`
- Local XCTest/build not run per repository MacBook policy; PR CI is the execution gate
- SwiftFormat unavailable in the environment

Closes #204


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registration failures now remain visible until a successful retry or a different registration state occurs.
  * Improved status reporting distinguishes approval-required failures from other registration errors.
  * Failed registrations consistently keep background execution disarmed until recovery.
* **Tests**
  * Added coverage for denied registrations, approval-required states, persistent failure handling, and successful re-enablement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->