### PR TITLE
fix(release): stop signing ad-hoc bundles with hardened runtime, gate on launch

### DIFF
--- a/.agents/SESSIONS/2026-08-03.md
+++ b/.agents/SESSIONS/2026-08-03.md
@@ -1,0 +1,166 @@
+# 2026-08-03
+
+**Summary:** Ad-hoc bundles passed the release gate but could not launch
+
+---
+
+## Session 1: Fix ad-hoc hardened-runtime signing, add a launch smoke gate
+
+**Status:** Complete — ready PR published, not merged.
+
+### Context
+
+`scripts/sign-and-verify-release.sh` reported "Ad-hoc nested signature integrity
+verified" for a bundle that died in dyld on launch:
+
+```text
+Library not loaded: @rpath/Sparkle.framework/Versions/B/Sparkle
+  Reason: code signature ... not valid for use in process:
+          mapping process and mapped file (non-platform) have different Team IDs
+```
+
+`sign_code` passed `--options runtime` on both signing branches. Hardened runtime
+turns on library validation, which requires the process and every library it maps
+to share a Team ID. Ad-hoc signatures carry none, so the app could not map
+Sparkle. The Developer ID path was unaffected because both sides carry team
+C76R5DRH64.
+
+The gate never noticed because every check it ran — `codesign --verify --deep
+--strict`, entitlement parity, `lipo -verify_arch` — inspects signatures at rest.
+None of them start the app.
+
+### System flow
+
+```text
+sign_code (ad-hoc)            sign_code (Developer ID)
+  no --options runtime          --options runtime + --timestamp
+        |                              |
+        +--------------+---------------+
+                       |
+        codesign --verify --deep --strict     <- signatures at rest
+        entitlement parity vs source plists   <- signatures at rest
+        embedded CLI wake --dry-run --json    <- CLI process only
+                       |
+        scripts/verify-app-launch.sh          <- NEW: the app itself
+                       |
+          MeterBarMain.main()
+            -> LaunchSmokeProbe.exitIfRequested()   (before SwiftUI)
+            -> one JSON line, exit 0
+```
+
+### What was done
+
+- [x] Dropped `--options runtime` from the ad-hoc branch of `sign_code`, with a
+  comment explaining why hardened runtime belongs only on the Developer ID path.
+- [x] Added `LaunchSmokeProbe` — a `--launch-smoke` flag answered before AppKit
+  starts, emitting one versioned, key-sorted JSON document then exiting 0.
+- [x] Moved the `@main` entry point to `MeterBarMain` so the probe runs ahead of
+  SwiftUI and every shared singleton.
+- [x] Added `scripts/verify-app-launch.sh`: resolves `CFBundleExecutable`, runs
+  the probe behind a watchdog, fails loudly on non-zero exit while surfacing the
+  loader diagnostic, and checks the JSON contract plus version agreement against
+  both the bundle's own `Info.plist` and the expected release versions.
+- [x] Wired that validator into `sign-and-verify-release.sh` on **both** signing
+  branches, before the success message.
+- [x] Made the ad-hoc summary stop claiming release-grade verification — it now
+  states what was *not* checked (no Team ID, no hardened runtime, no library
+  validation).
+- [x] Added `scripts/test-app-launch-smoke.sh` + `scripts/fixtures/app-launch/`
+  covering the dyld failure, silent non-zero exit, contaminated stdout, unknown
+  schema, a missing `launchSmoke` marker, four version-drift cases, a hang, and a
+  missing executable.
+- [x] Added the fixture test to the `build` job in `ci.yml`.
+
+### Files changed
+
+**New**
+
+- `MeterBar/App/LaunchSmokeProbe.swift` — flag detection and the JSON document.
+- `MeterBarTests/LaunchSmokeProbeTests.swift` — 7 tests.
+- `scripts/verify-app-launch.sh` — the launch gate.
+- `scripts/test-app-launch-smoke.sh`, `scripts/fixtures/app-launch/fake-app-executable.sh`
+  — fixture driver and the fake bundle executable.
+
+**Modified**
+
+- `scripts/sign-and-verify-release.sh` — ad-hoc branch drops `--options runtime`;
+  calls the launch gate; honest ad-hoc summary.
+- `MeterBar/App/MeterBarApp.swift` — `@main` moves to `MeterBarMain`.
+- `.github/workflows/ci.yml` — runs `scripts/test-app-launch-smoke.sh`.
+
+### Decisions
+
+- **Decision:** Drop `--options runtime` on the ad-hoc branch rather than adding
+  `com.apple.security.cs.disable-library-validation` for ad-hoc builds.
+  - **Context:** Both make the bundle launch; verified each against the real
+    bundle before choosing.
+  - **Rationale:** The script's byte-for-byte entitlement parity against
+    `MeterBar/MeterBar.entitlements` is a real invariant — an ad-hoc-only
+    entitlement would need an exception carved into it. Dropping the option
+    needs none, never ships a validation-disabling entitlement, and removes the
+    bug for future nested targets instead of per-target. Hardened runtime is a
+    Developer ID and notarization requirement; the branch that cannot satisfy it
+    should not claim it.
+  - **Cost:** The ad-hoc `wake --dry-run` check no longer runs under hardened
+    runtime. That coverage stays on the Developer ID path in
+    `_build-signed.yml`, which runs on every release.
+
+- **Decision:** Answer the probe before SwiftUI instead of launching the app and
+  waiting for it to settle.
+  - **Context:** The failure is at dyld load time.
+  - **Rationale:** By the time any Swift code runs, every embedded framework has
+    been mapped and its signature accepted by the kernel — which is the whole
+    property being gated. Exiting there needs no window server, touches no
+    disk or network state, and cannot leave anything behind on a CI runner.
+
+- **Decision:** Also keep the third suggested option — refuse to overclaim — even
+  though the signing fix makes ad-hoc bundles launchable.
+  - **Rationale:** "Ad-hoc nested signature integrity verified" was true and
+    still misleading. The summary now names what the ad-hoc path does not prove.
+
+- **Decision:** Compare the launched bundle's reported versions against its own
+  `Info.plist` as well as the expected release versions.
+  - **Rationale:** The probe reads `Bundle.main`, so agreement proves the bundle
+    that ran is the bundle that was signed — not a stale copy on the runner.
+
+### Mistakes and fixes
+
+- **Mistake:** The expected-JSON literal in `LaunchSmokeProbeTests` was split
+  across two raw string literals and doubled a `"` at the seam, so the first run
+  failed against correct output.
+- **Fix:** Corrected the split; the implementation was unchanged.
+- **Prevention:** Split concatenated JSON literals at a `,` boundary, never
+  inside a quoted token.
+
+- **Mistake:** Two version-drift fixtures asserted the "expected version"
+  message, but their bundles disagreed with their own `Info.plist`, so the
+  earlier plist check fired first.
+- **Fix:** Those cases now use the self-consistent `ok` fixture with a wrong
+  expected version passed on the command line.
+- **Prevention:** When a validator has layered checks, each test must fail on the
+  layer it names.
+
+### Verification
+
+- Reproduced end-to-end: Release universal build via the CI invocation, CLI
+  injected with `build-universal-cli.sh`, then `sign-and-verify-release.sh` with
+  `SIGNING_IDENTITY` unset. Gate passes **and** the bundle launches:
+  `{"buildVersion":"1.8.2",...,"launchSmoke":true,...}`.
+- Regression proof: re-signing that same bundle ad-hoc **with** `--options
+  runtime` still passes `codesign --verify --deep --strict`, and the new gate
+  fails it with the original dyld "different Team IDs" diagnostic in the output.
+- `scripts/test-app-launch-smoke.sh` green (11 rejection cases, 4 accept cases).
+- `swift test --skip APIIntegrationTests --skip ClaudeTokenRefresherTests`:
+  1590 executed, and the only failing cases are the two environmental ones
+  recorded on 2026-08-02 —
+  `LiquidGlassP1RegressionTests.testRapidShowDismissShowLeavesPanelVisibleAndOpaque`
+  and `SessionWakeAgentTests.testAgentLifetimeLockExcludesAppAndCLIHolders`.
+  All 7 new `LaunchSmokeProbeTests` pass. (The credential suites are skipped
+  locally because they block on a keychain prompt; CI runs them.)
+- SwiftLint `--strict` clean across 238 files. `shellcheck` clean on all four
+  new or changed scripts. `verify-release-workflow-contract.sh` still passes
+  after the `ci.yml` edit.
+
+### Next steps
+
+- [ ] Land the PR once CI completes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Test CLI JSON smoke validator
         run: scripts/test-cli-json-smoke.sh
 
+      - name: Test app launch smoke validator
+        run: scripts/test-app-launch-smoke.sh
+
       - name: Verify canonical repository URLs
         run: scripts/verify-canonical-repository-urls.sh
 

--- a/MeterBar/App/LaunchSmokeProbe.swift
+++ b/MeterBar/App/LaunchSmokeProbe.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// The `--launch-smoke` probe that proves a signed bundle can actually start.
+///
+/// `codesign --verify --deep --strict` only inspects signatures sitting on disk.
+/// It says nothing about whether dyld will map the app's embedded frameworks
+/// into the process, so a bundle can verify perfectly and still die before
+/// `main()` — which is exactly what an ad-hoc bundle signed with hardened
+/// runtime does, because library validation refuses to map an ad-hoc framework
+/// (no Team ID) into an ad-hoc process. Running the real executable is the only
+/// check that covers that gap.
+///
+/// The probe therefore answers before AppKit starts: one versioned JSON document
+/// on stdout, then exit. dyld has already resolved and validated every linked
+/// library by the time this runs, so reaching the output at all is the proof.
+/// Nothing is initialized, no window server is needed, and no network or disk
+/// state is touched — the same reasons `meterbar wake --dry-run` is safe to run
+/// from the release gate.
+nonisolated enum LaunchSmokeProbe {
+    /// Exact argument that requests the probe. Launch Services never passes it.
+    static let flag = "--launch-smoke"
+
+    enum ProbeError: Error, Equatable {
+        /// The bundle's `Info.plist` lacks a key the release gate cross-checks.
+        case missingBundleMetadata(key: String)
+        case invalidUTF8
+    }
+
+    private struct Response: Encodable {
+        let schemaVersion = 1
+        let launchSmoke = true
+        let bundleIdentifier: String
+        let shortVersion: String
+        let buildVersion: String
+    }
+
+    static func isRequested(in arguments: [String]) -> Bool {
+        arguments.contains(flag)
+    }
+
+    /// One compact, key-sorted JSON line describing the bundle that just booted.
+    ///
+    /// Versions come from the running process's own `Info.plist`, which lets the
+    /// release verifier confirm the bundle it signed is the bundle that ran.
+    static func responseJSON(info: [String: Any]) throws -> String {
+        let response = Response(
+            bundleIdentifier: try requireString(info, "CFBundleIdentifier"),
+            shortVersion: try requireString(info, "CFBundleShortVersionString"),
+            buildVersion: try requireString(info, "CFBundleVersion")
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        guard let json = String(data: try encoder.encode(response), encoding: .utf8) else {
+            throw ProbeError.invalidUTF8
+        }
+        return json
+    }
+
+    /// Answers the probe and exits, or returns so the app starts normally.
+    ///
+    /// Called as the very first thing in `main()`, ahead of every singleton and
+    /// SwiftUI itself, so a probe run can never leave state behind.
+    static func exitIfRequested(
+        arguments: [String] = CommandLine.arguments,
+        info: [String: Any] = Bundle.main.infoDictionary ?? [:]
+    ) {
+        guard isRequested(in: arguments) else { return }
+
+        do {
+            FileHandle.standardOutput.write(Data((try responseJSON(info: info) + "\n").utf8))
+            exit(0)
+        } catch {
+            // Failing loudly matters more than launching: a bundle that cannot
+            // describe itself must not report a successful launch smoke.
+            FileHandle.standardError.write(Data("MeterBar launch smoke failed: \(error)\n".utf8))
+            exit(1)
+        }
+    }
+
+    private static func requireString(_ info: [String: Any], _ key: String) throws -> String {
+        guard let value = info[key] as? String, !value.isEmpty else {
+            throw ProbeError.missingBundleMetadata(key: key)
+        }
+        return value
+    }
+}

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -4,7 +4,18 @@ import Combine
 import os
 import SwiftUI
 
+/// Real entry point, so the release gate's `--launch-smoke` probe can answer
+/// before SwiftUI (and therefore AppKit, the window server, and every shared
+/// singleton) starts. `MeterBarApp.main()` never returns, so this stays the only
+/// place either path is chosen.
 @main
+enum MeterBarMain {
+    static func main() {
+        LaunchSmokeProbe.exitIfRequested()
+        MeterBarApp.main()
+    }
+}
+
 struct MeterBarApp: App {
     @StateObject private var dataManager = UsageDataManager.shared
     @NSApplicationDelegateAdaptor(AppDelegate.self)

--- a/MeterBarTests/LaunchSmokeProbeTests.swift
+++ b/MeterBarTests/LaunchSmokeProbeTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import XCTest
+@testable import MeterBar
+
+/// Covers the `--launch-smoke` probe the release gate uses to prove a signed
+/// bundle actually starts.
+///
+/// The probe answers before AppKit does, so everything worth testing is pure:
+/// which argument vectors request it, and the exact JSON document it emits.
+final class LaunchSmokeProbeTests: XCTestCase {
+    private static let completeInfo: [String: Any] = [
+        "CFBundleIdentifier": "dev.meterbar.app",
+        "CFBundleShortVersionString": "1.8.2",
+        "CFBundleVersion": "1.8.2"
+    ]
+
+    func testFlagIsDetectedAlongsideLaunchServicesArguments() {
+        // Launch Services appends its own arguments (`-psn_…`) when the app is
+        // opened from Finder; the probe must still be found by exact match.
+        XCTAssertTrue(
+            LaunchSmokeProbe.isRequested(
+                in: ["/Applications/MeterBar.app/Contents/MacOS/MeterBar", "-psn_0_123456", "--launch-smoke"]
+            )
+        )
+    }
+
+    func testProbeIsNotRequestedWithoutTheFlag() {
+        XCTAssertFalse(LaunchSmokeProbe.isRequested(in: ["/tmp/MeterBar", "--open-dashboard"]))
+    }
+
+    func testProbeRequiresAnExactFlagMatch() {
+        // A prefix match would let an unrelated future flag silently short-circuit
+        // the real launch.
+        XCTAssertFalse(LaunchSmokeProbe.isRequested(in: ["/tmp/MeterBar", "--launch-smoke-please"]))
+        XCTAssertFalse(LaunchSmokeProbe.isRequested(in: ["/tmp/MeterBar", "launch-smoke"]))
+    }
+
+    func testResponseIsOneVersionedJSONDocumentWithSortedKeys() throws {
+        // Byte-exact: the release gate parses this from a process that must not
+        // print anything else on stdout.
+        XCTAssertEqual(
+            try LaunchSmokeProbe.responseJSON(info: Self.completeInfo),
+            #"{"buildVersion":"1.8.2","bundleIdentifier":"dev.meterbar.app","#
+                + #""launchSmoke":true,"schemaVersion":1,"shortVersion":"1.8.2"}"#
+        )
+    }
+
+    func testResponseCarriesTheDecoupledNightlyVersionPair() throws {
+        var info = Self.completeInfo
+        info["CFBundleShortVersionString"] = "1.8.3-nightly.42+a1b2c3d"
+        info["CFBundleVersion"] = "1.8.3.42"
+
+        let response = try LaunchSmokeProbe.responseJSON(info: info)
+        let decoded = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(response.utf8)) as? [String: Any]
+        )
+
+        XCTAssertEqual(decoded["shortVersion"] as? String, "1.8.3-nightly.42+a1b2c3d")
+        XCTAssertEqual(decoded["buildVersion"] as? String, "1.8.3.42")
+        XCTAssertEqual(decoded["schemaVersion"] as? Int, 1)
+        XCTAssertEqual(decoded["launchSmoke"] as? Bool, true)
+    }
+
+    func testResponseFailsWhenBundleMetadataIsIncomplete() throws {
+        // A bundle missing its version keys must fail the gate loudly rather than
+        // report a launch the release verifier cannot cross-check.
+        for missingKey in ["CFBundleIdentifier", "CFBundleShortVersionString", "CFBundleVersion"] {
+            var info = Self.completeInfo
+            info.removeValue(forKey: missingKey)
+
+            XCTAssertThrowsError(try LaunchSmokeProbe.responseJSON(info: info)) { error in
+                XCTAssertEqual(
+                    error as? LaunchSmokeProbe.ProbeError,
+                    .missingBundleMetadata(key: missingKey)
+                )
+            }
+        }
+    }
+
+    func testResponseRejectsNonStringBundleMetadata() {
+        var info = Self.completeInfo
+        info["CFBundleVersion"] = 182
+
+        XCTAssertThrowsError(try LaunchSmokeProbe.responseJSON(info: info)) { error in
+            XCTAssertEqual(
+                error as? LaunchSmokeProbe.ProbeError,
+                .missingBundleMetadata(key: "CFBundleVersion")
+            )
+        }
+    }
+}

--- a/scripts/fixtures/app-launch/fake-app-executable.sh
+++ b/scripts/fixtures/app-launch/fake-app-executable.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stands in for a signed MeterBar executable answering `--launch-smoke`.
+# `METERBAR_LAUNCH_FIXTURE` selects the failure the release gate must catch.
+scenario="${METERBAR_LAUNCH_FIXTURE:-ok}"
+
+if [ "${1:-}" != "--launch-smoke" ]; then
+  echo "Expected --launch-smoke." >&2
+  exit 64
+fi
+
+ok_document='{"buildVersion":"1.8.2","bundleIdentifier":"dev.meterbar.app","launchSmoke":true,"schemaVersion":1,"shortVersion":"1.8.2"}'
+
+case "$scenario" in
+  ok)
+    printf '%s\n' "$ok_document"
+    ;;
+  nightly)
+    printf '%s\n' \
+      '{"buildVersion":"1.8.3.42","bundleIdentifier":"dev.meterbar.app","launchSmoke":true,"schemaVersion":1,"shortVersion":"1.8.3-nightly.42+a1b2c3d"}'
+    ;;
+  dyld-failure)
+    # The real defect: hardened runtime plus ad-hoc signing, so library
+    # validation refuses to map Sparkle and the process dies before main().
+    cat >&2 <<'DYLD'
+dyld[4242]: Library not loaded: @rpath/Sparkle.framework/Versions/B/Sparkle
+  Reason: tried: '/Applications/MeterBar.app/Contents/Frameworks/Sparkle.framework/Versions/B/Sparkle' (code signature in <...> not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs)
+DYLD
+    exit 133
+    ;;
+  silent-failure)
+    exit 3
+    ;;
+  malformed)
+    printf '%s\n' 'debug output that contaminates stdout'
+    printf '%s\n' "$ok_document"
+    ;;
+  short-version-mismatch)
+    printf '%s\n' \
+      '{"buildVersion":"1.8.2","bundleIdentifier":"dev.meterbar.app","launchSmoke":true,"schemaVersion":1,"shortVersion":"9.9.9"}'
+    ;;
+  build-version-mismatch)
+    printf '%s\n' \
+      '{"buildVersion":"9999","bundleIdentifier":"dev.meterbar.app","launchSmoke":true,"schemaVersion":1,"shortVersion":"1.8.2"}'
+    ;;
+  unknown-schema)
+    printf '%s\n' \
+      '{"buildVersion":"1.8.2","bundleIdentifier":"dev.meterbar.app","launchSmoke":true,"schemaVersion":2,"shortVersion":"1.8.2"}'
+    ;;
+  not-a-smoke-response)
+    # A future build that answers the flag without running the probe must not
+    # be mistaken for a successful launch.
+    printf '%s\n' \
+      '{"buildVersion":"1.8.2","bundleIdentifier":"dev.meterbar.app","schemaVersion":1,"shortVersion":"1.8.2"}'
+    ;;
+  hang)
+    # A bundle that blocks (window server prompt, stuck singleton) must trip the
+    # watchdog instead of wedging the release job.
+    sleep 900
+    ;;
+  *)
+    echo "Unknown launch fixture scenario: $scenario" >&2
+    exit 64
+    ;;
+esac

--- a/scripts/sign-and-verify-release.sh
+++ b/scripts/sign-and-verify-release.sh
@@ -149,11 +149,16 @@ sign_code() {
       "$@" \
       "$target"
   else
+    # Ad-hoc: deliberately NO `--options runtime`. Hardened runtime turns on
+    # library validation, which requires the process and every library it maps
+    # to share a Team ID. Ad-hoc signatures carry no Team ID, so an ad-hoc app
+    # signed this way verifies perfectly and then dies in dyld the moment it
+    # tries to map Sparkle.framework. Hardened runtime is a Developer ID and
+    # notarization requirement; it belongs on the branch that can satisfy it.
     codesign \
       --force \
       --sign - \
       --timestamp=none \
-      --options runtime \
       --generate-entitlement-der \
       "$@" \
       "$target"
@@ -283,10 +288,19 @@ assert data["outcome"] == "success", data
 fi
 echo "Embedded CLI Session Wake dry-run verified from the signed bundle."
 
+# --- Launch smoke: every check above reads signatures at rest, and none of them
+# notice a bundle dyld will refuse to load. Start the app for real and make it
+# answer before AppKit does. This is what catches a signing option that verifies
+# clean and then fails library validation at map time.
+"$script_dir/verify-app-launch.sh" "$app_path" "$expected_short" "$expected_build"
+
 if [ -n "$signing_identity" ]; then
   echo "Developer ID nested signature integrity verified (identity: $signing_identity)."
   echo "Notarization and stapling run as separate release steps."
 else
-  echo "Ad-hoc nested signature integrity verified."
-  echo "Developer ID, notarization, and authorized app-group access remain separate release prerequisites."
+  echo "Ad-hoc signing verified: nested signature integrity, entitlement parity, and launch."
+  echo "This is NOT release-grade: ad-hoc bundles carry no Team ID and are signed"
+  echo "without hardened runtime, so library validation is not exercised here."
+  echo "Developer ID, hardened runtime, notarization, and authorized app-group access"
+  echo "remain separate release prerequisites verified only on the signed path."
 fi

--- a/scripts/test-app-launch-smoke.sh
+++ b/scripts/test-app-launch-smoke.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+launch_validator="$script_dir/verify-app-launch.sh"
+fake_executable="$script_dir/fixtures/app-launch/fake-app-executable.sh"
+temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/meterbar-app-launch-tests.XXXXXX")
+trap 'rm -rf "$temporary_directory"' EXIT
+
+# Builds a throwaway bundle around the fixture executable so the validator does
+# the same CFBundleExecutable resolution it performs on a real signed app.
+make_app() {
+  local name="$1"
+  local app_path="$temporary_directory/$name.app"
+
+  mkdir -p "$app_path/Contents/MacOS"
+  cp "$fake_executable" "$app_path/Contents/MacOS/MeterBar"
+  chmod +x "$app_path/Contents/MacOS/MeterBar"
+  cat > "$app_path/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>MeterBar</string>
+  <key>CFBundleIdentifier</key>
+  <string>dev.meterbar.app</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.8.2</string>
+  <key>CFBundleVersion</key>
+  <string>1.8.2</string>
+</dict>
+</plist>
+PLIST
+
+  printf '%s' "$app_path"
+}
+
+log_for() {
+  printf '%s' "$temporary_directory/$1.log"
+}
+
+expect_rejection() {
+  local label="$1"
+  local scenario="$2"
+  local expected_message="$3"
+  shift 3
+  local log_file
+  log_file=$(log_for "$label")
+
+  if METERBAR_LAUNCH_FIXTURE="$scenario" \
+    "$launch_validator" "$@" > "$log_file" 2>&1; then
+    echo "Launch smoke accepted the '$label' bundle." >&2
+    cat "$log_file" >&2
+    exit 1
+  fi
+  if ! grep -qF "$expected_message" "$log_file"; then
+    echo "The '$label' bundle failed for an unexpected reason." >&2
+    cat "$log_file" >&2
+    exit 1
+  fi
+}
+
+app=$(make_app MeterBar)
+
+METERBAR_LAUNCH_FIXTURE=ok "$launch_validator" "$app"
+METERBAR_LAUNCH_FIXTURE=ok "$launch_validator" "$app" 1.8.2
+METERBAR_LAUNCH_FIXTURE=ok "$launch_validator" "$app" 1.8.2 1.8.2
+
+# The reported defect: signatures verify, the process dies in dyld. The
+# validator must fail and surface the loader diagnostic that explains why.
+expect_rejection dyld-failure dyld-failure "exited with status 133" "$app"
+if ! grep -qF "different Team IDs" "$(log_for dyld-failure)"; then
+  echo "Launch smoke hid the dyld diagnostic that explains the failure." >&2
+  exit 1
+fi
+
+expect_rejection silent-failure silent-failure "exited with status 3" "$app"
+expect_rejection malformed malformed "is not one JSON document" "$app"
+expect_rejection unknown-schema unknown-schema "schemaVersion must equal 1" "$app"
+expect_rejection missing-marker not-a-smoke-response "launchSmoke must be true" "$app"
+
+# Version agreement: a bundle that launches but reports someone else's build
+# means the wrong artifact reached the signing step.
+expect_rejection plist-short-drift short-version-mismatch "CFBundleShortVersionString" "$app"
+expect_rejection plist-build-drift build-version-mismatch "CFBundleVersion" "$app"
+# A self-consistent bundle still fails when it is not the version being released.
+expect_rejection expected-short-drift ok "expected short version" "$app" 9.9.9
+expect_rejection expected-build-drift ok "expected build version" "$app" 1.8.2 9999
+
+# A decoupled nightly version pair is legitimate and must be accepted, but only
+# when the launched bundle agrees with it.
+nightly_app=$(make_app MeterBarNightly)
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString 1.8.3-nightly.42+a1b2c3d" \
+  "$nightly_app/Contents/Info.plist" > /dev/null
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion 1.8.3.42" \
+  "$nightly_app/Contents/Info.plist" > /dev/null
+METERBAR_LAUNCH_FIXTURE=nightly "$launch_validator" "$nightly_app" 1.8.3-nightly.42+a1b2c3d 1.8.3.42
+
+# A wedged bundle must fail the gate quickly instead of hanging the release job.
+(
+  export METERBAR_LAUNCH_SMOKE_TIMEOUT=2
+  expect_rejection hang hang "did not answer" "$app"
+)
+
+missing_executable_app=$(make_app MeterBarBroken)
+rm "$missing_executable_app/Contents/MacOS/MeterBar"
+expect_rejection missing-executable ok "not found or not executable" "$missing_executable_app"
+
+echo "App launch smoke validator fixtures passed."

--- a/scripts/verify-app-launch.sh
+++ b/scripts/verify-app-launch.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Proves a bundle can actually start.
+#
+# `codesign --verify --deep --strict` only inspects signatures at rest, so a
+# bundle whose frameworks dyld will refuse to map still verifies clean. That is
+# how an ad-hoc bundle signed with hardened runtime once passed the release gate
+# and then died on launch with "different Team IDs" for Sparkle. Running the real
+# executable is the only check that covers the loader.
+#
+# The app answers `--launch-smoke` before AppKit starts: one JSON document, then
+# exit. Reaching that output means every embedded framework was mapped and every
+# signature was accepted by the kernel, which is the property being gated.
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
+  echo "Usage: $0 APP_PATH [EXPECTED_SHORT_VERSION [EXPECTED_BUILD_VERSION]]" >&2
+  exit 64
+fi
+
+app_path="$1"
+expected_short_version="${2:-}"
+expected_build_version="${3:-}"
+launch_timeout="${METERBAR_LAUNCH_SMOKE_TIMEOUT:-90}"
+
+if [ ! -d "$app_path" ]; then
+  echo "App bundle not found: $app_path" >&2
+  exit 1
+fi
+
+info_plist="$app_path/Contents/Info.plist"
+if [ ! -f "$info_plist" ]; then
+  echo "App bundle has no Info.plist: $info_plist" >&2
+  exit 1
+fi
+
+executable_name=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$info_plist")
+plist_short_version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$info_plist")
+plist_build_version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$info_plist")
+
+app_binary="$app_path/Contents/MacOS/$executable_name"
+if [ ! -f "$app_binary" ] || [ ! -x "$app_binary" ]; then
+  echo "App executable not found or not executable: $app_binary" >&2
+  exit 1
+fi
+
+temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/meterbar-app-launch.XXXXXX")
+trap 'rm -rf "$temporary_directory"' EXIT
+
+stdout_file="$temporary_directory/launch.stdout"
+stderr_file="$temporary_directory/launch.stderr"
+
+# macOS ships no `timeout(1)`, so the probe runs in the background behind a
+# watchdog. A bundle that blocks (a stuck singleton, a window-server prompt on a
+# headless runner) must fail the gate instead of wedging the release job.
+"$app_binary" --launch-smoke > "$stdout_file" 2> "$stderr_file" &
+launch_pid=$!
+
+(
+  sleep "$launch_timeout"
+  kill -9 "$launch_pid" 2> /dev/null || true
+) &
+watchdog_pid=$!
+
+launch_status=0
+wait "$launch_pid" || launch_status=$?
+kill "$watchdog_pid" 2> /dev/null || true
+wait "$watchdog_pid" 2> /dev/null || true
+
+report_launch_diagnostics() {
+  if [ -s "$stderr_file" ]; then
+    echo "--- launch stderr ---" >&2
+    cat "$stderr_file" >&2
+    echo "--- end launch stderr ---" >&2
+  fi
+  if [ -s "$stdout_file" ]; then
+    echo "--- launch stdout ---" >&2
+    cat "$stdout_file" >&2
+    echo "--- end launch stdout ---" >&2
+  fi
+}
+
+# SIGKILL is how the watchdog fires, and also how the kernel reports a code
+# signature the loader refused, so name the timeout explicitly.
+if [ "$launch_status" -eq 137 ] && [ ! -s "$stdout_file" ]; then
+  echo "$app_path did not answer --launch-smoke within ${launch_timeout}s." >&2
+  report_launch_diagnostics
+  exit 1
+fi
+
+if [ "$launch_status" -ne 0 ]; then
+  echo "$app_path exited with status $launch_status instead of completing --launch-smoke." >&2
+  echo "The bundle's signatures may verify while dyld still refuses to load it." >&2
+  report_launch_diagnostics
+  exit 1
+fi
+
+python3 - \
+  "$stdout_file" \
+  "$plist_short_version" \
+  "$plist_build_version" \
+  "$expected_short_version" \
+  "$expected_build_version" <<'PY'
+import json
+import sys
+
+
+def fail(message):
+    raise SystemExit(message)
+
+
+def unique_object(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            fail(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def reject_constant(value):
+    fail(f"non-standard JSON numeric constant: {value}")
+
+
+def require(condition, message):
+    if not condition:
+        fail(message)
+
+
+(
+    stdout_path,
+    plist_short_version,
+    plist_build_version,
+    expected_short_version,
+    expected_build_version,
+) = sys.argv[1:6]
+
+try:
+    with open(stdout_path, "r", encoding="utf-8") as stream:
+        document = json.load(
+            stream,
+            parse_constant=reject_constant,
+            object_pairs_hook=unique_object,
+        )
+except (OSError, UnicodeError, json.JSONDecodeError) as error:
+    fail(f"launch smoke stdout is not one JSON document: {error}")
+
+require(isinstance(document, dict), "launch smoke response must be a JSON object")
+require(
+    document.get("schemaVersion") == 1,
+    "launch smoke response schemaVersion must equal 1",
+)
+require(
+    document.get("launchSmoke") is True,
+    "launch smoke response launchSmoke must be true",
+)
+require(
+    isinstance(document.get("bundleIdentifier"), str) and document["bundleIdentifier"],
+    "launch smoke response bundleIdentifier must be a non-empty string",
+)
+
+for field in ("shortVersion", "buildVersion"):
+    require(
+        isinstance(document.get(field), str) and document[field],
+        f"launch smoke response {field} must be a non-empty string",
+    )
+
+# The launched process reads its own Info.plist, so disagreement here means the
+# bundle that ran is not the bundle that was signed.
+require(
+    document["shortVersion"] == plist_short_version,
+    "launched bundle reported short version "
+    f"{document['shortVersion']!r} but its CFBundleShortVersionString is {plist_short_version!r}",
+)
+require(
+    document["buildVersion"] == plist_build_version,
+    "launched bundle reported build version "
+    f"{document['buildVersion']!r} but its CFBundleVersion is {plist_build_version!r}",
+)
+
+if expected_short_version:
+    require(
+        document["shortVersion"] == expected_short_version,
+        f"launched bundle reported short version {document['shortVersion']!r} "
+        f"but the expected short version is {expected_short_version!r}",
+    )
+if expected_build_version:
+    require(
+        document["buildVersion"] == expected_build_version,
+        f"launched bundle reported build version {document['buildVersion']!r} "
+        f"but the expected build version is {expected_build_version!r}",
+    )
+
+print(
+    f"Launch smoke passed: {document['bundleIdentifier']} "
+    f"{document['shortVersion']} ({document['buildVersion']}) started and answered."
+)
+PY
+
+if [ -s "$stderr_file" ]; then
+  echo "Launch smoke wrote diagnostics to stderr:"
+  cat "$stderr_file"
+fi


### PR DESCRIPTION
## The bug

`scripts/sign-and-verify-release.sh` printed **"Ad-hoc nested signature integrity verified"** for a bundle that could not start:

```
Library not loaded: @rpath/Sparkle.framework/Versions/B/Sparkle
  Reason: code signature ... not valid for use in process:
          mapping process and mapped file (non-platform) have different Team IDs
```

`sign_code` passed `--options runtime` on **both** signing branches. Hardened runtime turns on library validation, which requires the process and every library it maps to share a Team ID. Ad-hoc signatures carry none, so the app could not map Sparkle. The Developer ID path was fine because both sides carry team `C76R5DRH64`.

Every check the gate ran — `codesign --verify --deep --strict`, entitlement parity, `lipo -verify_arch` — inspects signatures **at rest**. None of them start the app, so the broken bundle reported green.

## The fix

**Drop `--options runtime` from the ad-hoc branch**, rather than adding `com.apple.security.cs.disable-library-validation` for ad-hoc builds:

- the gate's byte-for-byte entitlement parity against `MeterBar/MeterBar.entitlements` stays exception-free — an ad-hoc-only entitlement would need one carved into it
- no validation-disabling entitlement ever ships, on any path
- it removes the bug class for future nested targets instead of per-target
- hardened runtime is a Developer ID and notarization requirement; the branch that cannot satisfy it should not claim it

The ad-hoc summary also stops overclaiming — it now names what it does *not* prove (no Team ID, no hardened runtime, no library validation exercised).

**Cost:** the ad-hoc `wake --dry-run` check no longer runs under hardened runtime. That coverage stays on the Developer ID path in `_build-signed.yml`, which runs on every release.

## The gate

`scripts/verify-app-launch.sh` runs the real executable behind a watchdog and requires it to answer `--launch-smoke` with one versioned JSON document. `MeterBarMain` answers that flag **before SwiftUI starts**, so the probe is headless, needs no window server, and touches no state — while still proving dyld mapped and the kernel accepted every embedded signature, which is exactly where the crash was.

It also cross-checks the launched bundle's reported versions against its own `Info.plist` and the expected release versions, so a stale artifact on the runner cannot pass.

Both signing branches call it, so the Developer ID release path inherits it automatically.

## Verification

- **Reproduced end-to-end**: Release universal build via the CI invocation → CLI injected → `sign-and-verify-release.sh` with `SIGNING_IDENTITY` unset. Gate passes **and** the bundle launches.
- **Regression proof**: re-signing that same bundle ad-hoc *with* `--options runtime` still passes `codesign --verify --deep --strict`, and the new gate fails it with the original "different Team IDs" diagnostic surfaced in the output.
- `scripts/test-app-launch-smoke.sh` covers the dyld failure, a silent non-zero exit, contaminated stdout, unknown schema, a missing `launchSmoke` marker, four version-drift cases, a hang, and a missing executable — wired into the required `build` job.
- 7 new `LaunchSmokeProbeTests`, written first. Full suite locally shows only the two known environmental failures documented on 2026-08-02.
- SwiftLint `--strict` clean; `shellcheck` clean on all four new/changed scripts; `verify-release-workflow-contract.sh` still passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an app launch smoke check that confirms required metadata and returns structured validation results.
  * Release verification now launches the signed app and detects startup failures, malformed responses, version mismatches, and hangs.
* **Bug Fixes**
  * Improved ad-hoc signed app compatibility by avoiding runtime restrictions that can prevent launch.
* **Tests**
  * Added coverage for launch failures, invalid output, missing executables, timeouts, and version inconsistencies.
* **CI**
  * Added app launch validation to the build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->