### PR TITLE
fix(codex): classify quota windows by duration

### DIFF
--- a/.agents/SESSIONS/2026-07-28.md
+++ b/.agents/SESSIONS/2026-07-28.md
@@ -1,0 +1,37 @@
+# 2026-07-28
+
+## Session 1: Codex weekly-only quota window mapping
+
+**Status:** Complete
+
+### What was done
+
+- Fixed Codex quota mapping when OpenAI disables the 5-hour window and returns
+  the remaining 7-day window in `primary_window`.
+- Classified Codex quota windows by their reported duration instead of assuming
+  `primary_window` is always session and `secondary_window` is always weekly.
+- Removed the fabricated 0% weekly limit when the API omits a weekly window.
+- Added regression fixtures for session-only, weekly-only, normal two-window,
+  and reversed-position responses.
+
+### Files changed
+
+- `MeterBar/Services/CodexCliLocalService.swift`
+- `MeterBarTests/CodexCliLocalServiceTests.swift`
+- `MeterBarTests/CodexUsageMappingTests.swift`
+
+### Decision
+
+Treat sub-day Codex windows as session limits and day-or-longer windows as
+weekly limits. This preserves the normal 5-hour/7-day response and remains
+correct whether either window is temporarily absent or returns in a different
+response slot.
+
+### Verification
+
+- `swift test --filter 'CodexUsageMappingTests|CodexCliLocalServiceTests'`:
+  15 tests passed.
+- `swiftlint lint --strict --quiet`: passed.
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug
+  -derivedDataPath /tmp/meterbar-codex-window-build CODE_SIGNING_ALLOWED=NO
+  build`: succeeded.

--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -10,9 +10,13 @@ import os
 /// Similar to ClaudeCodeLocalService, but for Codex CLI usage tracking.
 ///
 /// The API endpoint returns usage data with:
-/// - Primary window: 5-hour limit (18000 seconds)
-/// - Secondary window: 7-day limit (604800 seconds)
+/// - Short window: normally a 5-hour limit (18000 seconds)
+/// - Long window: normally a 7-day limit (604800 seconds)
 /// - Code review rate limit: 7-day limit for code review features
+///
+/// The short/long windows have historically occupied `primary_window` and
+/// `secondary_window`, respectively. Their positions are not stable when OpenAI
+/// disables one window, so mapping uses each window's reported duration.
 class CodexCliLocalService: ObservableObject {
     static let shared = CodexCliLocalService()
 
@@ -528,9 +532,12 @@ extension CodexCliUsageResponse {
     /// `UsageMetrics`. Extracted from `fetchUsageMetrics()` so the window/limit
     /// derivation is unit-testable with fixture JSON, no network.
     ///
-    /// Windows map as: primary (5h) → session, secondary (7d) → weekly,
-    /// code-review primary (7d) → code-review limit. Free accounts (null
-    /// `rate_limit`) carry no windows, only the extra-usage/reset-credit signals.
+    /// Windows map by reported duration rather than response position: a
+    /// sub-day window is the session limit and a day-or-longer window is the
+    /// weekly limit. This matters when OpenAI temporarily disables the 5-hour
+    /// limit and moves the only remaining weekly window into `primary_window`.
+    /// Free accounts (null `rate_limit`) carry no windows, only the
+    /// extra-usage/reset-credit signals.
     func toUsageMetrics() -> UsageMetrics {
         guard let rateLimit else {
             // Free accounts have a null rate_limit — no quota windows to report.
@@ -544,34 +551,12 @@ extension CodexCliUsageResponse {
             )
         }
 
-        // Primary window (5 hours = 18000 seconds) = session limit
-        let primaryWindow = rateLimit.primaryWindow
-        let sessionLimit = UsageLimit(
-            used: primaryWindow.usedPercent,
-            total: 100.0,
-            resetTime: Date(timeIntervalSince1970: Double(primaryWindow.resetAt)),
-            windowSeconds: TimeInterval(primaryWindow.limitWindowSeconds)
-        )
-
-        // Secondary window (7 days = 604800 seconds) = weekly limit
-        let secondaryWindow = rateLimit.secondaryWindow
-        let weeklyLimit = UsageLimit(
-            used: secondaryWindow?.usedPercent ?? 0.0,
-            total: 100.0,
-            resetTime: secondaryWindow.map { Date(timeIntervalSince1970: Double($0.resetAt)) } ?? Date(),
-            windowSeconds: secondaryWindow.map { TimeInterval($0.limitWindowSeconds) }
-        )
+        let quotaWindows = [rateLimit.primaryWindow, rateLimit.secondaryWindow].compactMap { $0 }
+        let sessionLimit = quotaWindows.first(where: { $0.isSessionWindow })?.usageLimit
+        let weeklyLimit = quotaWindows.first(where: { $0.isWeeklyWindow })?.usageLimit
 
         // Code review rate limit (7 days window) = code review limit
-        var codeReviewLimit: UsageLimit?
-        if let codeReviewPrimary = codeReviewRateLimit?.primaryWindow {
-            codeReviewLimit = UsageLimit(
-                used: codeReviewPrimary.usedPercent,
-                total: 100.0,
-                resetTime: Date(timeIntervalSince1970: Double(codeReviewPrimary.resetAt)),
-                windowSeconds: TimeInterval(codeReviewPrimary.limitWindowSeconds)
-            )
-        }
+        let codeReviewLimit = codeReviewRateLimit?.primaryWindow.usageLimit
 
         return UsageMetrics(
             service: .codexCli,
@@ -641,10 +626,29 @@ nonisolated struct RateLimit: Codable {
 typealias CodeReviewRateLimit = RateLimit
 
 nonisolated struct LimitWindow: Codable {
+    private static let longWindowThresholdSeconds = 24 * 60 * 60
+
     let usedPercent: Double
     let limitWindowSeconds: Int
     let resetAfterSeconds: Int
     let resetAt: Int64
+
+    var isSessionWindow: Bool {
+        limitWindowSeconds < Self.longWindowThresholdSeconds
+    }
+
+    var isWeeklyWindow: Bool {
+        !isSessionWindow
+    }
+
+    var usageLimit: UsageLimit {
+        UsageLimit(
+            used: usedPercent,
+            total: 100.0,
+            resetTime: Date(timeIntervalSince1970: Double(resetAt)),
+            windowSeconds: TimeInterval(limitWindowSeconds)
+        )
+    }
 
     enum CodingKeys: String, CodingKey {
         case usedPercent = "used_percent"

--- a/MeterBarTests/CodexCliLocalServiceTests.swift
+++ b/MeterBarTests/CodexCliLocalServiceTests.swift
@@ -103,7 +103,7 @@ final class CodexCliLocalServiceTests: XCTestCase {
         XCTAssertEqual(metrics.extraUsage?.state, .unknown)
     }
 
-    func testMapUsageResponseWithoutSecondaryWindowZeroesWeekly() throws {
+    func testMapUsageResponseWithSessionOnlyOmitsWeekly() throws {
         let json = """
         {
           "plan_type": "plus",
@@ -123,9 +123,31 @@ final class CodexCliLocalServiceTests: XCTestCase {
         let metrics = CodexCliLocalService.mapUsageResponse(response)
 
         XCTAssertEqual(metrics.sessionLimit?.used, 12.0)
-        // No secondary window → weekly usage falls back to 0 with a nil windowSeconds.
-        XCTAssertEqual(metrics.weeklyLimit?.used, 0.0)
-        XCTAssertNil(metrics.weeklyLimit?.windowSeconds)
+        XCTAssertNil(metrics.weeklyLimit)
+    }
+
+    func testMapUsageResponseWithWeeklyOnlyOmitsSession() throws {
+        let json = """
+        {
+          "plan_type": "plus",
+          "rate_limit": {
+            "allowed": true,
+            "limit_reached": false,
+            "primary_window": {
+              "used_percent": 36.0,
+              "limit_window_seconds": 604800,
+              "reset_after_seconds": 540000,
+              "reset_at": 1785880800
+            }
+          }
+        }
+        """
+        let response = try decodeResponse(json)
+        let metrics = CodexCliLocalService.mapUsageResponse(response)
+
+        XCTAssertNil(metrics.sessionLimit)
+        XCTAssertEqual(metrics.weeklyLimit?.used, 36.0)
+        XCTAssertEqual(metrics.weeklyLimit?.windowSeconds, 604800)
     }
 
     // MARK: - Auth-file / token-expiry gating

--- a/MeterBarTests/CodexUsageMappingTests.swift
+++ b/MeterBarTests/CodexUsageMappingTests.swift
@@ -76,9 +76,9 @@ final class CodexUsageMappingTests: XCTestCase {
         XCTAssertEqual(metrics.extraUsage?.state, .on)
     }
 
-    // MARK: - Missing secondary window
+    // MARK: - Independently reported windows
 
-    func testWeeklyLimitDefaultsWhenSecondaryWindowAbsent() throws {
+    func testSessionOnlyResponseOmitsWeeklyLimit() throws {
         let json = """
         {
             "plan_type": "plus",
@@ -97,11 +97,67 @@ final class CodexUsageMappingTests: XCTestCase {
 
         let metrics = try decode(json).toUsageMetrics()
 
-        // Absent secondary window → weekly reported at 0% with no window length.
-        let weekly = try XCTUnwrap(metrics.weeklyLimit)
-        XCTAssertEqual(weekly.used, 0.0)
-        XCTAssertNil(weekly.windowSeconds)
+        XCTAssertEqual(metrics.sessionLimit?.used, 10.0)
+        XCTAssertNil(metrics.weeklyLimit)
         XCTAssertNil(metrics.codeReviewLimit)
+    }
+
+    func testWeeklyOnlyResponseMapsPrimaryWindowToWeeklyLimit() throws {
+        let json = """
+        {
+            "plan_type": "plus",
+            "rate_limit": {
+                "allowed": true,
+                "limit_reached": false,
+                "primary_window": {
+                    "used_percent": 36.0,
+                    "limit_window_seconds": 604800,
+                    "reset_after_seconds": 540000,
+                    "reset_at": 1785880800
+                }
+            }
+        }
+        """
+
+        let metrics = try decode(json).toUsageMetrics()
+
+        XCTAssertNil(metrics.sessionLimit)
+        let weekly = try XCTUnwrap(metrics.weeklyLimit)
+        XCTAssertEqual(weekly.used, 36.0)
+        XCTAssertEqual(weekly.windowSeconds, 604800)
+        XCTAssertEqual(weekly.resetTime, Date(timeIntervalSince1970: 1_785_880_800))
+        XCTAssertNil(metrics.codeReviewLimit)
+    }
+
+    func testWindowMappingDoesNotDependOnPrimarySecondaryOrder() throws {
+        let json = """
+        {
+            "plan_type": "plus",
+            "rate_limit": {
+                "allowed": true,
+                "limit_reached": false,
+                "primary_window": {
+                    "used_percent": 36.0,
+                    "limit_window_seconds": 604800,
+                    "reset_after_seconds": 540000,
+                    "reset_at": 1785880800
+                },
+                "secondary_window": {
+                    "used_percent": 8.0,
+                    "limit_window_seconds": 18000,
+                    "reset_after_seconds": 12000,
+                    "reset_at": 1785352800
+                }
+            }
+        }
+        """
+
+        let metrics = try decode(json).toUsageMetrics()
+
+        XCTAssertEqual(metrics.sessionLimit?.used, 8.0)
+        XCTAssertEqual(metrics.sessionLimit?.windowSeconds, 18000)
+        XCTAssertEqual(metrics.weeklyLimit?.used, 36.0)
+        XCTAssertEqual(metrics.weeklyLimit?.windowSeconds, 604800)
     }
 
     // MARK: - Free account: null rate_limit


### PR DESCRIPTION
## Summary
- classify Codex quota windows from their reported duration instead of primary/secondary position
- show the current weekly-only response as Weekly and omit the absent Session row
- stop fabricating a zero-percent weekly row when that window is absent
- preserve normal two-window behavior if the 5-hour limit returns

## Verification
- `swift test --filter "CodexUsageMappingTests|CodexCliLocalServiceTests"` — 15 passed
- `swiftlint lint --strict --quiet`
- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -derivedDataPath /tmp/meterbar-codex-window-build CODE_SIGNING_ALLOWED=NO build`

## Risk
Low and bounded to Codex response mapping. Fixtures cover normal, session-only, weekly-only, reversed-position, and null-rate-limit payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex usage-limit reporting when session or weekly windows are unavailable or returned in a different order.
  * Weekly limits are now omitted when no weekly window is provided, instead of displaying an inaccurate zero limit.
  * Session and weekly usage data are matched using each window’s reported duration for more reliable results.

* **Tests**
  * Added coverage for session-only, weekly-only, standard, and reordered limit-window responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->