### PR TITLE
fix(menubar): skip spent quotas in Auto and add per-provider items

### DIFF
--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -57,7 +57,20 @@ private struct MeterBarCommands: Commands {
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate {
-    private var statusItem: NSStatusItem?
+    /// Live status items keyed by `MenuBarStatusItemDescriptor.id`. Merged mode
+    /// keeps exactly one; per-provider mode owns one slot per tracked account.
+    private var statusItems: [String: NSStatusItem] = [:]
+    /// Descriptor ids in plan order, used to pick a stable fallback anchor.
+    private var statusItemIDs: [String] = []
+    /// The item the user last clicked, so the popover and the right-click menu
+    /// open under that icon instead of always under the leftmost one.
+    private var activeStatusItemID: String?
+    /// Latest probed candidates, kept so the right-click switcher can list every
+    /// pinnable window without re-running the probes.
+    private var latestStatusCandidates: [StatusLimitCandidate] = []
+    /// Menu bar icons are rebuilt on every refresh; rasterizing the provider
+    /// logos once keeps that off the hot path.
+    private var statusItemImageCache: [String: NSImage] = [:]
     private var menuPanel: MeterBarMenuPanelController?
     private let providerVisibilityStore = ProviderVisibilityStore.shared
     private let dockVisibilityStore = DockVisibilityStore.shared
@@ -93,29 +106,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         observeDockVisibility()
         observeSystemWake()
 
-        // Create menu bar item
-        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-
-        guard let button = statusItem?.button else {
+        // Create the initial menu bar item. The presentation plan takes over on
+        // the first metrics update and may add or remove items from there.
+        guard makeStatusItem(id: MenuBarStatusItemPlanner.mergedItemID) != nil else {
             AppLog.app.error("Failed to create status item button")
             return
         }
-
-        // Set up the menu bar icon with 3 progress bars
-        let image = createMenuBarIcon()
-        image.isTemplate = true
-        button.image = image
-
-        button.action = #selector(handleStatusItemClick)
-        button.target = self
-        button.sendAction(on: [.leftMouseUp, .rightMouseUp])
-        button.toolTip = "MeterBar"
-        button.imagePosition = .imageLeft
-        button.font = .systemFont(ofSize: 14, weight: .semibold)
+        statusItemIDs = [MenuBarStatusItemPlanner.mergedItemID]
 
         menuPanel = MeterBarMenuPanelController(
             statusButtonProvider: { [weak self] in
-                self?.statusItem?.button
+                self?.anchorStatusButton()
             },
             onDismiss: {
                 // Closing the popover only tears down the transient detail
@@ -158,16 +159,55 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// Creates one menu bar slot and wires its button. Returns nil when AppKit
+    /// refuses the button, in which case the (useless) item is released again.
+    @discardableResult
+    private func makeStatusItem(id: String) -> NSStatusItem? {
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        // Per-id autosave name so macOS restores each item's user-dragged
+        // position separately instead of collapsing them onto one slot.
+        item.autosaveName = "MeterBarStatusItem-\(id)"
+
+        guard let button = item.button else {
+            NSStatusBar.system.removeStatusItem(item)
+            return nil
+        }
+
+        button.image = statusItemImage(for: nil)
+        button.action = #selector(handleStatusItemClick(_:))
+        button.target = self
+        button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+        button.toolTip = "MeterBar"
+        button.imagePosition = .imageLeft
+        button.font = .systemFont(ofSize: 14, weight: .semibold)
+
+        statusItems[id] = item
+        return item
+    }
+
+    /// Button the popover and menus attach to: the one just clicked, or the
+    /// leftmost surviving item when nothing has been clicked yet.
+    private func anchorStatusButton() -> NSStatusBarButton? {
+        if let activeStatusItemID, let button = statusItems[activeStatusItemID]?.button {
+            return button
+        }
+        return statusItemIDs.compactMap { statusItems[$0]?.button }.first
+    }
+
     /// Left-click opens the popover; right-click (or control-click) opens a
     /// native menu so Quit stays reachable even when the Dock icon is hidden.
     @objc
-    private func handleStatusItemClick() {
+    private func handleStatusItemClick(_ sender: NSStatusBarButton) {
+        // Remember which of the (possibly several) items was hit so the panel
+        // and menu don't jump to a different icon than the one clicked.
+        activeStatusItemID = statusItemIDs.first { statusItems[$0]?.button === sender }
+
         let event = NSApp.currentEvent
         let isSecondaryClick = event?.type == .rightMouseUp
             || (event?.modifierFlags.contains(.control) ?? false)
 
         if isSecondaryClick {
-            showStatusMenu()
+            showStatusMenu(from: sender)
         } else {
             togglePopover()
         }
@@ -190,9 +230,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Shows a native menu anchored to the menu bar icon. This is the always-on
     /// escape hatch for Quit (and Dock visibility), independent of the popover.
-    private func showStatusMenu() {
-        guard let button = statusItem?.button else { return }
-
+    private func showStatusMenu(from button: NSStatusBarButton) {
         menuPanel?.dismiss()
 
         let menu = makeStatusMenu()
@@ -202,6 +240,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func makeStatusMenu() -> NSMenu {
         let menu = NSMenu()
+
+        let showsItem = NSMenuItem(title: "Menu Bar Shows", action: nil, keyEquivalent: "")
+        showsItem.image = NSImage(systemSymbolName: "menubar.rectangle", accessibilityDescription: nil)
+        showsItem.submenu = makeMenuBarShowsMenu()
+        menu.addItem(showsItem)
+
+        menu.addItem(.separator())
 
         let dockItem = NSMenuItem(
             title: "Show in Dock",
@@ -236,6 +281,66 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(quitItem)
 
         return menu
+    }
+
+    /// The menu-bar-side twin of the Settings picker: switch the shown quota (or
+    /// spread every provider across its own item) without opening Settings.
+    private func makeMenuBarShowsMenu() -> NSMenu {
+        let menu = NSMenu()
+        let mode = menuBarDisplayPreferences.presentationMode
+        let pinnedKey = menuBarDisplayPreferences.pinnedCandidateKey
+
+        let autoItem = NSMenuItem(title: "Auto", action: #selector(selectMenuBarAuto), keyEquivalent: "")
+        autoItem.target = self
+        autoItem.state = mode == .merged && pinnedKey == nil ? .on : .off
+        menu.addItem(autoItem)
+
+        let options = MenuBarStatusItemPlanner.switcherOptions(for: latestStatusCandidates)
+        if !options.isEmpty {
+            menu.addItem(.separator())
+            for option in options {
+                let item = NSMenuItem(
+                    title: option.title,
+                    action: #selector(selectMenuBarPin(_:)),
+                    keyEquivalent: ""
+                )
+                item.target = self
+                item.representedObject = option.id
+                item.state = mode == .merged && pinnedKey == option.id ? .on : .off
+                menu.addItem(item)
+            }
+        }
+
+        menu.addItem(.separator())
+
+        let allItem = NSMenuItem(
+            title: "All Providers",
+            action: #selector(selectMenuBarAllProviders),
+            keyEquivalent: ""
+        )
+        allItem.target = self
+        allItem.state = mode == .perProvider ? .on : .off
+        menu.addItem(allItem)
+
+        return menu
+    }
+
+    @objc
+    private func selectMenuBarAuto() {
+        menuBarDisplayPreferences.setPresentationMode(.merged)
+        menuBarDisplayPreferences.setPinnedCandidateKey(nil)
+    }
+
+    @objc
+    private func selectMenuBarPin(_ sender: NSMenuItem) {
+        guard let pinKey = sender.representedObject as? String else { return }
+        menuBarDisplayPreferences.setPresentationMode(.merged)
+        menuBarDisplayPreferences.setPinnedCandidateKey(pinKey)
+    }
+
+    @objc
+    private func selectMenuBarAllProviders() {
+        menuBarDisplayPreferences.setPresentationMode(.perProvider)
     }
 
     private func makeProviderStatusMenu() -> NSMenu {
@@ -700,8 +805,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
             .store(in: &cancellables)
 
-        Publishers.Merge3(
+        Publishers.Merge4(
             menuBarDisplayPreferences.$pinnedCandidateKey.map { _ in () },
+            menuBarDisplayPreferences.$presentationMode.map { _ in () },
             menuBarDisplayPreferences.$labelMetric.map { _ in () },
             menuBarDisplayPreferences.$labelSize.map { _ in () }
         )
@@ -730,7 +836,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @MainActor
     private func updateStatusItem(metrics: [ServiceType: UsageMetrics]) {
-        guard statusItem?.button != nil else { return }
+        guard !statusItems.isEmpty else { return }
 
         // Gather the cheap main-actor inputs now; run the activity probes
         // (directory scans) off the main actor; apply on return. A generation
@@ -747,6 +853,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                         StatusLimitCandidate(
                             key: seed.key,
                             pinKey: seed.pinKey,
+                            service: seed.service,
                             displayName: seed.displayName,
                             windowName: seed.windowName,
                             limit: seed.limit,
@@ -757,54 +864,102 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }.value
             guard let self, generation == self.statusItemUpdateGeneration else { return }
-            self.applyStatusItemSelection(candidates: candidates)
+            self.applyStatusItemPlan(candidates: candidates)
         }
     }
 
     @MainActor
-    private func applyStatusItemSelection(candidates: [StatusLimitCandidate]) {
-        guard let button = statusItem?.button else { return }
+    private func applyStatusItemPlan(candidates: [StatusLimitCandidate]) {
+        latestStatusCandidates = candidates
 
-        guard let selection = StatusItemLimitSelector.select(
+        let descriptors = MenuBarStatusItemPlanner.plan(
+            mode: menuBarDisplayPreferences.presentationMode,
             candidates: candidates,
             previousKey: shownStatusItemKey,
-            pinnedKey: menuBarDisplayPreferences.pinnedCandidateKey
-        ) else {
-            shownStatusItemKey = nil
-            setStatusButtonTitle(button, to: "")
-            button.imagePosition = .imageOnly
-            button.toolTip = "MeterBar"
-            button.setAccessibilityLabel("MeterBar")
-            applyParseHealthAppearance(to: button)
-            return
-        }
-
-        shownStatusItemKey = selection.key
-        let isPinned = menuBarDisplayPreferences.pinnedCandidateKey == selection.pinKey
-        let selectionName = isPinned
-            ? "\(selection.displayName) · \(selection.windowName)"
-            : selection.displayName
-        let title = StatusItemLabelFormatter.title(
-            for: selection.limit,
+            pinnedKey: menuBarDisplayPreferences.pinnedCandidateKey,
             metric: menuBarDisplayPreferences.labelMetric,
             size: menuBarDisplayPreferences.labelSize
         )
-        let spokenValue = StatusItemLabelFormatter.spokenValue(
-            for: selection.limit,
-            metric: menuBarDisplayPreferences.labelMetric
-        )
 
-        button.imagePosition = title == nil ? .imageOnly : .imageLeft
-        setStatusButtonTitle(button, to: title.map { " \($0)" } ?? "")
-        if let spokenValue {
-            button.toolTip = "MeterBar: \(spokenValue) on \(selectionName)"
-            button.setAccessibilityLabel("MeterBar \(spokenValue) on \(selectionName)")
-        } else {
-            button.toolTip = "MeterBar: \(selectionName)"
-            button.setAccessibilityLabel("MeterBar \(selectionName)")
+        // Only the merged item feeds sticky selection; per-provider items are
+        // each nailed to one account and report no key at all.
+        shownStatusItemKey = descriptors
+            .first { $0.id == MenuBarStatusItemPlanner.mergedItemID }?
+            .selectionKey
+
+        applyStatusItemDescriptors(descriptors)
+    }
+
+    /// Reconciles the live status items with the plan: drop the ones that are
+    /// gone, create the ones that are new, restyle the rest in place.
+    @MainActor
+    private func applyStatusItemDescriptors(_ descriptors: [MenuBarStatusItemDescriptor]) {
+        let liveIDs = Set(descriptors.map(\.id))
+
+        // Snapshot the keys: the loop mutates the dictionary it reads from.
+        for id in Array(statusItems.keys) where !liveIDs.contains(id) {
+            if let item = statusItems.removeValue(forKey: id) {
+                NSStatusBar.system.removeStatusItem(item)
+            }
         }
+
+        if let activeStatusItemID, !liveIDs.contains(activeStatusItemID) {
+            self.activeStatusItemID = nil
+        }
+
+        statusItemIDs = descriptors.map(\.id)
+
+        for descriptor in descriptors {
+            let item = statusItems[descriptor.id] ?? makeStatusItem(id: descriptor.id)
+            guard let button = item?.button else { continue }
+            apply(descriptor, to: button)
+        }
+    }
+
+    @MainActor
+    private func apply(_ descriptor: MenuBarStatusItemDescriptor, to button: NSStatusBarButton) {
+        button.image = statusItemImage(for: descriptor.service)
+        button.imagePosition = descriptor.title.isEmpty ? .imageOnly : .imageLeft
+        setStatusButtonTitle(button, to: descriptor.title)
+        button.toolTip = descriptor.tooltip
+        button.setAccessibilityLabel(descriptor.accessibilityLabel)
         applyParseHealthAppearance(to: button)
     }
+
+    /// Provider glyph for the item, so a bare `52%` says *whose* 52% it is.
+    /// Providers without a bundled logo keep MeterBar's own bars mark.
+    @MainActor
+    private func statusItemImage(for service: ServiceType?) -> NSImage {
+        guard let resourceName = service.flatMap({ ProviderLogoKind.forService($0).resourceName }) else {
+            return fallbackStatusItemImage()
+        }
+
+        if let cached = statusItemImageCache[resourceName] { return cached }
+
+        // The logo cache vends shared instances, so resize a copy — mutating
+        // the original would shrink every popover icon too.
+        guard let logo = ProviderLogoImageCache.image(named: resourceName)?.copy() as? NSImage else {
+            return fallbackStatusItemImage()
+        }
+        logo.size = NSSize(width: 16, height: 16)
+        logo.isTemplate = true
+        statusItemImageCache[resourceName] = logo
+        return logo
+    }
+
+    @MainActor
+    private func fallbackStatusItemImage() -> NSImage {
+        if let cached = statusItemImageCache[Self.fallbackStatusImageKey] { return cached }
+
+        let image = createMenuBarIcon()
+        image.isTemplate = true
+        statusItemImageCache[Self.fallbackStatusImageKey] = image
+        return image
+    }
+
+    /// Cache slot for the generic mark. Not a resource name, so it can't
+    /// collide with a provider logo.
+    private static let fallbackStatusImageKey = "meterbar.fallback"
 
     /// Sets the status-button title, crossfading the change so the menu-bar
     /// `NN%` doesn't snap on refresh. SwiftUI's `.contentTransition(.numericText())`

--- a/MeterBar/Models/MenuBarStatusItemPlanner.swift
+++ b/MeterBar/Models/MenuBarStatusItemPlanner.swift
@@ -1,0 +1,167 @@
+import Foundation
+import MeterBarShared
+
+/// One `NSStatusItem` the app should own, fully resolved.
+///
+/// The AppDelegate can't be reached by `swift test` (the SwiftPM target excludes
+/// `App/`), so every decision about *what* the menu bar shows lives here and the
+/// delegate is left with nothing but "create, update, remove" mechanics.
+struct MenuBarStatusItemDescriptor: Equatable, Identifiable, Sendable {
+    /// Stable identity across refreshes. Reusing it keeps the item's menu-bar
+    /// position (and its autosaved user ordering) instead of respawning it at
+    /// the far left on every update.
+    let id: String
+    /// Provider whose logo the item wears; nil for the placeholder item.
+    let service: ServiceType?
+    /// Legacy Auto key fed back to `StatusItemLimitSelector` as `previousKey`,
+    /// so hysteresis survives. Only merged mode has a meaningful value.
+    let selectionKey: String?
+    /// Menu bar label. Empty renders icon-only, and a non-empty title carries
+    /// the leading space that separates it from the icon.
+    let title: String
+    let tooltip: String
+    let accessibilityLabel: String
+}
+
+/// Turns the current quota candidates into the menu bar's status item layout.
+enum MenuBarStatusItemPlanner {
+    /// Identity of the single item in merged mode, and of the placeholder that
+    /// keeps MeterBar reachable when there is nothing to show.
+    static let mergedItemID = "merged"
+
+    static func plan(
+        mode: MenuBarPresentationMode,
+        candidates: [StatusLimitCandidate],
+        previousKey: String?,
+        pinnedKey: String?,
+        metric: StatusItemLabelMetric,
+        size: StatusItemLabelSize,
+        now: Date = Date()
+    ) -> [MenuBarStatusItemDescriptor] {
+        switch mode {
+        case .merged:
+            let descriptor = mergedDescriptor(
+                candidates: candidates,
+                previousKey: previousKey,
+                pinnedKey: pinnedKey,
+                metric: metric,
+                size: size,
+                now: now
+            )
+            return [descriptor]
+        case .perProvider:
+            let descriptors = perProviderDescriptors(candidates: candidates, metric: metric, size: size)
+            // Never return an empty plan: with no status item left the popover,
+            // settings, and Quit all become unreachable.
+            return descriptors.isEmpty ? [placeholderDescriptor] : descriptors
+        }
+    }
+
+    /// Every window the user can pin from the menu bar itself, deduplicated by
+    /// pin key and ordered like the rest of the app.
+    static func switcherOptions(for candidates: [StatusLimitCandidate]) -> [StatusItemPinOption] {
+        var seen: Set<String> = []
+        return candidates
+            .sorted { lhs, rhs in
+                (lhs.service.sortOrder, lhs.displayName, lhs.windowName)
+                    < (rhs.service.sortOrder, rhs.displayName, rhs.windowName)
+            }
+            .compactMap { candidate in
+                guard seen.insert(candidate.pinKey).inserted else { return nil }
+                return StatusItemPinOption(
+                    id: candidate.pinKey,
+                    title: "\(candidate.displayName) · \(candidate.windowName)"
+                )
+            }
+    }
+
+    private static var placeholderDescriptor: MenuBarStatusItemDescriptor {
+        MenuBarStatusItemDescriptor(
+            id: mergedItemID,
+            service: nil,
+            selectionKey: nil,
+            title: "",
+            tooltip: "MeterBar",
+            accessibilityLabel: "MeterBar"
+        )
+    }
+
+    private static func mergedDescriptor(
+        candidates: [StatusLimitCandidate],
+        previousKey: String?,
+        pinnedKey: String?,
+        metric: StatusItemLabelMetric,
+        size: StatusItemLabelSize,
+        now: Date
+    ) -> MenuBarStatusItemDescriptor {
+        guard let selection = StatusItemLimitSelector.select(
+            candidates: candidates,
+            previousKey: previousKey,
+            pinnedKey: pinnedKey,
+            now: now
+        ) else {
+            return placeholderDescriptor
+        }
+
+        // Auto already implies "whichever window matters", so the window name is
+        // noise there; a pin is a deliberate choice of one window and says so.
+        let isPinned = pinnedKey == selection.pinKey
+        return descriptor(
+            id: mergedItemID,
+            selectionKey: selection.key,
+            candidate: selection,
+            qualifiedName: isPinned,
+            metric: metric,
+            size: size
+        )
+    }
+
+    private static func perProviderDescriptors(
+        candidates: [StatusLimitCandidate],
+        metric: StatusItemLabelMetric,
+        size: StatusItemLabelSize
+    ) -> [MenuBarStatusItemDescriptor] {
+        candidates
+            .filter(\.isAutoSelectable)
+            .sorted { lhs, rhs in
+                // Deterministic order, otherwise the items reshuffle whenever
+                // the candidate list is rebuilt.
+                (lhs.service.sortOrder, lhs.key) < (rhs.service.sortOrder, rhs.key)
+            }
+            .map { candidate in
+                descriptor(
+                    id: candidate.pinKey,
+                    selectionKey: nil,
+                    candidate: candidate,
+                    qualifiedName: true,
+                    metric: metric,
+                    size: size
+                )
+            }
+    }
+
+    private static func descriptor(
+        id: String,
+        selectionKey: String?,
+        candidate: StatusLimitCandidate,
+        qualifiedName: Bool,
+        metric: StatusItemLabelMetric,
+        size: StatusItemLabelSize
+    ) -> MenuBarStatusItemDescriptor {
+        let name = qualifiedName
+            ? "\(candidate.displayName) · \(candidate.windowName)"
+            : candidate.displayName
+        let title = StatusItemLabelFormatter.title(for: candidate.limit, metric: metric, size: size)
+        let spokenValue = StatusItemLabelFormatter.spokenValue(for: candidate.limit, metric: metric)
+        let suffix = spokenValue.map { "\($0) on \(name)" } ?? name
+
+        return MenuBarStatusItemDescriptor(
+            id: id,
+            service: candidate.service,
+            selectionKey: selectionKey,
+            title: title.map { " \($0)" } ?? "",
+            tooltip: "MeterBar: \(suffix)",
+            accessibilityLabel: "MeterBar \(suffix)"
+        )
+    }
+}

--- a/MeterBar/Models/StatusItemLimitSelector.swift
+++ b/MeterBar/Models/StatusItemLimitSelector.swift
@@ -9,6 +9,9 @@ struct StatusLimitCandidate: Equatable, Sendable {
     let key: String
     /// Stable provider/account/window identity persisted for explicit pins.
     let pinKey: String
+    /// Provider this quota belongs to, used for per-provider status item icons
+    /// and deterministic left-to-right ordering in the menu bar.
+    let service: ServiceType
     /// Human-readable label for the status item tooltip.
     let displayName: String
     /// Provider-specific quota-window label (Session, Weekly, Sonnet, etc.).
@@ -25,6 +28,7 @@ struct StatusLimitCandidate: Equatable, Sendable {
 struct StatusLimitCandidateSeed: Sendable {
     let key: String
     let pinKey: String
+    let service: ServiceType
     let displayName: String
     let windowName: String
     let limit: UsageLimit
@@ -70,6 +74,7 @@ enum StatusItemLimitCandidateBuilder {
             return StatusLimitCandidateSeed(
                 key: limit.id == autoWindowID ? autoSelectionKey ?? pinKey : pinKey,
                 pinKey: pinKey,
+                service: service,
                 displayName: displayName,
                 windowName: limit.title,
                 limit: limit.usageLimit,
@@ -91,7 +96,9 @@ struct StatusItemPinOption: Identifiable, Equatable {
 /// selector instead follows the accounts with recent on-disk activity, and is
 /// sticky: when several accounts are active at once (one Claude + one Codex),
 /// the shown account only changes when it goes idle or another active account
-/// becomes clearly tighter — never ping-ponging on small fluctuations.
+/// becomes clearly tighter — never ping-ponging on small fluctuations. Accounts
+/// with nothing left are skipped entirely, since "tightest" would otherwise mean
+/// "the one you can't use" for as long as it stays drained.
 enum StatusItemLimitSelector {
     /// Activity newer than this counts as "in use".
     static let activityWindow: TimeInterval = 30 * 60
@@ -114,14 +121,23 @@ enum StatusItemLimitSelector {
         let autoCandidates = candidates.filter(\.isAutoSelectable)
         guard !autoCandidates.isEmpty else { return nil }
 
-        let active = autoCandidates.filter { candidate in
+        // A spent quota is always the tightest, so without this it wins every
+        // round it enters and freezes the menu bar on 0% for days — the exact
+        // symptom that made the title read "Codex 0%" while Claude had half its
+        // session left. Filtered before the activity pass, since a spent account
+        // is usually also the *only* recently active one. If everything is spent
+        // the whole pool comes back so the title still shows a number.
+        let withQuotaLeft = autoCandidates.filter { QuotaMath.percentLeft(for: $0.limit) > 0 }
+        let selectable = withQuotaLeft.isEmpty ? autoCandidates : withQuotaLeft
+
+        let active = selectable.filter { candidate in
             guard let lastActivity = candidate.lastActivity else { return false }
             return now.timeIntervalSince(lastActivity) <= activityWindow
         }
 
         // No detectable activity anywhere: fall back to the old behavior and
         // let every enabled account compete.
-        let pool = active.isEmpty ? autoCandidates : active
+        let pool = active.isEmpty ? selectable : active
 
         guard let tightest = pool.min(by: { lhs, rhs in
             let lhsLeft = QuotaMath.percentLeft(for: lhs.limit)

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -22,6 +22,8 @@ nonisolated enum StorageKeys {
     static let showInDock = "ShowMeterBarInDock"
     /// Stable provider/account/window key pinned into the menu bar title. Missing means Auto.
     static let statusItemPinnedCandidate = "StatusItemPinnedCandidate"
+    /// `MenuBarPresentationMode` raw value: one merged status item or one per provider.
+    static let statusItemPresentationMode = "StatusItemPresentationMode"
     /// `StatusItemLabelMetric` raw value (percent left, percent used, or icon only).
     static let statusItemLabelMetric = "StatusItemLabelMetric"
     /// `StatusItemLabelSize` raw value (compact or regular).

--- a/MeterBar/Services/MenuBarDisplayPreferencesStore.swift
+++ b/MeterBar/Services/MenuBarDisplayPreferencesStore.swift
@@ -18,6 +18,23 @@ nonisolated enum StatusItemLabelMetric: String, CaseIterable, Identifiable {
     }
 }
 
+/// How many status items MeterBar owns in the menu bar.
+nonisolated enum MenuBarPresentationMode: String, CaseIterable, Identifiable, Sendable {
+    /// One status item showing a single quota (Auto or an explicit pin).
+    case merged
+    /// One status item per tracked provider account, CodexBar-style.
+    case perProvider
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .merged: return "Single Item"
+        case .perProvider: return "One Per Provider"
+        }
+    }
+}
+
 nonisolated enum StatusItemLabelSize: String, CaseIterable, Identifiable {
     case compact
     case regular
@@ -48,6 +65,7 @@ final class MenuBarDisplayPreferencesStore: ObservableObject {
     static let shared = MenuBarDisplayPreferencesStore()
 
     @Published private(set) var pinnedCandidateKey: String?
+    @Published private(set) var presentationMode: MenuBarPresentationMode
     @Published private(set) var labelMetric: StatusItemLabelMetric
     @Published private(set) var labelSize: StatusItemLabelSize
     @Published private(set) var resetTimeFormat: ResetTimeFormat
@@ -58,6 +76,8 @@ final class MenuBarDisplayPreferencesStore: ObservableObject {
         self.userDefaults = userDefaults
         pinnedCandidateKey = userDefaults.string(forKey: StorageKeys.statusItemPinnedCandidate)
             .flatMap(Self.normalizedPin)
+        presentationMode = userDefaults.string(forKey: StorageKeys.statusItemPresentationMode)
+            .flatMap(MenuBarPresentationMode.init(rawValue:)) ?? .merged
         labelMetric = userDefaults.string(forKey: StorageKeys.statusItemLabelMetric)
             .flatMap(StatusItemLabelMetric.init(rawValue:)) ?? .percentLeft
         labelSize = userDefaults.string(forKey: StorageKeys.statusItemLabelSize)
@@ -75,6 +95,12 @@ final class MenuBarDisplayPreferencesStore: ObservableObject {
         } else {
             userDefaults.removeObject(forKey: StorageKeys.statusItemPinnedCandidate)
         }
+    }
+
+    func setPresentationMode(_ mode: MenuBarPresentationMode) {
+        guard mode != presentationMode else { return }
+        presentationMode = mode
+        userDefaults.set(mode.rawValue, forKey: StorageKeys.statusItemPresentationMode)
     }
 
     func setLabelMetric(_ metric: StatusItemLabelMetric) {

--- a/MeterBar/Views/Settings/GeneralSettingsView.swift
+++ b/MeterBar/Views/Settings/GeneralSettingsView.swift
@@ -128,6 +128,23 @@ struct GeneralSettingsView: View {
             color: MeterBarTheme.appAccent
         ) {
             SettingsRowView(
+                title: "Menu bar layout",
+                detail: "One Per Provider gives every tracked account its own menu bar item."
+            ) {
+                Picker("", selection: Binding(
+                    get: { menuBarDisplayPreferences.presentationMode },
+                    set: { menuBarDisplayPreferences.setPresentationMode($0) }
+                )) {
+                    ForEach(MenuBarPresentationMode.allCases) { mode in
+                        Text(mode.displayName).tag(mode)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .frame(width: 220)
+            }
+
+            SettingsRowView(
                 title: "Menu bar shows",
                 detail: "Auto follows recent activity. Pinning keeps one provider, account, and quota window visible."
             ) {
@@ -147,6 +164,9 @@ struct GeneralSettingsView: View {
                 .labelsHidden()
                 .pickerStyle(.menu)
                 .fixedSize()
+                // One-per-provider already shows every account, so there is
+                // nothing left for a pin to choose between.
+                .disabled(menuBarDisplayPreferences.presentationMode == .perProvider)
             }
 
             SettingsRowView(

--- a/MeterBarTests/MenuBarStatusItemPlannerTests.swift
+++ b/MeterBarTests/MenuBarStatusItemPlannerTests.swift
@@ -1,0 +1,234 @@
+import MeterBarShared
+import XCTest
+
+@testable import MeterBar
+
+/// Covers the pure layout decision behind the menu bar: how many status items
+/// exist, what each one shows, and how they are identified across refreshes.
+final class MenuBarStatusItemPlannerTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+    private func candidate(
+        key: String,
+        service: ServiceType = .claudeCode,
+        percentUsed: Double,
+        displayName: String? = nil,
+        windowName: String = "Session",
+        pinKey: String? = nil,
+        activeMinutesAgo: Double? = nil,
+        isAutoSelectable: Bool = true
+    ) -> StatusLimitCandidate {
+        StatusLimitCandidate(
+            key: key,
+            pinKey: pinKey ?? key,
+            service: service,
+            displayName: displayName ?? key,
+            windowName: windowName,
+            limit: UsageLimit(used: percentUsed, total: 100, resetTime: nil),
+            lastActivity: activeMinutesAgo.map { now.addingTimeInterval(-$0 * 60) },
+            isAutoSelectable: isAutoSelectable
+        )
+    }
+
+    private func plan(
+        _ candidates: [StatusLimitCandidate],
+        mode: MenuBarPresentationMode = .merged,
+        previousKey: String? = nil,
+        pinnedKey: String? = nil,
+        metric: StatusItemLabelMetric = .percentLeft,
+        size: StatusItemLabelSize = .compact
+    ) -> [MenuBarStatusItemDescriptor] {
+        MenuBarStatusItemPlanner.plan(
+            mode: mode,
+            candidates: candidates,
+            previousKey: previousKey,
+            pinnedKey: pinnedKey,
+            metric: metric,
+            size: size,
+            now: now
+        )
+    }
+
+    // MARK: - Merged mode
+
+    func testMergedModeProducesExactlyOneItemForTheSelectedQuota() {
+        let codex = candidate(key: "codex", service: .codexCli, percentUsed: 100, activeMinutesAgo: 1)
+        let claude = candidate(key: "claude:gen", percentUsed: 48, displayName: "genfeedai (Claude Code)")
+
+        let descriptors = plan([codex, claude])
+
+        XCTAssertEqual(descriptors.count, 1)
+        let item = descriptors.first
+        XCTAssertEqual(item?.id, MenuBarStatusItemPlanner.mergedItemID)
+        XCTAssertEqual(item?.service, .claudeCode)
+        XCTAssertEqual(item?.selectionKey, "claude:gen")
+        XCTAssertEqual(item?.title, " 52%")
+        XCTAssertEqual(item?.tooltip, "MeterBar: 52% left on genfeedai (Claude Code)")
+        XCTAssertEqual(item?.accessibilityLabel, "MeterBar 52% left on genfeedai (Claude Code)")
+    }
+
+    func testMergedModeQualifiesTheWindowOnlyWhenPinned() {
+        let claude = candidate(
+            key: "claude:gen",
+            percentUsed: 48,
+            displayName: "genfeedai (Claude Code)",
+            windowName: "Weekly",
+            pinKey: "Claude Code:gen:weekly",
+            isAutoSelectable: false
+        )
+
+        let descriptors = plan([claude], pinnedKey: "Claude Code:gen:weekly")
+
+        XCTAssertEqual(descriptors.first?.tooltip, "MeterBar: 52% left on genfeedai (Claude Code) · Weekly")
+    }
+
+    func testMergedModeWithoutASelectionKeepsOneIconOnlyItem() {
+        // Losing the item entirely would leave the app with no way to open the
+        // popover or quit, so an empty plan still owns one slot.
+        let descriptors = plan([])
+
+        XCTAssertEqual(descriptors.map(\.id), [MenuBarStatusItemPlanner.mergedItemID])
+        XCTAssertEqual(descriptors.first?.title, "")
+        XCTAssertNil(descriptors.first?.selectionKey)
+        XCTAssertNil(descriptors.first?.service)
+        XCTAssertEqual(descriptors.first?.tooltip, "MeterBar")
+        XCTAssertEqual(descriptors.first?.accessibilityLabel, "MeterBar")
+    }
+
+    func testMergedModeIconOnlyMetricDropsTheLabelButKeepsTheAccount() {
+        let claude = candidate(key: "claude:gen", percentUsed: 48, displayName: "genfeedai (Claude Code)")
+
+        let descriptors = plan([claude], metric: .iconOnly)
+
+        XCTAssertEqual(descriptors.first?.title, "")
+        XCTAssertEqual(descriptors.first?.tooltip, "MeterBar: genfeedai (Claude Code)")
+        XCTAssertEqual(descriptors.first?.accessibilityLabel, "MeterBar genfeedai (Claude Code)")
+    }
+
+    func testMergedModeHonorsTheRegularLabelSize() {
+        let claude = candidate(key: "claude:gen", percentUsed: 48)
+
+        XCTAssertEqual(plan([claude], size: .regular).first?.title, " 52% left")
+    }
+
+    func testMergedModeStaysStickyOnThePreviouslyShownAccount() {
+        let claude = candidate(key: "claude:gen", percentUsed: 48, activeMinutesAgo: 1)
+        let codex = candidate(key: "codex", service: .codexCli, percentUsed: 50, activeMinutesAgo: 1)
+
+        XCTAssertEqual(plan([claude, codex], previousKey: "codex").first?.selectionKey, "codex")
+    }
+
+    // MARK: - Per-provider mode
+
+    func testPerProviderModeCreatesOneItemPerAutoSelectableCandidate() {
+        let codex = candidate(key: "codex", service: .codexCli, percentUsed: 100, displayName: "Personal (Codex)")
+        let claude = candidate(key: "claude:gen", percentUsed: 48, displayName: "genfeedai (Claude Code)")
+
+        let descriptors = plan([codex, claude], mode: .perProvider)
+
+        // Sorted by provider so the items don't reshuffle between refreshes.
+        XCTAssertEqual(descriptors.map(\.id), ["claude:gen", "codex"])
+        XCTAssertEqual(descriptors.map(\.service), [.claudeCode, .codexCli])
+        XCTAssertEqual(descriptors.map(\.title), [" 52%", " 0%"])
+    }
+
+    func testPerProviderModeAlwaysNamesTheQuotaWindow() {
+        let claude = candidate(key: "claude:gen", percentUsed: 48, displayName: "genfeedai (Claude Code)")
+
+        let descriptors = plan([claude], mode: .perProvider)
+
+        XCTAssertEqual(descriptors.first?.tooltip, "MeterBar: 52% left on genfeedai (Claude Code) · Session")
+        XCTAssertEqual(
+            descriptors.first?.accessibilityLabel,
+            "MeterBar 52% left on genfeedai (Claude Code) · Session"
+        )
+    }
+
+    func testPerProviderModeIgnoresPinOnlyWindows() {
+        let session = candidate(key: "claude:gen", percentUsed: 48)
+        let weekly = candidate(
+            key: "Claude Code:gen:weekly",
+            percentUsed: 10,
+            windowName: "Weekly",
+            isAutoSelectable: false
+        )
+
+        XCTAssertEqual(plan([session, weekly], mode: .perProvider).map(\.id), ["claude:gen"])
+    }
+
+    func testPerProviderModeNeverReportsASelectionKey() {
+        // Per-provider items each own a fixed account, so feeding their keys
+        // back into the sticky selector would be meaningless.
+        let claude = candidate(key: "claude:gen", percentUsed: 48)
+
+        XCTAssertNil(plan([claude], mode: .perProvider).first?.selectionKey)
+    }
+
+    func testPerProviderModeFallsBackToASingleItemWhenNothingIsTracked() {
+        let descriptors = plan([], mode: .perProvider)
+
+        XCTAssertEqual(descriptors.map(\.id), [MenuBarStatusItemPlanner.mergedItemID])
+        XCTAssertEqual(descriptors.first?.tooltip, "MeterBar")
+    }
+
+    func testPerProviderModeShowsExhaustedAccountsInsteadOfHidingThem() {
+        // The Auto heuristic skips spent quotas; an explicit per-provider row
+        // is the user asking to see that account regardless.
+        let codex = candidate(key: "codex", service: .codexCli, percentUsed: 100)
+
+        XCTAssertEqual(plan([codex], mode: .perProvider).map(\.title), [" 0%"])
+    }
+
+    func testPerProviderModeOrdersEqualProvidersByKey() {
+        let second = candidate(key: "claude:zzz", percentUsed: 10)
+        let first = candidate(key: "claude:aaa", percentUsed: 90)
+
+        XCTAssertEqual(plan([second, first], mode: .perProvider).map(\.id), ["claude:aaa", "claude:zzz"])
+    }
+
+    // MARK: - Switcher options
+
+    func testSwitcherOffersEveryWindowIncludingPinOnlyOnes() {
+        let session = candidate(
+            key: "claude:gen",
+            percentUsed: 48,
+            displayName: "genfeedai (Claude Code)",
+            pinKey: "Claude Code:gen:session"
+        )
+        let weekly = candidate(
+            key: "Claude Code:gen:weekly",
+            percentUsed: 10,
+            displayName: "genfeedai (Claude Code)",
+            windowName: "Weekly",
+            pinKey: "Claude Code:gen:weekly",
+            isAutoSelectable: false
+        )
+        let codex = candidate(
+            key: "codex",
+            service: .codexCli,
+            percentUsed: 100,
+            displayName: "Personal (OpenAI Codex)",
+            pinKey: "Codex CLI:personal:session"
+        )
+
+        let options = MenuBarStatusItemPlanner.switcherOptions(for: [weekly, codex, session])
+
+        XCTAssertEqual(
+            options,
+            [
+                StatusItemPinOption(id: "Claude Code:gen:session", title: "genfeedai (Claude Code) · Session"),
+                StatusItemPinOption(id: "Claude Code:gen:weekly", title: "genfeedai (Claude Code) · Weekly"),
+                StatusItemPinOption(id: "Codex CLI:personal:session", title: "Personal (OpenAI Codex) · Session")
+            ]
+        )
+    }
+
+    func testSwitcherDropsDuplicatePinKeys() {
+        // The same account can surface twice across a refresh boundary; a menu
+        // with two identical radio items would be unusable.
+        let first = candidate(key: "claude:gen", percentUsed: 48, pinKey: "Claude Code:gen:session")
+        let duplicate = candidate(key: "claude:gen", percentUsed: 47, pinKey: "Claude Code:gen:session")
+
+        XCTAssertEqual(MenuBarStatusItemPlanner.switcherOptions(for: [first, duplicate]).count, 1)
+    }
+}

--- a/MeterBarTests/StatusItemLimitSelectorTests.swift
+++ b/MeterBarTests/StatusItemLimitSelectorTests.swift
@@ -12,11 +12,13 @@ final class StatusItemLimitSelectorTests: XCTestCase {
         displayName: String? = nil,
         pinKey: String? = nil,
         windowName: String = "Session",
-        isAutoSelectable: Bool = true
+        isAutoSelectable: Bool = true,
+        service: ServiceType = .claudeCode
     ) -> StatusLimitCandidate {
         StatusLimitCandidate(
             key: key,
             pinKey: pinKey ?? key,
+            service: service,
             displayName: displayName ?? key,
             windowName: windowName,
             limit: UsageLimit(used: percentUsed, total: 100, resetTime: nil),
@@ -74,6 +76,7 @@ final class StatusItemLimitSelectorTests: XCTestCase {
             StatusLimitCandidate(
                 key: seed.key,
                 pinKey: seed.pinKey,
+                service: seed.service,
                 displayName: seed.displayName,
                 windowName: seed.windowName,
                 limit: seed.limit,
@@ -120,6 +123,50 @@ final class StatusItemLimitSelectorTests: XCTestCase {
         let loose = candidate(key: "codex", percentUsed: 20, activeMinutesAgo: nil)
         let tight = candidate(key: "claude:ship", percentUsed: 80, activeMinutesAgo: 120)
         XCTAssertEqual(select([loose, tight])?.key, "claude:ship")
+    }
+
+    // MARK: - Exhausted quotas
+
+    func testExhaustedActiveAccountYieldsToAnAccountThatHasQuotaLeft() {
+        // The reported bug: Codex sat at 0% for days, and because it is always
+        // the tightest candidate it owned the menu bar the whole time.
+        let spentCodex = candidate(key: "codex", percentUsed: 100, activeMinutesAgo: 1)
+        let liveClaude = candidate(key: "claude:gen", percentUsed: 48)
+        XCTAssertEqual(select([spentCodex, liveClaude])?.key, "claude:gen")
+    }
+
+    func testExhaustedAccountIsSkippedInTheIdleFallbackPoolToo() {
+        let spentCodex = candidate(key: "codex", percentUsed: 100)
+        let liveClaude = candidate(key: "claude:gen", percentUsed: 60)
+        XCTAssertEqual(select([spentCodex, liveClaude])?.key, "claude:gen")
+    }
+
+    func testNearlyExhaustedAccountStillCompetes() {
+        // 99.6% used still reads "1% left" — only a truly spent quota is skipped.
+        let nearlySpent = candidate(key: "codex", percentUsed: 99.6, activeMinutesAgo: 1)
+        let claude = candidate(key: "claude:gen", percentUsed: 48, activeMinutesAgo: 1)
+        XCTAssertEqual(select([nearlySpent, claude])?.key, "codex")
+    }
+
+    func testEveryCandidateExhaustedStillShowsAQuota() {
+        // Skipping them all would blank the label; the pool is restored instead.
+        let codex = candidate(key: "codex", percentUsed: 100, activeMinutesAgo: 1)
+        let claude = candidate(key: "claude:gen", percentUsed: 100)
+        XCTAssertEqual(select([codex, claude])?.key, "codex")
+    }
+
+    func testStickySelectionDoesNotKeepAnExhaustedAccount() {
+        // Without the exhausted filter, hysteresis re-elects the 0% account.
+        let spentCodex = candidate(key: "codex", percentUsed: 100, activeMinutesAgo: 1)
+        let claude = candidate(key: "claude:gen", percentUsed: 97, activeMinutesAgo: 1)
+        XCTAssertEqual(select([spentCodex, claude], previousKey: "codex")?.key, "claude:gen")
+    }
+
+    func testExplicitPinStillShowsAnExhaustedQuota() {
+        // Pinning is a deliberate choice: "show me Codex" must keep showing 0%.
+        let spentCodex = candidate(key: "codex", percentUsed: 100, activeMinutesAgo: 1)
+        let claude = candidate(key: "claude:gen", percentUsed: 48, activeMinutesAgo: 1)
+        XCTAssertEqual(select([spentCodex, claude], pinnedKey: "codex")?.key, "codex")
     }
 
     // MARK: - Sticky selection (hysteresis)


### PR DESCRIPTION
## Problem

The menu bar read a permanent `0%` while a Claude account sat at 52% session left, unseen.

`StatusItemLimitSelector` picks `min(percentLeft)`. A **spent** quota is permanently the tightest, so once Codex hit 0% it won every round it entered — and it entered either when Codex showed recent on-disk activity, or when *nothing* showed activity (the `active.isEmpty` fallback admits the whole pool). With Codex out for 3d3h it owned the title continuously.

Two related gaps: nothing in the menu bar said *whose* percentage it was, and the only way to change it was Settings → General → "Menu bar shows".

## Changes

**1. Spent quotas are excluded from Auto.** `select` filters `percentLeft == 0` candidates **before** the activity pass — filtering after would leave `pool == [Codex]` in exactly the failing case, since being spent is what stops activity elsewhere. The full pool is restored when everything is spent, so the title never goes blank. Explicit pins still short-circuit ahead of the heuristic.

**2. `MenuBarStatusItemPlanner`** (new, in `Models/` so `swift test` can reach it — the SwiftPM target excludes `App/`). Turns candidates + preferences into `[MenuBarStatusItemDescriptor]`. Merged mode plans one item via the selector; per-provider mode plans one per auto-selectable account, sorted by `(service.sortOrder, key)`. Never plans zero items — an icon-only placeholder keeps the popover, Settings, and Quit reachable.

**3. Multi-item menu bar.** The AppDelegate moves from one `statusItem` to `statusItems: [String: NSStatusItem]`, reconciled by `applyStatusItemDescriptors(_:)` (remove stale → create new → restyle in place). Per-id `autosaveName` so macOS restores each item's user-dragged slot independently. Clicks record which item was hit, so the popover opens under that icon.

**4. Provider logos.** Each item wears its provider's bundled SVG at 16pt as a cached template image, so a bare `52%` visibly belongs to Claude. Providers without a logo keep MeterBar's own mark.

**5. Switchers.** A "Menu Bar Shows" right-click submenu (`Auto` / one radio per pinnable window / `All Providers`), plus a "Menu bar layout" segmented picker in General settings. "Menu bar shows" is disabled in per-provider mode, where every account is already visible.

## Notes

- Per-provider descriptors report `selectionKey: nil` — each is nailed to one account, so feeding their keys back as `previousKey` would poison merged mode's sticky selection.
- Per-provider mode deliberately **shows** spent accounts. Auto hides them by design; an explicit per-provider row is the user asking to see that account regardless.
- `statusItemImage(for:)` resizes a `.copy()` — the logo cache vends shared instances, and mutating the original would shrink every popover icon too.
- No `.pbxproj` edit needed; `MeterBar/` and `MeterBarTests/` are `PBXFileSystemSynchronizedRootGroup`s.

## Tests

21 new tests, written before the implementation:

- **6 selector tests** — spent-vs-live, spent skipped in the idle fallback too, near-spent still competes, all-spent still shows a number, sticky selection doesn't retain a spent account, explicit pin still shows 0%.
- **15 planner tests** — merged mode (selection, window qualification, empty plan, icon-only, label size, stickiness), per-provider mode (one per account, ordering, pin-only windows skipped, nil selection key, spent accounts shown, empty fallback), switcher options (every window including pin-only, duplicate pin keys dropped).

## Verification

- `swiftlint lint --quiet MeterBar MeterBarTests` → exit 0, no output.
- Nothing built, typechecked, or tested locally (machine policy). **CI is the gate.**