### PR TITLE
Cost: month-to-date window, display currency, project rollups

### DIFF
--- a/MeterBar/Models/CLIJSONOutput.swift
+++ b/MeterBar/Models/CLIJSONOutput.swift
@@ -104,21 +104,47 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
     private let providers: [Provider]
     private let totalCostUSD: Double
     private let totalTokens: Int
+    /// Presentation-only conversion of `totalCostUSD` (issue #270). `nil`
+    /// unless the caller explicitly supplies `displayCurrency` — the CLI has
+    /// no persisted rate of its own; `--currency`/`--rate` are stateless,
+    /// per-invocation flags, never a background exchange-rate fetch.
+    private let displayCurrency: DisplayCurrencyJSON?
 
     public init(
         cache: CostSummaryCache,
         days: Int? = nil,
+        monthToDate: Bool = false,
+        displayCurrency: DisplayCurrency? = nil,
         now: Date = Date(),
         calendar: Calendar = .current
     ) {
         lastScannedAt = cache.lastScanDate
 
-        if let days {
+        // `monthToDate` takes precedence over `--days`; the CLI's `validate()`
+        // rejects passing both, so this ordering only matters for direct callers.
+        if monthToDate {
+            // Month-to-date has no project dimension of its own: it's a window
+            // over the cached *daily* rows (`DailyTokenUsage`), which — unlike
+            // the full lifetime scan behind `TokenCost.projectBreakdowns` —
+            // carries no per-project field. Project grouping and calendar
+            // windowing are orthogonal axes in the current data model.
+            let window = cache.summary.monthToDateCostWindow(now: now, calendar: calendar)
+            period = Period(
+                requestedDays: window.requestedDays,
+                coveredDays: window.coveredDays,
+                isTruncated: window.isTruncated,
+                kind: "monthToDate"
+            )
+            providers = window.providers.map(Provider.init(total:))
+            totalCostUSD = window.totalCostUSD
+            totalTokens = window.totalTokens
+        } else if let days {
             let window = cache.summary.dailyCostWindow(lastDays: days, now: now, calendar: calendar)
             period = Period(
                 requestedDays: window.requestedDays,
                 coveredDays: window.coveredDays,
-                isTruncated: window.isTruncated
+                isTruncated: window.isTruncated,
+                kind: "days"
             )
             providers = window.providers.map(Provider.init(total:))
             totalCostUSD = window.totalCostUSD
@@ -127,7 +153,8 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
             period = Period(
                 requestedDays: cache.summary.periodDays,
                 coveredDays: cache.summary.periodDays,
-                isTruncated: false
+                isTruncated: false,
+                kind: nil
             )
             providers = cache.summary.costs
                 .sorted { $0.provider.sortOrder < $1.provider.sortOrder }
@@ -135,12 +162,22 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
             totalCostUSD = cache.summary.totalCostUSD
             totalTokens = cache.summary.totalTokens
         }
+
+        // Captured into a local first: referencing `self.totalCostUSD` directly
+        // inside the closure below would require `self` before every stored
+        // property (including `self.displayCurrency` itself) is initialized.
+        let finalTotalCostUSD = totalCostUSD
+        self.displayCurrency = displayCurrency.map { DisplayCurrencyJSON($0, totalCostUSD: finalTotalCostUSD) }
     }
 
     private struct Period: Encodable {
         let requestedDays: Int
         let coveredDays: Int
         let isTruncated: Bool
+        /// `"days"`, `"monthToDate"`, or omitted for the full lifetime summary
+        /// (issue #270). Optional so the unwindowed fixture's JSON shape is
+        /// unchanged — `nil` is simply never emitted.
+        let kind: String?
     }
 
     private struct Provider: Encodable {
@@ -153,6 +190,12 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
         let totalTokens: Int
         let estimatedCostUSD: Double
         let sessionCount: Int?
+        /// Per-project/worktree rollup (issue #270). `nil` — not merely empty —
+        /// whenever the underlying source carries no project dimension at all
+        /// (a `--days`/month-to-date window) or the scan found nothing to
+        /// attribute, so consumers can tell "not available here" apart from
+        /// "everything landed in one project".
+        let projectBreakdowns: [ProjectBreakdown]?
 
         init(cost: TokenCost) {
             provider = cost.provider.cliIdentifier
@@ -164,6 +207,9 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
             totalTokens = cost.totalTokens
             estimatedCostUSD = cost.estimatedCostUSD
             sessionCount = cost.sessionCount
+            projectBreakdowns = cost.projectBreakdowns.isEmpty
+                ? nil
+                : cost.projectBreakdowns.map(ProjectBreakdown.init)
         }
 
         init(total: ProviderDailyTotal) {
@@ -176,6 +222,76 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
             totalTokens = total.totalTokens
             estimatedCostUSD = total.estimatedCostUSD
             sessionCount = nil
+            projectBreakdowns = nil
+        }
+    }
+
+    /// Presentation-only currency conversion of `totalCostUSD` (issue #270).
+    /// `source` is always `"manual"`: the CLI never persists or fetches a
+    /// rate, so every emission is a fresh, explicit `--currency`/`--rate` pair
+    /// the caller typed for this one invocation — never a cached snapshot.
+    private struct DisplayCurrencyJSON: Encodable {
+        let code: String
+        let unitsPerUSD: Double
+        let enteredAt: Date
+        let totalCostConverted: Double
+        let source = "manual"
+
+        init(_ currency: DisplayCurrency, totalCostUSD: Double) {
+            code = currency.code
+            unitsPerUSD = currency.unitsPerUSD
+            enteredAt = currency.enteredAt
+            totalCostConverted = currency.convert(usd: totalCostUSD)
+        }
+    }
+
+    /// One project/worktree rollup row, with its own nested per-model slice
+    /// (issue #270). A hand-written mapper — like `Provider` above — rather
+    /// than encoding `TokenUsageBreakdown` directly, so the CLI JSON surface
+    /// stays independent of that type's internal shape.
+    private struct ProjectBreakdown: Encodable {
+        let name: String
+        let inputTokens: Int
+        let outputTokens: Int
+        let cacheCreationTokens: Int
+        let cacheReadTokens: Int
+        let totalTokens: Int
+        let estimatedCostUSD: Double
+        let sessionCount: Int
+        let modelBreakdowns: [ModelBreakdown]
+
+        init(_ breakdown: TokenUsageBreakdown) {
+            name = breakdown.name
+            inputTokens = breakdown.inputTokens
+            outputTokens = breakdown.outputTokens
+            cacheCreationTokens = breakdown.cacheCreationTokens
+            cacheReadTokens = breakdown.cacheReadTokens
+            totalTokens = breakdown.totalTokens
+            estimatedCostUSD = breakdown.estimatedCostUSD
+            sessionCount = breakdown.sessionCount
+            modelBreakdowns = breakdown.modelBreakdowns.map(ModelBreakdown.init)
+        }
+
+        struct ModelBreakdown: Encodable {
+            let name: String
+            let inputTokens: Int
+            let outputTokens: Int
+            let cacheCreationTokens: Int
+            let cacheReadTokens: Int
+            let totalTokens: Int
+            let estimatedCostUSD: Double
+            let sessionCount: Int
+
+            init(_ breakdown: TokenUsageBreakdown) {
+                name = breakdown.name
+                inputTokens = breakdown.inputTokens
+                outputTokens = breakdown.outputTokens
+                cacheCreationTokens = breakdown.cacheCreationTokens
+                cacheReadTokens = breakdown.cacheReadTokens
+                totalTokens = breakdown.totalTokens
+                estimatedCostUSD = breakdown.estimatedCostUSD
+                sessionCount = breakdown.sessionCount
+            }
         }
     }
 }

--- a/MeterBar/Models/DisplayCurrency.swift
+++ b/MeterBar/Models/DisplayCurrency.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// A user-supplied, presentation-only currency conversion for cost views and
+/// the CLI (issue #270). MeterBar NEVER fetches a live exchange rate — the
+/// rate is exactly what the user typed, and every converted figure must show
+/// both the rate and the date it was entered so it can't be mistaken for a
+/// live quote. Stored and exported cost data (JSON, daily usage, breakdowns)
+/// always stays USD; this type only affects what is rendered on screen.
+nonisolated public struct DisplayCurrency: Equatable, Sendable {
+    /// Free-form currency code/label the user types (e.g. "EUR", "JPY",
+    /// "credits"). Not validated against ISO 4217 or any live list — MeterBar
+    /// has no way to look one up without a network call, which is explicitly
+    /// out of scope for this feature.
+    public let code: String
+    /// User-supplied units of `code` per 1 USD. `convert` treats a
+    /// non-positive rate as an identity fallback; the store that persists
+    /// this value is responsible for rejecting one before it's saved.
+    public let unitsPerUSD: Double
+    /// When the user entered this rate — shown alongside every converted
+    /// figure so it reads as a manual snapshot, never a live quote.
+    public let enteredAt: Date
+
+    public init(code: String, unitsPerUSD: Double, enteredAt: Date) {
+        self.code = code
+        self.unitsPerUSD = unitsPerUSD
+        self.enteredAt = enteredAt
+    }
+
+    /// Converts a USD amount to `code`, rounded to 2 decimal places (the same
+    /// precision `UsageFormat.cost` displays), half-away-from-zero — matching
+    /// `Foundation`'s default `rounded()` behavior.
+    public func convert(usd amount: Double) -> Double {
+        guard unitsPerUSD > 0 else { return amount }
+        return (amount * unitsPerUSD * 100).rounded() / 100
+    }
+
+    /// Same stable, locale-independent day format used by `TokenCost`'s
+    /// day-keyed identifiers, reused here so the disclosure date is
+    /// unambiguous rather than a locale-dependent medium date style.
+    private static let enteredAtFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    /// Disclosure text shown next to every converted figure, e.g.
+    /// "1 USD = 0.92 EUR, entered 2026-07-20" — the fixed pairing of rate and
+    /// entry date that keeps a converted number from reading as a live quote.
+    public var disclosureText: String {
+        "1 USD = \(formattedRate) \(code), entered \(Self.enteredAtFormatter.string(from: enteredAt))"
+    }
+
+    /// Trims insignificant trailing zeros (e.g. `150` not `150.0000`,
+    /// `0.92` not `0.9200`) while keeping enough precision for rates typed
+    /// with more than two decimal places.
+    private var formattedRate: String {
+        String(format: "%.4g", unitsPerUSD)
+    }
+
+    /// Converted amount paired with the currency code, e.g. `"9.20 EUR"`.
+    /// Shared by the CLI's text output and any SwiftUI presentation so the
+    /// two never drift on rounding/format — always call this rather than
+    /// formatting `convert(usd:)` ad hoc at each call site.
+    public func formattedConverted(usd amount: Double) -> String {
+        String(format: "%.2f", convert(usd: amount)) + " " + code
+    }
+}

--- a/MeterBar/Models/DisplayCurrency.swift
+++ b/MeterBar/Models/DisplayCurrency.swift
@@ -30,7 +30,7 @@ nonisolated public struct DisplayCurrency: Equatable, Sendable {
     /// precision `UsageFormat.cost` displays), half-away-from-zero — matching
     /// `Foundation`'s default `rounded()` behavior.
     public func convert(usd amount: Double) -> Double {
-        guard unitsPerUSD > 0 else { return amount }
+        guard unitsPerUSD > 0, unitsPerUSD.isFinite else { return amount }
         return (amount * unitsPerUSD * 100).rounded() / 100
     }
 
@@ -54,8 +54,21 @@ nonisolated public struct DisplayCurrency: Equatable, Sendable {
     /// Trims insignificant trailing zeros (e.g. `150` not `150.0000`,
     /// `0.92` not `0.9200`) while keeping enough precision for rates typed
     /// with more than two decimal places.
+    ///
+    /// Deliberately not `%g`: that switches to scientific notation once the
+    /// exponent reaches the precision, so a legitimate rate like VND's
+    /// ~24,000 would render as "2.4e+04" in the disclosure line. Fixed
+    /// notation with the trailing zeros stripped keeps every rate readable.
     private var formattedRate: String {
-        String(format: "%.4g", unitsPerUSD)
+        var text = String(format: "%.4f", unitsPerUSD)
+        guard text.contains(".") else { return text }
+        while text.hasSuffix("0") {
+            text.removeLast()
+        }
+        if text.hasSuffix(".") {
+            text.removeLast()
+        }
+        return text
     }
 
     /// Converted amount paired with the currency code, e.g. `"9.20 EUR"`.

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -108,4 +108,17 @@ nonisolated enum StorageKeys {
     static let sessionWakeMaxTurns = "SessionWakeMaxTurns"
     /// JSON-encoded `WakeEventHookConfiguration`; missing means no configured or enabled hooks.
     static let sessionWakeEventHooks = "SessionWakeEventHooks"
+
+    // MARK: - Display Currency (#270)
+
+    /// User-typed currency code/label (e.g. "EUR"). Presentation only — stored
+    /// and exported cost data always stays USD. Missing means "no conversion,
+    /// show USD" — the default.
+    static let displayCurrencyCode = "DisplayCurrencyCode"
+    /// User-supplied units of `displayCurrencyCode` per 1 USD. MeterBar never
+    /// fetches this from a live/network source.
+    static let displayCurrencyRate = "DisplayCurrencyRate"
+    /// When the user entered the rate above. Shown next to every converted
+    /// figure so it can never be mistaken for a live quote.
+    static let displayCurrencyEnteredAt = "DisplayCurrencyEnteredAt"
 }

--- a/MeterBar/Models/TokenCost.swift
+++ b/MeterBar/Models/TokenCost.swift
@@ -17,6 +17,10 @@ nonisolated public struct TokenCost: Codable, Identifiable, Sendable {
     public let periodEnd: Date
     public var modelBreakdowns: [TokenUsageBreakdown]
     public var originBreakdowns: [TokenUsageBreakdown]
+    /// Per-project/worktree rollup (issue #270), derived from scanned session
+    /// paths. Defaults to `[]` so existing call sites that don't group by
+    /// project — and the CLI JSON fixture tests — see no shape change.
+    public var projectBreakdowns: [TokenUsageBreakdown]
 
     public init(
         provider: ServiceType,
@@ -29,7 +33,8 @@ nonisolated public struct TokenCost: Codable, Identifiable, Sendable {
         periodStart: Date,
         periodEnd: Date,
         modelBreakdowns: [TokenUsageBreakdown] = [],
-        originBreakdowns: [TokenUsageBreakdown] = []
+        originBreakdowns: [TokenUsageBreakdown] = [],
+        projectBreakdowns: [TokenUsageBreakdown] = []
     ) {
         self.provider = provider
         self.inputTokens = inputTokens
@@ -42,6 +47,7 @@ nonisolated public struct TokenCost: Codable, Identifiable, Sendable {
         self.periodEnd = periodEnd
         self.modelBreakdowns = modelBreakdowns
         self.originBreakdowns = originBreakdowns
+        self.projectBreakdowns = projectBreakdowns
     }
 
     public var totalTokens: Int {
@@ -68,6 +74,11 @@ nonisolated public struct TokenUsageBreakdown: Codable, Identifiable, Sendable {
     public let cacheReadTokens: Int
     public let estimatedCostUSD: Double
     public let sessionCount: Int
+    /// Nested per-model slice of this row's spend (issue #270). Populated
+    /// only for project rollup rows, via `TokenUsageAggregator.makeProjectBreakdowns`;
+    /// every other breakdown (model, origin) defaults to `[]` so existing
+    /// call sites and the CLI JSON fixtures are unaffected.
+    public let modelBreakdowns: [TokenUsageBreakdown]
 
     public init(
         provider: ServiceType,
@@ -77,7 +88,8 @@ nonisolated public struct TokenUsageBreakdown: Codable, Identifiable, Sendable {
         cacheCreationTokens: Int,
         cacheReadTokens: Int,
         estimatedCostUSD: Double,
-        sessionCount: Int
+        sessionCount: Int,
+        modelBreakdowns: [TokenUsageBreakdown] = []
     ) {
         self.provider = provider
         self.name = name
@@ -87,6 +99,7 @@ nonisolated public struct TokenUsageBreakdown: Codable, Identifiable, Sendable {
         self.cacheReadTokens = cacheReadTokens
         self.estimatedCostUSD = estimatedCostUSD
         self.sessionCount = sessionCount
+        self.modelBreakdowns = modelBreakdowns
     }
 
     public var totalTokens: Int {
@@ -339,6 +352,23 @@ nonisolated public struct CostSummary: Codable, Sendable {
             totalCostUSD: providers.reduce(0) { $0 + $1.estimatedCostUSD },
             totalTokens: providers.reduce(0) { $0 + $1.totalTokens }
         )
+    }
+
+    /// Calendar month-to-date window (issue #270): the 1st of `now`'s local
+    /// month through `now`, inclusive. A month-to-date span is exactly a
+    /// "last N days" window where N is the day-count since the 1st, so this
+    /// delegates straight to `dailyCostWindow` instead of duplicating its
+    /// filtering/aggregation/truncation logic. `now`/`calendar` are read
+    /// fresh on every call — never cached — so the window rolls over at
+    /// midnight on the 1st without a restart or rescan.
+    public func monthToDateCostWindow(
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> DailyCostWindow {
+        let today = calendar.startOfDay(for: now)
+        let monthStart = CostWindow.startOfCurrentMonth(now: now, calendar: calendar)
+        let daysElapsed = (calendar.dateComponents([.day], from: monthStart, to: today).day ?? 0) + 1
+        return dailyCostWindow(lastDays: daysElapsed, now: now, calendar: calendar)
     }
 
     public func filtered(to enabledServices: Set<ServiceType>) -> CostSummary {

--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -275,9 +275,8 @@ enum ClaudeCostScanner {
                 cacheRead: event.cacheRead,
                 estimatedCostUSD: eventCost
             )
-            totals.projectModels[projectID, default: [:]][
-                CostScanValues.displayModelName(event.model), default: TokenAccumulator()
-            ].add(
+            let displayModel = CostScanValues.displayModelName(event.model)
+            totals.projectModels[projectID, default: [:]][displayModel, default: TokenAccumulator()].add(
                 input: event.input,
                 output: event.output,
                 cacheCreation: event.cacheCreation,

--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -32,7 +32,11 @@ enum ClaudeCostScanner {
             // period window is already bounded by the per-event timestamp check
             // (an event is never newer than the file that holds it).
             for case let url as URL in enumerator where url.pathExtension == "jsonl" {
-                let file = Self.parseSessionWindows(at: url, since: cutoffDate)
+                // Computed once per file, not per event: project identity is a
+                // property of where the transcript lives, unlike `usageOrigin`
+                // which can vary line-to-line within the same file.
+                let projectID = CostProjectAttribution.claudeProjectID(forTranscriptURL: url, root: root)
+                let file = Self.parseSessionWindows(at: url, since: cutoffDate, projectID: projectID)
                 windows.period.merge(file.period)
                 windows.lifetime.merge(file.lifetime)
             }
@@ -77,6 +81,12 @@ enum ClaudeCostScanner {
             ),
             originBreakdowns: TokenUsageAggregator.makeBreakdowns(
                 from: totals.origins,
+                provider: .claudeCode,
+                pricing: pricing
+            ),
+            projectBreakdowns: TokenUsageAggregator.makeProjectBreakdowns(
+                from: totals.projects,
+                modelsByProject: totals.projectModels,
                 provider: .claudeCode,
                 pricing: pricing
             )
@@ -138,9 +148,16 @@ enum ClaudeCostScanner {
         return url.appendingPathComponent("projects", isDirectory: true)
     }
 
-    /// Convenience wrapper for the reporting window alone.
-    nonisolated static func parseSessionFile(at url: URL, since cutoffDate: Date) -> ClaudeSessionTotals {
-        Self.parseSessionWindows(at: url, since: cutoffDate).period
+    /// Convenience wrapper for the reporting window alone. `projectID` defaults
+    /// to the explicit "unknown" bucket so every pre-#270 call site (including
+    /// the bulk of this file's own test suite) keeps working unchanged instead
+    /// of being forced to name a project it doesn't care about.
+    nonisolated static func parseSessionFile(
+        at url: URL,
+        since cutoffDate: Date,
+        projectID: String = CostProjectAttribution.unknownProjectID
+    ) -> ClaudeSessionTotals {
+        Self.parseSessionWindows(at: url, since: cutoffDate, projectID: projectID).period
     }
 
     /// Parses one transcript into both windows in a single streaming pass.
@@ -149,9 +166,14 @@ enum ClaudeCostScanner {
     /// `messageID:requestID` key while straddling the cutoff; one shared map
     /// would let the older copy overwrite the in-window one and change the
     /// period total.
+    ///
+    /// `projectID` is a single value for the whole file (issue #270): unlike
+    /// per-event fields such as model or origin, project identity comes from
+    /// where the transcript lives on disk, not from anything inside it.
     nonisolated static func parseSessionWindows(
         at url: URL,
-        since cutoffDate: Date
+        since cutoffDate: Date,
+        projectID: String = CostProjectAttribution.unknownProjectID
     ) -> ScanWindows<ClaudeSessionTotals> {
         var periodKeyed: [String: ClaudeUsageEvent] = [:]
         var periodUnkeyed: [ClaudeUsageEvent] = []
@@ -193,15 +215,16 @@ enum ClaudeCostScanner {
         }
 
         return ScanWindows(
-            period: Self.tally(keyed: periodKeyed, unkeyed: periodUnkeyed),
-            lifetime: Self.tally(keyed: lifetimeKeyed, unkeyed: lifetimeUnkeyed),
+            period: Self.tally(keyed: periodKeyed, unkeyed: periodUnkeyed, projectID: projectID),
+            lifetime: Self.tally(keyed: lifetimeKeyed, unkeyed: lifetimeUnkeyed, projectID: projectID),
             cutoff: cutoffDate
         )
     }
 
     nonisolated private static func tally(
         keyed: [String: ClaudeUsageEvent],
-        unkeyed: [ClaudeUsageEvent]
+        unkeyed: [ClaudeUsageEvent],
+        projectID: String
     ) -> ClaudeSessionTotals {
         var totals = ClaudeSessionTotals()
         let events = keyed.keys.sorted().compactMap { keyed[$0] } + unkeyed
@@ -239,6 +262,22 @@ enum ClaudeCostScanner {
                 estimatedCostUSD: eventCost
             )
             totals.origins[event.origin, default: TokenAccumulator()].add(
+                input: event.input,
+                output: event.output,
+                cacheCreation: event.cacheCreation,
+                cacheRead: event.cacheRead,
+                estimatedCostUSD: eventCost
+            )
+            totals.projects[projectID, default: TokenAccumulator()].add(
+                input: event.input,
+                output: event.output,
+                cacheCreation: event.cacheCreation,
+                cacheRead: event.cacheRead,
+                estimatedCostUSD: eventCost
+            )
+            totals.projectModels[projectID, default: [:]][
+                CostScanValues.displayModelName(event.model), default: TokenAccumulator()
+            ].add(
                 input: event.input,
                 output: event.output,
                 cacheCreation: event.cacheCreation,

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -87,6 +87,13 @@ enum CodexCostScanner {
                 from: context.originTotals,
                 provider: .codexCli,
                 pricing: pricing
+            ),
+            projectBreakdowns: TokenUsageAggregator.makeProjectBreakdowns(
+                from: context.projectTotals,
+                modelsByProject: context.projectModelTotals,
+                provider: .codexCli,
+                pricing: pricing,
+                pricingForName: { ModelPricing.codex(for: $0) }
             )
         ), TokenUsageAggregator.makeDailyUsage(from: context.dailyTotals, provider: .codexCli, pricing: pricing))
     }
@@ -182,6 +189,7 @@ enum CodexCostScanner {
             // anyway so pre-turn events get named the day Codex populates it.
             rollout.sessionModel = (payload["model"] as? String) ?? rollout.sessionModel
             rollout.originator = (payload["originator"] as? String) ?? rollout.originator
+            rollout.cwd = (payload["cwd"] as? String) ?? rollout.cwd
         }
     }
 
@@ -212,8 +220,11 @@ enum CodexCostScanner {
             usage,
             timestamp: timestamp,
             sessionID: sessionID,
-            modelName: modelName,
-            originName: rollout.originator ?? "Codex CLI",
+            attribution: CodexUsageAttribution(
+                modelName: modelName,
+                originName: rollout.originator ?? "Codex CLI",
+                projectID: CostProjectAttribution.codexProjectID(cwd: rollout.cwd)
+            ),
             windows: &windows
         )
     }
@@ -273,22 +284,29 @@ enum CodexCostScanner {
                 usage,
                 timestamp: timestamp,
                 sessionID: sessionID,
-                modelName: Self.logValue("model", in: body) ?? Self.logValue("slug", in: body),
-                originName: Self.logValue("originator", in: body) ?? "Codex CLI",
+                attribution: CodexUsageAttribution(
+                    modelName: Self.logValue("model", in: body) ?? Self.logValue("slug", in: body),
+                    originName: Self.logValue("originator", in: body) ?? "Codex CLI",
+                    // The flat SQLite log format carries no cwd/path field at
+                    // all (issue #270) — always the explicit unknown bucket,
+                    // never a guess.
+                    projectID: CostProjectAttribution.unknownProjectID
+                ),
                 windows: &windows
             )
         }
     }
 
-    /// Stays at six parameters — SwiftLint's `function_parameter_count` warns at
-    /// seven and CI lints with `--strict` — because the cutoff travels inside
-    /// `ScanWindows` rather than as its own argument.
+    /// Stays at five named parameters — SwiftLint's `function_parameter_count`
+    /// warns at seven and CI lints with `--strict` — because the cutoff travels
+    /// inside `ScanWindows` rather than as its own argument, and `modelName`/
+    /// `originName`/`projectID` are bundled into one `CodexUsageAttribution`
+    /// value instead of three separate parameters.
     nonisolated private static func addUsage(
         _ usage: [String: Any],
         timestamp: Date,
         sessionID: String,
-        modelName: String?,
-        originName: String?,
+        attribution: CodexUsageAttribution,
         windows: inout ScanWindows<CodexScanContext>
     ) {
         let input = CostScanValues.int(usage["input_tokens"])
@@ -303,8 +321,9 @@ enum CodexCostScanner {
         let timestampMillis = Int((timestamp.timeIntervalSince1970 * 1000).rounded())
         let key = "\(timestampMillis)-\(sessionID)-\(input)-\(cached)-\(output)-\(reasoning)"
         let day = Calendar.current.startOfDay(for: timestamp)
-        let modelKey = CostScanValues.displayModelName(modelName)
-        let originKey = CostScanValues.displayOriginName(originName)
+        let modelKey = CostScanValues.displayModelName(attribution.modelName)
+        let originKey = CostScanValues.displayOriginName(attribution.originName)
+        let projectKey = attribution.projectID
 
         // Each window keeps its own `eventKeys`, so an event that lands in both
         // is deduplicated independently in each — exactly what the two separate
@@ -333,6 +352,18 @@ enum CodexCostScanner {
                 cacheRead: cached
             )
             context.originTotals[originKey, default: TokenAccumulator()].add(
+                input: input,
+                output: output + reasoning,
+                cacheCreation: 0,
+                cacheRead: cached
+            )
+            context.projectTotals[projectKey, default: TokenAccumulator()].add(
+                input: input,
+                output: output + reasoning,
+                cacheCreation: 0,
+                cacheRead: cached
+            )
+            context.projectModelTotals[projectKey, default: [:]][modelKey, default: TokenAccumulator()].add(
                 input: input,
                 output: output + reasoning,
                 cacheCreation: 0,
@@ -388,4 +419,18 @@ nonisolated struct CodexRolloutContext: Sendable {
     var turnModel: String?
     var sessionModel: String?
     var originator: String?
+    /// Real, unencoded working directory from `session_meta.payload.cwd`
+    /// (issue #270) — the non-prompt-content field project attribution is
+    /// derived from. `nil` until (or unless) a `session_meta` event supplies it.
+    var cwd: String?
+}
+
+/// Bundles the three "who/what/where" labels a single usage event needs so
+/// `addUsage` can stay under SwiftLint's `function_parameter_count` limit
+/// (issue #270 added `projectID` as the third label alongside the pre-existing
+/// model/origin pair).
+nonisolated struct CodexUsageAttribution: Sendable {
+    let modelName: String?
+    let originName: String?
+    let projectID: String
 }

--- a/MeterBar/Services/CostProjectAttribution.swift
+++ b/MeterBar/Services/CostProjectAttribution.swift
@@ -7,7 +7,9 @@ import Foundation
 /// bucket rather than being dropped or guessed at.
 enum CostProjectAttribution {
     /// Explicit fallback bucket for sessions with no derivable project.
-    static let unknownProjectID = "unknown"
+    /// `nonisolated` because every caller — both `sanitize` overloads and the
+    /// two scanners — reads it off the main actor while parsing transcripts.
+    nonisolated static let unknownProjectID = "unknown"
 
     /// Claude Code stores each transcript under
     /// `<projects-root>/<encoded-cwd>/<session>.jsonl`, where the encoded
@@ -50,11 +52,16 @@ enum CostProjectAttribution {
     /// Strips the encoded real-home-directory prefix so a displayed
     /// identifier never leaks a full home-directory path, then reads dashes
     /// in the remainder as path separators.
+    ///
+    /// The prefix must be followed by the encoded separator, so a sibling
+    /// directory that merely starts with the same characters (home
+    /// `/Users/alice`, encoded `-Users-alicexyz`) falls into `unknown`
+    /// instead of reporting a fabricated "xyz" project.
     nonisolated private static func sanitize(encodedDirectoryName raw: String) -> String {
-        let homeEncoded = "-" + ServiceSupport.realHomeDirectory()
+        let homeEncoded = "-" + homeDirectory()
             .split(separator: "/")
             .joined(separator: "-")
-        guard raw.hasPrefix(homeEncoded) else { return unknownProjectID }
+        guard raw.hasPrefix(homeEncoded + "-") else { return unknownProjectID }
 
         let remainder = String(raw.dropFirst(homeEncoded.count))
             .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
@@ -64,13 +71,29 @@ enum CostProjectAttribution {
 
     /// Strips the real home-directory prefix from an absolute path so a
     /// displayed identifier never leaks a full home-directory path.
+    ///
+    /// The prefix must end on a directory boundary, so a sibling path that
+    /// shares the home directory's leading characters (home `/Users/alice`,
+    /// path `/Users/alice-work/app`) resolves to `unknown` rather than the
+    /// fabricated project "-work/app".
     nonisolated private static func sanitize(absolutePath raw: String) -> String {
-        let home = ServiceSupport.realHomeDirectory()
-        guard raw.hasPrefix(home) else { return unknownProjectID }
+        let home = homeDirectory()
+        guard raw.hasPrefix(home + "/") else { return unknownProjectID }
 
         let remainder = String(raw.dropFirst(home.count))
             .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         guard !remainder.isEmpty else { return unknownProjectID }
         return remainder
+    }
+
+    /// Home directory without a trailing separator. Both `sanitize` overloads
+    /// append their own boundary character, so a `HOME` that happens to end in
+    /// "/" would otherwise never match and send every session to `unknown`.
+    nonisolated private static func homeDirectory() -> String {
+        var home = ServiceSupport.realHomeDirectory()
+        while home.count > 1, home.hasSuffix("/") {
+            home.removeLast()
+        }
+        return home
     }
 }

--- a/MeterBar/Services/CostProjectAttribution.swift
+++ b/MeterBar/Services/CostProjectAttribution.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Derives a per-project/worktree identifier strictly from the file-system
+/// location of a scanned transcript — never from prompt content, credentials,
+/// or git metadata (issue #270). Every session attributes to exactly one
+/// bucket; a session this can't place lands in the explicit `unknownProjectID`
+/// bucket rather than being dropped or guessed at.
+enum CostProjectAttribution {
+    /// Explicit fallback bucket for sessions with no derivable project.
+    static let unknownProjectID = "unknown"
+
+    /// Claude Code stores each transcript under
+    /// `<projects-root>/<encoded-cwd>/<session>.jsonl`, where the encoded
+    /// directory name is the session's absolute working directory with both
+    /// "/" and "." collapsed to "-". Computed once per file — unlike
+    /// `usageOrigin`, which can vary per event — because project identity is
+    /// a property of where the file lives, not of any one message inside it.
+    ///
+    /// The collapse is lossy: a literal "-" inside a real path segment can't
+    /// be told apart from an encoded separator. This is an accepted,
+    /// best-effort reconstruction, not a byte-exact decode.
+    nonisolated static func claudeProjectID(forTranscriptURL url: URL, root: URL) -> String {
+        let rootPath = root.standardizedFileURL.path
+        let filePath = url.standardizedFileURL.path
+        guard filePath.hasPrefix(rootPath) else { return unknownProjectID }
+
+        let relative = filePath
+            .dropFirst(rootPath.count)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard let encodedDirectory = relative.split(separator: "/").first, !encodedDirectory.isEmpty else {
+            return unknownProjectID
+        }
+
+        return sanitize(encodedDirectoryName: String(encodedDirectory))
+    }
+
+    /// Codex names the session's real, unencoded working directory once per
+    /// session in `session_meta.payload.cwd` — a legitimate non-prompt-content
+    /// field, distinct from anything the user typed. Sessions the scanner
+    /// can't attach a `cwd` to (including every event read from the flat
+    /// SQLite log format, which carries no path field at all) resolve to
+    /// `unknownProjectID` — correct behavior, never a guess.
+    nonisolated static func codexProjectID(cwd: String?) -> String {
+        guard let cwd, !cwd.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return unknownProjectID
+        }
+        return sanitize(absolutePath: cwd)
+    }
+
+    /// Strips the encoded real-home-directory prefix so a displayed
+    /// identifier never leaks a full home-directory path, then reads dashes
+    /// in the remainder as path separators.
+    nonisolated private static func sanitize(encodedDirectoryName raw: String) -> String {
+        let homeEncoded = "-" + ServiceSupport.realHomeDirectory()
+            .split(separator: "/")
+            .joined(separator: "-")
+        guard raw.hasPrefix(homeEncoded) else { return unknownProjectID }
+
+        let remainder = String(raw.dropFirst(homeEncoded.count))
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        guard !remainder.isEmpty else { return unknownProjectID }
+        return remainder.replacingOccurrences(of: "-", with: "/")
+    }
+
+    /// Strips the real home-directory prefix from an absolute path so a
+    /// displayed identifier never leaks a full home-directory path.
+    nonisolated private static func sanitize(absolutePath raw: String) -> String {
+        let home = ServiceSupport.realHomeDirectory()
+        guard raw.hasPrefix(home) else { return unknownProjectID }
+
+        let remainder = String(raw.dropFirst(home.count))
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard !remainder.isEmpty else { return unknownProjectID }
+        return remainder
+    }
+}

--- a/MeterBar/Services/CostScanWindows.swift
+++ b/MeterBar/Services/CostScanWindows.swift
@@ -49,6 +49,14 @@ nonisolated struct ClaudeSessionTotals: Sendable {
     var daily: [Date: TokenAccumulator] = [:]
     var models: [String: TokenAccumulator] = [:]
     var origins: [String: TokenAccumulator] = [:]
+    /// Per-project rollup, keyed by the sanitized identifier `CostProjectAttribution`
+    /// derives from the transcript's file-system path (issue #270). Every file
+    /// attributes to exactly one bucket, including the explicit `unknown` one —
+    /// never dropped, never guessed.
+    var projects: [String: TokenAccumulator] = [:]
+    /// Nested per-project, per-model totals powering the "drill-down to model
+    /// breakdown" view under each project's rollup row.
+    var projectModels: [String: [String: TokenAccumulator]] = [:]
 
     var hasUsage: Bool {
         input > 0 || output > 0 || cacheCreation > 0 || cacheRead > 0
@@ -74,6 +82,14 @@ nonisolated struct ClaudeSessionTotals: Sendable {
         }
         for (name, tokens) in other.origins {
             origins[name, default: TokenAccumulator()].merge(tokens)
+        }
+        for (project, tokens) in other.projects {
+            projects[project, default: TokenAccumulator()].merge(tokens)
+        }
+        for (project, modelTotals) in other.projectModels {
+            for (model, tokens) in modelTotals {
+                projectModels[project, default: [:]][model, default: TokenAccumulator()].merge(tokens)
+            }
         }
 
         earliest = Self.earlier(earliest, other.earliest)
@@ -121,6 +137,10 @@ nonisolated struct CodexScanContext: Sendable {
     var dailyTotals: [Date: TokenAccumulator] = [:]
     var modelTotals: [String: TokenAccumulator] = [:]
     var originTotals: [String: TokenAccumulator] = [:]
+    /// Per-project rollup keyed by `CostProjectAttribution.codexProjectID` —
+    /// see the matching fields on `ClaudeSessionTotals` (issue #270).
+    var projectTotals: [String: TokenAccumulator] = [:]
+    var projectModelTotals: [String: [String: TokenAccumulator]] = [:]
     var eventKeys: Set<String> = []
     var sessionIDs: Set<String> = []
     var earliestDate: Date

--- a/MeterBar/Services/CostWindow.swift
+++ b/MeterBar/Services/CostWindow.swift
@@ -22,4 +22,18 @@ enum CostWindow {
             to: today
         ) ?? today
     }
+
+    /// Midnight on the 1st of `now`'s local calendar month (issue #270). Takes
+    /// `now`/`calendar` as parameters rather than caching a start date, so the
+    /// boundary is recomputed on every call and rolls over at midnight on the
+    /// 1st without a restart or rescan.
+    nonisolated static func startOfCurrentMonth(
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> Date {
+        let today = calendar.startOfDay(for: now)
+        var components = calendar.dateComponents([.year, .month], from: today)
+        components.day = 1
+        return calendar.date(from: components) ?? today
+    }
 }

--- a/MeterBar/Services/DisplayCurrencyStore.swift
+++ b/MeterBar/Services/DisplayCurrencyStore.swift
@@ -1,0 +1,76 @@
+import Combine
+import Foundation
+
+/// Persists the user's optional presentation-only currency conversion
+/// (issue #270). MeterBar never fetches a live exchange rate: `currency` is
+/// exactly what the user typed, paired with the moment they entered it, so a
+/// converted figure is never mistaken for a live quote. `nil` means "no
+/// conversion, show USD" — the default and the only state that ships out of
+/// the box.
+final class DisplayCurrencyStore: ObservableObject {
+    static let shared = DisplayCurrencyStore()
+
+    @Published private(set) var currency: DisplayCurrency?
+
+    private let userDefaults: UserDefaults
+
+    /// Internal (not private) so tests can construct an instance backed by an
+    /// isolated `UserDefaults` suite; production code uses `shared`.
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        load()
+    }
+
+    /// Read-only projection for the CLI, mirroring `ProviderVisibilityStore`'s
+    /// second initializer — no `UserDefaults` access, just the decoded value.
+    init(currency: DisplayCurrency?) {
+        userDefaults = .standard
+        self.currency = currency
+    }
+
+    /// Saves a new rate. `code` is trimmed and uppercased for display
+    /// consistency. A non-positive `rate` can never produce a meaningful
+    /// converted figure, so it clears the conversion instead of saving one.
+    func set(code: String, rate: Double) {
+        let trimmedCode = code.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        guard !trimmedCode.isEmpty, rate > 0 else {
+            clear()
+            return
+        }
+        let next = DisplayCurrency(code: trimmedCode, unitsPerUSD: rate, enteredAt: Date())
+        currency = next
+        persist(next)
+    }
+
+    /// Removes any saved conversion, reverting cost views to plain USD.
+    func clear() {
+        currency = nil
+        userDefaults.removeObject(forKey: StorageKeys.displayCurrencyCode)
+        userDefaults.removeObject(forKey: StorageKeys.displayCurrencyRate)
+        userDefaults.removeObject(forKey: StorageKeys.displayCurrencyEnteredAt)
+    }
+
+    private func persist(_ currency: DisplayCurrency) {
+        userDefaults.set(currency.code, forKey: StorageKeys.displayCurrencyCode)
+        userDefaults.set(currency.unitsPerUSD, forKey: StorageKeys.displayCurrencyRate)
+        userDefaults.set(currency.enteredAt, forKey: StorageKeys.displayCurrencyEnteredAt)
+    }
+
+    private func load() {
+        guard
+            let code = userDefaults.string(forKey: StorageKeys.displayCurrencyCode),
+            !code.isEmpty,
+            userDefaults.object(forKey: StorageKeys.displayCurrencyRate) != nil
+        else {
+            currency = nil
+            return
+        }
+        let rate = userDefaults.double(forKey: StorageKeys.displayCurrencyRate)
+        guard rate > 0 else {
+            currency = nil
+            return
+        }
+        let enteredAt = userDefaults.object(forKey: StorageKeys.displayCurrencyEnteredAt) as? Date ?? Date()
+        currency = DisplayCurrency(code: code, unitsPerUSD: rate, enteredAt: enteredAt)
+    }
+}

--- a/MeterBar/Services/DisplayCurrencyStore.swift
+++ b/MeterBar/Services/DisplayCurrencyStore.swift
@@ -29,11 +29,13 @@ final class DisplayCurrencyStore: ObservableObject {
     }
 
     /// Saves a new rate. `code` is trimmed and uppercased for display
-    /// consistency. A non-positive `rate` can never produce a meaningful
-    /// converted figure, so it clears the conversion instead of saving one.
+    /// consistency. A rate that is non-positive, infinite, or NaN can never
+    /// produce a meaningful converted figure, so it clears the conversion
+    /// instead of saving one. (`Double.infinity` passes `> 0`, so the finite
+    /// check has to be explicit or every converted total becomes "inf".)
     func set(code: String, rate: Double) {
         let trimmedCode = code.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
-        guard !trimmedCode.isEmpty, rate > 0 else {
+        guard !trimmedCode.isEmpty, rate > 0, rate.isFinite else {
             clear()
             return
         }
@@ -66,7 +68,7 @@ final class DisplayCurrencyStore: ObservableObject {
             return
         }
         let rate = userDefaults.double(forKey: StorageKeys.displayCurrencyRate)
-        guard rate > 0 else {
+        guard rate > 0, rate.isFinite else {
             currency = nil
             return
         }

--- a/MeterBar/Services/TokenUsageAggregator.swift
+++ b/MeterBar/Services/TokenUsageAggregator.swift
@@ -72,4 +72,33 @@ enum TokenUsageAggregator {
             return lhs.estimatedCostUSD > rhs.estimatedCostUSD
         }
     }
+
+    /// Per-project rollup rows, each carrying its own nested per-model
+    /// breakdown (issue #270's "rollup view plus drill-down to model
+    /// breakdown"). Reuses `makeBreakdowns` twice — once for the top-level
+    /// rollup, once per project for its `modelBreakdowns` slice — rather than
+    /// inventing a second aggregation algorithm.
+    nonisolated static func makeProjectBreakdowns(
+        from projectTotals: [String: TokenAccumulator],
+        modelsByProject: [String: [String: TokenAccumulator]],
+        provider: ServiceType,
+        pricing: TokenPricing,
+        pricingForName: ((String) -> TokenPricing)? = nil
+    ) -> [TokenUsageBreakdown] {
+        makeBreakdowns(from: projectTotals, provider: provider, pricing: pricing).map { row in
+            TokenUsageBreakdown(
+                provider: row.provider,
+                name: row.name,
+                inputTokens: row.inputTokens,
+                outputTokens: row.outputTokens,
+                cacheCreationTokens: row.cacheCreationTokens,
+                cacheReadTokens: row.cacheReadTokens,
+                estimatedCostUSD: row.estimatedCostUSD,
+                sessionCount: row.sessionCount,
+                modelBreakdowns: modelsByProject[row.name].map {
+                    makeBreakdowns(from: $0, provider: provider, pricing: pricing, pricingForName: pricingForName)
+                } ?? []
+            )
+        }
+    }
 }

--- a/MeterBar/Views/Settings/CostSettingsView.swift
+++ b/MeterBar/Views/Settings/CostSettingsView.swift
@@ -1,19 +1,207 @@
 import MeterBarShared
 import SwiftUI
 
-/// The "Cost" settings tab: local session cost scan results and the 30-day
-/// scan control. Extracted from the SettingsView monolith.
+/// Which calendar window the cost summary section displays (issue #270).
+/// Presentation-only state — both windows read the same cached scan, no
+/// rescan, so switching modes never triggers new I/O.
+enum CostPeriodMode: String, CaseIterable, Identifiable {
+    case last30Days
+    case monthToDate
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .last30Days: "Last 30 Days"
+        case .monthToDate: "Month to Date"
+        }
+    }
+}
+
+/// Renders one cost-summary period — the rolling 30-day window or the
+/// calendar month-to-date window — plus its per-provider project/worktree
+/// rollup and, when set, a converted-currency caption (issue #270). A pure
+/// function of its inputs with no singleton access, so it can be exercised
+/// directly in tests with a synthetic `CostSummary`, independent of
+/// `CostTracker.shared`'s live scan state (mirrors how `SettingsPanelSection`
+/// and `EmptyStateCard` are already tested standalone).
+struct CostPeriodContentView: View {
+    let summary: CostSummary
+    let periodMode: CostPeriodMode
+    let currency: DisplayCurrency?
+
+    var body: some View {
+        switch periodMode {
+        case .last30Days:
+            last30DaysContent
+        case .monthToDate:
+            monthToDateContent
+        }
+    }
+
+    // MARK: Private
+
+    @ViewBuilder private var last30DaysContent: some View {
+        SettingsRowView(title: "Total cost") {
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(summary.formattedTotalCost)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                convertedCaption(summary.totalCostUSD)
+            }
+        }
+
+        SettingsRowView(title: "Daily average") {
+            Text(summary.formattedDailyCost)
+                .foregroundColor(.secondary)
+        }
+
+        ForEach(summary.costs) { cost in
+            SettingsRowView(title: cost.provider.displayName) {
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(cost.formattedCost)
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                    convertedCaption(cost.estimatedCostUSD)
+                    Text("\(cost.formattedTokens) tokens")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            // Per-project/worktree rollup (issue #270): every scanned session
+            // attributes to exactly one row here, including the explicit
+            // "unknown" bucket for anything unattributable — never dropped,
+            // never guessed.
+            if !cost.projectBreakdowns.isEmpty {
+                projectBreakdownRows(cost.projectBreakdowns)
+            }
+        }
+    }
+
+    @ViewBuilder private var monthToDateContent: some View {
+        // Computed fresh on every render (default `now: Date()`) rather than
+        // stored in state, so the boundary rolls over at midnight on the 1st
+        // without a restart or rescan.
+        let window = summary.monthToDateCostWindow()
+
+        SettingsRowView(title: "Total cost") {
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(window.formattedTotalCost)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                convertedCaption(window.totalCostUSD)
+            }
+        }
+
+        if window.isTruncated {
+            SettingsNotice(
+                text: "Cache covers \(window.coveredDays) of \(window.requestedDays) day(s) so far this month.",
+                color: .secondary
+            )
+        }
+
+        if window.providers.isEmpty {
+            EmptyStateCard(
+                systemImage: "calendar",
+                title: "No data yet",
+                message: "No cached daily usage recorded so far this month."
+            )
+        } else {
+            ForEach(window.providers) { provider in
+                SettingsRowView(title: provider.provider.displayName) {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Text(provider.formattedCost)
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                        convertedCaption(provider.estimatedCostUSD)
+                        // Daily rows carry no cache-creation tokens or session
+                        // counts, so this reports input+output+cache-read only —
+                        // matching `ProviderDailyTotal.totalTokens` exactly.
+                        Text("\(UsageFormat.groupedTokens(provider.totalTokens)) tokens")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Rollup view plus drill-down to model breakdown (issue #270): each
+    /// project/worktree row expands to the models used within it, without
+    /// duplicating the rollup row's own layout.
+    @ViewBuilder
+    private func projectBreakdownRows(_ projects: [TokenUsageBreakdown]) -> some View {
+        ForEach(projects.sorted(by: { $0.estimatedCostUSD > $1.estimatedCostUSD })) { project in
+            DisclosureGroup {
+                ForEach(project.modelBreakdowns) { model in
+                    HStack {
+                        Text(model.name)
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                        Spacer()
+                        Text(model.formattedCost)
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.leading, 20)
+                }
+            } label: {
+                HStack(alignment: .top) {
+                    Text(project.name)
+                        .font(.caption)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer(minLength: 8)
+                    VStack(alignment: .trailing, spacing: 1) {
+                        Text(project.formattedCost)
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                        convertedCaption(project.estimatedCostUSD)
+                        Text("\(project.sessionCount) session\(project.sessionCount == 1 ? "" : "s")")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            .padding(.leading, 8)
+            .accessibilityIdentifier("project-breakdown-\(project.name)")
+        }
+    }
+
+    /// Converted-currency caption shown under a USD figure, only when the
+    /// user has entered a rate. Uses `DisplayCurrency`'s shared formatter so
+    /// this never drifts from the CLI's own text output.
+    @ViewBuilder
+    private func convertedCaption(_ usd: Double) -> some View {
+        if let currency {
+            Text("\u{2248} \(currency.formattedConverted(usd: usd))")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+    }
+}
+
+/// The "Cost" settings tab: local session cost scan results, the 30-day scan
+/// control, and (issue #270) the month-to-date period switch and the display
+/// currency preference. Extracted from the SettingsView monolith.
 struct CostSettingsView: View {
     // MARK: Internal
 
     var body: some View {
         costTrackingSection
+        displayCurrencySection
     }
 
     // MARK: Private
 
     @StateObject private var costTracker = CostTracker.shared
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
+    @StateObject private var displayCurrencyStore = DisplayCurrencyStore.shared
+
+    @State private var periodMode: CostPeriodMode = .last30Days
+    @State private var currencyCodeInput: String = ""
+    @State private var currencyRateInput: String = ""
 
     private var visibleCostSummary: CostSummary? {
         costTracker.costSummary?.filtered(to: providerVisibility.enabledServices)
@@ -35,29 +223,9 @@ struct CostSettingsView: View {
                     }
                 }
             } else if let summary = visibleCostSummary, !summary.costs.isEmpty {
-                SettingsRowView(title: "Total cost") {
-                    Text(summary.formattedTotalCost)
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                }
+                periodPicker
 
-                SettingsRowView(title: "Daily average") {
-                    Text(summary.formattedDailyCost)
-                        .foregroundColor(.secondary)
-                }
-
-                ForEach(summary.costs) { cost in
-                    SettingsRowView(title: cost.provider.displayName) {
-                        VStack(alignment: .trailing, spacing: 2) {
-                            Text(cost.formattedCost)
-                                .font(.caption)
-                                .fontWeight(.semibold)
-                            Text("\(cost.formattedTokens) tokens")
-                                .font(.caption2)
-                                .foregroundColor(.secondary)
-                        }
-                    }
-                }
+                CostPeriodContentView(summary: summary, periodMode: periodMode, currency: displayCurrencyStore.currency)
 
                 if let lastScan = costTracker.lastScanDate {
                     SettingsNotice(text: "Last scanned \(formatDate(lastScan)) ago.", color: .secondary)
@@ -109,6 +277,82 @@ struct CostSettingsView: View {
                 .disabled(costTracker.isRefreshInProgress || !canScanCosts)
             }
         }
+    }
+
+    /// Switches between the rolling 30-day view and the calendar
+    /// month-to-date window (issue #270). Segmented to match the window
+    /// pickers already used elsewhere in Settings (e.g. `ApiUsageCard`).
+    private var periodPicker: some View {
+        Picker("Period", selection: $periodMode) {
+            ForEach(CostPeriodMode.allCases) { mode in
+                Text(mode.title).tag(mode)
+            }
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .accessibilityIdentifier("cost-period-picker")
+    }
+
+    /// Presentation-only currency preference entry (issue #270). MeterBar
+    /// never fetches a live rate — this only accepts what the user types —
+    /// and the disclosure notice below always pairs the stored rate with the
+    /// date it was entered so a converted figure can't read as a live quote.
+    /// Shown regardless of scan state: entering a rate ahead of the first
+    /// scan is harmless, since it only affects how future totals render.
+    private var displayCurrencySection: some View {
+        SettingsPanelSection(title: "Display Currency", systemImage: "banknote", color: MeterBarTheme.warning) {
+            Text("Converts the totals above for display only. Stored and exported cost data always stays USD.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            SettingsRowView(title: "Currency code") {
+                TextField("e.g. EUR", text: $currencyCodeInput)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityIdentifier("display-currency-code-field")
+            }
+
+            SettingsRowView(title: "Units per 1 USD") {
+                TextField("e.g. 0.92", text: $currencyRateInput)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityIdentifier("display-currency-rate-field")
+            }
+
+            HStack(spacing: 8) {
+                Spacer(minLength: 0)
+
+                Button("Save") {
+                    guard let rate = Double(currencyRateInput) else { return }
+                    displayCurrencyStore.set(code: currencyCodeInput, rate: rate)
+                }
+                .buttonStyle(.bordered)
+                .disabled(
+                    currencyCodeInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        || Double(currencyRateInput) == nil
+                )
+                .accessibilityIdentifier("display-currency-save-button")
+
+                if displayCurrencyStore.currency != nil {
+                    Button("Clear", role: .destructive) {
+                        displayCurrencyStore.clear()
+                        currencyCodeInput = ""
+                        currencyRateInput = ""
+                    }
+                    .buttonStyle(.bordered)
+                    .accessibilityIdentifier("display-currency-clear-button")
+                }
+            }
+
+            if let currency = displayCurrencyStore.currency {
+                SettingsNotice(text: currency.disclosureText, color: .secondary)
+            }
+        }
+        .onAppear(perform: syncCurrencyInputsFromStore)
+    }
+
+    private func syncCurrencyInputsFromStore() {
+        guard let currency = displayCurrencyStore.currency else { return }
+        currencyCodeInput = currency.code
+        currencyRateInput = String(currency.unitsPerUSD)
     }
 
     private func formatDate(_ date: Date) -> String {

--- a/MeterBar/Views/Settings/CostSettingsView.swift
+++ b/MeterBar/Views/Settings/CostSettingsView.swift
@@ -79,11 +79,23 @@ struct CostPeriodContentView: View {
         }
     }
 
+    /// Driven by a `TimelineView` tick rather than plain re-render, because
+    /// SwiftUI only recomputes a view when its inputs change: a settings
+    /// window left open across midnight on the 1st would otherwise keep
+    /// showing last month's window until unrelated state moved. Same
+    /// one-minute schedule the other time-driven settings rows already use.
     @ViewBuilder private var monthToDateContent: some View {
-        // Computed fresh on every render (default `now: Date()`) rather than
-        // stored in state, so the boundary rolls over at midnight on the 1st
-        // without a restart or rescan.
-        let window = summary.monthToDateCostWindow()
+        TimelineView(.periodic(from: .now, by: 60)) { context in
+            VStack(alignment: .leading, spacing: 10) {
+                monthToDateRows(now: context.date)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder
+    private func monthToDateRows(now: Date) -> some View {
+        let window = summary.monthToDateCostWindow(now: now)
 
         SettingsRowView(title: "Total cost") {
             VStack(alignment: .trailing, spacing: 2) {
@@ -321,13 +333,13 @@ struct CostSettingsView: View {
                 Spacer(minLength: 0)
 
                 Button("Save") {
-                    guard let rate = Double(currencyRateInput) else { return }
+                    guard let rate = parsedCurrencyRate else { return }
                     displayCurrencyStore.set(code: currencyCodeInput, rate: rate)
                 }
                 .buttonStyle(.bordered)
                 .disabled(
                     currencyCodeInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                        || Double(currencyRateInput) == nil
+                        || parsedCurrencyRate == nil
                 )
                 .accessibilityIdentifier("display-currency-save-button")
 
@@ -347,6 +359,14 @@ struct CostSettingsView: View {
             }
         }
         .onAppear(perform: syncCurrencyInputsFromStore)
+    }
+
+    /// `Double("inf")` and `Double("nan")` both parse, so plain
+    /// `Double(_:) != nil` would enable Save for a rate that can only render
+    /// as "inf". The store rejects those too; this keeps the button honest.
+    private var parsedCurrencyRate: Double? {
+        guard let rate = Double(currencyRateInput), rate > 0, rate.isFinite else { return nil }
+        return rate
     }
 
     private func syncCurrencyInputsFromStore() {

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -198,10 +198,52 @@ struct Cost: ParsableCommand {
     )
     var days: Int?
 
+    @Flag(
+        name: .customLong("month-to-date"),
+        help: ArgumentHelp("Limit to the calendar month-to-date window (1st of this month through now, "
+            + "in the local time zone), using the cached daily breakdown (no rescan).")
+    )
+    var monthToDate: Bool = false
+
+    @Option(
+        name: .customLong("currency"),
+        help: ArgumentHelp("Show cost converted to this currency code (e.g. EUR), alongside the rate and "
+            + "the date it was entered. Requires --rate. Presentation only — stored and "
+            + "exported data always stays USD.")
+    )
+    var currencyCode: String?
+
+    @Option(
+        name: .customLong("rate"),
+        help: ArgumentHelp("Units of --currency per 1 USD, e.g. 0.92. MeterBar never fetches a live "
+            + "exchange rate — you must supply one alongside --currency.")
+    )
+    var currencyRate: Double?
+
     func validate() throws {
         if let days, days < 1 {
             throw ValidationError("--days must be 1 or greater.")
         }
+        if monthToDate, days != nil {
+            throw ValidationError("--month-to-date cannot be combined with --days.")
+        }
+        // Both flags or neither: a code with no rate (or vice versa) can't
+        // produce a meaningful converted figure.
+        if (currencyCode == nil) != (currencyRate == nil) {
+            throw ValidationError("--currency and --rate must be supplied together.")
+        }
+        if let currencyRate, currencyRate <= 0 {
+            throw ValidationError("--rate must be greater than 0.")
+        }
+    }
+
+    /// Built fresh from the flags on every `run()` — the CLI has no
+    /// persisted rate of its own (that's `DisplayCurrencyStore`, used by the
+    /// app). `enteredAt` is "now" because a CLI invocation only ever reflects
+    /// what the caller just typed, never a cached/stale value (issue #270).
+    private var displayCurrency: DisplayCurrency? {
+        guard let currencyCode, let currencyRate else { return nil }
+        return DisplayCurrency(code: currencyCode, unitsPerUSD: currencyRate, enteredAt: Date())
     }
 
     func run() throws {
@@ -222,33 +264,67 @@ struct Cost: ParsableCommand {
             return
         }
 
-        // `--days N` reports a windowed view derived purely from the cached daily
-        // rows — no rescan. Falls through to the full cached summary otherwise.
+        // `--month-to-date` and `--days N` both report a windowed view derived
+        // purely from the cached daily rows — no rescan. `validate()` already
+        // rejects combining them. Falls through to the full cached summary
+        // otherwise.
+        if monthToDate {
+            if json {
+                try emitJSON(CostCLIJSONResponse(cache: cache, monthToDate: true, displayCurrency: displayCurrency))
+            } else {
+                let window = cache.summary.monthToDateCostWindow()
+                printWindow(window, cache: cache, periodLabel: "Month to date", currency: displayCurrency)
+            }
+            return
+        }
+
         if let days {
             if json {
-                try emitJSON(CostCLIJSONResponse(cache: cache, days: days))
+                try emitJSON(CostCLIJSONResponse(cache: cache, days: days, displayCurrency: displayCurrency))
             } else {
                 let window = cache.summary.dailyCostWindow(lastDays: days)
-                printWindow(window, cache: cache)
+                printWindow(
+                    window,
+                    cache: cache,
+                    periodLabel: "Last \(days) days (from cached daily data)",
+                    currency: displayCurrency
+                )
             }
             return
         }
 
         if json {
-            try emitJSON(CostCLIJSONResponse(cache: cache))
+            try emitJSON(CostCLIJSONResponse(cache: cache, displayCurrency: displayCurrency))
         } else {
-            printCosts(cache)
+            printCosts(cache, currency: displayCurrency)
         }
     }
 
-    private func printWindow(_ window: DailyCostWindow, cache: CostSummaryCache) {
+    /// A USD figure, plus its converted equivalent in parentheses when a
+    /// `--currency`/`--rate` pair was supplied — otherwise just the USD text.
+    private func costText(_ usd: Double, currency: DisplayCurrency?) -> String {
+        guard let currency else { return UsageFormat.cost(usd) }
+        return "\(UsageFormat.cost(usd)) (\(currency.formattedConverted(usd: usd)))"
+    }
+
+    private func printWindow(
+        _ window: DailyCostWindow,
+        cache: CostSummaryCache,
+        periodLabel: String,
+        currency: DisplayCurrency?
+    ) {
         print("╭─────────────────────────────────────────╮")
         print("│          MeterBar Cost Tracker          │")
         print("╰─────────────────────────────────────────╯")
         print()
-        print("Period: Last \(window.requestedDays) days (from cached daily data)")
+        print("Period: \(periodLabel)")
         print("Scanned: \(UsageFormat.relative(cache.lastScanDate))")
         print("Pricing: \(ModelPricing.revisionLabel)")
+        // Printed once, near every converted figure below, so a converted
+        // total can never be mistaken for a live quote (issue #270).
+        if let currency {
+            print("Currency: \(currency.disclosureText)")
+        }
 
         // The cache holds fewer days than asked for — don't imply full coverage.
         if window.isTruncated {
@@ -260,7 +336,7 @@ struct Cost: ParsableCommand {
 
         if window.providers.isEmpty {
             if cache.summary.costs.isEmpty {
-                print("No usage in the last \(window.requestedDays) days.")
+                print("No usage in the requested window.")
             } else {
                 // Legacy caches carry totals but no per-day rows.
                 print("No cached daily breakdown for this window.")
@@ -274,15 +350,15 @@ struct Cost: ParsableCommand {
             print("  Input:          \(UsageFormat.groupedTokens(provider.inputTokens))")
             print("  Output:         \(UsageFormat.groupedTokens(provider.outputTokens))")
             print("  Cache Read:     \(UsageFormat.groupedTokens(provider.cacheReadTokens))")
-            print("  Estimated Cost: \(provider.formattedCost)")
+            print("  Estimated Cost: \(costText(provider.estimatedCostUSD, currency: currency))")
             print()
         }
 
-        print("Total:          \(window.formattedTotalCost)")
+        print("Total:          \(costText(window.totalCostUSD, currency: currency))")
         print("Tokens:         \(UsageFormat.groupedTokens(window.totalTokens))")
     }
 
-    private func printCosts(_ cache: CostSummaryCache) {
+    private func printCosts(_ cache: CostSummaryCache, currency: DisplayCurrency?) {
         let summary = cache.summary
 
         print("╭─────────────────────────────────────────╮")
@@ -292,6 +368,9 @@ struct Cost: ParsableCommand {
         print("Period: Last \(summary.periodDays) days")
         print("Scanned: \(UsageFormat.relative(cache.lastScanDate))")
         print("Pricing: \(ModelPricing.revisionLabel)")
+        if let currency {
+            print("Currency: \(currency.disclosureText)")
+        }
         print()
 
         for cost in summary.costs {
@@ -301,12 +380,23 @@ struct Cost: ParsableCommand {
             print("  Output:         \(UsageFormat.groupedTokens(cost.outputTokens))")
             print("  Cache Creation: \(UsageFormat.groupedTokens(cost.cacheCreationTokens))")
             print("  Cache Read:     \(UsageFormat.groupedTokens(cost.cacheReadTokens))")
-            print("  Estimated Cost: \(cost.formattedCost)")
+            print("  Estimated Cost: \(costText(cost.estimatedCostUSD, currency: currency))")
+
+            // Per-project/worktree rollup (issue #270) — attributed straight
+            // from scanned session paths, never guessed or dropped; unattributable
+            // sessions surface as an explicit "unknown" row rather than vanishing.
+            if !cost.projectBreakdowns.isEmpty {
+                print("  Projects:")
+                for project in cost.projectBreakdowns.sorted(by: { $0.estimatedCostUSD > $1.estimatedCostUSD }) {
+                    print("    - \(project.name): \(costText(project.estimatedCostUSD, currency: currency))"
+                        + " (\(project.sessionCount) session\(project.sessionCount == 1 ? "" : "s"))")
+                }
+            }
             print()
         }
 
-        print("Total:          \(summary.formattedTotalCost)")
-        print("Daily Average:  \(summary.formattedDailyCost)")
+        print("Total:          \(costText(summary.totalCostUSD, currency: currency))")
+        print("Daily Average:  \(costText(summary.averageDailyCost, currency: currency)) / day")
         print("Tokens:         \(UsageFormat.groupedTokens(summary.totalTokens))")
     }
 }

--- a/MeterBarTests/CLIJSONOutputTests.swift
+++ b/MeterBarTests/CLIJSONOutputTests.swift
@@ -101,6 +101,158 @@ final class CLIJSONOutputTests: XCTestCase {
         XCTAssertEqual(provider["totalTokens"] as? Int, 150)
     }
 
+    // MARK: - Month-to-date window and project grouping (issue #270)
+
+    func testMonthToDateCostResponseLabelsThePeriodKindAndUsesElapsedDaysInMonth() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+        // referenceDate is 2023-11-14T22:13:20Z, the 14th of the month, so
+        // month-to-date should span 14 days (the 1st through today, inclusive)
+        // regardless of the `--days` value that would otherwise apply.
+        let daily = DailyTokenUsage(
+            date: referenceDate.addingTimeInterval(-86_400),
+            provider: .claudeCode,
+            inputTokens: 100,
+            outputTokens: 20,
+            cacheReadTokens: 30,
+            estimatedCostUSD: 0.5
+        )
+        let cache = CostSummaryCache(
+            summary: CostSummary(
+                costs: [],
+                totalCostUSD: 0.5,
+                totalTokens: 150,
+                periodDays: 30,
+                dailyUsage: [daily]
+            ),
+            lastScanDate: referenceDate
+        )
+
+        let response = CostCLIJSONResponse(
+            cache: cache,
+            monthToDate: true,
+            now: referenceDate,
+            calendar: calendar
+        )
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: response.jsonData()) as? [String: Any]
+        )
+        let period = try XCTUnwrap(object["period"] as? [String: Any])
+        XCTAssertEqual(period["requestedDays"] as? Int, 14)
+        XCTAssertEqual(period["kind"] as? String, "monthToDate")
+    }
+
+    func testCostResponseOmitsProjectBreakdownsWhenNoneAreScannedButIncludesThemWhenPresent() throws {
+        let costWithoutProjects = TokenCost(
+            provider: .claudeCode,
+            inputTokens: 10,
+            outputTokens: 2,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 0,
+            estimatedCostUSD: 0.1,
+            sessionCount: 1,
+            periodStart: referenceDate,
+            periodEnd: referenceDate
+        )
+        let costWithProjects = TokenCost(
+            provider: .codexCli,
+            inputTokens: 1_000,
+            outputTokens: 250,
+            cacheCreationTokens: 50,
+            cacheReadTokens: 500,
+            estimatedCostUSD: 1.25,
+            sessionCount: 3,
+            periodStart: referenceDate,
+            periodEnd: referenceDate,
+            projectBreakdowns: [
+                TokenUsageBreakdown(
+                    provider: .codexCli,
+                    name: "www/example/app",
+                    inputTokens: 1_000,
+                    outputTokens: 250,
+                    cacheCreationTokens: 50,
+                    cacheReadTokens: 500,
+                    estimatedCostUSD: 1.25,
+                    sessionCount: 3,
+                    modelBreakdowns: [
+                        TokenUsageBreakdown(
+                            provider: .codexCli,
+                            name: "gpt-5.6",
+                            inputTokens: 1_000,
+                            outputTokens: 250,
+                            cacheCreationTokens: 50,
+                            cacheReadTokens: 500,
+                            estimatedCostUSD: 1.25,
+                            sessionCount: 3
+                        )
+                    ]
+                )
+            ]
+        )
+        let cache = CostSummaryCache(
+            summary: CostSummary(
+                costs: [costWithoutProjects, costWithProjects],
+                totalCostUSD: 1.35,
+                totalTokens: 1_812,
+                periodDays: 30
+            ),
+            lastScanDate: referenceDate
+        )
+
+        let response = CostCLIJSONResponse(cache: cache)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: response.jsonData()) as? [String: Any]
+        )
+        let providers = try XCTUnwrap(object["providers"] as? [[String: Any]])
+
+        let claude = try XCTUnwrap(providers.first { $0["provider"] as? String == "claude" })
+        XCTAssertNil(claude["projectBreakdowns"])
+
+        let codex = try XCTUnwrap(providers.first { $0["provider"] as? String == "codex" })
+        let projects = try XCTUnwrap(codex["projectBreakdowns"] as? [[String: Any]])
+        let project = try XCTUnwrap(projects.first)
+        XCTAssertEqual(project["name"] as? String, "www/example/app")
+        XCTAssertEqual(project["estimatedCostUSD"] as? Double, 1.25)
+        let models = try XCTUnwrap(project["modelBreakdowns"] as? [[String: Any]])
+        XCTAssertEqual(models.first?["name"] as? String, "gpt-5.6")
+    }
+
+    func testCostResponseOmitsDisplayCurrencyByDefaultButIncludesItWhenSupplied() throws {
+        let cost = TokenCost(
+            provider: .codexCli,
+            inputTokens: 1_000,
+            outputTokens: 250,
+            cacheCreationTokens: 50,
+            cacheReadTokens: 500,
+            estimatedCostUSD: 1.25,
+            sessionCount: 3,
+            periodStart: referenceDate.addingTimeInterval(-86_400),
+            periodEnd: referenceDate
+        )
+        let cache = CostSummaryCache(
+            summary: CostSummary(costs: [cost], totalCostUSD: 1.25, totalTokens: 1_800, periodDays: 30),
+            lastScanDate: referenceDate
+        )
+
+        let withoutCurrency = CostCLIJSONResponse(cache: cache)
+        let plainObject = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: withoutCurrency.jsonData()) as? [String: Any]
+        )
+        XCTAssertNil(plainObject["displayCurrency"])
+
+        let currency = DisplayCurrency(code: "EUR", unitsPerUSD: 0.92, enteredAt: referenceDate)
+        let withCurrency = CostCLIJSONResponse(cache: cache, displayCurrency: currency)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: withCurrency.jsonData()) as? [String: Any]
+        )
+        let displayCurrency = try XCTUnwrap(object["displayCurrency"] as? [String: Any])
+        XCTAssertEqual(displayCurrency["code"] as? String, "EUR")
+        XCTAssertEqual(displayCurrency["unitsPerUSD"] as? Double, 0.92)
+        XCTAssertEqual(displayCurrency["totalCostConverted"] as? Double, currency.convert(usd: 1.25))
+        XCTAssertNotNil(displayCurrency["enteredAt"])
+        XCTAssertEqual(displayCurrency["source"] as? String, "manual")
+    }
+
     func testErrorResponseIsVersionedAndMachineStable() throws {
         let response = CLIJSONErrorResponse(
             code: "usage_cache_missing",

--- a/MeterBarTests/CostProjectAttributionTests.swift
+++ b/MeterBarTests/CostProjectAttributionTests.swift
@@ -50,6 +50,20 @@ final class CostProjectAttributionTests: XCTestCase {
         XCTAssertEqual(projectID, CostProjectAttribution.unknownProjectID)
     }
 
+    func testClaudeProjectIDFallsBackToUnknownForASiblingThatMerelySharesTheHomePrefix() {
+        let root = URL(fileURLWithPath: "\(home)/.claude/projects")
+        let encodedHome = "-" + home.split(separator: "/").joined(separator: "-")
+        // Home "/Users/alice" encodes to "-Users-alice"; a sibling directory
+        // "/Users/alicexyz/app" starts with those same characters but is NOT
+        // under home, so it must not surface as the project "xyz/app".
+        let encodedDir = "\(encodedHome)xyz-app"
+        let transcript = root.appendingPathComponent(encodedDir).appendingPathComponent("session-1.jsonl")
+
+        let projectID = CostProjectAttribution.claudeProjectID(forTranscriptURL: transcript, root: root)
+
+        XCTAssertEqual(projectID, CostProjectAttribution.unknownProjectID)
+    }
+
     // MARK: - Codex (real cwd)
 
     func testCodexProjectIDStripsRealHomePrefix() {
@@ -78,5 +92,18 @@ final class CostProjectAttributionTests: XCTestCase {
 
     func testCodexProjectIDFallsBackToUnknownWhenCwdIsExactlyHome() {
         XCTAssertEqual(CostProjectAttribution.codexProjectID(cwd: home), CostProjectAttribution.unknownProjectID)
+    }
+
+    func testCodexProjectIDFallsBackToUnknownForASiblingThatMerelySharesTheHomePrefix() {
+        // With home "/Users/alice", "/Users/alice-work/app" is a different
+        // user's tree — a plain prefix check would report it as "-work/app".
+        XCTAssertEqual(
+            CostProjectAttribution.codexProjectID(cwd: "\(home)-work/app"),
+            CostProjectAttribution.unknownProjectID
+        )
+        XCTAssertEqual(
+            CostProjectAttribution.codexProjectID(cwd: "\(home)-work"),
+            CostProjectAttribution.unknownProjectID
+        )
     }
 }

--- a/MeterBarTests/CostProjectAttributionTests.swift
+++ b/MeterBarTests/CostProjectAttributionTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import MeterBar
+
+/// Unit tests for `CostProjectAttribution` — the pure, path-only project/worktree
+/// identifier derivation behind issue #270. Every case must resolve to exactly
+/// one bucket, including the explicit `unknown` fallback; nothing is ever dropped.
+final class CostProjectAttributionTests: XCTestCase {
+    private let home = ServiceSupport.realHomeDirectory()
+
+    // MARK: - Claude (encoded directory name)
+
+    func testClaudeProjectIDDecodesEncodedWorkingDirectoryUnderHome() {
+        let root = URL(fileURLWithPath: "\(home)/.claude/projects")
+        let encodedHome = "-" + home.split(separator: "/").joined(separator: "-")
+        let encodedDir = "\(encodedHome)-www-vincentshipsit-public-meterbardev"
+        let transcript = root.appendingPathComponent(encodedDir).appendingPathComponent("session-1.jsonl")
+
+        let projectID = CostProjectAttribution.claudeProjectID(forTranscriptURL: transcript, root: root)
+
+        XCTAssertEqual(projectID, "www/vincentshipsit/public/meterbardev")
+    }
+
+    func testClaudeProjectIDFallsBackToUnknownWhenHomePrefixDoesNotMatch() {
+        let root = URL(fileURLWithPath: "\(home)/.claude/projects")
+        // No encoded-home prefix at all — can't be a Claude-style project dir.
+        let transcript = root.appendingPathComponent("garbage").appendingPathComponent("session-1.jsonl")
+
+        let projectID = CostProjectAttribution.claudeProjectID(forTranscriptURL: transcript, root: root)
+
+        XCTAssertEqual(projectID, CostProjectAttribution.unknownProjectID)
+    }
+
+    func testClaudeProjectIDFallsBackToUnknownWhenFileIsOutsideRoot() {
+        let root = URL(fileURLWithPath: "\(home)/.claude/projects")
+        let outsideFile = URL(fileURLWithPath: "/var/tmp/session-1.jsonl")
+
+        let projectID = CostProjectAttribution.claudeProjectID(forTranscriptURL: outsideFile, root: root)
+
+        XCTAssertEqual(projectID, CostProjectAttribution.unknownProjectID)
+    }
+
+    func testClaudeProjectIDFallsBackToUnknownWhenEncodedDirectoryIsExactlyHome() {
+        let root = URL(fileURLWithPath: "\(home)/.claude/projects")
+        let encodedHome = "-" + home.split(separator: "/").joined(separator: "-")
+        // The directory is the home prefix with nothing left over.
+        let transcript = root.appendingPathComponent(encodedHome).appendingPathComponent("session-1.jsonl")
+
+        let projectID = CostProjectAttribution.claudeProjectID(forTranscriptURL: transcript, root: root)
+
+        XCTAssertEqual(projectID, CostProjectAttribution.unknownProjectID)
+    }
+
+    // MARK: - Codex (real cwd)
+
+    func testCodexProjectIDStripsRealHomePrefix() {
+        let cwd = "\(home)/www/genfeed/apps/admin"
+
+        let projectID = CostProjectAttribution.codexProjectID(cwd: cwd)
+
+        XCTAssertEqual(projectID, "www/genfeed/apps/admin")
+    }
+
+    func testCodexProjectIDFallsBackToUnknownWhenCwdIsNil() {
+        XCTAssertEqual(CostProjectAttribution.codexProjectID(cwd: nil), CostProjectAttribution.unknownProjectID)
+    }
+
+    func testCodexProjectIDFallsBackToUnknownWhenCwdIsEmptyOrBlank() {
+        XCTAssertEqual(CostProjectAttribution.codexProjectID(cwd: ""), CostProjectAttribution.unknownProjectID)
+        XCTAssertEqual(CostProjectAttribution.codexProjectID(cwd: "   "), CostProjectAttribution.unknownProjectID)
+    }
+
+    func testCodexProjectIDFallsBackToUnknownWhenCwdIsOutsideHome() {
+        XCTAssertEqual(
+            CostProjectAttribution.codexProjectID(cwd: "/var/tmp/some-project"),
+            CostProjectAttribution.unknownProjectID
+        )
+    }
+
+    func testCodexProjectIDFallsBackToUnknownWhenCwdIsExactlyHome() {
+        XCTAssertEqual(CostProjectAttribution.codexProjectID(cwd: home), CostProjectAttribution.unknownProjectID)
+    }
+}

--- a/MeterBarTests/CostScanCollaboratorTests.swift
+++ b/MeterBarTests/CostScanCollaboratorTests.swift
@@ -273,6 +273,35 @@ final class CostScanCollaboratorTests: XCTestCase {
         XCTAssertEqual(unbilled, 0.0, accuracy: 0.0001)
     }
 
+    func testProjectBreakdownsNestTheirOwnModelSliceUnderEachRollupRow() {
+        let projectTotals: [String: TokenAccumulator] = [
+            "app-a": totals(input: 100, output: 0, cacheRead: 0, cost: 5),
+            "app-b": totals(input: 10, output: 0, cacheRead: 0, cost: 1)
+        ]
+        let modelsByProject: [String: [String: TokenAccumulator]] = [
+            "app-a": [
+                "opus": totals(input: 80, output: 0, cacheRead: 0, cost: 4),
+                "haiku": totals(input: 20, output: 0, cacheRead: 0, cost: 1)
+            ]
+            // "app-b" deliberately has no entry — must fall back to an empty slice.
+        ]
+
+        let rows = TokenUsageAggregator.makeProjectBreakdowns(
+            from: projectTotals,
+            modelsByProject: modelsByProject,
+            provider: .claudeCode,
+            pricing: ModelPricing.claude(for: nil)
+        )
+
+        XCTAssertEqual(rows.map(\.name), ["app-a", "app-b"])
+        let appA = try! XCTUnwrap(rows.first { $0.name == "app-a" })
+        XCTAssertEqual(Set(appA.modelBreakdowns.map(\.name)), ["opus", "haiku"])
+        XCTAssertEqual(appA.modelBreakdowns.reduce(0) { $0 + $1.inputTokens }, appA.inputTokens)
+
+        let appB = try! XCTUnwrap(rows.first { $0.name == "app-b" })
+        XCTAssertTrue(appB.modelBreakdowns.isEmpty)
+    }
+
     // MARK: - ClaudeCostScanner
 
     func testProjectsURLAppendsProjectsUnlessAlreadyPresent() {

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -188,6 +188,79 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(result.input, 5)
     }
 
+    // MARK: - Project attribution (issue #270)
+
+    func testParseSessionFileDefaultsUnattributedEventsToTheUnknownProjectBucket() throws {
+        // No projectID argument supplied: every existing call site (and every
+        // pre-#270 caller) must keep working exactly as before, landing in the
+        // explicit "unknown" bucket rather than silently dropping the totals.
+        let url = try writeSessionFile(lines: [
+            eventLine(timestamp: "2026-07-01T10:00:00.000Z", input: 10, output: 5)
+        ])
+
+        let cutoff = FlexibleISO8601.date(from: "2026-06-01T00:00:00Z")!
+        let result = ClaudeCostScanner.parseSessionFile(at: url, since: cutoff)
+
+        XCTAssertEqual(result.projects[CostProjectAttribution.unknownProjectID]?.input, 10)
+        XCTAssertEqual(result.projectModels[CostProjectAttribution.unknownProjectID]?["claude-sonnet-4-5"]?.input, 10)
+    }
+
+    func testParseSessionFileAttributesEventsToTheSuppliedProjectID() throws {
+        let url = try writeSessionFile(lines: [
+            eventLine(timestamp: "2026-07-01T10:00:00.000Z", input: 10, output: 5),
+            eventLine(
+                timestamp: "2026-07-01T11:00:00.000Z", messageID: "msg_2", requestID: "req_2",
+                model: "claude-opus-4-5", input: 7, output: 3
+            )
+        ])
+
+        let cutoff = FlexibleISO8601.date(from: "2026-06-01T00:00:00Z")!
+        let result = ClaudeCostScanner.parseSessionFile(at: url, since: cutoff, projectID: "meterbardev")
+
+        XCTAssertEqual(result.projects["meterbardev"]?.input, 17)
+        XCTAssertEqual(result.projectModels["meterbardev"]?["claude-sonnet-4-5"]?.input, 10)
+        XCTAssertEqual(result.projectModels["meterbardev"]?["claude-opus-4-5"]?.input, 7)
+        // No stray "unknown" bucket once a real projectID is threaded through.
+        XCTAssertNil(result.projects[CostProjectAttribution.unknownProjectID])
+    }
+
+    func testParseSessionWindowsAppliesTheSameProjectIDToBothWindows() throws {
+        let url = try writeSessionFile(lines: [
+            eventLine(timestamp: "2026-05-01T10:00:00.000Z", messageID: "old", requestID: "old", input: 4, output: 1),
+            eventLine(timestamp: "2026-07-01T10:00:00.000Z", messageID: "new", requestID: "new", input: 10, output: 5)
+        ])
+
+        let cutoff = FlexibleISO8601.date(from: "2026-06-01T00:00:00Z")!
+        let windows = ClaudeCostScanner.parseSessionWindows(at: url, since: cutoff, projectID: "meterbardev")
+
+        XCTAssertEqual(windows.period.projects["meterbardev"]?.input, 10)
+        XCTAssertEqual(windows.lifetime.projects["meterbardev"]?.input, 14)
+    }
+
+    func testScanSessionsDerivesProjectIDFromTheEncodedSessionDirectory() throws {
+        // Mirrors how Claude Code actually lays transcripts out on disk:
+        // <configDir>/projects/<encoded-cwd>/session.jsonl.
+        let configDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CostTrackerTests-account-\(UUID().uuidString)", isDirectory: true)
+        let home = ServiceSupport.realHomeDirectory()
+        let encodedHome = "-" + home.split(separator: "/").joined(separator: "-")
+        let encodedProjectDir = configDir
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent("\(encodedHome)-www-demo-project", isDirectory: true)
+        try FileManager.default.createDirectory(at: encodedProjectDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: configDir) }
+
+        let sessionURL = encodedProjectDir.appendingPathComponent("session.jsonl")
+        try eventLine(timestamp: "2026-07-01T10:00:00.000Z", input: 10, output: 5)
+            .write(to: sessionURL, atomically: true, encoding: .utf8)
+
+        let account = ClaudeCodeAccount(id: UUID(), name: "demo", configDirectory: configDir.path)
+        let cutoff = FlexibleISO8601.date(from: "2026-06-01T00:00:00Z")!
+        let windows = ClaudeCostScanner.scanSessions(since: cutoff, claudeAccounts: [account])
+
+        XCTAssertEqual(windows.period.projects["www/demo/project"]?.input, 10)
+    }
+
     // MARK: - Codex rollout scan
 
     /// Writes a `.jsonl` into an `archived_sessions` directory and returns that
@@ -345,6 +418,71 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(Array(context.originTotals.keys), ["Codex Desktop"])
         XCTAssertEqual(context.modelTotals["gpt-5.6-sol"]?.input, 1_000)
     }
+
+    // MARK: - Codex project attribution (issue #270)
+
+    /// `session_meta.payload.cwd` is the real, unencoded working directory —
+    /// legitimate non-prompt-content field, distinct from anything the user
+    /// typed. It's read once per file, same as Claude's directory-derived ID.
+    private func codexSessionMetaLineWithCwd(timestamp: String, cwd: String) -> String {
+        """
+        {"timestamp": "\(timestamp)", "type": "session_meta", "payload": \
+        {"id": "conv-1", "originator": "Codex CLI", "cwd": "\(cwd)", "cli_version": "0.0.0"}}
+        """
+    }
+
+    func testScanCodexRolloutsAttributesUsageToTheSessionMetaCwd() throws {
+        let home = ServiceSupport.realHomeDirectory()
+        let cwd = "\(home)/www/genfeed/apps/admin"
+        let dir = try writeCodexArchive(lines: [
+            codexSessionMetaLineWithCwd(timestamp: "2026-06-15T09:59:00Z", cwd: cwd),
+            codexUsageLine(timestamp: "2026-06-15T10:00:00Z")
+        ])
+        let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
+        var context = makeContext(cutoff: cutoff)
+
+        CodexCostScanner.scanRollouts(directory: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.projectTotals["www/genfeed/apps/admin"]?.input, 1_000)
+        XCTAssertNil(context.projectTotals[CostProjectAttribution.unknownProjectID])
+    }
+
+    func testScanCodexRolloutsFallBackToUnknownProjectWithoutSessionMetaCwd() throws {
+        // No session_meta at all: nothing to derive a project from.
+        let dir = try writeCodexArchive(lines: [
+            codexUsageLine(timestamp: "2026-06-15T10:00:00Z")
+        ])
+        let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
+        var context = makeContext(cutoff: cutoff)
+
+        CodexCostScanner.scanRollouts(directory: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.projectTotals[CostProjectAttribution.unknownProjectID]?.input, 1_000)
+    }
+
+    func testScanCodexRolloutsNestsPerProjectModelBreakdown() throws {
+        let home = ServiceSupport.realHomeDirectory()
+        let cwd = "\(home)/www/genfeed/apps/admin"
+        let dir = try writeCodexArchive(lines: [
+            codexSessionMetaLineWithCwd(timestamp: "2026-06-15T09:59:00Z", cwd: cwd),
+            codexTurnContextLine(timestamp: "2026-06-15T09:59:30Z", model: "gpt-5.6-sol"),
+            codexUsageLine(timestamp: "2026-06-15T10:00:00Z")
+        ])
+        let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
+        var context = makeContext(cutoff: cutoff)
+
+        CodexCostScanner.scanRollouts(directory: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.projectModelTotals["www/genfeed/apps/admin"]?["gpt-5.6-sol"]?.input, 1_000)
+    }
+
+    // Note: `scanSQLiteLogs` (the flat SQLite log format) is `private` with no
+    // existing fixture-injection seam — it always reads the real Codex home's
+    // `logs_2.sqlite` via `scanSessions`. That format carries no cwd/path field
+    // at all, so its call site passes `CostProjectAttribution.unknownProjectID`
+    // directly (verified by code inspection in `CodexCostScanner.swift`); the
+    // "unknown" bucket behavior itself is exercised above via the rollout path,
+    // which shares the same `addUsage` attribution logic.
 
     func testScanCodexRolloutsFollowsMidSessionModelSwitch() throws {
         let dir = try writeCodexArchive(lines: [

--- a/MeterBarTests/CostWindowTests.swift
+++ b/MeterBarTests/CostWindowTests.swift
@@ -169,4 +169,71 @@ final class CostWindowTests: XCTestCase {
         XCTAssertEqual(window.requestedDays, 1)
         XCTAssertEqual(window.providers.first?.inputTokens, 3)
     }
+
+    // MARK: - Month to date (issue #270)
+
+    /// `now` (1_750_000_000) is 2025-06-15T14:13:20Z — the 15th, so a
+    /// month-to-date window should span 15 calendar days (the 1st through
+    /// today, inclusive).
+    func testMonthToDateCoversFirstOfMonthThroughToday() {
+        let summary = summary(
+            dailyUsage: [
+                row(daysAgo: 0, provider: .claudeCode, input: 10, output: 5, cacheRead: 1, cost: 1.0),
+                row(daysAgo: 14, provider: .claudeCode, input: 20, output: 5, cacheRead: 1, cost: 2.0),
+                // The 1st of the prior month — 15 days back is the 31st of May,
+                // one day before June 1st, so this row must fall outside the window.
+                row(daysAgo: 15, provider: .claudeCode, input: 99, output: 99, cacheRead: 99, cost: 9.0)
+            ],
+            periodDays: 30
+        )
+
+        let window = summary.monthToDateCostWindow(now: now, calendar: calendar)
+
+        XCTAssertEqual(window.requestedDays, 15)
+        let claude = window.providers.first { $0.provider == .claudeCode }
+        XCTAssertEqual(claude?.inputTokens, 30)
+        XCTAssertEqual(window.totalCostUSD, 3.0, accuracy: 0.0001)
+    }
+
+    /// The boundary must be computed fresh from `now` on every call — never
+    /// cached — so a caller that re-invokes this after midnight on the 1st
+    /// sees the window reset to a single day, not still show the previous
+    /// month's accumulated span.
+    func testMonthToDateRollsOverOnTheFirstOfTheMonth() {
+        // 2025-07-01T00:00:00Z — the 1st of the following month.
+        var components = DateComponents()
+        components.year = 2025
+        components.month = 7
+        components.day = 1
+        let firstOfNextMonth = calendar.date(from: components) ?? now
+
+        let summary = summary(
+            dailyUsage: [
+                DailyTokenUsage(
+                    date: firstOfNextMonth,
+                    provider: .claudeCode,
+                    inputTokens: 7,
+                    outputTokens: 2,
+                    cacheReadTokens: 0,
+                    estimatedCostUSD: 0.7
+                ),
+                // Last day of June — must not leak into July's month-to-date window.
+                DailyTokenUsage(
+                    date: calendar.date(byAdding: .day, value: -1, to: firstOfNextMonth) ?? firstOfNextMonth,
+                    provider: .claudeCode,
+                    inputTokens: 999,
+                    outputTokens: 999,
+                    cacheReadTokens: 0,
+                    estimatedCostUSD: 99.0
+                )
+            ],
+            periodDays: 30
+        )
+
+        let window = summary.monthToDateCostWindow(now: firstOfNextMonth, calendar: calendar)
+
+        XCTAssertEqual(window.requestedDays, 1)
+        XCTAssertEqual(window.providers.first?.inputTokens, 7)
+        XCTAssertEqual(window.totalCostUSD, 0.7, accuracy: 0.0001)
+    }
 }

--- a/MeterBarTests/DisplayCurrencyStoreTests.swift
+++ b/MeterBarTests/DisplayCurrencyStoreTests.swift
@@ -51,6 +51,30 @@ final class DisplayCurrencyStoreTests: XCTestCase {
         }
     }
 
+    func testSetRejectsANonFiniteRateAndClearsAnyExistingConversion() {
+        withIsolatedDefaults { defaults in
+            let store = DisplayCurrencyStore(userDefaults: defaults)
+            store.set(code: "EUR", rate: 0.92)
+
+            // Infinity satisfies `rate > 0`, so without an explicit finite
+            // check it would persist and turn every converted total into "inf".
+            store.set(code: "EUR", rate: .infinity)
+
+            XCTAssertNil(store.currency)
+            XCTAssertNil(DisplayCurrencyStore(userDefaults: defaults).currency)
+        }
+    }
+
+    func testLoadIgnoresAPersistedNonFiniteRate() {
+        withIsolatedDefaults { defaults in
+            defaults.set("EUR", forKey: StorageKeys.displayCurrencyCode)
+            defaults.set(Double.infinity, forKey: StorageKeys.displayCurrencyRate)
+            defaults.set(Date(), forKey: StorageKeys.displayCurrencyEnteredAt)
+
+            XCTAssertNil(DisplayCurrencyStore(userDefaults: defaults).currency)
+        }
+    }
+
     func testSetRejectsAnEmptyOrBlankCode() {
         withIsolatedDefaults { defaults in
             let store = DisplayCurrencyStore(userDefaults: defaults)

--- a/MeterBarTests/DisplayCurrencyStoreTests.swift
+++ b/MeterBarTests/DisplayCurrencyStoreTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import MeterBar
+
+/// Unit tests for `DisplayCurrencyStore` — the `UserDefaults`-backed
+/// persistence layer for the presentation-only currency conversion behind
+/// issue #270, modeled on `ProviderVisibilityStore`'s test conventions.
+final class DisplayCurrencyStoreTests: XCTestCase {
+    func testDefaultsToNoConversionWhenNothingHasBeenSaved() {
+        withIsolatedDefaults { defaults in
+            let store = DisplayCurrencyStore(userDefaults: defaults)
+
+            XCTAssertNil(store.currency)
+        }
+    }
+
+    func testSetPersistsCodeRateAndAnEnteredAtTimestamp() {
+        withIsolatedDefaults { defaults in
+            let store = DisplayCurrencyStore(userDefaults: defaults)
+
+            store.set(code: "eur", rate: 0.92)
+
+            let currency = try! XCTUnwrap(store.currency)
+            XCTAssertEqual(currency.code, "EUR")
+            XCTAssertEqual(currency.unitsPerUSD, 0.92, accuracy: 0.0001)
+            XCTAssertLessThan(abs(currency.enteredAt.timeIntervalSinceNow), 5)
+
+            let reloaded = DisplayCurrencyStore(userDefaults: defaults)
+            XCTAssertEqual(reloaded.currency, currency)
+        }
+    }
+
+    func testSetTrimsAndUppercasesTheCode() {
+        withIsolatedDefaults { defaults in
+            let store = DisplayCurrencyStore(userDefaults: defaults)
+
+            store.set(code: "  jpy  ", rate: 150)
+
+            XCTAssertEqual(store.currency?.code, "JPY")
+        }
+    }
+
+    func testSetRejectsANonPositiveRateAndClearsAnyExistingConversion() {
+        withIsolatedDefaults { defaults in
+            let store = DisplayCurrencyStore(userDefaults: defaults)
+            store.set(code: "EUR", rate: 0.92)
+
+            store.set(code: "EUR", rate: 0)
+
+            XCTAssertNil(store.currency)
+            XCTAssertNil(DisplayCurrencyStore(userDefaults: defaults).currency)
+        }
+    }
+
+    func testSetRejectsAnEmptyOrBlankCode() {
+        withIsolatedDefaults { defaults in
+            let store = DisplayCurrencyStore(userDefaults: defaults)
+
+            store.set(code: "   ", rate: 0.92)
+
+            XCTAssertNil(store.currency)
+        }
+    }
+
+    func testClearRemovesAPersistedConversion() {
+        withIsolatedDefaults { defaults in
+            let store = DisplayCurrencyStore(userDefaults: defaults)
+            store.set(code: "EUR", rate: 0.92)
+
+            store.clear()
+
+            XCTAssertNil(store.currency)
+            XCTAssertNil(DisplayCurrencyStore(userDefaults: defaults).currency)
+        }
+    }
+
+    private func withIsolatedDefaults(_ body: (UserDefaults) -> Void) {
+        let suiteName = "DisplayCurrencyStoreTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Could not create isolated defaults")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(defaults)
+    }
+}

--- a/MeterBarTests/DisplayCurrencyTests.swift
+++ b/MeterBarTests/DisplayCurrencyTests.swift
@@ -61,10 +61,35 @@ final class DisplayCurrencyTests: XCTestCase {
         XCTAssertEqual(currency.disclosureText, "1 USD = 0.92 EUR, entered \(enteredAtDayString)")
     }
 
+    func testConvertTreatsANonFiniteRateAsAnIdentityFallback() {
+        // `Double.infinity` and `.nan` both slip past a bare `rate > 0` check
+        // (NaN fails it, infinity passes it), so a corrupted defaults value
+        // must not be able to render every total as "inf".
+        let infinite = DisplayCurrency(code: "EUR", unitsPerUSD: .infinity, enteredAt: enteredAt)
+        let notANumber = DisplayCurrency(code: "EUR", unitsPerUSD: .nan, enteredAt: enteredAt)
+
+        XCTAssertEqual(infinite.convert(usd: 10), 10, accuracy: 0.0001)
+        XCTAssertEqual(notANumber.convert(usd: 10), 10, accuracy: 0.0001)
+    }
+
     func testDisclosureTextTrimsTrailingZerosFromTheRate() {
         let currency = DisplayCurrency(code: "JPY", unitsPerUSD: 150, enteredAt: enteredAt)
 
         XCTAssertEqual(currency.disclosureText, "1 USD = 150 JPY, entered \(enteredAtDayString)")
+    }
+
+    func testDisclosureTextKeepsLargeRatesInPlainDecimalNotation() {
+        // %g would render VND's ~24,000 as "2.4e+04" — unreadable as a rate.
+        let currency = DisplayCurrency(code: "VND", unitsPerUSD: 24_000, enteredAt: enteredAt)
+
+        XCTAssertEqual(currency.disclosureText, "1 USD = 24000 VND, entered \(enteredAtDayString)")
+    }
+
+    func testDisclosureTextKeepsSmallRatesInPlainDecimalNotation() {
+        // …and %g would render 0.00008 as "8e-05" for the same reason.
+        let currency = DisplayCurrency(code: "BTC", unitsPerUSD: 0.0001, enteredAt: enteredAt)
+
+        XCTAssertEqual(currency.disclosureText, "1 USD = 0.0001 BTC, entered \(enteredAtDayString)")
     }
 
     func testFormattedConvertedPairsTheRoundedAmountWithTheCode() {

--- a/MeterBarTests/DisplayCurrencyTests.swift
+++ b/MeterBarTests/DisplayCurrencyTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import MeterBar
+
+/// Unit tests for `DisplayCurrency` — the presentation-only, user-supplied
+/// conversion behind issue #270. MeterBar never fetches a live exchange rate;
+/// these tests pin down the rounding rule and the disclosure text that keeps
+/// a converted figure from being mistaken for a live quote.
+final class DisplayCurrencyTests: XCTestCase {
+    private let enteredAt = Date(timeIntervalSince1970: 1_784_000_000)
+
+    /// Mirrors `DisplayCurrency`'s own day formatting so assertions don't
+    /// hardcode a calendar day that shifts with the test runner's time zone.
+    private var enteredAtDayString: String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: enteredAt)
+    }
+
+    func testConvertMultipliesUSDByTheUserSuppliedRate() {
+        let currency = DisplayCurrency(code: "EUR", unitsPerUSD: 0.92, enteredAt: enteredAt)
+
+        XCTAssertEqual(currency.convert(usd: 10), 9.2, accuracy: 0.0001)
+    }
+
+    func testConvertRoundsToTwoDecimalPlacesHalfAwayFromZero() {
+        // 1.005 * 100 = 100.49999999999999 in double arithmetic; picking a rate
+        // that lands exactly on a half-cent (1.115 -> 111.5 cents) pins down
+        // that the rule is round-half-away-from-zero, not floor/truncation.
+        let currency = DisplayCurrency(code: "USD", unitsPerUSD: 1.115, enteredAt: enteredAt)
+
+        XCTAssertEqual(currency.convert(usd: 1), 1.12, accuracy: 0.0001)
+    }
+
+    func testConvertRoundsDownWhenBelowTheHalfCent() {
+        let currency = DisplayCurrency(code: "USD", unitsPerUSD: 1.114, enteredAt: enteredAt)
+
+        XCTAssertEqual(currency.convert(usd: 1), 1.11, accuracy: 0.0001)
+    }
+
+    func testConvertAtAnIdentityRateReturnsTheSameUSDAmount() {
+        let currency = DisplayCurrency(code: "USD", unitsPerUSD: 1, enteredAt: enteredAt)
+
+        XCTAssertEqual(currency.convert(usd: 42.5), 42.5, accuracy: 0.0001)
+    }
+
+    func testConvertTreatsANonPositiveRateAsAnIdentityFallback() {
+        // The store is responsible for rejecting non-positive rates before
+        // persisting one, but `convert` stays defensive so a corrupted/edited
+        // defaults value can never silently zero out or invert a cost figure.
+        let zero = DisplayCurrency(code: "EUR", unitsPerUSD: 0, enteredAt: enteredAt)
+        let negative = DisplayCurrency(code: "EUR", unitsPerUSD: -1, enteredAt: enteredAt)
+
+        XCTAssertEqual(zero.convert(usd: 10), 10, accuracy: 0.0001)
+        XCTAssertEqual(negative.convert(usd: 10), 10, accuracy: 0.0001)
+    }
+
+    func testDisclosureTextPairsTheRateWithTheEnteredDateSoItReadsAsAManualSnapshot() {
+        let currency = DisplayCurrency(code: "EUR", unitsPerUSD: 0.92, enteredAt: enteredAt)
+
+        XCTAssertEqual(currency.disclosureText, "1 USD = 0.92 EUR, entered \(enteredAtDayString)")
+    }
+
+    func testDisclosureTextTrimsTrailingZerosFromTheRate() {
+        let currency = DisplayCurrency(code: "JPY", unitsPerUSD: 150, enteredAt: enteredAt)
+
+        XCTAssertEqual(currency.disclosureText, "1 USD = 150 JPY, entered \(enteredAtDayString)")
+    }
+
+    func testFormattedConvertedPairsTheRoundedAmountWithTheCode() {
+        let currency = DisplayCurrency(code: "EUR", unitsPerUSD: 0.92, enteredAt: enteredAt)
+
+        XCTAssertEqual(currency.formattedConverted(usd: 10), "9.20 EUR")
+    }
+
+    func testFormattedConvertedAlwaysShowsTwoDecimalPlaces() {
+        let currency = DisplayCurrency(code: "JPY", unitsPerUSD: 150, enteredAt: enteredAt)
+
+        XCTAssertEqual(currency.formattedConverted(usd: 1), "150.00 JPY")
+    }
+}

--- a/MeterBarTests/SettingsViewSmokeTests.swift
+++ b/MeterBarTests/SettingsViewSmokeTests.swift
@@ -74,4 +74,131 @@ final class SettingsViewSmokeTests: XCTestCase {
         hostingView.layoutSubtreeIfNeeded()
         XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
     }
+
+    // MARK: - Cost views (issue #270: month-to-date, display currency, projects)
+
+    private var referenceMonthStart: Date {
+        Calendar(identifier: .gregorian).date(from: DateComponents(year: 2026, month: 7, day: 1))!
+    }
+
+    /// A synthetic summary independent of `CostTracker.shared`'s live scan
+    /// state: one provider with cached daily rows spanning this month and
+    /// last month (so `monthToDateCostWindow` has something to filter), plus
+    /// a project rollup that includes an explicit "unknown" bucket and a
+    /// nested model breakdown — the shape `CostPeriodContentView` renders.
+    private func makeSyntheticCostSummary() -> CostSummary {
+        let calendar = Calendar(identifier: .gregorian)
+        let thisMonthDay = calendar.date(byAdding: .day, value: 2, to: referenceMonthStart)!
+        let lastMonthDay = calendar.date(byAdding: .day, value: -3, to: referenceMonthStart)!
+
+        let cost = TokenCost(
+            provider: .claudeCode,
+            inputTokens: 1_000,
+            outputTokens: 250,
+            cacheCreationTokens: 50,
+            cacheReadTokens: 500,
+            estimatedCostUSD: 12.5,
+            sessionCount: 4,
+            periodStart: lastMonthDay,
+            periodEnd: thisMonthDay,
+            projectBreakdowns: [
+                TokenUsageBreakdown(
+                    provider: .claudeCode,
+                    name: "www/example/app",
+                    inputTokens: 900,
+                    outputTokens: 200,
+                    cacheCreationTokens: 40,
+                    cacheReadTokens: 400,
+                    estimatedCostUSD: 10,
+                    sessionCount: 3,
+                    modelBreakdowns: [
+                        TokenUsageBreakdown(
+                            provider: .claudeCode,
+                            name: "claude-opus-5",
+                            inputTokens: 900,
+                            outputTokens: 200,
+                            cacheCreationTokens: 40,
+                            cacheReadTokens: 400,
+                            estimatedCostUSD: 10,
+                            sessionCount: 3
+                        ),
+                    ]
+                ),
+                TokenUsageBreakdown(
+                    provider: .claudeCode,
+                    name: "unknown",
+                    inputTokens: 100,
+                    outputTokens: 50,
+                    cacheCreationTokens: 10,
+                    cacheReadTokens: 100,
+                    estimatedCostUSD: 2.5,
+                    sessionCount: 1
+                ),
+            ]
+        )
+
+        return CostSummary(
+            costs: [cost],
+            totalCostUSD: 12.5,
+            totalTokens: cost.totalTokens,
+            periodDays: 30,
+            dailyUsage: [
+                DailyTokenUsage(
+                    date: thisMonthDay,
+                    provider: .claudeCode,
+                    inputTokens: 500,
+                    outputTokens: 125,
+                    cacheReadTokens: 250,
+                    estimatedCostUSD: 6
+                ),
+                DailyTokenUsage(
+                    date: lastMonthDay,
+                    provider: .claudeCode,
+                    inputTokens: 500,
+                    outputTokens: 125,
+                    cacheReadTokens: 250,
+                    estimatedCostUSD: 6.5
+                ),
+            ]
+        )
+    }
+
+    func testCostPeriodContentRendersLast30DaysWithProjectBreakdownDrillDown() {
+        let view = CostPeriodContentView(summary: makeSyntheticCostSummary(), periodMode: .last30Days, currency: nil)
+        let hostingView = NSHostingView(rootView: view.frame(width: 640))
+        hostingView.layoutSubtreeIfNeeded()
+
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+    }
+
+    func testCostPeriodContentRendersMonthToDateWindowFromCachedDailyUsage() {
+        let view = CostPeriodContentView(summary: makeSyntheticCostSummary(), periodMode: .monthToDate, currency: nil)
+        let hostingView = NSHostingView(rootView: view.frame(width: 640))
+        hostingView.layoutSubtreeIfNeeded()
+
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+    }
+
+    func testCostPeriodContentRendersConvertedCurrencyCaptionWhenSupplied() {
+        let currency = DisplayCurrency(code: "EUR", unitsPerUSD: 0.92, enteredAt: referenceMonthStart)
+        let view = CostPeriodContentView(
+            summary: makeSyntheticCostSummary(),
+            periodMode: .last30Days,
+            currency: currency
+        )
+        let hostingView = NSHostingView(rootView: view.frame(width: 640))
+        hostingView.layoutSubtreeIfNeeded()
+
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+    }
+
+    func testCostSettingsViewRendersDisplayCurrencySectionAlongsideCostTracking() {
+        // Hosts the real tab (real singletons, like testGlassCostScanAndRefreshCTAsStillRender
+        // above) so a broken Display Currency section or period picker fails to compile/layout
+        // here even though CostTracker.shared may hold no scan in the test process.
+        let hostingView = NSHostingView(rootView: CostSettingsView().frame(width: 720))
+        hostingView.layoutSubtreeIfNeeded()
+
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+    }
 }

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -69,6 +69,8 @@ context. `resetCreditsAvailable` is present only when the provider reports banke
 ```sh
 meterbar cost --json
 meterbar cost --days 7 --json
+meterbar cost --month-to-date --json
+meterbar cost --currency EUR --rate 0.92 --json
 ```
 
 Version 1 shape:
@@ -103,6 +105,107 @@ Version 1 shape:
 With `--days`, MeterBar derives the response from cached daily rows without rescanning logs.
 Daily rows do not retain `cacheCreationTokens` or `sessionCount`, so those fields are omitted in a
 windowed response. `period.isTruncated` is true when the cache covers fewer days than requested.
+
+### Month-to-date window
+
+`--month-to-date` is a second calendar-aware window alongside `--days`, in the same cached-daily-row
+family (no rescan, and mutually exclusive with `--days`). `period.kind` distinguishes the three
+period shapes: `"days"`, `"monthToDate"`, or omitted entirely for the full, unwindowed summary (the
+version 1 fixture above never sets it, so that response is byte-for-byte unchanged).
+
+```json
+{
+  "schemaVersion": 1,
+  "lastScannedAt": "2026-07-14T10:00:00Z",
+  "period": {
+    "requestedDays": 14,
+    "coveredDays": 14,
+    "isTruncated": false,
+    "kind": "monthToDate"
+  },
+  "providers": [ ],
+  "totalCostUSD": 1.25,
+  "totalTokens": 1800
+}
+```
+
+`requestedDays` for a month-to-date window is however many days have elapsed since the 1st of the
+current month (inclusive), computed in the local time zone at read time — it is never a cached start
+date, so the same cache reports a larger window tomorrow without a rescan or restart.
+
+### Project/worktree breakdown
+
+Each provider in the full, unwindowed summary (no `--days`/`--month-to-date`) may carry
+`projectBreakdowns`: a per-project/worktree rollup derived from scanned session paths, with its own
+nested `modelBreakdowns`. The field is omitted entirely when nothing was scanned with a project
+dimension — including every windowed (`--days`/`--month-to-date`) response, since daily rows carry no
+project dimension of their own.
+
+```json
+{
+  "provider": "claude",
+  "displayName": "Claude Code",
+  "inputTokens": 1000,
+  "outputTokens": 250,
+  "cacheCreationTokens": 50,
+  "cacheReadTokens": 500,
+  "totalTokens": 1800,
+  "estimatedCostUSD": 1.25,
+  "sessionCount": 3,
+  "projectBreakdowns": [
+    {
+      "name": "meterbardev",
+      "inputTokens": 800,
+      "outputTokens": 200,
+      "cacheCreationTokens": 40,
+      "cacheReadTokens": 400,
+      "totalTokens": 1440,
+      "estimatedCostUSD": 1.00,
+      "sessionCount": 2,
+      "modelBreakdowns": [ ]
+    },
+    {
+      "name": "unknown",
+      "inputTokens": 200,
+      "outputTokens": 50,
+      "cacheCreationTokens": 10,
+      "cacheReadTokens": 100,
+      "totalTokens": 360,
+      "estimatedCostUSD": 0.25,
+      "sessionCount": 1,
+      "modelBreakdowns": [ ]
+    }
+  ]
+}
+```
+
+Every session attributes to exactly one project row; a session whose path can't be attributed to a
+project lands in an explicit `unknown` row rather than being dropped or guessed. Names are sanitized
+before they ever reach this JSON — no full home-directory paths — and MeterBar never persists branch
+names, remotes, prompt content, or credentials to derive them.
+
+### Display currency
+
+`--currency CODE --rate N` (both required together) adds a top-level `displayCurrency` object
+converting `totalCostUSD` for display. This is presentation-only: stored and exported cost data
+always stays USD, and MeterBar never fetches a live exchange rate — `unitsPerUSD` and `enteredAt` are
+exactly what the caller typed for that one invocation. The field is omitted entirely unless both
+flags are supplied.
+
+```json
+{
+  "displayCurrency": {
+    "code": "EUR",
+    "unitsPerUSD": 0.92,
+    "enteredAt": "2026-07-20T10:00:00Z",
+    "totalCostConverted": 1.15,
+    "source": "manual"
+  }
+}
+```
+
+`source` is always `"manual"` — a marker (not a variant to branch on today) that a future live-rate
+source, if ever added, would need to distinguish itself from.
 
 ## Fable sessions
 

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -123,11 +123,25 @@ version 1 fixture above never sets it, so that response is byte-for-byte unchang
     "isTruncated": false,
     "kind": "monthToDate"
   },
-  "providers": [ ],
+  "providers": [
+    {
+      "provider": "claude",
+      "displayName": "Claude Code",
+      "inputTokens": 1000,
+      "outputTokens": 250,
+      "cacheReadTokens": 550,
+      "totalTokens": 1800,
+      "estimatedCostUSD": 1.25
+    }
+  ],
   "totalCostUSD": 1.25,
   "totalTokens": 1800
 }
 ```
+
+Both totals are always derived by summing `providers`, so an empty `providers` array pairs only with
+`"totalCostUSD": 0` / `"totalTokens": 0`. As with `--days`, windowed provider entries omit
+`cacheCreationTokens` and `sessionCount`, which daily rows do not retain.
 
 `requestedDays` for a month-to-date window is however many days have elapsed since the 1st of the
 current month (inclusive), computed in the local time zone at read time — it is never a cached start


### PR DESCRIPTION
## Summary

Closes #270. Adds three additive cost-view features, all reading the already-cached scan (no rescan, no network access introduced):

1. **Calendar month-to-date window** — alongside the existing rolling window, in both `meterbar cost` CLI (`--month-to-date` / JSON) and the SwiftUI Cost settings tab (segmented picker). The boundary is computed fresh from the local time zone on every read (`CostSummary.monthToDateCostWindow(now:calendar:)`, default `now: Date()`), never cached, so it rolls over at midnight on the 1st without an app restart or a rescan.
2. **Display currency** — a user-supplied, presentation-only conversion rate (`DisplayCurrency` / `DisplayCurrencyStore`). No live/network exchange rates are ever fetched. Stored and exported data (JSON, daily usage cache) always stays USD; only rendered figures are converted. Every converted figure is shown with the rate and the date it was entered (`DisplayCurrency.disclosureText`), via a single shared formatter (`formattedConverted(usd:)`) used by both the CLI text output and the new SwiftUI captions, so the two can never drift on rounding/format.
3. **Per-project/worktree grouping** — derived from session paths already scanned (`CostProjectAttribution`). Every session attributes to exactly one project identifier; anything unattributable lands in an explicit `unknown` bucket rather than being dropped or guessed. Exposed as a rollup with drill-down to per-model breakdown in the CLI JSON/text output and a new `DisclosureGroup`-based UI in Settings.

Out of scope (per issue): live exchange-rate fetching, provider billing reconciliation, changes to the pricing table or token-cost computation.

## Acceptance criteria → tests

| Criterion | Tests |
|---|---|
| Month-to-date window: local time zone, 1st-of-month through now, no restart/rescan needed to roll over | `CostWindowTests`, `CostScanCollaboratorTests` (model), `CLIJSONOutputTests` (JSON/CLI), `SettingsViewSmokeTests.testCostPeriodContentRendersMonthToDateWindowFromCachedDailyUsage` (SwiftUI) |
| Display currency: user-supplied rate only, no live rates, presentation-only, rate+date shown together | `DisplayCurrencyTests` (conversion/rounding/disclosure text), `DisplayCurrencyStoreTests` (persistence, positive-rate validation, clear), `SettingsViewSmokeTests.testCostPeriodContentRendersConvertedCurrencyCaptionWhenSupplied` (SwiftUI caption) |
| Project/worktree grouping: every session → exactly one project, explicit `unknown` bucket, rollup + model drill-down | `CostProjectAttributionTests` (attribution incl. unknown bucket), `CLIJSONOutputTests` (JSON schema, nested model breakdowns), `SettingsViewSmokeTests.testCostPeriodContentRendersLast30DaysWithProjectBreakdownDrillDown` (SwiftUI `DisclosureGroup`) |
| CLI JSON schema stability under existing version | `CLIJSONOutputTests` |
| Full Cost settings tab still renders (period picker + currency section + existing scan/refresh CTAs) | `SettingsViewSmokeTests.testCostSettingsViewRendersDisplayCurrencySectionAlongsideCostTracking`, `testGlassCostScanAndRefreshCTAsStillRender` |

CLI JSON schema changes are documented in `docs/cli-json-schema.md`.

## Verification

- `swift build` — clean, no errors or new warnings.
- `swiftlint lint --quiet` on touched production files — zero violations.
- `swift test` (filtered): all new/changed tests pass. Full unfiltered run: 1348 tests, 1 skipped, 25 failures — all pre-existing/environmental (`SessionWakeControllerTests`, `UsageDataManagerTests`, `WakeQuotaProviderSelectionTests`, `ProviderReadinessInspectorTests`, `LiquidGlassP1RegressionTests`, and one `SessionWakeAgentTests` temp-dir permission failure), unrelated to this change and not introduced by it. Zero new failures.

## Deliberately left out

- No live/network exchange-rate lookup (explicitly out of scope).
- No changes to the pricing table or token-cost computation.
- No provider billing reconciliation.

## Test plan

- [x] `swift build`
- [x] `swiftlint lint --quiet` on touched files
- [x] `swift test` (filtered) — new tests pass, no new failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added month-to-date cost views in Settings and the CLI.
  - Added optional presentation-only currency conversion with saved settings.
  - Added project/worktree cost breakdowns with nested model details.
  - CLI output now supports currency conversion and project summaries.

- **Bug Fixes**
  - Improved full-lifetime and empty-window reporting behavior.

- **Documentation**
  - Updated CLI JSON schema documentation for new options and output fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->