### PR TITLE
fix(ui): restore native neutral surfaces

### DIFF
--- a/.agents/DESIGN.md
+++ b/.agents/DESIGN.md
@@ -16,7 +16,7 @@ colors:
   text-secondary: "Color.secondary / NSColor.secondaryLabelColor"
   text-tertiary: ".tertiary"
   window-background: "Color(nsColor: .windowBackgroundColor)"
-  content-surface: "adaptive blue-green translucent tint over the window material; opaque controlBackgroundColor only for Reduce Transparency"
+  content-surface: "Color(nsColor: .controlBackgroundColor) — neutral, semantic, and appearance-adaptive"
   separator: "Color(nsColor: .separatorColor) / .quaternary"
   fill-subtle: ".quaternary  # tracks, inactive chips, zebra rows"
   accent: "Color.accentColor  # follows the user's system accent"
@@ -34,7 +34,7 @@ typography:
   section-title: ".title3 / .headline, semibold"
   body: ".body / .subheadline"
   label: ".caption, secondary"
-  metric: ".system(size: ~24-26, weight: .bold) — primary text unless exhausted"
+  metric: ".system(size: ~24-26, weight: .bold) — primary text; put semantic status color on the adjacent indicator"
   note: "On materials use Regular/Medium/Semibold/Bold weights; thin glyphs lose legibility. Letter spacing is zero. Never scale text with viewport width."
 rounded:
   note: "Prefer concentric / container-relative radii and Capsule over scattered fixed values. Native containers (List/GroupBox/Form) handle radii for you."
@@ -63,7 +63,7 @@ Both surfaces stay lean. Avoid decorative hero layouts, big nested cards, and ex
 Liquid Glass is the system's **chrome layer** — the menu bar, the popover surface, toolbars, sidebars, and the occasional floating control. We get it for free by using standard components and **removing** custom chrome. The work is subtraction, not decoration:
 
 - **Do not** paint popover/window backgrounds with a color + material. Let the system popover/window surface (and `NavigationSplitView` sidebar/toolbar) supply the glass.
-- **Do not** paint content cards with opaque dark-gray slabs. Use the shared adaptive translucent tint and hairline so the window material remains visible.
+- **Do not** paint content cards with fixed dark-gray or product-colored washes. Use the shared semantic `controlBackgroundColor` and hairline.
 - **Do not** wrap content cards in a second material layer ("fake glass"). Content is **not** a glass layer.
 - **Never** stack a material over another material (glass-on-glass).
 - For genuinely free-floating custom controls only, use a single `.glassEffect(.regular, in:)` inside a `GlassEffectContainer`. Use it sparingly.

--- a/.agents/SESSIONS/2026-07-23.md
+++ b/.agents/SESSIONS/2026-07-23.md
@@ -11,7 +11,7 @@
 - Updated the surface regression coverage and design guidance.
 
 **Files changed:**
-- `MeterBar/Views/MeterBarTheme.swift` - neutral semantic content and inset surfaces.
+- `MeterBar/Views/MeterBarTheme.swift` - one neutral semantic content surface.
 - `MeterBar/Views/DashboardCard.swift` - primary metric values and tinted indicator icons.
 - `MeterBar/Views/UsageDashboardView.swift` - removed decorative green/blue metric tints.
 - `MeterBar/Views/OptimizeInsightsView.swift` - adopted the indicator-tint API.
@@ -19,7 +19,8 @@
 - `.agents/DESIGN.md` - aligned the documented color system with the implementation.
 
 **Decisions:**
-- Use `NSColor.controlBackgroundColor` for cards and `NSColor.windowBackgroundColor` for recessed rows.
+- Use the already-opaque `NSColor.controlBackgroundColor` for cards in every transparency mode.
+- Do not keep unused surface tokens or a separate Reduce Transparency branch when both paths render identically.
 - Reserve semantic color for compact indicators rather than large metric typography.
 
 **Next steps:**

--- a/.agents/SESSIONS/2026-07-23.md
+++ b/.agents/SESSIONS/2026-07-23.md
@@ -1,0 +1,27 @@
+# 2026-07-23
+
+## Session 1: Neutral macOS card and metric colors
+
+**Status:** Complete
+
+**What was done:**
+- Replaced the custom cyan content-card wash with semantic AppKit background colors.
+- Moved dashboard metric tint from the value to its indicator icon; values now use primary text.
+- Kept quota and optimization status color where it communicates state.
+- Updated the surface regression coverage and design guidance.
+
+**Files changed:**
+- `MeterBar/Views/MeterBarTheme.swift` - neutral semantic content and inset surfaces.
+- `MeterBar/Views/DashboardCard.swift` - primary metric values and tinted indicator icons.
+- `MeterBar/Views/UsageDashboardView.swift` - removed decorative green/blue metric tints.
+- `MeterBar/Views/OptimizeInsightsView.swift` - adopted the indicator-tint API.
+- `MeterBarTests/LiquidGlassP1RegressionTests.swift` - verifies native semantic surface colors.
+- `.agents/DESIGN.md` - aligned the documented color system with the implementation.
+
+**Decisions:**
+- Use `NSColor.controlBackgroundColor` for cards and `NSColor.windowBackgroundColor` for recessed rows.
+- Reserve semantic color for compact indicators rather than large metric typography.
+
+**Next steps:**
+- [x] Run SwiftLint and inspect the final diff.
+- [ ] Use PR CI for tests/build verification.

--- a/MeterBar/Views/DashboardCard.swift
+++ b/MeterBar/Views/DashboardCard.swift
@@ -163,7 +163,7 @@ struct DashboardMetricTile: View {
   let value: String
   let caption: String
   let systemImage: String
-  let indicatorTint: Color
+  var indicatorTint: Color = .secondary
   var style: Style = .regular
 
   var body: some View {
@@ -175,6 +175,8 @@ struct DashboardMetricTile: View {
         } icon: {
           Image(systemName: systemImage)
             .foregroundStyle(indicatorTint)
+            .imageScale(.medium)
+            .symbolRenderingMode(.hierarchical)
         }
           .font(style.titleFont)
           .fontWeight(style.titleWeight)

--- a/MeterBar/Views/DashboardCard.swift
+++ b/MeterBar/Views/DashboardCard.swift
@@ -163,23 +163,28 @@ struct DashboardMetricTile: View {
   let value: String
   let caption: String
   let systemImage: String
-  let tint: Color
+  let indicatorTint: Color
   var style: Style = .regular
 
   var body: some View {
     DashboardTile(minHeight: style.minHeight) {
       VStack(alignment: .leading, spacing: style.spacing) {
-        Label(title, systemImage: systemImage)
+        Label {
+          Text(title)
+            .foregroundStyle(.secondary)
+        } icon: {
+          Image(systemName: systemImage)
+            .foregroundStyle(indicatorTint)
+        }
           .font(style.titleFont)
           .fontWeight(style.titleWeight)
-          .foregroundColor(.secondary)
           .labelStyle(.titleAndIcon)
           .lineLimit(1)
 
         Text(value)
           .font(style.valueFont)
           .fontWeight(.semibold)
-          .foregroundStyle(tint)
+          .foregroundStyle(.primary)
           .lineLimit(1)
           .minimumScaleFactor(style.valueMinimumScaleFactor)
           .contentTransition(.numericText())

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -109,18 +109,11 @@ enum MeterBarTheme {
     /// consumed by ``MeterBarDetailBackground``.
     static let chromeOpaqueFallback = Color(nsColor: .windowBackgroundColor)
 
-    /// **Layer 2 — content.** The single content-card fill. Every card sits on
-    /// this neutral, appearance-adaptive system color. Applied via
-    /// ``SwiftUI/View/meterBarCardSurface(cornerRadius:)`` — the one source of
-    /// truth for card fills.
+    /// **Layer 2 — content.** The single opaque content-card fill in every
+    /// transparency mode. This neutral, appearance-adaptive system color is
+    /// applied via ``SwiftUI/View/meterBarCardSurface(cornerRadius:)`` — the
+    /// one source of truth for card fills.
     static let content = Color(nsColor: .controlBackgroundColor)
-
-    /// Opaque accessibility fallback used only when Reduce Transparency is on.
-    static let contentOpaqueFallback = Color(nsColor: .controlBackgroundColor)
-
-    /// **Layer 2 — inset.** A row nested inside a ``content`` card, one step
-    /// recessed. Use for grouped rows *within* a card, not for the card itself.
-    static let inset = Color(nsColor: .windowBackgroundColor)
   }
 
   // MARK: - Brand accents (semantic indicators only; adapt to light/dark)
@@ -359,8 +352,6 @@ extension View {
 
 private struct MeterBarCardSurfaceModifier: ViewModifier {
   let cornerRadius: CGFloat
-  @Environment(\.accessibilityReduceTransparency)
-  private var reduceTransparency
 
   func body(content: Content) -> some View {
     let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
@@ -370,12 +361,7 @@ private struct MeterBarCardSurfaceModifier: ViewModifier {
     // wash. A hairline provides the boundary without shadows or a second glass
     // layer.
     content
-      .background(
-        reduceTransparency
-          ? MeterBarTheme.Surface.contentOpaqueFallback
-          : MeterBarTheme.Surface.content,
-        in: shape
-      )
+      .background(MeterBarTheme.Surface.content, in: shape)
       .overlay {
         shape.strokeBorder(MeterBarTheme.glassCardStroke, lineWidth: 1)
       }

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -82,11 +82,11 @@ enum MeterBarTheme {
   /// glass is not the goal; consistency is). Under Reduce Transparency both
   /// collapse to ``chromeOpaqueFallback`` — good citizenship, preserved.
   ///
-  /// **Layer 2 — CONTENT.** ``content`` is the single subtle, translucent fill
-  /// for every dashboard, settings, and popover card. It lets the window's
-  /// material/tint remain visible instead of turning each section into an
-  /// opaque dark-gray slab. ``inset`` is the quieter nested-row fill. Reduce
-  /// Transparency switches cards to ``contentOpaqueFallback``.
+  /// **Layer 2 — CONTENT.** ``content`` is the single neutral semantic fill for
+  /// every dashboard, settings, and popover card. It follows the system's
+  /// control background across appearances instead of washing content with a
+  /// product tint. ``inset`` is the quieter nested-row fill. Reduce Transparency
+  /// keeps the same opaque semantic treatment.
   ///
   /// The existing "glass shell containing flat-fill cards" structure is the
   /// correct Apple pattern; these tokens make it deliberate rather than
@@ -110,27 +110,17 @@ enum MeterBarTheme {
     static let chromeOpaqueFallback = Color(nsColor: .windowBackgroundColor)
 
     /// **Layer 2 — content.** The single content-card fill. Every card sits on
-    /// this subtle, appearance-adaptive tint. Applied via
+    /// this neutral, appearance-adaptive system color. Applied via
     /// ``SwiftUI/View/meterBarCardSurface(cornerRadius:)`` — the one source of
     /// truth for card fills.
-    static let content = Color.adaptive(
-      light: NSColor(srgbRed: 0.10, green: 0.42, blue: 0.50, alpha: 0.055),
-      dark: NSColor(srgbRed: 0.34, green: 0.72, blue: 0.80, alpha: 0.18),
-      lightHighContrast: NSColor(srgbRed: 0.08, green: 0.38, blue: 0.46, alpha: 0.12),
-      darkHighContrast: NSColor(srgbRed: 0.38, green: 0.76, blue: 0.84, alpha: 0.28)
-    )
+    static let content = Color(nsColor: .controlBackgroundColor)
 
     /// Opaque accessibility fallback used only when Reduce Transparency is on.
     static let contentOpaqueFallback = Color(nsColor: .controlBackgroundColor)
 
     /// **Layer 2 — inset.** A row nested inside a ``content`` card, one step
     /// recessed. Use for grouped rows *within* a card, not for the card itself.
-    static let inset = Color.adaptive(
-      light: NSColor(srgbRed: 0.08, green: 0.35, blue: 0.42, alpha: 0.04),
-      dark: NSColor(srgbRed: 0.28, green: 0.60, blue: 0.68, alpha: 0.10),
-      lightHighContrast: NSColor(srgbRed: 0.06, green: 0.32, blue: 0.39, alpha: 0.09),
-      darkHighContrast: NSColor(srgbRed: 0.32, green: 0.66, blue: 0.74, alpha: 0.18)
-    )
+    static let inset = Color(nsColor: .windowBackgroundColor)
   }
 
   // MARK: - Brand accents (semantic indicators only; adapt to light/dark)
@@ -375,10 +365,10 @@ private struct MeterBarCardSurfaceModifier: ViewModifier {
   func body(content: Content) -> some View {
     let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
 
-    // Every content card funnels through here. The adaptive translucent tint
-    // preserves the window's material instead of painting opaque gray slabs;
-    // Reduce Transparency gets a semantic opaque fallback. A hairline provides
-    // the boundary without shadows or a second glass layer.
+    // Every content card funnels through here. The semantic system fill follows
+    // the active appearance and accessibility contrast without a product-color
+    // wash. A hairline provides the boundary without shadows or a second glass
+    // layer.
     content
       .background(
         reduceTransparency

--- a/MeterBar/Views/OptimizeInsightsView.swift
+++ b/MeterBar/Views/OptimizeInsightsView.swift
@@ -120,15 +120,13 @@ struct OptimizeInsightsView: View {
         title: "Input : output",
         value: insights.formattedInputOutputRatio,
         caption: "context sent vs generated",
-        systemImage: "text.append",
-        indicatorTint: .secondary
+        systemImage: "text.append"
       )
       DashboardMetricTile(
         title: "Last 7 days",
         value: UsageFormat.tokens(insights.tokens7Day),
         caption: "\(UsageFormat.tokens(insights.tokens30Day)) over 30 days",
-        systemImage: "calendar",
-        indicatorTint: .secondary
+        systemImage: "calendar"
       )
     }
     .frame(maxWidth: .infinity)

--- a/MeterBar/Views/OptimizeInsightsView.swift
+++ b/MeterBar/Views/OptimizeInsightsView.swift
@@ -107,28 +107,28 @@ struct OptimizeInsightsView: View {
         value: insights.formattedPremiumShare,
         caption: "of tokens on premium models",
         systemImage: "bolt.fill",
-        tint: Self.shareTint(insights.premiumTokenShare)
+        indicatorTint: Self.shareTint(insights.premiumTokenShare)
       )
       DashboardMetricTile(
         title: "Cache reuse",
         value: insights.formattedCacheReuse,
         caption: "cache reads vs new context",
         systemImage: "arrow.triangle.2.circlepath",
-        tint: Self.cacheTint(insights.cacheReuseRatio)
+        indicatorTint: Self.cacheTint(insights.cacheReuseRatio)
       )
       DashboardMetricTile(
         title: "Input : output",
         value: insights.formattedInputOutputRatio,
         caption: "context sent vs generated",
         systemImage: "text.append",
-        tint: .secondary
+        indicatorTint: .secondary
       )
       DashboardMetricTile(
         title: "Last 7 days",
         value: UsageFormat.tokens(insights.tokens7Day),
         caption: "\(UsageFormat.tokens(insights.tokens30Day)) over 30 days",
         systemImage: "calendar",
-        tint: .secondary
+        indicatorTint: .secondary
       )
     }
     .frame(maxWidth: .infinity)

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -1150,7 +1150,6 @@ private struct OverviewSummaryStrip: View {
                 value: estimatedCost ?? "Scan needed",
                 caption: "\(formattedTokens) tokens",
                 systemImage: "chart.bar.xaxis",
-                indicatorTint: .secondary,
                 style: .compact
             )
 
@@ -1159,7 +1158,6 @@ private struct OverviewSummaryStrip: View {
                 value: "\(sourceCount)",
                 caption: sourceCaption,
                 systemImage: "checklist.checked",
-                indicatorTint: .secondary,
                 style: .compact
             )
         }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -1140,7 +1140,7 @@ private struct OverviewSummaryStrip: View {
                     value: tightestValue(now: timeline.date),
                     caption: tightestCaption,
                     systemImage: tightestIconName,
-                    tint: tightestColor,
+                    indicatorTint: tightestColor,
                     style: .compact
                 )
             }
@@ -1150,7 +1150,7 @@ private struct OverviewSummaryStrip: View {
                 value: estimatedCost ?? "Scan needed",
                 caption: "\(formattedTokens) tokens",
                 systemImage: "chart.bar.xaxis",
-                tint: MeterBarTheme.success,
+                indicatorTint: .secondary,
                 style: .compact
             )
 
@@ -1159,7 +1159,7 @@ private struct OverviewSummaryStrip: View {
                 value: "\(sourceCount)",
                 caption: sourceCaption,
                 systemImage: "checklist.checked",
-                tint: MeterBarTheme.appAccent,
+                indicatorTint: .secondary,
                 style: .compact
             )
         }

--- a/MeterBarTests/LiquidGlassP1RegressionTests.swift
+++ b/MeterBarTests/LiquidGlassP1RegressionTests.swift
@@ -8,22 +8,28 @@ import XCTest
 final class LiquidGlassP1RegressionTests: XCTestCase {
     // MARK: - Surface vocabulary invariants
 
-    /// Content layers use neutral semantic AppKit colors rather than a
-    /// product-colored wash, so they adapt with the active system appearance.
-    func testContentSurfaceTokensUseNeutralSystemColors() {
-        assertMatchesSystemColor(
+    /// Content uses a neutral, opaque fill that genuinely adapts between the
+    /// system's light and dark appearances rather than a product-colored wash.
+    func testContentSurfaceIsNeutralOpaqueAndAppearanceAdaptive() {
+        let aqua = resolvedSRGB(
             MeterBarTheme.Surface.content,
-            systemColor: .controlBackgroundColor
+            appearanceName: .aqua
         )
-        assertMatchesSystemColor(
-            MeterBarTheme.Surface.inset,
-            systemColor: .windowBackgroundColor
+        let darkAqua = resolvedSRGB(
+            MeterBarTheme.Surface.content,
+            appearanceName: .darkAqua
         )
-    }
 
-    /// Reduce Transparency still has an opaque semantic card fill.
-    func testContentReduceTransparencyFallbackIsOpaque() {
-        assertOpaque(MeterBarTheme.Surface.contentOpaqueFallback)
+        for color in [aqua, darkAqua] {
+            XCTAssertEqual(color.alphaComponent, 1, accuracy: 0.0001)
+            let channels = [color.redComponent, color.greenComponent, color.blueComponent]
+            XCTAssertLessThan(
+                (channels.max() ?? 1) - (channels.min() ?? 0),
+                0.02
+            )
+        }
+
+        XCTAssertNotEqual(aqua, darkAqua)
     }
 
     /// Chrome glass collapses to this fill under Reduce Transparency; the whole
@@ -60,23 +66,27 @@ final class LiquidGlassP1RegressionTests: XCTestCase {
         }
     }
 
-    private func assertMatchesSystemColor(
+    private func resolvedSRGB(
         _ color: Color,
-        systemColor: NSColor,
+        appearanceName: NSAppearance.Name,
         file: StaticString = #filePath,
         line: UInt = #line
-    ) {
-        let appearances = [NSAppearance(named: .aqua), NSAppearance(named: .darkAqua)]
-            .compactMap { $0 }
-        for appearance in appearances {
-            var actual: NSColor?
-            var expected: NSColor?
-            appearance.performAsCurrentDrawingAppearance {
-                actual = NSColor(color).usingColorSpace(.sRGB)
-                expected = systemColor.usingColorSpace(.sRGB)
-            }
-            XCTAssertEqual(actual, expected, file: file, line: line)
+    ) -> NSColor {
+        guard let appearance = NSAppearance(named: appearanceName) else {
+            XCTFail("Missing \(appearanceName) appearance", file: file, line: line)
+            return .clear
         }
+
+        var resolved: NSColor?
+        appearance.performAsCurrentDrawingAppearance {
+            resolved = NSColor(color).usingColorSpace(.sRGB)
+        }
+
+        guard let resolved else {
+            XCTFail("Could not resolve color in sRGB", file: file, line: line)
+            return .clear
+        }
+        return resolved
     }
 
     func testMenuPanelCanBecomeKey() {

--- a/MeterBarTests/LiquidGlassP1RegressionTests.swift
+++ b/MeterBarTests/LiquidGlassP1RegressionTests.swift
@@ -8,11 +8,17 @@ import XCTest
 final class LiquidGlassP1RegressionTests: XCTestCase {
     // MARK: - Surface vocabulary invariants
 
-    /// Normal content surfaces stay translucent so the window material remains
-    /// visible instead of becoming opaque dark-gray slabs.
-    func testContentSurfaceTokensAreTranslucent() {
-        assertTranslucent(MeterBarTheme.Surface.content)
-        assertTranslucent(MeterBarTheme.Surface.inset)
+    /// Content layers use neutral semantic AppKit colors rather than a
+    /// product-colored wash, so they adapt with the active system appearance.
+    func testContentSurfaceTokensUseNeutralSystemColors() {
+        assertMatchesSystemColor(
+            MeterBarTheme.Surface.content,
+            systemColor: .controlBackgroundColor
+        )
+        assertMatchesSystemColor(
+            MeterBarTheme.Surface.inset,
+            systemColor: .windowBackgroundColor
+        )
     }
 
     /// Reduce Transparency still has an opaque semantic card fill.
@@ -54,20 +60,22 @@ final class LiquidGlassP1RegressionTests: XCTestCase {
         }
     }
 
-    private func assertTranslucent(
+    private func assertMatchesSystemColor(
         _ color: Color,
+        systemColor: NSColor,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
         let appearances = [NSAppearance(named: .aqua), NSAppearance(named: .darkAqua)]
             .compactMap { $0 }
         for appearance in appearances {
-            var alpha: CGFloat = -1
+            var actual: NSColor?
+            var expected: NSColor?
             appearance.performAsCurrentDrawingAppearance {
-                alpha = NSColor(color).usingColorSpace(.sRGB)?.alphaComponent ?? -1
+                actual = NSColor(color).usingColorSpace(.sRGB)
+                expected = systemColor.usingColorSpace(.sRGB)
             }
-            XCTAssertGreaterThan(alpha, 0, file: file, line: line)
-            XCTAssertLessThan(alpha, 1, file: file, line: line)
+            XCTAssertEqual(actual, expected, file: file, line: line)
         }
     }
 


### PR DESCRIPTION
## Summary
- replace the cyan content-card wash with neutral AppKit semantic backgrounds
- render shared dashboard metric values in primary text and move meaningful status color to icons
- align design guidance and surface regression coverage with the native macOS hierarchy

## Verification
- `swiftlint lint --strict --no-cache` (0 violations)
- `git diff --check`
- local tests/typecheck/build intentionally not run per repository MacBook policy; PR CI is the verification gate

## Planning / review routing
- planning_degraded: Claude Fable and Opus structured planning calls both returned `Not logged in`; bounded Sol fallback plan used
- exact-head Opus review will be attempted against the pushed SHA