### PR TITLE
fix(release): gate signed artifacts on exact-commit tests

### DIFF
--- a/.github/workflows/_build-signed.yml
+++ b/.github/workflows/_build-signed.yml
@@ -54,7 +54,30 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    name: Tests + coverage gate
+    runs-on: macos-26
+    timeout-minutes: 20
+    env:
+      # Keep in parity with ci.yml and e2e.yml. The workflow contract verifier
+      # fails PR CI if any broad validation workflow lowers or drifts this floor.
+      COVERAGE_THRESHOLD: 19
+
+    steps:
+      - name: Checkout exact release commit
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+
+      - name: Run tests with coverage gate
+        run: bash scripts/check-coverage.sh
+
   build:
+    needs: test
     runs-on: macos-26
     timeout-minutes: 60
     environment: release
@@ -80,6 +103,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       # Resolve ephemeral file paths under RUNNER_TEMP (outside the workspace) and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Test release tag validation
         run: scripts/test-release-tag.sh
 
+      - name: Test release ancestry validation
+        run: scripts/test-release-ancestry.sh
+
+      - name: Verify signed-release workflow contract
+        run: scripts/verify-release-workflow-contract.sh
+
       - name: Build library (SwiftPM)
         run: swift build
 
@@ -107,6 +113,8 @@ jobs:
       # and the Codex cost scan. Floor sits just under the measured baseline as a
       # regression gate. Ratchet this up as coverage improves; never lower it to make
       # a PR pass.
+      # Keep this value in parity with e2e.yml and _build-signed.yml; the
+      # signed-release workflow contract check fails CI if they drift.
       COVERAGE_THRESHOLD: 19
 
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,8 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 40
     env:
-      # Keep in sync with the gate in ci.yml (`test` job). Never lower it.
+      # Keep in parity with ci.yml and _build-signed.yml. The signed-release
+      # workflow contract verifier fails PR CI if any broad gate drifts.
       COVERAGE_THRESHOLD: 19
 
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,9 +33,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          ref: ${{ github.sha }}
           persist-credentials: false
           # Full history + tags so `git describe` / `rev-list --count` work.
           fetch-depth: 0
+
+      # Scheduled runs are on master; this also prevents a manual dispatch from
+      # publishing an unmerged branch through the rolling signed channel.
+      - name: Require nightly commit on origin/master
+        env:
+          RELEASE_COMMIT: ${{ github.sha }}
+        run: scripts/verify-release-ancestry.sh "$RELEASE_COMMIT"
 
       - name: Derive nightly version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          ref: ${{ github.sha }}
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Validate release tag
         id: version
@@ -33,6 +35,13 @@ jobs:
             echo "tag=$REF_NAME"
             echo "version=$RELEASE_VERSION"
           } >> "$GITHUB_OUTPUT"
+
+      # Accidental-release guard. Release-environment branch/reviewer rules
+      # remain the authorization boundary for anyone who can push a tag.
+      - name: Require release commit on origin/master
+        env:
+          RELEASE_COMMIT: ${{ github.sha }}
+        run: scripts/verify-release-ancestry.sh "$RELEASE_COMMIT"
 
   build:
     needs: version

--- a/scripts/test-release-ancestry.sh
+++ b/scripts/test-release-ancestry.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+validator="$script_dir/verify-release-ancestry.sh"
+temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/meterbar-release-ancestry.XXXXXX")
+trap 'rm -rf "$temporary_directory"' EXIT
+
+# Scratch commits must not inherit signing, hooks, or templates from the runner.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
+repository="$temporary_directory/repository"
+git init --quiet --initial-branch=master "$repository"
+git -C "$repository" config user.name "MeterBar CI"
+git -C "$repository" config user.email "ci@meterbar.dev"
+
+touch "$repository/history"
+git -C "$repository" add history
+git -C "$repository" commit --quiet -m "Initial commit"
+ancestor_commit=$(git -C "$repository" rev-parse HEAD)
+
+echo "master" >> "$repository/history"
+git -C "$repository" commit --quiet -am "Master commit"
+master_commit=$(git -C "$repository" rev-parse HEAD)
+git -C "$repository" update-ref refs/remotes/origin/master "$master_commit"
+
+git -C "$repository" checkout --quiet -b unmerged-descendant "$master_commit"
+echo "unmerged descendant" >> "$repository/history"
+git -C "$repository" commit --quiet -am "Unmerged descendant"
+descendant_commit=$(git -C "$repository" rev-parse HEAD)
+
+git -C "$repository" checkout --quiet -b side-branch "$ancestor_commit"
+echo "side branch" >> "$repository/history"
+git -C "$repository" commit --quiet -am "Side-branch commit"
+side_branch_commit=$(git -C "$repository" rev-parse HEAD)
+
+git -C "$repository" checkout --quiet master
+
+(
+  cd "$repository"
+  "$validator" "$ancestor_commit"
+)
+
+(
+  cd "$repository"
+  "$validator" "$master_commit"
+)
+
+if (
+  cd "$repository"
+  "$validator" "$descendant_commit" >/dev/null 2>&1
+); then
+  echo "An unmerged descendant of origin/master was accepted." >&2
+  exit 1
+fi
+
+if (
+  cd "$repository"
+  "$validator" "$side_branch_commit" >/dev/null 2>&1
+); then
+  echo "A side-branch release commit was accepted." >&2
+  exit 1
+fi
+
+if (
+  cd "$temporary_directory"
+  "$validator" "$ancestor_commit" >/dev/null 2>&1
+); then
+  echo "Release ancestry passed outside a Git worktree." >&2
+  exit 1
+fi
+
+if (
+  cd "$repository"
+  "$validator" HEAD >/dev/null 2>&1
+); then
+  echo "Malformed release commit input was accepted." >&2
+  exit 1
+fi
+
+if (
+  cd "$repository"
+  "$validator" "$ancestor_commit" unexpected >/dev/null 2>&1
+); then
+  echo "Unexpected release ancestry arguments were accepted." >&2
+  exit 1
+fi
+
+git -C "$repository" update-ref -d refs/remotes/origin/master
+if (
+  cd "$repository"
+  "$validator" "$ancestor_commit" >/dev/null 2>&1
+); then
+  echo "Release ancestry passed without refs/remotes/origin/master." >&2
+  exit 1
+fi
+
+echo "Release ancestry validation cases passed."

--- a/scripts/verify-release-ancestry.sh
+++ b/scripts/verify-release-ancestry.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <release-commit-sha>" >&2
+  exit 64
+fi
+
+release_commit="$1"
+master_ref="refs/remotes/origin/master"
+
+# The workflow supplies github.sha, so accept only a full object ID. Besides
+# producing a precise malformed-input error, this prevents revision syntax from
+# changing what git resolves below.
+if [[ ! "$release_commit" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Release commit must be a full 40-character lowercase Git SHA." >&2
+  exit 64
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Release ancestry must be verified from inside a Git worktree." >&2
+  exit 1
+fi
+
+if ! release_commit=$(git rev-parse --verify "${release_commit}^{commit}" 2>/dev/null); then
+  echo "Release commit does not resolve to a commit: $1" >&2
+  exit 1
+fi
+
+if ! master_commit=$(git rev-parse --verify "${master_ref}^{commit}" 2>/dev/null); then
+  echo "Required master reference is missing or invalid: $master_ref" >&2
+  exit 1
+fi
+
+if ! git merge-base --is-ancestor "$release_commit" "$master_commit"; then
+  echo "Release commit $release_commit is not an ancestor of $master_ref ($master_commit)." >&2
+  exit 1
+fi
+
+echo "Release commit $release_commit is an ancestor of $master_ref ($master_commit)."

--- a/scripts/verify-release-workflow-contract.sh
+++ b/scripts/verify-release-workflow-contract.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repository_root=$(cd "$script_dir/.." && pwd)
+
+python3 - "$repository_root" <<'PYTHON'
+import re
+import sys
+from pathlib import Path
+
+repository_root = Path(sys.argv[1])
+ci_path = repository_root / ".github/workflows/ci.yml"
+e2e_path = repository_root / ".github/workflows/e2e.yml"
+nightly_path = repository_root / ".github/workflows/nightly.yml"
+release_path = repository_root / ".github/workflows/release.yml"
+signed_path = repository_root / ".github/workflows/_build-signed.yml"
+
+
+def read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise SystemExit(f"Unable to read workflow {path}: {error}") from error
+
+
+def job_block(workflow: str, job_name: str, path: Path) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(job_name)}:\s*\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\s*\n|\Z)",
+        workflow,
+    )
+    if match is None:
+        raise SystemExit(f"{path}: missing jobs.{job_name}")
+    return match.group("body")
+
+
+def require(pattern: str, text: str, message: str) -> None:
+    if re.search(pattern, text, re.MULTILINE) is None:
+        raise SystemExit(message)
+
+
+def require_checkout_input(job: str, name: str, value_pattern: str, path: Path, job_name: str) -> None:
+    pattern = (
+        r"^ {8}uses:\s*actions/checkout@[^\n]+\n"
+        r"^ {8}with:\s*\n"
+        r"(?:^ {10}[^\n]*\n)*?"
+        rf"^ {{10}}{re.escape(name)}:\s*{value_pattern}\s*$"
+    )
+    require(pattern, job, f"{path}: jobs.{job_name} checkout must set {name}")
+
+
+def require_ancestry_step(job: str, path: Path, job_name: str) -> None:
+    pattern = (
+        r"^ {6}- name:[^\n]*\n"
+        r"^ {8}env:\s*\n"
+        r"(?:^ {10}[^\n]*\n)*?"
+        r"^ {10}RELEASE_COMMIT:\s*\$\{\{\s*github\.sha\s*\}\}\s*\n"
+        r"(?:^ {10}[^\n]*\n)*?"
+        r'^ {8}run:\s*scripts/verify-release-ancestry\.sh "\$RELEASE_COMMIT"\s*$'
+    )
+    require(pattern, job, f"{path}: jobs.{job_name} must verify github.sha ancestry")
+
+
+def coverage_threshold(workflow: str, path: Path) -> str:
+    matches = re.findall(r"^\s+COVERAGE_THRESHOLD:\s*([0-9]+(?:\.[0-9]+)?)\s*$", workflow, re.MULTILINE)
+    if len(matches) != 1:
+        raise SystemExit(f"{path}: expected exactly one numeric COVERAGE_THRESHOLD, found {len(matches)}")
+    return matches[0]
+
+
+ci = read(ci_path)
+e2e = read(e2e_path)
+nightly = read(nightly_path)
+release = read(release_path)
+signed = read(signed_path)
+nightly_version_job = job_block(nightly, "version", nightly_path)
+version_job = job_block(release, "version", release_path)
+nightly_build_job = job_block(nightly, "build", nightly_path)
+release_build_job = job_block(release, "build", release_path)
+test_job = job_block(signed, "test", signed_path)
+build_job = job_block(signed, "build", signed_path)
+
+thresholds = {
+    ci_path: coverage_threshold(ci, ci_path),
+    e2e_path: coverage_threshold(e2e, e2e_path),
+    signed_path: coverage_threshold(signed, signed_path),
+}
+if len(set(thresholds.values())) != 1:
+    details = ", ".join(f"{path.name}={value}" for path, value in thresholds.items())
+    raise SystemExit(f"Coverage thresholds must match across broad validation workflows: {details}")
+
+require(
+    r"^\s+run:\s*bash scripts/check-coverage\.sh\s*$",
+    test_job,
+    f"{signed_path}: test must run scripts/check-coverage.sh",
+)
+require_checkout_input(
+    test_job,
+    "ref",
+    r"\$\{\{\s*github\.sha\s*\}\}",
+    signed_path,
+    "test",
+)
+if re.search(r"^\s+environment:\s*", test_job, re.MULTILINE) is not None:
+    raise SystemExit(f"{signed_path}: test must not enter the release environment")
+require(
+    r"^\s{4}needs:\s*test\s*$",
+    build_job,
+    f"{signed_path}: build must declare needs: test",
+)
+require(
+    r"^\s{4}environment:\s*release\s*$",
+    build_job,
+    f"{signed_path}: build must keep signing credentials in the release environment",
+)
+require_checkout_input(
+    build_job,
+    "ref",
+    r"\$\{\{\s*github\.sha\s*\}\}",
+    signed_path,
+    "build",
+)
+require_checkout_input(version_job, "fetch-depth", "0", release_path, "version")
+require_checkout_input(version_job, "ref", r"\$\{\{\s*github\.sha\s*\}\}", release_path, "version")
+require_ancestry_step(version_job, release_path, "version")
+require_checkout_input(nightly_version_job, "fetch-depth", "0", nightly_path, "version")
+require_checkout_input(
+    nightly_version_job,
+    "ref",
+    r"\$\{\{\s*github\.sha\s*\}\}",
+    nightly_path,
+    "version",
+)
+require_ancestry_step(nightly_version_job, nightly_path, "version")
+require(
+    r"^ {4}needs:\s*version\s*$",
+    release_build_job,
+    f"{release_path}: jobs.build must declare needs: version",
+)
+require(
+    r"^ {4}needs:\s*version\s*$",
+    nightly_build_job,
+    f"{nightly_path}: jobs.build must declare needs: version",
+)
+
+print(f"Signed-release workflow contract verified at coverage threshold {next(iter(thresholds.values()))}%.")
+PYTHON


### PR DESCRIPTION
Closes #220

## Summary
- gate the reusable signed build on test and coverage validation of the exact workflow commit
- reject stable and nightly publication when the selected commit is not reachable from `origin/master`
- add ancestry fixtures and workflow-contract checks to keep the release gates aligned

## Verification
- `bash -n scripts/verify-release-ancestry.sh scripts/test-release-ancestry.sh scripts/verify-release-workflow-contract.sh`
- ShellCheck passed for the three release scripts
- Actionlint passed for all changed workflows
- embedded Python syntax validation passed
- `git diff --check` passed
- Claude Opus 4.8 high-effort review completed; all safe in-scope findings applied

## Skipped locally
- Swift tests, Xcode builds, and coverage execution were intentionally deferred to GitHub Actions per the repository machine-safety policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Release, nightly, and signed-build processes now verify that artifacts come from valid repository history.
  - Builds and publishing are blocked when required tests, coverage checks, or release validations fail.
  - Checkout behavior is standardized to ensure artifacts correspond to the intended commit.

- **Tests**
  - Added comprehensive validation for release ancestry and workflow consistency.
  - Coverage requirements are enforced consistently across release-related checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->