### PR TITLE
fix(menubar): prevent unanchored popover flash

### DIFF
--- a/.agents/SESSIONS/2026-07-26.md
+++ b/.agents/SESSIONS/2026-07-26.md
@@ -325,3 +325,27 @@ CodexBar's `GrokRPCClient` works around Foundation escaping `/` as `\/`, which
 older Grok ACP servers treated as a different method name and answered `-32601`.
 MeterBar does not unescape, and id 3 succeeds on 0.2.112, so the quirk looks
 fixed upstream. Worth remembering if an older CLI ever reports `-32601`.
+
+## Session 6: stop the menu panel flashing at the screen origin
+
+### Root cause
+
+`MeterBarMenuPanelController.show()` created an `NSPanel` at AppKit's default
+origin and ordered it front even when the status item's button did not yet have
+a window. Positioning silently returned in that state, exposing the panel at
+the bottom-left of the screen until a later layout pass moved or dismissed it.
+This was MeterBar's own menu panel, not credential refresh UI.
+
+### What was done
+
+- [x] Resolve the status-item anchor frame before creating or ordering the panel
+- [x] Retry anchor resolution for a bounded 200 ms window
+- [x] Cancel stale retries on dismiss or a newer presentation
+- [x] Clear the presentation state if the anchor never resolves
+- [x] Add regressions for the unhosted, delayed-hosting, and cancelled-show cases
+
+### Verification
+
+- `LiquidGlassP1RegressionTests`: 16/16 passing
+- SwiftLint strict: clean
+- Debug app build: succeeded with code signing disabled

--- a/MeterBar/App/MeterBarMenuPanelController.swift
+++ b/MeterBar/App/MeterBarMenuPanelController.swift
@@ -7,6 +7,9 @@ final class KeyableMenuPanel: NSPanel {
 
 @MainActor
 final class MeterBarMenuPanelController {
+    private static let anchorRetryDelay: TimeInterval = 0.02
+    private static let anchorRetryLimit = 10
+
     private let statusButtonProvider: () -> NSStatusBarButton?
     private let onDismiss: () -> Void
 
@@ -20,9 +23,9 @@ final class MeterBarMenuPanelController {
     /// still in flight (the panel's `isVisible` lags the fade-out completion).
     private var isPresented = false
 
-    /// Bumped on every `show()`/`dismiss()`. A deferred fade-out completion only
-    /// orders the panel out if the token still matches, so a rapid re-show
-    /// cancels the pending hide instead of leaving the panel stuck at alpha 0.
+    /// Bumped on every `show()`/`dismiss()`. Deferred anchor retries and fade-out
+    /// completions only act while the token still matches, so stale work cannot
+    /// resurrect or hide a newer presentation.
     private var presentationToken = 0
 
     /// Whether show/hide/resize animate. Defaults to honoring the system Reduce
@@ -47,14 +50,40 @@ final class MeterBarMenuPanelController {
     }
 
     func show() {
-        guard let button = statusButtonProvider() else { return }
+        guard statusButtonProvider() != nil else { return }
         presentationToken &+= 1
         isPresented = true
-        let panel = ensurePanel()
-        // Position without animating: the panel is (re)appearing, so the frame
-        // should snap into place and only the alpha fades in.
-        position(panel, anchoredTo: button, size: contentSize, animated: false)
+        presentWhenAnchored(
+            token: presentationToken,
+            retriesRemaining: Self.anchorRetryLimit
+        )
+    }
 
+    private func presentWhenAnchored(token: Int, retriesRemaining: Int) {
+        guard isPresented, presentationToken == token else { return }
+        guard let button = statusButtonProvider(),
+              let frame = targetFrame(anchoredTo: button, size: contentSize) else {
+            guard retriesRemaining > 0 else {
+                // Do not leave togglePopover believing an invisible panel is
+                // open after the bounded anchor-resolution window expires.
+                isPresented = false
+                return
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.anchorRetryDelay) { [weak self] in
+                self?.presentWhenAnchored(
+                    token: token,
+                    retriesRemaining: retriesRemaining - 1
+                )
+            }
+            return
+        }
+
+        let panel = ensurePanel()
+        // Position before ordering front. A status item can exist for a run-loop
+        // turn before AppKit attaches its window; showing the panel before this
+        // frame resolves exposes its construction origin at the screen's
+        // bottom-left.
+        applyFrame(frame, to: panel, animated: false)
         if motionEnabled {
             // Assigning the model value cancels any in-flight fade-out and
             // restarts the fade from fully transparent.
@@ -76,11 +105,11 @@ final class MeterBarMenuPanelController {
         stopEventMonitoring()
         let wasPresented = isPresented
         isPresented = false
+        presentationToken &+= 1
         guard let panel else {
             onDismiss()
             return
         }
-        presentationToken &+= 1
         let token = presentationToken
 
         if motionEnabled, wasPresented {
@@ -107,8 +136,11 @@ final class MeterBarMenuPanelController {
 
     func resize(to size: NSSize) {
         contentSize = size
-        guard isPresented, let panel, let button = statusButtonProvider() else { return }
-        position(panel, anchoredTo: button, size: size, animated: motionEnabled)
+        guard isPresented,
+              let panel,
+              let button = statusButtonProvider(),
+              let frame = targetFrame(anchoredTo: button, size: size) else { return }
+        applyFrame(frame, to: panel, animated: motionEnabled)
     }
 
     private func ensurePanel() -> NSPanel {
@@ -142,13 +174,11 @@ final class MeterBarMenuPanelController {
         return panel
     }
 
-    private func position(
-        _ panel: NSPanel,
+    private func targetFrame(
         anchoredTo button: NSStatusBarButton,
-        size: NSSize,
-        animated: Bool
-    ) {
-        guard let buttonWindow = button.window else { return }
+        size: NSSize
+    ) -> NSRect? {
+        guard let buttonWindow = button.window else { return nil }
 
         let buttonRectInWindow = button.convert(button.bounds, to: nil)
         let buttonRect = buttonWindow.convertToScreen(buttonRectInWindow)
@@ -161,8 +191,10 @@ final class MeterBarMenuPanelController {
             visibleFrame.maxX - size.width - padding
         )
         let y = max(visibleFrame.minY + padding, buttonRect.minY - size.height - 6)
-        let frame = NSRect(x: x, y: y, width: size.width, height: size.height)
+        return NSRect(x: x, y: y, width: size.width, height: size.height)
+    }
 
+    private func applyFrame(_ frame: NSRect, to panel: NSPanel, animated: Bool) {
         if animated {
             NSAnimationContext.runAnimationGroup { context in
                 context.duration = MeterBarTheme.Motion.panelResize

--- a/MeterBar/App/MeterBarMenuPanelController.swift
+++ b/MeterBar/App/MeterBarMenuPanelController.swift
@@ -8,7 +8,7 @@ final class KeyableMenuPanel: NSPanel {
 @MainActor
 final class MeterBarMenuPanelController {
     private static let anchorRetryDelay: TimeInterval = 0.02
-    private static let anchorRetryLimit = 10
+    private static let anchorRetryWindow: TimeInterval = 0.2
 
     private let statusButtonProvider: () -> NSStatusBarButton?
     private let onDismiss: () -> Void
@@ -55,15 +55,15 @@ final class MeterBarMenuPanelController {
         isPresented = true
         presentWhenAnchored(
             token: presentationToken,
-            retriesRemaining: Self.anchorRetryLimit
+            deadline: .now() + Self.anchorRetryWindow
         )
     }
 
-    private func presentWhenAnchored(token: Int, retriesRemaining: Int) {
+    private func presentWhenAnchored(token: Int, deadline: DispatchTime) {
         guard isPresented, presentationToken == token else { return }
         guard let button = statusButtonProvider(),
               let frame = targetFrame(anchoredTo: button, size: contentSize) else {
-            guard retriesRemaining > 0 else {
+            guard DispatchTime.now() < deadline else {
                 // Do not leave togglePopover believing an invisible panel is
                 // open after the bounded anchor-resolution window expires.
                 isPresented = false
@@ -72,7 +72,7 @@ final class MeterBarMenuPanelController {
             DispatchQueue.main.asyncAfter(deadline: .now() + Self.anchorRetryDelay) { [weak self] in
                 self?.presentWhenAnchored(
                     token: token,
-                    retriesRemaining: retriesRemaining - 1
+                    deadline: deadline
                 )
             }
             return

--- a/MeterBarTests/LiquidGlassP1RegressionTests.swift
+++ b/MeterBarTests/LiquidGlassP1RegressionTests.swift
@@ -176,6 +176,89 @@ final class LiquidGlassP1RegressionTests: XCTestCase {
         XCTAssertEqual(dismissCount, 1)
     }
 
+    func testShowWithUnhostedStatusButtonNeverOrdersPanelFrontAtScreenOrigin() {
+        let button = NSStatusBarButton(frame: NSRect(x: 0, y: 0, width: 40, height: 22))
+        let controller = MeterBarMenuPanelController(
+            statusButtonProvider: { button },
+            onDismiss: {}
+        )
+        controller.motionEnabled = false
+
+        controller.show()
+
+        XCTAssertTrue(controller.isShown, "show intent should be synchronous while the anchor resolves")
+        XCTAssertNil(
+            controller.presentedPanel,
+            "an unanchored panel must remain uncreated instead of flashing at AppKit's (0,0) origin"
+        )
+
+        let retriesExhausted = expectation(description: "bounded anchor retries exhaust")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { retriesExhausted.fulfill() }
+        wait(for: [retriesExhausted], timeout: 1)
+
+        XCTAssertFalse(controller.isShown, "failed anchor resolution must not leave the toggle stuck open")
+        XCTAssertNil(controller.presentedPanel)
+    }
+
+    func testPendingShowPresentsAfterStatusButtonGetsAWindow() throws {
+        let button = NSStatusBarButton(frame: NSRect(x: 0, y: 0, width: 40, height: 22))
+        let controller = MeterBarMenuPanelController(
+            statusButtonProvider: { button },
+            onDismiss: {}
+        )
+        controller.motionEnabled = false
+        controller.show()
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 240, height: 40),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        defer { window.close() }
+        window.contentView?.addSubview(button)
+
+        let anchorResolved = expectation(description: "pending panel resolves its status-item anchor")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { anchorResolved.fulfill() }
+        wait(for: [anchorResolved], timeout: 1)
+
+        let panel = try XCTUnwrap(controller.presentedPanel)
+        XCTAssertTrue(controller.isShown)
+        XCTAssertTrue(panel.isVisible)
+        XCTAssertNotEqual(panel.frame.origin, .zero)
+
+        controller.dismiss()
+    }
+
+    func testDismissCancelsPendingUnanchoredShow() {
+        let button = NSStatusBarButton(frame: NSRect(x: 0, y: 0, width: 40, height: 22))
+        let controller = MeterBarMenuPanelController(
+            statusButtonProvider: { button },
+            onDismiss: {}
+        )
+        controller.motionEnabled = false
+        controller.show()
+        controller.dismiss()
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 240, height: 40),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        defer { window.close() }
+        window.contentView?.addSubview(button)
+
+        let staleRetryDrained = expectation(description: "stale anchor retry drains")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { staleRetryDrained.fulfill() }
+        wait(for: [staleRetryDrained], timeout: 1)
+
+        XCTAssertFalse(controller.isShown)
+        XCTAssertNil(controller.presentedPanel, "dismissed anchor retries must never resurrect the panel")
+    }
+
     func testResizeUpdatesTargetFrameWhileShown() throws {
         let (window, button) = makeHostedStatusButton()
         defer { window.close() }


### PR DESCRIPTION
## Summary
- wait for the status-item window before creating or ordering the menu panel
- retry anchor resolution for a bounded window and cancel stale presentations
- cover unhosted, delayed-anchor, and dismissed-anchor regressions

## Verification
- LiquidGlassP1RegressionTests: 16/16 passing
- SwiftLint strict: clean
- MeterBar Debug xcodebuild: succeeded (code signing disabled)

## Root cause
The panel was created at AppKit's default origin and ordered front even when the status button had no window yet, briefly exposing MeterBar's panel at the screen's bottom-left.