### PR TITLE
refactor(wake): unify provider runners behind a generic descriptor

### DIFF
--- a/.agents/SESSIONS/2026-07-24.md
+++ b/.agents/SESSIONS/2026-07-24.md
@@ -1,0 +1,72 @@
+# 2026-07-24
+
+## Session 1: DRY the Session Wake provider runners
+
+**Status:** Implementation complete; SwiftLint clean; PR CI + exact-head Opus verification pending
+
+```mermaid
+flowchart LR
+    Desc[WakeRunnerDescriptor] --> Runner[WakeProcessRunner]
+    Desc -->|binaryName, overrideEnvVar| Runner
+    Desc -->|buildCommand closure| Runner
+    Desc -->|classifyDenial closure?| Runner
+    ClaudeF[.claude factory] --> Desc
+    CodexF[.codex factory] --> Desc
+    Prov[WakeQuotaProviding&lt;Account&gt;] --> Auth[WakeQuotaAuthority&lt;Account&gt;]
+    LiveClaude[LiveWakeQuotaProvider] --> Prov
+    LiveCodex[LiveCodexWakeQuotaProvider] --> Prov
+```
+
+### Affected components
+
+- Session Wake process-execution seam (`WakeExecuting`)
+- Session Wake quota-authority seam (fail-closed gate)
+- Provider runtimes (Claude, Codex) and their orchestration call sites
+- Wake unit tests
+
+### Root cause / motivation
+
+- Two near-identical provider runners (`WakeProcessRunner` for Claude, `CodexWakeProcessRunner` for Codex) shared ~170 lines of structure — revalidate cwd, take the lock, spawn with an argv, enforce timeout, honor cancellation, record a metadata-only log line — differing only along four axes: binary name, override env var, command builder, and an optional denial classifier.
+- Two near-identical quota authorities (`WakeQuotaAuthority`, `CodexWakeQuotaAuthority`) differed only by account type.
+
+### What was done
+
+- Introduced `WakeRunnerDescriptor` — a `Sendable` value holding exactly the four axes that differ: `binaryName`, `overrideEnvVar`, a `@Sendable buildCommand` closure, and an optional `@Sendable classifyDenial` closure.
+- Collapsed both runners into one generic `WakeProcessRunner: WakeExecuting` parameterized by a descriptor; added `.claude(...)` and `.codex(...)` static factories preserving every prior default argument.
+- Made the quota seam generic: `WakeQuotaProviding<Account>` (primary associated type) and `WakeQuotaAuthority<Account>`, with `LiveWakeQuotaProvider` (Claude) and `LiveCodexWakeQuotaProvider` (Codex) as the two providers.
+- Folded the Claude permission-denial classification into the Claude descriptor's `classifyDenial`; Codex's classifier is `nil` (its `approval_policy=never` runs can't stop at a permission gate, so a non-zero exit is always a plain failure).
+- Repurposed `CodexWakeProcessRunner.swift` and `CodexWakeQuotaAuthority.swift` in place (removed their now-redundant types, kept the files) so all three build systems — the Xcode project's explicit membership, the root `Package.swift` glob, and the CLI `Package.swift` glob — stay in sync without any `.pbxproj`/manifest edits.
+- Updated every call site (`ClaudeWakeRuntime`, `CodexWakeRuntime`, `WakeCLIEngine`, `WakeCoordinator`, `SessionWakeController`, `SessionWakeAgent`, `SessionWakeCLI`) to the generic authority type and the runner factories.
+- Kept and adapted the existing wake tests; added focused descriptor-shape tests plus a Codex-runner argv/env/denial-as-failure test.
+
+### Key decisions
+
+- Parameterize only the four axes that genuinely differ — no speculative abstraction over the shared spawn/lock/timeout/log spine.
+- Preserve behavior bug-for-bug: the Claude denial gate keys off the **raw requested** `permissionMode` (not the effective/acknowledged mode), so that exact `permissionMode != .bypass` guard lives inside the Claude classifier.
+- Retain the lossy UTF-8 decode (with its `swiftlint:disable optional_data_string_conversion` wrap) for the bounded capture — strict decoding would drop a whole capture truncated mid-multibyte, disabling classification in exactly the long-output case the bounded sink exists for.
+- Repurpose-in-place rather than delete files, to avoid touching three separate build manifests and risking drift between them.
+
+### Verification
+
+- Implementation delegated to Codex GPT-5.6 Sol at high effort with a self-contained contract (Codex is blind to the session); the main model planned, designed, and verified.
+- `swiftlint lint --strict --quiet` (the exact CI command) passed with exit 0, no output.
+- Full `git diff` reviewed against `master`: 16 modified files only; no added/deleted/untracked files; no `.pbxproj`/`Package.swift` changes.
+- Outcome strings confirmed byte-for-byte preserved for both providers (`<bin> exited with status N`, `<bin> terminated by signal N`, `session timed out`, `<bin> binary not found`).
+- Removed symbols (`CodexWakeProcessRunner`, `CodexWakeQuotaAuthority`, `CodexWakeQuotaProviding`) and the legacy `mapOutcome(_:permissionMode:)` confirmed fully absent.
+- Local builds, tests, and typechecks skipped under the MacBook verification policy; PR CI is the execution gate.
+
+### Files changed
+
+- `MeterBar/SessionWake/WakeProcessRunner.swift` — generic runner + descriptor + `.claude` factories.
+- `MeterBar/SessionWake/CodexWakeProcessRunner.swift` — repurposed to Codex descriptor + `.codex` factory (struct removed, file retained).
+- `MeterBar/SessionWake/WakeQuotaAuthority.swift` — generic `WakeQuotaProviding<Account>` + `WakeQuotaAuthority<Account>`.
+- `MeterBar/SessionWake/CodexWakeQuotaAuthority.swift` — repurposed to `LiveCodexWakeQuotaProvider` only (protocol + authority removed, file retained).
+- `MeterBar/SessionWake/ClaudeWakeRuntime.swift`, `CodexWakeRuntime.swift`, `WakeCLIEngine.swift`, `WakeCoordinator.swift` — generic authority typing + runner factory wiring.
+- `MeterBar/SessionWake/SessionWakeController.swift`, `SessionWakeAgent.swift`, `SessionWakeCLI.swift` — runner factory call sites.
+- `MeterBarTests/WakeRunnerTests.swift`, `CodexWakeQuotaTests.swift`, `WakeCLIEngineTests.swift`, `WakeCoordinatorTests.swift`, `CodexSessionDiscoveryTests.swift` — adapted + new coverage.
+- `.agents/SESSIONS/2026-07-24.md`
+
+### Next steps
+
+- [ ] Require green CI on the pushed head.
+- [ ] Require an exact-head Opus 4.8 PASS before merge.

--- a/MeterBar/SessionWake/ClaudeWakeRuntime.swift
+++ b/MeterBar/SessionWake/ClaudeWakeRuntime.swift
@@ -6,13 +6,13 @@ import Foundation
 nonisolated struct ClaudeWakeRuntime: WakeProviderRuntime {
     let account: ClaudeCodeAccount
     private let discovery: SessionDiscovery
-    private let authority: WakeQuotaAuthority
+    private let authority: WakeQuotaAuthority<ClaudeCodeAccount>
     private let makeRunnerForAccount: @Sendable (ClaudeCodeAccount) -> WakeExecuting
 
     init(
         account: ClaudeCodeAccount,
         discovery: SessionDiscovery = SessionDiscovery(),
-        authority: WakeQuotaAuthority = WakeQuotaAuthority(),
+        authority: WakeQuotaAuthority<ClaudeCodeAccount> = WakeQuotaAuthority(provider: LiveWakeQuotaProvider()),
         makeRunner: @escaping @Sendable (ClaudeCodeAccount) -> WakeExecuting
     ) {
         self.account = account

--- a/MeterBar/SessionWake/CodexWakeProcessRunner.swift
+++ b/MeterBar/SessionWake/CodexWakeProcessRunner.swift
@@ -1,28 +1,42 @@
 import Foundation
 
-/// The native process runner for Codex resumes — the Codex sibling of
-/// `WakeProcessRunner`.
-///
-/// Same discipline: revalidate the target cwd immediately before exec, take the
-/// shared lock only when actually ready, spawn `codex` with an argument array
-/// (never a shell), enforce a timeout with process-tree cleanup, honor
-/// structured cancellation, and record a metadata-only log line. Codex `.safe`
-/// runs cannot escalate (approval_policy=never), so a non-zero exit is a plain
-/// failure — there is no permission-denial gate to classify as with Claude.
-nonisolated struct CodexWakeProcessRunner: WakeExecuting {
-    /// Explicit executable path; when nil the `codex` binary is resolved.
-    let executable: String?
-    let permissionMode: WakePermissionMode
-    let bypassAcknowledged: Bool
-    let prompt: String
-    let account: CodexAccount
-    private let baseEnvironment: [String: String]
-    private let lockFactory: @Sendable () -> WakeLock
-    private let lockMode: WakeExecutionLockMode
-    private let logger: WakeRunLogger
-    private let now: @Sendable () -> Date
+// Codex is the second Session Wake provider. It shares the one generic
+// `WakeProcessRunner`; only these two axes differ from Claude — the `codex`
+// binary/argv, and the absence of a permission-denial gate (Codex `.safe` runs
+// set `approval_policy=never`, so a non-zero exit is always a plain failure).
 
-    init(
+nonisolated extension WakeRunnerDescriptor {
+    /// Descriptor for a Codex resume.
+    static func codex(
+        account: CodexAccount,
+        permissionMode: WakePermissionMode,
+        bypassAcknowledged: Bool,
+        prompt: String,
+        baseEnvironment: [String: String]
+    ) -> WakeRunnerDescriptor {
+        WakeRunnerDescriptor(
+            binaryName: "codex",
+            overrideEnvVar: "CODEX_CLI_PATH",
+            buildCommand: { executable, candidate, bounds in
+                CodexWakeCommandBuilder.build(
+                    executable: executable,
+                    candidate: candidate,
+                    account: account,
+                    bounds: bounds,
+                    prompt: prompt,
+                    permissionMode: permissionMode,
+                    bypassAcknowledged: bypassAcknowledged,
+                    baseEnvironment: baseEnvironment
+                )
+            },
+            classifyDenial: nil
+        )
+    }
+}
+
+nonisolated extension WakeProcessRunner {
+    /// Codex runner — same defaults the removed provider-specific runner had.
+    static func codex(
         account: CodexAccount,
         executable: String? = nil,
         permissionMode: WakePermissionMode = .safe,
@@ -33,148 +47,20 @@ nonisolated struct CodexWakeProcessRunner: WakeExecuting {
         lockMode: WakeExecutionLockMode = .acquirePerRun,
         logger: WakeRunLogger = WakeRunLogger(),
         now: @escaping @Sendable () -> Date = { Date() }
-    ) {
-        self.account = account
-        self.executable = executable
-        self.permissionMode = permissionMode
-        self.bypassAcknowledged = bypassAcknowledged
-        self.prompt = prompt
-        self.baseEnvironment = baseEnvironment
-        self.lockFactory = lockFactory
-        self.lockMode = lockMode
-        self.logger = logger
-        self.now = now
-    }
-
-    func run(_ candidate: WakeSessionCandidate, bounds: WakeBounds) async -> WakeRunOutcome {
-        guard let cwd = candidate.workingDirectory, isDirectory(cwd) else {
-            record(candidate: candidate, outcome: .skipped(reason: .missingWorkingDirectory), result: nil, start: now())
-            return .skipped(reason: .missingWorkingDirectory)
-        }
-
-        let codexPath = executable ?? CLIBinaryLocator.resolve(command: "codex", overrideEnvVar: "CODEX_CLI_PATH")
-        guard let resolved = codexPath else {
-            record(candidate: candidate, outcome: .failed(reason: "codex binary not found"), result: nil, start: now())
-            return .failed(reason: "codex binary not found")
-        }
-
-        let lock = lockMode == .acquirePerRun ? lockFactory() : nil
-        if let lock {
-            switch lock.acquire() {
-            case .acquired:
-                break
-            case let .contended(holder):
-                let suffix = holder.map { " (\($0.shortDescription))" } ?? ""
-                let outcome = WakeRunOutcome.failed(reason: "another Session Wake holder is active\(suffix)")
-                record(candidate: candidate, outcome: outcome, result: nil, start: now())
-                return outcome
-            case let .legacyHeld(guidance):
-                let outcome = WakeRunOutcome.failed(reason: guidance)
-                record(candidate: candidate, outcome: outcome, result: nil, start: now())
-                return outcome
-            case let .unavailable(reason):
-                let outcome = WakeRunOutcome.failed(reason: "wake lock unavailable: \(reason)")
-                record(candidate: candidate, outcome: outcome, result: nil, start: now())
-                return outcome
-            }
-        }
-        defer { lock?.release() }
-
-        let command = CodexWakeCommandBuilder.build(
-            executable: resolved,
-            candidate: candidate,
-            account: account,
-            bounds: bounds,
-            prompt: prompt,
-            permissionMode: permissionMode,
-            bypassAcknowledged: bypassAcknowledged,
-            baseEnvironment: baseEnvironment
+    ) -> WakeProcessRunner {
+        WakeProcessRunner(
+            descriptor: .codex(
+                account: account,
+                permissionMode: permissionMode,
+                bypassAcknowledged: bypassAcknowledged,
+                prompt: prompt,
+                baseEnvironment: baseEnvironment
+            ),
+            executable: executable,
+            lockFactory: lockFactory,
+            lockMode: lockMode,
+            logger: logger,
+            now: now
         )
-        let validated = WakeCommand(
-            executable: command.executable,
-            arguments: command.arguments,
-            environment: command.environment,
-            workingDirectory: cwd
-        )
-
-        let start = now()
-        let cancellation = ManagedProcess.Cancellation()
-        let result = await withTaskCancellationHandler {
-            await spawn(validated, timeout: bounds.perSessionTimeout, cancellation: cancellation)
-        } onCancel: {
-            cancellation.cancel()
-        }
-
-        let outcome = Self.mapOutcome(result)
-        record(candidate: candidate, outcome: outcome, result: result, start: start)
-        return outcome
-    }
-
-    // MARK: - Helpers
-
-    private func spawn(
-        _ command: WakeCommand,
-        timeout: TimeInterval,
-        cancellation: ManagedProcess.Cancellation
-    ) async -> ManagedProcess.Result {
-        await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let result = ManagedProcess.run(
-                    executable: command.executable,
-                    arguments: command.arguments,
-                    environment: command.environment,
-                    workingDirectory: command.workingDirectory,
-                    timeout: timeout,
-                    cancellation: cancellation
-                )
-                continuation.resume(returning: result)
-            }
-        }
-    }
-
-    private func isDirectory(_ path: String) -> Bool {
-        var isDirectory: ObjCBool = false
-        return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue
-    }
-
-    static func mapOutcome(_ result: ManagedProcess.Result) -> WakeRunOutcome {
-        switch result.termination {
-        case .exited(0):
-            return .succeeded
-        case let .exited(code):
-            return .failed(reason: "codex exited with status \(code)")
-        case let .signalled(signal):
-            return .failed(reason: "codex terminated by signal \(signal)")
-        case .timedOut:
-            return .failed(reason: "session timed out")
-        case .cancelled:
-            return .cancelled
-        case let .launchFailed(message):
-            return .failed(reason: message)
-        }
-    }
-
-    private func record(
-        candidate: WakeSessionCandidate,
-        outcome: WakeRunOutcome,
-        result: ManagedProcess.Result?,
-        start: Date
-    ) {
-        let exitCode: Int32?
-        switch result?.termination {
-        case let .exited(code): exitCode = code
-        default: exitCode = nil
-        }
-        logger.append(WakeRunLogger.Record(
-            timestamp: start,
-            event: "resume",
-            sessionID: candidate.sessionID,
-            reason: candidate.reason.rawValue,
-            outcome: outcome.logLabel,
-            exitCode: exitCode,
-            durationMilliseconds: Int(now().timeIntervalSince(start) * 1000),
-            stdoutBytes: result?.stdoutByteCount,
-            stderrBytes: result?.stderrByteCount
-        ))
     }
 }

--- a/MeterBar/SessionWake/CodexWakeQuotaAuthority.swift
+++ b/MeterBar/SessionWake/CodexWakeQuotaAuthority.swift
@@ -1,52 +1,12 @@
 import Foundation
 import MeterBarShared
 
-/// Source of *fresh* Codex quota, scoped to a selected `CodexAccount`
-/// (CODEX_HOME). Mirrors `WakeQuotaProviding` but over the Codex account type;
-/// cached UI metrics are never accepted as launch authority.
-nonisolated protocol CodexWakeQuotaProviding: Sendable {
-    func fetchMetrics(account: CodexAccount) async throws -> UsageMetrics
-}
-
-/// Default provider: the same Codex usage service the app and menu bar use,
-/// scoped to the account's CODEX_HOME.
-nonisolated struct LiveCodexWakeQuotaProvider: CodexWakeQuotaProviding {
+/// Default provider for Codex quota: the same Codex usage service the app and
+/// menu bar use, scoped to the account's CODEX_HOME. Conforms to the unified
+/// `WakeQuotaProviding` with `Account == CodexAccount`; the generic
+/// `WakeQuotaAuthority<CodexAccount>` provides the fail-closed gate.
+nonisolated struct LiveCodexWakeQuotaProvider: WakeQuotaProviding {
     func fetchMetrics(account: CodexAccount) async throws -> UsageMetrics {
         try await CodexCliLocalService.shared.fetchUsageMetrics(account: account)
-    }
-}
-
-/// Resolves a fresh Codex quota decision, failing closed on any error,
-/// staleness, or ambiguity — the same contract as the Claude authority. The
-/// classification itself is provider-agnostic (`WakeQuota.classify` reads only
-/// the shared `UsageMetrics`), so Codex's primary (5h) window maps onto the
-/// session limit and its secondary (weekly) window onto the weekly limit with
-/// no change to the gate.
-nonisolated struct CodexWakeQuotaAuthority: Sendable {
-    private let provider: CodexWakeQuotaProviding
-    private let maxAge: TimeInterval
-    private let now: @Sendable () -> Date
-
-    init(
-        provider: CodexWakeQuotaProviding = LiveCodexWakeQuotaProvider(),
-        maxAge: TimeInterval = 120,
-        now: @escaping @Sendable () -> Date = { Date() }
-    ) {
-        self.provider = provider
-        self.maxAge = maxAge
-        self.now = now
-    }
-
-    func freshQuota(account: CodexAccount) async -> WakeQuota {
-        let metrics: UsageMetrics
-        do {
-            metrics = try await provider.fetchMetrics(account: account)
-        } catch {
-            return .unknown(reason: "quota fetch failed: \(error.localizedDescription)")
-        }
-        if now().timeIntervalSince(metrics.lastUpdated) > maxAge {
-            return .unknown(reason: "quota reading is stale")
-        }
-        return WakeQuota.classify(metrics)
     }
 }

--- a/MeterBar/SessionWake/CodexWakeRuntime.swift
+++ b/MeterBar/SessionWake/CodexWakeRuntime.swift
@@ -6,13 +6,13 @@ import Foundation
 nonisolated struct CodexWakeRuntime: WakeProviderRuntime {
     let account: CodexAccount
     private let discovery: CodexSessionDiscovery
-    private let authority: CodexWakeQuotaAuthority
+    private let authority: WakeQuotaAuthority<CodexAccount>
     private let makeRunnerForAccount: @Sendable (CodexAccount) -> WakeExecuting
 
     init(
         account: CodexAccount,
         discovery: CodexSessionDiscovery = CodexSessionDiscovery(),
-        authority: CodexWakeQuotaAuthority = CodexWakeQuotaAuthority(),
+        authority: WakeQuotaAuthority<CodexAccount> = WakeQuotaAuthority(provider: LiveCodexWakeQuotaProvider()),
         makeRunner: @escaping @Sendable (CodexAccount) -> WakeExecuting
     ) {
         self.account = account

--- a/MeterBar/SessionWake/SessionWakeAgent.swift
+++ b/MeterBar/SessionWake/SessionWakeAgent.swift
@@ -85,7 +85,7 @@ public enum SessionWakeAgent {
                 configDirectory: configuration.accountDirectory
             )
             return ClaudeWakeRuntime(account: account) { runnerAccount in
-                WakeProcessRunner(
+                WakeProcessRunner.claude(
                     account: runnerAccount,
                     permissionMode: configuration.permissionMode,
                     bypassAcknowledged: configuration.bypassAcknowledged,
@@ -100,7 +100,7 @@ public enum SessionWakeAgent {
                 homeDirectory: configuration.accountDirectory
             )
             return CodexWakeRuntime(account: account) { runnerAccount in
-                CodexWakeProcessRunner(
+                WakeProcessRunner.codex(
                     account: runnerAccount,
                     permissionMode: configuration.permissionMode,
                     bypassAcknowledged: configuration.bypassAcknowledged,

--- a/MeterBar/SessionWake/SessionWakeCLI.swift
+++ b/MeterBar/SessionWake/SessionWakeCLI.swift
@@ -111,7 +111,7 @@ public enum SessionWakeCLI {
         case .claude:
             let account = resolveAccount(configDirectory: configDirectory)
             return ClaudeWakeRuntime(account: account) { runnerAccount in
-                WakeProcessRunner(
+                WakeProcessRunner.claude(
                     account: runnerAccount,
                     permissionMode: mode,
                     bypassAcknowledged: bypassAcknowledged
@@ -120,7 +120,7 @@ public enum SessionWakeCLI {
         case .codex:
             let account = resolveCodexAccount(homeDirectory: configDirectory)
             return CodexWakeRuntime(account: account) { runnerAccount in
-                CodexWakeProcessRunner(
+                WakeProcessRunner.codex(
                     account: runnerAccount,
                     permissionMode: mode,
                     bypassAcknowledged: bypassAcknowledged

--- a/MeterBar/SessionWake/SessionWakeController.swift
+++ b/MeterBar/SessionWake/SessionWakeController.swift
@@ -209,7 +209,7 @@ final class SessionWakeController: ObservableObject {
             guard let id = store.wakeAccountID,
                   let account = accounts.enabledAccounts.first(where: { $0.id == id }) else { return nil }
             return ClaudeWakeRuntime(account: account) { runnerAccount in
-                WakeProcessRunner(
+                WakeProcessRunner.claude(
                     account: runnerAccount,
                     permissionMode: mode,
                     bypassAcknowledged: bypass,
@@ -220,7 +220,7 @@ final class SessionWakeController: ObservableObject {
             guard let id = store.wakeCodexAccountID,
                   let account = codexAccounts.enabledAccounts.first(where: { $0.id == id }) else { return nil }
             return CodexWakeRuntime(account: account) { runnerAccount in
-                CodexWakeProcessRunner(
+                WakeProcessRunner.codex(
                     account: runnerAccount,
                     permissionMode: mode,
                     bypassAcknowledged: bypass,

--- a/MeterBar/SessionWake/WakeCLIEngine.swift
+++ b/MeterBar/SessionWake/WakeCLIEngine.swift
@@ -12,7 +12,7 @@ import Foundation
 /// caller that already speaks `ClaudeCodeAccount` keeps working unchanged.
 struct WakeCLIEngine {
     private let discovery: SessionDiscovery
-    private let authority: WakeQuotaAuthority
+    private let authority: WakeQuotaAuthority<ClaudeCodeAccount>
     private let makeRunner: @Sendable (ClaudeCodeAccount) -> WakeExecuting
     private let ledgerFactory: @Sendable () -> ReplayLedger
     private let lock: WakeLock
@@ -21,8 +21,10 @@ struct WakeCLIEngine {
 
     init(
         discovery: SessionDiscovery = SessionDiscovery(),
-        authority: WakeQuotaAuthority = WakeQuotaAuthority(),
-        makeRunner: @escaping @Sendable (ClaudeCodeAccount) -> WakeExecuting = { WakeProcessRunner(account: $0) },
+        authority: WakeQuotaAuthority<ClaudeCodeAccount> = WakeQuotaAuthority(provider: LiveWakeQuotaProvider()),
+        makeRunner: @escaping @Sendable (ClaudeCodeAccount) -> WakeExecuting = {
+            WakeProcessRunner.claude(account: $0)
+        },
         ledgerFactory: @escaping @Sendable () -> ReplayLedger = { ReplayLedger() },
         lock: WakeLock = WakeLock(holderKind: .cli),
         bounds: WakeBounds = .default,

--- a/MeterBar/SessionWake/WakeCoordinator.swift
+++ b/MeterBar/SessionWake/WakeCoordinator.swift
@@ -12,7 +12,7 @@ import Foundation
 /// structured cancellation semantics are identical in both processes.
 actor WakeCoordinator {
     private let discovery: SessionDiscovery
-    private let authority: WakeQuotaAuthority
+    private let authority: WakeQuotaAuthority<ClaudeCodeAccount>
     private let runner: WakeExecuting
     private let ledger: ReplayLedger
     private let bounds: WakeBounds
@@ -26,7 +26,7 @@ actor WakeCoordinator {
 
     init(
         discovery: SessionDiscovery = SessionDiscovery(),
-        authority: WakeQuotaAuthority = WakeQuotaAuthority(),
+        authority: WakeQuotaAuthority<ClaudeCodeAccount> = WakeQuotaAuthority(provider: LiveWakeQuotaProvider()),
         runner: WakeExecuting,
         ledger: ReplayLedger = ReplayLedger(),
         bounds: WakeBounds = .default,

--- a/MeterBar/SessionWake/WakeProcessRunner.swift
+++ b/MeterBar/SessionWake/WakeProcessRunner.swift
@@ -7,44 +7,54 @@ nonisolated enum WakeExecutionLockMode: Equatable, Sendable {
     case externallyOwned
 }
 
+/// The per-provider axes a Session Wake process run differs along. Everything
+/// else (revalidate cwd, take the lock, spawn with an argv, enforce timeout,
+/// honor cancellation, record a metadata-only log line) is identical across
+/// providers and lives in `WakeProcessRunner`.
+nonisolated struct WakeRunnerDescriptor: Sendable {
+    /// CLI binary to resolve/spawn; also used verbatim in outcome messages.
+    let binaryName: String
+    /// Env var that overrides binary resolution (e.g. `CLAUDE_CLI_PATH`).
+    let overrideEnvVar: String
+    /// Builds the argv+env+cwd for one resume. Captures the bound account,
+    /// permission mode, bypass ack, prompt, and base environment.
+    let buildCommand: @Sendable (
+        _ executable: String,
+        _ candidate: WakeSessionCandidate,
+        _ bounds: WakeBounds
+    ) -> WakeCommand
+    /// Optional denial classifier for a non-zero exit. `nil` ⇒ a non-zero exit
+    /// is always a plain failure (Codex: `approval_policy=never` can't stop at a
+    /// permission gate, so there is nothing to classify).
+    let classifyDenial: (@Sendable (ManagedProcess.Result) -> Bool)?
+}
+
 /// The one native process runner shared by MeterBar and its CLI.
 ///
 /// Responsibilities: revalidate the target immediately before exec, take the
-/// shared lock only when actually ready to run, spawn `claude` with an argument
-/// array (never a shell), enforce a timeout with process-tree cleanup, honor
-/// structured-task cancellation, and record a metadata-only log line. A dead
-/// worktree is a structured skip, not a failure that aborts the queue.
+/// shared lock only when actually ready to run, spawn the provider CLI with an
+/// argument array (never a shell), enforce a timeout with process-tree cleanup,
+/// honor structured-task cancellation, and record a metadata-only log line. A
+/// dead worktree is a structured skip, not a failure that aborts the queue.
 nonisolated struct WakeProcessRunner: WakeExecuting {
-    /// Explicit executable path; when nil the `claude` binary is resolved.
+    /// Explicit executable path; when nil the descriptor's binary is resolved.
     let executable: String?
-    let permissionMode: WakePermissionMode
-    let bypassAcknowledged: Bool
-    let prompt: String
-    let account: ClaudeCodeAccount
-    private let baseEnvironment: [String: String]
+    private let descriptor: WakeRunnerDescriptor
     private let lockFactory: @Sendable () -> WakeLock
     private let lockMode: WakeExecutionLockMode
     private let logger: WakeRunLogger
     private let now: @Sendable () -> Date
 
     init(
-        account: ClaudeCodeAccount,
+        descriptor: WakeRunnerDescriptor,
         executable: String? = nil,
-        permissionMode: WakePermissionMode = .safe,
-        bypassAcknowledged: Bool = false,
-        prompt: String = WakeCommandBuilder.defaultPrompt,
-        baseEnvironment: [String: String] = ProcessInfo.processInfo.environment,
         lockFactory: @escaping @Sendable () -> WakeLock = { WakeLock() },
         lockMode: WakeExecutionLockMode = .acquirePerRun,
         logger: WakeRunLogger = WakeRunLogger(),
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
-        self.account = account
+        self.descriptor = descriptor
         self.executable = executable
-        self.permissionMode = permissionMode
-        self.bypassAcknowledged = bypassAcknowledged
-        self.prompt = prompt
-        self.baseEnvironment = baseEnvironment
         self.lockFactory = lockFactory
         self.lockMode = lockMode
         self.logger = logger
@@ -59,10 +69,14 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
             return .skipped(reason: .missingWorkingDirectory)
         }
 
-        let claudePath = executable ?? CLIBinaryLocator.resolve(command: "claude", overrideEnvVar: "CLAUDE_CLI_PATH")
-        guard let resolved = claudePath else {
-            record(candidate: candidate, outcome: .failed(reason: "claude binary not found"), result: nil, start: now())
-            return .failed(reason: "claude binary not found")
+        let path = executable ?? CLIBinaryLocator.resolve(
+            command: descriptor.binaryName,
+            overrideEnvVar: descriptor.overrideEnvVar
+        )
+        guard let resolved = path else {
+            let outcome = WakeRunOutcome.failed(reason: "\(descriptor.binaryName) binary not found")
+            record(candidate: candidate, outcome: outcome, result: nil, start: now())
+            return outcome
         }
 
         let lock = lockMode == .acquirePerRun ? lockFactory() : nil
@@ -90,16 +104,7 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
         }
         defer { lock?.release() }
 
-        let command = WakeCommandBuilder.build(
-            executable: resolved,
-            candidate: candidate,
-            account: account,
-            bounds: bounds,
-            prompt: prompt,
-            permissionMode: permissionMode,
-            bypassAcknowledged: bypassAcknowledged,
-            baseEnvironment: baseEnvironment
-        )
+        let command = descriptor.buildCommand(resolved, candidate, bounds)
         // Overwrite the resolved cwd with the just-revalidated one.
         let validated = WakeCommand(
             executable: command.executable,
@@ -116,7 +121,7 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
             cancellation.cancel()
         }
 
-        let outcome = Self.mapOutcome(result, permissionMode: permissionMode)
+        let outcome = Self.mapOutcome(result, descriptor: descriptor)
         record(candidate: candidate, outcome: outcome, result: result, start: start)
         return outcome
     }
@@ -148,20 +153,19 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
         return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue
     }
 
-    static func mapOutcome(_ result: ManagedProcess.Result, permissionMode: WakePermissionMode) -> WakeRunOutcome {
+    static func mapOutcome(_ result: ManagedProcess.Result, descriptor: WakeRunnerDescriptor) -> WakeRunOutcome {
         switch result.termination {
         case .exited(0):
             return .succeeded
         case let .exited(code):
-            // Classification only — the bounded capture is inspected here and
-            // never logged or retained beyond this call. Bypass runs skip the
-            // permission gate entirely, so a denial label can't apply there.
-            if permissionMode != .bypass, indicatesPermissionDenial(result) {
+            // Classification only — the bounded capture is inspected here and never
+            // logged or retained beyond this call.
+            if descriptor.classifyDenial?(result) == true {
                 return .permissionDenied
             }
-            return .failed(reason: "claude exited with status \(code)")
+            return .failed(reason: "\(descriptor.binaryName) exited with status \(code)")
         case let .signalled(signal):
-            return .failed(reason: "claude terminated by signal \(signal)")
+            return .failed(reason: "\(descriptor.binaryName) terminated by signal \(signal)")
         case .timedOut:
             return .failed(reason: "session timed out")
         case .cancelled:
@@ -169,22 +173,6 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
         case let .launchFailed(message):
             return .failed(reason: message)
         }
-    }
-
-    /// Whether a non-zero exit reads as a stop at the permission-approval gate.
-    /// The captured output exists only in memory on `result`; nothing here (or
-    /// downstream) writes it anywhere.
-    private static func indicatesPermissionDenial(_ result: ManagedProcess.Result) -> Bool {
-        // Lossy decode: a capture truncated at the byte cap can split a
-        // multibyte character, and strict decoding would drop the WHOLE
-        // capture — disabling classification in exactly the long-output case
-        // the bounded sink exists for.
-        // swiftlint:disable optional_data_string_conversion
-        let combined = String(decoding: result.stdoutCapture, as: UTF8.self)
-            + "\n"
-            + String(decoding: result.stderrCapture, as: UTF8.self)
-        // swiftlint:enable optional_data_string_conversion
-        return PermissionDenialDetector.indicatesDenial(in: combined)
     }
 
     private func record(
@@ -209,6 +197,82 @@ nonisolated struct WakeProcessRunner: WakeExecuting {
             stdoutBytes: result?.stdoutByteCount,
             stderrBytes: result?.stderrByteCount
         ))
+    }
+}
+
+nonisolated extension WakeRunnerDescriptor {
+    /// Descriptor for a Claude Code resume.
+    static func claude(
+        account: ClaudeCodeAccount,
+        permissionMode: WakePermissionMode,
+        bypassAcknowledged: Bool,
+        prompt: String,
+        baseEnvironment: [String: String]
+    ) -> WakeRunnerDescriptor {
+        WakeRunnerDescriptor(
+            binaryName: "claude",
+            overrideEnvVar: "CLAUDE_CLI_PATH",
+            buildCommand: { executable, candidate, bounds in
+                WakeCommandBuilder.build(
+                    executable: executable,
+                    candidate: candidate,
+                    account: account,
+                    bounds: bounds,
+                    prompt: prompt,
+                    permissionMode: permissionMode,
+                    bypassAcknowledged: bypassAcknowledged,
+                    baseEnvironment: baseEnvironment
+                )
+            },
+            classifyDenial: { result in
+                // BUG-FOR-BUG PRESERVATION: the original gate keyed off the RAW
+                // requested `permissionMode` (NOT the effective/acknowledged
+                // mode). A bypass request skips the permission gate entirely, so
+                // a denial label can't apply there. Keep this exact check.
+                guard permissionMode != .bypass else { return false }
+                // Lossy decode: a capture truncated at the byte cap can split a
+                // multibyte character; strict decoding would drop the WHOLE
+                // capture and disable classification in exactly the long-output
+                // case the bounded sink exists for.
+                // swiftlint:disable optional_data_string_conversion
+                let combined = String(decoding: result.stdoutCapture, as: UTF8.self)
+                    + "\n"
+                    + String(decoding: result.stderrCapture, as: UTF8.self)
+                // swiftlint:enable optional_data_string_conversion
+                return PermissionDenialDetector.indicatesDenial(in: combined)
+            }
+        )
+    }
+}
+
+nonisolated extension WakeProcessRunner {
+    /// Claude Code runner — same defaults the old `WakeProcessRunner.init` had.
+    static func claude(
+        account: ClaudeCodeAccount,
+        executable: String? = nil,
+        permissionMode: WakePermissionMode = .safe,
+        bypassAcknowledged: Bool = false,
+        prompt: String = WakeCommandBuilder.defaultPrompt,
+        baseEnvironment: [String: String] = ProcessInfo.processInfo.environment,
+        lockFactory: @escaping @Sendable () -> WakeLock = { WakeLock() },
+        lockMode: WakeExecutionLockMode = .acquirePerRun,
+        logger: WakeRunLogger = WakeRunLogger(),
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) -> WakeProcessRunner {
+        WakeProcessRunner(
+            descriptor: .claude(
+                account: account,
+                permissionMode: permissionMode,
+                bypassAcknowledged: bypassAcknowledged,
+                prompt: prompt,
+                baseEnvironment: baseEnvironment
+            ),
+            executable: executable,
+            lockFactory: lockFactory,
+            lockMode: lockMode,
+            logger: logger,
+            now: now
+        )
     }
 }
 

--- a/MeterBar/SessionWake/WakeQuotaAuthority.swift
+++ b/MeterBar/SessionWake/WakeQuotaAuthority.swift
@@ -3,9 +3,11 @@ import MeterBarShared
 
 /// Source of *fresh* account-scoped quota. Cached UI metrics are never passed
 /// here — the authority always pulls a live reading so a launch decision can
-/// never rest on stale numbers.
-nonisolated protocol WakeQuotaProviding: Sendable {
-    func fetchMetrics(account: ClaudeCodeAccount) async throws -> UsageMetrics
+/// never rest on stale numbers. Generic over the provider's account type so one
+/// authority serves every provider (Claude, Codex, ...).
+nonisolated protocol WakeQuotaProviding<Account>: Sendable {
+    associatedtype Account
+    func fetchMetrics(account: Account) async throws -> UsageMetrics
 }
 
 /// Default provider. For the default account it prefers the authenticated
@@ -56,16 +58,14 @@ nonisolated struct LiveWakeQuotaProvider: WakeQuotaProviding {
 }
 
 /// Resolves a fresh quota decision for the selected account, failing closed on
-/// any error, staleness, or ambiguity.
-nonisolated struct WakeQuotaAuthority: Sendable {
-    private let provider: WakeQuotaProviding
-    /// Metrics older than this are not accepted as execution authority even if
-    /// a fetch returned them.
+/// any error, staleness, or ambiguity. Generic over the account type.
+nonisolated struct WakeQuotaAuthority<Account>: Sendable {
+    private let provider: any WakeQuotaProviding<Account>
     private let maxAge: TimeInterval
     private let now: @Sendable () -> Date
 
     init(
-        provider: WakeQuotaProviding = LiveWakeQuotaProvider(),
+        provider: any WakeQuotaProviding<Account>,
         maxAge: TimeInterval = 120,
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
@@ -75,10 +75,9 @@ nonisolated struct WakeQuotaAuthority: Sendable {
     }
 
     /// Fetch and classify fresh quota for `account`.
-    ///
-    /// - A thrown fetch (missing OAuth, CLI error) ⇒ `.unknown` (fail closed).
+    /// - A thrown fetch ⇒ `.unknown` (fail closed).
     /// - Metrics older than `maxAge` ⇒ `.unknown` (never treat cache as truth).
-    func freshQuota(account: ClaudeCodeAccount) async -> WakeQuota {
+    func freshQuota(account: Account) async -> WakeQuota {
         let metrics: UsageMetrics
         do {
             metrics = try await provider.fetchMetrics(account: account)

--- a/MeterBarTests/CodexSessionDiscoveryTests.swift
+++ b/MeterBarTests/CodexSessionDiscoveryTests.swift
@@ -125,7 +125,7 @@ final class CodexSessionDiscoveryTests: XCTestCase {
         let runtime = CodexWakeRuntime(
             account: CodexAccount(id: UUID(), name: "a", homeDirectory: home.path),
             discovery: CodexSessionDiscovery(),
-            authority: CodexWakeQuotaAuthority(provider: OpenCodexProvider(), maxAge: 3600, now: { Date() }),
+            authority: WakeQuotaAuthority(provider: OpenCodexProvider(), maxAge: 3600, now: { Date() }),
             makeRunner: { _ in runner }
         )
         let engine = WakeCLIEngine(
@@ -145,7 +145,7 @@ final class CodexSessionDiscoveryTests: XCTestCase {
         let runner = CodexRecordingRunner(outcome: .succeeded)
         let runtime = CodexWakeRuntime(
             account: CodexAccount(id: UUID(), name: "a", homeDirectory: home.path),
-            authority: CodexWakeQuotaAuthority(provider: ThrowingCodexProvider2()),
+            authority: WakeQuotaAuthority(provider: ThrowingCodexProvider2()),
             makeRunner: { _ in runner }
         )
         let engine = WakeCLIEngine(
@@ -173,13 +173,13 @@ private actor CodexRecordingRunner: WakeExecuting {
     }
 }
 
-private struct OpenCodexProvider: CodexWakeQuotaProviding {
+private struct OpenCodexProvider: WakeQuotaProviding {
     func fetchMetrics(account: CodexAccount) async throws -> UsageMetrics {
         UsageMetrics(service: .codexCli, sessionLimit: UsageLimit(used: 5, total: 100, resetTime: nil), lastUpdated: Date())
     }
 }
 
-private struct ThrowingCodexProvider2: CodexWakeQuotaProviding {
+private struct ThrowingCodexProvider2: WakeQuotaProviding {
     struct Boom: Error {}
     func fetchMetrics(account: CodexAccount) async throws -> UsageMetrics { throw Boom() }
 }

--- a/MeterBarTests/CodexWakeQuotaTests.swift
+++ b/MeterBarTests/CodexWakeQuotaTests.swift
@@ -8,14 +8,14 @@ final class CodexWakeQuotaTests: XCTestCase {
     private func account() -> CodexAccount { CodexAccount(id: UUID(), name: "a", homeDirectory: nil) }
 
     func testFetchFailureIsUnknown() async {
-        let authority = CodexWakeQuotaAuthority(provider: ThrowingCodexProvider(), maxAge: 3600, now: { Date() })
+        let authority = WakeQuotaAuthority(provider: ThrowingCodexProvider(), maxAge: 3600, now: { Date() })
         let quota = await authority.freshQuota(account: account())
         guard case .unknown = quota else { return XCTFail("fetch failure must fail closed, got \(quota)") }
     }
 
     func testStaleMetricsAreUnknownNotAuthority() async {
         let stale = Date(timeIntervalSince1970: 0)
-        let authority = CodexWakeQuotaAuthority(
+        let authority = WakeQuotaAuthority(
             provider: FixedCodexProvider(.open, lastUpdated: stale), maxAge: 120, now: { Date() }
         )
         let quota = await authority.freshQuota(account: account())
@@ -23,13 +23,13 @@ final class CodexWakeQuotaTests: XCTestCase {
     }
 
     func testFreshOpenMetricsAreAvailable() async {
-        let authority = CodexWakeQuotaAuthority(provider: FixedCodexProvider(.open), maxAge: 3600, now: { Date() })
+        let authority = WakeQuotaAuthority(provider: FixedCodexProvider(.open), maxAge: 3600, now: { Date() })
         let quota = await authority.freshQuota(account: account())
         XCTAssertEqual(quota, .available)
     }
 
     func testFreshBlockedMetricsAreBlocked() async {
-        let authority = CodexWakeQuotaAuthority(provider: FixedCodexProvider(.blocked), maxAge: 3600, now: { Date() })
+        let authority = WakeQuotaAuthority(provider: FixedCodexProvider(.blocked), maxAge: 3600, now: { Date() })
         let quota = await authority.freshQuota(account: account())
         guard case .blocked = quota else { return XCTFail("maxed session window must block, got \(quota)") }
     }
@@ -37,12 +37,12 @@ final class CodexWakeQuotaTests: XCTestCase {
 
 // MARK: - Doubles
 
-private struct ThrowingCodexProvider: CodexWakeQuotaProviding {
+private struct ThrowingCodexProvider: WakeQuotaProviding {
     struct Boom: Error {}
     func fetchMetrics(account: CodexAccount) async throws -> UsageMetrics { throw Boom() }
 }
 
-private struct FixedCodexProvider: CodexWakeQuotaProviding {
+private struct FixedCodexProvider: WakeQuotaProviding {
     enum Kind { case open, blocked }
     let kind: Kind
     let lastUpdated: Date

--- a/MeterBarTests/WakeCLIEngineTests.swift
+++ b/MeterBarTests/WakeCLIEngineTests.swift
@@ -71,7 +71,7 @@ final class WakeCLIEngineTests: XCTestCase {
             discovery: SessionDiscovery(),
             authority: WakeQuotaAuthority(provider: FixedProvider(.open), maxAge: 3600, now: { Date() }),
             makeRunner: { runnerAccount in
-                WakeProcessRunner(
+                WakeProcessRunner.claude(
                     account: runnerAccount,
                     executable: fake,
                     baseEnvironment: ["PATH": "/usr/bin:/bin"],
@@ -91,7 +91,7 @@ final class WakeCLIEngineTests: XCTestCase {
     }
 
     private func makeEngine(
-        provider: WakeQuotaProviding,
+        provider: any WakeQuotaProviding<ClaudeCodeAccount>,
         runner: WakeExecuting,
         shouldCancel: @escaping @Sendable () -> Bool = { false }
     ) -> WakeCLIEngine {

--- a/MeterBarTests/WakeCoordinatorTests.swift
+++ b/MeterBarTests/WakeCoordinatorTests.swift
@@ -48,7 +48,7 @@ final class WakeCoordinatorTests: XCTestCase {
     }
 
     private func makeCoordinator(
-        provider: WakeQuotaProviding,
+        provider: any WakeQuotaProviding<ClaudeCodeAccount>,
         runner: WakeExecuting,
         bounds: WakeBounds = WakeBounds.default,
         sleep: @escaping @Sendable (TimeInterval) async throws -> Void

--- a/MeterBarTests/WakeRunnerTests.swift
+++ b/MeterBarTests/WakeRunnerTests.swift
@@ -21,7 +21,12 @@ final class WakeRunnerTests: XCTestCase {
         let script = """
         #!/bin/bash
         if [ -n "$WAKE_TEST_OUT" ]; then
-          { echo "ARGS:$*"; echo "PWD:$(pwd)"; echo "CFG:${CLAUDE_CONFIG_DIR}"; } >> "$WAKE_TEST_OUT"
+          {
+            echo "ARGS:$*"
+            echo "PWD:$(pwd)"
+            echo "CFG:${CLAUDE_CONFIG_DIR}"
+            echo "CODEX_HOME:${CODEX_HOME}"
+          } >> "$WAKE_TEST_OUT"
         fi
         if [ -n "$WAKE_STDERR_MSG" ]; then echo "$WAKE_STDERR_MSG" >&2; fi
         exit "${WAKE_EXIT:-0}"
@@ -51,6 +56,10 @@ final class WakeRunnerTests: XCTestCase {
         ClaudeCodeAccount(id: UUID(), name: "acct", configDirectory: tempDir.appendingPathComponent("cfg").path)
     }
 
+    private func codexAccount() -> CodexAccount {
+        CodexAccount(id: UUID(), name: "codex", homeDirectory: tempDir.appendingPathComponent("codex-home").path)
+    }
+
     private func makeRunner(
         fake: String,
         env: [String: String],
@@ -61,7 +70,7 @@ final class WakeRunnerTests: XCTestCase {
         var env = env
         env["PATH"] = env["PATH"] ?? "/usr/bin:/bin"
         let lockURL = tempDir.appendingPathComponent("wake.lock")
-        return WakeProcessRunner(
+        return WakeProcessRunner.claude(
             account: account(),
             executable: fake,
             permissionMode: permissionMode,
@@ -124,6 +133,36 @@ final class WakeRunnerTests: XCTestCase {
         XCTAssertTrue(command.arguments.contains(String(WakeBounds.default.maxTurns)))
     }
 
+    // MARK: - Descriptors
+
+    func testClaudeDescriptorShape() {
+        let descriptor = WakeRunnerDescriptor.claude(
+            account: account(),
+            permissionMode: .safe,
+            bypassAcknowledged: false,
+            prompt: "continue",
+            baseEnvironment: [:]
+        )
+
+        XCTAssertEqual(descriptor.binaryName, "claude")
+        XCTAssertEqual(descriptor.overrideEnvVar, "CLAUDE_CLI_PATH")
+        XCTAssertNotNil(descriptor.classifyDenial)
+    }
+
+    func testCodexDescriptorShape() {
+        let descriptor = WakeRunnerDescriptor.codex(
+            account: codexAccount(),
+            permissionMode: .safe,
+            bypassAcknowledged: false,
+            prompt: "continue",
+            baseEnvironment: [:]
+        )
+
+        XCTAssertEqual(descriptor.binaryName, "codex")
+        XCTAssertEqual(descriptor.overrideEnvVar, "CODEX_CLI_PATH")
+        XCTAssertNil(descriptor.classifyDenial)
+    }
+
     // MARK: - Runner
 
     func testRunPassesExactArgvEnvAndCwd() async throws {
@@ -137,6 +176,46 @@ final class WakeRunnerTests: XCTestCase {
         XCTAssertTrue(recorded.contains("--permission-mode default"))
         XCTAssertTrue(recorded.contains("PWD:") && recorded.contains(tempDir.lastPathComponent))
         XCTAssertTrue(recorded.contains("CFG:\(account().configDirectory!)"))
+    }
+
+    func testCodexRunnerPassesArgvEnvironmentAndKeepsDenialAsFailure() async throws {
+        let fake = try makeFake()
+        let out = tempDir.appendingPathComponent("codex-out.txt")
+        let lockURL = tempDir.appendingPathComponent("codex-wake.lock")
+        let account = codexAccount()
+        let codexCandidate = candidate(sessionID: "codex-sid", cwd: tempDir.path)
+        let runner = WakeProcessRunner.codex(
+            account: account,
+            executable: fake,
+            baseEnvironment: ["PATH": "/usr/bin:/bin", "WAKE_TEST_OUT": out.path],
+            lockFactory: { WakeLock(lockURL: lockURL, legacyLockURLs: []) },
+            logger: WakeRunLogger(directory: tempDir.appendingPathComponent("codex-logs"))
+        )
+
+        let outcome = await runner.run(codexCandidate, bounds: .default)
+        XCTAssertEqual(outcome, .succeeded)
+
+        let recorded = try String(contentsOf: out, encoding: .utf8)
+        XCTAssertTrue(recorded.contains(
+            "ARGS:exec resume codex-sid continue -c sandbox_mode=\"workspace-write\" -c approval_policy=\"never\""
+        ))
+        XCTAssertTrue(recorded.contains("PWD:") && recorded.contains(tempDir.lastPathComponent))
+        XCTAssertTrue(recorded.contains("CODEX_HOME:\(account.homeDirectory ?? "")"))
+
+        let denialRunner = WakeProcessRunner.codex(
+            account: account,
+            executable: fake,
+            baseEnvironment: [
+                "PATH": "/usr/bin:/bin",
+                "WAKE_EXIT": "7",
+                "WAKE_STDERR_MSG": "requires approval"
+            ],
+            lockFactory: { WakeLock(lockURL: lockURL, legacyLockURLs: []) },
+            logger: WakeRunLogger(directory: tempDir.appendingPathComponent("codex-denial-logs"))
+        )
+        let denialOutcome = await denialRunner.run(codexCandidate, bounds: .default)
+        XCTAssertEqual(denialOutcome, .failed(reason: "codex exited with status 7"))
+        XCTAssertNotEqual(denialOutcome, .permissionDenied)
     }
 
     func testDeadWorktreeIsSkippedWithoutLaunching() async throws {


### PR DESCRIPTION
## Summary

Pure refactor to DRY the near-duplicate Session Wake provider runners. The Claude and Codex paths shared ~170 lines of identical process-execution and quota-authority structure, differing only along a handful of well-defined axes. This collapses each pair into one generic implementation. **No user-facing change; no change to what commands run or how denials classify.**

## What changed

**Runner** — new `WakeRunnerDescriptor` holds exactly the four axes that differ between providers:
- `binaryName` (also used verbatim in outcome messages)
- `overrideEnvVar` (binary-resolution override, e.g. `CLAUDE_CLI_PATH` / `CODEX_CLI_PATH`)
- a `@Sendable buildCommand` closure (argv + env + cwd)
- an optional `@Sendable classifyDenial` closure

One generic `WakeProcessRunner: WakeExecuting` owns the shared spine — revalidate cwd immediately before exec, take the shared lock only when ready, spawn an argv (never a shell), enforce the timeout with process-tree cleanup, honor structured cancellation, and record a metadata-only log line. Static `.claude(...)` / `.codex(...)` factories preserve every prior default argument.

**Quota** — the seam is now generic: `WakeQuotaProviding<Account>` (primary associated type) and `WakeQuotaAuthority<Account>`, with `LiveWakeQuotaProvider` (Claude) and `LiveCodexWakeQuotaProvider` (Codex) as the two providers. The fail-closed gate (thrown fetch or stale reading ⇒ `.unknown`) is unchanged.

## Behavior preserved bug-for-bug

- The Claude permission-denial gate keys off the **raw requested** `permissionMode` (`permissionMode != .bypass`), folded into the Claude descriptor's classifier — not the effective/acknowledged mode.
- Codex's classifier is `nil`: its `approval_policy=never` runs can't stop at a permission gate, so a non-zero exit is always a plain failure.
- Outcome strings are byte-for-byte identical for both providers (`<bin> exited with status N`, `<bin> terminated by signal N`, `session timed out`, `<bin> binary not found`).
- The lossy UTF-8 decode of the bounded capture (with its `swiftlint:disable optional_data_string_conversion` wrap) is retained exactly.

## Why no build-manifest churn

`CodexWakeProcessRunner.swift` and `CodexWakeQuotaAuthority.swift` are repurposed in place (redundant types removed, files retained) and new tests are added to existing files. This keeps all three build systems — the Xcode project's explicit membership, the root `Package.swift` glob, and the CLI `Package.swift` glob — in sync with **zero** `.pbxproj` / manifest edits.

## Tests

Existing wake tests adapted; added focused descriptor-shape tests (`testClaudeDescriptorShape`, `testCodexDescriptorShape`) and a Codex-runner argv/env/denial-as-failure test asserting a non-zero exit with denial-like stderr stays `.failed`, never `.permissionDenied`.

## Verification

- `swiftlint lint --strict --quiet` (exact CI command) → exit 0, no output.
- Full diff reviewed vs `master`: 16 modified files only; no added/deleted files; no `.pbxproj` / `Package.swift` changes.
- Removed symbols (`CodexWakeProcessRunner`, `CodexWakeQuotaAuthority`, `CodexWakeQuotaProviding`) and the legacy `mapOutcome(_:permissionMode:)` confirmed fully absent.
- Local builds/tests/typechecks skipped per the MacBook verification policy; **PR CI is the execution gate.**