### PR TITLE
feat(cost): add month-to-date attribution breakdowns

### DIFF
--- a/.agents/SESSIONS/2026-07-29.md
+++ b/.agents/SESSIONS/2026-07-29.md
@@ -1,0 +1,101 @@
+# 2026-07-29
+
+## Session 1: Month-to-date project and model cost attribution
+
+**Status:** Complete
+
+### System flow
+
+```mermaid
+flowchart LR
+    A[Claude JSONL and Codex logs] --> B[Provider cost scanners]
+    B --> C[Day by model and sanitized project accumulators]
+    C --> D[Cost cache schema v2]
+    E[Legacy v1 cache] --> F[Copy-forward migration]
+    F --> D
+    D --> G[Calendar-bounded daily aggregation]
+    G --> H[Settings month-to-date view]
+    G --> I[meterbar cost JSON and text]
+```
+
+### Affected components
+
+- **Data:** Versioned cost-cache envelope and backward-compatible v1 migration.
+- **Scanning:** Claude and Codex day × model, day × project, and nested
+  day × project × model attribution.
+- **Presentation:** Month-to-date Settings rows and CLI text/JSON output.
+- **Documentation:** CLI JSON contract, architecture, and persisted-data map.
+
+### What was done
+
+- Added optional model/project attribution to each persisted daily usage row.
+  Missing values distinguish migrated v1 data from a v2 scan with no rows.
+- Bumped the cost cache to schema v2 and `cost-summary-v2.json`; a valid v1
+  cache is copied forward without deleting the recoverable original.
+- Made older pre-project cost payloads decode tolerantly and queued a normal
+  rescan when migrated rows lack attribution.
+- Aggregated project/model rollups over the exact selected calendar rows,
+  preserving recorded model-aware costs and omitting incomplete attribution.
+- Rendered month-to-date project rows with the same nested-model presentation
+  as the existing 30-day view.
+- Extended `meterbar cost --month-to-date` JSON and human-readable output.
+- Added migration, partial-month, legacy-partial, scanner attribution,
+  rollover-contract, JSON-contract, and presentation coverage.
+
+### Key decisions
+
+- Do not infer historical attribution during migration. Preserve the readable
+  totals, mark attribution unavailable, and refresh from source logs.
+- If any included daily row lacks a breakdown dimension, omit that entire
+  rollup instead of presenting a misleading partial total.
+- Persist only identifiers produced by `CostProjectAttribution`; raw paths,
+  branch names, remotes, prompts, and credentials remain outside the cache.
+- Keep the public CLI JSON schema at version 1 because all new fields are
+  additive and optional; the internal cost-cache schema independently moves
+  to version 2.
+
+### Files changed
+
+- `.agents/SYSTEM/ARCHITECTURE.md`
+- `MeterBar/Models/CLIJSONOutput.swift`
+- `MeterBar/Models/CostSummaryStore.swift`
+- `MeterBar/Models/TokenCost.swift`
+- `MeterBar/Services/ClaudeCostScanner.swift`
+- `MeterBar/Services/CodexCostScanner.swift`
+- `MeterBar/Services/CostScanWindows.swift`
+- `MeterBar/Services/TokenUsageAggregator.swift`
+- `MeterBar/Views/Settings/CostSettingsView.swift`
+- `MeterBarCLI/Sources/MeterBarCLI.swift`
+- `MeterBarTests/CLIJSONOutputTests.swift`
+- `MeterBarTests/CostSummaryStoreTests.swift`
+- `MeterBarTests/CostTrackerTests.swift`
+- `MeterBarTests/CostWindowTests.swift`
+- `MeterBarTests/SettingsViewSmokeTests.swift`
+- `docs/audits/00-repo-map.md`
+- `docs/cli-json-schema.md`
+
+### Mistakes and fixes
+
+- The first migration fixture exposed that caches predating project
+  attribution could not decode the newer required arrays. Added tolerant
+  custom decoding for additive breakdown fields.
+- The first lint pass found an optional-property initialization style issue
+  and nested dictionary mutation formatting. Refactored both and reran strict
+  lint successfully.
+- The configured Claude planning/review profile was unauthenticated, so no
+  quota-bearing fallback was probed. Planning used the bounded issue contract,
+  and verification used focused tests, strict lint, builds, and an exact-diff
+  local review.
+
+### Verification
+
+- Focused Swift tests: 112 passed, 0 failed.
+- `swiftlint lint --strict --quiet`: passed.
+- `swift build --package-path MeterBarCLI`: succeeded.
+- Debug app `xcodebuild` with code signing disabled: succeeded.
+- `git diff --check`: passed.
+
+### Next steps
+
+- Publish the ready PR for CI and maintainer review; do not merge until the
+  repository's required checks pass.

--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture - MeterBar
 
 **Purpose:** Document what IS implemented (not what WILL BE).
-**Last Updated:** 2026-07-26 (rewritten from a full-repo audit; see `docs/audits/00-repo-map.md`)
+**Last Updated:** 2026-07-29 (rewritten from a full-repo audit; see `docs/audits/00-repo-map.md`)
 
 ---
 
@@ -75,7 +75,7 @@ meterbar/
 - **OpenRouterService** — opt-in API-key provider; maps account credits/spend and optional per-key caps into shared metrics.
 - **GrokCLIUsageService** — first-class CLI provider (hidden only by explicit opt-out); resolves `grok`, authenticates the official ACP process with `cached_token`, and maps the reported quota periods onto the shared session/weekly windows with real reset times, plus prepaid balance and on-demand credits as `ExtraUsageStatus`. Decoding is tolerant (alternate field spellings, string/wrapped numbers); a shape it cannot read throws `.parsingError` rather than reporting a fabricated 0%, which `ProviderParseHealthStore` then counts as drift. Transport failures map to fixed `GrokRefreshFailure` strings that survive diagnostics sanitization as specific hints (not signed in, agent failed to start, timed out, unparseable, build too old). `GrokAgentProcess` supervises the child: own process group, bounded stdout buffer, 10 s deadline, `SIGTERM`→grace→`kill(-pgid, SIGKILL)`, and an app-termination sweep so no `grok` process is orphaned. Auto-update is disabled and stderr is drained but discarded to keep account metadata out of logs.
 - **ClaudeService / OpenAIService** — admin-key usage reports (paginated, 50-page cap) via `ServiceSupport.fetchDecoded`.
-- **CostTracker** — JSONL/SQLite log scanning, per-day/model/origin breakdowns, cache at `~/Library/Application Support/MeterBar/cost-summary-v1.json`. API-rate estimates come from the versioned `ModelPricing` table in `MeterBarShared`, which is shared with the CLI.
+- **CostTracker** — JSONL/SQLite log scanning with day × model and day × sanitized-project attribution, plus provider/model/origin rollups. Cache schema v2 lives at `~/Library/Application Support/MeterBar/cost-summary-v2.json`; reads copy a valid v1 cache forward without deleting it, preserve its provider totals, and queue a rescan because historical attribution cannot be reconstructed. Month-to-date app/CLI views aggregate only included v2 daily rows and omit incomplete breakdowns rather than substituting the full scan. API-rate estimates come from the versioned `ModelPricing` table in `MeterBarShared`, which is shared with the CLI.
 - **ClaudeFableSessionTracker** — schedules a coalesced, off-main scan after Claude quota refreshes. It reads bounded tails from configured profile JSONL roots, caches unchanged files by modification date and size, persists only profile/session/model/timestamp/lifecycle metadata in the app group, and retains deduplicated history for 30 days. Account cards show the latest account-attributed activity as Active, Recent, or No activity; Settings and CLI retain the full history surfaces. Transcript content, credentials, working directories, and git metadata are never retained.
 - **AuthenticationManager + KeychainManager** — the two admin keys, stored in keychain service `dev.meterbar.app`. Reads migrate the older `dev.shipshit.meterbar` (v1.6.x) and `com.agenticindiedev.quotaguard` (v1.0-v1.6) services into the current one, and removals delete all three so a legacy key cannot reappear.
 - **SharedDataStore** — app-group JSON file (`cached_usage_metrics.json`), atomic writes on a serial queue, `WidgetCenter.reloadTimelines` after save.

--- a/MeterBar/Models/CLIJSONOutput.swift
+++ b/MeterBar/Models/CLIJSONOutput.swift
@@ -123,11 +123,9 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
         // `monthToDate` takes precedence over `--days`; the CLI's `validate()`
         // rejects passing both, so this ordering only matters for direct callers.
         if monthToDate {
-            // Month-to-date has no project dimension of its own: it's a window
-            // over the cached *daily* rows (`DailyTokenUsage`), which — unlike
-            // the full lifetime scan behind `TokenCost.projectBreakdowns` —
-            // carries no per-project field. Project grouping and calendar
-            // windowing are orthogonal axes in the current data model.
+            // Cache v2's daily rows carry model and sanitized project
+            // attribution, so the window and all of its breakdowns share the
+            // same calendar boundary.
             let window = cache.summary.monthToDateCostWindow(now: now, calendar: calendar)
             period = Period(
                 requestedDays: window.requestedDays,
@@ -190,11 +188,13 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
         let totalTokens: Int
         let estimatedCostUSD: Double
         let sessionCount: Int?
+        /// Top-level per-model rollup. `nil` means the selected cache/window
+        /// does not have complete model attribution.
+        let modelBreakdowns: [ModelBreakdown]?
         /// Per-project/worktree rollup (issue #270). `nil` — not merely empty —
-        /// whenever the underlying source carries no project dimension at all
-        /// (a `--days`/month-to-date window) or the scan found nothing to
-        /// attribute, so consumers can tell "not available here" apart from
-        /// "everything landed in one project".
+        /// whenever the selected rows have incomplete project attribution or
+        /// the scan found nothing to attribute, so consumers can tell "not
+        /// available here" apart from "everything landed in one project".
         let projectBreakdowns: [ProjectBreakdown]?
 
         init(cost: TokenCost) {
@@ -207,6 +207,9 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
             totalTokens = cost.totalTokens
             estimatedCostUSD = cost.estimatedCostUSD
             sessionCount = cost.sessionCount
+            modelBreakdowns = cost.modelBreakdowns.isEmpty
+                ? nil
+                : cost.modelBreakdowns.map(ModelBreakdown.init)
             projectBreakdowns = cost.projectBreakdowns.isEmpty
                 ? nil
                 : cost.projectBreakdowns.map(ProjectBreakdown.init)
@@ -222,7 +225,8 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
             totalTokens = total.totalTokens
             estimatedCostUSD = total.estimatedCostUSD
             sessionCount = nil
-            projectBreakdowns = nil
+            modelBreakdowns = total.modelBreakdowns?.map(ModelBreakdown.init)
+            projectBreakdowns = total.projectBreakdowns?.map(ProjectBreakdown.init)
         }
     }
 
@@ -271,27 +275,27 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
             sessionCount = breakdown.sessionCount
             modelBreakdowns = breakdown.modelBreakdowns.map(ModelBreakdown.init)
         }
+    }
 
-        struct ModelBreakdown: Encodable {
-            let name: String
-            let inputTokens: Int
-            let outputTokens: Int
-            let cacheCreationTokens: Int
-            let cacheReadTokens: Int
-            let totalTokens: Int
-            let estimatedCostUSD: Double
-            let sessionCount: Int
+    private struct ModelBreakdown: Encodable {
+        let name: String
+        let inputTokens: Int
+        let outputTokens: Int
+        let cacheCreationTokens: Int
+        let cacheReadTokens: Int
+        let totalTokens: Int
+        let estimatedCostUSD: Double
+        let sessionCount: Int
 
-            init(_ breakdown: TokenUsageBreakdown) {
-                name = breakdown.name
-                inputTokens = breakdown.inputTokens
-                outputTokens = breakdown.outputTokens
-                cacheCreationTokens = breakdown.cacheCreationTokens
-                cacheReadTokens = breakdown.cacheReadTokens
-                totalTokens = breakdown.totalTokens
-                estimatedCostUSD = breakdown.estimatedCostUSD
-                sessionCount = breakdown.sessionCount
-            }
+        init(_ breakdown: TokenUsageBreakdown) {
+            name = breakdown.name
+            inputTokens = breakdown.inputTokens
+            outputTokens = breakdown.outputTokens
+            cacheCreationTokens = breakdown.cacheCreationTokens
+            cacheReadTokens = breakdown.cacheReadTokens
+            totalTokens = breakdown.totalTokens
+            estimatedCostUSD = breakdown.estimatedCostUSD
+            sessionCount = breakdown.sessionCount
         }
     }
 }

--- a/MeterBar/Models/CostSummaryStore.swift
+++ b/MeterBar/Models/CostSummaryStore.swift
@@ -5,19 +5,37 @@ import Foundation
 /// `meterbar cost` (which reports the app's scan instead of re-implementing
 /// a divergent one).
 nonisolated public struct CostSummaryCache: Codable, Sendable {
+    public static let currentSchemaVersion = 2
+
+    public let schemaVersion: Int
     public let summary: CostSummary
     public let lastScanDate: Date
 
     public init(summary: CostSummary, lastScanDate: Date) {
+        schemaVersion = Self.currentSchemaVersion
         self.summary = summary
         self.lastScanDate = lastScanDate
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // Version 1 had no envelope version field. Its DailyTokenUsage rows
+        // also decode their missing attribution arrays as nil.
+        schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 1
+        summary = try container.decode(CostSummary.self, forKey: .summary)
+        lastScanDate = try container.decode(Date.self, forKey: .lastScanDate)
+    }
+
+    fileprivate var migratedToCurrentVersion: CostSummaryCache {
+        CostSummaryCache(summary: summary, lastScanDate: lastScanDate)
     }
 }
 
 /// Single owner of the cost-summary cache location and encoding
-/// (`~/Library/Application Support/MeterBar/cost-summary-v1.json`).
+/// (`~/Library/Application Support/MeterBar/cost-summary-v2.json`).
 nonisolated public enum CostSummaryStore {
-    static let cacheFileName = "cost-summary-v1.json"
+    static let cacheFileName = "cost-summary-v2.json"
+    static let legacyCacheFileName = "cost-summary-v1.json"
 
     public static var cacheURL: URL? {
         guard let supportDirectory = FileManager.default.urls(
@@ -32,12 +50,45 @@ nonisolated public enum CostSummaryStore {
             .appendingPathComponent(cacheFileName)
     }
 
+    static var legacyCacheURL: URL? {
+        cacheURL?
+            .deletingLastPathComponent()
+            .appendingPathComponent(legacyCacheFileName)
+    }
+
     public static func load() -> CostSummaryCache? {
-        guard let cacheURL,
-              let data = try? Data(contentsOf: cacheURL) else {
-            return nil
+        guard let cacheURL, let legacyCacheURL else { return nil }
+        return load(currentURL: cacheURL, legacyURL: legacyCacheURL)
+    }
+
+    /// Testable migration seam. The v1 file is copied forward only after it
+    /// decodes successfully; it remains in place as a recoverable fallback.
+    static func load(currentURL: URL, legacyURL: URL) -> CostSummaryCache? {
+        if FileManager.default.fileExists(atPath: currentURL.path) {
+            guard let cache = decode(from: currentURL),
+                  cache.schemaVersion <= CostSummaryCache.currentSchemaVersion else {
+                return nil
+            }
+            if cache.schemaVersion == CostSummaryCache.currentSchemaVersion {
+                return cache
+            }
+
+            let migrated = cache.migratedToCurrentVersion
+            try? save(migrated, to: currentURL)
+            return migrated
         }
 
+        guard let legacy = decode(from: legacyURL),
+              legacy.schemaVersion < CostSummaryCache.currentSchemaVersion else {
+            return nil
+        }
+        let migrated = legacy.migratedToCurrentVersion
+        try? save(migrated, to: currentURL)
+        return migrated
+    }
+
+    private static func decode(from url: URL) -> CostSummaryCache? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         return try? decoder.decode(CostSummaryCache.self, from: data)
@@ -45,7 +96,10 @@ nonisolated public enum CostSummaryStore {
 
     static func save(_ cache: CostSummaryCache) throws {
         guard let cacheURL else { return }
+        try save(cache, to: cacheURL)
+    }
 
+    static func save(_ cache: CostSummaryCache, to cacheURL: URL) throws {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]

--- a/MeterBar/Models/TokenCost.swift
+++ b/MeterBar/Models/TokenCost.swift
@@ -50,6 +50,31 @@ nonisolated public struct TokenCost: Codable, Identifiable, Sendable {
         self.projectBreakdowns = projectBreakdowns
     }
 
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        provider = try container.decode(ServiceType.self, forKey: .provider)
+        inputTokens = try container.decode(Int.self, forKey: .inputTokens)
+        outputTokens = try container.decode(Int.self, forKey: .outputTokens)
+        cacheCreationTokens = try container.decode(Int.self, forKey: .cacheCreationTokens)
+        cacheReadTokens = try container.decode(Int.self, forKey: .cacheReadTokens)
+        estimatedCostUSD = try container.decode(Double.self, forKey: .estimatedCostUSD)
+        sessionCount = try container.decode(Int.self, forKey: .sessionCount)
+        periodStart = try container.decode(Date.self, forKey: .periodStart)
+        periodEnd = try container.decode(Date.self, forKey: .periodEnd)
+        modelBreakdowns = try container.decodeIfPresent(
+            [TokenUsageBreakdown].self,
+            forKey: .modelBreakdowns
+        ) ?? []
+        originBreakdowns = try container.decodeIfPresent(
+            [TokenUsageBreakdown].self,
+            forKey: .originBreakdowns
+        ) ?? []
+        projectBreakdowns = try container.decodeIfPresent(
+            [TokenUsageBreakdown].self,
+            forKey: .projectBreakdowns
+        ) ?? []
+    }
+
     public var totalTokens: Int {
         inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens
     }
@@ -102,6 +127,22 @@ nonisolated public struct TokenUsageBreakdown: Codable, Identifiable, Sendable {
         self.modelBreakdowns = modelBreakdowns
     }
 
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        provider = try container.decode(ServiceType.self, forKey: .provider)
+        name = try container.decode(String.self, forKey: .name)
+        inputTokens = try container.decode(Int.self, forKey: .inputTokens)
+        outputTokens = try container.decode(Int.self, forKey: .outputTokens)
+        cacheCreationTokens = try container.decode(Int.self, forKey: .cacheCreationTokens)
+        cacheReadTokens = try container.decode(Int.self, forKey: .cacheReadTokens)
+        estimatedCostUSD = try container.decode(Double.self, forKey: .estimatedCostUSD)
+        sessionCount = try container.decode(Int.self, forKey: .sessionCount)
+        modelBreakdowns = try container.decodeIfPresent(
+            [TokenUsageBreakdown].self,
+            forKey: .modelBreakdowns
+        ) ?? []
+    }
+
     public var totalTokens: Int {
         inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens
     }
@@ -124,6 +165,14 @@ nonisolated public struct DailyTokenUsage: Codable, Identifiable, Sendable {
     public let outputTokens: Int
     public let cacheReadTokens: Int
     public let estimatedCostUSD: Double
+    /// Day × model attribution from the v2 cost cache. `nil` means the row
+    /// came from a v1 cache that predates attribution; an empty array means a
+    /// v2 scan ran but had no model rows.
+    public let modelBreakdowns: [TokenUsageBreakdown]?
+    /// Day × project attribution, including each project's model slice.
+    /// Project names have already passed through `CostProjectAttribution`;
+    /// raw paths are never persisted here.
+    public let projectBreakdowns: [TokenUsageBreakdown]?
 
     public init(
         date: Date,
@@ -131,7 +180,9 @@ nonisolated public struct DailyTokenUsage: Codable, Identifiable, Sendable {
         inputTokens: Int,
         outputTokens: Int,
         cacheReadTokens: Int,
-        estimatedCostUSD: Double
+        estimatedCostUSD: Double,
+        modelBreakdowns: [TokenUsageBreakdown]? = nil,
+        projectBreakdowns: [TokenUsageBreakdown]? = nil
     ) {
         self.date = date
         self.provider = provider
@@ -139,6 +190,8 @@ nonisolated public struct DailyTokenUsage: Codable, Identifiable, Sendable {
         self.outputTokens = outputTokens
         self.cacheReadTokens = cacheReadTokens
         self.estimatedCostUSD = estimatedCostUSD
+        self.modelBreakdowns = modelBreakdowns
+        self.projectBreakdowns = projectBreakdowns
     }
 
     public var totalTokens: Int {
@@ -273,6 +326,11 @@ nonisolated public struct CostSummary: Codable, Sendable {
     ) -> Bool {
         guard !costs.isEmpty, totalTokens > 0 else { return false }
         guard !dailyUsage.isEmpty else { return true }
+        guard dailyUsage.allSatisfy({
+            $0.modelBreakdowns != nil && $0.projectBreakdowns != nil
+        }) else {
+            return true
+        }
 
         let today = calendar.startOfDay(for: now)
         if let lastScanDate,
@@ -316,19 +374,25 @@ nonisolated public struct CostSummary: Codable, Sendable {
             return day >= startDate && day <= today
         }
 
-        var byProvider: [ServiceType: ProviderDailyTotal] = [:]
-        for row in windowRows {
-            let existing = byProvider[row.provider]
-            byProvider[row.provider] = ProviderDailyTotal(
-                provider: row.provider,
-                inputTokens: (existing?.inputTokens ?? 0) + row.inputTokens,
-                outputTokens: (existing?.outputTokens ?? 0) + row.outputTokens,
-                cacheReadTokens: (existing?.cacheReadTokens ?? 0) + row.cacheReadTokens,
-                estimatedCostUSD: (existing?.estimatedCostUSD ?? 0) + row.estimatedCostUSD
-            )
-        }
-
-        let providers = byProvider.values.sorted { $0.provider.rawValue < $1.provider.rawValue }
+        let providers = Dictionary(grouping: windowRows, by: \.provider)
+            .map { provider, rows in
+                let hasCompleteModels = rows.allSatisfy { $0.modelBreakdowns != nil }
+                let hasCompleteProjects = rows.allSatisfy { $0.projectBreakdowns != nil }
+                return ProviderDailyTotal(
+                    provider: provider,
+                    inputTokens: rows.reduce(0) { $0 + $1.inputTokens },
+                    outputTokens: rows.reduce(0) { $0 + $1.outputTokens },
+                    cacheReadTokens: rows.reduce(0) { $0 + $1.cacheReadTokens },
+                    estimatedCostUSD: rows.reduce(0) { $0 + $1.estimatedCostUSD },
+                    modelBreakdowns: hasCompleteModels
+                        ? TokenUsageBreakdownAggregation.merge(rows.flatMap { $0.modelBreakdowns ?? [] })
+                        : nil,
+                    projectBreakdowns: hasCompleteProjects
+                        ? TokenUsageBreakdownAggregation.merge(rows.flatMap { $0.projectBreakdowns ?? [] })
+                        : nil
+                )
+            }
+            .sorted { $0.provider.rawValue < $1.provider.rawValue }
 
         // Days the cache demonstrably spans: earliest daily row through today,
         // inclusive. Zero-usage days inside that span carry no row, so this is
@@ -397,19 +461,29 @@ nonisolated public struct ProviderDailyTotal: Codable, Sendable, Identifiable {
     public let outputTokens: Int
     public let cacheReadTokens: Int
     public let estimatedCostUSD: Double
+    /// `nil` when any included row predates cache v2; otherwise the model
+    /// rollup over exactly the same days as this provider total.
+    public let modelBreakdowns: [TokenUsageBreakdown]?
+    /// `nil` when any included row predates cache v2; otherwise the project
+    /// rollup (with nested models) over exactly the same days.
+    public let projectBreakdowns: [TokenUsageBreakdown]?
 
     public init(
         provider: ServiceType,
         inputTokens: Int,
         outputTokens: Int,
         cacheReadTokens: Int,
-        estimatedCostUSD: Double
+        estimatedCostUSD: Double,
+        modelBreakdowns: [TokenUsageBreakdown]? = nil,
+        projectBreakdowns: [TokenUsageBreakdown]? = nil
     ) {
         self.provider = provider
         self.inputTokens = inputTokens
         self.outputTokens = outputTokens
         self.cacheReadTokens = cacheReadTokens
         self.estimatedCostUSD = estimatedCostUSD
+        self.modelBreakdowns = modelBreakdowns
+        self.projectBreakdowns = projectBreakdowns
     }
 
     /// Daily rows omit cache-creation tokens, so this is input + output + cache-read.
@@ -458,5 +532,36 @@ nonisolated public struct DailyCostWindow: Codable, Sendable {
 
     public var formattedTotalCost: String {
         UsageFormat.cost(totalCostUSD)
+    }
+}
+
+/// Sums persisted day-level attribution without repricing it. Daily rows
+/// already carry the exact model-aware estimated cost produced by the scan, so
+/// recomputing from provider defaults here could drift from the provider total.
+nonisolated private enum TokenUsageBreakdownAggregation {
+    static func merge(_ rows: [TokenUsageBreakdown]) -> [TokenUsageBreakdown] {
+        var byName: [String: TokenUsageBreakdown] = [:]
+
+        for row in rows {
+            let existing = byName[row.name]
+            byName[row.name] = TokenUsageBreakdown(
+                provider: row.provider,
+                name: row.name,
+                inputTokens: (existing?.inputTokens ?? 0) + row.inputTokens,
+                outputTokens: (existing?.outputTokens ?? 0) + row.outputTokens,
+                cacheCreationTokens: (existing?.cacheCreationTokens ?? 0) + row.cacheCreationTokens,
+                cacheReadTokens: (existing?.cacheReadTokens ?? 0) + row.cacheReadTokens,
+                estimatedCostUSD: (existing?.estimatedCostUSD ?? 0) + row.estimatedCostUSD,
+                sessionCount: (existing?.sessionCount ?? 0) + row.sessionCount,
+                modelBreakdowns: merge((existing?.modelBreakdowns ?? []) + row.modelBreakdowns)
+            )
+        }
+
+        return byName.values.sorted { lhs, rhs in
+            if lhs.estimatedCostUSD == rhs.estimatedCostUSD {
+                return lhs.totalTokens > rhs.totalTokens
+            }
+            return lhs.estimatedCostUSD > rhs.estimatedCostUSD
+        }
     }
 }

--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -90,7 +90,14 @@ enum ClaudeCostScanner {
                 provider: .claudeCode,
                 pricing: pricing
             )
-        ), TokenUsageAggregator.makeDailyUsage(from: totals.daily, provider: .claudeCode, pricing: pricing))
+        ), TokenUsageAggregator.makeDailyUsage(
+            from: totals.daily,
+            provider: .claudeCode,
+            pricing: pricing,
+            modelsByDay: totals.dailyModels,
+            projectsByDay: totals.dailyProjects,
+            projectModelsByDay: totals.dailyProjectModels
+        ))
     }
 
     nonisolated private static func projectRoots(accounts: [ClaudeCodeAccount]) -> [URL] {
@@ -254,7 +261,34 @@ enum ClaudeCostScanner {
                 cacheRead: event.cacheRead,
                 estimatedCostUSD: eventCost
             )
-            totals.models[CostScanValues.displayModelName(event.model), default: TokenAccumulator()].add(
+            let displayModel = CostScanValues.displayModelName(event.model)
+            totals.dailyModels[day, default: [:]][displayModel, default: TokenAccumulator()].add(
+                input: event.input,
+                output: event.output,
+                cacheCreation: event.cacheCreation,
+                cacheRead: event.cacheRead,
+                estimatedCostUSD: eventCost
+            )
+            totals.dailyProjects[day, default: [:]][projectID, default: TokenAccumulator()].add(
+                input: event.input,
+                output: event.output,
+                cacheCreation: event.cacheCreation,
+                cacheRead: event.cacheRead,
+                estimatedCostUSD: eventCost
+            )
+            var dailyProjectModels = totals.dailyProjectModels[day] ?? [:]
+            dailyProjectModels[projectID, default: [:]][
+                displayModel,
+                default: TokenAccumulator()
+            ].add(
+                input: event.input,
+                output: event.output,
+                cacheCreation: event.cacheCreation,
+                cacheRead: event.cacheRead,
+                estimatedCostUSD: eventCost
+            )
+            totals.dailyProjectModels[day] = dailyProjectModels
+            totals.models[displayModel, default: TokenAccumulator()].add(
                 input: event.input,
                 output: event.output,
                 cacheCreation: event.cacheCreation,
@@ -275,7 +309,6 @@ enum ClaudeCostScanner {
                 cacheRead: event.cacheRead,
                 estimatedCostUSD: eventCost
             )
-            let displayModel = CostScanValues.displayModelName(event.model)
             totals.projectModels[projectID, default: [:]][displayModel, default: TokenAccumulator()].add(
                 input: event.input,
                 output: event.output,

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -95,7 +95,15 @@ enum CodexCostScanner {
                 pricing: pricing,
                 pricingForName: { ModelPricing.codex(for: $0) }
             )
-        ), TokenUsageAggregator.makeDailyUsage(from: context.dailyTotals, provider: .codexCli, pricing: pricing))
+        ), TokenUsageAggregator.makeDailyUsage(
+            from: context.dailyTotals,
+            provider: .codexCli,
+            pricing: pricing,
+            modelsByDay: context.dailyModelTotals,
+            projectsByDay: context.dailyProjectTotals,
+            projectModelsByDay: context.dailyProjectModelTotals,
+            pricingForName: { ModelPricing.codex(for: $0) }
+        ))
     }
 
     /// Directories holding Codex rollout `.jsonl` files. Codex only moves a
@@ -345,6 +353,29 @@ enum CodexCostScanner {
                 cacheCreation: 0,
                 cacheRead: cached
             )
+            context.dailyModelTotals[day, default: [:]][modelKey, default: TokenAccumulator()].add(
+                input: input,
+                output: output + reasoning,
+                cacheCreation: 0,
+                cacheRead: cached
+            )
+            context.dailyProjectTotals[day, default: [:]][projectKey, default: TokenAccumulator()].add(
+                input: input,
+                output: output + reasoning,
+                cacheCreation: 0,
+                cacheRead: cached
+            )
+            var dailyProjectModels = context.dailyProjectModelTotals[day] ?? [:]
+            dailyProjectModels[projectKey, default: [:]][
+                modelKey,
+                default: TokenAccumulator()
+            ].add(
+                input: input,
+                output: output + reasoning,
+                cacheCreation: 0,
+                cacheRead: cached
+            )
+            context.dailyProjectModelTotals[day] = dailyProjectModels
             context.modelTotals[modelKey, default: TokenAccumulator()].add(
                 input: input,
                 output: output + reasoning,

--- a/MeterBar/Services/CostScanWindows.swift
+++ b/MeterBar/Services/CostScanWindows.swift
@@ -47,6 +47,9 @@ nonisolated struct ClaudeSessionTotals: Sendable {
     var earliest: Date?
     var latest: Date?
     var daily: [Date: TokenAccumulator] = [:]
+    var dailyModels: [Date: [String: TokenAccumulator]] = [:]
+    var dailyProjects: [Date: [String: TokenAccumulator]] = [:]
+    var dailyProjectModels: [Date: [String: [String: TokenAccumulator]]] = [:]
     var models: [String: TokenAccumulator] = [:]
     var origins: [String: TokenAccumulator] = [:]
     /// Per-project rollup, keyed by the sanitized identifier `CostProjectAttribution`
@@ -76,6 +79,26 @@ nonisolated struct ClaudeSessionTotals: Sendable {
 
         for (day, tokens) in other.daily {
             daily[day, default: TokenAccumulator()].merge(tokens)
+        }
+        for (day, modelTotals) in other.dailyModels {
+            for (model, tokens) in modelTotals {
+                dailyModels[day, default: [:]][model, default: TokenAccumulator()].merge(tokens)
+            }
+        }
+        for (day, projectTotals) in other.dailyProjects {
+            for (project, tokens) in projectTotals {
+                dailyProjects[day, default: [:]][project, default: TokenAccumulator()].merge(tokens)
+            }
+        }
+        for (day, projectTotals) in other.dailyProjectModels {
+            for (project, modelTotals) in projectTotals {
+                for (model, tokens) in modelTotals {
+                    dailyProjectModels[day, default: [:]][project, default: [:]][
+                        model,
+                        default: TokenAccumulator()
+                    ].merge(tokens)
+                }
+            }
         }
         for (name, tokens) in other.models {
             models[name, default: TokenAccumulator()].merge(tokens)
@@ -135,6 +158,9 @@ nonisolated struct CostScanResult {
 nonisolated struct CodexScanContext: Sendable {
     var totals = TokenAccumulator()
     var dailyTotals: [Date: TokenAccumulator] = [:]
+    var dailyModelTotals: [Date: [String: TokenAccumulator]] = [:]
+    var dailyProjectTotals: [Date: [String: TokenAccumulator]] = [:]
+    var dailyProjectModelTotals: [Date: [String: [String: TokenAccumulator]]] = [:]
     var modelTotals: [String: TokenAccumulator] = [:]
     var originTotals: [String: TokenAccumulator] = [:]
     /// Per-project rollup keyed by `CostProjectAttribution.codexProjectID` —

--- a/MeterBar/Services/TokenUsageAggregator.swift
+++ b/MeterBar/Services/TokenUsageAggregator.swift
@@ -8,7 +8,11 @@ enum TokenUsageAggregator {
     nonisolated static func makeDailyUsage(
         from dailyTotals: [Date: TokenAccumulator],
         provider: ServiceType,
-        pricing: TokenPricing
+        pricing: TokenPricing,
+        modelsByDay: [Date: [String: TokenAccumulator]] = [:],
+        projectsByDay: [Date: [String: TokenAccumulator]] = [:],
+        projectModelsByDay: [Date: [String: [String: TokenAccumulator]]] = [:],
+        pricingForName: ((String) -> TokenPricing)? = nil
     ) -> [DailyTokenUsage] {
         dailyTotals.map { day, tokens in
             let billableInput = provider == .codexCli ? max(0, tokens.input - tokens.cacheRead) : tokens.input
@@ -27,7 +31,24 @@ enum TokenUsageAggregator {
                 inputTokens: billableInput,
                 outputTokens: tokens.output + tokens.reasoning,
                 cacheReadTokens: tokens.cacheRead,
-                estimatedCostUSD: cost
+                estimatedCostUSD: cost,
+                modelBreakdowns: modelsByDay[day].map {
+                    makeBreakdowns(
+                        from: $0,
+                        provider: provider,
+                        pricing: pricing,
+                        pricingForName: pricingForName
+                    )
+                },
+                projectBreakdowns: projectsByDay[day].map {
+                    makeProjectBreakdowns(
+                        from: $0,
+                        modelsByProject: projectModelsByDay[day] ?? [:],
+                        provider: provider,
+                        pricing: pricing,
+                        pricingForName: pricingForName
+                    )
+                }
             )
         }
     }

--- a/MeterBar/Views/Settings/CostSettingsView.swift
+++ b/MeterBar/Views/Settings/CostSettingsView.swift
@@ -29,6 +29,21 @@ struct CostPeriodContentView: View {
     let summary: CostSummary
     let periodMode: CostPeriodMode
     let currency: DisplayCurrency?
+    /// Stable clock injection for presentation tests. Production leaves this
+    /// nil and keeps the minute-based TimelineView rollover behavior.
+    var monthToDateNow: Date?
+
+    init(
+        summary: CostSummary,
+        periodMode: CostPeriodMode,
+        currency: DisplayCurrency?,
+        monthToDateNow: Date? = nil
+    ) {
+        self.summary = summary
+        self.periodMode = periodMode
+        self.currency = currency
+        self.monthToDateNow = monthToDateNow
+    }
 
     var body: some View {
         switch periodMode {
@@ -85,11 +100,18 @@ struct CostPeriodContentView: View {
     /// showing last month's window until unrelated state moved. Same
     /// one-minute schedule the other time-driven settings rows already use.
     @ViewBuilder private var monthToDateContent: some View {
-        TimelineView(.periodic(from: .now, by: 60)) { context in
+        if let monthToDateNow {
             VStack(alignment: .leading, spacing: 10) {
-                monthToDateRows(now: context.date)
+                monthToDateRows(now: monthToDateNow)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            TimelineView(.periodic(from: .now, by: 60)) { context in
+                VStack(alignment: .leading, spacing: 10) {
+                    monthToDateRows(now: context.date)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
     }
 
@@ -134,6 +156,10 @@ struct CostPeriodContentView: View {
                             .font(.caption2)
                             .foregroundColor(.secondary)
                     }
+                }
+
+                if let projects = provider.projectBreakdowns, !projects.isEmpty {
+                    projectBreakdownRows(projects)
                 }
             }
         }

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -352,6 +352,13 @@ struct Cost: ParsableCommand {
             print("  Output:         \(UsageFormat.groupedTokens(provider.outputTokens))")
             print("  Cache Read:     \(UsageFormat.groupedTokens(provider.cacheReadTokens))")
             print("  Estimated Cost: \(costText(provider.estimatedCostUSD, currency: currency))")
+            if let projects = provider.projectBreakdowns, !projects.isEmpty {
+                print("  Projects:")
+                for project in projects.sorted(by: { $0.estimatedCostUSD > $1.estimatedCostUSD }) {
+                    print("    - \(project.name): \(costText(project.estimatedCostUSD, currency: currency))"
+                        + " (\(project.sessionCount) event\(project.sessionCount == 1 ? "" : "s"))")
+                }
+            }
             print()
         }
 

--- a/MeterBarTests/CLIJSONOutputTests.swift
+++ b/MeterBarTests/CLIJSONOutputTests.swift
@@ -142,6 +142,72 @@ final class CLIJSONOutputTests: XCTestCase {
         XCTAssertEqual(period["kind"] as? String, "monthToDate")
     }
 
+    func testMonthToDateCostResponseIncludesModelAndProjectBreakdowns() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+        let model = TokenUsageBreakdown(
+            provider: .claudeCode,
+            name: "claude-opus-5",
+            inputTokens: 100,
+            outputTokens: 20,
+            cacheCreationTokens: 5,
+            cacheReadTokens: 30,
+            estimatedCostUSD: 0.5,
+            sessionCount: 1
+        )
+        let project = TokenUsageBreakdown(
+            provider: .claudeCode,
+            name: "www/meterbardev",
+            inputTokens: 100,
+            outputTokens: 20,
+            cacheCreationTokens: 5,
+            cacheReadTokens: 30,
+            estimatedCostUSD: 0.5,
+            sessionCount: 1,
+            modelBreakdowns: [model]
+        )
+        let cache = CostSummaryCache(
+            summary: CostSummary(
+                costs: [],
+                totalCostUSD: 0.5,
+                totalTokens: 150,
+                periodDays: 30,
+                dailyUsage: [
+                    DailyTokenUsage(
+                        date: referenceDate.addingTimeInterval(-86_400),
+                        provider: .claudeCode,
+                        inputTokens: 100,
+                        outputTokens: 20,
+                        cacheReadTokens: 30,
+                        estimatedCostUSD: 0.5,
+                        modelBreakdowns: [model],
+                        projectBreakdowns: [project]
+                    )
+                ]
+            ),
+            lastScanDate: referenceDate
+        )
+
+        let response = CostCLIJSONResponse(
+            cache: cache,
+            monthToDate: true,
+            now: referenceDate,
+            calendar: calendar
+        )
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: response.jsonData()) as? [String: Any]
+        )
+        XCTAssertEqual(object["schemaVersion"] as? Int, 1)
+        let provider = try XCTUnwrap((object["providers"] as? [[String: Any]])?.first)
+        let models = try XCTUnwrap(provider["modelBreakdowns"] as? [[String: Any]])
+        let projects = try XCTUnwrap(provider["projectBreakdowns"] as? [[String: Any]])
+        let nestedModels = try XCTUnwrap(projects.first?["modelBreakdowns"] as? [[String: Any]])
+
+        XCTAssertEqual(models.first?["name"] as? String, "claude-opus-5")
+        XCTAssertEqual(projects.first?["name"] as? String, "www/meterbardev")
+        XCTAssertEqual(nestedModels.first?["name"] as? String, "claude-opus-5")
+    }
+
     func testCostResponseOmitsProjectBreakdownsWhenNoneAreScannedButIncludesThemWhenPresent() throws {
         let costWithoutProjects = TokenCost(
             provider: .claudeCode,

--- a/MeterBarTests/CostSummaryStoreTests.swift
+++ b/MeterBarTests/CostSummaryStoreTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+final class CostSummaryStoreTests: XCTestCase {
+    private var tempDirectory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CostSummaryStoreTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDirectory {
+            try? FileManager.default.removeItem(at: tempDirectory)
+        }
+        tempDirectory = nil
+        try super.tearDownWithError()
+    }
+
+    func testLoadMigratesVersionOneCacheToVersionTwoWithoutInventingAttribution() throws {
+        let currentURL = tempDirectory.appendingPathComponent("cost-summary-v2.json")
+        let legacyURL = tempDirectory.appendingPathComponent("cost-summary-v1.json")
+        try legacyPayload().write(to: legacyURL)
+
+        let migrated = try XCTUnwrap(
+            CostSummaryStore.load(currentURL: currentURL, legacyURL: legacyURL)
+        )
+
+        XCTAssertEqual(CostSummaryCache.currentSchemaVersion, 2)
+        XCTAssertEqual(migrated.schemaVersion, 2)
+        XCTAssertEqual(migrated.summary.dailyUsage.count, 1)
+        XCTAssertNil(migrated.summary.dailyUsage[0].modelBreakdowns)
+        XCTAssertNil(migrated.summary.dailyUsage[0].projectBreakdowns)
+        XCTAssertTrue(
+            migrated.summary.needsMissingDailyUsageRefresh(
+                days: 30,
+                lastScanDate: migrated.lastScanDate,
+                now: migrated.lastScanDate
+            )
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: legacyURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: currentURL.path))
+
+        let persisted = try JSONSerialization.jsonObject(
+            with: Data(contentsOf: currentURL)
+        ) as? [String: Any]
+        XCTAssertEqual(persisted?["schemaVersion"] as? Int, 2)
+    }
+
+    func testLoadPrefersCurrentVersionOverStaleLegacyCache() throws {
+        let currentURL = tempDirectory.appendingPathComponent("cost-summary-v2.json")
+        let legacyURL = tempDirectory.appendingPathComponent("cost-summary-v1.json")
+        try legacyPayload(inputTokens: 999).write(to: legacyURL)
+
+        let current = CostSummaryCache(
+            summary: CostSummary(
+                costs: [],
+                totalCostUSD: 1,
+                totalTokens: 10,
+                periodDays: 30,
+                dailyUsage: [
+                    DailyTokenUsage(
+                        date: Date(timeIntervalSince1970: 1_750_000_000),
+                        provider: .claudeCode,
+                        inputTokens: 10,
+                        outputTokens: 0,
+                        cacheReadTokens: 0,
+                        estimatedCostUSD: 1,
+                        modelBreakdowns: [],
+                        projectBreakdowns: []
+                    )
+                ]
+            ),
+            lastScanDate: Date(timeIntervalSince1970: 1_750_000_000)
+        )
+        try CostSummaryStore.save(current, to: currentURL)
+
+        let loaded = try XCTUnwrap(
+            CostSummaryStore.load(currentURL: currentURL, legacyURL: legacyURL)
+        )
+
+        XCTAssertEqual(loaded.summary.dailyUsage.first?.inputTokens, 10)
+        XCTAssertEqual(loaded.summary.dailyUsage.first?.modelBreakdowns?.count, 0)
+    }
+
+    private func legacyPayload(inputTokens: Int = 10) throws -> Data {
+        let payload = LegacyCache(
+            summary: LegacySummary(
+                costs: [
+                    LegacyTokenCost(
+                        provider: .claudeCode,
+                        inputTokens: inputTokens,
+                        outputTokens: 0,
+                        cacheCreationTokens: 0,
+                        cacheReadTokens: 0,
+                        estimatedCostUSD: 1,
+                        sessionCount: 1,
+                        periodStart: Date(timeIntervalSince1970: 1_750_000_000),
+                        periodEnd: Date(timeIntervalSince1970: 1_750_000_000),
+                        modelBreakdowns: [
+                            LegacyBreakdown(
+                                provider: .claudeCode,
+                                name: "claude-opus-5",
+                                inputTokens: inputTokens,
+                                outputTokens: 0,
+                                cacheCreationTokens: 0,
+                                cacheReadTokens: 0,
+                                estimatedCostUSD: 1,
+                                sessionCount: 1
+                            )
+                        ],
+                        originBreakdowns: []
+                    )
+                ],
+                totalCostUSD: 1,
+                totalTokens: inputTokens,
+                periodDays: 30,
+                dailyUsage: [
+                    LegacyDailyUsage(
+                        date: Date(timeIntervalSince1970: 1_750_000_000),
+                        provider: .claudeCode,
+                        inputTokens: inputTokens,
+                        outputTokens: 0,
+                        cacheReadTokens: 0,
+                        estimatedCostUSD: 1
+                    )
+                ]
+            ),
+            lastScanDate: Date(timeIntervalSince1970: 1_750_000_000)
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(payload)
+    }
+}
+
+private struct LegacyCache: Encodable {
+    let summary: LegacySummary
+    let lastScanDate: Date
+}
+
+private struct LegacySummary: Encodable {
+    let costs: [LegacyTokenCost]
+    let totalCostUSD: Double
+    let totalTokens: Int
+    let periodDays: Int
+    let dailyUsage: [LegacyDailyUsage]
+}
+
+private struct LegacyTokenCost: Encodable {
+    let provider: ServiceType
+    let inputTokens: Int
+    let outputTokens: Int
+    let cacheCreationTokens: Int
+    let cacheReadTokens: Int
+    let estimatedCostUSD: Double
+    let sessionCount: Int
+    let periodStart: Date
+    let periodEnd: Date
+    let modelBreakdowns: [LegacyBreakdown]
+    let originBreakdowns: [LegacyBreakdown]
+}
+
+private struct LegacyBreakdown: Encodable {
+    let provider: ServiceType
+    let name: String
+    let inputTokens: Int
+    let outputTokens: Int
+    let cacheCreationTokens: Int
+    let cacheReadTokens: Int
+    let estimatedCostUSD: Double
+    let sessionCount: Int
+}
+
+private struct LegacyDailyUsage: Encodable {
+    let date: Date
+    let provider: ServiceType
+    let inputTokens: Int
+    let outputTokens: Int
+    let cacheReadTokens: Int
+    let estimatedCostUSD: Double
+}

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -222,6 +222,25 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(result.projectModels["meterbardev"]?["claude-opus-4-5"]?.input, 7)
         // No stray "unknown" bucket once a real projectID is threaded through.
         XCTAssertNil(result.projects[CostProjectAttribution.unknownProjectID])
+
+        let day = Calendar.current.startOfDay(
+            for: try XCTUnwrap(FlexibleISO8601.date(from: "2026-07-01T10:00:00.000Z"))
+        )
+        XCTAssertEqual(result.dailyModels[day]?["claude-sonnet-4-5"]?.input, 10)
+        XCTAssertEqual(result.dailyModels[day]?["claude-opus-4-5"]?.input, 7)
+        XCTAssertEqual(result.dailyProjects[day]?["meterbardev"]?.input, 17)
+        XCTAssertEqual(
+            result.dailyProjectModels[day]?["meterbardev"]?["claude-opus-4-5"]?.input,
+            7
+        )
+
+        let (_, dailyRows) = try XCTUnwrap(
+            ClaudeCostScanner.makeCost(from: result, windowStart: cutoff)
+        )
+        let daily = try XCTUnwrap(dailyRows.first)
+        XCTAssertEqual(daily.modelBreakdowns?.count, 2)
+        XCTAssertEqual(daily.projectBreakdowns?.first?.name, "meterbardev")
+        XCTAssertEqual(daily.projectBreakdowns?.first?.modelBreakdowns.count, 2)
     }
 
     func testParseSessionWindowsAppliesTheSameProjectIDToBothWindows() throws {
@@ -474,6 +493,22 @@ final class CostTrackerTests: XCTestCase {
         CodexCostScanner.scanRollouts(directory: dir, since: cutoff, context: &context)
 
         XCTAssertEqual(context.projectModelTotals["www/genfeed/apps/admin"]?["gpt-5.6-sol"]?.input, 1_000)
+
+        let day = Calendar.current.startOfDay(
+            for: try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-15T10:00:00Z"))
+        )
+        XCTAssertEqual(context.dailyModelTotals[day]?["gpt-5.6-sol"]?.input, 1_000)
+        XCTAssertEqual(context.dailyProjectTotals[day]?["www/genfeed/apps/admin"]?.input, 1_000)
+        XCTAssertEqual(
+            context.dailyProjectModelTotals[day]?["www/genfeed/apps/admin"]?["gpt-5.6-sol"]?.input,
+            1_000
+        )
+
+        let (_, dailyRows) = try XCTUnwrap(CodexCostScanner.makeCost(from: context))
+        let daily = try XCTUnwrap(dailyRows.first)
+        XCTAssertEqual(daily.modelBreakdowns?.first?.name, "gpt-5.6-sol")
+        XCTAssertEqual(daily.projectBreakdowns?.first?.name, "www/genfeed/apps/admin")
+        XCTAssertEqual(daily.projectBreakdowns?.first?.modelBreakdowns.first?.name, "gpt-5.6-sol")
     }
 
     // Note: `scanSQLiteLogs` (the flat SQLite log format) is `private` with no

--- a/MeterBarTests/CostWindowTests.swift
+++ b/MeterBarTests/CostWindowTests.swift
@@ -21,7 +21,9 @@ final class CostWindowTests: XCTestCase {
         input: Int,
         output: Int,
         cacheRead: Int,
-        cost: Double
+        cost: Double,
+        modelBreakdowns: [TokenUsageBreakdown]? = nil,
+        projectBreakdowns: [TokenUsageBreakdown]? = nil
     ) -> DailyTokenUsage {
         let today = calendar.startOfDay(for: now)
         let date = calendar.date(byAdding: .day, value: -offset, to: today) ?? today
@@ -31,7 +33,29 @@ final class CostWindowTests: XCTestCase {
             inputTokens: input,
             outputTokens: output,
             cacheReadTokens: cacheRead,
-            estimatedCostUSD: cost
+            estimatedCostUSD: cost,
+            modelBreakdowns: modelBreakdowns,
+            projectBreakdowns: projectBreakdowns
+        )
+    }
+
+    private func breakdown(
+        name: String,
+        provider: ServiceType = .claudeCode,
+        input: Int,
+        cost: Double,
+        models: [TokenUsageBreakdown] = []
+    ) -> TokenUsageBreakdown {
+        TokenUsageBreakdown(
+            provider: provider,
+            name: name,
+            inputTokens: input,
+            outputTokens: 0,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 0,
+            estimatedCostUSD: cost,
+            sessionCount: 1,
+            modelBreakdowns: models
         )
     }
 
@@ -235,5 +259,103 @@ final class CostWindowTests: XCTestCase {
         XCTAssertEqual(window.requestedDays, 1)
         XCTAssertEqual(window.providers.first?.inputTokens, 7)
         XCTAssertEqual(window.totalCostUSD, 0.7, accuracy: 0.0001)
+    }
+
+    func testMonthToDateAggregatesProjectAndModelBreakdownsFromPartiallyCachedMonth() throws {
+        let opusDay = breakdown(name: "claude-opus-5", input: 20, cost: 2)
+        let fableDay = breakdown(name: "claude-fable-5", input: 10, cost: 1)
+        let summary = summary(
+            dailyUsage: [
+                // June 10: the scan itself covers only seven days through
+                // `now` (June 15 in the fixed fixture), so the month window is
+                // explicitly partial even though an older fixture row exists.
+                row(
+                    daysAgo: 5,
+                    provider: .claudeCode,
+                    input: 20,
+                    output: 0,
+                    cacheRead: 0,
+                    cost: 2,
+                    modelBreakdowns: [opusDay],
+                    projectBreakdowns: [
+                        breakdown(name: "meterbardev", input: 20, cost: 2, models: [opusDay])
+                    ]
+                ),
+                row(
+                    daysAgo: 0,
+                    provider: .claudeCode,
+                    input: 10,
+                    output: 0,
+                    cacheRead: 0,
+                    cost: 1,
+                    modelBreakdowns: [fableDay],
+                    projectBreakdowns: [
+                        breakdown(name: "meterbardev", input: 10, cost: 1, models: [fableDay])
+                    ]
+                ),
+                // May 31: cached, but outside the current month and therefore
+                // excluded from both the provider total and its attribution.
+                row(
+                    daysAgo: 15,
+                    provider: .claudeCode,
+                    input: 999,
+                    output: 0,
+                    cacheRead: 0,
+                    cost: 99,
+                    modelBreakdowns: [breakdown(name: "legacy-model", input: 999, cost: 99)],
+                    projectBreakdowns: [breakdown(name: "other-project", input: 999, cost: 99)]
+                )
+            ],
+            periodDays: 7
+        )
+
+        let window = summary.monthToDateCostWindow(now: now, calendar: calendar)
+        let provider = try XCTUnwrap(window.providers.first)
+        let project = try XCTUnwrap(provider.projectBreakdowns?.first)
+
+        XCTAssertTrue(window.isTruncated)
+        XCTAssertEqual(window.requestedDays, 15)
+        XCTAssertEqual(window.coveredDays, 7)
+        XCTAssertEqual(provider.modelBreakdowns?.map(\.name), ["claude-opus-5", "claude-fable-5"])
+        XCTAssertEqual(project.name, "meterbardev")
+        XCTAssertEqual(project.inputTokens, 30)
+        XCTAssertEqual(project.estimatedCostUSD, 3, accuracy: 0.0001)
+        XCTAssertEqual(Set(project.modelBreakdowns.map(\.name)), ["claude-opus-5", "claude-fable-5"])
+    }
+
+    func testMonthToDateOmitsAttributionWhenAnyIncludedLegacyRowLacksIt() throws {
+        let model = breakdown(name: "claude-opus-5", input: 10, cost: 1)
+        let summary = summary(
+            dailyUsage: [
+                row(
+                    daysAgo: 0,
+                    provider: .claudeCode,
+                    input: 10,
+                    output: 0,
+                    cacheRead: 0,
+                    cost: 1,
+                    modelBreakdowns: [model],
+                    projectBreakdowns: [
+                        breakdown(name: "meterbardev", input: 10, cost: 1, models: [model])
+                    ]
+                ),
+                row(
+                    daysAgo: 1,
+                    provider: .claudeCode,
+                    input: 5,
+                    output: 0,
+                    cacheRead: 0,
+                    cost: 0.5
+                )
+            ],
+            periodDays: 30
+        )
+
+        let provider = try XCTUnwrap(
+            summary.monthToDateCostWindow(now: now, calendar: calendar).providers.first
+        )
+
+        XCTAssertNil(provider.modelBreakdowns)
+        XCTAssertNil(provider.projectBreakdowns)
     }
 }

--- a/MeterBarTests/SettingsViewSmokeTests.swift
+++ b/MeterBarTests/SettingsViewSmokeTests.swift
@@ -86,7 +86,7 @@ final class SettingsViewSmokeTests: XCTestCase {
     /// last month (so `monthToDateCostWindow` has something to filter), plus
     /// a project rollup that includes an explicit "unknown" bucket and a
     /// nested model breakdown — the shape `CostPeriodContentView` renders.
-    private func makeSyntheticCostSummary() -> CostSummary {
+    private func makeSyntheticCostSummary(includeDailyAttribution: Bool = true) -> CostSummary {
         let calendar = Calendar(identifier: .gregorian)
         let thisMonthDay = calendar.date(byAdding: .day, value: 2, to: referenceMonthStart)!
         let lastMonthDay = calendar.date(byAdding: .day, value: -3, to: referenceMonthStart)!
@@ -137,6 +137,28 @@ final class SettingsViewSmokeTests: XCTestCase {
             ]
         )
 
+        let dailyModel = TokenUsageBreakdown(
+            provider: .claudeCode,
+            name: "claude-opus-5",
+            inputTokens: 500,
+            outputTokens: 125,
+            cacheCreationTokens: 25,
+            cacheReadTokens: 250,
+            estimatedCostUSD: 6,
+            sessionCount: 2
+        )
+        let dailyProject = TokenUsageBreakdown(
+            provider: .claudeCode,
+            name: "www/example/app",
+            inputTokens: 500,
+            outputTokens: 125,
+            cacheCreationTokens: 25,
+            cacheReadTokens: 250,
+            estimatedCostUSD: 6,
+            sessionCount: 2,
+            modelBreakdowns: [dailyModel]
+        )
+
         return CostSummary(
             costs: [cost],
             totalCostUSD: 12.5,
@@ -149,7 +171,9 @@ final class SettingsViewSmokeTests: XCTestCase {
                     inputTokens: 500,
                     outputTokens: 125,
                     cacheReadTokens: 250,
-                    estimatedCostUSD: 6
+                    estimatedCostUSD: 6,
+                    modelBreakdowns: includeDailyAttribution ? [dailyModel] : nil,
+                    projectBreakdowns: includeDailyAttribution ? [dailyProject] : nil
                 ),
                 DailyTokenUsage(
                     date: lastMonthDay,
@@ -172,11 +196,26 @@ final class SettingsViewSmokeTests: XCTestCase {
     }
 
     func testCostPeriodContentRendersMonthToDateWindowFromCachedDailyUsage() {
-        let view = CostPeriodContentView(summary: makeSyntheticCostSummary(), periodMode: .monthToDate, currency: nil)
-        let hostingView = NSHostingView(rootView: view.frame(width: 640))
-        hostingView.layoutSubtreeIfNeeded()
+        let calendar = Calendar(identifier: .gregorian)
+        let stableNow = calendar.date(byAdding: .day, value: 2, to: referenceMonthStart)!
+        let attributed = CostPeriodContentView(
+            summary: makeSyntheticCostSummary(),
+            periodMode: .monthToDate,
+            currency: nil,
+            monthToDateNow: stableNow
+        )
+        let legacy = CostPeriodContentView(
+            summary: makeSyntheticCostSummary(includeDailyAttribution: false),
+            periodMode: .monthToDate,
+            currency: nil,
+            monthToDateNow: stableNow
+        )
+        let attributedView = NSHostingView(rootView: attributed.frame(width: 640))
+        let legacyView = NSHostingView(rootView: legacy.frame(width: 640))
+        attributedView.layoutSubtreeIfNeeded()
+        legacyView.layoutSubtreeIfNeeded()
 
-        XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+        XCTAssertGreaterThan(attributedView.fittingSize.height, legacyView.fittingSize.height)
     }
 
     func testCostPeriodContentRendersConvertedCurrencyCaptionWhenSupplied() {

--- a/docs/audits/00-repo-map.md
+++ b/docs/audits/00-repo-map.md
@@ -91,7 +91,7 @@ All of these except the two admin APIs are **undocumented/private endpoints** su
 **Data written / persisted:**
 - `UserDefaults.standard`: metrics cache (`cached_usage_metrics`), refresh interval, hidden providers (`HiddenProviderServices`), dock flag (`ShowMeterBarInDock`), custom Claude accounts (`ClaudeCodeCustomAccounts`), OAuth-fallback flag.
 - App group container `group.dev.shipshit.meterbar`: `cached_usage_metrics.json`, atomic writes on a serial queue, triggers `WidgetCenter.reloadTimelines` (`SharedDataStore.swift`). Read by widget and CLI (`MeterBarCLI.swift:95-123`).
-- `~/Library/Application Support/MeterBar/cost-summary-v1.json` cost cache (`CostTracker.swift:175-225`).
+- `~/Library/Application Support/MeterBar/cost-summary-v2.json` cost cache; valid v1 files migrate forward on read (`CostSummaryStore.swift`).
 - Own keychain service `dev.shipshit.meterbar` for the two optional admin keys (`KeychainManager.swift:7`, `AuthenticationManager.swift`).
 
 **No database, no auth provider, no job queue** in the server sense. "Auth" is entirely: two admin keys in keychain + scavenged CLI credentials.

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -104,8 +104,10 @@ Version 1 shape:
 ```
 
 With `--days`, MeterBar derives the response from cached daily rows without rescanning logs.
-Daily rows do not retain `cacheCreationTokens` or `sessionCount`, so those fields are omitted in a
-windowed response. `period.isTruncated` is true when the cache covers fewer days than requested.
+Provider-level daily rows do not retain `cacheCreationTokens` or `sessionCount`, so those fields are
+omitted in a windowed response. Cost-cache schema v2 does retain day × model and day × project
+attribution; when every included row is v2, windowed providers may include `modelBreakdowns` and
+`projectBreakdowns`. `period.isTruncated` is true when the cache covers fewer days than requested.
 
 ### Month-to-date window
 
@@ -132,7 +134,43 @@ version 1 fixture above never sets it, so that response is byte-for-byte unchang
       "outputTokens": 250,
       "cacheReadTokens": 550,
       "totalTokens": 1800,
-      "estimatedCostUSD": 1.25
+      "estimatedCostUSD": 1.25,
+      "modelBreakdowns": [
+        {
+          "name": "claude-opus-5",
+          "inputTokens": 1000,
+          "outputTokens": 250,
+          "cacheCreationTokens": 50,
+          "cacheReadTokens": 550,
+          "totalTokens": 1850,
+          "estimatedCostUSD": 1.25,
+          "sessionCount": 3
+        }
+      ],
+      "projectBreakdowns": [
+        {
+          "name": "meterbardev",
+          "inputTokens": 1000,
+          "outputTokens": 250,
+          "cacheCreationTokens": 50,
+          "cacheReadTokens": 550,
+          "totalTokens": 1850,
+          "estimatedCostUSD": 1.25,
+          "sessionCount": 3,
+          "modelBreakdowns": [
+            {
+              "name": "claude-opus-5",
+              "inputTokens": 1000,
+              "outputTokens": 250,
+              "cacheCreationTokens": 50,
+              "cacheReadTokens": 550,
+              "totalTokens": 1850,
+              "estimatedCostUSD": 1.25,
+              "sessionCount": 3
+            }
+          ]
+        }
+      ]
     }
   ],
   "totalCostUSD": 1.25,
@@ -142,19 +180,25 @@ version 1 fixture above never sets it, so that response is byte-for-byte unchang
 
 Both totals are always derived by summing `providers`, so an empty `providers` array pairs only with
 `"totalCostUSD": 0` / `"totalTokens": 0`. As with `--days`, windowed provider entries omit
-`cacheCreationTokens` and `sessionCount`, which daily rows do not retain.
+provider-level `cacheCreationTokens` and `sessionCount`. Breakdown rows retain those fields as part
+of their attribution record, so their token total can include cache creation even though the
+provider's windowed `totalTokens` does not.
 
 `requestedDays` for a month-to-date window is however many days have elapsed since the 1st of the
 current month (inclusive), computed in the local time zone at read time — it is never a cached start
 date, so the same cache reports a larger window tomorrow without a rescan or restart.
 
-### Project/worktree breakdown
+### Model and project/worktree breakdown
 
-Each provider in the full, unwindowed summary (no `--days`/`--month-to-date`) may carry
-`projectBreakdowns`: a per-project/worktree rollup derived from scanned session paths, with its own
-nested `modelBreakdowns`. The field is omitted entirely when nothing was scanned with a project
-dimension — including every windowed (`--days`/`--month-to-date`) response, since daily rows carry no
-project dimension of their own.
+Each provider may carry `modelBreakdowns` plus `projectBreakdowns`: a per-project/worktree rollup
+derived from scanned session paths, with its own nested `modelBreakdowns`. Full unwindowed responses
+derive them from the scan totals. `--days` and `--month-to-date` derive them from cost-cache v2's
+daily attribution and restrict every row to the selected calendar days.
+
+Both fields are omitted when attribution is incomplete. In particular, a migrated v1 cache keeps
+its provider totals readable but cannot reconstruct historical model/project rows; MeterBar queues
+a normal background rescan, and the CLI omits the incomplete breakdowns until that v2 scan lands.
+It never substitutes the full 30-day breakdown into a shorter month window.
 
 ```json
 {
@@ -167,6 +211,18 @@ project dimension of their own.
   "totalTokens": 1800,
   "estimatedCostUSD": 1.25,
   "sessionCount": 3,
+  "modelBreakdowns": [
+    {
+      "name": "claude-opus-5",
+      "inputTokens": 1000,
+      "outputTokens": 250,
+      "cacheCreationTokens": 50,
+      "cacheReadTokens": 500,
+      "totalTokens": 1800,
+      "estimatedCostUSD": 1.25,
+      "sessionCount": 3
+    }
+  ],
   "projectBreakdowns": [
     {
       "name": "meterbardev",
@@ -194,10 +250,10 @@ project dimension of their own.
 }
 ```
 
-Every session attributes to exactly one project row; a session whose path can't be attributed to a
-project lands in an explicit `unknown` row rather than being dropped or guessed. Names are sanitized
-before they ever reach this JSON — no full home-directory paths — and MeterBar never persists branch
-names, remotes, prompt content, or credentials to derive them.
+Every usage event attributes to exactly one project row; an event whose path can't be attributed to
+a project lands in an explicit `unknown` row rather than being dropped or guessed. Names are
+sanitized before they ever reach the cache or this JSON — no full home-directory paths — and
+MeterBar never persists branch names, remotes, prompt content, or credentials to derive them.
 
 ### Display currency
 


### PR DESCRIPTION
## Summary

- persist day × model and day × sanitized-project attribution in cost cache schema v2
- copy valid v1 caches forward without inventing attribution, and queue a source rescan
- aggregate exact calendar-window project/model rollups for Settings and `meterbar cost --month-to-date`
- keep incomplete migrated rollups omitted and preserve path/privacy contracts

## Verification

- 112 focused Swift tests passed
- `swiftlint lint --strict --quiet`
- `swift build --package-path MeterBarCLI`
- Debug MeterBar `xcodebuild` with code signing disabled
- exact-diff correctness and privacy review

The configured Claude planning/review profile was unauthenticated, so no quota-bearing fallback was probed; local TDD, strict lint, both builds, and exact-head review completed successfully.

Closes #291