### PR TITLE
chore(release): bump MARKETING_VERSION to 1.8.1

### DIFF
--- a/.agents/SESSIONS/2026-07-26.md
+++ b/.agents/SESSIONS/2026-07-26.md
@@ -1,0 +1,68 @@
+# 2026-07-26
+
+## Session 1: realign the project version with the shipped tag (1.8.1)
+
+**Status:** Follow-up to the branch cleanup after #286 landed. Investigation
+first, because the reported symptom turned out to have a false premise.
+
+The checked-in `MARKETING_VERSION` read `1.7.2` while the newest tag was
+`v1.8.0` — the project file appeared to be *behind* a shipped release. The
+obvious reading was a mis-cut tag. It was not.
+
+### What the release path actually does
+
+`v1.8.0` points at `a754160`, where the pbxproj still said `1.7.1`. That is
+intentional. `.github/workflows/_build-signed.yml:168` documents it:
+
+> Version is injected explicitly (not read from the pbxproj) so both channels
+> get exactly the `CFBundleShortVersionString` + `CFBundleVersion` the caller
+> computed. This also removes stable's hidden dependency on a pre-tag pbxproj
+> bump: the tag alone now determines the shipped version.
+
+- **Stable** — `release.yml` derives the version from the pushed tag via
+  `scripts/validate-release-tag.sh`, then passes it to `_build-signed.yml`,
+  which overrides `MARKETING_VERSION` on the `xcodebuild` command line.
+- **Nightly** — `nightly.yml` derives from `git describe --tags`, not the
+  pbxproj.
+
+So **nothing in CI reads `MARKETING_VERSION` from the project file.** The
+shipped 1.8.0 binary reports 1.8.0. The tag is correct.
+
+### Why the tag was left alone
+
+Beyond being correct, `v1.8.0` is load-bearing: it carries a published GitHub
+release with three assets marked Latest, and both the Sparkle appcast and the
+Homebrew formula resolve download URLs under that tag. Retagging or deleting it
+would break in-place updates and `brew upgrade` for existing installs.
+
+### What was done
+
+- [x] Bumped `MARKETING_VERSION` `1.7.2` → `1.8.1` at all four sites
+      (two targets × Debug/Release)
+- [x] Left `CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)"` untouched — it
+      interpolates, so the four sites are the whole change
+- [x] Left every tag and release untouched
+
+### Key decisions
+
+| Decision | Rationale |
+|---|---|
+| Bump to `1.8.1`, not `1.7.3` | `1.7.2` was itself the drift — it was set after `v1.8.0` had already shipped. Next patch above the real shipped version is `1.8.1` |
+| Do not retag `v1.8.0` | The tag is correct by design, and it is referenced by a published release, the Sparkle appcast, and the Homebrew formula |
+| pbxproj value is dev-only metadata | It now affects only local Xcode builds; treat the tag as the release source of truth |
+
+### Verification
+
+- Site count asserted at exactly 4 before the substitution; the edit aborts otherwise
+- Diff is 4 insertions / 4 deletions, one file, no other keys touched
+- Tests/builds intentionally **not** run locally — PR CI is the gate
+
+### Follow-ups (not blocking)
+
+- Consider a CI check that fails when the pbxproj `MARKETING_VERSION` is lower
+  than the newest `v*` tag. The drift was invisible precisely because nothing
+  reads that value.
+- Carried over from 2026-07-25: the Session 14 heading reads `(#266)` while its
+  Status line reads `Merged as 93e4ab0 (#281)`.
+- Carried over: `origin/refactor/split-cost-tracker` (`f9f9332`) is a stale
+  remote branch superseded by merged #286.

--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.7.2;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -369,7 +369,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.7.2;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -534,7 +534,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.7.2;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug;
 				PRODUCT_NAME = "MeterBar Dev";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -580,7 +580,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.7.2;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## What

Bumps the checked-in `MARKETING_VERSION` from `1.7.2` to `1.8.1` at all four sites (two targets × Debug/Release). `CURRENT_PROJECT_VERSION = "\$(MARKETING_VERSION)"` interpolates, so those four lines are the entire change.

## Why 1.8.1 and not 1.7.3

`1.7.2` was itself the drift. `v1.8.0` shipped on 2026-07-24 from `a754160`, and the later bump set the project file to `1.7.2` — *below* the version already in users' hands. The next patch above the real shipped version is `1.8.1`.

## Why the tag was not touched

The initial read was that `v1.8.0` had been mis-cut, since the pbxproj at that commit said `1.7.1`. That read was wrong — it is intentional. [`_build-signed.yml:168`](.github/workflows/_build-signed.yml#L168):

> Version is injected explicitly (not read from the pbxproj) so both channels get exactly the `CFBundleShortVersionString` + `CFBundleVersion` the caller computed. This also removes stable's hidden dependency on a pre-tag pbxproj bump: the tag alone now determines the shipped version.

- **Stable** — `release.yml` derives the version from the pushed tag via `scripts/validate-release-tag.sh`, then `_build-signed.yml` overrides `MARKETING_VERSION` on the `xcodebuild` command line.
- **Nightly** — `nightly.yml` derives from `git describe --tags`.

**Nothing in CI reads `MARKETING_VERSION` from the project file.** The shipped 1.8.0 binary correctly reports 1.8.0. The key is dev-build metadata only — which is exactly why the drift went unnoticed.

`v1.8.0` is also load-bearing: it carries a published release with three assets marked Latest, and both the Sparkle appcast and the Homebrew formula resolve download URLs under that tag. Retagging or deleting it would break in-place updates and `brew upgrade` for existing installs.

## Verification

- Site count asserted at exactly 4 before substitution; the edit aborts otherwise
- Diff is 4 insertions / 4 deletions in one file, no other keys touched
- No tags or releases modified
- Tests/builds not run locally — PR CI is the gate

## Follow-up

Worth a CI check that fails when the pbxproj `MARKETING_VERSION` is lower than the newest `v*` tag. The drift was invisible precisely because nothing consumes that value.