### PR TITLE
fix(release): use canonical repository URLs for Homebrew assets

### DIFF
--- a/.agents/docs/SETUP.md
+++ b/.agents/docs/SETUP.md
@@ -55,8 +55,8 @@ These tools help maintain consistent code style across the project.
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/VincentShipsIt/meterbar.app.git
-cd meterbar.app
+git clone https://github.com/VincentShipsIt/meterbar.dev.git
+cd meterbar.dev
 ```
 
 ### 2. Open in Xcode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Test release tag validation
         run: scripts/test-release-tag.sh
 
+      - name: Test Homebrew cask update
+        run: scripts/test-update-homebrew-cask.sh
+
+      - name: Verify canonical repository URLs
+        run: scripts/verify-canonical-repository-urls.sh
+
       - name: Build library (SwiftPM)
         run: swift build
 

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -46,12 +46,13 @@ jobs:
       - name: Download SHA256
         id: sha
         env:
+          RELEASE_REPOSITORY: ${{ github.repository }}
           RELEASE_TAG: ${{ steps.version.outputs.tag }}
         run: |
           set -euo pipefail
           curl -fsSL \
             --connect-timeout 15 --max-time 120 --retry 3 \
-            "https://github.com/VincentShipsIt/meterbar.app/releases/download/${RELEASE_TAG}/MeterBar-${RELEASE_TAG}.zip.sha256" \
+            "https://github.com/${RELEASE_REPOSITORY}/releases/download/${RELEASE_TAG}/MeterBar-${RELEASE_TAG}.zip.sha256" \
             -o sha256.txt
           # Validate the asset is a bare 64-hex SHA256 before trusting it. On a 404 or
           # redirect-to-error, curl -f fails the step; this guards the case where a 200
@@ -73,18 +74,17 @@ jobs:
         env:
           FORMULA_VERSION: ${{ steps.version.outputs.formula }}
           RELEASE_SHA256: ${{ steps.sha.outputs.sha256 }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          cd homebrew-tap
-
-          # Update version
-          sed -i "s/version \".*\"/version \"${FORMULA_VERSION}\"/" Casks/meterbar.rb
-
-          # Update sha256
-          sed -i "s/sha256 \".*\"/sha256 \"${RELEASE_SHA256}\"/" Casks/meterbar.rb
+          scripts/update-homebrew-cask.sh \
+            homebrew-tap/Casks/meterbar.rb \
+            "$FORMULA_VERSION" \
+            "$RELEASE_SHA256" \
+            "$RELEASE_REPOSITORY"
 
           echo "Updated formula:"
-          cat Casks/meterbar.rb
+          cat homebrew-tap/Casks/meterbar.rb
 
       - name: Commit and push
         env:

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Maintainer setup and release verification are documented in [docs/sparkle-update
 Prerequisites: macOS 26+, Xcode 26+
 
 ```bash
-git clone https://github.com/VincentShipsIt/meterbar.app.git
-cd meterbar.app
+git clone https://github.com/VincentShipsIt/meterbar.dev.git
+cd meterbar.dev
 open MeterBar.xcodeproj
 # Build and run (Cmd+R)
 ```

--- a/scripts/fixtures/homebrew/meterbar-expected.rb
+++ b/scripts/fixtures/homebrew/meterbar-expected.rb
@@ -1,0 +1,9 @@
+cask "meterbar" do
+  version "9.8.7"
+  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+  url "https://github.com/VincentShipsIt/meterbar.dev/releases/download/v#{version}/MeterBar-v#{version}.zip"
+  name "MeterBar"
+  desc "Track AI coding assistant usage limits from the menu bar"
+  homepage "https://meterbar.dev/"
+end

--- a/scripts/fixtures/homebrew/meterbar-malformed.rb
+++ b/scripts/fixtures/homebrew/meterbar-malformed.rb
@@ -1,0 +1,7 @@
+cask "meterbar" do
+  version "1.7.1"
+  sha256 "18283ea5f0412f21f7013410e7a0b4efb9363fa17dfd2ec62b99a7ddcc88f0c5"
+
+  url "https://downloads.example.com/MeterBar-v#{version}.zip"
+  name "MeterBar"
+end

--- a/scripts/fixtures/homebrew/meterbar-stale.rb
+++ b/scripts/fixtures/homebrew/meterbar-stale.rb
@@ -1,0 +1,9 @@
+cask "meterbar" do
+  version "1.7.1"
+  sha256 "18283ea5f0412f21f7013410e7a0b4efb9363fa17dfd2ec62b99a7ddcc88f0c5"
+
+  url "https://github.com/VincentShipsIt/meterbar.app/releases/download/v#{version}/MeterBar-v#{version}.zip"
+  name "MeterBar"
+  desc "Track AI coding assistant usage limits from the menu bar"
+  homepage "https://meterbar.dev/"
+end

--- a/scripts/test-update-homebrew-cask.sh
+++ b/scripts/test-update-homebrew-cask.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+fixture_dir="$script_dir/fixtures/homebrew"
+updater="$script_dir/update-homebrew-cask.sh"
+temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/meterbar-homebrew-cask.XXXXXX")
+trap 'rm -rf "$temporary_directory"' EXIT
+
+test_sha256="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+updated_cask="$temporary_directory/meterbar.rb"
+
+cp "$fixture_dir/meterbar-stale.rb" "$updated_cask"
+"$updater" \
+  "$updated_cask" \
+  "9.8.7" \
+  "$test_sha256" \
+  "VincentShipsIt/meterbar.dev"
+diff -u "$fixture_dir/meterbar-expected.rb" "$updated_cask"
+
+malformed_cask="$temporary_directory/meterbar-malformed.rb"
+malformed_before="$temporary_directory/meterbar-malformed-before.rb"
+cp "$fixture_dir/meterbar-malformed.rb" "$malformed_cask"
+cp "$malformed_cask" "$malformed_before"
+
+if "$updater" \
+  "$malformed_cask" \
+  "9.8.7" \
+  "$test_sha256" \
+  "VincentShipsIt/meterbar.dev" >/dev/null 2>&1; then
+  echo "Unexpected Homebrew cask layout was accepted." >&2
+  exit 1
+fi
+
+if ! cmp -s "$malformed_before" "$malformed_cask"; then
+  echo "Rejected Homebrew cask was modified before validation completed." >&2
+  exit 1
+fi
+
+echo "Homebrew cask update fixtures passed."

--- a/scripts/update-homebrew-cask.sh
+++ b/scripts/update-homebrew-cask.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "Usage: $0 CASK_PATH VERSION SHA256 REPOSITORY" >&2
+  exit 64
+fi
+
+cask_path=$1
+version=$2
+sha256=$3
+repository=$4
+canonical_repository="VincentShipsIt/meterbar.dev"
+
+if [ ! -f "$cask_path" ]; then
+  echo "Homebrew cask not found: $cask_path" >&2
+  exit 66
+fi
+
+if [[ ! "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "Homebrew cask version must match canonical MAJOR.MINOR.PATCH syntax." >&2
+  exit 64
+fi
+
+if [[ ! "$sha256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "Homebrew cask SHA256 must be a lowercase 64-hex digest." >&2
+  exit 64
+fi
+
+if [ "$repository" != "$canonical_repository" ]; then
+  echo "Homebrew cask repository must be $canonical_repository, got $repository." >&2
+  exit 64
+fi
+
+python3 - "$cask_path" "$version" "$sha256" "$repository" <<'PY'
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+import tempfile
+
+cask_path = Path(sys.argv[1])
+version = sys.argv[2]
+sha256 = sys.argv[3]
+repository = sys.argv[4]
+original = cask_path.read_text(encoding="utf-8")
+
+
+def replace_once(text: str, pattern: str, replacement: str, label: str) -> str:
+    updated, count = re.subn(pattern, replacement, text, flags=re.MULTILINE)
+    if count != 1:
+        raise SystemExit(
+            f"Expected exactly one canonical {label} declaration in {cask_path}; found {count}."
+        )
+    return updated
+
+
+updated = replace_once(
+    original,
+    r'^(?P<indent>[ \t]*)version "[^"\n]+"[ \t]*$',
+    rf'\g<indent>version "{version}"',
+    "version",
+)
+updated = replace_once(
+    updated,
+    r'^(?P<indent>[ \t]*)sha256 "[0-9a-fA-F]{64}"[ \t]*$',
+    rf'\g<indent>sha256 "{sha256}"',
+    "SHA256",
+)
+updated = replace_once(
+    updated,
+    (
+        r'^(?P<indent>[ \t]*)url "https://github\.com/'
+        r'[^/\s"]+/[^/\s"]+/releases/download/v#\{version\}/'
+        r'MeterBar-v#\{version\}\.zip"[ \t]*$'
+    ),
+    (
+        rf'\g<indent>url "https://github.com/{repository}/releases/download/'
+        r'v#{version}/MeterBar-v#{version}.zip"'
+    ),
+    "release URL",
+)
+
+descriptor, temporary_name = tempfile.mkstemp(
+    prefix=f".{cask_path.name}.",
+    dir=cask_path.parent,
+)
+try:
+    with os.fdopen(descriptor, "w", encoding="utf-8") as temporary_file:
+        temporary_file.write(updated)
+    os.chmod(temporary_name, stat.S_IMODE(cask_path.stat().st_mode))
+    os.replace(temporary_name, cask_path)
+except BaseException:
+    try:
+        os.unlink(temporary_name)
+    except FileNotFoundError:
+        pass
+    raise
+PY

--- a/scripts/verify-canonical-repository-urls.sh
+++ b/scripts/verify-canonical-repository-urls.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repository_root=$(cd "$script_dir/.." && pwd)
+retired_repository_suffix="app"
+retired_repository="VincentShipsIt/meterbar.$retired_repository_suffix"
+# This input fixture is the sole intentional retired URL: it proves that the
+# cask updater migrates the old repository without letting source references regress.
+allowed_migration_fixture="scripts/fixtures/homebrew/meterbar-stale.rb"
+scan_paths=(
+  .github
+  MeterBar
+  MeterBarWidget
+  MeterBarCLI
+  Packages
+  scripts
+  README.md
+  .agents/docs/SETUP.md
+  Package.swift
+)
+violations=()
+
+while IFS= read -r file; do
+  if [ "$file" = "$allowed_migration_fixture" ]; then
+    continue
+  fi
+
+  while IFS= read -r match; do
+    violations+=("$file:$match")
+  done < <(grep -nF "$retired_repository" "$repository_root/$file" || true)
+done < <(git -C "$repository_root" ls-files -- "${scan_paths[@]}")
+
+if [ "${#violations[@]}" -gt 0 ]; then
+  echo "Retired repository URL found outside the documented migration fixture:" >&2
+  printf '  %s\n' "${violations[@]}" >&2
+  exit 1
+fi
+
+echo "Canonical repository URL hygiene verified."


### PR DESCRIPTION
Closes #222

## Summary

- build release checksum downloads from the canonical `${{ github.repository }}` value
- replace permissive `sed` edits with an atomic, fail-closed cask transformer that updates version, SHA256, and repository URL together
- add success and malformed-layout fixtures plus a tracked-source hygiene gate for the retired repository slug
- correct the live clone instructions in the README and setup guide

## Verification

- `bash -n scripts/update-homebrew-cask.sh scripts/test-update-homebrew-cask.sh scripts/verify-canonical-repository-urls.sh` — passed
- `shellcheck scripts/update-homebrew-cask.sh scripts/test-update-homebrew-cask.sh scripts/verify-canonical-repository-urls.sh` — passed
- `actionlint .github/workflows/ci.yml .github/workflows/update-homebrew.yml` — passed
- `scripts/verify-canonical-repository-urls.sh` — passed
- `git diff --cached --check` — passed before commit

## Skipped locally

- `scripts/test-update-homebrew-cask.sh` is intentionally CI-only under the issue verification contract.
- Swift tests, typechecks, builds, release workflows, and the real tap mutation were not run locally.

## Residual risk

The transformer intentionally fails if the external cask layout changes, requiring an explicit fixture and parser update instead of silently publishing a partial edit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build-from-source instructions to use the current repository address and directory name.

* **Maintenance**
  * Improved Homebrew cask release updates with validation and safer file replacement.
  * Added checks to prevent outdated repository URLs from being introduced.
  * Added automated verification for Homebrew cask updates and malformed cask handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->