### PR TITLE
fix(codex): add account management parity

### DIFF
--- a/.agents/SESSIONS/2026-07-29.md
+++ b/.agents/SESSIONS/2026-07-29.md
@@ -53,6 +53,10 @@ flowchart LR
 - `swift test --filter
   'AppDelegateSplitTests|SessionWakeControllerTests|WidgetSettingsTests|CodexCliLocalServiceTests|CodexAccountStoreTests|CodexAccountProfileRowTests|MenuBarAccountSelectionTests|WidgetPreferencesStoreTests|AccountActivityInspectorTests'`:
   114 tests passed.
+- `swift test --filter
+  UsageDataManagerTests/testRefreshAllRetainsAndRefreshesTheOnlyEnabledCodexAccount`:
+  passed after aligning the legacy all-disabled test with the new last-account
+  invariant.
 - `swiftlint lint --strict --quiet --no-cache`: passed.
 - `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug
   -derivedDataPath /private/tmp/MeterBarCodexParityDerivedData
@@ -67,4 +71,6 @@ flowchart LR
 - Session Wake tests originally resolved their lock file into a sandbox-denied
   temporary directory. Their test-only lock now lives under `.build`, matching
   the writable build environment without changing production lock behavior.
-
+- A local run of the entire coverage script was stopped after macOS Security
+  blocked on the developer machine's real Claude Keychain. The credential-free
+  exact-head CI run remains the authoritative full-suite and coverage gate.

--- a/.agents/SESSIONS/2026-07-29.md
+++ b/.agents/SESSIONS/2026-07-29.md
@@ -1,0 +1,70 @@
+# 2026-07-29
+
+## Session 1: Codex account-management parity
+
+**Status:** Complete
+
+### What was done
+
+- Added reliable inline editing for Codex account labels and `CODEX_HOME`,
+  including a user-selected directory override for the default profile.
+- Added enable/disable controls for every Codex account and guarded disable or
+  delete transitions that would otherwise leave no active profile.
+- Kept the default account as an internal migration sentinel while allowing it
+  to leave the active set after an alternative profile is enabled.
+- Added guarded custom profile edit/delete controls, direct per-profile auth
+  checks, honest connection states, and explicit accessibility labels.
+- Reconciled disabled or deleted Codex identities from menu-bar, widget, and
+  Session Wake selections.
+- Added store, presentation/UI, path-resolution, menu-bar, widget, and Session
+  Wake regression coverage.
+- Opened traceability issue
+  [#304](https://github.com/VincentShipsIt/meterbar.dev/issues/304).
+
+### Feature flow
+
+```mermaid
+flowchart LR
+    Settings["Codex Settings row"] --> Store["CodexAccountStore"]
+    Store --> Refresh["Usage refresh configuration"]
+    Store --> Menu["Menu-bar selection reconciliation"]
+    Store --> Widget["Widget selection reconciliation"]
+    Store --> Wake["Session Wake reconciliation"]
+    Store --> Auth["Configured auth.json probe"]
+```
+
+### Decisions
+
+- **Never permit an empty enabled-account set.** The store rejects disabling or
+  deleting the last enabled profile; legacy all-disabled data restores only the
+  zero-config default sentinel.
+- **Do not silently retarget account-scoped consumers.** Menu-bar and widget
+  selections are pruned, while Session Wake clears the unavailable selection
+  and disarms.
+- **Treat auth state and metrics state separately.** Settings reads the
+  configured profile's non-expired token instead of using cached metrics as a
+  connection proxy.
+- **Preserve focused edits across store publications.** Draft reconciliation
+  updates pristine fields only and explicitly commits the resolved post-save
+  value.
+
+### Verification
+
+- `swift test --filter
+  'AppDelegateSplitTests|SessionWakeControllerTests|WidgetSettingsTests|CodexCliLocalServiceTests|CodexAccountStoreTests|CodexAccountProfileRowTests|MenuBarAccountSelectionTests|WidgetPreferencesStoreTests|AccountActivityInspectorTests'`:
+  114 tests passed.
+- `swiftlint lint --strict --quiet --no-cache`: passed.
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug
+  -derivedDataPath /private/tmp/MeterBarCodexParityDerivedData
+  CODE_SIGNING_ALLOWED=NO build`: succeeded.
+- `git diff --check`: passed.
+
+### Notes
+
+- The preferred Fable planner and Opus verifier lane was unavailable because
+  the project Claude profile was not authenticated. Planning and exact-diff
+  review were completed locally; CI remains a delivery gate.
+- Session Wake tests originally resolved their lock file into a sandbox-denied
+  temporary directory. Their test-only lock now lives under `.build`, matching
+  the writable build environment without changing production lock behavior.
+

--- a/MeterBar/App/StatusItemRefreshTrigger.swift
+++ b/MeterBar/App/StatusItemRefreshTrigger.swift
@@ -21,9 +21,12 @@ enum StatusItemRefreshTrigger {
             ClaudeCodeAccountStore.shared.$defaultAccountConfigDirectory.map { _ in () },
             ClaudeCodeAccountStore.shared.$defaultAccountIsEnabled.map { _ in () }
         )
-        // Codex has no configurable default-account directory, so its account
-        // fan-in has one source where Claude has three. Not an oversight.
-        let codexAccountChanges = CodexAccountStore.shared.$customAccounts.map { _ in () }
+        let codexAccountChanges = Publishers.MergeMany([
+            CodexAccountStore.shared.$customAccounts.map { _ in () }.eraseToAnyPublisher(),
+            CodexAccountStore.shared.$defaultAccountName.map { _ in () }.eraseToAnyPublisher(),
+            CodexAccountStore.shared.$defaultAccountHomeDirectory.map { _ in () }.eraseToAnyPublisher(),
+            CodexAccountStore.shared.$defaultAccountIsEnabled.map { _ in () }.eraseToAnyPublisher(),
+        ])
         let displayPreferenceChanges = Publishers.Merge4(
             MenuBarDisplayPreferencesStore.shared.$pinnedCandidateKey.map { _ in () },
             MenuBarDisplayPreferencesStore.shared.$presentationMode.map { _ in () },

--- a/MeterBar/App/UsageNotificationCoordinator.swift
+++ b/MeterBar/App/UsageNotificationCoordinator.swift
@@ -103,10 +103,11 @@ final class UsageNotificationCoordinator {
             ClaudeCodeAccountStore.shared.$defaultAccountConfigDirectory.map { _ in () },
             ClaudeCodeAccountStore.shared.$defaultAccountIsEnabled.map { _ in () }
         )
-        let codexAccountChanges = Publishers.Merge(
-            CodexAccountStore.shared.$customAccounts.map { _ in () },
-            CodexAccountStore.shared.$defaultAccountIsEnabled.map { _ in () }
-        )
+        let codexAccountChanges = Publishers.MergeMany([
+            CodexAccountStore.shared.$customAccounts.map { _ in () }.eraseToAnyPublisher(),
+            CodexAccountStore.shared.$defaultAccountHomeDirectory.map { _ in () }.eraseToAnyPublisher(),
+            CodexAccountStore.shared.$defaultAccountIsEnabled.map { _ in () }.eraseToAnyPublisher(),
+        ])
         let thresholdChanges = Publishers.Merge3(
             notificationPreferences.$isEnabled.map { _ in () },
             notificationPreferences.$warningThreshold.map { _ in () },

--- a/MeterBar/Models/CodexAccount.swift
+++ b/MeterBar/Models/CodexAccount.swift
@@ -37,6 +37,12 @@ nonisolated struct CodexAccount: Codable, Equatable, Identifiable, Sendable {
     var isDefault: Bool { id == Self.defaultID }
 }
 
+nonisolated enum CodexAccountMutationOutcome: Equatable, Sendable {
+    case updated
+    case unchanged
+    case rejectedLastEnabledAccount
+}
+
 final class CodexAccountStore: ObservableObject {
     /// In demo mode the store is projected from the default account only, so
     /// provider cards title generically ("Codex") and never surface the owner's
@@ -48,6 +54,7 @@ final class CodexAccountStore: ObservableObject {
 
     @Published private(set) var customAccounts: [CodexAccount] = []
     @Published private(set) var defaultAccountName = CodexAccount.defaultName
+    @Published private(set) var defaultAccountHomeDirectory: String?
     @Published private(set) var defaultAccountIsEnabled = true
     @Published private(set) var accountOrder: [UUID] = []
 
@@ -59,7 +66,7 @@ final class CodexAccountStore: ObservableObject {
             CodexAccount(
                 id: CodexAccount.defaultID,
                 name: defaultAccountName,
-                homeDirectory: nil,
+                homeDirectory: defaultAccountHomeDirectory,
                 isEnabled: defaultAccountIsEnabled
             )
         ] + customAccounts)
@@ -83,6 +90,7 @@ final class CodexAccountStore: ObservableObject {
         refreshConfigurationDirectory = nil
         let defaultAccount = accounts.first(where: \.isDefault) ?? .defaultAccount
         defaultAccountName = defaultAccount.name
+        defaultAccountHomeDirectory = defaultAccount.homeDirectory
         defaultAccountIsEnabled = defaultAccount.isEnabled
         customAccounts = accounts.filter { !$0.isDefault }
         accountOrder = accounts.map(\.id)
@@ -111,19 +119,39 @@ final class CodexAccountStore: ObservableObject {
         guard !trimmedName.isEmpty else { return }
 
         if id == CodexAccount.defaultID {
-            guard trimmedName != defaultAccountName else { return }
-            defaultAccountName = trimmedName
-            saveDefaultAccountName()
+            if trimmedName != defaultAccountName {
+                defaultAccountName = trimmedName
+                saveDefaultAccountName()
+            }
+            if let homeDirectory {
+                let trimmedDirectory = homeDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+                let updatedDirectory = trimmedDirectory.isEmpty
+                    ? nil
+                    : (trimmedDirectory as NSString).standardizingPath
+                if updatedDirectory != defaultAccountHomeDirectory {
+                    defaultAccountHomeDirectory = updatedDirectory
+                    saveDefaultAccountHomeDirectory()
+                }
+            }
             return
         }
 
-        guard let index = customAccounts.firstIndex(where: { $0.id == id }), let homeDirectory else { return }
-        let trimmedDirectory = homeDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedDirectory.isEmpty else { return }
+        let standardizedDirectory: String?
+        if let homeDirectory {
+            let trimmedDirectory = homeDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedDirectory.isEmpty else { return }
+            standardizedDirectory = (trimmedDirectory as NSString).standardizingPath
+        } else {
+            standardizedDirectory = nil
+        }
+
+        guard let index = customAccounts.firstIndex(where: { $0.id == id }) else { return }
 
         var updated = customAccounts[index]
         updated.name = trimmedName
-        updated.homeDirectory = (trimmedDirectory as NSString).standardizingPath
+        if let standardizedDirectory {
+            updated.homeDirectory = standardizedDirectory
+        }
         guard updated != customAccounts[index] else { return }
         var updatedAccounts = customAccounts
         updatedAccounts[index] = updated
@@ -131,30 +159,59 @@ final class CodexAccountStore: ObservableObject {
         saveCustomAccounts()
     }
 
-    func removeAccount(id: UUID) {
-        guard id != CodexAccount.defaultID else { return }
+    func canDisableAccount(id: UUID) -> Bool {
+        guard let account = accounts.first(where: { $0.id == id }) else { return false }
+        return !account.isEnabled || enabledAccounts.count > 1
+    }
+
+    func canRemoveAccount(id: UUID) -> Bool {
+        guard id != CodexAccount.defaultID,
+              let account = customAccounts.first(where: { $0.id == id }) else {
+            return false
+        }
+        return !account.isEnabled || enabledAccounts.count > 1
+    }
+
+    @discardableResult
+    func removeAccount(id: UUID) -> CodexAccountMutationOutcome {
+        guard id != CodexAccount.defaultID,
+              let account = customAccounts.first(where: { $0.id == id }) else {
+            return .unchanged
+        }
+        guard !account.isEnabled || enabledAccounts.count > 1 else {
+            return .rejectedLastEnabledAccount
+        }
         customAccounts.removeAll { $0.id == id }
         accountOrder.removeAll { $0 == id }
         saveAccountOrder()
         saveCustomAccounts()
+        return .updated
     }
 
-    func setEnabled(_ enabled: Bool, for id: UUID) {
+    @discardableResult
+    func setEnabled(_ enabled: Bool, for id: UUID) -> CodexAccountMutationOutcome {
         if id == CodexAccount.defaultID {
-            guard enabled != defaultAccountIsEnabled else { return }
+            guard enabled != defaultAccountIsEnabled else { return .unchanged }
+            guard enabled || enabledAccounts.count > 1 else {
+                return .rejectedLastEnabledAccount
+            }
             defaultAccountIsEnabled = enabled
             saveDefaultAccountEnabled()
-            return
+            return .updated
         }
 
         guard let index = customAccounts.firstIndex(where: { $0.id == id }),
               customAccounts[index].isEnabled != enabled else {
-            return
+            return .unchanged
+        }
+        guard enabled || enabledAccounts.count > 1 else {
+            return .rejectedLastEnabledAccount
         }
         var updatedAccounts = customAccounts
         updatedAccounts[index].isEnabled = enabled
         customAccounts = updatedAccounts
         saveCustomAccounts()
+        return .updated
     }
 
     func moveAccounts(fromOffsets source: IndexSet, toOffset destination: Int) {
@@ -176,6 +233,10 @@ final class CodexAccountStore: ObservableObject {
             .trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
             defaultAccountName = name
         }
+        if let homeDirectory = userDefaults.string(forKey: StorageKeys.codexDefaultHomeDirectory)?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !homeDirectory.isEmpty {
+            defaultAccountHomeDirectory = (homeDirectory as NSString).standardizingPath
+        }
         if userDefaults.object(forKey: StorageKeys.codexDefaultAccountEnabled) != nil {
             defaultAccountIsEnabled = userDefaults.bool(forKey: StorageKeys.codexDefaultAccountEnabled)
         }
@@ -185,6 +246,7 @@ final class CodexAccountStore: ObservableObject {
            let decoded = try? JSONDecoder().decode([CodexAccount].self, from: data) {
             customAccounts = decoded.filter { !$0.isDefault }
         }
+        restoreDefaultAccountIfNeeded()
         pruneAccountOrder()
     }
 
@@ -199,6 +261,15 @@ final class CodexAccountStore: ObservableObject {
             userDefaults.removeObject(forKey: StorageKeys.codexDefaultAccountName)
         } else {
             userDefaults.set(defaultAccountName, forKey: StorageKeys.codexDefaultAccountName)
+        }
+        persistRefreshConfiguration()
+    }
+
+    private func saveDefaultAccountHomeDirectory() {
+        if let defaultAccountHomeDirectory {
+            userDefaults.set(defaultAccountHomeDirectory, forKey: StorageKeys.codexDefaultHomeDirectory)
+        } else {
+            userDefaults.removeObject(forKey: StorageKeys.codexDefaultHomeDirectory)
         }
         persistRefreshConfiguration()
     }
@@ -244,5 +315,14 @@ final class CodexAccountStore: ObservableObject {
         guard pruned != accountOrder else { return }
         accountOrder = pruned
         saveAccountOrder()
+    }
+
+    /// Profiles persisted by older builds could leave every account disabled.
+    /// Keep the sentinel internally and restore only that zero-config profile so
+    /// refresh, widgets, and automation never wake up with an ambiguous empty set.
+    private func restoreDefaultAccountIfNeeded() {
+        guard !defaultAccountIsEnabled, !customAccounts.contains(where: \.isEnabled) else { return }
+        defaultAccountIsEnabled = true
+        saveDefaultAccountEnabled()
     }
 }

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -71,6 +71,8 @@ nonisolated enum StorageKeys {
     static let codexCustomAccounts = "CodexCustomAccounts"
     /// User-chosen display name for the default Codex CLI profile.
     static let codexDefaultAccountName = "CodexDefaultAccountName"
+    /// User-chosen CODEX_HOME override for the default Codex CLI profile.
+    static let codexDefaultHomeDirectory = "CodexDefaultHomeDirectory"
     /// Whether the synthesized default Codex CLI profile participates in tracking.
     static let codexDefaultAccountEnabled = "CodexDefaultAccountEnabled"
     /// Persisted Codex account display order (array of UUID strings).

--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -106,8 +106,8 @@ class CodexCliLocalService: ObservableObject {
     }
 
     /// Check and update access status
-    nonisolated func checkAccess() {
-        let hasToken = getAuthToken() != nil
+    nonisolated func checkAccess(account: CodexAccount = .defaultAccount) {
+        let hasToken = getAuthToken(account: account) != nil
         ServiceSupport.applyOnMain { [weak self] in
             guard let self else { return }
             self.hasAccess = hasToken

--- a/MeterBar/Services/CodexHomeDirectory.swift
+++ b/MeterBar/Services/CodexHomeDirectory.swift
@@ -33,16 +33,41 @@ nonisolated enum CodexHomeDirectory {
             .appendingPathComponent("auth.json")
     }
 
-    static func path(for account: CodexAccount) -> String {
+    static func path(
+        for account: CodexAccount,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        realHomeDirectory: String = ServiceSupport.realHomeDirectory()
+    ) -> String {
         guard let homeDirectory = account.homeDirectory?
             .trimmingCharacters(in: .whitespacesAndNewlines), !homeDirectory.isEmpty else {
-            return path()
+            return path(environment: environment, realHomeDirectory: realHomeDirectory)
+        }
+        if homeDirectory == "~" {
+            return realHomeDirectory
+        }
+        if homeDirectory.hasPrefix("~/") {
+            return (realHomeDirectory as NSString).appendingPathComponent(String(homeDirectory.dropFirst(2)))
         }
         return (homeDirectory as NSString).standardizingPath
     }
 
     static func authFilePath(for account: CodexAccount) -> String {
         (path(for: account) as NSString).appendingPathComponent("auth.json")
+    }
+
+    static func authFileDisplayPath(
+        for account: CodexAccount,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        realHomeDirectory: String = ServiceSupport.realHomeDirectory()
+    ) -> String {
+        compactForDisplay(
+            (path(
+                for: account,
+                environment: environment,
+                realHomeDirectory: realHomeDirectory
+            ) as NSString).appendingPathComponent("auth.json"),
+            realHomeDirectory: realHomeDirectory
+        )
     }
 
     /// The resolved auth-file path for user-facing copy, compacting paths under
@@ -52,10 +77,17 @@ nonisolated enum CodexHomeDirectory {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         realHomeDirectory: String = ServiceSupport.realHomeDirectory()
     ) -> String {
-        let resolvedPath = (authFilePath(
+        compactForDisplay(
+            authFilePath(
             environment: environment,
             realHomeDirectory: realHomeDirectory
-        ) as NSString).standardizingPath
+            ),
+            realHomeDirectory: realHomeDirectory
+        )
+    }
+
+    private static func compactForDisplay(_ path: String, realHomeDirectory: String) -> String {
+        let resolvedPath = (path as NSString).standardizingPath
         let standardizedHome = (realHomeDirectory as NSString).standardizingPath
         let homePrefix = standardizedHome.hasSuffix("/") ? standardizedHome : "\(standardizedHome)/"
 

--- a/MeterBar/Services/MenuBarAccountSelectionStore.swift
+++ b/MeterBar/Services/MenuBarAccountSelectionStore.swift
@@ -84,6 +84,20 @@ final class MenuBarAccountSelectionStore: ObservableObject {
         }
     }
 
+    /// Removes selections that no longer identify enabled, tracked accounts.
+    /// Disabled keys must not invisibly consume one of the finite status-item
+    /// slots, and a switcher must never remain bound to an unavailable account.
+    func reconcile(availableKeys: Set<String>) {
+        let normalizedAvailable = Set(availableKeys.compactMap(Self.normalizedKey))
+        let reconciledSelection = selectedAccountKeys.filter(normalizedAvailable.contains)
+        if reconciledSelection != selectedAccountKeys {
+            persistSelection(reconciledSelection)
+        }
+        if let mergedAccountKey, !normalizedAvailable.contains(mergedAccountKey) {
+            setMergedAccountKey(nil)
+        }
+    }
+
     func setMergedAccountKey(_ key: String?) {
         let normalized = key.flatMap(Self.normalizedKey)
         guard normalized != mergedAccountKey else { return }

--- a/MeterBar/SessionWake/SessionWakeController.swift
+++ b/MeterBar/SessionWake/SessionWakeController.swift
@@ -139,10 +139,11 @@ final class SessionWakeController: ObservableObject {
             }
             .store(in: &cancellables)
 
-        Publishers.Merge(
-            codexAccounts.$customAccounts.map { _ in () },
-            codexAccounts.$defaultAccountIsEnabled.map { _ in () }
-        )
+        Publishers.MergeMany([
+            codexAccounts.$customAccounts.map { _ in () }.eraseToAnyPublisher(),
+            codexAccounts.$defaultAccountHomeDirectory.map { _ in () }.eraseToAnyPublisher(),
+            codexAccounts.$defaultAccountIsEnabled.map { _ in () }.eraseToAnyPublisher(),
+        ])
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 guard let self else { return }

--- a/MeterBar/Views/Settings/CodexAccountProfileRow.swift
+++ b/MeterBar/Views/Settings/CodexAccountProfileRow.swift
@@ -2,109 +2,364 @@ import AppKit
 import MeterBarShared
 import SwiftUI
 
+// MARK: - CodexAccountProfileDraft
+
+nonisolated struct CodexAccountProfileSave: Equatable, Sendable {
+    let name: String
+    /// `nil` means the directory did not change. An empty string is meaningful
+    /// for the default account: clear its override and resume CODEX_HOME fallback.
+    let homeDirectory: String?
+}
+
+/// Testable draft state for a SwiftUI account row.
+///
+/// Store publications can arrive while a field is focused (for example after
+/// toggling enablement or completing an auth check). Reconciliation updates only
+/// pristine fields so those publications never erase an in-progress label edit.
+nonisolated struct CodexAccountProfileDraft: Equatable, Sendable {
+    var name: String
+    var homeDirectory: String
+
+    init(account: CodexAccount, resolvedHomeDirectory: String) {
+        name = account.name
+        homeDirectory = resolvedHomeDirectory
+    }
+
+    mutating func reconcile(
+        from previousAccount: CodexAccount,
+        previousResolvedHomeDirectory: String,
+        to updatedAccount: CodexAccount,
+        updatedResolvedHomeDirectory: String
+    ) {
+        if name == previousAccount.name {
+            name = updatedAccount.name
+        }
+        if homeDirectory == previousResolvedHomeDirectory {
+            homeDirectory = updatedResolvedHomeDirectory
+        }
+    }
+
+    mutating func commit(
+        _ save: CodexAccountProfileSave,
+        committedResolvedHomeDirectory: String
+    ) {
+        name = save.name
+        if save.homeDirectory != nil {
+            homeDirectory = committedResolvedHomeDirectory
+        }
+    }
+
+    func savePayload(
+        for account: CodexAccount,
+        resolvedHomeDirectory: String
+    ) -> CodexAccountProfileSave? {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedHomeDirectory = homeDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty,
+              account.isDefault || !trimmedHomeDirectory.isEmpty else {
+            return nil
+        }
+
+        let nameChanged = trimmedName != account.name
+        let directoryChanged = trimmedHomeDirectory != resolvedHomeDirectory
+        guard nameChanged || directoryChanged else { return nil }
+
+        return CodexAccountProfileSave(
+            name: trimmedName,
+            homeDirectory: directoryChanged ? trimmedHomeDirectory : nil
+        )
+    }
+}
+
+// MARK: - CodexAccountAuthenticationState
+
+nonisolated enum CodexAccountAuthenticationState: Equatable, Sendable {
+    case checking
+    case authenticated
+    case loginRequired
+    case disabled
+
+    var title: String {
+        switch self {
+        case .checking: "Checking…"
+        case .authenticated: "Authenticated"
+        case .loginRequired: "Login required"
+        case .disabled: "Disabled"
+        }
+    }
+
+    var accessibilityValue: String {
+        switch self {
+        case .checking: "Checking the configured auth file"
+        case .authenticated: "A non-expired Codex access token is available"
+        case .loginRequired: "No usable Codex access token is available"
+        case .disabled: "This account is not included in tracking"
+        }
+    }
+}
+
 // MARK: - CodexAccountProfileRow
 
-/// One editable Codex account row (name + CODEX_HOME + save / delete).
-/// Extracted verbatim from the SettingsView monolith. The default profile is
-/// read-only for its home directory and cannot be removed.
+/// One editable Codex account row (label + CODEX_HOME + enable / save / delete).
+/// The fixed default id remains an internal migration sentinel, but its location
+/// and tracking state have the same user-facing semantics as custom profiles.
 struct CodexAccountProfileRow: View {
     // MARK: Lifecycle
 
     init(
         account: CodexAccount,
-        isConnected: Bool,
+        canDisable: Bool,
+        canRemove: Bool,
+        onEnabledChange: @escaping (Bool) -> Void,
         onSave: @escaping (String, String?) -> Void,
-        onRemove: @escaping () -> Void
+        onRemove: @escaping () -> Void,
+        connectionCheck: @escaping (CodexAccount) async -> Bool = {
+            await CodexCliLocalService.shared.canAccess(account: $0)
+        }
     ) {
         self.account = account
-        self.isConnected = isConnected
+        self.canDisable = canDisable
+        self.canRemove = canRemove
+        self.onEnabledChange = onEnabledChange
         self.onSave = onSave
         self.onRemove = onRemove
-        _nameDraft = State(initialValue: account.name)
-        _homeDirectoryDraft = State(initialValue: account.homeDirectory ?? "")
+        self.connectionCheck = connectionCheck
+        _draft = State(initialValue: CodexAccountProfileDraft(
+            account: account,
+            resolvedHomeDirectory: Self.resolvedHomeDirectory(for: account)
+        ))
+        _authenticationState = State(initialValue: account.isEnabled ? .checking : .disabled)
     }
 
     // MARK: Internal
 
     let account: CodexAccount
-    let isConnected: Bool
+    let canDisable: Bool
+    let canRemove: Bool
+    let onEnabledChange: (Bool) -> Void
     let onSave: (String, String?) -> Void
     let onRemove: () -> Void
+    let connectionCheck: (CodexAccount) async -> Bool
 
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
             Image(systemName: account.isDefault ? "person.crop.circle" : "person.crop.circle.badge.plus")
                 .foregroundStyle(MeterBarTheme.codexAccent)
                 .frame(width: 18)
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 8) {
-                    TextField("Account label", text: $nameDraft)
-                        .settingsInput(width: 240)
+                    accountFieldLabel("Account name")
+
+                    TextField("Account label", text: $draft.name)
+                        .settingsInput(width: AccountProfileRowMetrics.fieldWidth)
+                        .accessibilityLabel("Account name for \(account.name)")
                         .onSubmit(saveChanges)
-                    Text(account.isDefault ? "Default" : "Profile")
-                        .font(.caption)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(account.isDefault ? MeterBarTheme.appAccent : MeterBarTheme.codexAccent)
-                    StatusPill(title: isConnected ? "Connected" : "Not Connected", isConnected: isConnected)
-                        .font(.caption)
+
+                    MeterBarChip(
+                        account.isDefault ? "Default" : "Profile",
+                        tint: account.isDefault ? MeterBarTheme.appAccent : MeterBarTheme.codexAccent,
+                        style: .glass
+                    )
+
+                    MeterBarChip(
+                        authenticationState.title,
+                        tint: authenticationTint,
+                        style: .glass
+                    )
+                    .accessibilityLabel("Authentication status for \(account.name)")
+                    .accessibilityValue(authenticationState.accessibilityValue)
                 }
 
                 HStack(spacing: 8) {
-                    Text("CODEX_HOME")
-                        .font(.caption2)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(.secondary)
-                        .frame(width: 126, alignment: .leading)
-                    if account.isDefault {
-                        SettingsReadonlyField(text: CodexHomeDirectory.path(for: account))
-                    } else {
-                        TextField("Codex home directory", text: $homeDirectoryDraft)
-                            .settingsInput(width: 280)
-                            .onSubmit(saveChanges)
+                    accountFieldLabel("CODEX_HOME")
+
+                    TextField("Codex home directory", text: $draft.homeDirectory)
+                        .settingsInput(width: AccountProfileRowMetrics.fieldWidth)
+                        .accessibilityLabel("CODEX_HOME for \(account.name)")
+                        .onSubmit(saveChanges)
+
+                    Button {
+                        chooseHomeDirectory()
+                    } label: {
+                        Image(systemName: "folder")
                     }
+                    .buttonStyle(.bordered)
+                    .accessibilityLabel("Choose CODEX_HOME for \(account.name)")
+                    .help("Choose CODEX_HOME")
+                }
+
+                if account.isDefault {
+                    Text("Defaults to ~/.codex or $CODEX_HOME; clear the field to restore that default.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .padding(.leading, AccountProfileRowMetrics.labelWidth + 8)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
             HStack(spacing: 8) {
-                Button(action: saveChanges) { Image(systemName: "checkmark") }
+                Toggle("Enabled", isOn: Binding(
+                    get: { account.isEnabled },
+                    set: onEnabledChange
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .controlSize(.small)
+                .disabled(account.isEnabled && !canDisable)
+                .accessibilityLabel("Track \(account.name)")
+                .help(enablementHelp)
+
+                Button(action: saveChanges) {
+                    Image(systemName: "checkmark")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .frame(width: AccountProfileRowMetrics.actionWidth)
+                .disabled(savePayload == nil)
+                .accessibilityLabel("Save changes for \(account.name)")
+                .help("Save account changes")
+
+                if !account.isDefault {
+                    Button(role: .destructive) {
+                        showingDeleteConfirmation = true
+                    } label: {
+                        Image(systemName: "trash")
+                    }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
-                    .disabled(!hasChanges || !canSave)
-                    .help("Save account changes")
-                if !account.isDefault {
-                    Button(role: .destructive, action: onRemove) { Image(systemName: "trash") }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                        .help("Delete account")
+                    .frame(width: AccountProfileRowMetrics.actionWidth)
+                    .disabled(!canRemove)
+                    .accessibilityLabel("Delete \(account.name)")
+                    .help(deleteHelp)
+                } else {
+                    Color.clear
+                        .frame(width: AccountProfileRowMetrics.actionWidth, height: 1)
+                        .accessibilityHidden(true)
                 }
             }
-            .frame(minWidth: 80, alignment: .trailing)
+            .fixedSize()
         }
         .padding(.vertical, MeterBarTheme.Spacing.md)
-        .onChange(of: account) { _, updated in
-            nameDraft = updated.name
-            homeDirectoryDraft = updated.homeDirectory ?? ""
+        .onChange(of: account) { previousAccount, updatedAccount in
+            draft.reconcile(
+                from: previousAccount,
+                previousResolvedHomeDirectory: Self.resolvedHomeDirectory(for: previousAccount),
+                to: updatedAccount,
+                updatedResolvedHomeDirectory: Self.resolvedHomeDirectory(for: updatedAccount)
+            )
+        }
+        .task(id: connectionProbeID) {
+            await refreshAuthenticationState()
+        }
+        .confirmationDialog(
+            "Delete \(account.name)?",
+            isPresented: $showingDeleteConfirmation
+        ) {
+            Button("Delete Account", role: .destructive, action: onRemove)
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("MeterBar will stop tracking this CODEX_HOME. Files and Codex login data are not deleted.")
         }
     }
 
     // MARK: Private
 
-    @State private var nameDraft: String
-    @State private var homeDirectoryDraft: String
+    @State private var draft: CodexAccountProfileDraft
+    @State private var authenticationState: CodexAccountAuthenticationState
+    @State private var showingDeleteConfirmation = false
 
-    private var trimmedName: String { nameDraft.trimmingCharacters(in: .whitespacesAndNewlines) }
-    private var trimmedHomeDirectory: String {
-        homeDirectoryDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+    private var resolvedHomeDirectory: String {
+        Self.resolvedHomeDirectory(for: account)
     }
-    private var hasChanges: Bool {
-        trimmedName != account.name || (!account.isDefault && trimmedHomeDirectory != account.homeDirectory)
+
+    private var savePayload: CodexAccountProfileSave? {
+        draft.savePayload(for: account, resolvedHomeDirectory: resolvedHomeDirectory)
     }
-    private var canSave: Bool { !trimmedName.isEmpty && (account.isDefault || !trimmedHomeDirectory.isEmpty) }
+
+    private var authenticationTint: Color {
+        switch authenticationState {
+        case .authenticated: MeterBarTheme.success
+        case .loginRequired: MeterBarTheme.warning
+        case .checking, .disabled: .secondary
+        }
+    }
+
+    private var enablementHelp: String {
+        if account.isEnabled, !canDisable {
+            return "Enable another Codex account before disabling this one"
+        }
+        return account.isEnabled ? "Disable account" : "Enable account"
+    }
+
+    private var deleteHelp: String {
+        canRemove ? "Delete account" : "Enable another Codex account before deleting this one"
+    }
+
+    private var connectionProbeID: CodexConnectionProbeID {
+        CodexConnectionProbeID(
+            accountID: account.id,
+            homeDirectory: account.homeDirectory,
+            isEnabled: account.isEnabled
+        )
+    }
 
     private func saveChanges() {
-        guard hasChanges, canSave else { return }
-        onSave(trimmedName, account.isDefault ? nil : trimmedHomeDirectory)
+        guard let savePayload else { return }
+        onSave(savePayload.name, savePayload.homeDirectory)
+        var committedAccount = account
+        committedAccount.name = savePayload.name
+        if let homeDirectory = savePayload.homeDirectory {
+            let trimmedDirectory = homeDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+            committedAccount.homeDirectory = trimmedDirectory.isEmpty
+                ? nil
+                : (trimmedDirectory as NSString).standardizingPath
+        }
+        draft.commit(
+            savePayload,
+            committedResolvedHomeDirectory: Self.resolvedHomeDirectory(for: committedAccount)
+        )
     }
+
+    private func accountFieldLabel(_ title: String) -> some View {
+        Text(title)
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .foregroundStyle(.secondary)
+            .frame(width: AccountProfileRowMetrics.labelWidth, alignment: .leading)
+    }
+
+    private static func resolvedHomeDirectory(for account: CodexAccount) -> String {
+        CodexHomeDirectory.path(for: account)
+    }
+
+    private func chooseHomeDirectory() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Use"
+
+        if panel.runModal() == .OK, let url = panel.url {
+            draft.homeDirectory = url.path
+        }
+    }
+
+    private func refreshAuthenticationState() async {
+        guard account.isEnabled else {
+            authenticationState = .disabled
+            return
+        }
+        authenticationState = .checking
+        let isAuthenticated = await connectionCheck(account)
+        guard !Task.isCancelled else { return }
+        authenticationState = isAuthenticated ? .authenticated : .loginRequired
+    }
+}
+
+private struct CodexConnectionProbeID: Equatable {
+    let accountID: UUID
+    let homeDirectory: String?
+    let isEnabled: Bool
 }

--- a/MeterBar/Views/Settings/ProviderSettingsFacts+Live.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsFacts+Live.swift
@@ -63,7 +63,9 @@ extension ProviderSettingsFacts {
             errorText: live.error,
             updatedText: matching.filter(\.hasMetrics).map(\.updatedText).first ?? "No data",
             worstBand: matching.compactMap(\.band).max(by: { $0.severity < $1.severity }),
-            codexAuthFileDisplayPath: CodexHomeDirectory.authFileDisplayPath()
+            codexAuthFileDisplayPath: CodexHomeDirectory.authFileDisplayPath(
+                for: CodexAccountStore.shared.accounts.first(where: \.isDefault) ?? .defaultAccount
+            )
         )
     }
 }

--- a/MeterBar/Views/Settings/ProviderSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsView.swift
@@ -52,6 +52,14 @@ struct ProviderSettingsView: View {
                 Task { await dataManager.refreshAll() }
             }
         }
+        .task(id: codexDefaultAccount) {
+            guard service == .codexCli, codexDefaultAccount.isEnabled else { return }
+            let codexCliService = codexCliService
+            let account = codexDefaultAccount
+            await Task.detached(priority: .userInitiated) {
+                codexCliService.checkAccess(account: account)
+            }.value
+        }
     }
 
     // MARK: Private
@@ -66,6 +74,9 @@ struct ProviderSettingsView: View {
     @StateObject private var grokService = GrokCLIUsageService.shared
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
     @StateObject private var fableSessionTracker = ClaudeFableSessionTracker.shared
+    @StateObject private var menuBarAccountSelection = MenuBarAccountSelectionStore.shared
+    @StateObject private var widgetPreferences = WidgetPreferencesStore.shared
+    @StateObject private var sessionWakeSettings = SessionWakeSettingsStore.shared
 
     @State private var isAddingClaudeAccount = false
     @State private var isAddingCodexAccount = false
@@ -106,7 +117,16 @@ struct ProviderSettingsView: View {
     }
 
     private var codexAuthFileDisplayPath: String {
-        CodexHomeDirectory.authFileDisplayPath()
+        CodexHomeDirectory.authFileDisplayPath(for: codexDefaultAccount)
+    }
+
+    private var codexDefaultAccount: CodexAccount {
+        codexAccountStore.accounts.first(where: \.isDefault) ?? .defaultAccount
+    }
+
+    private var codexDefaultAuthenticationState: CodexAccountAuthenticationState {
+        guard codexDefaultAccount.isEnabled else { return .disabled }
+        return codexCliService.hasAccess ? .authenticated : .loginRequired
     }
 
     // MARK: - Provider pane
@@ -418,17 +438,25 @@ struct ProviderSettingsView: View {
                 detail: "Reads the OAuth session from \(codexAuthFileDisplayPath)."
             ) {
                 HStack(spacing: 8) {
-                    StatusPill(
-                        title: codexCliService.hasAccess ? "Connected" : "Not Connected",
-                        isConnected: codexCliService.hasAccess
+                    MeterBarChip(
+                        codexDefaultAuthenticationState.title,
+                        tint: codexDefaultAuthenticationState == .authenticated
+                            ? MeterBarTheme.success
+                            : .secondary,
+                        style: .glass
                     )
+                    .accessibilityLabel("Default Codex authentication status")
+                    .accessibilityValue(codexDefaultAuthenticationState.accessibilityValue)
 
                     Button {
                         // checkAccess does disk I/O — run it off the main actor
                         // (a plain Task would inherit MainActor and block the UI).
                         Task {
                             let service = codexCliService
-                            await Task.detached(priority: .userInitiated) { service.checkAccess() }.value
+                            let account = codexDefaultAccount
+                            await Task.detached(priority: .userInitiated) {
+                                service.checkAccess(account: account)
+                            }.value
                             await dataManager.refresh(service: .codexCli)
                         }
                     } label: {
@@ -436,6 +464,8 @@ struct ProviderSettingsView: View {
                             .labelStyle(.iconOnly)
                     }
                     .buttonStyle(.bordered)
+                    .disabled(!codexDefaultAccount.isEnabled)
+                    .accessibilityLabel("Check default Codex authentication")
                     .help(codexCliService.hasAccess ? "Refresh" : "Check again")
                 }
             }
@@ -446,7 +476,7 @@ struct ProviderSettingsView: View {
                         .font(.subheadline)
                         .fontWeight(.semibold)
                 }
-            } else if !codexCliService.hasAccess {
+            } else if codexDefaultAccount.isEnabled, !codexCliService.hasAccess {
                 EmptyStateCard(
                     systemImage: "person.crop.circle.badge.exclamationmark",
                     title: "Not connected",
@@ -477,7 +507,15 @@ struct ProviderSettingsView: View {
                         if index > 0 { SettingsDivider() }
                         CodexAccountProfileRow(
                             account: account,
-                            isConnected: dataManager.codexAccountMetrics[account.id] != nil,
+                            canDisable: codexAccountStore.canDisableAccount(id: account.id),
+                            canRemove: codexAccountStore.canRemoveAccount(id: account.id),
+                            onEnabledChange: { isEnabled in
+                                guard codexAccountStore.setEnabled(isEnabled, for: account.id) == .updated else {
+                                    return
+                                }
+                                reconcileCodexAccountSelections()
+                                Task { await dataManager.refreshAll() }
+                            },
                             onSave: { name, homeDirectory in
                                 codexAccountStore.updateAccount(
                                     id: account.id,
@@ -487,10 +525,8 @@ struct ProviderSettingsView: View {
                                 Task { await dataManager.refreshAll() }
                             },
                             onRemove: {
-                                codexAccountStore.removeAccount(id: account.id)
-                                MenuBarAccountSelectionStore.shared.forget(
-                                    MenuBarAccountKey.make(service: .codexCli, accountID: account.id)
-                                )
+                                guard codexAccountStore.removeAccount(id: account.id) == .updated else { return }
+                                reconcileCodexAccountSelections()
                                 Task { await dataManager.refreshAll() }
                             }
                         )
@@ -686,6 +722,9 @@ struct ProviderSettingsView: View {
             get: { providerVisibility.isEnabled(service) },
             set: { isEnabled in
                 providerVisibility.set(service, isEnabled: isEnabled)
+                if service == .codexCli {
+                    reconcileCodexAccountSelections()
+                }
                 Task {
                     await dataManager.refreshAll()
                 }
@@ -699,6 +738,7 @@ struct ProviderSettingsView: View {
             // main actor here, so hop to a detached task for the check itself.
             let claudeCode = claudeCodeService
             let codexCli = codexCliService
+            let codexDefaultAccount = codexDefaultAccount
             let cursor = cursorService
             let grok = grokService
             await Task.detached(priority: .userInitiated) {
@@ -706,7 +746,7 @@ struct ProviderSettingsView: View {
                 case .claudeCode:
                     claudeCode.checkAccess()
                 case .codexCli:
-                    codexCli.checkAccess()
+                    codexCli.checkAccess(account: codexDefaultAccount)
                 case .cursor:
                     cursor.checkAccess(forceRescan: true)
                 case .openRouter:
@@ -742,5 +782,32 @@ struct ProviderSettingsView: View {
         } catch {
             claudeReconnectError = error.localizedDescription
         }
+    }
+
+    /// Keep every account-scoped consumer on the same enabled identity set after
+    /// a Codex disable or delete. Session Wake clears and disarms rather than
+    /// silently retargeting; menu-bar and widget preferences prune stale keys.
+    private func reconcileCodexAccountSelections() {
+        let menuBarKeys = Set(
+            MenuBarAccountCatalog.identities(
+                claudeAccounts: claudeAccountStore.accounts,
+                codexAccounts: codexAccountStore.accounts,
+                enabledServices: providerVisibility.enabledServices
+            )
+            .filter(\.isEnabled)
+            .map(\.key)
+        )
+        menuBarAccountSelection.reconcile(availableKeys: menuBarKeys)
+
+        let widgetIdentifiers = Set(
+            WidgetSettingsAccountProjection.options(
+                enabledServices: providerVisibility.enabledServices,
+                claudeAccounts: claudeAccountStore.accounts,
+                codexAccounts: codexAccountStore.accounts
+            )
+            .map(\.id)
+        )
+        widgetPreferences.reconcileAvailableAccounts(widgetIdentifiers)
+        sessionWakeSettings.reconcileCodexAccounts(available: codexAccountStore.enabledAccounts.map(\.id))
     }
 }

--- a/MeterBar/Views/Settings/WidgetSettingsView.swift
+++ b/MeterBar/Views/Settings/WidgetSettingsView.swift
@@ -482,11 +482,7 @@ struct WidgetSettingsView: View {
     }
 
     private func reconcileExplicitSelection() {
-        let selection = preferencesStore.preferences.accountSelection
-        guard selection.mode == .explicit else { return }
-        let reconciled = selection.explicitIdentifiers.intersection(availableIdentifiers)
-        guard reconciled != selection.explicitIdentifiers else { return }
-        preferencesStore.setSelectedAccounts(reconciled)
+        preferencesStore.reconcileAvailableAccounts(availableIdentifiers)
     }
 }
 

--- a/MeterBarTests/AccountActivityInspectorTests.swift
+++ b/MeterBarTests/AccountActivityInspectorTests.swift
@@ -168,4 +168,29 @@ final class AccountActivityInspectorTests: XCTestCase {
             "/custom/codex/auth.json"
         )
     }
+
+    func testConfiguredDefaultCodexAccountOverridesEnvironmentHome() {
+        let account = CodexAccount(
+            id: CodexAccount.defaultID,
+            name: "Work",
+            homeDirectory: "~/profiles/codex-work"
+        )
+
+        XCTAssertEqual(
+            CodexHomeDirectory.path(
+                for: account,
+                environment: ["CODEX_HOME": "/ignored"],
+                realHomeDirectory: "/Users/tester"
+            ),
+            "/Users/tester/profiles/codex-work"
+        )
+        XCTAssertEqual(
+            CodexHomeDirectory.authFileDisplayPath(
+                for: account,
+                environment: ["CODEX_HOME": "/ignored"],
+                realHomeDirectory: "/Users/tester"
+            ),
+            "~/profiles/codex-work/auth.json"
+        )
+    }
 }

--- a/MeterBarTests/CodexAccountProfileRowTests.swift
+++ b/MeterBarTests/CodexAccountProfileRowTests.swift
@@ -1,0 +1,109 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import MeterBar
+
+@MainActor
+final class CodexAccountProfileRowTests: XCTestCase {
+    func testEnablementPublicationDoesNotOverwriteInProgressLabelEdit() {
+        let previous = CodexAccount(
+            id: CodexAccount.defaultID,
+            name: "Default CLI Profile",
+            homeDirectory: nil,
+            isEnabled: true
+        )
+        var updated = previous
+        updated.isEnabled = false
+        var draft = CodexAccountProfileDraft(
+            account: previous,
+            resolvedHomeDirectory: "/Users/tester/.codex"
+        )
+        draft.name = "Personal"
+
+        draft.reconcile(
+            from: previous,
+            previousResolvedHomeDirectory: "/Users/tester/.codex",
+            to: updated,
+            updatedResolvedHomeDirectory: "/Users/tester/.codex"
+        )
+
+        XCTAssertEqual(draft.name, "Personal")
+        XCTAssertEqual(draft.homeDirectory, "/Users/tester/.codex")
+    }
+
+    func testDefaultLabelOnlySaveDoesNotPersistResolvedFallbackAsOverride() {
+        let account = CodexAccount.defaultAccount
+        var draft = CodexAccountProfileDraft(
+            account: account,
+            resolvedHomeDirectory: "/Users/tester/.codex"
+        )
+        draft.name = "Personal"
+
+        XCTAssertEqual(
+            draft.savePayload(for: account, resolvedHomeDirectory: "/Users/tester/.codex"),
+            CodexAccountProfileSave(name: "Personal", homeDirectory: nil)
+        )
+    }
+
+    func testClearingDefaultDirectoryProducesExplicitClearMutation() {
+        let account = CodexAccount(
+            id: CodexAccount.defaultID,
+            name: "Personal",
+            homeDirectory: "/tmp/codex"
+        )
+        var draft = CodexAccountProfileDraft(account: account, resolvedHomeDirectory: "/tmp/codex")
+        draft.homeDirectory = "  "
+
+        XCTAssertEqual(
+            draft.savePayload(for: account, resolvedHomeDirectory: "/tmp/codex"),
+            CodexAccountProfileSave(name: "Personal", homeDirectory: "")
+        )
+
+        let save = CodexAccountProfileSave(name: "Personal", homeDirectory: "")
+        draft.commit(save, committedResolvedHomeDirectory: "/Users/tester/.codex")
+
+        XCTAssertNil(draft.savePayload(for: CodexAccount(
+            id: CodexAccount.defaultID,
+            name: "Personal",
+            homeDirectory: nil
+        ), resolvedHomeDirectory: "/Users/tester/.codex"))
+        XCTAssertEqual(draft.homeDirectory, "/Users/tester/.codex")
+    }
+
+    func testCustomLabelOnlySaveLeavesDirectoryUnchanged() {
+        let account = CodexAccount(id: UUID(), name: "Work", homeDirectory: "/tmp/codex-work")
+        var draft = CodexAccountProfileDraft(account: account, resolvedHomeDirectory: "/tmp/codex-work")
+        draft.name = "Team"
+
+        XCTAssertEqual(
+            draft.savePayload(for: account, resolvedHomeDirectory: "/tmp/codex-work"),
+            CodexAccountProfileSave(name: "Team", homeDirectory: nil)
+        )
+    }
+
+    func testAuthenticationPresentationUsesHonestTokenStates() {
+        XCTAssertEqual(CodexAccountAuthenticationState.checking.title, "Checking…")
+        XCTAssertEqual(CodexAccountAuthenticationState.authenticated.title, "Authenticated")
+        XCTAssertEqual(CodexAccountAuthenticationState.loginRequired.title, "Login required")
+        XCTAssertEqual(CodexAccountAuthenticationState.disabled.title, "Disabled")
+        XCTAssertTrue(CodexAccountAuthenticationState.authenticated.accessibilityValue.contains("access token"))
+    }
+
+    func testAccountRowRendersWithEveryControl() {
+        let account = CodexAccount(id: UUID(), name: "Work", homeDirectory: "/tmp/codex-work")
+        let view = CodexAccountProfileRow(
+            account: account,
+            canDisable: true,
+            canRemove: true,
+            onEnabledChange: { _ in },
+            onSave: { _, _ in },
+            onRemove: {},
+            connectionCheck: { _ in false }
+        )
+        let hostingView = NSHostingView(rootView: view.frame(width: 720))
+
+        hostingView.layoutSubtreeIfNeeded()
+
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+    }
+}

--- a/MeterBarTests/CodexAccountStoreTests.swift
+++ b/MeterBarTests/CodexAccountStoreTests.swift
@@ -29,6 +29,31 @@ final class CodexAccountStoreTests: XCTestCase {
         XCTAssertNil(reloaded.accounts.first?.homeDirectory)
     }
 
+    func testDefaultProfileHomeDirectoryCanBeEditedClearedAndPersists() {
+        let store = CodexAccountStore(userDefaults: defaults)
+
+        store.updateAccount(
+            id: CodexAccount.defaultID,
+            name: "Personal",
+            homeDirectory: "/tmp/old/../codex-personal"
+        )
+
+        XCTAssertEqual(store.accounts.first?.homeDirectory, "/tmp/codex-personal")
+        XCTAssertEqual(
+            CodexAccountStore(userDefaults: defaults).accounts.first?.homeDirectory,
+            "/tmp/codex-personal"
+        )
+
+        store.updateAccount(
+            id: CodexAccount.defaultID,
+            name: "Personal",
+            homeDirectory: "   "
+        )
+
+        XCTAssertNil(store.accounts.first?.homeDirectory)
+        XCTAssertNil(defaults.object(forKey: StorageKeys.codexDefaultHomeDirectory))
+    }
+
     func testCustomProfilesPersistIndependentHomesAndOrder() {
         let store = CodexAccountStore(userDefaults: defaults)
         store.addAccount(name: "Work", homeDirectory: "/tmp/codex-work")
@@ -55,7 +80,18 @@ final class CodexAccountStoreTests: XCTestCase {
         XCTAssertEqual(store.accounts.map(\.id), [CodexAccount.defaultID])
     }
 
-    // MARK: - Enablement (mirrors ClaudeCodeAccountStore)
+    func testCustomProfileLabelCanBeEditedWithoutResupplyingHomeDirectory() {
+        let store = CodexAccountStore(userDefaults: defaults)
+        store.addAccount(name: "Work", homeDirectory: "/tmp/codex-work")
+        let account = store.customAccounts[0]
+
+        store.updateAccount(id: account.id, name: "Team", homeDirectory: nil)
+
+        XCTAssertEqual(store.customAccounts[0].name, "Team")
+        XCTAssertEqual(store.customAccounts[0].homeDirectory, "/tmp/codex-work")
+    }
+
+    // MARK: - Enablement safety
 
     func testAccountsAreEnabledByDefault() {
         let store = CodexAccountStore(userDefaults: defaults)
@@ -64,14 +100,29 @@ final class CodexAccountStoreTests: XCTestCase {
         XCTAssertEqual(store.enabledAccounts.map(\.id), store.accounts.map(\.id))
     }
 
-    func testDisablingDefaultProfilePersistsAndFiltersEnabled() {
+    func testOnlyEnabledProfileCannotBeDisabled() {
         let store = CodexAccountStore(userDefaults: defaults)
-        store.setEnabled(false, for: CodexAccount.defaultID)
-        XCTAssertFalse(store.defaultAccountIsEnabled)
-        XCTAssertFalse(store.enabledAccounts.contains { $0.id == CodexAccount.defaultID })
+
+        XCTAssertEqual(
+            store.setEnabled(false, for: CodexAccount.defaultID),
+            .rejectedLastEnabledAccount
+        )
+        XCTAssertTrue(store.defaultAccountIsEnabled)
+        XCTAssertEqual(store.enabledAccounts.map(\.id), [CodexAccount.defaultID])
+    }
+
+    func testDefaultProfileCanLeaveActiveSetAfterAlternativeIsEnabled() {
+        let store = CodexAccountStore(userDefaults: defaults)
+        store.addAccount(name: "Work", homeDirectory: "/tmp/codex-work")
+        let workID = store.customAccounts[0].id
+
+        XCTAssertEqual(store.setEnabled(false, for: CodexAccount.defaultID), .updated)
+        XCTAssertEqual(store.enabledAccounts.map(\.id), [workID])
+        XCTAssertTrue(store.accounts.contains { $0.id == CodexAccount.defaultID })
 
         let reloaded = CodexAccountStore(userDefaults: defaults)
         XCTAssertFalse(reloaded.defaultAccountIsEnabled)
+        XCTAssertEqual(reloaded.enabledAccounts.map(\.id), [workID])
     }
 
     func testDisablingCustomProfilePersistsAndFiltersEnabled() {
@@ -87,6 +138,30 @@ final class CodexAccountStoreTests: XCTestCase {
         XCTAssertFalse(reloaded.enabledAccounts.contains { $0.id == account.id })
     }
 
+    func testLastEnabledCustomProfileCannotBeDisabledOrRemoved() {
+        let store = CodexAccountStore(userDefaults: defaults)
+        store.addAccount(name: "Work", homeDirectory: "/tmp/codex-work")
+        let account = store.customAccounts[0]
+        XCTAssertEqual(store.setEnabled(false, for: CodexAccount.defaultID), .updated)
+
+        XCTAssertFalse(store.canDisableAccount(id: account.id))
+        XCTAssertFalse(store.canRemoveAccount(id: account.id))
+        XCTAssertEqual(store.setEnabled(false, for: account.id), .rejectedLastEnabledAccount)
+        XCTAssertEqual(store.removeAccount(id: account.id), .rejectedLastEnabledAccount)
+        XCTAssertEqual(store.enabledAccounts.map(\.id), [account.id])
+    }
+
+    func testDisabledCustomProfileCanBeRemoved() {
+        let store = CodexAccountStore(userDefaults: defaults)
+        store.addAccount(name: "Work", homeDirectory: "/tmp/codex-work")
+        let account = store.customAccounts[0]
+        XCTAssertEqual(store.setEnabled(false, for: account.id), .updated)
+
+        XCTAssertTrue(store.canRemoveAccount(id: account.id))
+        XCTAssertEqual(store.removeAccount(id: account.id), .updated)
+        XCTAssertTrue(store.customAccounts.isEmpty)
+    }
+
     func testLegacyCustomProfilesDecodeAsEnabled() {
         // A profile persisted before `isEnabled` existed (no key) decodes enabled.
         let legacy = #"[{"id":"\#(UUID().uuidString)","name":"Legacy","homeDirectory":"/tmp/legacy"}]"#
@@ -95,5 +170,22 @@ final class CodexAccountStoreTests: XCTestCase {
         let store = CodexAccountStore(userDefaults: defaults)
         XCTAssertEqual(store.customAccounts.count, 1)
         XCTAssertTrue(store.customAccounts[0].isEnabled)
+    }
+
+    func testLegacyAllDisabledStateRestoresDefaultSentinel() throws {
+        let custom = CodexAccount(
+            id: UUID(),
+            name: "Legacy",
+            homeDirectory: "/tmp/legacy",
+            isEnabled: false
+        )
+        defaults.set(try JSONEncoder().encode([custom]), forKey: StorageKeys.codexCustomAccounts)
+        defaults.set(false, forKey: StorageKeys.codexDefaultAccountEnabled)
+
+        let store = CodexAccountStore(userDefaults: defaults)
+
+        XCTAssertTrue(store.defaultAccountIsEnabled)
+        XCTAssertEqual(store.enabledAccounts.map(\.id), [CodexAccount.defaultID])
+        XCTAssertNil(defaults.object(forKey: StorageKeys.codexDefaultAccountEnabled))
     }
 }

--- a/MeterBarTests/MenuBarAccountSelectionTests.swift
+++ b/MeterBarTests/MenuBarAccountSelectionTests.swift
@@ -233,6 +233,20 @@ final class MenuBarAccountSelectionTests: XCTestCase {
         XCTAssertEqual(store.mergedAccountKey, "claudeCode:a")
     }
 
+    func testReconcilePrunesDisabledSelectionsAndSwitcherBinding() throws {
+        let defaults = try XCTUnwrap(defaults)
+        let store = MenuBarAccountSelectionStore(userDefaults: defaults)
+        store.select("codexCli:enabled")
+        store.select("codexCli:disabled")
+        store.setMergedAccountKey("codexCli:disabled")
+
+        store.reconcile(availableKeys: ["codexCli:enabled"])
+
+        XCTAssertEqual(store.selectedAccountKeys, ["codexCli:enabled"])
+        XCTAssertNil(store.mergedAccountKey)
+        XCTAssertEqual(defaults.stringArray(forKey: StorageKeys.menuBarSelectedAccountKeys), ["codexCli:enabled"])
+    }
+
     func testBlankMergedKeyClearsThePreference() throws {
         let defaults = try XCTUnwrap(defaults)
         let store = MenuBarAccountSelectionStore(userDefaults: defaults)

--- a/MeterBarTests/SessionWakeControllerTests.swift
+++ b/MeterBarTests/SessionWakeControllerTests.swift
@@ -17,9 +17,7 @@ final class SessionWakeControllerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         defaults.removePersistentDomain(forName: suiteName)
-        try? FileManager.default.removeItem(
-            at: FileManager.default.temporaryDirectory.appendingPathComponent("\(suiteName ?? "")-watcher.lock")
-        )
+        try? FileManager.default.removeItem(at: testLockURL())
     }
 
     private func pump(_ seconds: TimeInterval = 0.1) {
@@ -43,9 +41,14 @@ final class SessionWakeControllerTests: XCTestCase {
     }
 
     private func lifetimeLockFactory() -> @Sendable () -> WakeLock {
-        let lockURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("\(suiteName ?? UUID().uuidString)-watcher.lock")
+        let lockURL = testLockURL()
         return { WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .app) }
+    }
+
+    private func testLockURL() -> URL {
+        URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+            .appendingPathComponent(".build/session-wake-tests", isDirectory: true)
+            .appendingPathComponent("\(suiteName ?? UUID().uuidString)-watcher.lock")
     }
 
     func testWatcherReArmsOnLaunchWhenToggleWasLeftOn() {
@@ -213,6 +216,41 @@ final class SessionWakeControllerTests: XCTestCase {
         XCTAssertTrue(controller.isWatching)
         poll { recorder.startCount >= 1 }
         XCTAssertEqual(recorder.startedProviders.first, .codex)
+    }
+
+    func testDisablingSelectedCodexAccountStopsWatcherAndClearsSelection() {
+        let codexAccounts = CodexAccountStore(userDefaults: defaults)
+        codexAccounts.addAccount(name: "Work", homeDirectory: "/tmp/session-wake-codex")
+        guard let selectedID = codexAccounts.customAccounts.first?.id else {
+            return XCTFail("adding a Codex account should yield a resolvable id")
+        }
+
+        let store = SessionWakeSettingsStore(userDefaults: defaults)
+        store.setWakeProvider(.codex)
+        store.setWakeCodexAccountID(selectedID)
+        store.acknowledgeFirstRunAndTurnOn()
+
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: SessionWakeStatus(),
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            codexAccounts: codexAccounts,
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
+        )
+        controller.activate()
+        poll { recorder.startCount >= 1 }
+
+        XCTAssertEqual(codexAccounts.setEnabled(false, for: selectedID), .updated)
+
+        poll { !controller.isWatching }
+        XCTAssertFalse(controller.isWatching)
+        XCTAssertFalse(store.isOn)
+        XCTAssertNil(store.wakeCodexAccountID)
+        poll { recorder.stopCount >= 1 }
+        XCTAssertGreaterThanOrEqual(recorder.stopCount, 1)
     }
 
     func testSwitchingProviderWhileArmedStopsTheWatcher() {

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -1279,14 +1279,14 @@ final class UsageDataManagerTests: XCTestCase {
         XCTAssertEqual(sharedStore.loadAccountMetrics().map(\.id), [CodexAccount.defaultID])
     }
 
-    func testRefreshAllClearsStaleCodexMetricsWhenEveryAccountIsDisabled() async throws {
-        let accountSuite = "UsageDataManagerTests-all-disabled-\(UUID().uuidString)"
+    func testRefreshAllRetainsAndRefreshesTheOnlyEnabledCodexAccount() async throws {
+        let accountSuite = "UsageDataManagerTests-last-enabled-\(UUID().uuidString)"
         createdSuiteNames.append(accountSuite)
         let accountDefaults = try XCTUnwrap(UserDefaults(suiteName: accountSuite))
         let accountStore = CodexAccountStore(userDefaults: accountDefaults)
-        accountStore.setEnabled(false, for: CodexAccount.defaultID)
         let staleMetrics = MetricsFixtures.codexCli(sessionUsedPercent: 80)
-        let provider = MultiAccountCodexProvider(metricsByAccount: [CodexAccount.defaultID: staleMetrics])
+        let freshMetrics = MetricsFixtures.codexCli(sessionUsedPercent: 20)
+        let provider = MultiAccountCodexProvider(metricsByAccount: [CodexAccount.defaultID: freshMetrics])
         let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
         let (manager, sharedStore) = makeManager(
             codex: provider,
@@ -1295,13 +1295,17 @@ final class UsageDataManagerTests: XCTestCase {
             preload: [.codexCli: staleMetrics]
         )
 
+        XCTAssertEqual(
+            accountStore.setEnabled(false, for: CodexAccount.defaultID),
+            .rejectedLastEnabledAccount
+        )
         await manager.refreshAll()
 
-        XCTAssertNil(manager.metrics[.codexCli])
-        XCTAssertTrue(manager.codexAccountMetrics.isEmpty)
+        XCTAssertEqual(manager.metrics[.codexCli]?.sessionLimit?.used, 20)
+        XCTAssertEqual(manager.codexAccountMetrics[CodexAccount.defaultID]?.sessionLimit?.used, 20)
         sharedStore.flushPendingWrites()
-        XCTAssertNil(sharedStore.loadMetrics()[.codexCli])
-        XCTAssertTrue(sharedStore.loadAccountMetrics().isEmpty)
+        XCTAssertEqual(sharedStore.loadMetrics()[.codexCli]?.sessionLimit?.used, 20)
+        XCTAssertEqual(sharedStore.loadAccountMetrics().map(\.id), [CodexAccount.defaultID])
     }
 
     func testRefreshAllDoesNotMoveAggregateMetricsBetweenCodexProfiles() async throws {

--- a/MeterBarTests/WidgetPreferencesStoreTests.swift
+++ b/MeterBarTests/WidgetPreferencesStoreTests.swift
@@ -168,6 +168,29 @@ final class WidgetPreferencesStoreTests: XCTestCase {
         XCTAssertFalse(makeStore().preferences.preservesLegacyOpenRouterBalance)
     }
 
+    func testReconcileAvailableAccountsPrunesExplicitDisabledSelection() {
+        var reloadCount = 0
+        let store = WidgetPreferencesStore(userDefaults: defaults) {
+            reloadCount += 1
+        }
+        let enabled = WidgetAccountIdentifier.account(service: .codexCli, id: UUID())
+        let disabled = WidgetAccountIdentifier.account(service: .codexCli, id: UUID())
+        store.setSelectedAccounts([enabled, disabled])
+
+        store.reconcileAvailableAccounts([enabled])
+
+        XCTAssertEqual(store.preferences.accountSelection.explicitIdentifiers, [enabled])
+        XCTAssertEqual(reloadCount, 2)
+    }
+
+    func testReconcileAvailableAccountsLeavesDynamicAllSelectionUntouched() {
+        let store = makeStore()
+
+        store.reconcileAvailableAccounts([])
+
+        XCTAssertEqual(store.preferences.accountSelection, .all)
+    }
+
     func testStableIdentifiersIncludeProviderAndAccountIdentity() {
         let accountID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9))
 

--- a/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPreferences.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPreferences.swift
@@ -271,6 +271,15 @@ public final class WidgetPreferencesStore: ObservableObject {
         update { $0.accountSelection = .all }
     }
 
+    /// Prunes explicit selections when an account is disabled or deleted.
+    /// `.all` remains dynamic by design and therefore needs no stored rewrite.
+    public func reconcileAvailableAccounts(_ availableIdentifiers: Set<WidgetAccountIdentifier>) {
+        guard preferences.accountSelection.mode == .explicit else { return }
+        let reconciled = preferences.accountSelection.explicitIdentifiers.intersection(availableIdentifiers)
+        guard reconciled != preferences.accountSelection.explicitIdentifiers else { return }
+        setSelectedAccounts(reconciled)
+    }
+
     public func setSelectedAccounts(_ identifiers: Set<WidgetAccountIdentifier>) {
         update { $0.accountSelection = .explicit(identifiers) }
     }


### PR DESCRIPTION
## Summary

- make Codex label and CODEX_HOME editing reliable for default and custom profiles
- expose guarded enable/disable and custom delete controls while retaining the default migration sentinel
- derive per-profile connection state from the configured non-expired auth token, with explicit accessibility labels
- reconcile disabled/deleted identities from menu-bar, widget, and Session Wake selections

## Safety invariants

- the active Codex account set can never become empty
- the default profile can be disabled once an alternative is enabled
- Session Wake clears and disarms instead of silently retargeting
- deleting a profile never deletes its CODEX_HOME or login data

## Verification

- `swiftlint lint --strict --quiet --no-cache`
- 114 focused Swift tests across store, UI/presentation, auth-path, menu-bar, widget, and Session Wake coverage
- unsigned Debug app build via `xcodebuild`
- `git diff --check` and local secret/debug scans

## Review note

The project Claude profile was unauthenticated, so the preferred Fable planning and Opus exact-head verification lanes were unavailable. Local exact-diff review and focused verification are complete; this PR remains open for CI and repository review.

Closes #304