### PR TITLE
feat(demo): METERBAR_DEMO sample-data mode for screenshots + onboarding

### DIFF
--- a/.agents/SESSIONS/2026-07-24.md
+++ b/.agents/SESSIONS/2026-07-24.md
@@ -70,3 +70,91 @@ flowchart LR
 
 - [ ] Require green CI on the pushed head.
 - [ ] Require an exact-head Opus 4.8 PASS before merge.
+
+---
+
+## Session 2: Demo / sample-data mode
+
+**Status:** Implementation + TDD complete; SwiftLint pending; PR CI + exact-head Opus verification pending
+
+```mermaid
+flowchart LR
+    Env[METERBAR_DEMO=1] --> Gate{DemoMode.isActive}
+    Pref[Hidden prefs toggle<br/>StorageKeys.demoMode] --> Gate
+    Gate -->|off, default| Real[Real cached data +<br/>live provider scans]
+    Gate -->|on| Fixture[DemoData fixture]
+
+    Fixture --> UDM[UsageDataManager.shared<br/>@Published metrics]
+    Fixture --> CT[CostTracker.shared<br/>costSummary]
+    Fixture --> Stores[Codex/ClaudeCode AccountStore<br/>.defaultAccount only]
+
+    UDM --> Overview[UsageDashboardView]
+    UDM --> Menu[MenuBarView]
+    UDM --> Planner[WidgetPresentationPlanner]
+    Planner --> Widget[Medium widget]
+    CT --> Costs[Overview cost cards]
+
+    Script[render-readme-screenshots.swift<br/>standalone, mirrored fixture] --> PNG[menubar.png +<br/>widget-medium.png]
+```
+
+### Affected components
+
+- App-UI data seam (`UsageDataManager.shared`) — Overview window + menu-bar panel
+- Cost seam (`CostTracker.shared`) — Overview cost cards
+- Account-store seams (`CodexAccountStore`, `ClaudeCodeAccountStore`) — generic card titles
+- Widget presentation (`WidgetPresentationPlanner`) — medium widget rows
+- Standalone landing-page screenshot renderer (`scripts/render-readme-screenshots.swift`)
+
+### Root cause / motivation
+
+- The only screenshot path for meterbar.dev used the owner's **live** account: ~$13k/30-day cost, private project names, all-red "Critical/Out/deficit" quota bars — unusable and off-message for a landing page.
+- No populated first-run experience: a new user sees an empty MeterBar before connecting any provider.
+
+### What was done
+
+- **Toggle** (`DemoMode`, nonisolated enum): launch var `METERBAR_DEMO` (truthy `1/true/yes/on`, case- and whitespace-insensitive) OR hidden pref `StorageKeys.demoMode`. Off by default; `isEnabled(environment:defaults:)` is injectable for tests.
+- **Fixture** (`DemoData`, in `MeterBarShared`, nonisolated, `Sendable` value types): three generic providers — Claude Code (42/58/34, model window "Fable"), OpenAI Codex (61/**82**/12, banked reset credits 2), Cursor (dollar-mapped, no window). Exactly one amber "tight" band (Codex weekly 82%), zero red, all windows read reserve/on-pace, `lastUpdated == now` (always fresh). Cost companion (`DemoData+Cost.swift`, app target since `CostSummary` lives there): total **$204.90** / 30 days, empty model+origin breakdowns, no lifetime, 30×2 daily token rows (Cursor excluded — dollar-billed).
+- **Seams**: all gated at `.shared` singleton construction on `DemoMode.isActive`, so no runtime branching leaks into hot paths and **real cache/logs are never read or written** in demo mode. `refreshAll()`/`refresh(_:)`/scan/save all early-return under demo. Account stores project `[.defaultAccount]` only (read-only; never touch real `.standard` data) → guarantees generic "Codex"/"Claude" titles.
+- **Widget**: the medium widget is a **separate process** (an env var can't reach it), so coverage is proven by a `WidgetPresentationPlanner.makePresentation` unit test over `DemoData.metrics`, not by writing the app group — demo mode deliberately does **not** clobber the shared cache.
+- **Screenshots**: aligned the standalone renderer's hard-coded fixture to mirror the `DemoData` scenario (same headline percentages, single amber, generic labels) with a cross-reference comment tying the two together.
+- **TDD**: tests written first — `DemoDataTests`, `DemoModeTests`, a widget-presentation demo case, plus demo cases added to `UsageDataManagerTests` (synthetic metrics + shared store stays empty + refresh outcomes `.skipped`) and `CostTrackerTests` (non-alarming summary, no scan).
+
+### Key decisions
+
+- **Gate at singleton construction, not per-call.** One branch at `.shared` init keeps the demo path fully out of the real data/scan code and makes "never touches real data" a structural guarantee, not a runtime discipline.
+- **Fixture lives in `MeterBarShared`** (nonisolated, tools 5.9, no default MainActor) so the same value types are reachable from app + widget + CLI; the **cost** fixture is app-side because `CostSummary`/`TokenCost` live in the app target, not Shared.
+- **Prove the widget via the planner unit, not the app group.** The widget process can't see the env var; writing the app group would risk clobbering a real user's cache. A planner test over `DemoData.metrics` is the correct, non-destructive coverage.
+- **Keep the screenshot renderer standalone** (single `swiftc`, no app link) but mirror its fixture to `DemoData` with an explicit "keep in lockstep" comment — avoids coupling the render script to the app build while keeping screenshots on-message.
+- **Non-alarming numbers on purpose**: mostly green + exactly one amber, ~$205 total — reads as a healthy, in-control product, not a crisis dashboard.
+
+### Files changed
+
+- `Packages/MeterBarShared/Sources/MeterBarShared/DemoData.swift` — fixture (new).
+- `MeterBar/Models/DemoMode.swift` — toggle (new).
+- `MeterBar/Models/DemoData+Cost.swift` — cost fixture (new).
+- `MeterBar/Models/StorageKeys.swift` — `demoMode` key.
+- `MeterBar/Services/UsageDataManager.swift` — demo gate at `shared` + refresh short-circuits.
+- `MeterBar/Services/CostTracker.swift` — demo gate at `shared` + scan/save short-circuits.
+- `MeterBar/Models/CodexAccount.swift`, `ClaudeCodeAccount.swift` — default-only projection under demo.
+- `scripts/render-readme-screenshots.swift` — fixture aligned to `DemoData` + cross-reference comment.
+- `MeterBarTests/DemoDataTests.swift`, `DemoModeTests.swift` (new); `WidgetPresentationTests.swift`, `UsageDataManagerTests.swift`, `CostTrackerTests.swift` (demo cases added).
+- `.agents/SESSIONS/2026-07-24.md`
+
+### Verification
+
+- TDD: tests authored before/alongside the seams; assertions lock every invariant (single amber, no red, fresh, generic labels, empty breakdowns, shared store untouched, refresh skipped).
+- SourceKit flagged transient "inaccessible init / extra argument" diagnostics on the test files — diagnosed as index-lag against pre-edit indexes (the real inits carry the new params); resolves at build.
+- Local builds/tests/typechecks skipped under the MacBook verification policy; PR CI (macos-26 / Xcode 26.2) is the execution gate. The screenshot renderer is a `swiftc` build+run and was **not** run locally for the same reason.
+
+### Screenshot regeneration
+
+- Menu + medium widget PNGs (`docs/screenshots/menubar.png`, `widget-medium.png`): run
+  `./scripts/render-readme-screenshots.sh` on a Mac with full Xcode.
+- Overview window + live surfaces: launch the app with `METERBAR_DEMO=1` and capture the Overview window.
+
+### Next steps
+
+- [ ] `swiftlint lint --strict --quiet` on the pushed head (via CI).
+- [ ] Require green CI on the pushed head.
+- [ ] Require an exact-head Opus 4.8 PASS before merge.
+- [ ] Regenerate `docs/screenshots/*.png` on a Mac with full Xcode and hand off to the landing repo.

--- a/MeterBar/Models/ClaudeCodeAccount.swift
+++ b/MeterBar/Models/ClaudeCodeAccount.swift
@@ -67,7 +67,13 @@ nonisolated struct ClaudeCodeAccount: Codable, Equatable, Identifiable, Sendable
 // MARK: - ClaudeCodeAccountStore
 
 final class ClaudeCodeAccountStore: ObservableObject {
-    static let shared = ClaudeCodeAccountStore()
+    /// In demo mode the store is projected from the default account only, so
+    /// provider cards title generically ("Claude") and never surface the owner's
+    /// real custom-account names. The `init(accounts:)` projection reads and
+    /// writes no real `.standard` data.
+    static let shared = DemoMode.isActive
+        ? ClaudeCodeAccountStore(accounts: [.defaultAccount])
+        : ClaudeCodeAccountStore()
 
     @Published private(set) var customAccounts: [ClaudeCodeAccount] = []
     @Published private(set) var defaultAccountName = ClaudeCodeAccount.defaultName

--- a/MeterBar/Models/CodexAccount.swift
+++ b/MeterBar/Models/CodexAccount.swift
@@ -38,7 +38,13 @@ nonisolated struct CodexAccount: Codable, Equatable, Identifiable, Sendable {
 }
 
 final class CodexAccountStore: ObservableObject {
-    static let shared = CodexAccountStore()
+    /// In demo mode the store is projected from the default account only, so
+    /// provider cards title generically ("Codex") and never surface the owner's
+    /// real custom-account names. The `init(accounts:)` projection reads and
+    /// writes no real `.standard` data.
+    static let shared = DemoMode.isActive
+        ? CodexAccountStore(accounts: [.defaultAccount])
+        : CodexAccountStore()
 
     @Published private(set) var customAccounts: [CodexAccount] = []
     @Published private(set) var defaultAccountName = CodexAccount.defaultName

--- a/MeterBar/Models/DemoData+Cost.swift
+++ b/MeterBar/Models/DemoData+Cost.swift
@@ -1,0 +1,130 @@
+import Foundation
+import MeterBarShared
+
+/// App-target demo cost fixture.
+///
+/// `CostSummary`/`TokenCost`/`DailyTokenUsage` live in the app target (not
+/// `MeterBarShared`), so the cost half of demo mode is an app-side extension on
+/// the shared `DemoData` namespace. `CostTracker` publishes this instead of
+/// scanning real CLI logs when demo mode is active.
+///
+/// The summary is deliberately **non-alarming** — a ~$205 30-day estimate split
+/// across three providers — and carries **no origin or model breakdowns**, so
+/// it never surfaces the owner's real project paths or private model routing.
+/// Daily rows are a smooth, deterministic weekly rhythm so the cost chart reads
+/// as populated and healthy in screenshots. Everything is a pure function of
+/// `now`.
+extension DemoData {
+    /// Per-provider 30-day totals (USD) and token magnitudes for the demo cost
+    /// summary. Sums to $204.90 ≈ "$205".
+    private struct DemoProviderCost {
+        let provider: ServiceType
+        let inputTokens: Int
+        let outputTokens: Int
+        let cacheCreationTokens: Int
+        let cacheReadTokens: Int
+        let costUSD: Double
+        let sessionCount: Int
+    }
+
+    private static let demoProviderCosts: [DemoProviderCost] = [
+        DemoProviderCost(
+            provider: .claudeCode,
+            inputTokens: 3_200_000,
+            outputTokens: 1_100_000,
+            cacheCreationTokens: 900_000,
+            cacheReadTokens: 42_000_000,
+            costUSD: 95.40,
+            sessionCount: 128
+        ),
+        DemoProviderCost(
+            provider: .codexCli,
+            inputTokens: 5_400_000,
+            outputTokens: 1_800_000,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 0,
+            costUSD: 68.20,
+            sessionCount: 96
+        ),
+        // Cursor is billed in dollars, not tokens, so it contributes cost only.
+        DemoProviderCost(
+            provider: .cursor,
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 0,
+            costUSD: 41.30,
+            sessionCount: 54
+        )
+    ]
+
+    private static let demoPeriodDays = 30
+
+    /// Synthetic 30-day cost summary for demo mode.
+    static func costSummary(now: Date = Date(), calendar: Calendar = .current) -> CostSummary {
+        let periodEnd = now
+        let periodStart = calendar.date(byAdding: .day, value: -demoPeriodDays, to: now) ?? now
+
+        let costs = demoProviderCosts.map { provider in
+            TokenCost(
+                provider: provider.provider,
+                inputTokens: provider.inputTokens,
+                outputTokens: provider.outputTokens,
+                cacheCreationTokens: provider.cacheCreationTokens,
+                cacheReadTokens: provider.cacheReadTokens,
+                estimatedCostUSD: provider.costUSD,
+                sessionCount: provider.sessionCount,
+                periodStart: periodStart,
+                periodEnd: periodEnd,
+                modelBreakdowns: [],
+                originBreakdowns: []
+            )
+        }
+
+        let totalCostUSD = costs.reduce(0) { $0 + $1.estimatedCostUSD }
+        let totalTokens = costs.reduce(0) { $0 + $1.totalTokens }
+
+        return CostSummary(
+            costs: costs,
+            totalCostUSD: totalCostUSD,
+            totalTokens: totalTokens,
+            periodDays: demoPeriodDays,
+            dailyUsage: dailyUsage(periodEnd: periodEnd, calendar: calendar),
+            lifetime: nil
+        )
+    }
+
+    /// One row per token-billed provider per day across the 30-day window,
+    /// following a fixed weekly weight pattern so the chart looks lived-in
+    /// without any random noise.
+    private static func dailyUsage(periodEnd: Date, calendar: Calendar) -> [DailyTokenUsage] {
+        // Lighter usage on weekend-position indices; heavier midweek. Deterministic.
+        let weeklyWeights = [3, 6, 7, 6, 7, 5, 2]
+        let today = calendar.startOfDay(for: periodEnd)
+
+        return demoProviderCosts
+            .filter { $0.inputTokens > 0 || $0.outputTokens > 0 }
+            .flatMap { provider -> [DailyTokenUsage] in
+                let weightTotal = (0..<demoPeriodDays).reduce(0) { sum, index in
+                    sum + weeklyWeights[index % weeklyWeights.count]
+                }
+                return (0..<demoPeriodDays).compactMap { index -> DailyTokenUsage? in
+                    guard let date = calendar.date(
+                        byAdding: .day,
+                        value: -(demoPeriodDays - 1 - index),
+                        to: today
+                    ) else { return nil }
+                    let weight = Double(weeklyWeights[index % weeklyWeights.count])
+                    let fraction = weight / Double(weightTotal)
+                    return DailyTokenUsage(
+                        date: date,
+                        provider: provider.provider,
+                        inputTokens: Int(Double(provider.inputTokens) * fraction),
+                        outputTokens: Int(Double(provider.outputTokens) * fraction),
+                        cacheReadTokens: Int(Double(provider.cacheReadTokens) * fraction),
+                        estimatedCostUSD: provider.costUSD * fraction
+                    )
+                }
+            }
+    }
+}

--- a/MeterBar/Models/DemoMode.swift
+++ b/MeterBar/Models/DemoMode.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// The single source of truth for whether demo / sample-data mode is active.
+///
+/// Demo mode swaps the signed-in owner's real usage for the synthetic
+/// `DemoData` fixture so the landing-page screenshots and the first-run
+/// onboarding preview render a populated, on-message MeterBar without exposing
+/// real costs or private project names. It is **off by default** and, when on,
+/// only changes what the singletons publish at construction — it never reads or
+/// writes real cached data, so real users are unaffected.
+///
+/// Two independent opt-ins, checked at `.shared` construction time:
+///  - the `METERBAR_DEMO` launch environment variable (`1`/`true`/`yes`/`on`),
+///    used by the screenshot tooling and CI; or
+///  - the hidden `StorageKeys.demoMode` preference, for a manual toggle.
+///
+/// `isEnabled(environment:defaults:)` is pure and injectable so the gate is unit
+/// tested without touching the process environment or standard defaults.
+nonisolated enum DemoMode {
+    /// Launch environment variable that forces demo mode on.
+    static let environmentKey = "METERBAR_DEMO"
+
+    static func isEnabled(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        if let raw = environment[environmentKey], isTruthy(raw) {
+            return true
+        }
+        return defaults.bool(forKey: StorageKeys.demoMode)
+    }
+
+    /// Resolved once against the real process environment and standard defaults.
+    /// Read by the `.shared` singletons that own the demo data seams.
+    static var isActive: Bool { isEnabled() }
+
+    private static func isTruthy(_ value: String) -> Bool {
+        switch value.trimmingCharacters(in: .whitespaces).lowercased() {
+        case "1", "true", "yes", "on":
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -30,6 +30,11 @@ nonisolated enum StorageKeys {
     static let popoverResetTimeFormat = "PopoverResetTimeFormat"
     /// Whether the one-time first-launch popover has been completed or dismissed.
     static let hasCompletedFirstRun = "HasCompletedFirstRun"
+    /// Hidden opt-in for demo / sample-data mode. When set (or `METERBAR_DEMO=1`
+    /// in the environment) the app publishes synthetic `DemoData` instead of the
+    /// signed-in account's real usage, for landing-page screenshots and the
+    /// first-run onboarding preview. Off by default; never affects real data.
+    static let demoMode = "DemoMode"
     /// Enables the Claude Code OAuth usage source (`/api/oauth/usage`), the
     /// primary reader for the default account. On by default; off forces the CLI
     /// output fallback. Legacy key name kept to preserve existing user settings.

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -5,7 +5,7 @@ import os
 import SQLite3
 
 class CostTracker: ObservableObject {
-    static let shared = CostTracker()
+    static let shared = CostTracker(demoMode: DemoMode.isActive)
 
     @Published var costSummary: CostSummary?
     @Published var isScanning: Bool = false
@@ -13,6 +13,11 @@ class CostTracker: ObservableObject {
     @Published var lastScanDate: Date?
 
     private let providerVisibilityStore = ProviderVisibilityStore.shared
+
+    /// When true, the tracker publishes the synthetic `DemoData.costSummary`
+    /// fixture and performs no real log scans or cache writes. Gated at `shared`
+    /// on `DemoMode.isActive`.
+    private let demoMode: Bool
 
     /// True while either a manual scan or a background missing-day backfill runs.
     var isRefreshInProgress: Bool {
@@ -38,11 +43,20 @@ class CostTracker: ObservableObject {
         return result
     }()
 
-    private init() {
+    init(demoMode: Bool = false) {
+        self.demoMode = demoMode
+        guard !demoMode else {
+            // Publish the synthetic fixture; never read the real cache or scan
+            // real CLI logs. Real cost data on disk is left untouched.
+            costSummary = DemoData.costSummary()
+            lastScanDate = Date()
+            return
+        }
         loadCachedSummary()
     }
 
     func scanCosts(days: Int = 30) async {
+        guard !demoMode else { return }
         let shouldStart = await MainActor.run {
             guard !isRefreshInProgress else { return false }
             isScanning = true
@@ -64,6 +78,7 @@ class CostTracker: ObservableObject {
     /// daily rows when Overview/Costs opens, without the visible "Scanning" UI
     /// a manual scan shows.
     func refreshMissingDaysInBackground(days: Int = 30) async {
+        guard !demoMode else { return }
         let shouldStart = await MainActor.run {
             guard !isRefreshInProgress,
                   let visibleSummary = costSummary?.filtered(to: providerVisibilityStore.enabledServices),
@@ -181,6 +196,7 @@ class CostTracker: ObservableObject {
     }
 
     private func saveCachedSummary() {
+        guard !demoMode else { return }
         guard let costSummary, let lastScanDate else { return }
 
         do {

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -33,7 +33,7 @@ extension CodexCliLocalService: CodexUsageProviding {}
 
 @MainActor
 class UsageDataManager: ObservableObject {
-    static let shared = UsageDataManager()
+    static let shared = UsageDataManager(demoMode: DemoMode.isActive)
 
     @Published var metrics: [ServiceType: UsageMetrics] = [:]
     @Published var claudeCodeAccountMetrics: [UUID: UsageMetrics] = [:]
@@ -66,6 +66,11 @@ class UsageDataManager: ObservableObject {
     private let providerVisibilityStore: ProviderVisibilityStore
     private let parseHealthStore: ProviderParseHealthStore
 
+    /// When true, the manager publishes the synthetic `DemoData` fixture and
+    /// performs no real fetches, cache reads, or shared-store writes. Gated at
+    /// `shared` on `DemoMode.isActive`; never touches real user data.
+    private let demoMode: Bool
+
     private var refreshTimer: Timer?
     private(set) var scheduledRefreshInterval: TimeInterval?
     private let cacheKey = StorageKeys.cachedUsageMetrics
@@ -93,8 +98,10 @@ class UsageDataManager: ObservableObject {
         preferences: UserDefaults = .standard,
         cacheDefaults: UserDefaults = .standard,
         parseHealthStore: ProviderParseHealthStore? = nil,
-        schedulesAutoRefresh: Bool = true
+        schedulesAutoRefresh: Bool = true,
+        demoMode: Bool = false
     ) {
+        self.demoMode = demoMode
         self.codexCliService = codexCliService ?? CodexCliLocalService.shared
         self.cursorService = cursorService
         self.openRouterService = openRouterService
@@ -109,6 +116,15 @@ class UsageDataManager: ObservableObject {
         self.cacheDefaults = cacheDefaults
         self.parseHealthStore = parseHealthStore ?? .shared
         refreshIntervalRaw = Self.savedRefreshInterval(in: preferences).rawValue
+
+        guard !demoMode else {
+            // Publish the synthetic fixture and stop: no cached reads, no
+            // per-account metrics, no auto-refresh timer. Real caches are left
+            // untouched so a normal launch is unaffected.
+            metrics = DemoData.metrics()
+            return
+        }
+
         loadCachedData()
         loadCachedAccountMetrics()
         if schedulesAutoRefresh {
@@ -125,6 +141,21 @@ class UsageDataManager: ObservableObject {
     @discardableResult
     func refreshAll() async -> UsageRefreshReport {
         let startedAt = Date()
+        guard !demoMode else {
+            return UsageRefreshReport(
+                startedAt: startedAt,
+                finishedAt: Date(),
+                outcomes: ServiceType.allCases.map {
+                    ProviderRefreshOutcome(
+                        provider: $0,
+                        state: .skipped,
+                        reason: Self.demoModeReason,
+                        servedFromCache: metrics[$0] != nil,
+                        lastUpdated: metrics[$0]?.lastUpdated
+                    )
+                }
+            )
+        }
         guard !isLoading else {
             return UsageRefreshReport(
                 startedAt: startedAt,
@@ -221,6 +252,7 @@ class UsageDataManager: ObservableObject {
     }
 
     private static let disabledReason = "Provider is turned off in MeterBar."
+    private static let demoModeReason = "Demo mode is showing sample data."
     private static let notSignedInReason = "No readable credentials for this provider."
     private static let noEnabledAccountsReason = "No enabled accounts for this provider."
 
@@ -273,6 +305,7 @@ class UsageDataManager: ObservableObject {
     }
 
     func refresh(service: ServiceType) async {
+        guard !demoMode else { return }
         guard !isLoading else { return }
         isLoading = true
         defer { isLoading = false }
@@ -343,6 +376,7 @@ class UsageDataManager: ObservableObject {
     /// enabled source has no data or its oldest successful snapshot is at least
     /// ten minutes old. Manual-only mode remains fully manual.
     func refreshAfterWakeIfNeeded(now: Date = Date()) async {
+        guard !demoMode else { return }
         guard refreshInterval != .manual, await shouldCatchUpAfterWake(now: now) else { return }
         await refreshAll()
     }
@@ -351,6 +385,7 @@ class UsageDataManager: ObservableObject {
     /// used by the popover, dashboard, widget, and CLI. The service has already
     /// performed the network refresh; this method only publishes that result.
     func applyCodexResetCreditRefresh(_ refreshedMetrics: UsageMetrics, accountID: UUID) {
+        guard !demoMode else { return }
         codexAccountMetrics[accountID] = refreshedMetrics
         if let representative = representativeCodexMetrics(from: codexAccountMetrics) {
             metrics[.codexCli] = representative

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -6,6 +6,26 @@ import MeterBarShared
 /// audit found ~1,000 lines of money math with zero tests, which is exactly
 /// where the CLI-vs-app cost divergence hid.
 final class CostTrackerTests: XCTestCase {
+    // MARK: - Demo mode
+
+    func testDemoModePublishesSyntheticNonAlarmingSummaryWithoutScanning() {
+        let tracker = CostTracker(demoMode: true)
+
+        let summary = tracker.costSummary
+        XCTAssertNotNil(summary, "demo mode should publish a summary at construction")
+        XCTAssertEqual(summary?.totalCostUSD ?? 0, 204.90, accuracy: 0.001)
+        XCTAssertEqual(summary?.periodDays, 30)
+        XCTAssertNil(summary?.lifetime)
+        XCTAssertNotNil(tracker.lastScanDate)
+        XCTAssertFalse(tracker.isScanning)
+
+        // Never leaks real project paths or private model routing.
+        for cost in summary?.costs ?? [] {
+            XCTAssertTrue(cost.modelBreakdowns.isEmpty)
+            XCTAssertTrue(cost.originBreakdowns.isEmpty)
+        }
+    }
+
     // MARK: - Model-id normalization
 
     func testNormalizeClaudeModelStripsDateSuffix() {

--- a/MeterBarTests/DemoDataTests.swift
+++ b/MeterBarTests/DemoDataTests.swift
@@ -1,0 +1,151 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// Locks the invariants the demo / sample-data fixture must uphold so the
+/// landing-page screenshots and the first-run onboarding preview stay
+/// on-message: populated, mostly-green, exactly one amber band, no red, no
+/// owner project names, and a non-alarming cost estimate.
+final class DemoDataTests: XCTestCase {
+    /// Fixed clock so reset timers — and therefore the pace math below — are
+    /// deterministic across runs and rendered screenshots.
+    private let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
+
+    // MARK: - Coverage & generic labels
+
+    func testCoversThreeProvidersKeyedByGenericServiceType() {
+        let metrics = DemoData.metrics(now: now)
+
+        XCTAssertEqual(Set(metrics.keys), [.claudeCode, .codexCli, .cursor])
+        // Labels come from the service enum's product display names, never the
+        // owner's custom account/profile names.
+        XCTAssertEqual(metrics[.claudeCode]?.service.displayName, "Claude Code")
+        XCTAssertEqual(metrics[.codexCli]?.service.displayName, "OpenAI Codex")
+        XCTAssertEqual(metrics[.cursor]?.service.displayName, "Cursor")
+        // The one free-text label the fixture sets is a model window name, not a
+        // project name.
+        XCTAssertEqual(metrics[.claudeCode]?.modelLimitLabel, "Fable")
+    }
+
+    func testEveryProviderHasData() {
+        let metrics = DemoData.metrics(now: now)
+        for service in [ServiceType.claudeCode, .codexCli, .cursor] {
+            XCTAssertEqual(metrics[service]?.hasData, true, "\(service) should have data")
+        }
+    }
+
+    // MARK: - Quota bands: mostly green, exactly one tight, zero red
+
+    func testQuotaBandsAreMostlyHealthyWithExactlyOneTightAndNoRed() {
+        let metrics = DemoData.metrics(now: now)
+        let bands = allWindows(in: metrics).map(QuotaBand.forLimit)
+
+        XCTAssertEqual(bands.filter { $0 == .tight }.count, 1, "exactly one amber 'tight' band")
+        XCTAssertEqual(bands.filter { $0 == .critical }.count, 0, "no critical red bands")
+        XCTAssertEqual(bands.filter { $0 == .exhausted }.count, 0, "no exhausted red bands")
+        XCTAssertEqual(
+            bands.filter { $0 == .healthy }.count,
+            bands.count - 1,
+            "every window except the single tight band is healthy"
+        )
+    }
+
+    func testCodexWeeklyIsTheSingleTightBand() {
+        let metrics = DemoData.metrics(now: now)
+        let codexWeekly = try? XCTUnwrap(metrics[.codexCli]?.weeklyLimit)
+        XCTAssertEqual(codexWeekly.map(QuotaBand.forLimit), .tight)
+    }
+
+    // MARK: - Trajectory: healthy, never a deficit
+
+    func testNoWindowReadsAsADeficitOnTrajectory() {
+        let metrics = DemoData.metrics(now: now)
+        for limit in allWindows(in: metrics) {
+            if let stage = limit.pace(now: now)?.stage {
+                XCTAssertNotEqual(stage, .deficit, "no window should read as 'Out'/deficit")
+            }
+        }
+    }
+
+    func testTightCodexWeeklyStillReadsAsReserveNotDeficit() {
+        let metrics = DemoData.metrics(now: now)
+        let codexWeekly = metrics[.codexCli]?.weeklyLimit
+        XCTAssertEqual(codexWeekly?.pace(now: now)?.stage, .reserve)
+    }
+
+    // MARK: - Freshness
+
+    func testDataIsFreshSoEverySurfaceTreatsItAsHealthy() {
+        let metrics = DemoData.metrics(now: now)
+        for service in metrics.keys {
+            XCTAssertEqual(metrics[service]?.lastUpdated, now, "\(service) should be stamped 'now'")
+        }
+    }
+
+    // MARK: - Provider specifics
+
+    func testCodexExposesBankedResetCreditsAndCursorHasNoPacedWindow() {
+        let metrics = DemoData.metrics(now: now)
+
+        XCTAssertEqual(metrics[.codexCli]?.resetCreditsAvailable, 2)
+        // Cursor mirrors the real dollar-denominated mapping: no window seconds,
+        // so no pace label is ever produced.
+        XCTAssertNil(metrics[.cursor]?.sessionLimit?.pace(now: now))
+        XCTAssertNil(metrics[.cursor]?.weeklyLimit?.pace(now: now))
+    }
+
+    // MARK: - Cost summary: non-alarming, no project/model leakage
+
+    func testCostSummaryIsNonAlarmingAndLeaksNoOriginOrModelBreakdowns() {
+        let summary = DemoData.costSummary(now: now)
+
+        XCTAssertEqual(summary.totalCostUSD, 204.90, accuracy: 0.001, "~$205, deliberately modest")
+        XCTAssertEqual(summary.periodDays, 30)
+        XCTAssertNil(summary.lifetime)
+        XCTAssertEqual(summary.costs.count, 3)
+        XCTAssertEqual(Set(summary.costs.map(\.provider)), [.claudeCode, .codexCli, .cursor])
+        XCTAssertEqual(
+            summary.totalTokens,
+            summary.costs.reduce(0) { $0 + $1.totalTokens },
+            "summary total is the sum of its per-provider costs"
+        )
+        XCTAssertGreaterThan(summary.totalTokens, 0)
+
+        // Never surface real project paths or private model routing.
+        for cost in summary.costs {
+            XCTAssertTrue(cost.modelBreakdowns.isEmpty, "\(cost.provider) must carry no model breakdown")
+            XCTAssertTrue(cost.originBreakdowns.isEmpty, "\(cost.provider) must carry no origin breakdown")
+        }
+    }
+
+    func testDailyUsageIsPopulatedAndExcludesTheDollarBilledProvider() {
+        let summary = DemoData.costSummary(now: now)
+
+        XCTAssertFalse(summary.dailyUsage.isEmpty)
+        // Cursor is billed in dollars (0 tokens) so it contributes cost only and
+        // never appears as a token row.
+        XCTAssertFalse(summary.dailyUsage.contains { $0.provider == .cursor })
+        XCTAssertTrue(summary.dailyUsage.allSatisfy { [.claudeCode, .codexCli].contains($0.provider) })
+        // One row per token-billed provider per day across the 30-day window.
+        XCTAssertEqual(summary.dailyUsage.count, 30 * 2)
+    }
+
+    func testFixtureIsDeterministicForAGivenClock() {
+        let a = DemoData.metrics(now: now)
+        let b = DemoData.metrics(now: now)
+        XCTAssertEqual(a[.codexCli]?.weeklyLimit?.used, b[.codexCli]?.weeklyLimit?.used)
+        XCTAssertEqual(
+            DemoData.costSummary(now: now).totalCostUSD,
+            DemoData.costSummary(now: now).totalCostUSD
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func allWindows(in metrics: [ServiceType: UsageMetrics]) -> [UsageLimit] {
+        metrics.values.flatMap { metric in
+            [metric.sessionLimit, metric.weeklyLimit, metric.codeReviewLimit].compactMap { $0 }
+        }
+    }
+}

--- a/MeterBarTests/DemoModeTests.swift
+++ b/MeterBarTests/DemoModeTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import XCTest
+@testable import MeterBar
+
+/// The demo-mode gate must be off by default and only flip on for an explicit
+/// opt-in: a truthy `METERBAR_DEMO` launch variable or the hidden prefs toggle.
+/// `isEnabled(environment:defaults:)` is injectable so this never touches the
+/// real process environment or standard defaults.
+final class DemoModeTests: XCTestCase {
+    private var suiteName = ""
+    private var defaults: UserDefaults!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        suiteName = "DemoModeTests-\(UUID().uuidString)"
+        defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        try super.tearDownWithError()
+    }
+
+    func testOffByDefaultWhenNoOptInIsPresent() {
+        XCTAssertFalse(DemoMode.isEnabled(environment: [:], defaults: defaults))
+    }
+
+    func testTruthyEnvironmentValuesEnableDemoMode() {
+        for raw in ["1", "true", "yes", "on", "TRUE", "On", "  yes  "] {
+            XCTAssertTrue(
+                DemoMode.isEnabled(environment: [DemoMode.environmentKey: raw], defaults: defaults),
+                "\(raw.debugDescription) should enable demo mode"
+            )
+        }
+    }
+
+    func testFalsyEnvironmentValuesDoNotEnableDemoMode() {
+        for raw in ["0", "false", "no", "off", "", "banana"] {
+            XCTAssertFalse(
+                DemoMode.isEnabled(environment: [DemoMode.environmentKey: raw], defaults: defaults),
+                "\(raw.debugDescription) should not enable demo mode"
+            )
+        }
+    }
+
+    func testHiddenPreferenceTogglesDemoModeWhenEnvironmentIsAbsent() {
+        defaults.set(true, forKey: StorageKeys.demoMode)
+        XCTAssertTrue(DemoMode.isEnabled(environment: [:], defaults: defaults))
+
+        defaults.set(false, forKey: StorageKeys.demoMode)
+        XCTAssertFalse(DemoMode.isEnabled(environment: [:], defaults: defaults))
+    }
+
+    func testTruthyEnvironmentWinsOverAFalsePreference() {
+        defaults.set(false, forKey: StorageKeys.demoMode)
+        XCTAssertTrue(
+            DemoMode.isEnabled(environment: [DemoMode.environmentKey: "1"], defaults: defaults)
+        )
+    }
+
+    func testFalsyEnvironmentFallsThroughToAnEnabledPreference() {
+        defaults.set(true, forKey: StorageKeys.demoMode)
+        XCTAssertTrue(
+            DemoMode.isEnabled(environment: [DemoMode.environmentKey: "0"], defaults: defaults)
+        )
+    }
+}

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -130,7 +130,8 @@ final class UsageDataManagerTests: XCTestCase {
         preloadSharedAccountMetrics: [AccountUsageSnapshot] = [],
         savedRefreshInterval: RefreshInterval? = nil,
         parseHealthStore: ProviderParseHealthStore? = nil,
-        schedulesAutoRefresh: Bool = false
+        schedulesAutoRefresh: Bool = false,
+        demoMode: Bool = false
     ) -> (manager: UsageDataManager, sharedStore: SharedDataStore) {
         let suiteName = "UsageDataManagerTests-\(UUID().uuidString)"
         createdSuiteNames.append(contentsOf: [suiteName, "\(suiteName)-vis"])
@@ -173,9 +174,37 @@ final class UsageDataManagerTests: XCTestCase {
             preferences: cacheDefaults,
             cacheDefaults: cacheDefaults,
             parseHealthStore: parseHealthStore,
-            schedulesAutoRefresh: schedulesAutoRefresh
+            schedulesAutoRefresh: schedulesAutoRefresh,
+            demoMode: demoMode
         )
         return (manager, sharedStore)
+    }
+
+    // MARK: - Demo mode
+
+    func testDemoModePublishesSyntheticMetricsAndNeverWritesTheSharedStore() async {
+        let codex = StubProvider(hasAccess: true, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: true, result: .success(MetricsFixtures.cursor()))
+        let (manager, sharedStore) = makeManager(codex: codex, cursor: cursor, demoMode: true)
+
+        // Publishes the synthetic fixture rather than any real/cached account data.
+        let expected = DemoData.metrics()
+        XCTAssertEqual(Set(manager.metrics.keys), Set(expected.keys))
+        XCTAssertEqual(manager.metrics[.codexCli]?.weeklyLimit?.used, 82)
+        XCTAssertEqual(manager.metrics[.claudeCode]?.modelLimitLabel, "Fable")
+
+        // The widget/CLI cache lives in a separate process; demo mode must never
+        // clobber the real user's on-disk metrics.
+        sharedStore.flushPendingWrites()
+        XCTAssertTrue(sharedStore.loadMetrics().isEmpty)
+
+        // Refreshing is a no-op that reports every provider as skipped-for-demo,
+        // and still leaves the shared cache untouched.
+        let report = await manager.refreshAll()
+        XCTAssertEqual(report.outcome(for: .codexCli)?.state, .skipped)
+        XCTAssertEqual(report.outcome(for: .cursor)?.state, .skipped)
+        sharedStore.flushPendingWrites()
+        XCTAssertTrue(sharedStore.loadMetrics().isEmpty)
     }
 
     func testRefreshRecordsSuccessAndFailureHealth() async {

--- a/MeterBarTests/WidgetPresentationTests.swift
+++ b/MeterBarTests/WidgetPresentationTests.swift
@@ -353,6 +353,26 @@ final class WidgetPresentationTests: XCTestCase {
         )
     }
 
+    // MARK: - Demo mode
+
+    func testMediumWidgetRendersDemoDataAsHealthyRowsWithSingleAmberBand() {
+        let result = presentation(
+            metrics: DemoData.metrics(now: now),
+            family: .medium
+        )
+
+        XCTAssertNil(result.emptyState)
+        XCTAssertFalse(result.rows.isEmpty)
+        // Fresh (`lastUpdated == now`), so every row is healthy — never stale.
+        XCTAssertTrue(result.rows.allSatisfy { $0.health == .healthy })
+        // Mostly green with exactly one amber band, and zero red.
+        let statuses = result.rows.map(\.usageStatus)
+        XCTAssertEqual(statuses.filter { $0 == .warning }.count, 1)
+        XCTAssertFalse(statuses.contains(.critical))
+        // Only generic product providers, never owner project names.
+        XCTAssertTrue(result.rows.allSatisfy { [.claudeCode, .codexCli, .cursor].contains($0.service) })
+    }
+
     private func presentation(
         metrics: [ServiceType: UsageMetrics],
         accountMetrics: [AccountUsageSnapshot] = [],

--- a/Packages/MeterBarShared/Sources/MeterBarShared/DemoData.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/DemoData.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Deterministic, synthetic usage fixture for demo / sample-data mode.
+///
+/// Demo mode (`METERBAR_DEMO=1` or the hidden prefs toggle — see the app's
+/// `DemoMode`) publishes this fixture instead of the signed-in owner's real
+/// account data, so the landing-page screenshots and the first-run onboarding
+/// preview both render a populated, on-message MeterBar without exposing real
+/// costs, private project names, or an all-red "everything is on fire" state.
+///
+/// Design rules the fixture upholds (each is asserted by `DemoDataTests`):
+///  - **Generic labels only.** The map is keyed by `ServiceType`, whose display
+///    names ("Claude Code", "OpenAI Codex", "Cursor") are product names, never
+///    the owner's custom account/profile names. The app's demo wiring pairs this
+///    with default-only account stores so provider cards title as "Claude" /
+///    "Codex" / "Cursor" regardless of the real accounts on the machine.
+///  - **Mostly comfortable green.** Every quota window sits at ≤75% used
+///    (`QuotaBand.healthy`) except exactly one.
+///  - **Exactly one "tight" amber band.** Codex's weekly window sits at 82%
+///    used (`QuotaBand.tight`, the 76–90% band) so screenshots show the amber
+///    state without any `.critical`/`.exhausted` red.
+///  - **Healthy trajectory.** Reset timers are chosen so every window's pace
+///    reads "reserve" or "on pace", never "deficit"/"Out" — including the tight
+///    Codex weekly window (tight by level, comfortably on track by trajectory).
+///  - **Fresh.** `lastUpdated == now`, so all surfaces treat the data as
+///    healthy (inside the widget planner's 2h staleness threshold).
+///
+/// The fixture is a pure function of `now`: the same clock always yields the
+/// same numbers, which keeps snapshot tests and rendered screenshots stable.
+public enum DemoData {
+    /// Session (5h) and weekly (7d) windows mirror the real provider windows so
+    /// the pace math and reset copy read the same as production.
+    private static let sessionWindowSeconds: TimeInterval = 5 * 3_600
+    private static let weeklyWindowSeconds: TimeInterval = 7 * 24 * 3_600
+    private static let modelWindowSeconds: TimeInterval = 5 * 3_600
+
+    /// Synthetic provider metrics for demo mode, keyed by service.
+    ///
+    /// Covers three providers — Claude Code, Codex CLI, Cursor — which is enough
+    /// to populate the Overview window, the menu-bar panel, and the medium
+    /// widget while staying visually uncluttered.
+    public static func metrics(now: Date = Date()) -> [ServiceType: UsageMetrics] {
+        [
+            .claudeCode: claudeCode(now: now),
+            .codexCli: codexCli(now: now),
+            .cursor: cursor(now: now)
+        ]
+    }
+
+    // MARK: - Providers
+
+    /// Claude Code: all three windows comfortably green.
+    private static func claudeCode(now: Date) -> UsageMetrics {
+        UsageMetrics(
+            service: .claudeCode,
+            sessionLimit: sessionLimit(usedPercent: 42, now: now),
+            weeklyLimit: weeklyLimit(usedPercent: 58, now: now),
+            codeReviewLimit: modelLimit(usedPercent: 34, now: now),
+            modelLimitLabel: "Fable",
+            lastUpdated: now
+        )
+    }
+
+    /// Codex CLI: session + code-review green; weekly is the single amber
+    /// "tight" band (82% used). Two banked reset credits available.
+    private static func codexCli(now: Date) -> UsageMetrics {
+        UsageMetrics(
+            service: .codexCli,
+            sessionLimit: sessionLimit(usedPercent: 61, now: now),
+            weeklyLimit: weeklyLimit(usedPercent: 82, now: now),
+            codeReviewLimit: modelLimit(usedPercent: 12, now: now),
+            resetCreditsAvailable: 2,
+            lastUpdated: now
+        )
+    }
+
+    /// Cursor: dollar-denominated plan + on-demand balances, both green. No
+    /// window seconds (matching the real Cursor mapping), so no pace label.
+    private static func cursor(now: Date) -> UsageMetrics {
+        UsageMetrics(
+            service: .cursor,
+            sessionLimit: UsageLimit(used: 2, total: 20, resetTime: nil),
+            weeklyLimit: UsageLimit(used: 205, total: 500, resetTime: nil),
+            lastUpdated: now
+        )
+    }
+
+    // MARK: - Window builders
+
+    /// A 5h session window resetting in 2h (60% elapsed): a used% below ~58
+    /// reads "reserve", ~59–61 reads "on pace".
+    private static func sessionLimit(usedPercent: Double, now: Date) -> UsageLimit {
+        UsageLimit(
+            used: usedPercent,
+            total: 100,
+            resetTime: now.addingTimeInterval(2 * 3_600),
+            windowSeconds: sessionWindowSeconds
+        )
+    }
+
+    /// A 7d weekly window resetting in ~1 day (≈86% elapsed): even the 82%
+    /// "tight" band stays in reserve on trajectory, never a deficit.
+    private static func weeklyLimit(usedPercent: Double, now: Date) -> UsageLimit {
+        UsageLimit(
+            used: usedPercent,
+            total: 100,
+            resetTime: now.addingTimeInterval(24 * 3_600),
+            windowSeconds: weeklyWindowSeconds
+        )
+    }
+
+    /// The model-scoped third window (Claude "Fable", Codex code review),
+    /// resetting in 2.5h (50% elapsed).
+    private static func modelLimit(usedPercent: Double, now: Date) -> UsageLimit {
+        UsageLimit(
+            used: usedPercent,
+            total: 100,
+            resetTime: now.addingTimeInterval(2 * 3_600 + 1_800),
+            windowSeconds: modelWindowSeconds
+        )
+    }
+}

--- a/scripts/render-readme-screenshots.swift
+++ b/scripts/render-readme-screenshots.swift
@@ -294,8 +294,8 @@ struct ClaudeCodeSnapshotRow: View {
                 LimitRow(title: "All Models (7d)", limit: weeklyLimit)
             }
 
-            if let sonnetLimit = metrics.codeReviewLimit {
-                LimitRow(title: "Sonnet (7d)", limit: sonnetLimit)
+            if let modelLimit = metrics.codeReviewLimit {
+                LimitRow(title: "Fable (5h)", limit: modelLimit)
             }
 
             HStack {
@@ -572,28 +572,38 @@ struct SnapshotRenderer {
 
         let now = Date()
 
+        // This standalone renderer is intentionally self-contained (its own model
+        // copies above) so it compiles with a single `swiftc` invocation and never
+        // links the app. The FIXTURE below, however, must stay in lockstep with the
+        // in-app demo scenario in `MeterBarShared/DemoData.swift` and its cost
+        // companion `MeterBar/Models/DemoData+Cost.swift`, so the landing-page
+        // screenshots match exactly what `METERBAR_DEMO=1` shows in the app:
+        // mostly-green windows, EXACTLY ONE amber "tight" band (the OpenAI/Codex
+        // weekly at 82%), zero red, generic product labels — never owner project
+        // names. When you change the scenario in DemoData, mirror the headline
+        // percentages here (and vice versa).
         let claudeCodeMetrics = UsageMetrics(
             service: .claudeCode,
             sessionLimit: UsageLimit(used: 42, total: 100, resetTime: now.addingTimeInterval(2 * 60 * 60)),
-            weeklyLimit: UsageLimit(used: 78, total: 100, resetTime: now.addingTimeInterval(3 * 24 * 60 * 60)),
-            codeReviewLimit: UsageLimit(used: 91, total: 100, resetTime: now.addingTimeInterval(3 * 24 * 60 * 60)),
-            lastUpdated: now.addingTimeInterval(-18 * 60)
+            weeklyLimit: UsageLimit(used: 58, total: 100, resetTime: now.addingTimeInterval(24 * 60 * 60)),
+            codeReviewLimit: UsageLimit(used: 34, total: 100, resetTime: now.addingTimeInterval((2 * 60 + 30) * 60)),
+            lastUpdated: now.addingTimeInterval(-3 * 60)
         )
 
         let openAIMetrics = UsageMetrics(
             service: .openai,
-            sessionLimit: UsageLimit(used: 1200, total: 5000, resetTime: now.addingTimeInterval(5 * 60 * 60)),
-            weeklyLimit: UsageLimit(used: 6200, total: 10000, resetTime: now.addingTimeInterval(6 * 24 * 60 * 60)),
+            sessionLimit: UsageLimit(used: 61, total: 100, resetTime: now.addingTimeInterval(2 * 60 * 60)),
+            weeklyLimit: UsageLimit(used: 82, total: 100, resetTime: now.addingTimeInterval(24 * 60 * 60)),
             codeReviewLimit: nil,
-            lastUpdated: now.addingTimeInterval(-42 * 60)
+            lastUpdated: now.addingTimeInterval(-5 * 60)
         )
 
         let cursorMetrics = UsageMetrics(
             service: .cursor,
-            sessionLimit: UsageLimit(used: 180, total: 500, resetTime: now.addingTimeInterval(3 * 60 * 60)),
-            weeklyLimit: UsageLimit(used: 760, total: 1000, resetTime: now.addingTimeInterval(12 * 24 * 60 * 60)),
-            codeReviewLimit: UsageLimit(used: 140, total: 200, resetTime: now.addingTimeInterval(12 * 24 * 60 * 60)),
-            lastUpdated: now.addingTimeInterval(-95 * 60)
+            sessionLimit: UsageLimit(used: 2, total: 20, resetTime: nil),
+            weeklyLimit: UsageLimit(used: 205, total: 500, resetTime: nil),
+            codeReviewLimit: nil,
+            lastUpdated: now.addingTimeInterval(-7 * 60)
         )
 
         let menuBarView = MenuBarSnapshotView(


### PR DESCRIPTION
## Why

The only screenshot path for meterbar.dev used the owner's **live** account — ~\$13k/30-day cost, private project names, all-red "Critical/Out/deficit" quota bars. Unusable and off-message for a landing page, and there was no populated first-run experience for a brand-new user.

This adds an **off-by-default demo mode** that renders realistic-but-synthetic data across every user-facing surface:
- **Safe landing-page screenshots** — no real account data ever exposed.
- **First-run onboarding preview** — a new user sees a populated MeterBar before connecting any provider.

## Toggle

- Launch variable `METERBAR_DEMO=1` (truthy `1/true/yes/on`, case- and whitespace-insensitive), **or**
- the hidden `StorageKeys.demoMode` preference.

Off by default. `DemoMode.isEnabled(environment:defaults:)` is injectable so tests never touch the real environment or standard defaults.

## Where the data seam lives

A single gate at each `.shared` singleton construction on `DemoMode.isActive` — no per-call branching leaks into hot paths, and "never touches real data" is a **structural** guarantee:

- **`DemoData`** (`MeterBarShared`, nonisolated, `Sendable`): three generic providers — Claude Code (42/58/34, model window "Fable"), OpenAI Codex (61/**82**/12, banked reset credits 2), Cursor (dollar-mapped, no window). Mostly green, **exactly one amber "tight" band** (Codex weekly 82%), zero red, all windows read on-pace/reserve, always fresh. Generic product labels only — never owner project names.
- **`DemoData+Cost`** (app target, since `CostSummary`/`TokenCost` live there): non-alarming **\$204.90 / 30-day** summary, empty model+origin breakdowns, no lifetime, 30×2 daily token rows (Cursor excluded — dollar-billed).
- **`UsageDataManager.shared` / `CostTracker.shared`**: publish the fixtures at construction and short-circuit every `refreshAll`/`refresh(_:)`/scan/cache-write — **real cache and CLI logs are never read or written** in demo mode.
- **Codex/ClaudeCode account stores**: project `[.defaultAccount]` only under demo (read-only; never touch real `.standard` data) → generic "Codex"/"Claude" card titles.

## Surfaces covered

- **Overview main window** (`UsageDashboardView`) — via `UsageDataManager.shared` metrics + `CostTracker.shared` cost cards.
- **Menu-bar panel** (`MenuBarView`) — same metrics seam.
- **Medium widget** (`WidgetPresentationPlanner` → `UsageWidget`) — the widget is a **separate process** an env var can't reach, so coverage is proven by a `makePresentation` unit test over `DemoData.metrics`, **not** by writing the shared app group. Demo mode deliberately does not clobber a real user's widget cache.

## Screenshot regeneration

- **Menu + medium-widget PNGs** (`docs/screenshots/menubar.png`, `widget-medium.png`):
  \`\`\`bash
  ./scripts/render-readme-screenshots.sh
  \`\`\`
  (standalone `swiftc` renderer; its hard-coded fixture is aligned to the `DemoData` scenario with a "keep in lockstep" cross-reference comment).
- **Overview window + live surfaces**: launch the app with `METERBAR_DEMO=1` and capture the Overview window.

## Tests (TDD — written first)

- `DemoDataTests` — coverage/generic labels, exactly one amber + zero red, no deficit pace, freshness, non-alarming cost, no model/origin leakage, determinism.
- `DemoModeTests` — off-by-default, truthy/falsy env parsing, hidden-pref fallthrough, env-wins-over-pref.
- `WidgetPresentationTests` — medium widget renders `DemoData` as healthy rows with a single amber band.
- `UsageDataManagerTests` — demo publishes synthetic metrics, **shared store stays empty**, refresh outcomes `.skipped`.
- `CostTrackerTests` — demo publishes the non-alarming summary without scanning.

## Verification

- `swiftlint lint --strict --quiet` → **exit 0, clean**.
- Local builds/tests/typechecks skipped per the repo's MacBook verification policy; **PR CI (macos-26 / Xcode 26.2) is the execution gate**. The screenshot renderer is a `swiftc` build+run and was likewise not run locally.
- New `.swift` files auto-compile in both the Xcode app target and the SwiftPM `MeterBar` target (synchronized groups + path glob) — no `.pbxproj`/manifest edits.

**Do not merge** until green CI + an exact-head Opus 4.8 PASS.