### PR TITLE
fix(updates): correct non-Sparkle availability copy

### DIFF
--- a/MeterBar/Services/SoftwareUpdateController.swift
+++ b/MeterBar/Services/SoftwareUpdateController.swift
@@ -171,7 +171,7 @@ final class SoftwareUpdateController: ObservableObject {
         _ = bundle
         userDefaults = defaults
         channel = Self.loadChannel(from: defaults)
-        configurationError = "Software updates are available in the app build."
+        configurationError = "Software updates are unavailable in this build."
     }
 
     func setAutomaticallyChecksForUpdates(_ enabled: Bool) {

--- a/MeterBarTests/SparkleUpdateTests.swift
+++ b/MeterBarTests/SparkleUpdateTests.swift
@@ -3,6 +3,15 @@ import Foundation
 import XCTest
 
 final class SparkleUpdateTests: XCTestCase {
+    #if !canImport(Sparkle)
+    func testFallbackConfigurationExplainsUpdatesAreUnavailable() {
+        let controller = SoftwareUpdateController()
+
+        XCTAssertEqual(controller.configurationError, "Software updates are unavailable in this build.")
+        XCTAssertFalse(controller.canCheckForUpdates)
+    }
+    #endif
+
     func testKeyValidatorRejectsUnsubstitutedBuildVariable() {
         // Debug and PR-gate builds never substitute the build setting, so the
         // literal variable is exactly what ships in their Info.plist.


### PR DESCRIPTION
## Summary

- correct the non-Sparkle fallback message so disabled update controls explain that updates are unavailable
- preserve the existing Sparkle-enabled initializer and messaging
- add SwiftPM regression coverage for the no-Sparkle configuration

## Verification

- `swiftlint lint --strict --quiet MeterBar/Services/SoftwareUpdateController.swift`
- `swiftlint lint --quiet MeterBarTests/SparkleUpdateTests.swift` (passes with one pre-existing line-length warning at line 88)
- `git diff --check`
- Claude Opus 4.8 high-effort review: `No findings.`
- local XCTest/build skipped per repository MacBook policy; PR CI is the execution gate
- SwiftFormat unavailable locally

Closes #165
