### PR TITLE
fix(settings): account row alignment + exhausted usage parity

### DIFF
--- a/.agents/SESSIONS/2026-07-29.md
+++ b/.agents/SESSIONS/2026-07-29.md
@@ -638,3 +638,16 @@ flowchart TD
   with one `ProviderAccountProfileRow` + `AddProviderAccountSheet`.
 - Codex keeps a thin `CodexAccountSettingsRow` only for async auth probing.
 - Deleted forked row/sheet files; shared draft/save/status models + reorder on all three.
+
+## Session 11: Account row layout + exhausted usage parity
+
+**Status:** Complete
+
+### What was done
+
+- Fixed multi-account Settings row layout: status/chips no longer crush into
+  vertical single-character text; trailing column holds status + controls.
+- StatusPill and MeterBarChip use fixedSize/layoutPriority so flexible HStacks
+  cannot wrap them.
+- Extracted ProviderBlockedUsageSummary (popover + Settings) so exhausted
+  sessions/weekly limits show the same status + hourglass reset line.

--- a/MeterBar/Views/Components/MeterBarChip.swift
+++ b/MeterBar/Views/Components/MeterBarChip.swift
@@ -59,6 +59,10 @@ struct MeterBarChip: View {
     var body: some View {
         content
             .modifier(ChipSurface(tint: tint, style: style))
+            // Chips are status badges, not flexible filler — keep them from
+            // collapsing to "…" or wrapping when a parent HStack is squeezed.
+            .fixedSize(horizontal: true, vertical: false)
+            .layoutPriority(1)
     }
 
     private var content: some View {

--- a/MeterBar/Views/Components/ProviderBlockedUsageSummary.swift
+++ b/MeterBar/Views/Components/ProviderBlockedUsageSummary.swift
@@ -1,0 +1,83 @@
+import MeterBarShared
+import SwiftUI
+
+/// Collapsed "you are blocked until this reset" summary shared by the popover
+/// provider card and Settings → Providers usage section.
+///
+/// When weekly (or another provider-blocking window) is exhausted, shorter
+/// gauges are non-actionable. Both surfaces must show the same status +
+/// hourglass reset line instead of drifting into a red bar in one place and a
+/// countdown chip in the other.
+struct ProviderBlockedUsageSummary: View {
+    enum Density {
+        /// Popover card header row (compact type, logo + title).
+        case popoverCard
+        /// Settings Usage panel (regular type, optional multi-account title).
+        case settings
+    }
+
+    let snapshot: ProviderSnapshot
+    var density: Density = .popoverCard
+    var showsTitle: Bool = true
+    var resetTimeFormat: ResetTimeFormat = .countdown
+
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
+    var body: some View {
+        TimelineView(.periodic(from: ResetCountdownSchedule.anchor, by: ResetCountdownSchedule.interval)) { timeline in
+            let blockingWindow = BlockingLimitResetCounter.selectBlockingWindow(
+                snapshot.resetWindows,
+                now: timeline.date
+            )
+            let title = BlockingLimitResetCounter.titleText(
+                for: blockingWindow,
+                in: snapshot.resetWindows
+            )
+            let counter = BlockingLimitResetCounter.counterText(
+                for: blockingWindow,
+                now: timeline.date,
+                format: resetTimeFormat
+            )
+            let statusText = ProviderCardPresentation.statusText(for: snapshot)
+            let statusColor = ProviderCardPresentation.statusColor(for: snapshot)
+
+            HStack(spacing: density == .popoverCard ? 7 : 10) {
+                if showsTitle {
+                    ProviderLogoView(
+                        kind: snapshot.logoKind,
+                        size: density == .popoverCard ? 17 : 16,
+                        foregroundColor: snapshot.accentColor
+                    )
+                    Text(snapshot.title)
+                        .font(density == .popoverCard ? .subheadline : .subheadline)
+                        .fontWeight(.semibold)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 8)
+
+                Text(statusText)
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(statusColor)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+
+                Label("\(title) \(counter)", systemImage: "hourglass")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(snapshot.accentColor)
+                    .monospacedDigit()
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.72)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .numericRefreshTransition(value: counter, reduceMotion: reduceMotion)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(
+                "\(snapshot.title), \(statusText), \(title) \(counter)"
+            )
+        }
+    }
+}

--- a/MeterBar/Views/Components/SettingsComponents.swift
+++ b/MeterBar/Views/Components/SettingsComponents.swift
@@ -272,9 +272,14 @@ struct StatusPill: View {
     let presentation: SettingsStatusPresentation
 
     var body: some View {
+        // Never allow a flexible parent HStack to crush this into vertical
+        // single-character wrapping — that was the multi-account Settings bug.
         Label(presentation.text, systemImage: presentation.systemImage)
             .foregroundStyle(presentation.color)
             .font(.subheadline)
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+            .layoutPriority(1)
     }
 }
 

--- a/MeterBar/Views/ProviderStatusCard.swift
+++ b/MeterBar/Views/ProviderStatusCard.swift
@@ -141,55 +141,25 @@ struct ProviderStatusCard: View {
     /// Keep the shared card surface, but collapse its content to the provider and
     /// the one reset that can restore service.
     private var weeklyExhaustedRow: some View {
-        TimelineView(.periodic(from: ResetCountdownSchedule.anchor, by: ResetCountdownSchedule.interval)) { timeline in
-            let blockingWindow = BlockingLimitResetCounter.selectBlockingWindow(
-                snapshot.resetWindows,
-                now: timeline.date
-            )
-            let title = BlockingLimitResetCounter.titleText(for: blockingWindow, in: snapshot.resetWindows)
-            let counter = BlockingLimitResetCounter.counterText(
-                for: blockingWindow,
-                now: timeline.date,
-                format: menuBarDisplayPreferences.resetTimeFormat
+        VStack(alignment: .leading, spacing: 9) {
+            ProviderBlockedUsageSummary(
+                snapshot: snapshot,
+                density: .popoverCard,
+                showsTitle: true,
+                resetTimeFormat: menuBarDisplayPreferences.resetTimeFormat
             )
 
-            VStack(alignment: .leading, spacing: 9) {
+            // Blocked is exactly when a banked reset is worth spending, so the
+            // collapsed row states how many are left instead of hiding the count
+            // behind an icon-only button. The count stands on its own when the
+            // action isn't usable — a visible control that would fail is worse.
+            if let resetCount = snapshot.resetCreditsAvailable, resetCount > 0 {
+                Divider()
                 HStack(spacing: 7) {
-                    ProviderLogoView(kind: snapshot.logoKind, size: 17, foregroundColor: snapshot.accentColor)
-                    Text(snapshot.title)
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                        .lineLimit(1)
-
+                    resetCreditsCountLabel(resetCount)
                     Spacer(minLength: 8)
-
-                    Text(statusText)
-                        .font(.caption2)
-                        .fontWeight(.semibold)
-                        .foregroundColor(statusColor)
-
-                    Label("\(title) \(counter)", systemImage: "hourglass")
-                        .font(.caption)
-                        .fontWeight(.semibold)
-                        .foregroundColor(snapshot.accentColor)
-                        .monospacedDigit()
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.72)
-                        .numericRefreshTransition(value: counter, reduceMotion: reduceMotion)
-                }
-
-                // Blocked is exactly when a banked reset is worth spending, so the
-                // collapsed row states how many are left instead of hiding the count
-                // behind an icon-only button. The count stands on its own when the
-                // action isn't usable — a visible control that would fail is worse.
-                if let resetCount = snapshot.resetCreditsAvailable, resetCount > 0 {
-                    Divider()
-                    HStack(spacing: 7) {
-                        resetCreditsCountLabel(resetCount)
-                        Spacer(minLength: 8)
-                        if showsResetCreditAction {
-                            resetCreditButton(isCompact: true)
-                        }
+                    if showsResetCreditAction {
+                        resetCreditButton(isCompact: true)
                     }
                 }
             }

--- a/MeterBar/Views/Settings/ProviderAccountProfileRow.swift
+++ b/MeterBar/Views/Settings/ProviderAccountProfileRow.swift
@@ -4,9 +4,11 @@ import SwiftUI
 
 /// One multi-account provider profile row shared by Claude, Codex, and Grok.
 ///
-/// Layout, chips, path field, enable/save/delete/reorder, and optional
-/// refresh/reconnect actions are identical; call sites only supply provider
-/// accent, path copy, status presentation, and capability flags.
+/// Layout contract (left → right, top → bottom):
+/// 1. Identity column: avatar + labeled name/path fields (fields flex).
+/// 2. Trailing column: status (never wraps) + controls (fixed size).
+/// Chips and status live outside the flexible field HStack so they cannot be
+/// crushed into vertical single-character text.
 struct ProviderAccountProfileRow: View {
     // MARK: Lifecycle
 
@@ -76,21 +78,59 @@ struct ProviderAccountProfileRow: View {
     // MARK: Internal
 
     var body: some View {
-        HStack(alignment: .center, spacing: 12) {
+        HStack(alignment: .top, spacing: 12) {
             Image(systemName: isDefault ? "person.crop.circle" : "person.crop.circle.badge.plus")
                 .foregroundStyle(accent)
-                .frame(width: 18)
+                .frame(width: 18, height: 22)
+                .padding(.top, 4)
                 .accessibilityHidden(true)
 
-            VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 8) {
-                    fieldLabel("Account name")
-
+            VStack(alignment: .leading, spacing: 10) {
+                fieldRow(label: "Account name") {
                     TextField("Account label", text: $draft.name)
-                        .settingsInput(width: AccountProfileRowMetrics.fieldWidth)
+                        .textFieldStyle(.plain)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 6)
+                        .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 6))
                         .accessibilityLabel("Account name for \(accountName)")
                         .onSubmit(saveChanges)
+                }
 
+                fieldRow(label: pathLabel) {
+                    HStack(spacing: 8) {
+                        TextField(pathPlaceholder, text: $draft.path)
+                            .textFieldStyle(.plain)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 6)
+                            .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 6))
+                            .accessibilityLabel("\(pathLabel) for \(accountName)")
+                            .onSubmit(saveChanges)
+
+                        Button {
+                            chooseDirectory()
+                        } label: {
+                            Image(systemName: "folder")
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .fixedSize()
+                        .accessibilityLabel("Choose \(pathLabel) for \(accountName)")
+                        .help("Choose \(pathLabel)")
+                    }
+                }
+
+                if let defaultPathHelp, isDefault {
+                    Text(defaultPathHelp)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.leading, AccountProfileRowMetrics.labelWidth + 8)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            VStack(alignment: .trailing, spacing: 10) {
+                HStack(spacing: 8) {
                     MeterBarChip(
                         isDefault ? "Default" : "Profile",
                         tint: isDefault ? MeterBarTheme.appAccent : accent,
@@ -101,99 +141,11 @@ struct ProviderAccountProfileRow: View {
                         .font(.caption)
                         .accessibilityLabel("Status for \(accountName)")
                 }
+                .fixedSize(horizontal: true, vertical: false)
 
-                HStack(spacing: 8) {
-                    fieldLabel(pathLabel)
-
-                    TextField(pathPlaceholder, text: $draft.path)
-                        .settingsInput(width: AccountProfileRowMetrics.fieldWidth)
-                        .accessibilityLabel("\(pathLabel) for \(accountName)")
-                        .onSubmit(saveChanges)
-
-                    Button {
-                        chooseDirectory()
-                    } label: {
-                        Image(systemName: "folder")
-                    }
-                    .buttonStyle(.bordered)
-                    .accessibilityLabel("Choose \(pathLabel) for \(accountName)")
-                    .help("Choose \(pathLabel)")
-                }
-
-                if let defaultPathHelp, isDefault {
-                    Text(defaultPathHelp)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .padding(.leading, AccountProfileRowMetrics.labelWidth + 8)
-                }
+                controls
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            HStack(spacing: 8) {
-                Toggle("Enabled", isOn: Binding(
-                    get: { isEnabled },
-                    set: onEnabledChange
-                ))
-                .labelsHidden()
-                .toggleStyle(.switch)
-                .controlSize(.small)
-                .disabled(isEnabled && !canDisable)
-                .accessibilityLabel("Track \(accountName)")
-                .help(enablementHelp)
-
-                if showsRefresh {
-                    authActionButton(.refresh)
-                        .frame(width: AccountProfileRowMetrics.actionWidth)
-                        .disabled(!isEnabled || isRefreshing)
-                }
-
-                if showsReconnect {
-                    authActionButton(.reconnect)
-                        .disabled(isRefreshing)
-                }
-
-                if onMoveUp != nil || onMoveDown != nil {
-                    Button { onMoveUp?() } label: { Image(systemName: "arrow.up") }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                        .disabled(!canMoveUp)
-                        .help("Move account up")
-                    Button { onMoveDown?() } label: { Image(systemName: "arrow.down") }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                        .disabled(!canMoveDown)
-                        .help("Move account down")
-                }
-
-                Button(action: saveChanges) {
-                    Image(systemName: "checkmark")
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .frame(width: AccountProfileRowMetrics.actionWidth)
-                .disabled(savePayload == nil)
-                .accessibilityLabel("Save changes for \(accountName)")
-                .help("Save account changes")
-
-                if !isDefault {
-                    Button(role: .destructive) {
-                        showingDeleteConfirmation = true
-                    } label: {
-                        Image(systemName: "trash")
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .frame(width: AccountProfileRowMetrics.actionWidth)
-                    .disabled(!canRemove)
-                    .accessibilityLabel("Delete \(accountName)")
-                    .help(deleteHelp)
-                } else {
-                    Color.clear
-                        .frame(width: AccountProfileRowMetrics.actionWidth, height: 1)
-                        .accessibilityHidden(true)
-                }
-            }
-            .fixedSize()
+            .fixedSize(horizontal: true, vertical: false)
         }
         .padding(.vertical, MeterBarTheme.Spacing.md)
         .onChange(of: accountName) { _, _ in reconcileDraftFromProps() }
@@ -288,12 +240,85 @@ struct ProviderAccountProfileRow: View {
         canRemove ? "Delete account" : "Enable another account before deleting this one"
     }
 
-    private func fieldLabel(_ title: String) -> some View {
-        Text(title)
-            .font(.caption2)
-            .fontWeight(.semibold)
-            .foregroundStyle(.secondary)
-            .frame(width: AccountProfileRowMetrics.labelWidth, alignment: .leading)
+    private var controls: some View {
+        HStack(spacing: 8) {
+            Toggle("Enabled", isOn: Binding(
+                get: { isEnabled },
+                set: onEnabledChange
+            ))
+            .labelsHidden()
+            .toggleStyle(.switch)
+            .controlSize(.small)
+            .disabled(isEnabled && !canDisable)
+            .accessibilityLabel("Track \(accountName)")
+            .help(enablementHelp)
+
+            if showsRefresh {
+                authActionButton(.refresh)
+                    .frame(width: AccountProfileRowMetrics.actionWidth)
+                    .disabled(!isEnabled || isRefreshing)
+            }
+
+            if showsReconnect {
+                authActionButton(.reconnect)
+                    .disabled(isRefreshing)
+            }
+
+            if onMoveUp != nil || onMoveDown != nil {
+                Button { onMoveUp?() } label: { Image(systemName: "arrow.up") }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(!canMoveUp)
+                    .help("Move account up")
+                Button { onMoveDown?() } label: { Image(systemName: "arrow.down") }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(!canMoveDown)
+                    .help("Move account down")
+            }
+
+            Button(action: saveChanges) {
+                Image(systemName: "checkmark")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .frame(width: AccountProfileRowMetrics.actionWidth)
+            .disabled(savePayload == nil)
+            .accessibilityLabel("Save changes for \(accountName)")
+            .help("Save account changes")
+
+            if !isDefault {
+                Button(role: .destructive) {
+                    showingDeleteConfirmation = true
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .frame(width: AccountProfileRowMetrics.actionWidth)
+                .disabled(!canRemove)
+                .accessibilityLabel("Delete \(accountName)")
+                .help(deleteHelp)
+            }
+        }
+        .fixedSize(horizontal: true, vertical: false)
+    }
+
+    private func fieldRow<Content: View>(
+        label: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        HStack(alignment: .center, spacing: 8) {
+            Text(label)
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+                .frame(width: AccountProfileRowMetrics.labelWidth, alignment: .leading)
+                .lineLimit(1)
+
+            content()
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
     }
 
     private func reconcileDraftFromProps() {
@@ -314,10 +339,6 @@ struct ProviderAccountProfileRow: View {
     private func saveChanges() {
         guard let savePayload else { return }
         onSave(savePayload.name, savePayload.path)
-        // Parent store republication drives `reconcileDraftFromProps`. Commit
-        // only the name immediately so a second save click is a no-op before
-        // the store publishes; path resolution (especially clear-to-default)
-        // must come from the parent.
         draft.name = savePayload.name
         identity = AccountIdentity(
             name: savePayload.name,
@@ -359,6 +380,7 @@ struct ProviderAccountProfileRow: View {
         }
         .buttonStyle(.bordered)
         .controlSize(.small)
+        .fixedSize()
         .accessibilityLabel(action.accessibilityLabel(accountName: accountName))
         .accessibilityHint(action.help(accountName: accountName))
         .help(action.help(accountName: accountName))

--- a/MeterBar/Views/Settings/ProviderSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsView.swift
@@ -257,7 +257,18 @@ struct ProviderSettingsView: View {
             } else {
                 ForEach(snapshots) { snapshot in
                     VStack(alignment: .leading, spacing: 10) {
-                        if snapshots.count > 1 {
+                        // Match the popover: when a blocking window is exhausted,
+                        // lead with status + reset countdown rather than only a
+                        // red "Out of quota" bar that omits when service resumes.
+                        if snapshot.hasExhaustedLimit {
+                            // Same collapsed status + reset line as the popover card.
+                            ProviderBlockedUsageSummary(
+                                snapshot: snapshot,
+                                density: .settings,
+                                showsTitle: true,
+                                resetTimeFormat: .countdown
+                            )
+                        } else if snapshots.count > 1 {
                             ProviderTitle(
                                 title: snapshot.title,
                                 logoKind: snapshot.logoKind,
@@ -274,7 +285,11 @@ struct ProviderSettingsView: View {
                             )
                         } else {
                             ForEach(snapshot.detailLimits) { limit in
-                                LimitRow(limit: limit, accentColor: snapshot.accentColor, density: .regular)
+                                LimitRow(
+                                    limit: limit,
+                                    accentColor: snapshot.accentColor,
+                                    density: .regular
+                                )
                             }
                         }
 


### PR DESCRIPTION
## Summary

### Account rows
- Restructured `ProviderAccountProfileRow`: fields flex in the middle; **Default chip + Connected status + controls** live in a fixed trailing column.
- `StatusPill` and `MeterBarChip` refuse compression (`.fixedSize` + layout priority) so "Connected" never stacks as vertical letters.

### Exhausted sessions / weekly
- New shared `ProviderBlockedUsageSummary` used by:
  - popover provider card (existing collapsed blocked UI)
  - Settings → Providers → Usage when `hasExhaustedLimit`
- Same **status + hourglass reset countdown** language on both surfaces; weekly `LimitRow` still shows underneath for the bar.

## Verification

- Focused tests for presentation/snapshots/account rows passed
- `swiftlint --strict` on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent provider status and reset countdown messaging for exhausted usage limits in Settings and provider popovers.
  * Improved accessibility labels for blocked-provider summaries.

* **Bug Fixes**
  * Prevented account status pills, chips, and action controls from wrapping or collapsing into narrow vertical layouts.
  * Improved multi-account Settings row alignment and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->