### PR TITLE
feat(costs): add lifetime local cost summary

### DIFF
--- a/.agents/SESSIONS/2026-07-18.md
+++ b/.agents/SESSIONS/2026-07-18.md
@@ -1,0 +1,80 @@
+# Sessions: 2026-07-18
+
+**Summary:** Lifetime local cost summary for issue #137
+
+---
+
+## Session 1: Add Lifetime Cost Summary
+
+**Duration:** ~1 hour
+**Status:** Complete; PR CI pending
+
+### System Flow
+
+```mermaid
+flowchart LR
+    Scan[CostTracker scan] --> Recent[30-day scan snapshot]
+    Scan --> Lifetime[All available local history snapshot]
+    Recent --> Cache[Existing cost-summary cache]
+    Lifetime --> Cache
+    Cache --> Filter[Enabled-provider filter]
+    Filter --> Card[Lifetime Local Cost dashboard card]
+```
+
+### Affected Components
+
+| Layer | Components |
+|-------|------------|
+| Models | `CostSummary`, `LifetimeCostSummary`, `LifetimeProviderCost` |
+| Services | `CostTracker` local Claude and Codex scanning |
+| UI | Costs dashboard lifetime summary card |
+| Tests | Lifetime aggregation and cache compatibility |
+
+### What was done
+
+- [x] Added a pure lifetime aggregation with provider subtotals and tracked date range.
+- [x] Rebuilt lifetime history from available local logs on every scan, replacing the cached snapshot instead of accumulating overlapping scans.
+- [x] Stored lifetime data in the existing cost-summary cache with backward-compatible decoding.
+- [x] Added a dashboard card for the lifetime total, provider reconciliation, loading, legacy-cache, and zero-history states.
+- [x] Added focused model tests for multi-provider aggregation, empty and zero-cost histories, repeated scans, filtering, and cache compatibility.
+
+### Files changed
+
+- `MeterBar/Models/TokenCost.swift` - Added lifetime summary models and provider-aware filtering.
+- `MeterBar/Services/CostTracker.swift` - Added all-history scanning and legacy-cache backfill.
+- `MeterBar/Views/DashboardCostCards.swift` - Added the lifetime dashboard card.
+- `MeterBar/Views/UsageDashboardView.swift` - Integrated the card into Costs.
+- `MeterBarTests/LifetimeCostSummaryTests.swift` - Added focused aggregation and persistence coverage.
+
+### Key decisions
+
+- **Decision:** Keep the 30-day summary unchanged and add a lifetime snapshot to the same cache.
+  - **Context:** Existing charts, provider breakdowns, and CLI windows rely on the current 30-day semantics.
+  - **Rationale:** This preserves behavior while avoiding a second persistence path or a cache migration.
+- **Decision:** Re-scan all available history and replace the lifetime snapshot.
+  - **Context:** Merging overlapping 30-day scans cannot reliably deduplicate history without persisting event identities.
+  - **Rationale:** A point-in-time rebuild uses the scanners' existing event deduplication and cannot compound totals across refreshes.
+
+### Mistakes and fixes
+
+- **Mistake:** The initial card treated a legacy cache with no lifetime field as a genuine zero-history result.
+- **Fix:** Added a distinct scan-needed state and automatic background backfill for legacy caches.
+- **Prevention:** Keep absence, loading, and valid-empty states explicit when extending persisted summaries.
+- **Mistake:** The first local commit body preserved newline escape characters literally.
+- **Fix:** Corrected the unpushed commit message before publication.
+
+### Verification
+
+- `swiftlint lint --strict --quiet` on all changed Swift files passed.
+- `git diff --check` passed.
+- Swift tests and builds were not run locally under the MacBook resource policy; PR CI is the execution gate.
+- SwiftFormat is not installed locally.
+
+### Next steps
+
+- [ ] Let PR CI compile and run the focused lifetime-summary coverage.
+- [ ] Review the lifetime card in light and dark appearances.
+
+---
+
+**Total sessions today:** 1

--- a/MeterBar/Models/TokenCost.swift
+++ b/MeterBar/Models/TokenCost.swift
@@ -140,25 +140,99 @@ nonisolated public struct DailyTokenUsage: Codable, Identifiable, Sendable {
     }()
 }
 
+nonisolated public struct LifetimeProviderCost: Codable, Identifiable, Equatable, Sendable {
+    public var id: String { provider.rawValue }
+
+    public let provider: ServiceType
+    public let estimatedCostUSD: Double
+    public let firstTrackedDate: Date
+    public let lastTrackedDate: Date
+
+    public init(
+        provider: ServiceType,
+        estimatedCostUSD: Double,
+        firstTrackedDate: Date,
+        lastTrackedDate: Date
+    ) {
+        self.provider = provider
+        self.estimatedCostUSD = estimatedCostUSD
+        self.firstTrackedDate = firstTrackedDate
+        self.lastTrackedDate = lastTrackedDate
+    }
+
+    public var formattedCost: String {
+        UsageFormat.cost(estimatedCostUSD)
+    }
+}
+
+/// A complete, point-in-time total over every billable local session currently
+/// available to CostTracker. Each scan replaces this snapshot instead of
+/// merging with the previous cache, so overlapping or repeated scans cannot
+/// inflate the lifetime total.
+nonisolated public struct LifetimeCostSummary: Codable, Equatable, Sendable {
+    public let providers: [LifetimeProviderCost]
+    public let totalCostUSD: Double
+    public let firstTrackedDate: Date?
+    public let lastTrackedDate: Date?
+
+    public init(costs: [TokenCost]) {
+        var byProvider: [ServiceType: LifetimeProviderCost] = [:]
+
+        for cost in costs where cost.estimatedCostUSD > 0 {
+            let existing = byProvider[cost.provider]
+            byProvider[cost.provider] = LifetimeProviderCost(
+                provider: cost.provider,
+                estimatedCostUSD: (existing?.estimatedCostUSD ?? 0) + cost.estimatedCostUSD,
+                firstTrackedDate: min(existing?.firstTrackedDate ?? cost.periodStart, cost.periodStart),
+                lastTrackedDate: max(existing?.lastTrackedDate ?? cost.periodEnd, cost.periodEnd)
+            )
+        }
+
+        self.init(providers: byProvider.values.sorted { $0.provider.rawValue < $1.provider.rawValue })
+    }
+
+    private init(providers: [LifetimeProviderCost]) {
+        self.providers = providers
+        totalCostUSD = providers.reduce(0) { $0 + $1.estimatedCostUSD }
+        firstTrackedDate = providers.map(\.firstTrackedDate).min()
+        lastTrackedDate = providers.map(\.lastTrackedDate).max()
+    }
+
+    public var hasBillableHistory: Bool {
+        !providers.isEmpty && totalCostUSD > 0
+    }
+
+    public var formattedTotalCost: String {
+        UsageFormat.cost(totalCostUSD)
+    }
+
+    public func filtered(to enabledServices: Set<ServiceType>) -> LifetimeCostSummary {
+        LifetimeCostSummary(providers: providers.filter { enabledServices.contains($0.provider) })
+    }
+}
+
 nonisolated public struct CostSummary: Codable, Sendable {
     public let costs: [TokenCost]
     public let totalCostUSD: Double
     public let totalTokens: Int
     public let periodDays: Int
     public let dailyUsage: [DailyTokenUsage]
+    public let lifetime: LifetimeCostSummary?
 
     public init(
         costs: [TokenCost],
         totalCostUSD: Double,
         totalTokens: Int,
         periodDays: Int,
-        dailyUsage: [DailyTokenUsage] = []
+        dailyUsage: [DailyTokenUsage] = [],
+        lifetime: LifetimeCostSummary? = nil
     ) {
         self.costs = costs
         self.totalCostUSD = totalCostUSD
         self.totalTokens = totalTokens
         self.periodDays = periodDays
         self.dailyUsage = dailyUsage
+        self.lifetime = lifetime
     }
 
     public var formattedTotalCost: String {
@@ -276,7 +350,8 @@ nonisolated public struct CostSummary: Codable, Sendable {
             totalCostUSD: visibleCosts.reduce(0) { $0 + $1.estimatedCostUSD },
             totalTokens: visibleCosts.reduce(0) { $0 + $1.totalTokens },
             periodDays: periodDays,
-            dailyUsage: visibleDailyUsage
+            dailyUsage: visibleDailyUsage,
+            lifetime: lifetime?.filtered(to: enabledServices)
         )
     }
 }

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -60,14 +60,15 @@ class CostTracker: ObservableObject {
         }
     }
 
-    /// Quietly backfills missing daily rows when Overview/Costs opens, without the
-    /// visible "Scanning" UI a manual scan shows. No-ops unless the cached summary
-    /// actually has gaps in the visible window (see `needsMissingDailyUsageRefresh`).
+    /// Quietly backfills a legacy cache's missing lifetime snapshot or missing
+    /// daily rows when Overview/Costs opens, without the visible "Scanning" UI
+    /// a manual scan shows.
     func refreshMissingDaysInBackground(days: Int = 30) async {
         let shouldStart = await MainActor.run {
             guard !isRefreshInProgress,
                   let visibleSummary = costSummary?.filtered(to: providerVisibilityStore.enabledServices),
-                  visibleSummary.needsMissingDailyUsageRefresh(days: days, lastScanDate: lastScanDate) else {
+                  visibleSummary.lifetime == nil
+                    || visibleSummary.needsMissingDailyUsageRefresh(days: days, lastScanDate: lastScanDate) else {
                 return false
             }
             isRefreshingMissingDays = true
@@ -106,10 +107,38 @@ class CostTracker: ObservableObject {
         claudeAccounts: [ClaudeCodeAccount]
     ) -> CostSummary {
         let cutoffDate = Calendar.current.date(byAdding: .day, value: -days, to: Date()) ?? Date()
+        let periodScan = Self.scanCostSources(
+            since: cutoffDate,
+            includeClaudeCode: includeClaudeCode,
+            includeCodexCli: includeCodexCli,
+            claudeAccounts: claudeAccounts
+        )
+        let lifetimeScan = Self.scanCostSources(
+            since: .distantPast,
+            includeClaudeCode: includeClaudeCode,
+            includeCodexCli: includeCodexCli,
+            claudeAccounts: claudeAccounts
+        )
+
+        return CostSummary(
+            costs: periodScan.costs,
+            totalCostUSD: periodScan.costs.reduce(0) { $0 + $1.estimatedCostUSD },
+            totalTokens: periodScan.costs.reduce(0) { $0 + $1.totalTokens },
+            periodDays: days,
+            dailyUsage: periodScan.dailyUsage.sorted { $0.date < $1.date },
+            lifetime: LifetimeCostSummary(costs: lifetimeScan.costs)
+        )
+    }
+
+    nonisolated private static func scanCostSources(
+        since cutoffDate: Date,
+        includeClaudeCode: Bool,
+        includeCodexCli: Bool,
+        claudeAccounts: [ClaudeCodeAccount]
+    ) -> (costs: [TokenCost], dailyUsage: [DailyTokenUsage]) {
         var allCosts: [TokenCost] = []
         var dailyUsage: [DailyTokenUsage] = []
 
-        // Scan Claude Code sessions
         if includeClaudeCode,
            let (claudeCost, claudeDailyUsage) = Self.scanClaudeCodeSessions(
             since: cutoffDate,
@@ -125,17 +154,7 @@ class CostTracker: ObservableObject {
             dailyUsage.append(contentsOf: codexDailyUsage)
         }
 
-        // Calculate summary
-        let totalCost = allCosts.reduce(0) { $0 + $1.estimatedCostUSD }
-        let totalTokens = allCosts.reduce(0) { $0 + $1.totalTokens }
-
-        return CostSummary(
-            costs: allCosts,
-            totalCostUSD: totalCost,
-            totalTokens: totalTokens,
-            periodDays: days,
-            dailyUsage: dailyUsage.sorted { $0.date < $1.date }
-        )
+        return (allCosts, dailyUsage)
     }
 
     private func loadCachedSummary() {

--- a/MeterBar/Views/DashboardCostCards.swift
+++ b/MeterBar/Views/DashboardCostCards.swift
@@ -134,6 +134,73 @@ struct CostOverviewStatusCard: View {
   }
 }
 
+struct LifetimeCostSummaryCard: View {
+  let summary: LifetimeCostSummary?
+  let isScanning: Bool
+
+  var body: some View {
+    DashboardCard(title: "Lifetime Local Cost", trailing: trackedDateRange) {
+      if let summary, summary.hasBillableHistory {
+        VStack(alignment: .leading, spacing: 12) {
+          Text(summary.formattedTotalCost)
+            .font(.largeTitle)
+            .fontWeight(.bold)
+            .contentTransition(.numericText())
+
+          ForEach(summary.providers) { provider in
+            HStack(spacing: 10) {
+              ProviderTitle(
+                title: provider.provider.displayName,
+                logoKind: .forService(provider.provider),
+                color: MeterBarTheme.accent(for: provider.provider),
+                font: .subheadline
+              )
+              Spacer()
+              Text(provider.formattedCost)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(provider.provider.displayName)
+            .accessibilityValue(provider.formattedCost)
+          }
+        }
+      } else if isScanning {
+        HStack(spacing: 10) {
+          ProgressView()
+            .controlSize(.small)
+          Text("Scanning all available local history…")
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+        }
+      } else if summary == nil {
+        EmptyStateCard(
+          systemImage: "magnifyingglass",
+          title: "Lifetime scan needed",
+          message: "Run a local scan to calculate lifetime cost from available history."
+        )
+      } else {
+        EmptyStateCard(
+          systemImage: "clock.arrow.circlepath",
+          title: "No lifetime cost",
+          message: "No billable Claude or Codex history was found in local logs."
+        )
+      }
+    }
+  }
+
+  private var trackedDateRange: String? {
+    guard let firstDate = summary?.firstTrackedDate,
+          let lastDate = summary?.lastTrackedDate else {
+      return nil
+    }
+
+    let first = firstDate.formatted(date: .abbreviated, time: .omitted)
+    let last = lastDate.formatted(date: .abbreviated, time: .omitted)
+    return first == last ? first : "\(first) – \(last)"
+  }
+}
+
 /// Full-area loading treatment for the **first** scan, when there is no cost
 /// data to show yet. It replaces the entire chart with an animated shimmer so
 /// the empty slot reads as "working on it" rather than "nothing here." Contrast

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -538,6 +538,11 @@ struct UsageDashboardView: View {
                 formattedTokens: UsageFormat.tokens(visibleCostSummary?.totalTokens ?? 0)
             )
 
+            LifetimeCostSummaryCard(
+                summary: visibleCostSummary?.lifetime,
+                isScanning: costTracker.isRefreshInProgress
+            )
+
             costTrendCard
 
             if let summary = visibleCostSummary, !summary.dailyUsage.isEmpty {

--- a/MeterBarTests/LifetimeCostSummaryTests.swift
+++ b/MeterBarTests/LifetimeCostSummaryTests.swift
@@ -1,0 +1,126 @@
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+final class LifetimeCostSummaryTests: XCTestCase {
+    private let firstDate = Date(timeIntervalSince1970: 1_700_000_000)
+    private let middleDate = Date(timeIntervalSince1970: 1_710_000_000)
+    private let lastDate = Date(timeIntervalSince1970: 1_720_000_000)
+
+    func testAggregatesFixtureAcrossProvidersAndDates() {
+        let summary = LifetimeCostSummary(costs: [
+            cost(provider: .claudeCode, amount: 1.25, start: firstDate, end: middleDate),
+            cost(provider: .claudeCode, amount: 2.75, start: middleDate, end: lastDate),
+            cost(provider: .codexCli, amount: 3.50, start: middleDate, end: lastDate)
+        ])
+
+        XCTAssertEqual(summary.providers.map(\.provider), [.claudeCode, .codexCli])
+        XCTAssertEqual(summary.providers[0].estimatedCostUSD, 4.00, accuracy: 0.0001)
+        XCTAssertEqual(summary.providers[1].estimatedCostUSD, 3.50, accuracy: 0.0001)
+        XCTAssertEqual(summary.totalCostUSD, 7.50, accuracy: 0.0001)
+        XCTAssertEqual(summary.firstTrackedDate, firstDate)
+        XCTAssertEqual(summary.lastTrackedDate, lastDate)
+        XCTAssertEqual(
+            summary.providers.reduce(0) { $0 + $1.estimatedCostUSD },
+            summary.totalCostUSD,
+            accuracy: 0.0001
+        )
+    }
+
+    func testEmptyAndZeroCostFixturesHaveNoBillableHistory() {
+        let empty = LifetimeCostSummary(costs: [])
+        let zero = LifetimeCostSummary(costs: [
+            cost(provider: .claudeCode, amount: 0, start: firstDate, end: lastDate)
+        ])
+
+        for summary in [empty, zero] {
+            XCTAssertFalse(summary.hasBillableHistory)
+            XCTAssertTrue(summary.providers.isEmpty)
+            XCTAssertEqual(summary.totalCostUSD, 0, accuracy: 0.0001)
+            XCTAssertNil(summary.firstTrackedDate)
+            XCTAssertNil(summary.lastTrackedDate)
+        }
+    }
+
+    func testRebuildingTheSameScanDoesNotAccumulateHistory() {
+        let fixture = [
+            cost(provider: .claudeCode, amount: 2.25, start: firstDate, end: lastDate),
+            cost(provider: .codexCli, amount: 1.75, start: middleDate, end: lastDate)
+        ]
+
+        let firstScan = LifetimeCostSummary(costs: fixture)
+        let repeatedScan = LifetimeCostSummary(costs: fixture)
+
+        XCTAssertEqual(repeatedScan, firstScan)
+        XCTAssertEqual(repeatedScan.totalCostUSD, 4.00, accuracy: 0.0001)
+    }
+
+    func testFilteringReconcilesProviderSubtotalAndTrackedRange() {
+        let summary = LifetimeCostSummary(costs: [
+            cost(provider: .claudeCode, amount: 2.00, start: firstDate, end: middleDate),
+            cost(provider: .codexCli, amount: 3.00, start: middleDate, end: lastDate)
+        ])
+
+        let filtered = summary.filtered(to: [.codexCli])
+
+        XCTAssertEqual(filtered.providers.map(\.provider), [.codexCli])
+        XCTAssertEqual(filtered.totalCostUSD, 3.00, accuracy: 0.0001)
+        XCTAssertEqual(filtered.firstTrackedDate, middleDate)
+        XCTAssertEqual(filtered.lastTrackedDate, lastDate)
+    }
+
+    func testLegacyCachedSummaryDecodesWithoutLifetimeSnapshot() throws {
+        let data = Data(
+            """
+            {
+              "costs": [],
+              "totalCostUSD": 0,
+              "totalTokens": 0,
+              "periodDays": 30,
+              "dailyUsage": []
+            }
+            """.utf8
+        )
+
+        let summary = try JSONDecoder().decode(CostSummary.self, from: data)
+
+        XCTAssertNil(summary.lifetime)
+    }
+
+    func testCachedSummaryRoundTripsLifetimeSnapshot() throws {
+        let lifetime = LifetimeCostSummary(costs: [
+            cost(provider: .claudeCode, amount: 4.25, start: firstDate, end: lastDate)
+        ])
+        let original = CostSummary(
+            costs: [],
+            totalCostUSD: 0,
+            totalTokens: 0,
+            periodDays: 30,
+            lifetime: lifetime
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(CostSummary.self, from: data)
+
+        XCTAssertEqual(decoded.lifetime, lifetime)
+    }
+
+    private func cost(
+        provider: ServiceType,
+        amount: Double,
+        start: Date,
+        end: Date
+    ) -> TokenCost {
+        TokenCost(
+            provider: provider,
+            inputTokens: 1_000,
+            outputTokens: 500,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 0,
+            estimatedCostUSD: amount,
+            sessionCount: 1,
+            periodStart: start,
+            periodEnd: end
+        )
+    }
+}


### PR DESCRIPTION
Closes #137

## Summary

- rebuild a point-in-time lifetime cost snapshot from all available Claude and Codex local history on every cost scan
- persist provider subtotals and first/last tracked dates inside the existing backward-compatible cost cache
- add a Lifetime Local Cost dashboard card with loading, legacy-cache, valid-empty, and provider-filtered states
- keep the existing 30-day charts, breakdowns, refresh lock, and pricing behavior unchanged
- add focused aggregation, repeat-scan, zero-history, filtering, and cache-compatibility coverage

## Verification

- `swiftlint lint --strict --quiet MeterBar/Models/TokenCost.swift MeterBar/Services/CostTracker.swift MeterBar/Views/DashboardCostCards.swift MeterBar/Views/UsageDashboardView.swift MeterBarTests/LifetimeCostSummaryTests.swift` — passed
- `git diff --check` — passed
- final diff self-review — no correctness, security, secret-handling, dead-code, or unrelated-change findings

## Skipped locally

- Swift tests, typechecks, coverage, and app builds were intentionally delegated to GitHub Actions under the repository MacBook resource policy
- SwiftFormat is not installed locally

## Residual risk

- PR CI must validate XCTest compilation and Swift 5 actor-isolation compatibility
- lifetime scans intentionally read all available local history and therefore do more disk work than the existing 30-day scan; refresh locking still prevents overlap
