### PR TITLE
feat(widget): apply deterministic family rendering

### DIFF
--- a/.agents/SESSIONS/2026-07-19.md
+++ b/.agents/SESSIONS/2026-07-19.md
@@ -120,3 +120,58 @@ flowchart LR
 
 - [ ] Publish and merge the focused pull request after CI passes.
 - [ ] Rebuild and reinstall the app and CLI from merged `master`.
+
+## Session 3: Deterministic widget preference rendering
+
+**Status:** Implementation complete; PR CI pending
+
+```mermaid
+flowchart LR
+    Preferences[App Group widget preferences] --> Planner[Widget presentation planner]
+    Metrics[Provider and account snapshots] --> Planner
+    Planner --> Small[Small family budget]
+    Planner --> Medium[Medium family budget]
+    Planner --> Large[Large family budget]
+```
+
+### What was done
+
+- Added one pure shared planner for account selection, provider/urgency ordering,
+  quota-window filtering, staleness, display modes, and exact overflow counts.
+- Applied the planner to every widget family, including reset/freshness metadata,
+  non-healthy indicators, and actionable no-selection and unavailable states.
+- Bridged enabled Claude account snapshots into the existing shared account cache
+  and persisted their per-account fallback data across launches.
+- Kept the legacy OpenRouter remaining-balance text until the user explicitly
+  chooses a display mode.
+- Added focused regression coverage for all family budgets, detail-aware layout,
+  ordering and display modes, selected windows, stale/missing data, overflow,
+  and multi-account cache recovery.
+
+### Decisions
+
+- **Pure presentation policy:** WidgetKit views render planner output rather than
+  independently selecting or sorting rows.
+  - **Rationale:** One deterministic policy prevents family-specific drift and is
+    directly testable without WidgetKit or new network access.
+- **One unavailable placeholder per missing account:** Missing account data does
+  not manufacture a row for every selected quota window.
+  - **Rationale:** Unavailable placeholders stay honest without hiding healthy
+    accounts behind artificial overflow.
+- **Detail-aware row budgets:** Reset/freshness metadata lowers medium and large
+  row capacity.
+  - **Rationale:** Metadata remains visible without clipping system family layouts.
+
+### Verification
+
+- Repository and explicit changed-file SwiftLint strict checks passed with zero
+  violations.
+- `git diff --check` passed.
+- Local Swift tests, typechecks, and builds were skipped per the MacBook policy;
+  PR CI is the execution gate.
+- SwiftFormat is unavailable locally.
+
+### Next steps
+
+- [ ] Publish the ready-for-review pull request for #218.
+- [ ] Confirm app, widget, package, and focused test coverage in CI.

--- a/.agents/SESSIONS/2026-07-19.md
+++ b/.agents/SESSIONS/2026-07-19.md
@@ -171,6 +171,13 @@ flowchart LR
   PR CI is the execution gate.
 - SwiftFormat is unavailable locally.
 
+### Mistakes and fixes
+
+- **Mistake:** The first CI compile could not infer `ServiceType` for several
+  shorthand dictionary keys in the new presentation tests.
+- **Fix:** Added explicit `[ServiceType: UsageMetrics]` annotations to those
+  fixtures and republished the branch.
+
 ### Next steps
 
 - [ ] Publish the ready-for-review pull request for #218.

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -44,6 +44,8 @@ nonisolated enum StorageKeys {
     static let claudeCodeDefaultAccountEnabled = "ClaudeCodeDefaultAccountEnabled"
     /// Persisted account display order (array of UUID strings).
     static let claudeCodeAccountOrder = "ClaudeCodeAccountOrder"
+    /// Cached per-account Claude Code metrics (JSON-encoded [UUID: UsageMetrics]).
+    static let cachedClaudeCodeAccountMetrics = "CachedClaudeCodeAccountMetrics"
     /// Extra Codex CLI account profiles (JSON-encoded [CodexAccount]).
     static let codexCustomAccounts = "CodexCustomAccounts"
     /// User-chosen display name for the default Codex CLI profile.

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -107,7 +107,7 @@ class UsageDataManager: ObservableObject {
         self.parseHealthStore = parseHealthStore ?? .shared
         refreshIntervalRaw = Self.savedRefreshInterval(in: preferences).rawValue
         loadCachedData()
-        loadCachedCodexAccountMetrics()
+        loadCachedAccountMetrics()
         if schedulesAutoRefresh {
             setupAutoRefresh()
         }
@@ -173,7 +173,7 @@ class UsageDataManager: ObservableObject {
 
         metrics = newMetrics
         saveCachedData()
-        saveCachedCodexAccountMetrics()
+        saveCachedAccountMetrics()
         saveSharedData(newMetrics)
     }
 
@@ -191,7 +191,7 @@ class UsageDataManager: ObservableObject {
                 codexAccountMetrics = [:]
             }
             saveCachedData()
-            saveCachedCodexAccountMetrics()
+            saveCachedAccountMetrics()
             saveSharedData(metrics)
             return
         }
@@ -200,6 +200,7 @@ class UsageDataManager: ObservableObject {
             claudeCodeAccountMetrics = [:]
             metrics.removeValue(forKey: service)
             saveCachedData()
+            saveCachedAccountMetrics()
             saveSharedData(metrics)
             return
         }
@@ -208,7 +209,7 @@ class UsageDataManager: ObservableObject {
             codexAccountMetrics = [:]
             metrics.removeValue(forKey: service)
             saveCachedData()
-            saveCachedCodexAccountMetrics()
+            saveCachedAccountMetrics()
             saveSharedData(metrics)
             return
         }
@@ -218,7 +219,7 @@ class UsageDataManager: ObservableObject {
 
             metrics[service] = newMetrics
             saveCachedData()
-            saveCachedCodexAccountMetrics()
+            saveCachedAccountMetrics()
             saveSharedData(metrics)
         } catch {
             if lastError == nil {
@@ -231,7 +232,7 @@ class UsageDataManager: ObservableObject {
                 // different profile's stale quota.
                 metrics.removeValue(forKey: service)
                 saveCachedData()
-                saveCachedCodexAccountMetrics()
+                saveCachedAccountMetrics()
                 saveSharedData(metrics)
             } else if metrics[service] == nil {
                 // Preserve existing cached metrics for single-account services.
@@ -261,7 +262,7 @@ class UsageDataManager: ObservableObject {
         }
         lastError = nil
         saveCachedData()
-        saveCachedCodexAccountMetrics()
+        saveCachedAccountMetrics()
         saveSharedData(metrics)
     }
 
@@ -314,23 +315,37 @@ class UsageDataManager: ObservableObject {
         }
     }
 
-    private func loadCachedCodexAccountMetrics() {
-        guard let data = cacheDefaults.data(forKey: StorageKeys.cachedCodexAccountMetrics),
-              let decoded = try? JSONDecoder().decode([UUID: UsageMetrics].self, from: data) else { return }
-        codexAccountMetrics = decoded
+    private func loadCachedAccountMetrics() {
+        if let data = cacheDefaults.data(forKey: StorageKeys.cachedClaudeCodeAccountMetrics),
+           let decoded = try? JSONDecoder().decode([UUID: UsageMetrics].self, from: data) {
+            claudeCodeAccountMetrics = decoded
+        }
+        if let data = cacheDefaults.data(forKey: StorageKeys.cachedCodexAccountMetrics),
+           let decoded = try? JSONDecoder().decode([UUID: UsageMetrics].self, from: data) {
+            codexAccountMetrics = decoded
+        }
     }
 
-    private func saveCachedCodexAccountMetrics() {
-        guard let data = try? JSONEncoder().encode(codexAccountMetrics) else { return }
-        cacheDefaults.set(data, forKey: StorageKeys.cachedCodexAccountMetrics)
+    private func saveCachedAccountMetrics() {
+        if let data = try? JSONEncoder().encode(claudeCodeAccountMetrics) {
+            cacheDefaults.set(data, forKey: StorageKeys.cachedClaudeCodeAccountMetrics)
+        }
+        if let data = try? JSONEncoder().encode(codexAccountMetrics) {
+            cacheDefaults.set(data, forKey: StorageKeys.cachedCodexAccountMetrics)
+        }
     }
 
     private func saveSharedData(_ metrics: [ServiceType: UsageMetrics]) {
         sharedStore.saveMetrics(metrics)
-        let accountSnapshots = codexAccountStore.enabledAccounts.compactMap { account -> AccountUsageSnapshot? in
+        let claudeSnapshots = claudeCodeAccountStore.enabledAccounts.compactMap { account -> AccountUsageSnapshot? in
+            guard let metrics = claudeCodeAccountMetrics[account.id] else { return nil }
+            return AccountUsageSnapshot(id: account.id, name: account.name, metrics: metrics)
+        }
+        let codexSnapshots = codexAccountStore.enabledAccounts.compactMap { account -> AccountUsageSnapshot? in
             guard let metrics = codexAccountMetrics[account.id] else { return nil }
             return AccountUsageSnapshot(id: account.id, name: account.name, metrics: metrics)
         }
+        let accountSnapshots = claudeSnapshots + codexSnapshots
         sharedStore.saveAccountMetrics(accountSnapshots)
     }
 

--- a/MeterBar/Views/Components/ProviderCardInteraction.swift
+++ b/MeterBar/Views/Components/ProviderCardInteraction.swift
@@ -176,6 +176,7 @@ enum ProviderCardCommands {
             },
             hide: { service in
                 ProviderVisibilityStore.shared.set(service, isEnabled: false)
+                Task { await UsageDataManager.shared.refresh(service: service) }
             },
             openInDashboard: openInDashboard ?? {
                 UsageDashboardWindowController.shared.show(

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -117,6 +117,7 @@ final class UsageDataManagerTests: XCTestCase {
         codexAccountStore: CodexAccountStore? = nil,
         hidden: Set<ServiceType> = [],
         preload: [ServiceType: UsageMetrics] = [:],
+        preloadClaudeAccountMetrics: [UUID: UsageMetrics] = [:],
         savedRefreshInterval: RefreshInterval? = nil,
         parseHealthStore: ProviderParseHealthStore? = nil,
         schedulesAutoRefresh: Bool = false
@@ -129,6 +130,10 @@ final class UsageDataManagerTests: XCTestCase {
         }
         if !preload.isEmpty, let data = MetricsCodec.encode(preload) {
             cacheDefaults.set(data, forKey: StorageKeys.cachedUsageMetrics)
+        }
+        if !preloadClaudeAccountMetrics.isEmpty,
+           let data = try? JSONEncoder().encode(preloadClaudeAccountMetrics) {
+            cacheDefaults.set(data, forKey: StorageKeys.cachedClaudeCodeAccountMetrics)
         }
         if let savedRefreshInterval {
             cacheDefaults.set(savedRefreshInterval.rawValue, forKey: StorageKeys.refreshInterval)
@@ -215,6 +220,70 @@ final class UsageDataManagerTests: XCTestCase {
         XCTAssertEqual(manager.metrics[.claudeCode]?.sessionLimit?.used, 7)
         sharedStore.flushPendingWrites()
         XCTAssertEqual(sharedStore.loadMetrics()[.claudeCode]?.sessionLimit?.used, 7)
+    }
+
+    func testRefreshAllBridgesEveryEnabledClaudeAccountToWidgetData() async throws {
+        let accountSuite = "UsageDataManagerTests-claude-widget-accounts-\(UUID().uuidString)"
+        createdSuiteNames.append(accountSuite)
+        let accountDefaults = try XCTUnwrap(UserDefaults(suiteName: accountSuite))
+        let accountStore = ClaudeCodeAccountStore(userDefaults: accountDefaults)
+        accountStore.addAccount(name: "Work", configDirectory: "/tmp/claude-work")
+        let work = try XCTUnwrap(accountStore.customAccounts.first)
+        let refreshed = MetricsFixtures.claudeCode(sessionUsedPercent: 17)
+        let claude = StubClaudeProvider(hasAccess: true, result: .success(refreshed))
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+        let (manager, sharedStore) = makeManager(
+            codex: codex,
+            cursor: cursor,
+            claude: claude,
+            claudeCodeAccountStore: accountStore,
+            hidden: [.codexCli, .cursor, .openRouter, .grok]
+        )
+
+        await manager.refreshAll()
+
+        XCTAssertEqual(Set(manager.claudeCodeAccountMetrics.keys), [ClaudeCodeAccount.defaultID, work.id])
+        sharedStore.flushPendingWrites()
+        XCTAssertEqual(
+            sharedStore.loadAccountMetrics().map(\.id),
+            [ClaudeCodeAccount.defaultID, work.id]
+        )
+        XCTAssertEqual(
+            sharedStore.loadAccountMetrics().map(\.name),
+            [ClaudeCodeAccount.defaultName, "Work"]
+        )
+    }
+
+    func testRefreshAllRestoresClaudeAccountCacheAfterRelaunchAndTransientFailure() async throws {
+        let accountSuite = "UsageDataManagerTests-claude-cache-\(UUID().uuidString)"
+        createdSuiteNames.append(accountSuite)
+        let accountDefaults = try XCTUnwrap(UserDefaults(suiteName: accountSuite))
+        let accountStore = ClaudeCodeAccountStore(userDefaults: accountDefaults)
+        let cached = MetricsFixtures.claudeCode(sessionUsedPercent: 23)
+        let claude = StubClaudeProvider(hasAccess: true, result: .failure(StubError.fetchFailed))
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+        let (manager, sharedStore) = makeManager(
+            codex: codex,
+            cursor: cursor,
+            claude: claude,
+            claudeCodeAccountStore: accountStore,
+            hidden: [.codexCli, .cursor, .openRouter, .grok],
+            preloadClaudeAccountMetrics: [ClaudeCodeAccount.defaultID: cached]
+        )
+
+        await manager.refreshAll()
+
+        XCTAssertEqual(
+            manager.claudeCodeAccountMetrics[ClaudeCodeAccount.defaultID]?.sessionLimit?.used,
+            23
+        )
+        sharedStore.flushPendingWrites()
+        XCTAssertEqual(
+            sharedStore.loadAccountMetrics().first?.metrics.sessionLimit?.used,
+            23
+        )
     }
 
     func testChangingRefreshIntervalPublishesToObservers() {

--- a/MeterBarTests/WidgetPreferencesStoreTests.swift
+++ b/MeterBarTests/WidgetPreferencesStoreTests.swift
@@ -28,6 +28,7 @@ final class WidgetPreferencesStoreTests: XCTestCase {
         XCTAssertFalse(store.preferences.showsResetTime)
         XCTAssertFalse(store.preferences.showsFreshness)
         XCTAssertEqual(store.preferences.accountOrdering, .provider)
+        XCTAssertTrue(store.preferences.preservesLegacyOpenRouterBalance)
     }
 
     func testPreferencesPersistAcrossRelaunch() {
@@ -37,7 +38,7 @@ final class WidgetPreferencesStoreTests: XCTestCase {
 
         store.setSelectedAccounts([claude, codex])
         store.setDisplayMode(.remaining)
-        store.setVisibleQuotaWindows([.session, .weekly])
+        store.setVisibleQuotaWindows([.session, .weekly, .codeReview])
         store.setShowsResetTime(true)
         store.setShowsFreshness(true)
         store.setAccountOrdering(.urgency)
@@ -46,10 +47,11 @@ final class WidgetPreferencesStoreTests: XCTestCase {
 
         XCTAssertEqual(reloaded.preferences.accountSelection.explicitIdentifiers, [claude, codex])
         XCTAssertEqual(reloaded.preferences.displayMode, .remaining)
-        XCTAssertEqual(reloaded.preferences.visibleQuotaWindows, [.session, .weekly])
+        XCTAssertEqual(reloaded.preferences.visibleQuotaWindows, [.session, .weekly, .codeReview])
         XCTAssertTrue(reloaded.preferences.showsResetTime)
         XCTAssertTrue(reloaded.preferences.showsFreshness)
         XCTAssertEqual(reloaded.preferences.accountOrdering, .urgency)
+        XCTAssertFalse(reloaded.preferences.preservesLegacyOpenRouterBalance)
     }
 
     func testSelectAllAutomaticallyIncludesNewEnabledAccounts() {
@@ -152,6 +154,20 @@ final class WidgetPreferencesStoreTests: XCTestCase {
         XCTAssertEqual(reloadCount, 7)
     }
 
+    func testChoosingUsedModeDisablesLegacyOpenRouterBalanceAndReloads() {
+        var reloadCount = 0
+        let store = WidgetPreferencesStore(userDefaults: defaults) {
+            reloadCount += 1
+        }
+
+        store.setDisplayMode(.used)
+
+        XCTAssertEqual(store.preferences.displayMode, .used)
+        XCTAssertFalse(store.preferences.preservesLegacyOpenRouterBalance)
+        XCTAssertEqual(reloadCount, 1)
+        XCTAssertFalse(makeStore().preferences.preservesLegacyOpenRouterBalance)
+    }
+
     func testStableIdentifiersIncludeProviderAndAccountIdentity() {
         let accountID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9))
 
@@ -163,6 +179,12 @@ final class WidgetPreferencesStoreTests: XCTestCase {
             WidgetAccountIdentifier.account(service: .claudeCode, id: accountID).rawValue,
             "account:Claude Code:00000000-0000-0000-0000-000000000009"
         )
+        XCTAssertEqual(WidgetAccountIdentifier.provider(.cursor).service, .cursor)
+        XCTAssertEqual(
+            WidgetAccountIdentifier.account(service: .claudeCode, id: accountID).service,
+            .claudeCode
+        )
+        XCTAssertNil(WidgetAccountIdentifier(rawValue: "removed").service)
     }
 
     func testOlderEncodedPreferencesUseDefaultsForMissingFields() throws {

--- a/MeterBarTests/WidgetPresentationTests.swift
+++ b/MeterBarTests/WidgetPresentationTests.swift
@@ -105,7 +105,9 @@ final class WidgetPresentationTests: XCTestCase {
     }
 
     func testUsedAndRemainingModesProduceComplementaryValues() throws {
-        let metrics = [.claudeCode: makeMetrics(.claudeCode, weeklyUsed: 25)]
+        let metrics: [ServiceType: UsageMetrics] = [
+            .claudeCode: makeMetrics(.claudeCode, weeklyUsed: 25)
+        ]
         var usedPreferences = WidgetPreferences.defaults
         usedPreferences.displayMode = .used
         var remainingPreferences = usedPreferences
@@ -126,7 +128,9 @@ final class WidgetPresentationTests: XCTestCase {
     }
 
     func testOpenRouterDefaultsToLegacyRemainingBalanceUntilDisplayModeIsChosen() throws {
-        let metrics = [.openRouter: makeMetrics(.openRouter, weeklyUsed: 25)]
+        let metrics: [ServiceType: UsageMetrics] = [
+            .openRouter: makeMetrics(.openRouter, weeklyUsed: 25)
+        ]
         let legacy = try XCTUnwrap(presentation(metrics: metrics).rows.first)
         var explicitlyUsed = WidgetPreferences.defaults
         explicitlyUsed.preservesLegacyOpenRouterBalance = false
@@ -147,7 +151,7 @@ final class WidgetPresentationTests: XCTestCase {
     func testSelectedQuotaWindowsUseStableOrderAndIgnoreUnavailableWindows() {
         var preferences = WidgetPreferences.defaults
         preferences.visibleQuotaWindows = [.codeReview, .weekly, .session]
-        let metrics = [
+        let metrics: [ServiceType: UsageMetrics] = [
             .claudeCode: makeMetrics(
                 .claudeCode,
                 sessionUsed: 10,
@@ -177,7 +181,7 @@ final class WidgetPresentationTests: XCTestCase {
 
     func testResetAndFreshnessMetadataObeyIndependentToggles() throws {
         let resetTime = now.addingTimeInterval(600)
-        let metrics = [
+        let metrics: [ServiceType: UsageMetrics] = [
             .claudeCode: makeMetrics(
                 .claudeCode,
                 weeklyUsed: 25,
@@ -203,14 +207,14 @@ final class WidgetPresentationTests: XCTestCase {
 
     func testStalenessBoundaryIsHealthyAndOneSecondOlderIsStale() throws {
         let threshold: TimeInterval = 3_600
-        let atBoundary = [
+        let atBoundary: [ServiceType: UsageMetrics] = [
             .claudeCode: makeMetrics(
                 .claudeCode,
                 weeklyUsed: 25,
                 lastUpdated: now.addingTimeInterval(-threshold)
             )
         ]
-        let older = [
+        let older: [ServiceType: UsageMetrics] = [
             .claudeCode: makeMetrics(
                 .claudeCode,
                 weeklyUsed: 25,
@@ -316,7 +320,9 @@ final class WidgetPresentationTests: XCTestCase {
     func testAccountSnapshotsReplaceAggregateProviderRowAndPreserveNames() {
         let firstID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1))
         let secondID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2))
-        let aggregate = [.claudeCode: makeMetrics(.claudeCode, weeklyUsed: 90)]
+        let aggregate: [ServiceType: UsageMetrics] = [
+            .claudeCode: makeMetrics(.claudeCode, weeklyUsed: 90)
+        ]
         let accounts = [
             AccountUsageSnapshot(
                 id: firstID,

--- a/MeterBarTests/WidgetPresentationTests.swift
+++ b/MeterBarTests/WidgetPresentationTests.swift
@@ -1,0 +1,388 @@
+import Foundation
+import MeterBarShared
+import XCTest
+
+final class WidgetPresentationTests: XCTestCase {
+    private let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
+
+    func testFamilyBudgetsReserveOverflowSlotAndReportExactOmittedCount() {
+        let cases: [(WidgetPresentationFamily, Int, Int, Int)] = [
+            (.small, 3, 3, 0),
+            (.small, 4, 2, 2),
+            (.medium, 3, 3, 0),
+            (.medium, 4, 2, 2),
+            (.large, 7, 7, 0),
+            (.large, 8, 6, 2)
+        ]
+
+        for (family, total, visible, hidden) in cases {
+            let budget = WidgetFamilyRowBudget.plan(totalRowCount: total, family: family)
+            XCTAssertEqual(budget.visibleRowCount, visible, "\(family) visible rows")
+            XCTAssertEqual(budget.hiddenRowCount, hidden, "\(family) hidden rows")
+        }
+
+        XCTAssertEqual(
+            WidgetFamilyRowBudget.plan(totalRowCount: -1, family: .small),
+            WidgetFamilyRowBudget(visibleRowCount: 0, hiddenRowCount: 0)
+        )
+    }
+
+    func testDetailedFamilyBudgetsLeaveRoomForMetadataAndOverflow() {
+        XCTAssertEqual(
+            WidgetFamilyRowBudget.plan(
+                totalRowCount: 3,
+                family: .medium,
+                showsDetails: true
+            ),
+            WidgetFamilyRowBudget(visibleRowCount: 2, hiddenRowCount: 1)
+        )
+        XCTAssertEqual(
+            WidgetFamilyRowBudget.plan(
+                totalRowCount: 6,
+                family: .large,
+                showsDetails: true
+            ),
+            WidgetFamilyRowBudget(visibleRowCount: 5, hiddenRowCount: 1)
+        )
+    }
+
+    func testEnabledResetDetailsDoNotReduceBudgetWhenNoRowHasResetMetadata() {
+        var preferences = WidgetPreferences.defaults
+        preferences.showsResetTime = true
+        let result = presentation(
+            metrics: [
+                .claudeCode: makeMetrics(.claudeCode, weeklyUsed: 10),
+                .codexCli: makeMetrics(.codexCli, weeklyUsed: 20),
+                .cursor: makeMetrics(.cursor, weeklyUsed: 30)
+            ],
+            preferences: preferences,
+            family: .medium
+        )
+
+        XCTAssertEqual(result.rows.count, 3)
+        XCTAssertEqual(result.hiddenRowCount, 0)
+        XCTAssertTrue(result.rows.allSatisfy { $0.resetTime == nil })
+    }
+
+    func testEveryFamilyAppliesTheSameProviderOrderingBeforeItsBudget() {
+        let metrics: [ServiceType: UsageMetrics] = [
+            .openRouter: makeMetrics(.openRouter, weeklyUsed: 40),
+            .cursor: makeMetrics(.cursor, weeklyUsed: 30),
+            .codexCli: makeMetrics(.codexCli, weeklyUsed: 20),
+            .claudeCode: makeMetrics(.claudeCode, weeklyUsed: 10)
+        ]
+        let expectedOrder: [ServiceType] = [.claudeCode, .codexCli, .cursor, .openRouter]
+
+        let small = presentation(metrics: metrics, family: .small)
+        let medium = presentation(metrics: metrics, family: .medium)
+        let large = presentation(metrics: metrics, family: .large)
+
+        XCTAssertEqual(small.rows.map(\.service), Array(expectedOrder.prefix(2)))
+        XCTAssertEqual(small.hiddenRowCount, 2)
+        XCTAssertEqual(medium.rows.map(\.service), Array(expectedOrder.prefix(2)))
+        XCTAssertEqual(medium.hiddenRowCount, 2)
+        XCTAssertEqual(large.rows.map(\.service), expectedOrder)
+        XCTAssertEqual(large.hiddenRowCount, 0)
+    }
+
+    func testUrgencyOrderingUsesOnlySelectedWindowsAndFallsBackToProviderOrder() {
+        var preferences = WidgetPreferences.defaults
+        preferences.accountOrdering = .urgency
+        preferences.visibleQuotaWindows = [.weekly]
+        let metrics: [ServiceType: UsageMetrics] = [
+            .claudeCode: makeMetrics(.claudeCode, sessionUsed: 99, weeklyUsed: 10),
+            .codexCli: makeMetrics(.codexCli, sessionUsed: 5, weeklyUsed: 80),
+            .cursor: makeMetrics(.cursor, sessionUsed: 60, weeklyUsed: 80)
+        ]
+
+        let result = presentation(
+            metrics: metrics,
+            preferences: preferences,
+            family: .large
+        )
+
+        XCTAssertEqual(result.rows.map(\.service), [.codexCli, .cursor, .claudeCode])
+    }
+
+    func testUsedAndRemainingModesProduceComplementaryValues() throws {
+        let metrics = [.claudeCode: makeMetrics(.claudeCode, weeklyUsed: 25)]
+        var usedPreferences = WidgetPreferences.defaults
+        usedPreferences.displayMode = .used
+        var remainingPreferences = usedPreferences
+        remainingPreferences.displayMode = .remaining
+
+        let used = try XCTUnwrap(
+            presentation(metrics: metrics, preferences: usedPreferences).rows.first
+        )
+        let remaining = try XCTUnwrap(
+            presentation(metrics: metrics, preferences: remainingPreferences).rows.first
+        )
+
+        XCTAssertEqual(used.progressValue, 25)
+        XCTAssertEqual(used.summaryText, "25% used")
+        XCTAssertEqual(remaining.progressValue, 75)
+        XCTAssertEqual(remaining.summaryText, "75% left")
+        XCTAssertEqual(used.progressTotal, remaining.progressTotal)
+    }
+
+    func testOpenRouterDefaultsToLegacyRemainingBalanceUntilDisplayModeIsChosen() throws {
+        let metrics = [.openRouter: makeMetrics(.openRouter, weeklyUsed: 25)]
+        let legacy = try XCTUnwrap(presentation(metrics: metrics).rows.first)
+        var explicitlyUsed = WidgetPreferences.defaults
+        explicitlyUsed.preservesLegacyOpenRouterBalance = false
+
+        let used = try XCTUnwrap(
+            presentation(metrics: metrics, preferences: explicitlyUsed).rows.first
+        )
+
+        XCTAssertEqual(legacy.displayMode, .used)
+        XCTAssertEqual(legacy.progressValue, 25)
+        XCTAssertEqual(legacy.summaryText, "$75.00 left")
+        XCTAssertEqual(legacy.compactSummaryText, "$75.00")
+        XCTAssertEqual(used.displayMode, .used)
+        XCTAssertEqual(used.summaryText, "$25.00 used")
+        XCTAssertEqual(used.compactSummaryText, "$25.00 used")
+    }
+
+    func testSelectedQuotaWindowsUseStableOrderAndIgnoreUnavailableWindows() {
+        var preferences = WidgetPreferences.defaults
+        preferences.visibleQuotaWindows = [.codeReview, .weekly, .session]
+        let metrics = [
+            .claudeCode: makeMetrics(
+                .claudeCode,
+                sessionUsed: 10,
+                weeklyUsed: 20,
+                codeReviewUsed: 30
+            ),
+            .cursor: makeMetrics(.cursor, sessionUsed: nil, weeklyUsed: 40)
+        ]
+
+        let result = presentation(
+            metrics: metrics,
+            preferences: preferences,
+            family: .large
+        )
+
+        XCTAssertEqual(
+            result.rows.map { "\($0.service.rawValue):\($0.quotaWindow.rawValue)" },
+            [
+                "Claude Code:session",
+                "Claude Code:weekly",
+                "Claude Code:codeReview",
+                "Cursor:weekly"
+            ]
+        )
+        XCTAssertEqual(result.rows[2].quotaTitle, "Sonnet")
+    }
+
+    func testResetAndFreshnessMetadataObeyIndependentToggles() throws {
+        let resetTime = now.addingTimeInterval(600)
+        let metrics = [
+            .claudeCode: makeMetrics(
+                .claudeCode,
+                weeklyUsed: 25,
+                resetTime: resetTime
+            )
+        ]
+
+        for showsReset in [false, true] {
+            for showsFreshness in [false, true] {
+                var preferences = WidgetPreferences.defaults
+                preferences.showsResetTime = showsReset
+                preferences.showsFreshness = showsFreshness
+
+                let row = try XCTUnwrap(
+                    presentation(metrics: metrics, preferences: preferences).rows.first
+                )
+
+                XCTAssertEqual(row.resetTime, showsReset ? resetTime : nil)
+                XCTAssertEqual(row.freshnessDate, showsFreshness ? now : nil)
+            }
+        }
+    }
+
+    func testStalenessBoundaryIsHealthyAndOneSecondOlderIsStale() throws {
+        let threshold: TimeInterval = 3_600
+        let atBoundary = [
+            .claudeCode: makeMetrics(
+                .claudeCode,
+                weeklyUsed: 25,
+                lastUpdated: now.addingTimeInterval(-threshold)
+            )
+        ]
+        let older = [
+            .claudeCode: makeMetrics(
+                .claudeCode,
+                weeklyUsed: 25,
+                lastUpdated: now.addingTimeInterval(-threshold - 1)
+            )
+        ]
+
+        let healthy = try XCTUnwrap(
+            presentation(metrics: atBoundary, stalenessThreshold: threshold).rows.first
+        )
+        let stale = try XCTUnwrap(
+            presentation(metrics: older, stalenessThreshold: threshold).rows.first
+        )
+
+        XCTAssertEqual(healthy.health, .healthy)
+        XCTAssertNotNil(healthy.usageStatus)
+        XCTAssertEqual(stale.health, .stale)
+        XCTAssertNil(stale.usageStatus)
+    }
+
+    func testExplicitMissingSelectionIsUnavailableRatherThanHealthy() throws {
+        var preferences = WidgetPreferences.defaults
+        let missing = WidgetAccountIdentifier.account(
+            service: .codexCli,
+            id: UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9))
+        )
+        preferences.accountSelection = .explicit([missing])
+
+        let row = try XCTUnwrap(
+            presentation(metrics: [:], preferences: preferences).rows.first
+        )
+
+        XCTAssertEqual(row.accountIdentifier, missing)
+        XCTAssertEqual(row.service, .codexCli)
+        XCTAssertEqual(row.health, .unavailable)
+        XCTAssertNil(row.usageStatus)
+        XCTAssertEqual(row.summaryText, "Unavailable")
+    }
+
+    func testMissingAccountProducesOneUnavailableRowWithoutHidingHealthyRows() {
+        var preferences = WidgetPreferences.defaults
+        let missing = WidgetAccountIdentifier.account(
+            service: .codexCli,
+            id: UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9))
+        )
+        preferences.accountSelection = .explicit([.provider(.claudeCode), missing])
+        preferences.visibleQuotaWindows = [.session, .weekly, .codeReview]
+
+        let result = presentation(
+            metrics: [
+                .claudeCode: makeMetrics(
+                    .claudeCode,
+                    sessionUsed: 10,
+                    weeklyUsed: 20,
+                    codeReviewUsed: 30
+                )
+            ],
+            preferences: preferences,
+            family: .large
+        )
+
+        XCTAssertEqual(result.rows.count, 4)
+        XCTAssertEqual(result.rows.filter { $0.health == .unavailable }.count, 1)
+        XCTAssertEqual(result.hiddenRowCount, 0)
+    }
+
+    func testExplicitEmptySelectionAndUnavailableCacheHaveDistinctStates() {
+        var noSelectionPreferences = WidgetPreferences.defaults
+        noSelectionPreferences.accountSelection = .explicit([])
+
+        let noSelection = presentation(
+            metrics: [.cursor: makeMetrics(.cursor, weeklyUsed: 20)],
+            preferences: noSelectionPreferences
+        )
+        let unavailable = presentation(metrics: [:])
+
+        XCTAssertEqual(noSelection.emptyState, .noSelection)
+        XCTAssertTrue(noSelection.emptyState?.detail.contains("MeterBar Settings") ?? false)
+        XCTAssertEqual(unavailable.emptyState, .unavailable)
+        XCTAssertNotEqual(noSelection.emptyState, unavailable.emptyState)
+    }
+
+    func testOverflowCountsOnlySelectedAvailableQuotaRows() {
+        var preferences = WidgetPreferences.defaults
+        preferences.visibleQuotaWindows = [.session, .weekly]
+        preferences.accountSelection = .explicit([.provider(.claudeCode)])
+        let metrics: [ServiceType: UsageMetrics] = [
+            .claudeCode: makeMetrics(.claudeCode, sessionUsed: 10, weeklyUsed: 20),
+            .codexCli: makeMetrics(.codexCli, sessionUsed: 30, weeklyUsed: 40),
+            .cursor: makeMetrics(.cursor, sessionUsed: nil, weeklyUsed: 50)
+        ]
+
+        let result = presentation(
+            metrics: metrics,
+            preferences: preferences,
+            family: .small
+        )
+
+        XCTAssertEqual(result.rows.map(\.quotaWindow), [.session, .weekly])
+        XCTAssertEqual(result.hiddenRowCount, 0)
+    }
+
+    func testAccountSnapshotsReplaceAggregateProviderRowAndPreserveNames() {
+        let firstID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1))
+        let secondID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2))
+        let aggregate = [.claudeCode: makeMetrics(.claudeCode, weeklyUsed: 90)]
+        let accounts = [
+            AccountUsageSnapshot(
+                id: firstID,
+                name: "Personal",
+                metrics: makeMetrics(.claudeCode, weeklyUsed: 10)
+            ),
+            AccountUsageSnapshot(
+                id: secondID,
+                name: "Work",
+                metrics: makeMetrics(.claudeCode, weeklyUsed: 20)
+            )
+        ]
+
+        let result = presentation(
+            metrics: aggregate,
+            accountMetrics: accounts,
+            family: .large
+        )
+
+        XCTAssertEqual(result.rows.map(\.accountName), ["Personal", "Work"])
+        XCTAssertEqual(
+            result.rows.map(\.accountIdentifier),
+            [
+                .account(service: .claudeCode, id: firstID),
+                .account(service: .claudeCode, id: secondID)
+            ]
+        )
+    }
+
+    private func presentation(
+        metrics: [ServiceType: UsageMetrics],
+        accountMetrics: [AccountUsageSnapshot] = [],
+        preferences: WidgetPreferences = .defaults,
+        family: WidgetPresentationFamily = .large,
+        stalenessThreshold: TimeInterval = WidgetPresentationPlanner.defaultStalenessThreshold
+    ) -> WidgetPresentation {
+        WidgetPresentationPlanner.makePresentation(
+            metrics: metrics,
+            accountMetrics: accountMetrics,
+            preferences: preferences,
+            family: family,
+            now: now,
+            stalenessThreshold: stalenessThreshold
+        )
+    }
+
+    private func makeMetrics(
+        _ service: ServiceType,
+        sessionUsed: Double? = nil,
+        weeklyUsed: Double? = nil,
+        codeReviewUsed: Double? = nil,
+        resetTime: Date? = nil,
+        lastUpdated: Date? = nil
+    ) -> UsageMetrics {
+        UsageMetrics(
+            service: service,
+            sessionLimit: sessionUsed.map {
+                UsageLimit(used: $0, total: 100, resetTime: resetTime)
+            },
+            weeklyLimit: weeklyUsed.map {
+                UsageLimit(used: $0, total: 100, resetTime: resetTime)
+            },
+            codeReviewLimit: codeReviewUsed.map {
+                UsageLimit(used: $0, total: 100, resetTime: resetTime)
+            },
+            lastUpdated: lastUpdated ?? now
+        )
+    }
+}

--- a/MeterBarTests/WidgetRenderingTests.swift
+++ b/MeterBarTests/WidgetRenderingTests.swift
@@ -14,22 +14,25 @@ import XCTest
 /// selection the layouts apply. A regression in any of these (a nil percentage, an
 /// empty display name, a broken sort, a lost provider) would blank a widget row.
 ///
-/// Family row caps mirror `UsageWidget.swift`:
-///   - SmallWidgetView:  `sortedServices.prefix(3)`
-///   - MediumWidgetView: 3 slots; overflow uses 2 rows plus a summary
-///   - LargeWidgetView:  `sortedServices.prefix(7)`
+/// The family caps below exercise the same shared budget used by
+/// `WidgetPresentationPlanner`; focused preference/window/state coverage lives
+/// in `WidgetPresentationTests`.
 final class WidgetRenderingTests: XCTestCase {
     private enum WidgetFamily: CaseIterable {
         case small, medium, large
 
         func visibleRowCount(totalRowCount: Int) -> Int {
+            WidgetFamilyRowBudget.plan(
+                totalRowCount: totalRowCount,
+                family: presentationFamily
+            ).visibleRowCount
+        }
+
+        private var presentationFamily: WidgetPresentationFamily {
             switch self {
-            case .small:
-                return min(totalRowCount, 3)
-            case .medium:
-                return MediumWidgetRowBudget.visibleRowCount(totalRowCount: totalRowCount)
-            case .large:
-                return min(totalRowCount, 7)
+            case .small: return .small
+            case .medium: return .medium
+            case .large: return .large
             }
         }
     }
@@ -129,7 +132,10 @@ final class WidgetRenderingTests: XCTestCase {
         let visibleRowCount = WidgetFamily.medium.visibleRowCount(totalRowCount: totalRowCount)
 
         XCTAssertEqual(visibleRowCount, 2)
-        XCTAssertEqual(MediumWidgetRowBudget.hiddenRowCount(totalRowCount: totalRowCount), 4)
+        XCTAssertEqual(
+            WidgetFamilyRowBudget.plan(totalRowCount: totalRowCount, family: .medium).hiddenRowCount,
+            4
+        )
     }
 
     // MARK: - Empty state

--- a/MeterBarWidget/UsageWidget.swift
+++ b/MeterBarWidget/UsageWidget.swift
@@ -1,6 +1,6 @@
 import MeterBarShared
-import WidgetKit
 import SwiftUI
+import WidgetKit
 
 // MARK: - Status Colors (widget presentation for the shared UsageStatus)
 
@@ -33,25 +33,17 @@ struct UsageWidgetEntry: TimelineEntry {
     let date: Date
     let metrics: [ServiceType: UsageMetrics]
     let accountMetrics: [AccountUsageSnapshot]
+    let preferences: WidgetPreferences
 
-    var rows: [WidgetUsageRow] {
-        let accountServices = Set(accountMetrics.map { $0.metrics.service })
-        let accountRows = accountMetrics.map {
-            WidgetUsageRow(id: $0.id.uuidString, name: $0.name, metrics: $0.metrics)
-        }
-        let providerRows = metrics
-            .filter { !accountServices.contains($0.key) }
-            .map { WidgetUsageRow(id: $0.key.rawValue, name: $0.key.displayName, metrics: $0.value) }
-        return (accountRows + providerRows).sorted {
-            ($0.metrics.service.sortOrder, $0.name) < ($1.metrics.service.sortOrder, $1.name)
-        }
+    func presentation(for family: WidgetPresentationFamily) -> WidgetPresentation {
+        WidgetPresentationPlanner.makePresentation(
+            metrics: metrics,
+            accountMetrics: accountMetrics,
+            preferences: preferences,
+            family: family,
+            now: date
+        )
     }
-}
-
-struct WidgetUsageRow: Identifiable {
-    let id: String
-    let name: String
-    let metrics: UsageMetrics
 }
 
 struct UsageWidgetProvider: TimelineProvider {
@@ -72,30 +64,30 @@ struct UsageWidgetProvider: TimelineProvider {
                     weeklyLimit: UsageLimit(used: 90, total: 100, resetTime: nil)
                 )
             ],
-            accountMetrics: []
+            accountMetrics: [],
+            preferences: .defaults
         )
     }
 
     func getSnapshot(in context: Context, completion: @escaping (UsageWidgetEntry) -> Void) {
-        let entry = UsageWidgetEntry(
-            date: Date(),
-            metrics: SharedMetricsStore.loadMetrics(),
-            accountMetrics: SharedMetricsStore.loadAccountMetrics()
-        )
-        completion(entry)
+        completion(currentEntry())
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<UsageWidgetEntry>) -> Void) {
-        let cachedMetrics = SharedMetricsStore.loadMetrics()
-        let entry = UsageWidgetEntry(
-            date: Date(),
-            metrics: cachedMetrics,
-            accountMetrics: SharedMetricsStore.loadAccountMetrics()
-        )
+        let entry = currentEntry()
 
         let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: Date()) ?? Date()
         let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
         completion(timeline)
+    }
+
+    private func currentEntry() -> UsageWidgetEntry {
+        UsageWidgetEntry(
+            date: Date(),
+            metrics: SharedMetricsStore.loadMetrics(),
+            accountMetrics: SharedMetricsStore.loadAccountMetrics(),
+            preferences: WidgetPreferencesStore().preferences
+        )
     }
 }
 
@@ -122,15 +114,15 @@ struct SmallWidgetView: View {
     let entry: UsageWidgetEntry
 
     var body: some View {
+        let presentation = entry.presentation(for: .small)
         VStack(alignment: .leading, spacing: 6) {
-            if entry.rows.isEmpty {
-                Text("No data")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+            if let emptyState = presentation.emptyState {
+                WidgetEmptyStateView(state: emptyState, compact: true)
             } else {
-                ForEach(Array(entry.rows.prefix(3))) { row in
+                ForEach(presentation.rows) { row in
                     ServiceMiniView(row: row)
                 }
+                WidgetOverflowView(hiddenRowCount: presentation.hiddenRowCount)
             }
         }
         .padding()
@@ -140,65 +132,55 @@ struct SmallWidgetView: View {
 }
 
 struct ServiceMiniView: View {
-    let row: WidgetUsageRow
+    let row: WidgetPresentationRow
 
     var body: some View {
-        HStack(spacing: 6) {
-            WidgetProviderIcon(service: row.metrics.service, size: 14)
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 5) {
+                WidgetProviderIcon(service: row.service, size: 13)
 
-            Text(row.name)
-                .font(.caption2)
-                .lineLimit(1)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(row.accountName)
+                        .font(.caption2)
+                        .lineLimit(1)
+                    Text(row.quotaTitle)
+                        .font(.system(size: 8))
+                        .foregroundStyle(.secondary)
+                }
 
-            if let weeklyLimit = row.metrics.weeklyLimit {
-                ProgressView(value: weeklyLimit.clampedUsed, total: weeklyLimit.clampedTotal)
-                    .tint(weeklyLimit.statusColor.color)
-                Text(limitSummary(weeklyLimit))
-                    .font(.caption2)
-                    .foregroundColor(.secondary)
+                if let progressValue = row.progressValue,
+                   let progressTotal = row.progressTotal {
+                    ProgressView(value: progressValue, total: progressTotal)
+                        .tint(row.usageStatus?.color ?? .secondary)
+                }
+
+                Text(row.compactSummaryText)
+                    .font(.system(size: 8))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+
+                WidgetHealthIndicator(row: row)
             }
 
-            WidgetStatusIndicator(status: row.metrics.overallStatus)
+            WidgetRowDetails(row: row)
         }
-    }
-
-    private func limitSummary(_ limit: UsageLimit) -> String {
-        if row.metrics.service == .openRouter {
-            return String(format: "$%.2f", max(0, limit.total - limit.used))
-        }
-        return limit.percentageText
+        .accessibilityElement(children: .combine)
     }
 }
 
 struct MediumWidgetView: View {
     let entry: UsageWidgetEntry
 
-    private var visibleRows: [WidgetUsageRow] {
-        let visibleLimit = MediumWidgetRowBudget.visibleRowCount(totalRowCount: entry.rows.count)
-        return Array(entry.rows.prefix(visibleLimit))
-    }
-
-    private var hiddenRowCount: Int {
-        MediumWidgetRowBudget.hiddenRowCount(totalRowCount: entry.rows.count)
-    }
-
     var body: some View {
+        let presentation = entry.presentation(for: .medium)
         VStack(alignment: .leading, spacing: 8) {
-            if entry.rows.isEmpty {
-                Text("No services connected")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+            if let emptyState = presentation.emptyState {
+                WidgetEmptyStateView(state: emptyState)
             } else {
-                ForEach(visibleRows) { row in
+                ForEach(presentation.rows) { row in
                     ServiceCompactView(row: row)
                 }
-
-                if hiddenRowCount > 0 {
-                    Label("+\(hiddenRowCount) more", systemImage: "ellipsis.circle")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                        .accessibilityLabel("\(hiddenRowCount) more usage sources")
-                }
+                WidgetOverflowView(hiddenRowCount: presentation.hiddenRowCount)
             }
         }
         .padding()
@@ -211,25 +193,18 @@ struct LargeWidgetView: View {
     let entry: UsageWidgetEntry
 
     var body: some View {
+        let presentation = entry.presentation(for: .large)
         VStack(alignment: .leading, spacing: 0) {
-            if entry.rows.isEmpty {
-                VStack {
-                    Image(systemName: "exclamationmark.triangle")
-                        .font(.largeTitle)
-                        .foregroundColor(.orange)
-                    Text("No services connected")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            if let emptyState = presentation.emptyState {
+                WidgetEmptyStateView(state: emptyState)
             } else {
-                let rows = Array(entry.rows.prefix(7))
-                ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                ForEach(Array(presentation.rows.enumerated()), id: \.element.id) { index, row in
                     ServiceCompactView(row: row)
-                    if index < rows.count - 1 {
+                    if index < presentation.rows.count - 1 {
                         Spacer()
                     }
                 }
+                WidgetOverflowView(hiddenRowCount: presentation.hiddenRowCount)
             }
         }
         .padding()
@@ -239,35 +214,125 @@ struct LargeWidgetView: View {
 }
 
 struct ServiceCompactView: View {
-    let row: WidgetUsageRow
+    let row: WidgetPresentationRow
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 3) {
             HStack {
-                WidgetProviderIcon(service: row.metrics.service, size: 18)
-                Text(row.name)
+                WidgetProviderIcon(service: row.service, size: 18)
+                Text(row.accountName)
                     .font(.subheadline)
                     .bold()
+                    .lineLimit(1)
+                Text(row.quotaTitle)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
                 Spacer()
-                WidgetStatusIndicator(status: row.metrics.overallStatus)
+                WidgetHealthIndicator(row: row)
             }
 
-            if let weeklyLimit = row.metrics.weeklyLimit {
+            if let progressValue = row.progressValue,
+               let progressTotal = row.progressTotal {
                 HStack {
-                    ProgressView(value: weeklyLimit.clampedUsed, total: weeklyLimit.clampedTotal)
-                        .tint(weeklyLimit.statusColor.color)
-                    Text(limitSummary(weeklyLimit))
+                    ProgressView(value: progressValue, total: progressTotal)
+                        .tint(row.usageStatus?.color ?? .secondary)
+                    Text(row.summaryText)
                         .font(.caption)
                 }
+            } else {
+                Text(row.summaryText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
+
+            WidgetRowDetails(row: row)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+struct WidgetRowDetails: View {
+    let row: WidgetPresentationRow
+
+    var body: some View {
+        if row.resetTime != nil || row.freshnessDate != nil {
+            HStack(spacing: 6) {
+                if let resetTime = row.resetTime {
+                    Label {
+                        Text(resetTime, style: .relative)
+                    } icon: {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                }
+                if let freshnessDate = row.freshnessDate {
+                    Label {
+                        Text(freshnessDate, style: .relative)
+                    } icon: {
+                        Image(systemName: "clock")
+                    }
+                }
+            }
+            .font(.system(size: 8))
+            .foregroundStyle(.secondary)
         }
     }
+}
 
-    private func limitSummary(_ limit: UsageLimit) -> String {
-        if row.metrics.service == .openRouter {
-            return String(format: "$%.2f left", max(0, limit.total - limit.used))
+struct WidgetHealthIndicator: View {
+    let row: WidgetPresentationRow
+
+    var body: some View {
+        switch row.health {
+        case .healthy:
+            if let status = row.usageStatus {
+                WidgetStatusIndicator(status: status)
+                    .accessibilityLabel("Current usage")
+            }
+        case .stale:
+            Image(systemName: "clock.badge.exclamationmark")
+                .foregroundStyle(.orange)
+                .accessibilityLabel("Stale usage data")
+        case .unavailable:
+            Image(systemName: "xmark.circle")
+                .foregroundStyle(.secondary)
+                .accessibilityLabel("Usage unavailable")
         }
-        return limit.percentageText
+    }
+}
+
+struct WidgetOverflowView: View {
+    let hiddenRowCount: Int
+
+    var body: some View {
+        if hiddenRowCount > 0 {
+            Label("+\(hiddenRowCount) more", systemImage: "ellipsis.circle")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel("\(hiddenRowCount) more usage rows")
+        }
+    }
+}
+
+struct WidgetEmptyStateView: View {
+    let state: WidgetPresentationEmptyState
+    var compact = false
+
+    var body: some View {
+        VStack(alignment: compact ? .leading : .center, spacing: 4) {
+            if !compact {
+                Image(systemName: state == .noSelection ? "slider.horizontal.3" : "exclamationmark.triangle")
+                    .font(.title2)
+                    .foregroundStyle(state == .noSelection ? Color.secondary : Color.orange)
+            }
+            Text(state.title)
+                .font(.caption)
+                .bold()
+            Text(state.detail)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(compact ? .leading : .center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: compact ? .topLeading : .center)
     }
 }
 

--- a/Packages/MeterBarShared/Sources/MeterBarShared/MediumWidgetRowBudget.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/MediumWidgetRowBudget.swift
@@ -1,12 +1,72 @@
+public enum WidgetPresentationFamily: CaseIterable, Sendable {
+    case small
+    case medium
+    case large
+
+    public var maximumSlots: Int {
+        switch self {
+        case .small, .medium:
+            return 3
+        case .large:
+            return 7
+        }
+    }
+}
+
+public struct WidgetFamilyRowBudget: Equatable, Sendable {
+    public let visibleRowCount: Int
+    public let hiddenRowCount: Int
+
+    public init(visibleRowCount: Int, hiddenRowCount: Int) {
+        self.visibleRowCount = visibleRowCount
+        self.hiddenRowCount = hiddenRowCount
+    }
+
+    public static func plan(
+        totalRowCount: Int,
+        family: WidgetPresentationFamily,
+        showsDetails: Bool = false
+    ) -> Self {
+        let total = max(0, totalRowCount)
+        let visible: Int
+        if showsDetails {
+            let detailedRowCapacity: Int
+            switch family {
+            case .small:
+                detailedRowCapacity = 3
+            case .medium:
+                detailedRowCapacity = 2
+            case .large:
+                detailedRowCapacity = 5
+            }
+            visible = min(total, detailedRowCapacity)
+        } else {
+            let maximumSlots = family.maximumSlots
+            visible = total > maximumSlots ? maximumSlots - 1 : total
+        }
+        return Self(
+            visibleRowCount: visible,
+            hiddenRowCount: max(0, total - visible)
+        )
+    }
+}
+
+/// Compatibility surface for existing callers. New widget planning uses
+/// `WidgetFamilyRowBudget` for all three supported families.
 public enum MediumWidgetRowBudget {
-    public static let maximumSlots = 3
+    public static let maximumSlots = WidgetPresentationFamily.medium.maximumSlots
 
     public static func visibleRowCount(totalRowCount: Int) -> Int {
-        guard totalRowCount > maximumSlots else { return max(0, totalRowCount) }
-        return maximumSlots - 1
+        WidgetFamilyRowBudget.plan(
+            totalRowCount: totalRowCount,
+            family: .medium
+        ).visibleRowCount
     }
 
     public static func hiddenRowCount(totalRowCount: Int) -> Int {
-        max(0, totalRowCount - visibleRowCount(totalRowCount: totalRowCount))
+        WidgetFamilyRowBudget.plan(
+            totalRowCount: totalRowCount,
+            family: .medium
+        ).hiddenRowCount
     }
 }

--- a/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPreferences.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPreferences.swift
@@ -22,6 +22,25 @@ public struct WidgetAccountIdentifier: RawRepresentable, Codable, Hashable, Send
     public static func account(service: ServiceType, id: UUID) -> Self {
         Self(rawValue: "account:\(service.rawValue):\(id.uuidString)")
     }
+
+    /// Recovers the provider identity from a persisted row key.
+    ///
+    /// Explicit selections can outlive a metrics snapshot (for example while
+    /// an enabled account is temporarily unavailable). The widget uses this
+    /// provider identity to render an honest unavailable row instead of
+    /// silently relabeling or dropping the selection.
+    public var service: ServiceType? {
+        let providerPrefix = "provider:"
+        if rawValue.hasPrefix(providerPrefix) {
+            return ServiceType(rawValue: String(rawValue.dropFirst(providerPrefix.count)))
+        }
+
+        let accountPrefix = "account:"
+        guard rawValue.hasPrefix(accountPrefix) else { return nil }
+        let accountValue = rawValue.dropFirst(accountPrefix.count)
+        guard let separator = accountValue.firstIndex(of: ":") else { return nil }
+        return ServiceType(rawValue: String(accountValue[..<separator]))
+    }
 }
 
 public enum WidgetAccountSelectionMode: String, Codable, Sendable {
@@ -59,6 +78,7 @@ public enum WidgetUsageDisplayMode: String, Codable, CaseIterable, Sendable {
 public enum WidgetQuotaWindow: String, Codable, CaseIterable, Sendable {
     case session
     case weekly
+    case codeReview
 }
 
 public enum WidgetAccountOrdering: String, Codable, CaseIterable, Sendable {
@@ -76,6 +96,9 @@ public struct WidgetPreferences: Codable, Equatable, Sendable {
     public var showsResetTime: Bool
     public var showsFreshness: Bool
     public var accountOrdering: WidgetAccountOrdering
+    /// Keeps the pre-preference OpenRouter balance (`remaining`) until the
+    /// user explicitly chooses either usage display mode.
+    public var preservesLegacyOpenRouterBalance: Bool
 
     public static let defaults = WidgetPreferences(
         accountSelection: .all,
@@ -83,7 +106,8 @@ public struct WidgetPreferences: Codable, Equatable, Sendable {
         visibleQuotaWindows: [.weekly],
         showsResetTime: false,
         showsFreshness: false,
-        accountOrdering: .provider
+        accountOrdering: .provider,
+        preservesLegacyOpenRouterBalance: true
     )
 
     public init(
@@ -92,7 +116,8 @@ public struct WidgetPreferences: Codable, Equatable, Sendable {
         visibleQuotaWindows: Set<WidgetQuotaWindow>,
         showsResetTime: Bool,
         showsFreshness: Bool,
-        accountOrdering: WidgetAccountOrdering
+        accountOrdering: WidgetAccountOrdering,
+        preservesLegacyOpenRouterBalance: Bool = true
     ) {
         self.accountSelection = accountSelection
         self.displayMode = displayMode
@@ -100,6 +125,7 @@ public struct WidgetPreferences: Codable, Equatable, Sendable {
         self.showsResetTime = showsResetTime
         self.showsFreshness = showsFreshness
         self.accountOrdering = accountOrdering
+        self.preservesLegacyOpenRouterBalance = preservesLegacyOpenRouterBalance
     }
 
     public init(from decoder: Decoder) throws {
@@ -128,6 +154,10 @@ public struct WidgetPreferences: Codable, Equatable, Sendable {
             WidgetAccountOrdering.self,
             forKey: .accountOrdering
         ) ?? Self.defaults.accountOrdering
+        preservesLegacyOpenRouterBalance = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .preservesLegacyOpenRouterBalance
+        ) ?? Self.defaults.preservesLegacyOpenRouterBalance
     }
 }
 
@@ -246,7 +276,10 @@ public final class WidgetPreferencesStore: ObservableObject {
     }
 
     public func setDisplayMode(_ displayMode: WidgetUsageDisplayMode) {
-        update { $0.displayMode = displayMode }
+        update {
+            $0.displayMode = displayMode
+            $0.preservesLegacyOpenRouterBalance = false
+        }
     }
 
     public func setVisibleQuotaWindows(_ windows: Set<WidgetQuotaWindow>) {

--- a/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPresentation.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPresentation.swift
@@ -1,0 +1,350 @@
+import Foundation
+
+public enum WidgetDataHealth: Equatable, Sendable {
+    case healthy
+    case stale
+    case unavailable
+}
+
+public enum WidgetPresentationEmptyState: Equatable, Sendable {
+    case noSelection
+    case unavailable
+
+    public var title: String {
+        switch self {
+        case .noSelection:
+            return "Choose usage to show"
+        case .unavailable:
+            return "Usage unavailable"
+        }
+    }
+
+    public var detail: String {
+        switch self {
+        case .noSelection:
+            return "Select accounts and quota windows in MeterBar Settings."
+        case .unavailable:
+            return "Open MeterBar to refresh provider usage."
+        }
+    }
+}
+
+public struct WidgetPresentationRow: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let accountIdentifier: WidgetAccountIdentifier
+    public let service: ServiceType
+    public let accountName: String
+    public let quotaWindow: WidgetQuotaWindow
+    public let limit: UsageLimit?
+    public let health: WidgetDataHealth
+    public let displayMode: WidgetUsageDisplayMode
+    public let preservesLegacyOpenRouterBalance: Bool
+    public let resetTime: Date?
+    public let freshnessDate: Date?
+
+    public var quotaTitle: String {
+        switch (service, quotaWindow) {
+        case (.openRouter, .session):
+            return "Key limit"
+        case (.openRouter, .weekly):
+            return "Account credits"
+        case (.claudeCode, .codeReview):
+            return "Sonnet"
+        case (_, .codeReview):
+            return "Code Review"
+        case (_, .session):
+            return "Session"
+        case (_, .weekly):
+            return "Weekly"
+        }
+    }
+
+    public var progressValue: Double? {
+        guard let limit else { return nil }
+        switch displayMode {
+        case .used:
+            return limit.clampedUsed
+        case .remaining:
+            return max(0, limit.total - limit.clampedUsed)
+        }
+    }
+
+    public var progressTotal: Double? {
+        limit?.clampedTotal
+    }
+
+    public var summaryText: String {
+        guard let limit else { return "Unavailable" }
+        if service == .openRouter {
+            let amount: Double
+            let suffix: String
+            switch preservesLegacyOpenRouterBalance ? .remaining : displayMode {
+            case .used:
+                amount = max(0, limit.used)
+                suffix = "used"
+            case .remaining:
+                amount = max(0, limit.total - limit.used)
+                suffix = "left"
+            }
+            return "\(ExtraUsageStatus.formatAmount(amount)) \(suffix)"
+        }
+
+        switch displayMode {
+        case .used:
+            return limit.usedPercentageText
+        case .remaining:
+            return limit.percentLeftText
+        }
+    }
+
+    public var compactSummaryText: String {
+        guard service == .openRouter,
+              preservesLegacyOpenRouterBalance,
+              let limit else {
+            return summaryText
+        }
+        return ExtraUsageStatus.formatAmount(max(0, limit.total - limit.used))
+    }
+
+    public var usageStatus: UsageStatus? {
+        guard health == .healthy else { return nil }
+        return limit?.statusColor
+    }
+}
+
+public struct WidgetPresentation: Equatable, Sendable {
+    public let rows: [WidgetPresentationRow]
+    public let hiddenRowCount: Int
+    public let emptyState: WidgetPresentationEmptyState?
+}
+
+/// Pure data-to-presentation policy shared by every widget family.
+///
+/// The planner reads no global state and owns no clock. Inputs are the existing
+/// App Group metrics snapshots plus the persisted widget preferences, which
+/// keeps ordering, staleness, quota-window filtering, and overflow deterministic
+/// and directly testable.
+public enum WidgetPresentationPlanner {
+    public static let defaultStalenessThreshold: TimeInterval = 2 * 60 * 60
+
+    public static func makePresentation(
+        metrics: [ServiceType: UsageMetrics],
+        accountMetrics: [AccountUsageSnapshot],
+        preferences: WidgetPreferences,
+        family: WidgetPresentationFamily,
+        now: Date,
+        stalenessThreshold: TimeInterval = defaultStalenessThreshold
+    ) -> WidgetPresentation {
+        guard preferences.accountSelection.mode != .explicit
+            || !preferences.accountSelection.explicitIdentifiers.isEmpty,
+            !preferences.visibleQuotaWindows.isEmpty
+        else {
+            return WidgetPresentation(rows: [], hiddenRowCount: 0, emptyState: .noSelection)
+        }
+
+        let sources = availableSources(metrics: metrics, accountMetrics: accountMetrics)
+        let selectedSources = selectedSources(from: sources, preferences: preferences)
+        let rows = selectedSources.flatMap {
+            presentationRows(
+                for: $0,
+                preferences: preferences,
+                now: now,
+                stalenessThreshold: stalenessThreshold
+            )
+        }
+
+        guard !rows.isEmpty else {
+            return WidgetPresentation(rows: [], hiddenRowCount: 0, emptyState: .unavailable)
+        }
+
+        let budget = WidgetFamilyRowBudget.plan(
+            totalRowCount: rows.count,
+            family: family,
+            showsDetails: rows.contains { $0.resetTime != nil || $0.freshnessDate != nil }
+        )
+        return WidgetPresentation(
+            rows: Array(rows.prefix(budget.visibleRowCount)),
+            hiddenRowCount: budget.hiddenRowCount,
+            emptyState: nil
+        )
+    }
+
+    private struct Source {
+        let identifier: WidgetAccountIdentifier
+        let service: ServiceType
+        let accountOrder: Int
+        let name: String
+        let metrics: UsageMetrics?
+    }
+
+    private static func availableSources(
+        metrics: [ServiceType: UsageMetrics],
+        accountMetrics: [AccountUsageSnapshot]
+    ) -> [Source] {
+        var accountOrderByService: [ServiceType: Int] = [:]
+        let accountSources = accountMetrics.map { snapshot -> Source in
+            let service = snapshot.metrics.service
+            let accountOrder = accountOrderByService[service, default: 0]
+            accountOrderByService[service] = accountOrder + 1
+            return Source(
+                identifier: .account(service: service, id: snapshot.id),
+                service: service,
+                accountOrder: accountOrder,
+                name: snapshot.name,
+                metrics: snapshot.metrics
+            )
+        }
+
+        let providerSources = metrics.map { service, providerMetrics in
+            Source(
+                identifier: .provider(service),
+                service: service,
+                accountOrder: 0,
+                name: service.displayName,
+                metrics: providerMetrics
+            )
+        }
+
+        return accountSources + providerSources
+    }
+
+    private static func selectedSources(
+        from sources: [Source],
+        preferences: WidgetPreferences
+    ) -> [Source] {
+        let selected: [Source]
+        switch preferences.accountSelection.mode {
+        case .all:
+            let accountServices = Set(
+                sources.compactMap { source in
+                    source.identifier == .provider(source.service) ? nil : source.service
+                }
+            )
+            selected = sources.filter {
+                $0.identifier != .provider($0.service) || !accountServices.contains($0.service)
+            }
+        case .explicit:
+            let sourceByIdentifier = Dictionary(
+                sources.map { ($0.identifier, $0) },
+                uniquingKeysWith: { first, _ in first }
+            )
+            selected = preferences.accountSelection.explicitIdentifiers.compactMap { identifier in
+                if let source = sourceByIdentifier[identifier] {
+                    return source
+                }
+                guard let service = identifier.service else { return nil }
+                return Source(
+                    identifier: identifier,
+                    service: service,
+                    accountOrder: Int.max,
+                    name: service.displayName,
+                    metrics: nil
+                )
+            }
+        }
+
+        return selected.sorted { lhs, rhs in
+            switch preferences.accountOrdering {
+            case .provider:
+                return providerOrder(lhs) < providerOrder(rhs)
+            case .urgency:
+                let lhsUrgency = urgency(lhs, visibleWindows: preferences.visibleQuotaWindows)
+                let rhsUrgency = urgency(rhs, visibleWindows: preferences.visibleQuotaWindows)
+                if lhsUrgency != rhsUrgency {
+                    return lhsUrgency > rhsUrgency
+                }
+                return providerOrder(lhs) < providerOrder(rhs)
+            }
+        }
+    }
+
+    private static func providerOrder(_ source: Source) -> (Int, Int, String) {
+        (source.service.sortOrder, source.accountOrder, source.identifier.rawValue)
+    }
+
+    private static func urgency(
+        _ source: Source,
+        visibleWindows: Set<WidgetQuotaWindow>
+    ) -> Double {
+        guard let metrics = source.metrics else { return -Double.infinity }
+        return WidgetQuotaWindow.allCases
+            .filter { visibleWindows.contains($0) }
+            .compactMap { limit(for: $0, metrics: metrics)?.percentage }
+            .max() ?? 0
+    }
+
+    private static func presentationRows(
+        for source: Source,
+        preferences: WidgetPreferences,
+        now: Date,
+        stalenessThreshold: TimeInterval
+    ) -> [WidgetPresentationRow] {
+        let windows = WidgetQuotaWindow.allCases.filter {
+            preferences.visibleQuotaWindows.contains($0)
+        }
+
+        guard let metrics = source.metrics else {
+            guard let firstWindow = windows.first else { return [] }
+            return [
+                row(
+                    source: source,
+                    window: firstWindow,
+                    limit: nil,
+                    health: .unavailable,
+                    preferences: preferences
+                )
+            ]
+        }
+
+        let health: WidgetDataHealth = now.timeIntervalSince(metrics.lastUpdated) > stalenessThreshold
+            ? .stale
+            : .healthy
+        return windows.compactMap { window in
+            guard let limit = limit(for: window, metrics: metrics) else { return nil }
+            return row(
+                source: source,
+                window: window,
+                limit: limit,
+                health: health,
+                preferences: preferences
+            )
+        }
+    }
+
+    private static func row(
+        source: Source,
+        window: WidgetQuotaWindow,
+        limit: UsageLimit?,
+        health: WidgetDataHealth,
+        preferences: WidgetPreferences
+    ) -> WidgetPresentationRow {
+        WidgetPresentationRow(
+            id: "\(source.identifier.rawValue):\(window.rawValue)",
+            accountIdentifier: source.identifier,
+            service: source.service,
+            accountName: source.name,
+            quotaWindow: window,
+            limit: limit,
+            health: health,
+            displayMode: preferences.displayMode,
+            preservesLegacyOpenRouterBalance: source.service == .openRouter
+                && preferences.preservesLegacyOpenRouterBalance,
+            resetTime: preferences.showsResetTime ? limit?.resetTime : nil,
+            freshnessDate: preferences.showsFreshness ? source.metrics?.lastUpdated : nil
+        )
+    }
+
+    private static func limit(
+        for window: WidgetQuotaWindow,
+        metrics: UsageMetrics
+    ) -> UsageLimit? {
+        switch window {
+        case .session:
+            return metrics.sessionLimit
+        case .weekly:
+            return metrics.weeklyLimit
+        case .codeReview:
+            return metrics.codeReviewLimit
+        }
+    }
+}


### PR DESCRIPTION
Closes #218

## Summary
- apply one pure selection and ordering policy across small, medium, and large widgets
- render selected accounts, quota windows, used/remaining modes, reset timing, freshness, health states, and exact overflow
- bridge and persist enabled Claude account snapshots alongside existing Codex account data
- preserve untouched OpenRouter widget defaults while honoring explicit display choices
- add focused family-budget, ordering, state, compatibility, and cache-recovery coverage

## Verification
- `swiftlint lint --strict --config .swiftlint.yml` — passed, 0 violations across 123 repository Swift files
- explicit strict SwiftLint over all 11 changed Swift files — passed, 0 violations
- `git diff --cached --check` — passed
- independent final diff review — passed with no actionable correctness or security findings
- SwiftFormat — unavailable locally (`swiftformat: command not found`)
- local tests, typechecks, and builds — intentionally skipped per repository machine policy; PR CI is the execution gate