### PR TITLE
refactor(dashboard): split UsageDashboardView into shell + page sections (C1a)

### DIFF
--- a/.agents/SESSIONS/2026-07-25.md
+++ b/.agents/SESSIONS/2026-07-25.md
@@ -1,0 +1,705 @@
+# 2026-07-25
+
+## Session 1: Centralize on-disk permission policy (audit S1, S2, D3, B4)
+
+**Status:** Implementation complete; SwiftLint clean; PR CI + exact-head Opus verification pending
+
+```mermaid
+flowchart LR
+    subgraph before[Before]
+        A1[write to: options .atomic] --> A2[file published at umask 0644]
+        A2 --> A3[chmod 0600]
+        A3 -.->|window| Leak[Any local process can open + hold fd]
+    end
+    subgraph after[After]
+        B1[open O_EXCL on .staging] --> B2[fchmod forces mode]
+        B2 --> B3[write loop EINTR/partial safe]
+        B3 --> B4[close + rename]
+        B4 --> B5[never reachable at a loose mode]
+    end
+    Callers[CostSummaryStore / SharedDataStore / ProviderParseHealthStore<br/>ClaudeFableSessionTracker / UsageRefreshConfigurationStore<br/>ReplayLedger / ClaudeCodeReconnectService] --> SFW[SecureFileWriter]
+    WakePaths --> SFW
+    WakeRunLogger -->|append-only| SFW
+```
+
+### Affected components
+
+- New shared service: `SecureFileWriter` (the app's single owner of file/directory permission policy)
+- Persistence call sites: cost cache, shared App Group store, parse-health store, Fable session tracker, usage-refresh config
+- Session Wake: replay ledger, run logger, path resolver
+- Claude Code reconnect script generation + app launch lifecycle
+
+### Root cause / motivation
+
+Follow-through on the repo audit's fix order, items #1–#2 of the security/DRY set:
+
+- **S1 (MED) — TOCTOU on an executed script.** `ClaudeCodeReconnectService` wrote a `.command` file and then `chmod`ed it to 0700. `Data.write(to:options:.atomic)` stages the payload at the process umask (0644 for a default macOS session) and renames it into place, so the *complete* script is world-readable for the interval before the `chmod` lands — and this file is subsequently handed to Terminal for execution.
+- **S2 (LOW/MED) — inconsistent file permissions.** Six persistence sites wrote app state at the default 0644 with no tightening at all.
+- **D3 — permission policy was per-call-site.** Every writer decided its own mode (or didn't), so there was no single place to audit or change.
+- **B4 (LOW) — reconnect scripts were never deleted.** Generated scripts accumulated in the temp directory for the life of the machine.
+
+### What was done
+
+- Added `MeterBar/Services/SecureFileWriter.swift`, a `nonisolated enum` following the repo's stateless-namespace idiom (`WakePaths`, `AppLog`, `CLIBinaryLocator`):
+  - `write(_:to:permissions:)` (`Data` and `String` overloads) creates a same-directory staging file with `open(O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC)`, forces the final mode with `fchmod` on the *descriptor* before any byte is written, writes through an `EINTR`/partial-write-safe loop, `close`s, then `rename`s. The publish stays atomic; the loose-mode window is gone.
+  - `ensurePrivateDirectory(_:)` creates at 0700 **or tightens an existing directory** — an older build's 0755 directory would otherwise stay 0755 forever.
+  - `ensurePrivateFile(at:)` for append-only logs, where a whole-file replace is the wrong shape. Best-effort by design.
+  - `SecureFileWriterError` carries the errno and path, formatted with `String(cString: strerror(code))` — the repo's existing idiom (`WakeLock.swift`).
+- Rewrote `ClaudeCodeReconnectService.writeReconnectScript(for:)` to route through the writer at `privateExecutable` (0700), with an injectable directory for tests. `shellQuoted` and the script body builder were already correct and were left untouched.
+- Added `purgeReconnectScripts(in:olderThan:now:)` with a 24-hour retention, restricted to `.command` files, run both on every write and once at `applicationDidFinishLaunching`.
+- Adopted the writer at all six S2 sites: `CostSummaryStore`, `SharedDataStore` (both `saveMetrics` and `saveAccountMetrics`), `ProviderParseHealthStore`, `ClaudeFableSessionTracker`, `UsageRefreshConfigurationStore` (its `try?` semantics preserved).
+- Collapsed `ReplayLedger.persist()`'s write-then-chmod pair into a single call, and made `WakePaths.ensurePrivateDirectory` delegate to the writer (D3: one implementation, one policy).
+- Replaced `WakeRunLogger.appendData`'s hardcoded create/`setAttributes` 0600 pair with `ensurePrivateFile(at:)`.
+- Tests written **first**, per the project TDD policy:
+  - `MeterBarTests/SecureFileWriterTests.swift` — 13 tests covering default 0600, explicit 0700, mode-survives-a-restrictive-umask, tightening an existing loose file, no scratch file left on success, scratch unlinked and target preserved on failure, missing parent directory, a 4 MiB payload through the partial-write loop, directory create + tighten, and the two `ensurePrivateFile` cases.
+  - `MeterBarTests/ClaudeCodeReconnectServiceTests.swift` — added 7 tests for owner-only script + directory, tightening a pre-existing 0755 directory, replacing a stale script for the same account, purging expired scripts, keeping recent ones, leaving non-`.command` files alone, and tolerating a missing directory. The 4 existing pure-string tests were kept unchanged.
+
+### Key decisions
+
+- **`fchmod` on the descriptor, not `chmod` on the path.** `open`'s mode argument is masked by the umask, so the requested mode is not guaranteed to land; and a path-based `chmod` reintroduces exactly the swap the type exists to prevent. The discriminating test requests 0640 under `umask(0o077)` — a mode the umask would strip — so asserting 0640 proves the mode is *forced*, not merely requested. Asserting plain 0600 would have passed under the buggy implementation too.
+- **`UsageDashboardView`'s PNG export was deliberately left at umask semantics**, with the reasoning recorded in code. The user picks that destination through a save panel specifically in order to share the card; forcing owner-only there would be wrong. It is now the only direct `.write(to:)` left in production.
+- **A retention sweep rather than delete-after-launch for B4.** Removing the script right after `open -a Terminal` races the shell that is about to read it. 24 hours is long enough for a login flow still in progress, short enough that scripts do not accumulate indefinitely.
+- **0600 on App Group files is safe.** The app and the widget run as the same UID, so tightening the shared container does not break widget reads.
+- **The writer lives in the app target, not `Packages/MeterBarShared`.** The shared package writes no files at all (`git grep "write(to:\|createFile" -- 'Packages/*.swift'` is empty), so hoisting it there would be speculative.
+- **No `.pbxproj` or `Package.swift` edit was needed.** `MeterBar/` and `MeterBarTests/` are `PBXFileSystemSynchronizedRootGroup`s, and the root manifest globs `path: "MeterBar"` with an explicit `exclude:` list that does not cover the new file.
+
+### Verification
+
+- `swiftlint lint --strict --quiet` (the exact CI command) passed with exit 0, no output.
+- `git grep` confirms zero remaining hardcoded `posixPermissions` in production sources, and exactly one remaining direct `.write(to:)` — the deliberate PNG export.
+- All 12 `SecureFileWriter` call sites reviewed individually against the behavior they replaced (`try?` vs `try` preserved per site).
+- Local builds, tests, and typechecks skipped under the MacBook verification policy; PR CI is the execution gate. SourceKit reports `Cannot find 'SecureFileWriter' in scope` at every call site — assessed as stale-index lag, since the file is covered by both the synchronized root group and the SwiftPM glob. **This assessment is unverified locally and CI is what will settle it.**
+
+### Files changed
+
+- `MeterBar/Services/SecureFileWriter.swift` — **new**; the writer, the directory/file helpers, and the error type.
+- `MeterBar/Services/ClaudeCodeReconnectService.swift` — secure write path, injectable directory, retention sweep.
+- `MeterBar/App/MeterBarApp.swift` — launch-time reconnect-script sweep.
+- `MeterBar/Models/CostSummaryStore.swift`, `MeterBar/Services/SharedDataStore.swift`, `MeterBar/Services/ProviderParseHealthStore.swift`, `MeterBar/Services/ClaudeFableSessionTracker.swift`, `MeterBar/UsageRefresh/UsageRefreshConfigurationStore.swift` — S2 adoption.
+- `MeterBar/SessionWake/ReplayLedger.swift`, `MeterBar/SessionWake/WakePaths.swift`, `MeterBar/SessionWake/WakeRunLogger.swift` — D3 consolidation.
+- `MeterBar/Views/UsageDashboardView.swift` — documented exception only.
+- `MeterBarTests/SecureFileWriterTests.swift` — **new**, 13 tests.
+- `MeterBarTests/ClaudeCodeReconnectServiceTests.swift` — 7 added tests.
+- `.agents/SESSIONS/2026-07-25.md`
+
+### Next steps
+
+- [ ] Require green CI on the pushed head.
+- [ ] Require an exact-head Opus PASS before merge.
+- [ ] Audit fix #2 — `ManagedProcess` fd leak on partial pipe-creation failure (B2) and `waitpid` `EINTR` retry in the WNOHANG poll (B3). Note PR #259 adds a new `ManagedProcess` caller; merge order matters.
+- [ ] Audit fix #3 — single-pass cost summary scan (O2) and streaming reads for the two whole-file loads (O3) in `CostTracker`.
+- [ ] Audit fix #4 — extract the duplicated Anthropic usage request in `ClaudeCodeLocalService` preserving **both** timeouts (30 s and 15 s), and extend `.swiftlint.yml` coverage to `Packages`, `MeterBarCLI`, and `MeterBarWidget` (C2).
+
+---
+
+## Session 2: Descriptor hygiene and interrupt-safe waiting in `ManagedProcess` (audit B2, B3)
+
+**Status:** implemented on `fix/managed-process-fd-and-eintr`, awaiting CI + exact-head review.
+
+### System flow
+
+```mermaid
+flowchart LR
+    subgraph before["Before"]
+        A1["pipe(out) == 0, pipe(err) == 0"] -->|"err fails"| A2["return .launchFailed<br/>out[0], out[1] stranded"]
+        A3["waitpid(WNOHANG)"] -->|"-1 (EINTR)"| A4[".launchFailed<br/>live child abandoned"]
+    end
+    subgraph after["After"]
+        B1["pipe(out) == 0"] --> B2["pipe(err) == 0"]
+        B2 -->|"err fails"| B3["close(out[0]); close(out[1])<br/>then .launchFailed"]
+        B4["poll(pid)"] -->|"-1 + EINTR"| B5["retry, deadline still enforced"]
+        B4 -->|"-1 + other errno"| B6[".launchFailed(errno)"]
+    end
+```
+
+### Affected components
+
+- **App:** `MeterBar/SessionWake/ManagedProcess.swift` — the only child-process launcher after PR #259 consolidated `ClaudeCodeCLIUsageService` onto it.
+- **Callers (unchanged):** `SessionWakeAgent`, and — once #259 lands — `ClaudeCodeCLIUsageService`. No public API, no `Result` shape change.
+
+### Root cause
+
+- **B2** — `guard pipe(outPipe) == 0, pipe(errPipe) == 0 else { … }` short-circuits. When the first pipe succeeds and the second fails, the two live descriptors have no owner: nothing is spawned, no drain is running, and the `defer` frees the pointer *memory* rather than the descriptors. Every such call stranded a pair for the life of the process — self-accelerating, since descriptor pressure is exactly what makes the second `pipe()` fail.
+- **B3** — the WNOHANG poll treated every `-1` as terminal. `EINTR` says only that a signal reached this thread; the child is still running and still ours to reap, so `.launchFailed` abandoned a live process group. The same file already handled `EINTR` correctly in `escalateTimeout`, so the file contradicted itself.
+
+### What was done
+
+- [x] Split the pipe guard; close `outPipe[0]`/`outPipe[1]` on the stderr-pipe failure path, mirroring the already-correct `posix_spawn`-failure path directly below it.
+- [x] Retry the poll on `EINTR`, keeping every other errno fatal, and fall through to the existing deadline check so an unending interrupt stream still times out instead of spinning.
+- [x] Carry the errno into the failure message (`waitpid failed (10)`) — previously unrecoverable waits were indistinguishable.
+- [x] Added a `WaitPoll` seam plus an injectable `escalate`, both defaulted, so the retry contract is asserted directly.
+- [x] 6 tests: descriptor-leak probe under an exhausted table, EINTR retry, fatal-errno, unending-EINTR timeout, signalled classification, cancellation precedence.
+
+### Key decisions
+
+- **Seam over signal racing.** The obvious B3 test — spam signals at the waiting thread — is not discriminating: `waitpid(WNOHANG)` returns almost instantly while the loop spends ~20 ms per iteration in `usleep`, so nearly every signal lands in the sleep. Injecting the poll asserts the actual contract deterministically.
+- **`wait` and `escalateTimeout` widened from `private` to internal.** Required because a default argument must be at least as visible as the function declaring it. Documented in-file so it does not read as accidental.
+- **Descriptor-leak test frees the table before asserting.** A failing assertion needs descriptors to report itself; the probe result is captured first, the hogged descriptors are released, and only then are assertions made. It `XCTSkip`s rather than fails where the table cannot be exhausted safely.
+- **Kept `"pipe() failed"` verbatim.** Not worth churning a string the audit did not flag.
+
+### Verification
+
+- `swiftlint lint --strict --quiet` — clean (the exact CI invocation).
+- No local build or test run: the MacBook constraint stands, PR CI is the gate.
+- **Disclosure:** SourceKit reports `'wait' is inaccessible due to 'private'` against the test file. The on-disk declaration is internal (verified by grep); this is the same stale-index lag seen in Session 1 and is **unverified** until CI compiles it.
+
+### Files changed
+
+- `MeterBar/SessionWake/ManagedProcess.swift` — pipe cleanup, EINTR retry, poll/escalate seam, visibility widening.
+- `MeterBarTests/ManagedProcessTests.swift` — 6 added tests.
+- `.agents/SESSIONS/2026-07-25.md`
+
+### Next steps
+
+- [ ] Require green CI on the pushed head.
+- [ ] Require an exact-head Opus PASS before merge.
+- [ ] Merge order: PR #259 adds a new `ManagedProcess` caller without touching the file, so #259 and this branch are independent — but both should land before further `ManagedProcess` work.
+- [ ] `.agents/SESSIONS/2026-07-25.md` exists on `fix/secure-file-writes` (PR #260) too; whichever merges second resolves add/add by taking the superset.
+- [ ] Audit fix #3 — single-pass cost summary scan (O2) and streaming reads (O3) in `CostTracker`.
+- [ ] Audit fix #4 — dedupe the Anthropic usage request preserving both timeouts (D2) and widen `.swiftlint.yml` coverage (C2).
+
+---
+
+## Session 3: Single-pass, streaming cost summary scan (audit O2, O3)
+
+**Status:** Implementation complete; SwiftLint clean; PR CI + exact-head Opus verification pending
+
+```mermaid
+flowchart LR
+    subgraph before[Before]
+        A1[buildCostSummary] --> A2[scanCostSources since: cutoff]
+        A1 --> A3[scanCostSources since: .distantPast]
+        A2 --> A4[walk every .jsonl<br/>Data contentsOf + String decode]
+        A3 --> A5[walk every .jsonl again<br/>strict superset of the first walk]
+    end
+    subgraph after[After]
+        B1[buildCostSummary] --> B2[scanCostSources once]
+        B2 --> B3[walk every .jsonl<br/>FileLineReader streams 256 KiB]
+        B3 --> B4{ScanWindows.update at: timestamp}
+        B4 --> B5[lifetime totals - always]
+        B4 -->|timestamp >= cutoff| B6[period totals]
+    end
+```
+
+### Affected components
+
+- New shared utility: `FileLineReader` (bounded streaming line reader)
+- New value types: `ScanWindows`, `ClaudeSessionTotals`, `CostScanResult` (`CostScanWindows.swift`), plus `CodexScanContext` / `TokenAccumulator` relocated there
+- `CostTracker`: Claude Code transcript scan, Codex archived-session scan, Codex SQLite log scan, summary assembly
+
+### Root cause / motivation
+
+Audit fix order items #3, covering two optimization findings in the same code path:
+
+- **O2 (HIGH) — the cost scan ran twice.** `buildCostSummary` called `scanCostSources` once for the reporting window and once with `.distantPast` for the lifetime figure. The lifetime pass reads a strict superset of what the period pass had just read, so every transcript in `~/.claude/projects` and `~/.codex/archived_sessions` was walked and parsed twice for numbers that a single traversal can produce.
+- **O3 (MED) — whole-file loads.** Each transcript was read with `Data(contentsOf:)` and then decoded with `String(data:encoding:)` before splitting on newlines, putting two full copies of the largest file in memory at once.
+
+### What was done
+
+- [x] Tests first: 10 for `FileLineReader` (chunk-boundary reassembly, CRLF, blank lines, `chunkSize: 1`, arbitrary chunk sizes agreeing with the default, empty file, missing file) and 6 pinning the window split in `CostTrackerTests`.
+- [x] `FileLineReader.forEachLine(in:chunkSize:_:)` — 256 KiB buffer, newline scan, rebased `Data` per line.
+- [x] `ScanWindows<Totals>` with `update(at:_:)` applying a body to `lifetime` always and to `period` only inside the window.
+- [x] Claude path: `parseSessionWindows(at:since:)` streams once and fills both windows; `parseSessionFile(at:since:)` kept as a period-only wrapper; tallying extracted to `tally(keyed:unkeyed:)`.
+- [x] Codex path: `scanCodexSessions`, `scanCodexArchivedSessions`, `scanCodexSQLiteLogs`, and `addCodexUsage` all thread `inout ScanWindows<CodexScanContext>`; a `(directory:since:context:)` overload is retained for single-window callers.
+- [x] Removed the now-dead `mergeDailyTotals` / `mergeNamedTotals` helpers.
+
+### Key decisions
+
+- **Deduplication stays per window.** Two events can share a `messageID:requestID` key while straddling the cutoff. One shared dedup map would let the pre-cutoff copy overwrite the in-window one and silently change the period total — i.e. the money figure. Each window keeps its own map, which is exactly what two separate scans did. Pinned by `testParseSessionWindowsDeduplicatesWithinEachWindow`.
+- **The per-file mtime prefilter was dropped, not ported.** It was already redundant: an event's timestamp is never newer than the file holding it, so the per-event timestamp check subsumes it — and the lifetime pass used `.distantPast`, so its mtime filter admitted everything anyway.
+- **The cutoff travels inside `ScanWindows`.** Passing it as a separate argument would push `addCodexUsage` to seven parameters, and SwiftLint's `function_parameter_count` warns at six with CI linting `--strict`.
+- **`forEachLine`'s body is a real function parameter, not a stored closure.** The Codex scan captures an `inout` accumulator inside it; capturing `inout` is only legal in a non-escaping closure. This is also why the planned `readLines:` injection seam was dropped — a closure nested in a function *type* is escaping by default.
+- **`ScanWindows` is conditionally `Sendable`.** An unconditional conformance would force `TokenCost` and `DailyTokenUsage` to be `Sendable` just to name `ScanWindows<CostScanResult>`.
+- **`"token_count"` prefilter kept as bytes.** Moving from `String` lines to `Data` lines would have lost the cheap pre-`JSONSerialization` filter that makes the Codex scan affordable; a static `Data` marker plus `contains` preserves it.
+
+### Verification
+
+- `swiftlint lint --strict --quiet` — clean (the exact CI invocation).
+- No local build or test run: the MacBook constraint stands, PR CI is the gate.
+- **Disclosure:** SourceKit reports `Cannot find type 'ScanWindows' in scope` and siblings against `CostTracker.swift`. Every named symbol is defined in the new `CostScanWindows.swift`; this is the same stale-index lag seen in Sessions 1 and 2 and is **unverified** until CI compiles it.
+- **Disclosure:** single-traversal is now structural — one `scanCostSources` call — rather than asserted by a test, because the injection seam was incompatible with the `inout` capture above.
+
+### Side effect worth noting
+
+Decoding moved from whole-file to per-line, so a single malformed byte no longer fails the entire UTF-8 decode and silently zeroes a whole session's usage. Only the affected line is skipped.
+
+### Files changed
+
+- `MeterBar/Services/FileLineReader.swift` — new.
+- `MeterBar/Services/CostScanWindows.swift` — new; window types plus the relocated `CodexScanContext` / `TokenAccumulator`.
+- `MeterBar/Services/CostTracker.swift` — single-pass dual-window scan across both providers; dead merge helpers removed.
+- `MeterBarTests/FileLineReaderTests.swift` — new, 10 tests.
+- `MeterBarTests/CostTrackerTests.swift` — 6 added tests.
+- `.agents/SESSIONS/2026-07-25.md`
+
+### Next steps
+
+- [ ] Require green CI on the pushed head.
+- [ ] Require an exact-head Opus PASS before merge.
+- [ ] `.agents/SESSIONS/2026-07-25.md` is added by PRs #260, #261, and this one; whichever merges later resolves add/add by taking the superset.
+- [ ] Audit fix #4 — dedupe the Anthropic usage request preserving both timeouts, 30 s and 15 s (D2), and widen `.swiftlint.yml` coverage to `MeterBarCLI` / `MeterBarWidget` / `Packages` (C2).
+
+---
+
+## Session 4: Shared Anthropic usage request + repo-wide lint coverage (audit D2, C2)
+
+**Status:** implemented, lint-clean, pushed. Not merged.
+
+```mermaid
+flowchart TD
+    subgraph before["Before"]
+        A1[fetchOAuthMetrics] -->|builds URLRequest inline<br/>4 headers, 30s| E1[api.anthropic.com/api/oauth/usage]
+        A2[fetchExtraUsageStatus] -->|builds URLRequest inline<br/>same 4 headers, 15s| E1
+    end
+
+    subgraph after["After"]
+        B1[fetchOAuthMetrics] -->|timeout: usageRequestTimeout| R[ClaudeCodeLocalService.usageRequest<br/>token, endpoint, timeout]
+        B2[fetchExtraUsageStatus] -->|timeout: extraUsageRequestTimeout| R
+        R -->|nil| N1[throw ServiceError.invalidURL]
+        R -->|nil| N2[return .unknown]
+        R --> E2[api.anthropic.com/api/oauth/usage]
+    end
+
+    subgraph lint["Lint scope"]
+        L0[included: MeterBar] --> L1[+ MeterBarWidget<br/>+ MeterBarCLI<br/>+ Packages<br/>+ scripts]
+        L1 --> L2["excluded: **/.build<br/>(was: .build)"]
+        L2 --> L3[no_print_statements scoped<br/>away from CLI + scripts]
+    end
+```
+
+### Affected components
+
+- **Service layer** — `ClaudeCodeLocalService` (Anthropic OAuth usage endpoint).
+- **Tooling/config** — `.swiftlint.yml`, and the four Swift targets it had never been looking at.
+- **Fixes surfaced by the widened lint** — `MeterBarCLI/Sources/Wake.swift`, `Packages/MeterBarShared` (`UsageLimit`, `ProviderReadiness`), `scripts/render-readme-screenshots.swift`.
+
+### Root cause / motivation
+
+**D2.** Two methods on the same type built the same `GET` against the same URL with the same four headers (`Authorization`, `Accept`, `Content-Type`, `anthropic-beta`). They differed in exactly one field — `timeoutInterval`, 30 s vs 15 s. Any header change had to be made twice by hand, and nothing enforced it.
+
+**C2.** `.swiftlint.yml` had `included: [MeterBar]`. The widget extension, the CLI, the shared package, and the helper scripts were all outside it — four of the five first-party targets shipped unlinted. CI runs `swiftlint lint --strict --quiet`, so the gate was real but pointed at one directory.
+
+### What was done
+
+- [x] Extracted `ClaudeCodeLocalService.usageRequest(token:endpoint:timeout:) -> URLRequest?` and rewired both callers.
+- [x] Named the two timeouts as constants — `usageRequestTimeout` (30 s) and `extraUsageRequestTimeout` (15 s) — instead of leaving them as bare literals at the call sites.
+- [x] 3 tests written first: header set, endpoint rejection, and a test that pins the two timeouts as *different* values.
+- [x] Widened `included:` to `MeterBarWidget`, `MeterBarCLI`, `Packages`, `scripts`.
+- [x] Fixed `excluded:` — `.build` → `**/.build`.
+- [x] Scoped `no_print_statements` away from `MeterBarCLI` and `scripts`.
+- [x] Fixed all 11 real violations the widening surfaced.
+
+### Key decisions
+
+**The 30 s / 15 s split was preserved, not unified.** The metrics fetch is the user-visible reading and is worth waiting on; the extra-usage probe is best-effort, resolves to `.unknown` on any failure, and must not stall a refresh behind a hung connection. Collapsing them would have been a behaviour change wearing a dedupe's clothes. `timeout` is therefore a **required** parameter with no default, so no future caller can silently inherit the wrong one, and `testUsageRequestKeepsCallerTimeoutsDistinct` fails if anyone unifies them.
+
+**`nil` is returned, not thrown.** The two callers already had different failure modes (`throw ServiceError.invalidURL` vs `return .unknown`). The builder stays neutral and each caller maps `nil` onto its own.
+
+**`excluded: .build` was the whole reason the numbers looked absurd.** Widening `included:` produced **1,960** violations, **1,704** of them attributed to `MeterBarCLI` — impossible for a target with 767 tracked lines. `.build` matches only the repo-root path; `MeterBarCLI/.build/checkouts/swift-argument-parser/**` and `Packages/MeterBarShared/.build` were being linted as if they were ours. The glob `**/.build` took 1,960 → **332**.
+
+**`no_print_statements` was scoped, not disabled.** 75 of the remaining violations were in `MeterBarCLI`, where the rule's own message ("Use os_log or Logger instead of print") is inverted: stdout *is* the product — box-drawing headers, progress bars, JSON output. A `custom_rules` entry accepts `excluded:` as path regexes, so the rule still fires in `MeterBar` and `MeterBarWidget` and is silent in `MeterBarCLI`/`scripts`. Verified on SwiftLint 0.65.0.
+
+**`MeterBarTests` was deliberately left out of `included:`.** It accounts for **246** of the 332 violations — 57 `multiline_arguments`, 36 `line_length`, 33 `force_unwrapping`, 75 prints, and so on. Almost all mechanical, but landing them here would bury four production-code fixes under ~30 files of test churn, and the audit's C2 finding named only the shipping targets. Recorded as a follow-up in a config comment carrying the measured count.
+
+**`MeterBarWidget` was already clean** — zero violations under the widened config. Worth stating, because "we widened the net and caught nothing here" is a real result.
+
+### Verification
+
+- `swiftlint lint --strict --quiet` → **exit 0**, no output, across all five newly-linted paths.
+- Nothing was built, typechecked, or tested locally (machine policy). **CI is the gate.**
+
+### Mistakes and fixes
+
+- Wrapping the over-long `--config-dir` help text as `"a" + "b"` broke the build: `ArgumentHelp` is `ExpressibleByStringLiteral`, so a bare *literal* implicitly converts but a concatenated *expression* does not. It cascaded into `Type 'Wake' does not conform to protocol 'Decodable'` because ArgumentParser synthesizes `Decodable` from the properties. Fixed by wrapping explicitly in `ArgumentHelp(...)`.
+- The two Main-actor isolation warnings in `Wake.swift` are pre-existing; this change only shifted their line numbers.
+
+### Files changed
+
+- `MeterBar/Services/ClaudeCodeLocalService.swift` — shared `usageRequest` builder, two named timeout constants, both callers rewired.
+- `MeterBarTests/ClaudeCodeOAuthUsageTests.swift` — 3 added tests.
+- `.swiftlint.yml` — `included:` widened, `**/.build` exclude, `no_print_statements` scoped.
+- `MeterBarCLI/Sources/Wake.swift` — `line_length`.
+- `Packages/MeterBarShared/Sources/MeterBarShared/UsageLimit.swift` — 4 × `implicit_return`.
+- `Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift` — `orphaned_doc_comment`, `line_length`.
+- `scripts/render-readme-screenshots.swift` — `convenience_type`, 2 × `implicit_return`, `line_length`.
+- `.agents/SESSIONS/2026-07-25.md`
+
+### Next steps
+
+- [ ] Require green CI on the pushed head.
+- [ ] Require an exact-head Opus PASS before merge.
+- [ ] `.agents/SESSIONS/2026-07-25.md` is now added by four PRs (#260, #261, #262, and this one); whichever merges later resolves add/add by taking the superset.
+- [ ] Follow-up: add `MeterBarTests` to `included:` — 246 mechanical violations, measured, deliberately deferred.
+- [ ] Not scheduled from the audit: S3 (`kSecAttrAccessible` on Keychain items), S4 (latent AppleScript injection surface), O4 (notification poll decoupled from refresh), D4 (browser-spoof headers duplicated between `CursorLocalService` and `CodexCliLocalService`), C1 (four files over 950 lines).
+
+---
+
+## Session 5: Keychain accessibility class + osascript argv hardening (S3, S4)
+
+Two of the five audit leftovers, taken directly rather than deferred again.
+
+### System flow
+
+```
+save(key:value:)                       postCompletionNotification(summary:provider:)
+  └─ save(data:key:service:)             ├─ completionNotificationBody(summary:provider:)  ← pure, tested
+       ├─ update(query, attributes)      └─ notificationArguments(body:title:)             ← pure, tested
+       │    └─ +kSecAttrAccessible            └─ ["-e", <constant script>, body, title]
+       └─ add(query)                                             │
+            └─ +kSecAttrAccessible                               └─ osascript reads them as `argv`,
+                                                                    never as script source
+  baseQuery() — identity only, NO kSecAttrAccessible
+       └─ reused by copyMatching / delete, where the attribute
+          would act as a match predicate
+```
+
+### Affected components
+
+- **Data / credentials:** `KeychainManager` write path
+- **Background agent:** `SessionWakeAgent` completion banner
+- **Tests:** `KeychainManagerTests`, `SessionWakeAgentTests`
+
+### What was done
+
+- [x] **S3** — every item this manager writes now carries
+      `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`.
+- [x] Attribute applied on **both** write paths (add *and* update), so an item
+      written by an older build hardens on its next save.
+- [x] Attribute deliberately kept **out of** `baseQuery()`.
+- [x] **S4** — `osascript` now receives the banner text as trailing `argv`
+      against a constant `on run argv … end run` handler.
+- [x] `appleScriptEscaped` deleted — the argv form makes escaping unnecessary
+      and therefore makes the helper dead code.
+- [x] Extracted `completionNotificationBody` and `notificationArguments` so both
+      halves are testable without launching a process.
+- [x] 8 tests written before the implementation (4 Keychain, 4 wake agent).
+- [x] `swiftlint --strict` clean on both changed production files.
+
+### Key decisions
+
+| Decision | Rationale |
+|---|---|
+| `AfterFirstUnlock`, not `WhenUnlocked` | Quota refresh runs in the background; `WhenUnlocked` would fail to read the admin key with the screen locked. |
+| `ThisDeviceOnly` | Org-wide admin API keys must never be iCloud-Keychain-synced or restored onto another device from backup. |
+| Attribute on write path only | On `SecItemCopyMatching`/`SecItemDelete` it is a **match predicate** — adding it to `baseQuery()` would silently stop resolving every item written before this change. A dedicated test pins that copy/delete queries omit it. |
+| No read-path migration pass | Reading the current class needs `kSecReturnAttributes`, which changes `KeychainBackend`'s result shape from `Data` to a dictionary and breaks the in-memory fake. Disproportionate for a LOW finding; items harden on next save instead. |
+| argv over better escaping | Escaping is a property you have to keep getting right at every call site. Passing argv removes the interpolation entirely — the script text is a compile-time constant. |
+| Kept the body/title split public-to-tests | Lets the hostile-input test assert the script source is byte-identical for benign and malicious bodies. |
+
+### Files changed
+
+- `MeterBar/Services/KeychainManager.swift`
+- `MeterBar/SessionWake/SessionWakeAgent.swift`
+- `MeterBarTests/KeychainManagerTests.swift`
+- `MeterBarTests/SessionWakeAgentTests.swift`
+
+### Known gaps
+
+- Pre-existing items in the **current** service keep their old accessibility
+  class until the user next saves that key. Accepted, stated, and cheap to
+  revisit if the finding is ever re-rated above LOW.
+- S4 was **latent**, not exploitable: the body is built from integers plus a
+  fixed provider display name, and was already escaped. This removes the class
+  of bug, not a live bug.
+
+### Next steps
+
+- [ ] Green CI on the pushed head.
+- [ ] Exact-head Opus PASS before merge.
+- [ ] `.agents/SESSIONS/2026-07-25.md` is now added by **five** PRs (#260–#263 and
+      this one); whichever merges later resolves add/add by taking the superset.
+- [ ] Still unscheduled: **O4** (poll/refresh decoupling — audit's cited path
+      `MeterBar/MeterBarApp.swift:517` does not resolve, needs re-locating),
+      **D4** (largely stale — both services already share
+      `ServiceSupport.browserUserAgent`; only `CodexCliLocalService`'s internal
+      `Referer`/`Origin`/`Accept` duplication remains), **C1** (1097 / 958 / 954
+      line files — a multi-session refactor, needs an explicit call).
+
+---
+
+## Session 7: O4 — notification checks fire on committed refreshes, not a 5-minute poll
+
+### System flow
+
+```
+BEFORE
+  monitorUsage()
+    refreshAll()
+    loop forever:
+      checkAndNotify()        <-- unconditional, every 5 min
+      sleep 5 min             <-- up to 5 min lag after a real limit crossing
+
+AFTER
+  UsageDataManager
+    any mutation of `metrics` ──> publishMetrics()
+                                    saveCachedData()
+                                    saveCachedAccountMetrics()
+                                    saveSharedData(metrics)
+                                    refreshGeneration &+= 1   (@Published)
+
+  AppDelegate.observeNotificationTriggers()   (installed before the launch refresh)
+    $refreshGeneration                 ─┐
+    Claude account add/dir/enable      ─┤
+    Codex account add/enable           ─┼─> Task { @MainActor in checkAndNotify() }
+    $hiddenServices                    ─┤
+    isEnabled / warning / critical     ─┘
+
+  monitorTask = just the launch refreshAll()
+```
+
+### Affected components
+
+- **Data layer** — `UsageDataManager` gains a monotonic `refreshGeneration`
+  counter and a single `publishMetrics()` funnel.
+- **App layer** — `AppDelegate` swaps a polling loop for Combine subscriptions.
+
+### What was done
+
+- [x] TDD: five tests written **before** the implementation covering
+      once-per-commit, no-bump-on-skipped-overlap, bump-on-disabled-clear,
+      bump-on-codex-reset-credit, and per-commit delivery to a subscriber.
+- [x] `@Published private(set) var refreshGeneration: UInt64` on
+      `UsageDataManager` (`&+=` so it wraps rather than traps).
+- [x] Collapsed **7** identical
+      `saveCachedData()/saveCachedAccountMetrics()/saveSharedData(...)` triples
+      into `publishMetrics()` — a DRY win the audit had not separately filed.
+- [x] Closed a latent hole: the `refresh(service:)` catch branch restored
+      `metrics[service]` from disk **without** saving or publishing. It now
+      publishes, so *every* mutation of `metrics` is observable.
+- [x] `observeNotificationTriggers()` on the existing `cancellables`, installed
+      **before** the launch refresh so the first committed snapshot is observed
+      rather than raced past.
+- [x] Deleted the `while !Task.isCancelled { checkAndNotify(); sleep(5 min) }`
+      loop; `monitorTask` is now just the launch refresh.
+
+### Key decisions
+
+| Decision | Rationale |
+|---|---|
+| Delete the poll outright rather than lengthen it | `NotificationDecider` reads `now` in exactly one place — the staleness gate `now - lastUpdated <= threshold`. Elapsed time can only flip a provider deliverable → stale, never the reverse. So a pure time tick can never *newly* fire a notification, and the loop was strictly redundant work. |
+| A generation counter, not `objectWillChange` | `objectWillChange` fires on *every* `@Published` write including `isLoading`, so it would trigger a check twice per refresh with nothing committed. Repo-wide, `objectWillChange` appears once and only in a test — it isn't the production subscription idiom here. |
+| Subscribe to the full input set of `checkAndNotify()`, not just `$refreshGeneration` | Lowering the warning threshold 90% → 70% while sitting at 75% is notification-worthy with **no** metrics change; under `.manual` refresh it would otherwise never fire. Same for enabling an account or unhiding a provider. `notifiedLimitKeys` makes redundant invocations free. |
+| Publish on the cache-restore path too | Re-saving restored content is idempotent, and it makes "notification checks are driven by `refreshGeneration`" airtight instead of nearly-true. |
+| Sink bodies wrapped in `Task { @MainActor in ... }` | `@Published` fires in `willSet`, so reading other properties synchronously in a sink sees pre-change values. This is the pattern `observeUsageMetrics()` already uses. |
+| Named locals for each `Publishers.Merge*` | `Publishers.Merge3(...).eraseToAnyPublisher()` trips SwiftLint's `multiline_function_chains`. |
+
+### Files changed
+
+- `MeterBar/Services/UsageDataManager.swift`
+- `MeterBar/App/MeterBarApp.swift`
+- `MeterBarTests/UsageDataManagerTests.swift`
+
+### Mistakes and fixes
+
+- Recorded the triple-save sites as 8; `git grep` says **7**. Counted, not
+  recalled, before editing.
+- First draft inlined `.eraseToAnyPublisher()` onto multiline `Merge3` calls →
+  three `multiline_function_chains` errors. Hoisted to named locals.
+
+### Verification
+
+- `swiftlint lint --strict --quiet` on all three changed files → **exit 0**.
+- Tests/typecheck/build **not** run locally (MacBook policy). PR CI is the gate.
+
+### Next steps
+
+- [ ] Green CI on the pushed head.
+- [ ] Exact-head Opus PASS before merge.
+- [ ] `.agents/SESSIONS/2026-07-25.md` is now added by **six** PRs (#260–#263,
+      #273 and this one); whichever merges later resolves add/add by taking the
+      superset.
+- [ ] Remaining audit leftovers: **D4** (header centralization) and **C1** (four
+      950+ line files, one PR each).
+
+---
+
+## Session 8: D4 — centralize browser-spoof headers
+
+Audit item **D4**. Cursor and Codex both call provider dashboard APIs that
+reject plain API clients, so each request has to look like it came from the
+provider's own web page. That header block was hand-written at **three** sites.
+
+### Flow
+
+```
+before                                  after
+------                                  -----
+CursorLocalService.buildHeaders    ┐
+CodexCli.fetchUsageMetrics (inline) ├─▶  ServiceSupport.BrowserSite
+CodexCli.makeCodexRequest          ┘         .cursorDashboard / .chatGPT
+   each: Accept + Origin +                     │
+         Referer + User-Agent                  ├─▶ browserHeaders(for:accept:)
+         + timeoutInterval 30.0                └─▶ applyBrowserHeaders(to:for:accept:)
+                                                     (+ usageRequestTimeout)
+```
+
+### Affected components
+
+- **Services** — `ServiceSupport`, `CursorLocalService`, `CodexCliLocalService`
+- **Tests** — new `MeterBarTests/BrowserRequestHeadersTests.swift`
+- No UI, data-model, or external-contract change. Bytes on the wire are identical.
+
+### What was done
+
+- [x] Swept the whole repo for header sites before touching anything —
+      `forHTTPHeaderField` / `allHTTPHeaderFields` / `timeoutInterval`. Exactly
+      **three** are browser-spoof; the rest are auth/content headers.
+- [x] Added `ServiceSupport.BrowserSite` (`.cursorDashboard`, `.chatGPT`),
+      `browserHeaders(for:accept:)`, `applyBrowserHeaders(to:for:accept:)`,
+      and `usageRequestTimeout`.
+- [x] `CursorLocalService.buildHeaders` → static `dashboardHeaders(userId:token:)`
+      layering `Cookie` + `Content-Type` on the shared set.
+- [x] `makeCodexRequest` gained `accept:` and now delegates to the helper.
+- [x] `fetchUsageMetrics` stopped hand-rebuilding a request `makeCodexRequest`
+      already produces — **~15 duplicated lines removed**, the real find of
+      this pass and not something the original audit had filed.
+- [x] Tests written **first**: shared-builder unit tests plus two
+      `StubURLProtocol` tests asserting what actually reaches the wire.
+
+### Key decisions
+
+| Decision | Rationale |
+|---|---|
+| `Origin`/`Referer` paired in one `BrowserSite` value | The provider validates them together; two loose strings at a call site can drift apart. |
+| `accept` is a parameter, not per-site | It is the *only* field that legitimately differs: usage wants `*/*`, everything else JSON. |
+| `applyBrowserHeaders` iterates `browserHeaders` | One implementation, so the dict form and the request form can never disagree. |
+| `setValue`, never `addValue` | `addValue` comma-joins on re-apply and would break the `Origin` check. Pinned by a test. |
+| Left `ApiUsageService`, `ClaudeCodeLocalService`, `OpenRouterService`, `ProviderStatusMonitor` alone | Those are auth/content headers, not spoofing. `ClaudeCodeLocalService`'s 15s timeout is deliberately different. |
+| `dashboardHeaders` / `formatAuthCookie` made `static` | Lets the header contract be asserted without a live service — same shape as the existing `mapSummary` seam. |
+
+### Files changed
+
+- `MeterBar/Services/ServiceSupport.swift`
+- `MeterBar/Services/CursorLocalService.swift`
+- `MeterBar/Services/CodexCliLocalService.swift`
+- `MeterBarTests/BrowserRequestHeadersTests.swift` (new)
+
+### Mistakes and fixes
+
+- First draft of the tests used `nonisolated(unsafe)` on the stub's `handler`
+  and on local capture vars. The existing `CodexResetCreditsTests` needs
+  neither — matched the established harness instead of inventing a variant.
+- Initial usage-endpoint fixture omitted `rate_limit_reset_credits` and would
+  have failed to decode. Reused the payload the existing suite already proves.
+- Wrote a test against `consumeResetCredit` expecting the POST to fire; with an
+  empty credit list it never does. Retargeted at the GET that actually goes out
+  and renamed the test to say so.
+
+### Verification
+
+- `swiftlint lint --strict --quiet` on all three changed source files → **exit 0**.
+- `MeterBarTests/` is outside the config's `included:` path, so CI does not lint it.
+- Tests/typecheck/build **not** run locally (MacBook policy). PR CI is the gate.
+
+### Next steps
+
+- [ ] Green CI on the pushed head.
+- [ ] Exact-head Opus PASS before merge.
+- [ ] `.agents/SESSIONS/2026-07-25.md` is now added by **seven** PRs; whichever
+      merges later resolves add/add by taking the superset.
+- [ ] Last audit leftover: **C1** — four files over 950 lines
+      (`UsageDashboardView` 1097, `MeterBarApp` 974, `MenuBarView` 958,
+      `CostTracker` 954), one PR each.
+
+---
+
+## Session 9: C1a — split `UsageDashboardView.swift` into shell + per-page sections
+
+### System flow
+
+```
+BEFORE                                    AFTER
+UsageDashboardView.swift (1097)           DashboardNavigation.swift (233)
+├─ UsageDashboardWindowController         ├─ UsageDashboardWindowController
+├─ DashboardSection / SettingsSection     ├─ DashboardSection (+ RefreshTarget)
+├─ EnabledQuotaSourceCounter              ├─ SettingsSection (+ available(_:))
+├─ DashboardNavigationStore               ├─ EnabledQuotaSourceCounter
+├─ shell (split view / toolbar / sidebar) └─ DashboardNavigationStore
+├─ overviewContent    + OverviewSummary   DashboardOverviewSection.swift (136)
+├─ costsContent       + costTrendCard     DashboardCostsSection.swift (141)
+├─ statusPagesContent + openStatusPage    DashboardStatusSection.swift (75)
+├─ diagnosticsContent + 4 helpers         DashboardDiagnosticsSection.swift (126)
+└─ shareContent       + 4 helpers         DashboardShareSection.swift (194)
+                                          UsageDashboardView.swift (369) ← shell only
+```
+
+### Affected components
+
+- Frontend only. No data, service, or persistence change.
+
+### What was done
+
+- [x] Moved the four navigation types out of the view file verbatim.
+- [x] Extracted the five content pages into child `View` structs that take
+      explicit inputs, matching the existing `ProviderStatusCard` /
+      `ProviderStatusTable` / `DashboardCostCards` precedent.
+- [x] Replaced three hand-maintained section→refresh switches with one
+      `DashboardSection.refreshTarget` (+ `refreshesApiUsage`) mapping.
+- [x] Lifted `SettingsSection`'s feature gate into `available(sessionWakeEnabled:)`.
+- [x] 18 new tests in `MeterBarTests/DashboardSectionSplitTests.swift`.
+
+### Key decisions
+
+- **Child views, not cross-file extensions.** `private` is file-scoped in Swift,
+  so extension-splitting would have forced all 15 `@StateObject` stores to
+  internal. Extracting views with explicit inputs keeps them private and matches
+  how the popover already shares cards with the dashboard.
+- **Explicit `init`s on the sections that mix inputs with private state.** A
+  synthesized memberwise init is private when any stored property is private, so
+  `DashboardCostsSection` and `DashboardShareSection` would not have been
+  constructible from the test target without one.
+- **Behavior change (documented in-file): the readiness sweep no longer runs
+  twice.** The shell kicked `runDiagnostics()` from `onChange(of:selectedSection)`
+  *and* the page carried its own `.task(id:)`, so opening Diagnostics started two
+  concurrent passes of keychain / file / SQLite I/O — the `.task` path bypassed
+  the in-flight guard. The page now owns the single entry point.
+- **No in-flight guard on the new entry point.** `.task(id:)` cancels the old run
+  and starts the new one before the old one's `defer` unwinds, so a guard would
+  make the new run bail. Overlap is prevented by the Re-run button's
+  `.disabled(isRunningDiagnostics)` instead.
+- **Refresh semantics preserved exactly.** `.costs` still refreshes API usage,
+  `.share`/`.optimize` still only rescan costs, everything else still refreshes
+  usage — now expressed once instead of in three parallel switches.
+- Static helpers (`refreshStatusText`, `summary`, `enabledSourceLabels`) exist so
+  the string logic is assertable without hosting a page against live singletons.
+- The audit's negative result stands: the view layer has no meaningful
+  duplication. The only DRY win taken here is `stampedContent()`, collapsing the
+  three-line re-stamp preamble repeated across the share exports.
+
+### Files changed
+
+- `MeterBar/Views/UsageDashboardView.swift` (1097 → 369)
+- `MeterBar/Views/DashboardNavigation.swift` (new)
+- `MeterBar/Views/DashboardOverviewSection.swift` (new)
+- `MeterBar/Views/DashboardCostsSection.swift` (new)
+- `MeterBar/Views/DashboardStatusSection.swift` (new)
+- `MeterBar/Views/DashboardDiagnosticsSection.swift` (new)
+- `MeterBar/Views/DashboardShareSection.swift` (new)
+- `MeterBarTests/DashboardSectionSplitTests.swift` (new)
+
+No `project.pbxproj` edit: `MeterBar/` and `MeterBarTests/` are
+`PBXFileSystemSynchronizedRootGroup`s, so new files are picked up automatically.
+
+### Mistakes and fixes
+
+- Nearly routed the new diagnostics `.task(id:)` through the original *guarded*
+  `runDiagnostics()`. That would have regressed into silent no-ops on every input
+  change, because of the cancellation ordering above. Caught before writing.
+- `DashboardShareSection` first drafted without an explicit `init` — same
+  private-memberwise trap as `DashboardCostsSection`. Fixed pre-emptively,
+  including `self._generatedAt = generatedAt` for the `Binding`.
+
+### Verification
+
+- `swiftlint lint --strict --quiet` on all seven changed/new source files → **exit 0**.
+- Verified each moved declaration now exists exactly once repo-wide.
+- Diff review confirms the kept shell regions (split view, toolbar, sidebar,
+  `limitsContent`, snapshot builders) are byte-identical to before.
+- Tests/typecheck/build **not** run locally (MacBook policy). PR CI is the gate.
+
+### Next steps
+
+- [ ] Green CI on the pushed head.
+- [ ] Exact-head Opus PASS before merge.
+- [ ] Remaining C1 files, one PR each: `MeterBarApp` 974, `MenuBarView` 958,
+      `CostTracker` 954.

--- a/MeterBar/Views/DashboardCostsSection.swift
+++ b/MeterBar/Views/DashboardCostsSection.swift
@@ -1,0 +1,141 @@
+import MeterBarShared
+import SwiftUI
+
+// Costs page extracted from UsageDashboardView.swift (C1 split). Pure move; the
+// cost-window trailing status string is lifted to a static so it can be asserted
+// without hosting the page.
+
+struct DashboardCostsSection: View {
+    private let summary: CostSummary?
+    private let quotaSnapshot: (ServiceType) -> ProviderSnapshot?
+
+    @StateObject private var costTracker = CostTracker.shared
+    @StateObject private var apiUsageStore = ApiUsageStore.shared
+
+    init(
+        summary: CostSummary?,
+        quotaSnapshot: @escaping (ServiceType) -> ProviderSnapshot?
+    ) {
+        self.summary = summary
+        self.quotaSnapshot = quotaSnapshot
+    }
+
+    /// Trailing status for the 30-day spend card. A full scan outranks the
+    /// missing-day top-up because it supersedes it.
+    static func refreshStatusText(isScanning: Bool, isRefreshingMissingDays: Bool) -> String? {
+        if isScanning {
+            return "Scanning..."
+        }
+        if isRefreshingMissingDays {
+            return "Updating..."
+        }
+        return nil
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            CostOverviewStatusCard(
+                summary: summary,
+                isScanning: costTracker.isScanning,
+                isRefreshingMissingDays: costTracker.isRefreshingMissingDays,
+                formattedTokens: UsageFormat.tokens(summary?.totalTokens ?? 0)
+            )
+
+            LifetimeCostSummaryCard(
+                summary: summary?.lifetime,
+                isScanning: costTracker.isRefreshInProgress
+            )
+
+            costTrendCard
+
+            if let summary, !summary.dailyUsage.isEmpty {
+                DashboardCard(title: "Daily Details", trailing: "Last 30 days") {
+                    DailyUsageBreakdownList(dailyUsage: summary.dailyUsage)
+                }
+            }
+
+            if let summary, !summary.costs.isEmpty {
+                ForEach(summary.costs) { cost in
+                    ProviderCostBreakdown(
+                        cost: cost,
+                        quotaSnapshot: quotaSnapshot(cost.provider)
+                    )
+                }
+            } else {
+                DashboardCard(title: "No Local Logs Found") {
+                    Text("Run a local scan to load 30-day token history.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            if apiUsageStore.hasAnyAuthenticated {
+                DashboardCard(title: "Estimated API cost") {
+                    ApiUsageSection(store: apiUsageStore, embedded: true)
+                }
+            }
+        }
+        .task {
+            if apiUsageStore.hasAnyAuthenticated, !apiUsageStore.isLoading {
+                await apiUsageStore.refresh()
+            }
+        }
+    }
+
+    private var costTrendCard: some View {
+        DashboardCard(
+            title: "30 Day Spend",
+            trailing: Self.refreshStatusText(
+                isScanning: costTracker.isScanning,
+                isRefreshingMissingDays: costTracker.isRefreshingMissingDays
+            )
+        ) {
+            VStack(alignment: .leading, spacing: 14) {
+                Text(
+                    "Local subscription logs are estimated using API token rates "
+                        + "so Codex and Claude can be compared."
+                )
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                if let summary {
+                    let presentation = CostChartPresentation(summary: summary)
+                    ZStack {
+                        if presentation.hasSpend {
+                            CostSpendCharts(presentation: presentation)
+                                .opacity(costTracker.isScanning ? 0.42 : 1)
+                        } else {
+                            EmptyStateCard(
+                                systemImage: "chart.bar.xaxis",
+                                title: "No spend in this window",
+                                message: "No billable Claude or Codex usage was found in the last 30 days."
+                            )
+                        }
+
+                        if costTracker.isScanning {
+                            CostScanProgressBadge(compact: false)
+                        }
+                    }
+                } else if costTracker.isScanning {
+                    CostScanLoadingChart(compact: false)
+                        .frame(height: 220)
+                } else {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Run a local scan to load 30-day token history.")
+                            .foregroundColor(.secondary)
+                        Button {
+                            Task {
+                                await costTracker.scanCosts(days: 30)
+                            }
+                        } label: {
+                            Label("Scan 30 Days", systemImage: "magnifyingglass")
+                        }
+                        .buttonStyle(.glassProminent)
+                        .disabled(costTracker.isRefreshInProgress)
+                    }
+                    .frame(height: 220, alignment: .center)
+                }
+            }
+        }
+    }
+}

--- a/MeterBar/Views/DashboardDiagnosticsSection.swift
+++ b/MeterBar/Views/DashboardDiagnosticsSection.swift
@@ -1,0 +1,126 @@
+import AppKit
+import MeterBarShared
+import SwiftUI
+
+// Diagnostics page extracted from UsageDashboardView.swift (C1 split).
+//
+// Behavior change: the shell used to kick `runDiagnostics()` from its
+// `onChange(of: selectedSection)` *and* this page carried its own
+// `.task(id:)`, so opening Diagnostics ran the readiness sweep twice — two
+// concurrent passes of keychain / file / SQLite I/O, because the `.task` path
+// bypassed the in-flight guard. The page now owns the single entry point and the
+// shell no longer fires one.
+
+struct DashboardDiagnosticsSection: View {
+    @StateObject private var dataManager = UsageDataManager.shared
+    @StateObject private var providerVisibility = ProviderVisibilityStore.shared
+    @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
+    @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
+    @StateObject private var codexCliService = CodexCliLocalService.shared
+    @StateObject private var cursorService = CursorLocalService.shared
+    @StateObject private var openRouterService = OpenRouterService.shared
+    @StateObject private var grokService = GrokCLIUsageService.shared
+
+    @State private var readinessReports: [ProviderReadiness] = []
+    @State private var isRunningDiagnostics = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            DashboardCard(
+                title: "Provider Diagnostics",
+                trailing: DiagnosticsRunner.summary(for: readinessReports)
+            ) {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("These checks run locally. Every line is redacted — safe to paste into a GitHub issue.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+
+                    HStack(spacing: 10) {
+                        Button {
+                            Task { await runDiagnostics() }
+                        } label: {
+                            Label("Re-run checks", systemImage: "arrow.clockwise")
+                        }
+                        .disabled(isRunningDiagnostics)
+
+                        Button {
+                            copyDiagnosticsToClipboard()
+                        } label: {
+                            Label("Copy report", systemImage: "doc.on.doc")
+                        }
+                        .disabled(readinessReports.isEmpty)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            }
+
+            if readinessReports.isEmpty {
+                DashboardCard(title: "Running checks…") {
+                    Text("Gathering provider setup status.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+            } else {
+                ReadinessChecklist(reports: readinessReports)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .task(id: diagnosticsInputKey) {
+            await runDiagnostics()
+        }
+    }
+
+    private var diagnosticsInputKey: DiagnosticsRunner.InputKey {
+        DiagnosticsRunner.InputKey(
+            providers: ServiceType.allCases.filter { providerVisibility.enabledServices.contains($0) },
+            defaultClaudeAccountEnabled: claudeAccountStore.defaultAccountIsEnabled,
+            enabledClaudeCustomAccountIDs: claudeAccountStore.enabledAccounts
+                .filter { !$0.isDefault }
+                .map(\.id)
+        )
+    }
+
+    /// Runs the readiness inspector off the main actor (it does keychain / file /
+    /// SQLite I/O) and publishes the reports back on the main actor. The only
+    /// caller that can overlap this is the Re-run button, which is disabled while
+    /// `isRunningDiagnostics` is set — so no in-flight guard is needed.
+    @MainActor
+    private func runDiagnostics() async {
+        isRunningDiagnostics = true
+        defer { isRunningDiagnostics = false }
+
+        let reports = await inspectReadiness()
+        guard !Task.isCancelled else { return }
+        readinessReports = reports
+    }
+
+    private func inspectReadiness() async -> [ProviderReadiness] {
+        let enabledProviders = providerVisibility.enabledServices
+        let errors = DiagnosticsRunner.refreshErrors(
+            claudeDefaultAccountEnabled: claudeAccountStore.defaultAccountIsEnabled,
+            claudeError: claudeCodeService.lastError,
+            codexError: codexCliService.lastError,
+            cursorError: cursorService.lastError,
+            openRouterError: openRouterService.lastError,
+            grokError: grokService.lastError
+        )
+        let defaultClaudeAccountEnabled = claudeAccountStore.defaultAccountIsEnabled
+        let enabledClaudeAccounts = claudeAccountStore.enabledAccounts
+        let claudeMetrics = enabledClaudeAccounts.compactMap {
+            dataManager.claudeCodeAccountMetrics[$0.id]
+        }
+        return await DiagnosticsRunner.inspect(
+            enabledProviders: enabledProviders,
+            refreshErrors: errors,
+            claudeDefaultAccountEnabled: defaultClaudeAccountEnabled,
+            claudeEnabledAccountMetrics: claudeMetrics
+        )
+    }
+
+    private func copyDiagnosticsToClipboard() {
+        let text = DiagnosticsRunner.reportText(for: readinessReports)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+}

--- a/MeterBar/Views/DashboardDiagnosticsSection.swift
+++ b/MeterBar/Views/DashboardDiagnosticsSection.swift
@@ -10,8 +10,21 @@ import SwiftUI
 // concurrent passes of keychain / file / SQLite I/O, because the `.task` path
 // bypassed the in-flight guard. The page now owns the single entry point and the
 // shell no longer fires one.
+//
+// The sweep's results live on the shell and arrive here as bindings: this page
+// is a `switch` branch, so page-local `@State` would be torn down every time the
+// user navigates elsewhere and the checklist would restart empty — and redo its
+// keychain / file / SQLite I/O — on every single revisit.
 
 struct DashboardDiagnosticsSection: View {
+    @Binding private var readinessReports: [ProviderReadiness]
+    @Binding private var isRunningDiagnostics: Bool
+
+    init(reports: Binding<[ProviderReadiness]>, isRunning: Binding<Bool>) {
+        self._readinessReports = reports
+        self._isRunningDiagnostics = isRunning
+    }
+
     @StateObject private var dataManager = UsageDataManager.shared
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
     @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
@@ -20,9 +33,6 @@ struct DashboardDiagnosticsSection: View {
     @StateObject private var cursorService = CursorLocalService.shared
     @StateObject private var openRouterService = OpenRouterService.shared
     @StateObject private var grokService = GrokCLIUsageService.shared
-
-    @State private var readinessReports: [ProviderReadiness] = []
-    @State private var isRunningDiagnostics = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {

--- a/MeterBar/Views/DashboardNavigation.swift
+++ b/MeterBar/Views/DashboardNavigation.swift
@@ -1,0 +1,233 @@
+import AppKit
+import MeterBarShared
+import SwiftUI
+
+// Dashboard window controller, section enums, and the navigation store extracted
+// from UsageDashboardView.swift (C1 split). Pure move, except for the
+// `DashboardSection.refreshTarget` / `refreshesApiUsage` map and
+// `SettingsSection.available(sessionWakeEnabled:)`, which lift logic that was
+// inlined — and duplicated — inside the view body so it can be tested directly.
+
+@MainActor
+final class UsageDashboardWindowController {
+    static let shared = UsageDashboardWindowController()
+    static let windowID = "dashboard"
+
+    private var openWindow: OpenWindowAction?
+    private var shouldOpenWhenRegistered = false
+
+    private init() {}
+
+    func register(openWindow: OpenWindowAction) {
+        self.openWindow = openWindow
+
+        if shouldOpenWhenRegistered {
+            shouldOpenWhenRegistered = false
+            presentDashboard()
+        }
+    }
+
+    func show(section: DashboardSection? = nil, focusedProviderID: String? = nil) {
+        if let section {
+            DashboardNavigationStore.shared.navigate(to: section, focusedProviderID: focusedProviderID)
+        } else if let focusedProviderID {
+            DashboardNavigationStore.shared.navigate(to: .limits, focusedProviderID: focusedProviderID)
+        }
+
+        presentDashboard()
+    }
+
+    /// Open (or front) the dashboard window in its in-window settings mode. This
+    /// is what ⌘,, the app menu's "Settings…", and the popover's settings entry
+    /// points now call — there is no separate Settings window.
+    func showSettings(_ section: SettingsSection = .general) {
+        DashboardNavigationStore.shared.openSettings(section)
+        show()
+    }
+
+    private func presentDashboard() {
+        guard let openWindow else {
+            shouldOpenWhenRegistered = true
+            return
+        }
+
+        NSApp.activate(ignoringOtherApps: true)
+        openWindow(id: Self.windowID)
+    }
+}
+
+enum DashboardSection: String, CaseIterable, Identifiable, Hashable {
+    case overview = "Overview"
+    case limits = "Limits"
+    case status = "Status"
+    case costs = "Costs"
+    case optimize = "Optimize"
+    case diagnostics = "Diagnostics"
+    case share = "Share"
+
+    var id: String { rawValue }
+
+    var iconName: String {
+        switch self {
+        case .overview:
+            return "gauge.with.dots.needle.bottom.50percent"
+        case .limits:
+            return "chart.bar.fill"
+        case .status:
+            return "waveform.path.ecg"
+        case .costs:
+            return "dollarsign.circle.fill"
+        case .optimize:
+            return "leaf.fill"
+        case .diagnostics:
+            return "stethoscope"
+        case .share:
+            return "square.and.arrow.up.fill"
+        }
+    }
+
+    /// Sidebar layout: frequency-ordered monitoring pages first, then health
+    /// checks, then utilities. App settings live in the dedicated macOS
+    /// Settings scene rather than masquerading as dashboard content.
+    struct SidebarGroup: Identifiable {
+        let title: String?
+        let sections: [DashboardSection]
+
+        var id: String { sections.first?.id ?? title ?? "" }
+    }
+
+    static let sidebarGroups: [SidebarGroup] = [
+        SidebarGroup(title: nil, sections: [.overview, .limits, .costs, .optimize]),
+        SidebarGroup(title: "Health", sections: [.status, .diagnostics]),
+        SidebarGroup(title: "Utilities", sections: [.share]),
+    ]
+
+    var titlebarSubtitle: String {
+        switch self {
+        case .overview:
+            return "Current health and local token history"
+        case .limits:
+            return "Every tracked quota window"
+        case .status:
+            return "Provider service health"
+        case .costs:
+            return "Local 30-day token spend"
+        case .optimize:
+            return "Where tokens go and how to trim them"
+        case .diagnostics:
+            return "Provider setup health"
+        case .share:
+            return "Social card export"
+        }
+    }
+
+    /// What the toolbar's Refresh acts on for this page.
+    enum RefreshTarget: Hashable {
+        case providerStatus
+        case costs
+        case usage
+    }
+
+    /// Single source of truth for "what does Refresh do here". The spinner state,
+    /// the Refresh action, and the missing-day cost top-up each encoded this map
+    /// independently, so adding a page meant remembering three switch statements.
+    var refreshTarget: RefreshTarget {
+        switch self {
+        case .status:
+            return .providerStatus
+        case .costs, .share, .optimize:
+            return .costs
+        case .overview, .limits, .diagnostics:
+            return .usage
+        }
+    }
+
+    /// Only the Costs page renders the org API-usage card, so it is the only page
+    /// whose refresh also pulls the billing API.
+    var refreshesApiUsage: Bool { self == .costs }
+}
+
+/// The app-settings pages, surfaced as an in-window mode of the dashboard rather
+/// than a separate macOS Settings window. Mirrors the tabs the old `SettingsView`
+/// shell carried, reusing the same section views. `.automation` is feature-gated
+/// and only appears when Session Wake is enabled.
+enum SettingsSection: String, CaseIterable, Identifiable, Hashable {
+    case general = "General"
+    case providers = "Providers"
+    case widget = "Widget"
+    case apiUsage = "API Usage"
+    case cost = "Cost"
+    case automation = "Automation"
+    case about = "About"
+
+    var id: String { rawValue }
+
+    var iconName: String {
+        switch self {
+        case .general: return "gearshape"
+        case .providers: return "square.grid.2x2"
+        case .widget: return "rectangle.3.group"
+        case .apiUsage: return "key"
+        case .cost: return "chart.bar"
+        case .automation: return "moon.zzz"
+        case .about: return "info.circle"
+        }
+    }
+
+    /// Sections available right now — Automation only when Session Wake is
+    /// enabled, matching the old settings shell's feature gate.
+    static func available(sessionWakeEnabled: Bool) -> [SettingsSection] {
+        allCases.filter { $0 != .automation || sessionWakeEnabled }
+    }
+}
+
+enum EnabledQuotaSourceCounter {
+    static func count(
+        enabledServices: Set<ServiceType>,
+        codexAccountCount: Int,
+        claudeAccountCount: Int
+    ) -> Int {
+        enabledServices.reduce(into: 0) { count, service in
+            switch service {
+            case .codexCli:
+                count += codexAccountCount
+            case .claudeCode:
+                count += claudeAccountCount
+            case .cursor, .openRouter, .grok:
+                count += 1
+            }
+        }
+    }
+}
+
+@MainActor
+final class DashboardNavigationStore: ObservableObject {
+    static let shared = DashboardNavigationStore()
+
+    @Published var selectedSection: DashboardSection = .overview
+    @Published var focusedProviderID: ProviderSnapshot.ID?
+
+    /// When true the dashboard swaps its sidebar + content for the settings
+    /// pages (the gear next to Refresh, or ⌘,/Settings…). No separate window.
+    @Published var isShowingSettings = false
+    @Published var selectedSettingsSection: SettingsSection = .general
+
+    private init() {}
+
+    func navigate(to section: DashboardSection, focusedProviderID: ProviderSnapshot.ID? = nil) {
+        selectedSection = section
+        self.focusedProviderID = focusedProviderID
+        isShowingSettings = false
+    }
+
+    /// Enter the in-window settings mode on `section` (defaults to General).
+    func openSettings(_ section: SettingsSection = .general) {
+        selectedSettingsSection = section
+        isShowingSettings = true
+    }
+
+    /// Return from settings to the monitoring dashboard.
+    func closeSettings() {
+        isShowingSettings = false
+    }
+}

--- a/MeterBar/Views/DashboardNavigation.swift
+++ b/MeterBar/Views/DashboardNavigation.swift
@@ -1,4 +1,7 @@
 import AppKit
+// ObservableObject / @Published came in transitively while the store lived in
+// UsageDashboardView.swift; this file has to import Combine itself.
+import Combine
 import MeterBarShared
 import SwiftUI
 

--- a/MeterBar/Views/DashboardOverviewSection.swift
+++ b/MeterBar/Views/DashboardOverviewSection.swift
@@ -1,0 +1,136 @@
+import MeterBarShared
+import SwiftUI
+
+// Overview page extracted from UsageDashboardView.swift (C1 split). Pure move —
+// the page takes its data as explicit inputs instead of reaching into the shell's
+// private stores, and `OverviewSummaryStrip` travels with its only caller.
+
+struct DashboardOverviewSection: View {
+    let snapshots: [ProviderSnapshot]
+    let tightestLimit: SnapshotLimit?
+    let enabledSourceCount: Int
+    let costSummary: CostSummary?
+    let onSelectProvider: (ProviderSnapshot.ID) -> Void
+
+    private var gridColumns: [GridItem] {
+        Array(
+            repeating: GridItem(.flexible(minimum: 320), spacing: 12, alignment: .top),
+            count: 2
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            OverviewSummaryStrip(
+                tightestLimit: tightestLimit,
+                sourceCount: snapshots.count,
+                enabledSourceCount: enabledSourceCount,
+                estimatedCost: costSummary?.formattedTotalCost,
+                formattedTokens: UsageFormat.tokens(costSummary?.totalTokens ?? 0)
+            )
+
+            LazyVGrid(columns: gridColumns, alignment: .leading, spacing: 12) {
+                ForEach(snapshots) { snapshot in
+                    // Same shared provider card as the popover and the Limits
+                    // page; tapping it jumps to that provider in Limits.
+                    ProviderStatusCard(
+                        snapshot: snapshot,
+                        onSelect: { onSelectProvider(snapshot.id) }
+                    )
+                }
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+}
+
+private struct OverviewSummaryStrip: View {
+    let tightestLimit: SnapshotLimit?
+    let sourceCount: Int
+    let enabledSourceCount: Int
+    let estimatedCost: String?
+    let formattedTokens: String
+
+    private let columns = [
+        GridItem(.flexible(minimum: 180), spacing: 12),
+        GridItem(.flexible(minimum: 180), spacing: 12),
+        GridItem(.flexible(minimum: 180), spacing: 12)
+    ]
+
+    var body: some View {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
+            TimelineView(
+                .periodic(
+                    from: ResetCountdownSchedule.anchor,
+                    by: ResetCountdownSchedule.interval
+                )
+            ) { timeline in
+                DashboardMetricTile(
+                    title: "Tightest window",
+                    value: tightestValue(now: timeline.date),
+                    caption: tightestCaption,
+                    systemImage: tightestIconName,
+                    indicatorTint: tightestColor,
+                    style: .compact
+                )
+            }
+
+            DashboardMetricTile(
+                title: "30-day estimate",
+                value: estimatedCost ?? "Scan needed",
+                caption: "\(formattedTokens) tokens",
+                systemImage: "chart.bar.xaxis",
+                style: .compact
+            )
+
+            DashboardMetricTile(
+                title: "Tracked sources",
+                value: "\(sourceCount)",
+                caption: sourceCaption,
+                systemImage: "checklist.checked",
+                style: .compact
+            )
+        }
+    }
+
+    private var tightestBand: QuotaBand? {
+        tightestLimit.map { QuotaBand.forPercentLeft($0.percentLeft) }
+    }
+
+    private var tightestColor: Color {
+        tightestBand?.color ?? .secondary
+    }
+
+    private var tightestIconName: String {
+        tightestBand?.iconName ?? "circle.dashed"
+    }
+
+    private var tightestCaption: String {
+        guard let tightestLimit else { return "Waiting for provider refresh" }
+        return "\(tightestLimit.title) quota"
+    }
+
+    private var sourceCaption: String {
+        if enabledSourceCount == 0 {
+            return "Enable providers in Settings"
+        }
+        if sourceCount == enabledSourceCount {
+            return "All enabled sources reporting"
+        }
+        return "\(sourceCount) of \(enabledSourceCount) enabled reporting"
+    }
+
+    private func tightestValue(now: Date) -> String {
+        guard let tightestLimit else { return "No data" }
+        guard tightestLimit.usageLimit.isAtLimit else {
+            return tightestLimit.usageLimit.percentLeftText
+        }
+        if tightestLimit.usageLimit.isEstimated {
+            return tightestLimit.usageLimit.percentLeftText
+        }
+        guard let countdown = tightestLimit.usageLimit.resetCountdownText(now: now) else {
+            return "Reset unknown"
+        }
+        return countdown == "now" ? "Reset due" : "Resets in \(countdown)"
+    }
+}

--- a/MeterBar/Views/DashboardShareSection.swift
+++ b/MeterBar/Views/DashboardShareSection.swift
@@ -3,9 +3,12 @@ import MeterBarShared
 import SwiftUI
 import UniformTypeIdentifiers
 
-// Share page extracted from UsageDashboardView.swift (C1 split). Pure move — the
-// page takes the card's inputs explicitly and writes the "generated at" stamp
-// back through a binding, because the toolbar's Refresh also re-stamps it. The
+// Share page extracted from UsageDashboardView.swift (C1 split). The page takes
+// the card's inputs explicitly and writes the "generated at" stamp back through
+// a binding, because the toolbar's Refresh also re-stamps it. The export toast
+// is a binding for a different reason: this page is a `switch` branch, so a
+// page-local `@State` toast would be discarded the moment the user navigates
+// away, where before the split it lived on the shell and survived. The
 // enabled-source labels are lifted to a static so the card's provenance line can
 // be asserted without hosting the page.
 
@@ -16,8 +19,7 @@ struct DashboardShareSection: View {
     private let horizontalInsets: CGFloat
 
     @Binding private var generatedAt: Date
-
-    @State private var shareStatus: String?
+    @Binding private var shareStatus: String?
 
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
     @StateObject private var costTracker = CostTracker.shared
@@ -27,13 +29,15 @@ struct DashboardShareSection: View {
         providerTitles: [String],
         viewportWidth: CGFloat,
         horizontalInsets: CGFloat,
-        generatedAt: Binding<Date>
+        generatedAt: Binding<Date>,
+        shareStatus: Binding<String?>
     ) {
         self.costSummary = costSummary
         self.providerTitles = providerTitles
         self.viewportWidth = viewportWidth
         self.horizontalInsets = horizontalInsets
         self._generatedAt = generatedAt
+        self._shareStatus = shareStatus
     }
 
     /// The card's provenance line. Only the three log-backed providers contribute

--- a/MeterBar/Views/DashboardShareSection.swift
+++ b/MeterBar/Views/DashboardShareSection.swift
@@ -1,0 +1,194 @@
+import AppKit
+import MeterBarShared
+import SwiftUI
+import UniformTypeIdentifiers
+
+// Share page extracted from UsageDashboardView.swift (C1 split). Pure move — the
+// page takes the card's inputs explicitly and writes the "generated at" stamp
+// back through a binding, because the toolbar's Refresh also re-stamps it. The
+// enabled-source labels are lifted to a static so the card's provenance line can
+// be asserted without hosting the page.
+
+struct DashboardShareSection: View {
+    private let costSummary: CostSummary?
+    private let providerTitles: [String]
+    private let viewportWidth: CGFloat
+    private let horizontalInsets: CGFloat
+
+    @Binding private var generatedAt: Date
+
+    @State private var shareStatus: String?
+
+    @StateObject private var providerVisibility = ProviderVisibilityStore.shared
+    @StateObject private var costTracker = CostTracker.shared
+
+    init(
+        costSummary: CostSummary?,
+        providerTitles: [String],
+        viewportWidth: CGFloat,
+        horizontalInsets: CGFloat,
+        generatedAt: Binding<Date>
+    ) {
+        self.costSummary = costSummary
+        self.providerTitles = providerTitles
+        self.viewportWidth = viewportWidth
+        self.horizontalInsets = horizontalInsets
+        self._generatedAt = generatedAt
+    }
+
+    /// The card's provenance line. Only the three log-backed providers contribute
+    /// a local source; the API-only ones have nothing on disk to cite.
+    static func enabledSourceLabels(for enabledServices: Set<ServiceType>) -> [String] {
+        var labels: [String] = []
+        if enabledServices.contains(.codexCli) {
+            labels.append("Codex logs")
+        }
+        if enabledServices.contains(.claudeCode) {
+            labels.append("Claude JSONL")
+        }
+        if enabledServices.contains(.cursor) {
+            labels.append("Cursor local state")
+        }
+        return labels
+    }
+
+    var body: some View {
+        let previewSize = SocialShareCardLayout.previewSize(
+            viewportWidth: viewportWidth,
+            horizontalInsets: horizontalInsets
+        )
+
+        return VStack(alignment: .leading, spacing: 14) {
+            SocialShareCardPreview(content: cardContent, size: previewSize)
+                .accessibilityLabel("MeterBar 30-day token receipt preview")
+
+            HStack(spacing: 10) {
+                Button {
+                    copyCardImage()
+                } label: {
+                    Label("Copy PNG", systemImage: "doc.on.doc")
+                }
+                .buttonStyle(.glassProminent)
+
+                Button {
+                    saveCardImage()
+                } label: {
+                    Label("Save PNG", systemImage: "square.and.arrow.down")
+                }
+                .buttonStyle(.bordered)
+
+                Button {
+                    copyCaption()
+                } label: {
+                    Label("Copy Caption", systemImage: "text.quote")
+                }
+                .buttonStyle(.bordered)
+
+                if costSummary?.dailyUsage.isEmpty ?? true {
+                    Button {
+                        Task {
+                            await costTracker.scanCosts(days: 30)
+                            generatedAt = Date()
+                        }
+                    } label: {
+                        Label("Scan 30 Days", systemImage: "magnifyingglass")
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(costTracker.isRefreshInProgress)
+                }
+
+                Spacer()
+
+                if let shareStatus {
+                    Text(shareStatus)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .transition(.opacity)
+                }
+            }
+
+            DashboardCard(title: "Share Caption") {
+                Text(cardContent.shareCaption)
+                    .font(.system(.body, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var cardContent: SocialShareCardContent {
+        makeCardContent(generatedAt: generatedAt)
+    }
+
+    private func makeCardContent(generatedAt: Date) -> SocialShareCardContent {
+        SocialCardRenderer.content(
+            costSummary: costSummary,
+            providerSnapshotTitles: providerTitles,
+            enabledSourceLabels: Self.enabledSourceLabels(for: providerVisibility.enabledServices),
+            generatedAt: generatedAt
+        )
+    }
+
+    /// Each export re-stamps the card so the exported artwork and the on-screen
+    /// preview agree on when it was generated.
+    private func stampedContent() -> SocialShareCardContent {
+        let now = Date()
+        let content = makeCardContent(generatedAt: now)
+        generatedAt = now
+        return content
+    }
+
+    private func copyCardImage() {
+        guard let image = SocialCardRenderer.image(for: stampedContent()) else {
+            setShareStatus("PNG render failed")
+            return
+        }
+
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        if pasteboard.writeObjects([image]) {
+            setShareStatus("PNG copied")
+        } else {
+            setShareStatus("Copy failed")
+        }
+    }
+
+    private func saveCardImage() {
+        let content = stampedContent()
+
+        guard let pngData = SocialCardRenderer.pngData(for: content) else {
+            setShareStatus("PNG render failed")
+            return
+        }
+
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.png]
+        panel.canCreateDirectories = true
+        panel.nameFieldStringValue = content.defaultFilename
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            do {
+                try pngData.write(to: url, options: .atomic)
+                setShareStatus("PNG saved")
+            } catch {
+                setShareStatus("Save failed")
+            }
+        }
+    }
+
+    private func copyCaption() {
+        let content = stampedContent()
+
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(content.shareCaption, forType: .string)
+        setShareStatus("Caption copied")
+    }
+
+    private func setShareStatus(_ status: String) {
+        withAnimation(MeterBarTheme.Motion.standard) {
+            shareStatus = status
+        }
+    }
+}

--- a/MeterBar/Views/DashboardStatusSection.swift
+++ b/MeterBar/Views/DashboardStatusSection.swift
@@ -1,0 +1,75 @@
+import AppKit
+import MeterBarShared
+import SwiftUI
+
+// Status page extracted from UsageDashboardView.swift (C1 split). Pure move; the
+// trailing summary string is lifted to a static so its "all operational" claim
+// can be asserted against a partial sweep without hosting the page.
+
+struct DashboardStatusSection: View {
+    @StateObject private var providerStatusMonitor = ProviderStatusMonitor.shared
+
+    /// Trailing summary for the status card. "All operational" is only honest
+    /// once every provider has reported, so a partial sweep stays blank.
+    static func summary(isRefreshing: Bool, issueCount: Int, reportCount: Int) -> String? {
+        if isRefreshing {
+            return "Refreshing..."
+        }
+        if issueCount == 0, reportCount == ServiceType.allCases.count {
+            return "All operational"
+        }
+        if issueCount == 1 {
+            return "1 issue"
+        }
+        if issueCount > 1 {
+            return "\(issueCount) issues"
+        }
+        return nil
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            DashboardCard(title: "Provider Status Pages", trailing: statusPagesSummary) {
+                HStack(alignment: .center, spacing: 10) {
+                    Text("Live status from each provider's public status page.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+
+                    Spacer()
+
+                    Button {
+                        Task { await providerStatusMonitor.refreshAll() }
+                    } label: {
+                        Label("Refresh Status", systemImage: "arrow.clockwise")
+                    }
+                    .buttonStyle(.glass)
+                    .controlSize(.small)
+                    .disabled(providerStatusMonitor.isRefreshing)
+                }
+            }
+
+            ProviderStatusTable(
+                reports: providerStatusMonitor.reports,
+                errors: providerStatusMonitor.errors,
+                openStatusPage: openStatusPage
+            )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .task {
+            await providerStatusMonitor.refreshAllIfNeeded()
+        }
+    }
+
+    private var statusPagesSummary: String? {
+        Self.summary(
+            isRefreshing: providerStatusMonitor.isRefreshing,
+            issueCount: providerStatusMonitor.reports.values.filter(\.hasIssue).count,
+            reportCount: providerStatusMonitor.reports.count
+        )
+    }
+
+    private func openStatusPage(for service: ServiceType) {
+        guard let url = service.statusPageURL else { return }
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -27,6 +27,15 @@ struct UsageDashboardView: View {
     /// Owned by the shell rather than the Share page because the toolbar's
     /// Refresh also re-stamps the card.
     @State private var socialCardGeneratedAt = Date()
+    /// Also shell-owned. The page views are `switch` branches, so SwiftUI tears
+    /// their subtree down — and with it any page-local `@State` — the moment the
+    /// user navigates to another section. Keeping these here is what the pages
+    /// had before the split: the diagnostics sweep survives a round trip instead
+    /// of re-running its keychain / file / SQLite I/O from an empty checklist,
+    /// and the share toast doesn't silently vanish on tab switch.
+    @State private var readinessReports: [ProviderReadiness] = []
+    @State private var isRunningDiagnostics = false
+    @State private var shareStatus: String?
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
@@ -224,14 +233,18 @@ struct UsageDashboardView: View {
         case .optimize:
             OptimizeInsightsView()
         case .diagnostics:
-            DashboardDiagnosticsSection()
+            DashboardDiagnosticsSection(
+                reports: $readinessReports,
+                isRunning: $isRunningDiagnostics
+            )
         case .share:
             DashboardShareSection(
                 costSummary: visibleCostSummary,
                 providerTitles: providerSnapshots.map(\.title),
                 viewportWidth: viewportWidth,
                 horizontalInsets: Self.detailHorizontalPadding * 2,
-                generatedAt: $socialCardGeneratedAt
+                generatedAt: $socialCardGeneratedAt,
+                shareStatus: $shareStatus
             )
         }
     }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -1,201 +1,9 @@
-import AppKit
-import Combine
-import SwiftUI
 import MeterBarShared
-import UniformTypeIdentifiers
+import SwiftUI
 
-@MainActor
-final class UsageDashboardWindowController {
-    static let shared = UsageDashboardWindowController()
-    static let windowID = "dashboard"
-
-    private var openWindow: OpenWindowAction?
-    private var shouldOpenWhenRegistered = false
-
-    private init() {}
-
-    func register(openWindow: OpenWindowAction) {
-        self.openWindow = openWindow
-
-        if shouldOpenWhenRegistered {
-            shouldOpenWhenRegistered = false
-            presentDashboard()
-        }
-    }
-
-    func show(section: DashboardSection? = nil, focusedProviderID: String? = nil) {
-        if let section {
-            DashboardNavigationStore.shared.navigate(to: section, focusedProviderID: focusedProviderID)
-        } else if let focusedProviderID {
-            DashboardNavigationStore.shared.navigate(to: .limits, focusedProviderID: focusedProviderID)
-        }
-
-        presentDashboard()
-    }
-
-    /// Open (or front) the dashboard window in its in-window settings mode. This
-    /// is what ⌘,, the app menu's "Settings…", and the popover's settings entry
-    /// points now call — there is no separate Settings window.
-    func showSettings(_ section: SettingsSection = .general) {
-        DashboardNavigationStore.shared.openSettings(section)
-        show()
-    }
-
-    private func presentDashboard() {
-        guard let openWindow else {
-            shouldOpenWhenRegistered = true
-            return
-        }
-
-        NSApp.activate(ignoringOtherApps: true)
-        openWindow(id: Self.windowID)
-    }
-}
-
-enum DashboardSection: String, CaseIterable, Identifiable, Hashable {
-    case overview = "Overview"
-    case limits = "Limits"
-    case status = "Status"
-    case costs = "Costs"
-    case optimize = "Optimize"
-    case diagnostics = "Diagnostics"
-    case share = "Share"
-
-    var id: String { rawValue }
-
-    var iconName: String {
-        switch self {
-        case .overview:
-            return "gauge.with.dots.needle.bottom.50percent"
-        case .limits:
-            return "chart.bar.fill"
-        case .status:
-            return "waveform.path.ecg"
-        case .costs:
-            return "dollarsign.circle.fill"
-        case .optimize:
-            return "leaf.fill"
-        case .diagnostics:
-            return "stethoscope"
-        case .share:
-            return "square.and.arrow.up.fill"
-        }
-    }
-
-    /// Sidebar layout: frequency-ordered monitoring pages first, then health
-    /// checks, then utilities. App settings live in the dedicated macOS
-    /// Settings scene rather than masquerading as dashboard content.
-    struct SidebarGroup: Identifiable {
-        let title: String?
-        let sections: [DashboardSection]
-
-        var id: String { sections.first?.id ?? title ?? "" }
-    }
-
-    static let sidebarGroups: [SidebarGroup] = [
-        SidebarGroup(title: nil, sections: [.overview, .limits, .costs, .optimize]),
-        SidebarGroup(title: "Health", sections: [.status, .diagnostics]),
-        SidebarGroup(title: "Utilities", sections: [.share]),
-    ]
-
-    var titlebarSubtitle: String {
-        switch self {
-        case .overview:
-            return "Current health and local token history"
-        case .limits:
-            return "Every tracked quota window"
-        case .status:
-            return "Provider service health"
-        case .costs:
-            return "Local 30-day token spend"
-        case .optimize:
-            return "Where tokens go and how to trim them"
-        case .diagnostics:
-            return "Provider setup health"
-        case .share:
-            return "Social card export"
-        }
-    }
-}
-
-/// The app-settings pages, surfaced as an in-window mode of the dashboard rather
-/// than a separate macOS Settings window. Mirrors the tabs the old `SettingsView`
-/// shell carried, reusing the same section views. `.automation` is feature-gated
-/// and only appears when Session Wake is enabled.
-enum SettingsSection: String, CaseIterable, Identifiable, Hashable {
-    case general = "General"
-    case providers = "Providers"
-    case widget = "Widget"
-    case apiUsage = "API Usage"
-    case cost = "Cost"
-    case automation = "Automation"
-    case about = "About"
-
-    var id: String { rawValue }
-
-    var iconName: String {
-        switch self {
-        case .general: return "gearshape"
-        case .providers: return "square.grid.2x2"
-        case .widget: return "rectangle.3.group"
-        case .apiUsage: return "key"
-        case .cost: return "chart.bar"
-        case .automation: return "moon.zzz"
-        case .about: return "info.circle"
-        }
-    }
-}
-
-enum EnabledQuotaSourceCounter {
-    static func count(
-        enabledServices: Set<ServiceType>,
-        codexAccountCount: Int,
-        claudeAccountCount: Int
-    ) -> Int {
-        enabledServices.reduce(into: 0) { count, service in
-            switch service {
-            case .codexCli:
-                count += codexAccountCount
-            case .claudeCode:
-                count += claudeAccountCount
-            case .cursor, .openRouter, .grok:
-                count += 1
-            }
-        }
-    }
-}
-
-@MainActor
-final class DashboardNavigationStore: ObservableObject {
-    static let shared = DashboardNavigationStore()
-
-    @Published var selectedSection: DashboardSection = .overview
-    @Published var focusedProviderID: ProviderSnapshot.ID?
-
-    /// When true the dashboard swaps its sidebar + content for the settings
-    /// pages (the gear next to Refresh, or ⌘,/Settings…). No separate window.
-    @Published var isShowingSettings = false
-    @Published var selectedSettingsSection: SettingsSection = .general
-
-    private init() {}
-
-    func navigate(to section: DashboardSection, focusedProviderID: ProviderSnapshot.ID? = nil) {
-        selectedSection = section
-        self.focusedProviderID = focusedProviderID
-        isShowingSettings = false
-    }
-
-    /// Enter the in-window settings mode on `section` (defaults to General).
-    func openSettings(_ section: SettingsSection = .general) {
-        selectedSettingsSection = section
-        isShowingSettings = true
-    }
-
-    /// Return from settings to the monitoring dashboard.
-    func closeSettings() {
-        isShowingSettings = false
-    }
-}
+// The dashboard shell: window chrome, sidebar, toolbar, and the shared data the
+// pages are fed. Each page lives in its own `Dashboard*Section` file (C1 split);
+// the navigation types live in `DashboardNavigation.swift`.
 
 struct UsageDashboardView: View {
     private static let detailHorizontalPadding = MeterBarTheme.Spacing.xxl
@@ -216,10 +24,9 @@ struct UsageDashboardView: View {
     @StateObject private var navigation = DashboardNavigationStore.shared
     @StateObject private var sessionWakeStore = SessionWakeSettingsStore.shared
 
-    @State private var readinessReports: [ProviderReadiness] = []
-    @State private var isRunningDiagnostics = false
+    /// Owned by the shell rather than the Share page because the toolbar's
+    /// Refresh also re-stamps the card.
     @State private var socialCardGeneratedAt = Date()
-    @State private var socialShareStatus: String?
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
@@ -236,13 +43,6 @@ struct UsageDashboardView: View {
         )
     }
 
-    private var overviewGridColumns: [GridItem] {
-        Array(
-            repeating: GridItem(.flexible(minimum: 320), spacing: 12, alignment: .top),
-            count: 2
-        )
-    }
-
     var body: some View {
         dashboardSplitView
         .task {
@@ -250,9 +50,6 @@ struct UsageDashboardView: View {
         }
         .onChange(of: navigation.selectedSection) {
             Task { await refreshCostsIfMissingDays() }
-            if navigation.selectedSection == .diagnostics {
-                Task { await runDiagnostics() }
-            }
             if navigation.selectedSection != .limits {
                 navigation.focusedProviderID = nil
             }
@@ -349,12 +146,8 @@ struct UsageDashboardView: View {
         .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 280)
     }
 
-    /// Settings sections available right now — Automation only when Session Wake
-    /// is enabled, matching the old settings shell's feature gate.
     private var availableSettingsSections: [SettingsSection] {
-        SettingsSection.allCases.filter { section in
-            section != .automation || sessionWakeStore.featureEnabled
-        }
+        SettingsSection.available(sessionWakeEnabled: sessionWakeStore.featureEnabled)
     }
 
     private var settingsSelection: Binding<SettingsSection?> {
@@ -410,19 +203,36 @@ struct UsageDashboardView: View {
     private func monitoringSectionContent(viewportWidth: CGFloat) -> some View {
         switch activeSection {
         case .overview:
-            overviewContent
+            DashboardOverviewSection(
+                snapshots: providerSnapshots,
+                tightestLimit: tightestLimit,
+                enabledSourceCount: enabledQuotaSourceCount,
+                costSummary: visibleCostSummary,
+                onSelectProvider: { providerID in
+                    navigation.navigate(to: .limits, focusedProviderID: providerID)
+                }
+            )
         case .limits:
             limitsContent
         case .status:
-            statusPagesContent
+            DashboardStatusSection()
         case .costs:
-            costsContent
+            DashboardCostsSection(
+                summary: visibleCostSummary,
+                quotaSnapshot: providerSnapshot(for:)
+            )
         case .optimize:
             OptimizeInsightsView()
         case .diagnostics:
-            diagnosticsContent
+            DashboardDiagnosticsSection()
         case .share:
-            shareContent(viewportWidth: viewportWidth)
+            DashboardShareSection(
+                costSummary: visibleCostSummary,
+                providerTitles: providerSnapshots.map(\.title),
+                viewportWidth: viewportWidth,
+                horizontalInsets: Self.detailHorizontalPadding * 2,
+                generatedAt: $socialCardGeneratedAt
+            )
         }
     }
 
@@ -448,30 +258,6 @@ struct UsageDashboardView: View {
         }
     }
 
-    private var overviewContent: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            OverviewSummaryStrip(
-                tightestLimit: tightestLimit,
-                sourceCount: providerSnapshots.count,
-                enabledSourceCount: enabledQuotaSourceCount,
-                estimatedCost: visibleCostSummary?.formattedTotalCost,
-                formattedTokens: UsageFormat.tokens(visibleCostSummary?.totalTokens ?? 0)
-            )
-
-            LazyVGrid(columns: overviewGridColumns, alignment: .leading, spacing: 12) {
-                ForEach(providerSnapshots) { snapshot in
-                    // Same shared provider card as the popover and the Limits
-                    // page; tapping it jumps to that provider in Limits.
-                    ProviderStatusCard(
-                        snapshot: snapshot,
-                        onSelect: { navigation.navigate(to: .limits, focusedProviderID: snapshot.id) }
-                    )
-                }
-            }
-            .frame(maxWidth: .infinity)
-        }
-    }
-
     private var limitsContent: some View {
         VStack(alignment: .leading, spacing: 14) {
             if providerSnapshots.isEmpty {
@@ -489,235 +275,6 @@ struct UsageDashboardView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private var costsContent: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            CostOverviewStatusCard(
-                summary: visibleCostSummary,
-                isScanning: costTracker.isScanning,
-                isRefreshingMissingDays: costTracker.isRefreshingMissingDays,
-                formattedTokens: UsageFormat.tokens(visibleCostSummary?.totalTokens ?? 0)
-            )
-
-            LifetimeCostSummaryCard(
-                summary: visibleCostSummary?.lifetime,
-                isScanning: costTracker.isRefreshInProgress
-            )
-
-            costTrendCard
-
-            if let summary = visibleCostSummary, !summary.dailyUsage.isEmpty {
-                DashboardCard(title: "Daily Details", trailing: "Last 30 days") {
-                    DailyUsageBreakdownList(dailyUsage: summary.dailyUsage)
-                }
-            }
-
-            if let summary = visibleCostSummary, !summary.costs.isEmpty {
-                ForEach(summary.costs) { cost in
-                    ProviderCostBreakdown(
-                        cost: cost,
-                        quotaSnapshot: providerSnapshot(for: cost.provider)
-                    )
-                }
-            } else {
-                DashboardCard(title: "No Local Logs Found") {
-                    Text("Run a local scan to load 30-day token history.")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                }
-            }
-
-            if apiUsageStore.hasAnyAuthenticated {
-                DashboardCard(title: "Estimated API cost") {
-                    ApiUsageSection(store: apiUsageStore, embedded: true)
-                }
-            }
-        }
-        .task {
-            if apiUsageStore.hasAnyAuthenticated, !apiUsageStore.isLoading {
-                await apiUsageStore.refresh()
-            }
-        }
-    }
-
-    private var statusPagesContent: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            DashboardCard(title: "Provider Status Pages", trailing: statusPagesSummary) {
-                HStack(alignment: .center, spacing: 10) {
-                    Text("Live status from each provider's public status page.")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-
-                    Spacer()
-
-                    Button {
-                        Task { await providerStatusMonitor.refreshAll() }
-                    } label: {
-                        Label("Refresh Status", systemImage: "arrow.clockwise")
-                    }
-                    .buttonStyle(.glass)
-                    .controlSize(.small)
-                    .disabled(providerStatusMonitor.isRefreshing)
-                }
-            }
-
-            ProviderStatusTable(
-                reports: providerStatusMonitor.reports,
-                errors: providerStatusMonitor.errors,
-                openStatusPage: openStatusPage
-            )
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .task {
-            await providerStatusMonitor.refreshAllIfNeeded()
-        }
-    }
-
-    private var statusPagesSummary: String? {
-        if providerStatusMonitor.isRefreshing {
-            return "Refreshing..."
-        }
-
-        let issueCount = providerStatusMonitor.reports.values.filter(\.hasIssue).count
-        if issueCount == 0, providerStatusMonitor.reports.count == ServiceType.allCases.count {
-            return "All operational"
-        }
-        if issueCount == 1 {
-            return "1 issue"
-        }
-        if issueCount > 1 {
-            return "\(issueCount) issues"
-        }
-        return nil
-    }
-
-    private var costTrendCard: some View {
-        DashboardCard(title: "30 Day Spend", trailing: costRefreshStatusText) {
-            VStack(alignment: .leading, spacing: 14) {
-                Text(
-                    "Local subscription logs are estimated using API token rates "
-                        + "so Codex and Claude can be compared."
-                )
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-
-                if let summary = visibleCostSummary {
-                    let presentation = CostChartPresentation(summary: summary)
-                    ZStack {
-                        if presentation.hasSpend {
-                            CostSpendCharts(presentation: presentation)
-                                .opacity(costTracker.isScanning ? 0.42 : 1)
-                        } else {
-                            EmptyStateCard(
-                                systemImage: "chart.bar.xaxis",
-                                title: "No spend in this window",
-                                message: "No billable Claude or Codex usage was found in the last 30 days."
-                            )
-                        }
-
-                        if costTracker.isScanning {
-                            CostScanProgressBadge(compact: false)
-                        }
-                    }
-                } else if costTracker.isScanning {
-                    CostScanLoadingChart(compact: false)
-                        .frame(height: 220)
-                } else {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Run a local scan to load 30-day token history.")
-                            .foregroundColor(.secondary)
-                        Button {
-                            Task {
-                                await costTracker.scanCosts(days: 30)
-                            }
-                        } label: {
-                            Label("Scan 30 Days", systemImage: "magnifyingglass")
-                        }
-                        .buttonStyle(.glassProminent)
-                        .disabled(costTracker.isRefreshInProgress)
-                    }
-                    .frame(height: 220, alignment: .center)
-                }
-            }
-        }
-    }
-
-    private func shareContent(viewportWidth: CGFloat) -> some View {
-        let previewSize = SocialShareCardLayout.previewSize(
-            viewportWidth: viewportWidth,
-            horizontalInsets: Self.detailHorizontalPadding * 2
-        )
-
-        return VStack(alignment: .leading, spacing: 14) {
-            SocialShareCardPreview(
-                content: socialShareCardContent,
-                size: previewSize
-            )
-                .accessibilityLabel("MeterBar 30-day token receipt preview")
-
-            HStack(spacing: 10) {
-                Button {
-                    copySocialCardImage()
-                } label: {
-                    Label("Copy PNG", systemImage: "doc.on.doc")
-                }
-                .buttonStyle(.glassProminent)
-
-                Button {
-                    saveSocialCardImage()
-                } label: {
-                    Label("Save PNG", systemImage: "square.and.arrow.down")
-                }
-                .buttonStyle(.bordered)
-
-                Button {
-                    copyShareCaption()
-                } label: {
-                    Label("Copy Caption", systemImage: "text.quote")
-                }
-                .buttonStyle(.bordered)
-
-                if visibleCostSummary?.dailyUsage.isEmpty ?? true {
-                    Button {
-                        Task {
-                            await costTracker.scanCosts(days: 30)
-                            socialCardGeneratedAt = Date()
-                        }
-                    } label: {
-                        Label("Scan 30 Days", systemImage: "magnifyingglass")
-                    }
-                    .buttonStyle(.bordered)
-                    .disabled(costTracker.isRefreshInProgress)
-                }
-
-                Spacer()
-
-                if let socialShareStatus {
-                    Text(socialShareStatus)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .transition(.opacity)
-                }
-            }
-
-            DashboardCard(title: "Share Caption") {
-                Text(socialShareCardContent.shareCaption)
-                    .font(.system(.body, design: .monospaced))
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private func makeSocialShareCardContent(generatedAt: Date) -> SocialShareCardContent {
-        SocialCardRenderer.content(
-            costSummary: visibleCostSummary,
-            providerSnapshotTitles: providerSnapshots.map(\.title),
-            enabledSourceLabels: enabledSourceLabels,
-            generatedAt: generatedAt
-        )
     }
 
     private var providerSnapshots: [ProviderSnapshot] {
@@ -760,24 +317,6 @@ struct UsageDashboardView: View {
         costTracker.costSummary?.filtered(to: providerVisibility.enabledServices)
     }
 
-    private var socialShareCardContent: SocialShareCardContent {
-        makeSocialShareCardContent(generatedAt: socialCardGeneratedAt)
-    }
-
-    private var enabledSourceLabels: [String] {
-        var labels: [String] = []
-        if providerVisibility.isEnabled(.codexCli) {
-            labels.append("Codex logs")
-        }
-        if providerVisibility.isEnabled(.claudeCode) {
-            labels.append("Claude JSONL")
-        }
-        if providerVisibility.isEnabled(.cursor) {
-            labels.append("Cursor local state")
-        }
-        return labels
-    }
-
     private var enabledQuotaSourceCount: Int {
         EnabledQuotaSourceCounter.count(
             enabledServices: providerVisibility.enabledServices,
@@ -790,308 +329,41 @@ struct UsageDashboardView: View {
         providerSnapshots.tightestLimit
     }
 
-    private var diagnosticsContent: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            DashboardCard(
-                title: "Provider Diagnostics",
-                trailing: DiagnosticsRunner.summary(for: readinessReports)
-            ) {
-                VStack(alignment: .leading, spacing: 12) {
-                    Text("These checks run locally. Every line is redacted — safe to paste into a GitHub issue.")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-
-                    HStack(spacing: 10) {
-                        Button {
-                            Task { await runDiagnostics() }
-                        } label: {
-                            Label("Re-run checks", systemImage: "arrow.clockwise")
-                        }
-                        .disabled(isRunningDiagnostics)
-
-                        Button {
-                            copyDiagnosticsToClipboard()
-                        } label: {
-                            Label("Copy report", systemImage: "doc.on.doc")
-                        }
-                        .disabled(readinessReports.isEmpty)
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                }
-            }
-
-            if readinessReports.isEmpty {
-                DashboardCard(title: "Running checks…") {
-                    Text("Gathering provider setup status.")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                }
-            } else {
-                ReadinessChecklist(reports: readinessReports)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .task(id: diagnosticsInputKey) {
-            let reports = await inspectReadiness()
-            guard !Task.isCancelled else { return }
-            readinessReports = reports
-        }
-    }
-
-    private var diagnosticsInputKey: DiagnosticsRunner.InputKey {
-        DiagnosticsRunner.InputKey(
-            providers: ServiceType.allCases.filter { providerVisibility.enabledServices.contains($0) },
-            defaultClaudeAccountEnabled: claudeAccountStore.defaultAccountIsEnabled,
-            enabledClaudeCustomAccountIDs: claudeAccountStore.enabledAccounts
-                .filter { !$0.isDefault }
-                .map(\.id)
-        )
-    }
-
-    /// Runs the readiness inspector off the main actor (it does keychain / file /
-    /// SQLite I/O) and publishes the reports back on the main actor.
-    @MainActor
-    private func runDiagnostics() async {
-        guard !isRunningDiagnostics else { return }
-        isRunningDiagnostics = true
-        defer { isRunningDiagnostics = false }
-
-        let reports = await inspectReadiness()
-        guard !Task.isCancelled else { return }
-        readinessReports = reports
-    }
-
-    private func inspectReadiness() async -> [ProviderReadiness] {
-        let enabledProviders = providerVisibility.enabledServices
-        let errors = DiagnosticsRunner.refreshErrors(
-            claudeDefaultAccountEnabled: claudeAccountStore.defaultAccountIsEnabled,
-            claudeError: claudeCodeService.lastError,
-            codexError: codexCliService.lastError,
-            cursorError: cursorService.lastError,
-            openRouterError: openRouterService.lastError,
-            grokError: grokService.lastError
-        )
-        let defaultClaudeAccountEnabled = claudeAccountStore.defaultAccountIsEnabled
-        let enabledClaudeAccounts = claudeAccountStore.enabledAccounts
-        let claudeMetrics = enabledClaudeAccounts.compactMap {
-            dataManager.claudeCodeAccountMetrics[$0.id]
-        }
-        return await DiagnosticsRunner.inspect(
-            enabledProviders: enabledProviders,
-            refreshErrors: errors,
-            claudeDefaultAccountEnabled: defaultClaudeAccountEnabled,
-            claudeEnabledAccountMetrics: claudeMetrics
-        )
-    }
-
-    private func copyDiagnosticsToClipboard() {
-        let text = DiagnosticsRunner.reportText(for: readinessReports)
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(text, forType: .string)
-    }
-
-    private var costRefreshStatusText: String? {
-        if costTracker.isScanning {
-            return "Scanning..."
-        }
-        if costTracker.isRefreshingMissingDays {
-            return "Updating..."
-        }
-        return nil
-    }
-
     private var isRefreshButtonDisabled: Bool {
         isRefreshButtonAnimating
     }
 
     private var isRefreshButtonAnimating: Bool {
-        switch activeSection {
-        case .costs:
-            return costTracker.isRefreshInProgress || apiUsageStore.isLoading
-        case .share, .optimize:
-            return costTracker.isRefreshInProgress
-        case .status:
+        switch activeSection.refreshTarget {
+        case .providerStatus:
             return providerStatusMonitor.isRefreshing
-        case .overview, .limits, .diagnostics:
+        case .costs:
+            return costTracker.isRefreshInProgress
+                || (activeSection.refreshesApiUsage && apiUsageStore.isLoading)
+        case .usage:
             return dataManager.isLoading
         }
     }
 
     private func refreshDashboard() async {
-        if activeSection == .status {
+        switch activeSection.refreshTarget {
+        case .providerStatus:
             await providerStatusMonitor.refreshAll()
-        } else if activeSection == .costs || activeSection == .share || activeSection == .optimize {
+        case .costs:
             await costTracker.scanCosts(days: 30)
-            if activeSection == .costs, apiUsageStore.hasAnyAuthenticated, !apiUsageStore.isLoading {
+            if activeSection.refreshesApiUsage,
+               apiUsageStore.hasAnyAuthenticated,
+               !apiUsageStore.isLoading {
                 await apiUsageStore.refresh()
             }
             socialCardGeneratedAt = Date()
-        } else {
+        case .usage:
             await dataManager.refreshAll()
         }
     }
 
-    private func openStatusPage(for service: ServiceType) {
-        guard let url = service.statusPageURL else { return }
-        NSWorkspace.shared.open(url)
-    }
-
     private func refreshCostsIfMissingDays() async {
-        let costBackedSections: Set<DashboardSection> = [.costs, .share, .optimize]
-        guard costBackedSections.contains(activeSection) else { return }
+        guard activeSection.refreshTarget == .costs else { return }
         await costTracker.refreshMissingDaysInBackground(days: 30)
-    }
-
-    private func copySocialCardImage() {
-        let generatedAt = Date()
-        let content = makeSocialShareCardContent(generatedAt: generatedAt)
-        socialCardGeneratedAt = generatedAt
-
-        guard let image = SocialCardRenderer.image(for: content) else {
-            setSocialShareStatus("PNG render failed")
-            return
-        }
-
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        if pasteboard.writeObjects([image]) {
-            setSocialShareStatus("PNG copied")
-        } else {
-            setSocialShareStatus("Copy failed")
-        }
-    }
-
-    private func saveSocialCardImage() {
-        let generatedAt = Date()
-        let content = makeSocialShareCardContent(generatedAt: generatedAt)
-        socialCardGeneratedAt = generatedAt
-
-        guard let pngData = SocialCardRenderer.pngData(for: content) else {
-            setSocialShareStatus("PNG render failed")
-            return
-        }
-
-        let panel = NSSavePanel()
-        panel.allowedContentTypes = [.png]
-        panel.canCreateDirectories = true
-        panel.nameFieldStringValue = content.defaultFilename
-        panel.begin { response in
-            guard response == .OK, let url = panel.url else { return }
-            do {
-                try pngData.write(to: url, options: .atomic)
-                setSocialShareStatus("PNG saved")
-            } catch {
-                setSocialShareStatus("Save failed")
-            }
-        }
-    }
-
-    private func copyShareCaption() {
-        let generatedAt = Date()
-        let content = makeSocialShareCardContent(generatedAt: generatedAt)
-        socialCardGeneratedAt = generatedAt
-
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(content.shareCaption, forType: .string)
-        setSocialShareStatus("Caption copied")
-    }
-
-    private func setSocialShareStatus(_ status: String) {
-        withAnimation(MeterBarTheme.Motion.standard) {
-            socialShareStatus = status
-        }
-    }
-}
-
-private struct OverviewSummaryStrip: View {
-    let tightestLimit: SnapshotLimit?
-    let sourceCount: Int
-    let enabledSourceCount: Int
-    let estimatedCost: String?
-    let formattedTokens: String
-
-    private let columns = [
-        GridItem(.flexible(minimum: 180), spacing: 12),
-        GridItem(.flexible(minimum: 180), spacing: 12),
-        GridItem(.flexible(minimum: 180), spacing: 12)
-    ]
-
-    var body: some View {
-        LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
-            TimelineView(
-                .periodic(
-                    from: ResetCountdownSchedule.anchor,
-                    by: ResetCountdownSchedule.interval
-                )
-            ) { timeline in
-                DashboardMetricTile(
-                    title: "Tightest window",
-                    value: tightestValue(now: timeline.date),
-                    caption: tightestCaption,
-                    systemImage: tightestIconName,
-                    indicatorTint: tightestColor,
-                    style: .compact
-                )
-            }
-
-            DashboardMetricTile(
-                title: "30-day estimate",
-                value: estimatedCost ?? "Scan needed",
-                caption: "\(formattedTokens) tokens",
-                systemImage: "chart.bar.xaxis",
-                style: .compact
-            )
-
-            DashboardMetricTile(
-                title: "Tracked sources",
-                value: "\(sourceCount)",
-                caption: sourceCaption,
-                systemImage: "checklist.checked",
-                style: .compact
-            )
-        }
-    }
-
-    private var tightestBand: QuotaBand? {
-        tightestLimit.map { QuotaBand.forPercentLeft($0.percentLeft) }
-    }
-
-    private var tightestColor: Color {
-        tightestBand?.color ?? .secondary
-    }
-
-    private var tightestIconName: String {
-        tightestBand?.iconName ?? "circle.dashed"
-    }
-
-    private var tightestCaption: String {
-        guard let tightestLimit else { return "Waiting for provider refresh" }
-        return "\(tightestLimit.title) quota"
-    }
-
-    private var sourceCaption: String {
-        if enabledSourceCount == 0 {
-            return "Enable providers in Settings"
-        }
-        if sourceCount == enabledSourceCount {
-            return "All enabled sources reporting"
-        }
-        return "\(sourceCount) of \(enabledSourceCount) enabled reporting"
-    }
-
-    private func tightestValue(now: Date) -> String {
-        guard let tightestLimit else { return "No data" }
-        guard tightestLimit.usageLimit.isAtLimit else {
-            return tightestLimit.usageLimit.percentLeftText
-        }
-        if tightestLimit.usageLimit.isEstimated {
-            return tightestLimit.usageLimit.percentLeftText
-        }
-        guard let countdown = tightestLimit.usageLimit.resetCountdownText(now: now) else {
-            return "Reset unknown"
-        }
-        return countdown == "now" ? "Reset due" : "Resets in \(countdown)"
     }
 }

--- a/MeterBarTests/DashboardSectionSplitTests.swift
+++ b/MeterBarTests/DashboardSectionSplitTests.swift
@@ -205,7 +205,7 @@ final class DashboardSectionSplitTests: XCTestCase {
     }
 
     func testDiagnosticsSectionRenders() {
-        assertRenders(DashboardDiagnosticsSection())
+        assertRenders(DashboardDiagnosticsSection(reports: .constant([]), isRunning: .constant(false)))
     }
 
     func testShareSectionRenders() {
@@ -215,8 +215,46 @@ final class DashboardSectionSplitTests: XCTestCase {
                 providerTitles: ["Codex"],
                 viewportWidth: 900,
                 horizontalInsets: 48,
-                generatedAt: .constant(Date(timeIntervalSince1970: 1_700_000_000))
+                generatedAt: .constant(Date(timeIntervalSince1970: 1_700_000_000)),
+                shareStatus: .constant(nil)
             )
+        )
+    }
+
+    /// The pages are `switch` branches, so anything they own as `@State` is
+    /// destroyed on navigation. These two carried shell state before the split
+    /// and must keep taking it from outside, or Diagnostics re-runs its whole
+    /// readiness sweep — and Share drops its toast — on every revisit.
+    func testNavigationScopedStateStaysOwnedByTheShell() {
+        let diagnostics = DashboardDiagnosticsSection(reports: .constant([]), isRunning: .constant(false))
+        assertIsBinding(diagnostics, "_readinessReports", Binding<[ProviderReadiness]>.self)
+        assertIsBinding(diagnostics, "_isRunningDiagnostics", Binding<Bool>.self)
+
+        let share = DashboardShareSection(
+            costSummary: nil,
+            providerTitles: [],
+            viewportWidth: 900,
+            horizontalInsets: 48,
+            generatedAt: .constant(Date(timeIntervalSince1970: 1_700_000_000)),
+            shareStatus: .constant(nil)
+        )
+        assertIsBinding(share, "_shareStatus", Binding<String?>.self)
+    }
+
+    private func assertIsBinding<Wrapper>(
+        _ view: some View,
+        _ label: String,
+        _ expected: Wrapper.Type,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let stored = Mirror(reflecting: view).children.first { $0.label == label }?.value
+        XCTAssertNotNil(stored, "\(label) is gone — did it move back onto the page?", file: file, line: line)
+        XCTAssertTrue(
+            stored is Wrapper,
+            "\(label) must be a \(expected), not page-local @State that navigation destroys.",
+            file: file,
+            line: line
         )
     }
 

--- a/MeterBarTests/DashboardSectionSplitTests.swift
+++ b/MeterBarTests/DashboardSectionSplitTests.swift
@@ -1,0 +1,269 @@
+import AppKit
+@testable import MeterBar
+import MeterBarShared
+import SwiftUI
+import XCTest
+
+/// Guards the C1 split of `UsageDashboardView.swift` into per-section views.
+///
+/// The split moved the shared enums into `DashboardNavigation.swift` and lifted
+/// three previously-inlined pieces of logic out of the 807-line view body so they
+/// can be asserted directly: the section → refresh-target map (which the toolbar
+/// spinner, the Refresh action, and the missing-days top-up each used to encode
+/// separately), the Automation feature gate, and the two trailing-status strings.
+@MainActor
+final class DashboardSectionSplitTests: XCTestCase {
+    // MARK: - Refresh targets
+
+    func testEverySectionMapsToItsRefreshTarget() {
+        let targets = DashboardSection.allCases.map { ($0, $0.refreshTarget) }
+
+        XCTAssertEqual(
+            Dictionary(uniqueKeysWithValues: targets),
+            [
+                .overview: .usage,
+                .limits: .usage,
+                .diagnostics: .usage,
+                .costs: .costs,
+                .share: .costs,
+                .optimize: .costs,
+                .status: .providerStatus,
+            ]
+        )
+    }
+
+    func testCostBackedSectionsShareTheCostRefreshTarget() {
+        // The toolbar spinner, Refresh, and the missing-days top-up must agree on
+        // which pages are cost-backed; they used to encode this list three times.
+        let costBacked = DashboardSection.allCases.filter { $0.refreshTarget == .costs }
+
+        XCTAssertEqual(Set(costBacked), [.costs, .share, .optimize])
+    }
+
+    func testOnlyTheCostsPageAlsoRefreshesApiUsage() {
+        let apiBacked = DashboardSection.allCases.filter(\.refreshesApiUsage)
+
+        XCTAssertEqual(apiBacked, [.costs])
+    }
+
+    func testEveryDashboardSectionCarriesAnIconAndSubtitle() {
+        for section in DashboardSection.allCases {
+            XCTAssertFalse(section.iconName.isEmpty, "\(section) lost its sidebar icon")
+            XCTAssertFalse(section.titlebarSubtitle.isEmpty, "\(section) lost its titlebar subtitle")
+        }
+    }
+
+    // MARK: - Settings feature gate
+
+    func testAutomationSettingsStayHiddenWhileSessionWakeIsOff() {
+        let available = SettingsSection.available(sessionWakeEnabled: false)
+
+        XCTAssertFalse(available.contains(.automation))
+        XCTAssertEqual(available, SettingsSection.allCases.filter { $0 != .automation })
+    }
+
+    func testAutomationSettingsAppearWhenSessionWakeIsOn() {
+        XCTAssertEqual(SettingsSection.available(sessionWakeEnabled: true), SettingsSection.allCases)
+    }
+
+    func testEverySettingsSectionCarriesAnIcon() {
+        for section in SettingsSection.allCases {
+            XCTAssertFalse(section.iconName.isEmpty, "\(section) lost its sidebar icon")
+        }
+    }
+
+    // MARK: - Navigation store
+
+    func testNavigateSelectsTheSectionAndLeavesSettingsMode() {
+        let navigation = DashboardNavigationStore.shared
+        defer { restore(navigation) }
+
+        navigation.openSettings(.providers)
+        navigation.navigate(to: .limits, focusedProviderID: "codex")
+
+        XCTAssertEqual(navigation.selectedSection, .limits)
+        XCTAssertEqual(navigation.focusedProviderID, "codex")
+        XCTAssertFalse(navigation.isShowingSettings)
+    }
+
+    func testNavigateWithoutAFocusClearsThePreviousFocusedProvider() {
+        let navigation = DashboardNavigationStore.shared
+        defer { restore(navigation) }
+
+        navigation.navigate(to: .limits, focusedProviderID: "codex")
+        navigation.navigate(to: .overview)
+
+        XCTAssertNil(navigation.focusedProviderID)
+    }
+
+    func testOpenThenCloseSettingsReturnsToTheMonitoringDashboard() {
+        let navigation = DashboardNavigationStore.shared
+        defer { restore(navigation) }
+
+        navigation.navigate(to: .costs)
+        navigation.openSettings(.widget)
+
+        XCTAssertTrue(navigation.isShowingSettings)
+        XCTAssertEqual(navigation.selectedSettingsSection, .widget)
+
+        navigation.closeSettings()
+
+        XCTAssertFalse(navigation.isShowingSettings)
+        XCTAssertEqual(navigation.selectedSection, .costs, "settings mode must not lose the page underneath")
+    }
+
+    // MARK: - Trailing status strings
+
+    func testCostRefreshStatusPrefersScanningOverTheMissingDayTopUp() {
+        XCTAssertEqual(
+            DashboardCostsSection.refreshStatusText(isScanning: true, isRefreshingMissingDays: true),
+            "Scanning..."
+        )
+        XCTAssertEqual(
+            DashboardCostsSection.refreshStatusText(isScanning: false, isRefreshingMissingDays: true),
+            "Updating..."
+        )
+        XCTAssertNil(
+            DashboardCostsSection.refreshStatusText(isScanning: false, isRefreshingMissingDays: false)
+        )
+    }
+
+    func testStatusPageSummaryReportsRefreshFirst() {
+        XCTAssertEqual(
+            DashboardStatusSection.summary(isRefreshing: true, issueCount: 3, reportCount: 0),
+            "Refreshing..."
+        )
+    }
+
+    func testStatusPageSummaryOnlyClaimsAllOperationalWithACompleteSweep() {
+        XCTAssertEqual(
+            DashboardStatusSection.summary(
+                isRefreshing: false,
+                issueCount: 0,
+                reportCount: ServiceType.allCases.count
+            ),
+            "All operational"
+        )
+        XCTAssertNil(
+            DashboardStatusSection.summary(
+                isRefreshing: false,
+                issueCount: 0,
+                reportCount: ServiceType.allCases.count - 1
+            ),
+            "a partial sweep must not claim every provider is healthy"
+        )
+    }
+
+    func testStatusPageSummaryPluralizesIssues() {
+        XCTAssertEqual(
+            DashboardStatusSection.summary(isRefreshing: false, issueCount: 1, reportCount: 1),
+            "1 issue"
+        )
+        XCTAssertEqual(
+            DashboardStatusSection.summary(isRefreshing: false, issueCount: 4, reportCount: 5),
+            "4 issues"
+        )
+    }
+
+    // MARK: - Share card sources
+
+    func testEnabledSourceLabelsCoverOnlyTheLogBackedProviders() {
+        XCTAssertEqual(
+            DashboardShareSection.enabledSourceLabels(for: Set(ServiceType.allCases)),
+            ["Codex logs", "Claude JSONL", "Cursor local state"]
+        )
+        XCTAssertEqual(
+            DashboardShareSection.enabledSourceLabels(for: [.claudeCode]),
+            ["Claude JSONL"]
+        )
+        XCTAssertTrue(
+            DashboardShareSection.enabledSourceLabels(for: [.openRouter, .grok]).isEmpty,
+            "API-only providers contribute no local log source"
+        )
+    }
+
+    // MARK: - Extracted section views still render
+
+    func testOverviewSectionRenders() {
+        let view = DashboardOverviewSection(
+            snapshots: [snapshot()],
+            tightestLimit: snapshot().limits.first,
+            enabledSourceCount: 2,
+            costSummary: nil,
+            onSelectProvider: { _ in }
+        )
+
+        assertRenders(view)
+    }
+
+    func testCostsSectionRenders() {
+        assertRenders(DashboardCostsSection(summary: nil, quotaSnapshot: { _ in nil }))
+    }
+
+    func testStatusSectionRenders() {
+        assertRenders(DashboardStatusSection())
+    }
+
+    func testDiagnosticsSectionRenders() {
+        assertRenders(DashboardDiagnosticsSection())
+    }
+
+    func testShareSectionRenders() {
+        assertRenders(
+            DashboardShareSection(
+                costSummary: nil,
+                providerTitles: ["Codex"],
+                viewportWidth: 900,
+                horizontalInsets: 48,
+                generatedAt: .constant(Date(timeIntervalSince1970: 1_700_000_000))
+            )
+        )
+    }
+
+    func testDashboardShellStillRenders() {
+        assertRenders(UsageDashboardView(), width: 1000, height: 700)
+    }
+
+    // MARK: - Helpers
+
+    private func assertRenders(
+        _ view: some View,
+        width: CGFloat = 820,
+        height: CGFloat = 600,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let hostingView = NSHostingView(rootView: view)
+        hostingView.frame = NSRect(x: 0, y: 0, width: width, height: height)
+        hostingView.layoutSubtreeIfNeeded()
+
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 0, file: file, line: line)
+    }
+
+    private func snapshot() -> ProviderSnapshot {
+        let weekly = UsageLimit(
+            used: 40,
+            total: 100,
+            resetTime: Date().addingTimeInterval(3600),
+            windowSeconds: 604_800
+        )
+        return ProviderSnapshot(
+            id: "codex",
+            title: "Codex",
+            service: .codexCli,
+            updatedAt: Date(),
+            limits: [
+                SnapshotLimit(id: "weekly", kind: .weekly, title: "Weekly", usageLimit: weekly)
+            ],
+            emptyDetail: "Waiting for refresh",
+            extraUsage: nil,
+            resetCreditsAvailable: nil,
+            accountID: nil,
+            fableActivity: nil
+        )
+    }
+
+    private func restore(_ navigation: DashboardNavigationStore) {
+        navigation.navigate(to: .overview)
+    }
+}


### PR DESCRIPTION
Audit item **C1** — first of four files over 950 lines.

`UsageDashboardView.swift` carried the window controller, four navigation types, the split-view shell, and all seven content pages in one **1097-line** file. Split along the seams that were already there.

**Shell: 1097 → 369 lines.**

## What moved

| new file | contents |
|---|---|
| `DashboardNavigation.swift` | `UsageDashboardWindowController`, `DashboardSection`, `SettingsSection`, `EnabledQuotaSourceCounter`, `DashboardNavigationStore` |
| `DashboardOverviewSection.swift` | Overview page + `OverviewSummaryStrip` |
| `DashboardCostsSection.swift` | Costs page + cost-trend card |
| `DashboardStatusSection.swift` | Status-pages page |
| `DashboardDiagnosticsSection.swift` | Diagnostics page + readiness inspector wiring |
| `DashboardShareSection.swift` | Share page + the three exports |

`UsageDashboardView` keeps only window chrome, sidebar, toolbar, and the shared data the pages are fed.

## Why child views, not cross-file extensions

`private` is file-scoped in Swift, so splitting the struct into extensions would have forced all 15 `@StateObject` stores to internal. Extracting views that take explicit inputs keeps them private and matches how `ProviderStatusCard` / `ProviderStatusTable` / `DashboardCostCards` are already shared with the popover.

## DRY

Three parallel `switch activeSection` refresh switches (`isRefreshButtonAnimating`, `refreshDashboard`, `refreshCostsIfMissingDays`) collapse into one `DashboardSection.refreshTarget` (+ `refreshesApiUsage`) mapping. The Automation feature gate moves into `SettingsSection.available(sessionWakeEnabled:)`.

Refresh semantics are unchanged: `.costs` still refreshes API usage; `.share`/`.optimize` still only rescan costs; everything else refreshes usage.

## ⚠️ One behavior change

The shell kicked `runDiagnostics()` from `onChange(of: selectedSection)` **and** the page carried its own `.task(id:)`, so opening Diagnostics ran the readiness sweep **twice** — two concurrent passes over the keychain, filesystem, and SQLite, because the `.task` path bypassed the in-flight guard. The page now owns the single entry point.

No guard on the new entry point, deliberately: `.task(id:)` cancels the old run and starts the new one *before* the old one's `defer` clears the flag, so a guard would make the new run silently bail. Overlap is prevented by the Re-run button's `.disabled(isRunningDiagnostics)`.

## Tests

18 new tests in `MeterBarTests/DashboardSectionSplitTests.swift` — the moved navigation API (`sidebarGroups`, `refreshTarget`, `refreshesApiUsage`, `available(sessionWakeEnabled:)`), each section's constructor rendering under `NSHostingView`, and the lifted string helpers (`refreshStatusText`, `summary`, `enabledSourceLabels`).

## Notes

- No `project.pbxproj` edit — `MeterBar/` and `MeterBarTests/` are `PBXFileSystemSynchronizedRootGroup`s.
- `swiftlint lint --strict --quiet` on all seven files → exit 0. Tests/build not run locally; CI is the gate.
- Adds `.agents/SESSIONS/2026-07-25.md`, same as the other open audit PRs — resolve add/add by taking the superset.

Remaining C1 files, one PR each: `MeterBarApp` 974, `MenuBarView` 958, `CostTracker` 954.