### PR TITLE
feat: harden Claude Keychain prompt behavior

### DIFF
--- a/.agents/SESSIONS/2026-07-26.md
+++ b/.agents/SESSIONS/2026-07-26.md
@@ -635,3 +635,87 @@ affect policy or OAuth orchestration.
   `ClaudeStatusRunner`.
 - Track the four master-side Grok `refreshAll` failures independently from
   #292; phase 3 deliberately does not repair or reclassify them.
+
+## Session 9: Keychain prompt hygiene (#292 phase 4)
+
+### Problem
+
+The profile-aware credential resolver still issued ordinary Keychain queries
+from background refresh, readiness inspection, fingerprint polling, and app
+startup. If macOS required ACL interaction, an automatic refresh could raise a
+blocking authorization dialog for each configured account. Treating a
+sandboxed Keychain denial as a missing credential also produced a false logout
+signal even though the genfeed.ai Claude account was connected.
+
+### Change
+
+- Added a fail-safe Keychain access mode derived from refresh intent:
+  background reads install both an `LAContext` with interaction disabled and
+  the explicit Security-framework no-UI policy; only menu-open and explicit
+  refresh paths request interactive access.
+- Added secret-free Keychain outcomes that preserve `notFound`,
+  `interactionRequired`, user denial, and other `OSStatus` failures instead of
+  collapsing every result into `nil`.
+- Added a persistent six-hour denial cooldown keyed by Claude's Keychain
+  service name. Automatic reads skip only the cooling service and continue to
+  the account's file fallback; an explicit user refresh bypasses the cooldown.
+- Limited an interactive candidate walk to one prompt opportunity. If the
+  canonical suffixed item is denied, the legacy bare-item probe is forced into
+  no-UI mode. The post-delegated-refresh credential reread is also no-UI, so one
+  click cannot prompt twice for an account.
+- Applied the same no-UI/cooldown policy to metadata-only fingerprint reads.
+- Added defense in depth at both credential stores: disabling OAuth usage
+  performs zero Claude Keychain queries, while retaining the existing
+  credentials-file fallback.
+- Propagated an inaccessible Keychain item as `unavailable`, not `missing`,
+  through the OAuth coordinator and CLI fallback. A sandbox/ACL failure can no
+  longer become `oauthUnauthenticated` or turn a CLI parse failure into a false
+  `needsLogin` state.
+- Changed the Claude Settings refresh button to enter the existing
+  user-initiated refresh pipeline directly, allowing that explicit action to
+  retry a denied ACL without making passive settings checks interactive.
+- Added 22 focused resolver, fingerprint, prompt-policy, and unavailable-state
+  regressions with injected Keychain backends and isolated UserDefaults suites.
+  No test touches a real Keychain or Claude process.
+
+### Key decisions
+
+| Decision | Rationale |
+|---|---|
+| Six-hour cooldown | Matches current CodexBar prompt-suppression prior art while avoiding a permanent denial state |
+| Both `LAContext.interactionNotAllowed` and explicit UI-fail policy | Defense in depth across Security-framework behavior and OS versions; background access must fail closed |
+| Cooldown key is the service name | The ACL belongs to the Keychain item, not the MeterBar account UUID; canonical suffixed and bare candidates must remain independently suppressible |
+| Explicit refresh bypasses cooldown | The user has supplied fresh intent, so retrying is correct; automatic refresh remains suppressed |
+| File fallback survives OAuth opt-out | The contract is zero Keychain access. Keeping the non-Keychain candidate available preserves the resolver's established fallback behavior |
+| Sandboxed denial is not logout evidence | The authenticated genfeed.ai session was verified outside the sandbox; inability to reach its Keychain item is an execution-environment limitation |
+
+### Verification
+
+- Planning: authenticated `fable` at high effort returned `READY`; its bounded
+  plan supplied the no-UI/status-preservation/candidate-budget structure.
+- TDD red: the new suites initially failed to compile because the access mode,
+  status outcome, denial store, and injected APIs did not exist.
+- Focused Keychain/OAuth suites: 57 tests, 0 failures outside the filesystem
+  sandbox, including both `LAContext.interactionNotAllowed` query assertions.
+- Delegated-refresh suite: 7 tests, 0 failures. The sandboxed command emitted
+  SwiftPM cache errors before execution but every selected test passed.
+- Phase 1–4 Claude regression suites: 64 tests, 0 test failures across the two
+  complementary focused runs.
+- `swiftlint lint --quiet MeterBar MeterBarTests`: clean.
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar
+  CODE_SIGNING_ALLOWED=NO build`: succeeded.
+- Full `swift test`: 1,493 tests, 1 skipped, 24 assertion failures across
+  exactly the documented 12 pre-existing test cases. The known case set is
+  unchanged: one readiness case, one Session Wake agent case, four Session Wake
+  controller cases, two wake-refresh manager cases, and four Grok `refreshAll`
+  regression cases. The assertion count is one higher than the previous run
+  because the existing sandbox-sensitive Session Wake case reached an
+  additional assertion; no new test case failed.
+
+### Follow-ups
+
+- Phase 4 completes the implementation scope currently described by #292.
+- Keep the separate master-side Grok `refreshAll` regression out of this epic.
+- A future macOS-only integration harness could exercise a disposable
+  access-controlled Keychain item, but unit and build verification deliberately
+  avoid real authorization dialogs.

--- a/.agents/SESSIONS/2026-07-26.md
+++ b/.agents/SESSIONS/2026-07-26.md
@@ -671,10 +671,19 @@ signal even though the genfeed.ai Claude account was connected.
   through the OAuth coordinator and CLI fallback. A sandbox/ACL failure can no
   longer become `oauthUnauthenticated` or turn a CLI parse failure into a false
   `needsLogin` state.
+- Preserved that same `unavailable` state when the no-UI credential reread
+  after delegated refresh encounters a new ACL, instead of collapsing it into
+  refresh failure and publishing `needsLogin`.
+- Made `refreshAll` background by default. Popover opens, account mutations,
+  and visibility changes therefore remain no-UI; only actual refresh buttons
+  and the explicit refresh CLI pass `userInitiated`.
+- Kept payload-denial cooldowns independent from metadata-only fingerprint
+  success, and made malformed interactive results consume the prompt budget so
+  a later candidate cannot raise a second dialog.
 - Changed the Claude Settings refresh button to enter the existing
   user-initiated refresh pipeline directly, allowing that explicit action to
   retry a denied ACL without making passive settings checks interactive.
-- Added 22 focused resolver, fingerprint, prompt-policy, and unavailable-state
+- Added 26 focused resolver, fingerprint, prompt-policy, trigger-routing, and unavailable-state
   regressions with injected Keychain backends and isolated UserDefaults suites.
   No test touches a real Keychain or Claude process.
 
@@ -695,16 +704,21 @@ signal even though the genfeed.ai Claude account was connected.
   plan supplied the no-UI/status-preservation/candidate-budget structure.
 - TDD red: the new suites initially failed to compile because the access mode,
   status outcome, denial store, and injected APIs did not exist.
-- Focused Keychain/OAuth suites: 57 tests, 0 failures outside the filesystem
+- The first exact-head authenticated `opus` review correctly failed commit
+  `37fc42d` on two blockers: the post-refresh unavailable reread still became
+  `needsLogin`, and bare `refreshAll()` calls defaulted to interactive access.
+  Four repair regressions were added first and all four failed before the fix.
+- Focused Keychain/OAuth suites: 60 tests, 0 failures outside the filesystem
   sandbox, including both `LAContext.interactionNotAllowed` query assertions.
 - Delegated-refresh suite: 7 tests, 0 failures. The sandboxed command emitted
   SwiftPM cache errors before execution but every selected test passed.
-- Phase 1–4 Claude regression suites: 64 tests, 0 test failures across the two
-  complementary focused runs.
+- Default-trigger orchestration regression: 1 test, 0 failures.
+- Phase 1–4 Claude/trigger regression group: 68 tests, 0 test failures across
+  the complementary focused runs.
 - `swiftlint lint --quiet MeterBar MeterBarTests`: clean.
 - `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar
   CODE_SIGNING_ALLOWED=NO build`: succeeded.
-- Full `swift test`: 1,493 tests, 1 skipped, 24 assertion failures across
+- Full `swift test`: 1,497 tests, 1 skipped, 24 assertion failures across
   exactly the documented 12 pre-existing test cases. The known case set is
   unchanged: one readiness case, one Session Wake agent case, four Session Wake
   controller cases, two wake-refresh manager cases, and four Grok `refreshAll`

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -56,6 +56,9 @@ nonisolated enum StorageKeys {
     static let claudeCodeDefaultConfigDirectory = "ClaudeCodeDefaultConfigDirectory"
     /// Per-account delegated OAuth-refresh outcome and completion time.
     static let claudeCodeRefreshCooldowns = "ClaudeCodeRefreshCooldowns"
+    /// Per-Keychain-service timestamps used to suppress repeated background
+    /// authorization attempts. Contains no credential material.
+    static let claudeCodeKeychainDenials = "ClaudeCodeKeychainDenials"
     /// Whether the synthesized default Claude Code CLI profile participates in tracking.
     static let claudeCodeDefaultAccountEnabled = "ClaudeCodeDefaultAccountEnabled"
     /// Persisted account display order (array of UUID strings).

--- a/MeterBar/Services/ClaudeCodeLocalService.swift
+++ b/MeterBar/Services/ClaudeCodeLocalService.swift
@@ -3,6 +3,16 @@ import MeterBarShared
 import AppKit
 import Combine
 
+nonisolated private enum ClaudeStoredCredentials {
+    case value(ClaudeCodeCredentials)
+    case missing
+    case unavailable
+}
+
+nonisolated private enum ClaudeCredentialReadBarrier: Error {
+    case unavailable
+}
+
 class ClaudeCodeLocalService: ObservableObject {
     // nonisolated: lets nonisolated code such as the readiness inspector
     // reference the singleton (methods keep their own isolation).
@@ -52,26 +62,60 @@ class ClaudeCodeLocalService: ObservableObject {
     // MARK: - Keychain Access
 
     /// Get the OAuth token for `account` from Claude Code's credential storage.
-    /// `nonisolated`: a keychain read can raise a blocking approval dialog —
-    /// never call synchronously from the main actor.
-    nonisolated func getOAuthToken(for account: ClaudeCodeAccount = .defaultAccount) -> String? {
-        guard case let .valid(token) = oauthCredentialAccessUpdatingSharedState(for: account) else {
+    /// `nonisolated`: a Keychain read can block. The default is no-UI;
+    /// interactive mode is reserved for explicit user refresh actions.
+    nonisolated func getOAuthToken(
+        for account: ClaudeCodeAccount = .defaultAccount,
+        mode: ClaudeKeychainAccessMode = .background
+    ) -> String? {
+        guard case let .valid(token) = oauthCredentialAccessUpdatingSharedState(
+            for: account,
+            mode: mode
+        ) else {
             return nil
         }
         return token
     }
 
     nonisolated private func getCredentials(
-        for account: ClaudeCodeAccount = .defaultAccount
+        for account: ClaudeCodeAccount = .defaultAccount,
+        mode: ClaudeKeychainAccessMode = .background
     ) -> ClaudeCodeCredentials? {
-        guard let data = credentialsData(for: account) else { return nil }
-        return try? JSONDecoder().decode(ClaudeCodeCredentials.self, from: data)
+        guard case let .value(credentials) = storedCredentials(for: account, mode: mode) else {
+            return nil
+        }
+        return credentials
+    }
+
+    nonisolated private func storedCredentials(
+        for account: ClaudeCodeAccount,
+        mode: ClaudeKeychainAccessMode
+    ) -> ClaudeStoredCredentials {
+        switch credentialStore.credentialsDataResult(for: account, mode: mode) {
+        case let .value(data):
+            guard let credentials = try? JSONDecoder().decode(ClaudeCodeCredentials.self, from: data) else {
+                return .missing
+            }
+            return .value(credentials)
+        case .notFound:
+            return .missing
+        case .interactionRequired, .denied, .failure:
+            return .unavailable
+        }
     }
 
     nonisolated func oauthCredentialAccess(
-        for account: ClaudeCodeAccount = .defaultAccount
+        for account: ClaudeCodeAccount = .defaultAccount,
+        mode: ClaudeKeychainAccessMode = .background
     ) -> ClaudeOAuthCredentialAccess {
-        Self.oauthCredentialAccess(from: getCredentials(for: account))
+        switch storedCredentials(for: account, mode: mode) {
+        case let .value(credentials):
+            return Self.oauthCredentialAccess(from: credentials)
+        case .missing:
+            return .missing
+        case .unavailable:
+            return .unavailable
+        }
     }
 
     nonisolated static func oauthCredentialAccess(
@@ -87,9 +131,14 @@ class ClaudeCodeLocalService: ObservableObject {
     }
 
     nonisolated private func oauthCredentialAccessUpdatingSharedState(
-        for account: ClaudeCodeAccount
+        for account: ClaudeCodeAccount,
+        mode: ClaudeKeychainAccessMode = .background
     ) -> ClaudeOAuthCredentialAccess {
-        guard let credentials = getCredentials(for: account) else {
+        let stored = storedCredentials(for: account, mode: mode)
+        guard case let .value(credentials) = stored else {
+            if case .unavailable = stored {
+                return .unavailable
+            }
             return .missing
         }
         let access = Self.oauthCredentialAccess(from: credentials)
@@ -113,13 +162,16 @@ class ClaudeCodeLocalService: ObservableObject {
     /// Exposed for provider-readiness diagnostics, which pass the bytes to the
     /// pure readiness core (it reads only the expiry claim — never surfaces the
     /// token). `ClaudeCredentialStore` owns the per-profile candidate walk.
-    nonisolated func credentialsData(for account: ClaudeCodeAccount = .defaultAccount) -> Data? {
-        credentialStore.credentialsData(for: account)
+    nonisolated func credentialsData(
+        for account: ClaudeCodeAccount = .defaultAccount,
+        mode: ClaudeKeychainAccessMode = .background
+    ) -> Data? {
+        credentialStore.credentialsData(for: account, mode: mode)
     }
 
     /// Check and update access status.
-    /// `nonisolated`: file stats + (with the OAuth fallback) a keychain read —
-    /// call from a detached task.
+    /// `nonisolated`: file stats + (with the OAuth fallback) a no-UI Keychain
+    /// read — call from a detached task.
     nonisolated func checkAccess() {
         let newHasAccess: Bool
         let newAuthState: ClaudeCodeAuthState
@@ -173,8 +225,15 @@ class ClaudeCodeLocalService: ObservableObject {
             // thrown error means either delegated refresh could not verify a
             // rotated token or an OAuth request/decode failed — surface it
             // rather than retry the headless-broken CLI.
-            if let metrics = try await fetchUsageViaOAuth(account: account, trigger: trigger) {
-                return metrics
+            do {
+                if let metrics = try await fetchUsageViaOAuth(account: account, trigger: trigger) {
+                    return metrics
+                }
+            } catch is ClaudeCredentialReadBarrier {
+                // The credential may exist behind an ACL that background
+                // access cannot satisfy. Preserve the CLI fallback without
+                // converting its failure into a false "Login required".
+                return try await fetchUsageViaCLI(account: account, isLoggedOut: false)
             }
             // No credential for this profile. Remember that, so a downstream
             // CLI parse failure reports "Login required" instead of a vague
@@ -200,10 +259,11 @@ class ClaudeCodeLocalService: ObservableObject {
         // dialog, and the app target runs async bodies on the main actor).
         // The state-updating read also refreshes `subscriptionType`/`hasAccess`.
         let publishesSharedState = Self.publishesSharedConnectionState(for: account)
+        let keychainMode = ClaudeKeychainAccessMode(trigger: trigger)
         let initialAccess = await Task.detached(priority: .userInitiated) { [self] in
             publishesSharedState
-                ? oauthCredentialAccessUpdatingSharedState(for: account)
-                : oauthCredentialAccess(for: account)
+                ? oauthCredentialAccessUpdatingSharedState(for: account, mode: keychainMode)
+                : oauthCredentialAccess(for: account, mode: keychainMode)
         }.value
 
         let tokenRefresher = self.tokenRefresher
@@ -215,8 +275,11 @@ class ClaudeCodeLocalService: ObservableObject {
                 await tokenRefresher.refresh(account: account, trigger: trigger)
             },
             reread: {
+                // An explicit refresh gets one interactive candidate walk. The
+                // post-CLI reread is no-UI so a single action cannot prompt
+                // twice for the same account.
                 await Task.detached(priority: .userInitiated) { [self] in
-                    oauthCredentialAccess(for: account)
+                    oauthCredentialAccess(for: account, mode: .background)
                 }.value
             }
         )
@@ -227,6 +290,8 @@ class ClaudeCodeLocalService: ObservableObject {
             resolvedToken = token
         case .missing:
             return nil
+        case .unavailable:
+            throw ClaudeCredentialReadBarrier.unavailable
         case .refreshFailed:
             publishNeedsLogin(account: account, publishesSharedState: publishesSharedState)
             throw ServiceError.notAuthenticated

--- a/MeterBar/Services/ClaudeCredentialFingerprint.swift
+++ b/MeterBar/Services/ClaudeCredentialFingerprint.swift
@@ -14,21 +14,50 @@ nonisolated enum ClaudeCredentialFingerprint: Equatable, Sendable {
 /// Reads the first metadata fingerprint in the same candidate order as
 /// `ClaudeCredentialStore`.
 nonisolated struct ClaudeCredentialFingerprintStore: Sendable {
-    static let shared = ClaudeCredentialFingerprintStore()
-
-    private let readKeychain: @Sendable (String) -> ClaudeCredentialFingerprint?
-    private let readFile: @Sendable (String) -> ClaudeCredentialFingerprint?
-
-    init(
-        readKeychain: @escaping @Sendable (String) -> ClaudeCredentialFingerprint? = {
+    static let shared = ClaudeCredentialFingerprintStore(
+        readKeychainResult: {
             ClaudeCredentialFingerprintStore.keychainFingerprint(service: $0)
         },
-        readFile: @escaping @Sendable (String) -> ClaudeCredentialFingerprint? = {
-            ClaudeCredentialFingerprintStore.fileFingerprint(path: $0)
-        }
+        readFile: { ClaudeCredentialFingerprintStore.fileFingerprint(path: $0) },
+        denialStore: ClaudeKeychainDenialStore(),
+        isOAuthEnabled: { ClaudeCodeLocalService.isOAuthUsageEnabled() }
+    )
+
+    private let readKeychainResult:
+        @Sendable (String) -> ClaudeKeychainReadOutcome<ClaudeCredentialFingerprint>
+    private let readFile: @Sendable (String) -> ClaudeCredentialFingerprint?
+    private let denialStore: ClaudeKeychainDenialStore
+    private let isOAuthEnabled: @Sendable () -> Bool
+    private let now: @Sendable () -> Date
+
+    /// Compatibility initializer for pure candidate-order tests.
+    init(
+        readKeychain: @escaping @Sendable (String) -> ClaudeCredentialFingerprint?,
+        readFile: @escaping @Sendable (String) -> ClaudeCredentialFingerprint?
     ) {
-        self.readKeychain = readKeychain
+        self.readKeychainResult = {
+            readKeychain($0).map(ClaudeKeychainReadOutcome.value) ?? .notFound
+        }
         self.readFile = readFile
+        self.denialStore = ClaudeKeychainDenialStore()
+        self.isOAuthEnabled = { true }
+        self.now = { Date() }
+    }
+
+    init(
+        readKeychainResult: @escaping @Sendable (
+            String
+        ) -> ClaudeKeychainReadOutcome<ClaudeCredentialFingerprint>,
+        readFile: @escaping @Sendable (String) -> ClaudeCredentialFingerprint?,
+        denialStore: ClaudeKeychainDenialStore,
+        isOAuthEnabled: @escaping @Sendable () -> Bool,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.readKeychainResult = readKeychainResult
+        self.readFile = readFile
+        self.denialStore = denialStore
+        self.isOAuthEnabled = isOAuthEnabled
+        self.now = now
     }
 
     func fingerprint(
@@ -45,8 +74,24 @@ nonisolated struct ClaudeCredentialFingerprintStore: Sendable {
         for source in candidates {
             switch source {
             case let .keychain(service):
-                if let fingerprint = readKeychain(service) {
+                guard isOAuthEnabled() else { continue }
+                let decision = ClaudeKeychainPromptPolicy.decision(
+                    requestedMode: .background,
+                    deniedAt: denialStore.deniedAt(for: service),
+                    now: now()
+                )
+                guard case .query = decision else { continue }
+
+                switch readKeychainResult(service) {
+                case let .value(fingerprint):
+                    denialStore.clearDenial(for: service)
                     return fingerprint
+                case .notFound:
+                    denialStore.clearDenial(for: service)
+                case .interactionRequired, .denied:
+                    denialStore.recordDenial(for: service, at: now())
+                case .failure:
+                    break
                 }
             case let .file(path):
                 if let fingerprint = readFile(path) {
@@ -58,22 +103,32 @@ nonisolated struct ClaudeCredentialFingerprintStore: Sendable {
     }
 
     /// Reads Keychain attributes without requesting the secret payload.
-    static func keychainFingerprint(service: String) -> ClaudeCredentialFingerprint? {
-        let query: [String: Any] = [
+    static func keychainFingerprint(
+        service: String,
+        backend: KeychainBackend = SecItemKeychainBackend()
+    ) -> ClaudeKeychainReadOutcome<ClaudeCredentialFingerprint> {
+        let baseQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecReturnAttributes as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
+        let query = ClaudeKeychainQuery.applyingAccessMode(.background, to: baseQuery)
 
         var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess,
-              let attributes = result as? [String: Any],
-              let modificationDate = attributes[kSecAttrModificationDate as String] as? Date else {
-            return nil
+        let status = backend.copyMatching(query: query, result: &result)
+        let fingerprint: ClaudeCredentialFingerprint?
+        if let attributes = result as? [String: Any],
+           let modificationDate = attributes[kSecAttrModificationDate as String] as? Date {
+            fingerprint = .keychain(service: service, modificationDate: modificationDate)
+        } else {
+            fingerprint = nil
         }
-        return .keychain(service: service, modificationDate: modificationDate)
+        return ClaudeKeychainQuery.outcome(
+            status: status,
+            result: fingerprint,
+            mode: .background
+        )
     }
 
     static func fileFingerprint(path: String) -> ClaudeCredentialFingerprint? {

--- a/MeterBar/Services/ClaudeCredentialFingerprint.swift
+++ b/MeterBar/Services/ClaudeCredentialFingerprint.swift
@@ -84,10 +84,9 @@ nonisolated struct ClaudeCredentialFingerprintStore: Sendable {
 
                 switch readKeychainResult(service) {
                 case let .value(fingerprint):
-                    denialStore.clearDenial(for: service)
                     return fingerprint
                 case .notFound:
-                    denialStore.clearDenial(for: service)
+                    continue
                 case .interactionRequired, .denied:
                     denialStore.recordDenial(for: service, at: now())
                 case .failure:

--- a/MeterBar/Services/ClaudeCredentialResolver.swift
+++ b/MeterBar/Services/ClaudeCredentialResolver.swift
@@ -1,5 +1,6 @@
 import CryptoKit
 import Foundation
+import Security
 import MeterBarShared
 
 /// Where a Claude Code profile's OAuth credential can live, in the order it is
@@ -97,21 +98,59 @@ nonisolated enum ClaudeCredentialResolver {
 /// `nonisolated`: a Keychain read can raise a blocking approval dialog and a
 /// file read hits disk — neither belongs on the main actor.
 nonisolated struct ClaudeCredentialStore: Sendable {
-    static let shared = ClaudeCredentialStore()
+    private enum KeychainCandidateResult {
+        case value(Data)
+        case continueWalk(
+            outcome: ClaudeKeychainReadOutcome<Data>,
+            consumedInteractivePrompt: Bool
+        )
+    }
 
-    private let readKeychain: @Sendable (String) -> Data?
+    static let shared = ClaudeCredentialStore(
+        readKeychainResult: { service, mode in
+            ClaudeCredentialStore.keychainPayload(service: service, mode: mode)
+        },
+        readFile: { ClaudeCredentialStore.filePayload(path: $0) },
+        denialStore: ClaudeKeychainDenialStore(),
+        isOAuthEnabled: { ClaudeCodeLocalService.isOAuthUsageEnabled() }
+    )
+
+    private let readKeychainResult:
+        @Sendable (String, ClaudeKeychainAccessMode) -> ClaudeKeychainReadOutcome<Data>
     private let readFile: @Sendable (String) -> Data?
+    private let denialStore: ClaudeKeychainDenialStore
+    private let isOAuthEnabled: @Sendable () -> Bool
+    private let now: @Sendable () -> Date
+
+    /// Compatibility initializer for pure candidate-order tests.
+    init(
+        readKeychain: @escaping @Sendable (String) -> Data?,
+        readFile: @escaping @Sendable (String) -> Data?
+    ) {
+        self.readKeychainResult = { service, _ in
+            readKeychain(service).map(ClaudeKeychainReadOutcome.value) ?? .notFound
+        }
+        self.readFile = readFile
+        self.denialStore = ClaudeKeychainDenialStore()
+        self.isOAuthEnabled = { true }
+        self.now = { Date() }
+    }
 
     init(
-        readKeychain: @escaping @Sendable (String) -> Data? = {
-            ClaudeCredentialStore.keychainPayload(service: $0)
-        },
-        readFile: @escaping @Sendable (String) -> Data? = {
-            ClaudeCredentialStore.filePayload(path: $0)
-        }
+        readKeychainResult: @escaping @Sendable (
+            String,
+            ClaudeKeychainAccessMode
+        ) -> ClaudeKeychainReadOutcome<Data>,
+        readFile: @escaping @Sendable (String) -> Data?,
+        denialStore: ClaudeKeychainDenialStore,
+        isOAuthEnabled: @escaping @Sendable () -> Bool,
+        now: @escaping @Sendable () -> Date = { Date() }
     ) {
-        self.readKeychain = readKeychain
+        self.readKeychainResult = readKeychainResult
         self.readFile = readFile
+        self.denialStore = denialStore
+        self.isOAuthEnabled = isOAuthEnabled
+        self.now = now
     }
 
     /// The raw credentials JSON for `account`, or nil when no candidate holds
@@ -119,45 +158,147 @@ nonisolated struct ClaudeCredentialStore: Sendable {
     /// item must not shadow a working file fallback.
     func credentialsData(
         for account: ClaudeCodeAccount,
+        mode: ClaudeKeychainAccessMode = .background,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         realHomeDirectory: String = ServiceSupport.realHomeDirectory()
     ) -> Data? {
+        guard case let .value(data) = credentialsDataResult(
+            for: account,
+            mode: mode,
+            environment: environment,
+            realHomeDirectory: realHomeDirectory
+        ) else {
+            return nil
+        }
+        return data
+    }
+
+    /// Resolves the credential without erasing the difference between an
+    /// absent item and one that exists behind an unavailable authorization
+    /// interaction. Callers use that distinction to avoid false logout state.
+    func credentialsDataResult(
+        for account: ClaudeCodeAccount,
+        mode: ClaudeKeychainAccessMode = .background,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        realHomeDirectory: String = ServiceSupport.realHomeDirectory()
+    ) -> ClaudeKeychainReadOutcome<Data> {
         let candidates = ClaudeCredentialResolver.candidates(
             for: account,
             environment: environment,
             realHomeDirectory: realHomeDirectory
         )
 
+        var remainingKeychainMode = mode
+        var promptBudgetConsumed = false
+        var deferredOutcome: ClaudeKeychainReadOutcome<Data> = .notFound
+
         for source in candidates {
-            let payload: Data?
             switch source {
             case let .keychain(service):
-                payload = readKeychain(service)
+                guard isOAuthEnabled() else { continue }
+                switch resolveKeychainCandidate(
+                    service: service,
+                    mode: remainingKeychainMode
+                ) {
+                case let .value(payload):
+                    return .value(payload)
+                case let .continueWalk(outcome, consumedInteractivePrompt):
+                    deferredOutcome = Self.mergedOutcome(
+                        existing: deferredOutcome,
+                        candidate: outcome
+                    )
+                    promptBudgetConsumed = promptBudgetConsumed || consumedInteractivePrompt
+                    if mode == .interactive, promptBudgetConsumed {
+                        remainingKeychainMode = .background
+                    }
+                }
             case let .file(path):
-                payload = readFile(path)
-            }
-            if let payload, !payload.isEmpty {
-                return payload
+                if let payload = readFile(path), !payload.isEmpty {
+                    return .value(payload)
+                }
             }
         }
-        return nil
+        return deferredOutcome
     }
 
-    static func keychainPayload(service: String) -> Data? {
-        let query: [String: Any] = [
+    private func resolveKeychainCandidate(
+        service: String,
+        mode: ClaudeKeychainAccessMode
+    ) -> KeychainCandidateResult {
+        let decision = ClaudeKeychainPromptPolicy.decision(
+            requestedMode: mode,
+            deniedAt: denialStore.deniedAt(for: service),
+            now: now()
+        )
+        guard case let .query(queryMode) = decision else {
+            return .continueWalk(
+                outcome: .interactionRequired,
+                consumedInteractivePrompt: false
+            )
+        }
+
+        switch readKeychainResult(service, queryMode) {
+        case let .value(payload):
+            denialStore.clearDenial(for: service)
+            return payload.isEmpty
+                ? .continueWalk(outcome: .notFound, consumedInteractivePrompt: false)
+                : .value(payload)
+        case .notFound:
+            denialStore.clearDenial(for: service)
+            return .continueWalk(outcome: .notFound, consumedInteractivePrompt: false)
+        case .interactionRequired:
+            denialStore.recordDenial(for: service, at: now())
+            return .continueWalk(
+                outcome: .interactionRequired,
+                consumedInteractivePrompt: queryMode == .interactive
+            )
+        case .denied:
+            denialStore.recordDenial(for: service, at: now())
+            return .continueWalk(
+                outcome: .denied,
+                consumedInteractivePrompt: queryMode == .interactive
+            )
+        case let .failure(status):
+            return .continueWalk(
+                outcome: .failure(status),
+                consumedInteractivePrompt: false
+            )
+        }
+    }
+
+    private static func mergedOutcome(
+        existing: ClaudeKeychainReadOutcome<Data>,
+        candidate: ClaudeKeychainReadOutcome<Data>
+    ) -> ClaudeKeychainReadOutcome<Data> {
+        if case .denied = candidate {
+            return .denied
+        }
+        if case .notFound = existing {
+            return candidate
+        }
+        return existing
+    }
+
+    static func keychainPayload(
+        service: String,
+        mode: ClaudeKeychainAccessMode,
+        backend: KeychainBackend = SecItemKeychainBackend()
+    ) -> ClaudeKeychainReadOutcome<Data> {
+        let baseQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
+        let query = ClaudeKeychainQuery.applyingAccessMode(mode, to: baseQuery)
 
         var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-
-        guard status == errSecSuccess, let data = result as? Data else {
-            return nil
-        }
-        return data
+        let status = backend.copyMatching(query: query, result: &result)
+        return ClaudeKeychainQuery.outcome(
+            status: status,
+            result: result as? Data,
+            mode: mode
+        )
     }
 
     static func filePayload(path: String) -> Data? {

--- a/MeterBar/Services/ClaudeCredentialResolver.swift
+++ b/MeterBar/Services/ClaudeCredentialResolver.swift
@@ -241,7 +241,10 @@ nonisolated struct ClaudeCredentialStore: Sendable {
         case let .value(payload):
             denialStore.clearDenial(for: service)
             return payload.isEmpty
-                ? .continueWalk(outcome: .notFound, consumedInteractivePrompt: false)
+                ? .continueWalk(
+                    outcome: .notFound,
+                    consumedInteractivePrompt: queryMode == .interactive
+                )
                 : .value(payload)
         case .notFound:
             denialStore.clearDenial(for: service)
@@ -261,7 +264,7 @@ nonisolated struct ClaudeCredentialStore: Sendable {
         case let .failure(status):
             return .continueWalk(
                 outcome: .failure(status),
-                consumedInteractivePrompt: false
+                consumedInteractivePrompt: queryMode == .interactive
             )
         }
     }

--- a/MeterBar/Services/ClaudeKeychainAccess.swift
+++ b/MeterBar/Services/ClaudeKeychainAccess.swift
@@ -1,0 +1,144 @@
+import Foundation
+import LocalAuthentication
+import Security
+
+/// Whether a Claude credential read is allowed to involve the user.
+///
+/// Background is deliberately the default at every call site. Interactive
+/// access is reserved for an explicit refresh/menu action.
+nonisolated enum ClaudeKeychainAccessMode: Equatable, Sendable {
+    case background
+    case interactive
+
+    init(trigger: ClaudeTokenRefreshTrigger) {
+        self = trigger == .userInitiated ? .interactive : .background
+    }
+}
+
+nonisolated enum ClaudeKeychainPromptDecision: Equatable, Sendable {
+    case skipKeychain
+    case query(ClaudeKeychainAccessMode)
+}
+
+/// Pure policy for suppressing repeated background Keychain authorization
+/// attempts after macOS reports that interaction would be required.
+nonisolated enum ClaudeKeychainPromptPolicy {
+    static let denialCooldown: TimeInterval = 6 * 60 * 60
+
+    static func decision(
+        requestedMode: ClaudeKeychainAccessMode,
+        deniedAt: Date?,
+        now: Date
+    ) -> ClaudeKeychainPromptDecision {
+        if requestedMode == .interactive {
+            return .query(.interactive)
+        }
+        guard let deniedAt, deniedAt <= now else {
+            return .query(.background)
+        }
+        return now < deniedAt.addingTimeInterval(denialCooldown)
+            ? .skipKeychain
+            : .query(.background)
+    }
+}
+
+/// Secret-free result of a Keychain query. Keeping the Security status classes
+/// distinct lets the candidate walker suppress prompts without confusing an
+/// authorization barrier with a genuinely absent credential.
+nonisolated enum ClaudeKeychainReadOutcome<Value: Sendable>: Sendable {
+    case value(Value)
+    case notFound
+    case interactionRequired
+    case denied
+    case failure(OSStatus)
+}
+
+extension ClaudeKeychainReadOutcome: Equatable where Value: Equatable {}
+
+nonisolated enum ClaudeKeychainQuery {
+    static func applyingAccessMode(
+        _ mode: ClaudeKeychainAccessMode,
+        to query: [String: Any]
+    ) -> [String: Any] {
+        guard mode == .background else { return query }
+
+        var noUIQuery = query
+        let context = LAContext()
+        context.interactionNotAllowed = true
+        noUIQuery[kSecUseAuthenticationContext as String] = context
+        noUIQuery[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUIFail
+        return noUIQuery
+    }
+
+    static func outcome<Value: Sendable>(
+        status: OSStatus,
+        result: Value?,
+        mode: ClaudeKeychainAccessMode
+    ) -> ClaudeKeychainReadOutcome<Value> {
+        switch status {
+        case errSecSuccess:
+            return result.map(ClaudeKeychainReadOutcome.value) ?? .failure(errSecInternalError)
+        case errSecItemNotFound:
+            return .notFound
+        case errSecInteractionNotAllowed:
+            return .interactionRequired
+        case errSecUserCanceled:
+            return .denied
+        case errSecAuthFailed:
+            return mode == .background ? .interactionRequired : .denied
+        default:
+            return .failure(status)
+        }
+    }
+}
+
+/// Persisted, per-service suppression state. Only a Keychain service name and
+/// timestamp are stored; credential payloads never enter UserDefaults.
+nonisolated final class ClaudeKeychainDenialStore: @unchecked Sendable {
+    private let userDefaults: UserDefaults
+    private let lock = NSLock()
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    func deniedAt(for service: String) -> Date? {
+        lock.lock()
+        defer { lock.unlock() }
+        return records()[service]
+    }
+
+    func recordDenial(for service: String, at date: Date) {
+        lock.lock()
+        defer { lock.unlock() }
+        var updated = records()
+        updated[service] = date
+        persist(updated)
+    }
+
+    func clearDenial(for service: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        var updated = records()
+        updated.removeValue(forKey: service)
+        persist(updated)
+    }
+
+    private func records() -> [String: Date] {
+        guard let data = userDefaults.data(forKey: StorageKeys.claudeCodeKeychainDenials),
+              let decoded = try? JSONDecoder().decode([String: Date].self, from: data) else {
+            return [:]
+        }
+        return decoded
+    }
+
+    private func persist(_ records: [String: Date]) {
+        guard !records.isEmpty else {
+            userDefaults.removeObject(forKey: StorageKeys.claudeCodeKeychainDenials)
+            return
+        }
+        if let data = try? JSONEncoder().encode(records) {
+            userDefaults.set(data, forKey: StorageKeys.claudeCodeKeychainDenials)
+        }
+    }
+}

--- a/MeterBar/Services/ClaudeTokenRefresher.swift
+++ b/MeterBar/Services/ClaudeTokenRefresher.swift
@@ -110,6 +110,7 @@ nonisolated enum ClaudeTokenRefreshResult: Equatable, Sendable {
 
 nonisolated enum ClaudeOAuthCredentialAccess: Equatable, Sendable {
     case missing
+    case unavailable
     case expired
     case valid(token: String)
 }
@@ -117,6 +118,7 @@ nonisolated enum ClaudeOAuthCredentialAccess: Equatable, Sendable {
 nonisolated enum ClaudeOAuthAccessResolution: Equatable, Sendable {
     case token(String)
     case missing
+    case unavailable
     case refreshFailed(ClaudeTokenRefreshResult)
 }
 
@@ -143,6 +145,8 @@ nonisolated enum ClaudeOAuthAccessCoordinator {
             return .token(token)
         case .missing:
             return .missing
+        case .unavailable:
+            return .unavailable
         case .expired:
             let result = await refresh(account, trigger)
             guard result.didRefresh else {

--- a/MeterBar/Services/ClaudeTokenRefresher.swift
+++ b/MeterBar/Services/ClaudeTokenRefresher.swift
@@ -152,10 +152,14 @@ nonisolated enum ClaudeOAuthAccessCoordinator {
             guard result.didRefresh else {
                 return .refreshFailed(result)
             }
-            guard case let .valid(token) = await reread() else {
+            switch await reread() {
+            case let .valid(token):
+                return .token(token)
+            case .unavailable:
+                return .unavailable
+            case .missing, .expired:
                 return .refreshFailed(result)
             }
-            return .token(token)
         }
     }
 }

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -168,7 +168,7 @@ class UsageDataManager: ObservableObject {
     /// re-deriving truth from `lastError`, which only holds the last failure.
     @discardableResult
     func refreshAll(
-        trigger: ClaudeTokenRefreshTrigger = .userInitiated
+        trigger: ClaudeTokenRefreshTrigger = .background
     ) async -> UsageRefreshReport {
         let startedAt = Date()
         guard !demoMode else {

--- a/MeterBar/UsageRefresh/UsageRefreshCLI.swift
+++ b/MeterBar/UsageRefresh/UsageRefreshCLI.swift
@@ -48,7 +48,7 @@ public enum UsageRefreshCLI {
         let engine = UsageRefreshEngine(
             lock: makeLock(),
             timeout: request.timeout,
-            refresh: { await manager.refreshAll() },
+            refresh: { await manager.refreshAll(trigger: .userInitiated) },
             cacheSnapshot: {
                 sharedStore.flushPendingWrites()
                 return sharedStore.loadMetrics()

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -179,7 +179,7 @@ struct MenuBarView: View {
         .accessibilityLabel("Open Dashboard")
 
         Button {
-          Task { await dataManager.refreshAll() }
+          Task { await dataManager.refreshAll(trigger: .userInitiated) }
         } label: {
           RefreshingIcon(isRefreshing: dataManager.isLoading)
             .font(.system(size: 12, weight: .semibold))

--- a/MeterBar/Views/Settings/GeneralSettingsView.swift
+++ b/MeterBar/Views/Settings/GeneralSettingsView.swift
@@ -93,7 +93,7 @@ struct GeneralSettingsView: View {
             SettingsRowView(title: "Manual refresh") {
                 Button {
                     Task {
-                        await dataManager.refreshAll()
+                        await dataManager.refreshAll(trigger: .userInitiated)
                     }
                 } label: {
                     Label("Refresh Now", systemImage: "arrow.clockwise")

--- a/MeterBar/Views/Settings/ProviderSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsView.swift
@@ -303,14 +303,10 @@ struct ProviderSettingsView: View {
                     StatusPill(title: claudeCodeService.authState.statusText, isConnected: claudeCodeService.hasAccess)
 
                     Button {
-                        // checkAccess can hit the keychain (blocking approval
-                        // dialog) — run it off the main actor.
+                        // This is an explicit user action, so it is the one
+                        // Settings path allowed to request Keychain access.
                         Task {
-                            let service = claudeCodeService
-                            await Task.detached(priority: .userInitiated) { service.checkAccess() }.value
-                            if claudeCodeService.hasAccess {
-                                await dataManager.refreshAll()
-                            }
+                            await dataManager.refreshAll(trigger: .userInitiated)
                         }
                     } label: {
                         Label(claudeCodeService.hasAccess ? "Refresh" : "Check again", systemImage: "arrow.clockwise")

--- a/MeterBar/Views/Settings/ProviderSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsView.swift
@@ -518,7 +518,7 @@ struct ProviderSettingsView: View {
                                 service.checkAccess(forceRescan: true)
                             }.value
                             if cursorService.hasAccess {
-                                await dataManager.refreshAll()
+                                await dataManager.refreshAll(trigger: .userInitiated)
                             }
                         }
                     } label: {

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -432,7 +432,7 @@ struct UsageDashboardView: View {
             }
             socialCardGeneratedAt = Date()
         case .usage:
-            await dataManager.refreshAll()
+            await dataManager.refreshAll(trigger: .userInitiated)
         }
     }
 

--- a/MeterBarTests/ClaudeCredentialFingerprintTests.swift
+++ b/MeterBarTests/ClaudeCredentialFingerprintTests.swift
@@ -1,3 +1,5 @@
+import LocalAuthentication
+import Security
 import XCTest
 @testable import MeterBar
 
@@ -92,5 +94,141 @@ final class ClaudeCredentialFingerprintTests: XCTestCase {
         let after = ClaudeCredentialFingerprint.file(path: path, modificationDate: date, size: 41)
 
         XCTAssertNotEqual(before, after)
+    }
+
+    func testFingerprintQueryAlwaysFailsWithoutAuthenticationUI() {
+        let service = "Claude Code-credentials-c4394a73"
+        let date = Date(timeIntervalSince1970: 100)
+        let backend = FingerprintRecordingKeychainBackend(
+            status: errSecSuccess,
+            result: [kSecAttrModificationDate as String: date] as NSDictionary
+        )
+
+        let outcome = ClaudeCredentialFingerprintStore.keychainFingerprint(
+            service: service,
+            backend: backend
+        )
+
+        XCTAssertEqual(
+            outcome,
+            .value(.keychain(service: service, modificationDate: date))
+        )
+        XCTAssertEqual(
+            backend.lastQuery[kSecUseAuthenticationUI as String] as? String,
+            kSecUseAuthenticationUIFail as String
+        )
+        let context = backend.lastQuery[kSecUseAuthenticationContext as String] as? LAContext
+        XCTAssertEqual(context?.interactionNotAllowed, true)
+    }
+
+    func testFingerprintStoreSkipsCoolingKeychainServiceAndUsesFileMetadata() throws {
+        let suite = "ClaudeCredentialFingerprintTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        addTeardownBlock { defaults.removePersistentDomain(forName: suite) }
+        let denialStore = ClaudeKeychainDenialStore(userDefaults: defaults)
+        let now = Date(timeIntervalSince1970: 10_000)
+        let service = "Claude Code-credentials-c4394a73"
+        denialStore.recordDenial(for: service, at: now)
+        let recorder = FingerprintReadRecorder()
+        let expected = ClaudeCredentialFingerprint.file(
+            path: "/Users/tester/.claude-work/.credentials.json",
+            modificationDate: now,
+            size: 42
+        )
+        let store = ClaudeCredentialFingerprintStore(
+            readKeychainResult: { service in recorder.read(service: service) },
+            readFile: { _ in expected },
+            denialStore: denialStore,
+            isOAuthEnabled: { true },
+            now: { now.addingTimeInterval(1) }
+        )
+        let account = ClaudeCodeAccount(
+            id: UUID(),
+            name: "Work",
+            configDirectory: "/Users/tester/.claude-work"
+        )
+
+        XCTAssertEqual(
+            store.fingerprint(
+                for: account,
+                environment: [:],
+                realHomeDirectory: "/Users/tester"
+            ),
+            expected
+        )
+        XCTAssertTrue(recorder.services.isEmpty)
+    }
+
+    func testFingerprintOAuthOptOutPerformsNoKeychainQuery() throws {
+        let suite = "ClaudeCredentialFingerprintOptOutTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        addTeardownBlock { defaults.removePersistentDomain(forName: suite) }
+        let recorder = FingerprintReadRecorder()
+        let store = ClaudeCredentialFingerprintStore(
+            readKeychainResult: { service in recorder.read(service: service) },
+            readFile: { _ in nil },
+            denialStore: ClaudeKeychainDenialStore(userDefaults: defaults),
+            isOAuthEnabled: { false }
+        )
+
+        XCTAssertNil(store.fingerprint(
+            for: .defaultAccount,
+            environment: [:],
+            realHomeDirectory: "/Users/tester"
+        ))
+        XCTAssertTrue(recorder.services.isEmpty)
+    }
+}
+
+nonisolated private final class FingerprintRecordingKeychainBackend: KeychainBackend {
+    private(set) var lastQuery: [String: Any] = [:]
+    let status: OSStatus
+    let result: AnyObject?
+
+    init(status: OSStatus, result: AnyObject? = nil) {
+        self.status = status
+        self.result = result
+    }
+
+    func update(query: [String: Any], attributes: [String: Any]) -> OSStatus {
+        _ = query
+        _ = attributes
+        return errSecUnimplemented
+    }
+
+    func add(query: [String: Any]) -> OSStatus {
+        _ = query
+        return errSecUnimplemented
+    }
+
+    func copyMatching(query: [String: Any], result: inout AnyObject?) -> OSStatus {
+        lastQuery = query
+        result = self.result
+        return status
+    }
+
+    func delete(query: [String: Any]) -> OSStatus {
+        _ = query
+        return errSecUnimplemented
+    }
+}
+
+nonisolated private final class FingerprintReadRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String] = []
+
+    var services: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func read(service: String) -> ClaudeKeychainReadOutcome<ClaudeCredentialFingerprint> {
+        lock.lock()
+        storage.append(service)
+        lock.unlock()
+        return .notFound
     }
 }

--- a/MeterBarTests/ClaudeCredentialFingerprintTests.swift
+++ b/MeterBarTests/ClaudeCredentialFingerprintTests.swift
@@ -160,6 +160,45 @@ final class ClaudeCredentialFingerprintTests: XCTestCase {
         XCTAssertTrue(recorder.services.isEmpty)
     }
 
+    func testFingerprintSuccessDoesNotClearPayloadDenialRecord() throws {
+        let suite = "ClaudeCredentialFingerprintDenialTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        addTeardownBlock { defaults.removePersistentDomain(forName: suite) }
+        let denialStore = ClaudeKeychainDenialStore(userDefaults: defaults)
+        let deniedAt = Date(timeIntervalSince1970: 10_000)
+        let service = "Claude Code-credentials-c4394a73"
+        denialStore.recordDenial(for: service, at: deniedAt)
+        let fingerprint = ClaudeCredentialFingerprint.keychain(
+            service: service,
+            modificationDate: deniedAt
+        )
+        let store = ClaudeCredentialFingerprintStore(
+            readKeychainResult: { _ in .value(fingerprint) },
+            readFile: { _ in nil },
+            denialStore: denialStore,
+            isOAuthEnabled: { true },
+            now: {
+                deniedAt.addingTimeInterval(ClaudeKeychainPromptPolicy.denialCooldown + 1)
+            }
+        )
+        let account = ClaudeCodeAccount(
+            id: UUID(),
+            name: "Work",
+            configDirectory: "/Users/tester/.claude-work"
+        )
+
+        XCTAssertEqual(
+            store.fingerprint(
+                for: account,
+                environment: [:],
+                realHomeDirectory: "/Users/tester"
+            ),
+            fingerprint
+        )
+        XCTAssertEqual(denialStore.deniedAt(for: service), deniedAt)
+    }
+
     func testFingerprintOAuthOptOutPerformsNoKeychainQuery() throws {
         let suite = "ClaudeCredentialFingerprintOptOutTests-\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))

--- a/MeterBarTests/ClaudeCredentialResolverTests.swift
+++ b/MeterBarTests/ClaudeCredentialResolverTests.swift
@@ -272,6 +272,33 @@ final class ClaudeCredentialResolverTests: XCTestCase {
         )
     }
 
+    func testInteractiveFailureConsumesPromptBudgetForRemainingCandidates() throws {
+        let fixture = try makeDenialStore()
+        let recorder = KeychainReadRecorder { service, _ in
+            service == "Claude Code-credentials-ee16a9f4"
+                ? .failure(errSecInternalError)
+                : .notFound
+        }
+        let store = ClaudeCredentialStore(
+            readKeychainResult: { service, mode in recorder.read(service: service, mode: mode) },
+            readFile: { _ in nil },
+            denialStore: fixture.store,
+            isOAuthEnabled: { true }
+        )
+
+        _ = store.credentialsDataResult(
+            for: .defaultAccount,
+            mode: .interactive,
+            environment: [:],
+            realHomeDirectory: "/Users/tester"
+        )
+
+        XCTAssertEqual(recorder.calls, [
+            .init(service: "Claude Code-credentials-ee16a9f4", mode: .interactive),
+            .init(service: ClaudeCredentialResolver.bareKeychainService, mode: .background)
+        ])
+    }
+
     func testBackgroundWalkSkipsCoolingServiceAndStillUsesFileFallback() throws {
         let fixture = try makeDenialStore()
         let service = "Claude Code-credentials-c4394a73"

--- a/MeterBarTests/ClaudeCredentialResolverTests.swift
+++ b/MeterBarTests/ClaudeCredentialResolverTests.swift
@@ -1,3 +1,5 @@
+import LocalAuthentication
+import Security
 import XCTest
 @testable import MeterBar
 
@@ -174,11 +176,304 @@ final class ClaudeCredentialResolverTests: XCTestCase {
 
         XCTAssertEqual(data.flatMap { String(bytes: $0, encoding: .utf8) }, "file")
     }
+
+    // MARK: - Prompt hygiene
+
+    func testBackgroundPayloadQueryFailsWithoutAuthenticationUI() {
+        let backend = RecordingKeychainBackend(
+            status: errSecSuccess,
+            result: Data("payload".utf8) as NSData
+        )
+
+        let outcome = ClaudeCredentialStore.keychainPayload(
+            service: "Claude Code-credentials-c4394a73",
+            mode: .background,
+            backend: backend
+        )
+
+        XCTAssertEqual(outcome, .value(Data("payload".utf8)))
+        XCTAssertEqual(
+            backend.lastQuery[kSecUseAuthenticationUI as String] as? String,
+            kSecUseAuthenticationUIFail as String
+        )
+        let context = backend.lastQuery[kSecUseAuthenticationContext as String] as? LAContext
+        XCTAssertEqual(context?.interactionNotAllowed, true)
+    }
+
+    func testInteractivePayloadQueryAllowsAuthenticationUI() {
+        let backend = RecordingKeychainBackend(
+            status: errSecSuccess,
+            result: Data("payload".utf8) as NSData
+        )
+
+        let outcome = ClaudeCredentialStore.keychainPayload(
+            service: "Claude Code-credentials-c4394a73",
+            mode: .interactive,
+            backend: backend
+        )
+
+        XCTAssertEqual(outcome, .value(Data("payload".utf8)))
+        XCTAssertNil(backend.lastQuery[kSecUseAuthenticationUI as String])
+        XCTAssertNil(backend.lastQuery[kSecUseAuthenticationContext as String])
+    }
+
+    func testPayloadQueryPreservesSecurityStatusClasses() {
+        let cases: [(OSStatus, ClaudeKeychainReadOutcome<Data>)] = [
+            (errSecItemNotFound, .notFound),
+            (errSecInteractionNotAllowed, .interactionRequired),
+            (errSecUserCanceled, .denied),
+            (errSecAuthFailed, .denied),
+            (-9_999, .failure(-9_999))
+        ]
+
+        for (status, expected) in cases {
+            let backend = RecordingKeychainBackend(status: status)
+            XCTAssertEqual(
+                ClaudeCredentialStore.keychainPayload(
+                    service: "Claude Code-credentials-c4394a73",
+                    mode: .interactive,
+                    backend: backend
+                ),
+                expected
+            )
+        }
+    }
+
+    func testCanonicalInteractiveWalkOffersAtMostOnePromptAfterDenial() throws {
+        let fixture = try makeDenialStore()
+        let recorder = KeychainReadRecorder { service, mode in
+            service == "Claude Code-credentials-ee16a9f4"
+                ? .denied
+                : .notFound
+        }
+        let store = ClaudeCredentialStore(
+            readKeychainResult: { service, mode in recorder.read(service: service, mode: mode) },
+            readFile: { _ in Data("file".utf8) },
+            denialStore: fixture.store,
+            isOAuthEnabled: { true },
+            now: { Date(timeIntervalSince1970: 10_000) }
+        )
+
+        let data = store.credentialsData(
+            for: .defaultAccount,
+            mode: .interactive,
+            environment: [:],
+            realHomeDirectory: "/Users/tester"
+        )
+
+        XCTAssertEqual(data.flatMap { String(bytes: $0, encoding: .utf8) }, "file")
+        XCTAssertEqual(recorder.calls, [
+            .init(service: "Claude Code-credentials-ee16a9f4", mode: .interactive),
+            .init(service: ClaudeCredentialResolver.bareKeychainService, mode: .background)
+        ])
+        XCTAssertEqual(
+            fixture.store.deniedAt(for: "Claude Code-credentials-ee16a9f4"),
+            Date(timeIntervalSince1970: 10_000)
+        )
+    }
+
+    func testBackgroundWalkSkipsCoolingServiceAndStillUsesFileFallback() throws {
+        let fixture = try makeDenialStore()
+        let service = "Claude Code-credentials-c4394a73"
+        let now = Date(timeIntervalSince1970: 10_000)
+        fixture.store.recordDenial(for: service, at: now)
+        let recorder = KeychainReadRecorder { _, _ in .value(Data("unexpected".utf8)) }
+        let store = ClaudeCredentialStore(
+            readKeychainResult: { service, mode in recorder.read(service: service, mode: mode) },
+            readFile: { _ in Data("file".utf8) },
+            denialStore: fixture.store,
+            isOAuthEnabled: { true },
+            now: { now.addingTimeInterval(1) }
+        )
+        let account = ClaudeCodeAccount(
+            id: UUID(),
+            name: "Work",
+            configDirectory: "/Users/tester/.claude-work"
+        )
+
+        let data = store.credentialsData(
+            for: account,
+            mode: .background,
+            environment: [:],
+            realHomeDirectory: "/Users/tester"
+        )
+
+        XCTAssertTrue(recorder.calls.isEmpty)
+        XCTAssertEqual(data.flatMap { String(bytes: $0, encoding: .utf8) }, "file")
+    }
+
+    func testUserInitiatedWalkExplicitlyRetriesCoolingService() throws {
+        let fixture = try makeDenialStore()
+        let service = "Claude Code-credentials-c4394a73"
+        let now = Date(timeIntervalSince1970: 10_000)
+        fixture.store.recordDenial(for: service, at: now)
+        let recorder = KeychainReadRecorder { _, _ in .value(Data("scoped".utf8)) }
+        let store = ClaudeCredentialStore(
+            readKeychainResult: { service, mode in recorder.read(service: service, mode: mode) },
+            readFile: { _ in nil },
+            denialStore: fixture.store,
+            isOAuthEnabled: { true },
+            now: { now.addingTimeInterval(1) }
+        )
+        let account = ClaudeCodeAccount(
+            id: UUID(),
+            name: "Work",
+            configDirectory: "/Users/tester/.claude-work"
+        )
+
+        let data = store.credentialsData(
+            for: account,
+            mode: .interactive,
+            environment: [:],
+            realHomeDirectory: "/Users/tester"
+        )
+
+        XCTAssertEqual(
+            recorder.calls,
+            [.init(service: service, mode: .interactive)]
+        )
+        XCTAssertEqual(data.flatMap { String(bytes: $0, encoding: .utf8) }, "scoped")
+        XCTAssertNil(fixture.store.deniedAt(for: service))
+    }
+
+    func testBackgroundInteractionRequirementRecordsCooldownAndFallsBackToFile() throws {
+        let fixture = try makeDenialStore()
+        let now = Date(timeIntervalSince1970: 10_000)
+        let service = "Claude Code-credentials-c4394a73"
+        let store = ClaudeCredentialStore(
+            readKeychainResult: { _, _ in .interactionRequired },
+            readFile: { _ in Data("file".utf8) },
+            denialStore: fixture.store,
+            isOAuthEnabled: { true },
+            now: { now }
+        )
+        let account = ClaudeCodeAccount(
+            id: UUID(),
+            name: "Work",
+            configDirectory: "/Users/tester/.claude-work"
+        )
+
+        let data = store.credentialsData(
+            for: account,
+            mode: .background,
+            environment: [:],
+            realHomeDirectory: "/Users/tester"
+        )
+
+        XCTAssertEqual(data.flatMap { String(bytes: $0, encoding: .utf8) }, "file")
+        XCTAssertEqual(fixture.store.deniedAt(for: service), now)
+    }
+
+    func testInteractionBarrierRemainsDistinctWhenNoFileFallbackExists() throws {
+        let fixture = try makeDenialStore()
+        let store = ClaudeCredentialStore(
+            readKeychainResult: { _, _ in .interactionRequired },
+            readFile: { _ in nil },
+            denialStore: fixture.store,
+            isOAuthEnabled: { true }
+        )
+        let account = ClaudeCodeAccount(
+            id: UUID(),
+            name: "Work",
+            configDirectory: "/Users/tester/.claude-work"
+        )
+
+        XCTAssertEqual(
+            store.credentialsDataResult(
+                for: account,
+                mode: .background,
+                environment: [:],
+                realHomeDirectory: "/Users/tester"
+            ),
+            .interactionRequired
+        )
+    }
+
+    func testCoolingServiceRemainsInteractionBarrierInsteadOfBecomingMissing() throws {
+        let fixture = try makeDenialStore()
+        let now = Date(timeIntervalSince1970: 10_000)
+        let service = "Claude Code-credentials-c4394a73"
+        fixture.store.recordDenial(for: service, at: now)
+        let store = ClaudeCredentialStore(
+            readKeychainResult: { _, _ in .value(Data("unexpected".utf8)) },
+            readFile: { _ in nil },
+            denialStore: fixture.store,
+            isOAuthEnabled: { true },
+            now: { now.addingTimeInterval(1) }
+        )
+        let account = ClaudeCodeAccount(
+            id: UUID(),
+            name: "Work",
+            configDirectory: "/Users/tester/.claude-work"
+        )
+
+        XCTAssertEqual(
+            store.credentialsDataResult(
+                for: account,
+                mode: .background,
+                environment: [:],
+                realHomeDirectory: "/Users/tester"
+            ),
+            .interactionRequired
+        )
+    }
+
+    func testAbsentCandidatesRemainNotFound() throws {
+        let fixture = try makeDenialStore()
+        let store = ClaudeCredentialStore(
+            readKeychainResult: { _, _ in .notFound },
+            readFile: { _ in nil },
+            denialStore: fixture.store,
+            isOAuthEnabled: { true }
+        )
+
+        XCTAssertEqual(
+            store.credentialsDataResult(
+                for: .defaultAccount,
+                mode: .background,
+                environment: [:],
+                realHomeDirectory: "/Users/tester"
+            ),
+            .notFound
+        )
+    }
+
+    func testOAuthOptOutSkipsEveryKeychainQueryButLeavesFileFallbackAvailable() throws {
+        let fixture = try makeDenialStore()
+        let recorder = KeychainReadRecorder { _, _ in .value(Data("unexpected".utf8)) }
+        let store = ClaudeCredentialStore(
+            readKeychainResult: { service, mode in recorder.read(service: service, mode: mode) },
+            readFile: { _ in Data("file".utf8) },
+            denialStore: fixture.store,
+            isOAuthEnabled: { false }
+        )
+
+        let data = store.credentialsData(
+            for: .defaultAccount,
+            mode: .interactive,
+            environment: [:],
+            realHomeDirectory: "/Users/tester"
+        )
+
+        XCTAssertTrue(recorder.calls.isEmpty)
+        XCTAssertEqual(data.flatMap { String(bytes: $0, encoding: .utf8) }, "file")
+    }
+
+    private func makeDenialStore() throws -> (
+        store: ClaudeKeychainDenialStore,
+        defaults: UserDefaults
+    ) {
+        let suite = "ClaudeCredentialResolverTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        addTeardownBlock { defaults.removePersistentDomain(forName: suite) }
+        return (ClaudeKeychainDenialStore(userDefaults: defaults), defaults)
+    }
 }
 
 /// Records the paths a store probed. The store's readers are `@Sendable`, so a
 /// captured `var` will not compile — a locked reference type is the substitute.
-private final class PathRecorder: @unchecked Sendable {
+nonisolated private final class PathRecorder: @unchecked Sendable {
     private let lock = NSLock()
     private var storage: [String] = []
 
@@ -192,5 +487,74 @@ private final class PathRecorder: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         storage.append(path)
+    }
+}
+
+nonisolated private final class RecordingKeychainBackend: KeychainBackend {
+    private(set) var lastQuery: [String: Any] = [:]
+    let status: OSStatus
+    let result: AnyObject?
+
+    init(status: OSStatus, result: AnyObject? = nil) {
+        self.status = status
+        self.result = result
+    }
+
+    func update(query: [String: Any], attributes: [String: Any]) -> OSStatus {
+        _ = query
+        _ = attributes
+        return errSecUnimplemented
+    }
+
+    func add(query: [String: Any]) -> OSStatus {
+        _ = query
+        return errSecUnimplemented
+    }
+
+    func copyMatching(query: [String: Any], result: inout AnyObject?) -> OSStatus {
+        lastQuery = query
+        result = self.result
+        return status
+    }
+
+    func delete(query: [String: Any]) -> OSStatus {
+        _ = query
+        return errSecUnimplemented
+    }
+}
+
+nonisolated private final class KeychainReadRecorder: @unchecked Sendable {
+    struct Call: Equatable {
+        let service: String
+        let mode: ClaudeKeychainAccessMode
+    }
+
+    private let lock = NSLock()
+    private let result: @Sendable (String, ClaudeKeychainAccessMode) -> ClaudeKeychainReadOutcome<Data>
+    private var storage: [Call] = []
+
+    init(
+        result: @escaping @Sendable (
+            String,
+            ClaudeKeychainAccessMode
+        ) -> ClaudeKeychainReadOutcome<Data>
+    ) {
+        self.result = result
+    }
+
+    var calls: [Call] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func read(
+        service: String,
+        mode: ClaudeKeychainAccessMode
+    ) -> ClaudeKeychainReadOutcome<Data> {
+        lock.lock()
+        storage.append(Call(service: service, mode: mode))
+        lock.unlock()
+        return result(service, mode)
     }
 }

--- a/MeterBarTests/ClaudeKeychainAccessPolicyTests.swift
+++ b/MeterBarTests/ClaudeKeychainAccessPolicyTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import MeterBar
+
+final class ClaudeKeychainAccessPolicyTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 10_000)
+
+    func testRefreshTriggerMapsToFailSafeKeychainAccessMode() {
+        XCTAssertEqual(ClaudeKeychainAccessMode(trigger: .background), .background)
+        XCTAssertEqual(ClaudeKeychainAccessMode(trigger: .userInitiated), .interactive)
+    }
+
+    func testBackgroundReadQueriesWithoutUIWhenNoDenialExists() {
+        XCTAssertEqual(
+            ClaudeKeychainPromptPolicy.decision(
+                requestedMode: .background,
+                deniedAt: nil,
+                now: now
+            ),
+            .query(.background)
+        )
+    }
+
+    func testBackgroundReadSkipsKeychainDuringSixHourDenialCooldown() {
+        XCTAssertEqual(
+            ClaudeKeychainPromptPolicy.decision(
+                requestedMode: .background,
+                deniedAt: now,
+                now: now.addingTimeInterval(6 * 60 * 60 - 1)
+            ),
+            .skipKeychain
+        )
+        XCTAssertEqual(
+            ClaudeKeychainPromptPolicy.decision(
+                requestedMode: .background,
+                deniedAt: now,
+                now: now.addingTimeInterval(6 * 60 * 60)
+            ),
+            .query(.background)
+        )
+    }
+
+    func testUserInitiatedReadExplicitlyRetriesDuringDenialCooldown() {
+        XCTAssertEqual(
+            ClaudeKeychainPromptPolicy.decision(
+                requestedMode: .interactive,
+                deniedAt: now,
+                now: now.addingTimeInterval(1)
+            ),
+            .query(.interactive)
+        )
+    }
+
+    func testFutureDenialTimestampDoesNotSuppressBackgroundReadsForever() {
+        XCTAssertEqual(
+            ClaudeKeychainPromptPolicy.decision(
+                requestedMode: .background,
+                deniedAt: now.addingTimeInterval(60),
+                now: now
+            ),
+            .query(.background)
+        )
+    }
+
+    func testDenialStorePersistsByServiceNameWithoutCredentialMaterial() throws {
+        let fixture = try makeStore()
+        let first = "Claude Code-credentials-c4394a73"
+        let second = "Claude Code-credentials-ee16a9f4"
+
+        fixture.store.recordDenial(for: first, at: now)
+        fixture.store.recordDenial(for: second, at: now.addingTimeInterval(1))
+
+        let reader = ClaudeKeychainDenialStore(userDefaults: fixture.defaults)
+        XCTAssertEqual(reader.deniedAt(for: first), now)
+        XCTAssertEqual(reader.deniedAt(for: second), now.addingTimeInterval(1))
+
+        let data = try XCTUnwrap(fixture.defaults.data(forKey: StorageKeys.claudeCodeKeychainDenials))
+        let serialized = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertTrue(serialized.contains(first))
+        XCTAssertTrue(serialized.contains(second))
+        XCTAssertFalse(serialized.lowercased().contains("token"))
+        XCTAssertFalse(serialized.lowercased().contains("credential payload"))
+    }
+
+    func testDenialStoreOverwritesAndClearsOneServiceWithoutAffectingAnother() throws {
+        let fixture = try makeStore()
+        let first = "Claude Code-credentials-c4394a73"
+        let second = "Claude Code-credentials-ee16a9f4"
+
+        fixture.store.recordDenial(for: first, at: now)
+        fixture.store.recordDenial(for: first, at: now.addingTimeInterval(2))
+        fixture.store.recordDenial(for: second, at: now.addingTimeInterval(3))
+        fixture.store.clearDenial(for: first)
+
+        XCTAssertNil(fixture.store.deniedAt(for: first))
+        XCTAssertEqual(fixture.store.deniedAt(for: second), now.addingTimeInterval(3))
+    }
+
+    private func makeStore() throws -> (
+        store: ClaudeKeychainDenialStore,
+        defaults: UserDefaults
+    ) {
+        let suite = "ClaudeKeychainAccessPolicyTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        addTeardownBlock { defaults.removePersistentDomain(forName: suite) }
+        return (ClaudeKeychainDenialStore(userDefaults: defaults), defaults)
+    }
+}

--- a/MeterBarTests/ClaudeOAuthAccessCoordinatorTests.swift
+++ b/MeterBarTests/ClaudeOAuthAccessCoordinatorTests.swift
@@ -40,6 +40,22 @@ final class ClaudeOAuthAccessCoordinatorTests: XCTestCase {
         XCTAssertEqual(callCount, 0)
     }
 
+    func testUnavailableCredentialDoesNotBecomeMissingOrSpawnRefresh() async {
+        let refresh = RefreshCallRecorder(result: .hardFailure)
+
+        let result = await ClaudeOAuthAccessCoordinator.resolve(
+            initialAccess: .unavailable,
+            account: account,
+            trigger: .background,
+            refresh: { account, trigger in await refresh.run(account: account, trigger: trigger) },
+            reread: { .valid(token: "unexpected") }
+        )
+
+        XCTAssertEqual(result, .unavailable)
+        let callCount = await refresh.callCount
+        XCTAssertEqual(callCount, 0)
+    }
+
     func testExpiredCredentialRefreshesAndRereadsTokenOnce() async {
         let refresh = RefreshCallRecorder(result: .refreshed)
         let reread = AccessSequence([.valid(token: "rotated")])

--- a/MeterBarTests/ClaudeOAuthAccessCoordinatorTests.swift
+++ b/MeterBarTests/ClaudeOAuthAccessCoordinatorTests.swift
@@ -91,6 +91,20 @@ final class ClaudeOAuthAccessCoordinatorTests: XCTestCase {
         XCTAssertEqual(result, .refreshFailed(.refreshed))
     }
 
+    func testChangedFingerprintWithUnavailableRereadPreservesAccessBarrier() async {
+        let refresh = RefreshCallRecorder(result: .refreshed)
+
+        let result = await ClaudeOAuthAccessCoordinator.resolve(
+            initialAccess: .expired,
+            account: account,
+            trigger: .background,
+            refresh: { account, trigger in await refresh.run(account: account, trigger: trigger) },
+            reread: { .unavailable }
+        )
+
+        XCTAssertEqual(result, .unavailable)
+    }
+
     func testInconclusiveRefreshDoesNotRereadCredential() async {
         let refresh = RefreshCallRecorder(result: .inconclusive)
         let reread = AccessSequence([.valid(token: "unexpected")])

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -348,6 +348,30 @@ final class UsageDataManagerTests: XCTestCase {
         )
     }
 
+    func testRefreshAllDefaultsToBackgroundClaudeAccess() async throws {
+        let accountSuite = "UsageDataManagerTests-default-claude-trigger-\(UUID().uuidString)"
+        createdSuiteNames.append(accountSuite)
+        let accountDefaults = try XCTUnwrap(UserDefaults(suiteName: accountSuite))
+        let accountStore = ClaudeCodeAccountStore(userDefaults: accountDefaults)
+        let claude = StubClaudeProvider(
+            hasAccess: true,
+            result: .success(MetricsFixtures.claudeCode())
+        )
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+        let (manager, _) = makeManager(
+            codex: codex,
+            cursor: cursor,
+            claude: claude,
+            claudeCodeAccountStore: accountStore,
+            hidden: [.codexCli, .cursor, .openRouter, .grok]
+        )
+
+        await manager.refreshAll()
+
+        XCTAssertEqual(claude.refreshTriggers, [.background])
+    }
+
     func testClaudeRefreshAlsoRefreshesFableSessionsForEnabledProfiles() async throws {
         let accountSuite = "UsageDataManagerTests-fable-accounts-\(UUID().uuidString)"
         createdSuiteNames.append(accountSuite)


### PR DESCRIPTION
## Summary
- make automatic Claude Keychain payload and fingerprint reads fail closed without authentication UI
- allow interactive access only from explicit refresh actions, with one prompt opportunity per candidate walk
- persist a six-hour per-service denial cooldown while preserving file fallback and OAuth opt-out
- keep inaccessible credentials distinct from missing credentials before and after delegated refresh so ACL failures cannot produce false logout state
- default all refresh orchestration to background access; refresh buttons and the explicit CLI opt in to user-initiated access

## Verification
- 60 focused Keychain and OAuth tests pass
- 7 delegated-refresh tests pass
- default-trigger orchestration regression passes
- SwiftLint clean
- unsigned Xcode app build succeeds
- full Swift suite: 1,497 tests, 1 skipped; same 12 documented pre-existing failing cases, no new failing case
- first exact-head Opus review findings repaired in b9b8c7c; fresh exact-head verdict pending

Closes #292