### PR TITLE
fix(tests): end the swift test keychain/coalescing hangs — gate, guard, and deterministic refresher test

### DIFF
--- a/MeterBar/App/MeterBarMenuPanelController.swift
+++ b/MeterBar/App/MeterBarMenuPanelController.swift
@@ -93,12 +93,37 @@ final class MeterBarMenuPanelController {
                 context.duration = MeterBarTheme.Motion.panelFadeIn
                 panel.animator().alphaValue = 1
             }
+            settleFadeIn(panel, token: token)
         } else {
             panel.alphaValue = 1
             panel.makeKeyAndOrderFront(nil)
         }
 
         startEventMonitoring()
+    }
+
+    /// Guarantees the fade-in reaches full opacity even when it never runs.
+    ///
+    /// `panel.animator().alphaValue = 1` publishes the model value only once the
+    /// fade actually ticks, and a fade scheduled on a panel the window server is
+    /// not compositing never ticks at all — its animation group never completes,
+    /// so a completion handler cannot recover it either. The panel is then left
+    /// at the 0 assigned just before it was ordered front: on screen and taking
+    /// clicks, but invisible. A wall-clock settle is the only thing that can
+    /// close that hole, so schedule one past the fade and assign the end state
+    /// directly. When the fade does run this is a redundant write of a value the
+    /// animator already published.
+    ///
+    /// The token guard is what makes it safe: a `dismiss()` or newer `show()`
+    /// bumps `presentationToken`, so a settle left over from a superseded
+    /// presentation cannot force a panel back to opaque.
+    private func settleFadeIn(_ panel: NSPanel, token: Int) {
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + MeterBarTheme.Motion.panelFadeIn
+        ) { [weak self] in
+            guard let self, presentationToken == token, isPresented else { return }
+            panel.alphaValue = 1
+        }
     }
 
     func dismiss() {

--- a/MeterBar/Services/ApiUsageStore.swift
+++ b/MeterBar/Services/ApiUsageStore.swift
@@ -57,13 +57,27 @@ final class ApiUsageStore: ObservableObject {
     init(
         authenticatedProviders: (() -> [ApiProvider])? = nil,
         adminKey: ((ApiProvider) -> String?)? = nil,
-        fetchUsage: UsageFetcher? = nil
+        fetchUsage: UsageFetcher? = nil,
+        hasStoredKey: @escaping @MainActor (ApiProvider) -> Bool = {
+            KeychainManager.shared.hasKey(key: $0.keychainKey)
+        },
+        authManager: @escaping @MainActor () -> AuthenticationManager = { .shared }
     ) {
-        let authManager = AuthenticationManager.shared
+        // Two separate keychain postures, on purpose:
+        //
+        // - Which providers have a key (drives card visibility, evaluated on
+        //   every dashboard render) only needs *existence*, so the default
+        //   goes through the attributes-only `hasKey` probe that can never
+        //   raise a securityd ACL prompt.
+        // - The key *value* is needed only when a fetch actually runs, so
+        //   `AuthenticationManager.shared` — whose init decrypts both admin
+        //   keys from the real login keychain, the issue #319 hang class — is
+        //   resolved lazily inside the default closure, never at construction
+        //   and never from a render.
         authenticatedProvidersSource = authenticatedProviders ?? {
-            ApiProvider.allCases.filter { authManager.isAuthenticated($0) }
+            ApiProvider.allCases.filter { hasStoredKey($0) }
         }
-        adminKeySource = adminKey ?? { authManager.adminKey(for: $0) }
+        adminKeySource = adminKey ?? { authManager().adminKey(for: $0) }
         self.fetchUsage = fetchUsage ?? { provider, adminKey, window in
             try await ApiUsageService.fetch(provider: provider, adminKey: adminKey, window: window)
         }

--- a/MeterBar/Services/ClaudeTokenRefresher.swift
+++ b/MeterBar/Services/ClaudeTokenRefresher.swift
@@ -224,6 +224,12 @@ actor ClaudeTokenRefresher {
     private let now: Clock
     private var inFlight: [UUID: Task<ClaudeTokenRefreshOutcome, Never>] = [:]
 
+    /// How many callers joined an already-running attempt instead of spawning
+    /// their own. Observability for the coalescing contract: the concurrency
+    /// test must know the second caller has actually joined before it lets the
+    /// first attempt finish, otherwise the assertion races the scheduler.
+    private(set) var coalescedJoins = 0
+
     init(
         cooldownStore: ClaudeRefreshCooldownStore = ClaudeRefreshCooldownStore(),
         fingerprint: @escaping FingerprintReader = {
@@ -253,6 +259,7 @@ actor ClaudeTokenRefresher {
         // stored cooldown, but it must not create a second process beside an
         // already-running background attempt.
         if let active = inFlight[account.id] {
+            coalescedJoins += 1
             return result(for: await active.value)
         }
 

--- a/MeterBar/Services/KeychainManager.swift
+++ b/MeterBar/Services/KeychainManager.swift
@@ -14,21 +14,50 @@ nonisolated protocol KeychainBackend {
 }
 
 /// Production backend: forwards straight to the Security framework.
+///
+/// Every call funnels through `assertTestProcessAllowsRealKeychain` first: a
+/// unit-test process that reaches the real login keychain without the
+/// live-integration opt-in is the silent-hang class of issue #319, and a loud
+/// debug-build failure here is the guard that keeps that class extinct.
 nonisolated struct SecItemKeychainBackend: KeychainBackend {
     func update(query: [String: Any], attributes: [String: Any]) -> OSStatus {
-        SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        assertTestProcessAllowsRealKeychain(.write)
+        return SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
     }
 
     func add(query: [String: Any]) -> OSStatus {
-        SecItemAdd(query as CFDictionary, nil)
+        assertTestProcessAllowsRealKeychain(.write)
+        return SecItemAdd(query as CFDictionary, nil)
     }
 
     func copyMatching(query: [String: Any], result: inout AnyObject?) -> OSStatus {
-        SecItemCopyMatching(query as CFDictionary, &result)
+        assertTestProcessAllowsRealKeychain(
+            .read(requestsSecretData: (query[kSecReturnData as String] as? Bool) == true)
+        )
+        return SecItemCopyMatching(query as CFDictionary, &result)
     }
 
     func delete(query: [String: Any]) -> OSStatus {
-        SecItemDelete(query as CFDictionary)
+        assertTestProcessAllowsRealKeychain(.write)
+        return SecItemDelete(query as CFDictionary)
+    }
+
+    private func assertTestProcessAllowsRealKeychain(
+        _ operation: RealKeychainTestGuard.Operation
+    ) {
+        #if DEBUG
+        precondition(
+            !RealKeychainTestGuard.isBlocked(operation),
+            """
+            Real login-keychain access from a unit-test run without the \
+            live-integration opt-in. This is the hang class of issue #319: \
+            securityd can raise an ACL approval dialog no headless run can \
+            answer, and `swift test` parks forever at 0% CPU. Either gate the \
+            test behind LiveIntegrationTestGate.skipUnlessEnabled() or opt in \
+            deliberately with \(RealKeychainTestGuard.environmentKey)=1.
+            """
+        )
+        #endif
     }
 }
 
@@ -110,8 +139,25 @@ nonisolated final class KeychainManager {
         return allDeleted
     }
 
+    /// Existence probe only. Deliberately requests attributes, never
+    /// `kSecReturnData`: decrypting the secret is what triggers securityd's
+    /// ACL approval dialog when the calling process is not in the item's
+    /// trusted-application list, and every `hasKey` caller only needs a
+    /// boolean. Attribute reads are always prompt-free. This also means
+    /// `hasKey` does not perform the legacy-service migration `get` does —
+    /// migration still happens on the first real read of the value.
     func hasKey(key: String) -> Bool {
-        get(key: key) != nil
+        for service in [currentService] + legacyServices {
+            var query = baseQuery(key: key, service: service)
+            query[kSecReturnAttributes as String] = true
+            query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+            var result: AnyObject?
+            if backend.copyMatching(query: query, result: &result) == errSecSuccess {
+                return true
+            }
+        }
+        return false
     }
 
     private enum ReadResult {

--- a/MeterBar/Services/KeychainManager.swift
+++ b/MeterBar/Services/KeychainManager.swift
@@ -13,48 +13,47 @@ nonisolated protocol KeychainBackend {
     func delete(query: [String: Any]) -> OSStatus
 }
 
-/// Production backend: forwards straight to the Security framework.
-///
-/// Every call funnels through `assertTestProcessAllowsRealKeychain` first: a
-/// unit-test process that reaches the real login keychain without the
-/// live-integration opt-in is the silent-hang class of issue #319, and a loud
-/// debug-build failure here is the guard that keeps that class extinct.
+/// Production backend: forwards straight to the Security framework — except
+/// in a unit-test process without the live-integration opt-in, where
+/// `RealKeychainTestGuard` hermetically seals the real login keychain off:
+/// reads behave as if it were empty (a decrypting read can hang a headless
+/// run behind a securityd ACL dialog — issue #319 — and its outcome is
+/// machine-dependent either way), and writes trap loudly because they would
+/// pollute the developer's real keychain.
 nonisolated struct SecItemKeychainBackend: KeychainBackend {
     func update(query: [String: Any], attributes: [String: Any]) -> OSStatus {
-        assertTestProcessAllowsRealKeychain(.write)
+        trapIfTestProcessWrites()
         return SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
     }
 
     func add(query: [String: Any]) -> OSStatus {
-        assertTestProcessAllowsRealKeychain(.write)
+        trapIfTestProcessWrites()
         return SecItemAdd(query as CFDictionary, nil)
     }
 
     func copyMatching(query: [String: Any], result: inout AnyObject?) -> OSStatus {
-        assertTestProcessAllowsRealKeychain(
-            .read(requestsSecretData: (query[kSecReturnData as String] as? Bool) == true)
-        )
+        #if DEBUG
+        if RealKeychainTestGuard.isBlocked(.read) {
+            return errSecItemNotFound
+        }
+        #endif
         return SecItemCopyMatching(query as CFDictionary, &result)
     }
 
     func delete(query: [String: Any]) -> OSStatus {
-        assertTestProcessAllowsRealKeychain(.write)
+        trapIfTestProcessWrites()
         return SecItemDelete(query as CFDictionary)
     }
 
-    private func assertTestProcessAllowsRealKeychain(
-        _ operation: RealKeychainTestGuard.Operation
-    ) {
+    private func trapIfTestProcessWrites() {
         #if DEBUG
         precondition(
-            !RealKeychainTestGuard.isBlocked(operation),
+            !RealKeychainTestGuard.isBlocked(.write),
             """
-            Real login-keychain access from a unit-test run without the \
-            live-integration opt-in. This is the hang class of issue #319: \
-            securityd can raise an ACL approval dialog no headless run can \
-            answer, and `swift test` parks forever at 0% CPU. Either gate the \
-            test behind LiveIntegrationTestGate.skipUnlessEnabled() or opt in \
-            deliberately with \(RealKeychainTestGuard.environmentKey)=1.
+            Real login-keychain write from a unit-test run without the \
+            live-integration opt-in — this would pollute the developer's real \
+            keychain. Point the test at an in-memory KeychainBackend, or opt \
+            in deliberately with \(RealKeychainTestGuard.environmentKey)=1.
             """
         )
         #endif

--- a/MeterBar/Services/RealKeychainTestGuard.swift
+++ b/MeterBar/Services/RealKeychainTestGuard.swift
@@ -1,36 +1,39 @@
 import Foundation
 
-/// Decides whether a real login-keychain operation is allowed in the current
-/// process. In the shipping app it always is. In a unit-test process it is
-/// allowed only with the explicit live-integration opt-in — the same
-/// `METERBAR_INTEGRATION_TESTS` switch `LiveIntegrationTestGate` uses to
-/// un-skip `APIIntegrationTests`.
+/// Decides how a real login-keychain operation behaves in the current
+/// process. In the shipping app: untouched. In a unit-test process without
+/// the explicit live-integration opt-in — the same `METERBAR_INTEGRATION_TESTS`
+/// switch `LiveIntegrationTestGate` uses to un-skip `APIIntegrationTests` —
+/// the real keychain is hermetically sealed off:
 ///
-/// Why this exists: a `SecItemCopyMatching` that has to *decrypt* an item can
-/// make securityd raise an ACL approval dialog when the calling process (the
-/// Apple `xctest` runner) is not in the item's trusted-application list. Under
-/// a headless `swift test` nobody can answer it, so the run parks forever at
-/// 0% CPU (issue #319). Gating individual known-live tests is necessary but
-/// not sufficient — any future test that wanders into a singleton holding a
-/// real `SecItemKeychainBackend` reintroduces the hang silently. This guard
-/// converts that entire class into an immediate, well-labelled debug-build
-/// failure at the exact call site.
+/// - **Reads behave as if the keychain were empty** (`errSecItemNotFound`,
+///   short-circuited before Security is ever called). A decrypting
+///   `SecItemCopyMatching` can make securityd raise an ACL approval dialog
+///   when the calling process (Apple's `xctest` runner) is not in the item's
+///   trusted-application list; under a headless `swift test` nobody can
+///   answer it and the run parks forever at 0% CPU (issue #319). Simulating
+///   absence also makes the default run machine-independent: logged in or
+///   not, credentials present or not, every unit test sees the same world —
+///   which is exactly what CI runners (no items) already showed.
+/// - **Writes fail loudly** (debug-build `precondition`): they cannot prompt,
+///   but they would pollute the developer's real login keychain, and a write
+///   from a unit test is always a test bug worth a stack trace.
 ///
-/// Attribute-only reads stay allowed: keychain item attributes are not
-/// encrypted, securityd never prompts for them, and existence probes such as
-/// `KeychainManager.hasKey` rely on that. Writes are always blocked in an
-/// un-opted-in test process — they cannot prompt, but they would pollute the
-/// developer's real login keychain.
+/// Gating individual known-live tests is necessary but not sufficient — app
+/// singletons (`ClaudeCodeLocalService.checkAccess()`, the auto-refresh
+/// timer) probe credentials from background tasks whenever a test touches
+/// them, and which branch they take depends on machine state. Sealing the
+/// backend severs that whole class at the funnel.
 ///
 /// The decision is pure and injectable so it is unit-testable; the enforcing
-/// `precondition` lives in `SecItemKeychainBackend`.
+/// code lives in `SecItemKeychainBackend`.
 nonisolated enum RealKeychainTestGuard {
     /// Launch environment variable that opts a run into live keychain and
     /// provider-API access. Shared with `LiveIntegrationTestGate`.
     static let environmentKey = "METERBAR_INTEGRATION_TESTS"
 
     enum Operation: Equatable {
-        case read(requestsSecretData: Bool)
+        case read
         case write
     }
 
@@ -45,12 +48,10 @@ nonisolated enum RealKeychainTestGuard {
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Bool {
         guard isTestProcess, !isOptedIn(environment: environment) else { return false }
-        switch operation {
-        case let .read(requestsSecretData):
-            return requestsSecretData
-        case .write:
-            return true
-        }
+        // Both operations are blocked; they differ only in consequence at the
+        // backend (reads simulate absence, writes trap).
+        _ = operation
+        return true
     }
 
     /// Truthy parse of the opt-in, shared by this guard and the test target's

--- a/MeterBar/Services/RealKeychainTestGuard.swift
+++ b/MeterBar/Services/RealKeychainTestGuard.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Decides whether a real login-keychain operation is allowed in the current
+/// process. In the shipping app it always is. In a unit-test process it is
+/// allowed only with the explicit live-integration opt-in — the same
+/// `METERBAR_INTEGRATION_TESTS` switch `LiveIntegrationTestGate` uses to
+/// un-skip `APIIntegrationTests`.
+///
+/// Why this exists: a `SecItemCopyMatching` that has to *decrypt* an item can
+/// make securityd raise an ACL approval dialog when the calling process (the
+/// Apple `xctest` runner) is not in the item's trusted-application list. Under
+/// a headless `swift test` nobody can answer it, so the run parks forever at
+/// 0% CPU (issue #319). Gating individual known-live tests is necessary but
+/// not sufficient — any future test that wanders into a singleton holding a
+/// real `SecItemKeychainBackend` reintroduces the hang silently. This guard
+/// converts that entire class into an immediate, well-labelled debug-build
+/// failure at the exact call site.
+///
+/// Attribute-only reads stay allowed: keychain item attributes are not
+/// encrypted, securityd never prompts for them, and existence probes such as
+/// `KeychainManager.hasKey` rely on that. Writes are always blocked in an
+/// un-opted-in test process — they cannot prompt, but they would pollute the
+/// developer's real login keychain.
+///
+/// The decision is pure and injectable so it is unit-testable; the enforcing
+/// `precondition` lives in `SecItemKeychainBackend`.
+nonisolated enum RealKeychainTestGuard {
+    /// Launch environment variable that opts a run into live keychain and
+    /// provider-API access. Shared with `LiveIntegrationTestGate`.
+    static let environmentKey = "METERBAR_INTEGRATION_TESTS"
+
+    enum Operation: Equatable {
+        case read(requestsSecretData: Bool)
+        case write
+    }
+
+    /// True when XCTest is loaded into this process — i.e. this is a test
+    /// runner, not the shipping app. Resolved via the runtime so the app
+    /// target never links XCTest.
+    static let processHostsXCTest = NSClassFromString("XCTestCase") != nil
+
+    static func isBlocked(
+        _ operation: Operation,
+        isTestProcess: Bool = processHostsXCTest,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        guard isTestProcess, !isOptedIn(environment: environment) else { return false }
+        switch operation {
+        case let .read(requestsSecretData):
+            return requestsSecretData
+        case .write:
+            return true
+        }
+    }
+
+    /// Truthy parse of the opt-in, shared by this guard and the test target's
+    /// `LiveIntegrationTestGate` so the two can never drift.
+    static func isOptedIn(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        guard let raw = environment[environmentKey] else { return false }
+        switch raw.trimmingCharacters(in: .whitespaces).lowercased() {
+        case "1", "true", "yes", "on":
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/MeterBar/Services/SecureFileWriter.swift
+++ b/MeterBar/Services/SecureFileWriter.swift
@@ -37,10 +37,22 @@ nonisolated enum SecureFileWriter {
     static func ensurePrivateDirectory(_ directory: URL) throws -> URL {
         let fileManager = FileManager.default
         if fileManager.fileExists(atPath: directory.path) {
-            try fileManager.setAttributes(
-                [.posixPermissions: privateDirectory],
-                ofItemAtPath: directory.path
-            )
+            // Only chmod a directory that actually needs it. `chmod(2)` can be
+            // refused on a directory that already satisfies the policy —
+            // `$TMPDIR` is owned by the user and already 0700 but carries the
+            // `sunlnk` system flag, so an unconditional tighten returned EPERM
+            // and every caller reported failure for a directory that was
+            // private to begin with. Reading the mode first keeps the tighten
+            // guarantee intact: anything looser still gets chmod'd, and a
+            // genuine refusal there still propagates.
+            let attributes = try fileManager.attributesOfItem(atPath: directory.path)
+            let current = (attributes[.posixPermissions] as? NSNumber)?.intValue
+            if current != privateDirectory {
+                try fileManager.setAttributes(
+                    [.posixPermissions: privateDirectory],
+                    ofItemAtPath: directory.path
+                )
+            }
         } else {
             try fileManager.createDirectory(
                 at: directory,

--- a/MeterBarTests/APIIntegrationTests.swift
+++ b/MeterBarTests/APIIntegrationTests.swift
@@ -4,12 +4,32 @@ import MeterBarShared
 
 /// Integration tests to verify API access for Claude Code, Codex CLI, and Cursor services.
 /// These tests make real API calls and require valid credentials to be set up.
+///
+/// **Opt-in only.** Reading those credentials means a real login-keychain read,
+/// and the xctest bundle is not in the keychain items' trusted-application ACL —
+/// so on a developer machine that is genuinely logged in, securityd raises an
+/// approval dialog with no foreground app to answer it and `swift test` parks
+/// forever at 0% CPU (issue #319). The per-test `hasAccess` guards did not help:
+/// on such a machine they return `true`, which is exactly how the run reached
+/// the keychain. Run these deliberately, from a shell that can surface the
+/// dialog:
+///
+/// ```
+/// METERBAR_INTEGRATION_TESTS=1 swift test --filter APIIntegrationTests
+/// ```
 final class APIIntegrationTests: XCTestCase {
 
     // MARK: - Test Configuration
 
     /// Timeout for API calls (30 seconds)
     let apiTimeout: TimeInterval = 30.0
+
+    /// Gate every test in the class, including ones added later and the
+    /// non-throwing async summary test that carries no `XCTSkip` of its own.
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try LiveIntegrationTestGate.skipUnlessEnabled()
+    }
 
     // MARK: - Claude Code (OAuth) Tests
 

--- a/MeterBarTests/ApiUsageStoreTests.swift
+++ b/MeterBarTests/ApiUsageStoreTests.swift
@@ -1,3 +1,4 @@
+import Security
 import XCTest
 @testable import MeterBar
 
@@ -310,6 +311,77 @@ final class ApiUsageStoreTests: XCTestCase {
         )
     }
 
+    // MARK: - AuthenticationManager reachability
+
+    /// Constructing a store with both sources injected — what every unit test
+    /// does — must never resolve `AuthenticationManager`. Its init decrypts
+    /// the admin keys from the real login keychain, which can raise a
+    /// securityd ACL prompt and park a headless `swift test` forever (issue
+    /// #319's hang class).
+    func testInjectedSourcesNeverResolveTheAuthenticationManager() {
+        _ = ApiUsageStore(
+            authenticatedProviders: { [] },
+            adminKey: { _ in nil },
+            fetchUsage: { _, _, _ in throw URLError(.badURL) },
+            authManager: {
+                XCTFail("injected sources must not touch AuthenticationManager")
+                return Self.isolatedAuthManager()
+            }
+        )
+    }
+
+    /// Provider visibility only needs *existence* (the prompt-free probe);
+    /// the decrypting `AuthenticationManager` is resolved lazily and only
+    /// when a fetch actually needs the key value — never at construction,
+    /// never from the render-driven `authenticatedProviders` path.
+    func testDefaultSourcesProbeExistenceAndDecryptOnlyWhenFetching() async {
+        let manager = Self.isolatedAuthManager()
+        XCTAssertTrue(manager.setAdminKey("sk-ant-admin", for: .anthropic))
+        var resolutions = 0
+        let usedKeys = KeyRecorder()
+
+        let store = ApiUsageStore(
+            fetchUsage: { provider, adminKey, window in
+                await usedKeys.record(adminKey)
+                return Self.usage(provider: provider, window: window, inputTokens: 1)
+            },
+            hasStoredKey: { $0 == .anthropic },
+            authManager: {
+                resolutions += 1
+                return manager
+            }
+        )
+        XCTAssertEqual(resolutions, 0, "construction must not resolve the auth manager")
+
+        XCTAssertEqual(store.authenticatedProviders, [.anthropic])
+        XCTAssertEqual(resolutions, 0, "existence probing must not decrypt")
+
+        await store.refresh()
+        let keys = await usedKeys.keys
+        XCTAssertEqual(keys, ["sk-ant-admin"])
+        XCTAssertGreaterThan(resolutions, 0, "fetching resolves the key value lazily")
+    }
+
+    private actor KeyRecorder {
+        private(set) var keys: [String] = []
+
+        func record(_ key: String) {
+            keys.append(key)
+        }
+    }
+
+    /// An `AuthenticationManager` backed entirely by in-memory storage, so
+    /// these tests exercise the real init/read paths without any keychain.
+    private static func isolatedAuthManager() -> AuthenticationManager {
+        AuthenticationManager(
+            keychain: KeychainManager(
+                backend: DictionaryKeychainBackend(),
+                currentService: "test.\(UUID().uuidString)",
+                legacyServices: []
+            )
+        )
+    }
+
     private func makeCredentialStore(
         authenticatedProviders: @escaping () -> [ApiProvider],
         adminKey: @escaping (ApiProvider) -> String?,
@@ -337,5 +409,62 @@ final class ApiUsageStoreTests: XCTestCase {
             estimatedCostUSD: 0,
             models: []
         )
+    }
+}
+
+/// Minimal in-memory `KeychainBackend` so `AuthenticationManager` can be
+/// exercised without the real login keychain. Just enough semantics for
+/// save/get: update on a missing item reports not-found so the manager falls
+/// through to add.
+nonisolated private final class DictionaryKeychainBackend: KeychainBackend {
+    private struct ItemKey: Hashable {
+        let service: String
+        let account: String
+    }
+
+    private var storage: [ItemKey: Data] = [:]
+
+    private func itemKey(in query: [String: Any]) -> ItemKey? {
+        guard let service = query[kSecAttrService as String] as? String,
+              let account = query[kSecAttrAccount as String] as? String else {
+            return nil
+        }
+        return ItemKey(service: service, account: account)
+    }
+
+    func update(query: [String: Any], attributes: [String: Any]) -> OSStatus {
+        guard let itemKey = itemKey(in: query), storage[itemKey] != nil,
+              let data = attributes[kSecValueData as String] as? Data else {
+            return errSecItemNotFound
+        }
+        storage[itemKey] = data
+        return errSecSuccess
+    }
+
+    func add(query: [String: Any]) -> OSStatus {
+        guard let itemKey = itemKey(in: query),
+              let data = query[kSecValueData as String] as? Data else {
+            return errSecParam
+        }
+        storage[itemKey] = data
+        return errSecSuccess
+    }
+
+    func copyMatching(query: [String: Any], result: inout AnyObject?) -> OSStatus {
+        guard let itemKey = itemKey(in: query), let data = storage[itemKey] else {
+            return errSecItemNotFound
+        }
+        if (query[kSecReturnData as String] as? Bool) == true {
+            result = data as AnyObject
+        }
+        return errSecSuccess
+    }
+
+    func delete(query: [String: Any]) -> OSStatus {
+        guard let itemKey = itemKey(in: query),
+              storage.removeValue(forKey: itemKey) != nil else {
+            return errSecItemNotFound
+        }
+        return errSecSuccess
     }
 }

--- a/MeterBarTests/ClaudeTokenRefresherTests.swift
+++ b/MeterBarTests/ClaudeTokenRefresherTests.swift
@@ -155,7 +155,9 @@ final class ClaudeTokenRefresherTests: XCTestCase {
         let first = Task {
             await refresher.refresh(account: account, trigger: .background)
         }
-        await gate.waitUntilStarted()
+        await poll(until: "the first attempt reaches the gate") {
+            await gate.callCount > 0
+        }
         let second = Task {
             await refresher.refresh(account: account, trigger: .userInitiated)
         }
@@ -165,9 +167,12 @@ final class ClaudeTokenRefresherTests: XCTestCase {
         // `refresh` ran, the user-initiated call bypassed cooldown, spawned a
         // second run, and parked forever on the already-spent gate — the
         // silent `swift test` hang behind issue #319's CI cancellation.
-        while await refresher.coalescedJoins == 0 {
-            await Task.yield()
+        await poll(until: "the second refresh joins the in-flight attempt") {
+            await refresher.coalescedJoins > 0
         }
+        // Unconditional, including after a poll timeout: the gate latches open,
+        // so releasing it is what lets both awaits below complete instead of
+        // parking a failed run forever.
         await gate.release()
 
         let firstResult = await first.value
@@ -176,6 +181,46 @@ final class ClaudeTokenRefresherTests: XCTestCase {
         XCTAssertEqual(secondResult, .inconclusive)
         let callCount = await gate.callCount
         XCTAssertEqual(callCount, 1)
+    }
+
+    /// The guarantee `poll` exists to provide: a condition that never holds
+    /// ends the wait with a named failure, not a spin that outlives the job.
+    func testPollTimesOutInsteadOfSpinningForever() async {
+        XCTExpectFailure("poll must report the timeout it is being asked for")
+        let started = Date()
+        await poll(0.2, until: "a condition that never holds") { false }
+        XCTAssertLessThan(
+            Date().timeIntervalSince(started),
+            5,
+            "poll must return at its deadline rather than spin"
+        )
+    }
+
+    /// Deadline-bounded wait on actor-observable state, mirroring the
+    /// `poll(_:until:)` idiom in `SessionWakeControllerTests`.
+    ///
+    /// Never spin unbounded here. `while !condition { await Task.yield() }`
+    /// is the same defect this suite exists to pin: if the state never
+    /// arrives, the loop burns a core until the CI job's 20-minute timeout
+    /// kills the whole run, naming no test — precisely how issue #319 hid.
+    /// A deadline turns that silent park into a named failure in seconds.
+    private func poll(
+        _ timeout: TimeInterval = 5,
+        until description: String,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        condition: () async -> Bool
+    ) async {
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        while Date() < deadline {
+            if await condition() { return }
+            await Task.yield()
+        }
+        XCTFail(
+            "timed out after \(timeout)s waiting for \(description)",
+            file: file,
+            line: line
+        )
     }
 
     private func makeRefresher(
@@ -270,12 +315,6 @@ private actor SpawnGate {
             self.continuation = continuation
         }
         return .succeeded
-    }
-
-    func waitUntilStarted() async {
-        while callCount == 0 {
-            await Task.yield()
-        }
     }
 
     /// Latches open. Any `run()` that arrives after release — the misuse that

--- a/MeterBarTests/ClaudeTokenRefresherTests.swift
+++ b/MeterBarTests/ClaudeTokenRefresherTests.swift
@@ -159,6 +159,15 @@ final class ClaudeTokenRefresherTests: XCTestCase {
         let second = Task {
             await refresher.refresh(account: account, trigger: .userInitiated)
         }
+        // The second refresh must have *joined* the in-flight attempt before
+        // the gate opens. Releasing on a mere `Task` handle raced the
+        // scheduler: when the first attempt finished before the second task's
+        // `refresh` ran, the user-initiated call bypassed cooldown, spawned a
+        // second run, and parked forever on the already-spent gate — the
+        // silent `swift test` hang behind issue #319's CI cancellation.
+        while await refresher.coalescedJoins == 0 {
+            await Task.yield()
+        }
         await gate.release()
 
         let firstResult = await first.value
@@ -269,12 +278,12 @@ private actor SpawnGate {
         }
     }
 
+    /// Latches open. Any `run()` that arrives after release — the misuse that
+    /// previously parked the suite forever — returns immediately instead of
+    /// storing a continuation nothing will ever resume.
     func release() {
-        if let continuation {
-            continuation.resume()
-            self.continuation = nil
-        } else {
-            released = true
-        }
+        released = true
+        continuation?.resume()
+        continuation = nil
     }
 }

--- a/MeterBarTests/KeychainManagerTests.swift
+++ b/MeterBarTests/KeychainManagerTests.swift
@@ -79,12 +79,23 @@ final class KeychainManagerTests: XCTestCase {
             return errSecSuccess
         }
 
+        // Every copy query, in order, so tests can assert on the shape of a
+        // whole walk (e.g. that `hasKey` never asks for secret data).
+        private(set) var copyMatchingQueries: [[String: Any]] = []
+
         func copyMatching(query: [String: Any], result: inout AnyObject?) -> OSStatus {
             lastCopyMatchingQuery = query
+            copyMatchingQueries.append(query)
             guard let itemKey = itemKey(in: query), let data = storage[itemKey] else {
                 return errSecItemNotFound
             }
-            result = data as AnyObject
+            // Mirror the real API: secret data comes back only when asked for.
+            // An attributes-only probe still resolves the item and succeeds.
+            if (query[kSecReturnData as String] as? Bool) == true {
+                result = data as AnyObject
+            } else if (query[kSecReturnAttributes as String] as? Bool) == true {
+                result = [kSecAttrService as String: itemKey.service] as AnyObject
+            }
             return errSecSuccess
         }
 
@@ -139,6 +150,47 @@ final class KeychainManagerTests: XCTestCase {
         XCTAssertFalse(manager.hasKey(key: "cursor"))
         XCTAssertTrue(manager.save(key: "cursor", value: "token"))
         XCTAssertTrue(manager.hasKey(key: "cursor"))
+    }
+
+    /// Decrypting an item is what triggers securityd's ACL approval dialog for
+    /// a process outside the item's trusted-application list — the issue #319
+    /// hang class. An existence probe never needs the secret, so `hasKey` must
+    /// stay attributes-only and therefore prompt-free by construction.
+    func testHasKeyNeverRequestsSecretDataSoItCannotRaiseAnACLPrompt() {
+        let (manager, backend) = makeManager()
+        XCTAssertTrue(manager.save(key: "openRouterAPIKey", value: "sk-or-secret"))
+
+        XCTAssertTrue(manager.hasKey(key: "openRouterAPIKey"))
+        XCTAssertFalse(manager.hasKey(key: "absent"))
+
+        XCTAssertFalse(backend.copyMatchingQueries.isEmpty)
+        for query in backend.copyMatchingQueries {
+            XCTAssertNotEqual(
+                query[kSecReturnData as String] as? Bool,
+                true,
+                "hasKey must never ask the keychain to decrypt the item"
+            )
+            XCTAssertEqual(
+                query[kSecReturnAttributes as String] as? Bool,
+                true,
+                "hasKey probes existence via attributes"
+            )
+        }
+    }
+
+    /// `get` migrates legacy items as a side effect; a boolean probe must not.
+    /// The legacy item stays where it is until the first real read of the
+    /// value, and `hasKey` still reports it as present.
+    func testHasKeyFindsLegacyItemsWithoutMigratingOrDeletingThem() {
+        let (manager, backend) = makeManager()
+        backend.seed(service: Self.oldestLegacyService, account: "cursor", value: "token")
+
+        XCTAssertTrue(manager.hasKey(key: "cursor"))
+
+        XCTAssertEqual(backend.value(service: Self.oldestLegacyService, account: "cursor"), "token")
+        XCTAssertNil(backend.value(service: Self.currentService, account: "cursor"))
+        XCTAssertEqual(backend.addCallCount, 0)
+        XCTAssertEqual(backend.updateCallCount, 0)
     }
 
     func testDeleteRemovesKeyAndIsIdempotent() {

--- a/MeterBarTests/LiveIntegrationTestGate.swift
+++ b/MeterBarTests/LiveIntegrationTestGate.swift
@@ -1,0 +1,62 @@
+import Foundation
+import XCTest
+
+/// Opt-in gate for tests that talk to the **real** credential stores and the
+/// **real** provider APIs.
+///
+/// `APIIntegrationTests` is documented as requiring live credentials, but it
+/// sat in the default test target with nothing but a `hasAccess` guard in front
+/// of it. On a machine actually logged into the Claude Code CLI that guard is
+/// `true`, so a plain `swift test` walked into a real `SecItemCopyMatching` on
+/// the login keychain. The xctest bundle is not in that item's trusted-app ACL,
+/// so securityd raised an approval dialog with no foreground app to answer it
+/// and the run parked at 0% CPU forever — no failure, no timeout, no output
+/// (issue #319).
+///
+/// Gating on an explicit environment variable makes the default run
+/// machine-independent: logged in or not, credentials present or not, the
+/// unattended suite behaves the same. CI never sets it, so nothing changes
+/// there; it was already skipping by accident because its runners have no
+/// credentials.
+///
+/// Enable with:
+/// ```
+/// METERBAR_INTEGRATION_TESTS=1 swift test --filter APIIntegrationTests
+/// ```
+///
+/// `isEnabled(environment:)` is pure and injectable so the gate is unit tested
+/// without touching the process environment, mirroring `DemoMode`.
+nonisolated enum LiveIntegrationTestGate {
+    /// Launch environment variable that opts into live-credential tests.
+    static let environmentKey = "METERBAR_INTEGRATION_TESTS"
+
+    static func isEnabled(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        guard let raw = environment[environmentKey] else { return false }
+        return isTruthy(raw)
+    }
+
+    /// Throws `XCTSkip` unless the opt-in is present. Call from `setUpWithError`
+    /// so every test in the class is gated, including ones added later.
+    static func skipUnlessEnabled(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws {
+        guard !isEnabled(environment: environment) else { return }
+        throw XCTSkip(
+            """
+            Live integration tests are opt-in. These reach the real keychain and \
+            the real provider APIs. Re-run with \(environmentKey)=1 to include them.
+            """
+        )
+    }
+
+    private static func isTruthy(_ value: String) -> Bool {
+        switch value.trimmingCharacters(in: .whitespaces).lowercased() {
+        case "1", "true", "yes", "on":
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/MeterBarTests/LiveIntegrationTestGate.swift
+++ b/MeterBarTests/LiveIntegrationTestGate.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+@testable import MeterBar
 
 /// Opt-in gate for tests that talk to the **real** credential stores and the
 /// **real** provider APIs.
@@ -28,13 +29,14 @@ import XCTest
 /// without touching the process environment, mirroring `DemoMode`.
 nonisolated enum LiveIntegrationTestGate {
     /// Launch environment variable that opts into live-credential tests.
-    static let environmentKey = "METERBAR_INTEGRATION_TESTS"
+    /// Owned by `RealKeychainTestGuard` so the skip decision here and the
+    /// real-keychain debug guard in the app target can never drift.
+    static let environmentKey = RealKeychainTestGuard.environmentKey
 
     static func isEnabled(
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Bool {
-        guard let raw = environment[environmentKey] else { return false }
-        return isTruthy(raw)
+        RealKeychainTestGuard.isOptedIn(environment: environment)
     }
 
     /// Throws `XCTSkip` unless the opt-in is present. Call from `setUpWithError`
@@ -49,14 +51,5 @@ nonisolated enum LiveIntegrationTestGate {
             the real provider APIs. Re-run with \(environmentKey)=1 to include them.
             """
         )
-    }
-
-    private static func isTruthy(_ value: String) -> Bool {
-        switch value.trimmingCharacters(in: .whitespaces).lowercased() {
-        case "1", "true", "yes", "on":
-            return true
-        default:
-            return false
-        }
     }
 }

--- a/MeterBarTests/LiveIntegrationTestGateTests.swift
+++ b/MeterBarTests/LiveIntegrationTestGateTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import XCTest
+
+/// The live-integration gate must be **off** by default, so a plain `swift test`
+/// can never walk into the real login keychain or the network. Only an explicit
+/// truthy `METERBAR_INTEGRATION_TESTS` opts in.
+///
+/// `isEnabled(environment:)` is injectable so these assertions never depend on
+/// the environment the suite happens to run under — including a developer shell
+/// that already exports the opt-in.
+final class LiveIntegrationTestGateTests: XCTestCase {
+    func testOffByDefaultWhenTheOptInIsAbsent() {
+        XCTAssertFalse(LiveIntegrationTestGate.isEnabled(environment: [:]))
+    }
+
+    func testTruthyEnvironmentValuesEnableTheGate() {
+        for raw in ["1", "true", "yes", "on", "TRUE", "On", "  yes  "] {
+            XCTAssertTrue(
+                LiveIntegrationTestGate.isEnabled(
+                    environment: [LiveIntegrationTestGate.environmentKey: raw]
+                ),
+                "\(raw.debugDescription) should enable live integration tests"
+            )
+        }
+    }
+
+    func testFalsyEnvironmentValuesDoNotEnableTheGate() {
+        for raw in ["0", "false", "no", "off", "", "banana"] {
+            XCTAssertFalse(
+                LiveIntegrationTestGate.isEnabled(
+                    environment: [LiveIntegrationTestGate.environmentKey: raw]
+                ),
+                "\(raw.debugDescription) should not enable live integration tests"
+            )
+        }
+    }
+
+    func testUnrelatedEnvironmentKeysDoNotEnableTheGate() {
+        XCTAssertFalse(
+            LiveIntegrationTestGate.isEnabled(environment: ["METERBAR_DEMO": "1", "CI": "true"])
+        )
+    }
+
+    func testSkipUnlessEnabledThrowsSkipWhenTheOptInIsAbsent() {
+        XCTAssertThrowsError(
+            try LiveIntegrationTestGate.skipUnlessEnabled(environment: [:])
+        ) { error in
+            XCTAssertTrue(error is XCTSkip, "expected XCTSkip, got \(type(of: error))")
+        }
+    }
+
+    func testSkipUnlessEnabledDoesNotThrowWhenTheOptInIsPresent() {
+        XCTAssertNoThrow(
+            try LiveIntegrationTestGate.skipUnlessEnabled(
+                environment: [LiveIntegrationTestGate.environmentKey: "1"]
+            )
+        )
+    }
+}

--- a/MeterBarTests/RealKeychainTestGuardTests.swift
+++ b/MeterBarTests/RealKeychainTestGuardTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import XCTest
+@testable import MeterBar
+
+/// The debug-build guard that turns issue #319's silent keychain hang into a
+/// loud failure: a unit-test process may never ask the real login keychain to
+/// decrypt an item, or write to it, unless the live-integration opt-in is set.
+/// The decision is pure and injectable; these tests pin the whole matrix.
+final class RealKeychainTestGuardTests: XCTestCase {
+    // MARK: - Test process, no opt-in
+
+    func testSecretDataReadsAreBlockedInATestProcessWithoutTheOptIn() {
+        XCTAssertTrue(
+            RealKeychainTestGuard.isBlocked(
+                .read(requestsSecretData: true),
+                isTestProcess: true,
+                environment: [:]
+            )
+        )
+    }
+
+    /// Attribute reads never decrypt and never prompt; existence probes such
+    /// as `KeychainManager.hasKey` depend on them staying allowed.
+    func testAttributeOnlyReadsStayAllowedSoExistenceProbesKeepWorking() {
+        XCTAssertFalse(
+            RealKeychainTestGuard.isBlocked(
+                .read(requestsSecretData: false),
+                isTestProcess: true,
+                environment: [:]
+            )
+        )
+    }
+
+    /// Writes cannot prompt, but they would pollute the developer's real
+    /// login keychain from a unit-test run.
+    func testWritesAreBlockedInATestProcessWithoutTheOptIn() {
+        XCTAssertTrue(
+            RealKeychainTestGuard.isBlocked(.write, isTestProcess: true, environment: [:])
+        )
+    }
+
+    // MARK: - Opt-in
+
+    func testTruthyOptInDisarmsTheGuard() {
+        for raw in ["1", "true", "yes", "on", "TRUE", "  yes  "] {
+            let environment = [RealKeychainTestGuard.environmentKey: raw]
+            XCTAssertFalse(
+                RealKeychainTestGuard.isBlocked(
+                    .read(requestsSecretData: true),
+                    isTestProcess: true,
+                    environment: environment
+                ),
+                "\(raw.debugDescription) should disarm the guard"
+            )
+            XCTAssertFalse(
+                RealKeychainTestGuard.isBlocked(
+                    .write,
+                    isTestProcess: true,
+                    environment: environment
+                ),
+                "\(raw.debugDescription) should disarm the guard"
+            )
+        }
+    }
+
+    func testFalsyOptInValuesKeepTheGuardArmed() {
+        for raw in ["0", "false", "no", "off", "", "banana"] {
+            XCTAssertTrue(
+                RealKeychainTestGuard.isBlocked(
+                    .read(requestsSecretData: true),
+                    isTestProcess: true,
+                    environment: [RealKeychainTestGuard.environmentKey: raw]
+                ),
+                "\(raw.debugDescription) should keep the guard armed"
+            )
+        }
+    }
+
+    // MARK: - Shipping app
+
+    func testNonTestProcessesAreNeverBlocked() {
+        XCTAssertFalse(
+            RealKeychainTestGuard.isBlocked(
+                .read(requestsSecretData: true),
+                isTestProcess: false,
+                environment: [:]
+            )
+        )
+        XCTAssertFalse(
+            RealKeychainTestGuard.isBlocked(.write, isTestProcess: false, environment: [:])
+        )
+    }
+
+    // MARK: - Process detection
+
+    /// This suite runs under XCTest, so the runtime probe must say so — this
+    /// is what arms the guard for the whole default `swift test` run.
+    func testThisTestProcessIsDetectedAsHostingXCTest() {
+        XCTAssertTrue(RealKeychainTestGuard.processHostsXCTest)
+    }
+}

--- a/MeterBarTests/RealKeychainTestGuardTests.swift
+++ b/MeterBarTests/RealKeychainTestGuardTests.swift
@@ -1,33 +1,22 @@
 import Foundation
+import Security
 import XCTest
 @testable import MeterBar
 
-/// The debug-build guard that turns issue #319's silent keychain hang into a
-/// loud failure: a unit-test process may never ask the real login keychain to
-/// decrypt an item, or write to it, unless the live-integration opt-in is set.
-/// The decision is pure and injectable; these tests pin the whole matrix.
+/// The debug-build seal that keeps issue #319's silent keychain hang extinct:
+/// a unit-test process without the live-integration opt-in sees an empty real
+/// login keychain (reads short-circuit to not-found — deterministic and
+/// prompt-free on every machine) and may never write to it. The decision is
+/// pure and injectable; these tests pin the whole matrix.
 final class RealKeychainTestGuardTests: XCTestCase {
     // MARK: - Test process, no opt-in
 
-    func testSecretDataReadsAreBlockedInATestProcessWithoutTheOptIn() {
+    /// A decrypting read can park a headless run behind a securityd ACL
+    /// dialog, and even a harmless one makes test outcomes depend on the
+    /// machine's login state — both blocked, simulated as absent.
+    func testReadsAreBlockedInATestProcessWithoutTheOptIn() {
         XCTAssertTrue(
-            RealKeychainTestGuard.isBlocked(
-                .read(requestsSecretData: true),
-                isTestProcess: true,
-                environment: [:]
-            )
-        )
-    }
-
-    /// Attribute reads never decrypt and never prompt; existence probes such
-    /// as `KeychainManager.hasKey` depend on them staying allowed.
-    func testAttributeOnlyReadsStayAllowedSoExistenceProbesKeepWorking() {
-        XCTAssertFalse(
-            RealKeychainTestGuard.isBlocked(
-                .read(requestsSecretData: false),
-                isTestProcess: true,
-                environment: [:]
-            )
+            RealKeychainTestGuard.isBlocked(.read, isTestProcess: true, environment: [:])
         )
     }
 
@@ -41,16 +30,16 @@ final class RealKeychainTestGuardTests: XCTestCase {
 
     // MARK: - Opt-in
 
-    func testTruthyOptInDisarmsTheGuard() {
+    func testTruthyOptInUnsealsTheRealKeychain() {
         for raw in ["1", "true", "yes", "on", "TRUE", "  yes  "] {
             let environment = [RealKeychainTestGuard.environmentKey: raw]
             XCTAssertFalse(
                 RealKeychainTestGuard.isBlocked(
-                    .read(requestsSecretData: true),
+                    .read,
                     isTestProcess: true,
                     environment: environment
                 ),
-                "\(raw.debugDescription) should disarm the guard"
+                "\(raw.debugDescription) should unseal the keychain"
             )
             XCTAssertFalse(
                 RealKeychainTestGuard.isBlocked(
@@ -58,20 +47,20 @@ final class RealKeychainTestGuardTests: XCTestCase {
                     isTestProcess: true,
                     environment: environment
                 ),
-                "\(raw.debugDescription) should disarm the guard"
+                "\(raw.debugDescription) should unseal the keychain"
             )
         }
     }
 
-    func testFalsyOptInValuesKeepTheGuardArmed() {
+    func testFalsyOptInValuesKeepTheSealInPlace() {
         for raw in ["0", "false", "no", "off", "", "banana"] {
             XCTAssertTrue(
                 RealKeychainTestGuard.isBlocked(
-                    .read(requestsSecretData: true),
+                    .read,
                     isTestProcess: true,
                     environment: [RealKeychainTestGuard.environmentKey: raw]
                 ),
-                "\(raw.debugDescription) should keep the guard armed"
+                "\(raw.debugDescription) should keep the seal in place"
             )
         }
     }
@@ -80,11 +69,7 @@ final class RealKeychainTestGuardTests: XCTestCase {
 
     func testNonTestProcessesAreNeverBlocked() {
         XCTAssertFalse(
-            RealKeychainTestGuard.isBlocked(
-                .read(requestsSecretData: true),
-                isTestProcess: false,
-                environment: [:]
-            )
+            RealKeychainTestGuard.isBlocked(.read, isTestProcess: false, environment: [:])
         )
         XCTAssertFalse(
             RealKeychainTestGuard.isBlocked(.write, isTestProcess: false, environment: [:])
@@ -94,8 +79,33 @@ final class RealKeychainTestGuardTests: XCTestCase {
     // MARK: - Process detection
 
     /// This suite runs under XCTest, so the runtime probe must say so — this
-    /// is what arms the guard for the whole default `swift test` run.
+    /// is what arms the seal for the whole default `swift test` run.
     func testThisTestProcessIsDetectedAsHostingXCTest() {
         XCTAssertTrue(RealKeychainTestGuard.processHostsXCTest)
+    }
+
+    // MARK: - The seal itself
+
+    /// End-to-end through the production backend: in this very (un-opted-in)
+    /// test process, a real read must come back not-found without ever
+    /// touching the Security framework, whatever this machine's keychain
+    /// actually holds.
+    func testProductionBackendSimulatesAnEmptyKeychainInThisProcess() throws {
+        guard !RealKeychainTestGuard.isOptedIn() else {
+            throw XCTSkip("run is opted into live keychain access")
+        }
+        let backend = SecItemKeychainBackend()
+        var result: AnyObject?
+        let status = backend.copyMatching(
+            query: [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: "dev.meterbar.app",
+                kSecReturnAttributes as String: true,
+                kSecMatchLimit as String: kSecMatchLimitOne
+            ],
+            result: &result
+        )
+        XCTAssertEqual(status, errSecItemNotFound)
+        XCTAssertNil(result)
     }
 }

--- a/MeterBarTests/SecureFileWriterTests.swift
+++ b/MeterBarTests/SecureFileWriterTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import XCTest
 @testable import MeterBar
 
@@ -141,6 +142,54 @@ final class SecureFileWriterTests: XCTestCase {
         XCTAssertEqual(try permissions(of: directory), 0o700)
     }
 
+    /// A directory can already satisfy the policy and still refuse `chmod`.
+    /// `$TMPDIR` is the case that bit us: owned by the user and already 0700,
+    /// but carrying the `sunlnk` system flag, so the unconditional tighten came
+    /// back EPERM and every caller reported failure for a directory that was
+    /// private to begin with — `WakeLock.acquire()` returned `.unavailable`
+    /// purely because it tried to re-tighten a parent it did not create.
+    ///
+    /// `uchg` reproduces that refusal deterministically: `chmod(2)` returns
+    /// EPERM for an immutable file even to its owner.
+    func testEnsurePrivateDirectoryAcceptsAnExistingPrivateDirectoryItCannotChmod() throws {
+        let directory = tempDirectory.appendingPathComponent("immutable-private", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try setImmutable(true, at: directory)
+        defer { try? setImmutable(false, at: directory) }
+
+        XCTAssertThrowsError(
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o700],
+                ofItemAtPath: directory.path
+            ),
+            "precondition: chmod must be refused for this directory"
+        )
+
+        XCTAssertNoThrow(try SecureFileWriter.ensurePrivateDirectory(directory))
+        XCTAssertEqual(try permissions(of: directory), 0o700)
+    }
+
+    /// The skip above is narrow on purpose. A directory that is *not* already
+    /// private must still fail loudly when it cannot be tightened — silently
+    /// accepting a world-readable directory would turn the S1 guard into a
+    /// no-op on exactly the systems that refuse the fix.
+    func testEnsurePrivateDirectoryStillThrowsWhenALooseDirectoryCannotBeTightened() throws {
+        let directory = tempDirectory.appendingPathComponent("immutable-loose", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o755]
+        )
+        try setImmutable(true, at: directory)
+        defer { try? setImmutable(false, at: directory) }
+
+        XCTAssertThrowsError(try SecureFileWriter.ensurePrivateDirectory(directory))
+    }
+
     // MARK: - Append-only files
 
     func testEnsurePrivateFileCreatesAnEmptyOwnerOnlyFile() throws {
@@ -173,5 +222,19 @@ final class SecureFileWriterTests: XCTestCase {
     private func permissions(of url: URL) throws -> Int {
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
         return try XCTUnwrap(attributes[.posixPermissions] as? Int)
+    }
+
+    /// Toggles `UF_IMMUTABLE` (`uchg`). A user flag, so the owner can both set
+    /// and clear it — unlike the `sunlnk` system flag on `$TMPDIR` that produced
+    /// the original failure — while producing the same EPERM from `chmod(2)`.
+    private func setImmutable(_ immutable: Bool, at url: URL) throws {
+        let flags: UInt32 = immutable ? UInt32(UF_IMMUTABLE) : 0
+        guard chflags(url.path, flags) == 0 else {
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(errno),
+                userInfo: [NSLocalizedDescriptionKey: String(cString: strerror(errno))]
+            )
+        }
     }
 }


### PR DESCRIPTION
Fixes #319.

## What this turned out to be

Two independent hang defects, compounding:

1. **The CI hang (run 30989912868's 19-minute park) was never the keychain, and never the SHA-256 test the log pointed at.** xctest writes progress to block-buffered stdout, so the last visible line is just the last flushed chunk. Reproduced locally (xctest at 0% CPU, ~10 min; `sample` shows the main thread in XCTest's async-test waiter, all workers idle, zero Security frames). The real culprit: `ClaudeTokenRefresherTests.testConcurrentRequestsForSameAccountCoalesceToOneSpawn` released its one-shot `SpawnGate` before the second refresh `Task` had joined the in-flight attempt. When the scheduler ran the release first, the user-initiated refresh bypassed cooldown, spawned a second run, and parked forever on the spent gate. Flaky by scheduler timing — which is why the same suite passed on master and on this branch's previous run.
2. **The #319 keychain-prompt class was still reachable** beyond `APIIntegrationTests`. A canary on `SecItemKeychainBackend` over a default `swift test` run found real decrypting login-keychain reads from `ApiUsageStore.init` (eager `AuthenticationManager.shared`), `OpenRouterService.init` (`hasKey` via `get`), `ClaudeCodeLocalService.init`'s detached `checkAccess()` probe, and — once a parked run crossed 10 minutes — `UsageDataManager.shared`'s 600 s auto-refresh timer firing `fetchUsageViaOAuth → ClaudeCredentialStore.shared → SecItemCopyMatching`: the exact stack in #319's report.

## Changes

- **Gate (original PR):** `LiveIntegrationTestGate` skips `APIIntegrationTests` unless `METERBAR_INTEGRATION_TESTS` is truthy.
- **Deterministic coalescing test:** `ClaudeTokenRefresher` gains a `coalescedJoins` probe; the test waits for the join before opening the gate, and `SpawnGate.release()` latches open so a late `run()` can never park. This is the actual CI-hang fix.
- **Prompt-free by construction:**
  - `KeychainManager.hasKey` is now an attributes-only existence probe — attribute reads never raise securityd's ACL dialog — with no legacy-migration side effect.
  - `ApiUsageStore` never resolves the decrypting `AuthenticationManager.shared` at construction or from the render-driven `authenticatedProviders` path (which dashboard render tests reach); key values resolve lazily at fetch time.
- **`RealKeychainTestGuard` seals the real keychain off from un-opted-in test runs (debug builds):** reads short-circuit to `errSecItemNotFound` before Security is called — deterministic, prompt-free, and machine-independent (exactly what credential-less CI runners already observed) — and writes trap loudly, since they would pollute the developer's real keychain. `LiveIntegrationTestGate` shares the guard's env parse so the two switches cannot drift. An earlier trap-on-read iteration caught every reachable live path during verification (that is how they were found), but its own first CI run showed read reachability is machine state, not a test bug — `checkAccess()` walks the keychain on a fresh runner yet is short-circuited by denial cooldowns on a logged-in machine — hence the hermetic-seal semantics.
- Plus the two rebased commits already on the branch: chmod skip for already-private directories, and the panel fade-in settle.

## Verification

- Full `swift test` on the branch rebased onto current master (v1.8.32, includes #328's Codex actor-hop fix): **1692 tests, 5 skipped (gated), 0 failures, ~106 s**, plus three earlier full green runs; `ClaudeTokenRefresherTests` ×5 green.
- `swiftlint lint --strict` (0.65.0): clean.
- An end-to-end test (`testProductionBackendSimulatesAnEmptyKeychainInThisProcess`) pins the seal through the production backend in-process.
- Forensics preserved: `xctest-2026-08-05-155807.ips` / `-160718.ips` hold the guard-captured stacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the menu panel could remain partially transparent after appearing.
  * Improved keychain checks to avoid unnecessary prompts and prevent unintended data access.
  * Improved refresh reliability when multiple requests occur simultaneously.
  * Ensured private directories only update permissions when necessary.

* **Tests**
  * Added safeguards so live integration tests are opt-in, preventing unexpected security prompts during test runs.
  * Expanded coverage for keychain access, refresh coordination, and secure directory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
