### PR TITLE
fix(refresh): let CLI read app group metrics

### DIFF
--- a/.agents/SESSIONS/2026-07-19.md
+++ b/.agents/SESSIONS/2026-07-19.md
@@ -81,3 +81,42 @@ flowchart LR
 
 - [ ] Publish a ready-for-review pull request.
 - [ ] Confirm tests, coverage, lint, secret scan, and app/widget/CLI builds in CI.
+
+## Session 2: Restore CLI access to refreshed app metrics
+
+**Status:** Implementation complete; PR CI pending
+
+### Root cause
+
+- The app refreshed Claude and Codex successfully, but a locally built CLI has
+  no App Group entitlement. Its call to
+  `containerURL(forSecurityApplicationGroupIdentifier:)` returned `nil`, so
+  `meterbar usage --json` could not read the app's newly written metrics file.
+- During live verification, the per-user `cfprefsd` process also wedged on an
+  unrelated Session Wake preference write. Restarting that daemon restored
+  normal app startup; no product workaround for the environmental fault was
+  retained.
+
+### What was done
+
+- Kept the entitlement-resolved App Group container as the preferred location.
+- Added a fallback to the existing canonical
+  `~/Library/Group Containers/group.dev.meterbar.app` directory for
+  non-sandboxed local builds and the installed CLI.
+- Refused to create or assume a missing fallback directory.
+- Added focused resolver coverage for entitlement preference, existing
+  canonical fallback, and a missing-container result.
+
+### Verification
+
+- Focused SwiftLint strict and `git diff --check` passed.
+- Explicitly requested Release app and CLI builds completed successfully.
+- The signed app refreshed the shared file, and the rebuilt CLI reported fresh
+  Claude and Codex timestamps from that file.
+- `meterbar doctor --json` now reports both Claude and Codex healthy with recent
+  successful refreshes.
+
+### Next steps
+
+- [ ] Publish and merge the focused pull request after CI passes.
+- [ ] Rebuild and reinstall the app and CLI from merged `master`.

--- a/MeterBarTests/SharedDataStoreTests.swift
+++ b/MeterBarTests/SharedDataStoreTests.swift
@@ -1,7 +1,7 @@
 import Foundation
-import MeterBarShared
 import XCTest
 @testable import MeterBar
+@testable import MeterBarShared
 
 /// Covers `SharedDataStore`'s disk I/O path — encode → atomic write → decode —
 /// which the wire-format contract tests do not exercise (they round-trip through
@@ -89,5 +89,41 @@ final class SharedDataStoreTests: XCTestCase {
         let loaded = store.loadAccountMetrics()
         XCTAssertEqual(loaded.map(\.name), ["Personal", "Work"])
         XCTAssertEqual(loaded.map { $0.metrics.sessionLimit?.used }, [30, 90])
+    }
+
+    func testSharedMetricsLocationPrefersEntitledContainer() {
+        let entitled = URL(fileURLWithPath: "/entitled/group", isDirectory: true)
+        let resolved = SharedMetricsStore.resolvedContainerURL(
+            entitledContainerURL: entitled,
+            homeDirectory: URL(fileURLWithPath: "/Users/example", isDirectory: true),
+            fileExists: { _ in false }
+        )
+
+        XCTAssertEqual(resolved, entitled)
+    }
+
+    func testSharedMetricsLocationFallsBackToExistingCanonicalGroupContainer() {
+        let home = URL(fileURLWithPath: "/Users/example", isDirectory: true)
+        let expected = home
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Group Containers", isDirectory: true)
+            .appendingPathComponent(SharedMetricsStore.appGroupIdentifier, isDirectory: true)
+        let resolved = SharedMetricsStore.resolvedContainerURL(
+            entitledContainerURL: nil,
+            homeDirectory: home,
+            fileExists: { $0 == expected.path }
+        )
+
+        XCTAssertEqual(resolved, expected)
+    }
+
+    func testSharedMetricsLocationDoesNotInventMissingGroupContainer() {
+        let resolved = SharedMetricsStore.resolvedContainerURL(
+            entitledContainerURL: nil,
+            homeDirectory: URL(fileURLWithPath: "/Users/example", isDirectory: true),
+            fileExists: { _ in false }
+        )
+
+        XCTAssertNil(resolved)
     }
 }

--- a/Packages/MeterBarShared/Sources/MeterBarShared/SharedMetricsStore.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/SharedMetricsStore.swift
@@ -24,7 +24,35 @@ public enum SharedMetricsStore {
     /// The shared App Group container, or `nil` when App Groups aren't
     /// provisioned for the running target.
     public static var containerURL: URL? {
-        FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)
+        let fileManager = FileManager.default
+        return resolvedContainerURL(
+            entitledContainerURL: fileManager.containerURL(
+                forSecurityApplicationGroupIdentifier: appGroupIdentifier
+            ),
+            homeDirectory: fileManager.homeDirectoryForCurrentUser,
+            fileExists: fileManager.fileExists(atPath:)
+        )
+    }
+
+    /// Non-sandboxed local builds can carry the App Group entitlement while
+    /// `containerURL(forSecurityApplicationGroupIdentifier:)` still returns
+    /// `nil`. The app and bundled CLI must keep using the same existing
+    /// container in that case or successful provider refreshes remain trapped
+    /// in the app's private preferences cache.
+    static func resolvedContainerURL(
+        entitledContainerURL: URL?,
+        homeDirectory: URL,
+        fileExists: (String) -> Bool
+    ) -> URL? {
+        if let entitledContainerURL {
+            return entitledContainerURL
+        }
+
+        let fallback = homeDirectory
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Group Containers", isDirectory: true)
+            .appendingPathComponent(appGroupIdentifier, isDirectory: true)
+        return fileExists(fallback.path) ? fallback : nil
     }
 
     /// URL of the cached-metrics JSON file inside the shared container.


### PR DESCRIPTION
## Summary
- fall back to the existing canonical App Group container when a non-entitled local CLI cannot resolve it through FileManager
- preserve entitlement resolution as the preferred path and never invent a missing container
- cover entitled, fallback, and missing-container behavior

## Verification
- focused SwiftLint strict passed
- git diff --check passed
- explicitly requested Release app and CLI builds succeeded
- live signed app refresh produced fresh Claude and Codex metrics readable through the rebuilt CLI

Local tests were skipped per workstation policy; PR CI is the execution gate.