### PR TITLE
fix(menu-bar): keep OpenRouter eligible for auto selection

### DIFF
--- a/.agents/SESSIONS/2026-07-16.md
+++ b/.agents/SESSIONS/2026-07-16.md
@@ -1,0 +1,55 @@
+# 2026-07-16 — Restore OpenRouter automatic selection
+
+## Session 1: OpenRouter menu-bar auto eligibility
+
+**Status:** Complete; PR CI pending
+
+```mermaid
+flowchart LR
+    Metrics[Provider usage metrics] --> Builder[Status-item candidate builder]
+    Builder --> Policy{Provider auto-window policy}
+    Policy -->|OpenRouter| Credits[Weekly account-credits candidate]
+    Credits --> Selector[Activity-aware auto selector]
+    Selector -->|CLI active| CLI[Keep active CLI provider]
+    Selector -->|all idle| Tightest[Choose tightest eligible provider]
+```
+
+### Affected components
+
+- Menu-bar quota candidate construction
+- Automatic provider selection policy
+- Focused selector regression coverage
+
+### What was done
+
+- Added a testable provider-to-auto-window policy that keeps Claude/Codex on session,
+  Cursor on weekly, and makes OpenRouter account credits eligible through weekly.
+- Extracted the existing candidate-seed construction from `AppDelegate` so production
+  wiring can be covered without exposing AppKit lifecycle code.
+- Added coverage proving OpenRouter participates in the idle fallback while active
+  CLI providers retain selection priority.
+
+### Key decisions
+
+- OpenRouter remains activity-neutral because it has no local CLI activity signal;
+  successful API refresh time would make it permanently active.
+- Grok remains excluded from automatic selection because no existing auto window is
+  defined for it.
+
+### Files changed
+
+- `MeterBar/App/MeterBarApp.swift`
+- `MeterBar/Models/StatusItemLimitSelector.swift`
+- `MeterBarTests/StatusItemLimitSelectorTests.swift`
+
+### Verification
+
+- SwiftLint strict passed on all changed Swift files.
+- `git diff --check` passed.
+- Local SwiftFormat was unavailable.
+- Local tests and builds were intentionally not run per the MacBook policy; PR CI is
+  the execution gate.
+
+### Next steps
+
+- [ ] Confirm PR CI and review the automatic-selection behavior.

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -714,18 +714,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         updateStatusItem(metrics: UsageDataManager.shared.metrics)
     }
 
-    /// One menu-bar-title candidate whose on-disk activity probe has not run
-    /// yet. The probe is a `@Sendable` closure so the filesystem scan can run
-    /// off the main actor (it previously ran inline here and stalled the UI).
-    private struct StatusLimitCandidateSeed: Sendable {
-        let key: String
-        let pinKey: String
-        let displayName: String
-        let windowName: String
-        let limit: UsageLimit
-        let isAutoSelectable: Bool
-    }
-
     private struct StatusLimitProbeRequest: Sendable {
         let seeds: [StatusLimitCandidateSeed]
         let probe: @Sendable () -> Date?
@@ -737,7 +725,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let autoSelectionKey: String?
         let displayName: String
         let metrics: UsageMetrics
-        let autoWindowID: String?
     }
 
     @MainActor
@@ -875,8 +862,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     accountID: account.id,
                     autoSelectionKey: "claude:\(account.id.uuidString)",
                     displayName: "\(account.name) (\(ServiceType.claudeCode.displayName))",
-                    metrics: accountMetrics,
-                    autoWindowID: "session"
+                    metrics: accountMetrics
                 )
                 requests.append(statusLimitProbeRequest(
                     source: source,
@@ -895,8 +881,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     accountID: account.id,
                     autoSelectionKey: "codex:\(account.id.uuidString)",
                     displayName: "\(account.name) (\(ServiceType.codexCli.displayName))",
-                    metrics: accountMetrics,
-                    autoWindowID: "session"
+                    metrics: accountMetrics
                 )
                 requests.append(statusLimitProbeRequest(
                     source: source,
@@ -910,8 +895,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 accountID: nil,
                 autoSelectionKey: "cursor",
                 displayName: ServiceType.cursor.displayName,
-                metrics: cursorMetrics,
-                autoWindowID: "weekly"
+                metrics: cursorMetrics
             )
             requests.append(statusLimitProbeRequest(
                 source: source,
@@ -924,8 +908,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 accountID: nil,
                 autoSelectionKey: nil,
                 displayName: ServiceType.openRouter.displayName,
-                metrics: openRouterMetrics,
-                autoWindowID: nil
+                metrics: openRouterMetrics
             )
             requests.append(statusLimitProbeRequest(
                 source: source,
@@ -940,21 +923,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         source: StatusLimitSource,
         probe: @escaping @Sendable () -> Date?
     ) -> StatusLimitProbeRequest {
-        let seeds = ProviderSnapshotBuilder.limits(for: source.metrics, service: source.service).map { limit in
-            let pinKey = StatusItemPinKey.make(
-                service: source.service,
-                accountID: source.accountID,
-                windowID: limit.id
-            )
-            return StatusLimitCandidateSeed(
-                key: limit.id == source.autoWindowID ? source.autoSelectionKey ?? pinKey : pinKey,
-                pinKey: pinKey,
-                displayName: source.displayName,
-                windowName: limit.title,
-                limit: limit.usageLimit,
-                isAutoSelectable: limit.id == source.autoWindowID
-            )
-        }
+        let seeds = StatusItemLimitCandidateBuilder.seeds(
+            service: source.service,
+            accountID: source.accountID,
+            autoSelectionKey: source.autoSelectionKey,
+            displayName: source.displayName,
+            limits: ProviderSnapshotBuilder.limits(for: source.metrics, service: source.service)
+        )
         return StatusLimitProbeRequest(seeds: seeds, probe: probe)
     }
 

--- a/MeterBar/Models/StatusItemLimitSelector.swift
+++ b/MeterBar/Models/StatusItemLimitSelector.swift
@@ -21,9 +21,61 @@ struct StatusLimitCandidate: Equatable, Sendable {
     let isAutoSelectable: Bool
 }
 
+/// One menu-bar-title candidate whose on-disk activity probe has not run yet.
+struct StatusLimitCandidateSeed: Sendable {
+    let key: String
+    let pinKey: String
+    let displayName: String
+    let windowName: String
+    let limit: UsageLimit
+    let isAutoSelectable: Bool
+}
+
 nonisolated enum StatusItemPinKey {
     static func make(service: ServiceType, accountID: UUID?, windowID: String) -> String {
         "\(service.rawValue):\(accountID?.uuidString ?? "default"):\(windowID)"
+    }
+}
+
+/// Identifies the quota window each provider contributes to automatic menu-bar
+/// selection. Other windows remain available for explicit pinning only.
+nonisolated enum StatusItemAutoSelectionPolicy {
+    static func windowID(for service: ServiceType) -> String? {
+        switch service {
+        case .claudeCode, .codexCli:
+            return "session"
+        case .cursor, .openRouter:
+            return "weekly"
+        case .grok:
+            return nil
+        }
+    }
+}
+
+enum StatusItemLimitCandidateBuilder {
+    static func seeds(
+        service: ServiceType,
+        accountID: UUID?,
+        autoSelectionKey: String?,
+        displayName: String,
+        limits: [SnapshotLimit]
+    ) -> [StatusLimitCandidateSeed] {
+        let autoWindowID = StatusItemAutoSelectionPolicy.windowID(for: service)
+        return limits.map { limit in
+            let pinKey = StatusItemPinKey.make(
+                service: service,
+                accountID: accountID,
+                windowID: limit.id
+            )
+            return StatusLimitCandidateSeed(
+                key: limit.id == autoWindowID ? autoSelectionKey ?? pinKey : pinKey,
+                pinKey: pinKey,
+                displayName: displayName,
+                windowName: limit.title,
+                limit: limit.usageLimit,
+                isAutoSelectable: limit.id == autoWindowID
+            )
+        }
     }
 }
 

--- a/MeterBarTests/StatusItemLimitSelectorTests.swift
+++ b/MeterBarTests/StatusItemLimitSelectorTests.swift
@@ -49,6 +49,50 @@ final class StatusItemLimitSelectorTests: XCTestCase {
         XCTAssertEqual(select([only])?.key, "codex")
     }
 
+    func testProviderAutoWindowPolicyPreservesExistingWindowsAndAddsOpenRouterCredits() {
+        XCTAssertEqual(StatusItemAutoSelectionPolicy.windowID(for: .claudeCode), "session")
+        XCTAssertEqual(StatusItemAutoSelectionPolicy.windowID(for: .codexCli), "session")
+        XCTAssertEqual(StatusItemAutoSelectionPolicy.windowID(for: .cursor), "weekly")
+        XCTAssertEqual(StatusItemAutoSelectionPolicy.windowID(for: .openRouter), "weekly")
+        XCTAssertNil(StatusItemAutoSelectionPolicy.windowID(for: .grok))
+    }
+
+    func testOpenRouterAccountCreditsParticipateInAutoSelection() {
+        let metrics = UsageMetrics(
+            service: .openRouter,
+            sessionLimit: UsageLimit(used: 10, total: 100, resetTime: now.addingTimeInterval(3600)),
+            weeklyLimit: UsageLimit(used: 80, total: 100, resetTime: nil)
+        )
+        let seeds = StatusItemLimitCandidateBuilder.seeds(
+            service: .openRouter,
+            accountID: nil,
+            autoSelectionKey: nil,
+            displayName: ServiceType.openRouter.displayName,
+            limits: ProviderSnapshotBuilder.limits(for: metrics, service: .openRouter)
+        )
+        let candidates = seeds.map { seed in
+            StatusLimitCandidate(
+                key: seed.key,
+                pinKey: seed.pinKey,
+                displayName: seed.displayName,
+                windowName: seed.windowName,
+                limit: seed.limit,
+                lastActivity: nil,
+                isAutoSelectable: seed.isAutoSelectable
+            )
+        }
+        let idleCodex = candidate(key: "codex-idle", percentUsed: 30)
+        let activeCodex = candidate(
+            key: "codex-active",
+            percentUsed: 30,
+            activeMinutesAgo: 5
+        )
+
+        XCTAssertEqual(seeds.filter(\.isAutoSelectable).map(\.windowName), ["Account credits"])
+        XCTAssertEqual(select(candidates + [idleCodex])?.windowName, "Account credits")
+        XCTAssertEqual(select(candidates + [activeCodex])?.key, activeCodex.key)
+    }
+
     // MARK: - Active-account filtering
 
     func testTightestAmongActiveWinsOverTighterIdleAccount() {


### PR DESCRIPTION
## Summary

- make OpenRouter weekly account credits eligible for menu-bar Auto selection
- extract a testable provider auto-window and candidate-seed builder
- preserve active CLI-provider priority while OpenRouter participates in idle fallback

## Root cause

OpenRouter was configured without an automatic window ID, so all of its candidate seeds were pin-only even when weekly account-credit usage was available.

## Verification

- `swiftlint lint --strict --quiet MeterBar/App/MeterBarApp.swift MeterBar/Models/StatusItemLimitSelector.swift MeterBarTests/StatusItemLimitSelectorTests.swift`
- `git diff --check`
- Claude Opus 4.8 high-effort review; applied the safe in-scope feedback and re-reviewed the final diff
- local Swift tests/build intentionally skipped per repository machine policy; PR CI is the broad validation gate
- SwiftFormat unavailable locally (`swiftformat: command not found`)

Closes #203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restored automatic provider selection for OpenRouter account credits.
  * The status bar now prioritizes the active command-line provider when activity is detected.
  * When no active provider is available, automatic selection chooses the most constrained eligible usage window.
  * OpenRouter weekly account-credit windows are now included in automatic selection.

* **Bug Fixes**
  * Improved provider quota candidate handling for more consistent status-item usage displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->