### PR TITLE
fix(refresh): keep CLI provider freshness accurate

### DIFF
--- a/.agents/SESSIONS/2026-07-19.md
+++ b/.agents/SESSIONS/2026-07-19.md
@@ -1,0 +1,76 @@
+# 2026-07-19 — Provider freshness fault
+
+## Session 1: Diagnose stale CLI provider snapshots
+
+**Status:** Implementation complete; PR CI pending
+
+```mermaid
+flowchart LR
+    Timer[Resident refresh timer] --> Manager[UsageDataManager]
+    Manager --> Claude[Enabled Claude accounts]
+    Manager --> Codex[Enabled Codex accounts]
+    Claude --> SharedCache[App Group metrics cache]
+    Codex --> SharedCache
+    Manager --> HealthFile[App Group provider-health file]
+    SharedCache --> CLI[meterbar usage / doctor]
+    HealthFile --> CLI
+```
+
+### Affected components
+
+- Provider refresh orchestration
+- Shared app-group usage cache
+- `meterbar doctor --json` and `meterbar usage --json` freshness reporting
+
+### Root causes
+
+- A failed default Claude fetch set the service's published `hasAccess` flag false.
+  `UsageDataManager` then used that mutable result as a pre-fetch gate, so every
+  later timer tick skipped Claude instead of retrying the real OAuth/CLI source.
+- Provider health was written through App Group `UserDefaults`, but the unentitled
+  bundled CLI resolved the ordinary preferences domain for the same suite name.
+  The app and CLI therefore read different health records.
+- Freshness was derived only from the health record's `lastSuccess`, allowing a
+  newly written metrics payload to remain incorrectly marked stale.
+- PR #227 already fixes ten-minute resident cadence, overlap protection, and wake
+  catch-up. This fix stays complementary and does not duplicate that scheduler.
+
+### What was done
+
+- Removed the Claude `hasAccess` circuit-breaker from refresh orchestration; enabled
+  accounts now retry through the authoritative fetch path and preserve cached data
+  on failure.
+- Added an injectable Claude provider seam and regression coverage for retrying when
+  published access is false.
+- Mirrored provider health to an atomic JSON file in the App Group container, with
+  preference fallback/migration for existing installs.
+- Made diagnostics reconcile health timestamps with the actual cached metrics
+  `lastUpdated` value and replace contradictory "no refresh errors" copy when the
+  persisted latest attempt failed.
+- Added focused tests for cross-process preference divergence, fresh-payload
+  precedence, and persisted refresh-failure reporting.
+
+### Files changed
+
+- `Packages/MeterBarShared/Sources/MeterBarShared/SharedMetricsStore.swift`
+- `MeterBar/Services/ProviderParseHealthStore.swift`
+- `MeterBar/Services/ProviderReadinessInspector.swift`
+- `MeterBar/Services/UsageDataManager.swift`
+- `MeterBarTests/ProviderParseHealthTests.swift`
+- `MeterBarTests/ProviderReadinessInspectorTests.swift`
+- `MeterBarTests/UsageDataManagerTests.swift`
+
+### Verification
+
+- Focused SwiftLint strict passed on every changed Swift file.
+- `git diff --check` passed.
+- Live installed-binary diagnosis confirmed the App Group metrics file was current
+  while the CLI-read ordinary preferences record remained stale.
+- Local Swift tests and builds were skipped per the MacBook policy; PR CI is the
+  execution gate.
+- SwiftFormat is unavailable locally.
+
+### Next steps
+
+- [ ] Publish a ready-for-review pull request.
+- [ ] Confirm tests, coverage, lint, secret scan, and app/widget/CLI builds in CI.

--- a/.agents/SESSIONS/2026-07-19.md
+++ b/.agents/SESSIONS/2026-07-19.md
@@ -70,6 +70,13 @@ flowchart LR
   execution gate.
 - SwiftFormat is unavailable locally.
 
+### Mistakes and fixes
+
+- **Mistake:** The first CI run found a missing explicit `return` in the
+  multi-statement diagnostics `map` closure.
+- **Fix:** Returned the constructed `ProviderReadiness` value explicitly and
+  republished the branch for CI verification.
+
 ### Next steps
 
 - [ ] Publish a ready-for-review pull request.

--- a/MeterBar/Services/ProviderParseHealthStore.swift
+++ b/MeterBar/Services/ProviderParseHealthStore.swift
@@ -1,6 +1,7 @@
 import Combine
 import Foundation
 import MeterBarShared
+import os
 
 /// Persisted fetch/parse health for one reverse-engineered provider integration.
 nonisolated public struct ProviderParseHealthRecord: Codable, Equatable, Sendable {
@@ -68,8 +69,9 @@ nonisolated public struct ProviderParseHealthRecord: Codable, Equatable, Sendabl
     }
 }
 
-/// Records provider outcomes in the app-group domain so the GUI and bundled
-/// `meterbar doctor` process read the same diagnostic state.
+/// Records provider outcomes in preferences for app observers and mirrors them
+/// to an explicit App Group file so the bundled `meterbar doctor` process reads
+/// the same diagnostic state.
 final class ProviderParseHealthStore: ObservableObject {
     static let shared = ProviderParseHealthStore()
     nonisolated static let storageKey = "ProviderParseHealthV1"
@@ -77,13 +79,32 @@ final class ProviderParseHealthStore: ObservableObject {
     @Published private(set) var records: [ServiceType: ProviderParseHealthRecord]
 
     private let userDefaults: UserDefaults
+    private let sharedFileURL: URL?
+    private let ioQueue = DispatchQueue(label: "dev.meterbar.app.ProviderParseHealthStore.io", qos: .utility)
 
-    init(userDefaults: UserDefaults? = nil) {
+    init(userDefaults: UserDefaults? = nil, sharedDirectoryOverride: URL? = nil) {
+        let usesProductionStore = userDefaults == nil && sharedDirectoryOverride == nil
         let resolved = userDefaults
             ?? UserDefaults(suiteName: SharedMetricsStore.appGroupIdentifier)
             ?? .standard
         self.userDefaults = resolved
-        records = Self.persistedRecords(from: resolved)
+        if let sharedDirectoryOverride {
+            sharedFileURL = sharedDirectoryOverride
+                .appendingPathComponent("\(SharedMetricsStore.parseHealthKey).json")
+        } else {
+            sharedFileURL = usesProductionStore ? SharedMetricsStore.parseHealthFileURL : nil
+        }
+
+        let sharedRecords = Self.loadRecords(from: sharedFileURL)
+        records = sharedRecords ?? Self.persistedRecords(from: resolved)
+
+        // Migrate the App Group preference-domain record to an explicit shared
+        // file. An unentitled bundled CLI can read the App Group container but
+        // `UserDefaults(suiteName:)` resolves its ordinary preferences domain,
+        // so the file is the only cross-process source that both targets share.
+        if sharedRecords == nil, !records.isEmpty {
+            persistSharedFile(records)
+        }
     }
 
     func recordSuccess(_ provider: ServiceType, at date: Date = Date()) {
@@ -116,13 +137,67 @@ final class ProviderParseHealthStore: ObservableObject {
     }
 
     nonisolated static func sharedRecords() -> [ServiceType: ProviderParseHealthRecord] {
-        guard let defaults = UserDefaults(suiteName: SharedMetricsStore.appGroupIdentifier) else { return [:] }
-        return persistedRecords(from: defaults)
+        sharedRecords(
+            fileURL: SharedMetricsStore.parseHealthFileURL,
+            fallbackUserDefaults: UserDefaults(suiteName: SharedMetricsStore.appGroupIdentifier)
+        )
+    }
+
+    nonisolated static func sharedRecords(
+        fileURL: URL?,
+        fallbackUserDefaults: UserDefaults?
+    ) -> [ServiceType: ProviderParseHealthRecord] {
+        if let records = loadRecords(from: fileURL) {
+            return records
+        }
+        guard let fallbackUserDefaults else { return [:] }
+        return persistedRecords(from: fallbackUserDefaults)
     }
 
     private func persist() {
-        guard let data = try? JSONEncoder().encode(Array(records.values)) else { return }
+        guard let data = Self.encodedRecords(records) else { return }
         userDefaults.set(data, forKey: Self.storageKey)
+        persistSharedData(data)
+    }
+
+    func flushPendingWrites() {
+        ioQueue.sync {}
+    }
+
+    nonisolated private static func loadRecords(
+        from fileURL: URL?
+    ) -> [ServiceType: ProviderParseHealthRecord]? {
+        guard let fileURL,
+              let data = try? Data(contentsOf: fileURL),
+              let decoded = try? JSONDecoder().decode([ProviderParseHealthRecord].self, from: data) else {
+            return nil
+        }
+        return Dictionary(uniqueKeysWithValues: decoded.map { ($0.provider, $0) })
+    }
+
+    nonisolated private static func encodedRecords(
+        _ records: [ServiceType: ProviderParseHealthRecord]
+    ) -> Data? {
+        let ordered = records.values.sorted { $0.provider.sortOrder < $1.provider.sortOrder }
+        return try? JSONEncoder().encode(ordered)
+    }
+
+    private func persistSharedFile(_ records: [ServiceType: ProviderParseHealthRecord]) {
+        guard let data = Self.encodedRecords(records) else { return }
+        persistSharedData(data)
+    }
+
+    private func persistSharedData(_ data: Data) {
+        guard let sharedFileURL else { return }
+        ioQueue.async {
+            do {
+                try data.write(to: sharedFileURL, options: [.atomic])
+            } catch {
+                AppLog.storage.error(
+                    "Failed to save provider health: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
     }
 
     nonisolated private static func isShapeMismatch(_ error: Error) -> Bool {

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -23,13 +23,17 @@ nonisolated public enum ProviderReadinessInspector {
         providers: Set<ServiceType> = Set(ServiceType.allCases),
         refreshErrors: [ServiceType: ServiceError] = [:],
         now: Date = Date(),
-        parseHealth: [ServiceType: ProviderParseHealthRecord]? = nil
+        parseHealth: [ServiceType: ProviderParseHealthRecord]? = nil,
+        cachedMetrics: [ServiceType: UsageMetrics]? = nil
     ) -> [ProviderReadiness] {
+        let metrics = cachedMetrics ?? SharedDataStore.shared.loadMetrics()
         let baseReports = reports(
             providers: providers,
             refreshErrors: refreshErrors,
             now: now,
-            claudeReport: { claudeReport(refreshError: $0, now: $1) },
+            claudeReport: {
+                claudeReport(refreshError: $0, now: $1, cachedMetrics: metrics[.claudeCode])
+            },
             codexReport: { codexReport(refreshError: $0, now: $1) },
             cursorReport: { cursorReport(refreshError: $0, now: $1) },
             openRouterReport: { error, _ in openRouterReport(refreshError: error) },
@@ -37,9 +41,15 @@ nonisolated public enum ProviderReadinessInspector {
         )
         let health = parseHealth ?? ProviderParseHealthStore.sharedRecords()
         return baseReports.map { report in
+            let record = health[report.provider]
+            let providerMetrics = metrics[report.provider]
             ProviderReadiness(
                 provider: report.provider,
-                checks: report.checks + [parseHealthCheck(health[report.provider], now: now)]
+                checks: reconciledRefreshChecks(
+                    report.checks,
+                    record: record,
+                    metrics: providerMetrics
+                ) + [parseHealthCheck(record, metrics: providerMetrics, now: now)]
             )
         }
     }
@@ -186,14 +196,24 @@ nonisolated public enum ProviderReadinessInspector {
 
     // MARK: - Helpers
 
-    private static func parseHealthCheck(_ record: ProviderParseHealthRecord?, now: Date) -> ReadinessCheck {
+    private static func parseHealthCheck(
+        _ record: ProviderParseHealthRecord?,
+        metrics: UsageMetrics?,
+        now: Date
+    ) -> ReadinessCheck {
         // Plain-English label. "Provider format health" was internal jargon; a
         // user reads this row to answer "is my usage current?", so the title
         // says exactly that and the detail carries the specifics.
         let title = "Usage data"
         let threshold = "Data is considered stale after 2 hours."
 
-        guard let record else {
+        let latestSuccess = [record?.lastSuccess, metrics?.lastUpdated].compactMap { $0 }.max()
+        let latestFailureIsCurrent = record.map {
+            $0.consecutiveFailures > 0
+                && $0.lastAttempt > (latestSuccess ?? .distantPast)
+        } ?? false
+
+        guard record != nil || latestSuccess != nil else {
             return ReadinessCheck(
                 id: ReadinessCheckID.parseHealth,
                 title: title,
@@ -204,7 +224,7 @@ nonisolated public enum ProviderReadinessInspector {
 
         // A genuine format drift is a real, immediate failure worth surfacing —
         // MeterBar reverse-engineers these feeds, so a shape change breaks reads.
-        if record.lastFailureWasShapeMismatch {
+        if latestFailureIsCurrent, record?.lastFailureWasShapeMismatch == true {
             return ReadinessCheck(
                 id: ReadinessCheckID.parseHealth,
                 title: title,
@@ -215,7 +235,9 @@ nonisolated public enum ProviderReadinessInspector {
             )
         }
         // Failures piling up mean the data on screen is genuinely going stale.
-        if record.consecutiveFailures >= ProviderParseHealthRecord.sustainedFailureCount {
+        if latestFailureIsCurrent,
+           let record,
+           record.consecutiveFailures >= ProviderParseHealthRecord.sustainedFailureCount {
             return ReadinessCheck(
                 id: ReadinessCheckID.parseHealth,
                 title: title,
@@ -230,7 +252,7 @@ nonisolated public enum ProviderReadinessInspector {
         // screen is invisible to the user and not worth a warning. (Warning on
         // it is exactly what made this row light up "all the time".)
         let hasRecentSuccess: Bool = {
-            guard let lastSuccess = record.lastSuccess else { return false }
+            guard let lastSuccess = latestSuccess else { return false }
             return now.timeIntervalSince(lastSuccess) <= ProviderParseHealthRecord.staleAfter
         }()
 
@@ -244,7 +266,7 @@ nonisolated public enum ProviderReadinessInspector {
         }
 
         // No recent success to fall back on: now the failure (or the age) matters.
-        if record.consecutiveFailures > 0 {
+        if latestFailureIsCurrent {
             return ReadinessCheck(
                 id: ReadinessCheckID.parseHealth,
                 title: title,
@@ -260,6 +282,32 @@ nonisolated public enum ProviderReadinessInspector {
             detail: "Usage data is older than the 2-hour freshness window.",
             recovery: "Refresh the provider and review any new error."
         )
+    }
+
+    private static func reconciledRefreshChecks(
+        _ checks: [ReadinessCheck],
+        record: ProviderParseHealthRecord?,
+        metrics: UsageMetrics?
+    ) -> [ReadinessCheck] {
+        guard let record,
+              record.consecutiveFailures > 0,
+              record.lastAttempt > (metrics?.lastUpdated ?? record.lastSuccess ?? .distantPast),
+              checks.first(where: { $0.id == ReadinessCheckID.refresh })?.level == .pass else {
+            return checks
+        }
+
+        let level: ReadinessLevel = record.lastFailureWasShapeMismatch
+            || record.consecutiveFailures >= ProviderParseHealthRecord.sustainedFailureCount
+            ? .fail
+            : .warn
+        let replacement = ReadinessCheck(
+            id: ReadinessCheckID.refresh,
+            title: "Last refresh",
+            level: level,
+            detail: "The latest recorded refresh failed; cached usage was preserved.",
+            recovery: "Refresh in MeterBar and review the Usage data check."
+        )
+        return checks.map { $0.id == ReadinessCheckID.refresh ? replacement : $0 }
     }
 
     private static func cursorAppPresent() -> Bool {

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -43,7 +43,7 @@ nonisolated public enum ProviderReadinessInspector {
         return baseReports.map { report in
             let record = health[report.provider]
             let providerMetrics = metrics[report.provider]
-            ProviderReadiness(
+            return ProviderReadiness(
                 provider: report.provider,
                 checks: reconciledRefreshChecks(
                     report.checks,

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -17,6 +17,13 @@ extension CursorLocalService: SimpleUsageProviding {}
 extension OpenRouterService: SimpleUsageProviding {}
 extension GrokCLIUsageService: SimpleUsageProviding {}
 
+protocol ClaudeCodeUsageProviding: AnyObject {
+    var hasAccess: Bool { get }
+    func fetchUsageMetrics(account: ClaudeCodeAccount) async throws -> UsageMetrics
+}
+
+extension ClaudeCodeLocalService: ClaudeCodeUsageProviding {}
+
 protocol CodexUsageProviding: AnyObject {
     func canAccess(account: CodexAccount) async -> Bool
     func fetchUsageMetrics(account: CodexAccount) async throws -> UsageMetrics
@@ -50,7 +57,7 @@ class UsageDataManager: ObservableObject {
         }
     }
 
-    private let claudeCodeService: ClaudeCodeLocalService
+    private let claudeCodeService: ClaudeCodeUsageProviding
     private let cursorService: SimpleUsageProviding
     private let codexCliService: CodexUsageProviding
     private let openRouterService: SimpleUsageProviding
@@ -76,7 +83,7 @@ class UsageDataManager: ObservableObject {
         cursorService: SimpleUsageProviding = CursorLocalService.shared,
         openRouterService: SimpleUsageProviding = OpenRouterService.shared,
         grokService: SimpleUsageProviding = GrokCLIUsageService.shared,
-        claudeCodeService: ClaudeCodeLocalService = .shared,
+        claudeCodeService: ClaudeCodeUsageProviding = ClaudeCodeLocalService.shared,
         claudeCodeAccountStore: ClaudeCodeAccountStore? = nil,
         codexAccountStore: CodexAccountStore? = nil,
         providerVisibilityStore: ProviderVisibilityStore? = nil,
@@ -111,7 +118,7 @@ class UsageDataManager: ObservableObject {
 
         // Fetch Claude Code metrics (local files)
         let hasEnabledClaudeAccount = !claudeCodeAccountStore.enabledAccounts.isEmpty
-        if providerVisibilityStore.isEnabled(.claudeCode), hasEnabledClaudeAccount, claudeCodeService.hasAccess {
+        if providerVisibilityStore.isEnabled(.claudeCode), hasEnabledClaudeAccount {
             let accountMetrics = await fetchClaudeCodeAccountMetrics()
             claudeCodeAccountMetrics = accountMetrics
 
@@ -251,7 +258,6 @@ class UsageDataManager: ObservableObject {
     private func refreshedMetrics(for service: ServiceType) async throws -> UsageMetrics {
         switch service {
         case .claudeCode:
-            guard claudeCodeService.hasAccess else { throw ServiceError.notAuthenticated }
             let accountMetrics = await fetchClaudeCodeAccountMetrics()
             claudeCodeAccountMetrics = accountMetrics
             if let representative = representativeClaudeCodeMetrics(from: accountMetrics) { return representative }

--- a/MeterBarTests/ProviderParseHealthTests.swift
+++ b/MeterBarTests/ProviderParseHealthTests.swift
@@ -5,14 +5,21 @@ import XCTest
 final class ProviderParseHealthTests: XCTestCase {
     private var suiteName: String!
     private var defaults: UserDefaults!
+    private var tempDirectory: URL!
 
     override func setUpWithError() throws {
         suiteName = "ProviderParseHealthTests-\(UUID().uuidString)"
         defaults = UserDefaults(suiteName: suiteName)
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ProviderParseHealthTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
     }
 
     override func tearDownWithError() throws {
         defaults.removePersistentDomain(forName: suiteName)
+        if let tempDirectory {
+            try? FileManager.default.removeItem(at: tempDirectory)
+        }
     }
 
     func testParseMismatchNeedsAttentionOnlyAfterConsecutiveMismatchesAndPersists() {
@@ -90,5 +97,31 @@ final class ProviderParseHealthTests: XCTestCase {
         XCTAssertFalse(record.needsAttention(now: now + ProviderParseHealthRecord.staleAfter - 1))
         XCTAssertTrue(record.needsAttention(now: now + ProviderParseHealthRecord.staleAfter + 1))
         XCTAssertEqual(ProviderParseHealthRecord.staleAfter, 2 * 60 * 60)
+    }
+
+    func testSharedFileWinsOverDivergentCLIPreferenceDomain() throws {
+        let now = Date(timeIntervalSince1970: 40_000)
+        let staleSuite = "ProviderParseHealthTests-stale-\(UUID().uuidString)"
+        let staleDefaults = try XCTUnwrap(UserDefaults(suiteName: staleSuite))
+        defer { staleDefaults.removePersistentDomain(forName: staleSuite) }
+
+        let staleStore = ProviderParseHealthStore(userDefaults: staleDefaults)
+        staleStore.recordSuccess(.codexCli, at: now.addingTimeInterval(-10_000))
+
+        let appStore = ProviderParseHealthStore(
+            userDefaults: defaults,
+            sharedDirectoryOverride: tempDirectory
+        )
+        appStore.recordSuccess(.codexCli, at: now)
+        appStore.flushPendingWrites()
+
+        let sharedFileURL = tempDirectory
+            .appendingPathComponent("\(SharedMetricsStore.parseHealthKey).json")
+        let records = ProviderParseHealthStore.sharedRecords(
+            fileURL: sharedFileURL,
+            fallbackUserDefaults: staleDefaults
+        )
+
+        XCTAssertEqual(records[.codexCli]?.lastSuccess, now)
     }
 }

--- a/MeterBarTests/ProviderReadinessInspectorTests.swift
+++ b/MeterBarTests/ProviderReadinessInspectorTests.swift
@@ -99,7 +99,10 @@ final class ProviderReadinessInspectorTests: XCTestCase {
     }
 
     func testSafeNetworkMessagesPassThrough() {
-        XCTAssertEqual(ProviderReadinessInspector.sanitize(.apiError("No internet connection")), "No internet connection")
+        XCTAssertEqual(
+            ProviderReadinessInspector.sanitize(.apiError("No internet connection")),
+            "No internet connection"
+        )
         XCTAssertEqual(ProviderReadinessInspector.sanitize(.apiError("Request timed out")), "Request timed out")
         XCTAssertEqual(
             ProviderReadinessInspector.sanitize(.apiError("Secure connection failed")),
@@ -133,6 +136,53 @@ final class ProviderReadinessInspectorTests: XCTestCase {
         XCTAssertEqual(check?.level, .fail)
         XCTAssertTrue(check?.detail.contains("format") ?? false)
         XCTAssertTrue(check?.detail.contains("2 hours") ?? false)
+    }
+
+    func testFreshPayloadSupersedesOlderParseHealthTimestamp() {
+        let now = Date(timeIntervalSince1970: 50_000)
+        let record = ProviderParseHealthRecord.success(
+            provider: .codexCli,
+            at: now.addingTimeInterval(-ProviderParseHealthRecord.staleAfter - 1)
+        )
+        let metrics = UsageMetrics(
+            service: .codexCli,
+            lastUpdated: now.addingTimeInterval(-60)
+        )
+
+        let reports = ProviderReadinessInspector.reports(
+            providers: [.codexCli],
+            now: now,
+            parseHealth: [.codexCli: record],
+            cachedMetrics: [.codexCli: metrics]
+        )
+
+        XCTAssertEqual(reports.first?.check(ReadinessCheckID.parseHealth)?.level, .pass)
+    }
+
+    func testPersistedFailureReplacesContradictoryNoErrorRefreshCheck() {
+        let now = Date(timeIntervalSince1970: 60_000)
+        let metrics = UsageMetrics(
+            service: .claudeCode,
+            lastUpdated: now.addingTimeInterval(-ProviderParseHealthRecord.staleAfter - 60)
+        )
+        let record = ProviderParseHealthRecord(
+            provider: .claudeCode,
+            lastSuccess: metrics.lastUpdated,
+            lastAttempt: now.addingTimeInterval(-60),
+            consecutiveFailures: 1,
+            lastFailureWasShapeMismatch: false
+        )
+
+        let reports = ProviderReadinessInspector.reports(
+            providers: [.claudeCode],
+            now: now,
+            parseHealth: [.claudeCode: record],
+            cachedMetrics: [.claudeCode: metrics]
+        )
+        let refresh = reports.first?.check(ReadinessCheckID.refresh)
+
+        XCTAssertEqual(refresh?.level, .warn)
+        XCTAssertTrue(refresh?.detail.contains("latest recorded refresh failed") ?? false)
     }
 
     func testHttpStatusExtraction() {

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -7,10 +7,26 @@ import XCTest
 /// Orchestration coverage for `UsageDataManager.refreshAll` / `refresh(service:)`
 /// — merge, graceful degradation on fetch failure, disabled-provider handling —
 /// driven through the provider seam so no network or local credentials are
-/// touched. Claude Code is hidden in every scenario (its account-aware path is
-/// out of scope here), leaving Codex + Cursor as the single-account providers.
+/// touched. Most scenarios hide Claude Code; focused coverage injects its
+/// account-aware provider seam directly.
 @MainActor
 final class UsageDataManagerTests: XCTestCase {
+    private final class StubClaudeProvider: ClaudeCodeUsageProviding {
+        var hasAccess: Bool
+        var result: Result<UsageMetrics, Error>
+        private(set) var fetchCount = 0
+
+        init(hasAccess: Bool, result: Result<UsageMetrics, Error>) {
+            self.hasAccess = hasAccess
+            self.result = result
+        }
+
+        func fetchUsageMetrics(account: ClaudeCodeAccount) async throws -> UsageMetrics {
+            fetchCount += 1
+            return try result.get()
+        }
+    }
+
     /// Stub provider whose access flag and fetch result are fully controlled.
     private final class StubProvider: SimpleUsageProviding, CodexUsageProviding {
         var hasAccess: Bool
@@ -83,6 +99,8 @@ final class UsageDataManagerTests: XCTestCase {
     private func makeManager(
         codex: CodexUsageProviding,
         cursor: StubProvider,
+        claude: ClaudeCodeUsageProviding? = nil,
+        claudeCodeAccountStore: ClaudeCodeAccountStore? = nil,
         codexAccountStore: CodexAccountStore? = nil,
         hidden: Set<ServiceType> = [],
         preload: [ServiceType: UsageMetrics] = [:],
@@ -99,7 +117,8 @@ final class UsageDataManagerTests: XCTestCase {
         }
 
         let visibility = ProviderVisibilityStore(userDefaults: visibilityDefaults)
-        for service in hidden.union([.claudeCode]) {
+        let hiddenProviders = claude == nil ? hidden.union([.claudeCode]) : hidden
+        for service in hiddenProviders {
             visibility.set(service, isEnabled: false)
         }
 
@@ -108,6 +127,8 @@ final class UsageDataManagerTests: XCTestCase {
         let manager = UsageDataManager(
             codexCliService: codex,
             cursorService: cursor,
+            claudeCodeService: claude ?? ClaudeCodeLocalService.shared,
+            claudeCodeAccountStore: claudeCodeAccountStore,
             codexAccountStore: codexAccountStore,
             providerVisibilityStore: visibility,
             sharedStore: sharedStore,
@@ -150,6 +171,31 @@ final class UsageDataManagerTests: XCTestCase {
         // The merged snapshot is mirrored to the App Group file for the widget.
         sharedStore.flushPendingWrites()
         XCTAssertEqual(Set(sharedStore.loadMetrics().keys), [.codexCli, .cursor])
+    }
+
+    func testRefreshAllRetriesEnabledClaudeWhenPublishedAccessIsFalse() async throws {
+        let accountSuite = "UsageDataManagerTests-claude-accounts-\(UUID().uuidString)"
+        createdSuiteNames.append(accountSuite)
+        let accountDefaults = try XCTUnwrap(UserDefaults(suiteName: accountSuite))
+        let accountStore = ClaudeCodeAccountStore(userDefaults: accountDefaults)
+        let refreshed = MetricsFixtures.claudeCode(sessionUsedPercent: 7)
+        let claude = StubClaudeProvider(hasAccess: false, result: .success(refreshed))
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+        let (manager, sharedStore) = makeManager(
+            codex: codex,
+            cursor: cursor,
+            claude: claude,
+            claudeCodeAccountStore: accountStore,
+            hidden: [.codexCli, .cursor, .openRouter, .grok]
+        )
+
+        await manager.refreshAll()
+
+        XCTAssertEqual(claude.fetchCount, 1)
+        XCTAssertEqual(manager.metrics[.claudeCode]?.sessionLimit?.used, 7)
+        sharedStore.flushPendingWrites()
+        XCTAssertEqual(sharedStore.loadMetrics()[.claudeCode]?.sessionLimit?.used, 7)
     }
 
     func testChangingRefreshIntervalPublishesToObservers() {

--- a/Packages/MeterBarShared/Sources/MeterBarShared/SharedMetricsStore.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/SharedMetricsStore.swift
@@ -19,6 +19,7 @@ public enum SharedMetricsStore {
     /// in-process UserDefaults cache key (see `StorageKeys.cachedUsageMetrics`).
     public static let metricsKey = "cached_usage_metrics"
     public static let accountMetricsKey = "cached_usage_account_metrics"
+    public static let parseHealthKey = "provider_parse_health_v1"
 
     /// The shared App Group container, or `nil` when App Groups aren't
     /// provisioned for the running target.
@@ -33,6 +34,10 @@ public enum SharedMetricsStore {
 
     public static var accountMetricsFileURL: URL? {
         containerURL?.appendingPathComponent("\(accountMetricsKey).json")
+    }
+
+    public static var parseHealthFileURL: URL? {
+        containerURL?.appendingPathComponent("\(parseHealthKey).json")
     }
 
     /// Decode the cached metrics, tolerating a missing file or malformed entries


### PR DESCRIPTION
## Summary

- retry every enabled Claude profile through the authoritative fetch path even when a prior failure set the published access flag false
- mirror provider parse-health records to an explicit atomic App Group file so the GUI and bundled CLI read the same cross-process state
- reconcile diagnostics against the cached payload's actual `lastUpdated` and surface persisted refresh failures instead of contradictory "no recent errors" copy

## Root cause

A transient Claude refresh failure set `ClaudeCodeLocalService.hasAccess` to false. `UsageDataManager` then treated that published UI state as a pre-fetch gate, so later timer ticks never retried Claude and its cached payload aged indefinitely.

Provider health had a separate cross-process fault: the app wrote `UserDefaults(suiteName:)` in the App Group preferences domain, while the unentitled bundled CLI resolved the ordinary preferences domain for the same suite identifier. Live reproduction showed a newly refreshed Codex metrics payload alongside a stale health record, so `meterbar doctor --json` incorrectly warned that Codex was older than two hours.

## Overlap

PR #227 remains the owner of ten-minute resident scheduling, overlap protection, and sleep/wake catch-up. This PR fixes the independent provider retry and app/CLI diagnostic-state faults without adding a `meterbar refresh` subcommand and without invoking reset-credit behavior. Related: #211, #237.

## Verification

- `swiftlint lint --strict --quiet` on all changed Swift and test files
- `git diff --check`
- live installed `meterbar doctor --json` / `meterbar usage --json` diagnosis plus direct inspection of the App Group metrics and preferences timestamps

## CI gate

Local Swift tests, typechecks, and Xcode builds were intentionally skipped per the MacBook safety policy. GitHub Actions is the execution gate for focused tests, coverage, lint, secret scan, and app/widget/CLI builds.
