### PR TITLE
feat(widget): add shared preferences domain

### DIFF
--- a/.agents/SESSIONS/2026-07-18.md
+++ b/.agents/SESSIONS/2026-07-18.md
@@ -1,0 +1,75 @@
+# Sessions: 2026-07-18
+
+**Summary:** Shared widget preferences and deterministic account selection
+
+---
+
+## Session 1: Shared widget preference domain
+
+**Duration:** ~30 minutes
+**Status:** Complete
+
+### System flow
+
+```mermaid
+flowchart LR
+    Settings[App settings] --> Store[App Group preference store]
+    Store --> Reload[Widget timeline reload]
+    Store --> Preferences[Shared Codable preferences]
+    Candidates[Configured provider accounts] --> Selector[Pure account selector]
+    Preferences --> Selector
+    Selector --> Rows[Enabled, available, selected rows]
+```
+
+### Affected components
+
+- Shared app/widget preference model and App Group store
+- Pure widget account filtering and ordering
+- SwiftPM regression coverage
+
+### What was done
+
+- Added select-all and explicit stable account selection.
+- Added used/remaining display mode, visible quota windows, reset/freshness details, and provider/urgency ordering.
+- Added a pure selector that filters disabled or unavailable providers and accounts without deleting persisted intent.
+- Added an injectable timeline-reload seam that fires once for each changed preference.
+- Preserved the existing widget presentation as the default and left the cached-metrics wire contract unchanged.
+- Added focused coverage for defaults, persistence, selection, filtering, ordering, stable identifiers, reloads, and older encodings.
+
+### Files changed
+
+- `Packages/MeterBarShared/Sources/MeterBarShared/WidgetPreferences.swift` - Shared preference domain, selector, and App Group store.
+- `MeterBarTests/WidgetPreferencesStoreTests.swift` - Focused domain and persistence coverage.
+- `.agents/sessions/2026-07-18.md` - Session record.
+
+### Key decisions
+
+- **Decision:** Store widget preferences in `MeterBarShared`.
+  - **Context:** Both the app and widget extension must decode the same values without duplicating a contract.
+  - **Rationale:** One module and one Codable representation prevent cross-target drift.
+- **Decision:** Keep explicit identifiers when accounts become disabled, unavailable, or removed.
+  - **Context:** Temporary account changes should not erase user intent.
+  - **Rationale:** The pure selector can ignore ineligible rows now and restore them automatically if they return.
+- **Decision:** Preserve weekly percentage-used provider ordering as the default.
+  - **Context:** Issue #217 must not change current widget rendering before #218 applies preferences.
+  - **Rationale:** Existing users retain the exact pre-preference behavior.
+
+### Mistakes and fixes
+
+- **Mistake:** Two initial test assertions chained a multiline selector call directly into `map`.
+- **Fix:** Bound each selection result to a local value before mapping, satisfying the repository SwiftLint rule.
+
+### Verification
+
+- `swiftlint lint --strict --quiet Packages/MeterBarShared/Sources/MeterBarShared/WidgetPreferences.swift MeterBarTests/WidgetPreferencesStoreTests.swift` - passed.
+- `git diff --check` - passed.
+- SwiftFormat - unavailable locally.
+- Swift tests, typechecks, and builds were not run locally per the issue's CI-only verification contract and MacBook resource policy.
+
+### Next steps
+
+- [ ] Let PR CI run focused tests, coverage, SwiftLint, and app/widget builds.
+
+---
+
+**Total sessions today:** 1

--- a/MeterBarTests/WidgetPreferencesStoreTests.swift
+++ b/MeterBarTests/WidgetPreferencesStoreTests.swift
@@ -1,0 +1,198 @@
+import Foundation
+import MeterBarShared
+import XCTest
+
+final class WidgetPreferencesStoreTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "WidgetPreferencesStoreTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testDefaultsPreserveExistingWidgetBehavior() {
+        let store = makeStore()
+
+        XCTAssertEqual(store.preferences.accountSelection, .all)
+        XCTAssertEqual(store.preferences.displayMode, .used)
+        XCTAssertEqual(store.preferences.visibleQuotaWindows, [.weekly])
+        XCTAssertFalse(store.preferences.showsResetTime)
+        XCTAssertFalse(store.preferences.showsFreshness)
+        XCTAssertEqual(store.preferences.accountOrdering, .provider)
+    }
+
+    func testPreferencesPersistAcrossRelaunch() {
+        let claude = WidgetAccountIdentifier.account(service: .claudeCode, id: UUID())
+        let codex = WidgetAccountIdentifier.account(service: .codexCli, id: UUID())
+        let store = makeStore()
+
+        store.setSelectedAccounts([claude, codex])
+        store.setDisplayMode(.remaining)
+        store.setVisibleQuotaWindows([.session, .weekly])
+        store.setShowsResetTime(true)
+        store.setShowsFreshness(true)
+        store.setAccountOrdering(.urgency)
+
+        let reloaded = makeStore()
+
+        XCTAssertEqual(reloaded.preferences.accountSelection.explicitIdentifiers, [claude, codex])
+        XCTAssertEqual(reloaded.preferences.displayMode, .remaining)
+        XCTAssertEqual(reloaded.preferences.visibleQuotaWindows, [.session, .weekly])
+        XCTAssertTrue(reloaded.preferences.showsResetTime)
+        XCTAssertTrue(reloaded.preferences.showsFreshness)
+        XCTAssertEqual(reloaded.preferences.accountOrdering, .urgency)
+    }
+
+    func testSelectAllAutomaticallyIncludesNewEnabledAccounts() {
+        let claude = candidate(service: .claudeCode, accountOrder: 0)
+        let codex = candidate(service: .codexCli, accountOrder: 0)
+        let preferences = WidgetPreferences.defaults
+
+        XCTAssertEqual(
+            WidgetAccountSelector.select(from: [claude], using: preferences).map(\.identifier),
+            [claude.identifier]
+        )
+        XCTAssertEqual(
+            WidgetAccountSelector.select(from: [claude, codex], using: preferences).map(\.identifier),
+            [claude.identifier, codex.identifier]
+        )
+        XCTAssertEqual(preferences.accountSelection, .all)
+    }
+
+    func testExplicitSelectionIgnoresUnselectedDisabledUnavailableAndRemovedAccounts() {
+        let selected = candidate(service: .claudeCode, accountOrder: 0)
+        let unselected = candidate(service: .codexCli, accountOrder: 0)
+        let disabledProvider = candidate(
+            service: .cursor,
+            accountOrder: 0,
+            isProviderEnabled: false
+        )
+        let disabledAccount = candidate(
+            service: .claudeCode,
+            accountOrder: 1,
+            isAccountEnabled: false
+        )
+        let unavailable = candidate(
+            service: .codexCli,
+            accountOrder: 1,
+            isAvailable: false
+        )
+        var preferences = WidgetPreferences.defaults
+        preferences.accountSelection = .explicit([
+            selected.identifier,
+            disabledProvider.identifier,
+            disabledAccount.identifier,
+            unavailable.identifier,
+            WidgetAccountIdentifier(rawValue: "account:removed")
+        ])
+
+        let result = WidgetAccountSelector.select(
+            from: [unselected, unavailable, disabledAccount, selected, disabledProvider],
+            using: preferences
+        )
+
+        XCTAssertEqual(result.map(\.identifier), [selected.identifier])
+    }
+
+    func testProviderAndUrgencyOrderingAreDeterministic() {
+        let claudeSecond = candidate(service: .claudeCode, accountOrder: 1, urgency: 90)
+        let claudeFirst = candidate(service: .claudeCode, accountOrder: 0, urgency: 20)
+        let codex = candidate(service: .codexCli, accountOrder: 0, urgency: 80)
+        var preferences = WidgetPreferences.defaults
+
+        let providerOrdered = WidgetAccountSelector.select(
+            from: [codex, claudeSecond, claudeFirst],
+            using: preferences
+        )
+        XCTAssertEqual(
+            providerOrdered.map(\.identifier),
+            [claudeFirst.identifier, claudeSecond.identifier, codex.identifier]
+        )
+
+        preferences.accountOrdering = .urgency
+
+        let urgencyOrdered = WidgetAccountSelector.select(
+            from: [codex, claudeSecond, claudeFirst],
+            using: preferences
+        )
+        XCTAssertEqual(
+            urgencyOrdered.map(\.identifier),
+            [claudeSecond.identifier, codex.identifier, claudeFirst.identifier]
+        )
+    }
+
+    func testEveryChangedPreferenceRequestsOneTimelineReload() {
+        var reloadCount = 0
+        let store = WidgetPreferencesStore(userDefaults: defaults) {
+            reloadCount += 1
+        }
+        let account = WidgetAccountIdentifier.provider(.claudeCode)
+
+        store.setSelectedAccounts([account])
+        store.selectAllAccounts()
+        store.setDisplayMode(.remaining)
+        store.setVisibleQuotaWindows([.session])
+        store.setShowsResetTime(true)
+        store.setShowsFreshness(true)
+        store.setAccountOrdering(.urgency)
+
+        XCTAssertEqual(reloadCount, 7)
+
+        store.setAccountOrdering(.urgency)
+
+        XCTAssertEqual(reloadCount, 7)
+    }
+
+    func testStableIdentifiersIncludeProviderAndAccountIdentity() {
+        let accountID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9))
+
+        XCTAssertEqual(
+            WidgetAccountIdentifier.provider(.cursor).rawValue,
+            "provider:Cursor"
+        )
+        XCTAssertEqual(
+            WidgetAccountIdentifier.account(service: .claudeCode, id: accountID).rawValue,
+            "account:Claude Code:00000000-0000-0000-0000-000000000009"
+        )
+    }
+
+    func testOlderEncodedPreferencesUseDefaultsForMissingFields() throws {
+        let legacyData = try JSONSerialization.data(withJSONObject: [:])
+
+        let decoded = try JSONDecoder().decode(WidgetPreferences.self, from: legacyData)
+
+        XCTAssertEqual(decoded, .defaults)
+    }
+
+    private func makeStore() -> WidgetPreferencesStore {
+        WidgetPreferencesStore(userDefaults: defaults, reloadTimelines: {})
+    }
+
+    private func candidate(
+        service: ServiceType,
+        accountOrder: Int,
+        isProviderEnabled: Bool = true,
+        isAccountEnabled: Bool = true,
+        isAvailable: Bool = true,
+        urgency: Double = 0
+    ) -> WidgetAccountCandidate {
+        WidgetAccountCandidate(
+            identifier: .account(service: service, id: UUID()),
+            service: service,
+            accountOrder: accountOrder,
+            isProviderEnabled: isProviderEnabled,
+            isAccountEnabled: isAccountEnabled,
+            isAvailable: isAvailable,
+            urgency: urgency
+        )
+    }
+}

--- a/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPreferences.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPreferences.swift
@@ -1,0 +1,285 @@
+import Combine
+import Foundation
+#if canImport(WidgetKit)
+import WidgetKit
+#endif
+
+/// Stable identity for one provider-level or account-level widget row.
+///
+/// The value deliberately includes the service for account rows so a UUID can
+/// never be attributed to the wrong provider after preferences are restored.
+public struct WidgetAccountIdentifier: RawRepresentable, Codable, Hashable, Sendable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public static func provider(_ service: ServiceType) -> Self {
+        Self(rawValue: "provider:\(service.rawValue)")
+    }
+
+    public static func account(service: ServiceType, id: UUID) -> Self {
+        Self(rawValue: "account:\(service.rawValue):\(id.uuidString)")
+    }
+}
+
+public enum WidgetAccountSelectionMode: String, Codable, Sendable {
+    case all
+    case explicit
+}
+
+public struct WidgetAccountSelection: Codable, Equatable, Sendable {
+    public let mode: WidgetAccountSelectionMode
+    public let accountIdentifiers: [WidgetAccountIdentifier]
+
+    public static let all = WidgetAccountSelection(mode: .all, accountIdentifiers: [])
+
+    public static func explicit(_ identifiers: Set<WidgetAccountIdentifier>) -> Self {
+        Self(mode: .explicit, accountIdentifiers: Array(identifiers))
+    }
+
+    public init(mode: WidgetAccountSelectionMode, accountIdentifiers: [WidgetAccountIdentifier]) {
+        self.mode = mode
+        self.accountIdentifiers = mode == .all
+            ? []
+            : Array(Set(accountIdentifiers)).sorted { $0.rawValue < $1.rawValue }
+    }
+
+    public var explicitIdentifiers: Set<WidgetAccountIdentifier> {
+        Set(accountIdentifiers)
+    }
+}
+
+public enum WidgetUsageDisplayMode: String, Codable, CaseIterable, Sendable {
+    case remaining
+    case used
+}
+
+public enum WidgetQuotaWindow: String, Codable, CaseIterable, Sendable {
+    case session
+    case weekly
+}
+
+public enum WidgetAccountOrdering: String, Codable, CaseIterable, Sendable {
+    case provider
+    case urgency
+}
+
+/// Cross-target value stored in the App Group and read by both the app and
+/// widget extension. Missing fields decode to the pre-preference widget
+/// behavior so future additions remain backward compatible.
+public struct WidgetPreferences: Codable, Equatable, Sendable {
+    public var accountSelection: WidgetAccountSelection
+    public var displayMode: WidgetUsageDisplayMode
+    public var visibleQuotaWindows: Set<WidgetQuotaWindow>
+    public var showsResetTime: Bool
+    public var showsFreshness: Bool
+    public var accountOrdering: WidgetAccountOrdering
+
+    public static let defaults = WidgetPreferences(
+        accountSelection: .all,
+        displayMode: .used,
+        visibleQuotaWindows: [.weekly],
+        showsResetTime: false,
+        showsFreshness: false,
+        accountOrdering: .provider
+    )
+
+    public init(
+        accountSelection: WidgetAccountSelection,
+        displayMode: WidgetUsageDisplayMode,
+        visibleQuotaWindows: Set<WidgetQuotaWindow>,
+        showsResetTime: Bool,
+        showsFreshness: Bool,
+        accountOrdering: WidgetAccountOrdering
+    ) {
+        self.accountSelection = accountSelection
+        self.displayMode = displayMode
+        self.visibleQuotaWindows = visibleQuotaWindows
+        self.showsResetTime = showsResetTime
+        self.showsFreshness = showsFreshness
+        self.accountOrdering = accountOrdering
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        accountSelection = try container.decodeIfPresent(
+            WidgetAccountSelection.self,
+            forKey: .accountSelection
+        ) ?? Self.defaults.accountSelection
+        displayMode = try container.decodeIfPresent(
+            WidgetUsageDisplayMode.self,
+            forKey: .displayMode
+        ) ?? Self.defaults.displayMode
+        visibleQuotaWindows = try container.decodeIfPresent(
+            Set<WidgetQuotaWindow>.self,
+            forKey: .visibleQuotaWindows
+        ) ?? Self.defaults.visibleQuotaWindows
+        showsResetTime = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .showsResetTime
+        ) ?? Self.defaults.showsResetTime
+        showsFreshness = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .showsFreshness
+        ) ?? Self.defaults.showsFreshness
+        accountOrdering = try container.decodeIfPresent(
+            WidgetAccountOrdering.self,
+            forKey: .accountOrdering
+        ) ?? Self.defaults.accountOrdering
+    }
+}
+
+/// Pure input to widget account filtering. The app can describe configured
+/// accounts even when metrics are missing; the selector safely removes
+/// disabled and unavailable rows without erasing the persisted selection.
+public struct WidgetAccountCandidate: Equatable, Sendable {
+    public let identifier: WidgetAccountIdentifier
+    public let service: ServiceType
+    public let accountOrder: Int
+    public let isProviderEnabled: Bool
+    public let isAccountEnabled: Bool
+    public let isAvailable: Bool
+    public let urgency: Double
+
+    public init(
+        identifier: WidgetAccountIdentifier,
+        service: ServiceType,
+        accountOrder: Int,
+        isProviderEnabled: Bool = true,
+        isAccountEnabled: Bool = true,
+        isAvailable: Bool = true,
+        urgency: Double = 0
+    ) {
+        self.identifier = identifier
+        self.service = service
+        self.accountOrder = accountOrder
+        self.isProviderEnabled = isProviderEnabled
+        self.isAccountEnabled = isAccountEnabled
+        self.isAvailable = isAvailable
+        self.urgency = urgency
+    }
+}
+
+public enum WidgetAccountSelector {
+    public static func select(
+        from candidates: [WidgetAccountCandidate],
+        using preferences: WidgetPreferences
+    ) -> [WidgetAccountCandidate] {
+        let explicitIdentifiers = preferences.accountSelection.explicitIdentifiers
+        let selected = candidates.filter { candidate in
+            guard candidate.isProviderEnabled,
+                  candidate.isAccountEnabled,
+                  candidate.isAvailable else {
+                return false
+            }
+
+            switch preferences.accountSelection.mode {
+            case .all:
+                return true
+            case .explicit:
+                return explicitIdentifiers.contains(candidate.identifier)
+            }
+        }
+
+        return selected.sorted { lhs, rhs in
+            switch preferences.accountOrdering {
+            case .provider:
+                return providerOrder(lhs) < providerOrder(rhs)
+            case .urgency:
+                if normalizedUrgency(lhs.urgency) != normalizedUrgency(rhs.urgency) {
+                    return normalizedUrgency(lhs.urgency) > normalizedUrgency(rhs.urgency)
+                }
+                return providerOrder(lhs) < providerOrder(rhs)
+            }
+        }
+    }
+
+    private static func providerOrder(_ candidate: WidgetAccountCandidate) -> (Int, Int, String) {
+        (candidate.service.sortOrder, candidate.accountOrder, candidate.identifier.rawValue)
+    }
+
+    private static func normalizedUrgency(_ urgency: Double) -> Double {
+        urgency.isFinite ? urgency : 0
+    }
+}
+
+/// App Group-backed preference store. Mutations persist one shared Codable
+/// value and request exactly one widget timeline reload through an injectable
+/// seam.
+public final class WidgetPreferencesStore: ObservableObject {
+    public static let shared = WidgetPreferencesStore()
+
+    @Published public private(set) var preferences: WidgetPreferences
+
+    private static let storageKey = "WidgetPreferences"
+
+    private let userDefaults: UserDefaults
+    private let reloadTimelines: () -> Void
+
+    public convenience init() {
+        self.init(
+            userDefaults: UserDefaults(suiteName: SharedMetricsStore.appGroupIdentifier) ?? .standard,
+            reloadTimelines: Self.reloadWidgetTimelines
+        )
+    }
+
+    public init(userDefaults: UserDefaults, reloadTimelines: @escaping () -> Void) {
+        self.userDefaults = userDefaults
+        self.reloadTimelines = reloadTimelines
+
+        if let data = userDefaults.data(forKey: Self.storageKey),
+           let decoded = try? JSONDecoder().decode(WidgetPreferences.self, from: data) {
+            preferences = decoded
+        } else {
+            preferences = .defaults
+        }
+    }
+
+    public func selectAllAccounts() {
+        update { $0.accountSelection = .all }
+    }
+
+    public func setSelectedAccounts(_ identifiers: Set<WidgetAccountIdentifier>) {
+        update { $0.accountSelection = .explicit(identifiers) }
+    }
+
+    public func setDisplayMode(_ displayMode: WidgetUsageDisplayMode) {
+        update { $0.displayMode = displayMode }
+    }
+
+    public func setVisibleQuotaWindows(_ windows: Set<WidgetQuotaWindow>) {
+        update { $0.visibleQuotaWindows = windows }
+    }
+
+    public func setShowsResetTime(_ showsResetTime: Bool) {
+        update { $0.showsResetTime = showsResetTime }
+    }
+
+    public func setShowsFreshness(_ showsFreshness: Bool) {
+        update { $0.showsFreshness = showsFreshness }
+    }
+
+    public func setAccountOrdering(_ accountOrdering: WidgetAccountOrdering) {
+        update { $0.accountOrdering = accountOrdering }
+    }
+
+    private func update(_ mutation: (inout WidgetPreferences) -> Void) {
+        var nextPreferences = preferences
+        mutation(&nextPreferences)
+        guard nextPreferences != preferences else { return }
+
+        preferences = nextPreferences
+        if let data = try? JSONEncoder().encode(nextPreferences) {
+            userDefaults.set(data, forKey: Self.storageKey)
+        }
+        reloadTimelines()
+    }
+
+    private static func reloadWidgetTimelines() {
+        #if canImport(WidgetKit)
+        WidgetCenter.shared.reloadTimelines(ofKind: "UsageWidget")
+        #endif
+    }
+}


### PR DESCRIPTION
Closes #217

## Summary

- add one App Group-backed `WidgetPreferencesStore` in `MeterBarShared` for app/widget parity
- model select-all and explicit account selection, remaining/used display, quota windows, reset/freshness details, and provider/urgency ordering
- add stable provider/account identifiers plus a pure selector that ignores disabled, unavailable, removed, and unselected rows without erasing persisted intent
- request one `UsageWidget` timeline reload for every changed preference through an injectable seam
- preserve the existing weekly percentage-used provider-order defaults and leave the cached-metrics wire contract unchanged

## Verification

- `swiftlint lint --strict --quiet Packages/MeterBarShared/Sources/MeterBarShared/WidgetPreferences.swift MeterBarTests/WidgetPreferencesStoreTests.swift` — passed
- `git diff --check` — passed
- final diff self-review — no correctness, security, secret-handling, or unrelated-change findings

## Skipped locally

- Swift tests, typechecks, coverage, and app/widget builds were intentionally delegated to GitHub Actions under the issue's CI-only verification contract and the repository MacBook resource policy
- SwiftFormat is not installed locally

## Residual risk

- The shared domain is compiled and exercised only by PR CI in this run; issue #218 will apply these preferences to family rendering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared widget preferences for account selection, usage display mode, quota windows, reset time, freshness, and account ordering.
  * Added support for selecting all accounts or specific eligible accounts.
  * Added provider-based and urgency-based account ordering.
  * Widget timelines now reload automatically when preferences change.

* **Bug Fixes**
  * Preserved saved account selections when accounts are temporarily unavailable or disabled.
  * Added backward-compatible defaults for incomplete saved preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->