### PR TITLE
chore(release): bump to 1.7.2 and reconcile the day's session log

### DIFF
--- a/.agents/SESSIONS/2026-07-25.md
+++ b/.agents/SESSIONS/2026-07-25.md
@@ -1,8 +1,84 @@
 # 2026-07-25
 
-## Session 1: Per-account menu bar status items and a merged account switcher (#266)
+## Session 15: Land the audit follow-through wave and bump to 1.7.2
 
-**Status:** Implementation complete; focused test target green (53 tests); SwiftLint clean; PR CI + exact-head verification pending
+**Status:** 21 PRs reviewed at exact head and merged; version bumped; this entry
+and the session-number reconciliation ride the bump PR.
+
+### System flow
+
+```text
+per PR:  exact-head review ─┬─ PASS ──> required checks ──> resolve threads ──> squash-merge
+                            └─ findings ──> repair on same branch ──> re-review at NEW head
+
+gate order actually observed on master:
+  required_status_checks (build · Tests + coverage gate · SwiftLint · Secret Scan)
+  strict: true                      ──> every merge staleness-invalidates every other PR
+  required_conversation_resolution  ──> BLOCKED with no diagnostic in `gh pr checks`
+  required_pull_request_reviews: null
+```
+
+### Affected components
+
+- Merge/release mechanics only. The one code change made in this session was to
+  a test file (#281); no production source was touched, and the version bump is
+  four `MARKETING_VERSION` lines in `project.pbxproj`.
+
+### What was done
+
+- [x] Reviewed all open PRs at their exact head and merged 21 of them. Because
+      `strict: true` invalidates every other PR's up-to-date status on each
+      merge, landing is inherently serial — one merge, one re-check, repeat.
+- [x] Diagnosed #281's `Tests + coverage gate` failure: three tooltip
+      assertions asserted only the name half of the string. `descriptor()`
+      composes `suffix = spokenValue.map { "\($0) on \(name)" } ?? name`, so the
+      real values carry a `20% left on` / `22% left on` prefix. The **test** was
+      wrong, not the source — every `selectionKey` assertion passed, so the
+      hysteresis and pin-scoping logic those tests exist to prove was already
+      correct. Fixed by pinning the full string, which also locks the
+      value/name composition instead of half of it (`33b45a5`).
+- [x] Bumped `MARKETING_VERSION` 1.7.1 → 1.7.2 at four sites.
+      `CURRENT_PROJECT_VERSION` interpolates `$(MARKETING_VERSION)` and needs no
+      edit. Every other `1.7.1` in the tree is historical prose, a workflow
+      parameter example, a Sparkle appcast fixture, or a Homebrew test fixture,
+      and was deliberately left alone.
+- [x] Reconciled this file's session numbering. It had five `Session 1`s and no
+      `Session 6`. Ordinals were reassigned from the commit time each entry was
+      introduced, so they are now unique and chronological.
+
+### Notes for next time
+
+- **`required_conversation_resolution` is the real merge gate, and it is
+  silent.** A PR with every required check green, `mergeable: MERGEABLE`, an
+  up-to-date head and no review requirement still reports `BLOCKED` and fails
+  with "the base branch policy prohibits the merge" if one review thread is
+  unresolved. Nothing in `gh pr checks` says so. Check unresolved threads
+  directly via the `reviewThreads` GraphQL field before assuming CI is at fault.
+- **A 4-second `build` failure means the tests failed.** The `build` job reads
+  `TEST_RESULT`/`LINT_RESULT` and exits 1 with `Required prerequisites failed`.
+  A genuine build takes ~6–9 minutes.
+- **Extracting a real test failure from CI logs takes a targeted grep.**
+  `--log-failed` emits ~7,500 lines dominated by actor-isolation warnings, and
+  grepping `error:|XCTAssert` returns only warning *context* snippets. Save to a
+  file, then `grep -E "Test Case .* failed \(|: error: -\["`.
+- **Fence balance must be checked by alternation, not parity.** A dropped
+  closing fence makes the next block's opener act as a closer, flipping polarity
+  downstream while the total stays even — so a `count % 2` check reports
+  "balanced" on an inverted document.
+
+### Follow-ups
+
+- [ ] Document why per-account hysteresis exists despite being inert under the
+      current auto-selection policy: `StatusItemAutoSelectionPolicy.windowID(for:)`
+      marks only one window auto-selectable per service, so a scoped pool never
+      has two competitors and the `previousKeys` path is exercised only by
+      synthetic fixtures today.
+- [ ] Reorder this file chronologically and renumber 1..N ascending, once no PR
+      is in flight against it. Ordinals are correct now; document order is not.
+
+## Session 14: Per-account menu bar status items and a merged account switcher (#266)
+
+**Status:** Merged as `93e4ab0` (#281) — all five required checks green, all eight review threads resolved, exact-head verification PASS at `33b45a5`
 
 ```mermaid
 flowchart LR
@@ -22,12 +98,14 @@ flowchart LR
     Ctrl -->|right-click| Switcher[MenuBarAccountSwitcher]
 ```
 
-> Sessions 1–10 of this day are documented in the sibling audit-follow-through PRs
-> (#259–#284), each of which carries its own entry for the same file. This branch
-> is based on `master`, so it starts the day file at its own session; the merge
-> resolution for the resulting add/add conflict is "take the superset".
+> This entry arrived from its own branch, which is why it sits at the top of a
+> file whose body runs oldest-first: every sibling audit PR (#259–#285) appended
+> its own entry to the same path, and each add/add conflict was resolved as "take
+> the superset". Section ordinals are chronological (see Session 15 for the
+> reconciliation); document order is not, and reordering was deferred so it does
+> not collide with the PRs still in flight against this file.
 
-## Session 11: Split `MenuBarView.swift` (audit C1c)
+## Session 12: Split `MenuBarView.swift` (audit C1c)
 
 **Status:** Implementation complete; SwiftLint `--strict` clean; PR CI + exact-head Opus verification pending
 
@@ -64,7 +142,7 @@ flowchart TB
         G -->|notifyContentSize reports with| Shell
 ```
 
-## Session 1: Promote providers into the settings sidebar
+## Session 11: Promote providers into the settings sidebar
 
 **Status:** Implementation complete; PR CI + exact-head verification pending
 
@@ -82,7 +160,7 @@ flowchart LR
     Facts --> Detail
 ```
 
-## Session 1: Fix Codex model attribution and rollout scan coverage
+## Session 10: Fix Codex model attribution and rollout scan coverage
 
 **Status:** Implementation complete (TDD); SwiftLint clean; PR CI + exact-head verification pending
 
@@ -103,7 +181,7 @@ flowchart LR
     Ctxt --> BD[makeBreakdowns<br/>pricingForName: ModelPricing.codex for:]
 ```
 
-## Session 1: Promote Grok Build to a first-class provider (#267)
+## Session 9: Promote Grok Build to a first-class provider (#267)
 
 **Status:** Implementation complete; PR CI + exact-head verification pending
 
@@ -874,7 +952,7 @@ save(key:value:)                       postCompletionNotification(summary:provid
 
 ---
 
-## Session 7: O4 — notification checks fire on committed refreshes, not a 5-minute poll
+## Session 6: O4 — notification checks fire on committed refreshes, not a 5-minute poll
 
 ### System flow
 
@@ -970,7 +1048,7 @@ AFTER
 
 ---
 
-## Session 8: D4 — centralize browser-spoof headers
+## Session 7: D4 — centralize browser-spoof headers
 
 Audit item **D4**. Cursor and Codex both call provider dashboard APIs that
 reject plain API clients, so each request has to look like it came from the
@@ -1060,7 +1138,7 @@ CodexCli.makeCodexRequest          ┘         .cursorDashboard / .chatGPT
 
 ---
 
-## Session 9: C1a — split `UsageDashboardView.swift` into shell + per-page sections
+## Session 8: C1a — split `UsageDashboardView.swift` into shell + per-page sections
 
 ### System flow
 
@@ -1161,7 +1239,7 @@ No `project.pbxproj` edit: `MeterBar/` and `MeterBarTests/` are
 - [ ] Remaining C1 files, one PR each: `MeterBarApp` 974, `MenuBarView` 958,
       `CostTracker` 954.
 
-## Session 10: C1b — split `MeterBarApp.swift` into shell + menu-bar collaborators
+## Session 13: C1b — split `MeterBarApp.swift` into shell + menu-bar collaborators
 
 ### System flow
 

--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.7.2;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -369,7 +369,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.7.2;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -534,7 +534,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.7.2;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug;
 				PRODUCT_NAME = "MeterBar Dev";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -580,7 +580,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.7.2;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
Closes out the audit follow-through wave: 21 PRs reviewed at exact head and merged, ending with #281 (`93e4ab0`).

## Version

`MARKETING_VERSION` 1.7.1 → 1.7.2 at its four sites. `CURRENT_PROJECT_VERSION` interpolates `$(MARKETING_VERSION)` and needs no edit.

Every other `1.7.1` in the tree is deliberately untouched — historical prose (`.agents/SESSIONS/2026-07-13.md`, `README.md`, `docs/sparkle-updates.md`), workflow parameter examples (`_build-signed.yml`, `nightly.yml`), Sparkle appcast fixtures (`SparkleUpdateTests.swift`), and a Homebrew test fixture.

## Session log

Adds the entry for the merge wave, and reconciles the numbering. Concurrent branches each appended to the same day file, which left **five `Session 1` headings and no `Session 6`**. Ordinals are reassigned from the commit time each entry was introduced, so they are now unique and chronological (1–15).

Document order is still *not* chronological — the file body runs oldest-first while branch-authored entries were prepended. Reordering is deferred rather than done here, because a wholesale reflow of this file would conflict badly with #286, which is still in flight against it.

## Notes

- No production source changes. The only code touched during the wave was a test file in #281.
- Two follow-ups are recorded in the entry: documenting why per-account hysteresis is inert under the current auto-selection policy, and the deferred chronological reorder.