### PR TITLE
chore: bump version to 1.8.3

### DIFF
--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.8.3;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -369,7 +369,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.8.3;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -534,7 +534,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.8.3;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug;
 				PRODUCT_NAME = "MeterBar Dev";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -580,7 +580,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.2;
+				MARKETING_VERSION = 1.8.3;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary

- Bump `MARKETING_VERSION` 1.8.2 → 1.8.3 across all four Xcode configs.
- `CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)"`, so stable ships identical short/build versions.

## Context

Pre-release bump for **v1.8.3**. The `v1.8.2` tag points at `b192a67` (Jul 28) and master is **13 commits ahead** of it, including three unreleased features (#268 quota hooks/webhooks, #269 menu-bar display options, #271 adaptive refresh), per-account Codex parity (#304), and month-to-date cost breakdowns.

Release builds derive their version from the git tag in `_build-signed.yml`, so this commit does not change what CI produces for a tagged release. What it fixes is **local** Release builds: with `MARKETING_VERSION` still at `1.8.2`, a locally built bundle reported a version already published, making it indistinguishable from the released v1.8.2 binary despite being 13 commits newer.

## Out of scope

The remaining `1.8.2` strings in `scripts/fixtures/app-launch/fake-app-executable.sh`, `scripts/test-app-launch-smoke.sh`, and `MeterBarTests/LaunchSmokeProbeTests.swift` are self-consistent launch-smoke **fixture** data, not the app version. Bumping them would be churn with no meaning. #310 left the equivalent fixtures alone for the same reason.

## Verification

- `xcodebuild -showBuildSettings` resolves `MARKETING_VERSION = 1.8.3` and `CURRENT_PROJECT_VERSION = 1.8.3`.
- Version grep shows a single marketing version across the project (4/4 configs).
- Full build/test coverage via PR CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MeterBar app and widget extension version to 1.8.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->