### PR TITLE
docs: record nightly release smoke verification

### DIFF
--- a/.agents/SESSIONS/2026-07-14.md
+++ b/.agents/SESSIONS/2026-07-14.md
@@ -1183,3 +1183,42 @@ regression**. Audited: **not a conflict.** Tree clean, zero conflict markers,
 - SwiftLint clean on all 11 changed files. Swift language mode `.v5` (no strict
   concurrency). `swift test` / build **not** run locally per MacBook policy —
   relying on PR CI + a local build to confirm visuals.
+
+# 2026-07-14 — Nightly deploy smoke test (#171)
+
+## What was done
+
+- Confirmed PR #171 merged to `master` and `.github/workflows/nightly.yml` was
+  present on the default branch.
+- Confirmed the `release` environment had no protection rules, then dispatched
+  Nightly run `29357570899` on `master`; it completed successfully in 6m26s.
+- Verified the rolling `nightly` prerelease contains `MeterBar-nightly.zip`,
+  `MeterBar-nightly.zip.sha256`, and `appcast-nightly.xml`.
+- Verified the live appcast reports build `1.7.0.54`, display version
+  `1.7.0-nightly.54+dd2b20b`, a non-empty EdDSA signature, and the fixed rolling
+  Nightly ZIP URL.
+- Streamed the release ZIP and confirmed its SHA-256 matches the published
+  checksum asset.
+- Exercised the in-app update in an isolated temporary clone of the signed
+  Nightly artifact: simulated prior build `1.7.0.53` was replaced in place by
+  the official `1.7.0.54` bundle, which passed `codesign`, `spctl`, and notarized
+  Developer ID checks.
+- Switched the installed test instance back to Stable through Settings. The UI
+  read back Stable, the app remained `1.7.0.54`, and no downgrade dialog or
+  Sparkle updater process appeared.
+- Removed the temporary app/artifacts without touching `/Applications/MeterBar.app`.
+- Created the active daily Codex automation
+  `meterbar-next-stable-release-smoke-test` to verify the first stable `v*`
+  release after `v1.7.0`, then self-pause after a conclusive result.
+
+## Evidence
+
+- Actions: <https://github.com/VincentShipsIt/meterbar.dev/actions/runs/29357570899>
+- Release: <https://github.com/VincentShipsIt/meterbar.dev/releases/tag/nightly>
+- Published ZIP SHA-256:
+  `59f01a9d1add4892cf4a3ebcf9fc59013a5b541abf843e5e8aa2b51d002bc85c`
+
+## Files changed
+
+- `.agents/SESSIONS/2026-07-14.md` — recorded deploy smoke-test evidence and
+  the stable-release follow-up monitor.


### PR DESCRIPTION
## Summary
- Preserve the July 14 nightly deploy smoke-test evidence in the repository session log.
- Record the verified release artifacts, signature/checksum validation, and stable-channel rollback check.

No product code changed.