### PR TITLE
fix(claude): separate Settings refresh from reconnect

### DIFF
--- a/.agents/SESSIONS/2026-07-29.md
+++ b/.agents/SESSIONS/2026-07-29.md
@@ -1,0 +1,66 @@
+# 2026-07-29
+
+## Session 1: Claude Settings refresh and reconnect semantics
+
+**Status:** Complete
+
+### What was done
+
+- Split the per-account Claude action into a non-mutating Refresh icon and an
+  explicit, visibly labeled Reconnect action with a distinct key symbol.
+- Added a destructive confirmation dialog that names the selected account and
+  explains that reconnect opens Terminal, logs out that profile, and starts a
+  new sign-in.
+- Added scoped per-account refresh support while retaining provider-level
+  refresh fan-out across every enabled Claude account.
+- Replaced independent status text and connection-color inputs with one
+  semantic presentation containing the text, symbol, and tone.
+- Added regression coverage for action routing, reconnect confirmation, status
+  presentation, provider-level fan-out, scoped refresh, peer preservation, and
+  login-required refresh failures.
+
+### Behavior flow
+
+```mermaid
+flowchart TD
+    ProviderRefresh["Provider Refresh (arrow.clockwise)"] --> AllAccounts["Fetch every enabled Claude account"]
+    AccountRefresh["Account Refresh (arrow.clockwise)"] --> SelectedAccount["Fetch only the selected Claude account"]
+    AllAccounts --> Merge["Merge usage and per-account auth states"]
+    SelectedAccount --> Merge
+    Merge --> SemanticStatus["Render text, symbol, and color from one semantic status"]
+    Reconnect["Reconnect (key.horizontal)"] --> Confirm{"User confirms account logout?"}
+    Confirm -->|Cancel| Stop["No mutation"]
+    Confirm -->|Reconnect| Terminal["Open Terminal logout/login flow"]
+```
+
+### Files changed
+
+- `MeterBar/Services/UsageDataManager.swift`
+- `MeterBar/Views/Components/SettingsComponents.swift`
+- `MeterBar/Views/Settings/ClaudeAccountProfileRow.swift`
+- `MeterBar/Views/Settings/ProviderSettingsView.swift`
+- `MeterBarTests/ClaudeAccountSettingsPresentationTests.swift`
+- `MeterBarTests/UsageDataManagerTests.swift`
+
+### Decisions
+
+- `arrow.clockwise` and Refresh remain exclusively non-mutating status/usage
+  operations in the Claude account UI.
+- Reconnect remains capable of logging out the selected profile, but only after
+  a clearly labeled, account-specific destructive confirmation.
+- A scoped account refresh does not record provider-wide parse health because
+  one selected profile is not evidence about the entire integration.
+- Claude planner and verifier profiles were unauthenticated, so implementation
+  planning and final review used repository evidence, focused tests, lint, and
+  a local structured QA pass.
+
+### Verification
+
+- Focused Claude Settings and account-refresh regressions: 9 tests passed.
+- Related Claude auth, reconnect service, Settings facts, and smoke tests:
+  48 tests passed.
+- `swiftlint lint --strict --quiet`: passed.
+- `git diff --check`: passed.
+- MeterBar Debug app build with code signing disabled: succeeded.
+- A broader `UsageDataManagerTests` filter still encounters the documented
+  machine-dependent Grok discovery baseline; no Claude regression failed.

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -481,6 +481,48 @@ class UsageDataManager: ObservableObject {
         }
     }
 
+    /// Refreshes one Claude profile without touching its peers.
+    ///
+    /// Settings uses this for the per-account arrow action. The provider-level
+    /// refresh continues to fan out across every enabled profile.
+    func refreshClaudeCodeAccount(id: UUID) async {
+        guard !demoMode, !isLoading else { return }
+        guard providerVisibilityStore.isEnabled(.claudeCode),
+              let account = claudeCodeAccountStore.enabledAccounts.first(where: { $0.id == id }) else {
+            return
+        }
+
+        isLoading = true
+        defer { isLoading = false }
+        lastError = nil
+
+        let fetch = await fetchClaudeCodeAccountMetrics(
+            accounts: [account],
+            trigger: .userInitiated,
+            recordsProviderHealth: false
+        )
+
+        if let refreshed = fetch.metrics[id] {
+            claudeCodeAccountMetrics[id] = refreshed
+        } else {
+            claudeCodeAccountMetrics.removeValue(forKey: id)
+        }
+
+        if let state = fetch.accountStates[id] {
+            claudeCodeAccountStates[id] = state
+        } else {
+            claudeCodeAccountStates.removeValue(forKey: id)
+        }
+
+        lastError = fetch.firstFailure
+        if let representative = representativeClaudeCodeMetrics(from: claudeCodeAccountMetrics) {
+            metrics[.claudeCode] = representative
+        } else {
+            metrics.removeValue(forKey: .claudeCode)
+        }
+        publishMetrics()
+    }
+
     /// A delayed repeating timer does not replay missed ticks after sleep. The
     /// workspace wake hook calls this method once; it catches up only when an
     /// enabled source has no data or its oldest successful snapshot is at least
@@ -724,9 +766,11 @@ class UsageDataManager: ObservableObject {
     }
 
     private func fetchClaudeCodeAccountMetrics(
-        trigger: ClaudeTokenRefreshTrigger
+        accounts: [ClaudeCodeAccount]? = nil,
+        trigger: ClaudeTokenRefreshTrigger,
+        recordsProviderHealth: Bool = true
     ) async -> AccountFetchResult {
-        let enabledAccounts = claudeCodeAccountStore.enabledAccounts
+        let enabledAccounts = accounts ?? claudeCodeAccountStore.enabledAccounts
         var refreshedMetrics: [UUID: UsageMetrics] = [:]
         var accountStates: [UUID: ClaudeCodeAuthState] = [:]
         var firstFailure: Error?
@@ -770,10 +814,12 @@ class UsageDataManager: ObservableObject {
         // Parse health tracks integration health, not per-account health:
         // if any account parses, the format contract still holds, so one
         // failing account must not dim the whole provider.
-        if successCount > 0 {
-            parseHealthStore.recordSuccess(.claudeCode)
-        } else if let firstFailure {
-            parseHealthStore.recordFailure(.claudeCode, error: firstFailure)
+        if recordsProviderHealth {
+            if successCount > 0 {
+                parseHealthStore.recordSuccess(.claudeCode)
+            } else if let firstFailure {
+                parseHealthStore.recordFailure(.claudeCode, error: firstFailure)
+            }
         }
 
         claudeFableSessionTracker.scheduleRefresh(accounts: enabledAccounts)

--- a/MeterBar/Views/Components/SettingsComponents.swift
+++ b/MeterBar/Views/Components/SettingsComponents.swift
@@ -173,13 +173,107 @@ struct SettingsDivider: View {
 
 // MARK: - StatusPill
 
+/// The complete semantic state of one Settings status label.
+///
+/// Keeping copy, symbol, and tone together prevents call sites from combining
+/// "Needs Attention" text with a green connected icon because a separate
+/// boolean happened to remain true.
+struct SettingsStatusPresentation: Equatable {
+    enum Tone: Equatable {
+        case success
+        case warning
+        case stale
+        case neutral
+    }
+
+    let text: String
+    let systemImage: String
+    let tone: Tone
+
+    var color: Color {
+        switch tone {
+        case .success:
+            MeterBarTheme.success
+        case .warning:
+            MeterBarTheme.warning
+        case .stale, .neutral:
+            .secondary
+        }
+    }
+
+    static func connection(title: String, isConnected: Bool) -> SettingsStatusPresentation {
+        SettingsStatusPresentation(
+            text: title,
+            systemImage: isConnected ? "checkmark.circle.fill" : "circle",
+            tone: isConnected ? .success : .neutral
+        )
+    }
+
+    static func claude(
+        _ state: ClaudeCodeAuthState?,
+        isEnabled: Bool
+    ) -> SettingsStatusPresentation {
+        guard isEnabled else {
+            return SettingsStatusPresentation(text: "Disabled", systemImage: "pause.circle", tone: .neutral)
+        }
+
+        switch state {
+        case let .connected(source):
+            return SettingsStatusPresentation(
+                text: "Connected (\(source.rawValue))",
+                systemImage: "checkmark.circle.fill",
+                tone: .success
+            )
+        case .cliAvailable:
+            return SettingsStatusPresentation(
+                text: "Ready (Claude CLI)",
+                systemImage: "checkmark.circle.fill",
+                tone: .success
+            )
+        case .needsLogin:
+            return SettingsStatusPresentation(
+                text: "Login Required",
+                systemImage: "person.crop.circle.badge.exclamationmark",
+                tone: .warning
+            )
+        case .error:
+            return SettingsStatusPresentation(
+                text: "Needs Attention",
+                systemImage: "exclamationmark.triangle.fill",
+                tone: .warning
+            )
+        case .stale:
+            return SettingsStatusPresentation(
+                text: "Stale",
+                systemImage: "clock.badge.exclamationmark",
+                tone: .stale
+            )
+        case .unavailable:
+            return SettingsStatusPresentation(text: "Not Connected", systemImage: "circle", tone: .neutral)
+        case .none:
+            return SettingsStatusPresentation(text: "Not Checked", systemImage: "questionmark.circle", tone: .neutral)
+        }
+    }
+}
+
 struct StatusPill: View {
-    let title: String
-    let isConnected: Bool
+    // MARK: Lifecycle
+
+    init(presentation: SettingsStatusPresentation) {
+        self.presentation = presentation
+    }
+
+    init(title: String, isConnected: Bool) {
+        self.presentation = .connection(title: title, isConnected: isConnected)
+    }
+
+    // MARK: Internal
+
+    let presentation: SettingsStatusPresentation
 
     var body: some View {
-        Label(title, systemImage: isConnected ? "checkmark.circle.fill" : "circle")
-            .foregroundStyle(isConnected ? MeterBarTheme.success : Color.secondary)
+        Label(presentation.text, systemImage: presentation.systemImage)
+            .foregroundStyle(presentation.color)
             .font(.subheadline)
     }
 }

--- a/MeterBar/Views/Settings/ClaudeAccountProfileRow.swift
+++ b/MeterBar/Views/Settings/ClaudeAccountProfileRow.swift
@@ -10,24 +10,100 @@ enum AccountProfileRowMetrics {
     static let actionWidth: CGFloat = 28
 }
 
+enum ClaudeAccountRowActionRoute: Equatable {
+    case performRefresh
+    case requestReconnectConfirmation
+}
+
+/// Presentation and routing contract for the two account-auth actions.
+///
+/// `arrow.clockwise` is intentionally exclusive to the non-mutating refresh.
+/// Reconnect is visibly labeled, uses a key symbol, and can only route to a
+/// confirmation request.
+enum ClaudeAccountRowAction: Equatable {
+    case refresh
+    case reconnect
+
+    var title: String {
+        switch self {
+        case .refresh:
+            "Refresh"
+        case .reconnect:
+            "Reconnect"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .refresh:
+            "arrow.clockwise"
+        case .reconnect:
+            "key.horizontal"
+        }
+    }
+
+    var route: ClaudeAccountRowActionRoute {
+        switch self {
+        case .refresh:
+            .performRefresh
+        case .reconnect:
+            .requestReconnectConfirmation
+        }
+    }
+
+    var showsVisibleTitle: Bool {
+        self == .reconnect
+    }
+
+    func accessibilityLabel(accountName: String) -> String {
+        "\(title) \(accountName)"
+    }
+
+    func help(accountName: String) -> String {
+        switch self {
+        case .refresh:
+            "Refresh status and usage for \(accountName)"
+        case .reconnect:
+            "Log out and sign in again for \(accountName)"
+        }
+    }
+}
+
+enum ClaudeReconnectConfirmation {
+    static let confirmButtonTitle = "Reconnect"
+
+    static func title(for account: ClaudeCodeAccount) -> String {
+        "Reconnect \(account.name)?"
+    }
+
+    static func message(for account: ClaudeCodeAccount) -> String {
+        "Terminal will open, log out the \(account.name) Claude profile, then ask you to sign in again."
+    }
+}
+
 // MARK: - AccountProfileRow
 
 /// One editable Claude Code account row (name + config directory + enable /
-/// reconnect / save / delete). Extracted verbatim from the SettingsView
-/// monolith. The default profile cannot be removed.
+/// refresh / reconnect / save / delete). The default profile cannot be removed.
 struct AccountProfileRow: View {
     // MARK: Lifecycle
 
     init(
         account: ClaudeCodeAccount,
+        authState: ClaudeCodeAuthState?,
+        isRefreshing: Bool,
         onEnabledChange: @escaping (Bool) -> Void,
         onSave: @escaping (String, String?) -> Void,
+        onRefresh: @escaping () -> Void,
         onReconnect: @escaping () -> Void,
         onRemove: @escaping () -> Void
     ) {
         self.account = account
+        self.authState = authState
+        self.isRefreshing = isRefreshing
         self.onEnabledChange = onEnabledChange
         self.onSave = onSave
+        self.onRefresh = onRefresh
         self.onReconnect = onReconnect
         self.onRemove = onRemove
         _nameDraft = State(initialValue: account.name)
@@ -37,8 +113,11 @@ struct AccountProfileRow: View {
     // MARK: Internal
 
     let account: ClaudeCodeAccount
+    let authState: ClaudeCodeAuthState?
+    let isRefreshing: Bool
     let onEnabledChange: (Bool) -> Void
     let onSave: (String, String?) -> Void
+    let onRefresh: () -> Void
     let onReconnect: () -> Void
     let onRemove: () -> Void
 
@@ -65,6 +144,11 @@ struct AccountProfileRow: View {
                         tint: account.isDefault ? MeterBarTheme.appAccent : MeterBarTheme.claudeAccent,
                         style: .glass
                     )
+
+                    StatusPill(
+                        presentation: .claude(authState, isEnabled: account.isEnabled)
+                    )
+                    .font(.caption)
                 }
 
                 HStack(spacing: 8) {
@@ -102,13 +186,12 @@ struct AccountProfileRow: View {
                 .controlSize(.small)
                 .help(account.isEnabled ? "Disable account" : "Enable account")
 
-                Button(action: onReconnect) {
-                    Image(systemName: "arrow.clockwise")
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .frame(width: AccountProfileRowMetrics.actionWidth)
-                .help("Reconnect Claude profile")
+                accountActionButton(.refresh)
+                    .frame(width: AccountProfileRowMetrics.actionWidth)
+                    .disabled(!account.isEnabled || isRefreshing)
+
+                accountActionButton(.reconnect)
+                    .disabled(isRefreshing)
 
                 Button(action: saveChanges) {
                     Image(systemName: "checkmark")
@@ -140,12 +223,23 @@ struct AccountProfileRow: View {
             nameDraft = updatedAccount.name
             configDirectoryDraft = Self.resolvedConfigDirectory(for: updatedAccount)
         }
+        .confirmationDialog(
+            ClaudeReconnectConfirmation.title(for: account),
+            isPresented: $showingReconnectConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(ClaudeReconnectConfirmation.confirmButtonTitle, role: .destructive, action: onReconnect)
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(ClaudeReconnectConfirmation.message(for: account))
+        }
     }
 
     // MARK: Private
 
     @State private var nameDraft: String
     @State private var configDirectoryDraft: String
+    @State private var showingReconnectConfirmation = false
 
     private var trimmedName: String {
         nameDraft.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -188,6 +282,37 @@ struct AccountProfileRow: View {
 
     private static func resolvedConfigDirectory(for account: ClaudeCodeAccount) -> String {
         account.configDirectory ?? (account.isDefault ? ClaudeCodeAccount.defaultConfigDirectory() : "")
+    }
+
+    private func accountActionButton(_ action: ClaudeAccountRowAction) -> some View {
+        Button {
+            route(action)
+        } label: {
+            if isRefreshing, action == .refresh {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityLabel(action.accessibilityLabel(accountName: account.name))
+            } else if action.showsVisibleTitle {
+                Label(action.title, systemImage: action.systemImage)
+            } else {
+                Label(action.title, systemImage: action.systemImage)
+                    .labelStyle(.iconOnly)
+            }
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .accessibilityLabel(action.accessibilityLabel(accountName: account.name))
+        .accessibilityHint(action.help(accountName: account.name))
+        .help(action.help(accountName: account.name))
+    }
+
+    private func route(_ action: ClaudeAccountRowAction) {
+        switch action.route {
+        case .performRefresh:
+            onRefresh()
+        case .requestReconnectConfirmation:
+            showingReconnectConfirmation = true
+        }
     }
 
     private func chooseConfigDirectory() {

--- a/MeterBar/Views/Settings/ProviderSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsView.swift
@@ -69,6 +69,7 @@ struct ProviderSettingsView: View {
 
     @State private var isAddingClaudeAccount = false
     @State private var isAddingCodexAccount = false
+    @State private var refreshingClaudeAccountIDs: Set<UUID> = []
     @State private var claudeReconnectError: String?
     @State private var openRouterKeyDraft = ""
 
@@ -145,7 +146,8 @@ struct ProviderSettingsView: View {
                 Button {
                     refreshProvider(service)
                 } label: {
-                    Image(systemName: "arrow.clockwise")
+                    Label("Refresh \(service.displayName)", systemImage: "arrow.clockwise")
+                        .labelStyle(.iconOnly)
                 }
                 .buttonStyle(.borderless)
                 .help("Refresh \(service.displayName)")
@@ -300,7 +302,12 @@ struct ProviderSettingsView: View {
         SettingsPanelSection(title: "Claude Code (Pro/Max)", logoKind: .claude, color: MeterBarTheme.claudeAccent) {
             SettingsRowView(title: "CLI status") {
                 HStack(spacing: 8) {
-                    StatusPill(title: claudeCodeService.authState.statusText, isConnected: claudeCodeService.hasAccess)
+                    StatusPill(
+                        presentation: .claude(
+                            defaultClaudeAuthState,
+                            isEnabled: claudeAccountStore.defaultAccountIsEnabled
+                        )
+                    )
 
                     Button {
                         // This is an explicit user action, so it is the one
@@ -386,6 +393,8 @@ struct ProviderSettingsView: View {
                         }
                         AccountProfileRow(
                             account: account,
+                            authState: claudeAuthState(for: account),
+                            isRefreshing: refreshingClaudeAccountIDs.contains(account.id),
                             onEnabledChange: { isEnabled in
                                 claudeAccountStore.setEnabled(isEnabled, for: account.id)
                                 SessionWakeSettingsStore.shared.reconcileAccounts(
@@ -396,6 +405,7 @@ struct ProviderSettingsView: View {
                             onSave: { name, configDirectory in
                                 updateClaudeAccount(id: account.id, name: name, configDirectory: configDirectory)
                             },
+                            onRefresh: { refreshClaudeAccount(account) },
                             onReconnect: { reconnectClaudeAccount(account) },
                             onRemove: {
                                 claudeAccountStore.removeAccount(id: account.id)
@@ -741,6 +751,23 @@ struct ProviderSettingsView: View {
             try ClaudeCodeReconnectService.openReconnectTerminal(for: account)
         } catch {
             claudeReconnectError = error.localizedDescription
+        }
+    }
+
+    private var defaultClaudeAuthState: ClaudeCodeAuthState? {
+        dataManager.claudeCodeAccountStates[ClaudeCodeAccount.defaultID] ?? claudeCodeService.authState
+    }
+
+    private func claudeAuthState(for account: ClaudeCodeAccount) -> ClaudeCodeAuthState? {
+        dataManager.claudeCodeAccountStates[account.id]
+            ?? (account.isDefault ? claudeCodeService.authState : nil)
+    }
+
+    private func refreshClaudeAccount(_ account: ClaudeCodeAccount) {
+        guard refreshingClaudeAccountIDs.insert(account.id).inserted else { return }
+        Task { @MainActor in
+            defer { refreshingClaudeAccountIDs.remove(account.id) }
+            await dataManager.refreshClaudeCodeAccount(id: account.id)
         }
     }
 }

--- a/MeterBarTests/ClaudeAccountSettingsPresentationTests.swift
+++ b/MeterBarTests/ClaudeAccountSettingsPresentationTests.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+import XCTest
+@testable import MeterBar
+
+final class ClaudeAccountSettingsPresentationTests: XCTestCase {
+    func testRefreshActionOwnsArrowClockwiseWithoutRequestingConfirmation() {
+        let action = ClaudeAccountRowAction.refresh
+
+        XCTAssertEqual(action.title, "Refresh")
+        XCTAssertEqual(action.systemImage, "arrow.clockwise")
+        XCTAssertEqual(action.route, .performRefresh)
+        XCTAssertFalse(action.showsVisibleTitle)
+    }
+
+    func testReconnectActionIsVisiblyLabeledDistinctAndConfirmationGated() {
+        let action = ClaudeAccountRowAction.reconnect
+
+        XCTAssertEqual(action.title, "Reconnect")
+        XCTAssertNotEqual(action.systemImage, ClaudeAccountRowAction.refresh.systemImage)
+        XCTAssertEqual(action.route, .requestReconnectConfirmation)
+        XCTAssertTrue(action.showsVisibleTitle)
+    }
+
+    func testReconnectConfirmationExplainsLogoutBeforeLogin() {
+        let account = ClaudeCodeAccount(
+            id: UUID(),
+            name: "Work",
+            configDirectory: "/tmp/work-claude"
+        )
+
+        XCTAssertEqual(ClaudeReconnectConfirmation.confirmButtonTitle, "Reconnect")
+        XCTAssertTrue(ClaudeReconnectConfirmation.title(for: account).contains("Work"))
+        XCTAssertTrue(ClaudeReconnectConfirmation.message(for: account).contains("log out"))
+        XCTAssertTrue(ClaudeReconnectConfirmation.message(for: account).contains("sign in"))
+    }
+
+    func testClaudeStatusPresentationKeepsTextIconAndToneSemantic() {
+        let connected = SettingsStatusPresentation.claude(.connected(.oauth), isEnabled: true)
+        XCTAssertEqual(connected.text, "Connected (OAuth)")
+        XCTAssertEqual(connected.systemImage, "checkmark.circle.fill")
+        XCTAssertEqual(connected.tone, .success)
+        XCTAssertEqual(connected.color, MeterBarTheme.success)
+
+        let attention = SettingsStatusPresentation.claude(.error("boom"), isEnabled: true)
+        XCTAssertEqual(attention.text, "Needs Attention")
+        XCTAssertNotEqual(attention.systemImage, "checkmark.circle.fill")
+        XCTAssertEqual(attention.tone, .warning)
+        XCTAssertEqual(attention.color, MeterBarTheme.warning)
+    }
+
+    func testWarningStaleAndLoginRequiredStatesNeverPresentAsGreenConnected() {
+        let degradedStates: [ClaudeCodeAuthState] = [
+            .needsLogin,
+            .stale(since: Date(timeIntervalSince1970: 1_720_000_000)),
+            .error("boom")
+        ]
+
+        for state in degradedStates {
+            let presentation = SettingsStatusPresentation.claude(state, isEnabled: true)
+            XCTAssertNotEqual(presentation.tone, .success)
+            XCTAssertNotEqual(presentation.systemImage, "checkmark.circle.fill")
+            XCTAssertNotEqual(presentation.color, MeterBarTheme.success)
+        }
+    }
+
+    func testDisabledAndUncheckedProfilesStayNeutral() {
+        let disabled = SettingsStatusPresentation.claude(.connected(.oauth), isEnabled: false)
+        XCTAssertEqual(disabled.text, "Disabled")
+        XCTAssertEqual(disabled.tone, .neutral)
+
+        let unchecked = SettingsStatusPresentation.claude(nil, isEnabled: true)
+        XCTAssertEqual(unchecked.text, "Not Checked")
+        XCTAssertEqual(unchecked.tone, .neutral)
+    }
+}

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -46,6 +46,7 @@ final class UsageDataManagerTests: XCTestCase {
         var accountAuthStates: [UUID: ClaudeCodeAuthState] = [:]
         var probe: ConcurrencyProbe?
         private(set) var fetchCount = 0
+        private(set) var fetchedAccountIDs: [UUID] = []
         private(set) var refreshTriggers: [ClaudeTokenRefreshTrigger] = []
 
         init(hasAccess: Bool, result: Result<UsageMetrics, Error>) {
@@ -62,9 +63,16 @@ final class UsageDataManagerTests: XCTestCase {
             trigger: ClaudeTokenRefreshTrigger
         ) async throws -> UsageMetrics {
             fetchCount += 1
+            fetchedAccountIDs.append(account.id)
             refreshTriggers.append(trigger)
             await probe?.recordFetch()
             return try (resultsByAccount[account.id] ?? result).get()
+        }
+
+        func resetFetchLog() {
+            fetchCount = 0
+            fetchedAccountIDs = []
+            refreshTriggers = []
         }
     }
 
@@ -558,6 +566,103 @@ final class UsageDataManagerTests: XCTestCase {
             manager.claudeCodeAccountStates[ClaudeCodeAccount.defaultID],
             .connected(.oauth)
         )
+        XCTAssertEqual(
+            Set(claude.fetchedAccountIDs),
+            [ClaudeCodeAccount.defaultID, work.id],
+            "Provider-level refresh must update every enabled Claude account"
+        )
+    }
+
+    func testAccountClaudeRefreshOnlyFetchesSelectedProfileAndPreservesPeers() async throws {
+        let accountSuite = "UsageDataManagerTests-scoped-claude-refresh-\(UUID().uuidString)"
+        createdSuiteNames.append(accountSuite)
+        let accountDefaults = try XCTUnwrap(UserDefaults(suiteName: accountSuite))
+        let accountStore = ClaudeCodeAccountStore(userDefaults: accountDefaults)
+        accountStore.addAccount(name: "Work", configDirectory: "/tmp/work-claude")
+        let work = try XCTUnwrap(accountStore.enabledAccounts.first { !$0.isDefault })
+        let claude = StubClaudeProvider(
+            hasAccess: true,
+            result: .success(MetricsFixtures.claudeCode(sessionUsedPercent: 20))
+        )
+        claude.resultsByAccount[work.id] = .success(MetricsFixtures.claudeCode(sessionUsedPercent: 80))
+        claude.accountAuthStates = [
+            ClaudeCodeAccount.defaultID: .connected(.oauth),
+            work.id: .connected(.oauth)
+        ]
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+        let (manager, _) = makeManager(
+            codex: codex,
+            cursor: cursor,
+            claude: claude,
+            claudeCodeAccountStore: accountStore,
+            hidden: [.codexCli, .cursor, .openRouter, .grok]
+        )
+
+        await manager.refresh(service: .claudeCode)
+        claude.resetFetchLog()
+        claude.resultsByAccount[work.id] = .success(MetricsFixtures.claudeCode(sessionUsedPercent: 55))
+        claude.accountAuthStates[work.id] = .connected(.cli)
+
+        await manager.refreshClaudeCodeAccount(id: work.id)
+
+        XCTAssertEqual(claude.fetchedAccountIDs, [work.id])
+        XCTAssertEqual(claude.refreshTriggers, [.userInitiated])
+        XCTAssertEqual(
+            manager.claudeCodeAccountMetrics[ClaudeCodeAccount.defaultID]?.sessionLimit?.used,
+            20,
+            "Refreshing Work must not replace or discard the default profile"
+        )
+        XCTAssertEqual(manager.claudeCodeAccountMetrics[work.id]?.sessionLimit?.used, 55)
+        XCTAssertEqual(manager.claudeCodeAccountStates[ClaudeCodeAccount.defaultID], .connected(.oauth))
+        XCTAssertEqual(manager.claudeCodeAccountStates[work.id], .connected(.cli))
+    }
+
+    func testAccountClaudeRefreshPublishesSelectedLoginFailureWithoutChangingPeer() async throws {
+        let accountSuite = "UsageDataManagerTests-scoped-claude-login-\(UUID().uuidString)"
+        createdSuiteNames.append(accountSuite)
+        let accountDefaults = try XCTUnwrap(UserDefaults(suiteName: accountSuite))
+        let accountStore = ClaudeCodeAccountStore(userDefaults: accountDefaults)
+        accountStore.addAccount(name: "Work", configDirectory: "/tmp/work-claude")
+        let work = try XCTUnwrap(accountStore.enabledAccounts.first { !$0.isDefault })
+        let claude = StubClaudeProvider(
+            hasAccess: true,
+            result: .success(MetricsFixtures.claudeCode(sessionUsedPercent: 20))
+        )
+        claude.resultsByAccount[work.id] = .success(MetricsFixtures.claudeCode(sessionUsedPercent: 80))
+        claude.accountAuthStates = [
+            ClaudeCodeAccount.defaultID: .connected(.oauth),
+            work.id: .connected(.oauth)
+        ]
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+        let (manager, _) = makeManager(
+            codex: codex,
+            cursor: cursor,
+            claude: claude,
+            claudeCodeAccountStore: accountStore,
+            hidden: [.codexCli, .cursor, .openRouter, .grok]
+        )
+
+        await manager.refresh(service: .claudeCode)
+        claude.resetFetchLog()
+        claude.resultsByAccount[work.id] = .failure(StubError.fetchFailed)
+        claude.accountAuthStates[work.id] = .needsLogin
+
+        await manager.refreshClaudeCodeAccount(id: work.id)
+
+        XCTAssertEqual(claude.fetchedAccountIDs, [work.id])
+        XCTAssertEqual(
+            manager.claudeCodeAccountMetrics[ClaudeCodeAccount.defaultID]?.sessionLimit?.used,
+            20
+        )
+        XCTAssertEqual(
+            manager.claudeCodeAccountMetrics[work.id]?.sessionLimit?.used,
+            80,
+            "A login failure should retain that profile's last-known usage"
+        )
+        XCTAssertEqual(manager.claudeCodeAccountStates[ClaudeCodeAccount.defaultID], .connected(.oauth))
+        XCTAssertEqual(manager.claudeCodeAccountStates[work.id], .needsLogin)
     }
 
     func testSingleClaudeRefreshClearsAccountStateWhenEveryAccountIsDisabled() async throws {


### PR DESCRIPTION
## Summary

- reserve `arrow.clockwise` and Refresh for non-mutating Claude status/usage refreshes
- expose reconnect as a visibly labeled key action with an account-specific destructive confirmation before logout
- render Claude Settings status text, symbol, and color from one semantic presentation
- support scoped account refreshes while provider refresh continues to fan out across all enabled Claude accounts

## Verification

- `swift test --filter 'ClaudeAccountSettingsPresentationTests|UsageDataManagerTests/testAccountClaudeRefreshOnlyFetchesSelectedProfileAndPreservesPeers|UsageDataManagerTests/testAccountClaudeRefreshPublishesSelectedLoginFailureWithoutChangingPeer|UsageDataManagerTests/testSingleClaudeRefreshPublishesLoggedOutSecondaryAccountState'` (9 passed)
- related Claude auth/reconnect/Settings regressions (48 passed)
- `swiftlint lint --strict --quiet`
- `git diff --check`
- MeterBar Debug app build with code signing disabled

## Notes

- A broader `UsageDataManagerTests` filter still encounters the existing machine-dependent Grok discovery baseline documented in recent session history; the focused Claude tests pass.
- Claude planner/verifier profiles were unauthenticated, so the final gate used repository evidence, focused tests, lint, a clean app build, and a structured local QA review.
