### PR TITLE
chore: bump version to 1.8.2

### DIFF
--- a/.agents/SESSIONS/2026-07-29.md
+++ b/.agents/SESSIONS/2026-07-29.md
@@ -577,3 +577,31 @@ flowchart TD
 - MeterBar Debug app build with code signing disabled: succeeded.
 - A broader `UsageDataManagerTests` filter still encounters the documented
   machine-dependent Grok discovery baseline; no Claude regression failed.
+
+## Session 8: Merge open PRs + integration audit
+
+**Status:** Complete
+
+### What was done
+
+- Reviewed open PRs #301–#308; #302 and #303 merged first.
+- #301 CodeRabbit threads fixed (Adaptive reschedule on publish-path movement + diagnostics selection label).
+- Remaining feature PRs had cross-conflicts; landed via integration PR #309 after conflict resolution.
+- Integration fix: StatusItem refresh fan-in for Grok accounts/metrics.
+- Closed superseded #301, #305–#308 after #309 merged.
+- Audited master for DRY, security, and optimization (findings below / in agent report).
+
+### Files changed
+
+- Integration composition on `master` via #309 (80 files).
+- Pre-merge: Adaptive refresh CodeRabbit fix on #301 branch.
+
+### Decisions
+
+- Use one integration PR rather than serial rebase thrash across five conflicting feature branches.
+- Keep webhook SSRF policy as-is (HTTPS/443, DNS public-only, redirect-blocked, ephemeral session).
+
+### Next steps
+
+- [ ] Patch bump 1.8.1 → 1.8.2
+- [ ] Local Debug/Release install for manual test before `/release`

--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -369,7 +369,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -534,7 +534,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug;
 				PRODUCT_NAME = "MeterBar Dev";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -580,7 +580,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary

- Bump `MARKETING_VERSION` 1.8.1 → 1.8.2 across all Xcode configs.
- Session note for the merge/integration/audit pass.

## Context

Pre-release local test build after #302, #303, and #309 landed.

## Verification

- Version grep shows a single marketing version (1.8.2).