### PR TITLE
feat(ui): surface Codex reset credits in the popover and dashboard

### DIFF
--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -319,8 +319,42 @@ class CodexCliLocalService: ObservableObject {
 // MARK: - Reset-credit models and public CLI facade
 
 nonisolated enum CodexResetCreditEligibility {
-    static func isEligible(isBlocked: Bool, availableCredits: Int?, isAuthenticated: Bool) -> Bool {
-        isBlocked && (availableCredits ?? 0) > 0 && isAuthenticated
+    /// `hasResolvedAccount` guards the multi-account case: a snapshot whose
+    /// `accountID` no longer matches a stored Codex profile has no `CODEX_HOME`
+    /// to redeem against, so the control is hidden rather than offered with a
+    /// handler that would silently no-op.
+    static func isEligible(
+        isBlocked: Bool,
+        availableCredits: Int?,
+        isAuthenticated: Bool,
+        hasResolvedAccount: Bool
+    ) -> Bool {
+        isBlocked && (availableCredits ?? 0) > 0 && isAuthenticated && hasResolvedAccount
+    }
+}
+
+/// Confirmation copy for the irreversible redemption, kept next to the service
+/// so the UI dialog and the CLI's `--yes` gate describe the same spend. Both
+/// strings name the account because a Codex profile is selected per
+/// `CODEX_HOME` and the popover can show several cards at once.
+nonisolated enum CodexResetCreditConfirmation {
+    static func title(accountName: String) -> String {
+        "Use a reset credit for \(accountName)?"
+    }
+
+    static func message(accountName: String, availableCredits: Int?) -> String {
+        let remaining = max(availableCredits ?? 0, 0)
+        let spend: String
+        switch remaining {
+        case 0:
+            // Unknown or stale count: never render a remainder we cannot trust.
+            spend = "This spends one reset credit on \(accountName)"
+        case 1:
+            spend = "This spends your last reset credit on \(accountName)"
+        default:
+            spend = "This spends 1 of \(remaining) reset credits on \(accountName)"
+        }
+        return "\(spend) and resets its blocked usage window. This cannot be undone."
     }
 }
 

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -604,7 +604,7 @@ struct ProviderStatusCard: View {
         await refreshCodexAuthenticationState()
       }
       .confirmationDialog(
-        "Use a Codex reset credit?",
+        CodexResetCreditConfirmation.title(accountName: resetCreditAccountName),
         isPresented: $showingResetCreditConfirmation,
         titleVisibility: .visible
       ) {
@@ -612,8 +612,10 @@ struct ProviderStatusCard: View {
         Button("Cancel", role: .cancel) {}
       } message: {
         Text(
-          "This spends one of your finite Codex reset credits and resets the active blocked usage window. " +
-            "The action cannot be undone."
+          CodexResetCreditConfirmation.message(
+            accountName: resetCreditAccountName,
+            availableCredits: snapshot.resetCreditsAvailable
+          )
         )
       }
       .alert(
@@ -697,41 +699,58 @@ struct ProviderStatusCard: View {
         format: menuBarDisplayPreferences.resetTimeFormat
       )
 
-      HStack(spacing: 7) {
-        ProviderLogoView(kind: snapshot.logoKind, size: 17, foregroundColor: snapshot.accentColor)
-        Text(snapshot.title)
-          .font(.subheadline)
-          .fontWeight(.semibold)
-          .lineLimit(1)
+      VStack(alignment: .leading, spacing: 9) {
+        HStack(spacing: 7) {
+          ProviderLogoView(kind: snapshot.logoKind, size: 17, foregroundColor: snapshot.accentColor)
+          Text(snapshot.title)
+            .font(.subheadline)
+            .fontWeight(.semibold)
+            .lineLimit(1)
 
-        Spacer(minLength: 8)
+          Spacer(minLength: 8)
 
-        Text(statusText)
-          .font(.caption2)
-          .fontWeight(.semibold)
-          .foregroundColor(statusColor)
+          Text(statusText)
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .foregroundColor(statusColor)
 
-        Label("\(title) \(counter)", systemImage: "hourglass")
-          .font(.caption)
-          .fontWeight(.semibold)
-          .foregroundColor(snapshot.accentColor)
-          .monospacedDigit()
-          .lineLimit(1)
-          .minimumScaleFactor(0.72)
-          .numericRefreshTransition(value: counter, reduceMotion: reduceMotion)
+          Label("\(title) \(counter)", systemImage: "hourglass")
+            .font(.caption)
+            .fontWeight(.semibold)
+            .foregroundColor(snapshot.accentColor)
+            .monospacedDigit()
+            .lineLimit(1)
+            .minimumScaleFactor(0.72)
+            .numericRefreshTransition(value: counter, reduceMotion: reduceMotion)
+        }
 
-        if showsResetCreditAction {
-          Button {
-            showingResetCreditConfirmation = true
-          } label: {
-            Image(systemName: "arrow.clockwise.circle.fill")
+        // Blocked is exactly when a banked reset is worth spending, so the
+        // collapsed row states how many are left instead of hiding the count
+        // behind an icon-only button. The count stands on its own when the
+        // action isn't usable — a visible control that would fail is worse.
+        if let resetCount = snapshot.resetCreditsAvailable, resetCount > 0 {
+          Divider()
+          HStack(spacing: 7) {
+            resetCreditsCountLabel(resetCount)
+            Spacer(minLength: 8)
+            if showsResetCreditAction {
+              resetCreditButton(isCompact: true)
+            }
           }
-          .buttonStyle(.borderless)
-          .help("Use a Codex reset credit")
-          .disabled(isConsumingResetCredit)
         }
       }
     }
+  }
+
+  private func resetCreditsCountLabel(_ resetCount: Int) -> some View {
+    Label(
+      ProviderStatusBadges.resetCreditsLabel(resetCount),
+      systemImage: "arrow.clockwise.circle.fill"
+    )
+    .font(.caption2)
+    .fontWeight(.semibold)
+    .foregroundColor(snapshot.accentColor)
+    .lineLimit(1)
   }
 
   private var expandedCardBody: some View {
@@ -780,7 +799,7 @@ struct ProviderStatusCard: View {
 
       if showsResetCreditAction {
         Divider()
-        resetCreditButton
+        resetCreditButton(isCompact: false)
       }
     }
   }
@@ -847,7 +866,10 @@ struct ProviderStatusCard: View {
     }
   }
 
-  private var resetCreditButton: some View {
+  /// `isCompact` keeps the collapsed blocked row on one line; the expanded card
+  /// stretches the same control to full width. One implementation either way so
+  /// the two states cannot drift in copy or behavior.
+  private func resetCreditButton(isCompact: Bool) -> some View {
     Button {
       showingResetCreditConfirmation = true
     } label: {
@@ -859,12 +881,19 @@ struct ProviderStatusCard: View {
           Image(systemName: "arrow.clockwise.circle.fill")
         }
         Text(isConsumingResetCredit ? "Using reset credit…" : "Use reset credit")
+          .lineLimit(1)
       }
-      .frame(maxWidth: .infinity)
+      .frame(maxWidth: isCompact ? nil : .infinity)
     }
     .buttonStyle(.borderedProminent)
     .controlSize(.small)
     .disabled(isConsumingResetCredit)
+    .help(
+      CodexResetCreditConfirmation.message(
+        accountName: resetCreditAccountName,
+        availableCredits: snapshot.resetCreditsAvailable
+      )
+    )
   }
 
   private var updatedText: String {
@@ -877,13 +906,20 @@ struct ProviderStatusCard: View {
     return CodexResetCreditEligibility.isEligible(
       isBlocked: snapshot.hasExhaustedLimit,
       availableCredits: snapshot.resetCreditsAvailable,
-      isAuthenticated: isCodexAuthenticated
+      isAuthenticated: isCodexAuthenticated,
+      hasResolvedAccount: codexAccount != nil
     )
   }
 
   private var codexAccount: CodexAccount? {
     guard snapshot.service == .codexCli, let accountID = snapshot.accountID else { return nil }
     return codexAccounts.accounts.first { $0.id == accountID }
+  }
+
+  /// The profile name the redemption will hit — the same label Settings shows,
+  /// so a multi-account popover confirms which `CODEX_HOME` is being spent.
+  private var resetCreditAccountName: String {
+    codexAccount?.name ?? snapshot.title
   }
 
   private func refreshCodexAuthenticationState() async {

--- a/MeterBarTests/CodexResetCreditsTests.swift
+++ b/MeterBarTests/CodexResetCreditsTests.swift
@@ -102,28 +102,76 @@ final class CodexResetCreditsTests: XCTestCase {
         XCTAssertTrue(CodexResetCreditEligibility.isEligible(
             isBlocked: true,
             availableCredits: 1,
-            isAuthenticated: true
+            isAuthenticated: true,
+            hasResolvedAccount: true
         ))
         XCTAssertFalse(CodexResetCreditEligibility.isEligible(
             isBlocked: false,
             availableCredits: 1,
-            isAuthenticated: true
+            isAuthenticated: true,
+            hasResolvedAccount: true
         ))
         XCTAssertFalse(CodexResetCreditEligibility.isEligible(
             isBlocked: true,
             availableCredits: 0,
-            isAuthenticated: true
+            isAuthenticated: true,
+            hasResolvedAccount: true
         ))
         XCTAssertFalse(CodexResetCreditEligibility.isEligible(
             isBlocked: true,
             availableCredits: nil,
-            isAuthenticated: true
+            isAuthenticated: true,
+            hasResolvedAccount: true
         ))
         XCTAssertFalse(CodexResetCreditEligibility.isEligible(
             isBlocked: true,
             availableCredits: 1,
-            isAuthenticated: false
+            isAuthenticated: false,
+            hasResolvedAccount: true
         ))
+    }
+
+    /// An unresolvable account (snapshot without a matching stored profile) has
+    /// nothing to redeem against. Hide the control rather than offering a button
+    /// whose handler silently no-ops.
+    func testActionIsIneligibleWithoutAResolvedAccount() {
+        XCTAssertFalse(CodexResetCreditEligibility.isEligible(
+            isBlocked: true,
+            availableCredits: 1,
+            isAuthenticated: true,
+            hasResolvedAccount: false
+        ))
+    }
+
+    // MARK: - Confirmation copy
+
+    func testConfirmationNamesTheTargetAccount() {
+        let title = CodexResetCreditConfirmation.title(accountName: "Work")
+        XCTAssertTrue(title.contains("Work"), "confirmation title must name the account being spent from")
+    }
+
+    func testConfirmationMessageNamesAccountAndRemainingCredits() {
+        let message = CodexResetCreditConfirmation.message(accountName: "Work", availableCredits: 3)
+        XCTAssertTrue(message.contains("Work"), "message must name the target account")
+        XCTAssertTrue(message.contains("3"), "message must state the remaining credit count")
+        XCTAssertTrue(
+            message.lowercased().contains("cannot be undone"),
+            "message must state that the spend is irreversible"
+        )
+    }
+
+    func testConfirmationMessageCallsOutTheFinalCredit() {
+        let message = CodexResetCreditConfirmation.message(accountName: "Default CLI Profile", availableCredits: 1)
+        XCTAssertTrue(message.contains("Default CLI Profile"))
+        XCTAssertTrue(message.lowercased().contains("last reset credit"))
+    }
+
+    /// Defensive: a missing or negative count must never render "1 of -1" copy
+    /// on a dialog that authorizes an irreversible spend.
+    func testConfirmationMessageToleratesMissingCount() {
+        let message = CodexResetCreditConfirmation.message(accountName: "Work", availableCredits: nil)
+        XCTAssertFalse(message.contains("-"), "unknown counts must not render a negative remainder")
+        XCTAssertTrue(message.contains("Work"))
     }
 
     func testConsumeUsesAvailableCreditAndImmediatelyRefreshesUsage() async throws {
@@ -220,6 +268,104 @@ final class CodexResetCreditsTests: XCTestCase {
         XCTAssertEqual(result.usageRefreshErrorDescription, "HTTP 500")
     }
 
+    /// Multi-account targeting: the redemption must read the acted-on card's
+    /// `CODEX_HOME` and address the provider with that profile's account id, not
+    /// the default profile's.
+    func testConsumeTargetsTheAccountWhoseCardActed() async throws {
+        let work = CodexAccount(id: UUID(), name: "Work", homeDirectory: "/tmp/codex-work")
+        let readAccounts = AccountRecorder()
+        let service = CodexCliLocalService(
+            accountAuthFileDataProvider: { account in
+                readAccounts.record(account.homeDirectory)
+                return self.authFileData(accountID: account.isDefault ? "account-default" : "account-work")
+            },
+            urlSession: makeStubSession()
+        )
+        var accountHeaders: [String?] = []
+
+        StubURLProtocol.handler = { request in
+            accountHeaders.append(request.value(forHTTPHeaderField: "ChatGPT-Account-Id"))
+            let url = try XCTUnwrap(request.url)
+            let response = try XCTUnwrap(
+                HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+            )
+
+            switch (request.httpMethod, url.path) {
+            case ("GET", "/backend-api/wham/rate-limit-reset-credits"):
+                return (response, Self.availableCreditsBody)
+            case ("POST", "/backend-api/wham/rate-limit-reset-credits/consume"):
+                return (response, Data(#"{"code":"reset","credit":null,"windows_reset":1}"#.utf8))
+            default:
+                return (response, Data(#"{"plan_type":"pro","rate_limit":null}"#.utf8))
+            }
+        }
+
+        _ = try await service.consumeResetCredit(account: work)
+
+        // `nil` is the default profile's (unset) CODEX_HOME, read by the
+        // init-time access probe. What matters is that no *other* configured
+        // profile's home was consulted for this redemption.
+        XCTAssertEqual(Set(readAccounts.homeDirectories.compactMap { $0 }), ["/tmp/codex-work"])
+        XCTAssertEqual(Set(accountHeaders.compactMap { $0 }), ["account-work"])
+    }
+
+    /// A failed redemption must surface an error and never claim a credit was
+    /// spent, so the caller can leave the previously displayed metrics intact.
+    func testFailedConsumeThrowsAndSkipsTheUsageRefresh() async {
+        let service = CodexCliLocalService(
+            authFileDataProvider: { self.authFileData() },
+            urlSession: makeStubSession()
+        )
+        var paths: [String] = []
+
+        StubURLProtocol.handler = { request in
+            let url = try XCTUnwrap(request.url)
+            paths.append(url.path)
+            let statusCode = request.httpMethod == "POST" ? 500 : 200
+            let response = try XCTUnwrap(
+                HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)
+            )
+            if request.httpMethod == "POST" {
+                return (response, Data())
+            }
+            return (response, Self.availableCreditsBody)
+        }
+
+        do {
+            _ = try await service.consumeResetCredit()
+            XCTFail("Expected the failed redemption to throw")
+        } catch {
+            XCTAssertFalse(
+                error.localizedDescription.isEmpty,
+                "failure must carry an actionable message for the UI alert"
+            )
+        }
+
+        XCTAssertFalse(
+            paths.contains("/backend-api/wham/usage"),
+            "a failed redemption must not refresh usage and overwrite displayed metrics"
+        )
+    }
+
+    /// `homeDirectory` values seen by the auth-file provider, recorded across the
+    /// concurrency boundary the provider closure crosses.
+    private final class AccountRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values: [String?] = []
+
+        func record(_ homeDirectory: String?) {
+            lock.lock()
+            defer { lock.unlock() }
+            values.append(homeDirectory)
+        }
+
+        var homeDirectories: [String?] {
+            lock.lock()
+            defer { lock.unlock() }
+            return values
+        }
+    }
+
     private func makeStubSession() -> URLSession {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [StubURLProtocol.self]
@@ -250,12 +396,17 @@ final class CodexResetCreditsTests: XCTestCase {
         return body
     }
 
-    private func authFileData() -> Data {
+    /// One available credit, the shape the GET endpoint returns.
+    private static let availableCreditsBody = Data(#"""
+    {"credits":[{"id":"credit-1","reset_type":"codex_rate_limits","status":"available"}]}
+    """#.utf8)
+
+    private func authFileData(accountID: String = "account-1") -> Data {
         let payload = Data(#"{"exp":4102444800}"#.utf8)
             .base64EncodedString()
             .replacingOccurrences(of: "+", with: "-")
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
-        return Data(#"{"tokens":{"access_token":"header.\#(payload).signature","account_id":"account-1"}}"#.utf8)
+        return Data(#"{"tokens":{"access_token":"header.\#(payload).signature","account_id":"\#(accountID)"}}"#.utf8)
     }
 }

--- a/MeterBarTests/LimitRowTests.swift
+++ b/MeterBarTests/LimitRowTests.swift
@@ -162,7 +162,11 @@ final class LimitRowTests: XCTestCase {
 /// content for the limit list without swapping to a second card design.
 @MainActor
 final class ProviderStatusCardSmokeTests: XCTestCase {
-    private func snapshot(exhausted: Bool) -> ProviderSnapshot {
+    private func snapshot(
+        exhausted: Bool,
+        resetCreditsAvailable: Int? = nil,
+        accountID: UUID? = nil
+    ) -> ProviderSnapshot {
         let weekly = UsageLimit(
             used: exhausted ? 100 : 40,
             total: 100,
@@ -179,8 +183,8 @@ final class ProviderStatusCardSmokeTests: XCTestCase {
             ],
             emptyDetail: "Waiting for refresh",
             extraUsage: nil,
-            resetCreditsAvailable: nil,
-            accountID: nil,
+            resetCreditsAvailable: resetCreditsAvailable,
+            accountID: accountID,
             fableActivity: nil
         )
     }
@@ -197,6 +201,18 @@ final class ProviderStatusCardSmokeTests: XCTestCase {
         let card = ProviderStatusCard(snapshot: snapshot(exhausted: true))
         XCTAssertTrue(card.snapshot.hasExhaustedLimit, "fixture should drive the reset-only content")
         let host = NSHostingView(rootView: card.frame(width: 360))
+        host.layoutSubtreeIfNeeded()
+        XCTAssertGreaterThan(host.fittingSize.height, 0)
+    }
+
+    /// The blocked Codex card grows a reset-credit line (count + action) once
+    /// credits are banked. It must still lay out on the popover's narrow width.
+    func testExhaustedCardWithResetCreditsRenders() {
+        let card = ProviderStatusCard(
+            snapshot: snapshot(exhausted: true, resetCreditsAvailable: 2, accountID: CodexAccount.defaultID)
+        )
+        XCTAssertEqual(card.snapshot.resetCreditsAvailable, 2)
+        let host = NSHostingView(rootView: card.frame(width: 300))
         host.layoutSubtreeIfNeeded()
         XCTAssertGreaterThan(host.fittingSize.height, 0)
     }

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -801,4 +801,36 @@ final class UsageDataManagerTests: XCTestCase {
         sharedStore.flushPendingWrites()
         XCTAssertEqual(sharedStore.loadMetrics()[.codexCli]?.resetCreditsAvailable, 0)
     }
+
+    /// Redemption is scoped to the card that acted: refreshing one Codex profile
+    /// must leave every other profile's cached metrics exactly as they were.
+    func testApplyResetCreditRefreshOnlyTouchesTheRedeemingAccount() async throws {
+        let accountSuite = "UsageDataManagerTests-reset-credit-scope-\(UUID().uuidString)"
+        createdSuiteNames.append(accountSuite)
+        let accountDefaults = try XCTUnwrap(UserDefaults(suiteName: accountSuite))
+        let accountStore = CodexAccountStore(userDefaults: accountDefaults)
+        accountStore.addAccount(name: "Work", homeDirectory: "/tmp/codex-work")
+        let work = try XCTUnwrap(accountStore.customAccounts.first)
+        let provider = MultiAccountCodexProvider(metricsByAccount: [
+            CodexAccount.defaultID: MetricsFixtures.codexCli(sessionUsedPercent: 20, resetCreditsAvailable: 2),
+            work.id: MetricsFixtures.codexCli(sessionUsedPercent: 100, resetCreditsAvailable: 2)
+        ])
+        let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+        let (manager, _) = makeManager(
+            codex: provider,
+            cursor: cursor,
+            codexAccountStore: accountStore
+        )
+
+        await manager.refreshAll()
+        manager.applyCodexResetCreditRefresh(
+            MetricsFixtures.codexCli(sessionUsedPercent: 0, resetCreditsAvailable: 1),
+            accountID: work.id
+        )
+
+        XCTAssertEqual(manager.codexAccountMetrics[work.id]?.sessionLimit?.used, 0)
+        XCTAssertEqual(manager.codexAccountMetrics[work.id]?.resetCreditsAvailable, 1)
+        XCTAssertEqual(manager.codexAccountMetrics[CodexAccount.defaultID]?.sessionLimit?.used, 20)
+        XCTAssertEqual(manager.codexAccountMetrics[CodexAccount.defaultID]?.resetCreditsAvailable, 2)
+    }
 }


### PR DESCRIPTION
Closes #265.

## Problem

Redemption already existed end-to-end (`CodexCliLocalService.consumeResetCredit`, `meterbar reset-credit`), but the app surface was thin: the blocked Codex card offered an icon-only button with a generic confirmation. In a multi-account popover it never said **which** `CODEX_HOME` was about to lose a finite credit, and the collapsed blocked row never showed how many credits were left.

## What changed

- **`CodexResetCreditConfirmation`** (new, next to the service): title and message name the target account and the remaining count, and call out the last credit explicitly ("your last reset credit"). Unknown/stale counts clamp to copy without a remainder instead of rendering `-1`. The same message doubles as the button tooltip.
- **Count on the card (AC1):** the collapsed blocked row now shows the banked-credit count using the shared `ProviderStatusBadges.resetCreditsLabel`, with the action beside it. The count renders on its own when the action isn't usable, so the number is never hidden behind an unavailable control. The expanded card already showed the badge.
- **Eligibility gating (AC2/AC6):** `CodexResetCreditEligibility.isEligible` gains `hasResolvedAccount`. A snapshot whose `accountID` no longer matches a stored Codex profile has no `CODEX_HOME` to redeem against, so the control is hidden rather than offered with a handler that silently no-ops.
- **One button, two densities:** `resetCreditButton(isCompact:)` replaces the duplicated variants, so the collapsed and expanded states can't drift in copy or behavior.

Not changed by design: redemption still goes through `CodexCliLocalService.consumeResetCredit(account:)` — the exact path the CLI uses, no second request path (AC7). Success still routes through `UsageDataManager.applyCodexResetCreditRefresh` for the bounded refresh (AC4); failure still throws before any refresh and leaves cached metrics untouched, surfacing an alert (AC5). Dashboard Limits and Overview render the same `ProviderStatusCard`, so they inherit all of the above. The widget is untouched — widgets perform no irreversible account mutations.

## Verification

Focused test run (`swift test --filter CodexResetCreditsTests|ProviderStatusCardSmokeTests|LimitRowTests|UsageDataManagerTests|CodexCliLocalServiceTests`) — **70 tests, 0 failures**. Tests were written first; the suite was red on `hasResolvedAccount` and `CodexResetCreditConfirmation` before the implementation landed.

New coverage (AC8):
- `testActionIsIneligibleWithoutAResolvedAccount` — gating on an unresolvable account.
- Four confirmation-copy tests — names the account, states the remaining count, says the spend cannot be undone, calls out the final credit, and tolerates a missing count without a negative remainder.
- `testConsumeTargetsTheAccountWhoseCardActed` — asserts the redemption reads only the acting profile's `CODEX_HOME` and sends that profile's `ChatGPT-Account-Id`.
- `testFailedConsumeThrowsAndSkipsTheUsageRefresh` — a failed POST throws with an actionable message and issues no usage refresh.
- `testApplyResetCreditRefreshOnlyTouchesTheRedeemingAccount` — a refresh for one profile leaves the other profile's cached metrics and credit count intact.
- `testExhaustedCardWithResetCreditsRenders` — the blocked-with-credits card lays out at popover width.

SwiftLint is clean on the changed files. Broad validation (full suite + builds) runs in PR CI.