### PR TITLE
ci(release): move publisher action to Node 24

### DIFF
--- a/.agents/SESSIONS/2026-07-27.md
+++ b/.agents/SESSIONS/2026-07-27.md
@@ -1,0 +1,63 @@
+# 2026-07-27
+
+## Session 1: move the release publisher action to Node 24
+
+### System flow
+
+```text
+tag push
+  -> signed-release workflow
+  -> softprops/action-gh-release v3.0.2 (Node 24)
+  -> GitHub Release + assets
+
+required CI
+  -> verify-release-workflow-contract.sh
+  -> reject any release publisher other than the reviewed full-SHA pin
+```
+
+### Affected components
+
+- GitHub Actions signed release and nightly publishing.
+- The required release-workflow contract check.
+
+### What was done
+
+- [x] Replaced `softprops/action-gh-release` v2.6.2, which declares the deprecated
+      Node 20 Actions runtime, with v3.0.2 at its immutable full commit SHA.
+- [x] Added a workflow-contract assertion that requires exactly one release
+      publisher and binds it to the reviewed v3.0.2 SHA.
+- [x] Preserved the existing release inputs and stable/nightly behavior.
+
+### Key decisions
+
+- **Use v3.0.2 rather than a floating `v3` tag.** The repository pins every
+  third-party action by full SHA; v3.0.2 is the current upstream stable release
+  and its action manifest declares `node24`.
+- **Make the runtime upgrade a required-CI invariant.** The release action only
+  executes while publishing, so a contract check prevents a future workflow
+  edit from silently restoring the deprecated runtime between releases.
+
+### Files changed
+
+- `.github/workflows/_build-signed.yml`
+- `scripts/verify-release-workflow-contract.sh`
+- `.agents/SESSIONS/2026-07-27.md`
+
+### Verification
+
+- TDD red: the new contract assertion rejected the v2.6.2 SHA and reported the
+  expected Node 24 pin.
+- `scripts/verify-release-workflow-contract.sh`
+- `shellcheck scripts/verify-release-workflow-contract.sh`
+- `actionlint .github/workflows/_build-signed.yml .github/workflows/release.yml .github/workflows/nightly.yml`
+- `git diff --check`
+
+### Mistakes and fixes
+
+- The Fable and Opus planning calls both hit the account's weekly limit.
+  Planning used the documented non-blocking implementer fallback.
+
+### Next steps
+
+- [ ] Required PR CI must pass before merge.
+- [ ] Exact-head Opus review remains the merge gate.

--- a/.github/workflows/_build-signed.yml
+++ b/.github/workflows/_build-signed.yml
@@ -431,7 +431,7 @@ jobs:
           gh release delete "$RELEASE_TAG" --cleanup-tag --yes || true
 
       - name: Create Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ inputs.release_tag }}
           target_commitish: ${{ github.sha }}

--- a/scripts/verify-release-workflow-contract.sh
+++ b/scripts/verify-release-workflow-contract.sh
@@ -89,6 +89,21 @@ if len(set(thresholds.values())) != 1:
     details = ", ".join(f"{path.name}={value}" for path, value in thresholds.items())
     raise SystemExit(f"Coverage thresholds must match across broad validation workflows: {details}")
 
+release_publishers = re.findall(
+    r"^\s+uses:\s*softprops/action-gh-release@([0-9a-f]{40})\s+#\s+(v[0-9.]+)\s*$",
+    build_job,
+    re.MULTILINE,
+)
+expected_release_publishers = [
+    ("3d0d9888cb7fd7b750713d6e236d1fcb99157228", "v3.0.2"),
+]
+if release_publishers != expected_release_publishers:
+    raise SystemExit(
+        f"{signed_path}: release publisher must pin Node 24 action "
+        "softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2; "
+        f"found {release_publishers}"
+    )
+
 require(
     r"^\s+run:\s*bash scripts/check-coverage\.sh\s*$",
     test_job,


### PR DESCRIPTION
## Summary
- upgrade softprops/action-gh-release from v2.6.2 to v3.0.2 at the immutable full SHA
- move release publishing from the deprecated Node 20 Actions runtime to Node 24
- make the reviewed publisher pin a required release-workflow contract invariant

## Verification
- TDD red: contract rejected the v2.6.2 pin
- scripts/verify-release-workflow-contract.sh
- shellcheck scripts/verify-release-workflow-contract.sh
- actionlint .github/workflows/_build-signed.yml .github/workflows/release.yml .github/workflows/nightly.yml
- git diff --check

## Risk
Low. All existing action inputs remain supported by v3.0.2. This PR does not publish a release; required CI is the delivery gate.