### PR TITLE
refactor(anthropic): share the OAuth usage request and lint every target

### DIFF
--- a/.agents/SESSIONS/2026-07-25.md
+++ b/.agents/SESSIONS/2026-07-25.md
@@ -1,0 +1,333 @@
+# 2026-07-25
+
+## Session 1: Centralize on-disk permission policy (audit S1, S2, D3, B4)
+
+**Status:** Implementation complete; SwiftLint clean; PR CI + exact-head Opus verification pending
+
+```mermaid
+flowchart LR
+    subgraph before[Before]
+        A1[write to: options .atomic] --> A2[file published at umask 0644]
+        A2 --> A3[chmod 0600]
+        A3 -.->|window| Leak[Any local process can open + hold fd]
+    end
+    subgraph after[After]
+        B1[open O_EXCL on .staging] --> B2[fchmod forces mode]
+        B2 --> B3[write loop EINTR/partial safe]
+        B3 --> B4[close + rename]
+        B4 --> B5[never reachable at a loose mode]
+    end
+    Callers[CostSummaryStore / SharedDataStore / ProviderParseHealthStore<br/>ClaudeFableSessionTracker / UsageRefreshConfigurationStore<br/>ReplayLedger / ClaudeCodeReconnectService] --> SFW[SecureFileWriter]
+    WakePaths --> SFW
+    WakeRunLogger -->|append-only| SFW
+```
+
+### Affected components
+
+- New shared service: `SecureFileWriter` (the app's single owner of file/directory permission policy)
+- Persistence call sites: cost cache, shared App Group store, parse-health store, Fable session tracker, usage-refresh config
+- Session Wake: replay ledger, run logger, path resolver
+- Claude Code reconnect script generation + app launch lifecycle
+
+### Root cause / motivation
+
+Follow-through on the repo audit's fix order, items #1–#2 of the security/DRY set:
+
+- **S1 (MED) — TOCTOU on an executed script.** `ClaudeCodeReconnectService` wrote a `.command` file and then `chmod`ed it to 0700. `Data.write(to:options:.atomic)` stages the payload at the process umask (0644 for a default macOS session) and renames it into place, so the *complete* script is world-readable for the interval before the `chmod` lands — and this file is subsequently handed to Terminal for execution.
+- **S2 (LOW/MED) — inconsistent file permissions.** Six persistence sites wrote app state at the default 0644 with no tightening at all.
+- **D3 — permission policy was per-call-site.** Every writer decided its own mode (or didn't), so there was no single place to audit or change.
+- **B4 (LOW) — reconnect scripts were never deleted.** Generated scripts accumulated in the temp directory for the life of the machine.
+
+### What was done
+
+- Added `MeterBar/Services/SecureFileWriter.swift`, a `nonisolated enum` following the repo's stateless-namespace idiom (`WakePaths`, `AppLog`, `CLIBinaryLocator`):
+  - `write(_:to:permissions:)` (`Data` and `String` overloads) creates a same-directory staging file with `open(O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC)`, forces the final mode with `fchmod` on the *descriptor* before any byte is written, writes through an `EINTR`/partial-write-safe loop, `close`s, then `rename`s. The publish stays atomic; the loose-mode window is gone.
+  - `ensurePrivateDirectory(_:)` creates at 0700 **or tightens an existing directory** — an older build's 0755 directory would otherwise stay 0755 forever.
+  - `ensurePrivateFile(at:)` for append-only logs, where a whole-file replace is the wrong shape. Best-effort by design.
+  - `SecureFileWriterError` carries the errno and path, formatted with `String(cString: strerror(code))` — the repo's existing idiom (`WakeLock.swift`).
+- Rewrote `ClaudeCodeReconnectService.writeReconnectScript(for:)` to route through the writer at `privateExecutable` (0700), with an injectable directory for tests. `shellQuoted` and the script body builder were already correct and were left untouched.
+- Added `purgeReconnectScripts(in:olderThan:now:)` with a 24-hour retention, restricted to `.command` files, run both on every write and once at `applicationDidFinishLaunching`.
+- Adopted the writer at all six S2 sites: `CostSummaryStore`, `SharedDataStore` (both `saveMetrics` and `saveAccountMetrics`), `ProviderParseHealthStore`, `ClaudeFableSessionTracker`, `UsageRefreshConfigurationStore` (its `try?` semantics preserved).
+- Collapsed `ReplayLedger.persist()`'s write-then-chmod pair into a single call, and made `WakePaths.ensurePrivateDirectory` delegate to the writer (D3: one implementation, one policy).
+- Replaced `WakeRunLogger.appendData`'s hardcoded create/`setAttributes` 0600 pair with `ensurePrivateFile(at:)`.
+- Tests written **first**, per the project TDD policy:
+  - `MeterBarTests/SecureFileWriterTests.swift` — 13 tests covering default 0600, explicit 0700, mode-survives-a-restrictive-umask, tightening an existing loose file, no scratch file left on success, scratch unlinked and target preserved on failure, missing parent directory, a 4 MiB payload through the partial-write loop, directory create + tighten, and the two `ensurePrivateFile` cases.
+  - `MeterBarTests/ClaudeCodeReconnectServiceTests.swift` — added 7 tests for owner-only script + directory, tightening a pre-existing 0755 directory, replacing a stale script for the same account, purging expired scripts, keeping recent ones, leaving non-`.command` files alone, and tolerating a missing directory. The 4 existing pure-string tests were kept unchanged.
+
+### Key decisions
+
+- **`fchmod` on the descriptor, not `chmod` on the path.** `open`'s mode argument is masked by the umask, so the requested mode is not guaranteed to land; and a path-based `chmod` reintroduces exactly the swap the type exists to prevent. The discriminating test requests 0640 under `umask(0o077)` — a mode the umask would strip — so asserting 0640 proves the mode is *forced*, not merely requested. Asserting plain 0600 would have passed under the buggy implementation too.
+- **`UsageDashboardView`'s PNG export was deliberately left at umask semantics**, with the reasoning recorded in code. The user picks that destination through a save panel specifically in order to share the card; forcing owner-only there would be wrong. It is now the only direct `.write(to:)` left in production.
+- **A retention sweep rather than delete-after-launch for B4.** Removing the script right after `open -a Terminal` races the shell that is about to read it. 24 hours is long enough for a login flow still in progress, short enough that scripts do not accumulate indefinitely.
+- **0600 on App Group files is safe.** The app and the widget run as the same UID, so tightening the shared container does not break widget reads.
+- **The writer lives in the app target, not `Packages/MeterBarShared`.** The shared package writes no files at all (`git grep "write(to:\|createFile" -- 'Packages/*.swift'` is empty), so hoisting it there would be speculative.
+- **No `.pbxproj` or `Package.swift` edit was needed.** `MeterBar/` and `MeterBarTests/` are `PBXFileSystemSynchronizedRootGroup`s, and the root manifest globs `path: "MeterBar"` with an explicit `exclude:` list that does not cover the new file.
+
+### Verification
+
+- `swiftlint lint --strict --quiet` (the exact CI command) passed with exit 0, no output.
+- `git grep` confirms zero remaining hardcoded `posixPermissions` in production sources, and exactly one remaining direct `.write(to:)` — the deliberate PNG export.
+- All 12 `SecureFileWriter` call sites reviewed individually against the behavior they replaced (`try?` vs `try` preserved per site).
+- Local builds, tests, and typechecks skipped under the MacBook verification policy; PR CI is the execution gate. SourceKit reports `Cannot find 'SecureFileWriter' in scope` at every call site — assessed as stale-index lag, since the file is covered by both the synchronized root group and the SwiftPM glob. **This assessment is unverified locally and CI is what will settle it.**
+
+### Files changed
+
+- `MeterBar/Services/SecureFileWriter.swift` — **new**; the writer, the directory/file helpers, and the error type.
+- `MeterBar/Services/ClaudeCodeReconnectService.swift` — secure write path, injectable directory, retention sweep.
+- `MeterBar/App/MeterBarApp.swift` — launch-time reconnect-script sweep.
+- `MeterBar/Models/CostSummaryStore.swift`, `MeterBar/Services/SharedDataStore.swift`, `MeterBar/Services/ProviderParseHealthStore.swift`, `MeterBar/Services/ClaudeFableSessionTracker.swift`, `MeterBar/UsageRefresh/UsageRefreshConfigurationStore.swift` — S2 adoption.
+- `MeterBar/SessionWake/ReplayLedger.swift`, `MeterBar/SessionWake/WakePaths.swift`, `MeterBar/SessionWake/WakeRunLogger.swift` — D3 consolidation.
+- `MeterBar/Views/UsageDashboardView.swift` — documented exception only.
+- `MeterBarTests/SecureFileWriterTests.swift` — **new**, 13 tests.
+- `MeterBarTests/ClaudeCodeReconnectServiceTests.swift` — 7 added tests.
+- `.agents/SESSIONS/2026-07-25.md`
+
+### Next steps
+
+- [ ] Require green CI on the pushed head.
+- [ ] Require an exact-head Opus PASS before merge.
+- [ ] Audit fix #2 — `ManagedProcess` fd leak on partial pipe-creation failure (B2) and `waitpid` `EINTR` retry in the WNOHANG poll (B3). Note PR #259 adds a new `ManagedProcess` caller; merge order matters.
+- [ ] Audit fix #3 — single-pass cost summary scan (O2) and streaming reads for the two whole-file loads (O3) in `CostTracker`.
+- [ ] Audit fix #4 — extract the duplicated Anthropic usage request in `ClaudeCodeLocalService` preserving **both** timeouts (30 s and 15 s), and extend `.swiftlint.yml` coverage to `Packages`, `MeterBarCLI`, and `MeterBarWidget` (C2).
+
+---
+
+## Session 2: Descriptor hygiene and interrupt-safe waiting in `ManagedProcess` (audit B2, B3)
+
+**Status:** implemented on `fix/managed-process-fd-and-eintr`, awaiting CI + exact-head review.
+
+### System flow
+
+```mermaid
+flowchart LR
+    subgraph before["Before"]
+        A1["pipe(out) == 0, pipe(err) == 0"] -->|"err fails"| A2["return .launchFailed<br/>out[0], out[1] stranded"]
+        A3["waitpid(WNOHANG)"] -->|"-1 (EINTR)"| A4[".launchFailed<br/>live child abandoned"]
+    end
+    subgraph after["After"]
+        B1["pipe(out) == 0"] --> B2["pipe(err) == 0"]
+        B2 -->|"err fails"| B3["close(out[0]); close(out[1])<br/>then .launchFailed"]
+        B4["poll(pid)"] -->|"-1 + EINTR"| B5["retry, deadline still enforced"]
+        B4 -->|"-1 + other errno"| B6[".launchFailed(errno)"]
+    end
+```
+
+### Affected components
+
+- **App:** `MeterBar/SessionWake/ManagedProcess.swift` — the only child-process launcher after PR #259 consolidated `ClaudeCodeCLIUsageService` onto it.
+- **Callers (unchanged):** `SessionWakeAgent`, and — once #259 lands — `ClaudeCodeCLIUsageService`. No public API, no `Result` shape change.
+
+### Root cause
+
+- **B2** — `guard pipe(outPipe) == 0, pipe(errPipe) == 0 else { … }` short-circuits. When the first pipe succeeds and the second fails, the two live descriptors have no owner: nothing is spawned, no drain is running, and the `defer` frees the pointer *memory* rather than the descriptors. Every such call stranded a pair for the life of the process — self-accelerating, since descriptor pressure is exactly what makes the second `pipe()` fail.
+- **B3** — the WNOHANG poll treated every `-1` as terminal. `EINTR` says only that a signal reached this thread; the child is still running and still ours to reap, so `.launchFailed` abandoned a live process group. The same file already handled `EINTR` correctly in `escalateTimeout`, so the file contradicted itself.
+
+### What was done
+
+- [x] Split the pipe guard; close `outPipe[0]`/`outPipe[1]` on the stderr-pipe failure path, mirroring the already-correct `posix_spawn`-failure path directly below it.
+- [x] Retry the poll on `EINTR`, keeping every other errno fatal, and fall through to the existing deadline check so an unending interrupt stream still times out instead of spinning.
+- [x] Carry the errno into the failure message (`waitpid failed (10)`) — previously unrecoverable waits were indistinguishable.
+- [x] Added a `WaitPoll` seam plus an injectable `escalate`, both defaulted, so the retry contract is asserted directly.
+- [x] 6 tests: descriptor-leak probe under an exhausted table, EINTR retry, fatal-errno, unending-EINTR timeout, signalled classification, cancellation precedence.
+
+### Key decisions
+
+- **Seam over signal racing.** The obvious B3 test — spam signals at the waiting thread — is not discriminating: `waitpid(WNOHANG)` returns almost instantly while the loop spends ~20 ms per iteration in `usleep`, so nearly every signal lands in the sleep. Injecting the poll asserts the actual contract deterministically.
+- **`wait` and `escalateTimeout` widened from `private` to internal.** Required because a default argument must be at least as visible as the function declaring it. Documented in-file so it does not read as accidental.
+- **Descriptor-leak test frees the table before asserting.** A failing assertion needs descriptors to report itself; the probe result is captured first, the hogged descriptors are released, and only then are assertions made. It `XCTSkip`s rather than fails where the table cannot be exhausted safely.
+- **Kept `"pipe() failed"` verbatim.** Not worth churning a string the audit did not flag.
+
+### Verification
+
+- `swiftlint lint --strict --quiet` — clean (the exact CI invocation).
+- No local build or test run: the MacBook constraint stands, PR CI is the gate.
+- **Disclosure:** SourceKit reports `'wait' is inaccessible due to 'private'` against the test file. The on-disk declaration is internal (verified by grep); this is the same stale-index lag seen in Session 1 and is **unverified** until CI compiles it.
+
+### Files changed
+
+- `MeterBar/SessionWake/ManagedProcess.swift` — pipe cleanup, EINTR retry, poll/escalate seam, visibility widening.
+- `MeterBarTests/ManagedProcessTests.swift` — 6 added tests.
+- `.agents/SESSIONS/2026-07-25.md`
+
+### Next steps
+
+- [ ] Require green CI on the pushed head.
+- [ ] Require an exact-head Opus PASS before merge.
+- [ ] Merge order: PR #259 adds a new `ManagedProcess` caller without touching the file, so #259 and this branch are independent — but both should land before further `ManagedProcess` work.
+- [ ] `.agents/SESSIONS/2026-07-25.md` exists on `fix/secure-file-writes` (PR #260) too; whichever merges second resolves add/add by taking the superset.
+- [ ] Audit fix #3 — single-pass cost summary scan (O2) and streaming reads (O3) in `CostTracker`.
+- [ ] Audit fix #4 — dedupe the Anthropic usage request preserving both timeouts (D2) and widen `.swiftlint.yml` coverage (C2).
+
+---
+
+## Session 3: Single-pass, streaming cost summary scan (audit O2, O3)
+
+**Status:** Implementation complete; SwiftLint clean; PR CI + exact-head Opus verification pending
+
+```mermaid
+flowchart LR
+    subgraph before[Before]
+        A1[buildCostSummary] --> A2[scanCostSources since: cutoff]
+        A1 --> A3[scanCostSources since: .distantPast]
+        A2 --> A4[walk every .jsonl<br/>Data contentsOf + String decode]
+        A3 --> A5[walk every .jsonl again<br/>strict superset of the first walk]
+    end
+    subgraph after[After]
+        B1[buildCostSummary] --> B2[scanCostSources once]
+        B2 --> B3[walk every .jsonl<br/>FileLineReader streams 256 KiB]
+        B3 --> B4{ScanWindows.update at: timestamp}
+        B4 --> B5[lifetime totals - always]
+        B4 -->|timestamp >= cutoff| B6[period totals]
+    end
+```
+
+### Affected components
+
+- New shared utility: `FileLineReader` (bounded streaming line reader)
+- New value types: `ScanWindows`, `ClaudeSessionTotals`, `CostScanResult` (`CostScanWindows.swift`), plus `CodexScanContext` / `TokenAccumulator` relocated there
+- `CostTracker`: Claude Code transcript scan, Codex archived-session scan, Codex SQLite log scan, summary assembly
+
+### Root cause / motivation
+
+Audit fix order items #3, covering two optimization findings in the same code path:
+
+- **O2 (HIGH) — the cost scan ran twice.** `buildCostSummary` called `scanCostSources` once for the reporting window and once with `.distantPast` for the lifetime figure. The lifetime pass reads a strict superset of what the period pass had just read, so every transcript in `~/.claude/projects` and `~/.codex/archived_sessions` was walked and parsed twice for numbers that a single traversal can produce.
+- **O3 (MED) — whole-file loads.** Each transcript was read with `Data(contentsOf:)` and then decoded with `String(data:encoding:)` before splitting on newlines, putting two full copies of the largest file in memory at once.
+
+### What was done
+
+- [x] Tests first: 10 for `FileLineReader` (chunk-boundary reassembly, CRLF, blank lines, `chunkSize: 1`, arbitrary chunk sizes agreeing with the default, empty file, missing file) and 6 pinning the window split in `CostTrackerTests`.
+- [x] `FileLineReader.forEachLine(in:chunkSize:_:)` — 256 KiB buffer, newline scan, rebased `Data` per line.
+- [x] `ScanWindows<Totals>` with `update(at:_:)` applying a body to `lifetime` always and to `period` only inside the window.
+- [x] Claude path: `parseSessionWindows(at:since:)` streams once and fills both windows; `parseSessionFile(at:since:)` kept as a period-only wrapper; tallying extracted to `tally(keyed:unkeyed:)`.
+- [x] Codex path: `scanCodexSessions`, `scanCodexArchivedSessions`, `scanCodexSQLiteLogs`, and `addCodexUsage` all thread `inout ScanWindows<CodexScanContext>`; a `(directory:since:context:)` overload is retained for single-window callers.
+- [x] Removed the now-dead `mergeDailyTotals` / `mergeNamedTotals` helpers.
+
+### Key decisions
+
+- **Deduplication stays per window.** Two events can share a `messageID:requestID` key while straddling the cutoff. One shared dedup map would let the pre-cutoff copy overwrite the in-window one and silently change the period total — i.e. the money figure. Each window keeps its own map, which is exactly what two separate scans did. Pinned by `testParseSessionWindowsDeduplicatesWithinEachWindow`.
+- **The per-file mtime prefilter was dropped, not ported.** It was already redundant: an event's timestamp is never newer than the file holding it, so the per-event timestamp check subsumes it — and the lifetime pass used `.distantPast`, so its mtime filter admitted everything anyway.
+- **The cutoff travels inside `ScanWindows`.** Passing it as a separate argument would push `addCodexUsage` to seven parameters, and SwiftLint's `function_parameter_count` warns at six with CI linting `--strict`.
+- **`forEachLine`'s body is a real function parameter, not a stored closure.** The Codex scan captures an `inout` accumulator inside it; capturing `inout` is only legal in a non-escaping closure. This is also why the planned `readLines:` injection seam was dropped — a closure nested in a function *type* is escaping by default.
+- **`ScanWindows` is conditionally `Sendable`.** An unconditional conformance would force `TokenCost` and `DailyTokenUsage` to be `Sendable` just to name `ScanWindows<CostScanResult>`.
+- **`"token_count"` prefilter kept as bytes.** Moving from `String` lines to `Data` lines would have lost the cheap pre-`JSONSerialization` filter that makes the Codex scan affordable; a static `Data` marker plus `contains` preserves it.
+
+### Verification
+
+- `swiftlint lint --strict --quiet` — clean (the exact CI invocation).
+- No local build or test run: the MacBook constraint stands, PR CI is the gate.
+- **Disclosure:** SourceKit reports `Cannot find type 'ScanWindows' in scope` and siblings against `CostTracker.swift`. Every named symbol is defined in the new `CostScanWindows.swift`; this is the same stale-index lag seen in Sessions 1 and 2 and is **unverified** until CI compiles it.
+- **Disclosure:** single-traversal is now structural — one `scanCostSources` call — rather than asserted by a test, because the injection seam was incompatible with the `inout` capture above.
+
+### Side effect worth noting
+
+Decoding moved from whole-file to per-line, so a single malformed byte no longer fails the entire UTF-8 decode and silently zeroes a whole session's usage. Only the affected line is skipped.
+
+### Files changed
+
+- `MeterBar/Services/FileLineReader.swift` — new.
+- `MeterBar/Services/CostScanWindows.swift` — new; window types plus the relocated `CodexScanContext` / `TokenAccumulator`.
+- `MeterBar/Services/CostTracker.swift` — single-pass dual-window scan across both providers; dead merge helpers removed.
+- `MeterBarTests/FileLineReaderTests.swift` — new, 10 tests.
+- `MeterBarTests/CostTrackerTests.swift` — 6 added tests.
+- `.agents/SESSIONS/2026-07-25.md`
+
+### Next steps
+
+- [ ] Require green CI on the pushed head.
+- [ ] Require an exact-head Opus PASS before merge.
+- [ ] `.agents/SESSIONS/2026-07-25.md` is added by PRs #260, #261, and this one; whichever merges later resolves add/add by taking the superset.
+- [ ] Audit fix #4 — dedupe the Anthropic usage request preserving both timeouts, 30 s and 15 s (D2), and widen `.swiftlint.yml` coverage to `MeterBarCLI` / `MeterBarWidget` / `Packages` (C2).
+
+---
+
+## Session 4: Shared Anthropic usage request + repo-wide lint coverage (audit D2, C2)
+
+**Status:** implemented, lint-clean, pushed. Not merged.
+
+```mermaid
+flowchart TD
+    subgraph before["Before"]
+        A1[fetchOAuthMetrics] -->|builds URLRequest inline<br/>4 headers, 30s| E1[api.anthropic.com/api/oauth/usage]
+        A2[fetchExtraUsageStatus] -->|builds URLRequest inline<br/>same 4 headers, 15s| E1
+    end
+
+    subgraph after["After"]
+        B1[fetchOAuthMetrics] -->|timeout: usageRequestTimeout| R[ClaudeCodeLocalService.usageRequest<br/>token, endpoint, timeout]
+        B2[fetchExtraUsageStatus] -->|timeout: extraUsageRequestTimeout| R
+        R -->|nil| N1[throw ServiceError.invalidURL]
+        R -->|nil| N2[return .unknown]
+        R --> E2[api.anthropic.com/api/oauth/usage]
+    end
+
+    subgraph lint["Lint scope"]
+        L0[included: MeterBar] --> L1[+ MeterBarWidget<br/>+ MeterBarCLI<br/>+ Packages<br/>+ scripts]
+        L1 --> L2["excluded: **/.build<br/>(was: .build)"]
+        L2 --> L3[no_print_statements scoped<br/>away from CLI + scripts]
+    end
+```
+
+### Affected components
+
+- **Service layer** — `ClaudeCodeLocalService` (Anthropic OAuth usage endpoint).
+- **Tooling/config** — `.swiftlint.yml`, and the four Swift targets it had never been looking at.
+- **Fixes surfaced by the widened lint** — `MeterBarCLI/Sources/Wake.swift`, `Packages/MeterBarShared` (`UsageLimit`, `ProviderReadiness`), `scripts/render-readme-screenshots.swift`.
+
+### Root cause / motivation
+
+**D2.** Two methods on the same type built the same `GET` against the same URL with the same four headers (`Authorization`, `Accept`, `Content-Type`, `anthropic-beta`). They differed in exactly one field — `timeoutInterval`, 30 s vs 15 s. Any header change had to be made twice by hand, and nothing enforced it.
+
+**C2.** `.swiftlint.yml` had `included: [MeterBar]`. The widget extension, the CLI, the shared package, and the helper scripts were all outside it — four of the five first-party targets shipped unlinted. CI runs `swiftlint lint --strict --quiet`, so the gate was real but pointed at one directory.
+
+### What was done
+
+- [x] Extracted `ClaudeCodeLocalService.usageRequest(token:endpoint:timeout:) -> URLRequest?` and rewired both callers.
+- [x] Named the two timeouts as constants — `usageRequestTimeout` (30 s) and `extraUsageRequestTimeout` (15 s) — instead of leaving them as bare literals at the call sites.
+- [x] 3 tests written first: header set, endpoint rejection, and a test that pins the two timeouts as *different* values.
+- [x] Widened `included:` to `MeterBarWidget`, `MeterBarCLI`, `Packages`, `scripts`.
+- [x] Fixed `excluded:` — `.build` → `**/.build`.
+- [x] Scoped `no_print_statements` away from `MeterBarCLI` and `scripts`.
+- [x] Fixed all 11 real violations the widening surfaced.
+
+### Key decisions
+
+**The 30 s / 15 s split was preserved, not unified.** The metrics fetch is the user-visible reading and is worth waiting on; the extra-usage probe is best-effort, resolves to `.unknown` on any failure, and must not stall a refresh behind a hung connection. Collapsing them would have been a behaviour change wearing a dedupe's clothes. `timeout` is therefore a **required** parameter with no default, so no future caller can silently inherit the wrong one, and `testUsageRequestKeepsCallerTimeoutsDistinct` fails if anyone unifies them.
+
+**`nil` is returned, not thrown.** The two callers already had different failure modes (`throw ServiceError.invalidURL` vs `return .unknown`). The builder stays neutral and each caller maps `nil` onto its own.
+
+**`excluded: .build` was the whole reason the numbers looked absurd.** Widening `included:` produced **1,960** violations, **1,704** of them attributed to `MeterBarCLI` — impossible for a target with 767 tracked lines. `.build` matches only the repo-root path; `MeterBarCLI/.build/checkouts/swift-argument-parser/**` and `Packages/MeterBarShared/.build` were being linted as if they were ours. The glob `**/.build` took 1,960 → **332**.
+
+**`no_print_statements` was scoped, not disabled.** 75 of the remaining violations were in `MeterBarCLI`, where the rule's own message ("Use os_log or Logger instead of print") is inverted: stdout *is* the product — box-drawing headers, progress bars, JSON output. A `custom_rules` entry accepts `excluded:` as path regexes, so the rule still fires in `MeterBar` and `MeterBarWidget` and is silent in `MeterBarCLI`/`scripts`. Verified on SwiftLint 0.65.0.
+
+**`MeterBarTests` was deliberately left out of `included:`.** It accounts for **246** of the 332 violations — 57 `multiline_arguments`, 36 `line_length`, 33 `force_unwrapping`, 75 prints, and so on. Almost all mechanical, but landing them here would bury four production-code fixes under ~30 files of test churn, and the audit's C2 finding named only the shipping targets. Recorded as a follow-up in a config comment carrying the measured count.
+
+**`MeterBarWidget` was already clean** — zero violations under the widened config. Worth stating, because "we widened the net and caught nothing here" is a real result.
+
+### Verification
+
+- `swiftlint lint --strict --quiet` → **exit 0**, no output, across all five newly-linted paths.
+- Nothing was built, typechecked, or tested locally (machine policy). **CI is the gate.**
+
+### Mistakes and fixes
+
+- Wrapping the over-long `--config-dir` help text as `"a" + "b"` broke the build: `ArgumentHelp` is `ExpressibleByStringLiteral`, so a bare *literal* implicitly converts but a concatenated *expression* does not. It cascaded into `Type 'Wake' does not conform to protocol 'Decodable'` because ArgumentParser synthesizes `Decodable` from the properties. Fixed by wrapping explicitly in `ArgumentHelp(...)`.
+- The two Main-actor isolation warnings in `Wake.swift` are pre-existing; this change only shifted their line numbers.
+
+### Files changed
+
+- `MeterBar/Services/ClaudeCodeLocalService.swift` — shared `usageRequest` builder, two named timeout constants, both callers rewired.
+- `MeterBarTests/ClaudeCodeOAuthUsageTests.swift` — 3 added tests.
+- `.swiftlint.yml` — `included:` widened, `**/.build` exclude, `no_print_statements` scoped.
+- `MeterBarCLI/Sources/Wake.swift` — `line_length`.
+- `Packages/MeterBarShared/Sources/MeterBarShared/UsageLimit.swift` — 4 × `implicit_return`.
+- `Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift` — `orphaned_doc_comment`, `line_length`.
+- `scripts/render-readme-screenshots.swift` — `convenience_type`, 2 × `implicit_return`, `line_length`.
+- `.agents/SESSIONS/2026-07-25.md`
+
+### Next steps
+
+- [ ] Require green CI on the pushed head.
+- [ ] Require an exact-head Opus PASS before merge.
+- [ ] `.agents/SESSIONS/2026-07-25.md` is now added by four PRs (#260, #261, #262, and this one); whichever merges later resolves add/add by taking the superset.
+- [ ] Follow-up: add `MeterBarTests` to `included:` — 246 mechanical violations, measured, deliberately deferred.
+- [ ] Not scheduled from the audit: S3 (`kSecAttrAccessible` on Keychain items), S4 (latent AppleScript injection surface), O4 (notification poll decoupled from refresh), D4 (browser-spoof headers duplicated between `CursorLocalService` and `CodexCliLocalService`), C1 (four files over 950 lines).

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,17 +1,29 @@
 # SwiftLint Configuration for MeterBar
 # https://github.com/realm/SwiftLint
 
-# Paths to include
+# Paths to include.
+# Every first-party Swift target that ships to a user is linted — the app, the
+# widget extension, the CLI, the shared package, and the repo's helper scripts.
+# Previously only `MeterBar` was, so four of the five went unchecked.
 included:
   - MeterBar
+  - MeterBarWidget
+  - MeterBarCLI
+  - Packages
+  - scripts
+# Not yet included: MeterBarTests (332 → 246 of the violations this widening
+# surfaced live there, almost all mechanical). Landing them here would bury the
+# production-code fixes in test churn, so they stay a separate pass.
 
-# Paths to exclude
+# Paths to exclude.
+# `**/.build` (not just `.build`) matters now that the SwiftPM targets are
+# linted: MeterBarCLI and Packages each carry their own build directory full of
+# vendored dependency checkouts, which are not ours to lint.
 excluded:
   - Pods
   - DerivedData
-  - .build
   - Build
-  - Packages
+  - "**/.build"
 
 # Rules configuration
 disabled_rules:
@@ -110,6 +122,14 @@ custom_rules:
   no_print_statements:
     name: "No Print Statements"
     regex: "\\bprint\\s*\\("
+    # Scoped to the GUI targets. In a menu-bar app or a widget extension there is
+    # no terminal attached, so `print` writes to a stream nobody reads and the
+    # unified log is the only place a message survives. In `MeterBarCLI` and the
+    # helper scripts stdout *is* the product — every line the user sees is a
+    # `print` — so applying the rule there would invert its own rationale.
+    excluded:
+      - ".*/MeterBarCLI/.*"
+      - ".*/scripts/.*"
     message: "Use os_log or Logger instead of print"
     severity: warning
 

--- a/MeterBar/Services/ClaudeCodeLocalService.swift
+++ b/MeterBar/Services/ClaudeCodeLocalService.swift
@@ -14,6 +14,14 @@ class ClaudeCodeLocalService: ObservableObject {
     /// without touching main-actor state.
     nonisolated static let defaultUsageEndpoint = "https://api.anthropic.com/api/oauth/usage"
 
+    /// Timeout for the metrics fetch — the user-visible reading, worth waiting on.
+    nonisolated static let usageRequestTimeout: TimeInterval = 30.0
+
+    /// Timeout for the extra-usage probe. Deliberately shorter than
+    /// `usageRequestTimeout`: it is best-effort, resolves to `.unknown` on any
+    /// failure, and must not stall a refresh behind a hung connection.
+    nonisolated static let extraUsageRequestTimeout: TimeInterval = 15.0
+
     private let usageEndpoint = ClaudeCodeLocalService.defaultUsageEndpoint
 
     private let keychainService = "Claude Code-credentials"
@@ -182,6 +190,33 @@ class ClaudeCodeLocalService: ObservableObject {
         }
     }
 
+    /// Builds an authenticated GET against the OAuth usage endpoint.
+    ///
+    /// Both callers — the metrics fetch and the extra-usage probe — hit the same
+    /// URL with the same four headers and differed only in `timeoutInterval`, so
+    /// the header set had to be kept in sync by hand. `timeout` stays a required
+    /// parameter precisely because that difference is intentional: see
+    /// `usageRequestTimeout` and `extraUsageRequestTimeout`.
+    ///
+    /// - Returns: `nil` when `endpoint` is empty or unparseable, which each
+    ///   caller maps onto its own failure mode.
+    nonisolated static func usageRequest(
+        token: String,
+        endpoint: String = defaultUsageEndpoint,
+        timeout: TimeInterval
+    ) -> URLRequest? {
+        guard !endpoint.isEmpty, let url = URL(string: endpoint) else { return nil }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+        request.timeoutInterval = timeout
+        return request
+    }
+
     /// Pure, side-effect-free fetch of Claude Code usage from `/api/oauth/usage`.
     ///
     /// Reads no `@Published` state and performs no `MainActor` mutation, so it
@@ -196,17 +231,13 @@ class ClaudeCodeLocalService: ObservableObject {
         endpoint: String = defaultUsageEndpoint,
         session: URLSession = ServiceSupport.session
     ) async throws -> UsageMetrics {
-        guard let url = URL(string: endpoint), !endpoint.isEmpty else {
+        guard let request = Self.usageRequest(
+            token: token,
+            endpoint: endpoint,
+            timeout: Self.usageRequestTimeout
+        ) else {
             throw ServiceError.invalidURL
         }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
-        request.timeoutInterval = 30.0
 
         do {
             let (data, response) = try await session.data(for: request)
@@ -379,15 +410,13 @@ class ClaudeCodeLocalService: ObservableObject {
             return .unknown
         }
 
-        guard let url = URL(string: usageEndpoint) else { return .unknown }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(credentials.claudeAiOauth.accessToken)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
-        request.timeoutInterval = 15.0
+        guard let request = Self.usageRequest(
+            token: credentials.claudeAiOauth.accessToken,
+            endpoint: usageEndpoint,
+            timeout: Self.extraUsageRequestTimeout
+        ) else {
+            return .unknown
+        }
 
         do {
             let (data, response) = try await urlSession.data(for: request)

--- a/MeterBarCLI/Sources/Wake.swift
+++ b/MeterBarCLI/Sources/Wake.swift
@@ -32,7 +32,15 @@ struct Wake: AsyncParsableCommand {
     @Option(name: .shortAndLong, help: "Provider: 'claude' (default) or 'codex'.")
     var provider: String = "claude"
 
-    @Option(name: .long, help: "Explicit config dir for the wake account (CLAUDE_CONFIG_DIR for claude, CODEX_HOME for codex).")
+    // `ArgumentHelp` is only `ExpressibleByStringLiteral`, so the wrapped text
+    // has to be built explicitly rather than concatenated in place.
+    @Option(
+        name: .long,
+        help: ArgumentHelp(
+            "Explicit config dir for the wake account "
+                + "(CLAUDE_CONFIG_DIR for claude, CODEX_HOME for codex)."
+        )
+    )
     var configDir: String?
 
     @Option(name: .shortAndLong, help: "Maximum sessions to resume this run.")

--- a/MeterBarTests/ClaudeCodeOAuthUsageTests.swift
+++ b/MeterBarTests/ClaudeCodeOAuthUsageTests.swift
@@ -139,6 +139,45 @@ final class ClaudeCodeOAuthUsageTests: XCTestCase {
         }
     }
 
+    // MARK: - Shared usage request builder
+
+    func testUsageRequestCarriesTheOAuthHeaderSet() throws {
+        let request = try XCTUnwrap(ClaudeCodeLocalService.usageRequest(
+            token: "secret-token",
+            endpoint: ClaudeCodeLocalService.defaultUsageEndpoint,
+            timeout: 30
+        ))
+
+        XCTAssertEqual(request.url?.absoluteString, ClaudeCodeLocalService.defaultUsageEndpoint)
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer secret-token")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "anthropic-beta"), "oauth-2025-04-20")
+    }
+
+    func testUsageRequestKeepsCallerTimeoutsDistinct() throws {
+        // The two call sites deliberately differ: the metrics fetch is the
+        // user-visible reading and gets 30s, while the extra-usage probe is
+        // best-effort and must not stall a refresh, so it gets 15s. Collapsing
+        // them onto one value would be a behaviour change, not a dedupe.
+        let metrics = try XCTUnwrap(ClaudeCodeLocalService.usageRequest(
+            token: "t",
+            timeout: ClaudeCodeLocalService.usageRequestTimeout
+        ))
+        let extraUsage = try XCTUnwrap(ClaudeCodeLocalService.usageRequest(
+            token: "t",
+            timeout: ClaudeCodeLocalService.extraUsageRequestTimeout
+        ))
+
+        XCTAssertEqual(metrics.timeoutInterval, 30)
+        XCTAssertEqual(extraUsage.timeoutInterval, 15)
+    }
+
+    func testUsageRequestRejectsAnUnusableEndpoint() {
+        XCTAssertNil(ClaudeCodeLocalService.usageRequest(token: "t", endpoint: "", timeout: 30))
+    }
+
     // MARK: - Enabled-by-default flag
 
     func testOAuthUsageEnabledDefaultsTrueWhenUnset() throws {

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-/// Pure, testable provider-readiness check logic shared by the app and the CLI.
-///
-/// This is the single core behind three surfaces: the `meterbar doctor` CLI
-/// subcommand, the app's Diagnostics view, and the first-run/empty-state
-/// checklist. Lives in `MeterBarShared` — mirroring how the wire-format metrics
-/// types were unified — so `MeterBarCLI` and `MeterBar` genuinely share it
-/// instead of each re-deriving the checks.
-///
-/// The evaluators are pure functions of fixture-able inputs: the impure
-/// gathering (PATH scan, keychain, `CODEX_HOME/auth.json`, Cursor SQLite) is done
-/// by `ProviderReadinessInspector` in the app target. Every string produced here
-/// is safe to paste into a public GitHub issue — no token, account id, or raw
-/// file/response body is ever emitted.
+// Pure, testable provider-readiness check logic shared by the app and the CLI.
+//
+// This is the single core behind three surfaces: the `meterbar doctor` CLI
+// subcommand, the app's Diagnostics view, and the first-run/empty-state
+// checklist. Lives in `MeterBarShared` — mirroring how the wire-format metrics
+// types were unified — so `MeterBarCLI` and `MeterBar` genuinely share it
+// instead of each re-deriving the checks.
+//
+// The evaluators are pure functions of fixture-able inputs: the impure
+// gathering (PATH scan, keychain, `CODEX_HOME/auth.json`, Cursor SQLite) is done
+// by `ProviderReadinessInspector` in the app target. Every string produced here
+// is safe to paste into a public GitHub issue — no token, account id, or raw
+// file/response body is ever emitted.
 
 // MARK: - Result types
 
@@ -367,7 +367,9 @@ public enum ProviderReadinessEvaluator {
             detail: input.isCLIInstalled
                 ? "Codex CLI found on PATH."
                 : "Codex CLI not found on PATH (usage is still read from CODEX_HOME/auth.json).",
-            recovery: input.isCLIInstalled ? nil : "Install the Codex CLI (`npm i -g @openai/codex`) to use `codex login`."
+            recovery: input.isCLIInstalled
+                ? nil
+                : "Install the Codex CLI (`npm i -g @openai/codex`) to use `codex login`."
         )
 
         let auth = codexAuthCheck(input)

--- a/Packages/MeterBarShared/Sources/MeterBarShared/UsageLimit.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/UsageLimit.swift
@@ -46,7 +46,7 @@ public struct UsageLimit: Codable, Equatable, Sendable {
     }
 
     public var percentage: Double {
-        return min(100, rawPercentage)
+        min(100, rawPercentage)
     }
 
     /// User-facing percentage labels shared by the app, widget, and CLI. A
@@ -71,18 +71,18 @@ public struct UsageLimit: Codable, Equatable, Sendable {
     /// `used` clamped into `0...total`, for progress bars that reject
     /// out-of-range values (e.g. `ProgressView`).
     public var clampedUsed: Double {
-        return max(0, min(used, total))
+        max(0, min(used, total))
     }
 
     /// `total` clamped away from zero so progress-bar math never divides by 0.
     public var clampedTotal: Double {
-        return max(0.001, total)
+        max(0.001, total)
     }
 
     // Severity thresholds and "% left" live in `QuotaBands` — the single
     // source of truth for every surface. Only the hard at-limit check stays.
     public var isAtLimit: Bool {
-        return percentage >= 100
+        percentage >= 100
     }
 
     /// Three-level status derived from the shared `QuotaBand` thresholds, for

--- a/scripts/render-readme-screenshots.swift
+++ b/scripts/render-readme-screenshots.swift
@@ -13,11 +13,11 @@ struct UsageLimit: Equatable {
     }
 
     var isNearLimit: Bool {
-        return percentage >= 80
+        percentage >= 80
     }
 
     var isAtLimit: Bool {
-        return percentage >= 100
+        percentage >= 100
     }
 
     var statusColor: UsageStatus {
@@ -446,7 +446,10 @@ struct WidgetServiceCompactView: View {
 
             if let weeklyLimit = metrics.weeklyLimit {
                 HStack {
-                    UsageProgressBar(progress: weeklyLimit.total > 0 ? weeklyLimit.used / weeklyLimit.total : 0, tint: weeklyLimit.statusColor.color)
+                    UsageProgressBar(
+                        progress: weeklyLimit.total > 0 ? weeklyLimit.used / weeklyLimit.total : 0,
+                        tint: weeklyLimit.statusColor.color
+                    )
                     Text("\(Int(weeklyLimit.percentage))%")
                         .font(.caption)
                 }
@@ -555,8 +558,10 @@ func captureWindow(_ window: NSWindow, to url: URL) throws {
     }
 }
 
+// Caseless enum, not a struct: this type only hosts `main`, so making it
+// uninstantiable is both the lint rule's intent and the honest shape.
 @main
-struct SnapshotRenderer {
+enum SnapshotRenderer {
     @MainActor
     static func main() throws {
         let app = NSApplication.shared


### PR DESCRIPTION
Audit follow-through — items **D2** (duplicated Anthropic request) and **C2** (lint coverage). Fourth and last of the scheduled fixes, after #260, #261, #262.

## D2 — one request builder, two deliberate timeouts

`fetchOAuthMetrics` and `fetchExtraUsageStatus` each built a `GET` against the same URL with the same four headers (`Authorization`, `Accept`, `Content-Type`, `anthropic-beta`). They differed in exactly one field. Any header change had to be made twice, by hand, with nothing enforcing it.

Extracted `ClaudeCodeLocalService.usageRequest(token:endpoint:timeout:) -> URLRequest?`.

**The 30 s / 15 s split is preserved, not unified.** The metrics fetch is the user-visible reading and is worth waiting on. The extra-usage probe is best-effort, resolves to `.unknown` on any failure, and must not stall a refresh behind a hung connection. Collapsing them would have been a behaviour change wearing a dedupe's clothes.

Two guards against that happening later:
- `timeout` is a **required** parameter with no default, so no caller can silently inherit the wrong one.
- `testUsageRequestKeepsCallerTimeoutsDistinct` fails if anyone unifies them.

The builder returns `nil` rather than throwing, because the two callers already had different failure modes (`throw ServiceError.invalidURL` vs `return .unknown`) and each maps `nil` onto its own.

## C2 — four of five targets were never linted

`.swiftlint.yml` had `included: [MeterBar]`. The widget extension, the CLI, the shared package and the helper scripts were all outside it. CI runs `swiftlint lint --strict --quiet`, so the gate was real — it was just pointed at one directory.

Widening it surfaced **1,960** violations, **1,704** attributed to `MeterBarCLI`. That is impossible for a target with 767 tracked lines, and the reason is a config bug worth naming:

> `excluded: .build` matches **only** the repo-root `.build`. `MeterBarCLI/.build/checkouts/swift-argument-parser/**` and `Packages/MeterBarShared/.build` were being linted as first-party code.

The glob `**/.build` took **1,960 → 332**.

**`no_print_statements` was scoped, not disabled.** 75 of the remainder were in `MeterBarCLI`, where the rule's own message — "Use os_log or Logger instead of print" — is inverted: there is no unread stream, stdout *is* the product (box-drawing headers, progress bars, JSON). A `custom_rules` entry accepts `excluded:` as path regexes, so the rule still fires in `MeterBar` and `MeterBarWidget` and is silent in `MeterBarCLI`/`scripts`. Verified on SwiftLint 0.65.0.

Then 11 real violations, all fixed:
| file | rule |
|---|---|
| `MeterBarCLI/Sources/Wake.swift` | `line_length` |
| `Packages/…/UsageLimit.swift` | 4 × `implicit_return` |
| `Packages/…/ProviderReadiness.swift` | `orphaned_doc_comment`, `line_length` |
| `scripts/render-readme-screenshots.swift` | `convenience_type`, 2 × `implicit_return`, `line_length` |

## Disclosures

- **`MeterBarTests` was deliberately left out of `included:`.** It is **246** of the 332 — 57 `multiline_arguments`, 36 `line_length`, 33 `force_unwrapping`, 75 prints. Almost all mechanical, but landing them here would bury four production-code fixes under ~30 files of test churn, and the audit's C2 finding named only the shipping targets. Recorded as a follow-up in a config comment carrying the measured count.
- **`MeterBarWidget` was already clean** — zero violations under the widened config.
- **`.agents/SESSIONS/2026-07-25.md` is added by four PRs now** (#260, #261, #262, this one). Whichever merges later hits an add/add conflict; resolution is *take the superset* — this branch carries Sessions 1+2+3+4.
- **Nothing was built, typechecked, or tested locally** (machine policy). `swiftlint --strict` exits 0 across all five newly-linted paths. **CI is the gate.**
- The two Main-actor isolation warnings in `Wake.swift` are pre-existing; this change only shifted their line numbers.

## Test plan

- 3 new tests in `ClaudeCodeOAuthUsageTests`, written before the implementation: header set, endpoint rejection, and the timeout-distinctness pin.
- Required CI green on this head.
- Exact-head review PASS before merge.