### PR TITLE
docs(sessions): log the v1.8.31 release

### DIFF
--- a/.agents/SESSIONS/2026-08-05.md
+++ b/.agents/SESSIONS/2026-08-05.md
@@ -1,6 +1,6 @@
 # Sessions: 2026-08-05
 
-**Summary:** Fix 1.8.3 Settings → Codex crash
+**Summary:** Fix 1.8.3 Settings → Codex crash, ship v1.8.31
 
 ---
 
@@ -63,11 +63,73 @@
 
 ### Next steps
 
-- [ ] Land PR #325 once CI completes.
+- [x] Land PR #325 once CI completes.
 - [ ] Consider auditing other `@in_guaranteed`-after-`await` uses of accounts
       reached through stored async closures (e.g. `fetchUsageMetrics` closures
       are direct-call paths today, but the pattern is fragile).
 
 ---
 
-**Total sessions today:** 1
+## Session 2: Cut and publish v1.8.31
+
+**Duration:** ~35 min
+**Status:** Complete (released)
+
+### What was done
+
+- Landed #325 after all four required checks passed (`build`, `Tests +
+  coverage gate`, `SwiftLint`, `Secret Scan`).
+- Bumped `MARKETING_VERSION` 1.8.3 → 1.8.31 across all four Xcode configs
+  (#326) and merged it. Patch release cut solely to ship the crash fix: the
+  Settings → Codex segfault reproduces on every 1.8.3 install, so it did not
+  wait for the next feature batch.
+- Ran `/release`: preflight (clean master in sync with origin, single
+  `MARKETING_VERSION`, tag free, `validate-release-tag.sh` pass), then
+  `git tag -a v1.8.31` + push.
+- Release workflow green end to end — `version`, `build / Tests + coverage
+  gate`, `build / build`, `update-homebrew / update-formula`.
+
+### Files changed
+
+- `MeterBar.xcodeproj/project.pbxproj` - `MARKETING_VERSION` 1.8.3 → 1.8.31
+  (4/4 configs)
+
+### Decisions
+
+- **Decision:** Release as `1.8.31` rather than `1.8.4`.
+  - **Context:** Requested version. `v1.8.31` satisfies
+    `validate-release-tag.sh`'s canonical `vMAJOR.MINOR.PATCH` pattern.
+  - **Rationale:** Sorts above `1.8.3` for both SemVer and Sparkle's standard
+    comparator (component-wise numeric, 31 > 3), so 1.8.3 users are offered
+    the update normally. Verified in the published appcast.
+- **Decision:** Ship without #324.
+  - **Context:** #324 (`fix/319-keychain-test-hang`) has two failing required
+    checks — its `Tests + coverage gate` job hung 19 min on
+    `ClaudeCredentialResolverTests.testKeychainServiceIsFirstEightHexCharactersOfConfigDirSHA256`
+    and was cancelled, which then failed `build` on its prerequisite. The same
+    test passes in 0.000s on master.
+  - **Rationale:** Not mergeable under branch protection, and it carries no
+    user-facing change that the crash fix release needed.
+
+### Verification
+
+- GitHub Release `v1.8.31` published (not draft, not prerelease) with
+  `MeterBar-v1.8.31.zip`, its `.sha256`, and `appcast.xml`.
+- Appcast advertises `sparkle:version` / `shortVersionString` `1.8.31` with an
+  EdDSA signature on the enclosure.
+- Homebrew cask `VincentShipsIt/homebrew-tap` bumped to `version "1.8.31"`
+  with a matching `sha256`.
+
+### Next steps
+
+- [ ] #324 is red and 2 commits behind master: its gate covers
+      `APIIntegrationTests` only, but the CI hang landed in
+      `ClaudeCredentialResolverTests`, so #319 is not actually fixed. Rebase,
+      widen the gate to every suite that reaches the real keychain, re-run.
+- [ ] `/release` step 2's version grep matches `CURRENT_PROJECT_VERSION =
+      "$(MARKETING_VERSION)"` too, so the "entries differ" guard false-positives.
+      Tighten to `MARKETING_VERSION = [0-9]`.
+
+---
+
+**Total sessions today:** 2


### PR DESCRIPTION
## Summary

Appends Session 2 to `.agents/SESSIONS/2026-08-05.md` covering the v1.8.31 cut: what shipped, the two version decisions, the release verification, and the two follow-ups discovered along the way.

## Notes

Doc-only. Two follow-ups recorded rather than fixed here:

- **#324 is red**, not merely unmerged. Its `Tests + coverage gate` job hung 19 min on `ClaudeCredentialResolverTests.testKeychainServiceIsFirstEightHexCharactersOfConfigDirSHA256` and was cancelled, failing `build` on its prerequisite. `LiveIntegrationTestGate` gates `APIIntegrationTests` only, so #319's hang is not actually fixed.
- **`/release` step 2's version grep** matches `CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)"` as well, so its "entries differ" guard false-positives on a correct project file.