### PR TITLE
test(ci): smoke public JSON commands from built bundles

### DIFF
--- a/.agents/SESSIONS/2026-07-17.md
+++ b/.agents/SESSIONS/2026-07-17.md
@@ -29,3 +29,77 @@
 - `MeterBarWidget/UsageWidget.swift`
 - `Packages/MeterBarShared/Sources/MeterBarShared/MediumWidgetRowBudget.swift`
 - Focused tests under `MeterBarTests/`
+
+## Session 2: Built-bundle JSON contract verification
+
+**Status:** Complete; PR CI pending
+
+```mermaid
+flowchart LR
+    Bundle[Universal or stapled MeterBar bundle] --> CLI[Embedded meterbar executable]
+    CLI --> Usage[usage --json]
+    CLI --> Cost[cost --json]
+    CLI --> Doctor[doctor --json]
+    Usage --> Validator[Strict JSON contract validator]
+    Cost --> Validator
+    Doctor --> Validator
+    Validator --> Gate[CI or signed-release gate]
+```
+
+### Affected components
+
+- Public CLI JSON integration surface
+- Pull-request app-bundle verification
+- Signed and stapled release verification
+- CLI schema documentation
+
+### What was done
+
+- Added a reusable smoke validator that accepts the built `meterbar` executable and runs
+  `usage --json`, `cost --json`, and `doctor --json`.
+- Enforced strict, single-document JSON parsing; version 1 usage/cost data and cache-missing
+  envelopes; and the exact redacted doctor DTO.
+- Added fake-binary fixtures covering data, cache-missing, stderr isolation, contaminated stdout,
+  and forbidden secret-bearing doctor fields.
+- Added the fixture harness and real executable smoke to the CI build job.
+- Added the same real executable smoke after notarization and stapling in the signed-build workflow.
+- Documented the existing doctor JSON contract.
+
+### Key decisions
+
+- Keep the validator outside the CLI so it tests ArgumentParser wiring, output channels, bundle
+  access, and the executable actually being shipped.
+- Capture stdout and stderr separately. Diagnostics may remain on stderr, while any stdout
+  contamination makes strict JSON parsing fail.
+- Allow version 1 usage/cost data or their documented cache-missing envelopes so credential-free
+  runners remain deterministic without provider calls.
+
+### Files changed
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/_build-signed.yml`
+- `docs/cli-json-schema.md`
+- `scripts/verify-cli-json-smoke.sh`
+- `scripts/test-cli-json-smoke.sh`
+- `scripts/fixtures/cli-json-smoke/fake-meterbar.sh`
+
+### Verification
+
+- `bash -n` passed for all three new shell scripts.
+- ShellCheck passed for all three new shell scripts.
+- Actionlint passed for both changed workflows.
+- Embedded Python validator syntax compilation passed.
+- `git diff --check` passed.
+- Fixture execution, CLI builds, executable smokes, Swift tests, and Xcode builds were not run
+  locally; the issue contract and MacBook safety policy delegate them to PR CI.
+
+### Mistakes and fixes
+
+- The Projects REST claim response omitted expanded field values, so the immediate response parser
+  could not confirm the new status. A direct item re-query verified the claim as `In Progress`
+  before any branch or file change.
+
+### Next steps
+
+- [ ] Confirm the CI fixture harness and universal built-bundle smoke pass.
+- [ ] Confirm the signed workflow exercises the same validator on the stapled release artifact.

--- a/.github/workflows/_build-signed.yml
+++ b/.github/workflows/_build-signed.yml
@@ -340,6 +340,9 @@ jobs:
           printf '%s' "$WAKE_JSON" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['schemaVersion']==1 and d['dryRun'] is True and d['outcome']=='success', d; print('Session Wake dry-run OK on stapled artifact')"
           echo "::endgroup::"
 
+      - name: Smoke public CLI JSON commands on stapled artifact
+        run: scripts/verify-cli-json-smoke.sh "$APP_PATH/Contents/Helpers/meterbar"
+
       # Zip the STAPLED bundle and compute the SHA256 on that FINAL artifact
       # (this is what the Homebrew cask consumes via <zip>.sha256). The pre-staple
       # notarization zip differs byte-for-byte, so the SHA must be computed here,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Test Homebrew cask update
         run: scripts/test-update-homebrew-cask.sh
 
+      - name: Test CLI JSON smoke validator
+        run: scripts/test-cli-json-smoke.sh
+
       - name: Verify canonical repository URLs
         run: scripts/verify-canonical-repository-urls.sh
 
@@ -100,6 +103,11 @@ jobs:
           APP_PATH="$RUNNER_TEMP/MeterBarDerivedData/Build/Products/Release/MeterBar.app"
           APP_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_PATH/Contents/Info.plist")
           scripts/sign-and-verify-release.sh "$APP_PATH" "$APP_VERSION"
+
+      - name: Smoke public CLI JSON commands
+        run: |
+          APP_PATH="$RUNNER_TEMP/MeterBarDerivedData/Build/Products/Release/MeterBar.app"
+          scripts/verify-cli-json-smoke.sh "$APP_PATH/Contents/Helpers/meterbar"
 
   test:
     name: Tests + coverage gate

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -118,3 +118,36 @@ When cached input is unavailable, JSON mode still emits a versioned document:
 ```
 
 Stable version 1 error codes are `usage_cache_missing` and `cost_cache_missing`.
+
+## Doctor
+
+```sh
+meterbar doctor --json
+```
+
+Doctor emits a JSON array of redacted readiness reports. Unlike the usage and cost integration
+documents, it is a diagnostic DTO rather than a versioned cache schema:
+
+```json
+[
+  {
+    "provider": "Codex CLI",
+    "overall": "warn",
+    "healthy": false,
+    "checks": [
+      {
+        "id": "auth",
+        "title": "Signed in",
+        "level": "warn",
+        "detail": "Sign-in not verified yet.",
+        "recovery": "Run `codex login`."
+      }
+    ]
+  }
+]
+```
+
+`overall` and `checks[].level` are `pass`, `warn`, or `fail`. `healthy` is true only when
+`overall` is `pass`. The report contains only the fields shown above; credential, token, password,
+authorization, and secret-bearing fields are never emitted. Diagnostic messages may use standard
+error, but standard output remains one JSON document.

--- a/scripts/fixtures/cli-json-smoke/fake-meterbar.sh
+++ b/scripts/fixtures/cli-json-smoke/fake-meterbar.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+scenario="${METERBAR_CLI_SMOKE_FIXTURE:-cache-missing}"
+command_name="${1:-}"
+format="${2:-}"
+
+if [ "$format" != "--json" ]; then
+  echo "Expected --json." >&2
+  exit 64
+fi
+
+case "$scenario:$command_name" in
+  cache-missing:usage)
+    printf '%s\n' \
+      '{"schemaVersion":1,"error":{"code":"usage_cache_missing","message":"No cached metrics found."}}'
+    ;;
+  cache-missing:cost)
+    printf '%s\n' \
+      '{"schemaVersion":1,"error":{"code":"cost_cache_missing","message":"No cached cost found."}}'
+    ;;
+  cache-missing:doctor)
+    printf '%s\n' \
+      '[{"provider":"Codex CLI","overall":"warn","healthy":false,"checks":[{"id":"auth","title":"Signed in","level":"warn","detail":"Sign-in not verified."}]}]'
+    ;;
+  data:usage)
+    printf '%s\n' \
+      '{"schemaVersion":1,"providers":[{"provider":"codex","displayName":"OpenAI Codex","lastUpdated":"2026-07-17T00:00:00Z","windows":[{"kind":"weekly","used":25,"total":100,"percentUsed":25,"percentLeft":75,"quotaBand":"healthy","estimated":false}]}]}'
+    ;;
+  data:cost)
+    printf '%s\n' \
+      '{"schemaVersion":1,"lastScannedAt":"2026-07-17T00:00:00Z","period":{"requestedDays":30,"coveredDays":1,"isTruncated":true},"providers":[{"provider":"codex","displayName":"OpenAI Codex","inputTokens":100,"outputTokens":20,"cacheReadTokens":5,"totalTokens":125,"estimatedCostUSD":0.01}],"totalCostUSD":0.01,"totalTokens":125}'
+    ;;
+  data:doctor)
+    echo "fixture diagnostic remains on stderr" >&2
+    printf '%s\n' \
+      '[{"provider":"Codex CLI","overall":"pass","healthy":true,"checks":[{"id":"auth","title":"Signed in","level":"pass","detail":"Signed in.","recovery":null}]}]'
+    ;;
+  malformed:usage)
+    printf '%s\n' 'debug output that contaminates stdout'
+    printf '%s\n' \
+      '{"schemaVersion":1,"error":{"code":"usage_cache_missing","message":"No cached metrics found."}}'
+    ;;
+  malformed:cost)
+    METERBAR_CLI_SMOKE_FIXTURE=cache-missing "$0" "$@"
+    ;;
+  malformed:doctor)
+    METERBAR_CLI_SMOKE_FIXTURE=cache-missing "$0" "$@"
+    ;;
+  secret-field:usage)
+    METERBAR_CLI_SMOKE_FIXTURE=cache-missing "$0" "$@"
+    ;;
+  secret-field:cost)
+    METERBAR_CLI_SMOKE_FIXTURE=cache-missing "$0" "$@"
+    ;;
+  secret-field:doctor)
+    printf '%s\n' \
+      '[{"provider":"Codex CLI","overall":"pass","healthy":true,"accessToken":"must-not-ship","checks":[]}]'
+    ;;
+  *)
+    echo "Unknown fixture scenario or command: $scenario:$command_name" >&2
+    exit 64
+    ;;
+esac

--- a/scripts/test-cli-json-smoke.sh
+++ b/scripts/test-cli-json-smoke.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+smoke_validator="$script_dir/verify-cli-json-smoke.sh"
+fake_cli="$script_dir/fixtures/cli-json-smoke/fake-meterbar.sh"
+temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/meterbar-cli-json-smoke-tests.XXXXXX")
+trap 'rm -rf "$temporary_directory"' EXIT
+
+METERBAR_CLI_SMOKE_FIXTURE=cache-missing "$smoke_validator" "$fake_cli"
+METERBAR_CLI_SMOKE_FIXTURE=data "$smoke_validator" "$fake_cli"
+
+if METERBAR_CLI_SMOKE_FIXTURE=malformed \
+  "$smoke_validator" "$fake_cli" > "$temporary_directory/malformed.log" 2>&1; then
+  echo "CLI JSON smoke accepted stdout contaminated with non-JSON diagnostics." >&2
+  exit 1
+fi
+if ! grep -qF "usage stdout is not one JSON document" "$temporary_directory/malformed.log"; then
+  echo "Malformed stdout fixture failed for an unexpected reason." >&2
+  cat "$temporary_directory/malformed.log" >&2
+  exit 1
+fi
+
+if METERBAR_CLI_SMOKE_FIXTURE=secret-field \
+  "$smoke_validator" "$fake_cli" > "$temporary_directory/secret-field.log" 2>&1; then
+  echo "CLI JSON smoke accepted a secret-bearing doctor field." >&2
+  exit 1
+fi
+if ! grep -qF "forbidden secret-bearing field 'accessToken'" "$temporary_directory/secret-field.log"; then
+  echo "Secret-bearing doctor fixture failed for an unexpected reason." >&2
+  cat "$temporary_directory/secret-field.log" >&2
+  exit 1
+fi
+
+echo "CLI JSON smoke validator fixtures passed."

--- a/scripts/verify-cli-json-smoke.sh
+++ b/scripts/verify-cli-json-smoke.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 METERBAR_EXECUTABLE" >&2
+  exit 64
+fi
+
+cli_binary="$1"
+if [ ! -f "$cli_binary" ] || [ ! -x "$cli_binary" ]; then
+  echo "MeterBar CLI executable not found or not executable: $cli_binary" >&2
+  exit 1
+fi
+
+temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/meterbar-cli-json-smoke.XXXXXX")
+trap 'rm -rf "$temporary_directory"' EXIT
+
+run_json_command() {
+  local command_name="$1"
+  local stdout_file="$temporary_directory/$command_name.stdout"
+  local stderr_file="$temporary_directory/$command_name.stderr"
+
+  if ! "$cli_binary" "$command_name" --json > "$stdout_file" 2> "$stderr_file"; then
+    echo "meterbar $command_name --json failed." >&2
+    if [ -s "$stderr_file" ]; then
+      cat "$stderr_file" >&2
+    fi
+    exit 1
+  fi
+
+  if [ -s "$stderr_file" ]; then
+    echo "meterbar $command_name --json wrote diagnostics to stderr; validating stdout separately."
+  fi
+}
+
+run_json_command usage
+run_json_command cost
+run_json_command doctor
+
+python3 - \
+  "$temporary_directory/usage.stdout" \
+  "$temporary_directory/cost.stdout" \
+  "$temporary_directory/doctor.stdout" <<'PY'
+import json
+import math
+import sys
+
+
+def fail(message):
+    raise SystemExit(message)
+
+
+def reject_constant(value):
+    fail(f"non-standard JSON numeric constant: {value}")
+
+
+def unique_object(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            fail(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_document(path, label):
+    try:
+        with open(path, "r", encoding="utf-8") as stream:
+            return json.load(
+                stream,
+                parse_constant=reject_constant,
+                object_pairs_hook=unique_object,
+            )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        fail(f"{label} stdout is not one JSON document: {error}")
+
+
+def require(condition, message):
+    if not condition:
+        fail(message)
+
+
+def require_number(value, path):
+    require(
+        isinstance(value, (int, float)) and not isinstance(value, bool),
+        f"{path} must be numeric",
+    )
+    require(math.isfinite(value), f"{path} must be finite")
+
+
+def require_integer(value, path, minimum=0):
+    require(
+        isinstance(value, int) and not isinstance(value, bool) and value >= minimum,
+        f"{path} must be an integer greater than or equal to {minimum}",
+    )
+
+
+def validate_error_or_providers(document, label, expected_error_code):
+    require(isinstance(document, dict), f"{label} must be a JSON object")
+    require_integer(document.get("schemaVersion"), f"{label}.schemaVersion", minimum=1)
+    require(document["schemaVersion"] == 1, f"{label}.schemaVersion must equal 1")
+
+    if "error" in document:
+        require("providers" not in document, f"{label} cannot contain both error and providers")
+        error = document["error"]
+        require(isinstance(error, dict), f"{label}.error must be an object")
+        require(error.get("code") == expected_error_code, f"{label}.error.code is unexpected")
+        require(
+            isinstance(error.get("message"), str) and error["message"],
+            f"{label}.error.message must be a non-empty string",
+        )
+        return None
+
+    providers = document.get("providers")
+    require(isinstance(providers, list), f"{label}.providers must be an array")
+    require("error" not in document, f"{label} cannot contain both providers and error")
+    return providers
+
+
+def validate_usage(document):
+    providers = validate_error_or_providers(
+        document,
+        "usage",
+        "usage_cache_missing",
+    )
+    if providers is None:
+        return
+
+    require(providers, "usage.providers must contain at least one provider")
+    for provider_index, provider in enumerate(providers):
+        path = f"usage.providers[{provider_index}]"
+        require(isinstance(provider, dict), f"{path} must be an object")
+        require(
+            isinstance(provider.get("provider"), str) and provider["provider"],
+            f"{path}.provider must be a non-empty string",
+        )
+        require(
+            isinstance(provider.get("displayName"), str) and provider["displayName"],
+            f"{path}.displayName must be a non-empty string",
+        )
+        require(
+            isinstance(provider.get("lastUpdated"), str) and provider["lastUpdated"],
+            f"{path}.lastUpdated must be a non-empty string",
+        )
+        windows = provider.get("windows")
+        require(isinstance(windows, list), f"{path}.windows must be an array")
+        for window_index, window in enumerate(windows):
+            window_path = f"{path}.windows[{window_index}]"
+            require(isinstance(window, dict), f"{window_path} must be an object")
+            require(
+                window.get("kind") in {"session", "weekly", "codeReview"},
+                f"{window_path}.kind is unexpected",
+            )
+            require(
+                window.get("quotaBand") in {"healthy", "tight", "critical", "exhausted"},
+                f"{window_path}.quotaBand is unexpected",
+            )
+            require(
+                isinstance(window.get("estimated"), bool),
+                f"{window_path}.estimated must be boolean",
+            )
+            for field in ("used", "total", "percentUsed", "percentLeft"):
+                require_number(window.get(field), f"{window_path}.{field}")
+
+
+def validate_cost(document):
+    providers = validate_error_or_providers(
+        document,
+        "cost",
+        "cost_cache_missing",
+    )
+    if providers is None:
+        return
+
+    require(
+        isinstance(document.get("lastScannedAt"), str) and document["lastScannedAt"],
+        "cost.lastScannedAt must be a non-empty string",
+    )
+    period = document.get("period")
+    require(isinstance(period, dict), "cost.period must be an object")
+    require_integer(period.get("requestedDays"), "cost.period.requestedDays", minimum=1)
+    require_integer(period.get("coveredDays"), "cost.period.coveredDays")
+    require(
+        isinstance(period.get("isTruncated"), bool),
+        "cost.period.isTruncated must be boolean",
+    )
+    require_number(document.get("totalCostUSD"), "cost.totalCostUSD")
+    require_integer(document.get("totalTokens"), "cost.totalTokens")
+
+    for provider_index, provider in enumerate(providers):
+        path = f"cost.providers[{provider_index}]"
+        require(isinstance(provider, dict), f"{path} must be an object")
+        require(
+            isinstance(provider.get("provider"), str) and provider["provider"],
+            f"{path}.provider must be a non-empty string",
+        )
+        require(
+            isinstance(provider.get("displayName"), str) and provider["displayName"],
+            f"{path}.displayName must be a non-empty string",
+        )
+        for field in (
+            "inputTokens",
+            "outputTokens",
+            "cacheReadTokens",
+            "totalTokens",
+        ):
+            require_integer(provider.get(field), f"{path}.{field}")
+        require_number(provider.get("estimatedCostUSD"), f"{path}.estimatedCostUSD")
+
+
+def reject_secret_keys(value, path="doctor"):
+    forbidden_fragments = (
+        "authorization",
+        "credential",
+        "password",
+        "secret",
+        "token",
+    )
+    if isinstance(value, dict):
+        for key, child in value.items():
+            normalized = key.lower().replace("_", "").replace("-", "")
+            require(
+                not any(fragment in normalized for fragment in forbidden_fragments),
+                f"{path} contains forbidden secret-bearing field {key!r}",
+            )
+            reject_secret_keys(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            reject_secret_keys(child, f"{path}[{index}]")
+
+
+def validate_doctor(document):
+    require(isinstance(document, list), "doctor must be a JSON array")
+    require(document, "doctor must contain at least one provider report")
+    reject_secret_keys(document)
+
+    report_keys = {"provider", "overall", "healthy", "checks"}
+    required_check_keys = {"id", "title", "level", "detail"}
+    allowed_check_keys = required_check_keys | {"recovery"}
+    levels = {"pass", "warn", "fail"}
+
+    for report_index, report in enumerate(document):
+        path = f"doctor[{report_index}]"
+        require(isinstance(report, dict), f"{path} must be an object")
+        require(set(report) == report_keys, f"{path} fields do not match the redacted DTO")
+        require(
+            isinstance(report["provider"], str) and report["provider"],
+            f"{path}.provider must be a non-empty string",
+        )
+        require(report["overall"] in levels, f"{path}.overall is unexpected")
+        require(isinstance(report["healthy"], bool), f"{path}.healthy must be boolean")
+        require(
+            report["healthy"] == (report["overall"] == "pass"),
+            f"{path}.healthy conflicts with overall",
+        )
+        require(isinstance(report["checks"], list), f"{path}.checks must be an array")
+
+        for check_index, check in enumerate(report["checks"]):
+            check_path = f"{path}.checks[{check_index}]"
+            require(isinstance(check, dict), f"{check_path} must be an object")
+            require(
+                required_check_keys <= set(check) <= allowed_check_keys,
+                f"{check_path} fields do not match the redacted DTO",
+            )
+            for field in ("id", "title", "detail"):
+                require(
+                    isinstance(check[field], str) and check[field],
+                    f"{check_path}.{field} must be a non-empty string",
+                )
+            require(check["level"] in levels, f"{check_path}.level is unexpected")
+            if "recovery" in check:
+                require(
+                    check["recovery"] is None or isinstance(check["recovery"], str),
+                    f"{check_path}.recovery must be a string or null",
+                )
+
+
+usage = load_document(sys.argv[1], "usage")
+cost = load_document(sys.argv[2], "cost")
+doctor = load_document(sys.argv[3], "doctor")
+
+validate_usage(usage)
+validate_cost(cost)
+validate_doctor(doctor)
+print("Usage, cost, and doctor JSON command contracts verified.")
+PY


### PR DESCRIPTION
Closes #221

## Summary

- add one reusable fail-closed smoke validator for `usage --json`, `cost --json`, and `doctor --json`
- cover data and cache-missing envelopes, strict stdout parsing, stderr isolation, and secret-bearing doctor fields with fake-binary fixtures
- run the validator against the universal PR bundle and the final notarized, stapled release binary
- document the existing redacted doctor JSON DTO

## Verification

- `bash -n scripts/verify-cli-json-smoke.sh scripts/test-cli-json-smoke.sh scripts/fixtures/cli-json-smoke/fake-meterbar.sh` — passed
- `shellcheck scripts/verify-cli-json-smoke.sh scripts/test-cli-json-smoke.sh scripts/fixtures/cli-json-smoke/fake-meterbar.sh` — passed
- `actionlint .github/workflows/ci.yml .github/workflows/_build-signed.yml` — passed
- embedded Python validator syntax compilation — passed
- `git diff --check` — passed
- GitHub Actions `Tests + coverage gate`, `SwiftLint`, `Secret Scan`, and required `build` — passed
- the required build passed the fake-binary fixture harness, Debug and universal app/widget builds, universal CLI injection, nested-bundle verification, and the real bundled CLI JSON smoke

## Skipped locally

- fixture execution, CLI builds, executable smokes, Swift tests, coverage, and Xcode builds were intentionally delegated to GitHub Actions under the issue contract and MacBook safety policy

## Residual risk

- the signed workflow path is structurally linted and uses the same passing validator, but final stapled-artifact execution requires a release/nightly run with signing and notarization credentials