### PR TITLE
fix(settings): no empty progress bar when weekly is exhausted

### DIFF
--- a/MeterBar/Views/Settings/ProviderSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsView.swift
@@ -257,11 +257,10 @@ struct ProviderSettingsView: View {
             } else {
                 ForEach(snapshots) { snapshot in
                     VStack(alignment: .leading, spacing: 10) {
-                        // Match the popover: when a blocking window is exhausted,
-                        // lead with status + reset countdown rather than only a
-                        // red "Out of quota" bar that omits when service resumes.
+                        // Blocking exhaustion matches the popover card: status +
+                        // reset countdown only. A full red bar that reads
+                        // "100% / Out of quota" just repeats the same fact.
                         if snapshot.hasExhaustedLimit {
-                            // Same collapsed status + reset line as the popover card.
                             ProviderBlockedUsageSummary(
                                 snapshot: snapshot,
                                 density: .settings,
@@ -277,19 +276,21 @@ struct ProviderSettingsView: View {
                             )
                         }
 
-                        if snapshot.detailLimits.isEmpty {
-                            EmptyStateCard(
-                                systemImage: "clock.badge.questionmark",
-                                title: "No quota windows",
-                                message: "This provider didn't report any limit windows."
-                            )
-                        } else {
-                            ForEach(snapshot.detailLimits) { limit in
-                                LimitRow(
-                                    limit: limit,
-                                    accentColor: snapshot.accentColor,
-                                    density: .regular
+                        if !snapshot.hasExhaustedLimit {
+                            if snapshot.detailLimits.isEmpty {
+                                EmptyStateCard(
+                                    systemImage: "clock.badge.questionmark",
+                                    title: "No quota windows",
+                                    message: "This provider didn't report any limit windows."
                                 )
+                            } else {
+                                ForEach(snapshot.detailLimits) { limit in
+                                    LimitRow(
+                                        limit: limit,
+                                        accentColor: snapshot.accentColor,
+                                        density: .regular
+                                    )
+                                }
                             }
                         }
 


### PR DESCRIPTION
## Summary

When Usage is blocked (weekly/session exhausted), Settings already shows the shared popover-style summary:

`genfeedai · Stale · Weekly reset in 23h 28m`

The full `LimitRow` under it was redundant: a red bar at 100% saying "Out of quota" plus the same reset time again.

**Change:** if `snapshot.hasExhaustedLimit`, render only `ProviderBlockedUsageSummary` (plus badges). No progress bar.

## Verification

- Layout-only; existing snapshot/presentation tests still cover exhaustion flags.
- `swiftlint --strict` on the settings file.