### PR TITLE
fix(codex): 1.8.3 Settings → Codex crash — account used after suspension in canAccess

### DIFF
--- a/.agents/SESSIONS/2026-08-05.md
+++ b/.agents/SESSIONS/2026-08-05.md
@@ -1,0 +1,73 @@
+# Sessions: 2026-08-05
+
+**Summary:** Fix 1.8.3 Settings → Codex crash
+
+---
+
+## Session 1: Settings → Codex segfault (1.8.3)
+
+**Duration:** ~30 min
+**Status:** Complete (PR #325 open)
+
+### What was done
+
+- Diagnosed the 1.8.3 crash report: `EXC_BAD_ACCESS` in `swift_retain` at
+  `0x8`, main thread, frames `CodexCliLocalService.canAccess(account:)` →
+  `outlined init with copy of CodexAccount`, entered through
+  `CodexAccountSettingsRow.refreshConnectionState()` and a
+  `nonisolated(nonsending)` reabstraction thunk
+  (`@guaranteed Builtin.ImplicitActor, @in_guaranteed CodexAccount`).
+- Root cause: regression from #317. `canAccess(account:)` gained a use of its
+  parameter **after** the `await` (`record(isAuthenticated, for: account)`).
+  Through the settings row's stored `(CodexAccount) async -> Bool` closure the
+  account is passed by address (`@in_guaranteed`) via the thunk, and that
+  caller-owned buffer does not survive the suspension (app builds with
+  `SWIFT_APPROACHABLE_CONCURRENCY` + default `MainActor` isolation). The
+  resume-path copy retains a garbage `String` field → segfault. Direct callers
+  (popover, `UsageDataManager`) never cross the thunk, which is why only the
+  Settings pane crashed.
+- Fix: `canAccess` copies `account.id` / `account.isDefault` into frame-owned
+  locals before suspending and never reads the parameter after the `await`.
+  `record` gained a primitive `(accountID:isDefault:)` overload; the existing
+  `record(_:for:)` forwards to it, all other call sites unchanged.
+- TDD: added `testProbeThroughStoredRowClosureRecordsPerAccountResult`, which
+  drives `canAccess` through a stored closure — the exact thunked path. Noted
+  honestly: the lifetime bug is codegen-dependent, so the old code does not
+  deterministically crash under the test allocator; the test pins behavior and
+  path.
+
+### Files changed
+
+- `MeterBar/Services/CodexCliLocalService.swift` - hoist id/isDefault before
+  the suspension in `canAccess`; split `record` into a primitive overload
+- `MeterBarTests/CodexAccountAccessTests.swift` - stored-closure probe
+  regression test
+
+### Decisions
+
+- **Decision:** Fix at the callee (`canAccess`) rather than at the row's
+  closure or by making the closure `@Sendable`.
+  - **Context:** The unsafe pattern is "read an `@in_guaranteed` parameter
+    after a suspension point"; any future caller through any closure shape
+    would hit it again.
+  - **Rationale:** Removing the post-await parameter use fixes every entry
+    path at once and keeps the row's API unchanged.
+
+### Verification
+
+- `swift build` clean; SwiftLint clean on touched files.
+- `CodexAccountAccessTests` (8), `CodexCliLocalServiceTests` (10),
+  `CodexAccountProfileRowTests` + `ProviderSnapshotTests` (44) all green.
+- Not reproduced end-to-end in a release build (crash is
+  optimization/codegen-dependent); PR CI is the merge gate.
+
+### Next steps
+
+- [ ] Land PR #325 once CI completes.
+- [ ] Consider auditing other `@in_guaranteed`-after-`await` uses of accounts
+      reached through stored async closures (e.g. `fetchUsageMetrics` closures
+      are direct-call paths today, but the pattern is fragile).
+
+---
+
+**Total sessions today:** 1

--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -111,10 +111,18 @@ class CodexCliLocalService: ObservableObject {
     }
 
     func canAccess(account: CodexAccount) async -> Bool {
+        // `account` can arrive @in_guaranteed through the settings row's stored
+        // `(CodexAccount) async -> Bool` closure (a nonisolated(nonsending)
+        // reabstraction thunk), and that indirect argument is not reliably
+        // alive after a suspension point — 1.8.3 crashed in swift_retain
+        // copying it on resume. Copy out everything needed after the await
+        // before suspending, and never touch `account` past this point.
+        let accountID = account.id
+        let isDefault = account.isDefault
         let isAuthenticated = await Task.detached(priority: .userInitiated) { [self] in
             hasAccess(account: account)
         }.value
-        record(isAuthenticated, for: account)
+        record(isAuthenticated, accountID: accountID, isDefault: isDefault)
         return isAuthenticated
     }
 
@@ -130,8 +138,12 @@ class CodexCliLocalService: ObservableObject {
     /// pair still describes the default sentinel, so a custom profile records
     /// only its own entry and never publishes over the default's.
     private func record(_ isAuthenticated: Bool, for account: CodexAccount) {
-        accountAccess[account.id] = isAuthenticated
-        guard account.isDefault else { return }
+        record(isAuthenticated, accountID: account.id, isDefault: account.isDefault)
+    }
+
+    private func record(_ isAuthenticated: Bool, accountID: UUID, isDefault: Bool) {
+        accountAccess[accountID] = isAuthenticated
+        guard isDefault else { return }
         hasAccess = isAuthenticated
         if !isAuthenticated { subscriptionType = nil }
     }

--- a/MeterBarTests/CodexAccountAccessTests.swift
+++ b/MeterBarTests/CodexAccountAccessTests.swift
@@ -117,6 +117,29 @@ final class CodexAccountAccessTests: XCTestCase {
         XCTAssertEqual(service.accountAccess[work.id], .some(true))
     }
 
+    /// Regression for the 1.8.3 Settings → Codex crash: the settings row probes
+    /// through a stored `(CodexAccount) async -> Bool` closure, so the account
+    /// reaches `canAccess` @in_guaranteed via a nonisolated(nonsending)
+    /// reabstraction thunk, and that indirect argument did not survive the
+    /// probe's suspension point. This drives the exact same thunked path; the
+    /// service must record the result without touching the argument after resume.
+    func testProbeThroughStoredRowClosureRecordsPerAccountResult() async {
+        let work = custom()
+        let service = makeService(authenticatedAccountIDs: [work.id])
+        let connectionCheck: (CodexAccount) async -> Bool = {
+            await service.canAccess(account: $0)
+        }
+
+        let workConnected = await connectionCheck(work)
+        let defaultConnected = await connectionCheck(.defaultAccount)
+
+        XCTAssertTrue(workConnected)
+        XCTAssertFalse(defaultConnected)
+        XCTAssertEqual(service.accountAccess[work.id], .some(true))
+        XCTAssertEqual(service.accountAccess[CodexAccount.defaultID], .some(false))
+        XCTAssertFalse(service.hasAccess)
+    }
+
     func testProviderAccessSpansEveryEnabledProfile() {
         let work = custom()
         let service = makeService(authenticatedAccountIDs: [work.id])


### PR DESCRIPTION
## Crash

1.8.3 segfaults on opening **Settings → Codex** (`EXC_BAD_ACCESS`, `swift_retain` at `0x8`, main thread):

```
0 swift_retain
2 outlined init with copy of CodexAccount
3 CodexCliLocalService.canAccess(account:)
4 thunk for @escaping @async (@guaranteed Builtin.ImplicitActor, @in_guaranteed CodexAccount) -> Bool
5 CodexAccountSettingsRow.refreshConnectionState()
```

## Root cause

Regression from #317. `canAccess(account:)` gained a use of its parameter **after** the `await`:

```swift
let isAuthenticated = await Task.detached { ... }.value
record(isAuthenticated, for: account)   // ← new in #317
```

When the probe runs through `CodexAccountSettingsRow`'s stored `(CodexAccount) async -> Bool` closure (its default argument), the account arrives `@in_guaranteed` — by address — via a `nonisolated(nonsending)` reabstraction thunk (the `Builtin.ImplicitActor` frame; the app builds with `SWIFT_APPROACHABLE_CONCURRENCY` + default `MainActor` isolation). That caller-owned indirect buffer does not survive the suspension, so the resume-path copy of `CodexAccount` retains a garbage `String` reference and faults. Direct callers (popover, `UsageDataManager`) never cross this thunk, which is why only the Settings pane crashed.

## Fix

`canAccess` copies `account.id` / `account.isDefault` into frame-owned locals **before** suspending and never reads the parameter after the `await`. `record` gains a primitive `(accountID:isDefault:)` overload; the existing `record(_:for:)` forwards to it, so all other call sites are unchanged.

## Tests

- New `testProbeThroughStoredRowClosureRecordsPerAccountResult` drives `canAccess` through a stored `(CodexAccount) async -> Bool` closure — the exact thunked path the settings row uses — and asserts per-account recording plus the untouched default flag. Note: the underlying lifetime bug is a codegen issue, so the old code does not deterministically crash in-process under the test allocator; the test pins the behavior and the path.
- `swift build` clean; SwiftLint clean on touched files.
- `CodexAccountAccessTests` (8), `CodexCliLocalServiceTests` (10), `CodexAccountProfileRowTests` + `ProviderSnapshotTests` (44) all green.

Refs #317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account access checks to reliably record authentication for the correct account, including custom and default profiles.
  * Preserved accurate shared default-account access status during asynchronous checks.

* **Tests**
  * Added regression coverage for account-specific access results and default-account status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->