### PR TITLE
refactor(notifications): extract multi-account planning

### DIFF
--- a/.agents/SESSIONS/2026-07-18.md
+++ b/.agents/SESSIONS/2026-07-18.md
@@ -1,0 +1,42 @@
+# 2026-07-18 — Extract account notification planning
+
+## Session 1: Pure multi-account notification planner
+
+**Status:** Complete; PR CI pending
+
+```mermaid
+flowchart LR
+    Stores[Account and metric snapshots] --> Planner[AccountNotificationPlanner]
+    Planner -->|account data available| Accounts[Per-account decisions]
+    Planner -->|all enabled accounts unavailable| Fallback[Provider fallback decision]
+    Accounts --> Result[Fired notifications and updated dedup keys]
+    Fallback --> Result
+    Result --> Delegate[AppDelegate posts banners]
+```
+
+### What was done
+
+- Moved Claude and Codex account iteration, fallback selection, enablement cleanup,
+  and sequential dedup-key threading into a pure service.
+- Defined a no-duplicate namespace transition policy: switching between provider
+  fallback and per-account data primes the new namespace without posting the same
+  quota state again.
+- Left `AppDelegate` as the side-effect adapter that gathers snapshots and posts
+  returned notifications.
+- Added focused coverage for account identity, fallback behavior, namespace
+  transitions, provider/account disablement, stale data, unavailable accounts,
+  and Claude-to-Codex key threading.
+
+### Files changed
+
+- `MeterBar/Services/AccountNotificationPlanner.swift`
+- `MeterBar/Services/NotificationDecider.swift`
+- `MeterBar/App/MeterBarApp.swift`
+- `MeterBarTests/AccountNotificationPlannerTests.swift`
+
+### Verification
+
+- SwiftLint strict passed for all changed Swift files.
+- `git diff --check` passed.
+- Swift tests, typechecks, and builds were intentionally left to GitHub Actions
+  under issue #224's CI-only verification contract.

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -487,9 +487,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// Evaluates every tracked service's metrics against the user's notification
-    /// preferences and posts any warning/critical crossings. All decision logic
-    /// lives in the pure, unit-tested `NotificationDecider`; this method only
-    /// threads the dedup key set and turns fired decisions into banners.
+    /// preferences and posts any warning/critical crossings. Threshold decisions
+    /// live in `NotificationDecider`; account/fallback orchestration lives in
+    /// `AccountNotificationPlanner`.
     private func checkAndNotify() {
         let decider = NotificationDecider(preferences: notificationPreferences.preferences)
         let now = Date()
@@ -513,77 +513,42 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
-        keys = evaluateAccountNotifications(
-            AccountNotificationInput(
-                service: .claudeCode,
-                accounts: ClaudeCodeAccountStore.shared.accounts.map { ($0.id, $0.name) },
-                accountMetrics: UsageDataManager.shared.claudeCodeAccountMetrics,
-                fallbackMetrics: currentMetrics[.claudeCode]
-            ),
-            decider: decider,
-            keys: keys,
+        let accountPlan = AccountNotificationPlanner(decider: decider).plan(
+            inputs: [
+                AccountNotificationPlanInput(
+                    service: .claudeCode,
+                    providerEnabled: providerVisibilityStore.isEnabled(.claudeCode),
+                    accounts: ClaudeCodeAccountStore.shared.accounts.map {
+                        AccountNotificationIdentity(
+                            id: $0.id,
+                            name: $0.name,
+                            isEnabled: $0.isEnabled
+                        )
+                    },
+                    accountMetrics: UsageDataManager.shared.claudeCodeAccountMetrics,
+                    fallbackMetrics: currentMetrics[.claudeCode]
+                ),
+                AccountNotificationPlanInput(
+                    service: .codexCli,
+                    providerEnabled: providerVisibilityStore.isEnabled(.codexCli),
+                    accounts: CodexAccountStore.shared.accounts.map {
+                        AccountNotificationIdentity(
+                            id: $0.id,
+                            name: $0.name,
+                            isEnabled: $0.isEnabled
+                        )
+                    },
+                    accountMetrics: UsageDataManager.shared.codexAccountMetrics,
+                    fallbackMetrics: currentMetrics[.codexCli]
+                )
+            ],
+            alreadyNotified: keys,
             now: now
         )
-        keys = evaluateAccountNotifications(
-            AccountNotificationInput(
-                service: .codexCli,
-                accounts: CodexAccountStore.shared.accounts.map { ($0.id, $0.name) },
-                accountMetrics: UsageDataManager.shared.codexAccountMetrics,
-                fallbackMetrics: currentMetrics[.codexCli]
-            ),
-            decider: decider,
-            keys: keys,
-            now: now
-        )
+        keys = accountPlan.notifiedKeys
+        accountPlan.notifications.forEach(postNotification)
 
         notifiedLimitKeys = keys
-    }
-
-    private struct AccountNotificationInput {
-        let service: ServiceType
-        let accounts: [(id: UUID, name: String)]
-        let accountMetrics: [UUID: UsageMetrics]
-        let fallbackMetrics: UsageMetrics?
-    }
-
-    private func evaluateAccountNotifications(
-        _ input: AccountNotificationInput,
-        decider: NotificationDecider,
-        keys: Set<String>,
-        now: Date
-    ) -> Set<String> {
-        var updatedKeys = keys
-        let available = input.accounts.compactMap { account -> (UUID, String, UsageMetrics)? in
-            guard let metrics = input.accountMetrics[account.id] else { return nil }
-            return (account.id, account.name, metrics)
-        }
-
-        if available.isEmpty {
-            let metrics = input.fallbackMetrics ?? UsageMetrics(service: input.service, lastUpdated: now)
-            let evaluation = decider.evaluate(
-                metrics: metrics,
-                providerEnabled: providerVisibilityStore.isEnabled(input.service),
-                alreadyNotified: updatedKeys,
-                now: now
-            )
-            updatedKeys = evaluation.notifiedKeys
-            evaluation.notifications.forEach(postNotification)
-            return updatedKeys
-        }
-
-        for (id, name, metrics) in available {
-            let evaluation = decider.evaluate(
-                metrics: metrics,
-                providerEnabled: providerVisibilityStore.isEnabled(input.service),
-                alreadyNotified: updatedKeys,
-                accountKey: id.uuidString,
-                serviceDisplayName: "\(name) (\(input.service.displayName))",
-                now: now
-            )
-            updatedKeys = evaluation.notifiedKeys
-            evaluation.notifications.forEach(postNotification)
-        }
-        return updatedKeys
     }
 
     private func postNotification(_ fired: FiredNotification) {

--- a/MeterBar/Services/AccountNotificationPlanner.swift
+++ b/MeterBar/Services/AccountNotificationPlanner.swift
@@ -102,15 +102,17 @@ struct AccountNotificationPlanner {
         }
 
         guard !availableAccounts.isEmpty else {
-            let accountState = clearAccountState(service: input.service, keys: &keys)
             guard let fallbackMetrics = input.fallbackMetrics else {
-                keys.formUnion(accountState)
                 clearFallbackState(service: input.service, keys: &keys)
                 return
             }
             for account in enabledAccounts {
                 keys.formUnion(translatedKeys(
-                    accountState,
+                    notificationState(
+                        service: input.service,
+                        accountKey: account.id.uuidString,
+                        keys: keys
+                    ),
                     service: input.service,
                     fromAccountKey: account.id.uuidString,
                     toAccountKey: nil
@@ -130,23 +132,37 @@ struct AccountNotificationPlanner {
 
         let fallbackState = clearFallbackState(service: input.service, keys: &keys)
         for available in availableAccounts {
-            keys.formUnion(translatedKeys(
-                fallbackState,
+            let accountKey = available.identity.id.uuidString
+            guard !hasObservedAccountState(
                 service: input.service,
-                fromAccountKey: nil,
-                toAccountKey: available.identity.id.uuidString
-            ))
+                accountKey: accountKey,
+                keys: keys
+            ) else { continue }
+            keys.formUnion(
+                translatedKeys(
+                    fallbackState,
+                    service: input.service,
+                    fromAccountKey: nil,
+                    toAccountKey: accountKey
+                )
+            )
         }
         for available in availableAccounts {
+            let accountKey = available.identity.id.uuidString
             let evaluation = decider.evaluate(
                 metrics: available.metrics,
                 providerEnabled: true,
                 alreadyNotified: keys,
-                accountKey: available.identity.id.uuidString,
+                accountKey: accountKey,
                 serviceDisplayName: "\(available.identity.name) (\(input.service.displayName))",
                 now: now
             )
             keys = evaluation.notifiedKeys
+            recordObservedAccountState(
+                service: input.service,
+                accountKey: accountKey,
+                keys: &keys
+            )
             notifications.append(contentsOf: evaluation.notifications)
         }
     }
@@ -174,6 +190,45 @@ struct AccountNotificationPlanner {
         })
         keys.subtract(accountKeys)
         return accountKeys
+    }
+
+    private func notificationState(
+        service: ServiceType,
+        accountKey: String,
+        keys: Set<String>
+    ) -> Set<String> {
+        keys.intersection(
+            NotificationDecider.notificationKeys(
+                service: service,
+                accountKey: accountKey
+            )
+        )
+    }
+
+    private func hasObservedAccountState(
+        service: ServiceType,
+        accountKey: String,
+        keys: Set<String>
+    ) -> Bool {
+        keys.contains(observedAccountKey(service: service, accountKey: accountKey))
+            || !notificationState(service: service, accountKey: accountKey, keys: keys).isEmpty
+    }
+
+    private func recordObservedAccountState(
+        service: ServiceType,
+        accountKey: String,
+        keys: inout Set<String>
+    ) {
+        let observedKey = observedAccountKey(service: service, accountKey: accountKey)
+        if notificationState(service: service, accountKey: accountKey, keys: keys).isEmpty {
+            keys.insert(observedKey)
+        } else {
+            keys.remove(observedKey)
+        }
+    }
+
+    private func observedAccountKey(service: ServiceType, accountKey: String) -> String {
+        "\(service.rawValue)-\(accountKey)-namespace-observed"
     }
 
     private func translatedKeys(

--- a/MeterBar/Services/AccountNotificationPlanner.swift
+++ b/MeterBar/Services/AccountNotificationPlanner.swift
@@ -104,6 +104,7 @@ struct AccountNotificationPlanner {
         guard !availableAccounts.isEmpty else {
             let accountState = clearAccountState(service: input.service, keys: &keys)
             guard let fallbackMetrics = input.fallbackMetrics else {
+                keys.formUnion(accountState)
                 clearFallbackState(service: input.service, keys: &keys)
                 return
             }

--- a/MeterBar/Services/AccountNotificationPlanner.swift
+++ b/MeterBar/Services/AccountNotificationPlanner.swift
@@ -82,14 +82,24 @@ struct AccountNotificationPlanner {
         now: Date
     ) {
         let enabledAccounts = input.accounts.filter(\.isEnabled)
-        guard input.providerEnabled, !enabledAccounts.isEmpty else {
+        guard input.providerEnabled else {
             clearProviderState(service: input.service, keys: &keys)
             return
+        }
+
+        if enabledAccounts.isEmpty {
+            clearAccountState(service: input.service, keys: &keys)
         }
 
         for account in input.accounts where !account.isEnabled {
             keys.subtract(
                 NotificationDecider.notificationKeys(
+                    service: input.service,
+                    accountKey: account.id.uuidString
+                )
+            )
+            keys.remove(
+                observedAccountKey(
                     service: input.service,
                     accountKey: account.id.uuidString
                 )
@@ -106,17 +116,19 @@ struct AccountNotificationPlanner {
                 clearFallbackState(service: input.service, keys: &keys)
                 return
             }
-            for account in enabledAccounts {
-                keys.formUnion(translatedKeys(
-                    notificationState(
+            if !hasObservedFallbackState(service: input.service, keys: keys) {
+                for account in enabledAccounts {
+                    keys.formUnion(translatedKeys(
+                        notificationState(
+                            service: input.service,
+                            accountKey: account.id.uuidString,
+                            keys: keys
+                        ),
                         service: input.service,
-                        accountKey: account.id.uuidString,
-                        keys: keys
-                    ),
-                    service: input.service,
-                    fromAccountKey: account.id.uuidString,
-                    toAccountKey: nil
-                ))
+                        fromAccountKey: account.id.uuidString,
+                        toAccountKey: nil
+                    ))
+                }
             }
 
             let evaluation = decider.evaluate(
@@ -126,6 +138,7 @@ struct AccountNotificationPlanner {
                 now: now
             )
             keys = evaluation.notifiedKeys
+            recordObservedFallbackState(service: input.service, keys: &keys)
             notifications.append(contentsOf: evaluation.notifications)
             return
         }
@@ -175,6 +188,7 @@ struct AccountNotificationPlanner {
         let fallbackKeys = NotificationDecider.notificationKeys(service: service)
         let removedState = keys.intersection(fallbackKeys)
         keys.subtract(fallbackKeys)
+        keys.remove(observedFallbackKey(service: service))
         return removedState
     }
 
@@ -184,9 +198,10 @@ struct AccountNotificationPlanner {
         keys: inout Set<String>
     ) -> Set<String> {
         let fallbackKeys = NotificationDecider.notificationKeys(service: service)
+        let fallbackStateKeys = fallbackKeys.union([observedFallbackKey(service: service)])
         let servicePrefix = "\(service.rawValue)-"
         let accountKeys = Set(keys.filter {
-            $0.hasPrefix(servicePrefix) && !fallbackKeys.contains($0)
+            $0.hasPrefix(servicePrefix) && !fallbackStateKeys.contains($0)
         })
         keys.subtract(accountKeys)
         return accountKeys
@@ -229,6 +244,30 @@ struct AccountNotificationPlanner {
 
     private func observedAccountKey(service: ServiceType, accountKey: String) -> String {
         "\(service.rawValue)-\(accountKey)-namespace-observed"
+    }
+
+    private func hasObservedFallbackState(
+        service: ServiceType,
+        keys: Set<String>
+    ) -> Bool {
+        keys.contains(observedFallbackKey(service: service))
+            || !keys.isDisjoint(with: NotificationDecider.notificationKeys(service: service))
+    }
+
+    private func recordObservedFallbackState(
+        service: ServiceType,
+        keys: inout Set<String>
+    ) {
+        let observedKey = observedFallbackKey(service: service)
+        if keys.isDisjoint(with: NotificationDecider.notificationKeys(service: service)) {
+            keys.insert(observedKey)
+        } else {
+            keys.remove(observedKey)
+        }
+    }
+
+    private func observedFallbackKey(service: ServiceType) -> String {
+        "\(service.rawValue)-namespace-observed"
     }
 
     private func translatedKeys(

--- a/MeterBar/Services/AccountNotificationPlanner.swift
+++ b/MeterBar/Services/AccountNotificationPlanner.swift
@@ -1,0 +1,169 @@
+import Foundation
+import MeterBarShared
+
+/// Account metadata required to plan quota notifications without reading stores.
+struct AccountNotificationIdentity: Equatable, Sendable {
+    let id: UUID
+    let name: String
+    let isEnabled: Bool
+}
+
+/// One account-aware provider snapshot for the pure notification planner.
+struct AccountNotificationPlanInput {
+    let service: ServiceType
+    let providerEnabled: Bool
+    let accounts: [AccountNotificationIdentity]
+    let accountMetrics: [UUID: UsageMetrics]
+    let fallbackMetrics: UsageMetrics?
+}
+
+/// Fired notifications and the dedup state to thread into the next planning pass.
+struct AccountNotificationPlan: Equatable, Sendable {
+    let notifications: [FiredNotification]
+    let notifiedKeys: Set<String>
+}
+
+/// Pure account/fallback orchestration shared by Claude Code and Codex.
+///
+/// Account metrics take precedence whenever at least one enabled account has
+/// data. Provider fallback is used only when every enabled account is
+/// unavailable. Switching between those namespaces primes the new namespace
+/// without delivering, so the same quota state does not produce a duplicate
+/// banner merely because account data appeared or disappeared.
+struct AccountNotificationPlanner {
+    private typealias AvailableAccount = (
+        identity: AccountNotificationIdentity,
+        metrics: UsageMetrics
+    )
+
+    private let decider: NotificationDecider
+
+    init(
+        preferences: NotificationPreferences,
+        stalenessThreshold: TimeInterval = NotificationDecider.defaultStalenessThreshold
+    ) {
+        decider = NotificationDecider(
+            preferences: preferences,
+            stalenessThreshold: stalenessThreshold
+        )
+    }
+
+    init(decider: NotificationDecider) {
+        self.decider = decider
+    }
+
+    func plan(
+        inputs: [AccountNotificationPlanInput],
+        alreadyNotified: Set<String>,
+        now: Date = Date()
+    ) -> AccountNotificationPlan {
+        var keys = alreadyNotified
+        var notifications: [FiredNotification] = []
+
+        for input in inputs {
+            plan(
+                input: input,
+                keys: &keys,
+                notifications: &notifications,
+                now: now
+            )
+        }
+
+        return AccountNotificationPlan(
+            notifications: notifications,
+            notifiedKeys: keys
+        )
+    }
+
+    private func plan(
+        input: AccountNotificationPlanInput,
+        keys: inout Set<String>,
+        notifications: inout [FiredNotification],
+        now: Date
+    ) {
+        let enabledAccounts = input.accounts.filter(\.isEnabled)
+        guard input.providerEnabled, !enabledAccounts.isEmpty else {
+            clearProviderState(service: input.service, keys: &keys)
+            return
+        }
+
+        for account in input.accounts where !account.isEnabled {
+            keys.subtract(
+                NotificationDecider.notificationKeys(
+                    service: input.service,
+                    accountKey: account.id.uuidString
+                )
+            )
+        }
+
+        let availableAccounts = enabledAccounts.compactMap { account -> AvailableAccount? in
+            guard let metrics = input.accountMetrics[account.id] else { return nil }
+            return (account, metrics)
+        }
+
+        guard !availableAccounts.isEmpty else {
+            let changedNamespace = clearAccountState(service: input.service, keys: &keys)
+            guard let fallbackMetrics = input.fallbackMetrics else {
+                clearFallbackState(service: input.service, keys: &keys)
+                return
+            }
+
+            let evaluation = decider.evaluate(
+                metrics: fallbackMetrics,
+                providerEnabled: !changedNamespace,
+                alreadyNotified: keys,
+                now: now
+            )
+            keys = evaluation.notifiedKeys
+            notifications.append(contentsOf: evaluation.notifications)
+            return
+        }
+
+        let changedNamespace = clearFallbackState(service: input.service, keys: &keys)
+        for available in availableAccounts {
+            let evaluation = decider.evaluate(
+                metrics: available.metrics,
+                providerEnabled: !changedNamespace,
+                alreadyNotified: keys,
+                accountKey: available.identity.id.uuidString,
+                serviceDisplayName: "\(available.identity.name) (\(input.service.displayName))",
+                now: now
+            )
+            keys = evaluation.notifiedKeys
+            notifications.append(contentsOf: evaluation.notifications)
+        }
+    }
+
+    @discardableResult
+    private func clearFallbackState(
+        service: ServiceType,
+        keys: inout Set<String>
+    ) -> Bool {
+        let fallbackKeys = NotificationDecider.notificationKeys(service: service)
+        let removedState = !keys.isDisjoint(with: fallbackKeys)
+        keys.subtract(fallbackKeys)
+        return removedState
+    }
+
+    @discardableResult
+    private func clearAccountState(
+        service: ServiceType,
+        keys: inout Set<String>
+    ) -> Bool {
+        let fallbackKeys = NotificationDecider.notificationKeys(service: service)
+        let servicePrefix = "\(service.rawValue)-"
+        let accountKeys = keys.filter {
+            $0.hasPrefix(servicePrefix) && !fallbackKeys.contains($0)
+        }
+        keys.subtract(accountKeys)
+        return !accountKeys.isEmpty
+    }
+
+    private func clearProviderState(
+        service: ServiceType,
+        keys: inout Set<String>
+    ) {
+        clearFallbackState(service: service, keys: &keys)
+        clearAccountState(service: service, keys: &keys)
+    }
+}

--- a/MeterBar/Services/AccountNotificationPlanner.swift
+++ b/MeterBar/Services/AccountNotificationPlanner.swift
@@ -102,15 +102,23 @@ struct AccountNotificationPlanner {
         }
 
         guard !availableAccounts.isEmpty else {
-            let changedNamespace = clearAccountState(service: input.service, keys: &keys)
+            let accountState = clearAccountState(service: input.service, keys: &keys)
             guard let fallbackMetrics = input.fallbackMetrics else {
                 clearFallbackState(service: input.service, keys: &keys)
                 return
             }
+            for account in enabledAccounts {
+                keys.formUnion(translatedKeys(
+                    accountState,
+                    service: input.service,
+                    fromAccountKey: account.id.uuidString,
+                    toAccountKey: nil
+                ))
+            }
 
             let evaluation = decider.evaluate(
                 metrics: fallbackMetrics,
-                providerEnabled: !changedNamespace,
+                providerEnabled: true,
                 alreadyNotified: keys,
                 now: now
             )
@@ -119,11 +127,19 @@ struct AccountNotificationPlanner {
             return
         }
 
-        let changedNamespace = clearFallbackState(service: input.service, keys: &keys)
+        let fallbackState = clearFallbackState(service: input.service, keys: &keys)
+        for available in availableAccounts {
+            keys.formUnion(translatedKeys(
+                fallbackState,
+                service: input.service,
+                fromAccountKey: nil,
+                toAccountKey: available.identity.id.uuidString
+            ))
+        }
         for available in availableAccounts {
             let evaluation = decider.evaluate(
                 metrics: available.metrics,
-                providerEnabled: !changedNamespace,
+                providerEnabled: true,
                 alreadyNotified: keys,
                 accountKey: available.identity.id.uuidString,
                 serviceDisplayName: "\(available.identity.name) (\(input.service.displayName))",
@@ -138,9 +154,9 @@ struct AccountNotificationPlanner {
     private func clearFallbackState(
         service: ServiceType,
         keys: inout Set<String>
-    ) -> Bool {
+    ) -> Set<String> {
         let fallbackKeys = NotificationDecider.notificationKeys(service: service)
-        let removedState = !keys.isDisjoint(with: fallbackKeys)
+        let removedState = keys.intersection(fallbackKeys)
         keys.subtract(fallbackKeys)
         return removedState
     }
@@ -149,14 +165,32 @@ struct AccountNotificationPlanner {
     private func clearAccountState(
         service: ServiceType,
         keys: inout Set<String>
-    ) -> Bool {
+    ) -> Set<String> {
         let fallbackKeys = NotificationDecider.notificationKeys(service: service)
         let servicePrefix = "\(service.rawValue)-"
-        let accountKeys = keys.filter {
+        let accountKeys = Set(keys.filter {
             $0.hasPrefix(servicePrefix) && !fallbackKeys.contains($0)
-        }
+        })
         keys.subtract(accountKeys)
-        return !accountKeys.isEmpty
+        return accountKeys
+    }
+
+    private func translatedKeys(
+        _ keys: Set<String>,
+        service: ServiceType,
+        fromAccountKey: String?,
+        toAccountKey: String?
+    ) -> Set<String> {
+        let sourcePrefix = [service.rawValue, fromAccountKey]
+            .compactMap { $0 }
+            .joined(separator: "-") + "-"
+        let destinationPrefix = [service.rawValue, toAccountKey]
+            .compactMap { $0 }
+            .joined(separator: "-") + "-"
+        return Set(keys.compactMap { key in
+            guard key.hasPrefix(sourcePrefix) else { return nil }
+            return destinationPrefix + String(key.dropFirst(sourcePrefix.count))
+        })
     }
 
     private func clearProviderState(

--- a/MeterBar/Services/NotificationDecider.swift
+++ b/MeterBar/Services/NotificationDecider.swift
@@ -116,9 +116,11 @@ struct NotificationDecider {
         let criticalRank = Self.severityRank(preferences.criticalThreshold.band)
 
         for (limit, quotaKind) in limits {
-            let baseKey = [metrics.service.rawValue, accountKey, quotaKind.rawValue]
-                .compactMap { $0 }
-                .joined(separator: "-")
+            let baseKey = Self.notificationBaseKey(
+                service: metrics.service,
+                accountKey: accountKey,
+                quotaKind: quotaKind
+            )
             let warnKey = "\(baseKey)-warn"
             let criticalKey = "\(baseKey)-critical"
 
@@ -185,6 +187,33 @@ struct NotificationDecider {
         return NotificationEvaluation(notifications: fired, notifiedKeys: keys)
     }
 
+    /// Every warning/critical key the decider can emit for one provider
+    /// namespace. The account planner uses this same key contract to clear
+    /// inactive account and fallback state without duplicating key construction.
+    static func notificationKeys(
+        service: ServiceType,
+        accountKey: String? = nil
+    ) -> Set<String> {
+        Set(QuotaKind.allCases.flatMap { quotaKind in
+            let baseKey = notificationBaseKey(
+                service: service,
+                accountKey: accountKey,
+                quotaKind: quotaKind
+            )
+            return ["\(baseKey)-warn", "\(baseKey)-critical"]
+        })
+    }
+
+    private static func notificationBaseKey(
+        service: ServiceType,
+        accountKey: String?,
+        quotaKind: QuotaKind
+    ) -> String {
+        [service.rawValue, accountKey, quotaKind.rawValue]
+            .compactMap { $0 }
+            .joined(separator: "-")
+    }
+
     /// Orders the shared quota bands by severity so a user-selected threshold
     /// band can be compared against a limit's current band. This only ranks the
     /// existing `QuotaBand` cases — it is not a second threshold scheme.
@@ -199,7 +228,7 @@ struct NotificationDecider {
 
     /// Stable quota key plus provider-specific display copy. `codeReviewLimit`
     /// represents Sonnet-only usage for Claude and Code Review usage for Codex.
-    private enum QuotaKind: String, Equatable, Sendable {
+    private enum QuotaKind: String, CaseIterable, Equatable, Sendable {
         case session
         case weekly
         case codeReview

--- a/MeterBarTests/AccountNotificationPlannerTests.swift
+++ b/MeterBarTests/AccountNotificationPlannerTests.swift
@@ -23,11 +23,13 @@ final class AccountNotificationPlannerTests: XCTestCase {
     private func metrics(
         service: ServiceType,
         used: Double,
+        weeklyUsed: Double? = nil,
         lastUpdated: Date? = nil
     ) -> UsageMetrics {
         UsageMetrics(
             service: service,
             sessionLimit: UsageLimit(used: used, total: 100, resetTime: nil),
+            weeklyLimit: weeklyUsed.map { UsageLimit(used: $0, total: 100, resetTime: nil) },
             lastUpdated: lastUpdated ?? now
         )
     }
@@ -126,6 +128,43 @@ final class AccountNotificationPlannerTests: XCTestCase {
             accountResult.notifiedKeys.contains(
                 "Claude Code-\(claudeAccountID.uuidString)-session-critical"
             )
+        )
+    }
+
+    func testFallbackToAccountTransitionStillDeliversEscalationsAndNewQuotaKinds() {
+        let fallbackResult = planner.plan(
+            inputs: [
+                input(
+                    accounts: [account(id: claudeAccountID, name: "Work")],
+                    fallbackMetrics: metrics(service: .claudeCode, used: 90)
+                )
+            ],
+            alreadyNotified: [],
+            now: now
+        )
+        XCTAssertEqual(fallbackResult.notifications.map(\.level), [.warning])
+
+        let accountResult = planner.plan(
+            inputs: [
+                input(
+                    accounts: [account(id: claudeAccountID, name: "Work")],
+                    accountMetrics: [
+                        claudeAccountID: metrics(
+                            service: .claudeCode,
+                            used: 100,
+                            weeklyUsed: 100
+                        )
+                    ]
+                )
+            ],
+            alreadyNotified: fallbackResult.notifiedKeys,
+            now: now
+        )
+
+        XCTAssertEqual(accountResult.notifications.map(\.level), [.critical, .critical])
+        XCTAssertEqual(
+            accountResult.notifications.map(\.quotaDisplayName),
+            ["5-hour limit", "Weekly limit"]
         )
     }
 

--- a/MeterBarTests/AccountNotificationPlannerTests.swift
+++ b/MeterBarTests/AccountNotificationPlannerTests.swift
@@ -218,8 +218,107 @@ final class AccountNotificationPlannerTests: XCTestCase {
         XCTAssertTrue(fallbackResult.notifications.isEmpty)
         XCTAssertEqual(
             fallbackResult.notifiedKeys,
-            Set(["Claude Code-session-warn", "Claude Code-session-critical"])
+            Set([
+                "Claude Code-\(claudeAccountID.uuidString)-session-warn",
+                "Claude Code-\(claudeAccountID.uuidString)-session-critical",
+                "Claude Code-session-warn",
+                "Claude Code-session-critical"
+            ])
         )
+    }
+
+    func testCachedHealthyFallbackDoesNotLoseExhaustedAccountDedupState() {
+        let accounts = [
+            account(id: claudeAccountID, name: "Healthy"),
+            account(id: secondClaudeAccountID, name: "Exhausted")
+        ]
+        let available = input(
+            accounts: accounts,
+            accountMetrics: [
+                claudeAccountID: metrics(service: .claudeCode, used: 0),
+                secondClaudeAccountID: metrics(service: .claudeCode, used: 100)
+            ]
+        )
+        let first = planner.plan(inputs: [available], alreadyNotified: [], now: now)
+        XCTAssertEqual(first.notifications.map(\.key), [
+            "Claude Code-\(secondClaudeAccountID.uuidString)-session-critical"
+        ])
+
+        let unavailable = planner.plan(
+            inputs: [
+                input(
+                    accounts: accounts,
+                    fallbackMetrics: metrics(service: .claudeCode, used: 0)
+                )
+            ],
+            alreadyNotified: first.notifiedKeys,
+            now: now
+        )
+        let recovered = planner.plan(
+            inputs: [available],
+            alreadyNotified: unavailable.notifiedKeys,
+            now: now
+        )
+
+        XCTAssertTrue(unavailable.notifications.isEmpty)
+        XCTAssertTrue(recovered.notifications.isEmpty)
+        XCTAssertTrue(
+            recovered.notifiedKeys.contains(
+                "Claude Code-\(secondClaudeAccountID.uuidString)-session-critical"
+            )
+        )
+    }
+
+    func testCachedExhaustedFallbackDoesNotMaskAnotherAccountsFirstCrossing() {
+        let accounts = [
+            account(id: claudeAccountID, name: "Exhausted"),
+            account(id: secondClaudeAccountID, name: "Healthy")
+        ]
+        let first = planner.plan(
+            inputs: [
+                input(
+                    accounts: accounts,
+                    accountMetrics: [
+                        claudeAccountID: metrics(service: .claudeCode, used: 100),
+                        secondClaudeAccountID: metrics(service: .claudeCode, used: 0)
+                    ]
+                )
+            ],
+            alreadyNotified: [],
+            now: now
+        )
+        XCTAssertEqual(first.notifications.map(\.key), [
+            "Claude Code-\(claudeAccountID.uuidString)-session-critical"
+        ])
+
+        let unavailable = planner.plan(
+            inputs: [
+                input(
+                    accounts: accounts,
+                    fallbackMetrics: metrics(service: .claudeCode, used: 100)
+                )
+            ],
+            alreadyNotified: first.notifiedKeys,
+            now: now
+        )
+        let recovered = planner.plan(
+            inputs: [
+                input(
+                    accounts: accounts,
+                    accountMetrics: [
+                        claudeAccountID: metrics(service: .claudeCode, used: 100),
+                        secondClaudeAccountID: metrics(service: .claudeCode, used: 100)
+                    ]
+                )
+            ],
+            alreadyNotified: unavailable.notifiedKeys,
+            now: now
+        )
+
+        XCTAssertTrue(unavailable.notifications.isEmpty)
+        XCTAssertEqual(recovered.notifications.map(\.key), [
+            "Claude Code-\(secondClaudeAccountID.uuidString)-session-critical"
+        ])
     }
 
     func testDisabledAccountCleanupRearmsLaterCrossing() {

--- a/MeterBarTests/AccountNotificationPlannerTests.swift
+++ b/MeterBarTests/AccountNotificationPlannerTests.swift
@@ -98,6 +98,22 @@ final class AccountNotificationPlannerTests: XCTestCase {
         XCTAssertTrue(result.notifiedKeys.contains("Claude Code-session-critical"))
     }
 
+    func testUsesProviderFallbackWhenNoAccountsAreConfigured() {
+        let result = planner.plan(
+            inputs: [
+                input(
+                    accounts: [],
+                    fallbackMetrics: metrics(service: .claudeCode, used: 100)
+                )
+            ],
+            alreadyNotified: [],
+            now: now
+        )
+
+        XCTAssertEqual(result.notifications.map(\.key), ["Claude Code-session-critical"])
+        XCTAssertTrue(result.notifiedKeys.contains("Claude Code-session-critical"))
+    }
+
     func testFallbackToAccountTransitionPrimesNewNamespaceWithoutDuplicate() {
         let fallbackResult = planner.plan(
             inputs: [
@@ -319,6 +335,56 @@ final class AccountNotificationPlannerTests: XCTestCase {
         XCTAssertEqual(recovered.notifications.map(\.key), [
             "Claude Code-\(secondClaudeAccountID.uuidString)-session-critical"
         ])
+    }
+
+    func testFallbackRearmsDuringExtendedAccountDataGap() {
+        let accounts = [account(id: claudeAccountID, name: "Work")]
+        let first = planner.plan(
+            inputs: [
+                input(
+                    accounts: accounts,
+                    accountMetrics: [claudeAccountID: metrics(service: .claudeCode, used: 100)]
+                )
+            ],
+            alreadyNotified: [],
+            now: now
+        )
+        XCTAssertEqual(first.notifications.count, 1)
+
+        let initialFallback = planner.plan(
+            inputs: [
+                input(
+                    accounts: accounts,
+                    fallbackMetrics: metrics(service: .claudeCode, used: 100)
+                )
+            ],
+            alreadyNotified: first.notifiedKeys,
+            now: now
+        )
+        let resetFallback = planner.plan(
+            inputs: [
+                input(
+                    accounts: accounts,
+                    fallbackMetrics: metrics(service: .claudeCode, used: 0)
+                )
+            ],
+            alreadyNotified: initialFallback.notifiedKeys,
+            now: now
+        )
+        let crossedFallback = planner.plan(
+            inputs: [
+                input(
+                    accounts: accounts,
+                    fallbackMetrics: metrics(service: .claudeCode, used: 100)
+                )
+            ],
+            alreadyNotified: resetFallback.notifiedKeys,
+            now: now
+        )
+
+        XCTAssertTrue(initialFallback.notifications.isEmpty)
+        XCTAssertTrue(resetFallback.notifications.isEmpty)
+        XCTAssertEqual(crossedFallback.notifications.map(\.key), ["Claude Code-session-critical"])
     }
 
     func testDisabledAccountCleanupRearmsLaterCrossing() {

--- a/MeterBarTests/AccountNotificationPlannerTests.swift
+++ b/MeterBarTests/AccountNotificationPlannerTests.swift
@@ -164,8 +164,31 @@ final class AccountNotificationPlannerTests: XCTestCase {
         XCTAssertEqual(accountResult.notifications.map(\.level), [.critical, .critical])
         XCTAssertEqual(
             accountResult.notifications.map(\.quotaDisplayName),
-            ["5-hour limit", "Weekly limit"]
+            ["Session", "Weekly"]
         )
+    }
+
+    func testTemporaryFullDataGapPreservesAccountDedupState() {
+        let available = input(
+            accounts: [account(id: claudeAccountID, name: "Work")],
+            accountMetrics: [claudeAccountID: metrics(service: .claudeCode, used: 100)]
+        )
+        let first = planner.plan(inputs: [available], alreadyNotified: [], now: now)
+        XCTAssertEqual(first.notifications.count, 1)
+
+        let unavailable = planner.plan(
+            inputs: [input(accounts: [account(id: claudeAccountID, name: "Work")])],
+            alreadyNotified: first.notifiedKeys,
+            now: now
+        )
+        let recovered = planner.plan(
+            inputs: [available],
+            alreadyNotified: unavailable.notifiedKeys,
+            now: now
+        )
+
+        XCTAssertEqual(unavailable.notifiedKeys, first.notifiedKeys)
+        XCTAssertTrue(recovered.notifications.isEmpty)
     }
 
     func testAccountToFallbackTransitionPrimesNewNamespaceWithoutDuplicate() {

--- a/MeterBarTests/AccountNotificationPlannerTests.swift
+++ b/MeterBarTests/AccountNotificationPlannerTests.swift
@@ -1,0 +1,311 @@
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+final class AccountNotificationPlannerTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private let claudeAccountID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10))
+    private let secondClaudeAccountID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11))
+    private let codexAccountID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12))
+
+    private var planner: AccountNotificationPlanner {
+        AccountNotificationPlanner(preferences: .default)
+    }
+
+    private func account(
+        id: UUID,
+        name: String,
+        isEnabled: Bool = true
+    ) -> AccountNotificationIdentity {
+        AccountNotificationIdentity(id: id, name: name, isEnabled: isEnabled)
+    }
+
+    private func metrics(
+        service: ServiceType,
+        used: Double,
+        lastUpdated: Date? = nil
+    ) -> UsageMetrics {
+        UsageMetrics(
+            service: service,
+            sessionLimit: UsageLimit(used: used, total: 100, resetTime: nil),
+            lastUpdated: lastUpdated ?? now
+        )
+    }
+
+    private func input(
+        service: ServiceType = .claudeCode,
+        providerEnabled: Bool = true,
+        accounts: [AccountNotificationIdentity],
+        accountMetrics: [UUID: UsageMetrics] = [:],
+        fallbackMetrics: UsageMetrics? = nil
+    ) -> AccountNotificationPlanInput {
+        AccountNotificationPlanInput(
+            service: service,
+            providerEnabled: providerEnabled,
+            accounts: accounts,
+            accountMetrics: accountMetrics,
+            fallbackMetrics: fallbackMetrics
+        )
+    }
+
+    func testPlansPerAccountKeysAndDisplayNames() {
+        let result = planner.plan(
+            inputs: [
+                input(
+                    accounts: [
+                        account(id: claudeAccountID, name: "Work"),
+                        account(id: secondClaudeAccountID, name: "Personal")
+                    ],
+                    accountMetrics: [
+                        claudeAccountID: metrics(service: .claudeCode, used: 100),
+                        secondClaudeAccountID: metrics(service: .claudeCode, used: 100)
+                    ]
+                )
+            ],
+            alreadyNotified: [],
+            now: now
+        )
+
+        XCTAssertEqual(result.notifications.count, 2)
+        XCTAssertEqual(Set(result.notifications.map(\.key)), [
+            "Claude Code-\(claudeAccountID.uuidString)-session-critical",
+            "Claude Code-\(secondClaudeAccountID.uuidString)-session-critical"
+        ])
+        XCTAssertEqual(Set(result.notifications.map(\.serviceDisplayName)), [
+            "Work (Claude Code)",
+            "Personal (Claude Code)"
+        ])
+    }
+
+    func testUsesProviderFallbackWhenEveryEnabledAccountIsUnavailable() {
+        let result = planner.plan(
+            inputs: [
+                input(
+                    accounts: [
+                        account(id: claudeAccountID, name: "Work"),
+                        account(id: secondClaudeAccountID, name: "Personal")
+                    ],
+                    fallbackMetrics: metrics(service: .claudeCode, used: 100)
+                )
+            ],
+            alreadyNotified: [],
+            now: now
+        )
+
+        XCTAssertEqual(result.notifications.map(\.key), ["Claude Code-session-critical"])
+        XCTAssertTrue(result.notifiedKeys.contains("Claude Code-session-critical"))
+    }
+
+    func testFallbackToAccountTransitionPrimesNewNamespaceWithoutDuplicate() {
+        let fallbackResult = planner.plan(
+            inputs: [
+                input(
+                    accounts: [account(id: claudeAccountID, name: "Work")],
+                    fallbackMetrics: metrics(service: .claudeCode, used: 100)
+                )
+            ],
+            alreadyNotified: [],
+            now: now
+        )
+        XCTAssertEqual(fallbackResult.notifications.map(\.key), ["Claude Code-session-critical"])
+
+        let accountResult = planner.plan(
+            inputs: [
+                input(
+                    accounts: [account(id: claudeAccountID, name: "Work")],
+                    accountMetrics: [claudeAccountID: metrics(service: .claudeCode, used: 100)]
+                )
+            ],
+            alreadyNotified: fallbackResult.notifiedKeys,
+            now: now
+        )
+
+        XCTAssertTrue(accountResult.notifications.isEmpty)
+        XCTAssertFalse(accountResult.notifiedKeys.contains("Claude Code-session-critical"))
+        XCTAssertTrue(
+            accountResult.notifiedKeys.contains(
+                "Claude Code-\(claudeAccountID.uuidString)-session-critical"
+            )
+        )
+    }
+
+    func testAccountToFallbackTransitionPrimesNewNamespaceWithoutDuplicate() {
+        let accountResult = planner.plan(
+            inputs: [
+                input(
+                    accounts: [account(id: claudeAccountID, name: "Work")],
+                    accountMetrics: [claudeAccountID: metrics(service: .claudeCode, used: 100)]
+                )
+            ],
+            alreadyNotified: [],
+            now: now
+        )
+        XCTAssertEqual(accountResult.notifications.count, 1)
+
+        let fallbackResult = planner.plan(
+            inputs: [
+                input(
+                    accounts: [account(id: claudeAccountID, name: "Work")],
+                    fallbackMetrics: metrics(service: .claudeCode, used: 100)
+                )
+            ],
+            alreadyNotified: accountResult.notifiedKeys,
+            now: now
+        )
+
+        XCTAssertTrue(fallbackResult.notifications.isEmpty)
+        XCTAssertEqual(
+            fallbackResult.notifiedKeys,
+            Set(["Claude Code-session-warn", "Claude Code-session-critical"])
+        )
+    }
+
+    func testDisabledAccountCleanupRearmsLaterCrossing() {
+        let enabledInput = input(
+            accounts: [
+                account(id: claudeAccountID, name: "Work"),
+                account(id: secondClaudeAccountID, name: "Personal")
+            ],
+            accountMetrics: [
+                claudeAccountID: metrics(service: .claudeCode, used: 100),
+                secondClaudeAccountID: metrics(service: .claudeCode, used: 100)
+            ]
+        )
+        let first = planner.plan(inputs: [enabledInput], alreadyNotified: [], now: now)
+        XCTAssertEqual(first.notifications.count, 2)
+
+        let disabled = planner.plan(
+            inputs: [
+                input(
+                    accounts: [
+                        account(id: claudeAccountID, name: "Work", isEnabled: false),
+                        account(id: secondClaudeAccountID, name: "Personal")
+                    ],
+                    accountMetrics: [
+                        claudeAccountID: metrics(service: .claudeCode, used: 100),
+                        secondClaudeAccountID: metrics(service: .claudeCode, used: 100)
+                    ]
+                )
+            ],
+            alreadyNotified: first.notifiedKeys,
+            now: now
+        )
+        XCTAssertTrue(disabled.notifications.isEmpty)
+        XCTAssertFalse(disabled.notifiedKeys.contains {
+            $0.hasPrefix("Claude Code-\(claudeAccountID.uuidString)")
+        })
+        XCTAssertTrue(disabled.notifiedKeys.contains {
+            $0.hasPrefix("Claude Code-\(secondClaudeAccountID.uuidString)")
+        })
+
+        let reenabled = planner.plan(
+            inputs: [enabledInput],
+            alreadyNotified: disabled.notifiedKeys,
+            now: now
+        )
+        XCTAssertEqual(reenabled.notifications.count, 1)
+        XCTAssertTrue(
+            reenabled.notifications[0].key.hasPrefix(
+                "Claude Code-\(claudeAccountID.uuidString)"
+            )
+        )
+    }
+
+    func testDisabledProviderCleanupRearmsLaterCrossing() {
+        let enabledInput = input(
+            service: .codexCli,
+            accounts: [account(id: codexAccountID, name: "Work")],
+            accountMetrics: [codexAccountID: metrics(service: .codexCli, used: 100)]
+        )
+        let first = planner.plan(inputs: [enabledInput], alreadyNotified: [], now: now)
+
+        let disabled = planner.plan(
+            inputs: [
+                input(
+                    service: .codexCli,
+                    providerEnabled: false,
+                    accounts: [account(id: codexAccountID, name: "Work")],
+                    accountMetrics: [codexAccountID: metrics(service: .codexCli, used: 100)]
+                )
+            ],
+            alreadyNotified: first.notifiedKeys,
+            now: now
+        )
+        XCTAssertTrue(disabled.notifications.isEmpty)
+        XCTAssertTrue(disabled.notifiedKeys.isEmpty)
+
+        let reenabled = planner.plan(
+            inputs: [enabledInput],
+            alreadyNotified: disabled.notifiedKeys,
+            now: now
+        )
+        XCTAssertEqual(reenabled.notifications.count, 1)
+    }
+
+    func testThreadsKeysSequentiallyAcrossClaudeThenCodex() {
+        let inputs = [
+            input(
+                accounts: [account(id: claudeAccountID, name: "Claude Work")],
+                accountMetrics: [claudeAccountID: metrics(service: .claudeCode, used: 100)]
+            ),
+            input(
+                service: .codexCli,
+                accounts: [account(id: codexAccountID, name: "Codex Work")],
+                accountMetrics: [codexAccountID: metrics(service: .codexCli, used: 100)]
+            )
+        ]
+
+        let first = planner.plan(inputs: inputs, alreadyNotified: [], now: now)
+        XCTAssertEqual(first.notifications.count, 2)
+        XCTAssertTrue(first.notifiedKeys.contains {
+            $0.hasPrefix("Claude Code-\(claudeAccountID.uuidString)")
+        })
+        XCTAssertTrue(first.notifiedKeys.contains {
+            $0.hasPrefix("Codex CLI-\(codexAccountID.uuidString)")
+        })
+
+        let repeated = planner.plan(inputs: inputs, alreadyNotified: first.notifiedKeys, now: now)
+        XCTAssertTrue(repeated.notifications.isEmpty)
+        XCTAssertEqual(repeated.notifiedKeys, first.notifiedKeys)
+    }
+
+    func testStaleAndUnavailableAccountsDoNotBlockFreshAccountPlanning() {
+        let unavailableKey = "Claude Code-\(secondClaudeAccountID.uuidString)-session-warn"
+        let result = planner.plan(
+            inputs: [
+                input(
+                    accounts: [
+                        account(id: claudeAccountID, name: "Stale"),
+                        account(id: secondClaudeAccountID, name: "Unavailable"),
+                        account(id: codexAccountID, name: "Fresh")
+                    ],
+                    accountMetrics: [
+                        claudeAccountID: metrics(
+                            service: .claudeCode,
+                            used: 100,
+                            lastUpdated: now.addingTimeInterval(
+                                -NotificationDecider.defaultStalenessThreshold - 1
+                            )
+                        ),
+                        codexAccountID: metrics(service: .claudeCode, used: 100)
+                    ],
+                    fallbackMetrics: metrics(service: .claudeCode, used: 100)
+                )
+            ],
+            alreadyNotified: [unavailableKey],
+            now: now
+        )
+
+        XCTAssertEqual(
+            result.notifications.map(\.key),
+            ["Claude Code-\(codexAccountID.uuidString)-session-critical"]
+        )
+        XCTAssertTrue(result.notifiedKeys.contains(unavailableKey))
+        XCTAssertTrue(
+            result.notifiedKeys.contains(
+                "Claude Code-\(claudeAccountID.uuidString)-session-critical"
+            )
+        )
+        XCTAssertFalse(result.notifiedKeys.contains("Claude Code-session-critical"))
+    }
+}


### PR DESCRIPTION
Closes #224

## Summary

- extract Claude and Codex account iteration, fallback selection, enablement cleanup, and sequential dedup-key threading into a pure `AccountNotificationPlanner`
- define a no-duplicate namespace transition policy that primes account or provider-fallback state without reposting the same quota crossing
- leave `AppDelegate` as the side-effect adapter that gathers snapshots and posts returned notification values
- add focused coverage for per-account identity, fallback behavior, both namespace transitions, disabled accounts/providers, stale and unavailable metrics, and Claude-to-Codex key threading

## Verification

- `swiftlint lint --strict --quiet MeterBar/App/MeterBarApp.swift MeterBar/Services/AccountNotificationPlanner.swift MeterBar/Services/NotificationDecider.swift MeterBarTests/AccountNotificationPlannerTests.swift` — passed
- `git diff --check` — passed
- final diff self-review — no correctness, security, secret-handling, or unrelated-change findings

## Skipped locally

- Swift tests, typechecks, coverage, and app builds were intentionally delegated to GitHub Actions under issue #224's CI-only verification contract and the repository MacBook resource policy
- SwiftFormat is not installed locally

## Residual risk

- PR CI must validate XCTest compilation and Swift 5/MainActor isolation compatibility for the new pure service; no networking, persistence, notification copy, or threshold behavior changed
