### PR TITLE
feat(session-wake): add secure quota event hooks

### DIFF
--- a/.agents/SESSIONS/2026-07-18.md
+++ b/.agents/SESSIONS/2026-07-18.md
@@ -1,0 +1,38 @@
+# 2026-07-18 — Session Wake event hooks
+
+## Session 1: Bounded local hooks for quota transitions
+
+**Status:** Complete; PR CI pending
+
+### What was done
+
+- Added an opt-in executable path, literal argument vector, and separate toggles for quota exhausted, quota reset, and wake complete.
+- Added a direct `Process` runner with an absolute-path requirement, sanitized environment, bounded stdout/stderr capture, timeout enforcement, and metadata-only diagnostics.
+- Deduplicated quota transitions across watcher retries and serialized qualifying hook launches without allowing failures to change watcher state.
+- Propagated hook configuration through the in-app watcher and managed launch agent with backward-compatible agent configuration decoding.
+- Added Automation settings for exact executable/argv review, per-event enablement, and a bounded test run.
+- Added focused coverage for persistence, opt-in behavior, literal argv, transition deduplication, output bounds, timeouts, and launch failures.
+
+### Files changed
+
+- `MeterBar/SessionWake/WakeEventHook.swift`
+- `MeterBar/SessionWake/SessionWakeSettingsStore.swift`
+- `MeterBar/SessionWake/SessionWakeController.swift`
+- `MeterBar/SessionWake/SessionWakeAgent.swift`
+- `MeterBar/SessionWake/SessionWakeAgentState.swift`
+- `MeterBar/Views/SessionWakeSettingsView.swift`
+- `MeterBar/Models/StorageKeys.swift`
+- `MeterBarTests/WakeEventHookTests.swift`
+- `MeterBarTests/SessionWakeAgentTests.swift`
+
+### Decisions
+
+- User arguments remain exact argv entries; event and provider metadata use fixed environment variables and are never interpolated.
+- Automatic hooks inherit only a small non-secret environment instead of the app's complete process environment.
+- Hook failures remain diagnostic-only and cannot stop, fail, or delay the Session Wake state machine.
+
+### Verification
+
+- `swiftlint lint --strict --quiet` passed for every changed app Swift file.
+- `git diff --check` passed.
+- Local tests and builds were intentionally not run under the MacBook verification policy; PR CI is the execution gate.

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -86,4 +86,6 @@ nonisolated enum StorageKeys {
     static let sessionWakeMaxSessionsPerRun = "SessionWakeMaxSessionsPerRun"
     /// Per-session max agent turns (Int).
     static let sessionWakeMaxTurns = "SessionWakeMaxTurns"
+    /// JSON-encoded `WakeEventHookConfiguration`; missing means no configured or enabled hooks.
+    static let sessionWakeEventHooks = "SessionWakeEventHooks"
 }

--- a/MeterBar/SessionWake/SessionWakeAgent.swift
+++ b/MeterBar/SessionWake/SessionWakeAgent.swift
@@ -28,17 +28,20 @@ public enum SessionWakeAgent {
             lock.release()
         }
 
+        let hookDispatcher = WakeEventHookDispatcher()
         while !shouldCancel() {
             guard let configuration = stateStore.loadConfiguration(), configuration.canRun else {
                 return 0
             }
 
+            hookDispatcher.update(configuration: configuration.eventHooks)
             let runtime = makeRuntime(configuration: configuration)
             let coordinator = WakeCoordinator(
                 runner: runtime.makeRunner(),
                 bounds: configuration.bounds,
                 onState: { state in
                     stateStore.saveStatus(.init(state: state))
+                    hookDispatcher.observe(state, provider: configuration.provider)
                 }
             )
 

--- a/MeterBar/SessionWake/SessionWakeAgent.swift
+++ b/MeterBar/SessionWake/SessionWakeAgent.swift
@@ -49,6 +49,7 @@ public enum SessionWakeAgent {
                 coordinator: coordinator,
                 runtime: runtime,
                 configuration: configuration,
+                hookDispatcher: hookDispatcher,
                 stateStore: stateStore,
                 shouldCancel: shouldCancel
             )
@@ -117,6 +118,7 @@ public enum SessionWakeAgent {
         coordinator: WakeCoordinator,
         runtime: WakeProviderRuntime,
         configuration: SessionWakeAgentConfiguration,
+        hookDispatcher: WakeEventHookDispatcher,
         stateStore: SessionWakeAgentStateStore,
         shouldCancel: @escaping @Sendable () -> Bool
     ) async -> Bool {
@@ -131,6 +133,11 @@ public enum SessionWakeAgent {
                     guard let latest = stateStore.loadConfiguration(), latest.canRun else {
                         return false
                     }
+                    // Hook edits are deliberately live configuration, not a
+                    // reason to restart a potentially hours-long wake pass.
+                    // Refresh the dispatcher from the same durable snapshot
+                    // before the coordinator can emit its next transition.
+                    hookDispatcher.update(configuration: latest.eventHooks)
                     if shouldCancel() || latest.requiresRuntimeRestart(comparedTo: configuration) { return false }
                     stateStore.refreshHeartbeat()
                     try? await Task.sleep(nanoseconds: 2_000_000_000)

--- a/MeterBar/SessionWake/SessionWakeAgentState.swift
+++ b/MeterBar/SessionWake/SessionWakeAgentState.swift
@@ -17,6 +17,33 @@ nonisolated struct SessionWakeAgentConfiguration: Codable, Equatable, Sendable {
     let notifyOnCompletion: Bool
     let maxSessionsPerRun: Int
     let maxTurns: Int
+    let eventHooks: WakeEventHookConfiguration
+
+    init(
+        featureEnabled: Bool,
+        isArmed: Bool,
+        provider: WakeProvider,
+        accountDirectory: String?,
+        permissionMode: WakePermissionMode,
+        bypassAcknowledged: Bool,
+        prompt: String,
+        notifyOnCompletion: Bool,
+        maxSessionsPerRun: Int,
+        maxTurns: Int,
+        eventHooks: WakeEventHookConfiguration = .disabled
+    ) {
+        self.featureEnabled = featureEnabled
+        self.isArmed = isArmed
+        self.provider = provider
+        self.accountDirectory = accountDirectory
+        self.permissionMode = permissionMode
+        self.bypassAcknowledged = bypassAcknowledged
+        self.prompt = prompt
+        self.notifyOnCompletion = notifyOnCompletion
+        self.maxSessionsPerRun = maxSessionsPerRun
+        self.maxTurns = maxTurns
+        self.eventHooks = eventHooks
+    }
 
     var canRun: Bool {
         featureEnabled
@@ -47,7 +74,8 @@ nonisolated struct SessionWakeAgentConfiguration: Codable, Equatable, Sendable {
             prompt: prompt,
             notifyOnCompletion: notifyOnCompletion,
             maxSessionsPerRun: maxSessionsPerRun,
-            maxTurns: maxTurns
+            maxTurns: maxTurns,
+            eventHooks: eventHooks
         )
     }
 
@@ -59,6 +87,36 @@ nonisolated struct SessionWakeAgentConfiguration: Codable, Equatable, Sendable {
             || prompt != other.prompt
             || maxSessionsPerRun != other.maxSessionsPerRun
             || maxTurns != other.maxTurns
+            || eventHooks != other.eventHooks
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case featureEnabled
+        case isArmed
+        case provider
+        case accountDirectory
+        case permissionMode
+        case bypassAcknowledged
+        case prompt
+        case notifyOnCompletion
+        case maxSessionsPerRun
+        case maxTurns
+        case eventHooks
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        featureEnabled = try values.decode(Bool.self, forKey: .featureEnabled)
+        isArmed = try values.decode(Bool.self, forKey: .isArmed)
+        provider = try values.decode(WakeProvider.self, forKey: .provider)
+        accountDirectory = try values.decodeIfPresent(String.self, forKey: .accountDirectory)
+        permissionMode = try values.decode(WakePermissionMode.self, forKey: .permissionMode)
+        bypassAcknowledged = try values.decode(Bool.self, forKey: .bypassAcknowledged)
+        prompt = try values.decode(String.self, forKey: .prompt)
+        notifyOnCompletion = try values.decode(Bool.self, forKey: .notifyOnCompletion)
+        maxSessionsPerRun = try values.decode(Int.self, forKey: .maxSessionsPerRun)
+        maxTurns = try values.decode(Int.self, forKey: .maxTurns)
+        eventHooks = try values.decodeIfPresent(WakeEventHookConfiguration.self, forKey: .eventHooks) ?? .disabled
     }
 }
 

--- a/MeterBar/SessionWake/SessionWakeAgentState.swift
+++ b/MeterBar/SessionWake/SessionWakeAgentState.swift
@@ -87,7 +87,6 @@ nonisolated struct SessionWakeAgentConfiguration: Codable, Equatable, Sendable {
             || prompt != other.prompt
             || maxSessionsPerRun != other.maxSessionsPerRun
             || maxTurns != other.maxTurns
-            || eventHooks != other.eventHooks
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/MeterBar/SessionWake/SessionWakeController.swift
+++ b/MeterBar/SessionWake/SessionWakeController.swift
@@ -47,6 +47,7 @@ final class SessionWakeController: ObservableObject {
     private let rescanInterval: TimeInterval
     private let makeWatcher: WakeWatcherFactory
     private let makeLifetimeLock: @Sendable () -> WakeLock
+    private let hookDispatcher: WakeEventHookDispatcher
 
     private var cancellables = Set<AnyCancellable>()
     private var watchTask: Task<Void, Never>?
@@ -71,7 +72,8 @@ final class SessionWakeController: ObservableObject {
         makeWatcher: @escaping WakeWatcherFactory = { runner, bounds, onState in
             WakeCoordinator(runner: runner, bounds: bounds, onState: onState)
         },
-        makeLifetimeLock: @escaping @Sendable () -> WakeLock = { WakeLock(holderKind: .app) }
+        makeLifetimeLock: @escaping @Sendable () -> WakeLock = { WakeLock(holderKind: .app) },
+        hookDispatcher: WakeEventHookDispatcher? = nil
     ) {
         self.store = store ?? .shared
         self.status = status ?? .shared
@@ -84,6 +86,7 @@ final class SessionWakeController: ObservableObject {
         self.rescanInterval = rescanInterval
         self.makeWatcher = makeWatcher
         self.makeLifetimeLock = makeLifetimeLock
+        self.hookDispatcher = hookDispatcher ?? WakeEventHookDispatcher()
     }
 
     /// Begin observing the toggle and re-arm if it was left on. Idempotent;
@@ -107,7 +110,8 @@ final class SessionWakeController: ObservableObject {
             store.$prompt.map { _ in () }.eraseToAnyPublisher(),
             store.$notifyOnCompletion.map { _ in () }.eraseToAnyPublisher(),
             store.$maxSessionsPerRun.map { _ in () }.eraseToAnyPublisher(),
-            store.$maxTurns.map { _ in () }.eraseToAnyPublisher()
+            store.$maxTurns.map { _ in () }.eraseToAnyPublisher(),
+            store.$eventHookConfiguration.map { _ in () }.eraseToAnyPublisher()
         ]
         Publishers.MergeMany(triggers)
             .receive(on: RunLoop.main)
@@ -160,6 +164,7 @@ final class SessionWakeController: ObservableObject {
     // MARK: - Reconciliation
 
     private func reconcile() {
+        hookDispatcher.update(configuration: store.eventHookConfiguration)
         let account = selectedAccount()
         saveAgentConfiguration(account: account)
 
@@ -263,10 +268,13 @@ final class SessionWakeController: ObservableObject {
         let interval = rescanInterval
         let make = makeWatcher
         let publishedStatus = status
+        let hookDispatcher = hookDispatcher
+        let provider = runtime.provider
 
         watchTask = Task {
             while !Task.isCancelled {
                 let watcher = make(runner, bounds) { state in
+                    hookDispatcher.observe(state, provider: provider)
                     Task { @MainActor in publishedStatus.update(state: state) }
                 }
                 await watcher.start(runtime: runtime)
@@ -315,7 +323,8 @@ final class SessionWakeController: ObservableObject {
                 prompt: store.prompt,
                 notifyOnCompletion: notificationsAllowed,
                 maxSessionsPerRun: store.maxSessionsPerRun,
-                maxTurns: store.maxTurns
+                maxTurns: store.maxTurns,
+                eventHooks: store.eventHookConfiguration
             )
         )
     }

--- a/MeterBar/SessionWake/SessionWakeSettingsStore.swift
+++ b/MeterBar/SessionWake/SessionWakeSettingsStore.swift
@@ -26,6 +26,7 @@ final class SessionWakeSettingsStore: ObservableObject {
     @Published var notifyOnCompletion: Bool
     @Published private(set) var maxSessionsPerRun: Int
     @Published private(set) var maxTurns: Int
+    @Published private(set) var eventHookConfiguration: WakeEventHookConfiguration
 
     private let userDefaults: UserDefaults
     private let agentStateStore: SessionWakeAgentStateStore?
@@ -65,6 +66,9 @@ final class SessionWakeSettingsStore: ObservableObject {
         maxSessionsPerRun = storedSessions ?? WakeBounds.default.maxSessionsPerRun
         let storedTurns = userDefaults.object(forKey: StorageKeys.sessionWakeMaxTurns) as? Int
         maxTurns = storedTurns ?? WakeBounds.default.maxTurns
+        eventHookConfiguration = userDefaults.data(forKey: StorageKeys.sessionWakeEventHooks)
+            .flatMap { try? JSONDecoder().decode(WakeEventHookConfiguration.self, from: $0) }
+            ?? .disabled
 
         // Invariant: never persist "on" while the master switch is off or
         // without the remaining preconditions still holding.
@@ -221,6 +225,45 @@ final class SessionWakeSettingsStore: ObservableObject {
         userDefaults.set(clamped, forKey: StorageKeys.sessionWakeMaxTurns)
     }
 
+    // MARK: - Event hooks
+
+    func setHookExecutablePath(_ path: String) {
+        guard path != eventHookConfiguration.executablePath else { return }
+        eventHookConfiguration.executablePath = path
+        if !eventHookConfiguration.isConfigured {
+            eventHookConfiguration.enabledEvents.removeAll()
+        }
+        persistEventHooks()
+    }
+
+    func addHookArgument() {
+        eventHookConfiguration.arguments.append("")
+        persistEventHooks()
+    }
+
+    func setHookArgument(_ value: String, at index: Int) {
+        guard eventHookConfiguration.arguments.indices.contains(index),
+              eventHookConfiguration.arguments[index] != value else { return }
+        eventHookConfiguration.arguments[index] = value
+        persistEventHooks()
+    }
+
+    func removeHookArgument(at index: Int) {
+        guard eventHookConfiguration.arguments.indices.contains(index) else { return }
+        eventHookConfiguration.arguments.remove(at: index)
+        persistEventHooks()
+    }
+
+    func setHookEnabled(_ enabled: Bool, for event: WakeEventHookEvent) {
+        if enabled {
+            guard eventHookConfiguration.isConfigured else { return }
+            eventHookConfiguration.enabledEvents.insert(event)
+        } else {
+            eventHookConfiguration.enabledEvents.remove(event)
+        }
+        persistEventHooks()
+    }
+
     /// Reconcile with the currently available Claude accounts. If the selected
     /// Claude wake account disappeared, clear it and turn off — automation must
     /// never silently retarget another account.
@@ -285,6 +328,11 @@ final class SessionWakeSettingsStore: ObservableObject {
     private func syncSharedFeatureFlag() {
         UserDefaults(suiteName: SharedMetricsStore.appGroupIdentifier)?
             .set(featureEnabled, forKey: SessionWakeCLI.sharedFeatureEnabledKey)
+    }
+
+    private func persistEventHooks() {
+        guard let data = try? JSONEncoder().encode(eventHookConfiguration) else { return }
+        userDefaults.set(data, forKey: StorageKeys.sessionWakeEventHooks)
     }
 
     /// Synchronous kill-switch propagation. The controller writes the complete

--- a/MeterBar/SessionWake/WakeEventHook.swift
+++ b/MeterBar/SessionWake/WakeEventHook.swift
@@ -1,0 +1,387 @@
+import Darwin
+import Foundation
+
+/// The three Session Wake transitions that may invoke a user-configured local command.
+nonisolated enum WakeEventHookEvent: String, Codable, CaseIterable, Sendable {
+    case quotaExhausted = "quota-exhausted"
+    case quotaReset = "quota-reset"
+    case wakeComplete = "wake-complete"
+
+    var displayName: String {
+        switch self {
+        case .quotaExhausted: return "Quota exhausted"
+        case .quotaReset: return "Quota reset"
+        case .wakeComplete: return "Wake complete"
+        }
+    }
+}
+
+/// Persisted command and per-event opt-ins. Arguments are literal argv entries:
+/// no shell parsing, interpolation, placeholder expansion, or environment templates.
+nonisolated struct WakeEventHookConfiguration: Codable, Equatable, Sendable {
+    var executablePath: String
+    var arguments: [String]
+    var enabledEvents: Set<WakeEventHookEvent>
+
+    static let disabled = Self(executablePath: "", arguments: [], enabledEvents: [])
+
+    var normalizedExecutablePath: String {
+        executablePath.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var isConfigured: Bool {
+        normalizedExecutablePath.hasPrefix("/")
+    }
+
+    func isEnabled(for event: WakeEventHookEvent) -> Bool {
+        isConfigured && enabledEvents.contains(event)
+    }
+}
+
+/// Metadata is passed only through a fixed environment contract. User arguments
+/// are never rewritten with event or provider values.
+nonisolated struct WakeEventHookContext: Equatable, Sendable {
+    let eventName: String
+    let provider: WakeProvider?
+
+    static func automatic(_ event: WakeEventHookEvent, provider: WakeProvider) -> Self {
+        Self(eventName: event.rawValue, provider: provider)
+    }
+
+    static let test = Self(eventName: "test", provider: nil)
+}
+
+/// Pure transition tracker shared by the app and launch-agent dispatchers.
+///
+/// `quotaBlocked` deliberately survives scanning/unknown states and repeated
+/// watcher passes, so retries cannot launch duplicate exhausted hooks. A later
+/// `.running` transition proves quota became available and emits one reset.
+nonisolated struct WakeEventHookTransitionTracker: Sendable {
+    private var quotaBlocked = false
+    private var wasCompleted = false
+
+    mutating func event(for state: WakeWatcherState) -> WakeEventHookEvent? {
+        defer {
+            if case .completed = state {
+                wasCompleted = true
+            } else {
+                wasCompleted = false
+            }
+        }
+
+        switch state {
+        case .waiting:
+            guard !quotaBlocked else { return nil }
+            quotaBlocked = true
+            return .quotaExhausted
+        case .running:
+            guard quotaBlocked else { return nil }
+            quotaBlocked = false
+            return .quotaReset
+        case let .completed(summary):
+            guard !wasCompleted, summary.attempted > 0 || summary.remaining > 0 else { return nil }
+            quotaBlocked = false
+            return .wakeComplete
+        case .off:
+            quotaBlocked = false
+            return nil
+        case .idle, .scanning, .quotaUnknown, .stopping, .failed:
+            return nil
+        }
+    }
+}
+
+/// Result from one bounded direct-`Process` invocation. Captured bytes are kept
+/// only in memory for focused verification and are never written to diagnostics.
+nonisolated struct WakeEventHookResult: Sendable {
+    enum Termination: Equatable, Sendable {
+        case exited(Int32)
+        case timedOut
+        case launchFailed(String)
+    }
+
+    let termination: Termination
+    let stdoutByteCount: Int
+    let stderrByteCount: Int
+    let stdoutCapture: Data
+    let stderrCapture: Data
+
+    var succeeded: Bool {
+        termination == .exited(0)
+    }
+
+    var userMessage: String {
+        switch termination {
+        case .exited(0): return "Hook completed successfully."
+        case let .exited(code): return "Hook exited with status \(code)."
+        case .timedOut: return "Hook timed out."
+        case let .launchFailed(reason): return reason
+        }
+    }
+}
+
+/// Launches one hook with Foundation `Process` directly. Output is drained
+/// concurrently and retained only up to `maxCaptureBytes`; runtime is bounded
+/// by `timeout`, and timeout escalation terminates then kills the child.
+nonisolated struct WakeEventHookRunner: Sendable {
+    private let timeout: TimeInterval
+    private let maxCaptureBytes: Int
+    private let logger: WakeRunLogger
+    private let now: @Sendable () -> Date
+
+    init(
+        timeout: TimeInterval = 10,
+        maxCaptureBytes: Int = 16 * 1024,
+        logger: WakeRunLogger = WakeRunLogger(),
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.timeout = max(0.01, timeout)
+        self.maxCaptureBytes = max(0, maxCaptureBytes)
+        self.logger = logger
+        self.now = now
+    }
+
+    func run(
+        configuration: WakeEventHookConfiguration,
+        context: WakeEventHookContext
+    ) async -> WakeEventHookResult {
+        let start = now()
+        let result = await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                continuation.resume(returning: runBlocking(configuration: configuration, context: context))
+            }
+        }
+        record(result, context: context, start: start)
+        return result
+    }
+
+    private func runBlocking(
+        configuration: WakeEventHookConfiguration,
+        context: WakeEventHookContext
+    ) -> WakeEventHookResult {
+        let executable = configuration.normalizedExecutablePath
+        guard !executable.isEmpty else {
+            return emptyResult(.launchFailed("Configure an executable before testing the hook."))
+        }
+        guard executable.hasPrefix("/") else {
+            return emptyResult(.launchFailed("The configured executable path must be absolute."))
+        }
+        guard FileManager.default.fileExists(atPath: executable) else {
+            return emptyResult(.launchFailed("The configured executable does not exist."))
+        }
+        guard FileManager.default.isExecutableFile(atPath: executable) else {
+            return emptyResult(.launchFailed("The configured file is not executable."))
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = configuration.arguments
+        process.currentDirectoryURL = URL(
+            fileURLWithPath: ServiceSupport.realHomeDirectory(),
+            isDirectory: true
+        )
+        let parentEnvironment = ProcessInfo.processInfo.environment
+        var environment = [
+            "HOME": ServiceSupport.realHomeDirectory(),
+            "PATH": CLIBinaryLocator.augmentedPATH(environment: parentEnvironment),
+            "TMPDIR": parentEnvironment["TMPDIR"] ?? NSTemporaryDirectory(),
+            "LANG": parentEnvironment["LANG"] ?? "en_US.UTF-8",
+            "NO_COLOR": "1"
+        ]
+        environment["METERBAR_WAKE_EVENT"] = context.eventName
+        environment["METERBAR_WAKE_PROVIDER"] = context.provider?.rawValue ?? "test"
+        process.environment = environment
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        let finished = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in finished.signal() }
+
+        do {
+            try process.run()
+        } catch {
+            close(pipe: stdoutPipe)
+            close(pipe: stderrPipe)
+            return emptyResult(.launchFailed("The configured executable could not be launched."))
+        }
+
+        try? stdoutPipe.fileHandleForWriting.close()
+        try? stderrPipe.fileHandleForWriting.close()
+
+        let stdout = BoundedCapture(limit: maxCaptureBytes)
+        let stderr = BoundedCapture(limit: maxCaptureBytes)
+        let drains = DispatchGroup()
+        drain(stdoutPipe.fileHandleForReading, into: stdout, group: drains)
+        drain(stderrPipe.fileHandleForReading, into: stderr, group: drains)
+
+        let didTimeOut = finished.wait(timeout: .now() + timeout) == .timedOut
+        if didTimeOut {
+            process.terminate()
+            if finished.wait(timeout: .now() + 1) == .timedOut {
+                _ = kill(process.processIdentifier, SIGKILL)
+                _ = finished.wait(timeout: .now() + 1)
+            }
+        }
+
+        if drains.wait(timeout: .now() + 1) == .timedOut {
+            try? stdoutPipe.fileHandleForReading.close()
+            try? stderrPipe.fileHandleForReading.close()
+        }
+
+        return WakeEventHookResult(
+            termination: didTimeOut ? .timedOut : .exited(process.terminationStatus),
+            stdoutByteCount: stdout.byteCount,
+            stderrByteCount: stderr.byteCount,
+            stdoutCapture: stdout.data,
+            stderrCapture: stderr.data
+        )
+    }
+
+    private func record(_ result: WakeEventHookResult, context: WakeEventHookContext, start: Date) {
+        let outcome: String
+        let exitCode: Int32?
+        switch result.termination {
+        case .exited(0):
+            outcome = "succeeded"
+            exitCode = 0
+        case let .exited(code):
+            outcome = "failed"
+            exitCode = code
+        case .timedOut:
+            outcome = "timed-out"
+            exitCode = nil
+        case .launchFailed:
+            outcome = "launch-failed"
+            exitCode = nil
+        }
+        logger.append(WakeRunLogger.Record(
+            timestamp: start,
+            event: "hook",
+            sessionID: context.provider?.rawValue ?? "test",
+            reason: context.eventName,
+            outcome: outcome,
+            exitCode: exitCode,
+            durationMilliseconds: Int(now().timeIntervalSince(start) * 1000),
+            stdoutBytes: result.stdoutByteCount,
+            stderrBytes: result.stderrByteCount
+        ))
+    }
+
+    private func emptyResult(_ termination: WakeEventHookResult.Termination) -> WakeEventHookResult {
+        WakeEventHookResult(
+            termination: termination,
+            stdoutByteCount: 0,
+            stderrByteCount: 0,
+            stdoutCapture: Data(),
+            stderrCapture: Data()
+        )
+    }
+
+    private func close(pipe: Pipe) {
+        try? pipe.fileHandleForWriting.close()
+        try? pipe.fileHandleForReading.close()
+    }
+
+    private func drain(
+        _ handle: FileHandle,
+        into capture: BoundedCapture,
+        group: DispatchGroup
+    ) {
+        group.enter()
+        DispatchQueue.global(qos: .utility).async {
+            defer {
+                try? handle.close()
+                group.leave()
+            }
+            while true {
+                do {
+                    guard let chunk = try handle.read(upToCount: 8 * 1024),
+                          !chunk.isEmpty else { return }
+                    capture.append(chunk)
+                } catch {
+                    return
+                }
+            }
+        }
+    }
+}
+
+/// Thread-safe bridge from synchronous watcher state callbacks to a serial
+/// async hook queue. Hook failures are intentionally discarded here: the runner
+/// records bounded metadata and never changes watcher state.
+nonisolated final class WakeEventHookDispatcher: @unchecked Sendable {
+    private let lock = NSLock()
+    private let runner: WakeEventHookRunner
+    private var configuration: WakeEventHookConfiguration
+    private var tracker = WakeEventHookTransitionTracker()
+    private var pending: Task<Void, Never>?
+
+    init(
+        configuration: WakeEventHookConfiguration = .disabled,
+        runner: WakeEventHookRunner = WakeEventHookRunner()
+    ) {
+        self.configuration = configuration
+        self.runner = runner
+    }
+
+    func update(configuration: WakeEventHookConfiguration) {
+        lock.lock()
+        self.configuration = configuration
+        lock.unlock()
+    }
+
+    func observe(_ state: WakeWatcherState, provider: WakeProvider) {
+        lock.lock()
+        guard let event = tracker.event(for: state),
+              configuration.isEnabled(for: event) else {
+            lock.unlock()
+            return
+        }
+        let command = configuration
+        let previous = pending
+        let runner = self.runner
+        let context = WakeEventHookContext.automatic(event, provider: provider)
+        let task = Task.detached(priority: .utility) {
+            await previous?.value
+            _ = await runner.run(configuration: command, context: context)
+        }
+        pending = task
+        lock.unlock()
+    }
+}
+
+nonisolated private final class BoundedCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private let limit: Int
+    private var total = 0
+    private var storage = Data()
+
+    init(limit: Int) {
+        self.limit = limit
+    }
+
+    func append(_ chunk: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        total += chunk.count
+        let remaining = limit - storage.count
+        if remaining > 0 {
+            storage.append(contentsOf: chunk.prefix(remaining))
+        }
+    }
+
+    var byteCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return total
+    }
+
+    var data: Data {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+}

--- a/MeterBar/SessionWake/WakeEventHook.swift
+++ b/MeterBar/SessionWake/WakeEventHook.swift
@@ -83,7 +83,6 @@ nonisolated struct WakeEventHookTransitionTracker: Sendable {
             quotaBlocked = false
             return .wakeComplete
         case .off:
-            quotaBlocked = false
             return nil
         case .idle, .scanning, .quotaUnknown, .stopping, .failed:
             return nil

--- a/MeterBar/Views/SessionWakeSettingsView.swift
+++ b/MeterBar/Views/SessionWakeSettingsView.swift
@@ -12,6 +12,8 @@ struct SessionWakeSettingsView: View {
     @ObservedObject private var accounts: ClaudeCodeAccountStore
     @ObservedObject private var codexAccounts: CodexAccountStore
     @State private var showingFirstRunConfirmation = false
+    @State private var isTestingHook = false
+    @State private var hookTestMessage: String?
 
     @MainActor
     init(
@@ -56,6 +58,7 @@ struct SessionWakeSettingsView: View {
         previewSection
         limitsSection
         permissionSection
+        eventHookSection
         notificationSection
     }
 
@@ -231,6 +234,102 @@ struct SessionWakeSettingsView: View {
         }
     }
 
+    private var eventHookSection: some View {
+        SettingsPanelSection(title: "Event hooks", systemImage: "terminal", color: MeterBarTheme.appAccent) {
+            SettingsNotice(
+                text: "Optional local commands run directly without a shell. " +
+                    "Each argument below is one literal argv entry.",
+                color: .secondary
+            )
+
+            SettingsRowView(
+                title: "Executable",
+                detail: "Use an absolute path to an executable file."
+            ) {
+                TextField("/usr/local/bin/my-hook", text: hookExecutableBinding)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            ForEach(store.eventHookConfiguration.arguments.indices, id: \.self) { index in
+                SettingsRowView(title: "Argument \(index + 1)") {
+                    HStack(spacing: 6) {
+                        TextField("Literal argument", text: hookArgumentBinding(at: index))
+                            .textFieldStyle(.roundedBorder)
+
+                        Button {
+                            store.removeHookArgument(at: index)
+                        } label: {
+                            Image(systemName: "minus.circle")
+                        }
+                        .buttonStyle(.borderless)
+                        .help("Remove argument \(index + 1)")
+                    }
+                }
+            }
+
+            SettingsRowView(
+                title: "Arguments",
+                detail: "Add one field for every argv entry, including flags and values."
+            ) {
+                Button("Add Argument") {
+                    store.addHookArgument()
+                }
+                .buttonStyle(.bordered)
+            }
+
+            commandPreview
+
+            ForEach(WakeEventHookEvent.allCases, id: \.self) { event in
+                SettingsRowView(title: event.displayName) {
+                    Toggle(event.displayName, isOn: hookEventBinding(event))
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .disabled(!store.eventHookConfiguration.isConfigured)
+                }
+            }
+
+            SettingsRowView(
+                title: "Test hook",
+                detail: "Runs once with METERBAR_WAKE_EVENT=test and the same literal arguments."
+            ) {
+                Button(isTestingHook ? "Running…" : "Run Test") {
+                    testHook()
+                }
+                .buttonStyle(.bordered)
+                .disabled(!store.eventHookConfiguration.isConfigured || isTestingHook)
+            }
+
+            if let hookTestMessage {
+                SettingsNotice(
+                    text: hookTestMessage,
+                    color: hookTestColor
+                )
+            }
+        }
+    }
+
+    private var commandPreview: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text("Exact command")
+                .font(.caption)
+                .fontWeight(.semibold)
+            Text("executable: \(store.eventHookConfiguration.normalizedExecutablePath)")
+            ForEach(Array(store.eventHookConfiguration.arguments.enumerated()), id: \.offset) { index, argument in
+                Text("argv[\(index)]: \(argument)")
+            }
+        }
+        .font(.system(.caption, design: .monospaced))
+        .foregroundStyle(.secondary)
+        .textSelection(.enabled)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    private var hookTestColor: Color {
+        hookTestMessage == "Hook completed successfully." ? MeterBarTheme.success : MeterBarTheme.warning
+    }
+
     private var notificationSection: some View {
         SettingsPanelSection(title: "Notifications", systemImage: "bell", color: MeterBarTheme.appAccent) {
             SettingsRowView(
@@ -283,6 +382,30 @@ struct SessionWakeSettingsView: View {
         )
     }
 
+    private var hookExecutableBinding: Binding<String> {
+        Binding(
+            get: { store.eventHookConfiguration.executablePath },
+            set: { store.setHookExecutablePath($0) }
+        )
+    }
+
+    private func hookArgumentBinding(at index: Int) -> Binding<String> {
+        Binding(
+            get: {
+                guard store.eventHookConfiguration.arguments.indices.contains(index) else { return "" }
+                return store.eventHookConfiguration.arguments[index]
+            },
+            set: { store.setHookArgument($0, at: index) }
+        )
+    }
+
+    private func hookEventBinding(_ event: WakeEventHookEvent) -> Binding<Bool> {
+        Binding(
+            get: { store.eventHookConfiguration.enabledEvents.contains(event) },
+            set: { store.setHookEnabled($0, for: event) }
+        )
+    }
+
     /// The Claude config directory to preview against. Preview uses Claude
     /// session discovery, so it is only meaningful for the Claude provider.
     private var selectedConfigDirectory: String? {
@@ -292,6 +415,20 @@ struct SessionWakeSettingsView: View {
 
     private func binding<Value>(_ value: Value, _ setter: @escaping (Value) -> Void) -> Binding<Value> {
         Binding(get: { value }, set: { setter($0) })
+    }
+
+    private func testHook() {
+        let configuration = store.eventHookConfiguration
+        isTestingHook = true
+        hookTestMessage = nil
+        Task {
+            let result = await WakeEventHookRunner().run(
+                configuration: configuration,
+                context: .test
+            )
+            hookTestMessage = result.userMessage
+            isTestingHook = false
+        }
     }
 }
 

--- a/MeterBarTests/SessionWakeAgentTests.swift
+++ b/MeterBarTests/SessionWakeAgentTests.swift
@@ -26,7 +26,12 @@ final class SessionWakeAgentTests: XCTestCase {
             prompt: "continue",
             notifyOnCompletion: true,
             maxSessionsPerRun: 9_999,
-            maxTurns: 0
+            maxTurns: 0,
+            eventHooks: WakeEventHookConfiguration(
+                executablePath: "/usr/bin/true",
+                arguments: ["literal value"],
+                enabledEvents: [.wakeComplete]
+            )
         )
 
         store.saveConfiguration(configuration)
@@ -36,6 +41,7 @@ final class SessionWakeAgentTests: XCTestCase {
         XCTAssertTrue(restored.canRun)
         XCTAssertEqual(restored.bounds.maxSessionsPerRun, WakeBounds.sessionsRange.upperBound)
         XCTAssertEqual(restored.bounds.maxTurns, WakeBounds.maxTurnsRange.lowerBound)
+        XCTAssertTrue(restored.eventHooks.isEnabled(for: .wakeComplete))
     }
 
     func testBypassWithoutAcknowledgementFailsClosed() {
@@ -53,6 +59,29 @@ final class SessionWakeAgentTests: XCTestCase {
         )
 
         XCTAssertFalse(configuration.canRun)
+    }
+
+    func testLegacyConfigurationDecodesWithHooksDisabled() throws {
+        let legacy: [String: Any] = [
+            "featureEnabled": true,
+            "isArmed": true,
+            "provider": WakeProvider.claude.rawValue,
+            "permissionMode": WakePermissionMode.safe.rawValue,
+            "bypassAcknowledged": false,
+            "prompt": "continue",
+            "notifyOnCompletion": true,
+            "maxSessionsPerRun": 5,
+            "maxTurns": 40
+        ]
+        defaults.set(
+            try JSONSerialization.data(withJSONObject: legacy),
+            forKey: SessionWakeAgentStateStore.configurationKey
+        )
+
+        let restored = try XCTUnwrap(SessionWakeAgentStateStore(userDefaults: defaults).loadConfiguration())
+
+        XCTAssertEqual(restored.eventHooks, .disabled)
+        XCTAssertTrue(restored.canRun)
     }
 
     func testDisarmSynchronouslyUpdatesRunningAgentConfiguration() throws {
@@ -118,9 +147,27 @@ final class SessionWakeAgentTests: XCTestCase {
             maxSessionsPerRun: 5,
             maxTurns: 40
         )
+        let hookChange = SessionWakeAgentConfiguration(
+            featureEnabled: true,
+            isArmed: true,
+            provider: .claude,
+            accountDirectory: nil,
+            permissionMode: .safe,
+            bypassAcknowledged: false,
+            prompt: "continue",
+            notifyOnCompletion: true,
+            maxSessionsPerRun: 5,
+            maxTurns: 40,
+            eventHooks: .init(
+                executablePath: "/usr/bin/true",
+                arguments: [],
+                enabledEvents: [.quotaReset]
+            )
+        )
 
         XCTAssertFalse(notificationOnly.requiresRuntimeRestart(comparedTo: baseline))
         XCTAssertTrue(saferPermission.requiresRuntimeRestart(comparedTo: baseline))
+        XCTAssertTrue(hookChange.requiresRuntimeRestart(comparedTo: baseline))
     }
 
     func testStatusRoundTripsEveryAssociatedValue() throws {

--- a/MeterBarTests/SessionWakeAgentTests.swift
+++ b/MeterBarTests/SessionWakeAgentTests.swift
@@ -110,7 +110,7 @@ final class SessionWakeAgentTests: XCTestCase {
         XCTAssertFalse(try XCTUnwrap(agentState.loadConfiguration()).isArmed)
     }
 
-    func testExecutionChangesRestartButNotificationOnlyChangeDoesNot() {
+    func testExecutionChangesRestartButNotificationAndHookChangesDoNot() {
         let baseline = SessionWakeAgentConfiguration(
             featureEnabled: true,
             isArmed: true,
@@ -167,7 +167,7 @@ final class SessionWakeAgentTests: XCTestCase {
 
         XCTAssertFalse(notificationOnly.requiresRuntimeRestart(comparedTo: baseline))
         XCTAssertTrue(saferPermission.requiresRuntimeRestart(comparedTo: baseline))
-        XCTAssertTrue(hookChange.requiresRuntimeRestart(comparedTo: baseline))
+        XCTAssertFalse(hookChange.requiresRuntimeRestart(comparedTo: baseline))
     }
 
     func testStatusRoundTripsEveryAssociatedValue() throws {

--- a/MeterBarTests/WakeEventHookTests.swift
+++ b/MeterBarTests/WakeEventHookTests.swift
@@ -68,6 +68,8 @@ final class WakeEventHookTests: XCTestCase {
 
         XCTAssertEqual(tracker.event(for: .waiting(until: nil)), .quotaExhausted)
         XCTAssertNil(tracker.event(for: .waiting(until: nil)))
+        XCTAssertNil(tracker.event(for: .off))
+        XCTAssertNil(tracker.event(for: .waiting(until: nil)))
         XCTAssertNil(tracker.event(for: .quotaUnknown(reason: "retry")))
         XCTAssertNil(tracker.event(for: .scanning))
         XCTAssertNil(tracker.event(for: .waiting(until: Date())))

--- a/MeterBarTests/WakeEventHookTests.swift
+++ b/MeterBarTests/WakeEventHookTests.swift
@@ -100,7 +100,7 @@ final class WakeEventHookTests: XCTestCase {
 
         XCTAssertTrue(result.succeeded)
         XCTAssertEqual(
-            String(decoding: result.stdoutCapture, as: UTF8.self),
+            try XCTUnwrap(String(bytes: result.stdoutCapture, encoding: .utf8)),
             "<value with spaces>\n<\(literal)>\n<; echo injected>\n"
         )
         XCTAssertFalse(FileManager.default.fileExists(atPath: sentinel.path))

--- a/MeterBarTests/WakeEventHookTests.swift
+++ b/MeterBarTests/WakeEventHookTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import XCTest
+@testable import MeterBar
+
+final class WakeEventHookTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+    private var tempDirectory: URL!
+
+    override func setUpWithError() throws {
+        suiteName = "WakeEventHookTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WakeEventHookTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        try? FileManager.default.removeItem(at: tempDirectory)
+    }
+
+    private func makeRunner(
+        timeout: TimeInterval = 10,
+        maxCaptureBytes: Int = 16 * 1024
+    ) -> WakeEventHookRunner {
+        WakeEventHookRunner(
+            timeout: timeout,
+            maxCaptureBytes: maxCaptureBytes,
+            logger: WakeRunLogger(directory: tempDirectory.appendingPathComponent("logs", isDirectory: true))
+        )
+    }
+
+    func testHooksDefaultOffAndRequireAConfiguredCommand() {
+        let store = SessionWakeSettingsStore(userDefaults: defaults)
+
+        XCTAssertEqual(store.eventHookConfiguration, .disabled)
+        store.setHookEnabled(true, for: .quotaExhausted)
+        XCTAssertFalse(store.eventHookConfiguration.enabledEvents.contains(.quotaExhausted))
+
+        store.setHookExecutablePath("/usr/bin/true")
+        store.setHookEnabled(true, for: .quotaExhausted)
+        XCTAssertTrue(store.eventHookConfiguration.enabledEvents.contains(.quotaExhausted))
+
+        store.setHookExecutablePath("")
+        XCTAssertTrue(store.eventHookConfiguration.enabledEvents.isEmpty)
+    }
+
+    func testCommandArgumentsAndEventOptInsPersistExactly() {
+        let store = SessionWakeSettingsStore(userDefaults: defaults)
+        store.setHookExecutablePath("/usr/bin/printf")
+        store.addHookArgument()
+        store.setHookArgument("value with spaces", at: 0)
+        store.addHookArgument()
+        store.setHookArgument("$(not-expanded)", at: 1)
+        store.setHookEnabled(true, for: .quotaReset)
+        store.setHookEnabled(true, for: .wakeComplete)
+
+        let reloaded = SessionWakeSettingsStore(userDefaults: defaults)
+
+        XCTAssertEqual(reloaded.eventHookConfiguration.executablePath, "/usr/bin/printf")
+        XCTAssertEqual(reloaded.eventHookConfiguration.arguments, ["value with spaces", "$(not-expanded)"])
+        XCTAssertEqual(reloaded.eventHookConfiguration.enabledEvents, [.quotaReset, .wakeComplete])
+    }
+
+    func testTransitionTrackerDeduplicatesRetriesAndDetectsReset() {
+        var tracker = WakeEventHookTransitionTracker()
+
+        XCTAssertEqual(tracker.event(for: .waiting(until: nil)), .quotaExhausted)
+        XCTAssertNil(tracker.event(for: .waiting(until: nil)))
+        XCTAssertNil(tracker.event(for: .quotaUnknown(reason: "retry")))
+        XCTAssertNil(tracker.event(for: .scanning))
+        XCTAssertNil(tracker.event(for: .waiting(until: Date())))
+        XCTAssertEqual(tracker.event(for: .running(sessionID: "session-1")), .quotaReset)
+        XCTAssertNil(tracker.event(for: .running(sessionID: "session-2")))
+    }
+
+    func testWakeCompleteRequiresMeaningfulWorkAndFiresOncePerTransition() {
+        var tracker = WakeEventHookTransitionTracker()
+        let empty = WakeRunSummary()
+        let resumed = WakeRunSummary(resumed: 1)
+
+        XCTAssertNil(tracker.event(for: .completed(summary: empty)))
+        XCTAssertNil(tracker.event(for: .completed(summary: resumed)))
+        XCTAssertNil(tracker.event(for: .scanning))
+        XCTAssertEqual(tracker.event(for: .completed(summary: resumed)), .wakeComplete)
+        XCTAssertNil(tracker.event(for: .completed(summary: resumed)))
+    }
+
+    func testRunnerPreservesLiteralArgvWithoutShellExpansion() async throws {
+        let sentinel = tempDirectory.appendingPathComponent("must-not-exist")
+        let literal = "$(touch \(sentinel.path))"
+        let configuration = WakeEventHookConfiguration(
+            executablePath: "/usr/bin/printf",
+            arguments: ["<%s>\\n", "value with spaces", literal, "; echo injected"],
+            enabledEvents: []
+        )
+
+        let result = await makeRunner().run(configuration: configuration, context: .test)
+
+        XCTAssertTrue(result.succeeded)
+        XCTAssertEqual(
+            String(decoding: result.stdoutCapture, as: UTF8.self),
+            "<value with spaces>\n<\(literal)>\n<; echo injected>\n"
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: sentinel.path))
+    }
+
+    func testRunnerBoundsCapturedOutput() async {
+        let configuration = WakeEventHookConfiguration(
+            executablePath: "/usr/bin/printf",
+            arguments: ["%s", String(repeating: "x", count: 2_048)],
+            enabledEvents: []
+        )
+
+        let result = await makeRunner(maxCaptureBytes: 32)
+            .run(configuration: configuration, context: .test)
+
+        XCTAssertEqual(result.stdoutByteCount, 2_048)
+        XCTAssertEqual(result.stdoutCapture.count, 32)
+    }
+
+    func testTimeoutNonzeroMissingAndPermissionFailuresReturnWithoutThrowing() async throws {
+        let timeout = await makeRunner(timeout: 0.05).run(
+            configuration: .init(executablePath: "/bin/sleep", arguments: ["5"], enabledEvents: []),
+            context: .test
+        )
+        XCTAssertEqual(timeout.termination, .timedOut)
+
+        let nonzero = await makeRunner().run(
+            configuration: .init(executablePath: "/usr/bin/false", arguments: [], enabledEvents: []),
+            context: .test
+        )
+        XCTAssertEqual(nonzero.termination, .exited(1))
+
+        let missing = await makeRunner().run(
+            configuration: .init(
+                executablePath: tempDirectory.appendingPathComponent("missing").path,
+                arguments: [],
+                enabledEvents: []
+            ),
+            context: .test
+        )
+        guard case .launchFailed = missing.termination else {
+            return XCTFail("Missing executable should be a launch failure")
+        }
+
+        let nonExecutable = tempDirectory.appendingPathComponent("not-executable")
+        try Data("hook".utf8).write(to: nonExecutable)
+        let denied = await makeRunner().run(
+            configuration: .init(executablePath: nonExecutable.path, arguments: [], enabledEvents: []),
+            context: .test
+        )
+        guard case .launchFailed = denied.termination else {
+            return XCTFail("Non-executable file should be a launch failure")
+        }
+    }
+}


### PR DESCRIPTION
Closes #140

## Summary

- persist an explicit executable path, literal argv entries, and separate opt-ins for quota exhausted, quota reset, and wake complete
- deduplicate watcher transitions and run hooks through Foundation Process without a shell, using a sanitized environment, bounded output capture, and a hard timeout
- propagate hooks through the in-app watcher and managed launch agent while keeping failures isolated from Session Wake
- add Automation settings that show the exact executable and argv, expose per-event toggles, and run a bounded test invocation
- add focused coverage for opt-in persistence, literal argv preservation, retry deduplication, output bounds, timeout, nonzero exit, missing executable, and permission failures

## Verification

- `swiftlint lint --strict --quiet` on every changed app Swift file — passed
- `git diff --check` — passed
- local Swift tests and builds were not run under the repository MacBook policy; PR CI is the execution gate

## Residual risk

- user-configured executables can perform arbitrary local actions by design, but no event is enabled by default and Settings shows the exact path and arguments before opt-in


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable session wake event hooks for quota exhaustion, quota reset, and wake completion.
  * Added settings to configure the executable, literal arguments, enabled events, and a test action.
  * Hook configuration now persists across app launches and updates without restarting session monitoring.
  * Hook execution is bounded, serialized, and protected from failures affecting session activity.

* **Bug Fixes**
  * Prevented duplicate hook notifications during repeated quota-related transitions.
  * Preserved compatibility with existing configurations by disabling hooks when no prior configuration exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->