### PR TITLE
feat(claude): delegate expired token refresh

### DIFF
--- a/.agents/SESSIONS/2026-07-26.md
+++ b/.agents/SESSIONS/2026-07-26.md
@@ -531,3 +531,107 @@ This was MeterBar's own menu panel, not credential refresh UI.
 - `LiquidGlassP1RegressionTests`: 16/16 passing
 - SwiftLint strict: clean
 - Debug app build: succeeded with code signing disabled
+
+## Session 8: delegated Claude token refresh (#292 phase 3)
+
+### Problem
+
+Phase 2 could identify an expired credential, but recovery still required the
+user to leave MeterBar and run Claude Code. MeterBar also had no safe definition
+of delegated-refresh success: a zero-exit child process alone does not prove
+that Claude rotated the credential belonging to the requested profile.
+
+### Change
+
+- Added metadata-only `ClaudeCredentialFingerprintStore`, using the same
+  per-profile candidate order as `ClaudeCredentialStore`. Keychain fingerprints
+  use service name plus modification date; file fingerprints use path,
+  modification date, and size. Token bytes are never read, hashed, logged, or
+  persisted by the fingerprint layer.
+- Added actor-isolated `ClaudeTokenRefresher`. It coalesces concurrent work by
+  account UUID, runs `claude /status` with that account's
+  `CLAUDE_CONFIG_DIR`, captures zero output bytes, and polls the credential
+  fingerprint after a successful exit.
+- Added persistent per-account cooldowns: 20 seconds after an inconclusive
+  result and 5 minutes after either verified success or hard failure. Manual
+  refresh bypasses stored cooldowns but still joins an active attempt.
+- Added pure `ClaudeOAuthAccessCoordinator`: valid tokens pass through, missing
+  credentials preserve the existing CLI fallback, and expired credentials get
+  exactly one delegated attempt followed by one credential re-read only after a
+  verified fingerprint change.
+- Threaded `background` versus `userInitiated` refresh intent through
+  `UsageDataManager`, including launch, timer, and wake paths.
+- Added 28 tests covering policy, metadata identity, coalescing, account
+  isolation, outcome mapping, one-time re-read, `/status` environment
+  propagation, and refresh-intent threading.
+
+```mermaid
+flowchart TD
+    A["Read profile-scoped credential"] --> B{"Credential state"}
+    B -->|"valid"| C["Call OAuth usage endpoint"]
+    B -->|"missing"| D["Preserve CLI usage fallback"]
+    B -->|"expired"| E{"Cooldown or active attempt?"}
+    E -->|"active"| F["Join same-account task"]
+    E -->|"background cooldown"| G["Report refresh failure"]
+    E -->|"attempt"| H["Fingerprint credential metadata"]
+    H --> I["Run claude /status with CLAUDE_CONFIG_DIR"]
+    I --> J{"Exit succeeded and fingerprint changed?"}
+    J -->|"yes"| K["Re-read credential once"]
+    K --> L{"Now valid?"}
+    L -->|"yes"| C
+    L -->|"no"| G
+    J -->|"no change"| G
+    I -->|"launch, timeout, or nonzero failure"| G
+```
+
+### Key decisions
+
+| Decision | Rationale |
+|---|---|
+| A process exit is necessary but never sufficient | The acceptance signal is a changed credential fingerprint for the requested profile, so another account's activity or a no-op `/status` cannot become a false success |
+| Fingerprint metadata, not token material | Modification date and file size are enough to detect rotation without expanding the number of code paths that handle OAuth secrets |
+| Missing and expired credentials follow different paths | Missing preserves the existing CLI fallback; only an expired credential proves that MeterBar has a profile-scoped OAuth identity it can safely ask Claude Code to rotate |
+| User refresh bypasses stored cooldown, not in-flight work | A click should retry recovery immediately, but spawning a second Claude process beside the same account's active background attempt adds risk without adding information |
+| Cooldowns persist only UUID, outcome, and timestamp | Recovery survives app restarts without retaining credential paths, service names, process output, or token-derived data |
+
+### PTY experiment
+
+The required pipe-versus-PTY check was performed before committing to the
+runner. A pipe-backed `claude /status` for the genfeed profile exited zero and
+produced no stderr, but that profile had no `claudeAiOauth` credential in either
+the expected scoped Keychain item or its credential file. Its metadata therefore
+did not change. This is an inconclusive environment result, not evidence that a
+pipe can rotate a near-expiry token. The process boundary remains isolated in
+`ClaudeStatusRunner` so a future PTY replacement does not affect policy or OAuth
+orchestration.
+
+### Verification
+
+- Cross-provider planning degraded cleanly: both the `fable` planner and `opus`
+  fallback returned nonzero with `Not logged in`; implementation continued
+  under the documented non-blocking fallback rule.
+- The independent exact-head `opus` verifier also returned nonzero with
+  `Not logged in` and zero model tokens. That is a provider/runtime failure,
+  not a PASS; the PR must remain unmerged until the current head receives a
+  real verifier verdict.
+- Focused phase 1–3/auth suites: 74 tests, 0 failures.
+- `ClaudeTokenRefresherTests`: 7 tests, 0 failures.
+- `UsageDataManagerTests`: every new phase-3 assertion passed; its 8 failures
+  remain the same six pre-existing wake/Grok cases.
+- `swiftlint lint --quiet MeterBar MeterBarTests`: clean.
+- Unsigned Debug app build: succeeded, with only the existing actor-isolation
+  and asset warnings.
+- Full `swift test`: 1,465 tests, 1 skipped, 23 failures across exactly the same
+  12 pre-existing cases recorded in the handoff (8 older failures plus 4 Grok
+  `refreshAll` regressions). The branch adds 28 passing tests and does not alter
+  the known-failure set.
+
+### Follow-ups
+
+- Phase 4 of #292 remains separate: no-UI background Keychain probes,
+  user-initiated interaction only, and per-service denial cooldowns.
+- Repeat the pipe-versus-PTY rotation experiment when a disposable profile has
+  a real near-expiry Claude OAuth credential. If a TTY is required, replace only
+  `ClaudeStatusRunner`.
+- Track the four master-side Grok `refreshAll` failures independently from
+  #292; phase 3 deliberately does not repair or reclassify them.

--- a/.agents/SESSIONS/2026-07-26.md
+++ b/.agents/SESSIONS/2026-07-26.md
@@ -598,22 +598,22 @@ flowchart TD
 
 The required pipe-versus-PTY check was performed before committing to the
 runner. A pipe-backed `claude /status` for the genfeed profile exited zero and
-produced no stderr, but that profile had no `claudeAiOauth` credential in either
-the expected scoped Keychain item or its credential file. Its metadata therefore
-did not change. This is an inconclusive environment result, not evidence that a
-pipe can rotate a near-expiry token. The process boundary remains isolated in
-`ClaudeStatusRunner` so a future PTY replacement does not affect policy or OAuth
-orchestration.
+produced no stderr, but the launch was inside the filesystem sandbox that later
+proved unable to reach the authenticated profile's Keychain credential. Its
+metadata therefore did not change. This is an inconclusive environment result,
+not evidence that a pipe can rotate a near-expiry token. The process boundary
+remains isolated in `ClaudeStatusRunner` so a future PTY replacement does not
+affect policy or OAuth orchestration.
 
 ### Verification
 
-- Cross-provider planning degraded cleanly: both the `fable` planner and `opus`
-  fallback returned nonzero with `Not logged in`; implementation continued
-  under the documented non-blocking fallback rule.
-- The independent exact-head `opus` verifier also returned nonzero with
-  `Not logged in` and zero model tokens. That is a provider/runtime failure,
-  not a PASS; the PR must remain unmerged until the current head receives a
-  real verifier verdict.
+- The initial `fable` planner, `opus` fallback, and verifier launches were
+  sandboxed and falsely returned `Not logged in` because the child could not
+  reach the authenticated genfeed.ai Keychain credential. Planning therefore
+  used the documented non-blocking implementer fallback.
+- Re-running `opus` outside that sandbox used the active genfeed.ai Max session
+  and returned an exact-head PASS for the phase-3 implementation, with only two
+  advisory minor notes and no required code change.
 - Focused phase 1–3/auth suites: 74 tests, 0 failures.
 - `ClaudeTokenRefresherTests`: 7 tests, 0 failures.
 - `UsageDataManagerTests`: every new phase-3 assertion passed; its 8 failures

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture - MeterBar
 
 **Purpose:** Document what IS implemented (not what WILL BE).
-**Last Updated:** 2026-07-17 (rewritten from a full-repo audit; see `docs/audits/00-repo-map.md`)
+**Last Updated:** 2026-07-26 (rewritten from a full-repo audit; see `docs/audits/00-repo-map.md`)
 
 ---
 
@@ -13,7 +13,7 @@ Providers tracked:
 
 | Provider | `ServiceType` case | Data source |
 |---|---|---|
-| Claude Code | `.claudeCode` | Unscoped default account: calls the authenticated `https://api.anthropic.com/api/oauth/usage` endpoint with the global `Claude Code-credentials` Keychain OAuth token (primary; on by default via the `ClaudeCodeEnableOAuthFallback` flag). Falls back to shelling out to `claude /usage` and regex-parsing terminal output when no token is available. Any account with an explicit `CLAUDE_CONFIG_DIR`, including the editable default row, uses the CLI so credentials cannot cross-contaminate profiles. |
+| Claude Code | `.claudeCode` | Resolves each profile's scoped Keychain or credential-file OAuth token and calls the authenticated `https://api.anthropic.com/api/oauth/usage` endpoint (primary; on by default via `ClaudeCodeEnableOAuthFallback`). An expired token delegates rotation to `claude /status` with that account's `CLAUDE_CONFIG_DIR`; MeterBar accepts success only when the credential metadata fingerprint changes. Missing credentials retain the `claude /usage` fallback. |
 | OpenAI Codex CLI | `.codexCli` | Reads `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`), calls `https://chatgpt.com/backend-api/wham/usage`; exhausted accounts can consume a banked reset credit through the authenticated reset-credit endpoints after explicit confirmation |
 | Cursor | `.cursor` | Reads session JWT from Cursor's `state.vscdb` SQLite, calls `https://cursor.com/api/usage-summary` |
 | OpenRouter | `.openRouter` | User-provided API key in Keychain; calls documented `/api/v1/credits` and `/api/v1/key` endpoints |
@@ -68,7 +68,8 @@ meterbar/
 
 - **UsageDataManager** (`@MainActor`, ObservableObject) — orchestrates refresh across providers, caches to UserDefaults (`cached_usage_metrics`), mirrors to the app group via SharedDataStore, records per-provider refresh outcomes in `ProviderParseHealthStore`, and drives a non-overlapping `Timer` auto-refresh (default 10 min; `RefreshInterval` supports 1/2/5/10/15/30 min + manual). The app forwards system wake events so stale enabled data catches up once without replaying missed ticks.
 - **ClaudeCodeCLIUsageService** — fallback source. Resolves the `claude` binary (`CLAUDE_CLI_PATH`, `$PATH`, 7 fallback paths), runs `claude /usage` (12 s timeout, dedicated GCD queue bridged to async), parses output with `ClaudeCodeCLIUsageParser`. `/usage` no longer renders in a headless spawn (it prints a session cost summary), so the parser detects that shape and throws a legible error. Multi-account via `CLAUDE_CONFIG_DIR` env injection.
-- **ClaudeCodeLocalService** — OAuth-primary wrapper. For the default account it reads `api.anthropic.com/api/oauth/usage` with the Keychain token (`metrics(from:)` maps windows + extra-usage), falling back to the CLI parser only when no token is available; custom accounts use the CLI. The model-scoped third window retains its provider label (`Sonnet` or `Fable`) and remains non-blocking for provider-wide health. `prefersOAuth`/`isOAuthUsageEnabled` are the pure source-selection helpers.
+- **ClaudeCodeLocalService** — OAuth-primary wrapper. Every profile resolves only its own scoped Keychain/file credential before calling `api.anthropic.com/api/oauth/usage`; a missing credential retains the CLI fallback, while an expired credential must pass delegated-refresh verification before it is re-read once. The model-scoped third window retains its provider label (`Sonnet` or `Fable`) and remains non-blocking for provider-wide health. The existing OAuth opt-out remains the source-selection switch.
+- **ClaudeTokenRefresher** — per-account delegated rotation coordinator. It coalesces concurrent attempts, applies persistent per-account outcome cooldowns (manual refresh bypasses a stored cooldown but joins in-flight work), runs `claude /status` with the account environment, captures no process output, and reports success only after the scoped credential's Keychain modification date or file modification date/size changes.
 - **CodexCliLocalService** — Codex auth file + wham/usage endpoint; maps credits/spend to `ExtraUsageStatus` (safety-biased: never false "Off"). It also lists and consumes banked rate-limit resets with an idempotency key, then immediately refreshes usage. The exhausted popover card and `meterbar reset-credit --yes` are the two explicit-confirmation entry points.
 - **CursorLocalService** — SQLite token extraction + usage-summary endpoint; assumed 500-request default quota when API omits totals.
 - **OpenRouterService** — opt-in API-key provider; maps account credits/spend and optional per-key caps into shared metrics.

--- a/MeterBar/App/UsageNotificationCoordinator.swift
+++ b/MeterBar/App/UsageNotificationCoordinator.swift
@@ -82,7 +82,7 @@ final class UsageNotificationCoordinator {
         // and so it isn't an orphaned unstructured Task.
         monitorTask?.cancel()
         monitorTask = Task { @MainActor in
-            await UsageDataManager.shared.refreshAll()
+            await UsageDataManager.shared.refreshAll(trigger: .background)
         }
     }
 

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -54,6 +54,8 @@ nonisolated enum StorageKeys {
     static let claudeCodeDefaultAccountName = "ClaudeCodeDefaultAccountName"
     /// User-chosen config directory for the default Claude Code CLI profile.
     static let claudeCodeDefaultConfigDirectory = "ClaudeCodeDefaultConfigDirectory"
+    /// Per-account delegated OAuth-refresh outcome and completion time.
+    static let claudeCodeRefreshCooldowns = "ClaudeCodeRefreshCooldowns"
     /// Whether the synthesized default Claude Code CLI profile participates in tracking.
     static let claudeCodeDefaultAccountEnabled = "ClaudeCodeDefaultAccountEnabled"
     /// Persisted account display order (array of UUID strings).

--- a/MeterBar/Services/ClaudeCodeCLIUsageService.swift
+++ b/MeterBar/Services/ClaudeCodeCLIUsageService.swift
@@ -36,7 +36,7 @@ nonisolated final class ClaudeCodeCLIUsageService: Sendable {
         return try ClaudeCodeCLIUsageParser.parseMetrics(from: output)
     }
 
-    private func resolveClaudeBinaryPath() -> String? {
+    func resolveClaudeBinaryPath() -> String? {
         CLIBinaryLocator.resolve(command: "claude", overrideEnvVar: "CLAUDE_CLI_PATH")
     }
 

--- a/MeterBar/Services/ClaudeCodeLocalService.swift
+++ b/MeterBar/Services/ClaudeCodeLocalService.swift
@@ -26,6 +26,7 @@ class ClaudeCodeLocalService: ObservableObject {
 
     private let credentialStore = ClaudeCredentialStore.shared
     private let cliUsageService = ClaudeCodeCLIUsageService.shared
+    private let tokenRefresher = ClaudeTokenRefresher.shared
 
     private let urlSession = ServiceSupport.session
 
@@ -54,26 +55,10 @@ class ClaudeCodeLocalService: ObservableObject {
     /// `nonisolated`: a keychain read can raise a blocking approval dialog —
     /// never call synchronously from the main actor.
     nonisolated func getOAuthToken(for account: ClaudeCodeAccount = .defaultAccount) -> String? {
-        guard let credentials = getCredentials(for: account) else {
+        guard case let .valid(token) = oauthCredentialAccessUpdatingSharedState(for: account) else {
             return nil
         }
-
-        guard !OAuthTokenExpiry.isExpired(unixTimestamp: credentials.claudeAiOauth.expiresAt) else {
-            ServiceSupport.applyOnMain {
-                self.subscriptionType = credentials.claudeAiOauth.subscriptionType
-                self.rateLimitTier = credentials.claudeAiOauth.rateLimitTier
-                self.hasAccess = false
-            }
-            return nil
-        }
-
-        ServiceSupport.applyOnMain {
-            self.subscriptionType = credentials.claudeAiOauth.subscriptionType
-            self.rateLimitTier = credentials.claudeAiOauth.rateLimitTier
-            self.hasAccess = true
-        }
-
-        return credentials.claudeAiOauth.accessToken
+        return token
     }
 
     nonisolated private func getCredentials(
@@ -81,6 +66,45 @@ class ClaudeCodeLocalService: ObservableObject {
     ) -> ClaudeCodeCredentials? {
         guard let data = credentialsData(for: account) else { return nil }
         return try? JSONDecoder().decode(ClaudeCodeCredentials.self, from: data)
+    }
+
+    nonisolated func oauthCredentialAccess(
+        for account: ClaudeCodeAccount = .defaultAccount
+    ) -> ClaudeOAuthCredentialAccess {
+        Self.oauthCredentialAccess(from: getCredentials(for: account))
+    }
+
+    nonisolated static func oauthCredentialAccess(
+        from credentials: ClaudeCodeCredentials?
+    ) -> ClaudeOAuthCredentialAccess {
+        guard let credentials else {
+            return .missing
+        }
+        guard !OAuthTokenExpiry.isExpired(unixTimestamp: credentials.claudeAiOauth.expiresAt) else {
+            return .expired
+        }
+        return .valid(token: credentials.claudeAiOauth.accessToken)
+    }
+
+    nonisolated private func oauthCredentialAccessUpdatingSharedState(
+        for account: ClaudeCodeAccount
+    ) -> ClaudeOAuthCredentialAccess {
+        guard let credentials = getCredentials(for: account) else {
+            return .missing
+        }
+        let access = Self.oauthCredentialAccess(from: credentials)
+        let hasValidToken: Bool
+        if case .valid = access {
+            hasValidToken = true
+        } else {
+            hasValidToken = false
+        }
+        ServiceSupport.applyOnMain {
+            self.subscriptionType = credentials.claudeAiOauth.subscriptionType
+            self.rateLimitTier = credentials.claudeAiOauth.rateLimitTier
+            self.hasAccess = hasValidToken
+        }
+        return access
     }
 
     /// The raw Claude Code credential blob for `account`, or nil if
@@ -129,6 +153,13 @@ class ClaudeCodeLocalService: ObservableObject {
     // MARK: - Usage Fetching
 
     func fetchUsageMetrics(account: ClaudeCodeAccount = .defaultAccount) async throws -> UsageMetrics {
+        try await fetchUsageMetrics(account: account, trigger: .background)
+    }
+
+    func fetchUsageMetrics(
+        account: ClaudeCodeAccount,
+        trigger: ClaudeTokenRefreshTrigger
+    ) async throws -> UsageMetrics {
         // Primary source: the authenticated `/api/oauth/usage` endpoint — the
         // same data Claude Code's own `/usage` screen reads. `claude /usage` no
         // longer renders in a headless (non-TTY) spawn (it prints a session cost
@@ -138,18 +169,18 @@ class ClaudeCodeLocalService: ObservableObject {
         // reach the unscoped item, so identities cannot cross-contaminate.
         var oauthUnauthenticated = false
         if isOAuthFallbackEnabled {
-            // `nil` ⇒ no usable Keychain token; fall back to the CLI. A thrown
-            // error means a token was in hand but the request/decode failed —
-            // surface it rather than retry the headless-broken CLI.
-            if let metrics = try await fetchUsageViaOAuth(account: account) {
+            // `nil` ⇒ no credential for this profile; fall back to the CLI. A
+            // thrown error means either delegated refresh could not verify a
+            // rotated token or an OAuth request/decode failed — surface it
+            // rather than retry the headless-broken CLI.
+            if let metrics = try await fetchUsageViaOAuth(account: account, trigger: trigger) {
                 return metrics
             }
-            // No usable credential for this profile: Claude Code either never
-            // wrote one or the token expired. Remember that, so a downstream CLI
-            // parse failure reports "Login required" instead of a vague "Needs
-            // attention" — a logged-out profile is by far the common cause, and
-            // `claude /usage` prints a cost summary rather than the usage screen
-            // when the profile is not logged in.
+            // No credential for this profile. Remember that, so a downstream
+            // CLI parse failure reports "Login required" instead of a vague
+            // "Needs attention" — a logged-out profile is by far the common
+            // cause, and `claude /usage` prints a cost summary rather than the
+            // usage screen when the profile is not logged in.
             oauthUnauthenticated = true
         }
 
@@ -158,23 +189,51 @@ class ClaudeCodeLocalService: ObservableObject {
 
     /// Fetches usage from the OAuth `/api/oauth/usage` endpoint for `account`
     /// and, for the default profile only, updates the app's `@Published`
-    /// auth/error state. Returns `nil` when there is no usable token (missing or
-    /// expired) so the caller can fall back to the CLI. The actual
-    /// request/decode is delegated to the pure `fetchOAuthMetrics(token:)`; this
-    /// wrapper adds only the UI side effects.
-    private func fetchUsageViaOAuth(account: ClaudeCodeAccount) async throws -> UsageMetrics? {
+    /// auth/error state. A missing credential retains the CLI fallback. An
+    /// expired credential first delegates refresh to the Claude CLI, accepts
+    /// success only when its metadata fingerprint changes, and re-reads once.
+    private func fetchUsageViaOAuth(
+        account: ClaudeCodeAccount,
+        trigger: ClaudeTokenRefreshTrigger
+    ) async throws -> UsageMetrics? {
         // Keychain read — off the main actor (it can raise a blocking approval
         // dialog, and the app target runs async bodies on the main actor).
-        // `getOAuthToken(for:)` also refreshes `subscriptionType`/`hasAccess`.
+        // The state-updating read also refreshes `subscriptionType`/`hasAccess`.
         let publishesSharedState = Self.publishesSharedConnectionState(for: account)
-        let token = await Task.detached(priority: .userInitiated) { [self] in
-            publishesSharedState ? getOAuthToken(for: account) : nonMutatingOAuthToken(for: account)
+        let initialAccess = await Task.detached(priority: .userInitiated) { [self] in
+            publishesSharedState
+                ? oauthCredentialAccessUpdatingSharedState(for: account)
+                : oauthCredentialAccess(for: account)
         }.value
 
-        guard let token else { return nil }
+        let tokenRefresher = self.tokenRefresher
+        let resolvedAccess = await ClaudeOAuthAccessCoordinator.resolve(
+            initialAccess: initialAccess,
+            account: account,
+            trigger: trigger,
+            refresh: { account, trigger in
+                await tokenRefresher.refresh(account: account, trigger: trigger)
+            },
+            reread: {
+                await Task.detached(priority: .userInitiated) { [self] in
+                    oauthCredentialAccess(for: account)
+                }.value
+            }
+        )
+
+        let resolvedToken: String
+        switch resolvedAccess {
+        case let .token(token):
+            resolvedToken = token
+        case .missing:
+            return nil
+        case .refreshFailed:
+            publishNeedsLogin(account: account, publishesSharedState: publishesSharedState)
+            throw ServiceError.notAuthenticated
+        }
 
         do {
-            let metrics = try await Self.fetchOAuthMetrics(token: token, session: urlSession)
+            let metrics = try await Self.fetchOAuthMetrics(token: resolvedToken, session: urlSession)
             await MainActor.run {
                 // Same rule as the CLI path: this observable service describes
                 // the default Claude connection, so a secondary profile must not
@@ -206,6 +265,17 @@ class ClaudeCodeLocalService: ObservableObject {
             }
             throw serviceError
         }
+    }
+
+    private func publishNeedsLogin(
+        account: ClaudeCodeAccount,
+        publishesSharedState: Bool
+    ) {
+        accountAuthStates[account.id] = .needsLogin
+        guard publishesSharedState else { return }
+        lastError = .notAuthenticated
+        hasAccess = false
+        authState = .needsLogin
     }
 
     /// Builds an authenticated GET against the OAuth usage endpoint.

--- a/MeterBar/Services/ClaudeCredentialFingerprint.swift
+++ b/MeterBar/Services/ClaudeCredentialFingerprint.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Security
+
+/// Privacy-safe identity for the credential backing one Claude Code profile.
+///
+/// Keychain fingerprints contain metadata only; they never read, hash, log, or
+/// persist the OAuth payload. The file fallback follows the same rule by using
+/// filesystem metadata instead of credential bytes.
+nonisolated enum ClaudeCredentialFingerprint: Equatable, Sendable {
+    case keychain(service: String, modificationDate: Date)
+    case file(path: String, modificationDate: Date, size: UInt64)
+}
+
+/// Reads the first metadata fingerprint in the same candidate order as
+/// `ClaudeCredentialStore`.
+nonisolated struct ClaudeCredentialFingerprintStore: Sendable {
+    static let shared = ClaudeCredentialFingerprintStore()
+
+    private let readKeychain: @Sendable (String) -> ClaudeCredentialFingerprint?
+    private let readFile: @Sendable (String) -> ClaudeCredentialFingerprint?
+
+    init(
+        readKeychain: @escaping @Sendable (String) -> ClaudeCredentialFingerprint? = {
+            ClaudeCredentialFingerprintStore.keychainFingerprint(service: $0)
+        },
+        readFile: @escaping @Sendable (String) -> ClaudeCredentialFingerprint? = {
+            ClaudeCredentialFingerprintStore.fileFingerprint(path: $0)
+        }
+    ) {
+        self.readKeychain = readKeychain
+        self.readFile = readFile
+    }
+
+    func fingerprint(
+        for account: ClaudeCodeAccount,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        realHomeDirectory: String = ServiceSupport.realHomeDirectory()
+    ) -> ClaudeCredentialFingerprint? {
+        let candidates = ClaudeCredentialResolver.candidates(
+            for: account,
+            environment: environment,
+            realHomeDirectory: realHomeDirectory
+        )
+
+        for source in candidates {
+            switch source {
+            case let .keychain(service):
+                if let fingerprint = readKeychain(service) {
+                    return fingerprint
+                }
+            case let .file(path):
+                if let fingerprint = readFile(path) {
+                    return fingerprint
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Reads Keychain attributes without requesting the secret payload.
+    static func keychainFingerprint(service: String) -> ClaudeCredentialFingerprint? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess,
+              let attributes = result as? [String: Any],
+              let modificationDate = attributes[kSecAttrModificationDate as String] as? Date else {
+            return nil
+        }
+        return .keychain(service: service, modificationDate: modificationDate)
+    }
+
+    static func fileFingerprint(path: String) -> ClaudeCredentialFingerprint? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path),
+              let modificationDate = attributes[.modificationDate] as? Date,
+              let size = attributes[.size] as? NSNumber else {
+            return nil
+        }
+        return .file(
+            path: path,
+            modificationDate: modificationDate,
+            size: size.uint64Value
+        )
+    }
+}

--- a/MeterBar/Services/ClaudeCredentialResolver.swift
+++ b/MeterBar/Services/ClaudeCredentialResolver.swift
@@ -103,8 +103,12 @@ nonisolated struct ClaudeCredentialStore: Sendable {
     private let readFile: @Sendable (String) -> Data?
 
     init(
-        readKeychain: @escaping @Sendable (String) -> Data? = ClaudeCredentialStore.keychainPayload,
-        readFile: @escaping @Sendable (String) -> Data? = ClaudeCredentialStore.filePayload
+        readKeychain: @escaping @Sendable (String) -> Data? = {
+            ClaudeCredentialStore.keychainPayload(service: $0)
+        },
+        readFile: @escaping @Sendable (String) -> Data? = {
+            ClaudeCredentialStore.filePayload(path: $0)
+        }
     ) {
         self.readKeychain = readKeychain
         self.readFile = readFile

--- a/MeterBar/Services/ClaudeTokenRefresher.swift
+++ b/MeterBar/Services/ClaudeTokenRefresher.swift
@@ -1,0 +1,313 @@
+import Foundation
+
+nonisolated enum ClaudeTokenRefreshTrigger: Equatable, Sendable {
+    case background
+    case userInitiated
+}
+
+nonisolated enum ClaudeTokenRefreshOutcome: String, CaseIterable, Codable, Equatable, Sendable {
+    case refreshed
+    case inconclusive
+    case hardFailure
+}
+
+nonisolated struct ClaudeRefreshCooldownRecord: Codable, Equatable, Sendable {
+    let outcome: ClaudeTokenRefreshOutcome
+    let completedAt: Date
+}
+
+nonisolated enum ClaudeRefreshDecision: Equatable, Sendable {
+    case attempt
+    case cooldown(until: Date)
+}
+
+/// Pure cooldown policy for delegated refresh attempts.
+nonisolated enum ClaudeRefreshPolicy {
+    static let inconclusiveCooldown: TimeInterval = 20
+    static let settledCooldown: TimeInterval = 5 * 60
+
+    static func decision(
+        record: ClaudeRefreshCooldownRecord?,
+        trigger: ClaudeTokenRefreshTrigger,
+        now: Date
+    ) -> ClaudeRefreshDecision {
+        if trigger == .userInitiated {
+            return .attempt
+        }
+        guard let record else { return .attempt }
+
+        // A clock correction or corrupt future timestamp must not disable
+        // automatic recovery until that future instant finally arrives.
+        guard record.completedAt <= now else { return .attempt }
+
+        let deadline = record.completedAt.addingTimeInterval(cooldownDuration(for: record.outcome))
+        return now < deadline ? .cooldown(until: deadline) : .attempt
+    }
+
+    static func cooldownDuration(for outcome: ClaudeTokenRefreshOutcome) -> TimeInterval {
+        outcome == .inconclusive ? inconclusiveCooldown : settledCooldown
+    }
+}
+
+/// Persisted per-account cooldown records. The payload contains only account
+/// UUIDs, outcome labels, and timestamps.
+nonisolated final class ClaudeRefreshCooldownStore: @unchecked Sendable {
+    private struct Entry: Codable {
+        let accountID: UUID
+        let record: ClaudeRefreshCooldownRecord
+    }
+
+    private let userDefaults: UserDefaults
+    private let lock = NSLock()
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    func record(for accountID: UUID) -> ClaudeRefreshCooldownRecord? {
+        lock.lock()
+        defer { lock.unlock() }
+        return records()[accountID]
+    }
+
+    func record(_ outcome: ClaudeTokenRefreshOutcome, for accountID: UUID, at date: Date) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        var updated = records()
+        updated[accountID] = ClaudeRefreshCooldownRecord(outcome: outcome, completedAt: date)
+        let entries = updated
+            .map { Entry(accountID: $0.key, record: $0.value) }
+            .sorted { $0.accountID.uuidString < $1.accountID.uuidString }
+        guard let data = try? JSONEncoder().encode(entries) else { return }
+        userDefaults.set(data, forKey: StorageKeys.claudeCodeRefreshCooldowns)
+    }
+
+    private func records() -> [UUID: ClaudeRefreshCooldownRecord] {
+        guard let data = userDefaults.data(forKey: StorageKeys.claudeCodeRefreshCooldowns),
+              let entries = try? JSONDecoder().decode([Entry].self, from: data) else {
+            return [:]
+        }
+        return Dictionary(uniqueKeysWithValues: entries.map { ($0.accountID, $0.record) })
+    }
+}
+
+nonisolated enum ClaudeStatusRunResult: Equatable, Sendable {
+    case succeeded
+    case failed
+}
+
+nonisolated enum ClaudeTokenRefreshResult: Equatable, Sendable {
+    case refreshed
+    case inconclusive
+    case hardFailure
+    case cooldown(until: Date, previousOutcome: ClaudeTokenRefreshOutcome)
+
+    var didRefresh: Bool {
+        self == .refreshed
+    }
+}
+
+nonisolated enum ClaudeOAuthCredentialAccess: Equatable, Sendable {
+    case missing
+    case expired
+    case valid(token: String)
+}
+
+nonisolated enum ClaudeOAuthAccessResolution: Equatable, Sendable {
+    case token(String)
+    case missing
+    case refreshFailed(ClaudeTokenRefreshResult)
+}
+
+/// Pure orchestration around the refresher: valid credentials pass through,
+/// missing credentials retain the existing CLI fallback, and expired
+/// credentials get exactly one verified delegated-refresh attempt plus one
+/// credential re-read.
+nonisolated enum ClaudeOAuthAccessCoordinator {
+    typealias Refresh = @Sendable (
+        ClaudeCodeAccount,
+        ClaudeTokenRefreshTrigger
+    ) async -> ClaudeTokenRefreshResult
+    typealias Reread = @Sendable () async -> ClaudeOAuthCredentialAccess
+
+    static func resolve(
+        initialAccess: ClaudeOAuthCredentialAccess,
+        account: ClaudeCodeAccount,
+        trigger: ClaudeTokenRefreshTrigger,
+        refresh: Refresh,
+        reread: Reread
+    ) async -> ClaudeOAuthAccessResolution {
+        switch initialAccess {
+        case let .valid(token):
+            return .token(token)
+        case .missing:
+            return .missing
+        case .expired:
+            let result = await refresh(account, trigger)
+            guard result.didRefresh else {
+                return .refreshFailed(result)
+            }
+            guard case let .valid(token) = await reread() else {
+                return .refreshFailed(result)
+            }
+            return .token(token)
+        }
+    }
+}
+
+/// Performs the privacy-sensitive process launch. Captures are bounded to zero
+/// bytes because delegated refresh needs only the termination result.
+nonisolated enum ClaudeStatusRunner {
+    private static let processQueue = DispatchQueue(
+        label: "dev.meterbar.app.ClaudeStatus.process",
+        qos: .utility,
+        attributes: .concurrent
+    )
+
+    static func run(account: ClaudeCodeAccount) async -> ClaudeStatusRunResult {
+        await withCheckedContinuation { continuation in
+            processQueue.async {
+                guard let binaryPath = ClaudeCodeCLIUsageService.shared.resolveClaudeBinaryPath() else {
+                    continuation.resume(returning: .failed)
+                    return
+                }
+
+                continuation.resume(returning: runBlocking(
+                    binaryPath: binaryPath,
+                    account: account
+                ))
+            }
+        }
+    }
+
+    static func runBlocking(
+        binaryPath: String,
+        account: ClaudeCodeAccount,
+        timeout: TimeInterval = ClaudeCodeCLIUsageService.commandTimeout
+    ) -> ClaudeStatusRunResult {
+        let result = ManagedProcess.run(
+            executable: binaryPath,
+            arguments: ["/status"],
+            environment: ClaudeCodeCLIUsageService.shared.processEnvironment(account: account),
+            workingDirectory: ServiceSupport.realHomeDirectory(),
+            timeout: timeout,
+            maxCaptureBytes: 0
+        )
+        return result.isSuccess ? .succeeded : .failed
+    }
+}
+
+/// Coalesces delegated refreshes by account and verifies success by observing a
+/// changed credential fingerprint after Claude exits successfully.
+actor ClaudeTokenRefresher {
+    typealias FingerprintReader = @Sendable (ClaudeCodeAccount) -> ClaudeCredentialFingerprint?
+    typealias StatusRunner = @Sendable (ClaudeCodeAccount) async -> ClaudeStatusRunResult
+    typealias Sleeper = @Sendable (TimeInterval) async -> Void
+    typealias Clock = @Sendable () -> Date
+
+    static let shared = ClaudeTokenRefresher()
+
+    private let cooldownStore: ClaudeRefreshCooldownStore
+    private let fingerprint: FingerprintReader
+    private let runStatus: StatusRunner
+    private let sleep: Sleeper
+    private let pollDelays: [TimeInterval]
+    private let now: Clock
+    private var inFlight: [UUID: Task<ClaudeTokenRefreshOutcome, Never>] = [:]
+
+    init(
+        cooldownStore: ClaudeRefreshCooldownStore = ClaudeRefreshCooldownStore(),
+        fingerprint: @escaping FingerprintReader = {
+            ClaudeCredentialFingerprintStore.shared.fingerprint(for: $0)
+        },
+        runStatus: @escaping StatusRunner = { await ClaudeStatusRunner.run(account: $0) },
+        sleep: @escaping Sleeper = { delay in
+            let nanoseconds = UInt64(max(0, delay) * 1_000_000_000)
+            try? await Task.sleep(nanoseconds: nanoseconds)
+        },
+        pollDelays: [TimeInterval] = [0.2, 0.5, 0.8],
+        now: @escaping Clock = { Date() }
+    ) {
+        self.cooldownStore = cooldownStore
+        self.fingerprint = fingerprint
+        self.runStatus = runStatus
+        self.sleep = sleep
+        self.pollDelays = pollDelays
+        self.now = now
+    }
+
+    func refresh(
+        account: ClaudeCodeAccount,
+        trigger: ClaudeTokenRefreshTrigger
+    ) async -> ClaudeTokenRefreshResult {
+        // In-flight work wins over cooldown/preemption. A user action bypasses a
+        // stored cooldown, but it must not create a second process beside an
+        // already-running background attempt.
+        if let active = inFlight[account.id] {
+            return result(for: await active.value)
+        }
+
+        let currentDate = now()
+        let record = cooldownStore.record(for: account.id)
+        switch ClaudeRefreshPolicy.decision(record: record, trigger: trigger, now: currentDate) {
+        case .attempt:
+            break
+        case let .cooldown(until):
+            guard let record else { return .inconclusive }
+            return .cooldown(until: until, previousOutcome: record.outcome)
+        }
+
+        let fingerprint = self.fingerprint
+        let runStatus = self.runStatus
+        let sleep = self.sleep
+        let pollDelays = self.pollDelays
+        let task = Task.detached(priority: .utility) {
+            await Self.performRefresh(
+                account: account,
+                fingerprint: fingerprint,
+                runStatus: runStatus,
+                sleep: sleep,
+                pollDelays: pollDelays
+            )
+        }
+        inFlight[account.id] = task
+
+        let outcome = await task.value
+        inFlight[account.id] = nil
+        cooldownStore.record(outcome, for: account.id, at: now())
+        return result(for: outcome)
+    }
+
+    private static func performRefresh(
+        account: ClaudeCodeAccount,
+        fingerprint: FingerprintReader,
+        runStatus: StatusRunner,
+        sleep: Sleeper,
+        pollDelays: [TimeInterval]
+    ) async -> ClaudeTokenRefreshOutcome {
+        let before = fingerprint(account)
+        guard await runStatus(account) == .succeeded else {
+            return .hardFailure
+        }
+
+        for delay in pollDelays {
+            await sleep(delay)
+            if let after = fingerprint(account), after != before {
+                return .refreshed
+            }
+        }
+        return .inconclusive
+    }
+
+    private func result(for outcome: ClaudeTokenRefreshOutcome) -> ClaudeTokenRefreshResult {
+        switch outcome {
+        case .refreshed:
+            .refreshed
+        case .inconclusive:
+            .inconclusive
+        case .hardFailure:
+            .hardFailure
+        }
+    }
+}

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -25,6 +25,20 @@ protocol ClaudeCodeUsageProviding: AnyObject {
     /// account's cache with no way to mark the card as stale or logged out.
     var accountAuthStates: [UUID: ClaudeCodeAuthState] { get }
     func fetchUsageMetrics(account: ClaudeCodeAccount) async throws -> UsageMetrics
+    func fetchUsageMetrics(
+        account: ClaudeCodeAccount,
+        trigger: ClaudeTokenRefreshTrigger
+    ) async throws -> UsageMetrics
+}
+
+extension ClaudeCodeUsageProviding {
+    func fetchUsageMetrics(
+        account: ClaudeCodeAccount,
+        trigger: ClaudeTokenRefreshTrigger
+    ) async throws -> UsageMetrics {
+        _ = trigger
+        return try await fetchUsageMetrics(account: account)
+    }
 }
 
 extension ClaudeCodeLocalService: ClaudeCodeUsageProviding {}
@@ -153,7 +167,9 @@ class UsageDataManager: ObservableObject {
     /// refresh` uses it to report refreshed/failed/skipped state without
     /// re-deriving truth from `lastError`, which only holds the last failure.
     @discardableResult
-    func refreshAll() async -> UsageRefreshReport {
+    func refreshAll(
+        trigger: ClaudeTokenRefreshTrigger = .userInitiated
+    ) async -> UsageRefreshReport {
         let startedAt = Date()
         guard !demoMode else {
             return UsageRefreshReport(
@@ -203,7 +219,8 @@ class UsageDataManager: ObservableObject {
         // is what lets the account fetchers keep reading the *previous* cache for
         // their graceful-degradation fallbacks.
         async let claudeFetch = claudeAccountFetch(
-            isEnabled: providerVisibilityStore.isEnabled(.claudeCode) && hasEnabledClaudeAccount
+            isEnabled: providerVisibilityStore.isEnabled(.claudeCode) && hasEnabledClaudeAccount,
+            trigger: trigger
         )
         async let codexFetch = codexAccountFetch(
             isEnabled: providerVisibilityStore.isEnabled(.codexCli) && hasEnabledCodexAccount
@@ -471,7 +488,7 @@ class UsageDataManager: ObservableObject {
     func refreshAfterWakeIfNeeded(now: Date = Date()) async {
         guard !demoMode else { return }
         guard refreshInterval != .manual, await shouldCatchUpAfterWake(now: now) else { return }
-        await refreshAll()
+        await refreshAll(trigger: .background)
     }
 
     /// Installs the post-redemption Codex usage response into the same caches
@@ -492,7 +509,7 @@ class UsageDataManager: ObservableObject {
         // The account fetchers report their first failure instead of writing
         // `lastError` themselves (see `refreshAll`), so this path surfaces it.
         case .claudeCode:
-            let fetch = await fetchClaudeCodeAccountMetrics()
+            let fetch = await fetchClaudeCodeAccountMetrics(trigger: .userInitiated)
             claudeCodeAccountMetrics = fetch.metrics
             claudeCodeAccountStates = fetch.accountStates
             if let failure = fetch.firstFailure { lastError = failure }
@@ -621,7 +638,7 @@ class UsageDataManager: ObservableObject {
         let interval = refreshInterval.seconds
         let timer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
             Task { @MainActor in
-                await self?.refreshAll()
+                await self?.refreshAll(trigger: .background)
             }
         }
         RunLoop.main.add(timer, forMode: .common)
@@ -693,9 +710,12 @@ class UsageDataManager: ObservableObject {
     /// account contributes no metrics, no cached fallback, and no failure.
     private struct CodexAccountUnreachable: Error {}
 
-    private func claudeAccountFetch(isEnabled: Bool) async -> AccountFetchResult? {
+    private func claudeAccountFetch(
+        isEnabled: Bool,
+        trigger: ClaudeTokenRefreshTrigger
+    ) async -> AccountFetchResult? {
         guard isEnabled else { return nil }
-        return await fetchClaudeCodeAccountMetrics()
+        return await fetchClaudeCodeAccountMetrics(trigger: trigger)
     }
 
     private func codexAccountFetch(isEnabled: Bool) async -> AccountFetchResult? {
@@ -703,7 +723,9 @@ class UsageDataManager: ObservableObject {
         return await fetchCodexAccountMetrics()
     }
 
-    private func fetchClaudeCodeAccountMetrics() async -> AccountFetchResult {
+    private func fetchClaudeCodeAccountMetrics(
+        trigger: ClaudeTokenRefreshTrigger
+    ) async -> AccountFetchResult {
         let enabledAccounts = claudeCodeAccountStore.enabledAccounts
         var refreshedMetrics: [UUID: UsageMetrics] = [:]
         var accountStates: [UUID: ClaudeCodeAuthState] = [:]
@@ -711,7 +733,10 @@ class UsageDataManager: ObservableObject {
         var successCount = 0
 
         let legs = await fanOut(count: enabledAccounts.count) { [enabledAccounts] index in
-            try await self.claudeCodeService.fetchUsageMetrics(account: enabledAccounts[index])
+            try await self.claudeCodeService.fetchUsageMetrics(
+                account: enabledAccounts[index],
+                trigger: trigger
+            )
         }
 
         let serviceStates = claudeCodeService.accountAuthStates

--- a/MeterBarTests/ClaudeCodeCLIUsageServiceTests.swift
+++ b/MeterBarTests/ClaudeCodeCLIUsageServiceTests.swift
@@ -161,6 +161,21 @@ final class ClaudeCodeCLIUsageServiceTests: XCTestCase {
         XCTAssertTrue(recorded.contains("CFG:/tmp/claude-alt"), "recorded=\(recorded)")
     }
 
+    func testStatusRunnerUsesStatusCommandAndScopedEnvironment() async throws {
+        let marker = tempDirectory.appendingPathComponent("status-env.txt")
+        let binary = try makeFakeCLI(named: "status.sh", body: """
+        { echo "ARG:$1"; echo "CFG:${CLAUDE_CONFIG_DIR}"; } > "\(marker.path)"
+        """)
+        let account = ClaudeCodeAccount(id: UUID(), name: "alt", configDirectory: "/tmp/claude-alt")
+
+        let result = await runStatusBlocking(binaryPath: binary, account: account)
+
+        XCTAssertEqual(result, .succeeded)
+        let recorded = try String(contentsOf: marker, encoding: .utf8)
+        XCTAssertTrue(recorded.contains("ARG:/status"), "recorded=\(recorded)")
+        XCTAssertTrue(recorded.contains("CFG:/tmp/claude-alt"), "recorded=\(recorded)")
+    }
+
     // MARK: - Helpers
 
     private func makeFakeCLI(named name: String, body: String) throws -> String {
@@ -186,6 +201,22 @@ final class ClaudeCodeCLIUsageServiceTests: XCTestCase {
                         timeout: timeout
                     )
                 })
+            }
+        }
+    }
+
+    private func runStatusBlocking(
+        binaryPath: String,
+        account: ClaudeCodeAccount,
+        timeout: TimeInterval = 10
+    ) async -> ClaudeStatusRunResult {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                continuation.resume(returning: ClaudeStatusRunner.runBlocking(
+                    binaryPath: binaryPath,
+                    account: account,
+                    timeout: timeout
+                ))
             }
         }
     }

--- a/MeterBarTests/ClaudeCodeOAuthUsageTests.swift
+++ b/MeterBarTests/ClaudeCodeOAuthUsageTests.swift
@@ -143,6 +143,20 @@ final class ClaudeCodeOAuthUsageTests: XCTestCase {
         }
     }
 
+    func testCredentialAccessDistinguishesMissingExpiredAndValidTokens() {
+        XCTAssertEqual(ClaudeCodeLocalService.oauthCredentialAccess(from: nil), .missing)
+        XCTAssertEqual(
+            ClaudeCodeLocalService.oauthCredentialAccess(from: credentials(expiresAt: 0)),
+            .expired
+        )
+        XCTAssertEqual(
+            ClaudeCodeLocalService.oauthCredentialAccess(
+                from: credentials(expiresAt: 4_102_444_800, accessToken: "current")
+            ),
+            .valid(token: "current")
+        )
+    }
+
     // MARK: - Shared usage request builder
 
     func testUsageRequestCarriesTheOAuthHeaderSet() throws {
@@ -205,6 +219,22 @@ final class ClaudeCodeOAuthUsageTests: XCTestCase {
         decoder.dateDecodingStrategy = .iso8601
         let data = try XCTUnwrap(json.data(using: .utf8))
         return try decoder.decode(ClaudeCodeUsageResponse.self, from: data)
+    }
+
+    private func credentials(
+        expiresAt: Int64,
+        accessToken: String = "token"
+    ) -> ClaudeCodeCredentials {
+        ClaudeCodeCredentials(
+            claudeAiOauth: ClaudeAiOAuth(
+                accessToken: accessToken,
+                refreshToken: "refresh",
+                expiresAt: expiresAt,
+                scopes: [],
+                subscriptionType: nil,
+                rateLimitTier: nil
+            )
+        )
     }
 
     private func makeEmptyDefaults() throws -> UserDefaults {

--- a/MeterBarTests/ClaudeCredentialFingerprintTests.swift
+++ b/MeterBarTests/ClaudeCredentialFingerprintTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import MeterBar
+
+final class ClaudeCredentialFingerprintTests: XCTestCase {
+    func testScopedKeychainFingerprintWinsOverFileFallback() {
+        let account = ClaudeCodeAccount(
+            id: UUID(),
+            name: "Work",
+            configDirectory: "/Users/tester/.claude-work"
+        )
+        let keychain = ClaudeCredentialFingerprint.keychain(
+            service: "Claude Code-credentials-c4394a73",
+            modificationDate: Date(timeIntervalSince1970: 100)
+        )
+        let file = ClaudeCredentialFingerprint.file(
+            path: "/Users/tester/.claude-work/.credentials.json",
+            modificationDate: Date(timeIntervalSince1970: 200),
+            size: 42
+        )
+        let store = ClaudeCredentialFingerprintStore(
+            readKeychain: { _ in keychain },
+            readFile: { _ in file }
+        )
+
+        XCTAssertEqual(
+            store.fingerprint(
+                for: account,
+                environment: [:],
+                realHomeDirectory: "/Users/tester"
+            ),
+            keychain
+        )
+    }
+
+    func testFingerprintFallsBackToCredentialFileMetadata() {
+        let account = ClaudeCodeAccount(
+            id: UUID(),
+            name: "Work",
+            configDirectory: "/Users/tester/.claude-work"
+        )
+        let expected = ClaudeCredentialFingerprint.file(
+            path: "/Users/tester/.claude-work/.credentials.json",
+            modificationDate: Date(timeIntervalSince1970: 200),
+            size: 42
+        )
+        let store = ClaudeCredentialFingerprintStore(
+            readKeychain: { _ in nil },
+            readFile: { _ in expected }
+        )
+
+        XCTAssertEqual(
+            store.fingerprint(
+                for: account,
+                environment: [:],
+                realHomeDirectory: "/Users/tester"
+            ),
+            expected
+        )
+    }
+
+    func testFingerprintReturnsNilWhenNoCredentialMetadataExists() {
+        let store = ClaudeCredentialFingerprintStore(
+            readKeychain: { _ in nil },
+            readFile: { _ in nil }
+        )
+
+        XCTAssertNil(store.fingerprint(
+            for: .defaultAccount,
+            environment: [:],
+            realHomeDirectory: "/Users/tester"
+        ))
+    }
+
+    func testFingerprintChangesWhenKeychainModificationDateChanges() {
+        let service = "Claude Code-credentials-c4394a73"
+        let before = ClaudeCredentialFingerprint.keychain(
+            service: service,
+            modificationDate: Date(timeIntervalSince1970: 100)
+        )
+        let after = ClaudeCredentialFingerprint.keychain(
+            service: service,
+            modificationDate: Date(timeIntervalSince1970: 101)
+        )
+
+        XCTAssertNotEqual(before, after)
+    }
+
+    func testFingerprintChangesWhenFileSizeChangesAtSameModificationDate() {
+        let path = "/Users/tester/.claude-work/.credentials.json"
+        let date = Date(timeIntervalSince1970: 100)
+        let before = ClaudeCredentialFingerprint.file(path: path, modificationDate: date, size: 40)
+        let after = ClaudeCredentialFingerprint.file(path: path, modificationDate: date, size: 41)
+
+        XCTAssertNotEqual(before, after)
+    }
+}

--- a/MeterBarTests/ClaudeOAuthAccessCoordinatorTests.swift
+++ b/MeterBarTests/ClaudeOAuthAccessCoordinatorTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import MeterBar
+
+final class ClaudeOAuthAccessCoordinatorTests: XCTestCase {
+    private let account = ClaudeCodeAccount(
+        id: UUID(),
+        name: "Work",
+        configDirectory: "/Users/tester/.claude-work"
+    )
+
+    func testValidCredentialSkipsDelegatedRefresh() async {
+        let refresh = RefreshCallRecorder(result: .hardFailure)
+
+        let result = await ClaudeOAuthAccessCoordinator.resolve(
+            initialAccess: .valid(token: "current"),
+            account: account,
+            trigger: .background,
+            refresh: { account, trigger in await refresh.run(account: account, trigger: trigger) },
+            reread: { .missing }
+        )
+
+        XCTAssertEqual(result, .token("current"))
+        let callCount = await refresh.callCount
+        XCTAssertEqual(callCount, 0)
+    }
+
+    func testMissingCredentialPreservesCLIFallbackWithoutSpawningStatus() async {
+        let refresh = RefreshCallRecorder(result: .hardFailure)
+
+        let result = await ClaudeOAuthAccessCoordinator.resolve(
+            initialAccess: .missing,
+            account: account,
+            trigger: .background,
+            refresh: { account, trigger in await refresh.run(account: account, trigger: trigger) },
+            reread: { .valid(token: "unexpected") }
+        )
+
+        XCTAssertEqual(result, .missing)
+        let callCount = await refresh.callCount
+        XCTAssertEqual(callCount, 0)
+    }
+
+    func testExpiredCredentialRefreshesAndRereadsTokenOnce() async {
+        let refresh = RefreshCallRecorder(result: .refreshed)
+        let reread = AccessSequence([.valid(token: "rotated")])
+
+        let result = await ClaudeOAuthAccessCoordinator.resolve(
+            initialAccess: .expired,
+            account: account,
+            trigger: .userInitiated,
+            refresh: { account, trigger in await refresh.run(account: account, trigger: trigger) },
+            reread: { await reread.next() }
+        )
+
+        XCTAssertEqual(result, .token("rotated"))
+        let callCount = await refresh.callCount
+        let observedTrigger = await refresh.observedTrigger
+        let rereadCount = await reread.callCount
+        XCTAssertEqual(callCount, 1)
+        XCTAssertEqual(observedTrigger, .userInitiated)
+        XCTAssertEqual(rereadCount, 1)
+    }
+
+    func testChangedFingerprintWithoutAUsableTokenIsRefreshFailure() async {
+        let refresh = RefreshCallRecorder(result: .refreshed)
+
+        let result = await ClaudeOAuthAccessCoordinator.resolve(
+            initialAccess: .expired,
+            account: account,
+            trigger: .background,
+            refresh: { account, trigger in await refresh.run(account: account, trigger: trigger) },
+            reread: { .expired }
+        )
+
+        XCTAssertEqual(result, .refreshFailed(.refreshed))
+    }
+
+    func testInconclusiveRefreshDoesNotRereadCredential() async {
+        let refresh = RefreshCallRecorder(result: .inconclusive)
+        let reread = AccessSequence([.valid(token: "unexpected")])
+
+        let result = await ClaudeOAuthAccessCoordinator.resolve(
+            initialAccess: .expired,
+            account: account,
+            trigger: .background,
+            refresh: { account, trigger in await refresh.run(account: account, trigger: trigger) },
+            reread: { await reread.next() }
+        )
+
+        XCTAssertEqual(result, .refreshFailed(.inconclusive))
+        let rereadCount = await reread.callCount
+        XCTAssertEqual(rereadCount, 0)
+    }
+
+    func testHardFailureBecomesRefreshFailure() async {
+        let refresh = RefreshCallRecorder(result: .hardFailure)
+
+        let result = await ClaudeOAuthAccessCoordinator.resolve(
+            initialAccess: .expired,
+            account: account,
+            trigger: .background,
+            refresh: { account, trigger in await refresh.run(account: account, trigger: trigger) },
+            reread: { .valid(token: "unexpected") }
+        )
+
+        XCTAssertEqual(result, .refreshFailed(.hardFailure))
+    }
+}
+
+private actor RefreshCallRecorder {
+    private(set) var callCount = 0
+    private(set) var observedTrigger: ClaudeTokenRefreshTrigger?
+    private let result: ClaudeTokenRefreshResult
+
+    init(result: ClaudeTokenRefreshResult) {
+        self.result = result
+    }
+
+    func run(
+        account: ClaudeCodeAccount,
+        trigger: ClaudeTokenRefreshTrigger
+    ) -> ClaudeTokenRefreshResult {
+        _ = account
+        callCount += 1
+        observedTrigger = trigger
+        return result
+    }
+}
+
+private actor AccessSequence {
+    private(set) var callCount = 0
+    private var values: [ClaudeOAuthCredentialAccess]
+
+    init(_ values: [ClaudeOAuthCredentialAccess]) {
+        self.values = values
+    }
+
+    func next() -> ClaudeOAuthCredentialAccess {
+        callCount += 1
+        guard !values.isEmpty else { return .missing }
+        return values.removeFirst()
+    }
+}

--- a/MeterBarTests/ClaudeRefreshPolicyTests.swift
+++ b/MeterBarTests/ClaudeRefreshPolicyTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import MeterBar
+
+final class ClaudeRefreshPolicyTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 10_000)
+
+    func testBackgroundAttemptIsAllowedWithoutARecord() {
+        XCTAssertEqual(
+            ClaudeRefreshPolicy.decision(record: nil, trigger: .background, now: now),
+            .attempt
+        )
+    }
+
+    func testInconclusiveOutcomeUsesShortCooldown() {
+        let record = ClaudeRefreshCooldownRecord(
+            outcome: .inconclusive,
+            completedAt: now
+        )
+
+        XCTAssertEqual(
+            ClaudeRefreshPolicy.decision(
+                record: record,
+                trigger: .background,
+                now: now.addingTimeInterval(19)
+            ),
+            .cooldown(until: now.addingTimeInterval(20))
+        )
+        XCTAssertEqual(
+            ClaudeRefreshPolicy.decision(
+                record: record,
+                trigger: .background,
+                now: now.addingTimeInterval(20)
+            ),
+            .attempt
+        )
+    }
+
+    func testSuccessUsesLongCooldown() {
+        let record = ClaudeRefreshCooldownRecord(
+            outcome: .refreshed,
+            completedAt: now
+        )
+
+        XCTAssertEqual(
+            ClaudeRefreshPolicy.decision(
+                record: record,
+                trigger: .background,
+                now: now.addingTimeInterval(299)
+            ),
+            .cooldown(until: now.addingTimeInterval(300))
+        )
+    }
+
+    func testHardFailureUsesLongCooldown() {
+        let record = ClaudeRefreshCooldownRecord(
+            outcome: .hardFailure,
+            completedAt: now
+        )
+
+        XCTAssertEqual(
+            ClaudeRefreshPolicy.decision(
+                record: record,
+                trigger: .background,
+                now: now.addingTimeInterval(299)
+            ),
+            .cooldown(until: now.addingTimeInterval(300))
+        )
+    }
+
+    func testUserInitiatedAttemptBypassesActiveCooldown() {
+        for outcome in ClaudeTokenRefreshOutcome.allCases {
+            let record = ClaudeRefreshCooldownRecord(outcome: outcome, completedAt: now)
+
+            XCTAssertEqual(
+                ClaudeRefreshPolicy.decision(
+                    record: record,
+                    trigger: .userInitiated,
+                    now: now.addingTimeInterval(1)
+                ),
+                .attempt
+            )
+        }
+    }
+
+    func testFutureCompletionDateDoesNotDisableRefreshForever() {
+        let future = now.addingTimeInterval(60 * 60)
+        let record = ClaudeRefreshCooldownRecord(outcome: .hardFailure, completedAt: future)
+
+        XCTAssertEqual(
+            ClaudeRefreshPolicy.decision(record: record, trigger: .background, now: now),
+            .attempt
+        )
+    }
+
+    func testCooldownStorePersistsRecordsByAccount() throws {
+        let suite = "ClaudeRefreshPolicyTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        addTeardownBlock { defaults.removePersistentDomain(forName: suite) }
+        let firstAccount = UUID()
+        let secondAccount = UUID()
+
+        let writer = ClaudeRefreshCooldownStore(userDefaults: defaults)
+        writer.record(.refreshed, for: firstAccount, at: now)
+        writer.record(.inconclusive, for: secondAccount, at: now.addingTimeInterval(1))
+
+        let reader = ClaudeRefreshCooldownStore(userDefaults: defaults)
+        XCTAssertEqual(
+            reader.record(for: firstAccount),
+            ClaudeRefreshCooldownRecord(outcome: .refreshed, completedAt: now)
+        )
+        XCTAssertEqual(
+            reader.record(for: secondAccount),
+            ClaudeRefreshCooldownRecord(
+                outcome: .inconclusive,
+                completedAt: now.addingTimeInterval(1)
+            )
+        )
+    }
+}

--- a/MeterBarTests/ClaudeTokenRefresherTests.swift
+++ b/MeterBarTests/ClaudeTokenRefresherTests.swift
@@ -1,0 +1,280 @@
+import XCTest
+@testable import MeterBar
+
+final class ClaudeTokenRefresherTests: XCTestCase {
+    private let account = ClaudeCodeAccount(
+        id: UUID(),
+        name: "Work",
+        configDirectory: "/Users/tester/.claude-work"
+    )
+    private let now = Date(timeIntervalSince1970: 20_000)
+
+    func testFingerprintChangeIsRequiredForSuccessfulRefresh() async throws {
+        let before = keychainFingerprint(at: 100)
+        let after = keychainFingerprint(at: 101)
+        let fingerprints = LockedFingerprintSequence([before, after])
+        let spawn = SpawnRecorder(result: .succeeded)
+        let store = try makeStore()
+        let refresher = makeRefresher(
+            store: store,
+            fingerprints: fingerprints,
+            spawn: spawn
+        )
+
+        let result = await refresher.refresh(account: account, trigger: .background)
+
+        XCTAssertEqual(result, .refreshed)
+        XCTAssertEqual(spawn.callCount, 1)
+        XCTAssertEqual(
+            store.record(for: account.id),
+            ClaudeRefreshCooldownRecord(outcome: .refreshed, completedAt: now)
+        )
+
+        let unchangedFingerprints = LockedFingerprintSequence([before, before])
+        let unchangedSpawn = SpawnRecorder(result: .succeeded)
+        let unchangedStore = try makeStore()
+        let unchangedRefresher = makeRefresher(
+            store: unchangedStore,
+            fingerprints: unchangedFingerprints,
+            spawn: unchangedSpawn
+        )
+
+        let unchangedResult = await unchangedRefresher.refresh(
+            account: account,
+            trigger: .background
+        )
+
+        XCTAssertEqual(unchangedResult, .inconclusive)
+        XCTAssertEqual(
+            unchangedStore.record(for: account.id),
+            ClaudeRefreshCooldownRecord(outcome: .inconclusive, completedAt: now)
+        )
+    }
+
+    func testNewFingerprintAfterMissingCredentialCountsAsRefreshed() async throws {
+        let fingerprints = LockedFingerprintSequence([nil, keychainFingerprint(at: 100)])
+        let spawn = SpawnRecorder(result: .succeeded)
+        let refresher = makeRefresher(
+            store: try makeStore(),
+            fingerprints: fingerprints,
+            spawn: spawn
+        )
+
+        let result = await refresher.refresh(account: account, trigger: .background)
+
+        XCTAssertEqual(result, .refreshed)
+    }
+
+    func testCredentialDisappearanceDoesNotCountAsRefreshed() async throws {
+        let fingerprints = LockedFingerprintSequence([keychainFingerprint(at: 100), nil])
+        let spawn = SpawnRecorder(result: .succeeded)
+        let refresher = makeRefresher(
+            store: try makeStore(),
+            fingerprints: fingerprints,
+            spawn: spawn
+        )
+
+        let result = await refresher.refresh(account: account, trigger: .background)
+
+        XCTAssertEqual(result, .inconclusive)
+    }
+
+    func testProcessFailureIsHardFailureWithoutPolling() async throws {
+        let fingerprints = LockedFingerprintSequence([keychainFingerprint(at: 100)])
+        let spawn = SpawnRecorder(result: .failed)
+        let store = try makeStore()
+        let refresher = makeRefresher(
+            store: store,
+            fingerprints: fingerprints,
+            spawn: spawn
+        )
+
+        let result = await refresher.refresh(account: account, trigger: .background)
+
+        XCTAssertEqual(result, .hardFailure)
+        XCTAssertEqual(fingerprints.callCount, 1)
+        XCTAssertEqual(
+            store.record(for: account.id),
+            ClaudeRefreshCooldownRecord(outcome: .hardFailure, completedAt: now)
+        )
+    }
+
+    func testBackgroundRequestRespectsPersistedCooldown() async throws {
+        let store = try makeStore()
+        store.record(.inconclusive, for: account.id, at: now.addingTimeInterval(-10))
+        let spawn = SpawnRecorder(result: .succeeded)
+        let refresher = makeRefresher(
+            store: store,
+            fingerprints: LockedFingerprintSequence([]),
+            spawn: spawn
+        )
+
+        let result = await refresher.refresh(account: account, trigger: .background)
+
+        XCTAssertEqual(
+            result,
+            .cooldown(
+                until: now.addingTimeInterval(10),
+                previousOutcome: .inconclusive
+            )
+        )
+        XCTAssertEqual(spawn.callCount, 0)
+    }
+
+    func testUserInitiatedRequestBypassesPersistedCooldown() async throws {
+        let store = try makeStore()
+        store.record(.hardFailure, for: account.id, at: now.addingTimeInterval(-10))
+        let before = keychainFingerprint(at: 100)
+        let after = keychainFingerprint(at: 101)
+        let spawn = SpawnRecorder(result: .succeeded)
+        let refresher = makeRefresher(
+            store: store,
+            fingerprints: LockedFingerprintSequence([before, after]),
+            spawn: spawn
+        )
+
+        let result = await refresher.refresh(account: account, trigger: .userInitiated)
+
+        XCTAssertEqual(result, .refreshed)
+        XCTAssertEqual(spawn.callCount, 1)
+    }
+
+    func testConcurrentRequestsForSameAccountCoalesceToOneSpawn() async throws {
+        let fingerprint = keychainFingerprint(at: 100)
+        let gate = SpawnGate()
+        let store = try makeStore()
+        let refresher = ClaudeTokenRefresher(
+            cooldownStore: store,
+            fingerprint: { _ in fingerprint },
+            runStatus: { _ in await gate.run() },
+            sleep: { _ in },
+            pollDelays: [0],
+            now: { self.now }
+        )
+
+        let first = Task {
+            await refresher.refresh(account: account, trigger: .background)
+        }
+        await gate.waitUntilStarted()
+        let second = Task {
+            await refresher.refresh(account: account, trigger: .userInitiated)
+        }
+        await gate.release()
+
+        let firstResult = await first.value
+        let secondResult = await second.value
+        XCTAssertEqual(firstResult, .inconclusive)
+        XCTAssertEqual(secondResult, .inconclusive)
+        let callCount = await gate.callCount
+        XCTAssertEqual(callCount, 1)
+    }
+
+    private func makeRefresher(
+        store: ClaudeRefreshCooldownStore,
+        fingerprints: LockedFingerprintSequence,
+        spawn: SpawnRecorder
+    ) -> ClaudeTokenRefresher {
+        ClaudeTokenRefresher(
+            cooldownStore: store,
+            fingerprint: { _ in fingerprints.next() },
+            runStatus: { _ in spawn.run() },
+            sleep: { _ in },
+            pollDelays: [0],
+            now: { self.now }
+        )
+    }
+
+    private func makeStore() throws -> ClaudeRefreshCooldownStore {
+        let suite = "ClaudeTokenRefresherTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        addTeardownBlock { defaults.removePersistentDomain(forName: suite) }
+        return ClaudeRefreshCooldownStore(userDefaults: defaults)
+    }
+
+    private func keychainFingerprint(at timestamp: TimeInterval) -> ClaudeCredentialFingerprint {
+        .keychain(
+            service: "Claude Code-credentials-c4394a73",
+            modificationDate: Date(timeIntervalSince1970: timestamp)
+        )
+    }
+}
+
+nonisolated private final class LockedFingerprintSequence: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [ClaudeCredentialFingerprint?]
+    private var calls = 0
+
+    init(_ values: [ClaudeCredentialFingerprint?]) {
+        self.values = values
+    }
+
+    var callCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return calls
+    }
+
+    func next() -> ClaudeCredentialFingerprint? {
+        lock.lock()
+        defer { lock.unlock() }
+        calls += 1
+        guard !values.isEmpty else { return nil }
+        return values.removeFirst()
+    }
+}
+
+nonisolated private final class SpawnRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private let result: ClaudeStatusRunResult
+    private var calls = 0
+
+    init(result: ClaudeStatusRunResult) {
+        self.result = result
+    }
+
+    var callCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return calls
+    }
+
+    func run() -> ClaudeStatusRunResult {
+        lock.lock()
+        defer { lock.unlock() }
+        calls += 1
+        return result
+    }
+}
+
+private actor SpawnGate {
+    private(set) var callCount = 0
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var released = false
+
+    func run() async -> ClaudeStatusRunResult {
+        callCount += 1
+        if released {
+            return .succeeded
+        }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+        return .succeeded
+    }
+
+    func waitUntilStarted() async {
+        while callCount == 0 {
+            await Task.yield()
+        }
+    }
+
+    func release() {
+        if let continuation {
+            continuation.resume()
+            self.continuation = nil
+        } else {
+            released = true
+        }
+    }
+}

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -46,6 +46,7 @@ final class UsageDataManagerTests: XCTestCase {
         var accountAuthStates: [UUID: ClaudeCodeAuthState] = [:]
         var probe: ConcurrencyProbe?
         private(set) var fetchCount = 0
+        private(set) var refreshTriggers: [ClaudeTokenRefreshTrigger] = []
 
         init(hasAccess: Bool, result: Result<UsageMetrics, Error>) {
             self.hasAccess = hasAccess
@@ -53,7 +54,15 @@ final class UsageDataManagerTests: XCTestCase {
         }
 
         func fetchUsageMetrics(account: ClaudeCodeAccount) async throws -> UsageMetrics {
+            try await fetchUsageMetrics(account: account, trigger: .background)
+        }
+
+        func fetchUsageMetrics(
+            account: ClaudeCodeAccount,
+            trigger: ClaudeTokenRefreshTrigger
+        ) async throws -> UsageMetrics {
             fetchCount += 1
+            refreshTriggers.append(trigger)
             await probe?.recordFetch()
             return try (resultsByAccount[account.id] ?? result).get()
         }
@@ -308,6 +317,35 @@ final class UsageDataManagerTests: XCTestCase {
         XCTAssertEqual(manager.metrics[.claudeCode]?.sessionLimit?.used, 7)
         sharedStore.flushPendingWrites()
         XCTAssertEqual(sharedStore.loadMetrics()[.claudeCode]?.sessionLimit?.used, 7)
+    }
+
+    func testRefreshAllThreadsRefreshTriggerToEveryClaudeAccount() async throws {
+        let accountSuite = "UsageDataManagerTests-claude-trigger-\(UUID().uuidString)"
+        createdSuiteNames.append(accountSuite)
+        let accountDefaults = try XCTUnwrap(UserDefaults(suiteName: accountSuite))
+        let accountStore = ClaudeCodeAccountStore(userDefaults: accountDefaults)
+        accountStore.addAccount(name: "Secondary", configDirectory: "/tmp/secondary-claude")
+        let claude = StubClaudeProvider(
+            hasAccess: true,
+            result: .success(MetricsFixtures.claudeCode())
+        )
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+        let (manager, _) = makeManager(
+            codex: codex,
+            cursor: cursor,
+            claude: claude,
+            claudeCodeAccountStore: accountStore,
+            hidden: [.codexCli, .cursor, .openRouter, .grok]
+        )
+
+        await manager.refreshAll(trigger: .background)
+        await manager.refreshAll(trigger: .userInitiated)
+
+        XCTAssertEqual(
+            claude.refreshTriggers,
+            [.background, .background, .userInitiated, .userInitiated]
+        )
     }
 
     func testClaudeRefreshAlsoRefreshesFableSessionsForEnabledProfiles() async throws {
@@ -737,7 +775,7 @@ final class UsageDataManagerTests: XCTestCase {
         }
         guard cursor.fetchCount == 1, manager.isLoading else {
             cursor.resumeFetch()
-            await firstRefresh.value
+            _ = await firstRefresh.value
             return XCTFail("the first refresh should be suspended inside the provider fetch")
         }
 
@@ -745,7 +783,7 @@ final class UsageDataManagerTests: XCTestCase {
 
         XCTAssertEqual(cursor.fetchCount, 1)
         cursor.resumeFetch()
-        await firstRefresh.value
+        _ = await firstRefresh.value
         XCTAssertFalse(manager.isLoading)
     }
 
@@ -780,7 +818,7 @@ final class UsageDataManagerTests: XCTestCase {
         }
         guard cursor.fetchCount == 1, manager.isLoading else {
             cursor.resumeFetch()
-            await firstRefresh.value
+            _ = await firstRefresh.value
             return XCTFail("the first refresh should be suspended inside the provider fetch")
         }
 
@@ -789,7 +827,7 @@ final class UsageDataManagerTests: XCTestCase {
         XCTAssertEqual(manager.refreshGeneration, 0)
 
         cursor.resumeFetch()
-        await firstRefresh.value
+        _ = await firstRefresh.value
         XCTAssertEqual(manager.refreshGeneration, 1)
     }
 


### PR DESCRIPTION
## Summary

Implements phase 3 of #292 after the merged phases 1–2 from #293:

- fingerprints each account's scoped Keychain item or credential-file metadata without reading token bytes
- delegates expired-token rotation to `claude /status` with the account's `CLAUDE_CONFIG_DIR`
- accepts refresh success only when the scoped credential fingerprint changes
- coalesces concurrent same-account attempts and persists per-account outcome cooldowns
- lets user-initiated refresh bypass stored background cooldowns while still joining active work
- re-reads the credential exactly once after verified rotation; unverified refresh publishes `needsLogin`
- threads background versus user-initiated intent through launch, timer, wake, UI, and CLI refresh paths

Missing credentials retain the existing CLI fallback. The OAuth opt-out remains
intact. No process output or token-derived material is logged or persisted.

## Validation

- focused phase 1–3/auth suites: 74 tests, 0 failures
- post-review focused run: 48 tests, 0 failures
- SwiftLint: clean
- unsigned Debug app build: succeeded (existing warnings only)
- full `swift test`: 1,465 tests, 1 skipped, 23 assertion failures across exactly the same 12 pre-existing cases as the 1,437-test baseline; this branch adds 28 passing tests

## Known constraints

The pipe-versus-PTY experiment was inconclusive because its sandboxed launch
could not reach the profile's Keychain credential. A pipe-backed `/status`
exited zero without changing credential metadata, so this implementation
correctly classifies that shape as inconclusive. `ClaudeStatusRunner` isolates
the process boundary for a future PTY substitution if a real near-expiry
credential proves it necessary.

The authenticated genfeed.ai Opus verifier returned PASS on exact head
`9403b43447d5af7923e30c71715e2dc7115a7eed` with advisory notes only. The
required CI matrix is green on that same head.

Phase 4 Keychain prompt hygiene is intentionally out of scope.
