### PR TITLE
feat(cli): add meterbar serve — token-gated read-only local HTTP endpoint

### DIFF
--- a/MeterBar/Serve/ServeBindConfiguration.swift
+++ b/MeterBar/Serve/ServeBindConfiguration.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Resolves the address `meterbar serve` binds to. Loopback is the default
+/// and requires nothing extra; reaching any other interface is an explicit
+/// opt-in the caller must request and be warned about (docs/cli-json-schema.md).
+nonisolated public enum ServeBindConfiguration {
+    public static let loopbackHost = "127.0.0.1"
+    public static let allInterfacesHost = "0.0.0.0"
+
+    public struct Resolution: Sendable {
+        public let host: String
+        public let isRemoteExposed: Bool
+        public let warning: String?
+    }
+
+    public static func resolve(allowRemote: Bool) -> Resolution {
+        guard allowRemote else {
+            return Resolution(host: loopbackHost, isRemoteExposed: false, warning: nil)
+        }
+        return Resolution(
+            host: allInterfacesHost,
+            isRemoteExposed: true,
+            warning: "meterbar serve is bound to all network interfaces (--allow-remote). Usage and "
+                + "cost data will be reachable from other devices on this network; anyone with the "
+                + "printed bearer token can read it."
+        )
+    }
+}

--- a/MeterBar/Serve/ServeCLI.swift
+++ b/MeterBar/Serve/ServeCLI.swift
@@ -41,6 +41,12 @@ nonisolated public enum ServeCLI {
         onReady: @Sendable (StartupInfo) -> Void = { _ in },
         shouldCancel: @Sendable () -> Bool
     ) async -> Outcome {
+        // Fail before binding rather than exposing an endpoint whose auth
+        // check can never reject anything.
+        guard ServeToken.isUsable(request.token) else {
+            return .failedToStart(message: "The bearer token must not be blank.")
+        }
+
         let server = ServeHTTPServer(configuration: ServeHTTPServer.Configuration(
             host: request.host,
             port: request.port,

--- a/MeterBar/Serve/ServeCLI.swift
+++ b/MeterBar/Serve/ServeCLI.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Orchestrates one `meterbar serve` run: start the listener, report where it
+/// bound, wait for a cancellation signal, then shut down. Kept separate from
+/// `ServeHTTPServer` so the CLI's signal-handling glue (`Serve.swift`) has a
+/// single async entry point to await, and so it's testable without spawning
+/// a real process or touching SIGINT/SIGTERM.
+nonisolated public enum ServeCLI {
+    public struct Request: Sendable {
+        public let host: String
+        public let port: UInt16
+        public let token: String
+        public let maxRequestsPerSecond: Int
+
+        public init(host: String, port: UInt16, token: String, maxRequestsPerSecond: Int) {
+            self.host = host
+            self.port = port
+            self.token = token
+            self.maxRequestsPerSecond = maxRequestsPerSecond
+        }
+    }
+
+    public struct StartupInfo: Sendable, Equatable {
+        public let host: String
+        public let port: UInt16
+    }
+
+    public enum Outcome: Sendable, Equatable {
+        case stopped
+        case failedToStart(message: String)
+    }
+
+    /// How often to poll `shouldCancel` while the server is running. Short
+    /// enough that `meterbar serve` reacts to a signal promptly, long enough
+    /// not to busy-loop.
+    private static let pollInterval: UInt64 = 50_000_000 // 50ms
+
+    public static func run(
+        _ request: Request,
+        dataSource: ServeRouter.DataSource,
+        onReady: @Sendable (StartupInfo) -> Void = { _ in },
+        shouldCancel: @Sendable () -> Bool
+    ) async -> Outcome {
+        let server = ServeHTTPServer(configuration: ServeHTTPServer.Configuration(
+            host: request.host,
+            port: request.port,
+            token: request.token,
+            maxRequestsPerSecond: request.maxRequestsPerSecond,
+            dataSource: dataSource
+        ))
+
+        do {
+            try server.start()
+        } catch {
+            return .failedToStart(message: String(describing: error))
+        }
+
+        server.runAcceptLoop()
+        onReady(StartupInfo(host: request.host, port: server.boundPort))
+
+        while !shouldCancel() {
+            try? await Task.sleep(nanoseconds: pollInterval)
+        }
+
+        server.stop()
+        return .stopped
+    }
+}

--- a/MeterBar/Serve/ServeHTTPMessages.swift
+++ b/MeterBar/Serve/ServeHTTPMessages.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// A parsed HTTP request, decoupled from the socket it arrived on so routing
+/// logic (`ServeRouter`) can be unit-tested without a real listener.
+nonisolated public struct ServeHTTPRequest: Sendable {
+    public let method: String
+    public let path: String
+    public let query: [String: String]
+    public let authorizationHeader: String?
+
+    public init(method: String, path: String, query: [String: String] = [:], authorizationHeader: String? = nil) {
+        self.method = method
+        self.path = path
+        self.query = query
+        self.authorizationHeader = authorizationHeader
+    }
+}
+
+/// A rendered HTTP response, independent of how it gets serialized onto the
+/// wire — `ServeHTTPServer` turns this into an HTTP/1.1 status line + headers.
+nonisolated public struct ServeHTTPResponse: Sendable {
+    public let status: Int
+    public let headers: [String: String]
+    public let body: Data
+
+    public init(status: Int, headers: [String: String] = [:], body: Data = Data()) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+}

--- a/MeterBar/Serve/ServeHTTPServer.swift
+++ b/MeterBar/Serve/ServeHTTPServer.swift
@@ -1,0 +1,280 @@
+import Darwin
+import Foundation
+
+nonisolated public enum ServeHTTPServerError: Error, Sendable {
+    case invalidHost(String)
+    case socketCreationFailed(Int32)
+    case bindFailed(Int32)
+    case listenFailed(Int32)
+}
+
+/// Minimal HTTP/1.1, GET-only listener over a raw BSD socket. `meterbar serve`
+/// needs one bounded, read-only endpoint rather than a general-purpose
+/// server, and the brief asks to keep the dependency footprint minimal
+/// (docs/cli-json-schema.md) — a raw socket also gives explicit, verifiable
+/// control over the loopback-vs-all-interfaces bind address, which
+/// `Network.framework`'s listener APIs do not expose as directly.
+///
+/// `@unchecked Sendable`: all mutable state (the listening fd and the running
+/// flag) is guarded by `stateLock`; everything else is immutable.
+nonisolated public final class ServeHTTPServer: @unchecked Sendable {
+    public struct Configuration: Sendable {
+        public let host: String
+        public let port: UInt16
+        public let token: String
+        public let maxRequestsPerSecond: Int
+        public let dataSource: ServeRouter.DataSource
+
+        public init(
+            host: String,
+            port: UInt16,
+            token: String,
+            maxRequestsPerSecond: Int,
+            dataSource: ServeRouter.DataSource
+        ) {
+            self.host = host
+            self.port = port
+            self.token = token
+            self.maxRequestsPerSecond = maxRequestsPerSecond
+            self.dataSource = dataSource
+        }
+    }
+
+    /// Per-connection socket read/write bound, defensive against a slow or
+    /// stalled client tying up a handler thread indefinitely.
+    private static let connectionTimeoutSeconds: Int = 5
+    private static let maxRequestBytes = 8_192
+    private static let listenBacklog: Int32 = 16
+
+    private let configuration: Configuration
+    private let rateLimiter: ServeRateLimiter
+    private let stateLock = NSLock()
+    private var listenSocket: Int32 = -1
+
+    public private(set) var boundPort: UInt16 = 0
+
+    public init(configuration: Configuration) {
+        self.configuration = configuration
+        rateLimiter = ServeRateLimiter(maxPerSecond: configuration.maxRequestsPerSecond)
+    }
+
+    /// Creates, binds, and starts listening. Does not accept connections yet
+    /// — call `runAcceptLoop()` to start serving.
+    public func start() throws {
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = configuration.port.bigEndian
+        let ptonResult = configuration.host.withCString { hostPointer in
+            inet_pton(AF_INET, hostPointer, &addr.sin_addr)
+        }
+        guard ptonResult == 1 else {
+            throw ServeHTTPServerError.invalidHost(configuration.host)
+        }
+
+        let fd = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw ServeHTTPServerError.socketCreationFailed(errno) }
+
+        var reuse: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size))
+
+        let bindResult = withUnsafePointer(to: &addr) { pointer -> Int32 in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                Darwin.bind(fd, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            let code = errno
+            Darwin.close(fd)
+            throw ServeHTTPServerError.bindFailed(code)
+        }
+
+        guard Darwin.listen(fd, Self.listenBacklog) == 0 else {
+            let code = errno
+            Darwin.close(fd)
+            throw ServeHTTPServerError.listenFailed(code)
+        }
+
+        var actual = sockaddr_in()
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        _ = withUnsafeMutablePointer(to: &actual) { pointer -> Int32 in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                getsockname(fd, sockaddrPointer, &length)
+            }
+        }
+
+        stateLock.lock()
+        listenSocket = fd
+        boundPort = UInt16(bigEndian: actual.sin_port)
+        stateLock.unlock()
+    }
+
+    /// Runs the accept loop on a dedicated background queue so the caller
+    /// (an async CLI command) never parks a cooperative thread on a blocking
+    /// syscall. Each connection is handled on a concurrent queue so one slow
+    /// client can't stall new accepts.
+    public func runAcceptLoop() {
+        let acceptQueue = DispatchQueue(label: "dev.meterbar.serve.accept")
+        acceptQueue.async { [weak self] in
+            self?.acceptLoop()
+        }
+    }
+
+    /// Closes the listening socket, which unblocks the accept loop's blocking
+    /// `accept()` call with an error so it exits immediately.
+    public func stop() {
+        stateLock.lock()
+        let fd = listenSocket
+        listenSocket = -1
+        stateLock.unlock()
+        guard fd >= 0 else { return }
+        shutdown(fd, SHUT_RDWR)
+        Darwin.close(fd)
+    }
+
+    private func acceptLoop() {
+        while true {
+            stateLock.lock()
+            let fd = listenSocket
+            stateLock.unlock()
+            guard fd >= 0 else { return }
+
+            let clientFD = Darwin.accept(fd, nil, nil)
+            guard clientFD >= 0 else { return } // stop() closed the socket, or an unrecoverable error
+
+            configureTimeouts(clientFD)
+            DispatchQueue.global(qos: .utility).async { [weak self] in
+                self?.handle(connection: clientFD)
+            }
+        }
+    }
+
+    private func configureTimeouts(_ fd: Int32) {
+        var timeout = timeval(tv_sec: Self.connectionTimeoutSeconds, tv_usec: 0)
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+        setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+    }
+
+    private func handle(connection fd: Int32) {
+        defer { Darwin.close(fd) }
+
+        guard rateLimiter.allow() else {
+            write(response: ServeRouter.tooManyRequestsResponse(), to: fd)
+            return
+        }
+
+        guard let request = Self.readRequest(from: fd) else {
+            write(response: ServeRouter.malformedRequestResponse(), to: fd)
+            return
+        }
+
+        let response = ServeRouter.handle(request, token: configuration.token, dataSource: configuration.dataSource)
+        write(response: response, to: fd)
+    }
+
+    private func write(response: ServeHTTPResponse, to fd: Int32) {
+        let data = Self.serialize(response)
+        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
+            var remaining = buffer.count
+            var pointer = buffer.baseAddress
+            while remaining > 0, let base = pointer {
+                let written = Darwin.write(fd, base, remaining)
+                guard written > 0 else { return }
+                remaining -= written
+                pointer = base + written
+            }
+        }
+    }
+
+    // MARK: Parsing
+
+    private static func readRequest(from fd: Int32) -> ServeHTTPRequest? {
+        var buffer = [UInt8]()
+        var chunk = [UInt8](repeating: 0, count: 1_024)
+        while buffer.count < maxRequestBytes {
+            let bytesRead = chunk.withUnsafeMutableBytes { recv(fd, $0.baseAddress, $0.count, 0) }
+            guard bytesRead > 0 else { break }
+            buffer.append(contentsOf: chunk[0..<bytesRead])
+            if let terminatorIndex = headerTerminatorIndex(in: buffer) {
+                return parse(headerBytes: Array(buffer[..<terminatorIndex]))
+            }
+        }
+        return nil
+    }
+
+    private static func headerTerminatorIndex(in buffer: [UInt8]) -> Int? {
+        let terminator: [UInt8] = [13, 10, 13, 10] // \r\n\r\n
+        guard buffer.count >= terminator.count else { return nil }
+        let lastIndex = buffer.count - terminator.count
+        for index in 0...lastIndex where Array(buffer[index..<(index + terminator.count)]) == terminator {
+            return index
+        }
+        return nil
+    }
+
+    private static func parse(headerBytes: [UInt8]) -> ServeHTTPRequest? {
+        guard let text = String(bytes: headerBytes, encoding: .utf8) else { return nil }
+        let lines = text.components(separatedBy: "\r\n")
+        guard let requestLine = lines.first else { return nil }
+        let parts = requestLine.split(separator: " ", omittingEmptySubsequences: true)
+        guard parts.count >= 2 else { return nil }
+
+        let (path, query) = splitTarget(String(parts[1]))
+
+        var authorizationHeader: String?
+        for line in lines.dropFirst() where !line.isEmpty {
+            guard let colonIndex = line.firstIndex(of: ":") else { continue }
+            let name = line[line.startIndex..<colonIndex].trimmingCharacters(in: .whitespaces)
+            guard name.caseInsensitiveCompare("Authorization") == .orderedSame else { continue }
+            authorizationHeader = line[line.index(after: colonIndex)...].trimmingCharacters(in: .whitespaces)
+        }
+
+        return ServeHTTPRequest(
+            method: String(parts[0]),
+            path: path,
+            query: query,
+            authorizationHeader: authorizationHeader
+        )
+    }
+
+    private static func splitTarget(_ target: String) -> (path: String, query: [String: String]) {
+        guard let queryIndex = target.firstIndex(of: "?") else { return (target, [:]) }
+        let path = String(target[target.startIndex..<queryIndex])
+        var query: [String: String] = [:]
+        for pair in target[target.index(after: queryIndex)...].split(separator: "&") {
+            let keyValue = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard let rawKey = keyValue.first else { continue }
+            let key = rawKey.removingPercentEncoding ?? String(rawKey)
+            let value = keyValue.count > 1 ? (String(keyValue[1]).removingPercentEncoding ?? String(keyValue[1])) : ""
+            query[key] = value
+        }
+        return (path, query)
+    }
+
+    private static func serialize(_ response: ServeHTTPResponse) -> Data {
+        var headers = response.headers
+        headers["Content-Length"] = String(response.body.count)
+        headers["Connection"] = "close"
+
+        var head = "HTTP/1.1 \(response.status) \(statusText(response.status))\r\n"
+        for (name, value) in headers.sorted(by: { $0.key < $1.key }) {
+            head += "\(name): \(value)\r\n"
+        }
+        head += "\r\n"
+
+        var data = Data(head.utf8)
+        data.append(response.body)
+        return data
+    }
+
+    private static func statusText(_ status: Int) -> String {
+        switch status {
+        case 200: return "OK"
+        case 400: return "Bad Request"
+        case 401: return "Unauthorized"
+        case 404: return "Not Found"
+        case 405: return "Method Not Allowed"
+        case 429: return "Too Many Requests"
+        default: return "Internal Server Error"
+        }
+    }
+}

--- a/MeterBar/Serve/ServeHTTPServer.swift
+++ b/MeterBar/Serve/ServeHTTPServer.swift
@@ -24,25 +24,35 @@ nonisolated public final class ServeHTTPServer: @unchecked Sendable {
         public let token: String
         public let maxRequestsPerSecond: Int
         public let dataSource: ServeRouter.DataSource
+        public let requestTimeout: TimeInterval
 
         public init(
             host: String,
             port: UInt16,
             token: String,
             maxRequestsPerSecond: Int,
-            dataSource: ServeRouter.DataSource
+            dataSource: ServeRouter.DataSource,
+            requestTimeout: TimeInterval = ServeHTTPServer.defaultRequestTimeout
         ) {
             self.host = host
             self.port = port
             self.token = token
             self.maxRequestsPerSecond = maxRequestsPerSecond
             self.dataSource = dataSource
+            self.requestTimeout = requestTimeout
         }
     }
 
-    /// Per-connection socket read/write bound, defensive against a slow or
-    /// stalled client tying up a handler thread indefinitely.
-    private static let connectionTimeoutSeconds: Int = 5
+    /// Wall-clock bound on how long one connection may take to deliver a
+    /// complete request head. Configurable only so tests can drive it down;
+    /// nothing on the CLI surface exposes it.
+    public static let defaultRequestTimeout: TimeInterval = 5
+
+    /// How long a single `recv`/`write` may block. Deliberately shorter than
+    /// the request deadline: `SO_RCVTIMEO` restarts on every byte received, so
+    /// it can't bound a connection on its own — it only needs to wake the read
+    /// loop often enough to notice the deadline has passed.
+    private static let socketPollSeconds: Int = 1
     private static let maxRequestBytes = 8_192
     private static let listenBacklog: Int32 = 16
 
@@ -139,7 +149,19 @@ nonisolated public final class ServeHTTPServer: @unchecked Sendable {
             guard fd >= 0 else { return }
 
             let clientFD = Darwin.accept(fd, nil, nil)
-            guard clientFD >= 0 else { return } // stop() closed the socket, or an unrecoverable error
+            if clientFD < 0 {
+                guard Self.isTransientAcceptError(errno) else { return }
+                // stop() closing the listening socket lands in the `return`
+                // above (EBADF); everything here is a peer or a signal
+                // misbehaving on one connection, which must not take the
+                // listener down with it.
+                if errno == EMFILE || errno == ENFILE {
+                    // Descriptor exhaustion clears only when an in-flight
+                    // handler closes, so back off instead of spinning hot.
+                    usleep(100_000)
+                }
+                continue
+            }
 
             configureTimeouts(clientFD)
             DispatchQueue.global(qos: .utility).async { [weak self] in
@@ -148,8 +170,16 @@ nonisolated public final class ServeHTTPServer: @unchecked Sendable {
         }
     }
 
+    /// `accept` failures a live listener recovers from: a signal arriving
+    /// mid-call, a peer that disconnected between the SYN and the accept, a
+    /// spurious wakeup, or transient descriptor exhaustion.
+    private static func isTransientAcceptError(_ code: Int32) -> Bool {
+        code == EINTR || code == ECONNABORTED || code == EAGAIN
+            || code == EWOULDBLOCK || code == EMFILE || code == ENFILE
+    }
+
     private func configureTimeouts(_ fd: Int32) {
-        var timeout = timeval(tv_sec: Self.connectionTimeoutSeconds, tv_usec: 0)
+        var timeout = timeval(tv_sec: Self.socketPollSeconds, tv_usec: 0)
         setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
         setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
     }
@@ -162,7 +192,8 @@ nonisolated public final class ServeHTTPServer: @unchecked Sendable {
             return
         }
 
-        guard let request = Self.readRequest(from: fd) else {
+        let deadline = Date().addingTimeInterval(configuration.requestTimeout)
+        guard let request = Self.readRequest(from: fd, deadline: deadline) else {
             write(response: ServeRouter.malformedRequestResponse(), to: fd)
             return
         }
@@ -187,16 +218,29 @@ nonisolated public final class ServeHTTPServer: @unchecked Sendable {
 
     // MARK: Parsing
 
-    private static func readRequest(from fd: Int32) -> ServeHTTPRequest? {
+    /// Bounded by `deadline` rather than by the socket's own receive timeout:
+    /// `SO_RCVTIMEO` restarts on every byte that arrives, so a client sending
+    /// one byte just inside that window could otherwise hold a handler thread
+    /// open indefinitely.
+    private static func readRequest(from fd: Int32, deadline: Date) -> ServeHTTPRequest? {
         var buffer = [UInt8]()
         var chunk = [UInt8](repeating: 0, count: 1_024)
         while buffer.count < maxRequestBytes {
+            guard Date() < deadline else { return nil }
+
             let bytesRead = chunk.withUnsafeMutableBytes { recv(fd, $0.baseAddress, $0.count, 0) }
-            guard bytesRead > 0 else { break }
-            buffer.append(contentsOf: chunk[0..<bytesRead])
-            if let terminatorIndex = headerTerminatorIndex(in: buffer) {
-                return parse(headerBytes: Array(buffer[..<terminatorIndex]))
+            if bytesRead > 0 {
+                buffer.append(contentsOf: chunk[0..<bytesRead])
+                if let terminatorIndex = headerTerminatorIndex(in: buffer) {
+                    return parse(headerBytes: Array(buffer[..<terminatorIndex]))
+                }
+                continue
             }
+
+            // 0 means the peer closed; there is no more request coming. -1 with
+            // EAGAIN/EWOULDBLOCK is just this recv hitting `socketPollSeconds`,
+            // so loop back and re-check the deadline instead of giving up.
+            guard bytesRead < 0, errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR else { return nil }
         }
         return nil
     }

--- a/MeterBar/Serve/ServeRateLimiter.swift
+++ b/MeterBar/Serve/ServeRateLimiter.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Bounds how many requests `meterbar serve` answers per second. Even a
+/// loopback-only, token-gated listener can be pointed at repeatedly by a
+/// misbehaving script; this keeps a single caller from turning polling into
+/// an unbounded CPU/encoding cost.
+nonisolated public final class ServeRateLimiter: @unchecked Sendable {
+    private let maxPerSecond: Int
+    private let clock: @Sendable () -> Date
+    private let lock = NSLock()
+    private var windowStart: Date
+    private var countInWindow = 0
+
+    public init(maxPerSecond: Int, clock: @escaping @Sendable () -> Date = Date.init) {
+        self.maxPerSecond = max(1, maxPerSecond)
+        self.clock = clock
+        self.windowStart = clock()
+    }
+
+    /// Sliding-by-reset (not sliding-window) counter: cheap, thread-safe, and
+    /// precise enough for a bounded local endpoint.
+    public func allow() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let now = clock()
+        if now.timeIntervalSince(windowStart) >= 1 {
+            windowStart = now
+            countInWindow = 0
+        }
+
+        guard countInWindow < maxPerSecond else { return false }
+        countInWindow += 1
+        return true
+    }
+}

--- a/MeterBar/Serve/ServeRateLimiter.swift
+++ b/MeterBar/Serve/ServeRateLimiter.swift
@@ -11,7 +11,10 @@ nonisolated public final class ServeRateLimiter: @unchecked Sendable {
     private var windowStart: Date
     private var countInWindow = 0
 
-    public init(maxPerSecond: Int, clock: @escaping @Sendable () -> Date = Date.init) {
+    // The default is a closure rather than the `Date.init` reference: an
+    // unapplied initializer reference is not itself `@Sendable`, so passing it
+    // directly warns under Swift 6 strict concurrency.
+    public init(maxPerSecond: Int, clock: @escaping @Sendable () -> Date = { Date() }) {
         self.maxPerSecond = max(1, maxPerSecond)
         self.clock = clock
         self.windowStart = clock()

--- a/MeterBar/Serve/ServeRouter.swift
+++ b/MeterBar/Serve/ServeRouter.swift
@@ -1,0 +1,132 @@
+import Foundation
+import MeterBarShared
+
+/// Pure request handling for `meterbar serve`: authenticates, routes, and
+/// builds responses from the same DTOs `meterbar usage --json` / `cost --json`
+/// already emit. Deliberately has no socket code so it can be unit-tested
+/// directly against `ServeHTTPRequest` values.
+nonisolated public enum ServeRouter {
+    /// Reads MeterBar's existing cached snapshots. Never triggers a provider
+    /// refresh — serving must not be able to amplify into a request storm
+    /// under polling (docs/cli-json-schema.md).
+    public struct DataSource: Sendable {
+        public let loadUsageMetrics: @Sendable () -> [ServiceType: UsageMetrics]
+        public let loadCostCache: @Sendable () -> CostSummaryCache?
+
+        public init(
+            loadUsageMetrics: @escaping @Sendable () -> [ServiceType: UsageMetrics],
+            loadCostCache: @escaping @Sendable () -> CostSummaryCache?
+        ) {
+            self.loadUsageMetrics = loadUsageMetrics
+            self.loadCostCache = loadCostCache
+        }
+
+        public static let liveCache = DataSource(
+            loadUsageMetrics: { SharedDataStore.shared.loadMetrics() },
+            loadCostCache: { CostSummaryStore.load() }
+        )
+    }
+
+    /// Auth is checked before routing so an unauthenticated caller can't use
+    /// the status code to learn which paths exist or which methods they take.
+    public static func handle(_ request: ServeHTTPRequest, token: String, dataSource: DataSource) -> ServeHTTPResponse {
+        guard ServeToken.matches(presented: request.authorizationHeader, expected: token) else {
+            return unauthorizedResponse()
+        }
+
+        switch request.path {
+        case "/usage":
+            guard request.method == "GET" else { return methodNotAllowedResponse() }
+            return usageResponse(dataSource: dataSource, query: request.query)
+        case "/cost":
+            guard request.method == "GET" else { return methodNotAllowedResponse() }
+            return costResponse(dataSource: dataSource, query: request.query)
+        default:
+            return notFoundResponse()
+        }
+    }
+
+    public static func tooManyRequestsResponse() -> ServeHTTPResponse {
+        errorResponse(status: 429, code: "too_many_requests", message: "Rate limit exceeded.")
+    }
+
+    public static func malformedRequestResponse() -> ServeHTTPResponse {
+        errorResponse(status: 400, code: "bad_request", message: "Malformed HTTP request.")
+    }
+
+    // MARK: Endpoints
+
+    private static func usageResponse(dataSource: DataSource, query: [String: String]) -> ServeHTTPResponse {
+        let metrics = dataSource.loadUsageMetrics()
+        guard !metrics.isEmpty else {
+            return errorResponse(
+                code: "usage_cache_missing",
+                message: "No cached metrics found. Open MeterBar app to fetch data."
+            )
+        }
+
+        let filtered: [ServiceType: UsageMetrics]
+        if let provider = query["provider"]?.lowercased(), !provider.isEmpty {
+            filtered = metrics.filter {
+                $0.key.rawValue.lowercased().contains(provider)
+                    || $0.key.displayName.lowercased().contains(provider)
+            }
+        } else {
+            filtered = metrics
+        }
+
+        return jsonResponse(UsageCLIJSONResponse(metrics: filtered))
+    }
+
+    private static func costResponse(dataSource: DataSource, query: [String: String]) -> ServeHTTPResponse {
+        guard let cache = dataSource.loadCostCache() else {
+            return errorResponse(
+                code: "cost_cache_missing",
+                message: "No cost data cached. Open MeterBar and run a scan (Costs tab)."
+            )
+        }
+
+        // Mirrors `meterbar cost --days`: an invalid or non-positive value is
+        // ignored rather than rejected, falling back to the full cached summary.
+        let days = query["days"].flatMap(Int.init).flatMap { $0 >= 1 ? $0 : nil }
+        return jsonResponse(CostCLIJSONResponse(cache: cache, days: days))
+    }
+
+    // MARK: Response construction
+
+    private static func jsonResponse(_ document: some CLIJSONDocument) -> ServeHTTPResponse {
+        let body = (try? document.jsonData()) ?? Data()
+        return ServeHTTPResponse(
+            status: 200,
+            headers: [
+                "Content-Type": "application/json; charset=utf-8",
+                "Cache-Control": "no-store",
+            ],
+            body: body
+        )
+    }
+
+    private static func unauthorizedResponse() -> ServeHTTPResponse {
+        errorResponse(status: 401, code: "unauthorized", message: "Missing or invalid bearer token.")
+    }
+
+    private static func notFoundResponse() -> ServeHTTPResponse {
+        errorResponse(status: 404, code: "not_found", message: "Unknown path.")
+    }
+
+    private static func methodNotAllowedResponse() -> ServeHTTPResponse {
+        errorResponse(status: 405, code: "method_not_allowed", message: "Only GET is supported.")
+    }
+
+    private static func errorResponse(status: Int = 200, code: String, message: String) -> ServeHTTPResponse {
+        let body = (try? CLIJSONErrorResponse(code: code, message: message).jsonData()) ?? Data()
+        return ServeHTTPResponse(
+            status: status,
+            headers: [
+                "Content-Type": "application/json; charset=utf-8",
+                "Cache-Control": "no-store",
+            ],
+            body: body
+        )
+    }
+}

--- a/MeterBar/Serve/ServeRouter.swift
+++ b/MeterBar/Serve/ServeRouter.swift
@@ -94,8 +94,23 @@ nonisolated public enum ServeRouter {
 
     // MARK: Response construction
 
-    private static func jsonResponse(_ document: some CLIJSONDocument) -> ServeHTTPResponse {
-        let body = (try? document.jsonData()) ?? Data()
+    private static let staticEncodingFailureBody = """
+    {"schemaVersion":1,"error":{"code":"internal_error","message":"Failed to encode the error payload."}}
+    """
+
+    /// An encoding failure must not surface as an empty body labelled
+    /// `200 OK` / `application/json` — a client would read that as success it
+    /// merely failed to parse, rather than as the server-side fault it is.
+    /// Internal rather than private so tests can drive the failure path.
+    static func jsonResponse(_ document: some CLIJSONDocument) -> ServeHTTPResponse {
+        guard let body = try? document.jsonData() else {
+            return errorResponse(
+                status: 500,
+                code: "internal_error",
+                message: "Failed to encode the response payload."
+            )
+        }
+
         return ServeHTTPResponse(
             status: 200,
             headers: [
@@ -118,8 +133,12 @@ nonisolated public enum ServeRouter {
         errorResponse(status: 405, code: "method_not_allowed", message: "Only GET is supported.")
     }
 
+    /// The last stop for every failure path, so its own fallback is a literal
+    /// rather than an empty body: a caller must always get something it can
+    /// parse, even if encoding the real detail failed.
     private static func errorResponse(status: Int = 200, code: String, message: String) -> ServeHTTPResponse {
-        let body = (try? CLIJSONErrorResponse(code: code, message: message).jsonData()) ?? Data()
+        let body = (try? CLIJSONErrorResponse(code: code, message: message).jsonData())
+            ?? Data(Self.staticEncodingFailureBody.utf8)
         return ServeHTTPResponse(
             status: status,
             headers: [

--- a/MeterBar/Serve/ServeToken.swift
+++ b/MeterBar/Serve/ServeToken.swift
@@ -24,9 +24,21 @@ nonisolated public enum ServeToken {
         return bytes.map { String(format: "%02x", $0) }.joined()
     }
 
+    /// Whether a token is strong enough to gate anything. A blank token would
+    /// otherwise compare equal to the empty string a caller gets from a bare
+    /// `Authorization: Bearer ` header, turning the auth check into a no-op.
+    public static func isUsable(_ token: String) -> Bool {
+        !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     /// `presented` is the raw `Authorization` header value. Anything other
     /// than an exact `Bearer <token>` shape fails without a byte comparison.
+    ///
+    /// An unusable `expected` fails closed: callers are expected to reject a
+    /// blank token before binding a socket (`ServeCLI.run`), and this is the
+    /// second layer that keeps a missed check from opening the endpoint.
     public static func matches(presented: String?, expected: String) -> Bool {
+        guard isUsable(expected) else { return false }
         guard let presented, presented.hasPrefix(bearerPrefix) else { return false }
         let candidate = String(presented.dropFirst(bearerPrefix.count))
         return constantTimeEquals(candidate, expected)

--- a/MeterBar/Serve/ServeToken.swift
+++ b/MeterBar/Serve/ServeToken.swift
@@ -1,0 +1,49 @@
+import Darwin
+import Foundation
+import Security
+
+/// Bearer token generation and comparison for `meterbar serve`. Comparison
+/// runs in constant time so a network caller can't use response latency to
+/// guess the token one byte at a time (docs/cli-json-schema.md security notes).
+nonisolated public enum ServeToken {
+    private static let byteCount = 32
+    private static let bearerPrefix = "Bearer "
+
+    public static func generate() -> String {
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        let status = bytes.withUnsafeMutableBytes { buffer -> Int32 in
+            guard let baseAddress = buffer.baseAddress else { return errSecParam }
+            return SecRandomCopyBytes(kSecRandomDefault, byteCount, baseAddress)
+        }
+        if status != errSecSuccess {
+            // SecRandomCopyBytes practically never fails on Apple platforms;
+            // arc4random_buf is still a CSPRNG, so this keeps token
+            // generation from crashing the process rather than degrading it.
+            arc4random_buf(&bytes, byteCount)
+        }
+        return bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// `presented` is the raw `Authorization` header value. Anything other
+    /// than an exact `Bearer <token>` shape fails without a byte comparison.
+    public static func matches(presented: String?, expected: String) -> Bool {
+        guard let presented, presented.hasPrefix(bearerPrefix) else { return false }
+        let candidate = String(presented.dropFirst(bearerPrefix.count))
+        return constantTimeEquals(candidate, expected)
+    }
+
+    /// Always walks the full length of the longer input — no early return on
+    /// a length or byte mismatch — so equal-length-but-wrong tokens and
+    /// wrong-length tokens take the same code path.
+    private static func constantTimeEquals(_ lhs: String, _ rhs: String) -> Bool {
+        let lhsBytes = Array(lhs.utf8)
+        let rhsBytes = Array(rhs.utf8)
+        var difference: UInt8 = lhsBytes.count == rhsBytes.count ? 0 : 1
+        for index in 0..<max(lhsBytes.count, rhsBytes.count) {
+            let lhsByte = index < lhsBytes.count ? lhsBytes[index] : 0
+            let rhsByte = index < rhsBytes.count ? rhsBytes[index] : 0
+            difference |= lhsByte ^ rhsByte
+        }
+        return difference == 0
+    }
+}

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -20,6 +20,7 @@ struct MeterBarCLI: AsyncParsableCommand {
             Wake.self,
             WakeAgent.self,
             ResetCredit.self,
+            Serve.self,
         ],
         defaultSubcommand: Usage.self
     )

--- a/MeterBarCLI/Sources/Serve.swift
+++ b/MeterBarCLI/Sources/Serve.swift
@@ -1,0 +1,107 @@
+import ArgumentParser
+import Darwin
+import Dispatch
+import Foundation
+import MeterBar
+
+/// `meterbar serve` — a local, token-gated, read-only HTTP view of the same
+/// cached usage/cost data `meterbar usage --json` / `cost --json` emit. Never
+/// triggers a provider refresh and never mutates state (docs/cli-json-schema.md).
+struct Serve: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "serve",
+        abstract: "Serve usage and cost data over a local, token-gated, read-only HTTP endpoint"
+    )
+
+    static let defaultPort: UInt16 = 47_663
+    static let defaultMaxRequestsPerSecond = 5
+
+    @Option(help: "Port to listen on.")
+    var port: UInt16 = Serve.defaultPort
+
+    @Option(help: "Bearer token required on every request. If omitted, one is generated and printed once.")
+    var token: String?
+
+    @Flag(help: "Bind to all network interfaces instead of loopback only. Exposes usage/cost data to other devices.")
+    var allowRemote: Bool = false
+
+    @Option(help: "Maximum requests served per second before responding 429 Too Many Requests.")
+    var maxRequestsPerSecond: Int = Serve.defaultMaxRequestsPerSecond
+
+    func validate() throws {
+        if maxRequestsPerSecond < 1 {
+            throw ValidationError("--max-requests-per-second must be 1 or greater.")
+        }
+    }
+
+    func run() async throws {
+        let generatedToken = token == nil
+        let resolvedToken = token ?? ServeToken.generate()
+        let bind = ServeBindConfiguration.resolve(allowRemote: allowRemote)
+
+        if let warning = bind.warning {
+            FileHandle.standardError.write(Data("⚠ \(warning)\n".utf8))
+        }
+
+        let cancellation = ServeCancellation()
+        let signalSources = installSignalHandlers(cancellation)
+        defer { signalSources.forEach { $0.cancel() } }
+
+        let request = ServeCLI.Request(
+            host: bind.host,
+            port: port,
+            token: resolvedToken,
+            maxRequestsPerSecond: maxRequestsPerSecond
+        )
+
+        let outcome = await ServeCLI.run(
+            request,
+            dataSource: .liveCache,
+            onReady: { info in
+                print("meterbar serve listening on http://\(info.host):\(info.port)")
+                print("Endpoints: GET /usage, GET /cost (Authorization: Bearer <token> required)")
+                if generatedToken {
+                    // Printed exactly once, at startup, and never logged again —
+                    // this is the only place the token is ever surfaced.
+                    print("Bearer token (generated, shown once): \(resolvedToken)")
+                }
+                print("Press Ctrl-C to stop.")
+            },
+            shouldCancel: { cancellation.isCancelled }
+        )
+
+        switch outcome {
+        case .stopped:
+            return
+        case .failedToStart(let message):
+            throw ValidationError("Failed to start meterbar serve: \(message)")
+        }
+    }
+
+    private func installSignalHandlers(_ cancellation: ServeCancellation) -> [DispatchSourceSignal] {
+        [SIGINT, SIGTERM].map { signalNumber in
+            signal(signalNumber, SIG_IGN)
+            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global())
+            source.setEventHandler { cancellation.cancel() }
+            source.resume()
+            return source
+        }
+    }
+}
+
+private final class ServeCancellation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+}

--- a/MeterBarCLI/Sources/Serve.swift
+++ b/MeterBarCLI/Sources/Serve.swift
@@ -32,6 +32,12 @@ struct Serve: AsyncParsableCommand {
         if maxRequestsPerSecond < 1 {
             throw ValidationError("--max-requests-per-second must be 1 or greater.")
         }
+        // `--token ""` survives the `??` below, so reject it here rather than
+        // starting a server whose auth check can never reject anything. Omit
+        // the flag entirely to get a generated token.
+        if let token, !ServeToken.isUsable(token) {
+            throw ValidationError("--token must not be blank. Omit it to have one generated.")
+        }
     }
 
     func run() async throws {

--- a/MeterBarTests/ServeBindConfigurationTests.swift
+++ b/MeterBarTests/ServeBindConfigurationTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import MeterBar
+
+final class ServeBindConfigurationTests: XCTestCase {
+    func testDefaultResolutionBindsToLoopbackWithoutWarning() {
+        let resolution = ServeBindConfiguration.resolve(allowRemote: false)
+
+        XCTAssertEqual(resolution.host, "127.0.0.1")
+        XCTAssertFalse(resolution.isRemoteExposed)
+        XCTAssertNil(resolution.warning)
+    }
+
+    func testAllowRemoteBindsToAllInterfacesAndWarns() {
+        let resolution = ServeBindConfiguration.resolve(allowRemote: true)
+
+        XCTAssertEqual(resolution.host, "0.0.0.0")
+        XCTAssertTrue(resolution.isRemoteExposed)
+        let warning = try? XCTUnwrap(resolution.warning)
+        XCTAssertTrue(warning?.localizedCaseInsensitiveContains("network") ?? false)
+        XCTAssertTrue(warning?.localizedCaseInsensitiveContains("reachable") ?? false)
+    }
+}

--- a/MeterBarTests/ServeCLITests.swift
+++ b/MeterBarTests/ServeCLITests.swift
@@ -50,6 +50,29 @@ final class ServeCLITests: XCTestCase {
         XCTAssertNotEqual(info?.port, 0, "an ephemeral bind should resolve to a real port")
     }
 
+    /// Refuses to bind at all rather than starting an endpoint whose auth
+    /// check can never reject anything.
+    func testRunRefusesToStartWithABlankToken() async {
+        for blank in ["", "   "] {
+            let outcome = await ServeCLI.run(
+                ServeCLI.Request(
+                    host: ServeBindConfiguration.loopbackHost,
+                    port: 0,
+                    token: blank,
+                    maxRequestsPerSecond: 10
+                ),
+                dataSource: makeDataSource(),
+                shouldCancel: { true }
+            )
+
+            guard case .failedToStart(let message) = outcome else {
+                XCTFail("expected a blank token to fail startup, got \(outcome)")
+                return
+            }
+            XCTAssertTrue(message.lowercased().contains("token"), "message should name the token: \(message)")
+        }
+    }
+
     func testRunReportsFailureWhenTheHostCannotBeResolved() async {
         let outcome = await ServeCLI.run(
             ServeCLI.Request(host: "not-an-ip-address", port: 0, token: "t", maxRequestsPerSecond: 10),

--- a/MeterBarTests/ServeCLITests.swift
+++ b/MeterBarTests/ServeCLITests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+final class ServeCLITests: XCTestCase {
+    private func makeDataSource() -> ServeRouter.DataSource {
+        ServeRouter.DataSource(loadUsageMetrics: { [:] }, loadCostCache: { nil })
+    }
+
+    func testRunNotifiesOnReadyWithTheBoundPortThenStopsWhenCancelled() async {
+        final class CancelBox: @unchecked Sendable {
+            private let lock = NSLock()
+            private var cancelled = false
+            var isCancelled: Bool { lock.withLock { cancelled } }
+            func cancel() { lock.withLock { cancelled = true } }
+        }
+
+        let box = CancelBox()
+        final class ReadyBox: @unchecked Sendable {
+            private let lock = NSLock()
+            private var info: ServeCLI.StartupInfo?
+            var value: ServeCLI.StartupInfo? { lock.withLock { info } }
+            func set(_ newValue: ServeCLI.StartupInfo) { lock.withLock { info = newValue } }
+        }
+        let readyBox = ReadyBox()
+
+        let runTask = Task {
+            await ServeCLI.run(
+                ServeCLI.Request(
+                    host: ServeBindConfiguration.loopbackHost,
+                    port: 0,
+                    token: "t",
+                    maxRequestsPerSecond: 10
+                ),
+                dataSource: makeDataSource(),
+                onReady: { readyBox.set($0) },
+                shouldCancel: { box.isCancelled }
+            )
+        }
+
+        // Give the server a moment to bind and invoke onReady, then stop it.
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        box.cancel()
+        let outcome = await runTask.value
+
+        XCTAssertEqual(outcome, .stopped)
+        let info = try? XCTUnwrap(readyBox.value)
+        XCTAssertEqual(info?.host, ServeBindConfiguration.loopbackHost)
+        XCTAssertNotEqual(info?.port, 0, "an ephemeral bind should resolve to a real port")
+    }
+
+    func testRunReportsFailureWhenTheHostCannotBeResolved() async {
+        let outcome = await ServeCLI.run(
+            ServeCLI.Request(host: "not-an-ip-address", port: 0, token: "t", maxRequestsPerSecond: 10),
+            dataSource: makeDataSource(),
+            shouldCancel: { true }
+        )
+
+        guard case .failedToStart = outcome else {
+            XCTFail("expected a failedToStart outcome, got \(outcome)")
+            return
+        }
+    }
+}

--- a/MeterBarTests/ServeHTTPServerTests.swift
+++ b/MeterBarTests/ServeHTTPServerTests.swift
@@ -24,13 +24,17 @@ final class ServeHTTPServerTests: XCTestCase {
         )
     }
 
-    private func startServer(maxRequestsPerSecond: Int = 100) throws -> ServeHTTPServer {
+    private func startServer(
+        maxRequestsPerSecond: Int = 100,
+        requestTimeout: TimeInterval = 5
+    ) throws -> ServeHTTPServer {
         let server = ServeHTTPServer(configuration: ServeHTTPServer.Configuration(
             host: ServeBindConfiguration.loopbackHost,
             port: 0,
             token: token,
             maxRequestsPerSecond: maxRequestsPerSecond,
-            dataSource: makeDataSource()
+            dataSource: makeDataSource(),
+            requestTimeout: requestTimeout
         ))
         try server.start()
         server.runAcceptLoop()
@@ -133,5 +137,104 @@ final class ServeHTTPServerTests: XCTestCase {
         ))
 
         XCTAssertThrowsError(try second.start())
+    }
+
+    // MARK: Connection lifetime
+
+    /// `SO_RCVTIMEO` bounds each individual `recv`, not the connection, so a
+    /// client that dribbles one byte just often enough to reset that timer can
+    /// otherwise hold a handler thread forever. Only an overall deadline ends
+    /// this connection.
+    func testServerDropsAClientThatTricklesHeaderBytesWithoutFinishing() throws {
+        let server = try startServer(requestTimeout: 1)
+        defer { server.stop() }
+
+        let fd = try connectRawClient(port: server.boundPort)
+        defer { Darwin.close(fd) }
+
+        // A request line with no terminating blank line — the server can never
+        // consider this request complete.
+        try sendRaw("GET /usage HTTP/1.1\r\nHost: localhost\r\n", to: fd)
+
+        let start = Date()
+        var serverEnded = false
+        var buffer = [UInt8](repeating: 0, count: 1_024)
+        for _ in 0..<25 {
+            _ = try? sendRaw("X", to: fd)
+            // The client socket carries a 50ms receive timeout, so this polls
+            // rather than blocks; <= 0 means the server answered and hung up,
+            // or hung up outright.
+            if Darwin.recv(fd, &buffer, buffer.count, 0) > 0 {
+                serverEnded = true
+                break
+            }
+            if errno != EAGAIN, errno != EWOULDBLOCK {
+                serverEnded = true
+                break
+            }
+            Thread.sleep(forTimeInterval: 0.2)
+        }
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertTrue(serverEnded, "the server never ended a trickling connection")
+        XCTAssertLessThan(elapsed, 3, "connection outlived its 1s request deadline (took \(elapsed)s)")
+    }
+
+    /// A peer that vanishes between the SYN and the `accept` surfaces as a
+    /// transient `accept` error. Treating that as fatal would take the whole
+    /// listener down with it.
+    func testServerKeepsServingAfterConnectionsThatCloseImmediately() async throws {
+        let server = try startServer()
+        defer { server.stop() }
+
+        for _ in 0..<5 {
+            let fd = try connectRawClient(port: server.boundPort)
+            Darwin.close(fd)
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let (response, _) = try await get("/usage", port: server.boundPort, bearerToken: token)
+
+        XCTAssertEqual(response.statusCode, 200, "the accept loop stopped after abrupt disconnects")
+    }
+
+    // MARK: Raw socket helpers
+
+    private func connectRawClient(port: UInt16, receiveTimeoutMicroseconds: Int32 = 50_000) throws -> Int32 {
+        let fd = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw RawClientError.socketFailed }
+
+        var enabled: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &enabled, socklen_t(MemoryLayout<Int32>.size))
+        var timeout = timeval(tv_sec: 0, tv_usec: receiveTimeoutMicroseconds)
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+
+        var address = sockaddr_in()
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = port.bigEndian
+        address.sin_addr.s_addr = inet_addr("127.0.0.1")
+
+        let connected = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard connected == 0 else {
+            Darwin.close(fd)
+            throw RawClientError.connectFailed
+        }
+        return fd
+    }
+
+    private func sendRaw(_ text: String, to fd: Int32) throws {
+        let bytes = Array(text.utf8)
+        let sent = bytes.withUnsafeBytes { Darwin.send(fd, $0.baseAddress, $0.count, 0) }
+        guard sent == bytes.count else { throw RawClientError.sendFailed }
+    }
+
+    private enum RawClientError: Error {
+        case socketFailed
+        case connectFailed
+        case sendFailed
     }
 }

--- a/MeterBarTests/ServeHTTPServerTests.swift
+++ b/MeterBarTests/ServeHTTPServerTests.swift
@@ -1,0 +1,137 @@
+import Darwin
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+final class ServeHTTPServerTests: XCTestCase {
+    private let referenceDate = Date(timeIntervalSince1970: 1_700_000_000)
+    private let token = "integration-test-token"
+
+    private func makeDataSource() -> ServeRouter.DataSource {
+        let metrics: [ServiceType: UsageMetrics] = [
+            .claudeCode: UsageMetrics(
+                service: .claudeCode,
+                sessionLimit: UsageLimit(used: 10, total: 100, resetTime: nil, windowSeconds: 18_000),
+                weeklyLimit: nil,
+                extraUsage: nil,
+                lastUpdated: referenceDate
+            ),
+        ]
+        return ServeRouter.DataSource(
+            loadUsageMetrics: { metrics },
+            loadCostCache: { nil }
+        )
+    }
+
+    private func startServer(maxRequestsPerSecond: Int = 100) throws -> ServeHTTPServer {
+        let server = ServeHTTPServer(configuration: ServeHTTPServer.Configuration(
+            host: ServeBindConfiguration.loopbackHost,
+            port: 0,
+            token: token,
+            maxRequestsPerSecond: maxRequestsPerSecond,
+            dataSource: makeDataSource()
+        ))
+        try server.start()
+        server.runAcceptLoop()
+        return server
+    }
+
+    private func get(
+        _ path: String,
+        port: UInt16,
+        bearerToken: String?,
+        method: String = "GET"
+    ) async throws -> (HTTPURLResponse, Data) {
+        let url = try XCTUnwrap(URL(string: "http://127.0.0.1:\(port)\(path)"))
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        if let bearerToken {
+            request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+        }
+        request.timeoutInterval = 5
+        let (data, response) = try await URLSession.shared.data(for: request)
+        return (try XCTUnwrap(response as? HTTPURLResponse), data)
+    }
+
+    func testServerBindsToLoopbackAndServesAnAuthenticatedUsageRequest() async throws {
+        let server = try startServer()
+        defer { server.stop() }
+
+        let (response, data) = try await get("/usage", port: server.boundPort, bearerToken: token)
+
+        XCTAssertEqual(response.statusCode, 200)
+        XCTAssertEqual(response.value(forHTTPHeaderField: "Cache-Control"), "no-store")
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(object["schemaVersion"] as? Int, 1)
+    }
+
+    func testServerRejectsMissingTokenWithoutLeakingData() async throws {
+        let server = try startServer()
+        defer { server.stop() }
+
+        let (response, data) = try await get("/usage", port: server.boundPort, bearerToken: nil)
+
+        XCTAssertEqual(response.statusCode, 401)
+        let body = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertFalse(body.contains("providers"))
+    }
+
+    func testServerRejectsNonGetMethod() async throws {
+        let server = try startServer()
+        defer { server.stop() }
+
+        let (response, _) = try await get("/usage", port: server.boundPort, bearerToken: token, method: "POST")
+
+        XCTAssertEqual(response.statusCode, 405)
+    }
+
+    func testServerRejectsUnknownPath() async throws {
+        let server = try startServer()
+        defer { server.stop() }
+
+        let (response, _) = try await get("/does-not-exist", port: server.boundPort, bearerToken: token)
+
+        XCTAssertEqual(response.statusCode, 404)
+    }
+
+    func testServerEnforcesRateLimit() async throws {
+        let server = try startServer(maxRequestsPerSecond: 1)
+        defer { server.stop() }
+
+        _ = try await get("/usage", port: server.boundPort, bearerToken: token)
+        let (second, _) = try await get("/usage", port: server.boundPort, bearerToken: token)
+
+        XCTAssertEqual(second.statusCode, 429)
+    }
+
+    func testStopClosesTheListeningSocketSoNewConnectionsAreRefused() async throws {
+        let server = try startServer()
+        let port = server.boundPort
+
+        server.stop()
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        do {
+            _ = try await get("/usage", port: port, bearerToken: token)
+            XCTFail("expected the connection to be refused after stop()")
+        } catch {
+            // Connection refused (or similar) is expected; the listening socket is gone.
+        }
+    }
+
+    func testStartingOnAnAlreadyBoundPortFails() throws {
+        let first = try startServer()
+        defer { first.stop() }
+
+        let second = ServeHTTPServer(configuration: ServeHTTPServer.Configuration(
+            host: ServeBindConfiguration.loopbackHost,
+            port: first.boundPort,
+            token: token,
+            maxRequestsPerSecond: 10,
+            dataSource: makeDataSource()
+        ))
+
+        XCTAssertThrowsError(try second.start())
+    }
+}

--- a/MeterBarTests/ServeRateLimiterTests.swift
+++ b/MeterBarTests/ServeRateLimiterTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import MeterBar
+
+final class ServeRateLimiterTests: XCTestCase {
+    func testAllowsUpToTheConfiguredLimitWithinAWindow() {
+        var now = Date(timeIntervalSince1970: 0)
+        let limiter = ServeRateLimiter(maxPerSecond: 3, clock: { now })
+
+        XCTAssertTrue(limiter.allow())
+        XCTAssertTrue(limiter.allow())
+        XCTAssertTrue(limiter.allow())
+        XCTAssertFalse(limiter.allow())
+
+        now = now.addingTimeInterval(0.5)
+        XCTAssertFalse(limiter.allow(), "still inside the same one-second window")
+    }
+
+    func testResetsAfterTheWindowElapses() {
+        var now = Date(timeIntervalSince1970: 0)
+        let limiter = ServeRateLimiter(maxPerSecond: 1, clock: { now })
+
+        XCTAssertTrue(limiter.allow())
+        XCTAssertFalse(limiter.allow())
+
+        now = now.addingTimeInterval(1.1)
+        XCTAssertTrue(limiter.allow(), "a new window should allow requests again")
+    }
+
+    func testTreatsNonPositiveLimitsAsAtLeastOne() {
+        let limiter = ServeRateLimiter(maxPerSecond: 0, clock: { Date(timeIntervalSince1970: 0) })
+
+        XCTAssertTrue(limiter.allow())
+    }
+}

--- a/MeterBarTests/ServeRouterTests.swift
+++ b/MeterBarTests/ServeRouterTests.swift
@@ -111,6 +111,28 @@ final class ServeRouterTests: XCTestCase {
         XCTAssertEqual(response.status, 401)
     }
 
+    /// A blank configured token must lock the endpoint down, not open it: the
+    /// bare `Authorization: Bearer ` header a caller can trivially send would
+    /// otherwise compare equal to "" and authorize everything.
+    func testBlankConfiguredTokenRejectsEveryRequest() {
+        for configured in ["", "   "] {
+            for presented in [nil, "", " ", "anything"] as [String?] {
+                let response = ServeRouter.handle(
+                    request(path: "/usage", token: presented),
+                    token: configured,
+                    dataSource: makeDataSource()
+                )
+
+                XCTAssertEqual(
+                    response.status,
+                    401,
+                    "configured=\(configured.debugDescription) presented=\(presented.debugDescription)"
+                )
+                assertBodyContainsNoUsageData(response)
+            }
+        }
+    }
+
     func testErrorResponseBodyNeverContainsTheToken() throws {
         let response = ServeRouter.handle(
             request(path: "/usage", token: nil),
@@ -272,6 +294,36 @@ final class ServeRouterTests: XCTestCase {
         XCTAssertEqual(response.status, 400)
         assertBodyContainsNoUsageData(response)
         XCTAssertEqual(response.headers["Cache-Control"], "no-store")
+    }
+
+    // MARK: Encoding failures
+
+    /// A document that fails to encode must surface as a 500, never as an
+    /// empty body wearing a `200 OK` / `application/json` label — a caller
+    /// would read that as a successful response it simply can't parse.
+    func testJSONResponseReportsAnEncodingFailureAsFiveHundred() throws {
+        let response = ServeRouter.jsonResponse(FailingDocument())
+
+        XCTAssertEqual(response.status, 500)
+        XCTAssertFalse(response.body.isEmpty, "a 500 must still carry a parseable error body")
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: response.body) as? [String: Any])
+        let error = try XCTUnwrap(object["error"] as? [String: Any])
+        XCTAssertEqual(error["code"] as? String, "internal_error")
+    }
+
+    func testErrorResponseAlwaysCarriesAParseableBody() throws {
+        let response = ServeRouter.malformedRequestResponse()
+
+        XCTAssertFalse(response.body.isEmpty)
+        XCTAssertNotNil(try JSONSerialization.jsonObject(with: response.body) as? [String: Any])
+    }
+
+    private struct FailingDocument: CLIJSONDocument {
+        struct EncodingFailure: Error {}
+
+        func encode(to encoder: Encoder) throws {
+            throw EncodingFailure()
+        }
     }
 
     // MARK: Helpers

--- a/MeterBarTests/ServeRouterTests.swift
+++ b/MeterBarTests/ServeRouterTests.swift
@@ -1,0 +1,287 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+final class ServeRouterTests: XCTestCase {
+    private let referenceDate = Date(timeIntervalSince1970: 1_700_000_000)
+    private let token = "test-secret-token"
+
+    private lazy var metrics: [ServiceType: UsageMetrics] = [
+        .claudeCode: UsageMetrics(
+            service: .claudeCode,
+            sessionLimit: UsageLimit(used: 42.5, total: 100, resetTime: referenceDate, windowSeconds: 18_000),
+            weeklyLimit: UsageLimit(used: 90, total: 100, resetTime: nil, windowSeconds: 604_800, isEstimated: true),
+            extraUsage: ExtraUsageStatus(state: .on, detail: "$0.00 used"),
+            lastUpdated: referenceDate
+        ),
+    ]
+
+    private lazy var costCache = CostSummaryCache(
+        summary: CostSummary(
+            costs: [
+                TokenCost(
+                    provider: .codexCli,
+                    inputTokens: 1_000,
+                    outputTokens: 250,
+                    cacheCreationTokens: 50,
+                    cacheReadTokens: 500,
+                    estimatedCostUSD: 1.25,
+                    sessionCount: 3,
+                    periodStart: referenceDate.addingTimeInterval(-86_400),
+                    periodEnd: referenceDate
+                ),
+            ],
+            totalCostUSD: 1.25,
+            totalTokens: 1_800,
+            periodDays: 30
+        ),
+        lastScanDate: referenceDate
+    )
+
+    private func makeDataSource(
+        metrics: [ServiceType: UsageMetrics]? = nil,
+        costCache: CostSummaryCache?? = nil
+    ) -> ServeRouter.DataSource {
+        let resolvedMetrics = metrics ?? self.metrics
+        let resolvedCostCache = costCache ?? .some(self.costCache)
+        return ServeRouter.DataSource(
+            loadUsageMetrics: { resolvedMetrics },
+            loadCostCache: { resolvedCostCache }
+        )
+    }
+
+    private func request(
+        method: String = "GET",
+        path: String,
+        query: [String: String] = [:],
+        token providedToken: String?
+    ) -> ServeHTTPRequest {
+        ServeHTTPRequest(
+            method: method,
+            path: path,
+            query: query,
+            authorizationHeader: providedToken.map { "Bearer \($0)" }
+        )
+    }
+
+    // MARK: Authentication
+
+    func testMissingTokenReturnsUnauthorizedWithNoData() {
+        let response = ServeRouter.handle(
+            request(path: "/usage", token: nil),
+            token: token,
+            dataSource: makeDataSource()
+        )
+
+        XCTAssertEqual(response.status, 401)
+        assertBodyContainsNoUsageData(response)
+    }
+
+    func testInvalidTokenReturnsUnauthorizedWithNoData() {
+        let response = ServeRouter.handle(
+            request(path: "/usage", token: "wrong-token"),
+            token: token,
+            dataSource: makeDataSource()
+        )
+
+        XCTAssertEqual(response.status, 401)
+        assertBodyContainsNoUsageData(response)
+    }
+
+    func testUnauthenticatedRequestToUnknownPathStillReturnsUnauthorizedNotNotFound() {
+        // Auth is checked before routing so an unauthenticated caller can't use
+        // status codes to enumerate which paths exist.
+        let response = ServeRouter.handle(
+            request(path: "/does-not-exist", token: nil),
+            token: token,
+            dataSource: makeDataSource()
+        )
+
+        XCTAssertEqual(response.status, 401)
+    }
+
+    func testUnauthenticatedNonGetRequestStillReturnsUnauthorizedNotMethodNotAllowed() {
+        let response = ServeRouter.handle(
+            request(method: "POST", path: "/usage", token: nil),
+            token: token,
+            dataSource: makeDataSource()
+        )
+
+        XCTAssertEqual(response.status, 401)
+    }
+
+    func testErrorResponseBodyNeverContainsTheToken() throws {
+        let response = ServeRouter.handle(
+            request(path: "/usage", token: nil),
+            token: token,
+            dataSource: makeDataSource()
+        )
+
+        let body = try XCTUnwrap(String(data: response.body, encoding: .utf8))
+        XCTAssertFalse(body.contains(token))
+    }
+
+    // MARK: Method and path rejection
+
+    func testNonGetMethodWithValidTokenReturnsMethodNotAllowedWithNoData() {
+        let response = ServeRouter.handle(
+            request(method: "POST", path: "/usage", token: token),
+            token: token,
+            dataSource: makeDataSource()
+        )
+
+        XCTAssertEqual(response.status, 405)
+        assertBodyContainsNoUsageData(response)
+    }
+
+    func testUnknownPathWithValidTokenReturnsNotFoundWithNoData() {
+        let response = ServeRouter.handle(
+            request(path: "/unknown", token: token),
+            token: token,
+            dataSource: makeDataSource()
+        )
+
+        XCTAssertEqual(response.status, 404)
+        assertBodyContainsNoUsageData(response)
+    }
+
+    // MARK: Cache headers
+
+    func testEveryResponseCarriesNoStoreCacheControl() {
+        let responses = [
+            ServeRouter.handle(request(path: "/usage", token: token), token: token, dataSource: makeDataSource()),
+            ServeRouter.handle(request(path: "/cost", token: token), token: token, dataSource: makeDataSource()),
+            ServeRouter.handle(request(path: "/usage", token: nil), token: token, dataSource: makeDataSource()),
+            ServeRouter.handle(request(path: "/nope", token: token), token: token, dataSource: makeDataSource()),
+            ServeRouter.handle(
+                request(method: "POST", path: "/usage", token: token),
+                token: token,
+                dataSource: makeDataSource()
+            ),
+        ]
+
+        for response in responses {
+            XCTAssertEqual(response.headers["Cache-Control"], "no-store")
+        }
+    }
+
+    // MARK: Schema stability — the served payload must be byte-identical to the CLI's own DTO output.
+
+    func testUsageEndpointBodyMatchesUsageCLIJSONResponseExactly() throws {
+        let response = ServeRouter.handle(
+            request(path: "/usage", token: token),
+            token: token,
+            dataSource: makeDataSource()
+        )
+
+        let expected = try UsageCLIJSONResponse(metrics: metrics).jsonData()
+        XCTAssertEqual(response.body, expected)
+        XCTAssertEqual(response.headers["Content-Type"], "application/json; charset=utf-8")
+    }
+
+    func testCostEndpointBodyMatchesCostCLIJSONResponseExactly() throws {
+        let response = ServeRouter.handle(
+            request(path: "/cost", token: token),
+            token: token,
+            dataSource: makeDataSource()
+        )
+
+        let expected = try CostCLIJSONResponse(cache: costCache).jsonData()
+        XCTAssertEqual(response.body, expected)
+    }
+
+    func testUsageEndpointHonorsProviderQueryFilterLikeTheCLI() throws {
+        let response = ServeRouter.handle(
+            request(path: "/usage", query: ["provider": "codex"], token: token),
+            token: token,
+            dataSource: makeDataSource()
+        )
+
+        let expected = try UsageCLIJSONResponse(metrics: [:]).jsonData()
+        XCTAssertEqual(response.body, expected, "no codex entry in the fixture, so filtering should yield an empty set")
+    }
+
+    func testCostEndpointHonorsDaysQueryLikeTheCLI() throws {
+        let response = ServeRouter.handle(
+            request(path: "/cost", query: ["days": "7"], token: token),
+            token: token,
+            dataSource: makeDataSource()
+        )
+
+        let expected = try CostCLIJSONResponse(cache: costCache, days: 7).jsonData()
+        XCTAssertEqual(response.body, expected)
+    }
+
+    func testCostEndpointIgnoresNonPositiveDaysQuery() throws {
+        let response = ServeRouter.handle(
+            request(path: "/cost", query: ["days": "0"], token: token),
+            token: token,
+            dataSource: makeDataSource()
+        )
+
+        let expected = try CostCLIJSONResponse(cache: costCache).jsonData()
+        XCTAssertEqual(response.body, expected)
+    }
+
+    // MARK: Cache-missing parity with the CLI's own error envelope
+
+    func testUsageEndpointReportsCacheMissingWhenNoMetricsAreCached() throws {
+        let response = ServeRouter.handle(
+            request(path: "/usage", token: token),
+            token: token,
+            dataSource: makeDataSource(metrics: [:])
+        )
+
+        XCTAssertEqual(response.status, 200)
+        let expected = try CLIJSONErrorResponse(
+            code: "usage_cache_missing",
+            message: "No cached metrics found. Open MeterBar app to fetch data."
+        ).jsonData()
+        XCTAssertEqual(response.body, expected)
+    }
+
+    func testCostEndpointReportsCacheMissingWhenNoCostCacheExists() throws {
+        let response = ServeRouter.handle(
+            request(path: "/cost", token: token),
+            token: token,
+            dataSource: makeDataSource(costCache: .some(nil))
+        )
+
+        XCTAssertEqual(response.status, 200)
+        let expected = try CLIJSONErrorResponse(
+            code: "cost_cache_missing",
+            message: "No cost data cached. Open MeterBar and run a scan (Costs tab)."
+        ).jsonData()
+        XCTAssertEqual(response.body, expected)
+    }
+
+    // MARK: Rate limiting
+
+    func testTooManyRequestsResponseHasNoDataAndNoStoreHeader() {
+        let response = ServeRouter.tooManyRequestsResponse()
+
+        XCTAssertEqual(response.status, 429)
+        assertBodyContainsNoUsageData(response)
+        XCTAssertEqual(response.headers["Cache-Control"], "no-store")
+    }
+
+    func testMalformedRequestResponseHasNoDataAndNoStoreHeader() {
+        let response = ServeRouter.malformedRequestResponse()
+
+        XCTAssertEqual(response.status, 400)
+        assertBodyContainsNoUsageData(response)
+        XCTAssertEqual(response.headers["Cache-Control"], "no-store")
+    }
+
+    // MARK: Helpers
+
+    private func assertBodyContainsNoUsageData(_ response: ServeHTTPResponse, file: StaticString = #filePath, line: UInt = #line) {
+        guard let body = String(data: response.body, encoding: .utf8) else {
+            XCTFail("expected a UTF-8 body", file: file, line: line)
+            return
+        }
+        XCTAssertFalse(body.contains("\"providers\""), "error body leaked provider data", file: file, line: line)
+        XCTAssertFalse(body.contains("claude"), "error body leaked a provider identifier", file: file, line: line)
+    }
+}

--- a/MeterBarTests/ServeTokenTests.swift
+++ b/MeterBarTests/ServeTokenTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import MeterBar
+
+final class ServeTokenTests: XCTestCase {
+    func testGeneratedTokensAreSixtyFourHexCharacters() {
+        let token = ServeToken.generate()
+
+        XCTAssertEqual(token.count, 64)
+        XCTAssertTrue(token.allSatisfy { $0.isHexDigit })
+    }
+
+    func testGeneratedTokensAreNotRepeated() {
+        let first = ServeToken.generate()
+        let second = ServeToken.generate()
+
+        XCTAssertNotEqual(first, second)
+    }
+
+    func testMatchesAcceptsCorrectBearerToken() {
+        XCTAssertTrue(ServeToken.matches(presented: "Bearer secret-token", expected: "secret-token"))
+    }
+
+    func testMatchesRejectsWrongToken() {
+        XCTAssertFalse(ServeToken.matches(presented: "Bearer wrong-token", expected: "secret-token"))
+    }
+
+    func testMatchesRejectsMissingHeader() {
+        XCTAssertFalse(ServeToken.matches(presented: nil, expected: "secret-token"))
+    }
+
+    func testMatchesRejectsHeaderWithoutBearerScheme() {
+        XCTAssertFalse(ServeToken.matches(presented: "secret-token", expected: "secret-token"))
+        XCTAssertFalse(ServeToken.matches(presented: "Basic secret-token", expected: "secret-token"))
+    }
+
+    func testMatchesRejectsDifferingLengthTokens() {
+        XCTAssertFalse(ServeToken.matches(presented: "Bearer short", expected: "much-longer-secret-token"))
+    }
+
+    func testMatchesRejectsEmptyPresentedToken() {
+        XCTAssertFalse(ServeToken.matches(presented: "Bearer ", expected: "secret-token"))
+    }
+}

--- a/MeterBarTests/ServeTokenTests.swift
+++ b/MeterBarTests/ServeTokenTests.swift
@@ -40,4 +40,20 @@ final class ServeTokenTests: XCTestCase {
     func testMatchesRejectsEmptyPresentedToken() {
         XCTAssertFalse(ServeToken.matches(presented: "Bearer ", expected: "secret-token"))
     }
+
+    /// An empty configured token must never authenticate anyone. Without this,
+    /// a bare `Authorization: Bearer ` header compares equal to "" and every
+    /// request is authorized — an open endpoint, not a locked one.
+    func testMatchesRejectsEmptyExpectedToken() {
+        XCTAssertFalse(ServeToken.matches(presented: "Bearer ", expected: ""))
+        XCTAssertFalse(ServeToken.matches(presented: "Bearer anything", expected: ""))
+        XCTAssertFalse(ServeToken.matches(presented: nil, expected: ""))
+    }
+
+    func testIsUsableRejectsBlankTokens() {
+        XCTAssertFalse(ServeToken.isUsable(""))
+        XCTAssertFalse(ServeToken.isUsable("   "))
+        XCTAssertFalse(ServeToken.isUsable("\t\n"))
+        XCTAssertTrue(ServeToken.isUsable("secret-token"))
+    }
 }

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -3,7 +3,8 @@
 `meterbar usage --json`, `meterbar cost --json`, `meterbar refresh --json`,
 `meterbar guard --json`, and `meterbar fable-sessions --json` emit stable,
 versioned JSON for menu bars, shell prompts, dashboards, and other third-party integrations.
-Human-readable output remains the default when `--json` is absent.
+Human-readable output remains the default when `--json` is absent. `meterbar serve` exposes the
+same versioned usage/cost documents over a local HTTP endpoint instead of standard output.
 
 ## Compatibility contract
 
@@ -339,3 +340,74 @@ documents, it is a diagnostic DTO rather than a versioned cache schema:
 `overall` is `pass`. The report contains only the fields shown above; credential, token, password,
 authorization, and secret-bearing fields are never emitted. Diagnostic messages may use standard
 error, but standard output remains one JSON document.
+
+## Serve
+
+```sh
+meterbar serve
+meterbar serve --port 8787 --max-requests-per-second 10
+meterbar serve --token "$(openssl rand -hex 32)"
+meterbar serve --allow-remote
+```
+
+`meterbar serve` runs a small, opt-in HTTP endpoint that serves the exact same schema-versioned
+`UsageCLIJSONResponse` and `CostCLIJSONResponse` documents `meterbar usage --json` and
+`meterbar cost --json` print — there is no second serialization to drift from the CLI. It reads
+MeterBar's existing cached app-group snapshot; it never triggers a provider refresh, never spends a
+reset credit, and never accepts a write, mutation, or configuration change. There is no endpoint
+that changes state.
+
+**Bind address.** The server binds to loopback (`127.0.0.1`) only by default, so it is not reachable
+from other devices. Reaching any other interface requires the explicit `--allow-remote` flag, which
+also prints a warning to standard error before the server starts:
+
+```
+⚠ meterbar serve is bound to all network interfaces (--allow-remote). Usage and cost data will be
+reachable from other devices on this network; anyone with the printed bearer token can read it.
+```
+
+**Authentication.** Every request must carry `Authorization: Bearer <token>`. If `--token` is not
+supplied, a random 256-bit token is generated and printed once, at startup, to standard output; it
+is never logged again and never appears in any response body, including error bodies. Token
+comparison is constant-time. A missing or incorrect token always returns `401` with a generic
+`unauthorized` error body — before routing even inspects the path or method, so an unauthenticated
+caller cannot use status codes to enumerate endpoints.
+
+**Endpoints** (`GET` only; any other method on a known path returns `405`):
+
+| Method & path | Query parameters | Behavior |
+| --- | --- | --- |
+| `GET /usage` | `provider` (optional, same matching as `meterbar usage --provider`) | Returns `UsageCLIJSONResponse` |
+| `GET /cost` | `days` (optional, same matching as `meterbar cost --days`; non-positive or non-numeric values are ignored) | Returns `CostCLIJSONResponse` |
+
+An unknown path returns `404` with the same generic error envelope. If the underlying cache is
+empty (no metrics yet, or no cost scan yet), the endpoint returns `200` with the same
+`usage_cache_missing` / `cost_cache_missing` error document `meterbar usage --json` /
+`meterbar cost --json` already return in that situation — same codes, same messages.
+
+**Headers.** Every response — data and error alike — sets `Cache-Control: no-store` and
+`Content-Type: application/json; charset=utf-8`. Responses are never cached by clients or
+intermediaries.
+
+**Rate limiting.** Requests are bounded to `--max-requests-per-second` (default 5) per server
+instance; requests beyond that return `429` with the standard error envelope (`too_many_requests`).
+A malformed HTTP request returns `400` (`bad_request`).
+
+**Lifecycle.** `meterbar serve` runs until it receives `SIGINT` or `SIGTERM` (for example, Ctrl-C),
+at which point it stops accepting new connections, closes its listening socket, and exits cleanly.
+
+Errors reuse the same `CLIJSONErrorResponse` envelope as the rest of the CLI:
+
+```json
+{
+  "schemaVersion": 1,
+  "error": {
+    "code": "unauthorized",
+    "message": "Missing or invalid bearer token."
+  }
+}
+```
+
+Stable version 1 serve error codes are `unauthorized` (401), `not_found` (404),
+`method_not_allowed` (405), `too_many_requests` (429), `bad_request` (400), and the
+pre-existing `usage_cache_missing` / `cost_cache_missing` (200).

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -478,7 +478,7 @@ that changes state.
 from other devices. Reaching any other interface requires the explicit `--allow-remote` flag, which
 also prints a warning to standard error before the server starts:
 
-```
+```text
 ⚠ meterbar serve is bound to all network interfaces (--allow-remote). Usage and cost data will be
 reachable from other devices on this network; anyone with the printed bearer token can read it.
 ```
@@ -486,9 +486,14 @@ reachable from other devices on this network; anyone with the printed bearer tok
 **Authentication.** Every request must carry `Authorization: Bearer <token>`. If `--token` is not
 supplied, a random 256-bit token is generated and printed once, at startup, to standard output; it
 is never logged again and never appears in any response body, including error bodies. Token
-comparison is constant-time. A missing or incorrect token always returns `401` with a generic
-`unauthorized` error body — before routing even inspects the path or method, so an unauthenticated
-caller cannot use status codes to enumerate endpoints.
+comparison is constant-time. A blank `--token` is rejected before the socket binds, so the server
+can never come up with an auth check that accepts every caller. A missing or incorrect token always
+returns `401` with a generic `unauthorized` error body — before routing even inspects the path or
+method, so an unauthenticated caller cannot use status codes to enumerate endpoints.
+
+**Connection limits.** A request must deliver its complete header block within 5 seconds of
+connecting, measured against the connection as a whole rather than per socket read, so a client that
+trickles bytes cannot hold a handler open indefinitely. Request heads over 8 KiB are rejected.
 
 **Endpoints** (`GET` only; any other method on a known path returns `405`):
 


### PR DESCRIPTION
## Summary

Adds `meterbar serve`, a new CLI subcommand that exposes the same schema-versioned JSON DTOs `meterbar usage --json` / `meterbar cost --json` already emit, over a local, token-gated, read-only HTTP endpoint. No second serialization path: `GET /usage` and `GET /cost` build `UsageCLIJSONResponse` / `CostCLIJSONResponse` directly, and every error path (auth, routing, cache-missing) uses the existing `CLIJSONErrorResponse` envelope.

This is the first network-listening surface in the product, so the implementation deliberately uses raw Darwin sockets (`socket`/`bind`/`listen`/`accept`) rather than pulling in `Network.framework` or a third-party HTTP library, per the "minimal dependency footprint" guidance already in `docs/cli-json-schema.md`.

## What changed

- `MeterBar/Serve/ServeToken.swift` — 32-byte token generation (`SecRandomCopyBytes`, `arc4random_buf` fallback) and constant-time comparison (XOR-accumulate over UTF-8 bytes, no early return on length mismatch).
- `MeterBar/Serve/ServeBindConfiguration.swift` — resolves the bind host: loopback (`127.0.0.1`) by default, `0.0.0.0` only with an explicit opt-in flag, which also produces a warning string.
- `MeterBar/Serve/ServeRateLimiter.swift` — fixed-window limiter (default 5 req/s), injectable clock for deterministic tests.
- `MeterBar/Serve/ServeHTTPMessages.swift` — plain value types (`ServeHTTPRequest`, `ServeHTTPResponse`) decoupled from socket I/O.
- `MeterBar/Serve/ServeRouter.swift` — pure routing/auth logic: checks the `Authorization: Bearer <token>` header **before** looking at path or method (so an unauthenticated request never leaks routing information via its status code), then dispatches `GET /usage` and `GET /cost` against an injectable `DataSource` (`static let liveCache` wires production `SharedDataStore`/`CostSummaryStore`, read-only, no refresh triggered). Supports `?provider=` and `?days=` query filtering, mirroring the CLI's own filter logic.
- `MeterBar/Serve/ServeHTTPServer.swift` — the raw-socket listener: bind/listen/accept loop on a background queue, per-connection read/write with 5s timeouts, graceful `stop()` via `shutdown(SHUT_RDWR)` + `close()` to unblock the blocking `accept()` call.
- `MeterBar/Serve/ServeCLI.swift` — orchestration facade: starts the server, invokes `onReady` with the bound host/port, polls a cancellation closure, stops the server on cancellation.
- `MeterBarCLI/Sources/Serve.swift` — the `ArgumentParser` subcommand (`--port`, `--token`, `--allow-remote`, `--max-requests-per-second`), wired into `MeterBarCLI/Sources/MeterBarCLI.swift`'s `subcommands`. Prints the endpoint, auth requirement, and (if generated) the one-time token to stdout; prints the non-loopback warning to stderr. Installs SIGINT/SIGTERM handlers mirroring the existing `WakeAgent.swift` pattern for clean shutdown.
- `docs/cli-json-schema.md` — new "Serve" section documenting usage, bind-address behavior, auth model, endpoints, headers, rate limiting, lifecycle, and the stable v1 serve error codes (`unauthorized`, `not_found`, `method_not_allowed`, `too_many_requests`, `bad_request`, alongside the pre-existing `usage_cache_missing`/`cost_cache_missing`).
- `MeterBarTests/Serve*Tests.swift` (6 new files, 39 tests) — written first (TDD), covering token generation/comparison, bind resolution, rate limiting, router auth/routing/schema behavior, and true socket-level integration tests (`ServeHTTPServerTests` binds a real ephemeral loopback port and drives it with `URLSession`).

## Acceptance criteria

- **Loopback by default:** `ServeBindConfiguration.resolve(allowRemote: false)` returns `127.0.0.1`; verified by `ServeBindConfigurationTests` and `ServeHTTPServerTests.testServerBindsToLoopbackAndServesAnAuthenticatedUsageRequest`.
- **Explicit flag + warning for non-loopback:** `--allow-remote` binds `0.0.0.0` and only then produces a warning, printed to stderr in `Serve.run()`; verified by `ServeBindConfigurationTests`.
- **401 + no data on missing/invalid token:** `ServeRouter.handle` checks auth first; `ServeHTTPServerTests.testServerRejectsMissingTokenWithoutLeakingData` and multiple `ServeRouterTests` assert the body is a bare `CLIJSONErrorResponse` with no usage/cost fields.
- **Correct status + no data for non-GET/unknown path:** `ServeRouterTests`/`ServeHTTPServerTests` cover 405 (`method_not_allowed`) and 404 (`not_found`); also verified that an *unauthenticated* non-GET/unknown-path request still returns 401, not 404/405 (no routing info leak).
- **`Cache-Control: no-store`:** applied to every response in `ServeRouter`/`ServeHTTPServer.serialize`; asserted in `ServeRouterTests`.
- **Schema stability:** `/usage` and `/cost` responses are literally `UsageCLIJSONResponse`/`CostCLIJSONResponse` — no second DTO.
- **Clean SIGINT/SIGTERM shutdown:** `Serve.swift` installs handlers identical in shape to `WakeAgent.swift`; `ServeCLI`/`ServeHTTPServer` cooperative cancellation covered by `ServeCLITests` and `ServeHTTPServerTests.testStopClosesTheListeningSocketSoNewConnectionsAreRefused`.
- **No mutation endpoints:** only `GET /usage` and `GET /cost` are routed; everything else is 404/405.
- **Focused tests:** 39 new tests across auth rejection, method/path rejection, schema stability, loopback default, rate limiting, and shutdown — see test evidence below.
- **PR CI runs tests and builds:** relies on the existing CI workflow (not modified in this PR).

## Deliberately out of scope

- No write/mutation/control endpoints.
- No TLS.
- No user accounts/sessions.
- No auto-start at login or background-agent registration — `meterbar serve` is a plain foreground CLI invocation the user starts explicitly.

## Test evidence

All commands run from the worktree at `/tmp/mb-wt/serve` on `feat/cli-serve-endpoint`.

**`swift test` (full suite, most recent run after all lint fixes):**
```
Executed 1346 tests, with 1 test skipped and 25 failures (0 unexpected) in 77.799 seconds
```
All 39 `Serve*` tests passed with zero failures. The 25 failures are a **fixed, pre-existing set of 12 test names** — `ProviderReadinessInspectorTests`, `SessionWakeAgentTests`, `SessionWakeControllerTests` (×4), `UsageDataManagerTests` (×2), `WakeQuotaProviderSelectionTests` (×3), and the flaky UI test `LiquidGlassP1RegressionTests.testRapidShowDismissShowLeavesPanelVisibleAndOpaque` — confirmed identical across three separate full-suite runs, including one run with all Serve changes fully stashed out (`git stash push -u`), which reproduced the same failures on master with none of this PR's code present. None of these touch any file this PR creates or modifies; they're pre-existing async/timing-sensitive failures (`Task.sleep`-based watchers, account-switch state machines) unrelated to this change.

**Focused Serve test run:** 39/39 `Serve*` tests passed (`ServeBindConfigurationTests`, `ServeCLITests`, `ServeHTTPServerTests`, `ServeRateLimiterTests`, `ServeRouterTests`, `ServeTokenTests`).

**`swift build` (MeterBarCLI package):**
```
Build complete!
```
Only pre-existing Swift 6 actor-isolation warnings in unrelated files (`ResetCredit.swift`, `Refresh.swift`) appeared; no warnings or errors in any Serve file.

**`swiftlint lint` on all touched/created production files** (`MeterBar/Serve/*.swift`, `MeterBarCLI/Sources/Serve.swift`, `MeterBarCLI/Sources/MeterBarCLI.swift`, plus the new `MeterBarTests/Serve*Tests.swift` for completeness even though `MeterBarTests` isn't in the lint `included` scope):
```
(no output — exit 0, zero warnings, zero errors)
```

Closes #272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `meterbar serve` command for serving cached usage and cost data over a local HTTP endpoint.
  * Added authenticated `/usage` and `/cost` endpoints with filtering, rate limiting, and JSON responses.
  * Added optional remote access with security warnings and configurable request limits.
  * Added automatic bearer-token generation and graceful shutdown support.

* **Documentation**
  * Documented endpoint behavior, authentication, filtering, errors, and JSON schemas.

* **Tests**
  * Added coverage for serving, routing, authentication, rate limiting, shutdown, and remote binding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->