### PR TITLE
refactor(dashboard): split share + diagnostics out of UsageDashboardView

### DIFF
--- a/MeterBar/Services/DiagnosticsRunner.swift
+++ b/MeterBar/Services/DiagnosticsRunner.swift
@@ -1,0 +1,63 @@
+import Foundation
+import MeterBarShared
+
+/// Owns diagnostics input mapping, readiness inspection, and report formatting.
+enum DiagnosticsRunner {
+    struct InputKey: Equatable {
+        let providers: [ServiceType]
+        let defaultClaudeAccountEnabled: Bool
+        let enabledClaudeCustomAccountIDs: [UUID]
+    }
+
+    static func refreshErrors(
+        claudeDefaultAccountEnabled: Bool,
+        claudeError: ServiceError?,
+        codexError: ServiceError?,
+        cursorError: ServiceError?,
+        openRouterError: ServiceError?,
+        grokError: ServiceError?
+    ) -> [ServiceType: ServiceError] {
+        var result: [ServiceType: ServiceError] = [:]
+        if claudeDefaultAccountEnabled, let claudeError {
+            result[.claudeCode] = claudeError
+        }
+        if let codexError {
+            result[.codexCli] = codexError
+        }
+        if let cursorError {
+            result[.cursor] = cursorError
+        }
+        if let openRouterError {
+            result[.openRouter] = openRouterError
+        }
+        if let grokError {
+            result[.grok] = grokError
+        }
+        return result
+    }
+
+    static func inspect(
+        enabledProviders: Set<ServiceType>,
+        refreshErrors: [ServiceType: ServiceError],
+        claudeDefaultAccountEnabled: Bool,
+        claudeEnabledAccountMetrics: [UsageMetrics]
+    ) async -> [ProviderReadiness] {
+        await Task.detached(priority: .userInitiated) {
+            ProviderReadinessInspector.reports(
+                providers: enabledProviders,
+                refreshErrors: refreshErrors,
+                claudeDefaultAccountEnabled: claudeDefaultAccountEnabled,
+                claudeEnabledAccountMetrics: claudeEnabledAccountMetrics
+            )
+        }.value
+    }
+
+    static func summary(for reports: [ProviderReadiness]) -> String? {
+        guard !reports.isEmpty else { return nil }
+        return ProviderReadinessSummary(reports: reports).displayText
+    }
+
+    static func reportText(for reports: [ProviderReadiness]) -> String {
+        DiagnosticsReportText.plainText(reports)
+    }
+}

--- a/MeterBar/Views/SocialCardRenderer.swift
+++ b/MeterBar/Views/SocialCardRenderer.swift
@@ -1,4 +1,5 @@
 import AppKit
+import MeterBarShared
 import SwiftUI
 
 /// Owns share-card content assembly and PNG rendering outside UsageDashboardView.

--- a/MeterBar/Views/SocialCardRenderer.swift
+++ b/MeterBar/Views/SocialCardRenderer.swift
@@ -1,0 +1,71 @@
+import AppKit
+import SwiftUI
+
+/// Owns share-card content assembly and PNG rendering outside UsageDashboardView.
+enum SocialCardRenderer {
+    nonisolated static func content(
+        costSummary: CostSummary?,
+        providerSnapshotTitles: [String],
+        enabledSourceLabels: [String],
+        generatedAt: Date
+    ) -> SocialShareCardContent {
+        let tokenTotal = costSummary?.totalTokens
+        let sessionCount = costSummary?.costs.reduce(0) { $0 + $1.sessionCount }
+        let topProviderName = costSummary?.costs.max {
+            $0.totalTokens < $1.totalTokens
+        }?.provider.displayName
+
+        let providerNames: [String]
+        if let costs = costSummary?.costs, !costs.isEmpty {
+            providerNames = costs.map(\.provider.displayName)
+        } else if !providerSnapshotTitles.isEmpty {
+            providerNames = providerSnapshotTitles
+        } else {
+            providerNames = enabledSourceLabels
+        }
+
+        let dailyTokenTotals: [Int]
+        if let costSummary {
+            dailyTokenTotals = SocialShareCardContent.dailyTokenTotals(
+                from: costSummary.dailyUsage,
+                now: generatedAt
+            )
+        } else {
+            dailyTokenTotals = []
+        }
+
+        return SocialShareCardContent(
+            tokenTotal: tokenTotal,
+            sessionCount: sessionCount,
+            providerNames: providerNames,
+            topProviderName: topProviderName,
+            dailyTokenTotals: dailyTokenTotals,
+            generatedAt: generatedAt
+        )
+    }
+
+    @MainActor
+    static func image(for content: SocialShareCardContent) -> NSImage? {
+        let exportSize = SocialShareCardLayout.exportSize
+        let renderer = ImageRenderer(
+            content: SocialShareCard(content: content)
+                .frame(width: exportSize.width, height: exportSize.height)
+        )
+        renderer.proposedSize = ProposedViewSize(width: exportSize.width, height: exportSize.height)
+        renderer.scale = 1
+        return renderer.nsImage
+    }
+
+    @MainActor
+    static func pngData(for content: SocialShareCardContent) -> Data? {
+        guard
+            let image = image(for: content),
+            let tiffData = image.tiffRepresentation,
+            let bitmap = NSBitmapImageRep(data: tiffData)
+        else {
+            return nil
+        }
+
+        return bitmap.representation(using: .png, properties: [:])
+    }
+}

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -712,21 +712,11 @@ struct UsageDashboardView: View {
     }
 
     private func makeSocialShareCardContent(generatedAt: Date) -> SocialShareCardContent {
-        SocialShareCardContent(
-            tokenTotal: visibleCostSummary?.totalTokens,
-            sessionCount: socialSessionCount,
-            providerNames: socialProviderNames,
-            topProviderName: socialTopProviderName,
-            dailyTokenTotals: socialDailyTokenTotals(generatedAt: generatedAt),
+        SocialCardRenderer.content(
+            costSummary: visibleCostSummary,
+            providerSnapshotTitles: providerSnapshots.map(\.title),
+            enabledSourceLabels: enabledSourceLabels,
             generatedAt: generatedAt
-        )
-    }
-
-    private func socialDailyTokenTotals(generatedAt: Date) -> [Int] {
-        guard let visibleCostSummary else { return [] }
-        return SocialShareCardContent.dailyTokenTotals(
-            from: visibleCostSummary.dailyUsage,
-            now: generatedAt
         )
     }
 
@@ -774,30 +764,6 @@ struct UsageDashboardView: View {
         makeSocialShareCardContent(generatedAt: socialCardGeneratedAt)
     }
 
-    private var socialSessionCount: Int? {
-        guard let costs = visibleCostSummary?.costs else { return nil }
-        return costs.reduce(0) { $0 + $1.sessionCount }
-    }
-
-    private var socialTopProviderName: String? {
-        visibleCostSummary?.costs.max { lhs, rhs in
-            lhs.totalTokens < rhs.totalTokens
-        }?.provider.displayName
-    }
-
-    private var socialProviderNames: [String] {
-        if let costs = visibleCostSummary?.costs, !costs.isEmpty {
-            return costs.map(\.provider.displayName)
-        }
-
-        let snapshotTitles = providerSnapshots.map(\.title)
-        if !snapshotTitles.isEmpty {
-            return snapshotTitles
-        }
-
-        return enabledSourceLabels
-    }
-
     private var enabledSourceLabels: [String] {
         var labels: [String] = []
         if providerVisibility.isEnabled(.codexCli) {
@@ -826,7 +792,10 @@ struct UsageDashboardView: View {
 
     private var diagnosticsContent: some View {
         VStack(alignment: .leading, spacing: 14) {
-            DashboardCard(title: "Provider Diagnostics", trailing: diagnosticsSummary) {
+            DashboardCard(
+                title: "Provider Diagnostics",
+                trailing: DiagnosticsRunner.summary(for: readinessReports)
+            ) {
                 VStack(alignment: .leading, spacing: 12) {
                     Text("These checks run locally. Every line is redacted — safe to paste into a GitHub issue.")
                         .font(.subheadline)
@@ -870,25 +839,14 @@ struct UsageDashboardView: View {
         }
     }
 
-    private struct DiagnosticsInputKey: Equatable {
-        let providers: [ServiceType]
-        let defaultClaudeAccountEnabled: Bool
-        let enabledClaudeCustomAccountIDs: [UUID]
-    }
-
-    private var diagnosticsInputKey: DiagnosticsInputKey {
-        DiagnosticsInputKey(
+    private var diagnosticsInputKey: DiagnosticsRunner.InputKey {
+        DiagnosticsRunner.InputKey(
             providers: ServiceType.allCases.filter { providerVisibility.enabledServices.contains($0) },
             defaultClaudeAccountEnabled: claudeAccountStore.defaultAccountIsEnabled,
             enabledClaudeCustomAccountIDs: claudeAccountStore.enabledAccounts
                 .filter { !$0.isDefault }
                 .map(\.id)
         )
-    }
-
-    private var diagnosticsSummary: String? {
-        guard !readinessReports.isEmpty else { return nil }
-        return ProviderReadinessSummary(reports: readinessReports).displayText
     }
 
     /// Runs the readiness inspector off the main actor (it does keychain / file /
@@ -906,39 +864,29 @@ struct UsageDashboardView: View {
 
     private func inspectReadiness() async -> [ProviderReadiness] {
         let enabledProviders = providerVisibility.enabledServices
-        let errors = currentRefreshErrors()
+        let errors = DiagnosticsRunner.refreshErrors(
+            claudeDefaultAccountEnabled: claudeAccountStore.defaultAccountIsEnabled,
+            claudeError: claudeCodeService.lastError,
+            codexError: codexCliService.lastError,
+            cursorError: cursorService.lastError,
+            openRouterError: openRouterService.lastError,
+            grokError: grokService.lastError
+        )
         let defaultClaudeAccountEnabled = claudeAccountStore.defaultAccountIsEnabled
         let enabledClaudeAccounts = claudeAccountStore.enabledAccounts
         let claudeMetrics = enabledClaudeAccounts.compactMap {
             dataManager.claudeCodeAccountMetrics[$0.id]
         }
-        return await Task.detached(priority: .userInitiated) {
-            ProviderReadinessInspector.reports(
-                providers: enabledProviders,
-                refreshErrors: errors,
-                claudeDefaultAccountEnabled: defaultClaudeAccountEnabled,
-                claudeEnabledAccountMetrics: claudeMetrics
-            )
-        }.value
-    }
-
-    /// Each provider's live last-refresh error, fed into the readiness core so the
-    /// "Last refresh" check reflects the app's actual runtime state.
-    private func currentRefreshErrors() -> [ServiceType: ServiceError] {
-        var result: [ServiceType: ServiceError] = [:]
-        if claudeAccountStore.defaultAccountIsEnabled,
-           let error = claudeCodeService.lastError {
-            result[.claudeCode] = error
-        }
-        if let error = codexCliService.lastError { result[.codexCli] = error }
-        if let error = cursorService.lastError { result[.cursor] = error }
-        if let error = openRouterService.lastError { result[.openRouter] = error }
-        if let error = grokService.lastError { result[.grok] = error }
-        return result
+        return await DiagnosticsRunner.inspect(
+            enabledProviders: enabledProviders,
+            refreshErrors: errors,
+            claudeDefaultAccountEnabled: defaultClaudeAccountEnabled,
+            claudeEnabledAccountMetrics: claudeMetrics
+        )
     }
 
     private func copyDiagnosticsToClipboard() {
-        let text = DiagnosticsReportText.plainText(readinessReports)
+        let text = DiagnosticsRunner.reportText(for: readinessReports)
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
     }
@@ -1000,7 +948,7 @@ struct UsageDashboardView: View {
         let content = makeSocialShareCardContent(generatedAt: generatedAt)
         socialCardGeneratedAt = generatedAt
 
-        guard let image = renderSocialCardImage(content: content) else {
+        guard let image = SocialCardRenderer.image(for: content) else {
             setSocialShareStatus("PNG render failed")
             return
         }
@@ -1019,7 +967,7 @@ struct UsageDashboardView: View {
         let content = makeSocialShareCardContent(generatedAt: generatedAt)
         socialCardGeneratedAt = generatedAt
 
-        guard let pngData = renderSocialCardPNGData(content: content) else {
+        guard let pngData = SocialCardRenderer.pngData(for: content) else {
             setSocialShareStatus("PNG render failed")
             return
         }
@@ -1048,29 +996,6 @@ struct UsageDashboardView: View {
         pasteboard.clearContents()
         pasteboard.setString(content.shareCaption, forType: .string)
         setSocialShareStatus("Caption copied")
-    }
-
-    private func renderSocialCardImage(content: SocialShareCardContent) -> NSImage? {
-        let exportSize = SocialShareCardLayout.exportSize
-        let renderer = ImageRenderer(
-            content: SocialShareCard(content: content)
-                .frame(width: exportSize.width, height: exportSize.height)
-        )
-        renderer.proposedSize = ProposedViewSize(width: exportSize.width, height: exportSize.height)
-        renderer.scale = 1
-        return renderer.nsImage
-    }
-
-    private func renderSocialCardPNGData(content: SocialShareCardContent) -> Data? {
-        guard
-            let image = renderSocialCardImage(content: content),
-            let tiffData = image.tiffRepresentation,
-            let bitmap = NSBitmapImageRep(data: tiffData)
-        else {
-            return nil
-        }
-
-        return bitmap.representation(using: .png, properties: [:])
     }
 
     private func setSocialShareStatus(_ status: String) {

--- a/MeterBarTests/DiagnosticsRunnerTests.swift
+++ b/MeterBarTests/DiagnosticsRunnerTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+import MeterBarShared
+@testable import MeterBar
+
+final class DiagnosticsRunnerTests: XCTestCase {
+    func testRefreshErrorsIncludesEnabledDefaultClaudeError() {
+        let result = DiagnosticsRunner.refreshErrors(
+            claudeDefaultAccountEnabled: true,
+            claudeError: .apiError("x"),
+            codexError: nil,
+            cursorError: nil,
+            openRouterError: nil,
+            grokError: nil
+        )
+
+        XCTAssertNotNil(result[.claudeCode])
+    }
+
+    func testRefreshErrorsOmitsDisabledDefaultClaudeAndKeepsCodexError() {
+        let result = DiagnosticsRunner.refreshErrors(
+            claudeDefaultAccountEnabled: false,
+            claudeError: .apiError("claude"),
+            codexError: .apiError("codex"),
+            cursorError: nil,
+            openRouterError: nil,
+            grokError: nil
+        )
+
+        XCTAssertNil(result[.claudeCode])
+        XCTAssertNotNil(result[.codexCli])
+    }
+
+    func testRefreshErrorsWithNoErrorsIsEmpty() {
+        let result = DiagnosticsRunner.refreshErrors(
+            claudeDefaultAccountEnabled: true,
+            claudeError: nil,
+            codexError: nil,
+            cursorError: nil,
+            openRouterError: nil,
+            grokError: nil
+        )
+
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testRefreshErrorsMapsEachNonClaudeProvider() {
+        let result = DiagnosticsRunner.refreshErrors(
+            claudeDefaultAccountEnabled: true,
+            claudeError: nil,
+            codexError: .apiError("codex"),
+            cursorError: .apiError("cursor"),
+            openRouterError: .apiError("openrouter"),
+            grokError: .apiError("grok")
+        )
+
+        XCTAssertNotNil(result[.codexCli])
+        XCTAssertNotNil(result[.cursor])
+        XCTAssertNotNil(result[.openRouter])
+        XCTAssertNotNil(result[.grok])
+    }
+
+    func testSummaryReturnsNilForEmptyReports() {
+        XCTAssertNil(DiagnosticsRunner.summary(for: []))
+    }
+
+    func testSummaryMatchesProviderReadinessSummary() {
+        let reports = [report()]
+
+        XCTAssertEqual(
+            DiagnosticsRunner.summary(for: reports),
+            ProviderReadinessSummary(reports: reports).displayText
+        )
+    }
+
+    func testReportTextMatchesDiagnosticsReportText() {
+        let reports = [report()]
+
+        XCTAssertEqual(
+            DiagnosticsRunner.reportText(for: reports),
+            DiagnosticsReportText.plainText(reports)
+        )
+    }
+
+    private func report() -> ProviderReadiness {
+        ProviderReadiness(
+            provider: .codexCli,
+            checks: [
+                ReadinessCheck(
+                    id: "test",
+                    title: "Test",
+                    level: .pass,
+                    detail: "Ready"
+                ),
+            ]
+        )
+    }
+}

--- a/MeterBarTests/SocialCardRendererTests.swift
+++ b/MeterBarTests/SocialCardRendererTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+import MeterBarShared
+@testable import MeterBar
+
+final class SocialCardRendererTests: XCTestCase {
+    func testContentAggregatesSessionsAndUsesCostProviders() {
+        let generatedAt = Date(timeIntervalSince1970: 10_000)
+        let codexCost = makeCost(
+            provider: .codexCli,
+            inputTokens: 100,
+            outputTokens: 50,
+            sessionCount: 3
+        )
+        let claudeCost = makeCost(
+            provider: .claudeCode,
+            inputTokens: 400,
+            outputTokens: 200,
+            sessionCount: 7
+        )
+        let costs = [codexCost, claudeCost]
+        let summary = CostSummary(
+            costs: costs,
+            totalCostUSD: 1.5,
+            totalTokens: costs.reduce(0) { $0 + $1.totalTokens },
+            periodDays: 30
+        )
+
+        let content = SocialCardRenderer.content(
+            costSummary: summary,
+            providerSnapshotTitles: ["Snapshot"],
+            enabledSourceLabels: ["Enabled"],
+            generatedAt: generatedAt
+        )
+
+        XCTAssertEqual(content.sessionCount, 10)
+        XCTAssertEqual(content.topProviderName, ServiceType.claudeCode.displayName)
+        XCTAssertEqual(content.providerNames, costs.map(\.provider.displayName))
+    }
+
+    func testContentWithoutSummaryUsesEnabledSourceLabels() {
+        let content = SocialCardRenderer.content(
+            costSummary: nil,
+            providerSnapshotTitles: [],
+            enabledSourceLabels: ["Codex logs", "Claude JSONL"],
+            generatedAt: Date(timeIntervalSince1970: 10_000)
+        )
+
+        XCTAssertNil(content.tokenTotal)
+        XCTAssertNil(content.sessionCount)
+        XCTAssertEqual(content.providerNames, ["Codex logs", "Claude JSONL"])
+        XCTAssertEqual(content.dailyTokenTotals, [])
+    }
+
+    func testContentWithEmptyCostsUsesProviderSnapshotTitles() {
+        let summary = CostSummary(
+            costs: [],
+            totalCostUSD: 0,
+            totalTokens: 0,
+            periodDays: 30
+        )
+
+        let content = SocialCardRenderer.content(
+            costSummary: summary,
+            providerSnapshotTitles: ["Codex", "Claude"],
+            enabledSourceLabels: ["Enabled"],
+            generatedAt: Date(timeIntervalSince1970: 10_000)
+        )
+
+        XCTAssertEqual(content.providerNames, ["Codex", "Claude"])
+    }
+
+    func testContentBuildsDailyTokenTotalsFromSummary() {
+        let generatedAt = Date(timeIntervalSince1970: 86400 * 10)
+        let dailyUsage = [
+            DailyTokenUsage(
+                date: generatedAt.addingTimeInterval(-86400),
+                provider: .codexCli,
+                inputTokens: 100,
+                outputTokens: 50,
+                cacheReadTokens: 25,
+                estimatedCostUSD: 0.1
+            ),
+            DailyTokenUsage(
+                date: generatedAt,
+                provider: .claudeCode,
+                inputTokens: 200,
+                outputTokens: 75,
+                cacheReadTokens: 10,
+                estimatedCostUSD: 0.2
+            ),
+        ]
+        let summary = CostSummary(
+            costs: [],
+            totalCostUSD: 0.3,
+            totalTokens: dailyUsage.reduce(0) { $0 + $1.totalTokens },
+            periodDays: 30,
+            dailyUsage: dailyUsage
+        )
+
+        let content = SocialCardRenderer.content(
+            costSummary: summary,
+            providerSnapshotTitles: [],
+            enabledSourceLabels: [],
+            generatedAt: generatedAt
+        )
+
+        XCTAssertEqual(
+            content.dailyTokenTotals,
+            SocialShareCardContent.dailyTokenTotals(from: summary.dailyUsage, now: generatedAt)
+        )
+    }
+
+    @MainActor
+    func testImageAndPNGRendering() {
+        let content = SocialShareCardContent(
+            tokenTotal: 1_000_000,
+            sessionCount: 10,
+            providerNames: ["Codex", "Claude"],
+            topProviderName: "Claude",
+            dailyTokenTotals: Array(repeating: 100, count: 30),
+            generatedAt: Date(timeIntervalSince1970: 10_000)
+        )
+
+        guard let image = SocialCardRenderer.image(for: content) else {
+            XCTFail("Expected share-card image")
+            return
+        }
+        XCTAssertEqual(image.size, SocialShareCardLayout.exportSize)
+
+        guard let pngData = SocialCardRenderer.pngData(for: content) else {
+            XCTFail("Expected share-card PNG data")
+            return
+        }
+        XCTAssertEqual(
+            Array(pngData.prefix(8)),
+            [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+        )
+    }
+
+    private func makeCost(
+        provider: ServiceType,
+        inputTokens: Int,
+        outputTokens: Int,
+        sessionCount: Int
+    ) -> TokenCost {
+        TokenCost(
+            provider: provider,
+            inputTokens: inputTokens,
+            outputTokens: outputTokens,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 0,
+            estimatedCostUSD: 0.5,
+            sessionCount: sessionCount,
+            periodStart: Date(timeIntervalSince1970: 0),
+            periodEnd: Date(timeIntervalSince1970: 10_000)
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Pure structural refactor. Splits the two non-view concerns out of `UsageDashboardView.swift` (~1170 lines mixing SwiftUI view code, share-card rendering, and diagnostics) into focused, independently-testable helpers. Behavior is preserved exactly — identical rendered cards, identical diagnostics output.

- **`SocialCardRenderer`** (`MeterBar/Views/SocialCardRenderer.swift`) — owns share-card content assembly (`content(...)`) and PNG/`NSImage` rendering (`image(for:)`, `pngData(for:)`).
- **`DiagnosticsRunner`** (`MeterBar/Services/DiagnosticsRunner.swift`) — owns diagnostics input mapping (`InputKey`, `refreshErrors(...)`), off-main readiness inspection (`inspect(...)`), and report formatting (`summary(for:)`, `reportText(for:)`).
- **`UsageDashboardView`** shrinks from 1172 → 1097 lines and becomes a thin delegator. All `@State` and AppKit side effects stay in the view.

Follows the repo's established extraction convention: pure-logic helpers as `enum` with `static` funcs taking primitive inputs (cf. `ProviderReadinessInspector`, `EnabledQuotaSourceCounter`).

## Tests

- `MeterBarTests/SocialCardRendererTests.swift` — content aggregation across cost providers, fallback to snapshot titles / enabled labels, daily-token-total construction, and image + PNG-signature rendering.
- `MeterBarTests/DiagnosticsRunnerTests.swift` — refresh-error mapping variants, empty-report summary handling, and parity with `ProviderReadinessSummary` / `DiagnosticsReportText`.

## Verification

- SwiftLint `--strict` clean (`force_unwrapping` + `non_optional_string_data_conversion` enabled); no force-unwraps in new source.
- No orphaned symbol references; view diff confirmed behavior-preserving.
- Build/test via CI (not run locally).