### PR TITLE
feat(cli): quota-aware `meterbar guard` with stable exit codes

### DIFF
--- a/MeterBar/Guard/GuardCLIResponse.swift
+++ b/MeterBar/Guard/GuardCLIResponse.swift
@@ -1,0 +1,89 @@
+import Foundation
+import MeterBarShared
+
+/// Version 1 contract for `meterbar guard --json`.
+///
+/// Every field except `schemaVersion`, `outcome`, `exitCode`, `checkedAt`, and
+/// `message` is optional: a usage error never reaches a provider, and an
+/// unavailable snapshot has no quota numbers to report. Omission is how the
+/// document says "not known" instead of inventing a safe-looking zero.
+nonisolated struct GuardCLIResponse: CLIJSONDocument {
+    static let currentSchemaVersion = 1
+
+    private let schemaVersion = currentSchemaVersion
+    private let outcome: String
+    private let exitCode: Int32
+    private let checkedAt: Date
+    private let provider: String?
+    private let displayName: String?
+    private let window: String?
+    private let account: Account?
+    private let used: Double?
+    private let total: Double?
+    private let percentUsed: Double?
+    private let percentLeft: Int?
+    private let quotaBand: String?
+    private let estimated: Bool?
+    private let resetAt: Date?
+    private let minRemainingPercent: Double?
+    private let snapshot: Snapshot?
+    private let message: String
+    private let error: ErrorDetail?
+
+    init(evaluation: QuotaGuardEvaluation) {
+        outcome = evaluation.outcome.rawValue
+        exitCode = evaluation.outcome.exitCode
+        checkedAt = evaluation.checkedAt
+        provider = evaluation.service?.cliIdentifier
+        displayName = evaluation.service?.displayName
+        window = evaluation.window?.cliIdentifier
+        account = evaluation.account.map(Account.init(account:))
+        used = evaluation.quota?.used
+        total = evaluation.quota?.total
+        percentUsed = evaluation.quota?.percentUsed
+        percentLeft = evaluation.quota?.percentLeft
+        quotaBand = evaluation.quota?.band.cliIdentifier
+        estimated = evaluation.quota?.estimated
+        resetAt = evaluation.quota?.resetAt
+        minRemainingPercent = evaluation.minRemainingPercent
+        snapshot = evaluation.snapshot.map(Snapshot.init(info:))
+        message = evaluation.message
+        error = evaluation.failure.map(ErrorDetail.init(failure:))
+    }
+
+    private struct Account: Encodable {
+        let scope: String
+        let name: String
+
+        init(account: QuotaGuardAccount) {
+            scope = account.scope.rawValue
+            name = account.name
+        }
+    }
+
+    private struct Snapshot: Encodable {
+        let lastUpdated: Date
+        let ageSeconds: TimeInterval
+        let isStale: Bool
+
+        init(info: QuotaGuardSnapshotInfo) {
+            lastUpdated = info.lastUpdated
+            ageSeconds = info.ageSeconds
+            isStale = info.isStale
+        }
+    }
+
+    private struct ErrorDetail: Encodable {
+        let code: String
+        let message: String
+        let flag: String?
+        let value: String?
+
+        init(failure: QuotaGuardFailure) {
+            code = failure.code
+            message = failure.message
+            flag = failure.flag
+            value = failure.value
+        }
+    }
+}

--- a/MeterBar/Guard/QuotaGuardCLI.swift
+++ b/MeterBar/Guard/QuotaGuardCLI.swift
@@ -30,7 +30,9 @@ nonisolated public enum QuotaGuardCLI {
         public let minRemaining: String?
         public let configDirectory: String?
         public let refresh: Bool
-        public let refreshTimeout: TimeInterval
+        /// Raw `--refresh-timeout` text, parsed in the core for the same reason
+        /// as `minRemaining`. `nil` means `defaultRefreshTimeout`.
+        public let refreshTimeout: String?
 
         public init(
             provider: String = defaultProvider,
@@ -38,7 +40,7 @@ nonisolated public enum QuotaGuardCLI {
             minRemaining: String? = nil,
             configDirectory: String? = nil,
             refresh: Bool = false,
-            refreshTimeout: TimeInterval = defaultRefreshTimeout
+            refreshTimeout: String? = nil
         ) {
             self.provider = provider
             self.window = window

--- a/MeterBar/Guard/QuotaGuardCLI.swift
+++ b/MeterBar/Guard/QuotaGuardCLI.swift
@@ -1,0 +1,123 @@
+import Foundation
+import MeterBarShared
+
+/// Public facade used by the bundled `meterbar guard` command.
+///
+/// Reads the cached app-group snapshot by default so a shell hook costs a file
+/// read, not a provider round trip. `--refresh` opts into one bounded refresh
+/// through the same coordinator `meterbar refresh` uses; guard never waits,
+/// polls, or consumes reset credits (that is `meterbar wake`).
+nonisolated public enum QuotaGuardCLI {
+    public static let defaultProvider = "claude"
+    public static let defaultWindow = "session"
+    public static let defaultRefreshTimeout: TimeInterval = 20
+    public static let minimumRefreshTimeout: TimeInterval = 1
+    public static let maximumRefreshTimeout: TimeInterval = 600
+
+    public struct Result: Sendable {
+        public let jsonOutput: String
+        public let summaryLine: String
+        public let message: String?
+        public let exitCode: Int32
+    }
+
+    public struct Request: Sendable {
+        public let provider: String
+        public let window: String
+        /// Raw `--min-remaining` text. Parsed in the core, not in
+        /// `validate()`, so a malformed value exits with the documented usage
+        /// code instead of ArgumentParser's generic one.
+        public let minRemaining: String?
+        public let configDirectory: String?
+        public let refresh: Bool
+        public let refreshTimeout: TimeInterval
+
+        public init(
+            provider: String = defaultProvider,
+            window: String = defaultWindow,
+            minRemaining: String? = nil,
+            configDirectory: String? = nil,
+            refresh: Bool = false,
+            refreshTimeout: TimeInterval = defaultRefreshTimeout
+        ) {
+            self.provider = provider
+            self.window = window
+            self.minRemaining = minRemaining
+            self.configDirectory = configDirectory
+            self.refresh = refresh
+            self.refreshTimeout = refreshTimeout
+        }
+    }
+
+    public static func run(_ request: Request) async -> Result {
+        let now = Date()
+        let resolved = QuotaGuardTarget.resolve(
+            provider: request.provider,
+            window: request.window,
+            minRemaining: request.minRemaining,
+            configDirectory: request.configDirectory,
+            refreshTimeout: request.refreshTimeout
+        )
+
+        let target: QuotaGuardTarget
+        switch resolved {
+        case let .failure(failure):
+            return result(from: .failed(failure, checkedAt: now))
+        case let .success(value):
+            target = value
+        }
+
+        if request.refresh {
+            // A failed refresh is not itself a guard failure: the cached
+            // snapshot is still evaluated below, and reports its own staleness.
+            await performRefresh(timeout: target.refreshTimeout)
+        }
+
+        return result(from: evaluate(target: target))
+    }
+
+    /// One bounded refresh through the coordinator the app and `meterbar
+    /// refresh` share, so `--refresh` cannot start a second concurrent poll.
+    @MainActor
+    private static func performRefresh(timeout: TimeInterval) async {
+        _ = await UsageRefreshCLI.run(UsageRefreshCLI.Request(timeout: timeout))
+    }
+
+    private static func evaluate(target: QuotaGuardTarget) -> QuotaGuardEvaluation {
+        let store = SharedDataStore.shared
+        store.flushPendingWrites()
+
+        let selection = QuotaGuardAccountResolver.resolve(
+            target: target,
+            // Only the `--config-dir` path needs the account projection; the
+            // provider-wide path stays a single cache read.
+            configuration: target.configDirectory == nil ? nil : UsageRefreshConfigurationStore.load(),
+            accountSnapshots: store.loadAccountMetrics(),
+            providerMetrics: store.loadMetrics(),
+            defaultDirectories: .current()
+        )
+
+        switch selection {
+        case let .failure(failure):
+            return .failed(failure, checkedAt: Date())
+        case let .success(value):
+            return QuotaGuardEvaluator.evaluate(
+                target: target,
+                account: value.account,
+                metrics: value.metrics
+            )
+        }
+    }
+
+    private static func result(from evaluation: QuotaGuardEvaluation) -> Result {
+        let response = GuardCLIResponse(evaluation: evaluation)
+        return Result(
+            jsonOutput: (try? response.jsonString()) ?? "{}",
+            summaryLine: evaluation.summaryLine,
+            // Success needs no second line; every other outcome explains itself
+            // on stderr so `guard >/dev/null` still surfaces the reason.
+            message: evaluation.outcome == .available ? nil : evaluation.message,
+            exitCode: evaluation.exitCode
+        )
+    }
+}

--- a/MeterBar/Guard/QuotaGuardEvaluator.swift
+++ b/MeterBar/Guard/QuotaGuardEvaluator.swift
@@ -1,0 +1,350 @@
+import Foundation
+import MeterBarShared
+
+/// Which snapshot the answer came from: the provider-wide roll-up or one
+/// configured account selected with `--config-dir`.
+nonisolated struct QuotaGuardAccount: Equatable, Sendable {
+    enum Scope: String, Equatable, Sendable {
+        case provider
+        case account
+    }
+
+    let scope: Scope
+    let name: String
+    let id: UUID?
+
+    static let providerWide = QuotaGuardAccount(scope: .provider, name: "All accounts", id: nil)
+}
+
+/// Freshness of the cached snapshot the decision was made from.
+nonisolated struct QuotaGuardSnapshotInfo: Equatable, Sendable {
+    let lastUpdated: Date
+    let ageSeconds: TimeInterval
+    let isStale: Bool
+}
+
+/// The evaluated quota window, expressed with the shared band/percent rules.
+nonisolated struct QuotaGuardQuota: Equatable, Sendable {
+    let used: Double
+    let total: Double
+    let percentUsed: Double
+    let percentLeft: Int
+    let band: QuotaBand
+    let resetAt: Date?
+    let resetCountdown: String?
+    let estimated: Bool
+}
+
+/// The complete answer `meterbar guard` returns: one outcome, the numbers it
+/// was derived from, and — when the answer is not "available" — the stable
+/// failure code that explains why.
+nonisolated struct QuotaGuardEvaluation: Sendable {
+    let outcome: QuotaGuardOutcome
+    let checkedAt: Date
+    let service: ServiceType?
+    let window: QuotaGuardWindow?
+    let account: QuotaGuardAccount?
+    let minRemainingPercent: Double?
+    let quota: QuotaGuardQuota?
+    let snapshot: QuotaGuardSnapshotInfo?
+    let message: String
+    let failure: QuotaGuardFailure?
+
+    var exitCode: Int32 { outcome.exitCode }
+    var isStale: Bool { snapshot?.isStale ?? false }
+    var percentLeft: Int? { quota?.percentLeft }
+    var band: QuotaBand? { quota?.band }
+    var resetAt: Date? { quota?.resetAt }
+
+    /// One-line human summary for terminals and log lines.
+    var summaryLine: String {
+        var parts = ["Guard: \(outcome.rawValue)"]
+        if let service {
+            parts.append([service.displayName, window?.displayName].compactMap { $0 }.joined(separator: " "))
+        }
+        if let quota {
+            parts.append("\(quota.percentLeft)% left")
+            parts.append(quota.band.cliIdentifier)
+        } else if let failure {
+            parts.append(failure.code)
+        }
+        if let minRemainingPercent {
+            parts.append("minimum \(QuotaGuardNumber.text(minRemainingPercent))%")
+        }
+        if let countdown = quota?.resetCountdown {
+            parts.append("resets in \(countdown)")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    /// A resolution failure that never reached a provider snapshot.
+    static func failed(_ failure: QuotaGuardFailure, checkedAt: Date) -> QuotaGuardEvaluation {
+        QuotaGuardEvaluation(
+            outcome: failure.outcome,
+            checkedAt: checkedAt,
+            service: nil,
+            window: nil,
+            account: nil,
+            minRemainingPercent: nil,
+            quota: nil,
+            snapshot: nil,
+            message: failure.message,
+            failure: failure
+        )
+    }
+}
+
+/// The `meterbar guard` decision core.
+///
+/// Pure and synchronous: it takes an already-validated target plus whatever
+/// snapshot the caller found and returns the outcome. Severity comes from
+/// `QuotaBand`/`QuotaMath`, so changing a shared threshold changes guard's
+/// behavior without a second edit here.
+nonisolated enum QuotaGuardEvaluator {
+    static func evaluate(
+        target: QuotaGuardTarget,
+        account: QuotaGuardAccount,
+        metrics: UsageMetrics?,
+        now: Date = Date(),
+        stalenessLimit: TimeInterval = ProviderParseHealthRecord.staleAfter
+    ) -> QuotaGuardEvaluation {
+        let provider = target.service.displayName
+
+        guard let metrics else {
+            return unavailable(
+                target: target,
+                account: account,
+                now: now,
+                snapshot: nil,
+                code: "snapshot_missing",
+                message: "No cached \(provider) usage found. "
+                    + "Run `meterbar guard --refresh` or open MeterBar."
+            )
+        }
+
+        let age = max(0, now.timeIntervalSince(metrics.lastUpdated))
+        let snapshot = QuotaGuardSnapshotInfo(
+            lastUpdated: metrics.lastUpdated,
+            ageSeconds: age,
+            isStale: age > stalenessLimit
+        )
+
+        guard !snapshot.isStale else {
+            return unavailable(
+                target: target,
+                account: account,
+                now: now,
+                snapshot: snapshot,
+                code: "snapshot_stale",
+                message: "Cached \(provider) usage is \(UsageDurationText.short(seconds: age)) old "
+                    + "(freshness limit \(UsageDurationText.short(seconds: stalenessLimit))). "
+                    + "Re-run with --refresh."
+            )
+        }
+
+        guard let limit = target.window.limit(in: metrics) else {
+            return unavailable(
+                target: target,
+                account: account,
+                now: now,
+                snapshot: snapshot,
+                code: "window_unavailable",
+                message: "\(provider) did not report a \(target.window.displayName) quota window."
+            )
+        }
+
+        // A zero/absent total would otherwise read as "100% left" through the
+        // shared percent math, which is exactly the false availability the
+        // guard contract forbids.
+        guard limit.total > 0 else {
+            return unavailable(
+                target: target,
+                account: account,
+                now: now,
+                snapshot: snapshot,
+                code: "window_unavailable",
+                message: "\(provider) reported a \(target.window.displayName) quota window "
+                    + "without a usable total."
+            )
+        }
+
+        let band = QuotaBand.forLimit(limit)
+        let percentLeft = QuotaMath.percentLeft(for: limit)
+        let countdown = limit.resetCountdownText(now: now)
+        let quota = QuotaGuardQuota(
+            used: limit.used,
+            total: limit.total,
+            percentUsed: limit.percentage,
+            percentLeft: percentLeft,
+            band: band,
+            resetAt: limit.resetTime,
+            resetCountdown: countdown,
+            estimated: limit.isEstimated
+        )
+        let window = target.window.displayName
+        let resetSentence = countdown.map { "Resets in \($0)." } ?? "Reset time unknown."
+
+        // Exhaustion outranks the caller's threshold: the quota is blocking
+        // regardless of what minimum was asked for.
+        if band == .exhausted {
+            return QuotaGuardEvaluation(
+                outcome: .exhausted,
+                checkedAt: now,
+                service: target.service,
+                window: target.window,
+                account: account,
+                minRemainingPercent: target.minRemainingPercent,
+                quota: quota,
+                snapshot: snapshot,
+                message: "\(provider) \(window) quota exhausted. \(resetSentence)",
+                failure: nil
+            )
+        }
+
+        if let minimum = target.minRemainingPercent, Double(percentLeft) < minimum {
+            return QuotaGuardEvaluation(
+                outcome: .belowThreshold,
+                checkedAt: now,
+                service: target.service,
+                window: target.window,
+                account: account,
+                minRemainingPercent: minimum,
+                quota: quota,
+                snapshot: snapshot,
+                message: "\(provider) \(window) quota below threshold: \(percentLeft)% left "
+                    + "(minimum \(QuotaGuardNumber.text(minimum))%). \(resetSentence)",
+                failure: nil
+            )
+        }
+
+        let minimumSuffix = target.minRemainingPercent
+            .map { " (minimum \(QuotaGuardNumber.text($0))%)" } ?? ""
+        return QuotaGuardEvaluation(
+            outcome: .available,
+            checkedAt: now,
+            service: target.service,
+            window: target.window,
+            account: account,
+            minRemainingPercent: target.minRemainingPercent,
+            quota: quota,
+            snapshot: snapshot,
+            message: "\(provider) \(window) quota available: \(percentLeft)% left\(minimumSuffix).",
+            failure: nil
+        )
+    }
+
+    private static func unavailable(
+        target: QuotaGuardTarget,
+        account: QuotaGuardAccount,
+        now: Date,
+        snapshot: QuotaGuardSnapshotInfo?,
+        code: String,
+        message: String
+    ) -> QuotaGuardEvaluation {
+        QuotaGuardEvaluation(
+            outcome: .dataUnavailable,
+            checkedAt: now,
+            service: target.service,
+            window: target.window,
+            account: account,
+            minRemainingPercent: target.minRemainingPercent,
+            quota: nil,
+            snapshot: snapshot,
+            message: message,
+            failure: QuotaGuardFailure(outcome: .dataUnavailable, code: code, message: message)
+        )
+    }
+}
+
+/// The snapshot `guard` will read, plus the account label describing it.
+nonisolated struct QuotaGuardSelection: Sendable {
+    let account: QuotaGuardAccount
+    let metrics: UsageMetrics?
+}
+
+/// Maps `--config-dir` onto the account snapshots the app mirrors.
+///
+/// `AccountUsageSnapshot` carries no directory, so the configured account list
+/// is the bridge: match the directory to an account, then that account's id to
+/// its snapshot.
+nonisolated enum QuotaGuardAccountResolver {
+    static func resolve(
+        target: QuotaGuardTarget,
+        configuration: UsageRefreshConfigurationStore.Snapshot?,
+        accountSnapshots: [AccountUsageSnapshot],
+        providerMetrics: [ServiceType: UsageMetrics],
+        defaultDirectories: QuotaGuardDefaultDirectories
+    ) -> Result<QuotaGuardSelection, QuotaGuardFailure> {
+        guard let requestedDirectory = target.configDirectory else {
+            return .success(QuotaGuardSelection(
+                account: .providerWide,
+                metrics: providerMetrics[target.service]
+            ))
+        }
+
+        guard let configuration else {
+            return .failure(QuotaGuardFailure(
+                outcome: .dataUnavailable,
+                code: "account_lookup_unavailable",
+                message: "MeterBar account configuration is unavailable. "
+                    + "Open the MeterBar app and try again."
+            ))
+        }
+
+        let home = ServiceSupport.realHomeDirectory()
+        let needle = QuotaGuardPath.normalize(requestedDirectory, home: home)
+        let candidates: [(id: UUID, name: String, directory: String)]
+        switch target.service {
+        case .claudeCode:
+            candidates = configuration.claudeAccounts.map {
+                (
+                    id: $0.id,
+                    name: $0.name,
+                    directory: QuotaGuardPath.normalize(
+                        $0.configDirectory ?? defaultDirectories.claude,
+                        home: home
+                    )
+                )
+            }
+        default:
+            candidates = configuration.codexAccounts.map {
+                (
+                    id: $0.id,
+                    name: $0.name,
+                    directory: QuotaGuardPath.normalize(
+                        $0.homeDirectory ?? defaultDirectories.codex,
+                        home: home
+                    )
+                )
+            }
+        }
+
+        guard let match = candidates.first(where: { $0.directory == needle }) else {
+            return .failure(QuotaGuardFailure(
+                outcome: .usageError,
+                code: "unknown_account",
+                message: "No configured \(target.service.displayName) account uses "
+                    + "config dir '\(requestedDirectory)'.",
+                flag: "--config-dir",
+                value: requestedDirectory
+            ))
+        }
+
+        return .success(QuotaGuardSelection(
+            account: QuotaGuardAccount(scope: .account, name: match.name, id: match.id),
+            metrics: accountSnapshots.first { $0.id == match.id }?.metrics
+        ))
+    }
+}
+
+/// Echoes a caller-supplied number back without gratuitous decimals (`25`,
+/// `58.5`). Formats through `String(format:)` rather than `Int(_:)` so an
+/// out-of-range or non-finite flag value is reported, not a trap.
+nonisolated enum QuotaGuardNumber {
+    static func text(_ value: Double) -> String {
+        guard value.isFinite else { return String(format: "%g", value) }
+        return value == value.rounded()
+            ? String(format: "%.0f", value)
+            : String(format: "%g", value)
+    }
+}

--- a/MeterBar/Guard/QuotaGuardOutcome.swift
+++ b/MeterBar/Guard/QuotaGuardOutcome.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Stable outcomes and exit codes for `meterbar guard`.
+///
+/// Scripts branch on these numbers, so they are a published contract
+/// (`docs/cli-json-schema.md`): the values never change meaning within schema
+/// version 1. "Below threshold" stays distinct from "exhausted" so a caller can
+/// throttle before it is actually blocked.
+nonisolated public enum QuotaGuardOutcome: String, Codable, CaseIterable, Equatable, Sendable {
+    case available
+    case belowThreshold
+    case exhausted
+    case dataUnavailable
+    case usageError
+
+    public var exitCode: Int32 {
+        switch self {
+        case .available: return 0
+        case .belowThreshold: return 10
+        case .exhausted: return 11
+        case .dataUnavailable: return 12
+        case .usageError: return 13
+        }
+    }
+}
+
+/// A non-success reason with a stable machine code.
+///
+/// The outcome travels with the failure so callers can distinguish "you passed
+/// something invalid" (usage error) from "MeterBar has nothing trustworthy to
+/// answer with" (data unavailable) without a second lookup table.
+nonisolated struct QuotaGuardFailure: Error, Equatable, Sendable {
+    let outcome: QuotaGuardOutcome
+    let code: String
+    let message: String
+    let flag: String?
+    let value: String?
+
+    init(
+        outcome: QuotaGuardOutcome,
+        code: String,
+        message: String,
+        flag: String? = nil,
+        value: String? = nil
+    ) {
+        self.outcome = outcome
+        self.code = code
+        self.message = message
+        self.flag = flag
+        self.value = value
+    }
+}

--- a/MeterBar/Guard/QuotaGuardTarget.swift
+++ b/MeterBar/Guard/QuotaGuardTarget.swift
@@ -1,0 +1,201 @@
+import Foundation
+import MeterBarShared
+
+/// The quota window `meterbar guard` can evaluate. Raw values match the
+/// `windows[].kind` tokens already emitted by `meterbar usage --json`.
+nonisolated enum QuotaGuardWindow: String, CaseIterable, Equatable, Sendable {
+    case session
+    case weekly
+    case codeReview
+
+    /// Accepts the documented spellings plus the hyphen/underscore and casing
+    /// variants a shell script is likely to pass.
+    static func parse(_ raw: String) -> QuotaGuardWindow? {
+        let needle = raw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: "_", with: "")
+        switch needle {
+        case "session": return .session
+        case "weekly": return .weekly
+        case "codereview": return .codeReview
+        default: return nil
+        }
+    }
+
+    static let acceptedValues = "session, weekly, code-review"
+
+    var cliIdentifier: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .session: return "session"
+        case .weekly: return "weekly"
+        case .codeReview: return "code review"
+        }
+    }
+
+    func limit(in metrics: UsageMetrics) -> UsageLimit? {
+        switch self {
+        case .session: return metrics.sessionLimit
+        case .weekly: return metrics.weeklyLimit
+        case .codeReview: return metrics.codeReviewLimit
+        }
+    }
+}
+
+/// Validated `meterbar guard` inputs. Every caller-supplied value is checked
+/// here so an invalid flag produces the stable usage-error exit code instead of
+/// ArgumentParser's generic one.
+nonisolated struct QuotaGuardTarget: Equatable, Sendable {
+    let service: ServiceType
+    let window: QuotaGuardWindow
+    /// Minimum percent of quota that must remain. `nil` means the default
+    /// policy: anything short of exhaustion passes.
+    let minRemainingPercent: Double?
+    let configDirectory: String?
+    let refreshTimeout: TimeInterval
+
+    static func resolve(
+        provider: String,
+        window: String,
+        minRemaining: String?,
+        configDirectory: String?,
+        refreshTimeout: Double
+    ) -> Result<QuotaGuardTarget, QuotaGuardFailure> {
+        guard let service = ServiceType.fromCLIIdentifier(provider) else {
+            return .failure(QuotaGuardFailure(
+                outcome: .usageError,
+                code: "invalid_provider",
+                message: "Unknown provider '\(provider.trimmed)' for --provider. "
+                    + "Expected one of: \(ServiceType.cliIdentifiers).",
+                flag: "--provider",
+                value: provider.trimmed
+            ))
+        }
+
+        guard let resolvedWindow = QuotaGuardWindow.parse(window) else {
+            return .failure(QuotaGuardFailure(
+                outcome: .usageError,
+                code: "invalid_window",
+                message: "Unknown quota window '\(window.trimmed)' for --limit. "
+                    + "Expected one of: \(QuotaGuardWindow.acceptedValues).",
+                flag: "--limit",
+                value: window.trimmed
+            ))
+        }
+
+        var threshold: Double?
+        if let minRemaining {
+            guard let parsed = Double(minRemaining.trimmed),
+                  parsed.isFinite,
+                  (0...100).contains(parsed) else {
+                return .failure(QuotaGuardFailure(
+                    outcome: .usageError,
+                    code: "invalid_threshold",
+                    message: "Invalid --min-remaining value '\(minRemaining.trimmed)'. "
+                        + "Expected a percentage between 0 and 100.",
+                    flag: "--min-remaining",
+                    value: minRemaining.trimmed
+                ))
+            }
+            threshold = parsed
+        }
+
+        guard refreshTimeout.isFinite,
+              (QuotaGuardCLI.minimumRefreshTimeout...QuotaGuardCLI.maximumRefreshTimeout)
+                  .contains(refreshTimeout) else {
+            return .failure(QuotaGuardFailure(
+                outcome: .usageError,
+                code: "invalid_refresh_timeout",
+                message: "Invalid --refresh-timeout value '\(QuotaGuardNumber.text(refreshTimeout))'. "
+                    + "Expected \(QuotaGuardNumber.text(QuotaGuardCLI.minimumRefreshTimeout))"
+                    + "...\(QuotaGuardNumber.text(QuotaGuardCLI.maximumRefreshTimeout)) seconds.",
+                flag: "--refresh-timeout",
+                value: QuotaGuardNumber.text(refreshTimeout)
+            ))
+        }
+
+        let trimmedConfigDirectory = configDirectory?.trimmed
+        if let trimmedConfigDirectory, !trimmedConfigDirectory.isEmpty {
+            guard service.supportsGuardConfigDirectory else {
+                return .failure(QuotaGuardFailure(
+                    outcome: .usageError,
+                    code: "unsupported_config_dir",
+                    message: "--config-dir is not supported for \(service.displayName). "
+                        + "Only Claude Code and OpenAI Codex have per-account config directories.",
+                    flag: "--config-dir",
+                    value: trimmedConfigDirectory
+                ))
+            }
+        }
+
+        return .success(QuotaGuardTarget(
+            service: service,
+            window: resolvedWindow,
+            minRemainingPercent: threshold,
+            configDirectory: trimmedConfigDirectory?.isEmpty == false ? trimmedConfigDirectory : nil,
+            refreshTimeout: refreshTimeout
+        ))
+    }
+}
+
+/// Default per-provider configuration directories, injected so account matching
+/// is testable without touching the real environment.
+nonisolated struct QuotaGuardDefaultDirectories: Equatable, Sendable {
+    let claude: String
+    let codex: String
+
+    static func current(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        realHomeDirectory: String = ServiceSupport.realHomeDirectory()
+    ) -> QuotaGuardDefaultDirectories {
+        let rawCodexHome = environment["CODEX_HOME"]?.trimmed
+        let codex: String
+        if let rawCodexHome, !rawCodexHome.isEmpty {
+            codex = QuotaGuardPath.normalize(rawCodexHome, home: realHomeDirectory)
+        } else {
+            codex = (realHomeDirectory as NSString).appendingPathComponent(".codex")
+        }
+        return QuotaGuardDefaultDirectories(
+            claude: ClaudeCodeAccount.defaultConfigDirectory(
+                environment: environment,
+                realHomeDirectory: realHomeDirectory
+            ),
+            codex: codex
+        )
+    }
+}
+
+/// Tilde expansion + standardization so `~/.claude`, `/Users/me/.claude`, and
+/// `/Users/me/.claude/` all select the same configured account.
+nonisolated enum QuotaGuardPath {
+    static func normalize(_ raw: String, home: String) -> String {
+        var value = raw.trimmed
+        if value == "~" {
+            value = home
+        } else if value.hasPrefix("~/") {
+            value = (home as NSString).appendingPathComponent(String(value.dropFirst(2)))
+        }
+        value = (value as NSString).standardizingPath
+        while value.count > 1, value.hasSuffix("/") {
+            value.removeLast()
+        }
+        return value
+    }
+}
+
+nonisolated extension ServiceType {
+    /// Only the CLI-backed providers keep per-account config directories the
+    /// app mirrors for cross-process reads.
+    var supportsGuardConfigDirectory: Bool {
+        self == .claudeCode || self == .codexCli
+    }
+}
+
+nonisolated private extension String {
+    var trimmed: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/MeterBar/Guard/QuotaGuardTarget.swift
+++ b/MeterBar/Guard/QuotaGuardTarget.swift
@@ -62,7 +62,7 @@ nonisolated struct QuotaGuardTarget: Equatable, Sendable {
         window: String,
         minRemaining: String?,
         configDirectory: String?,
-        refreshTimeout: Double
+        refreshTimeout: String?
     ) -> Result<QuotaGuardTarget, QuotaGuardFailure> {
         guard let service = ServiceType.fromCLIIdentifier(provider) else {
             return .failure(QuotaGuardFailure(
@@ -103,18 +103,23 @@ nonisolated struct QuotaGuardTarget: Equatable, Sendable {
             threshold = parsed
         }
 
-        guard refreshTimeout.isFinite,
-              (QuotaGuardCLI.minimumRefreshTimeout...QuotaGuardCLI.maximumRefreshTimeout)
-                  .contains(refreshTimeout) else {
-            return .failure(QuotaGuardFailure(
-                outcome: .usageError,
-                code: "invalid_refresh_timeout",
-                message: "Invalid --refresh-timeout value '\(QuotaGuardNumber.text(refreshTimeout))'. "
-                    + "Expected \(QuotaGuardNumber.text(QuotaGuardCLI.minimumRefreshTimeout))"
-                    + "...\(QuotaGuardNumber.text(QuotaGuardCLI.maximumRefreshTimeout)) seconds.",
-                flag: "--refresh-timeout",
-                value: QuotaGuardNumber.text(refreshTimeout)
-            ))
+        var timeout = QuotaGuardCLI.defaultRefreshTimeout
+        if let refreshTimeout {
+            guard let parsed = Double(refreshTimeout.trimmed),
+                  parsed.isFinite,
+                  (QuotaGuardCLI.minimumRefreshTimeout...QuotaGuardCLI.maximumRefreshTimeout)
+                      .contains(parsed) else {
+                return .failure(QuotaGuardFailure(
+                    outcome: .usageError,
+                    code: "invalid_refresh_timeout",
+                    message: "Invalid --refresh-timeout value '\(refreshTimeout.trimmed)'. "
+                        + "Expected \(QuotaGuardNumber.text(QuotaGuardCLI.minimumRefreshTimeout))"
+                        + "...\(QuotaGuardNumber.text(QuotaGuardCLI.maximumRefreshTimeout)) seconds.",
+                    flag: "--refresh-timeout",
+                    value: refreshTimeout.trimmed
+                ))
+            }
+            timeout = parsed
         }
 
         let trimmedConfigDirectory = configDirectory?.trimmed
@@ -136,7 +141,7 @@ nonisolated struct QuotaGuardTarget: Equatable, Sendable {
             window: resolvedWindow,
             minRemainingPercent: threshold,
             configDirectory: trimmedConfigDirectory?.isEmpty == false ? trimmedConfigDirectory : nil,
-            refreshTimeout: refreshTimeout
+            refreshTimeout: timeout
         ))
     }
 }

--- a/MeterBar/Models/CLIJSONOutput.swift
+++ b/MeterBar/Models/CLIJSONOutput.swift
@@ -245,9 +245,23 @@ nonisolated extension ServiceType {
         case .grok: return "grok"
         }
     }
+
+    /// The same tokens in documented order, for `--provider` help and error text.
+    static var cliIdentifiers: String {
+        allCases.sorted { $0.sortOrder < $1.sortOrder }
+            .map(\.cliIdentifier)
+            .joined(separator: ", ")
+    }
+
+    /// Parses a caller-supplied `--provider` value. Tolerant of surrounding
+    /// whitespace and casing so shell interpolation doesn't become a usage error.
+    static func fromCLIIdentifier(_ raw: String) -> ServiceType? {
+        let needle = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return allCases.first { $0.cliIdentifier == needle }
+    }
 }
 
-nonisolated private extension QuotaBand {
+nonisolated extension QuotaBand {
     var cliIdentifier: String {
         switch self {
         case .healthy: return "healthy"

--- a/MeterBarCLI/Sources/Guard.swift
+++ b/MeterBarCLI/Sources/Guard.swift
@@ -1,0 +1,80 @@
+import ArgumentParser
+import Foundation
+import MeterBar
+
+/// Answer "may I spend quota right now?" with a stable exit code.
+struct Guard: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "guard",
+        abstract: "Check whether a provider quota window is safe to spend",
+        discussion: """
+            Exit codes are a scripting contract (see docs/cli-json-schema.md):
+            0 available, 10 below --min-remaining, 11 exhausted,
+            12 no usable or fresh snapshot, 13 usage error.
+
+            Reads the cached snapshot MeterBar maintains. Pass --refresh to run
+            one bounded refresh first. guard never waits for a quota to reset
+            and never consumes reset credits — that is `meterbar wake`.
+            """
+    )
+
+    @Flag(name: .shortAndLong, help: "Emit only the versioned JSON response on stdout.")
+    var json: Bool = false
+
+    @Option(name: .shortAndLong, help: "Provider to check (claude, codex, cursor, openrouter, grok).")
+    var provider: String = QuotaGuardCLI.defaultProvider
+
+    @Option(name: .shortAndLong, help: "Quota window to check (session, weekly, code-review).")
+    var limit: String = QuotaGuardCLI.defaultWindow
+
+    // Taken as text, not Double, so a malformed threshold exits with the
+    // documented usage code instead of ArgumentParser's generic one.
+    @Option(
+        name: .long,
+        help: "Minimum percent of quota that must remain. Default: anything short of exhausted passes."
+    )
+    var minRemaining: String?
+
+    @Option(name: .long, help: "Check one configured account by its config directory.")
+    var configDir: String?
+
+    @Flag(name: .long, help: "Refresh usage before deciding instead of reading the cached snapshot.")
+    var refresh: Bool = false
+
+    @Option(name: .long, help: "Seconds to allow for --refresh before falling back to the cache.")
+    var refreshTimeout: Double = QuotaGuardCLI.defaultRefreshTimeout
+
+    func run() async throws {
+        let result = await QuotaGuardCLI.run(
+            QuotaGuardCLI.Request(
+                provider: provider,
+                window: limit,
+                minRemaining: minRemaining,
+                configDirectory: configDir,
+                refresh: refresh,
+                refreshTimeout: refreshTimeout
+            )
+        )
+        emit(result)
+        throw ExitCode(result.exitCode)
+    }
+
+    private func emit(_ result: QuotaGuardCLI.Result) {
+        if json {
+            print(result.jsonOutput)
+            return
+        }
+        print(result.summaryLine)
+        if let message = result.message {
+            var stderr = GuardStandardError()
+            Swift.print(message, to: &stderr)
+        }
+    }
+}
+
+private struct GuardStandardError: TextOutputStream {
+    func write(_ string: String) {
+        guard let data = string.data(using: .utf8) else { return }
+        FileHandle.standardError.write(data)
+    }
+}

--- a/MeterBarCLI/Sources/Guard.swift
+++ b/MeterBarCLI/Sources/Guard.swift
@@ -41,8 +41,11 @@ struct Guard: AsyncParsableCommand {
     @Flag(name: .long, help: "Refresh usage before deciding instead of reading the cached snapshot.")
     var refresh: Bool = false
 
+    // Text for the same reason as --min-remaining: typed as Double, a
+    // non-numeric value dies inside ArgumentParser's own conversion with
+    // EX_USAGE and no JSON document, never reaching the documented exit 13.
     @Option(name: .long, help: "Seconds to allow for --refresh before falling back to the cache.")
-    var refreshTimeout: Double = QuotaGuardCLI.defaultRefreshTimeout
+    var refreshTimeout: String?
 
     func run() async throws {
         let result = await QuotaGuardCLI.run(

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -16,6 +16,7 @@ struct MeterBarCLI: AsyncParsableCommand {
             Refresh.self,
             FableSessions.self,
             Doctor.self,
+            Guard.self,
             Wake.self,
             WakeAgent.self,
             ResetCredit.self,

--- a/MeterBarTests/QuotaGuardTests.swift
+++ b/MeterBarTests/QuotaGuardTests.swift
@@ -1,0 +1,519 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// Contract coverage for `meterbar guard`: input resolution, the quota decision
+/// core, the stable exit codes scripts depend on, and the versioned JSON body.
+final class QuotaGuardTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - Exit-code contract
+
+    func testExitCodesAreStableAndDistinct() {
+        XCTAssertEqual(QuotaGuardOutcome.available.exitCode, 0)
+        XCTAssertEqual(QuotaGuardOutcome.belowThreshold.exitCode, 10)
+        XCTAssertEqual(QuotaGuardOutcome.exhausted.exitCode, 11)
+        XCTAssertEqual(QuotaGuardOutcome.dataUnavailable.exitCode, 12)
+        XCTAssertEqual(QuotaGuardOutcome.usageError.exitCode, 13)
+
+        let codes = QuotaGuardOutcome.allCases.map(\.exitCode)
+        XCTAssertEqual(Set(codes).count, codes.count)
+    }
+
+    // MARK: - Input resolution
+
+    func testResolveAcceptsDocumentedWindowSpellings() throws {
+        XCTAssertEqual(try target(window: "session").window, .session)
+        XCTAssertEqual(try target(window: "weekly").window, .weekly)
+        XCTAssertEqual(try target(window: "code-review").window, .codeReview)
+        XCTAssertEqual(try target(window: "codeReview").window, .codeReview)
+        XCTAssertEqual(try target(window: " CODE_REVIEW ").window, .codeReview)
+    }
+
+    func testResolveAcceptsStableProviderTokens() throws {
+        XCTAssertEqual(try target(provider: "claude").service, .claudeCode)
+        XCTAssertEqual(try target(provider: "codex").service, .codexCli)
+        XCTAssertEqual(try target(provider: " Cursor ").service, .cursor)
+    }
+
+    func testUnknownProviderIsAUsageErrorNamingTheInput() {
+        let failure = expectFailure(provider: "clod")
+        XCTAssertEqual(failure.outcome, .usageError)
+        XCTAssertEqual(failure.code, "invalid_provider")
+        XCTAssertEqual(failure.flag, "--provider")
+        XCTAssertEqual(failure.value, "clod")
+        XCTAssertTrue(failure.message.contains("clod"), failure.message)
+        XCTAssertTrue(failure.message.contains("claude"), failure.message)
+    }
+
+    func testUnknownWindowIsAUsageErrorNamingTheInput() {
+        let failure = expectFailure(window: "hourly")
+        XCTAssertEqual(failure.outcome, .usageError)
+        XCTAssertEqual(failure.code, "invalid_window")
+        XCTAssertEqual(failure.flag, "--limit")
+        XCTAssertTrue(failure.message.contains("hourly"), failure.message)
+    }
+
+    func testMalformedThresholdIsAUsageErrorNamingTheInput() {
+        for raw in ["abc", "-5", "120", ""] {
+            let failure = expectFailure(minRemaining: raw)
+            XCTAssertEqual(failure.outcome, .usageError, raw)
+            XCTAssertEqual(failure.code, "invalid_threshold", raw)
+            XCTAssertEqual(failure.flag, "--min-remaining", raw)
+            XCTAssertTrue(failure.message.contains("--min-remaining"), failure.message)
+        }
+    }
+
+    func testOutOfRangeRefreshTimeoutIsAUsageError() {
+        let failure = expectFailure(refreshTimeout: 100_000)
+        XCTAssertEqual(failure.outcome, .usageError)
+        XCTAssertEqual(failure.code, "invalid_refresh_timeout")
+        XCTAssertEqual(failure.flag, "--refresh-timeout")
+    }
+
+    func testConfigDirIsRejectedForProvidersWithoutAccounts() {
+        let failure = expectFailure(provider: "cursor", configDirectory: "/tmp/x")
+        XCTAssertEqual(failure.outcome, .usageError)
+        XCTAssertEqual(failure.code, "unsupported_config_dir")
+        XCTAssertTrue(failure.message.contains("Cursor"), failure.message)
+    }
+
+    // MARK: - Available
+
+    func testQuotaAboveThresholdExitsZeroAndReportsTheEvaluatedWindow() throws {
+        let evaluation = QuotaGuardEvaluator.evaluate(
+            target: try target(minRemaining: "25"),
+            account: .providerWide,
+            metrics: metrics(session: limit(used: 42.5)),
+            now: now
+        )
+
+        XCTAssertEqual(evaluation.outcome, .available)
+        XCTAssertEqual(evaluation.outcome.exitCode, 0)
+        XCTAssertEqual(evaluation.window, .session)
+        XCTAssertEqual(evaluation.percentLeft, 58)
+        XCTAssertEqual(evaluation.band, .healthy)
+        XCTAssertTrue(evaluation.summaryLine.contains("session"), evaluation.summaryLine)
+    }
+
+    func testQuotaExactlyAtThresholdIsAvailable() throws {
+        let evaluation = QuotaGuardEvaluator.evaluate(
+            target: try target(minRemaining: "25"),
+            account: .providerWide,
+            metrics: metrics(session: limit(used: 75)),
+            now: now
+        )
+
+        XCTAssertEqual(evaluation.percentLeft, 25)
+        XCTAssertEqual(evaluation.outcome, .available)
+    }
+
+    func testWithoutAThresholdOnlyExhaustionBlocks() throws {
+        let evaluation = QuotaGuardEvaluator.evaluate(
+            target: try target(),
+            account: .providerWide,
+            metrics: metrics(session: limit(used: 98)),
+            now: now
+        )
+
+        XCTAssertEqual(evaluation.band, .critical)
+        XCTAssertEqual(evaluation.outcome, .available)
+        XCTAssertNil(evaluation.minRemainingPercent)
+    }
+
+    // MARK: - Below threshold
+
+    func testBelowThresholdUsesItsOwnExitCodeNotTheExhaustedOne() throws {
+        let evaluation = QuotaGuardEvaluator.evaluate(
+            target: try target(minRemaining: "25"),
+            account: .providerWide,
+            metrics: metrics(session: limit(used: 82)),
+            now: now
+        )
+
+        XCTAssertEqual(evaluation.outcome, .belowThreshold)
+        XCTAssertEqual(evaluation.outcome.exitCode, 10)
+        XCTAssertNotEqual(evaluation.outcome.exitCode, QuotaGuardOutcome.exhausted.exitCode)
+        XCTAssertEqual(evaluation.percentLeft, 18)
+        XCTAssertTrue(evaluation.message.contains("25%"), evaluation.message)
+    }
+
+    func testFractionalThresholdIsHonored() throws {
+        let evaluation = QuotaGuardEvaluator.evaluate(
+            target: try target(minRemaining: "58.5"),
+            account: .providerWide,
+            metrics: metrics(session: limit(used: 42.5)),
+            now: now
+        )
+
+        XCTAssertEqual(evaluation.percentLeft, 58)
+        XCTAssertEqual(evaluation.outcome, .belowThreshold)
+    }
+
+    // MARK: - Exhausted
+
+    func testExhaustedQuotaReportsResetTimeAndOutranksTheThreshold() throws {
+        let evaluation = QuotaGuardEvaluator.evaluate(
+            target: try target(minRemaining: "25"),
+            account: .providerWide,
+            metrics: metrics(session: limit(used: 100)),
+            now: now
+        )
+
+        XCTAssertEqual(evaluation.outcome, .exhausted)
+        XCTAssertEqual(evaluation.outcome.exitCode, 11)
+        XCTAssertEqual(evaluation.band, .exhausted)
+        XCTAssertEqual(evaluation.resetAt, now.addingTimeInterval(3_600))
+        XCTAssertTrue(evaluation.message.contains("1h"), evaluation.message)
+        XCTAssertTrue(evaluation.summaryLine.contains("1h"), evaluation.summaryLine)
+    }
+
+    func testExhaustionDerivesFromTheSharedQuotaBandModel() throws {
+        // A limit that lands exactly on the shared "no percent left" rule must be
+        // exhausted here too — guard owns no second threshold table.
+        let spent = limit(used: 100)
+        XCTAssertEqual(QuotaBand.forLimit(spent), .exhausted)
+
+        let evaluation = QuotaGuardEvaluator.evaluate(
+            target: try target(),
+            account: .providerWide,
+            metrics: metrics(session: spent),
+            now: now
+        )
+
+        XCTAssertEqual(evaluation.outcome, .exhausted)
+        XCTAssertEqual(evaluation.band, QuotaBand.forLimit(spent))
+        XCTAssertEqual(evaluation.percentLeft, QuotaMath.percentLeft(for: spent))
+    }
+
+    // MARK: - Data unavailable
+
+    func testMissingSnapshotNeverReportsAvailability() throws {
+        let evaluation = QuotaGuardEvaluator.evaluate(
+            target: try target(),
+            account: .providerWide,
+            metrics: nil,
+            now: now
+        )
+
+        XCTAssertEqual(evaluation.outcome, .dataUnavailable)
+        XCTAssertEqual(evaluation.outcome.exitCode, 12)
+        XCTAssertEqual(evaluation.failure?.code, "snapshot_missing")
+    }
+
+    func testSnapshotOlderThanTheFreshnessBoundIsUnavailable() throws {
+        let evaluation = QuotaGuardEvaluator.evaluate(
+            target: try target(),
+            account: .providerWide,
+            metrics: metrics(
+                session: limit(used: 10),
+                ageSeconds: ProviderParseHealthRecord.staleAfter + 60
+            ),
+            now: now
+        )
+
+        XCTAssertEqual(evaluation.outcome, .dataUnavailable)
+        XCTAssertEqual(evaluation.failure?.code, "snapshot_stale")
+        XCTAssertTrue(evaluation.isStale)
+        XCTAssertTrue(evaluation.message.contains("--refresh"), evaluation.message)
+    }
+
+    func testSnapshotInsideTheFreshnessBoundIsUsable() throws {
+        let evaluation = QuotaGuardEvaluator.evaluate(
+            target: try target(),
+            account: .providerWide,
+            metrics: metrics(
+                session: limit(used: 10),
+                ageSeconds: ProviderParseHealthRecord.staleAfter - 60
+            ),
+            now: now
+        )
+
+        XCTAssertFalse(evaluation.isStale)
+        XCTAssertEqual(evaluation.outcome, .available)
+    }
+
+    func testWindowTheProviderDoesNotReportIsUnavailable() throws {
+        let evaluation = QuotaGuardEvaluator.evaluate(
+            target: try target(window: "code-review"),
+            account: .providerWide,
+            metrics: metrics(session: limit(used: 10)),
+            now: now
+        )
+
+        XCTAssertEqual(evaluation.outcome, .dataUnavailable)
+        XCTAssertEqual(evaluation.failure?.code, "window_unavailable")
+        XCTAssertTrue(evaluation.message.contains("code review"), evaluation.message)
+    }
+
+    func testWindowWithoutAUsableTotalIsUnavailableRatherThanFullyAvailable() throws {
+        let evaluation = QuotaGuardEvaluator.evaluate(
+            target: try target(),
+            account: .providerWide,
+            metrics: metrics(session: limit(used: 0, total: 0)),
+            now: now
+        )
+
+        XCTAssertEqual(evaluation.outcome, .dataUnavailable)
+        XCTAssertEqual(evaluation.failure?.code, "window_unavailable")
+    }
+
+    // MARK: - Account selection
+
+    func testConfigDirSelectsTheMatchingAccountSnapshot() throws {
+        let account = ClaudeCodeAccount(id: UUID(), name: "Work", configDirectory: "/tmp/work-claude")
+        let snapshot = AccountUsageSnapshot(
+            id: account.id,
+            name: account.name,
+            metrics: metrics(session: limit(used: 10))
+        )
+
+        let selection = try QuotaGuardAccountResolver.resolve(
+            target: try target(configDirectory: "/tmp/work-claude/"),
+            configuration: configuration(claudeAccounts: [account]),
+            accountSnapshots: [snapshot],
+            providerMetrics: [:],
+            defaultDirectories: defaultDirectories
+        ).get()
+
+        XCTAssertEqual(selection.account.scope, .account)
+        XCTAssertEqual(selection.account.name, "Work")
+        XCTAssertEqual(selection.metrics?.sessionLimit?.used, 10)
+    }
+
+    func testUnknownConfigDirIsAUsageErrorNamingTheDirectory() throws {
+        let failure = QuotaGuardAccountResolver.resolve(
+            target: try target(configDirectory: "/tmp/nowhere"),
+            configuration: configuration(claudeAccounts: [.defaultAccount]),
+            accountSnapshots: [],
+            providerMetrics: [:],
+            defaultDirectories: defaultDirectories
+        ).failureValue
+
+        XCTAssertEqual(failure?.outcome, .usageError)
+        XCTAssertEqual(failure?.code, "unknown_account")
+        XCTAssertTrue(failure?.message.contains("/tmp/nowhere") == true, failure?.message ?? "")
+    }
+
+    func testMissingMirroredConfigurationIsUnavailableNotAUsageError() throws {
+        let failure = QuotaGuardAccountResolver.resolve(
+            target: try target(configDirectory: "/tmp/work-claude"),
+            configuration: nil,
+            accountSnapshots: [],
+            providerMetrics: [:],
+            defaultDirectories: defaultDirectories
+        ).failureValue
+
+        XCTAssertEqual(failure?.outcome, .dataUnavailable)
+        XCTAssertEqual(failure?.code, "account_lookup_unavailable")
+    }
+
+    func testWithoutConfigDirTheProviderWideSnapshotIsUsed() throws {
+        let selection = try QuotaGuardAccountResolver.resolve(
+            target: try target(),
+            configuration: nil,
+            accountSnapshots: [],
+            providerMetrics: [.claudeCode: metrics(session: limit(used: 5))],
+            defaultDirectories: defaultDirectories
+        ).get()
+
+        XCTAssertEqual(selection.account, .providerWide)
+        XCTAssertEqual(selection.metrics?.sessionLimit?.used, 5)
+    }
+
+    // MARK: - JSON contract
+
+    func testAvailableResponseMatchesVersionOneFixture() throws {
+        let evaluation = QuotaGuardEvaluator.evaluate(
+            target: try target(minRemaining: "25"),
+            account: .providerWide,
+            metrics: metrics(session: limit(used: 42.5)),
+            now: now
+        )
+
+        XCTAssertEqual(try GuardCLIResponse(evaluation: evaluation).jsonString(), availableFixture)
+    }
+
+    func testExhaustedResponseCarriesResetTimeAndBand() throws {
+        let evaluation = QuotaGuardEvaluator.evaluate(
+            target: try target(provider: "codex", window: "weekly"),
+            account: .providerWide,
+            metrics: metrics(service: .codexCli, weekly: limit(used: 100)),
+            now: now
+        )
+        let object = try json(evaluation)
+
+        XCTAssertEqual(object["schemaVersion"] as? Int, 1)
+        XCTAssertEqual(object["outcome"] as? String, "exhausted")
+        XCTAssertEqual(object["exitCode"] as? Int, 11)
+        XCTAssertEqual(object["provider"] as? String, "codex")
+        XCTAssertEqual(object["window"] as? String, "weekly")
+        XCTAssertEqual(object["quotaBand"] as? String, "exhausted")
+        XCTAssertEqual(object["percentLeft"] as? Int, 0)
+        XCTAssertEqual(object["resetAt"] as? String, "2023-11-14T23:13:20Z")
+        XCTAssertNil(object["minRemainingPercent"])
+    }
+
+    func testUnavailableResponseCarriesTheStableReasonCode() throws {
+        let evaluation = QuotaGuardEvaluator.evaluate(
+            target: try target(),
+            account: .providerWide,
+            metrics: nil,
+            now: now
+        )
+        let object = try json(evaluation)
+        let error = try XCTUnwrap(object["error"] as? [String: Any])
+
+        XCTAssertEqual(object["outcome"] as? String, "dataUnavailable")
+        XCTAssertEqual(object["exitCode"] as? Int, 12)
+        XCTAssertEqual(error["code"] as? String, "snapshot_missing")
+        XCTAssertNil(object["percentLeft"])
+        XCTAssertNil(object["quotaBand"])
+    }
+
+    func testUsageErrorResponseNamesTheOffendingFlagAndValue() throws {
+        let failure = expectFailure(provider: "clod")
+        let object = try json(.failed(failure, checkedAt: now))
+        let error = try XCTUnwrap(object["error"] as? [String: Any])
+
+        XCTAssertEqual(object["outcome"] as? String, "usageError")
+        XCTAssertEqual(object["exitCode"] as? Int, 13)
+        XCTAssertEqual(error["code"] as? String, "invalid_provider")
+        XCTAssertEqual(error["flag"] as? String, "--provider")
+        XCTAssertEqual(error["value"] as? String, "clod")
+        XCTAssertNil(object["provider"])
+    }
+
+    // MARK: - Helpers
+
+    private var defaultDirectories: QuotaGuardDefaultDirectories {
+        QuotaGuardDefaultDirectories(claude: "/Users/test/.claude", codex: "/Users/test/.codex")
+    }
+
+    private func configuration(
+        claudeAccounts: [ClaudeCodeAccount] = [],
+        codexAccounts: [CodexAccount] = []
+    ) -> UsageRefreshConfigurationStore.Snapshot {
+        UsageRefreshConfigurationStore.Snapshot(
+            hiddenServices: [],
+            claudeAccounts: claudeAccounts,
+            codexAccounts: codexAccounts
+        )
+    }
+
+    private func limit(
+        used: Double,
+        total: Double = 100,
+        resetOffset: TimeInterval? = 3_600
+    ) -> UsageLimit {
+        UsageLimit(
+            used: used,
+            total: total,
+            resetTime: resetOffset.map { now.addingTimeInterval($0) },
+            windowSeconds: 18_000
+        )
+    }
+
+    private func metrics(
+        service: ServiceType = .claudeCode,
+        session: UsageLimit? = nil,
+        weekly: UsageLimit? = nil,
+        codeReview: UsageLimit? = nil,
+        ageSeconds: TimeInterval = 60
+    ) -> UsageMetrics {
+        UsageMetrics(
+            service: service,
+            sessionLimit: session,
+            weeklyLimit: weekly,
+            codeReviewLimit: codeReview,
+            lastUpdated: now.addingTimeInterval(-ageSeconds)
+        )
+    }
+
+    private func target(
+        provider: String = "claude",
+        window: String = "session",
+        minRemaining: String? = nil,
+        configDirectory: String? = nil,
+        refreshTimeout: Double = QuotaGuardCLI.defaultRefreshTimeout
+    ) throws -> QuotaGuardTarget {
+        try QuotaGuardTarget.resolve(
+            provider: provider,
+            window: window,
+            minRemaining: minRemaining,
+            configDirectory: configDirectory,
+            refreshTimeout: refreshTimeout
+        ).get()
+    }
+
+    private func expectFailure(
+        provider: String = "claude",
+        window: String = "session",
+        minRemaining: String? = nil,
+        configDirectory: String? = nil,
+        refreshTimeout: Double = QuotaGuardCLI.defaultRefreshTimeout,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> QuotaGuardFailure {
+        let result = QuotaGuardTarget.resolve(
+            provider: provider,
+            window: window,
+            minRemaining: minRemaining,
+            configDirectory: configDirectory,
+            refreshTimeout: refreshTimeout
+        )
+        guard let failure = result.failureValue else {
+            XCTFail("Expected resolution to fail", file: file, line: line)
+            return QuotaGuardFailure(outcome: .usageError, code: "unexpected", message: "")
+        }
+        return failure
+    }
+
+    private func json(_ evaluation: QuotaGuardEvaluation) throws -> [String: Any] {
+        try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: GuardCLIResponse(evaluation: evaluation).jsonData()
+            ) as? [String: Any]
+        )
+    }
+
+    private var availableFixture: String {
+        """
+        {
+          "account" : {
+            "name" : "All accounts",
+            "scope" : "provider"
+          },
+          "checkedAt" : "2023-11-14T22:13:20Z",
+          "displayName" : "Claude Code",
+          "estimated" : false,
+          "exitCode" : 0,
+          "message" : "Claude Code session quota available: 58% left (minimum 25%).",
+          "minRemainingPercent" : 25,
+          "outcome" : "available",
+          "percentLeft" : 58,
+          "percentUsed" : 42.5,
+          "provider" : "claude",
+          "quotaBand" : "healthy",
+          "resetAt" : "2023-11-14T23:13:20Z",
+          "schemaVersion" : 1,
+          "snapshot" : {
+            "ageSeconds" : 60,
+            "isStale" : false,
+            "lastUpdated" : "2023-11-14T22:12:20Z"
+          },
+          "total" : 100,
+          "used" : 42.5,
+          "window" : "session"
+        }
+        """
+    }
+}
+
+private extension Result {
+    var failureValue: Failure? {
+        guard case let .failure(error) = self else { return nil }
+        return error
+    }
+}

--- a/MeterBarTests/QuotaGuardTests.swift
+++ b/MeterBarTests/QuotaGuardTests.swift
@@ -65,11 +65,25 @@ final class QuotaGuardTests: XCTestCase {
         }
     }
 
-    func testOutOfRangeRefreshTimeoutIsAUsageError() {
-        let failure = expectFailure(refreshTimeout: 100_000)
-        XCTAssertEqual(failure.outcome, .usageError)
-        XCTAssertEqual(failure.code, "invalid_refresh_timeout")
-        XCTAssertEqual(failure.flag, "--refresh-timeout")
+    /// `--refresh-timeout` is taken as text so a non-numeric value reaches this
+    /// check at all: typed as `Double` it died inside ArgumentParser's own
+    /// conversion with EX_USAGE and no JSON document, never producing the
+    /// exit 13 that docs/cli-json-schema.md promises for this flag.
+    func testMalformedOrOutOfRangeRefreshTimeoutIsAUsageErrorNamingTheInput() {
+        for raw in ["abc", "100000", "0", "-5", "", "1e"] {
+            let failure = expectFailure(refreshTimeout: raw)
+            XCTAssertEqual(failure.outcome, .usageError, raw)
+            XCTAssertEqual(failure.outcome.exitCode, 13, raw)
+            XCTAssertEqual(failure.code, "invalid_refresh_timeout", raw)
+            XCTAssertEqual(failure.flag, "--refresh-timeout", raw)
+            XCTAssertEqual(failure.value, raw, raw)
+            XCTAssertTrue(failure.message.contains("--refresh-timeout"), failure.message)
+        }
+    }
+
+    func testRefreshTimeoutFallsBackToTheDefaultWhenOmitted() throws {
+        XCTAssertEqual(try target().refreshTimeout, QuotaGuardCLI.defaultRefreshTimeout)
+        XCTAssertEqual(try target(refreshTimeout: " 45 ").refreshTimeout, 45)
     }
 
     func testConfigDirIsRejectedForProvidersWithoutAccounts() {
@@ -436,7 +450,7 @@ final class QuotaGuardTests: XCTestCase {
         window: String = "session",
         minRemaining: String? = nil,
         configDirectory: String? = nil,
-        refreshTimeout: Double = QuotaGuardCLI.defaultRefreshTimeout
+        refreshTimeout: String? = nil
     ) throws -> QuotaGuardTarget {
         try QuotaGuardTarget.resolve(
             provider: provider,
@@ -452,7 +466,7 @@ final class QuotaGuardTests: XCTestCase {
         window: String = "session",
         minRemaining: String? = nil,
         configDirectory: String? = nil,
-        refreshTimeout: Double = QuotaGuardCLI.defaultRefreshTimeout,
+        refreshTimeout: String? = nil,
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> QuotaGuardFailure {

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -1,7 +1,7 @@
 # MeterBar CLI JSON schema
 
-`meterbar usage --json`, `meterbar cost --json`, `meterbar refresh --json`, and
-`meterbar fable-sessions --json` emit stable,
+`meterbar usage --json`, `meterbar cost --json`, `meterbar refresh --json`,
+`meterbar guard --json`, and `meterbar fable-sessions --json` emit stable,
 versioned JSON for menu bars, shell prompts, dashboards, and other third-party integrations.
 Human-readable output remains the default when `--json` is absent.
 
@@ -208,6 +208,104 @@ Version 1 shape:
 Exit codes are stable for scripting: `0` success, `10` already running, `11` timeout,
 `12` partial provider failure, `13` complete/configuration failure, and `130` cancellation.
 Non-success JSON remains on standard output; optional human diagnostics use standard error.
+
+## Guard
+
+```sh
+meterbar guard --provider claude --limit session --min-remaining 25
+meterbar guard --provider codex --limit weekly --json
+meterbar guard --config-dir ~/.claude-work --refresh --json
+```
+
+Guard answers one question — may this caller spend quota right now? — and encodes the answer in
+its exit code. It reads the cached snapshot MeterBar maintains, so a shell hook costs a file read
+rather than a provider round trip; `--refresh` opts into one bounded refresh through the same
+coordinator `meterbar refresh` uses, then evaluates the resulting cache. Guard never waits for a
+quota to reset and never consumes a reset credit — that is `meterbar wake`.
+
+Severity comes from the shared quota band model the menu bar and `meterbar usage` already use, so
+a band threshold change moves guard's behavior with it.
+
+`--limit` accepts `session`, `weekly`, and `code-review`. `--min-remaining` is a percentage of
+quota that must remain; without it, only exhaustion blocks. `--config-dir` narrows the check to one
+configured Claude Code or OpenAI Codex account by its configuration directory.
+
+Version 1 shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "outcome": "belowThreshold",
+  "exitCode": 10,
+  "checkedAt": "2026-07-20T17:00:00Z",
+  "provider": "claude",
+  "displayName": "Claude Code",
+  "window": "session",
+  "account": {
+    "scope": "provider",
+    "name": "All accounts"
+  },
+  "used": 82,
+  "total": 100,
+  "percentUsed": 82,
+  "percentLeft": 18,
+  "quotaBand": "tight",
+  "estimated": false,
+  "resetAt": "2026-07-20T18:00:00Z",
+  "minRemainingPercent": 25,
+  "snapshot": {
+    "lastUpdated": "2026-07-20T16:59:00Z",
+    "ageSeconds": 60,
+    "isStale": false
+  },
+  "message": "Claude Code session quota below threshold: 18% left (minimum 25%). Resets in 1h."
+}
+```
+
+`outcome` is `available`, `belowThreshold`, `exhausted`, `dataUnavailable`, or `usageError`.
+`quotaBand` uses the same tokens as `meterbar usage --json`. `account.scope` is `provider` for the
+provider-wide roll-up or `account` when `--config-dir` selected one account.
+
+Every field beyond `schemaVersion`, `outcome`, `exitCode`, `checkedAt`, and `message` is optional:
+a usage error never reaches a provider, and an unavailable snapshot has no numbers to report.
+Omission means "not known" — guard never emits a zero that could read as available.
+
+Non-success outcomes add an `error` object with a stable `code`, plus `flag` and `value` when a
+caller-supplied input was at fault:
+
+```json
+{
+  "schemaVersion": 1,
+  "outcome": "usageError",
+  "exitCode": 13,
+  "checkedAt": "2026-07-20T17:00:00Z",
+  "message": "Unknown quota window 'hourly' for --limit. Expected one of: session, weekly, code-review.",
+  "error": {
+    "code": "invalid_window",
+    "message": "Unknown quota window 'hourly' for --limit. Expected one of: session, weekly, code-review.",
+    "flag": "--limit",
+    "value": "hourly"
+  }
+}
+```
+
+Stable version 1 guard error codes are `snapshot_missing`, `snapshot_stale`, `window_unavailable`,
+`account_lookup_unavailable`, `invalid_provider`, `invalid_window`, `invalid_threshold`,
+`invalid_refresh_timeout`, `unsupported_config_dir`, and `unknown_account`.
+
+Exit codes are stable for scripting:
+
+| Code | Outcome | Meaning |
+| --- | --- | --- |
+| `0` | `available` | The evaluated window is at or above `--min-remaining` and not exhausted. |
+| `10` | `belowThreshold` | Quota remains, but less than `--min-remaining`. Distinct from exhausted so a caller can throttle before it is blocked. |
+| `11` | `exhausted` | The window is spent. `resetAt` and the message carry the reset time. |
+| `12` | `dataUnavailable` | No usable snapshot, a snapshot older than the freshness bound without `--refresh`, or a window the provider did not report. Never reported as available. |
+| `13` | `usageError` | An invalid `--provider`, `--limit`, `--min-remaining`, `--refresh-timeout`, or `--config-dir`. The message names the offending input. |
+
+The freshness bound is two hours, shared with the provider parse-health model. A snapshot older
+than that is `dataUnavailable` rather than a stale pass. Non-success JSON stays on standard output;
+the human-readable reason uses standard error.
 
 ## Doctor
 


### PR DESCRIPTION
Closes #264

## What changed

Adds `meterbar guard` — a check that answers "may I spend quota right now?" in its exit code, so a shell hook or agent runner can branch on quota without parsing output.

```sh
meterbar guard --provider claude --limit session --min-remaining 25
meterbar guard --provider codex --limit weekly --json
meterbar guard --config-dir ~/.claude-work --refresh --json
```

**Exit-code contract** (documented in `docs/cli-json-schema.md`, asserted by tests):

| Code | Outcome | Meaning |
| --- | --- | --- |
| `0` | `available` | At or above `--min-remaining`, not exhausted |
| `10` | `belowThreshold` | Quota remains but below the threshold — distinct from exhausted so a caller can throttle *before* it is blocked |
| `11` | `exhausted` | Window spent; `resetAt` and the message carry the reset time |
| `12` | `dataUnavailable` | No usable snapshot, a stale one without `--refresh`, an unreported window, or a window without a usable total |
| `13` | `usageError` | Invalid `--provider` / `--limit` / `--min-remaining` / `--refresh-timeout` / `--config-dir`, named in the message |

### Design notes

- **No parallel band logic.** Severity comes from the shared `QuotaBand` / `QuotaMath` model in `MeterBarShared`. Changing a band threshold changes guard's behavior without a second edit, per the issue's acceptance criteria.
- **Never a false pass.** `total <= 0` would read as "100% left" through the shared percent math, so it reports `window_unavailable` (12) instead. Same for a snapshot older than the shared two-hour freshness bound (`ProviderParseHealthRecord.staleAfter`).
- **`--min-remaining` is parsed in the core, not `validate()`.** ArgumentParser's `ValidationError` exits 64, which would break the published contract; parsing in `QuotaGuardTarget.resolve` keeps a malformed threshold on exit 13.
- **Cache-first.** Reads the app-group snapshot by default so a prompt hook costs a file read. `--refresh` opts into one bounded refresh through the same coordinator `meterbar refresh` uses, so it cannot start a second concurrent poll; a failed refresh still falls through to the cached snapshot, which reports its own staleness.
- **Out of scope, as specified:** no waiting/polling (that is `meterbar wake`), no reset-credit consumption, no auth or account-selection changes, no network call beyond the existing bounded refresh.
- Decision logic lives in `MeterBar/Guard/` (the `MeterBar` library) rather than the CLI target, mirroring `SessionWakeCLI` / `UsageRefreshCLI`, because `MeterBarTests` does not depend on `MeterBarCLI`. `MeterBarCLI/Sources/Guard.swift` is a thin flag wrapper.

### JSON

`--json` emits a schema-versioned object with provider, account scope, window, used/total, percentages, quota band, reset time, and snapshot freshness. Every field beyond `schemaVersion`/`outcome`/`exitCode`/`checkedAt`/`message` is optional — omission means "not known", never a zero that could read as available. Non-success adds an `error` object with a stable code plus `flag`/`value` when a caller-supplied input was at fault.

## Files

- `MeterBar/Guard/QuotaGuardOutcome.swift` — outcomes, exit codes, failure envelope
- `MeterBar/Guard/QuotaGuardTarget.swift` — flag validation, window/provider parsing, path normalization
- `MeterBar/Guard/QuotaGuardEvaluator.swift` — the pure decision core + `--config-dir` account resolution
- `MeterBar/Guard/GuardCLIResponse.swift` — version 1 JSON document
- `MeterBar/Guard/QuotaGuardCLI.swift` — async facade (cache read, optional bounded refresh)
- `MeterBarCLI/Sources/Guard.swift` + registration in `MeterBarCLI.swift`
- `MeterBar/Models/CLIJSONOutput.swift` — `ServiceType.cliIdentifiers` / `fromCLIIdentifier(_:)` so `--provider` reuses the documented tokens instead of a second mapping
- `docs/cli-json-schema.md` — Guard section: JSON shape, error codes, exit-code table

## Verification

- TDD: `MeterBarTests/QuotaGuardTests.swift` written first (28 tests), then the implementation.
- `swift test --filter QuotaGuard` — **28 passed, 0 failures**. Covers available, at-threshold, below-threshold, exhausted-outranks-threshold, stale snapshot, missing snapshot, unreported window, zero-total window, provider-wide vs `--config-dir` account selection, every invalid-input path, exit-code distinctness, and the exact JSON for all four outcome families.
- `swiftlint lint --strict` — clean (the mode CI runs).
- Full suite and builds intentionally left to PR CI.

## Not done

Skipped the `.agents/SESSIONS/2026-07-25.md` entry the repo convention asks for, per the explicit instruction in this task not to create new `.md` files beyond the `docs/cli-json-schema.md` update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `meterbar guard` command for checking quota availability and remaining usage.
  * Supports provider, quota window, minimum-remaining thresholds, account targeting, optional refresh, and human-readable or JSON output.
  * Added stable exit codes and structured error details for unavailable, stale, exhausted, or below-threshold quotas.

* **Documentation**
  * Documented the guard command’s options, exit codes, JSON response schema, and refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->