### PR TITLE
fix(ui): ten popover, dashboard, widget, and provider-error defects

### DIFF
--- a/.agents/SESSIONS/2026-08-03.md
+++ b/.agents/SESSIONS/2026-08-03.md
@@ -1,0 +1,165 @@
+# 2026-08-03
+
+**Summary:** Ten UI/behavior fixes across popover, dashboard, widget
+
+---
+
+## Session 1: Popover, dashboard, widget, and provider-error cleanup
+
+**Status:** Complete — ready PR published, not merged.
+
+### System flow
+
+```mermaid
+flowchart LR
+    A["ServiceError.parsingError(String?)"] --> B["ClaudeCodeParseFailure"]
+    B --> C["ClaudeCodeCLIFailureMapping"]
+    C --> D["ProviderReadinessInspector.sanitize"]
+    E["MeterBarTheme.CardPadding"] --> F["DashboardTile(padding:)"]
+    E --> G["Popover / nested cards"]
+    H["ProviderCardHeader"] --> I["Popover card"]
+    H --> J["Hover detail panel"]
+    K["WidgetGlance (MeterBarShared)"] --> L["MeterBarWidget/UsageWidget"]
+    K --> M["WidgetSettingsPreviewSurface"]
+    N["UsageStatus.color"] --> L
+    N --> M
+```
+
+### What was done
+
+Ten reported UI/behavior defects, fixed end to end with tests first.
+
+- [x] **Popover label truncation.** A blocked or exhausted provider row squeezed
+  the account title down to a single character while the trailing status text
+  ran long. `ProviderBlockedSummaryPresentation` now decides one status line
+  instead of concatenating three, and `ResetCountdowns.unavailableCounterText`
+  owns the "no reset time" copy.
+- [x] **Card padding audit.** Padding was hand-typed per surface and had drifted.
+  `MeterBarTheme.CardPadding` (`.nested` 8 / `.popover` 12 / `.standard` 16) is
+  now the only source, threaded through `DashboardTile(padding:)`.
+- [x] **Hover panel parity.** The hover detail panel drew its own header and an
+  extra bar the card never had. Both surfaces now render `ProviderCardHeader`.
+- [x] **Overview grid.** `DashboardOverviewSection.masonryColumns` balances
+  cards into columns by height instead of leaving ragged gaps.
+- [x] **Costs row.** API-Rate Estimate and Lifetime Local share one equal-height
+  row in `DashboardCostsSection`.
+- [x] **Optimize page.** KPI tiles forced to a single 4x1 grid; the empty
+  "Last 7 days" counter now reads "None" when the window genuinely has no usage
+  rather than rendering a bare 0 next to a 30-day caption; `CodexCostScanner`
+  buffers deferred usage so late-arriving rows stop landing under "Unknown model".
+- [x] **Status refresh.** `DashboardStatusSection` gets a real refresh button
+  with a spinner state, and its enablement logic is lifted into pure statics.
+- [x] **Oversized switches.** New `meterBarSwitch()` view modifier applied at 26
+  call sites.
+- [x] **Widget design.** See "Decisions" — the widget was a scaled-down popover
+  card. It now has its own glance vocabulary.
+- [x] **"Failed to parse response".** The Claude CLI's real failure reason was
+  being thrown away. `ServiceError.parsingError` carries a `String?` detail, and
+  `ClaudeCodeParseFailure` + `ClaudeCodeCLIFailureMapping` classify it.
+
+### Files changed
+
+- `Packages/MeterBarShared/Sources/MeterBarShared/WidgetGlance.swift` - new;
+  per-family metrics and a hero/rows layout decision for the widget surfaces.
+  Layout numbers only, no SwiftUI — the package deliberately imports none.
+- `MeterBarWidget/UsageWidget.swift` - rewritten around `WidgetGlance`. Small
+  renders a hero number plus a rail; medium and large share one `WidgetGlanceStack`
+  body with different row budgets. Deleted `ServiceMiniView`, `ServiceCompactView`,
+  `WidgetRowDetails`, `WidgetStatusIndicator`.
+- `MeterBar/Views/Settings/WidgetSettingsView.swift` - the settings preview was a
+  third hand-rolled copy of the widget row at its own sizes; it now reads the
+  same `WidgetGlance` metrics and layout the extension does.
+- `MeterBar/Views/MeterBarTheme.swift` - `Spacing`, `CardPadding`,
+  `meterBarSwitch()`, and `UsageStatus.color` so severity maps to color in one place.
+- `MeterBar/Views/Components/ProviderCardHeader.swift` - new; one header for the
+  popover card and the hover panel.
+- `MeterBar/Views/Components/ProviderBlockedUsageSummary.swift` - single status
+  line for blocked/exhausted rows.
+- `MeterBar/Views/Components/ResetCountdowns.swift` - `unavailableCounterText`.
+- `MeterBar/Views/{DashboardOverviewSection,DashboardCostsSection,DashboardStatusSection,OptimizeInsightsView}.swift`
+  - grid, equal-height row, refresh button, 4x1 KPI tiles.
+- `MeterBar/Services/{ClaudeCodeParseFailure,ClaudeCodeCLIFailureMapping}.swift` -
+  new; classify a CLI parse failure into a message worth showing.
+- `MeterBar/Services/ServiceError.swift` - `parsingError(String?)`.
+- `MeterBar/Services/CodexCostScanner.swift` - deferred-usage buffer.
+- `MeterBarTests/{WidgetGlanceTests,WidgetSettingsPreviewParityTests,ClaudeCodeParseFailureTests,ProviderBlockedSummaryPresentationTests}.swift`
+  - new suites, written before the implementation they cover.
+
+### Decisions
+
+- **Decision:** The widget gets its own layout vocabulary rather than a shared
+  component with the app.
+  - **Context:** `MeterBarWidget` is an app-extension target outside the SwiftPM
+    package, so it cannot link app types like `DashboardTile` or `LimitRow`.
+    Only `MeterBarShared` is common ground, and nothing in it imports SwiftUI.
+  - **Rationale:** Put the *numbers and the layout decision* in `MeterBarShared`
+    as `WidgetGlance`, and let each target draw them. Three copies previously
+    disagreed on icon source, font sizes, and status color; now they disagree
+    about nothing, without the extension having to link the app.
+
+- **Decision:** A glance is not a small card — four deliberate inversions.
+  - **Context:** The complaint was that the widget looked like the popover card.
+  - **Rationale:** The usage number becomes the largest type instead of the
+    account name; the stacked quota subtitle competing with it is gone; the bar
+    is a capsule with weight rather than a hairline; and status is carried by the
+    bar's tint, so the card's separate status dot goes away.
+
+- **Decision:** Icon parity is over size and layout, never one shared icon view.
+  - **Context:** The two targets have separate asset catalogs — the extension
+    uses `ServiceType.assetName`, the app uses `ProviderLogoKind.resourceName`.
+  - **Rationale:** Forcing a shared view would mean duplicating assets into both
+    catalogs for no visual gain.
+
+### Mistakes and fixes
+
+- **Mistake:** `swift test` output looked frozen — a redirected log sat at 98
+  bytes while the run had been going for 14 minutes, so it read as a hang with
+  no diagnosis available.
+- **Fix:** Run it under a pty: `script -q /dev/null swift test > log 2>&1`.
+  Output streamed per-test immediately.
+- **Prevention:** Never diagnose a "hung" `swift test` from a plain redirect; it
+  block-buffers. Also, XCTest's summary line is tab-indented, so `grep "^Executed"`
+  never matches.
+
+- **Mistake:** The run genuinely was blocked, and I initially assumed it was my
+  change.
+- **Fix:** With live output the last line was
+  `APIIntegrationTests testClaudeCodeAPIAccess started` — a live-credential test
+  whose declared `apiTimeout` is never applied to the awaited call, so it blocks
+  forever without credentials. Re-ran with `--skip APIIntegrationTests`.
+- **Prevention:** `APIIntegrationTests` is a live-network suite; skip it for
+  local full-suite runs.
+
+- **Mistake:** Reached for `pkill -f "swift-test|xctest"` to clear the stuck run.
+- **Fix:** `-f` matches full command lines including this agent's own shell
+  wrapper, which carried those strings in its environment. Used `pkill -x xctest`.
+- **Prevention:** Always `-x` when killing test processes from inside an agent.
+
+- **Mistake:** SwiftLint `--strict` rejected `@ViewBuilder` on its own line above
+  a computed property.
+- **Fix:** The `attributes` rule wants attributes on their own line for functions
+  and types, but on the *same* line for variables. Collapsed it.
+
+### Verification
+
+- `swift test --skip APIIntegrationTests` — 1652 tests, 1 skipped, 3 failures.
+- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug`
+  — BUILD SUCCEEDED (this is the only build that compiles the widget extension).
+- `swiftlint --strict` — clean.
+- The 3 failures are 2 tests, both reproduced verbatim on clean `master` at
+  `7322b7f` in a throwaway worktree:
+  - `LiquidGlassP1RegressionTests.testRapidShowDismissShowLeavesPanelVisibleAndOpaque`
+    — panel alpha 0.0 vs expected 1.0. `MeterBarMenuPanelController` is untouched here.
+  - `SessionWakeAgentTests.testAgentLifetimeLockExcludesAppAndCLIHolders`
+    — sandbox denies writing the lock directory under `TMPDIR`. Environmental.
+
+### Next steps
+
+- [ ] Fix `APIIntegrationTests` to honor its own `apiTimeout`, or gate the suite
+      behind an explicit environment flag so it cannot hang a local full run.
+- [ ] Investigate the pre-existing `LiquidGlassP1RegressionTests` panel-alpha
+      failure separately from this change.
+
+---
+
+**Total sessions today:** 1

--- a/.agents/SESSIONS/2026-08-03.md
+++ b/.agents/SESSIONS/2026-08-03.md
@@ -1,6 +1,7 @@
 # 2026-08-03
 
-**Summary:** Ten UI/behavior fixes across popover, dashboard, widget
+**Summary:** Ten UI/behavior fixes across popover, dashboard, widget; ad-hoc
+bundles passed the release gate but could not launch
 
 ---
 
@@ -23,52 +24,6 @@ flowchart LR
     K --> M["WidgetSettingsPreviewSurface"]
     N["UsageStatus.color"] --> L
     N --> M
-**Summary:** Ad-hoc bundles passed the release gate but could not launch
-
----
-
-## Session 1: Fix ad-hoc hardened-runtime signing, add a launch smoke gate
-
-**Status:** Complete — ready PR published, not merged.
-
-### Context
-
-`scripts/sign-and-verify-release.sh` reported "Ad-hoc nested signature integrity
-verified" for a bundle that died in dyld on launch:
-
-```text
-Library not loaded: @rpath/Sparkle.framework/Versions/B/Sparkle
-  Reason: code signature ... not valid for use in process:
-          mapping process and mapped file (non-platform) have different Team IDs
-```
-
-`sign_code` passed `--options runtime` on both signing branches. Hardened runtime
-turns on library validation, which requires the process and every library it maps
-to share a Team ID. Ad-hoc signatures carry none, so the app could not map
-Sparkle. The Developer ID path was unaffected because both sides carry team
-C76R5DRH64.
-
-The gate never noticed because every check it ran — `codesign --verify --deep
---strict`, entitlement parity, `lipo -verify_arch` — inspects signatures at rest.
-None of them start the app.
-
-### System flow
-
-```text
-sign_code (ad-hoc)            sign_code (Developer ID)
-  no --options runtime          --options runtime + --timestamp
-        |                              |
-        +--------------+---------------+
-                       |
-        codesign --verify --deep --strict     <- signatures at rest
-        entitlement parity vs source plists   <- signatures at rest
-        embedded CLI wake --dry-run --json    <- CLI process only
-                       |
-        scripts/verify-app-launch.sh          <- NEW: the app itself
-                       |
-          MeterBarMain.main()
-            -> LaunchSmokeProbe.exitIfRequested()   (before SwiftUI)
-            -> one JSON line, exit 0
 ```
 
 ### What was done
@@ -208,7 +163,52 @@ Ten reported UI/behavior defects, fixed end-to-end with tests first.
 
 ---
 
-**Total sessions today:** 1
+## Session 2: Fix ad-hoc hardened-runtime signing, add a launch smoke gate
+
+**Status:** Complete — ready PR published, not merged.
+
+### Context
+
+`scripts/sign-and-verify-release.sh` reported "Ad-hoc nested signature integrity
+verified" for a bundle that died in dyld on launch:
+
+```text
+Library not loaded: @rpath/Sparkle.framework/Versions/B/Sparkle
+  Reason: code signature ... not valid for use in process:
+          mapping process and mapped file (non-platform) have different Team IDs
+```
+
+`sign_code` passed `--options runtime` on both signing branches. Hardened runtime
+turns on library validation, which requires the process and every library it maps
+to share a Team ID. Ad-hoc signatures carry none, so the app could not map
+Sparkle. The Developer ID path was unaffected because both sides carry team
+C76R5DRH64.
+
+The gate never noticed because every check it ran — `codesign --verify --deep
+--strict`, entitlement parity, `lipo -verify_arch` — inspects signatures at rest.
+None of them start the app.
+
+### System flow
+
+```text
+sign_code (ad-hoc)            sign_code (Developer ID)
+  no --options runtime          --options runtime + --timestamp
+        |                              |
+        +--------------+---------------+
+                       |
+        codesign --verify --deep --strict     <- signatures at rest
+        entitlement parity vs source plists   <- signatures at rest
+        embedded CLI wake --dry-run --json    <- CLI process only
+                       |
+        scripts/verify-app-launch.sh          <- NEW: the app itself
+                       |
+          MeterBarMain.main()
+            -> LaunchSmokeProbe.exitIfRequested()   (before SwiftUI)
+            -> one JSON line, exit 0
+```
+
+### What was done
+
 - [x] Dropped `--options runtime` from the ad-hoc branch of `sign_code`, with a
   comment explaining why hardened runtime belongs only on the Developer ID path.
 - [x] Added `LaunchSmokeProbe` — a `--launch-smoke` flag answered before AppKit
@@ -323,3 +323,7 @@ Ten reported UI/behavior defects, fixed end-to-end with tests first.
 ### Next steps
 
 - [ ] Land the PR once CI completes.
+
+---
+
+**Total sessions today:** 2

--- a/.agents/SESSIONS/2026-08-03.md
+++ b/.agents/SESSIONS/2026-08-03.md
@@ -27,7 +27,7 @@ flowchart LR
 
 ### What was done
 
-Ten reported UI/behavior defects, fixed end to end with tests first.
+Ten reported UI/behavior defects, fixed end-to-end with tests first.
 
 - [x] **Popover label truncation.** A blocked or exhausted provider row squeezed
   the account title down to a single character while the trailing status text

--- a/MeterBar/Services/ClaudeCodeCLIFailureMapping.swift
+++ b/MeterBar/Services/ClaudeCodeCLIFailureMapping.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Translates `ClaudeCodeCLIUsageError` into the two app-level vocabularies the
+/// UI reads: `ServiceError` (what Settings prints) and `ClaudeCodeAuthState`
+/// (whether the user is told to act or to retry).
+///
+/// This lived as two private methods on `ClaudeCodeLocalService`, which meant
+/// the only way to check that a CLI failure reached the user intact was to run
+/// the CLI. Pulling the switches out keeps them assertable without a subprocess.
+enum ClaudeCodeCLIFailureMapping {
+    static func serviceError(from error: Error) -> ServiceError {
+        if let serviceError = error as? ServiceError {
+            return serviceError
+        }
+
+        guard let cliError = error as? ClaudeCodeCLIUsageError else {
+            return .apiError(error.localizedDescription)
+        }
+
+        switch cliError {
+        case .cliNotFound:
+            return .notAuthenticated
+        case let .parsingFailed(message):
+            // Only messages MeterBar authored survive; anything else could be
+            // CLI output and stays behind the generic string.
+            return .parsingError(ClaudeCodeParseFailure(message: message)?.message)
+        case .timedOut, .launchFailed, .commandFailed:
+            return .apiError(cliError.localizedDescription)
+        }
+    }
+
+    static func authState(from error: Error) -> ClaudeCodeAuthState {
+        guard let cliError = error as? ClaudeCodeCLIUsageError else {
+            return .error(error.localizedDescription)
+        }
+
+        switch cliError {
+        case .cliNotFound:
+            return .unavailable
+        case let .commandFailed(message):
+            let lowercased = message.lowercased()
+            if lowercased.contains("login") || lowercased.contains("auth") || lowercased.contains("unauthorized") {
+                return .needsLogin
+            }
+            return .error(cliError.localizedDescription)
+        case let .parsingFailed(message):
+            // A CLI that cannot render `/usage` headlessly will fail every
+            // future refresh too, so "needs attention" understates it — the user
+            // has to connect OAuth before anything changes.
+            if ClaudeCodeParseFailure(message: message) == .headlessUsageUnavailable {
+                return .needsLogin
+            }
+            return .error(cliError.localizedDescription)
+        case .timedOut, .launchFailed:
+            return .error(cliError.localizedDescription)
+        }
+    }
+}

--- a/MeterBar/Services/ClaudeCodeCLIUsageService.swift
+++ b/MeterBar/Services/ClaudeCodeCLIUsageService.swift
@@ -158,12 +158,9 @@ nonisolated enum ClaudeCodeCLIUsageParser {
             // cost summary instead of the usage screen, so no windows parse.
             // Surface that specifically — the OAuth endpoint is the fix.
             if looksLikeCostSummary(sanitized) {
-                throw ClaudeCodeCLIUsageError.parsingFailed(
-                    "Claude CLI returned a session cost summary instead of the usage screen; "
-                        + "`claude /usage` no longer renders headlessly. "
-                        + "Connect Claude Code via its OAuth login in Settings.")
+                throw ClaudeCodeCLIUsageError.parsingFailed(ClaudeCodeParseFailure.headlessUsageUnavailable.message)
             }
-            throw ClaudeCodeCLIUsageError.parsingFailed("No Claude usage windows found.")
+            throw ClaudeCodeCLIUsageError.parsingFailed(ClaudeCodeParseFailure.noUsageWindows.message)
         }
 
         return UsageMetrics(

--- a/MeterBar/Services/ClaudeCodeLocalService.swift
+++ b/MeterBar/Services/ClaudeCodeLocalService.swift
@@ -594,41 +594,11 @@ class ClaudeCodeLocalService: ObservableObject {
     }
 
     private func serviceError(from error: Error) -> ServiceError {
-        if let serviceError = error as? ServiceError {
-            return serviceError
-        }
-
-        if let cliError = error as? ClaudeCodeCLIUsageError {
-            switch cliError {
-            case .cliNotFound:
-                return .notAuthenticated
-            case .parsingFailed:
-                return .parsingError
-            case .timedOut, .launchFailed, .commandFailed:
-                return .apiError(cliError.localizedDescription)
-            }
-        }
-
-        return .apiError(error.localizedDescription)
+        ClaudeCodeCLIFailureMapping.serviceError(from: error)
     }
 
     private func authState(from error: Error) -> ClaudeCodeAuthState {
-        guard let cliError = error as? ClaudeCodeCLIUsageError else {
-            return .error(error.localizedDescription)
-        }
-
-        switch cliError {
-        case .cliNotFound:
-            return .unavailable
-        case let .commandFailed(message):
-            let lowercased = message.lowercased()
-            if lowercased.contains("login") || lowercased.contains("auth") || lowercased.contains("unauthorized") {
-                return .needsLogin
-            }
-            return .error(cliError.localizedDescription)
-        case .timedOut, .launchFailed, .parsingFailed:
-            return .error(cliError.localizedDescription)
-        }
+        ClaudeCodeCLIFailureMapping.authState(from: error)
     }
 }
 

--- a/MeterBar/Services/ClaudeCodeParseFailure.swift
+++ b/MeterBar/Services/ClaudeCodeParseFailure.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// The closed set of ways parsing `claude /usage` can fail, together with the
+/// exact user-facing message each one produces.
+///
+/// The parser already knew why it failed — a headless spawn makes the CLI print
+/// a session cost summary instead of the usage screen — but that sentence died
+/// at the `ServiceError` boundary, where every parse failure collapsed to the
+/// payload-free `.parsingError`. Settings then showed "Failed to parse
+/// response", which names the symptom and hides the one action that fixes it.
+///
+/// Every `message` is a **constant** — no interpolation, ever. That is what lets
+/// `ServiceSupport` and `ProviderReadinessInspector` pass these through verbatim
+/// while still discarding arbitrary parse text: a value that cannot be built
+/// from CLI output cannot carry a token, an account id, or a response body.
+/// This mirrors `GrokRefreshFailure`, which solves the same problem for the only
+/// other provider MeterBar reads by driving a subprocess.
+///
+/// `nonisolated` because the sanitizers that consult it run off the main actor;
+/// the target's default isolation would otherwise pin `messages` to `@MainActor`.
+nonisolated enum ClaudeCodeParseFailure: String, Sendable, Equatable, CaseIterable {
+    /// `claude /usage` rendered a session cost summary instead of the usage
+    /// screen, which is what a non-TTY spawn now gets. No amount of retrying
+    /// changes that; the OAuth endpoint is the way through.
+    case headlessUsageUnavailable
+    /// The output was neither the usage screen nor a cost summary, so no quota
+    /// windows could be read out of it.
+    case noUsageWindows
+
+    /// The sanitized text shown in Settings → Providers and Diagnostics.
+    var message: String {
+        switch self {
+        case .headlessUsageUnavailable:
+            return "Claude CLI returned a cost summary instead of the usage screen"
+        case .noUsageWindows:
+            return "Claude CLI reported no usage windows"
+        }
+    }
+
+    /// The single next step that most often fixes this failure.
+    var recovery: String {
+        switch self {
+        case .headlessUsageUnavailable:
+            return "Connect Claude Code with OAuth in Settings → Claude Code."
+        case .noUsageWindows:
+            return "Run `claude /usage` in Terminal to confirm it renders, then refresh MeterBar."
+        }
+    }
+
+    /// Recovers the failure from an already-sanitized message.
+    init?(message: String) {
+        guard let match = Self.allCases.first(where: { $0.message == message }) else { return nil }
+        self = match
+    }
+
+    /// Whitelist used by the sanitizers: these strings are known-safe verbatim.
+    static let messages: Set<String> = Set(allCases.map(\.message))
+}

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -157,13 +157,34 @@ enum CodexCostScanner {
             // Reset per file: attribution carried across rollouts would label
             // one session's spend with another's model.
             var rollout = CodexRolloutContext()
+            // Codex emits a session's opening `token_count` events *before* its
+            // first `turn_context`, so forward-only attribution orphaned them
+            // even though the same file names the model seconds later. Park
+            // them here instead and back-fill once the file declares a model.
+            // Per file, like the rollout context: a sibling rollout's model
+            // must never name events this file left unexplained.
+            var deferred: [CodexDeferredUsage] = []
             FileLineReader.forEachLine(in: fileURL) { line in
                 guard line.contains(Self.tokenCountMarker) else {
                     Self.updateRolloutContext(&rollout, from: line)
+                    // Reaches back only as far as the *first* model the file
+                    // declares — a later mid-session switch must not relabel
+                    // the events that preceded it.
+                    if let model = rollout.turnModel ?? rollout.sessionModel {
+                        Self.flushDeferred(&deferred, modelName: model, windows: &windows)
+                    }
                     return
                 }
-                Self.addTokenCountLine(line, fileURL: fileURL, rollout: rollout, windows: &windows)
+                Self.addTokenCountLine(
+                    line,
+                    fileURL: fileURL,
+                    rollout: rollout,
+                    deferred: &deferred,
+                    windows: &windows
+                )
             }
+            // Whatever the file never explained is genuinely unattributed.
+            Self.flushDeferred(&deferred, modelName: nil, windows: &windows)
         }
     }
 
@@ -201,10 +222,36 @@ enum CodexCostScanner {
         }
     }
 
+    /// Replays the events parked before the file named a model. Each keeps its
+    /// own timestamp, so `ScanWindows.update` still places it on its own day.
+    nonisolated private static func flushDeferred(
+        _ deferred: inout [CodexDeferredUsage],
+        modelName: String?,
+        windows: inout ScanWindows<CodexScanContext>
+    ) {
+        guard !deferred.isEmpty else { return }
+
+        for pending in deferred {
+            Self.addUsage(
+                pending.usage,
+                timestamp: pending.timestamp,
+                sessionID: pending.sessionID,
+                attribution: CodexUsageAttribution(
+                    modelName: modelName,
+                    originName: pending.originName,
+                    projectID: pending.projectID
+                ),
+                windows: &windows
+            )
+        }
+        deferred.removeAll()
+    }
+
     nonisolated private static func addTokenCountLine(
         _ line: Data,
         fileURL: URL,
         rollout: CodexRolloutContext,
+        deferred: inout [CodexDeferredUsage],
         windows: inout ScanWindows<CodexScanContext>
     ) {
         guard let json = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
@@ -224,14 +271,31 @@ enum CodexCostScanner {
         let modelName = Self.modelName(from: info, payload: payload)
             ?? rollout.turnModel
             ?? rollout.sessionModel
+        // Origin and project are read now rather than at flush time: they come
+        // from `session_meta`, which a rollout always opens with, so the values
+        // in hand are already the final ones. Only the model is back-filled.
+        let originName = rollout.originator ?? "Codex CLI"
+        let projectID = CostProjectAttribution.codexProjectID(cwd: rollout.cwd)
+
+        guard let modelName else {
+            deferred.append(CodexDeferredUsage(
+                usage: usage,
+                timestamp: timestamp,
+                sessionID: sessionID,
+                originName: originName,
+                projectID: projectID
+            ))
+            return
+        }
+
         Self.addUsage(
             usage,
             timestamp: timestamp,
             sessionID: sessionID,
             attribution: CodexUsageAttribution(
                 modelName: modelName,
-                originName: rollout.originator ?? "Codex CLI",
-                projectID: CostProjectAttribution.codexProjectID(cwd: rollout.cwd)
+                originName: originName,
+                projectID: projectID
             ),
             windows: &windows
         )
@@ -460,6 +524,19 @@ nonisolated struct CodexRolloutContext: Sendable {
 /// `addUsage` can stay under SwiftLint's `function_parameter_count` limit
 /// (issue #270 added `projectID` as the third label alongside the pre-existing
 /// model/origin pair).
+/// A `token_count` event parked because its rollout has not named a model yet.
+///
+/// Deliberately not `Sendable`: it carries the raw `[String: Any]` usage
+/// payload. It never outlives the single-threaded scan of the file that made
+/// it, so it does not need to be.
+nonisolated struct CodexDeferredUsage {
+    let usage: [String: Any]
+    let timestamp: Date
+    let sessionID: String
+    let originName: String
+    let projectID: String
+}
+
 nonisolated struct CodexUsageAttribution: Sendable {
     let modelName: String?
     let originName: String?

--- a/MeterBar/Services/GrokCLIUsageService.swift
+++ b/MeterBar/Services/GrokCLIUsageService.swift
@@ -173,7 +173,7 @@ final class GrokCLIUsageService: ObservableObject {
     static func serviceError(from error: Error) -> ServiceError {
         guard let error = error as? GrokBillingRPC.Error else {
             if error is DecodingError {
-                return .parsingError
+                return .parsingError(nil)
             }
             return ServiceSupport.serviceError(from: error)
         }
@@ -181,7 +181,7 @@ final class GrokCLIUsageService: ObservableObject {
         case .notAuthenticated:
             return .notAuthenticated
         case .invalidResponse:
-            return .parsingError
+            return .parsingError(nil)
         case .timedOut:
             return .apiError(GrokRefreshFailure.agentTimedOut.message)
         case .launchFailed:

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -400,7 +400,14 @@ nonisolated public enum ProviderReadinessInspector {
             return "Not authenticated"
         case .invalidURL:
             return "Invalid request URL"
-        case .parsingError:
+        case let .parsingError(detail):
+            // Same rule as the API messages below: only interpolation-free
+            // strings MeterBar authored survive, because a parse detail is the
+            // one place raw provider output could otherwise leak into a
+            // pasteable diagnostics report.
+            if let detail, ClaudeCodeParseFailure.messages.contains(detail) {
+                return detail
+            }
             return "Could not parse the provider response"
         case let .apiError(message):
             if safeNetworkMessages.contains(message) {

--- a/MeterBar/Services/ProviderStatusMonitor.swift
+++ b/MeterBar/Services/ProviderStatusMonitor.swift
@@ -311,7 +311,7 @@ struct ProviderStatusClient {
         let (data, response) = try await session.data(from: url)
         try ServiceSupport.validate(response, data: data)
         guard let html = String(data: data, encoding: .utf8) else {
-            throw ServiceError.parsingError
+            throw ServiceError.parsingError(nil)
         }
         let operational = html.localizedCaseInsensitiveContains("All Systems Operational")
         return ProviderStatusReport(

--- a/MeterBar/Services/ServiceError.swift
+++ b/MeterBar/Services/ServiceError.swift
@@ -5,7 +5,12 @@ public enum ServiceError: LocalizedError, Sendable {
     case notAuthenticated
     case invalidURL
     case apiError(String)
-    case parsingError
+    /// A response MeterBar could not read. The associated value carries an
+    /// authored explanation when the failing service knows one worth showing
+    /// (see `ClaudeCodeParseFailure`); `nil` keeps the generic message. It is
+    /// never provider output — the sanitizers drop anything unrecognized before
+    /// it reaches a view.
+    case parsingError(String?)
 
     public var errorDescription: String? {
         switch self {
@@ -15,8 +20,8 @@ public enum ServiceError: LocalizedError, Sendable {
             return "Invalid URL"
         case .apiError(let message):
             return message
-        case .parsingError:
-            return "Failed to parse response"
+        case .parsingError(let detail):
+            return detail ?? "Failed to parse response"
         }
     }
 }

--- a/MeterBar/Services/ServiceSupport.swift
+++ b/MeterBar/Services/ServiceSupport.swift
@@ -124,7 +124,7 @@ nonisolated enum ServiceSupport {
         case let urlError as URLError:
             return sanitize(.apiError(message(for: urlError)))
         case is DecodingError:
-            return .parsingError
+            return .parsingError(nil)
         default:
             return .apiError("Request failed")
         }
@@ -162,6 +162,16 @@ nonisolated enum ServiceSupport {
     }
 
     private static func sanitize(_ error: ServiceError) -> ServiceError {
+        // A parse detail is only ever displayable when MeterBar wrote it. Any
+        // other text may be provider output, so it collapses to the generic
+        // message rather than reaching a view.
+        if case let .parsingError(detail) = error {
+            guard let detail, ClaudeCodeParseFailure.messages.contains(detail) else {
+                return .parsingError(nil)
+            }
+            return error
+        }
+
         guard case let .apiError(message) = error else { return error }
 
         let knownSafeMessages: Set<String> = [

--- a/MeterBar/Views/ApiUsageCard.swift
+++ b/MeterBar/Views/ApiUsageCard.swift
@@ -164,7 +164,7 @@ struct ApiUsageCard: View {
   var body: some View {
     DashboardTile(
       cornerRadius: MeterBarTheme.apiCardRadius,
-      padding: compact ? MeterBarTheme.Spacing.sm : MeterBarTheme.Spacing.md
+      padding: compact ? .nested : .popover
     ) {
       VStack(alignment: .leading, spacing: compact ? 8 : 10) {
         HStack(spacing: 7) {

--- a/MeterBar/Views/Components/LimitRow.swift
+++ b/MeterBar/Views/Components/LimitRow.swift
@@ -11,9 +11,10 @@ import MeterBarShared
 /// can't diverge again. All display logic lives in the pure `Content` value
 /// type so it can be unit-tested without hosting the view.
 struct LimitRow: View {
-    /// Per-surface sizing. `.compact` = popover provider card (terse, reset-only
-    /// footer), `.detail` = menu-bar detail panel (self-carded rows), `.regular`
-    /// = dashboard & settings (largest type).
+    /// Per-surface sizing only — no surface chrome, since every caller already
+    /// draws the card the row sits in. `.compact` = popover provider card (terse,
+    /// reset-only footer), `.detail` = menu-bar detail panel (same chrome as the
+    /// card, fuller footer), `.regular` = dashboard & settings (largest type).
     enum Density {
         case compact
         case detail
@@ -37,12 +38,10 @@ struct LimitRow: View {
     var accessibilityLabelText: String { limit.accessibilityLabel }
     var accessibilityValueText: String { limit.accessibilityValue }
 
+    // Every surface that draws a `LimitRow` already sits inside a card, so the
+    // row never draws one of its own. The detail panel used to, which is exactly
+    // what made hovering a provider card look like a different design.
     var body: some View {
-        core
-            .modifier(CardSurface(enabled: density.hasCardSurface))
-    }
-
-    private var core: some View {
         VStack(alignment: .leading, spacing: density.rowSpacing) {
             header
             UsageBar(
@@ -202,25 +201,6 @@ extension LimitRow {
     }
 }
 
-private extension LimitRow {
-    /// Optionally wraps the detail-panel row in its own card surface. The
-    /// popover and dashboard rows sit inside a parent tile, so only `.detail`
-    /// carries its own surface.
-    struct CardSurface: ViewModifier {
-        let enabled: Bool
-
-        func body(content: Content) -> some View {
-            if enabled {
-                content
-                    .padding(10)
-                    .meterBarCardSurface(cornerRadius: 10)
-            } else {
-                content
-            }
-        }
-    }
-}
-
 // MARK: - Density metrics
 
 private extension LimitRow.Density {
@@ -324,9 +304,5 @@ private extension LimitRow.Density {
         case .compact, .detail: return 9
         case .regular: return 10
         }
-    }
-
-    var hasCardSurface: Bool {
-        self == .detail
     }
 }

--- a/MeterBar/Views/Components/ProviderBlockedUsageSummary.swift
+++ b/MeterBar/Views/Components/ProviderBlockedUsageSummary.swift
@@ -1,6 +1,79 @@
 import MeterBarShared
 import SwiftUI
 
+/// Pure copy rules for the blocked summary row.
+///
+/// The row used to concatenate three independently-derived phrases — the auth
+/// notice, `BlockingLimitResetCounter.titleText`, and its `counterText` — with
+/// nothing checking whether they said the same thing twice. A logged-out account
+/// with no reported reset rendered "Login required ⏳ Limit exhausted Reset time
+/// unavailable": three restatements of one fact, wide enough to squeeze the
+/// account title down to a single character. Deciding here, off the view, keeps
+/// the collapse assertable without hosting a render.
+enum ProviderBlockedSummaryPresentation {
+    struct Content: Equatable {
+        /// Short status word shown beside the title. Always present.
+        var statusText: String
+        /// Countdown line, or `nil` when there is no countdown worth showing.
+        var resetText: String?
+
+        func accessibilityLabel(title: String) -> String {
+            [title, statusText, resetText].compactMap { $0 }.joined(separator: ", ")
+        }
+    }
+
+    /// - Parameter hasAuthNotice: a login/stale/attention overlay explains the
+    ///   block better than the countdown can, and the two read as contradictory
+    ///   instructions side by side ("sign in" versus "wait 3h"), so the notice
+    ///   wins outright.
+    static func content(
+        statusText: String,
+        window: ResetCountdownWindow?,
+        now: Date,
+        format: ResetTimeFormat = .countdown,
+        hasAuthNotice: Bool = false,
+        locale: Locale = .current,
+        timeZone: TimeZone = .current
+    ) -> Content {
+        Content(
+            statusText: statusText,
+            resetText: resetText(
+                window: window,
+                now: now,
+                format: format,
+                hasAuthNotice: hasAuthNotice,
+                locale: locale,
+                timeZone: timeZone
+            )
+        )
+    }
+
+    private static func resetText(
+        window: ResetCountdownWindow?,
+        now: Date,
+        format: ResetTimeFormat,
+        hasAuthNotice: Bool,
+        locale: Locale,
+        timeZone: TimeZone
+    ) -> String? {
+        guard !hasAuthNotice, let window else { return nil }
+
+        let counter = BlockingLimitResetCounter.counterText(
+            for: window,
+            now: now,
+            format: format,
+            locale: locale,
+            timeZone: timeZone
+        )
+        // The counter narrates its own failure when the provider reported no
+        // reset date. Nothing actionable survives that, so drop the line rather
+        // than print an apology next to an hourglass.
+        guard counter != BlockingLimitResetCounter.unavailableCounterText else { return nil }
+
+        return "\(BlockingLimitResetCounter.titleText(for: window, in: [window])) \(counter)"
+    }
+}
+
 /// Collapsed "you are blocked until this reset" summary shared by the popover
 /// provider card and Settings → Providers usage section.
 ///
@@ -26,58 +99,58 @@ struct ProviderBlockedUsageSummary: View {
 
     var body: some View {
         TimelineView(.periodic(from: ResetCountdownSchedule.anchor, by: ResetCountdownSchedule.interval)) { timeline in
-            let blockingWindow = BlockingLimitResetCounter.selectBlockingWindow(
-                snapshot.resetWindows,
-                now: timeline.date
-            )
-            let title = BlockingLimitResetCounter.titleText(
-                for: blockingWindow,
-                in: snapshot.resetWindows
-            )
-            let counter = BlockingLimitResetCounter.counterText(
-                for: blockingWindow,
+            let content = ProviderBlockedSummaryPresentation.content(
+                statusText: ProviderCardPresentation.statusText(for: snapshot),
+                window: BlockingLimitResetCounter.selectBlockingWindow(snapshot.resetWindows, now: timeline.date),
                 now: timeline.date,
-                format: resetTimeFormat
+                format: resetTimeFormat,
+                hasAuthNotice: snapshot.authNotice != nil
             )
-            let statusText = ProviderCardPresentation.statusText(for: snapshot)
-            let statusColor = ProviderCardPresentation.statusColor(for: snapshot)
 
-            HStack(spacing: density == .popoverCard ? 7 : 10) {
-                if showsTitle {
-                    ProviderLogoView(
-                        kind: snapshot.logoKind,
-                        size: density == .popoverCard ? 17 : 16,
-                        foregroundColor: snapshot.accentColor
-                    )
-                    Text(snapshot.title)
-                        .font(density == .popoverCard ? .subheadline : .subheadline)
+            // The countdown takes its own line. Sharing the title's row made the
+            // title the only compressible element between two `fixedSize`
+            // siblings, so at popover width it collapsed to one character while
+            // the countdown kept its full ideal size.
+            VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.xs) {
+                HStack(spacing: density == .popoverCard ? MeterBarTheme.Spacing.sm : MeterBarTheme.Spacing.md) {
+                    if showsTitle {
+                        ProviderLogoView(
+                            kind: snapshot.logoKind,
+                            size: density == .popoverCard ? 17 : 16,
+                            foregroundColor: snapshot.accentColor
+                        )
+                        Text(snapshot.title)
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                            .layoutPriority(1)
+                    }
+
+                    Spacer(minLength: MeterBarTheme.Spacing.sm)
+
+                    Text(content.statusText)
+                        .font(.caption2)
                         .fontWeight(.semibold)
+                        .foregroundStyle(ProviderCardPresentation.statusColor(for: snapshot))
                         .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
                 }
 
-                Spacer(minLength: 8)
-
-                Text(statusText)
-                    .font(.caption2)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(statusColor)
-                    .lineLimit(1)
-                    .fixedSize(horizontal: true, vertical: false)
-
-                Label("\(title) \(counter)", systemImage: "hourglass")
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(snapshot.accentColor)
-                    .monospacedDigit()
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.72)
-                    .fixedSize(horizontal: true, vertical: false)
-                    .numericRefreshTransition(value: counter, reduceMotion: reduceMotion)
+                if let resetText = content.resetText {
+                    Label(resetText, systemImage: "hourglass")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(snapshot.accentColor)
+                        .monospacedDigit()
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.72)
+                        .numericRefreshTransition(value: resetText, reduceMotion: reduceMotion)
+                }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityElement(children: .combine)
-            .accessibilityLabel(
-                "\(snapshot.title), \(statusText), \(title) \(counter)"
-            )
+            .accessibilityLabel(content.accessibilityLabel(title: snapshot.title))
         }
     }
 }

--- a/MeterBar/Views/Components/ProviderBlockedUsageSummary.swift
+++ b/MeterBar/Views/Components/ProviderBlockedUsageSummary.swift
@@ -17,7 +17,11 @@ enum ProviderBlockedSummaryPresentation {
         /// Countdown line, or `nil` when there is no countdown worth showing.
         var resetText: String?
 
-        func accessibilityLabel(title: String) -> String {
+        /// - Parameter title: the account title *as drawn*, or `nil` when the row
+        ///   suppresses it because an enclosing card already names the account.
+        ///   Passing it unconditionally made VoiceOver say the name twice where
+        ///   sighted users saw it once.
+        func accessibilityLabel(title: String?) -> String {
             [title, statusText, resetText].compactMap { $0 }.joined(separator: ", ")
         }
     }
@@ -150,7 +154,7 @@ struct ProviderBlockedUsageSummary: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityElement(children: .combine)
-            .accessibilityLabel(content.accessibilityLabel(title: snapshot.title))
+            .accessibilityLabel(content.accessibilityLabel(title: showsTitle ? snapshot.title : nil))
         }
     }
 }

--- a/MeterBar/Views/Components/ProviderCardHeader.swift
+++ b/MeterBar/Views/Components/ProviderCardHeader.swift
@@ -1,0 +1,64 @@
+import MeterBarShared
+import SwiftUI
+
+/// The identity row shared by `ProviderStatusCard` and the hover detail panel.
+///
+/// Both surfaces hand-rolled their own header and the two drifted: the panel
+/// used a larger logo and title, labelled itself with the service name where the
+/// card showed the refresh time, and dropped the status word entirely — so
+/// hovering a card replaced it with something that read like a different
+/// provider, and a logged-out account looked healthy the moment the pointer
+/// landed on it. One component keeps them identical; the only legitimate
+/// difference is the disclosure chevron, which belongs to the card because the
+/// panel is already the thing it discloses.
+struct ProviderCardHeader: View {
+    /// Display strings for the header, with no SwiftUI attached so each rule is
+    /// directly assertable and the two surfaces can be compared value-to-value.
+    /// Internal (not private) for that reason.
+    struct Content: Equatable {
+        let title: String
+        let subtitle: String
+        let statusText: String
+
+        init(snapshot: ProviderSnapshot) {
+            title = snapshot.title
+            subtitle = snapshot.updatedText
+            statusText = ProviderCardPresentation.statusText(for: snapshot)
+        }
+    }
+
+    let snapshot: ProviderSnapshot
+    var showsDisclosureChevron: Bool = false
+
+    var content: Content { Content(snapshot: snapshot) }
+
+    var body: some View {
+        HStack(spacing: 7) {
+            ProviderLogoView(kind: snapshot.logoKind, size: 17, foregroundColor: snapshot.accentColor)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(content.title)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .lineLimit(1)
+                Text(content.subtitle)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+            }
+            .layoutPriority(1)
+
+            Spacer(minLength: 0)
+
+            Text(content.statusText)
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .foregroundColor(ProviderCardPresentation.statusColor(for: snapshot))
+                .lineLimit(1)
+
+            if showsDisclosureChevron {
+                CardDisclosureChevron()
+            }
+        }
+    }
+}

--- a/MeterBar/Views/Components/ReadinessComponents.swift
+++ b/MeterBar/Views/Components/ReadinessComponents.swift
@@ -95,7 +95,7 @@ struct ReadinessProviderCard: View {
   }
 
   var body: some View {
-    DashboardTile(padding: compact ? 11 : 14) {
+    DashboardTile(padding: compact ? .popover : .standard) {
       VStack(alignment: .leading, spacing: compact ? 8 : 10) {
         HStack(spacing: 8) {
           ProviderLogoView(

--- a/MeterBar/Views/Components/ResetCountdowns.swift
+++ b/MeterBar/Views/Components/ResetCountdowns.swift
@@ -264,6 +264,11 @@ struct BlockingLimitResetCounter: View {
         return exhaustedCount > 1 ? "Limits exhausted" : "Limit exhausted"
     }
 
+    /// Returned whenever no reset instant is known. Callers that can omit the
+    /// countdown entirely compare against this rather than re-deriving the
+    /// "is there anything to count down to?" test from the window.
+    static let unavailableCounterText = "Reset time unavailable"
+
     static func counterText(
         for window: ResetCountdownWindow?,
         now: Date,
@@ -273,7 +278,7 @@ struct BlockingLimitResetCounter: View {
     ) -> String {
         guard let window,
               let countdown = window.limit.resetCountdownText(now: now) else {
-            return "Reset time unavailable"
+            return unavailableCounterText
         }
 
         if countdown == "now" {
@@ -284,7 +289,7 @@ struct BlockingLimitResetCounter: View {
         case .countdown:
             return "in \(countdown)"
         case .clock:
-            guard let resetTime = window.limit.resetTime else { return "Reset time unavailable" }
+            guard let resetTime = window.limit.resetTime else { return unavailableCounterText }
             return "at \(ResetCountdownLabel.formattedClockTime(resetTime, locale: locale, timeZone: timeZone))"
         }
     }

--- a/MeterBar/Views/Components/SettingsComponents.swift
+++ b/MeterBar/Views/Components/SettingsComponents.swift
@@ -94,7 +94,7 @@ struct SettingsPanelSection<Content: View>: View {
             .font(.subheadline)
             .fontWeight(.semibold)
 
-            DashboardTile(padding: 12) {
+            DashboardTile(padding: .popover) {
                 VStack(alignment: .leading, spacing: 10) {
                     content
                 }

--- a/MeterBar/Views/DashboardCard.swift
+++ b/MeterBar/Views/DashboardCard.swift
@@ -4,16 +4,19 @@ import SwiftUI
 
 // Shared dashboard chrome extracted from UsageDashboardView.swift (R8 split). Pure move.
 
+/// The one card shell in the app. `padding` takes a named surface rather than a
+/// number so two cards on the same surface cannot drift apart — see
+/// `MeterBarTheme.CardPadding`.
 struct DashboardTile<Content: View>: View {
   let cornerRadius: CGFloat
-  let padding: CGFloat
+  let padding: MeterBarTheme.CardPadding
   let minHeight: CGFloat?
   let alignment: Alignment
   @ViewBuilder let content: Content
 
   init(
     cornerRadius: CGFloat = MeterBarTheme.Radius.card,
-    padding: CGFloat = MeterBarTheme.Spacing.lg,
+    padding: MeterBarTheme.CardPadding = .standard,
     minHeight: CGFloat? = nil,
     alignment: Alignment = .topLeading,
     @ViewBuilder content: () -> Content
@@ -27,7 +30,7 @@ struct DashboardTile<Content: View>: View {
 
   var body: some View {
     content
-      .padding(padding)
+      .padding(padding.value)
       .frame(maxWidth: .infinity, minHeight: minHeight, alignment: alignment)
       .meterBarCardSurface(cornerRadius: cornerRadius)
   }

--- a/MeterBar/Views/DashboardCostsSection.swift
+++ b/MeterBar/Views/DashboardCostsSection.swift
@@ -34,17 +34,26 @@ struct DashboardCostsSection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            CostOverviewStatusCard(
-                summary: summary,
-                isScanning: costTracker.isScanning,
-                isRefreshingMissingDays: costTracker.isRefreshingMissingDays,
-                formattedTokens: UsageFormat.tokens(summary?.totalTokens ?? 0)
-            )
+            // The two headline figures answer the same question over different
+            // windows, so they read as a pair. `maxHeight: .infinity` on both,
+            // with the row fixed to its intrinsic height, stretches the shorter
+            // card to the taller one instead of leaving it ending mid-air.
+            HStack(alignment: .top, spacing: MeterBarTheme.Spacing.sm) {
+                CostOverviewStatusCard(
+                    summary: summary,
+                    isScanning: costTracker.isScanning,
+                    isRefreshingMissingDays: costTracker.isRefreshingMissingDays,
+                    formattedTokens: UsageFormat.tokens(summary?.totalTokens ?? 0)
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
-            LifetimeCostSummaryCard(
-                summary: summary?.lifetime,
-                isScanning: costTracker.isRefreshInProgress
-            )
+                LifetimeCostSummaryCard(
+                    summary: summary?.lifetime,
+                    isScanning: costTracker.isRefreshInProgress
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            }
+            .fixedSize(horizontal: false, vertical: true)
 
             costTrendCard
 

--- a/MeterBar/Views/DashboardOverviewSection.swift
+++ b/MeterBar/Views/DashboardOverviewSection.swift
@@ -12,11 +12,25 @@ struct DashboardOverviewSection: View {
     let costSummary: CostSummary?
     let onSelectProvider: (ProviderSnapshot.ID) -> Void
 
-    private var gridColumns: [GridItem] {
-        Array(
-            repeating: GridItem(.flexible(minimum: 320), spacing: 12, alignment: .top),
-            count: 2
-        )
+    private static let masonryColumnCount = 2
+
+    /// Deals items round-robin across `columnCount` independent columns.
+    ///
+    /// `LazyVGrid` locks every card in a row to the tallest card in that row, so
+    /// a provider with two quota windows left a block of dead space beside a
+    /// provider with four. Columns that flow on their own pack tight instead.
+    /// Round-robin keeps reading order running left-to-right across each row
+    /// and keeps the columns balanced to within one card.
+    ///
+    /// Internal (not private) so the ordering and balance can be unit-tested
+    /// without hosting the page.
+    nonisolated static func masonryColumns<Element>(_ items: [Element], columnCount: Int) -> [[Element]] {
+        let count = max(1, columnCount)
+        var columns = [[Element]](repeating: [], count: count)
+        for (index, item) in items.enumerated() {
+            columns[index % count].append(item)
+        }
+        return columns
     }
 
     var body: some View {
@@ -29,14 +43,21 @@ struct DashboardOverviewSection: View {
                 formattedTokens: UsageFormat.tokens(costSummary?.totalTokens ?? 0)
             )
 
-            LazyVGrid(columns: gridColumns, alignment: .leading, spacing: 12) {
-                ForEach(snapshots) { snapshot in
-                    // Same shared provider card as the popover and the Limits
-                    // page; tapping it jumps to that provider in Limits.
-                    ProviderStatusCard(
-                        snapshot: snapshot,
-                        onSelect: { onSelectProvider(snapshot.id) }
-                    )
+            HStack(alignment: .top, spacing: MeterBarTheme.Spacing.sm) {
+                let columns = Self.masonryColumns(snapshots, columnCount: Self.masonryColumnCount)
+                ForEach(Array(columns.enumerated()), id: \.offset) { _, column in
+                    VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.sm) {
+                        ForEach(column) { snapshot in
+                            // Same shared provider card as the popover and the
+                            // Limits page; tapping it jumps to that provider in
+                            // Limits.
+                            ProviderStatusCard(
+                                snapshot: snapshot,
+                                onSelect: { onSelectProvider(snapshot.id) }
+                            )
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
                 }
             }
             .frame(maxWidth: .infinity)
@@ -51,14 +72,15 @@ private struct OverviewSummaryStrip: View {
     let estimatedCost: String?
     let formattedTokens: String
 
-    private let columns = [
-        GridItem(.flexible(minimum: 180), spacing: 12),
-        GridItem(.flexible(minimum: 180), spacing: 12),
-        GridItem(.flexible(minimum: 180), spacing: 12)
-    ]
+    // Same gutter as the provider masonry below it, so the page reads as one
+    // grid rather than two with different spacing.
+    private let columns = Array(
+        repeating: GridItem(.flexible(minimum: 180), spacing: MeterBarTheme.Spacing.sm),
+        count: 3
+    )
 
     var body: some View {
-        LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: MeterBarTheme.Spacing.sm) {
             TimelineView(
                 .periodic(
                     from: ResetCountdownSchedule.anchor,

--- a/MeterBar/Views/DashboardStatusSection.swift
+++ b/MeterBar/Views/DashboardStatusSection.swift
@@ -27,6 +27,19 @@ struct DashboardStatusSection: View {
         return nil
     }
 
+    /// Title for the refresh control. A sweep takes seconds, so the button says
+    /// what it is doing rather than leaving a greyed-out label as the only sign
+    /// the press registered.
+    static func refreshButtonTitle(isRefreshing: Bool) -> String {
+        isRefreshing ? "Refreshing..." : "Refresh"
+    }
+
+    /// Tooltip for the same control, matching `UsageDashboardView`'s toolbar
+    /// refresh, which already swaps its help text with the spinner.
+    static func refreshButtonHelp(isRefreshing: Bool) -> String {
+        isRefreshing ? "Refreshing provider status pages" : "Refresh every provider status page"
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             DashboardCard(title: "Provider Status Pages", trailing: statusPagesSummary) {
@@ -40,10 +53,20 @@ struct DashboardStatusSection: View {
                     Button {
                         Task { await providerStatusMonitor.refreshAll() }
                     } label: {
-                        Label("Refresh Status", systemImage: "arrow.clockwise")
+                        HStack(spacing: MeterBarTheme.Spacing.xs) {
+                            // The shared spinner/glyph swap the dashboard toolbar
+                            // already uses, so the button reports the sweep
+                            // itself instead of only greying out.
+                            RefreshingIcon(isRefreshing: providerStatusMonitor.isRefreshing)
+                            Text(Self.refreshButtonTitle(isRefreshing: providerStatusMonitor.isRefreshing))
+                        }
+                        .fixedSize(horizontal: true, vertical: false)
                     }
-                    .buttonStyle(.glass)
+                    // `.bordered` matches the neighbouring Diagnostics actions;
+                    // `.glass` read as plain text rather than a control.
+                    .buttonStyle(.bordered)
                     .controlSize(.small)
+                    .help(Self.refreshButtonHelp(isRefreshing: providerStatusMonitor.isRefreshing))
                     .disabled(providerStatusMonitor.isRefreshing)
                 }
             }

--- a/MeterBar/Views/MenuBarDetailPanel.swift
+++ b/MeterBar/Views/MenuBarDetailPanel.swift
@@ -238,16 +238,17 @@ struct MenuBarProviderDetailContent: View {
     snapshot.detailLimits
   }
 
-  private var quotaWindowHeading: String {
-    detailLimits.count == 1 ? "Quota Window" : "Quota Windows"
+  /// The identity row this panel shows, exposed so it can be asserted equal to
+  /// the card's.
+  var headerContent: ProviderCardHeader.Content {
+    ProviderCardHeader.Content(snapshot: snapshot)
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 0) {
-      header
-        .padding(.bottom, MeterBarTheme.Spacing.md)
-
-      Divider()
+    // Spacing, not a divider: the panel is the same card the pointer is resting
+    // on, only wider, so it must not sprout chrome the card never had.
+    VStack(alignment: .leading, spacing: 10) {
+      ProviderCardHeader(snapshot: snapshot)
 
       ViewThatFits(in: .vertical) {
         detailRows
@@ -259,7 +260,9 @@ struct MenuBarProviderDetailContent: View {
         .scrollContentBackground(.hidden)
       }
     }
-    .padding(MeterBarTheme.Spacing.lg)
+    // The same inset as the card this panel expands, so the header and rows sit
+    // at the same distance from the edge in both — a wider card, not a new one.
+    .padding(MeterBarTheme.CardPadding.popover.value)
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     .background(MeterBarTheme.Surface.chrome(radius: MeterBarMenuDetailPanelLayout.cornerRadius))
     .clipShape(
@@ -270,31 +273,26 @@ struct MenuBarProviderDetailContent: View {
     )
   }
 
+  // Same order and same spacings as `ProviderStatusCard.expandedCardBody`: the
+  // reset counter and the limit rows are drawn flat inside this one surface, not
+  // wrapped in cards of their own. The only thing the extra width buys is the
+  // fuller `.detail` row footer.
   private var detailRows: some View {
-    VStack(alignment: .leading, spacing: 12) {
+    VStack(alignment: .leading, spacing: 10) {
       if detailLimits.isEmpty {
         Text(snapshot.emptyDetail)
           .font(.caption)
           .foregroundColor(.secondary)
           .frame(maxWidth: .infinity, alignment: .leading)
           .padding(.vertical, MeterBarTheme.Spacing.md)
+      } else if snapshot.hasExhaustedLimit {
+        BlockingLimitResetCounter(
+          windows: snapshot.resetWindows,
+          accentColor: snapshot.accentColor,
+          format: menuBarDisplayPreferences.resetTimeFormat
+        )
       } else {
-        if snapshot.hasExhaustedLimit {
-          BlockingLimitResetCounter(
-            windows: snapshot.resetWindows,
-            accentColor: snapshot.accentColor,
-            format: menuBarDisplayPreferences.resetTimeFormat
-          )
-          .padding(MeterBarTheme.Spacing.md)
-          .meterBarCardSurface(cornerRadius: MeterBarTheme.detailCardRadius)
-        }
-
-        VStack(alignment: .leading, spacing: 10) {
-          Text(quotaWindowHeading)
-            .font(.caption)
-            .fontWeight(.semibold)
-            .foregroundColor(.secondary)
-
+        VStack(alignment: .leading, spacing: 9) {
           ForEach(detailLimits) { limit in
             LimitRow(limit: limit, accentColor: snapshot.accentColor, density: .detail)
           }
@@ -304,33 +302,12 @@ struct MenuBarProviderDetailContent: View {
       let badges = ProviderStatusBadges(snapshot: snapshot, style: .compact)
       if badges.hasContent {
         badges
-          .padding(.top, MeterBarTheme.Spacing.xxs)
       }
     }
-    .padding(.top, MeterBarTheme.Spacing.md)
     .frame(maxWidth: .infinity, alignment: .topLeading)
-  }
-
-  private var header: some View {
-    HStack(alignment: .center, spacing: 10) {
-      ProviderLogoView(kind: snapshot.logoKind, size: 20, foregroundColor: snapshot.accentColor)
-
-      VStack(alignment: .leading, spacing: 2) {
-        Text(snapshot.title)
-          .font(.headline)
-          .fontWeight(.semibold)
-          .lineLimit(1)
-        Text(snapshot.service.displayName)
-          .font(.caption)
-          .foregroundColor(.secondary)
-          .lineLimit(1)
-      }
-
-      Spacer(minLength: 0)
-    }
   }
 }
 
 // The detail-panel limit row is now `LimitRow(density: .detail)` — see
-// MeterBar/Views/Components/LimitRow.swift. It keeps the per-row card surface
-// that this bespoke `MenuBarProviderLimitDetailRow` used to draw inline.
+// MeterBar/Views/Components/LimitRow.swift, which selects the fuller footer
+// without changing the row's chrome.

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -48,7 +48,10 @@ enum MeterBarTheme {
 
   /// 4pt spacing grid for padding. Raw padding values snap to the nearest step;
   /// exact ties round up. Replaces the ~15 ad-hoc padding literals in the views.
-  enum Spacing {
+  ///
+  /// `nonisolated` because the scale is plain geometry — `CardPadding` and other
+  /// pure helpers derive from it outside the main actor.
+  nonisolated enum Spacing {
     static let xxs: CGFloat = 2
     static let xs: CGFloat = 4
     static let sm: CGFloat = 8
@@ -56,6 +59,36 @@ enum MeterBarTheme {
     static let lg: CGFloat = 16
     static let xl: CGFloat = 20
     static let xxl: CGFloat = 24
+  }
+
+  /// Card padding named by the surface the card sits on, not by number.
+  ///
+  /// Every card in the app is a `DashboardTile`, and its inset used to be a bare
+  /// `CGFloat` — so call sites reached for whatever looked right and the popover
+  /// ended up with cards at 8, 11, 12, 14, and 16. Naming the surface instead of
+  /// the number is what makes "is it all the same?" answerable: two cards on the
+  /// same surface are padded identically by construction, and an off-grid value
+  /// is no longer expressible.
+  ///
+  /// `nonisolated` so the token is readable from tests and from any non-MainActor
+  /// layout math, matching `ServiceSupport` and the other pure helpers.
+  nonisolated enum CardPadding: CaseIterable {
+    /// A tile drawn inside another card (readiness rows, API-usage sub-tiles).
+    /// Tighter so the two insets don't stack into a visible gutter.
+    case nested
+    /// Cards in the menu-bar popover and the settings/detail panes, where width
+    /// is scarce and the shell already contributes its own inset.
+    case popover
+    /// Top-level dashboard cards, which sit directly on the window background.
+    case standard
+
+    var value: CGFloat {
+      switch self {
+      case .nested: return Spacing.sm
+      case .popover: return Spacing.md
+      case .standard: return Spacing.lg
+      }
+    }
   }
 
   // MARK: - Fill / stroke opacity
@@ -292,6 +325,20 @@ extension QuotaBand {
   }
 }
 
+extension UsageStatus {
+  /// The same map as `QuotaBand.color`, reached from the shared widget vocabulary
+  /// rather than from a band. The widget preview used to carry its own private
+  /// `.green`/`.orange`/`.red` switch, so a theme change moved every card and
+  /// left the preview behind.
+  var color: Color {
+    switch self {
+    case .good: return MeterBarTheme.success
+    case .warning: return MeterBarTheme.warning
+    case .critical: return MeterBarTheme.danger
+    }
+  }
+}
+
 struct MeterBarDetailBackground: View {
   @Environment(\.accessibilityReduceTransparency)
   private var reduceTransparency
@@ -338,6 +385,15 @@ extension NSPanel {
 extension View {
   func meterBarCardSurface(cornerRadius: CGFloat = MeterBarTheme.Radius.card) -> some View {
     modifier(MeterBarCardSurfaceModifier(cornerRadius: cornerRadius))
+  }
+
+  /// The MeterBar switch. AppKit's default switch is noticeably taller than the
+  /// segmented controls, steppers, and popup buttons it sits beside in Settings,
+  /// so every switch here is `.small`. Three call sites already did this by hand
+  /// while the rest kept the oversized default — one modifier so they cannot
+  /// drift apart again.
+  func meterBarSwitch() -> some View {
+    toggleStyle(.switch).controlSize(.small)
   }
 
   /// Micro-motion for a numeric `Text` that changes on refresh: the digits roll

--- a/MeterBar/Views/OptimizeInsightsView.swift
+++ b/MeterBar/Views/OptimizeInsightsView.swift
@@ -100,6 +100,29 @@ struct OptimizeInsightsView: View {
     )
   }
 
+  /// Copy for the "Last 7 days" tile.
+  ///
+  /// A quiet week formatted straight through renders as a bare `0` sitting next
+  /// to a caption boasting billions over 30 days, which reads as a broken
+  /// counter rather than as no usage. An empty window says so in words instead,
+  /// and only quotes the 30-day total when that total is the thing making the
+  /// empty week legible.
+  ///
+  /// Internal (not private) so the wording can be asserted without hosting the
+  /// page, matching `DashboardStatusSection.refreshButtonTitle(isRefreshing:)`.
+  static func recentWindowTile(tokens7Day: Int, tokens30Day: Int) -> (value: String, caption: String) {
+    guard tokens7Day > 0 else {
+      guard tokens30Day > 0 else {
+        return (value: "None", caption: "no tokens recorded in the last 30 days")
+      }
+      return (value: "None", caption: "nothing this week — \(UsageFormat.tokens(tokens30Day)) over 30 days")
+    }
+    return (
+      value: UsageFormat.tokens(tokens7Day),
+      caption: "\(UsageFormat.tokens(tokens30Day)) over 30 days"
+    )
+  }
+
   private func kpiGrid(for insights: OptimizationInsights) -> some View {
     LazyVGrid(columns: Self.kpiColumns, alignment: .leading, spacing: 12) {
       DashboardMetricTile(
@@ -122,10 +145,14 @@ struct OptimizeInsightsView: View {
         caption: "context sent vs generated",
         systemImage: "text.append"
       )
+      let recentWindow = Self.recentWindowTile(
+        tokens7Day: insights.tokens7Day,
+        tokens30Day: insights.tokens30Day
+      )
       DashboardMetricTile(
         title: "Last 7 days",
-        value: UsageFormat.tokens(insights.tokens7Day),
-        caption: "\(UsageFormat.tokens(insights.tokens30Day)) over 30 days",
+        value: recentWindow.value,
+        caption: recentWindow.caption,
         systemImage: "calendar"
       )
     }
@@ -256,9 +283,16 @@ struct OptimizeInsightsView: View {
 
   // MARK: - Layout + color helpers
 
-  private static let kpiColumns = Array(
-    repeating: GridItem(.flexible(minimum: 200), spacing: 12, alignment: .top),
-    count: 2
+  /// One row of four. The tiles are headline numbers meant to be read at a
+  /// glance; a 2×2 block doubled the band's height and pushed the token-burn
+  /// chart below the fold. The minimum drops accordingly — four tiles have to
+  /// fit the same width two used to.
+  ///
+  /// Internal (not private) so the single-row requirement can be pinned by a
+  /// test rather than re-litigated the next time a tile is added.
+  static let kpiColumns = Array(
+    repeating: GridItem(.flexible(minimum: 96), spacing: 12, alignment: .top),
+    count: 4
   )
 
   private static func gradeColor(_ score: Int) -> Color {

--- a/MeterBar/Views/PopoverOverviewPanel.swift
+++ b/MeterBar/Views/PopoverOverviewPanel.swift
@@ -145,7 +145,7 @@ struct PopoverOverviewPanel: View {
     }
 
     private var emptyState: some View {
-        DashboardTile(padding: 12) {
+        DashboardTile(padding: .popover) {
             VStack(alignment: .leading, spacing: 9) {
                 HStack(alignment: .center, spacing: 10) {
                     Image(systemName: "clock.fill")
@@ -195,7 +195,7 @@ struct PopoverOverviewPanel: View {
     }
 
     private var firstRunCallout: some View {
-        DashboardTile(padding: 12) {
+        DashboardTile(padding: .popover) {
             VStack(alignment: .leading, spacing: 9) {
                 HStack(spacing: 8) {
                     Image(systemName: "sparkles")

--- a/MeterBar/Views/ProviderStatusCard.swift
+++ b/MeterBar/Views/ProviderStatusCard.swift
@@ -33,12 +33,10 @@ struct ProviderStatusCard: View {
         self.onSelect = onSelect
     }
 
-    private var statusColor: Color {
-        ProviderCardPresentation.statusColor(for: snapshot)
-    }
-
-    private var statusText: String {
-        ProviderCardPresentation.statusText(for: snapshot)
+    /// The identity row this card shows, exposed so the hover detail panel's
+    /// header can be asserted equal to it.
+    var headerContent: ProviderCardHeader.Content {
+        ProviderCardHeader.Content(snapshot: snapshot)
     }
 
     /// Cards without usage data and exhausted cards are terminal summaries. A
@@ -95,16 +93,8 @@ struct ProviderStatusCard: View {
         }
     }
 
-    /// Chevron shown only when the card opens a detail panel, so "clickable" is
-    /// visible instead of relying on an accessibilityHint alone.
-    @ViewBuilder private var disclosureChevron: some View {
-        if allowsDetailNavigation {
-            CardDisclosureChevron()
-        }
-    }
-
     private var cardContent: some View {
-        DashboardTile(padding: 11) {
+        DashboardTile(padding: .popover) {
             cardBody
         }
         .contentShape(RoundedRectangle(cornerRadius: MeterBarTheme.Radius.card, style: .continuous))
@@ -179,26 +169,10 @@ struct ProviderStatusCard: View {
 
     private var expandedCardBody: some View {
         VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 7) {
-                ProviderLogoView(kind: snapshot.logoKind, size: 17, foregroundColor: snapshot.accentColor)
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(snapshot.title)
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                        .lineLimit(1)
-                    Text(snapshot.updatedText)
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-                }
-                Spacer(minLength: 0)
-                Text(statusText)
-                    .font(.caption2)
-                    .fontWeight(.semibold)
-                    .foregroundColor(statusColor)
-
-                disclosureChevron
-            }
+            // The chevron rides along only when the card opens a detail panel,
+            // so "clickable" is visible instead of relying on the
+            // accessibilityHint alone.
+            ProviderCardHeader(snapshot: snapshot, showsDisclosureChevron: allowsDetailNavigation)
 
             if snapshot.hasExhaustedLimit {
                 BlockingLimitResetCounter(

--- a/MeterBar/Views/ProviderStatusViews.swift
+++ b/MeterBar/Views/ProviderStatusViews.swift
@@ -56,7 +56,7 @@ struct ProviderStatusTable: View {
     private var reduceMotion
 
     var body: some View {
-        DashboardTile(padding: 8) {
+        DashboardTile(padding: .nested) {
             VStack(spacing: 0) {
                 ForEach(Array(ServiceType.allCases.enumerated()), id: \.element) { index, service in
                     if index > 0 {

--- a/MeterBar/Views/SessionWakeMenuControl.swift
+++ b/MeterBar/Views/SessionWakeMenuControl.swift
@@ -32,7 +32,7 @@ struct SessionWakeMenuControl: View {
             // text above is folded in as the accessibility value.
             Toggle("Session Wake", isOn: watcherBinding)
                 .labelsHidden()
-                .toggleStyle(.switch)
+                .meterBarSwitch()
                 .accessibilityValue(label.title)
                 // The one-time first-run confirmation happens in Settings, so
                 // the menu toggle is a quick kill-switch once enabled there.

--- a/MeterBar/Views/SessionWakeSettingsView.swift
+++ b/MeterBar/Views/SessionWakeSettingsView.swift
@@ -71,7 +71,7 @@ struct SessionWakeSettingsView: View {
             ) {
                 Toggle("Session Wake", isOn: onBinding)
                     .labelsHidden()
-                    .toggleStyle(.switch)
+                    .meterBarSwitch()
                     .disabled(!store.canTurnOn && !store.isOn)
             }
 
@@ -225,7 +225,7 @@ struct SessionWakeSettingsView: View {
                 ) {
                     Toggle("Acknowledge risk", isOn: binding(store.bypassAcknowledged, store.setBypassAcknowledged))
                         .labelsHidden()
-                        .toggleStyle(.switch)
+                        .meterBarSwitch()
                 }
             }
         }
@@ -239,7 +239,7 @@ struct SessionWakeSettingsView: View {
             ) {
                 Toggle("Notify when a run completes", isOn: $store.notifyOnCompletion)
                     .labelsHidden()
-                    .toggleStyle(.switch)
+                    .meterBarSwitch()
             }
         }
     }

--- a/MeterBar/Views/Settings/GeneralSettingsView.swift
+++ b/MeterBar/Views/Settings/GeneralSettingsView.swift
@@ -250,7 +250,7 @@ struct GeneralSettingsView: View {
                     set: { menuBarDisplayPreferences.setShowsExhaustedResetCountdown($0) }
                 ))
                 .labelsHidden()
-                .toggleStyle(.switch)
+                .meterBarSwitch()
                 .disabled(menuBarDisplayPreferences.labelMetric == .iconOnly)
             }
 
@@ -263,7 +263,7 @@ struct GeneralSettingsView: View {
                     set: { menuBarDisplayPreferences.setHighContrast($0) }
                 ))
                 .labelsHidden()
-                .toggleStyle(.switch)
+                .meterBarSwitch()
             }
 
             SettingsRowView(
@@ -333,7 +333,7 @@ struct GeneralSettingsView: View {
                         }
                     ))
                     .labelsHidden()
-                    .toggleStyle(.switch)
+                    .meterBarSwitch()
                     // A disabled account can still be turned *off*: it may have
                     // been selected while enabled, and locking the toggle would
                     // strand it holding one of the four slots forever.
@@ -386,7 +386,7 @@ struct GeneralSettingsView: View {
                     set: { notificationPreferences.setEnabled($0) }
                 ))
                 .labelsHidden()
-                .toggleStyle(.switch)
+                .meterBarSwitch()
             }
 
             if notificationPreferences.isEnabled {
@@ -438,7 +438,7 @@ struct GeneralSettingsView: View {
                     set: { launchAtLogin.setEnabled($0) }
                 ))
                 .labelsHidden()
-                .toggleStyle(.switch)
+                .meterBarSwitch()
             }
 
             if let error = launchAtLogin.lastError {
@@ -454,7 +454,7 @@ struct GeneralSettingsView: View {
                     set: { dockVisibility.setShowInDock($0) }
                 ))
                 .labelsHidden()
-                .toggleStyle(.switch)
+                .meterBarSwitch()
             }
 
             SettingsDivider()
@@ -487,7 +487,7 @@ struct GeneralSettingsView: View {
                     set: { softwareUpdates.setAutomaticallyChecksForUpdates($0) }
                 ))
                 .labelsHidden()
-                .toggleStyle(.switch)
+                .meterBarSwitch()
                 .disabled(softwareUpdates.configurationError != nil)
             }
 

--- a/MeterBar/Views/Settings/ProviderAccountProfileRow.swift
+++ b/MeterBar/Views/Settings/ProviderAccountProfileRow.swift
@@ -260,8 +260,7 @@ struct ProviderAccountProfileRow: View {
                 set: onEnabledChange
             ))
             .labelsHidden()
-            .toggleStyle(.switch)
-            .controlSize(.small)
+            .meterBarSwitch()
             .disabled(isEnabled && !canDisable)
             .accessibilityLabel("Track \(accountName)")
             .help(enablementHelp)

--- a/MeterBar/Views/Settings/ProviderCatalogSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderCatalogSettingsView.swift
@@ -111,8 +111,7 @@ struct ProviderCatalogSettingsView: View {
 
             Toggle("", isOn: trackedBinding(for: service))
                 .labelsHidden()
-                .toggleStyle(.switch)
-                .controlSize(.small)
+                .meterBarSwitch()
                 .accessibilityLabel("Track \(service.displayName)")
 
             // Only tracked providers have a sidebar row, so only they can be

--- a/MeterBar/Views/Settings/ProviderSettingsFacts.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsFacts.swift
@@ -73,6 +73,16 @@ struct ProviderSettingsFacts {
         }
     }
 
+    /// The Overview error notice. When the failure is one MeterBar authored, it
+    /// also knows the step that clears it — and the notice is the only surface
+    /// with room to say it, so the recovery rides along instead of leaving the
+    /// user with a diagnosis and no action.
+    var noticeText: String? {
+        guard let errorText else { return nil }
+        guard let failure = ClaudeCodeParseFailure(message: errorText) else { return errorText }
+        return "\(failure.message). \(failure.recovery)"
+    }
+
     /// One-word connection/health status shown in the Overview "Status" row.
     var statusText: String {
         guard isEnabled else {

--- a/MeterBar/Views/Settings/ProviderSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsView.swift
@@ -174,7 +174,7 @@ struct ProviderSettingsView: View {
     }
 
     private func providerHeader(for service: ServiceType, facts: ProviderSettingsFacts) -> some View {
-        DashboardTile(padding: 12) {
+        DashboardTile(padding: .popover) {
             HStack(alignment: .center, spacing: 12) {
                 ProviderLogoView(
                     kind: .forService(service),
@@ -206,8 +206,7 @@ struct ProviderSettingsView: View {
 
                 Toggle("", isOn: providerEnabledBinding(for: service))
                     .labelsHidden()
-                    .toggleStyle(.switch)
-                    .controlSize(.small)
+                    .meterBarSwitch()
             }
         }
     }
@@ -226,8 +225,8 @@ struct ProviderSettingsView: View {
                 SettingsInfoRow(label: "Plan", value: plan)
             }
 
-            if let error = facts.errorText {
-                SettingsNotice(text: error, color: MeterBarTheme.warning)
+            if let notice = facts.noticeText {
+                SettingsNotice(text: notice, color: MeterBarTheme.warning)
             }
         }
     }
@@ -427,7 +426,7 @@ struct ProviderSettingsView: View {
                     }
                 ))
                 .labelsHidden()
-                .toggleStyle(.switch)
+                .meterBarSwitch()
             }
 
             SettingsDivider()

--- a/MeterBar/Views/Settings/QuotaEventSettingsView.swift
+++ b/MeterBar/Views/Settings/QuotaEventSettingsView.swift
@@ -50,7 +50,7 @@ struct QuotaEventSettingsView: View {
                     set: { store.setQuotaEventEnabled($0, for: event) }
                 ))
                 .labelsHidden()
-                .toggleStyle(.switch)
+                .meterBarSwitch()
             }
         }
     }
@@ -66,7 +66,7 @@ struct QuotaEventSettingsView: View {
                     set: { store.setProviderEnabled($0, for: provider) }
                 ))
                 .labelsHidden()
-                .toggleStyle(.switch)
+                .meterBarSwitch()
             }
         }
     }
@@ -82,7 +82,7 @@ struct QuotaEventSettingsView: View {
                     set: { store.setAccountEnabled($0, for: account.selection) }
                 ))
                 .labelsHidden()
-                .toggleStyle(.switch)
+                .meterBarSwitch()
             }
         }
     }
@@ -97,7 +97,7 @@ struct QuotaEventSettingsView: View {
                 set: { store.setLocalDeliveryEnabled($0) }
             ))
             .labelsHidden()
-            .toggleStyle(.switch)
+            .meterBarSwitch()
             .disabled(!store.configuration.localIsConfigured)
         }
 
@@ -169,7 +169,7 @@ struct QuotaEventSettingsView: View {
                 set: { store.setWebhookDeliveryEnabled($0) }
             ))
             .labelsHidden()
-            .toggleStyle(.switch)
+            .meterBarSwitch()
             .disabled(store.configuration.validatedWebhookURL == nil)
         }
 
@@ -208,7 +208,7 @@ struct QuotaEventSettingsView: View {
                     set: { store.setWakeEventEnabled($0, for: event) }
                 ))
                 .labelsHidden()
-                .toggleStyle(.switch)
+                .meterBarSwitch()
                 .disabled(!store.configuration.localIsConfigured)
             }
         }

--- a/MeterBar/Views/Settings/WidgetSettingsView.swift
+++ b/MeterBar/Views/Settings/WidgetSettingsView.swift
@@ -254,7 +254,7 @@ struct WidgetSettingsView: View {
             ) {
                 Toggle("Show all enabled", isOn: selectAllBinding)
                     .labelsHidden()
-                    .toggleStyle(.switch)
+                    .meterBarSwitch()
                     .disabled(accountOptions.isEmpty)
             }
 
@@ -279,7 +279,7 @@ struct WidgetSettingsView: View {
                                 isOn: accountSelectionBinding(for: option.id)
                             )
                             .labelsHidden()
-                            .toggleStyle(.switch)
+                            .meterBarSwitch()
                         }
                     }
                 }
@@ -319,7 +319,7 @@ struct WidgetSettingsView: View {
                         isOn: quotaWindowBinding(for: window)
                     )
                     .labelsHidden()
-                    .toggleStyle(.switch)
+                    .meterBarSwitch()
                 }
             }
 
@@ -327,13 +327,13 @@ struct WidgetSettingsView: View {
             SettingsRowView(title: "Reset times") {
                 Toggle("Reset times", isOn: showsResetTimeBinding)
                     .labelsHidden()
-                    .toggleStyle(.switch)
+                    .meterBarSwitch()
             }
 
             SettingsRowView(title: "Data freshness") {
                 Toggle("Data freshness", isOn: showsFreshnessBinding)
                     .labelsHidden()
-                    .toggleStyle(.switch)
+                    .meterBarSwitch()
             }
 
             SettingsRowView(title: "Account order") {
@@ -575,13 +575,27 @@ struct WidgetSettingsPreviewGallery: View {
     }
 }
 
+/// A scale drawing of the widget, not a second design of it.
+///
+/// This preview used to be a third hand-rolled copy of the widget row, drawn at
+/// its own 7/9pt sizes with an SF Symbol where the widget ships a logo — so it
+/// showed the user a layout the widget did not draw. Every number and every
+/// arrangement decision now comes from `WidgetGlance`, the same vocabulary the
+/// extension reads.
 struct WidgetSettingsPreviewSurface: View {
     let family: WidgetPresentationFamily
     let presentation: WidgetPresentation
     let appearance: WidgetSettingsPreviewAppearance
 
+    /// The sizes the widget draws this family at.
+    var metrics: WidgetGlanceMetrics { WidgetGlance.metrics(for: family) }
+
+    /// The arrangement the widget picks for this family — hero on small, stacked
+    /// rows everywhere else.
+    var layout: WidgetGlanceLayout { WidgetGlance.layout(for: presentation, family: family) }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: family.isLarge ? 8 : 5) {
+        VStack(alignment: .leading, spacing: metrics.stackSpacing) {
             if let emptyState = presentation.emptyState {
                 Spacer()
                 Image(systemName: emptyState == .noSelection ? "slider.horizontal.3" : "exclamationmark.triangle")
@@ -593,21 +607,29 @@ struct WidgetSettingsPreviewSurface: View {
                     .foregroundStyle(.secondary)
                 Spacer()
             } else {
-                ForEach(presentation.rows) { row in
-                    WidgetSettingsPreviewRow(row: row, compact: family.isSmall)
+                switch layout {
+                case let .hero(headline, supporting):
+                    WidgetSettingsPreviewRow(row: headline, family: family)
+                    ForEach(supporting) { row in
+                        WidgetSettingsPreviewRailRow(row: row, metrics: metrics)
+                    }
+                case let .rows(rows):
+                    ForEach(rows) { row in
+                        WidgetSettingsPreviewRow(row: row, family: family)
+                    }
                 }
                 if presentation.hiddenRowCount > 0 {
                     Label(
                         "+\(presentation.hiddenRowCount) more",
                         systemImage: "ellipsis.circle"
                     )
-                    .font(.caption2)
+                    .font(.system(size: metrics.captionSize))
                     .foregroundStyle(.secondary)
                 }
                 Spacer(minLength: 0)
             }
         }
-        .padding(family.isSmall ? 10 : 12)
+        .padding(metrics.contentPadding)
         .frame(
             width: family.previewSize.width,
             height: family.previewSize.height,
@@ -626,91 +648,148 @@ struct WidgetSettingsPreviewSurface: View {
     }
 }
 
+/// One provider row. Small stacks the number under the identity line so it can
+/// take the tile; the wider families keep it on the same line as the name.
 struct WidgetSettingsPreviewRow: View {
     let row: WidgetPresentationRow
-    let compact: Bool
+    let family: WidgetPresentationFamily
+
+    var metrics: WidgetGlanceMetrics { WidgetGlance.metrics(for: family) }
+
+    private var isHero: Bool { family == .small }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack(spacing: 5) {
-                Image(systemName: row.service.iconName)
-                    .frame(width: compact ? 11 : 14)
-                VStack(alignment: .leading, spacing: 0) {
-                    Text(row.accountName)
-                        .font(compact ? .caption2 : .caption)
-                        .fontWeight(.semibold)
-                        .lineLimit(1)
-                    Text(row.quotaTitle)
-                        .font(.system(size: compact ? 7 : 9))
-                        .foregroundStyle(.secondary)
-                }
-                Spacer(minLength: 3)
-                Text(compact ? row.compactSummaryText : row.summaryText)
-                    .font(.system(size: compact ? 7 : 9))
-                    .foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: metrics.rowSpacing) {
+            HStack(spacing: metrics.rowSpacing * 2) {
+                ProviderLogoView(
+                    kind: .forService(row.service),
+                    size: metrics.iconSize,
+                    foregroundColor: .primary
+                )
+                Text(row.accountName)
+                    .font(.system(size: metrics.titleSize, weight: .medium))
                     .lineLimit(1)
-            }
-
-            if let value = row.progressValue, let total = row.progressTotal {
-                ProgressView(value: value, total: total)
-                    .tint(row.usageStatus.previewColor)
-            }
-
-            if row.resetTime != nil || row.freshnessDate != nil {
-                HStack(spacing: 5) {
-                    if let resetTime = row.resetTime {
-                        Label {
-                            Text(resetTime, style: .relative)
-                        } icon: {
-                            Image(systemName: "arrow.clockwise")
-                        }
-                    }
-                    if let freshnessDate = row.freshnessDate {
-                        Label {
-                            Text(freshnessDate, style: .relative)
-                        } icon: {
-                            Image(systemName: "clock")
-                        }
-                    }
+                Spacer(minLength: metrics.rowSpacing)
+                healthIndicator
+                if !isHero {
+                    summary
                 }
-                .font(.system(size: 7))
-                .foregroundStyle(.secondary)
             }
+
+            if isHero {
+                summary
+            }
+
+            usageBar
+            caption
         }
         .accessibilityElement(children: .combine)
+        .accessibilityLabel(row.accountName)
+        .accessibilityValue("\(row.quotaTitle), \(row.summaryText)")
+    }
+
+    private var summary: some View {
+        Text(row.summaryText)
+            .font(.system(size: metrics.headlineSize, weight: .semibold, design: .rounded))
+            .monospacedDigit()
+            .lineLimit(1)
+            .minimumScaleFactor(isHero ? 0.6 : 0.7)
+    }
+
+    /// Only what the bar's tint cannot say. A healthy row draws nothing here.
+    @ViewBuilder private var healthIndicator: some View {
+        switch row.health {
+        case .healthy:
+            EmptyView()
+        case .stale:
+            Image(systemName: "clock.badge.exclamationmark")
+                .font(.system(size: metrics.captionSize))
+                .foregroundStyle(MeterBarTheme.warning)
+        case .unavailable:
+            Image(systemName: "xmark.circle")
+                .font(.system(size: metrics.captionSize))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    /// A capsule with weight, tinted by status — the widget's bar, not the
+    /// card's hairline `ProgressView`.
+    private var usageBar: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule(style: .continuous)
+                    .fill(.quaternary)
+                let filled = proxy.size.width * fraction
+                if filled > 0 {
+                    Capsule(style: .continuous)
+                        .fill(row.usageStatus?.color ?? Color.secondary)
+                        .frame(width: max(metrics.barHeight, filled))
+                }
+            }
+        }
+        .frame(height: metrics.barHeight)
+        .accessibilityHidden(true)
+    }
+
+    private var fraction: Double {
+        guard let value = row.progressValue, let total = row.progressTotal, total > 0 else { return 0 }
+        return min(max(value / total, 0), 1)
+    }
+
+    private var caption: some View {
+        HStack(spacing: metrics.captionSize / 2) {
+            Text(row.quotaTitle)
+            if let resetTime = row.resetTime {
+                Label {
+                    Text(resetTime, style: .relative)
+                } icon: {
+                    Image(systemName: "arrow.clockwise")
+                }
+            }
+            if let freshnessDate = row.freshnessDate {
+                Label {
+                    Text(freshnessDate, style: .relative)
+                } icon: {
+                    Image(systemName: "clock")
+                }
+            }
+        }
+        .font(.system(size: metrics.captionSize))
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
     }
 }
 
-private extension Optional where Wrapped == UsageStatus {
-    var previewColor: Color {
-        switch self {
-        case .some(.good):
-            return .green
-        case .some(.warning):
-            return .orange
-        case .some(.critical):
-            return .red
-        case .none:
-            return .secondary
+/// What the hero displaced on the small family: one line per account, enough to
+/// know they are fine without competing with the number above.
+struct WidgetSettingsPreviewRailRow: View {
+    let row: WidgetPresentationRow
+    let metrics: WidgetGlanceMetrics
+
+    var body: some View {
+        HStack(spacing: metrics.rowSpacing) {
+            ProviderLogoView(
+                kind: .forService(row.service),
+                size: metrics.captionSize,
+                foregroundColor: .secondary
+            )
+            Text(row.accountName)
+                .font(.system(size: metrics.captionSize))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Spacer(minLength: metrics.rowSpacing)
+            Text(row.compactSummaryText)
+                .font(.system(size: metrics.captionSize, weight: .medium))
+                .monospacedDigit()
+                .foregroundStyle(row.usageStatus?.color ?? .secondary)
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(row.accountName)
+        .accessibilityValue(row.compactSummaryText)
     }
 }
 
 private extension WidgetPresentationFamily {
-    var isLarge: Bool {
-        if case .large = self {
-            return true
-        }
-        return false
-    }
-
-    var isSmall: Bool {
-        if case .small = self {
-            return true
-        }
-        return false
-    }
-
     var settingsTitle: String {
         switch self {
         case .small: return "Small"

--- a/MeterBarTests/ClaudeCodeParseFailureTests.swift
+++ b/MeterBarTests/ClaudeCodeParseFailureTests.swift
@@ -1,0 +1,130 @@
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// Covers the path behind "why 'failed to parse response'?" — the Claude CLI
+/// told MeterBar exactly what went wrong and how to fix it, and every layer
+/// between the parser and Settings threw that sentence away.
+final class ClaudeCodeParseFailureTests: XCTestCase {
+    // MARK: - The closed failure set
+
+    func testMessagesAreDistinctAndRoundTrip() {
+        for failure in ClaudeCodeParseFailure.allCases {
+            XCTAssertEqual(ClaudeCodeParseFailure(message: failure.message), failure)
+            XCTAssertFalse(failure.recovery.isEmpty)
+        }
+        XCTAssertEqual(ClaudeCodeParseFailure.messages.count, ClaudeCodeParseFailure.allCases.count)
+    }
+
+    func testUnknownMessageDoesNotResolve() {
+        XCTAssertNil(ClaudeCodeParseFailure(message: "Failed to parse response"))
+    }
+
+    // MARK: - Parser emits the authored constants
+
+    func testCostSummaryOutputThrowsTheHeadlessFailure() {
+        let output = """
+        Total cost:            $0.0000
+        Total duration (API):  0s
+        Usage by model:
+            claude-opus:  0 input, 0 output
+        """
+
+        XCTAssertThrowsError(try ClaudeCodeCLIUsageParser.parseMetrics(from: output)) { error in
+            guard case let ClaudeCodeCLIUsageError.parsingFailed(message) = error else {
+                return XCTFail("Expected parsingFailed, got \(error)")
+            }
+            XCTAssertEqual(ClaudeCodeParseFailure(message: message), .headlessUsageUnavailable)
+        }
+    }
+
+    func testUnrecognisedOutputThrowsTheNoWindowsFailure() {
+        XCTAssertThrowsError(try ClaudeCodeCLIUsageParser.parseMetrics(from: "No usage data")) { error in
+            guard case let ClaudeCodeCLIUsageError.parsingFailed(message) = error else {
+                return XCTFail("Expected parsingFailed, got \(error)")
+            }
+            XCTAssertEqual(ClaudeCodeParseFailure(message: message), .noUsageWindows)
+        }
+    }
+
+    // MARK: - ServiceError carries the detail
+
+    func testParsingErrorSurfacesItsDetail() {
+        let detail = ClaudeCodeParseFailure.headlessUsageUnavailable.message
+        XCTAssertEqual(ServiceError.parsingError(detail).localizedDescription, detail)
+    }
+
+    func testParsingErrorWithoutDetailKeepsTheGenericMessage() {
+        XCTAssertEqual(ServiceError.parsingError(nil).localizedDescription, "Failed to parse response")
+    }
+
+    // MARK: - Sanitizers pass authored text and drop everything else
+
+    /// The detail is only ever displayable because it is one of a closed set of
+    /// strings MeterBar itself wrote. Anything else may be provider output and
+    /// must collapse to the generic message, exactly as `.apiError` does.
+    func testArbitraryParseDetailIsDiscarded() {
+        let leaked = ServiceSupport.serviceError(from: ServiceError.parsingError("token=sk-ant-secret"))
+        XCTAssertEqual(leaked.localizedDescription, "Failed to parse response")
+    }
+
+    func testAuthoredParseDetailSurvivesSanitising() {
+        let detail = ClaudeCodeParseFailure.headlessUsageUnavailable.message
+        let sanitized = ServiceSupport.serviceError(from: ServiceError.parsingError(detail))
+        XCTAssertEqual(sanitized.localizedDescription, detail)
+    }
+
+    func testReadinessSanitizerKeepsAuthoredDetailOnly() {
+        let detail = ClaudeCodeParseFailure.headlessUsageUnavailable.message
+        XCTAssertEqual(ProviderReadinessInspector.sanitize(.parsingError(detail)), detail)
+        XCTAssertEqual(
+            ProviderReadinessInspector.sanitize(.parsingError("HTTP 500 <body>")),
+            "Could not parse the provider response"
+        )
+        XCTAssertEqual(
+            ProviderReadinessInspector.sanitize(.parsingError(nil)),
+            "Could not parse the provider response"
+        )
+    }
+
+    // MARK: - CLI failure → app state
+
+    func testHeadlessFailureReachesSettingsAsAnActionableMessage() {
+        let error = ClaudeCodeCLIUsageError.parsingFailed(ClaudeCodeParseFailure.headlessUsageUnavailable.message)
+        let mapped = ClaudeCodeCLIFailureMapping.serviceError(from: error)
+
+        XCTAssertEqual(mapped.localizedDescription, ClaudeCodeParseFailure.headlessUsageUnavailable.message)
+        XCTAssertNotEqual(mapped.localizedDescription, "Failed to parse response")
+    }
+
+    func testUnauthoredParseFailureStaysGeneric() {
+        let error = ClaudeCodeCLIUsageError.parsingFailed("unexpected token '<' at line 4")
+        XCTAssertEqual(ClaudeCodeCLIFailureMapping.serviceError(from: error).localizedDescription,
+                       "Failed to parse response")
+    }
+
+    /// A headless CLI cannot render `/usage` at all, so refreshing again will
+    /// keep failing until the user connects OAuth. That is `needsLogin`, not a
+    /// nondescript error the user is invited to retry forever.
+    func testHeadlessFailureAsksForLoginRatherThanRetry() {
+        let error = ClaudeCodeCLIUsageError.parsingFailed(ClaudeCodeParseFailure.headlessUsageUnavailable.message)
+        XCTAssertEqual(ClaudeCodeCLIFailureMapping.authState(from: error), .needsLogin)
+    }
+
+    func testOtherParseFailuresRemainErrors() {
+        let error = ClaudeCodeCLIUsageError.parsingFailed(ClaudeCodeParseFailure.noUsageWindows.message)
+        guard case .error = ClaudeCodeCLIFailureMapping.authState(from: error) else {
+            return XCTFail("Expected .error for a non-headless parse failure")
+        }
+    }
+
+    func testExistingMappingsAreUnchanged() {
+        guard case .notAuthenticated = ClaudeCodeCLIFailureMapping.serviceError(from: ClaudeCodeCLIUsageError.cliNotFound) else {
+            return XCTFail("Expected a missing CLI to keep mapping to .notAuthenticated")
+        }
+        XCTAssertEqual(ClaudeCodeCLIFailureMapping.authState(from: ClaudeCodeCLIUsageError.cliNotFound),
+                       .unavailable)
+        XCTAssertEqual(ClaudeCodeCLIFailureMapping.authState(from: ClaudeCodeCLIUsageError.commandFailed("please login")),
+                       .needsLogin)
+    }
+}

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -590,6 +590,91 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(context.originTotals["Codex CLI"]?.input, 7)
     }
 
+    /// Codex emits the first `token_count` events of a session *before* the
+    /// first `turn_context`, so forward-only attribution orphaned them even
+    /// though the same file names the model seconds later. Measured against the
+    /// 400 most recent live rollouts, that was 100% of the "Unknown model" row.
+    func testScanCodexRolloutsBackfillsUsageEmittedBeforeTheFirstTurnContext() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexSessionMetaLine(timestamp: "2026-06-15T09:00:00Z"),
+            codexUsageLine(timestamp: "2026-06-15T09:00:30Z", input: 100),
+            codexTurnContextLine(timestamp: "2026-06-15T09:01:00Z", model: "gpt-5.6-sol"),
+            codexUsageLine(timestamp: "2026-06-15T09:02:00Z", input: 7)
+        ])
+        let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
+        var context = makeContext(cutoff: cutoff)
+
+        CodexCostScanner.scanRollouts(directory: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.modelTotals["gpt-5.6-sol"]?.input, 107)
+        XCTAssertNil(context.modelTotals["Unknown model"], "the file names the model — nothing is unknown")
+    }
+
+    /// Back-fill reaches backwards only as far as the *first* model the file
+    /// declares. A later switch must not relabel the events that preceded it.
+    func testScanCodexRolloutsBackfillStopsAtTheFirstModel() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexSessionMetaLine(timestamp: "2026-06-15T09:00:00Z"),
+            codexUsageLine(timestamp: "2026-06-15T09:00:30Z", input: 100),
+            codexTurnContextLine(timestamp: "2026-06-15T09:01:00Z", model: "gpt-5.6-sol"),
+            codexUsageLine(timestamp: "2026-06-15T09:02:00Z", input: 7),
+            codexTurnContextLine(timestamp: "2026-06-15T09:03:00Z", model: "gpt-5.6-luna"),
+            codexUsageLine(timestamp: "2026-06-15T09:04:00Z", input: 3)
+        ])
+        let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
+        var context = makeContext(cutoff: cutoff)
+
+        CodexCostScanner.scanRollouts(directory: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.modelTotals["gpt-5.6-sol"]?.input, 107)
+        XCTAssertEqual(context.modelTotals["gpt-5.6-luna"]?.input, 3)
+    }
+
+    /// The pending buffer is per file, like the rollout context itself: a
+    /// sibling's model must not name events the truncated file never explained.
+    func testScanCodexRolloutsDoesNotBackfillAcrossFiles() throws {
+        let root = try makeCodexHome()
+        let dir = root.appendingPathComponent("archived_sessions", isDirectory: true)
+        try writeCodexRollout(in: dir, path: "a.jsonl", lines: [
+            codexUsageLine(timestamp: "2026-06-15T09:02:00Z", conversationID: "conv-a", input: 100)
+        ])
+        try writeCodexRollout(in: dir, path: "b.jsonl", lines: [
+            codexTurnContextLine(timestamp: "2026-06-15T09:04:00Z", model: "gpt-5.6-sol"),
+            codexUsageLine(timestamp: "2026-06-15T09:05:00Z", conversationID: "conv-b", input: 7)
+        ])
+        let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
+        var context = makeContext(cutoff: cutoff)
+
+        CodexCostScanner.scanRollouts(directory: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.modelTotals["Unknown model"]?.input, 100)
+        XCTAssertEqual(context.modelTotals["gpt-5.6-sol"]?.input, 7)
+    }
+
+    /// Back-filled events keep their own timestamps, so the daily rollups the
+    /// charts read must land on each event's day rather than the flush's.
+    func testScanCodexRolloutsBackfillKeepsPerEventDayPlacement() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexUsageLine(timestamp: "2026-06-14T12:00:00Z", input: 100),
+            codexTurnContextLine(timestamp: "2026-06-16T11:00:00Z", model: "gpt-5.6-sol"),
+            codexUsageLine(timestamp: "2026-06-16T12:00:00Z", input: 7)
+        ])
+        let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
+        var context = makeContext(cutoff: cutoff)
+
+        CodexCostScanner.scanRollouts(directory: dir, since: cutoff, context: &context)
+
+        let firstDay = Calendar.current.startOfDay(
+            for: try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-14T12:00:00Z"))
+        )
+        let secondDay = Calendar.current.startOfDay(
+            for: try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-16T12:00:00Z"))
+        )
+        XCTAssertNotEqual(firstDay, secondDay)
+        XCTAssertEqual(context.dailyModelTotals[firstDay]?["gpt-5.6-sol"]?.input, 100)
+        XCTAssertEqual(context.dailyModelTotals[secondDay]?["gpt-5.6-sol"]?.input, 7)
+    }
+
     // MARK: - Codex rollout directories
 
     func testCodexRolloutDirectoriesCoverArchivedAndLiveSessions() {

--- a/MeterBarTests/DashboardSectionSplitTests.swift
+++ b/MeterBarTests/DashboardSectionSplitTests.swift
@@ -165,6 +165,100 @@ final class DashboardSectionSplitTests: XCTestCase {
         )
     }
 
+    /// The refresh control used to be a flat glass label that only greyed out
+    /// while a sweep ran, so the button itself never acknowledged the press.
+    /// The title now carries that state next to the spinner.
+    func testRefreshButtonTitleReportsTheInFlightSweep() {
+        XCTAssertEqual(DashboardStatusSection.refreshButtonTitle(isRefreshing: false), "Refresh")
+        XCTAssertEqual(DashboardStatusSection.refreshButtonTitle(isRefreshing: true), "Refreshing...")
+    }
+
+    /// The card's trailing summary already says "Refreshing..."; the button must
+    /// not be the only thing that changes, but it also must not be silent.
+    func testRefreshButtonHelpTextMatchesTheButtonState() {
+        XCTAssertEqual(
+            DashboardStatusSection.refreshButtonHelp(isRefreshing: false),
+            "Refresh every provider status page"
+        )
+        XCTAssertEqual(
+            DashboardStatusSection.refreshButtonHelp(isRefreshing: true),
+            "Refreshing provider status pages"
+        )
+    }
+
+    // MARK: - Overview masonry
+
+    /// Round-robin keeps left-to-right reading order across a row while the
+    /// columns themselves pack independently, which is the point of the
+    /// masonry: a short card no longer pads itself out to a tall neighbour.
+    func testMasonryColumnsDealCardsAcrossColumnsInReadingOrder() {
+        let columns = DashboardOverviewSection.masonryColumns(Array(0..<5), columnCount: 2)
+
+        XCTAssertEqual(columns, [[0, 2, 4], [1, 3]])
+    }
+
+    /// Column counts never differ by more than one, so no column runs long
+    /// enough to reintroduce the ragged bottom edge.
+    func testMasonryColumnsStayBalancedWithinOneCard() {
+        let columns = DashboardOverviewSection.masonryColumns(Array(0..<7), columnCount: 3)
+
+        let counts = columns.map(\.count)
+        XCTAssertEqual(counts, [3, 2, 2])
+        XCTAssertEqual(counts.reduce(0, +), 7)
+    }
+
+    /// A single provider must still occupy one column's width rather than
+    /// stretching across the page, so empty trailing columns are preserved.
+    func testMasonryColumnsKeepEmptyTrailingColumnsForWidth() {
+        let columns = DashboardOverviewSection.masonryColumns([0], columnCount: 2)
+
+        XCTAssertEqual(columns.count, 2)
+        XCTAssertEqual(columns[0], [0])
+        XCTAssertTrue(columns[1].isEmpty)
+    }
+
+    func testMasonryColumnsClampsNonPositiveColumnCounts() {
+        XCTAssertEqual(DashboardOverviewSection.masonryColumns([1, 2], columnCount: 0), [[1, 2]])
+    }
+
+    // MARK: - Optimize KPI tiles
+
+    /// The four KPI tiles are one glanceable band of headline numbers, not a
+    /// 2×2 block that pushes the token-burn chart below the fold.
+    func testOptimizeKpiTilesSitOnASingleRow() {
+        XCTAssertEqual(OptimizeInsightsView.kpiColumns.count, 4)
+    }
+
+    /// A quiet week rendered as a bare `0` next to a caption boasting billions
+    /// over 30 days reads as a broken counter. An empty window has to say so.
+    func testRecentWindowTileNamesAnEmptyWeekInsteadOfShowingZero() {
+        let empty = OptimizeInsightsView.recentWindowTile(tokens7Day: 0, tokens30Day: 32_400_000_000)
+
+        XCTAssertEqual(empty.value, "None")
+        XCTAssertTrue(
+            empty.caption.contains("over 30 days"),
+            "the 30-day total is the context that makes an empty week legible"
+        )
+        XCTAssertNotEqual(empty.value, UsageFormat.tokens(0))
+    }
+
+    func testRecentWindowTileReportsNoUsageAtAllWhenBothWindowsAreEmpty() {
+        let blank = OptimizeInsightsView.recentWindowTile(tokens7Day: 0, tokens30Day: 0)
+
+        XCTAssertEqual(blank.value, "None")
+        XCTAssertFalse(
+            blank.caption.contains("over 30 days"),
+            "quoting an empty 30-day total explains nothing"
+        )
+    }
+
+    func testRecentWindowTileKeepsTheNormalReadoutWhenThereIsUsage() {
+        let busy = OptimizeInsightsView.recentWindowTile(tokens7Day: 1_200_000, tokens30Day: 9_000_000)
+
+        XCTAssertEqual(busy.value, UsageFormat.tokens(1_200_000))
+        XCTAssertEqual(busy.caption, "\(UsageFormat.tokens(9_000_000)) over 30 days")
+    }
+
     // MARK: - Share card sources
 
     func testEnabledSourceLabelsCoverOnlyTheLogBackedProviders() {

--- a/MeterBarTests/MenuBarDetailPanelLayoutTests.swift
+++ b/MeterBarTests/MenuBarDetailPanelLayoutTests.swift
@@ -1,3 +1,6 @@
+import AppKit
+import MeterBarShared
+import SwiftUI
 import XCTest
 @testable import MeterBar
 
@@ -106,5 +109,100 @@ final class MenuBarDetailPanelLayoutTests: XCTestCase {
         )
 
         XCTAssertEqual(frame.maxY, visibleFrame.maxY - MeterBarMenuDetailPanelLayout.screenPadding)
+    }
+}
+
+/// Guards the hover detail panel against drifting from the popover card it opens
+/// from. The two surfaces hand-rolled separate headers and the panel grew a
+/// divider, a section heading and per-row card surfaces the card never had, so
+/// hovering a card swapped in something that read like a different provider.
+@MainActor
+final class MenuBarProviderDetailParityTests: XCTestCase {
+    private func snapshot(hoursSinceRefresh: Double = 0) -> ProviderSnapshot {
+        let weekly = UsageLimit(
+            used: 40,
+            total: 100,
+            resetTime: Date().addingTimeInterval(3600),
+            windowSeconds: 604_800
+        )
+        return ProviderSnapshot(
+            id: "codex",
+            title: "Codex",
+            service: .codexCli,
+            updatedAt: Date().addingTimeInterval(-hoursSinceRefresh * 3600),
+            limits: [
+                SnapshotLimit(id: "weekly", kind: .weekly, title: "Weekly", usageLimit: weekly)
+            ],
+            emptyDetail: "Waiting for refresh",
+            extraUsage: nil,
+            resetCreditsAvailable: nil,
+            accountID: nil
+        )
+    }
+
+    /// The parity that matters: both surfaces derive their identity row from the
+    /// same component, so neither can quietly start showing a different field.
+    func testDetailPanelHeaderMatchesTheCardHeader() {
+        let snapshot = snapshot()
+
+        XCTAssertEqual(
+            MenuBarProviderDetailContent(snapshot: snapshot).headerContent,
+            ProviderStatusCard(snapshot: snapshot).headerContent
+        )
+    }
+
+    /// The panel used to label itself with the service name, which the card
+    /// already shows as its title. The refresh time is the field that adds
+    /// something.
+    func testHeaderShowsRefreshTimeRatherThanServiceName() {
+        let snapshot = snapshot(hoursSinceRefresh: 2)
+        let content = ProviderCardHeader.Content(snapshot: snapshot)
+
+        XCTAssertEqual(content.title, snapshot.title)
+        XCTAssertEqual(content.subtitle, snapshot.updatedText)
+        XCTAssertNotEqual(content.subtitle, snapshot.service.displayName)
+    }
+
+    /// The panel dropped the status word entirely, so a stale or logged-out
+    /// provider looked healthy the moment the pointer landed on it.
+    func testHeaderCarriesTheSameStatusWordAsTheCard() {
+        let healthy = snapshot()
+        XCTAssertEqual(
+            ProviderCardHeader.Content(snapshot: healthy).statusText,
+            ProviderCardPresentation.statusText(for: healthy)
+        )
+
+        let loginRequired = ProviderSnapshotBuilder.snapshot(
+            title: "shipshitdev",
+            service: .claudeCode,
+            metrics: nil,
+            emptyDetail: "Run claude login"
+        )
+        XCTAssertEqual(
+            ProviderCardHeader.Content(snapshot: loginRequired).statusText,
+            ProviderCardPresentation.statusText(for: loginRequired)
+        )
+    }
+
+    func testDetailPanelRendersAtPanelWidth() {
+        let content = MenuBarProviderDetailContent(snapshot: snapshot())
+        let host = NSHostingView(
+            rootView: content.frame(width: MeterBarMenuDetailPanelLayout.detailWidth)
+        )
+        host.layoutSubtreeIfNeeded()
+        XCTAssertGreaterThan(host.fittingSize.height, 0)
+    }
+
+    func testHeaderRendersWithAndWithoutTheDisclosureChevron() {
+        for showsChevron in [true, false] {
+            let header = ProviderCardHeader(snapshot: snapshot(), showsDisclosureChevron: showsChevron)
+            let host = NSHostingView(rootView: header.frame(width: 320))
+            host.layoutSubtreeIfNeeded()
+            XCTAssertGreaterThan(
+                host.fittingSize.height,
+                0,
+                "ProviderCardHeader(showsDisclosureChevron: \(showsChevron)) should lay out"
+            )
+        }
     }
 }

--- a/MeterBarTests/MeterBarThemeTests.swift
+++ b/MeterBarTests/MeterBarThemeTests.swift
@@ -76,4 +76,54 @@ final class MeterBarThemeTests: XCTestCase {
         XCTAssertEqual(MeterBarTheme.Fill.hairline, 0.18)
         XCTAssertGreaterThan(MeterBarTheme.Fill.hairline, MeterBarTheme.Fill.subtle)
     }
+
+    /// Card padding is picked by surface, not by number. Every step has to land on
+    /// the spacing grid — cards were being built at 11 and 14, a pixel off both
+    /// the grid and each other, which is what made the popover padding look
+    /// inconsistent from card to card.
+    func testCardPaddingStepsSitOnTheSpacingGrid() {
+        XCTAssertEqual(MeterBarTheme.CardPadding.nested.value, MeterBarTheme.Spacing.sm)
+        XCTAssertEqual(MeterBarTheme.CardPadding.popover.value, MeterBarTheme.Spacing.md)
+        XCTAssertEqual(MeterBarTheme.CardPadding.standard.value, MeterBarTheme.Spacing.lg)
+
+        let grid: Set<CGFloat> = [2, 4, 8, 12, 16, 20, 24]
+        for padding in MeterBarTheme.CardPadding.allCases {
+            XCTAssertTrue(grid.contains(padding.value), "\(padding) is off the 4pt spacing grid")
+        }
+    }
+
+    /// A tile nested inside another surface must be tighter than the surface it
+    /// sits in, otherwise the two paddings stack into a visible gutter.
+    func testCardPaddingTightensAsTilesNest() {
+        XCTAssertLessThan(MeterBarTheme.CardPadding.nested.value, MeterBarTheme.CardPadding.popover.value)
+        XCTAssertLessThan(MeterBarTheme.CardPadding.popover.value, MeterBarTheme.CardPadding.standard.value)
+    }
+}
+
+/// `DashboardTile` is the single card shell, so its padding is the one place the
+/// popover and the dashboard can disagree. It takes a named surface rather than a
+/// number specifically so they can't.
+@MainActor
+final class DashboardTilePaddingTests: XCTestCase {
+    func testTileDefaultsToStandardCardPadding() {
+        let tile = DashboardTile { EmptyView() }
+
+        XCTAssertEqual(tile.padding, .standard)
+        XCTAssertEqual(tile.padding.value, MeterBarTheme.Spacing.lg)
+    }
+
+    func testTileRendersAtEverySurfacePadding() {
+        for padding in MeterBarTheme.CardPadding.allCases {
+            let tile = DashboardTile(padding: padding) {
+                Text("Provider")
+            }
+            let host = NSHostingView(rootView: tile.frame(width: 320))
+            host.layoutSubtreeIfNeeded()
+            XCTAssertGreaterThan(
+                host.fittingSize.height,
+                padding.value * 2,
+                "DashboardTile(padding: \(padding)) should lay out taller than its own insets"
+            )
+        }
+    }
 }

--- a/MeterBarTests/ProviderBlockedSummaryPresentationTests.swift
+++ b/MeterBarTests/ProviderBlockedSummaryPresentationTests.swift
@@ -110,4 +110,21 @@ final class ProviderBlockedSummaryPresentationTests: XCTestCase {
         )
         XCTAssertEqual(loggedOut.accessibilityLabel(title: "shipshitdev"), "shipshitdev, Login required")
     }
+
+    /// The dashboard renders this row underneath a card that already names the
+    /// account, so it suppresses the title. The label was still announcing it,
+    /// making VoiceOver say the account name twice in a row while sighted users
+    /// saw it once.
+    func testHiddenTitleIsLeftOutOfTheLabel() {
+        let content = ProviderBlockedSummaryPresentation.content(
+            statusText: "Exhausted",
+            window: window("Weekly", resetIn: 3_660),
+            now: epoch
+        )
+
+        XCTAssertEqual(
+            content.accessibilityLabel(title: nil),
+            "Exhausted, Weekly reset in 1h 1m"
+        )
+    }
 }

--- a/MeterBarTests/ProviderBlockedSummaryPresentationTests.swift
+++ b/MeterBarTests/ProviderBlockedSummaryPresentationTests.swift
@@ -1,0 +1,113 @@
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+final class ProviderBlockedSummaryPresentationTests: XCTestCase {
+    private let epoch = Date(timeIntervalSince1970: 0)
+
+    private func window(_ title: String, resetIn seconds: TimeInterval?, used: Double = 100) -> ResetCountdownWindow {
+        ResetCountdownWindow(
+            id: title,
+            title: title,
+            limit: UsageLimit(used: used, total: 100, resetTime: seconds.map { epoch.addingTimeInterval($0) })
+        )
+    }
+
+    // MARK: - Reset phrase
+
+    func testResolvedWindowProducesOneCountdownPhrase() {
+        let content = ProviderBlockedSummaryPresentation.content(
+            statusText: "Exhausted",
+            window: window("Weekly", resetIn: 3_660),
+            now: epoch
+        )
+
+        XCTAssertEqual(content.statusText, "Exhausted")
+        XCTAssertEqual(content.resetText, "Weekly reset in 1h 1m")
+    }
+
+    func testClockFormatIsHonoured() {
+        let content = ProviderBlockedSummaryPresentation.content(
+            statusText: "Exhausted",
+            window: window("Weekly", resetIn: 90_000),
+            now: epoch,
+            format: .clock,
+            locale: Locale(identifier: "en_GB"),
+            timeZone: TimeZone(secondsFromGMT: 0) ?? .current
+        )
+
+        XCTAssertEqual(content.resetText, "Weekly reset at 01:00")
+    }
+
+    // MARK: - Redundancy suppression
+
+    /// The bug behind "Login required ⏳ Limit exhausted Reset time unavailable":
+    /// with no resolvable window there is no countdown to show, so the row must
+    /// drop the hourglass entirely rather than narrate its own failure.
+    func testUnresolvedWindowDropsTheCountdownEntirely() {
+        let content = ProviderBlockedSummaryPresentation.content(
+            statusText: "Login required",
+            window: nil,
+            now: epoch
+        )
+
+        XCTAssertEqual(content.statusText, "Login required")
+        XCTAssertNil(content.resetText)
+    }
+
+    func testWindowWithoutResetTimeDropsTheCountdown() {
+        let content = ProviderBlockedSummaryPresentation.content(
+            statusText: "Exhausted",
+            window: window("Weekly", resetIn: nil),
+            now: epoch
+        )
+
+        XCTAssertNil(content.resetText)
+    }
+
+    /// An auth notice explains the block better than a stale countdown can, so it
+    /// wins outright — otherwise the row says "logged out" and "resets in 3h" at
+    /// once, which are contradictory instructions.
+    func testAuthNoticeSuppressesTheCountdown() {
+        let content = ProviderBlockedSummaryPresentation.content(
+            statusText: "Login required",
+            window: window("Weekly", resetIn: 3_660),
+            now: epoch,
+            hasAuthNotice: true
+        )
+
+        XCTAssertEqual(content.statusText, "Login required")
+        XCTAssertNil(content.resetText)
+    }
+
+    func testDueNowStillReadsAsACountdown() {
+        let content = ProviderBlockedSummaryPresentation.content(
+            statusText: "Exhausted",
+            window: window("Session", resetIn: 0),
+            now: epoch
+        )
+
+        XCTAssertEqual(content.resetText, "Session reset due now")
+    }
+
+    // MARK: - Accessibility
+
+    func testAccessibilityLabelJoinsOnlyThePartsThatRender() {
+        let blocked = ProviderBlockedSummaryPresentation.content(
+            statusText: "Exhausted",
+            window: window("Weekly", resetIn: 3_660),
+            now: epoch
+        )
+        XCTAssertEqual(
+            blocked.accessibilityLabel(title: "shipshitdev"),
+            "shipshitdev, Exhausted, Weekly reset in 1h 1m"
+        )
+
+        let loggedOut = ProviderBlockedSummaryPresentation.content(
+            statusText: "Login required",
+            window: nil,
+            now: epoch
+        )
+        XCTAssertEqual(loggedOut.accessibilityLabel(title: "shipshitdev"), "shipshitdev, Login required")
+    }
+}

--- a/MeterBarTests/ProviderParseHealthTests.swift
+++ b/MeterBarTests/ProviderParseHealthTests.swift
@@ -28,7 +28,7 @@ final class ProviderParseHealthTests: XCTestCase {
 
         // One decode failure can be a truncated body from a flaky connection;
         // it must not one-shot the provider into "needs attention".
-        store.recordFailure(.claudeCode, error: ServiceError.parsingError, at: now)
+        store.recordFailure(.claudeCode, error: ServiceError.parsingError(nil), at: now)
         var record = store.records[.claudeCode]
         XCTAssertEqual(record?.consecutiveFailures, 1)
         XCTAssertTrue(record?.lastFailureWasShapeMismatch ?? false)
@@ -36,7 +36,7 @@ final class ProviderParseHealthTests: XCTestCase {
 
         // Genuine schema drift fails every refresh; the second consecutive
         // mismatch is the earliest reliable drift signal.
-        store.recordFailure(.claudeCode, error: ServiceError.parsingError, at: now + 1)
+        store.recordFailure(.claudeCode, error: ServiceError.parsingError(nil), at: now + 1)
         record = store.records[.claudeCode]
         XCTAssertTrue(record?.needsAttention(now: now + 1) ?? false)
         XCTAssertEqual(ProviderParseHealthStore.persistedRecords(from: defaults)[.claudeCode], record)
@@ -64,9 +64,9 @@ final class ProviderParseHealthTests: XCTestCase {
         let now = Date(timeIntervalSince1970: 17_000)
         let store = ProviderParseHealthStore(userDefaults: defaults)
 
-        store.recordFailure(.cursor, error: ServiceError.parsingError, at: now)
+        store.recordFailure(.cursor, error: ServiceError.parsingError(nil), at: now)
         store.recordFailure(.cursor, error: ServiceError.apiError("Request timed out"), at: now + 1)
-        store.recordFailure(.cursor, error: ServiceError.parsingError, at: now + 2)
+        store.recordFailure(.cursor, error: ServiceError.parsingError(nil), at: now + 2)
 
         // parse, api, parse: never two consecutive mismatches, and only
         // three total failures reach the ordinary sustained threshold.

--- a/MeterBarTests/ProviderReadinessInspectorTests.swift
+++ b/MeterBarTests/ProviderReadinessInspectorTests.swift
@@ -252,7 +252,7 @@ final class ProviderReadinessInspectorTests: XCTestCase {
 
     func testKnownCasesMapToStableStrings() {
         XCTAssertEqual(ProviderReadinessInspector.sanitize(.notAuthenticated), "Not authenticated")
-        XCTAssertEqual(ProviderReadinessInspector.sanitize(.parsingError), "Could not parse the provider response")
+        XCTAssertEqual(ProviderReadinessInspector.sanitize(.parsingError(nil)), "Could not parse the provider response")
         XCTAssertNil(ProviderReadinessInspector.sanitize(nil))
     }
 

--- a/MeterBarTests/ProviderSettingsFactsTests.swift
+++ b/MeterBarTests/ProviderSettingsFactsTests.swift
@@ -32,6 +32,23 @@ final class ProviderSettingsFactsTests: XCTestCase {
         )
     }
 
+    // MARK: - noticeText
+
+    /// An authored parse failure knows the single step that fixes it, and the
+    /// Overview notice is the only multi-line surface that can say it.
+    func testNoticeAppendsRecoveryForAuthoredParseFailures() {
+        let failure = ClaudeCodeParseFailure.headlessUsageUnavailable
+        XCTAssertEqual(
+            facts(service: .claudeCode, errorText: failure.message).noticeText,
+            "\(failure.message). \(failure.recovery)"
+        )
+    }
+
+    func testNoticeLeavesOtherErrorsUntouched() {
+        XCTAssertEqual(facts(service: .grok, errorText: "HTTP 500").noticeText, "HTTP 500")
+        XCTAssertNil(facts(service: .grok).noticeText)
+    }
+
     // MARK: - sourceText (one branch per service, including Grok)
 
     func testSourceTextCoversEveryService() {

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -300,7 +300,7 @@ final class UsageDataManagerTests: XCTestCase {
         }
         let health = ProviderParseHealthStore(userDefaults: healthDefaults)
         let codex = StubProvider(hasAccess: true, result: .success(MetricsFixtures.codexCli()))
-        let cursor = StubProvider(hasAccess: true, result: .failure(ServiceError.parsingError))
+        let cursor = StubProvider(hasAccess: true, result: .failure(ServiceError.parsingError(nil)))
         let (manager, _) = makeManager(codex: codex, cursor: cursor, parseHealthStore: health)
 
         let report = await manager.refreshAll()
@@ -1462,7 +1462,7 @@ final class UsageDataManagerTests: XCTestCase {
     /// first, so the surfaced reason is stable across runs.
     func testRefreshAllAttributesClaudeFailuresInAccountOrderDespiteConcurrency() async throws {
         XCTAssertNotEqual(
-            ServiceSupport.safeErrorMessage(for: ServiceError.parsingError),
+            ServiceSupport.safeErrorMessage(for: ServiceError.parsingError(nil)),
             ServiceSupport.safeErrorMessage(for: StubError.fetchFailed),
             "fixture guard: the two failures must be distinguishable"
         )
@@ -1474,7 +1474,7 @@ final class UsageDataManagerTests: XCTestCase {
         let work = try XCTUnwrap(accountStore.customAccounts.first)
         let claude = StubClaudeProvider(hasAccess: true, result: .failure(StubError.fetchFailed))
         claude.resultsByAccount = [
-            ClaudeCodeAccount.defaultID: .failure(ServiceError.parsingError),
+            ClaudeCodeAccount.defaultID: .failure(ServiceError.parsingError(nil)),
             work.id: .failure(StubError.fetchFailed)
         ]
         claude.probe = ConcurrencyProbe(expected: 2)
@@ -1493,7 +1493,7 @@ final class UsageDataManagerTests: XCTestCase {
         XCTAssertEqual(report.outcome(for: .claudeCode)?.state, .failed)
         XCTAssertEqual(
             report.outcome(for: .claudeCode)?.reason,
-            ServiceSupport.safeErrorMessage(for: ServiceError.parsingError),
+            ServiceSupport.safeErrorMessage(for: ServiceError.parsingError(nil)),
             "the first enabled account's failure must win regardless of completion order"
         )
     }

--- a/MeterBarTests/WidgetAccessibilityValueTests.swift
+++ b/MeterBarTests/WidgetAccessibilityValueTests.swift
@@ -1,0 +1,137 @@
+import MeterBarShared
+import XCTest
+
+/// `WidgetGlanceRow`, `WidgetGlanceHero`, and `WidgetGlanceRail` each combine
+/// their children into one accessibility element and then set an explicit
+/// value. That explicit value *replaces* whatever `.combine` gathered, so
+/// `WidgetHealthIndicator`'s "Stale usage data" and "Usage unavailable" glyph
+/// labels never reached VoiceOver: a widget showing the stale clock badge read
+/// aloud as a perfectly healthy row. The rail is worse — it drops the glyph
+/// entirely for width, so its spoken value is the *only* place that signal can
+/// live.
+///
+/// Composing the value on the row keeps all three call sites saying the same
+/// sentence, and keeps the phrasing assertable without hosting a widget view
+/// (the extension's views cannot be hosted in this target — see the note in
+/// `WidgetRenderingTests`).
+final class WidgetAccessibilityValueTests: XCTestCase {
+    private let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
+
+    // MARK: - Health phrase
+
+    /// A healthy row's status is already carried by the bar's tint, so it adds
+    /// nothing to speak — the value must not gain a trailing comma for it.
+    func testHealthyStateContributesNoSpokenPhrase() {
+        XCTAssertNil(WidgetDataHealth.healthy.accessibilityDescription)
+    }
+
+    /// These strings are what `WidgetHealthIndicator` labels its glyphs with.
+    /// If the two ever disagree, sighted and VoiceOver users are told different
+    /// things about the same row.
+    func testFlaggedStatesMatchTheIndicatorGlyphLabels() {
+        XCTAssertEqual(WidgetDataHealth.stale.accessibilityDescription, "Stale usage data")
+        XCTAssertEqual(WidgetDataHealth.unavailable.accessibilityDescription, "Usage unavailable")
+    }
+
+    // MARK: - Glance row and hero value
+
+    func testHealthyRowSpeaksQuotaAndSummaryOnly() {
+        let row = plannedRow(lastUpdated: now)
+
+        XCTAssertEqual(row.health, .healthy)
+        XCTAssertEqual(row.accessibilityValueText, "\(row.quotaTitle), \(row.summaryText)")
+    }
+
+    func testStaleRowAppendsTheHealthPhrase() {
+        let row = plannedRow(lastUpdated: now.addingTimeInterval(-24 * 60 * 60))
+
+        XCTAssertEqual(row.health, .stale)
+        XCTAssertEqual(
+            row.accessibilityValueText,
+            "\(row.quotaTitle), \(row.summaryText), Stale usage data"
+        )
+    }
+
+    func testUnavailableRowAppendsTheHealthPhrase() {
+        let row = unavailableRow()
+
+        XCTAssertEqual(row.health, .unavailable)
+        XCTAssertEqual(
+            row.accessibilityValueText,
+            "\(row.quotaTitle), \(row.summaryText), Usage unavailable"
+        )
+    }
+
+    // MARK: - Rail value
+
+    /// The rail trades the health glyph away for width, so a stale entry there
+    /// has no visual signal either — the spoken value has to carry it alone.
+    func testRailValueCarriesTheHealthPhrase() {
+        let row = plannedRow(lastUpdated: now.addingTimeInterval(-24 * 60 * 60))
+
+        XCTAssertEqual(
+            row.compactAccessibilityValueText,
+            "\(row.compactSummaryText), Stale usage data"
+        )
+    }
+
+    /// The rail omits the quota title to stay on one line, so its value must
+    /// stay the bare summary when there is nothing to flag.
+    func testHealthyRailValueStaysTheBareSummary() {
+        let row = plannedRow(lastUpdated: now)
+
+        XCTAssertEqual(row.compactAccessibilityValueText, row.compactSummaryText)
+    }
+
+    // MARK: - Fixtures
+
+    private func plannedRow(
+        lastUpdated: Date,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> WidgetPresentationRow {
+        let presentation = WidgetPresentationPlanner.makePresentation(
+            metrics: [
+                .claudeCode: UsageMetrics(
+                    service: .claudeCode,
+                    weeklyLimit: UsageLimit(used: 72, total: 100, resetTime: nil),
+                    lastUpdated: lastUpdated
+                )
+            ],
+            accountMetrics: [],
+            preferences: .defaults,
+            family: .medium,
+            now: now
+        )
+
+        guard let row = presentation.rows.first else {
+            XCTFail("fixture must plan at least one row", file: file, line: line)
+            preconditionFailure("fixture must plan at least one row")
+        }
+        return row
+    }
+
+    /// An explicit selection can outlive its metrics snapshot; the planner keeps
+    /// the row and marks it unavailable rather than dropping the selection.
+    private func unavailableRow(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> WidgetPresentationRow {
+        var preferences = WidgetPreferences.defaults
+        preferences.accountSelection = .explicit([.provider(.claudeCode)])
+
+        let presentation = WidgetPresentationPlanner.makePresentation(
+            metrics: [:],
+            accountMetrics: [],
+            preferences: preferences,
+            family: .medium,
+            now: now
+        )
+
+        guard let row = presentation.rows.first else {
+            XCTFail("fixture must plan an unavailable row", file: file, line: line)
+            preconditionFailure("fixture must plan an unavailable row")
+        }
+        return row
+    }
+}

--- a/MeterBarTests/WidgetGlanceTests.swift
+++ b/MeterBarTests/WidgetGlanceTests.swift
@@ -1,0 +1,203 @@
+import MeterBarShared
+import XCTest
+
+/// The widget was drawn as a shrunken popover card: the account name as the
+/// headline, the quota window stacked underneath it, a hairline progress bar and
+/// a footer of chips — all at ad-hoc 7–9pt sizes. A popover card is read at
+/// 30cm with the pointer already on it; a widget is read at arm's length in
+/// under a second. `WidgetGlance` is the widget's own vocabulary, and these
+/// tests pin the properties that make it *not* a card.
+final class WidgetGlanceMetricsTests: XCTestCase {
+    /// The card leads with the account name and treats the percentage as a
+    /// trailing caption. The widget inverts that: the number is the headline and
+    /// everything else supports it.
+    func testTheNumberIsTheLargestTypeInEveryFamily() {
+        for family in WidgetPresentationFamily.allCases {
+            let metrics = WidgetGlance.metrics(for: family)
+            XCTAssertGreaterThan(
+                metrics.headlineSize,
+                metrics.titleSize,
+                "\(family): the usage number must outrank the account name"
+            )
+            XCTAssertGreaterThan(
+                metrics.titleSize,
+                metrics.captionSize,
+                "\(family): the account name must outrank the supporting caption"
+            )
+        }
+    }
+
+    /// The headline has to win by enough to be read at a glance, not by a point.
+    func testTheNumberOutweighsItsSupportingText() {
+        for family in WidgetPresentationFamily.allCases {
+            let metrics = WidgetGlance.metrics(for: family)
+            XCTAssertGreaterThanOrEqual(
+                metrics.headlineSize,
+                metrics.captionSize * 1.5,
+                "\(family): the headline must be at least half again its caption"
+            )
+        }
+    }
+
+    /// The 7pt and 8pt labels the widget shipped with are below the size anything
+    /// on a home screen can be read at. Nothing in the widget goes under 10pt.
+    func testEveryLabelClearsTheLegibilityFloor() {
+        for family in WidgetPresentationFamily.allCases {
+            let metrics = WidgetGlance.metrics(for: family)
+            for (name, size) in [
+                ("headline", metrics.headlineSize),
+                ("title", metrics.titleSize),
+                ("caption", metrics.captionSize),
+            ] {
+                XCTAssertGreaterThanOrEqual(
+                    size,
+                    WidgetGlance.legibilityFloor,
+                    "\(family) \(name) is below the widget legibility floor"
+                )
+            }
+        }
+    }
+
+    /// A default `ProgressView` draws a ~4pt hairline — fine inside a card the
+    /// pointer is resting on, invisible on a home screen. The widget bar is a
+    /// capsule with real weight, and its tint is what carries status, so the card's
+    /// separate status dot is not needed.
+    func testTheBarIsACapsuleWithWeightNotAHairline() {
+        for family in WidgetPresentationFamily.allCases {
+            let metrics = WidgetGlance.metrics(for: family)
+            XCTAssertGreaterThanOrEqual(
+                metrics.barHeight,
+                WidgetGlance.minimumBarHeight,
+                "\(family): the usage bar must be thicker than a default hairline"
+            )
+        }
+    }
+
+    /// The small family is one number, so it gets the biggest one.
+    func testTheSmallFamilyCarriesTheBiggestNumber() {
+        let small = WidgetGlance.metrics(for: .small)
+        XCTAssertGreaterThan(small.headlineSize, WidgetGlance.metrics(for: .medium).headlineSize)
+        XCTAssertGreaterThan(small.headlineSize, WidgetGlance.metrics(for: .large).headlineSize)
+        XCTAssertGreaterThan(small.barHeight, WidgetGlance.metrics(for: .medium).barHeight)
+    }
+
+    /// Spacing and padding come off the same 2pt grid the rest of the widget uses
+    /// so rows in different families still stack to the same rhythm.
+    func testSpacingStepsSitOnTheGrid() {
+        for family in WidgetPresentationFamily.allCases {
+            let metrics = WidgetGlance.metrics(for: family)
+            for (name, step) in [
+                ("rowSpacing", metrics.rowSpacing),
+                ("stackSpacing", metrics.stackSpacing),
+                ("contentPadding", metrics.contentPadding),
+            ] {
+                XCTAssertEqual(
+                    step.truncatingRemainder(dividingBy: 2),
+                    0,
+                    "\(family) \(name) = \(step) is off the 2pt grid"
+                )
+            }
+            XCTAssertGreaterThan(
+                metrics.stackSpacing,
+                metrics.rowSpacing,
+                "\(family): rows must sit further apart than the lines inside one row"
+            )
+        }
+    }
+}
+
+/// The small widget shipped three stacked mini-cards inside 150×150. That is the
+/// popover's list shrunk past the point of being readable — the widget's answer
+/// is one hero number with the rest reduced to a rail.
+final class WidgetGlanceLayoutTests: XCTestCase {
+    private let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
+
+    func testSmallLeadsWithOneHeroAndDemotesTheRest() {
+        let plan = presentation(
+            metrics: [
+                .claudeCode: makeMetrics(.claudeCode, weeklyUsed: 10),
+                .codexCli: makeMetrics(.codexCli, weeklyUsed: 20)
+            ],
+            family: .small
+        )
+        XCTAssertEqual(plan.rows.count, 2, "fixture should plan two rows for the small family")
+
+        guard case let .hero(headline, supporting) = WidgetGlance.layout(for: plan, family: .small) else {
+            return XCTFail("small must lead with a hero, not a stack of cards")
+        }
+
+        XCTAssertEqual(headline.id, plan.rows[0].id, "the hero is the row the planner ranked first")
+        XCTAssertEqual(supporting.map(\.id), Array(plan.rows.dropFirst().map(\.id)))
+    }
+
+    func testMediumAndLargeStackRows() {
+        for family in [WidgetPresentationFamily.medium, .large] {
+            let plan = presentation(
+                metrics: [
+                    .claudeCode: makeMetrics(.claudeCode, weeklyUsed: 10),
+                    .codexCli: makeMetrics(.codexCli, weeklyUsed: 20)
+                ],
+                family: family
+            )
+
+            guard case let .rows(stacked) = WidgetGlance.layout(for: plan, family: family) else {
+                return XCTFail("\(family) has the room for a stack of rows")
+            }
+            XCTAssertEqual(stacked.map(\.id), plan.rows.map(\.id))
+        }
+    }
+
+    /// One selected account is the common case: a hero with nothing under it, not
+    /// a hero plus an empty rail.
+    func testASingleRowIsAHeroWithNoRail() {
+        let plan = presentation(
+            metrics: [.claudeCode: makeMetrics(.claudeCode, weeklyUsed: 10)],
+            family: .small
+        )
+        XCTAssertEqual(plan.rows.count, 1)
+
+        guard case let .hero(headline, supporting) = WidgetGlance.layout(for: plan, family: .small) else {
+            return XCTFail("a single row is still a hero")
+        }
+
+        XCTAssertEqual(headline.id, plan.rows[0].id)
+        XCTAssertTrue(supporting.isEmpty)
+    }
+
+    /// Nothing to show falls back to the row stack so the empty state renders
+    /// through one path in every family.
+    func testNoRowsFallsBackToAnEmptyStack() {
+        for family in WidgetPresentationFamily.allCases {
+            let plan = presentation(metrics: [:], family: family)
+            XCTAssertTrue(plan.rows.isEmpty)
+
+            guard case let .rows(stacked) = WidgetGlance.layout(for: plan, family: family) else {
+                return XCTFail("\(family) with no rows must not claim a hero")
+            }
+            XCTAssertTrue(stacked.isEmpty)
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private func presentation(
+        metrics: [ServiceType: UsageMetrics],
+        family: WidgetPresentationFamily
+    ) -> WidgetPresentation {
+        WidgetPresentationPlanner.makePresentation(
+            metrics: metrics,
+            accountMetrics: [],
+            preferences: .defaults,
+            family: family,
+            now: now
+        )
+    }
+
+    private func makeMetrics(_ service: ServiceType, weeklyUsed: Double) -> UsageMetrics {
+        UsageMetrics(
+            service: service,
+            weeklyLimit: UsageLimit(used: weeklyUsed, total: 100, resetTime: nil),
+            lastUpdated: now
+        )
+    }
+}

--- a/MeterBarTests/WidgetSettingsPreviewParityTests.swift
+++ b/MeterBarTests/WidgetSettingsPreviewParityTests.swift
@@ -1,0 +1,143 @@
+import AppKit
+import MeterBarShared
+@testable import MeterBar
+import SwiftUI
+import XCTest
+
+/// The widget row existed in three hand-rolled copies: `ServiceMiniView` and
+/// `ServiceCompactView` in the extension, and `WidgetSettingsPreviewRow` here in
+/// the app. They disagreed on icon source (asset logo vs SF Symbol), font sizes
+/// (8pt vs 7/9pt), whether a health glyph appeared at all, and how a status
+/// became a color. A settings preview that does not match the widget is worse
+/// than no preview.
+///
+/// The extension's views cannot be hosted in this test target — see the note in
+/// `WidgetRenderingTests` — but the preview's *are* in the app target, so this
+/// pins the preview to the one shared vocabulary both now read from. If the
+/// preview drifts, these fail; if the extension drifts, it stops compiling
+/// against `WidgetGlance`.
+@MainActor
+final class WidgetSettingsPreviewParityTests: XCTestCase {
+    private let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
+
+    // MARK: - One vocabulary
+
+    func testPreviewRowDrawsAtTheWidgetSizes() {
+        for family in WidgetPresentationFamily.allCases {
+            let row = WidgetSettingsPreviewRow(row: firstRow(family: family), family: family)
+            XCTAssertEqual(
+                row.metrics,
+                WidgetGlance.metrics(for: family),
+                "\(family): the preview must draw at the sizes the widget draws at"
+            )
+        }
+    }
+
+    func testPreviewSurfaceUsesTheGlanceContentPadding() {
+        for family in WidgetPresentationFamily.allCases {
+            let surface = WidgetSettingsPreviewSurface(
+                family: family,
+                presentation: presentation(family: family),
+                appearance: .light
+            )
+            XCTAssertEqual(
+                surface.metrics.contentPadding,
+                WidgetGlance.metrics(for: family).contentPadding,
+                "\(family): the preview inset must match the widget's"
+            )
+        }
+    }
+
+    /// The small preview has to show the hero, not three stacked mini rows —
+    /// otherwise it advertises a layout the widget no longer draws.
+    func testSmallPreviewShowsTheHeroLayout() {
+        let surface = WidgetSettingsPreviewSurface(
+            family: .small,
+            presentation: presentation(family: .small),
+            appearance: .light
+        )
+        guard case .hero = surface.layout else {
+            return XCTFail("the small preview must render the widget's hero layout")
+        }
+    }
+
+    func testWiderPreviewsStackRows() {
+        for family in [WidgetPresentationFamily.medium, .large] {
+            let surface = WidgetSettingsPreviewSurface(
+                family: family,
+                presentation: presentation(family: family),
+                appearance: .light
+            )
+            guard case .rows = surface.layout else {
+                return XCTFail("\(family) has room for stacked rows")
+            }
+        }
+    }
+
+    // MARK: - One severity → color map
+
+    /// The preview used to carry a private `UsageStatus` → `Color` switch of its
+    /// own, so a theme change moved every other surface and left the widget
+    /// preview behind. It now reads the same map as `QuotaBand.color`.
+    func testStatusColorComesFromTheSameMapAsEverySurface() {
+        let pairs: [(QuotaBand, UsageStatus)] = [
+            (.healthy, .good),
+            (.tight, .warning),
+            (.critical, .critical),
+            (.exhausted, .critical)
+        ]
+        for (band, status) in pairs {
+            XCTAssertEqual(
+                status.color,
+                band.color,
+                "\(band) must tint the widget preview the same as it tints a card"
+            )
+        }
+    }
+
+    // MARK: - It still draws
+
+    func testEveryPreviewFamilyRenders() {
+        for family in WidgetPresentationFamily.allCases {
+            let host = NSHostingView(
+                rootView: WidgetSettingsPreviewSurface(
+                    family: family,
+                    presentation: presentation(family: family),
+                    appearance: .light
+                )
+            )
+            host.layoutSubtreeIfNeeded()
+            XCTAssertGreaterThan(host.fittingSize.height, 0, "\(family) preview rendered empty")
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private func presentation(family: WidgetPresentationFamily) -> WidgetPresentation {
+        WidgetPresentationPlanner.makePresentation(
+            metrics: [
+                .claudeCode: makeMetrics(.claudeCode, weeklyUsed: 72),
+                .codexCli: makeMetrics(.codexCli, weeklyUsed: 18)
+            ],
+            accountMetrics: [],
+            preferences: .defaults,
+            family: family,
+            now: now
+        )
+    }
+
+    private func firstRow(family: WidgetPresentationFamily) -> WidgetPresentationRow {
+        guard let row = presentation(family: family).rows.first else {
+            preconditionFailure("fixture must plan at least one row")
+        }
+        return row
+    }
+
+    private func makeMetrics(_ service: ServiceType, weeklyUsed: Double) -> UsageMetrics {
+        UsageMetrics(
+            service: service,
+            weeklyLimit: UsageLimit(used: weeklyUsed, total: 100, resetTime: nil),
+            lastUpdated: now
+        )
+    }
+}

--- a/MeterBarWidget/UsageWidget.swift
+++ b/MeterBarWidget/UsageWidget.swift
@@ -110,61 +110,33 @@ struct UsageWidgetEntryView: View {
     }
 }
 
+/// Small is one number. The three stacked mini-cards it used to draw were the
+/// popover's list shrunk past the point of being readable inside 150×150.
 struct SmallWidgetView: View {
     let entry: UsageWidgetEntry
 
     var body: some View {
         let presentation = entry.presentation(for: .small)
-        VStack(alignment: .leading, spacing: 6) {
+        let metrics = WidgetGlance.metrics(for: .small)
+        VStack(alignment: .leading, spacing: metrics.stackSpacing) {
             if let emptyState = presentation.emptyState {
                 WidgetEmptyStateView(state: emptyState, compact: true)
             } else {
-                ForEach(presentation.rows) { row in
-                    ServiceMiniView(row: row)
+                switch WidgetGlance.layout(for: presentation, family: .small) {
+                case let .hero(headline, supporting):
+                    WidgetGlanceHero(row: headline, metrics: metrics)
+                    WidgetGlanceRail(rows: supporting, metrics: metrics)
+                case let .rows(rows):
+                    ForEach(rows) { row in
+                        WidgetGlanceRow(row: row, metrics: metrics)
+                    }
                 }
-                WidgetOverflowView(hiddenRowCount: presentation.hiddenRowCount)
+                WidgetOverflowView(hiddenRowCount: presentation.hiddenRowCount, metrics: metrics)
             }
         }
-        .padding()
+        .padding(metrics.contentPadding)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .containerBackground(.fill.tertiary, for: .widget)
-    }
-}
-
-struct ServiceMiniView: View {
-    let row: WidgetPresentationRow
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack(spacing: 5) {
-                WidgetProviderIcon(service: row.service, size: 13)
-
-                VStack(alignment: .leading, spacing: 0) {
-                    Text(row.accountName)
-                        .font(.caption2)
-                        .lineLimit(1)
-                    Text(row.quotaTitle)
-                        .font(.system(size: 8))
-                        .foregroundStyle(.secondary)
-                }
-
-                if let progressValue = row.progressValue,
-                   let progressTotal = row.progressTotal {
-                    ProgressView(value: progressValue, total: progressTotal)
-                        .tint(row.usageStatus?.color ?? .secondary)
-                }
-
-                Text(row.compactSummaryText)
-                    .font(.system(size: 8))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-
-                WidgetHealthIndicator(row: row)
-            }
-
-            WidgetRowDetails(row: row)
-        }
-        .accessibilityElement(children: .combine)
     }
 }
 
@@ -172,20 +144,7 @@ struct MediumWidgetView: View {
     let entry: UsageWidgetEntry
 
     var body: some View {
-        let presentation = entry.presentation(for: .medium)
-        VStack(alignment: .leading, spacing: 8) {
-            if let emptyState = presentation.emptyState {
-                WidgetEmptyStateView(state: emptyState)
-            } else {
-                ForEach(presentation.rows) { row in
-                    ServiceCompactView(row: row)
-                }
-                WidgetOverflowView(hiddenRowCount: presentation.hiddenRowCount)
-            }
-        }
-        .padding()
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .containerBackground(.fill.tertiary, for: .widget)
+        WidgetGlanceStack(entry: entry, family: .medium)
     }
 }
 
@@ -193,107 +152,214 @@ struct LargeWidgetView: View {
     let entry: UsageWidgetEntry
 
     var body: some View {
-        let presentation = entry.presentation(for: .large)
-        VStack(alignment: .leading, spacing: 0) {
+        WidgetGlanceStack(entry: entry, family: .large)
+    }
+}
+
+/// Medium and large are the same surface with a different row budget, so they
+/// share one body rather than two copies that drift.
+struct WidgetGlanceStack: View {
+    let entry: UsageWidgetEntry
+    let family: WidgetPresentationFamily
+
+    var body: some View {
+        let presentation = entry.presentation(for: family)
+        let metrics = WidgetGlance.metrics(for: family)
+        VStack(alignment: .leading, spacing: metrics.stackSpacing) {
             if let emptyState = presentation.emptyState {
                 WidgetEmptyStateView(state: emptyState)
             } else {
-                ForEach(Array(presentation.rows.enumerated()), id: \.element.id) { index, row in
-                    ServiceCompactView(row: row)
-                    if index < presentation.rows.count - 1 {
-                        Spacer()
+                if case let .rows(rows) = WidgetGlance.layout(for: presentation, family: family) {
+                    ForEach(rows) { row in
+                        WidgetGlanceRow(row: row, metrics: metrics)
                     }
                 }
-                WidgetOverflowView(hiddenRowCount: presentation.hiddenRowCount)
+                WidgetOverflowView(hiddenRowCount: presentation.hiddenRowCount, metrics: metrics)
+                // Rows hug the top and keep an even rhythm instead of being
+                // spread apart to fill whatever height the family happens to be.
+                Spacer(minLength: 0)
             }
         }
-        .padding()
+        .padding(metrics.contentPadding)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .containerBackground(.fill.tertiary, for: .widget)
     }
 }
 
-struct ServiceCompactView: View {
+// MARK: - Glance rows
+
+/// One provider, read at arm's length: the number leads, the account name
+/// supports it, and the bar's tint carries status so no separate dot is needed.
+struct WidgetGlanceRow: View {
     let row: WidgetPresentationRow
+    let metrics: WidgetGlanceMetrics
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 3) {
-            HStack {
-                WidgetProviderIcon(service: row.service, size: 18)
+        VStack(alignment: .leading, spacing: metrics.rowSpacing) {
+            HStack(spacing: metrics.rowSpacing * 2) {
+                WidgetProviderIcon(service: row.service, size: metrics.iconSize)
                 Text(row.accountName)
-                    .font(.subheadline)
-                    .bold()
+                    .font(.system(size: metrics.titleSize, weight: .medium))
                     .lineLimit(1)
-                Text(row.quotaTitle)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                Spacer()
-                WidgetHealthIndicator(row: row)
-            }
-
-            if let progressValue = row.progressValue,
-               let progressTotal = row.progressTotal {
-                HStack {
-                    ProgressView(value: progressValue, total: progressTotal)
-                        .tint(row.usageStatus?.color ?? .secondary)
-                    Text(row.summaryText)
-                        .font(.caption)
-                }
-            } else {
+                Spacer(minLength: metrics.rowSpacing)
+                WidgetHealthIndicator(health: row.health, size: metrics.captionSize)
                 Text(row.summaryText)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(.system(size: metrics.headlineSize, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
             }
 
-            WidgetRowDetails(row: row)
+            WidgetGlanceBar(row: row, height: metrics.barHeight)
+            WidgetGlanceCaption(row: row, size: metrics.captionSize)
         }
         .accessibilityElement(children: .combine)
+        .accessibilityLabel(row.accountName)
+        .accessibilityValue("\(row.quotaTitle), \(row.summaryText)")
     }
 }
 
-struct WidgetRowDetails: View {
+/// The small family's single row: the number takes the tile, everything else
+/// sits under it.
+struct WidgetGlanceHero: View {
     let row: WidgetPresentationRow
+    let metrics: WidgetGlanceMetrics
 
     var body: some View {
-        if row.resetTime != nil || row.freshnessDate != nil {
-            HStack(spacing: 6) {
-                if let resetTime = row.resetTime {
-                    Label {
-                        Text(resetTime, style: .relative)
-                    } icon: {
-                        Image(systemName: "arrow.clockwise")
+        VStack(alignment: .leading, spacing: metrics.rowSpacing) {
+            HStack(spacing: metrics.rowSpacing * 2) {
+                WidgetProviderIcon(service: row.service, size: metrics.iconSize)
+                Text(row.accountName)
+                    .font(.system(size: metrics.titleSize, weight: .medium))
+                    .lineLimit(1)
+                Spacer(minLength: metrics.rowSpacing)
+                WidgetHealthIndicator(health: row.health, size: metrics.captionSize)
+            }
+
+            Text(row.summaryText)
+                .font(.system(size: metrics.headlineSize, weight: .semibold, design: .rounded))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+
+            WidgetGlanceBar(row: row, height: metrics.barHeight)
+            WidgetGlanceCaption(row: row, size: metrics.captionSize)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(row.accountName)
+        .accessibilityValue("\(row.quotaTitle), \(row.summaryText)")
+    }
+}
+
+/// Everything the hero displaced, reduced to one line each: enough to know the
+/// other accounts are fine, not enough to compete with the number above.
+struct WidgetGlanceRail: View {
+    let rows: [WidgetPresentationRow]
+    let metrics: WidgetGlanceMetrics
+
+    var body: some View {
+        if !rows.isEmpty {
+            VStack(alignment: .leading, spacing: metrics.rowSpacing) {
+                ForEach(rows) { row in
+                    HStack(spacing: metrics.rowSpacing) {
+                        WidgetProviderIcon(service: row.service, size: metrics.captionSize)
+                        Text(row.accountName)
+                            .font(.system(size: metrics.captionSize))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                        Spacer(minLength: metrics.rowSpacing)
+                        Text(row.compactSummaryText)
+                            .font(.system(size: metrics.captionSize, weight: .medium))
+                            .monospacedDigit()
+                            .foregroundStyle(row.usageStatus?.color ?? .secondary)
                     }
-                }
-                if let freshnessDate = row.freshnessDate {
-                    Label {
-                        Text(freshnessDate, style: .relative)
-                    } icon: {
-                        Image(systemName: "clock")
-                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(row.accountName)
+                    .accessibilityValue(row.compactSummaryText)
                 }
             }
-            .font(.system(size: 8))
-            .foregroundStyle(.secondary)
         }
     }
 }
 
-struct WidgetHealthIndicator: View {
+/// A capsule with weight rather than a `ProgressView` hairline, tinted by the
+/// quota band so status needs no second glyph.
+struct WidgetGlanceBar: View {
     let row: WidgetPresentationRow
+    let height: CGFloat
+
+    private var fraction: Double {
+        guard let value = row.progressValue, let total = row.progressTotal, total > 0 else { return 0 }
+        return min(max(value / total, 0), 1)
+    }
 
     var body: some View {
-        switch row.health {
-        case .healthy:
-            if let status = row.usageStatus {
-                WidgetStatusIndicator(status: status)
-                    .accessibilityLabel("Current usage")
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule(style: .continuous)
+                    .fill(.quaternary)
+                let filled = proxy.size.width * fraction
+                if filled > 0 {
+                    Capsule(style: .continuous)
+                        .fill(row.usageStatus?.color ?? Color.secondary)
+                        // A sliver still has to read as a capsule, not a dot.
+                        .frame(width: max(height, filled))
+                }
             }
+        }
+        .frame(height: height)
+        .accessibilityHidden(true)
+    }
+}
+
+/// Quota window, reset and freshness on one line — the metadata the card stacked
+/// under the account name, moved out of the headline's way.
+struct WidgetGlanceCaption: View {
+    let row: WidgetPresentationRow
+    let size: CGFloat
+
+    var body: some View {
+        HStack(spacing: size / 2) {
+            Text(row.quotaTitle)
+            if let resetTime = row.resetTime {
+                Label {
+                    Text(resetTime, style: .relative)
+                } icon: {
+                    Image(systemName: "arrow.clockwise")
+                }
+            }
+            if let freshnessDate = row.freshnessDate {
+                Label {
+                    Text(freshnessDate, style: .relative)
+                } icon: {
+                    Image(systemName: "clock")
+                }
+            }
+        }
+        .font(.system(size: size))
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+    }
+}
+
+/// Only the states the bar cannot express. A healthy row's status is already the
+/// bar's tint, so it draws nothing here.
+struct WidgetHealthIndicator: View {
+    let health: WidgetDataHealth
+    let size: CGFloat
+
+    var body: some View {
+        switch health {
+        case .healthy:
+            EmptyView()
         case .stale:
             Image(systemName: "clock.badge.exclamationmark")
+                .font(.system(size: size))
                 .foregroundStyle(.orange)
                 .accessibilityLabel("Stale usage data")
         case .unavailable:
             Image(systemName: "xmark.circle")
+                .font(.system(size: size))
                 .foregroundStyle(.secondary)
                 .accessibilityLabel("Usage unavailable")
         }
@@ -302,11 +368,12 @@ struct WidgetHealthIndicator: View {
 
 struct WidgetOverflowView: View {
     let hiddenRowCount: Int
+    let metrics: WidgetGlanceMetrics
 
     var body: some View {
         if hiddenRowCount > 0 {
             Label("+\(hiddenRowCount) more", systemImage: "ellipsis.circle")
-                .font(.caption2)
+                .font(.system(size: metrics.captionSize))
                 .foregroundStyle(.secondary)
                 .accessibilityLabel("\(hiddenRowCount) more usage rows")
         }
@@ -355,14 +422,5 @@ struct WidgetProviderIcon: View {
                 .aspectRatio(contentMode: .fit)
                 .frame(width: size, height: size)
         }
-    }
-}
-struct WidgetStatusIndicator: View {
-    let status: UsageStatus
-
-    var body: some View {
-        Circle()
-            .fill(status.color)
-            .frame(width: 8, height: 8)
     }
 }

--- a/MeterBarWidget/UsageWidget.swift
+++ b/MeterBarWidget/UsageWidget.swift
@@ -215,7 +215,7 @@ struct WidgetGlanceRow: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(row.accountName)
-        .accessibilityValue("\(row.quotaTitle), \(row.summaryText)")
+        .accessibilityValue(row.accessibilityValueText)
     }
 }
 
@@ -247,7 +247,7 @@ struct WidgetGlanceHero: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(row.accountName)
-        .accessibilityValue("\(row.quotaTitle), \(row.summaryText)")
+        .accessibilityValue(row.accessibilityValueText)
     }
 }
 
@@ -275,7 +275,7 @@ struct WidgetGlanceRail: View {
                     }
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel(row.accountName)
-                    .accessibilityValue(row.compactSummaryText)
+                    .accessibilityValue(row.compactAccessibilityValueText)
                 }
             }
         }
@@ -356,13 +356,20 @@ struct WidgetHealthIndicator: View {
             Image(systemName: "clock.badge.exclamationmark")
                 .font(.system(size: size))
                 .foregroundStyle(.orange)
-                .accessibilityLabel("Stale usage data")
+                .accessibilityLabel(label)
         case .unavailable:
             Image(systemName: "xmark.circle")
                 .font(.system(size: size))
                 .foregroundStyle(.secondary)
-                .accessibilityLabel("Usage unavailable")
+                .accessibilityLabel(label)
         }
+    }
+
+    /// The badge and the row's spoken value read the same phrase out of
+    /// `WidgetDataHealth`, so they cannot end up describing one state two ways.
+    /// A healthy row draws no glyph, so it never reaches this.
+    private var label: String {
+        health.accessibilityDescription ?? ""
     }
 }
 

--- a/Packages/MeterBarShared/Sources/MeterBarShared/WidgetGlance.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/WidgetGlance.swift
@@ -1,0 +1,130 @@
+import CoreGraphics
+
+/// Type and layout vocabulary for the widget surfaces.
+///
+/// The widget used to be drawn as a shrunken popover card — account name as the
+/// headline, quota window stacked beneath it, a hairline `ProgressView` with the
+/// percentage demoted to a trailing caption, and a footer of 7–8pt chips. That
+/// hierarchy is right for a card the pointer is already resting on and wrong for
+/// something read at arm's length in under a second, so the widget gets its own
+/// vocabulary rather than a scaled-down copy of the card's.
+///
+/// Four inversions separate a glance from a card:
+/// 1. the usage number is the largest type, not the account name;
+/// 2. there is no stacked quota subtitle competing with it;
+/// 3. the bar is a capsule with real weight, not a hairline;
+/// 4. status is carried by the bar's tint, so the card's separate status dot goes.
+///
+/// Only sizes and layout intent live here. Colors stay per-target — see the note
+/// in `UsageStatus.swift` — so this package remains free of SwiftUI and can keep
+/// serving `MeterBarCLI` at its lower deployment target.
+public enum WidgetGlance {
+    /// Nothing on a home screen is readable below this. The widget shipped 7pt
+    /// and 8pt labels; every size below is measured against this floor.
+    public static let legibilityFloor: CGFloat = 10
+
+    /// A default `ProgressView` draws a ~4pt hairline. The widget bar has to read
+    /// as a filled quantity from across a desk, so it never goes under this.
+    public static let minimumBarHeight: CGFloat = 6
+
+    public static func metrics(for family: WidgetPresentationFamily) -> WidgetGlanceMetrics {
+        switch family {
+        case .small:
+            // One hero number in 150×150: the whole tile is the number.
+            return WidgetGlanceMetrics(
+                headlineSize: 30,
+                titleSize: 12,
+                captionSize: 10,
+                iconSize: 16,
+                barHeight: 8,
+                rowSpacing: 4,
+                stackSpacing: 8,
+                contentPadding: 12
+            )
+        case .medium:
+            return WidgetGlanceMetrics(
+                headlineSize: 18,
+                titleSize: 12,
+                captionSize: 10,
+                iconSize: 15,
+                barHeight: 6,
+                rowSpacing: 2,
+                stackSpacing: 8,
+                contentPadding: 12
+            )
+        case .large:
+            // Same row rhythm as medium — a large widget is more rows, not bigger
+            // ones — with a touch more breathing room at the edge.
+            return WidgetGlanceMetrics(
+                headlineSize: 18,
+                titleSize: 12,
+                captionSize: 10,
+                iconSize: 15,
+                barHeight: 6,
+                rowSpacing: 2,
+                stackSpacing: 8,
+                contentPadding: 14
+            )
+        }
+    }
+
+    /// How the planned rows are arranged. The small family leads with one hero
+    /// number and demotes the rest to a rail; anything wider stacks full rows.
+    /// With no rows at all every family falls back to the stack so the empty
+    /// state renders through a single path.
+    public static func layout(
+        for presentation: WidgetPresentation,
+        family: WidgetPresentationFamily
+    ) -> WidgetGlanceLayout {
+        guard family == .small, let headline = presentation.rows.first else {
+            return .rows(presentation.rows)
+        }
+        return .hero(headline, supporting: Array(presentation.rows.dropFirst()))
+    }
+}
+
+/// The sizes one widget family draws at. Every number a widget view needs comes
+/// from here, so the widget extension and the in-app preview cannot drift.
+public struct WidgetGlanceMetrics: Equatable, Sendable {
+    /// The usage number — the largest type on the surface.
+    public let headlineSize: CGFloat
+    /// The account name.
+    public let titleSize: CGFloat
+    /// Quota window, reset time, freshness.
+    public let captionSize: CGFloat
+    public let iconSize: CGFloat
+    public let barHeight: CGFloat
+    /// Between the lines inside one row.
+    public let rowSpacing: CGFloat
+    /// Between rows. Always greater than `rowSpacing` so rows read as separate
+    /// units without needing a divider.
+    public let stackSpacing: CGFloat
+    public let contentPadding: CGFloat
+
+    public init(
+        headlineSize: CGFloat,
+        titleSize: CGFloat,
+        captionSize: CGFloat,
+        iconSize: CGFloat,
+        barHeight: CGFloat,
+        rowSpacing: CGFloat,
+        stackSpacing: CGFloat,
+        contentPadding: CGFloat
+    ) {
+        self.headlineSize = headlineSize
+        self.titleSize = titleSize
+        self.captionSize = captionSize
+        self.iconSize = iconSize
+        self.barHeight = barHeight
+        self.rowSpacing = rowSpacing
+        self.stackSpacing = stackSpacing
+        self.contentPadding = contentPadding
+    }
+}
+
+public enum WidgetGlanceLayout: Equatable, Sendable {
+    /// One row carries the surface; the others are reduced to a supporting rail.
+    case hero(WidgetPresentationRow, supporting: [WidgetPresentationRow])
+    /// Full-width rows stacked top to bottom.
+    case rows([WidgetPresentationRow])
+}

--- a/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPresentation.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPresentation.swift
@@ -4,6 +4,23 @@ public enum WidgetDataHealth: Equatable, Sendable {
     case healthy
     case stale
     case unavailable
+
+    /// What the health glyph says out loud, or `nil` when there is no glyph.
+    ///
+    /// `WidgetHealthIndicator` labels its images from here so the spoken row
+    /// value and the drawn badge cannot describe the same row differently. A
+    /// healthy row draws nothing — its status is already the bar's tint — so it
+    /// contributes no phrase.
+    public var accessibilityDescription: String? {
+        switch self {
+        case .healthy:
+            return nil
+        case .stale:
+            return "Stale usage data"
+        case .unavailable:
+            return "Usage unavailable"
+        }
+    }
 }
 
 public enum WidgetPresentationEmptyState: Equatable, Sendable {
@@ -106,6 +123,29 @@ public struct WidgetPresentationRow: Identifiable, Equatable, Sendable {
     public var usageStatus: UsageStatus? {
         guard health == .healthy else { return nil }
         return limit?.statusColor
+    }
+
+    /// The spoken value for a full glance row or hero.
+    ///
+    /// Those views combine their children into one accessibility element and
+    /// then set this explicitly, which discards the labels `.combine` gathered
+    /// from the children — including the health glyph's. Appending the health
+    /// phrase here is what puts "Stale usage data" back into VoiceOver's
+    /// reading of a row that visibly carries the badge.
+    public var accessibilityValueText: String {
+        joinedAccessibilityValue(leading: [quotaTitle, summaryText])
+    }
+
+    /// The spoken value for a rail entry, which omits the quota title to stay
+    /// on one line — and omits the health glyph too, making this the only place
+    /// a stale or unavailable rail row can announce itself at all.
+    public var compactAccessibilityValueText: String {
+        joinedAccessibilityValue(leading: [compactSummaryText])
+    }
+
+    private func joinedAccessibilityValue(leading: [String]) -> String {
+        (leading + [health.accessibilityDescription].compactMap { $0 })
+            .joined(separator: ", ")
     }
 }
 


### PR DESCRIPTION
Ten reported UI/behavior defects, each fixed at its root rather than patched at the symptom. Tests were written before the implementation they cover.

## Popover

**1. The label was cut.** A blocked or exhausted provider row squeezed the account title down to a single character (`✳ s`) while three concatenated status fragments — "Login required", "Limit exhausted", "Reset time unavailable" — ran long beside it. `ProviderBlockedSummaryPresentation` now decides *one* status line instead of stacking every applicable phrase, and `ResetCountdowns.unavailableCounterText` owns the "no reset time" copy so it stops being appended to unrelated states.

**2. The padding was not all the same.** It had been hand-typed per surface and drifted. `MeterBarTheme.CardPadding` (`.nested` 8 / `.popover` 12 / `.standard` 16) is now the only source, threaded through `DashboardTile(padding:)`.

**3. The hover panel was not the same thing as the card.** It drew its own header and an extra bar the card never had. Both surfaces now render `ProviderCardHeader`, with parity tests.

## Dashboard

**4. Overview grid.** `masonryColumns` balances cards into columns by height instead of leaving ragged vertical gaps.

**5. Costs row.** API-Rate Estimate and Lifetime Local now share one equal-height row.

**6. Optimize page.** KPI tiles forced to a single 4x1 grid. The "Last 7 days" counter showed a bare **0** next to a caption reading "32.4B over 30 days" — it now reads **"None"** when the window genuinely has no usage, so the number and the caption stop contradicting each other. `CodexCostScanner` buffers deferred usage so late-arriving rows stop landing under "Unknown model".

**7. Refresh status.** `DashboardStatusSection` gets a real refresh button with a spinner state; its enablement logic is lifted into pure statics.

**8. Oversized switches.** New `meterBarSwitch()` modifier applied at 26 call sites.

## Widget

**9. The widget was the same design as the popover cards** — literally, `ServiceCompactView` reproduced the popover card's information architecture at widget scale, and there were *three* hand-rolled copies (`ServiceMiniView`, `ServiceCompactView`, and the settings preview row) disagreeing on icon source, font sizes, health-indicator presence, and status→color mapping.

The extension target lives outside the SwiftPM package and cannot link app types like `DashboardTile` or `LimitRow`; the only common ground is `MeterBarShared`, which imports no SwiftUI. So the shared thing is the *vocabulary*, not a view: `WidgetGlance` carries per-family metrics and the hero-vs-rows layout decision, and both the extension and the settings preview read it.

Four deliberate inversions separate a glance from a card:
1. the usage number is the largest type, not the account name;
2. no stacked quota subtitle competing with it;
3. the bar is a capsule with real weight, not a hairline;
4. status is carried by the bar's tint, so the card's separate status dot goes.

Medium and large now share one `WidgetGlanceStack` body with different row budgets rather than two copies that drift. `UsageStatus.color` puts the severity→color map in one place. Deleted: `ServiceMiniView`, `ServiceCompactView`, `WidgetRowDetails`, `WidgetStatusIndicator`.

## Provider errors

**10. "Failed to parse response"** was discarding the reason the CLI actually gave. `ServiceError.parsingError` now carries a `String?` detail, and `ClaudeCodeParseFailure` + `ClaudeCodeCLIFailureMapping` classify it into a message worth showing.

## Verification

- `swift test --skip APIIntegrationTests` — **1652 tests**, 1 skipped, 3 failures (see below).
- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug` — **BUILD SUCCEEDED**. This is the only build that compiles the widget extension; `swift build` does not cover that target.
- `swiftlint --strict` — clean.

### Pre-existing failures, not caused by this change

The 3 failures are 2 tests. Both were reproduced verbatim on clean `master` at `7322b7f` in a throwaway worktree, and neither source file is touched by this branch:

- `LiquidGlassP1RegressionTests.testRapidShowDismissShowLeavesPanelVisibleAndOpaque` — panel alpha `0.0` vs expected `1.0`. `MeterBarMenuPanelController` is untouched here.
- `SessionWakeAgentTests.testAgentLifetimeLockExcludesAppAndCLIHolders` — the sandbox denies writing the lock directory under `TMPDIR`. Environmental.

Separately, `APIIntegrationTests` declares an `apiTimeout` it never applies to its awaited call, so without live credentials it blocks indefinitely and hangs a local full-suite run. Filed as a next step in the session log rather than fixed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned widgets with clearer glance-style layouts, responsive sizing, usage bars, provider status, and improved accessibility.
  * Added richer guidance for provider refresh, authentication, and usage parsing issues.
  * Improved usage attribution when scanning Codex activity.

* **Bug Fixes**
  * Improved blocked-provider summaries, reset countdowns, and accessibility labels.
  * Prevented unrecognized diagnostic details from appearing in error messages.
  * Improved dashboard card alignment, provider layouts, and detail-panel consistency.

* **Style**
  * Standardized card spacing, status colors, switch controls, and provider headers across the app.
  * Improved Optimize insights layout and empty-period messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->