### PR TITLE
fix(menubar): follow active Grok and DRY path expansion

### DIFF
--- a/.agents/SESSIONS/2026-07-29.md
+++ b/.agents/SESSIONS/2026-07-29.md
@@ -605,3 +605,25 @@ flowchart TD
 
 - [ ] Patch bump 1.8.1 → 1.8.2
 - [ ] Local Debug/Release install for manual test before `/release`
+
+## Session 9: Empty menu bar / Grok not auto-selected
+
+**Status:** Complete
+
+### What was done
+
+- Root cause: Grok menu-bar activity probe was hard-coded to `nil`, so Auto never
+  followed active Grok work when Claude still had recent on-disk activity.
+- Added `AccountActivityInspector.grokActivity` over `GROK_HOME`.
+- Auto window policy now falls back to weekly when session is absent (Codex weekly-only).
+- Hardened status-item realization: never drop to zero items; force `isVisible`;
+  reject zero-size images.
+- DRY: shared `ServiceSupport.expandUserPath` / `compactPathForDisplay` used by
+  Codex, Grok, Claude config, and Fable path expansion.
+
+### Files changed
+
+- `MeterBar/Services/{ServiceSupport,AccountActivityInspector,CodexHomeDirectory,GrokHomeDirectory,ClaudeFableSessionTracker}.swift`
+- `MeterBar/Models/{StatusItemLimitSelector,ClaudeCodeAccount}.swift`
+- `MeterBar/App/{StatusLimitProbeRequests,StatusItemPresenter,MeterBarApp}.swift`
+- Tests for selector + activity + path expansion

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -199,7 +199,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// the delegate's half of the split — deciding *what* each item says is the
     /// presenter's, and it calls back in here to have the plan realized.
     private func applyStatusItemDescriptors(_ descriptors: [MenuBarStatusItemDescriptor]) {
-        let liveIDs = Set(descriptors.map(\.id))
+        // A plan is allowed to be empty only as a bug. Keep the merged
+        // placeholder alive so Quit / Settings stay reachable from the menu bar.
+        let plan = descriptors.isEmpty
+            ? [
+                MenuBarStatusItemDescriptor(
+                    id: MenuBarStatusItemPlanner.mergedItemID,
+                    service: nil,
+                    selectionKey: nil,
+                    title: "",
+                    tooltip: "MeterBar",
+                    accessibilityLabel: "MeterBar",
+                    visualStyle: StatusItemVisualStyle(fontSize: .standard, highContrast: false)
+                )
+            ]
+            : descriptors
+        let liveIDs = Set(plan.map(\.id))
 
         // Snapshot the keys: the loop mutates the dictionary it reads from.
         for id in Array(statusItems.keys) where !liveIDs.contains(id) {
@@ -212,11 +227,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self.activeStatusItemID = nil
         }
 
-        statusItemIDs = descriptors.map(\.id)
+        statusItemIDs = plan.map(\.id)
 
-        for descriptor in descriptors {
+        for descriptor in plan {
             let item = statusItems[descriptor.id] ?? makeStatusItem(id: descriptor.id)
-            guard let button = item?.button else { continue }
+            guard let item, let button = item.button else { continue }
+            // macOS can hide an autosaved item after a mode change; force it
+            // back so Auto never leaves the user with a blank menu bar slot.
+            item.isVisible = true
+            if item.length <= 0 {
+                item.length = NSStatusItem.variableLength
+            }
             statusItemPresenter.apply(descriptor, to: button)
         }
     }

--- a/MeterBar/App/StatusItemPresenter.swift
+++ b/MeterBar/App/StatusItemPresenter.swift
@@ -142,7 +142,14 @@ final class StatusItemPresenter {
 
     @MainActor
     func apply(_ descriptor: MenuBarStatusItemDescriptor, to button: NSStatusBarButton) {
-        button.image = image(for: descriptor.service)
+        let resolvedImage = image(for: descriptor.service)
+        // Never publish a zero-size template — AppKit collapses the status item
+        // to an invisible slot when both image and title are empty-width.
+        if resolvedImage.size.width < 1 || resolvedImage.size.height < 1 {
+            button.image = fallbackImage()
+        } else {
+            button.image = resolvedImage
+        }
         button.imagePosition = descriptor.title.isEmpty ? .imageOnly : .imageLeft
         applyVisualStyle(descriptor.visualStyle, to: button)
         setTitle(button, to: descriptor.title, style: descriptor.visualStyle)

--- a/MeterBar/App/StatusLimitProbeRequests.swift
+++ b/MeterBar/App/StatusLimitProbeRequests.swift
@@ -94,6 +94,7 @@ nonisolated enum StatusLimitProbeRequestBuilder {
                     accountMetrics: UsageDataManager.shared.grokAccountMetrics,
                     providerMetrics: metrics[.grok]
                 ) else { continue }
+                let homeDirectory = account.homeDirectory
                 let source = StatusLimitSource(
                     service: .grok,
                     accountID: account.id,
@@ -102,7 +103,10 @@ nonisolated enum StatusLimitProbeRequestBuilder {
                     displayName: "\(account.name) (\(ServiceType.grok.displayName))",
                     metrics: accountMetrics
                 )
-                requests.append(request(source: source, probe: { nil }))
+                requests.append(request(
+                    source: source,
+                    probe: { AccountActivityInspector.grokActivity(homeDirectory: homeDirectory) }
+                ))
             }
         }
         if visibility.isEnabled(.cursor), let cursorMetrics = metrics[.cursor] {

--- a/MeterBar/Models/ClaudeCodeAccount.swift
+++ b/MeterBar/Models/ClaudeCodeAccount.swift
@@ -66,13 +66,7 @@ nonisolated struct ClaudeCodeAccount: Codable, Equatable, Identifiable, Sendable
         _ rawValue: String,
         realHomeDirectory: String = ServiceSupport.realHomeDirectory()
     ) -> String {
-        if rawValue == "~" {
-            return realHomeDirectory
-        }
-        if rawValue.hasPrefix("~/") {
-            return (realHomeDirectory as NSString).appendingPathComponent(String(rawValue.dropFirst(2)))
-        }
-        return (rawValue as NSString).standardizingPath
+        ServiceSupport.expandUserPath(rawValue, realHomeDirectory: realHomeDirectory)
     }
 }
 

--- a/MeterBar/Models/StatusItemLimitSelector.swift
+++ b/MeterBar/Models/StatusItemLimitSelector.swift
@@ -117,13 +117,30 @@ nonisolated enum StatusItemPinKey {
 /// Identifies the quota window each provider contributes to automatic menu-bar
 /// selection. Other windows remain available for explicit pinning only.
 nonisolated enum StatusItemAutoSelectionPolicy {
-    static func windowID(for service: ServiceType) -> String? {
+    /// Preferred Auto windows in priority order. The first window actually
+    /// present in the provider response becomes the Auto candidate — so a
+    /// weekly-only Codex profile still participates when session is absent.
+    static func preferredWindowIDs(for service: ServiceType) -> [String] {
         switch service {
         case .claudeCode, .codexCli:
-            return "session"
+            return ["session", "weekly"]
         case .cursor, .openRouter, .grok:
-            return "weekly"
+            return ["weekly", "session"]
         }
+    }
+
+    /// Default preferred window when no availability set is provided (tests and
+    /// documentation). Prefer the live `autoWindowID(for:availableWindowIDs:)`
+    /// path when seeds are built from real limits.
+    static func windowID(for service: ServiceType) -> String? {
+        preferredWindowIDs(for: service).first
+    }
+
+    static func autoWindowID(
+        for service: ServiceType,
+        availableWindowIDs: Set<String>
+    ) -> String? {
+        preferredWindowIDs(for: service).first { availableWindowIDs.contains($0) }
     }
 }
 
@@ -137,7 +154,11 @@ enum StatusItemLimitCandidateBuilder {
         limits: [SnapshotLimit],
         lastUpdated: Date = Date()
     ) -> [StatusLimitCandidateSeed] {
-        let autoWindowID = StatusItemAutoSelectionPolicy.windowID(for: service)
+        let availableWindowIDs = Set(limits.map(\.id))
+        let autoWindowID = StatusItemAutoSelectionPolicy.autoWindowID(
+            for: service,
+            availableWindowIDs: availableWindowIDs
+        )
         return limits.map { limit in
             let pinKey = StatusItemPinKey.make(
                 service: service,

--- a/MeterBar/Services/AccountActivityInspector.swift
+++ b/MeterBar/Services/AccountActivityInspector.swift
@@ -70,6 +70,19 @@ nonisolated enum AccountActivityInspector {
         return lastActivity(inDirectory: CodexHomeDirectory.path(for: account))
     }
 
+    /// Grok Build keeps session transcripts, locks, and caches under
+    /// `GROK_HOME` (default `~/.grok`). Depth-1 covers `sessions/`,
+    /// `active_sessions.json`, and other top-level files the CLI rewrites while
+    /// a run is live — without opening credential bytes.
+    static func grokActivity(homeDirectory: String?) -> Date? {
+        let account = GrokAccount(
+            id: GrokAccount.defaultID,
+            name: GrokAccount.defaultName,
+            homeDirectory: homeDirectory
+        )
+        return lastActivity(inDirectory: GrokHomeDirectory.path(for: account))
+    }
+
     /// Cursor continuously checkpoints its state database while running; the
     /// WAL sibling is the hottest file. Mirrors the candidate paths used by
     /// `CursorLocalService.getCursorDatabasePath`.

--- a/MeterBar/Services/ClaudeFableSessionTracker.swift
+++ b/MeterBar/Services/ClaudeFableSessionTracker.swift
@@ -406,14 +406,7 @@ actor ClaudeFableSessionScanner {
         _ rawPath: String,
         realHomeDirectory: String
     ) -> String {
-        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed == "~" {
-            return realHomeDirectory
-        }
-        if trimmed.hasPrefix("~/") {
-            return (realHomeDirectory as NSString).appendingPathComponent(String(trimmed.dropFirst(2)))
-        }
-        return (trimmed as NSString).standardizingPath
+        ServiceSupport.expandUserPath(rawPath, realHomeDirectory: realHomeDirectory)
     }
 
     nonisolated private static func isNewer(

--- a/MeterBar/Services/CodexHomeDirectory.swift
+++ b/MeterBar/Services/CodexHomeDirectory.swift
@@ -15,14 +15,7 @@ nonisolated enum CodexHomeDirectory {
             !rawValue.isEmpty else {
             return (realHomeDirectory as NSString).appendingPathComponent(".codex")
         }
-
-        if rawValue == "~" {
-            return realHomeDirectory
-        }
-        if rawValue.hasPrefix("~/") {
-            return (realHomeDirectory as NSString).appendingPathComponent(String(rawValue.dropFirst(2)))
-        }
-        return (rawValue as NSString).standardizingPath
+        return ServiceSupport.expandUserPath(rawValue, realHomeDirectory: realHomeDirectory)
     }
 
     static func authFilePath(
@@ -42,13 +35,7 @@ nonisolated enum CodexHomeDirectory {
             .trimmingCharacters(in: .whitespacesAndNewlines), !homeDirectory.isEmpty else {
             return path(environment: environment, realHomeDirectory: realHomeDirectory)
         }
-        if homeDirectory == "~" {
-            return realHomeDirectory
-        }
-        if homeDirectory.hasPrefix("~/") {
-            return (realHomeDirectory as NSString).appendingPathComponent(String(homeDirectory.dropFirst(2)))
-        }
-        return (homeDirectory as NSString).standardizingPath
+        return ServiceSupport.expandUserPath(homeDirectory, realHomeDirectory: realHomeDirectory)
     }
 
     static func authFilePath(for account: CodexAccount) -> String {
@@ -87,13 +74,6 @@ nonisolated enum CodexHomeDirectory {
     }
 
     private static func compactForDisplay(_ path: String, realHomeDirectory: String) -> String {
-        let resolvedPath = (path as NSString).standardizingPath
-        let standardizedHome = (realHomeDirectory as NSString).standardizingPath
-        let homePrefix = standardizedHome.hasSuffix("/") ? standardizedHome : "\(standardizedHome)/"
-
-        guard resolvedPath.hasPrefix(homePrefix) else {
-            return resolvedPath
-        }
-        return "~/\(resolvedPath.dropFirst(homePrefix.count))"
+        ServiceSupport.compactPathForDisplay(path, realHomeDirectory: realHomeDirectory)
     }
 }

--- a/MeterBar/Services/GrokHomeDirectory.swift
+++ b/MeterBar/Services/GrokHomeDirectory.swift
@@ -40,12 +40,6 @@ nonisolated enum GrokHomeDirectory {
         _ rawValue: String,
         realHomeDirectory: String = ServiceSupport.realHomeDirectory()
     ) -> String {
-        if rawValue == "~" {
-            return realHomeDirectory
-        }
-        if rawValue.hasPrefix("~/") {
-            return (realHomeDirectory as NSString).appendingPathComponent(String(rawValue.dropFirst(2)))
-        }
-        return (rawValue as NSString).standardizingPath
+        ServiceSupport.expandUserPath(rawValue, realHomeDirectory: realHomeDirectory)
     }
 }

--- a/MeterBar/Services/ServiceSupport.swift
+++ b/MeterBar/Services/ServiceSupport.swift
@@ -216,4 +216,37 @@ nonisolated enum ServiceSupport {
         }
         return FileManager.default.homeDirectoryForCurrentUser.path
     }
+
+    /// Expand `~` / `~/…` against the real home directory, and standardize every
+    /// other path. Shared by account homes, config dirs, and CLI state roots so
+    /// providers cannot diverge on `~/`-expansion edge cases.
+    static func expandUserPath(
+        _ rawValue: String,
+        realHomeDirectory: String = realHomeDirectory()
+    ) -> String {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed == "~" {
+            return realHomeDirectory
+        }
+        if trimmed.hasPrefix("~/") {
+            return (realHomeDirectory as NSString).appendingPathComponent(String(trimmed.dropFirst(2)))
+        }
+        return (trimmed as NSString).standardizingPath
+    }
+
+    /// Compact an absolute path under the real home directory back to `~/…` for
+    /// user-facing copy. Paths outside the home stay absolute.
+    static func compactPathForDisplay(
+        _ path: String,
+        realHomeDirectory: String = realHomeDirectory()
+    ) -> String {
+        let resolvedPath = (path as NSString).standardizingPath
+        let standardizedHome = (realHomeDirectory as NSString).standardizingPath
+        let homePrefix = standardizedHome.hasSuffix("/") ? standardizedHome : "\(standardizedHome)/"
+
+        guard resolvedPath.hasPrefix(homePrefix) else {
+            return resolvedPath
+        }
+        return "~/\(resolvedPath.dropFirst(homePrefix.count))"
+    }
 }

--- a/MeterBarTests/AccountActivityInspectorTests.swift
+++ b/MeterBarTests/AccountActivityInspectorTests.swift
@@ -103,6 +103,41 @@ final class AccountActivityInspectorTests: XCTestCase {
         XCTAssertEqual(activity.timeIntervalSince1970, newest.timeIntervalSince1970, accuracy: 2)
     }
 
+    func testGrokActivityHonorsExplicitHomeDirectory() throws {
+        let grokHome = tempDir.appendingPathComponent("custom-grok", isDirectory: true)
+        try FileManager.default.createDirectory(at: grokHome, withIntermediateDirectories: true)
+        let newest = Date(timeIntervalSinceNow: -45)
+        let sessions = grokHome.appendingPathComponent("sessions", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessions, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.modificationDate: newest], ofItemAtPath: sessions.path)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: -3_600)],
+            ofItemAtPath: grokHome.path
+        )
+
+        let activity = try XCTUnwrap(
+            AccountActivityInspector.grokActivity(homeDirectory: grokHome.path)
+        )
+        XCTAssertEqual(activity.timeIntervalSince1970, newest.timeIntervalSince1970, accuracy: 2)
+    }
+
+    func testExpandUserPathHandlesTildeAndAbsolutePaths() {
+        let home = tempDir.path
+        XCTAssertEqual(ServiceSupport.expandUserPath("~", realHomeDirectory: home), home)
+        XCTAssertEqual(
+            ServiceSupport.expandUserPath("~/Library/State", realHomeDirectory: home),
+            "\(home)/Library/State"
+        )
+        XCTAssertEqual(
+            ServiceSupport.expandUserPath("/opt/tools", realHomeDirectory: home),
+            "/opt/tools"
+        )
+        XCTAssertEqual(
+            ServiceSupport.compactPathForDisplay("\(home)/.grok/auth.json", realHomeDirectory: home),
+            "~/.grok/auth.json"
+        )
+    }
+
     func testCodexHomeResolverDefaultsBlankValuesAndBuildsAuthPath() {
         let home = tempDir.path
 

--- a/MeterBarTests/StatusItemLimitSelectorTests.swift
+++ b/MeterBarTests/StatusItemLimitSelectorTests.swift
@@ -80,6 +80,48 @@ final class StatusItemLimitSelectorTests: XCTestCase {
         XCTAssertEqual(seeds.first(where: \.isAutoSelectable)?.windowName, "Weekly")
     }
 
+    /// When OpenAI temporarily disables the 5-hour window, Codex still reports a
+    /// weekly window. Auto must fall back to weekly so the menu bar is not left
+    /// without a Codex candidate.
+    func testCodexWeeklyOnlyQuotaFallsBackToWeeklyForAutoSelection() {
+        let limits = ProviderSnapshotBuilder.limits(
+            for: UsageMetrics(
+                service: .codexCli,
+                weeklyLimit: UsageLimit(used: 19, total: 100, resetTime: now.addingTimeInterval(3_600))
+            ),
+            service: .codexCli
+        )
+        let seeds = StatusItemLimitCandidateBuilder.seeds(
+            service: .codexCli,
+            accountID: CodexAccount.defaultID,
+            autoSelectionKey: "codex:\(CodexAccount.defaultID.uuidString)",
+            displayName: "Codex",
+            limits: limits
+        )
+
+        XCTAssertEqual(seeds.map(\.windowName), ["Weekly"])
+        XCTAssertEqual(seeds.filter(\.isAutoSelectable).map(\.windowName), ["Weekly"])
+    }
+
+    /// Grok never auto-won while its activity probe was hard-coded to `nil`
+    /// and Claude still had recent on-disk activity. Active Grok must win.
+    func testActiveGrokBeatsIdleClaudeInAutoSelection() {
+        let idleClaude = candidate(
+            key: "claude:default",
+            percentUsed: 66,
+            activeMinutesAgo: nil,
+            service: .claudeCode
+        )
+        let activeGrok = candidate(
+            key: "grok:default",
+            percentUsed: 19,
+            activeMinutesAgo: 1,
+            windowName: "Weekly",
+            service: .grok
+        )
+        XCTAssertEqual(select([idleClaude, activeGrok])?.key, "grok:default")
+    }
+
     func testOpenRouterAccountCreditsParticipateInAutoSelection() {
         let metrics = UsageMetrics(
             service: .openRouter,


### PR DESCRIPTION
## Summary

- **Bug:** Grok never auto-won the menu bar while Claude still had recent on-disk activity, because Grok's activity probe was hard-coded to `nil`.
- Probe `GROK_HOME` (depth-1) the same way we probe Claude/Codex homes.
- Auto window policy falls back to **weekly** when **session** is absent (weekly-only Codex).
- Harden status-item realization: never apply an empty plan, force `isVisible`, reject zero-size images.
- **DRY:** `ServiceSupport.expandUserPath` / `compactPathForDisplay` shared by Codex, Grok, Claude config, and Fable path expansion.

## Verification

- `swift test --filter 'StatusItemLimitSelectorTests|AccountActivityInspectorTests'` — 40+ focused tests including new Grok activity / weekly-only Codex / path expansion cases.
- `swiftlint lint --strict` on touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the menu bar could appear empty or fail to select Grok automatically.
  * Improved automatic quota selection when preferred windows are unavailable.
  * Added safeguards against invalid status-item images and hidden menu-bar items.
  * Grok activity is now detected from recent session activity.

* **Improvements**
  * Standardized path handling and display across supported services.
  * Added coverage for Grok activity detection, path handling, and automatic selection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->