### PR TITLE
fix(ui): bound multi-account quota surfaces

### DIFF
--- a/.agents/SESSIONS/2026-07-17.md
+++ b/.agents/SESSIONS/2026-07-17.md
@@ -1,0 +1,31 @@
+# 2026-07-17 — Multi-account quota UI follow-ups
+
+## Session 1: Bound widget rows and isolate enabled Codex profiles
+
+**Status:** Complete; PR CI pending
+
+### What changed
+
+- Count every enabled Codex and Claude profile in the dashboard overview, plus each enabled single-account provider.
+- Exclude disabled Codex profiles from provider cards, status-item probes, refreshes, aggregate metrics, and widget snapshots.
+- Keep Codex graceful degradation account-scoped so cached quota data cannot move between profile labels.
+- Bound the medium widget to three row slots, using two rows plus a `+N more` summary when usage sources overflow.
+- Add regression coverage for source counts, disabled/all-disabled/profile-switched Codex accounts, and widget row budgeting.
+
+### Verification
+
+- Focused SwiftLint strict: zero violations on all changed Swift files.
+- `git diff --check`: clean.
+- Claude Opus 4.8 high-effort review completed; all correctness findings applied and the final profile-isolation verdict passed.
+- Local XCTest and Xcode build skipped per MacBook policy; PR CI is the broad validation gate.
+- SwiftFormat unavailable locally.
+
+### Files changed
+
+- `MeterBar/App/MeterBarApp.swift`
+- `MeterBar/Services/UsageDataManager.swift`
+- `MeterBar/Views/ProviderSnapshot.swift`
+- `MeterBar/Views/UsageDashboardView.swift`
+- `MeterBarWidget/UsageWidget.swift`
+- `Packages/MeterBarShared/Sources/MeterBarShared/MediumWidgetRowBudget.swift`
+- Focused tests under `MeterBarTests/`

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -885,9 +885,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
         if providerVisibilityStore.isEnabled(.codexCli) {
-            for account in CodexAccountStore.shared.accounts {
+            let enabledAccounts = CodexAccountStore.shared.enabledAccounts
+            for account in enabledAccounts {
+                let fallbackMetrics = account.isDefault
+                    && enabledAccounts.count == 1
+                    && UsageDataManager.shared.codexAccountMetrics.isEmpty
+                    ? metrics[.codexCli]
+                    : nil
                 let accountMetrics = UsageDataManager.shared.codexAccountMetrics[account.id]
-                    ?? (account.isDefault ? metrics[.codexCli] : nil)
+                    ?? fallbackMetrics
                 guard let accountMetrics else { continue }
                 let homeDirectory = account.homeDirectory
                 let source = StatusLimitSource(

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -124,13 +124,12 @@ class UsageDataManager: ObservableObject {
             claudeCodeAccountMetrics = [:]
         }
 
-        if providerVisibilityStore.isEnabled(.codexCli) {
+        let hasEnabledCodexAccount = !codexAccountStore.enabledAccounts.isEmpty
+        if providerVisibilityStore.isEnabled(.codexCli), hasEnabledCodexAccount {
             let accountMetrics = await fetchCodexAccountMetrics()
             codexAccountMetrics = accountMetrics
             if let representative = representativeCodexMetrics(from: accountMetrics) {
                 newMetrics[.codexCli] = representative
-            } else if let cachedMetrics = self.metrics[.codexCli] {
-                newMetrics[.codexCli] = cachedMetrics
             }
         } else {
             codexAccountMetrics = [:]
@@ -153,6 +152,8 @@ class UsageDataManager: ObservableObject {
         // Merge new metrics with existing cached metrics for services that failed to fetch
         for service in ServiceType.allCases where providerVisibilityStore.isEnabled(service) {
             if service == .claudeCode, !hasEnabledClaudeAccount { continue }
+            // Codex cache entries are account-scoped and merged during account refresh.
+            if service == .codexCli { continue }
             if newMetrics[service] == nil, let cachedMetric = self.metrics[service] {
                 newMetrics[service] = cachedMetric
             }
@@ -192,6 +193,16 @@ class UsageDataManager: ObservableObject {
             return
         }
 
+        if service == .codexCli, codexAccountStore.enabledAccounts.isEmpty {
+            codexAccountMetrics = [:]
+            metrics.removeValue(forKey: service)
+            saveCachedData()
+            saveCachedCodexAccountMetrics()
+            saveSharedData(metrics)
+            isLoading = false
+            return
+        }
+
         do {
             let newMetrics = try await refreshedMetrics(for: service)
 
@@ -203,8 +214,17 @@ class UsageDataManager: ObservableObject {
             if lastError == nil {
                 lastError = error
             }
-            // Preserve existing cached metrics for this service on error
-            if metrics[service] == nil {
+            if service == .codexCli {
+                // Codex aggregate metrics carry no account identity. Scoped
+                // per-account caches are restored inside fetchCodexAccountMetrics;
+                // if none exist, showing no data is safer than relabeling a
+                // different profile's stale quota.
+                metrics.removeValue(forKey: service)
+                saveCachedData()
+                saveCachedCodexAccountMetrics()
+                saveSharedData(metrics)
+            } else if metrics[service] == nil {
+                // Preserve existing cached metrics for single-account services.
                 if let cachedData = loadCachedMetricsFromDisk()[service] {
                     metrics[service] = cachedData
                 }
@@ -239,6 +259,7 @@ class UsageDataManager: ObservableObject {
             let accountMetrics = await fetchCodexAccountMetrics()
             codexAccountMetrics = accountMetrics
             if let representative = representativeCodexMetrics(from: accountMetrics) { return representative }
+            throw ServiceError.notAuthenticated
         case .cursor, .openRouter, .grok:
             guard hasProviderAccess(service) else { throw ServiceError.notAuthenticated }
             do {
@@ -290,7 +311,7 @@ class UsageDataManager: ObservableObject {
 
     private func saveSharedData(_ metrics: [ServiceType: UsageMetrics]) {
         sharedStore.saveMetrics(metrics)
-        let accountSnapshots = codexAccountStore.accounts.compactMap { account -> AccountUsageSnapshot? in
+        let accountSnapshots = codexAccountStore.enabledAccounts.compactMap { account -> AccountUsageSnapshot? in
             guard let metrics = codexAccountMetrics[account.id] else { return nil }
             return AccountUsageSnapshot(id: account.id, name: account.name, metrics: metrics)
         }
@@ -355,7 +376,7 @@ class UsageDataManager: ObservableObject {
         var firstFailure: Error?
         var successCount = 0
 
-        for account in codexAccountStore.accounts {
+        for account in codexAccountStore.enabledAccounts {
             guard await codexCliService.canAccess(account: account) else { continue }
             do {
                 refreshedMetrics[account.id] = try await codexCliService.fetchUsageMetrics(account: account)
@@ -379,8 +400,11 @@ class UsageDataManager: ObservableObject {
     }
 
     private func representativeCodexMetrics(from accountMetrics: [UUID: UsageMetrics]) -> UsageMetrics? {
-        accountMetrics[CodexAccount.defaultID]
-            ?? codexAccountStore.accounts.lazy.compactMap { accountMetrics[$0.id] }.first
+        if codexAccountStore.defaultAccountIsEnabled,
+           let defaultMetrics = accountMetrics[CodexAccount.defaultID] {
+            return defaultMetrics
+        }
+        return codexAccountStore.enabledAccounts.lazy.compactMap { accountMetrics[$0.id] }.first
     }
 
     // MARK: - Provider strategy

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -208,25 +208,26 @@ enum ProviderSnapshotBuilder {
         var result: [ProviderSnapshot] = []
 
         if input.enabledServices.contains(.codexCli) {
-            if !input.codexAccountMetrics.isEmpty {
-                for account in input.codexAccounts {
-                    let title = account.isDefault && input.codexAccounts.count == 1 ? "Codex" : account.name
+            let enabledAccounts = input.codexAccounts.filter(\.isEnabled)
+            if !enabledAccounts.isEmpty {
+                for account in enabledAccounts {
+                    let title = account.isDefault && enabledAccounts.count == 1 ? "Codex" : account.name
+                    let emptyDetail = account.isDefault && input.codexCliHasAccess
+                        ? "Waiting for refresh"
+                        : "Run codex login"
+                    let fallbackMetrics = account.isDefault
+                        && enabledAccounts.count == 1
+                        && input.codexAccountMetrics.isEmpty
+                        ? input.metrics[.codexCli]
+                        : nil
                     result.append(snapshot(
                         title: title,
                         service: .codexCli,
-                        metrics: input.codexAccountMetrics[account.id],
-                        emptyDetail: account.isDefault ? "Waiting for refresh" : "Run codex login",
+                        metrics: input.codexAccountMetrics[account.id] ?? fallbackMetrics,
+                        emptyDetail: emptyDetail,
                         accountID: account.id
                     ))
                 }
-            } else {
-                result.append(snapshot(
-                    title: "Codex",
-                    service: .codexCli,
-                    metrics: input.metrics[.codexCli],
-                    emptyDetail: input.codexCliHasAccess ? "Waiting for refresh" : "Run codex login",
-                    accountID: CodexAccount.defaultID
-                ))
             }
         }
 

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -186,6 +186,25 @@ enum SettingsSection: String, CaseIterable, Identifiable, Hashable {
     }
 }
 
+enum EnabledQuotaSourceCounter {
+    static func count(
+        enabledServices: Set<ServiceType>,
+        codexAccountCount: Int,
+        claudeAccountCount: Int
+    ) -> Int {
+        enabledServices.reduce(into: 0) { count, service in
+            switch service {
+            case .codexCli:
+                count += codexAccountCount
+            case .claudeCode:
+                count += claudeAccountCount
+            case .cursor, .openRouter, .grok:
+                count += 1
+            }
+        }
+    }
+}
+
 @MainActor
 final class DashboardNavigationStore: ObservableObject {
     static let shared = DashboardNavigationStore()
@@ -821,17 +840,11 @@ struct UsageDashboardView: View {
     }
 
     private var enabledQuotaSourceCount: Int {
-        var count = 0
-        if providerVisibility.isEnabled(.codexCli) {
-            count += 1
-        }
-        if providerVisibility.isEnabled(.claudeCode) {
-            count += claudeAccountStore.enabledAccounts.count
-        }
-        if providerVisibility.isEnabled(.cursor) {
-            count += 1
-        }
-        return count
+        EnabledQuotaSourceCounter.count(
+            enabledServices: providerVisibility.enabledServices,
+            codexAccountCount: codexAccountStore.enabledAccounts.count,
+            claudeAccountCount: claudeAccountStore.enabledAccounts.count
+        )
     }
 
     private var tightestLimit: SnapshotLimit? {

--- a/MeterBarTests/DashboardLayoutTests.swift
+++ b/MeterBarTests/DashboardLayoutTests.swift
@@ -32,6 +32,41 @@ final class DashboardLayoutTests: XCTestCase {
         )
     }
 
+    // MARK: - Enabled quota-source count
+
+    func testEnabledQuotaSourceCountIncludesEveryEnabledAccount() {
+        XCTAssertEqual(
+            EnabledQuotaSourceCounter.count(
+                enabledServices: [.codexCli, .claudeCode, .cursor],
+                codexAccountCount: 3,
+                claudeAccountCount: 2
+            ),
+            6
+        )
+    }
+
+    func testEnabledQuotaSourceCountIncludesSingleAccountProviders() {
+        XCTAssertEqual(
+            EnabledQuotaSourceCounter.count(
+                enabledServices: Set(ServiceType.allCases),
+                codexAccountCount: 2,
+                claudeAccountCount: 3
+            ),
+            8
+        )
+    }
+
+    func testEnabledQuotaSourceCountIgnoresAccountsForHiddenProviders() {
+        XCTAssertEqual(
+            EnabledQuotaSourceCounter.count(
+                enabledServices: [.cursor],
+                codexAccountCount: 3,
+                claudeAccountCount: 2
+            ),
+            1
+        )
+    }
+
     // MARK: - DashboardCard trailing view slot
 
     func testDashboardCardAcceptsTrailingControl() {

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -21,12 +21,16 @@ final class ProviderSnapshotTests: XCTestCase {
 
     private func makeInput(
         metrics: [ServiceType: UsageMetrics] = [:],
+        codexAccounts: [CodexAccount] = [.defaultAccount],
+        codexAccountMetrics: [UUID: UsageMetrics] = [:],
         claudeAccounts: [ClaudeCodeAccount] = [.defaultAccount],
         claudeAccountMetrics: [UUID: UsageMetrics] = [:],
         enabledServices: Set<ServiceType> = Set(ServiceType.allCases)
     ) -> ProviderSnapshotBuilder.Input {
         ProviderSnapshotBuilder.Input(
             metrics: metrics,
+            codexAccounts: codexAccounts,
+            codexAccountMetrics: codexAccountMetrics,
             claudeAccounts: claudeAccounts,
             claudeAccountMetrics: claudeAccountMetrics,
             enabledServices: enabledServices
@@ -160,6 +164,72 @@ final class ProviderSnapshotTests: XCTestCase {
         XCTAssertEqual(snapshots.map(\.accountID), [CodexAccount.defaultID, work.id])
         XCTAssertEqual(snapshots.map { $0.primaryLimit?.usedPercent }, [25, 75])
         XCTAssertEqual(Set(snapshots.map(\.id)).count, 2)
+    }
+
+    func testDisabledCodexAccountsAreExcludedEvenWithCachedMetrics() {
+        let disabled = CodexAccount(
+            id: UUID(),
+            name: "Disabled",
+            homeDirectory: "/tmp/codex-disabled",
+            isEnabled: false
+        )
+        let enabled = CodexAccount(id: UUID(), name: "Enabled", homeDirectory: "/tmp/codex-enabled")
+        let snapshots = ProviderSnapshotBuilder.snapshots(makeInput(
+            codexAccounts: [disabled, enabled],
+            codexAccountMetrics: [
+                disabled.id: makeMetrics(service: .codexCli, weekly: 80),
+                enabled.id: makeMetrics(service: .codexCli, weekly: 20)
+            ],
+            enabledServices: [.codexCli]
+        ))
+
+        XCTAssertEqual(snapshots.map(\.title), ["Enabled"])
+        XCTAssertEqual(snapshots.first?.limits.first?.usageLimit.used, 20)
+    }
+
+    func testDefaultCodexAccountDoesNotBorrowAnotherEnabledAccountsMetrics() {
+        let work = CodexAccount(id: UUID(), name: "Work", homeDirectory: "/tmp/codex-work")
+        let workMetrics = makeMetrics(service: .codexCli, weekly: 75)
+        let snapshots = ProviderSnapshotBuilder.snapshots(makeInput(
+            metrics: [.codexCli: workMetrics],
+            codexAccounts: [.defaultAccount, work],
+            codexAccountMetrics: [work.id: workMetrics],
+            enabledServices: [.codexCli]
+        ))
+
+        XCTAssertEqual(snapshots.map(\.title), [CodexAccount.defaultName, "Work"])
+        XCTAssertFalse(snapshots[0].hasMetrics)
+        XCTAssertEqual(snapshots[1].primaryLimit?.usedPercent, 75)
+    }
+
+    func testSoleDefaultCodexAccountDoesNotBorrowAggregateWhileAnotherAccountCacheExists() {
+        let work = CodexAccount(id: UUID(), name: "Work", homeDirectory: "/tmp/codex-work")
+        let workMetrics = makeMetrics(service: .codexCli, weekly: 75)
+        let snapshots = ProviderSnapshotBuilder.snapshots(makeInput(
+            metrics: [.codexCli: workMetrics],
+            codexAccounts: [.defaultAccount],
+            codexAccountMetrics: [work.id: workMetrics],
+            enabledServices: [.codexCli]
+        ))
+
+        XCTAssertEqual(snapshots.map(\.title), ["Codex"])
+        XCTAssertFalse(snapshots[0].hasMetrics)
+    }
+
+    func testCodexProviderHasNoSnapshotWhenAllAccountsAreDisabled() {
+        let disabledDefault = CodexAccount(
+            id: CodexAccount.defaultID,
+            name: CodexAccount.defaultName,
+            homeDirectory: nil,
+            isEnabled: false
+        )
+        let snapshots = ProviderSnapshotBuilder.snapshots(makeInput(
+            metrics: [.codexCli: makeMetrics(service: .codexCli, weekly: 90)],
+            codexAccounts: [disabledDefault],
+            enabledServices: [.codexCli]
+        ))
+
+        XCTAssertTrue(snapshots.isEmpty)
     }
 
     func testStatusItemPinOptionsUseStableProviderAccountWindowKeys() {

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -11,7 +11,6 @@ import XCTest
 /// out of scope here), leaving Codex + Cursor as the single-account providers.
 @MainActor
 final class UsageDataManagerTests: XCTestCase {
-
     /// Stub provider whose access flag and fetch result are fully controlled.
     private final class StubProvider: SimpleUsageProviding, CodexUsageProviding {
         var hasAccess: Bool
@@ -37,7 +36,8 @@ final class UsageDataManagerTests: XCTestCase {
     private enum StubError: Error { case fetchFailed }
 
     private final class MultiAccountCodexProvider: CodexUsageProviding {
-        let metricsByAccount: [UUID: UsageMetrics]
+        var metricsByAccount: [UUID: UsageMetrics]
+        var failingAccountIDs: Set<UUID> = []
 
         init(metricsByAccount: [UUID: UsageMetrics]) {
             self.metricsByAccount = metricsByAccount
@@ -48,6 +48,7 @@ final class UsageDataManagerTests: XCTestCase {
         }
 
         func fetchUsageMetrics(account: CodexAccount) async throws -> UsageMetrics {
+            if failingAccountIDs.contains(account.id) { throw StubError.fetchFailed }
             guard let metrics = metricsByAccount[account.id] else { throw StubError.fetchFailed }
             return metrics
         }
@@ -89,12 +90,14 @@ final class UsageDataManagerTests: XCTestCase {
     ) -> (manager: UsageDataManager, sharedStore: SharedDataStore) {
         let suiteName = "UsageDataManagerTests-\(UUID().uuidString)"
         createdSuiteNames.append(contentsOf: [suiteName, "\(suiteName)-vis"])
-        let cacheDefaults = UserDefaults(suiteName: suiteName)!
+        guard let cacheDefaults = UserDefaults(suiteName: suiteName),
+              let visibilityDefaults = UserDefaults(suiteName: "\(suiteName)-vis") else {
+            preconditionFailure("Unable to create isolated test defaults")
+        }
         if !preload.isEmpty, let data = MetricsCodec.encode(preload) {
             cacheDefaults.set(data, forKey: StorageKeys.cachedUsageMetrics)
         }
 
-        let visibilityDefaults = UserDefaults(suiteName: "\(suiteName)-vis")!
         let visibility = ProviderVisibilityStore(userDefaults: visibilityDefaults)
         for service in hidden.union([.claudeCode]) {
             visibility.set(service, isEnabled: false)
@@ -118,7 +121,10 @@ final class UsageDataManagerTests: XCTestCase {
     func testRefreshRecordsSuccessAndFailureHealth() async {
         let healthSuite = "UsageDataManagerHealthTests-\(UUID().uuidString)"
         createdSuiteNames.append(healthSuite)
-        let health = ProviderParseHealthStore(userDefaults: UserDefaults(suiteName: healthSuite)!)
+        guard let healthDefaults = UserDefaults(suiteName: healthSuite) else {
+            return XCTFail("Unable to create isolated health defaults")
+        }
+        let health = ProviderParseHealthStore(userDefaults: healthDefaults)
         let codex = StubProvider(hasAccess: true, result: .success(MetricsFixtures.codexCli()))
         let cursor = StubProvider(hasAccess: true, result: .failure(ServiceError.parsingError))
         let (manager, _) = makeManager(codex: codex, cursor: cursor, parseHealthStore: health)
@@ -253,6 +259,136 @@ final class UsageDataManagerTests: XCTestCase {
         XCTAssertEqual(manager.metrics[.codexCli]?.sessionLimit?.used, 20)
         sharedStore.flushPendingWrites()
         XCTAssertEqual(sharedStore.loadAccountMetrics().map(\.name), [CodexAccount.defaultName, "Work"])
+    }
+
+    func testRefreshAllExcludesDisabledCodexAccountsFromMetricsAndWidgetData() async throws {
+        let accountSuite = "UsageDataManagerTests-disabled-accounts-\(UUID().uuidString)"
+        createdSuiteNames.append(accountSuite)
+        let accountDefaults = try XCTUnwrap(UserDefaults(suiteName: accountSuite))
+        let accountStore = CodexAccountStore(userDefaults: accountDefaults)
+        accountStore.addAccount(name: "Work", homeDirectory: "/tmp/codex-work")
+        let work = try XCTUnwrap(accountStore.customAccounts.first)
+        accountStore.setEnabled(false, for: work.id)
+        let provider = MultiAccountCodexProvider(metricsByAccount: [
+            CodexAccount.defaultID: MetricsFixtures.codexCli(sessionUsedPercent: 20),
+            work.id: MetricsFixtures.codexCli(sessionUsedPercent: 80)
+        ])
+        let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+        let (manager, sharedStore) = makeManager(
+            codex: provider,
+            cursor: cursor,
+            codexAccountStore: accountStore
+        )
+
+        await manager.refreshAll()
+
+        XCTAssertEqual(Set(manager.codexAccountMetrics.keys), [CodexAccount.defaultID])
+        XCTAssertEqual(manager.metrics[.codexCli]?.sessionLimit?.used, 20)
+        sharedStore.flushPendingWrites()
+        XCTAssertEqual(sharedStore.loadAccountMetrics().map(\.id), [CodexAccount.defaultID])
+    }
+
+    func testRefreshAllClearsStaleCodexMetricsWhenEveryAccountIsDisabled() async throws {
+        let accountSuite = "UsageDataManagerTests-all-disabled-\(UUID().uuidString)"
+        createdSuiteNames.append(accountSuite)
+        let accountDefaults = try XCTUnwrap(UserDefaults(suiteName: accountSuite))
+        let accountStore = CodexAccountStore(userDefaults: accountDefaults)
+        accountStore.setEnabled(false, for: CodexAccount.defaultID)
+        let staleMetrics = MetricsFixtures.codexCli(sessionUsedPercent: 80)
+        let provider = MultiAccountCodexProvider(metricsByAccount: [CodexAccount.defaultID: staleMetrics])
+        let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+        let (manager, sharedStore) = makeManager(
+            codex: provider,
+            cursor: cursor,
+            codexAccountStore: accountStore,
+            preload: [.codexCli: staleMetrics]
+        )
+
+        await manager.refreshAll()
+
+        XCTAssertNil(manager.metrics[.codexCli])
+        XCTAssertTrue(manager.codexAccountMetrics.isEmpty)
+        sharedStore.flushPendingWrites()
+        XCTAssertNil(sharedStore.loadMetrics()[.codexCli])
+        XCTAssertTrue(sharedStore.loadAccountMetrics().isEmpty)
+    }
+
+    func testRefreshAllDoesNotMoveAggregateMetricsBetweenCodexProfiles() async throws {
+        let accountSuite = "UsageDataManagerTests-profile-switch-\(UUID().uuidString)"
+        createdSuiteNames.append(accountSuite)
+        let accountDefaults = try XCTUnwrap(UserDefaults(suiteName: accountSuite))
+        let accountStore = CodexAccountStore(userDefaults: accountDefaults)
+        accountStore.addAccount(name: "Work", homeDirectory: "/tmp/codex-work")
+        let work = try XCTUnwrap(accountStore.customAccounts.first)
+        accountStore.setEnabled(false, for: CodexAccount.defaultID)
+        let workMetrics = MetricsFixtures.codexCli(sessionUsedPercent: 80)
+        let provider = MultiAccountCodexProvider(metricsByAccount: [work.id: workMetrics])
+        let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+        let (manager, sharedStore) = makeManager(
+            codex: provider,
+            cursor: cursor,
+            codexAccountStore: accountStore
+        )
+
+        await manager.refreshAll()
+        XCTAssertEqual(manager.metrics[.codexCli]?.sessionLimit?.used, 80)
+
+        accountStore.setEnabled(true, for: CodexAccount.defaultID)
+        accountStore.setEnabled(false, for: work.id)
+        await manager.refreshAll()
+
+        XCTAssertNil(manager.metrics[.codexCli])
+        XCTAssertTrue(manager.codexAccountMetrics.isEmpty)
+        sharedStore.flushPendingWrites()
+        XCTAssertNil(sharedStore.loadMetrics()[.codexCli])
+        XCTAssertTrue(sharedStore.loadAccountMetrics().isEmpty)
+    }
+
+    func testRefreshAllClearsCachedCodexMetricsWhenAccountLosesAccess() async {
+        let initialMetrics = MetricsFixtures.codexCli(sessionUsedPercent: 80)
+        let provider = MultiAccountCodexProvider(metricsByAccount: [CodexAccount.defaultID: initialMetrics])
+        let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+        let (manager, sharedStore) = makeManager(codex: provider, cursor: cursor)
+
+        await manager.refreshAll()
+        XCTAssertEqual(manager.codexAccountMetrics[CodexAccount.defaultID]?.sessionLimit?.used, 80)
+
+        provider.metricsByAccount = [:]
+        await manager.refreshAll()
+
+        XCTAssertNil(manager.metrics[.codexCli])
+        XCTAssertTrue(manager.codexAccountMetrics.isEmpty)
+        sharedStore.flushPendingWrites()
+        XCTAssertNil(sharedStore.loadMetrics()[.codexCli])
+        XCTAssertTrue(sharedStore.loadAccountMetrics().isEmpty)
+    }
+
+    func testRefreshAllKeepsTransientCodexFailureCacheScopedToItsAccount() async throws {
+        let accountSuite = "UsageDataManagerTests-transient-failure-\(UUID().uuidString)"
+        createdSuiteNames.append(accountSuite)
+        let accountDefaults = try XCTUnwrap(UserDefaults(suiteName: accountSuite))
+        let accountStore = CodexAccountStore(userDefaults: accountDefaults)
+        accountStore.addAccount(name: "Work", homeDirectory: "/tmp/codex-work")
+        let work = try XCTUnwrap(accountStore.customAccounts.first)
+        let provider = MultiAccountCodexProvider(metricsByAccount: [
+            CodexAccount.defaultID: MetricsFixtures.codexCli(sessionUsedPercent: 20),
+            work.id: MetricsFixtures.codexCli(sessionUsedPercent: 80)
+        ])
+        let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+        let (manager, _) = makeManager(
+            codex: provider,
+            cursor: cursor,
+            codexAccountStore: accountStore
+        )
+
+        await manager.refreshAll()
+        provider.failingAccountIDs = [CodexAccount.defaultID]
+        provider.metricsByAccount[work.id] = MetricsFixtures.codexCli(sessionUsedPercent: 90)
+        await manager.refreshAll()
+
+        XCTAssertEqual(manager.codexAccountMetrics[CodexAccount.defaultID]?.sessionLimit?.used, 20)
+        XCTAssertEqual(manager.codexAccountMetrics[work.id]?.sessionLimit?.used, 90)
+        XCTAssertEqual(manager.metrics[.codexCli]?.sessionLimit?.used, 20)
     }
 
     func testApplyResetCreditRefreshPublishesAccountAndSharedMetrics() {

--- a/MeterBarTests/WidgetRenderingTests.swift
+++ b/MeterBarTests/WidgetRenderingTests.swift
@@ -16,18 +16,20 @@ import XCTest
 ///
 /// Family row caps mirror `UsageWidget.swift`:
 ///   - SmallWidgetView:  `sortedServices.prefix(3)`
-///   - MediumWidgetView: `sortedServices` (all)
+///   - MediumWidgetView: 3 slots; overflow uses 2 rows plus a summary
 ///   - LargeWidgetView:  `sortedServices.prefix(7)`
 final class WidgetRenderingTests: XCTestCase {
-
     private enum WidgetFamily: CaseIterable {
         case small, medium, large
-        /// Max provider rows the widget renders for this family (nil = unbounded).
-        var rowCap: Int? {
+
+        func visibleRowCount(totalRowCount: Int) -> Int {
             switch self {
-            case .small: return 3
-            case .medium: return nil
-            case .large: return 7
+            case .small:
+                return min(totalRowCount, 3)
+            case .medium:
+                return MediumWidgetRowBudget.visibleRowCount(totalRowCount: totalRowCount)
+            case .large:
+                return min(totalRowCount, 7)
             }
         }
     }
@@ -38,8 +40,7 @@ final class WidgetRenderingTests: XCTestCase {
         family: WidgetFamily
     ) -> [ServiceType] {
         let sorted = metrics.keys.sorted { $0.sortOrder < $1.sortOrder }
-        guard let cap = family.rowCap else { return sorted }
-        return Array(sorted.prefix(cap))
+        return Array(sorted.prefix(family.visibleRowCount(totalRowCount: sorted.count)))
     }
 
     /// Asserts a single provider's metrics yield a fully-populated widget row.
@@ -81,7 +82,8 @@ final class WidgetRenderingTests: XCTestCase {
         for family in WidgetFamily.allCases {
             let services = renderedServices(metrics, family: family)
             XCTAssertEqual(
-                Set(services), Set(metrics.keys),
+                Set(services),
+                Set(metrics.keys),
                 "family \(family) dropped a provider (cap too low for the fixture set)"
             )
             for service in services {
@@ -120,6 +122,14 @@ final class WidgetRenderingTests: XCTestCase {
             renderedServices(metrics, family: .medium),
             [.claudeCode, .codexCli, .cursor]
         )
+    }
+
+    func testMediumWidgetReservesAThirdSlotForOverflowSummary() {
+        let totalRowCount = 6
+        let visibleRowCount = WidgetFamily.medium.visibleRowCount(totalRowCount: totalRowCount)
+
+        XCTAssertEqual(visibleRowCount, 2)
+        XCTAssertEqual(MediumWidgetRowBudget.hiddenRowCount(totalRowCount: totalRowCount), 4)
     }
 
     // MARK: - Empty state

--- a/MeterBarWidget/UsageWidget.swift
+++ b/MeterBarWidget/UsageWidget.swift
@@ -101,7 +101,8 @@ struct UsageWidgetProvider: TimelineProvider {
 
 struct UsageWidgetEntryView: View {
     var entry: UsageWidgetEntry
-    @Environment(\.widgetFamily) var family
+    @Environment(\.widgetFamily)
+    var family
 
     var body: some View {
         switch family {
@@ -172,15 +173,31 @@ struct ServiceMiniView: View {
 struct MediumWidgetView: View {
     let entry: UsageWidgetEntry
 
+    private var visibleRows: [WidgetUsageRow] {
+        let visibleLimit = MediumWidgetRowBudget.visibleRowCount(totalRowCount: entry.rows.count)
+        return Array(entry.rows.prefix(visibleLimit))
+    }
+
+    private var hiddenRowCount: Int {
+        MediumWidgetRowBudget.hiddenRowCount(totalRowCount: entry.rows.count)
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: 8) {
             if entry.rows.isEmpty {
                 Text("No services connected")
                     .font(.caption)
                     .foregroundColor(.secondary)
             } else {
-                ForEach(entry.rows) { row in
+                ForEach(visibleRows) { row in
                     ServiceCompactView(row: row)
+                }
+
+                if hiddenRowCount > 0 {
+                    Label("+\(hiddenRowCount) more", systemImage: "ellipsis.circle")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .accessibilityLabel("\(hiddenRowCount) more usage sources")
                 }
             }
         }

--- a/Packages/MeterBarShared/Sources/MeterBarShared/MediumWidgetRowBudget.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/MediumWidgetRowBudget.swift
@@ -1,0 +1,12 @@
+public enum MediumWidgetRowBudget {
+    public static let maximumSlots = 3
+
+    public static func visibleRowCount(totalRowCount: Int) -> Int {
+        guard totalRowCount > maximumSlots else { return max(0, totalRowCount) }
+        return maximumSlots - 1
+    }
+
+    public static func hiddenRowCount(totalRowCount: Int) -> Int {
+        max(0, totalRowCount - visibleRowCount(totalRowCount: totalRowCount))
+    }
+}


### PR DESCRIPTION
Closes #166

## Summary
- count every enabled Codex and Claude profile in the dashboard quota-source total
- keep Codex quota cache and fallbacks isolated to the correct enabled account
- cap medium-widget usage rows at three slots with an overflow summary
- add focused regression coverage for counts, account state changes, cache isolation, and widget budgeting

## Verification
- SwiftLint strict on all changed Swift files: passed
- git diff --check: passed
- Claude Opus 4.8 high-effort review: completed; safe findings applied
- Local XCTest and Xcode build: skipped per repository MacBook policy; PR CI is the broad validation gate
- SwiftFormat: unavailable locally

## Residual risk
- Live WidgetKit visual preview was not run locally; CI validates compilation and focused tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard quota-source counts now include all enabled Codex and Claude accounts, plus supported single-account providers.
  * Disabled Codex accounts are excluded from provider cards, refreshes, status checks, metrics, and widgets.
  * Codex quota data remains separated by account to prevent profile data from mixing.
  * Medium widgets now display up to two provider rows and a “+N more” summary when additional providers exist.

* **Bug Fixes**
  * Improved handling of disabled accounts, account switching, missing access, and account-specific refresh failures.
  * Prevented stale or incorrect aggregate quota data from being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->