### PR TITLE
feat(refresh): keep usage current every 10 minutes

### DIFF
--- a/.agents/SESSIONS/2026-07-17.md
+++ b/.agents/SESSIONS/2026-07-17.md
@@ -1,31 +1,50 @@
-# 2026-07-17 — Multi-account quota UI follow-ups
+# 2026-07-17
 
-## Session 1: Bound widget rows and isolate enabled Codex profiles
+## Session 1: Ten-minute resident usage refresh (#211)
 
-**Status:** Complete; PR CI pending
+**Status:** Implementation complete; PR CI pending
 
-### What changed
+```mermaid
+flowchart LR
+    Preference[Saved refresh preference] --> Manager[UsageDataManager]
+    Manager --> Timer[One common-run-loop timer]
+    Timer --> Guard[Non-overlapping refresh guard]
+    Wake[macOS wake event] --> Freshness[Enabled-data freshness check]
+    Freshness -->|stale or missing| Guard
+    Guard --> Providers[Enabled provider and account fetches]
+    Providers --> Cache[Existing cache, widget, and parse-health paths]
+```
 
-- Count every enabled Codex and Claude profile in the dashboard overview, plus each enabled single-account provider.
-- Exclude disabled Codex profiles from provider cards, status-item probes, refreshes, aggregate metrics, and widget snapshots.
-- Keep Codex graceful degradation account-scoped so cached quota data cannot move between profile labels.
-- Bound the medium widget to three row slots, using two rows plus a `+N more` summary when usage sources overflow.
-- Add regression coverage for source counts, disabled/all-disabled/profile-switched Codex accounts, and widget row budgeting.
+### Affected components
+
+- Refresh interval preference and Settings picker
+- Usage refresh orchestration and overlap protection
+- macOS application wake lifecycle
+- Focused refresh scheduling tests and current documentation
+
+### What was done
+
+- Added a 10-minute interval and made it the default only when no valid saved preference exists.
+- Preserved existing 1, 2, 5, 15, 30-minute, and manual-only selections.
+- Kept `UsageDataManager` as the cadence owner with one main-run-loop timer in common modes.
+- Coalesced overlapping full and provider-specific refresh requests through the existing loading state.
+- Forwarded the macOS wake notification to a stale-data policy that refreshes enabled sources once when data is missing or at least 10 minutes old.
+- Added focused coverage for defaults, migration, timer cadence, overlap, stale wake catch-up, fresh wake behavior, and manual-only mode.
+
+### Key decisions
+
+- Wake freshness uses the oldest enabled provider/account snapshot so one fresh source cannot hide another stale source.
+- Disabled or inaccessible sources do not force wake catch-up; missing data for an enabled source does.
+- Timer ticks are not replayed after sleep. The wake path requests at most one catch-up cycle, and the overlap guard handles a delayed timer racing the wake event.
 
 ### Verification
 
-- Focused SwiftLint strict: zero violations on all changed Swift files.
-- `git diff --check`: clean.
-- Claude Opus 4.8 high-effort review completed; all correctness findings applied and the final profile-isolation verdict passed.
-- Local XCTest and Xcode build skipped per MacBook policy; PR CI is the broad validation gate.
-- SwiftFormat unavailable locally.
+- `swiftlint lint --strict --quiet` on all changed Swift and test files — passed.
+- `git diff --check` — passed.
+- SwiftFormat — unavailable locally.
+- Swift tests, typechecks, and Xcode builds — skipped locally per the MacBook safety rule; PR CI is the execution gate.
+- Claude Opus 4.8 high-effort review — unavailable after two attempts; the retry returned `API Error: 529 Overloaded`.
 
-### Files changed
+### Next steps
 
-- `MeterBar/App/MeterBarApp.swift`
-- `MeterBar/Services/UsageDataManager.swift`
-- `MeterBar/Views/ProviderSnapshot.swift`
-- `MeterBar/Views/UsageDashboardView.swift`
-- `MeterBarWidget/UsageWidget.swift`
-- `Packages/MeterBarShared/Sources/MeterBarShared/MediumWidgetRowBudget.swift`
-- Focused tests under `MeterBarTests/`
+- [ ] Let PR CI run focused tests, coverage, lint, secret scan, and app/widget/CLI builds.

--- a/.agents/SESSIONS/2026-07-17.md
+++ b/.agents/SESSIONS/2026-07-17.md
@@ -1,6 +1,36 @@
-# 2026-07-17
+# 2026-07-17 — Multi-account quota UI follow-ups
 
-## Session 1: Ten-minute resident usage refresh (#211)
+## Session 1: Bound widget rows and isolate enabled Codex profiles
+
+**Status:** Complete; PR CI pending
+
+### What changed
+
+- Count every enabled Codex and Claude profile in the dashboard overview, plus each enabled single-account provider.
+- Exclude disabled Codex profiles from provider cards, status-item probes, refreshes, aggregate metrics, and widget snapshots.
+- Keep Codex graceful degradation account-scoped so cached quota data cannot move between profile labels.
+- Bound the medium widget to three row slots, using two rows plus a `+N more` summary when usage sources overflow.
+- Add regression coverage for source counts, disabled/all-disabled/profile-switched Codex accounts, and widget row budgeting.
+
+### Verification
+
+- Focused SwiftLint strict: zero violations on all changed Swift files.
+- `git diff --check`: clean.
+- Claude Opus 4.8 high-effort review completed; all correctness findings applied and the final profile-isolation verdict passed.
+- Local XCTest and Xcode build skipped per MacBook policy; PR CI is the broad validation gate.
+- SwiftFormat unavailable locally.
+
+### Files changed
+
+- `MeterBar/App/MeterBarApp.swift`
+- `MeterBar/Services/UsageDataManager.swift`
+- `MeterBar/Views/ProviderSnapshot.swift`
+- `MeterBar/Views/UsageDashboardView.swift`
+- `MeterBarWidget/UsageWidget.swift`
+- `Packages/MeterBarShared/Sources/MeterBarShared/MediumWidgetRowBudget.swift`
+- Focused tests under `MeterBarTests/`
+
+## Session 2: Ten-minute resident usage refresh (#211)
 
 **Status:** Implementation complete; PR CI pending
 

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture - MeterBar
 
 **Purpose:** Document what IS implemented (not what WILL BE).
-**Last Updated:** 2026-07-14 (rewritten from a full-repo audit; see `docs/audits/00-repo-map.md`)
+**Last Updated:** 2026-07-17 (rewritten from a full-repo audit; see `docs/audits/00-repo-map.md`)
 
 ---
 
@@ -66,7 +66,7 @@ meterbar/
 
 ## Services (all `.shared` singletons)
 
-- **UsageDataManager** (`@MainActor`, ObservableObject) — orchestrates refresh across providers, caches to UserDefaults (`cached_usage_metrics`), mirrors to the app group via SharedDataStore, records per-provider refresh outcomes in `ProviderParseHealthStore`, and drives a `Timer` auto-refresh (default 15 min; `RefreshInterval` supports 1/2/5/15/30 min + manual).
+- **UsageDataManager** (`@MainActor`, ObservableObject) — orchestrates refresh across providers, caches to UserDefaults (`cached_usage_metrics`), mirrors to the app group via SharedDataStore, records per-provider refresh outcomes in `ProviderParseHealthStore`, and drives a non-overlapping `Timer` auto-refresh (default 10 min; `RefreshInterval` supports 1/2/5/10/15/30 min + manual). The app forwards system wake events so stale enabled data catches up once without replaying missed ticks.
 - **ClaudeCodeCLIUsageService** — fallback source. Resolves the `claude` binary (`CLAUDE_CLI_PATH`, `$PATH`, 7 fallback paths), runs `claude /usage` (12 s timeout, dedicated GCD queue bridged to async), parses output with `ClaudeCodeCLIUsageParser`. `/usage` no longer renders in a headless spawn (it prints a session cost summary), so the parser detects that shape and throws a legible error. Multi-account via `CLAUDE_CONFIG_DIR` env injection.
 - **ClaudeCodeLocalService** — OAuth-primary wrapper. For the default account it reads `api.anthropic.com/api/oauth/usage` with the Keychain token (`metrics(from:)` maps windows + extra-usage), falling back to the CLI parser only when no token is available; custom accounts use the CLI. `prefersOAuth`/`isOAuthUsageEnabled` are the pure source-selection helpers.
 - **CodexCliLocalService** — Codex auth file + wham/usage endpoint; maps credits/spend to `ExtraUsageStatus` (safety-biased: never false "Off"). It also lists and consumes banked rate-limit resets with an idempotency key, then immediately refreshes usage. The exhausted popover card and `meterbar reset-credit --yes` are the two explicit-confirmation entry points.

--- a/.agents/docs/TESTING.md
+++ b/.agents/docs/TESTING.md
@@ -162,7 +162,7 @@ Once basic functionality is verified:
 1. Test with real credentials (if available)
 2. Test widget functionality (requires Xcode project setup)
 3. Test notification alerts
-4. Test auto-refresh (wait 15 minutes)
+4. Test auto-refresh (wait 10 minutes, then sleep/wake with stale data)
 5. Test usage limit monitoring (wait 5 minutes)
 
 ## Common Issues
@@ -231,4 +231,3 @@ each state:
       the remaining providers rather than going fully empty.
 - [ ] **Reload** — change the refresh interval or force a refresh in the app and
       confirm the widget updates (via `WidgetCenter.reloadTimelines`).
-

--- a/.agents/docs/TESTING.md
+++ b/.agents/docs/TESTING.md
@@ -162,7 +162,8 @@ Once basic functionality is verified:
 1. Test with real credentials (if available)
 2. Test widget functionality (requires Xcode project setup)
 3. Test notification alerts
-4. Test auto-refresh (wait 10 minutes, then sleep/wake with stale data)
+4. Test auto-refresh (verify a refresh after 10 minutes, then sleep for at
+   least 10 minutes and wake to verify stale-data catch-up)
 5. Test usage limit monitoring (wait 5 minutes)
 
 ## Common Issues

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -71,6 +71,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Keep Dock visibility in sync with the user's preference.
         observeDockVisibility()
+        observeSystemWake()
 
         // Create menu bar item
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -414,6 +415,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             .sink { [weak self] showInDock in
                 Task { @MainActor in
                     self?.applyActivationPolicy(showInDock: showInDock)
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    /// A repeating timer may be delayed while macOS sleeps. Forward one wake
+    /// event to the usage manager, which owns cadence, freshness, and overlap
+    /// policy and only refreshes when enabled data is stale.
+    private func observeSystemWake() {
+        NSWorkspace.shared.notificationCenter
+            .publisher(for: NSWorkspace.didWakeNotification)
+            .sink { _ in
+                Task { @MainActor in
+                    await UsageDataManager.shared.refreshAfterWakeIfNeeded()
                 }
             }
             .store(in: &cancellables)

--- a/MeterBar/Models/RefreshInterval.swift
+++ b/MeterBar/Models/RefreshInterval.swift
@@ -4,9 +4,12 @@ enum RefreshInterval: Int, CaseIterable, Identifiable {
     case oneMinute = 60
     case twoMinutes = 120
     case fiveMinutes = 300
+    case tenMinutes = 600
     case fifteenMinutes = 900
     case thirtyMinutes = 1800
     case manual = 0
+
+    static let defaultInterval: RefreshInterval = .tenMinutes
 
     var id: Int { rawValue }
 
@@ -18,6 +21,8 @@ enum RefreshInterval: Int, CaseIterable, Identifiable {
             return "2 minutes"
         case .fiveMinutes:
             return "5 minutes"
+        case .tenMinutes:
+            return "10 minutes"
         case .fifteenMinutes:
             return "15 minutes"
         case .thirtyMinutes:

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -34,16 +34,14 @@ class UsageDataManager: ObservableObject {
     @Published var isLoading: Bool = false
     @Published var lastError: Error?
 
-    @Published private var refreshIntervalRaw: Int =
-        UserDefaults.standard.object(forKey: StorageKeys.refreshInterval) as? Int
-        ?? RefreshInterval.fifteenMinutes.rawValue {
+    @Published private var refreshIntervalRaw: Int {
         didSet {
-            UserDefaults.standard.set(refreshIntervalRaw, forKey: StorageKeys.refreshInterval)
+            preferences.set(refreshIntervalRaw, forKey: StorageKeys.refreshInterval)
         }
     }
 
     var refreshInterval: RefreshInterval {
-        get { RefreshInterval(rawValue: refreshIntervalRaw) ?? .fifteenMinutes }
+        get { RefreshInterval(rawValue: refreshIntervalRaw) ?? .defaultInterval }
         set {
             refreshIntervalRaw = newValue.rawValue
             setupAutoRefresh()
@@ -61,8 +59,10 @@ class UsageDataManager: ObservableObject {
     private let parseHealthStore: ProviderParseHealthStore
 
     private var refreshTimer: Timer?
+    private(set) var scheduledRefreshInterval: TimeInterval?
     private let cacheKey = StorageKeys.cachedUsageMetrics
     private let sharedStore: SharedDataStore
+    private let preferences: UserDefaults
     private let cacheDefaults: UserDefaults
 
     /// Defaults wire the production singletons so `shared` behaves exactly as
@@ -81,6 +81,7 @@ class UsageDataManager: ObservableObject {
         codexAccountStore: CodexAccountStore? = nil,
         providerVisibilityStore: ProviderVisibilityStore? = nil,
         sharedStore: SharedDataStore = .shared,
+        preferences: UserDefaults = .standard,
         cacheDefaults: UserDefaults = .standard,
         parseHealthStore: ProviderParseHealthStore? = nil,
         schedulesAutoRefresh: Bool = true
@@ -94,8 +95,10 @@ class UsageDataManager: ObservableObject {
         self.codexAccountStore = codexAccountStore ?? .shared
         self.providerVisibilityStore = providerVisibilityStore ?? .shared
         self.sharedStore = sharedStore
+        self.preferences = preferences
         self.cacheDefaults = cacheDefaults
         self.parseHealthStore = parseHealthStore ?? .shared
+        refreshIntervalRaw = Self.savedRefreshInterval(in: preferences).rawValue
         loadCachedData()
         loadCachedCodexAccountMetrics()
         if schedulesAutoRefresh {
@@ -104,7 +107,9 @@ class UsageDataManager: ObservableObject {
     }
 
     func refreshAll() async {
+        guard !isLoading else { return }
         isLoading = true
+        defer { isLoading = false }
         lastError = nil
 
         var newMetrics: [ServiceType: UsageMetrics] = [:]
@@ -163,11 +168,12 @@ class UsageDataManager: ObservableObject {
         saveCachedData()
         saveCachedCodexAccountMetrics()
         saveSharedData(newMetrics)
-        isLoading = false
     }
 
     func refresh(service: ServiceType) async {
+        guard !isLoading else { return }
         isLoading = true
+        defer { isLoading = false }
         lastError = nil
 
         guard providerVisibilityStore.isEnabled(service) else {
@@ -180,7 +186,6 @@ class UsageDataManager: ObservableObject {
             saveCachedData()
             saveCachedCodexAccountMetrics()
             saveSharedData(metrics)
-            isLoading = false
             return
         }
 
@@ -189,7 +194,6 @@ class UsageDataManager: ObservableObject {
             metrics.removeValue(forKey: service)
             saveCachedData()
             saveSharedData(metrics)
-            isLoading = false
             return
         }
 
@@ -199,7 +203,6 @@ class UsageDataManager: ObservableObject {
             saveCachedData()
             saveCachedCodexAccountMetrics()
             saveSharedData(metrics)
-            isLoading = false
             return
         }
 
@@ -230,8 +233,15 @@ class UsageDataManager: ObservableObject {
                 }
             }
         }
+    }
 
-        isLoading = false
+    /// A delayed repeating timer does not replay missed ticks after sleep. The
+    /// workspace wake hook calls this method once; it catches up only when an
+    /// enabled source has no data or its oldest successful snapshot is at least
+    /// ten minutes old. Manual-only mode remains fully manual.
+    func refreshAfterWakeIfNeeded(now: Date = Date()) async {
+        guard refreshInterval != .manual, shouldCatchUpAfterWake(now: now) else { return }
+        await refreshAll()
     }
 
     /// Installs the post-redemption Codex usage response into the same caches
@@ -319,18 +329,68 @@ class UsageDataManager: ObservableObject {
     }
 
     private func setupAutoRefresh() {
-        // Cancel existing timer
         refreshTimer?.invalidate()
         refreshTimer = nil
+        scheduledRefreshInterval = nil
 
-        // Don't schedule if manual refresh only
         guard refreshInterval != .manual else { return }
 
-        refreshTimer = Timer.scheduledTimer(withTimeInterval: refreshInterval.seconds, repeats: true) { [weak self] _ in
+        let interval = refreshInterval.seconds
+        let timer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
             Task { @MainActor in
                 await self?.refreshAll()
             }
         }
+        RunLoop.main.add(timer, forMode: .common)
+        refreshTimer = timer
+        scheduledRefreshInterval = interval
+    }
+
+    private static func savedRefreshInterval(in preferences: UserDefaults) -> RefreshInterval {
+        guard let rawValue = preferences.object(forKey: StorageKeys.refreshInterval) as? Int else {
+            return .defaultInterval
+        }
+        return RefreshInterval(rawValue: rawValue) ?? .defaultInterval
+    }
+
+    private func shouldCatchUpAfterWake(now: Date) -> Bool {
+        var lastUpdatedDates: [Date] = []
+        var hasEnabledSource = false
+        var hasMissingData = false
+
+        func collect(_ metric: UsageMetrics?) {
+            hasEnabledSource = true
+            guard let metric else {
+                hasMissingData = true
+                return
+            }
+            lastUpdatedDates.append(metric.lastUpdated)
+        }
+
+        if providerVisibilityStore.isEnabled(.claudeCode),
+           claudeCodeService.hasAccess,
+           !claudeCodeAccountStore.enabledAccounts.isEmpty {
+            for account in claudeCodeAccountStore.enabledAccounts {
+                collect(claudeCodeAccountMetrics[account.id])
+            }
+        }
+
+        if providerVisibilityStore.isEnabled(.codexCli),
+           !codexAccountStore.enabledAccounts.isEmpty {
+            for account in codexAccountStore.enabledAccounts {
+                collect(codexAccountMetrics[account.id])
+            }
+        }
+
+        for service in [ServiceType.cursor, .openRouter, .grok]
+        where providerVisibilityStore.isEnabled(service) && hasProviderAccess(service) {
+            collect(metrics[service])
+        }
+
+        guard hasEnabledSource else { return false }
+        if hasMissingData { return true }
+        guard let oldestUpdate = lastUpdatedDates.min() else { return true }
+        return now.timeIntervalSince(oldestUpdate) >= RefreshInterval.tenMinutes.seconds
     }
 
     private func fetchClaudeCodeAccountMetrics() async -> [UUID: UsageMetrics] {

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -240,7 +240,7 @@ class UsageDataManager: ObservableObject {
     /// enabled source has no data or its oldest successful snapshot is at least
     /// ten minutes old. Manual-only mode remains fully manual.
     func refreshAfterWakeIfNeeded(now: Date = Date()) async {
-        guard refreshInterval != .manual, shouldCatchUpAfterWake(now: now) else { return }
+        guard refreshInterval != .manual, await shouldCatchUpAfterWake(now: now) else { return }
         await refreshAll()
     }
 
@@ -353,7 +353,7 @@ class UsageDataManager: ObservableObject {
         return RefreshInterval(rawValue: rawValue) ?? .defaultInterval
     }
 
-    private func shouldCatchUpAfterWake(now: Date) -> Bool {
+    private func shouldCatchUpAfterWake(now: Date) async -> Bool {
         var lastUpdatedDates: [Date] = []
         var hasEnabledSource = false
         var hasMissingData = false
@@ -378,6 +378,7 @@ class UsageDataManager: ObservableObject {
         if providerVisibilityStore.isEnabled(.codexCli),
            !codexAccountStore.enabledAccounts.isEmpty {
             for account in codexAccountStore.enabledAccounts {
+                guard await codexCliService.canAccess(account: account) else { continue }
                 collect(codexAccountMetrics[account.id])
             }
         }

--- a/MeterBarTests/RefreshIntervalTests.swift
+++ b/MeterBarTests/RefreshIntervalTests.swift
@@ -6,6 +6,7 @@ final class RefreshIntervalTests: XCTestCase {
         XCTAssertEqual(RefreshInterval.oneMinute.rawValue, 60)
         XCTAssertEqual(RefreshInterval.twoMinutes.rawValue, 120)
         XCTAssertEqual(RefreshInterval.fiveMinutes.rawValue, 300)
+        XCTAssertEqual(RefreshInterval.tenMinutes.rawValue, 600)
         XCTAssertEqual(RefreshInterval.fifteenMinutes.rawValue, 900)
         XCTAssertEqual(RefreshInterval.thirtyMinutes.rawValue, 1800)
         XCTAssertEqual(RefreshInterval.manual.rawValue, 0)
@@ -15,6 +16,7 @@ final class RefreshIntervalTests: XCTestCase {
         XCTAssertEqual(RefreshInterval.oneMinute.displayName, "1 minute")
         XCTAssertEqual(RefreshInterval.twoMinutes.displayName, "2 minutes")
         XCTAssertEqual(RefreshInterval.fiveMinutes.displayName, "5 minutes")
+        XCTAssertEqual(RefreshInterval.tenMinutes.displayName, "10 minutes")
         XCTAssertEqual(RefreshInterval.fifteenMinutes.displayName, "15 minutes")
         XCTAssertEqual(RefreshInterval.thirtyMinutes.displayName, "30 minutes")
         XCTAssertEqual(RefreshInterval.manual.displayName, "Manual only")
@@ -24,6 +26,7 @@ final class RefreshIntervalTests: XCTestCase {
         XCTAssertEqual(RefreshInterval.oneMinute.seconds, 60.0, accuracy: 0.01)
         XCTAssertEqual(RefreshInterval.twoMinutes.seconds, 120.0, accuracy: 0.01)
         XCTAssertEqual(RefreshInterval.fiveMinutes.seconds, 300.0, accuracy: 0.01)
+        XCTAssertEqual(RefreshInterval.tenMinutes.seconds, 600.0, accuracy: 0.01)
         XCTAssertEqual(RefreshInterval.fifteenMinutes.seconds, 900.0, accuracy: 0.01)
         XCTAssertEqual(RefreshInterval.thirtyMinutes.seconds, 1800.0, accuracy: 0.01)
         XCTAssertEqual(RefreshInterval.manual.seconds, 0.0, accuracy: 0.01)
@@ -35,7 +38,7 @@ final class RefreshIntervalTests: XCTestCase {
     }
 
     func testAllCasesCount() {
-        XCTAssertEqual(RefreshInterval.allCases.count, 6)
+        XCTAssertEqual(RefreshInterval.allCases.count, 7)
     }
 
     func testAllCasesContainsExpectedValues() {
@@ -43,8 +46,13 @@ final class RefreshIntervalTests: XCTestCase {
         XCTAssertTrue(allCases.contains(.oneMinute))
         XCTAssertTrue(allCases.contains(.twoMinutes))
         XCTAssertTrue(allCases.contains(.fiveMinutes))
+        XCTAssertTrue(allCases.contains(.tenMinutes))
         XCTAssertTrue(allCases.contains(.fifteenMinutes))
         XCTAssertTrue(allCases.contains(.thirtyMinutes))
         XCTAssertTrue(allCases.contains(.manual))
+    }
+
+    func testDefaultIntervalIsTenMinutes() {
+        XCTAssertEqual(RefreshInterval.defaultInterval, .tenMinutes)
     }
 }

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -15,7 +15,9 @@ final class UsageDataManagerTests: XCTestCase {
     private final class StubProvider: SimpleUsageProviding, CodexUsageProviding {
         var hasAccess: Bool
         var result: Result<UsageMetrics, Error>
+        var suspendsFetch = false
         private(set) var fetchCount = 0
+        private var fetchContinuation: CheckedContinuation<Void, Never>?
 
         init(hasAccess: Bool, result: Result<UsageMetrics, Error>) {
             self.hasAccess = hasAccess
@@ -24,12 +26,23 @@ final class UsageDataManagerTests: XCTestCase {
 
         func fetchUsageMetrics() async throws -> UsageMetrics {
             fetchCount += 1
+            if suspendsFetch {
+                await withCheckedContinuation { continuation in
+                    fetchContinuation = continuation
+                }
+            }
             return try result.get()
         }
 
         func canAccess(account: CodexAccount) async -> Bool { hasAccess }
         func fetchUsageMetrics(account: CodexAccount) async throws -> UsageMetrics {
             try await fetchUsageMetrics()
+        }
+
+        func resumeFetch() {
+            suspendsFetch = false
+            fetchContinuation?.resume()
+            fetchContinuation = nil
         }
     }
 
@@ -86,7 +99,9 @@ final class UsageDataManagerTests: XCTestCase {
         codexAccountStore: CodexAccountStore? = nil,
         hidden: Set<ServiceType> = [],
         preload: [ServiceType: UsageMetrics] = [:],
-        parseHealthStore: ProviderParseHealthStore? = nil
+        savedRefreshInterval: RefreshInterval? = nil,
+        parseHealthStore: ProviderParseHealthStore? = nil,
+        schedulesAutoRefresh: Bool = false
     ) -> (manager: UsageDataManager, sharedStore: SharedDataStore) {
         let suiteName = "UsageDataManagerTests-\(UUID().uuidString)"
         createdSuiteNames.append(contentsOf: [suiteName, "\(suiteName)-vis"])
@@ -96,6 +111,9 @@ final class UsageDataManagerTests: XCTestCase {
         }
         if !preload.isEmpty, let data = MetricsCodec.encode(preload) {
             cacheDefaults.set(data, forKey: StorageKeys.cachedUsageMetrics)
+        }
+        if let savedRefreshInterval {
+            cacheDefaults.set(savedRefreshInterval.rawValue, forKey: StorageKeys.refreshInterval)
         }
 
         let visibility = ProviderVisibilityStore(userDefaults: visibilityDefaults)
@@ -111,9 +129,10 @@ final class UsageDataManagerTests: XCTestCase {
             codexAccountStore: codexAccountStore,
             providerVisibilityStore: visibility,
             sharedStore: sharedStore,
+            preferences: cacheDefaults,
             cacheDefaults: cacheDefaults,
             parseHealthStore: parseHealthStore,
-            schedulesAutoRefresh: false
+            schedulesAutoRefresh: schedulesAutoRefresh
         )
         return (manager, sharedStore)
     }
@@ -153,15 +172,6 @@ final class UsageDataManagerTests: XCTestCase {
     }
 
     func testChangingRefreshIntervalPublishesToObservers() {
-        let savedRefreshInterval = UserDefaults.standard.object(forKey: StorageKeys.refreshInterval)
-        defer {
-            if let savedRefreshInterval {
-                UserDefaults.standard.set(savedRefreshInterval, forKey: StorageKeys.refreshInterval)
-            } else {
-                UserDefaults.standard.removeObject(forKey: StorageKeys.refreshInterval)
-            }
-        }
-
         let codex = StubProvider(hasAccess: true, result: .success(MetricsFixtures.codexCli()))
         let cursor = StubProvider(hasAccess: true, result: .success(MetricsFixtures.cursor()))
         let (manager, _) = makeManager(codex: codex, cursor: cursor)
@@ -173,6 +183,127 @@ final class UsageDataManagerTests: XCTestCase {
 
         XCTAssertEqual(publicationCount, 1)
         withExtendedLifetime(cancellable) {}
+    }
+
+    func testMissingRefreshPreferenceDefaultsToTenMinutes() {
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+        let (manager, _) = makeManager(codex: codex, cursor: cursor)
+
+        XCTAssertEqual(manager.refreshInterval, .tenMinutes)
+    }
+
+    func testExistingRefreshPreferencesArePreserved() {
+        let existingChoices: [RefreshInterval] = [
+            .oneMinute,
+            .twoMinutes,
+            .fiveMinutes,
+            .fifteenMinutes,
+            .thirtyMinutes,
+            .manual
+        ]
+
+        for existingChoice in existingChoices {
+            let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+            let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+            let (manager, _) = makeManager(
+                codex: codex,
+                cursor: cursor,
+                savedRefreshInterval: existingChoice
+            )
+
+            XCTAssertEqual(manager.refreshInterval, existingChoice)
+        }
+    }
+
+    func testDefaultBackgroundSchedulerUsesTenMinuteCadence() throws {
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+        let (manager, _) = makeManager(
+            codex: codex,
+            cursor: cursor,
+            schedulesAutoRefresh: true
+        )
+
+        XCTAssertEqual(try XCTUnwrap(manager.scheduledRefreshInterval), 600, accuracy: 0.01)
+
+        manager.refreshInterval = .manual
+        XCTAssertNil(manager.scheduledRefreshInterval)
+    }
+
+    func testRefreshAllSkipsOverlappingCycle() async {
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: true, result: .success(MetricsFixtures.cursor()))
+        cursor.suspendsFetch = true
+        let (manager, _) = makeManager(codex: codex, cursor: cursor)
+
+        let firstRefresh = Task { await manager.refreshAll() }
+        for _ in 0..<100 where cursor.fetchCount == 0 {
+            await Task.yield()
+        }
+        guard cursor.fetchCount == 1, manager.isLoading else {
+            cursor.resumeFetch()
+            await firstRefresh.value
+            return XCTFail("the first refresh should be suspended inside the provider fetch")
+        }
+
+        await manager.refreshAll()
+
+        XCTAssertEqual(cursor.fetchCount, 1)
+        cursor.resumeFetch()
+        await firstRefresh.value
+        XCTAssertFalse(manager.isLoading)
+    }
+
+    func testWakeRefreshesWhenEnabledCachedDataIsTenMinutesOld() async {
+        let now = Date(timeIntervalSinceReferenceDate: 800_000_000)
+        let staleMetrics = UsageMetrics(
+            service: .cursor,
+            weeklyLimit: UsageLimit(used: 1, total: 10, resetTime: now),
+            lastUpdated: now.addingTimeInterval(-RefreshInterval.tenMinutes.seconds)
+        )
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: true, result: .success(MetricsFixtures.cursor()))
+        let (manager, _) = makeManager(
+            codex: codex,
+            cursor: cursor,
+            hidden: [.codexCli],
+            preload: [.cursor: staleMetrics]
+        )
+
+        await manager.refreshAfterWakeIfNeeded(now: now)
+
+        XCTAssertEqual(cursor.fetchCount, 1)
+    }
+
+    func testWakeDoesNotRefreshFreshOrManualOnlyData() async {
+        let now = Date(timeIntervalSinceReferenceDate: 800_000_000)
+        let freshMetrics = UsageMetrics(
+            service: .cursor,
+            weeklyLimit: UsageLimit(used: 1, total: 10, resetTime: now),
+            lastUpdated: now.addingTimeInterval(-RefreshInterval.tenMinutes.seconds + 1)
+        )
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: true, result: .success(MetricsFixtures.cursor()))
+        let (manager, _) = makeManager(
+            codex: codex,
+            cursor: cursor,
+            hidden: [.codexCli],
+            preload: [.cursor: freshMetrics]
+        )
+
+        await manager.refreshAfterWakeIfNeeded(now: now)
+        XCTAssertEqual(cursor.fetchCount, 0)
+
+        manager.metrics[.cursor] = UsageMetrics(
+            service: .cursor,
+            weeklyLimit: freshMetrics.weeklyLimit,
+            lastUpdated: now.addingTimeInterval(-RefreshInterval.tenMinutes.seconds)
+        )
+        manager.refreshInterval = .manual
+        await manager.refreshAfterWakeIfNeeded(now: now)
+
+        XCTAssertEqual(cursor.fetchCount, 0)
     }
 
     func testRefreshAllPreservesCachedMetricsWhenProviderFails() async {

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -306,6 +306,26 @@ final class UsageDataManagerTests: XCTestCase {
         XCTAssertEqual(cursor.fetchCount, 0)
     }
 
+    func testWakeIgnoresMissingMetricsForInaccessibleCodexAccounts() async {
+        let now = Date(timeIntervalSinceReferenceDate: 800_000_000)
+        let freshMetrics = UsageMetrics(
+            service: .cursor,
+            weeklyLimit: UsageLimit(used: 1, total: 10, resetTime: now),
+            lastUpdated: now
+        )
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: true, result: .success(MetricsFixtures.cursor()))
+        let (manager, _) = makeManager(
+            codex: codex,
+            cursor: cursor,
+            preload: [.cursor: freshMetrics]
+        )
+
+        await manager.refreshAfterWakeIfNeeded(now: now)
+
+        XCTAssertEqual(cursor.fetchCount, 0)
+    }
+
     func testRefreshAllPreservesCachedMetricsWhenProviderFails() async {
         // Cursor previously cached a distinctive value; this refresh it throws.
         let cachedCursor = MetricsFixtures.cursor(planUsed: 999)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A lightweight macOS menu bar app that monitors Claude Code, Codex CLI, Cursor, O
 - **Widget Support**: macOS widget for at-a-glance monitoring
 - **Multi-Service Support**: Track Claude Code, Codex CLI, Cursor, OpenRouter, and Grok
 - **Zero Configuration for CLI Providers**: Reuses local CLI sign-ins without password entry
-- **Real-time Updates**: Background refresh every 15 minutes
+- **Real-time Updates**: Background refresh every 10 minutes, including prompt catch-up after wake
 - **Pace-aware Bars**: Usage bars show quota left with an expected-pace marker and burn-rate projection
 - **Color-coded Status**: Green (healthy), Orange (tight), Red (critical/exhausted)
 


### PR DESCRIPTION
Closes #211

## Summary

- add a 10-minute refresh option and make it the missing-preference default while preserving every existing saved interval
- keep one resident common-run-loop timer and coalesce overlapping full/provider refresh requests
- catch up once after macOS wake when enabled provider/account data is missing or at least 10 minutes old
- cover default migration, timer cadence, overlap protection, wake freshness, and manual-only behavior

## Verification

- `swiftlint lint --strict --quiet MeterBar/Models/RefreshInterval.swift MeterBar/Services/UsageDataManager.swift MeterBar/App/MeterBarApp.swift MeterBarTests/RefreshIntervalTests.swift MeterBarTests/UsageDataManagerTests.swift` — passed
- `git diff --check` — passed
- independent structured QA review — no actionable correctness or security findings

## Skipped locally

- Swift tests, typechecks, coverage, and Xcode builds were intentionally deferred to GitHub Actions per the MacBook safety rule.
- SwiftFormat is not installed locally.

## Review blocker

- Claude Opus 4.8 high-effort review was attempted twice before publication. The first invocation stalled for five minutes; the tool-disabled retry returned `API Error: 529 Overloaded`.

## Residual risk

- PR CI must validate XCTest compilation and the macOS app/widget/CLI build matrix, including actor-isolation compatibility for the injected preference and wake paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a 10-minute automatic refresh interval.
  * Added refresh catch-up after waking from sleep when usage data is missing or outdated.
  * Preserved existing refresh preferences and manual-only mode.

* **Bug Fixes**
  * Prevented overlapping refresh operations.
  * Improved refresh scheduling and stale-data handling.

* **Documentation**
  * Updated the README and testing guidance to reflect the new refresh cadence and wake behavior.

* **Tests**
  * Added coverage for interval defaults, preference persistence, wake refreshes, and concurrent refresh prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->