### PR TITLE
fix(readiness): ignore disabled default Claude profile

### DIFF
--- a/.agents/SESSIONS/2026-07-17.md
+++ b/.agents/SESSIONS/2026-07-17.md
@@ -1,0 +1,63 @@
+# 2026-07-17 — Account-scoped Claude readiness
+
+## Session 1: Ignore disabled default-profile authentication
+
+**Status:** Complete; PR CI pending
+
+```mermaid
+flowchart LR
+    Accounts[Enabled Claude accounts] --> Evidence[Enabled-account usage evidence]
+    Evidence --> Readiness[Provider readiness inspector]
+    Default{Default profile enabled?} -->|Yes| Cache[Shared cache and Keychain fallback]
+    Default -->|No| Skip[Skip global cache and Keychain]
+    Cache --> Readiness
+    Skip --> Readiness
+    Readiness --> Popover[Finish setup checklist]
+    Readiness --> Diagnostics[Dashboard diagnostics]
+```
+
+### Affected components
+
+- Claude provider readiness gathering
+- Menu-bar setup checklist invalidation
+- Dashboard diagnostics error selection
+- Provider readiness regression coverage
+
+### What was done
+
+- Scoped recent-usage evidence to enabled Claude accounts.
+- Prevented global Claude Keychain inspection when the default profile is disabled.
+- Preserved the shared-cache cold-start fallback when the default profile remains enabled.
+- Excluded stale default-profile refresh errors from dashboard readiness after disabling that profile.
+- Re-ran popover readiness when enabled-account freshness changes, with cancellation-safe state publication.
+- Added coverage for authenticated, missing, stale, disabled-default, and forwarding cases.
+
+### Key decisions
+
+- The global Keychain and shared-cache identity belong only to the default profile, so both are gated by its enabled state.
+- Custom-profile failures remain represented by their account cards; they do not reuse or masquerade as default-profile authentication failures.
+- The CLI doctor keeps its existing default-profile behavior through default inspector arguments.
+
+### Files changed
+
+- `MeterBar/Services/ProviderReadinessInspector.swift`
+- `MeterBar/Views/MenuBarView.swift`
+- `MeterBar/Views/UsageDashboardView.swift`
+- `MeterBarTests/ProviderReadinessInspectorTests.swift`
+
+### Verification
+
+- SwiftLint strict passed on all changed Swift files.
+- `git diff --check` passed.
+- Claude Opus 4.8 high-effort review completed in three passes; safe in-scope findings were applied.
+- SwiftFormat was unavailable locally.
+- Swift tests and Xcode builds were not run locally per the MacBook policy; PR CI is the execution gate.
+
+### Mistakes and fixes
+
+- The first readiness draft discarded valid shared-cache evidence when per-account memory was empty after launch. Review caught it, and the final logic uses shared cached evidence only while the default profile is enabled.
+- The first invalidation task could publish an older detached result after cancellation. The final task checks cancellation before mutating view state.
+
+### Next steps
+
+- [ ] Confirm PR CI tests, coverage, app/widget/CLI builds, lint, and secret scan.

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -23,13 +23,22 @@ nonisolated public enum ProviderReadinessInspector {
         providers: Set<ServiceType> = Set(ServiceType.allCases),
         refreshErrors: [ServiceType: ServiceError] = [:],
         now: Date = Date(),
+        claudeDefaultAccountEnabled: Bool = true,
+        claudeEnabledAccountMetrics: [UsageMetrics] = [],
         parseHealth: [ServiceType: ProviderParseHealthRecord]? = nil
     ) -> [ProviderReadiness] {
         let baseReports = reports(
             providers: providers,
             refreshErrors: refreshErrors,
             now: now,
-            claudeReport: { claudeReport(refreshError: $0, now: $1) },
+            claudeReport: {
+                claudeReport(
+                    refreshError: $0,
+                    now: $1,
+                    defaultAccountEnabled: claudeDefaultAccountEnabled,
+                    enabledAccountMetrics: claudeEnabledAccountMetrics
+                )
+            },
             codexReport: { codexReport(refreshError: $0, now: $1) },
             cursorReport: { cursorReport(refreshError: $0, now: $1) },
             openRouterReport: { error, _ in openRouterReport(refreshError: error) },
@@ -88,24 +97,36 @@ nonisolated public enum ProviderReadinessInspector {
     static func claudeReport(
         refreshError: ServiceError? = nil,
         now: Date = Date(),
-        cachedMetrics: UsageMetrics? = SharedDataStore.shared.loadMetrics()[.claudeCode],
+        cachedMetrics: @autoclosure () -> UsageMetrics? = SharedDataStore.shared.loadMetrics()[.claudeCode],
+        defaultAccountEnabled: Bool = true,
+        enabledAccountMetrics: [UsageMetrics] = [],
+        isCLIInstalled: Bool = CLIBinaryLocator.isAvailable(
+            command: "claude",
+            overrideEnvVar: "CLAUDE_CLI_PATH"
+        ),
         isOAuthFallbackEnabled: () -> Bool = {
             ClaudeCodeLocalService.isOAuthUsageEnabled()
         },
         credentialsData: () -> Data? = { ClaudeCodeLocalService.shared.credentialsData() }
     ) -> ProviderReadiness {
-        let hasRecentUsageFetch = hasRecentClaudeUsageFetch(metrics: cachedMetrics, now: now)
+        let hasRecentUsageFetch = enabledAccountMetrics.contains {
+            hasRecentClaudeUsageFetch(metrics: $0, now: now)
+        } || (
+            defaultAccountEnabled
+                && hasRecentClaudeUsageFetch(metrics: cachedMetrics(), now: now)
+        )
         let credentialsJSON: Data?
-        if hasRecentUsageFetch || !isOAuthFallbackEnabled() {
+        if hasRecentUsageFetch || !defaultAccountEnabled || !isOAuthFallbackEnabled() {
             credentialsJSON = nil
         } else {
             credentialsJSON = credentialsData()
         }
         let input = ClaudeReadinessInput(
-            isCLIInstalled: CLIBinaryLocator.isAvailable(command: "claude", overrideEnvVar: "CLAUDE_CLI_PATH"),
+            isCLIInstalled: isCLIInstalled,
             // Direct CLI evidence wins, so do not even query Keychain when a
             // recent successful fetch already proves readiness. The legacy
-            // credential is likewise irrelevant while fallback is disabled.
+            // credential is likewise irrelevant while fallback or the default
+            // account is disabled.
             credentialsJSON: credentialsJSON,
             hasRecentUsageFetch: hasRecentUsageFetch,
             refreshError: sanitize(refreshError),
@@ -120,7 +141,7 @@ nonisolated public enum ProviderReadinessInspector {
     /// app cannot read (issue: keychain-only check false-negatived every
     /// `claude login` user). The cache is the same file `meterbar cost` and the
     /// widget already read, so the app and `meterbar doctor` agree.
-    private static func hasRecentClaudeUsageFetch(metrics: UsageMetrics?, now: Date) -> Bool {
+    static func hasRecentClaudeUsageFetch(metrics: UsageMetrics?, now: Date) -> Bool {
         guard let metrics else {
             return false
         }

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -24,6 +24,7 @@ nonisolated public enum ProviderReadinessInspector {
         refreshErrors: [ServiceType: ServiceError] = [:],
         now: Date = Date(),
         claudeDefaultAccountEnabled: Bool = true,
+        claudeHasEnabledCustomAccount: Bool = false,
         claudeEnabledAccountMetrics: [UsageMetrics] = [],
         parseHealth: [ServiceType: ProviderParseHealthRecord]? = nil
     ) -> [ProviderReadiness] {
@@ -36,6 +37,7 @@ nonisolated public enum ProviderReadinessInspector {
                     refreshError: $0,
                     now: $1,
                     defaultAccountEnabled: claudeDefaultAccountEnabled,
+                    hasEnabledCustomAccount: claudeHasEnabledCustomAccount,
                     enabledAccountMetrics: claudeEnabledAccountMetrics
                 )
             },
@@ -99,6 +101,7 @@ nonisolated public enum ProviderReadinessInspector {
         now: Date = Date(),
         cachedMetrics: @autoclosure () -> UsageMetrics? = SharedDataStore.shared.loadMetrics()[.claudeCode],
         defaultAccountEnabled: Bool = true,
+        hasEnabledCustomAccount: Bool = false,
         enabledAccountMetrics: [UsageMetrics] = [],
         isCLIInstalled: Bool = CLIBinaryLocator.isAvailable(
             command: "claude",
@@ -112,7 +115,7 @@ nonisolated public enum ProviderReadinessInspector {
         let hasRecentUsageFetch = enabledAccountMetrics.contains {
             hasRecentClaudeUsageFetch(metrics: $0, now: now)
         } || (
-            defaultAccountEnabled
+            (defaultAccountEnabled || hasEnabledCustomAccount)
                 && hasRecentClaudeUsageFetch(metrics: cachedMetrics(), now: now)
         )
         let credentialsJSON: Data?

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -24,7 +24,6 @@ nonisolated public enum ProviderReadinessInspector {
         refreshErrors: [ServiceType: ServiceError] = [:],
         now: Date = Date(),
         claudeDefaultAccountEnabled: Bool = true,
-        claudeHasEnabledCustomAccount: Bool = false,
         claudeEnabledAccountMetrics: [UsageMetrics] = [],
         parseHealth: [ServiceType: ProviderParseHealthRecord]? = nil
     ) -> [ProviderReadiness] {
@@ -37,7 +36,6 @@ nonisolated public enum ProviderReadinessInspector {
                     refreshError: $0,
                     now: $1,
                     defaultAccountEnabled: claudeDefaultAccountEnabled,
-                    hasEnabledCustomAccount: claudeHasEnabledCustomAccount,
                     enabledAccountMetrics: claudeEnabledAccountMetrics
                 )
             },
@@ -101,7 +99,6 @@ nonisolated public enum ProviderReadinessInspector {
         now: Date = Date(),
         cachedMetrics: @autoclosure () -> UsageMetrics? = SharedDataStore.shared.loadMetrics()[.claudeCode],
         defaultAccountEnabled: Bool = true,
-        hasEnabledCustomAccount: Bool = false,
         enabledAccountMetrics: [UsageMetrics] = [],
         isCLIInstalled: Bool = CLIBinaryLocator.isAvailable(
             command: "claude",
@@ -115,7 +112,7 @@ nonisolated public enum ProviderReadinessInspector {
         let hasRecentUsageFetch = enabledAccountMetrics.contains {
             hasRecentClaudeUsageFetch(metrics: $0, now: now)
         } || (
-            (defaultAccountEnabled || hasEnabledCustomAccount)
+            defaultAccountEnabled
                 && hasRecentClaudeUsageFetch(metrics: cachedMetrics(), now: now)
         )
         let credentialsJSON: Data?

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -90,6 +90,9 @@ struct MenuBarView: View {
             openProviderOverview: openProviderDetail,
             hoverProviderOverview: hoverProviderDetailChanged,
             claudeDefaultAccountEnabled: claudeAccountStore.defaultAccountIsEnabled,
+            claudeEnabledCustomAccountIDs: claudeAccountStore.enabledAccounts
+              .filter { !$0.isDefault }
+              .map(\.id),
             claudeEnabledAccountMetrics: claudeAccountStore.enabledAccounts.compactMap {
               dataManager.claudeCodeAccountMetrics[$0.id]
             }
@@ -331,6 +334,7 @@ struct PopoverOverviewPanel: View {
   /// enter). Optional so existing/test call sites stay valid.
   var hoverProviderOverview: ((ProviderSnapshot, Bool) -> Void)?
   let claudeDefaultAccountEnabled: Bool
+  let claudeEnabledCustomAccountIDs: [UUID]
   let claudeEnabledAccountMetrics: [UsageMetrics]
 
   @State private var setupReports: [ProviderReadiness] = []
@@ -348,6 +352,7 @@ struct PopoverOverviewPanel: View {
     openProviderOverview: @escaping (ProviderSnapshot) -> Void,
     hoverProviderOverview: ((ProviderSnapshot, Bool) -> Void)? = nil,
     claudeDefaultAccountEnabled: Bool = true,
+    claudeEnabledCustomAccountIDs: [UUID] = [],
     claudeEnabledAccountMetrics: [UsageMetrics] = []
   ) {
     self.snapshots = snapshots
@@ -356,6 +361,7 @@ struct PopoverOverviewPanel: View {
     self.openProviderOverview = openProviderOverview
     self.hoverProviderOverview = hoverProviderOverview
     self.claudeDefaultAccountEnabled = claudeDefaultAccountEnabled
+    self.claudeEnabledCustomAccountIDs = claudeEnabledCustomAccountIDs
     self.claudeEnabledAccountMetrics = claudeEnabledAccountMetrics
   }
 
@@ -389,6 +395,7 @@ struct PopoverOverviewPanel: View {
   private struct ReadinessInputKey: Equatable {
     let providers: [ServiceType]
     let defaultClaudeAccountEnabled: Bool
+    let enabledClaudeCustomAccountIDs: [UUID]
     let claudeMetricFreshness: [Bool]
   }
 
@@ -406,6 +413,7 @@ struct PopoverOverviewPanel: View {
     return ReadinessInputKey(
       providers: ServiceType.allCases.filter { enabledProviders.contains($0) },
       defaultClaudeAccountEnabled: claudeDefaultAccountEnabled,
+      enabledClaudeCustomAccountIDs: claudeEnabledCustomAccountIDs,
       claudeMetricFreshness: claudeEnabledAccountMetrics.map {
         ProviderReadinessInspector.hasRecentClaudeUsageFetch(metrics: $0, now: now)
       }
@@ -529,11 +537,13 @@ struct PopoverOverviewPanel: View {
   private func loadSetupReports() async {
     let requestedProviders = enabledProviders
     let defaultAccountEnabled = claudeDefaultAccountEnabled
+    let hasEnabledCustomAccount = !claudeEnabledCustomAccountIDs.isEmpty
     let accountMetrics = claudeEnabledAccountMetrics
     let reports = await Task.detached(priority: .utility) {
       ProviderReadinessInspector.reports(
         providers: requestedProviders,
         claudeDefaultAccountEnabled: defaultAccountEnabled,
+        claudeHasEnabledCustomAccount: hasEnabledCustomAccount,
         claudeEnabledAccountMetrics: accountMetrics
       )
     }.value

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -88,7 +88,11 @@ struct MenuBarView: View {
             openDashboard: openDashboard,
             openStatusDetail: openStatusDetail,
             openProviderOverview: openProviderDetail,
-            hoverProviderOverview: hoverProviderDetailChanged
+            hoverProviderOverview: hoverProviderDetailChanged,
+            claudeDefaultAccountEnabled: claudeAccountStore.defaultAccountIsEnabled,
+            claudeEnabledAccountMetrics: claudeAccountStore.enabledAccounts.compactMap {
+              dataManager.claudeCodeAccountMetrics[$0.id]
+            }
           )
 
           if SessionWakeMenuControl.shouldShow(
@@ -326,6 +330,8 @@ struct PopoverOverviewPanel: View {
   /// Hover-driven open for a provider card (opens its detail panel on pointer
   /// enter). Optional so existing/test call sites stay valid.
   var hoverProviderOverview: ((ProviderSnapshot, Bool) -> Void)?
+  let claudeDefaultAccountEnabled: Bool
+  let claudeEnabledAccountMetrics: [UsageMetrics]
 
   @State private var setupReports: [ProviderReadiness] = []
   @StateObject private var onboarding = FirstRunOnboardingStore.shared
@@ -340,13 +346,17 @@ struct PopoverOverviewPanel: View {
     openDashboard: @escaping () -> Void,
     openStatusDetail: @escaping () -> Void,
     openProviderOverview: @escaping (ProviderSnapshot) -> Void,
-    hoverProviderOverview: ((ProviderSnapshot, Bool) -> Void)? = nil
+    hoverProviderOverview: ((ProviderSnapshot, Bool) -> Void)? = nil,
+    claudeDefaultAccountEnabled: Bool = true,
+    claudeEnabledAccountMetrics: [UsageMetrics] = []
   ) {
     self.snapshots = snapshots
     self.openDashboard = openDashboard
     self.openStatusDetail = openStatusDetail
     self.openProviderOverview = openProviderOverview
     self.hoverProviderOverview = hoverProviderOverview
+    self.claudeDefaultAccountEnabled = claudeDefaultAccountEnabled
+    self.claudeEnabledAccountMetrics = claudeEnabledAccountMetrics
   }
 
   /// The enabled providers currently shown in the popover.
@@ -376,12 +386,29 @@ struct PopoverOverviewPanel: View {
     let snapshotIDs: [String]
   }
 
+  private struct ReadinessInputKey: Equatable {
+    let providers: [ServiceType]
+    let defaultClaudeAccountEnabled: Bool
+    let claudeMetricFreshness: [Bool]
+  }
+
   private var structuralKey: StructuralKey {
     StructuralKey(
       showsFirstRun: onboarding.shouldPresent,
       isEmpty: snapshots.isEmpty,
       setupProviders: providersNeedingSetup.map(\.provider),
       snapshotIDs: snapshots.map(\.id)
+    )
+  }
+
+  private var readinessInputKey: ReadinessInputKey {
+    let now = Date()
+    return ReadinessInputKey(
+      providers: ServiceType.allCases.filter { enabledProviders.contains($0) },
+      defaultClaudeAccountEnabled: claudeDefaultAccountEnabled,
+      claudeMetricFreshness: claudeEnabledAccountMetrics.map {
+        ProviderReadinessInspector.hasRecentClaudeUsageFetch(metrics: $0, now: now)
+      }
     )
   }
 
@@ -442,7 +469,7 @@ struct PopoverOverviewPanel: View {
       MeterBarTheme.Motion.resolve(MeterBarTheme.Motion.standard, reduceMotion: reduceMotion),
       value: structuralKey
     )
-    .task {
+    .task(id: readinessInputKey) {
       await loadSetupReports()
     }
   }
@@ -501,9 +528,16 @@ struct PopoverOverviewPanel: View {
   /// I/O) and publishes the reports back for the checklist.
   private func loadSetupReports() async {
     let requestedProviders = enabledProviders
+    let defaultAccountEnabled = claudeDefaultAccountEnabled
+    let accountMetrics = claudeEnabledAccountMetrics
     let reports = await Task.detached(priority: .utility) {
-      ProviderReadinessInspector.reports(providers: requestedProviders)
+      ProviderReadinessInspector.reports(
+        providers: requestedProviders,
+        claudeDefaultAccountEnabled: defaultAccountEnabled,
+        claudeEnabledAccountMetrics: accountMetrics
+      )
     }.value
+    guard !Task.isCancelled else { return }
     setupReports = reports
   }
 }

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -537,13 +537,11 @@ struct PopoverOverviewPanel: View {
   private func loadSetupReports() async {
     let requestedProviders = enabledProviders
     let defaultAccountEnabled = claudeDefaultAccountEnabled
-    let hasEnabledCustomAccount = !claudeEnabledCustomAccountIDs.isEmpty
     let accountMetrics = claudeEnabledAccountMetrics
     let reports = await Task.detached(priority: .utility) {
       ProviderReadinessInspector.reports(
         providers: requestedProviders,
         claudeDefaultAccountEnabled: defaultAccountEnabled,
-        claudeHasEnabledCustomAccount: hasEnabledCustomAccount,
         claudeEnabledAccountMetrics: accountMetrics
       )
     }.value

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -877,11 +877,27 @@ struct UsageDashboardView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .task {
-            if readinessReports.isEmpty {
-                await runDiagnostics()
-            }
+        .task(id: diagnosticsInputKey) {
+            let reports = await inspectReadiness()
+            guard !Task.isCancelled else { return }
+            readinessReports = reports
         }
+    }
+
+    private struct DiagnosticsInputKey: Equatable {
+        let providers: [ServiceType]
+        let defaultClaudeAccountEnabled: Bool
+        let enabledClaudeCustomAccountIDs: [UUID]
+    }
+
+    private var diagnosticsInputKey: DiagnosticsInputKey {
+        DiagnosticsInputKey(
+            providers: ServiceType.allCases.filter { providerVisibility.enabledServices.contains($0) },
+            defaultClaudeAccountEnabled: claudeAccountStore.defaultAccountIsEnabled,
+            enabledClaudeCustomAccountIDs: claudeAccountStore.enabledAccounts
+                .filter { !$0.isDefault }
+                .map(\.id)
+        )
     }
 
     private var diagnosticsSummary: String? {
@@ -897,21 +913,29 @@ struct UsageDashboardView: View {
         isRunningDiagnostics = true
         defer { isRunningDiagnostics = false }
 
+        let reports = await inspectReadiness()
+        guard !Task.isCancelled else { return }
+        readinessReports = reports
+    }
+
+    private func inspectReadiness() async -> [ProviderReadiness] {
         let enabledProviders = providerVisibility.enabledServices
         let errors = currentRefreshErrors()
         let defaultClaudeAccountEnabled = claudeAccountStore.defaultAccountIsEnabled
-        let claudeMetrics = claudeAccountStore.enabledAccounts.compactMap {
+        let enabledClaudeAccounts = claudeAccountStore.enabledAccounts
+        let hasEnabledCustomClaudeAccount = enabledClaudeAccounts.contains { !$0.isDefault }
+        let claudeMetrics = enabledClaudeAccounts.compactMap {
             dataManager.claudeCodeAccountMetrics[$0.id]
         }
-        let reports = await Task.detached(priority: .userInitiated) {
+        return await Task.detached(priority: .userInitiated) {
             ProviderReadinessInspector.reports(
                 providers: enabledProviders,
                 refreshErrors: errors,
                 claudeDefaultAccountEnabled: defaultClaudeAccountEnabled,
+                claudeHasEnabledCustomAccount: hasEnabledCustomClaudeAccount,
                 claudeEnabledAccountMetrics: claudeMetrics
             )
         }.value
-        readinessReports = reports
     }
 
     /// Each provider's live last-refresh error, fed into the readiness core so the

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -899,10 +899,16 @@ struct UsageDashboardView: View {
 
         let enabledProviders = providerVisibility.enabledServices
         let errors = currentRefreshErrors()
+        let defaultClaudeAccountEnabled = claudeAccountStore.defaultAccountIsEnabled
+        let claudeMetrics = claudeAccountStore.enabledAccounts.compactMap {
+            dataManager.claudeCodeAccountMetrics[$0.id]
+        }
         let reports = await Task.detached(priority: .userInitiated) {
             ProviderReadinessInspector.reports(
                 providers: enabledProviders,
-                refreshErrors: errors
+                refreshErrors: errors,
+                claudeDefaultAccountEnabled: defaultClaudeAccountEnabled,
+                claudeEnabledAccountMetrics: claudeMetrics
             )
         }.value
         readinessReports = reports
@@ -912,7 +918,10 @@ struct UsageDashboardView: View {
     /// "Last refresh" check reflects the app's actual runtime state.
     private func currentRefreshErrors() -> [ServiceType: ServiceError] {
         var result: [ServiceType: ServiceError] = [:]
-        if let error = claudeCodeService.lastError { result[.claudeCode] = error }
+        if claudeAccountStore.defaultAccountIsEnabled,
+           let error = claudeCodeService.lastError {
+            result[.claudeCode] = error
+        }
         if let error = codexCliService.lastError { result[.codexCli] = error }
         if let error = cursorService.lastError { result[.cursor] = error }
         if let error = openRouterService.lastError { result[.openRouter] = error }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -923,7 +923,6 @@ struct UsageDashboardView: View {
         let errors = currentRefreshErrors()
         let defaultClaudeAccountEnabled = claudeAccountStore.defaultAccountIsEnabled
         let enabledClaudeAccounts = claudeAccountStore.enabledAccounts
-        let hasEnabledCustomClaudeAccount = enabledClaudeAccounts.contains { !$0.isDefault }
         let claudeMetrics = enabledClaudeAccounts.compactMap {
             dataManager.claudeCodeAccountMetrics[$0.id]
         }
@@ -932,7 +931,6 @@ struct UsageDashboardView: View {
                 providers: enabledProviders,
                 refreshErrors: errors,
                 claudeDefaultAccountEnabled: defaultClaudeAccountEnabled,
-                claudeHasEnabledCustomAccount: hasEnabledCustomClaudeAccount,
                 claudeEnabledAccountMetrics: claudeMetrics
             )
         }.value

--- a/MeterBarTests/ProviderReadinessInspectorTests.swift
+++ b/MeterBarTests/ProviderReadinessInspectorTests.swift
@@ -107,6 +107,32 @@ final class ProviderReadinessInspectorTests: XCTestCase {
         XCTAssertFalse(report.needsSetup)
     }
 
+    func testDisabledDefaultClaudeProfileUsesRecentSharedMetricsForEnabledCustomProfile() {
+        let now = Date(timeIntervalSince1970: 25_000)
+        let recentSharedMetrics = UsageMetrics(
+            service: .claudeCode,
+            lastUpdated: now.addingTimeInterval(-60)
+        )
+        var didReadCredentials = false
+
+        let report = ProviderReadinessInspector.claudeReport(
+            now: now,
+            cachedMetrics: recentSharedMetrics,
+            defaultAccountEnabled: false,
+            hasEnabledCustomAccount: true,
+            enabledAccountMetrics: [],
+            isCLIInstalled: true,
+            credentialsData: {
+                didReadCredentials = true
+                return nil
+            }
+        )
+
+        XCTAssertFalse(didReadCredentials)
+        XCTAssertEqual(report.check(ReadinessCheckID.auth)?.level, .pass)
+        XCTAssertFalse(report.needsSetup)
+    }
+
     func testDisabledDefaultClaudeProfileNeverReadsGlobalCredentials() {
         var didReadCredentials = false
 

--- a/MeterBarTests/ProviderReadinessInspectorTests.swift
+++ b/MeterBarTests/ProviderReadinessInspectorTests.swift
@@ -82,6 +82,118 @@ final class ProviderReadinessInspectorTests: XCTestCase {
         XCTAssertFalse(didReadCredentials)
     }
 
+    func testDisabledDefaultClaudeProfileUsesEnabledCustomProfileMetrics() {
+        let now = Date(timeIntervalSince1970: 20_000)
+        let recentCustomMetrics = UsageMetrics(
+            service: .claudeCode,
+            lastUpdated: now.addingTimeInterval(-60)
+        )
+        var didReadCredentials = false
+
+        let report = ProviderReadinessInspector.claudeReport(
+            now: now,
+            cachedMetrics: nil,
+            defaultAccountEnabled: false,
+            enabledAccountMetrics: [recentCustomMetrics],
+            isCLIInstalled: true,
+            credentialsData: {
+                didReadCredentials = true
+                return nil
+            }
+        )
+
+        XCTAssertFalse(didReadCredentials)
+        XCTAssertEqual(report.check(ReadinessCheckID.auth)?.level, .pass)
+        XCTAssertFalse(report.needsSetup)
+    }
+
+    func testDisabledDefaultClaudeProfileNeverReadsGlobalCredentials() {
+        var didReadCredentials = false
+
+        let report = ProviderReadinessInspector.claudeReport(
+            cachedMetrics: UsageMetrics(service: .claudeCode),
+            defaultAccountEnabled: false,
+            enabledAccountMetrics: [],
+            isCLIInstalled: true,
+            credentialsData: {
+                didReadCredentials = true
+                return Data(#"{"claudeAiOauth":{"accessToken":"disabled-default"}}"#.utf8)
+            }
+        )
+
+        XCTAssertFalse(didReadCredentials)
+        XCTAssertEqual(report.check(ReadinessCheckID.auth)?.level, .warn)
+        XCTAssertFalse(report.needsSetup)
+    }
+
+    func testEnabledDefaultClaudeProfileFallsBackToRecentSharedMetrics() {
+        let now = Date(timeIntervalSince1970: 30_000)
+        let recentCachedMetrics = UsageMetrics(
+            service: .claudeCode,
+            lastUpdated: now.addingTimeInterval(-60)
+        )
+        var didReadCredentials = false
+
+        let report = ProviderReadinessInspector.claudeReport(
+            now: now,
+            cachedMetrics: recentCachedMetrics,
+            defaultAccountEnabled: true,
+            enabledAccountMetrics: [],
+            isCLIInstalled: true,
+            credentialsData: {
+                didReadCredentials = true
+                return nil
+            }
+        )
+
+        XCTAssertFalse(didReadCredentials)
+        XCTAssertEqual(report.check(ReadinessCheckID.auth)?.level, .pass)
+        XCTAssertFalse(report.needsSetup)
+    }
+
+    func testDisabledDefaultClaudeProfileIgnoresStaleCustomMetricsWithoutCredentialRead() {
+        let now = Date(timeIntervalSince1970: 40_000)
+        let staleCustomMetrics = UsageMetrics(
+            service: .claudeCode,
+            lastUpdated: now.addingTimeInterval(-ProviderReadinessInspector.recentUsageFetchWindow - 1)
+        )
+        var didReadCredentials = false
+
+        let report = ProviderReadinessInspector.claudeReport(
+            now: now,
+            cachedMetrics: nil,
+            defaultAccountEnabled: false,
+            enabledAccountMetrics: [staleCustomMetrics],
+            isCLIInstalled: true,
+            credentialsData: {
+                didReadCredentials = true
+                return nil
+            }
+        )
+
+        XCTAssertFalse(didReadCredentials)
+        XCTAssertEqual(report.check(ReadinessCheckID.auth)?.level, .warn)
+        XCTAssertFalse(report.needsSetup)
+    }
+
+    func testReportsForwardEnabledCustomClaudeMetrics() {
+        let now = Date(timeIntervalSince1970: 50_000)
+        let recentCustomMetrics = UsageMetrics(
+            service: .claudeCode,
+            lastUpdated: now.addingTimeInterval(-60)
+        )
+
+        let reports = ProviderReadinessInspector.reports(
+            providers: [.claudeCode],
+            now: now,
+            claudeDefaultAccountEnabled: false,
+            claudeEnabledAccountMetrics: [recentCustomMetrics],
+            parseHealth: [:]
+        )
+
+        XCTAssertEqual(reports.first?.check(ReadinessCheckID.auth)?.level, .pass)
+    }
+
     func testApiErrorDropsResponseBodyKeepsStatusCode() {
         let raw = ServiceError.apiError("HTTP 500: {\"user\":\"vincent@genfeed.ai\",\"token\":\"sk-SECRET\"}")
         let sanitized = ProviderReadinessInspector.sanitize(raw)
@@ -99,7 +211,10 @@ final class ProviderReadinessInspectorTests: XCTestCase {
     }
 
     func testSafeNetworkMessagesPassThrough() {
-        XCTAssertEqual(ProviderReadinessInspector.sanitize(.apiError("No internet connection")), "No internet connection")
+        XCTAssertEqual(
+            ProviderReadinessInspector.sanitize(.apiError("No internet connection")),
+            "No internet connection"
+        )
         XCTAssertEqual(ProviderReadinessInspector.sanitize(.apiError("Request timed out")), "Request timed out")
         XCTAssertEqual(
             ProviderReadinessInspector.sanitize(.apiError("Secure connection failed")),

--- a/MeterBarTests/ProviderReadinessInspectorTests.swift
+++ b/MeterBarTests/ProviderReadinessInspectorTests.swift
@@ -107,32 +107,6 @@ final class ProviderReadinessInspectorTests: XCTestCase {
         XCTAssertFalse(report.needsSetup)
     }
 
-    func testDisabledDefaultClaudeProfileUsesRecentSharedMetricsForEnabledCustomProfile() {
-        let now = Date(timeIntervalSince1970: 25_000)
-        let recentSharedMetrics = UsageMetrics(
-            service: .claudeCode,
-            lastUpdated: now.addingTimeInterval(-60)
-        )
-        var didReadCredentials = false
-
-        let report = ProviderReadinessInspector.claudeReport(
-            now: now,
-            cachedMetrics: recentSharedMetrics,
-            defaultAccountEnabled: false,
-            hasEnabledCustomAccount: true,
-            enabledAccountMetrics: [],
-            isCLIInstalled: true,
-            credentialsData: {
-                didReadCredentials = true
-                return nil
-            }
-        )
-
-        XCTAssertFalse(didReadCredentials)
-        XCTAssertEqual(report.check(ReadinessCheckID.auth)?.level, .pass)
-        XCTAssertFalse(report.needsSetup)
-    }
-
     func testDisabledDefaultClaudeProfileNeverReadsGlobalCredentials() {
         var didReadCredentials = false
 


### PR DESCRIPTION
Closes #210

## Summary

- scope Claude readiness evidence to enabled profiles
- skip shared-cache and global Keychain authentication checks when the default profile is disabled
- suppress stale default-profile refresh errors in dashboard diagnostics
- refresh the popover setup checklist when enabled-account readiness changes, without allowing cancelled work to overwrite newer results
- preserve the shared-cache cold-start fallback while the default profile remains enabled

## Verification

- `swiftlint lint --strict --quiet MeterBar/Services/ProviderReadinessInspector.swift MeterBar/Views/MenuBarView.swift MeterBar/Views/UsageDashboardView.swift MeterBarTests/ProviderReadinessInspectorTests.swift` — passed
- `git diff --check` — passed
- Claude Opus 4.8 high-effort review — three passes completed; safe in-scope findings applied
- Swift tests and Xcode builds — skipped locally per repository MacBook policy; PR CI is the execution gate
- SwiftFormat — unavailable locally

## Residual risk

- Custom-profile refresh failures remain account-card state rather than per-profile Diagnostics rows; this preserves existing behavior and avoids attributing them to the disabled default profile.
