### PR TITLE
chore: bump version to 1.8.31

### DIFF
--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.3;
+				MARKETING_VERSION = 1.8.31;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -369,7 +369,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.3;
+				MARKETING_VERSION = 1.8.31;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -534,7 +534,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.3;
+				MARKETING_VERSION = 1.8.31;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug;
 				PRODUCT_NAME = "MeterBar Dev";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -580,7 +580,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.3;
+				MARKETING_VERSION = 1.8.31;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary

- Bump `MARKETING_VERSION` 1.8.3 → 1.8.31 across all four Xcode configs (app, app-debug, widget, widget-debug).
- `CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)"`, so stable ships identical short/build versions.

## Context

Pre-release bump for **v1.8.31**, cut to ship the 1.8.3 Settings → Codex crash fix (#325). That crash is a hard `EXC_BAD_ACCESS` on opening Settings → Codex on every 1.8.3 install, so it warrants an immediate patch release rather than waiting for the next feature batch.

`v1.8.31` sorts above `v1.8.3` for both SemVer and Sparkle's standard version comparator (component-wise numeric: 31 > 3), so 1.8.3 users are offered the update normally.

Release builds derive their version from the git tag in `_build-signed.yml`, so this commit does not change what CI produces for a tagged release — it keeps **local** Release builds from reporting an already-published version.

## Out of scope

The `1.8.3` strings in `scripts/fixtures/app-launch/fake-app-executable.sh`, `scripts/test-app-launch-smoke.sh`, and `MeterBarTests/LaunchSmokeProbeTests.swift` are self-consistent launch-smoke **fixture** data, not the app version. Left alone, as in #323 and #310.

## Verification

- `xcodebuild -showBuildSettings` resolves `MARKETING_VERSION = 1.8.31` and `CURRENT_PROJECT_VERSION = 1.8.31`.
- Version grep shows a single marketing version across the project (4/4 configs).
- Full build/test coverage via PR CI.