### PR TITLE
fix(codex): stop the Settings → Codex crash at the actor entry hop

### DIFF
--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -110,19 +110,38 @@ class CodexCliLocalService: ObservableObject {
         getAuthToken(account: account) != nil
     }
 
-    func canAccess(account: CodexAccount) async -> Bool {
-        // `account` can arrive @in_guaranteed through the settings row's stored
-        // `(CodexAccount) async -> Bool` closure (a nonisolated(nonsending)
-        // reabstraction thunk), and that indirect argument is not reliably
-        // alive after a suspension point — 1.8.3 crashed in swift_retain
-        // copying it on resume. Copy out everything needed after the await
-        // before suspending, and never touch `account` past this point.
-        let accountID = account.id
-        let isDefault = account.isDefault
+    /// `nonisolated` is load-bearing — see the lifetime note below. Do not
+    /// re-isolate this to the main actor.
+    nonisolated func canAccess(account: CodexAccount) async -> Bool {
+        // The settings row probes through a stored `(CodexAccount) async -> Bool`
+        // closure, so `account` arrives @in_guaranteed: an address the *caller*
+        // owns, not storage this frame owns. A main-actor-isolated `async`
+        // callee hops to the main actor before its body runs, and that address
+        // does not survive the hop — both 1.8.3 and 1.8.31 faulted in
+        // `swift_retain` while the outlined copy retained the parameter's
+        // `String` fields on the far side of that entry hop. (1.8.31 only moved
+        // the *later* `record` read, which was never the faulting one.)
+        //
+        // Two rules keep this safe, and both are required:
+        //   1. `nonisolated` — under `SWIFT_APPROACHABLE_CONCURRENCY` that means
+        //      `nonisolated(nonsending)`, so the body starts on the caller's
+        //      executor with no entry hop and `account` is still live.
+        //   2. Copy into frame-owned storage first, then never read `account`
+        //      again — every later use goes through `snapshot`.
+        // Verify after any change: in the Release binary, the call to
+        // `outlined init with copy of CodexAccount` inside `canAccess` must come
+        // *before* the first `swift_task_switch`.
+        let snapshot = account
+        let accountID = snapshot.id
+        let isDefault = snapshot.isDefault
+
         let isAuthenticated = await Task.detached(priority: .userInitiated) { [self] in
-            hasAccess(account: account)
+            hasAccess(account: snapshot)
         }.value
-        record(isAuthenticated, accountID: accountID, isDefault: isDefault)
+
+        await MainActor.run {
+            record(isAuthenticated, accountID: accountID, isDefault: isDefault)
+        }
         return isAuthenticated
     }
 

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -43,7 +43,11 @@ extension ClaudeCodeUsageProviding {
 extension ClaudeCodeLocalService: ClaudeCodeUsageProviding {}
 
 protocol CodexUsageProviding: AnyObject {
-    func canAccess(account: CodexAccount) async -> Bool
+    /// `nonisolated` so the witness thunk forwards `account` without a main-actor
+    /// entry hop — see the lifetime note on `CodexCliLocalService.canAccess`.
+    /// The refresh legs call this off the main actor, which is exactly where a
+    /// hopping thunk would strand the indirect argument.
+    nonisolated func canAccess(account: CodexAccount) async -> Bool
     func fetchUsageMetrics(account: CodexAccount) async throws -> UsageMetrics
 }
 

--- a/MeterBar/Views/Settings/CodexAccountSettingsRow.swift
+++ b/MeterBar/Views/Settings/CodexAccountSettingsRow.swift
@@ -87,6 +87,11 @@ struct CodexAccountSettingsRow: View {
     }
 
     private func refreshConnectionState() async {
+        // Snapshot into frame-owned storage before probing: `connectionCheck` is
+        // a stored async closure, so the account travels through a reabstraction
+        // thunk as an indirect (`@in_guaranteed`) argument. Passing a copy this
+        // frame owns keeps that address valid for the callee's whole lifetime.
+        let account = self.account
         guard account.isEnabled else {
             connectionState = .disabled
             return

--- a/MeterBarTests/CodexAccountAccessTests.swift
+++ b/MeterBarTests/CodexAccountAccessTests.swift
@@ -140,6 +140,26 @@ final class CodexAccountAccessTests: XCTestCase {
         XCTAssertFalse(service.hasAccess)
     }
 
+    /// `canAccess` must stay `nonisolated`. A main-actor-isolated `async` probe
+    /// hops to the main actor *before its body runs*, and the caller-owned
+    /// `@in_guaranteed` account address does not survive that entry hop — that
+    /// is the codegen that segfaulted in both 1.8.3 and 1.8.31. Probing from a
+    /// detached task pins the requirement: this only completes without a
+    /// deadlock-free main hop if the callee starts on the caller's executor and
+    /// re-enters the main actor explicitly to record.
+    func testProbeFromOffTheMainActorThroughStoredClosureStillRecords() async {
+        let work = custom()
+        let service = makeService(authenticatedAccountIDs: [work.id])
+        let connectionCheck: @Sendable (CodexAccount) async -> Bool = {
+            await service.canAccess(account: $0)
+        }
+
+        let connected = await Task.detached { await connectionCheck(work) }.value
+
+        XCTAssertTrue(connected)
+        XCTAssertEqual(service.accountAccess[work.id], .some(true))
+    }
+
     func testProviderAccessSpansEveryEnabledProfile() {
         let work = custom()
         let service = makeService(authenticatedAccountIDs: [work.id])


### PR DESCRIPTION
## The 1.8.31 fix did not work

The user reported the Providers → Codex page still crashing after 1.8.31. Confirmed at the binary level.

PR #325 hoisted `account.id` / `account.isDefault` above the `await` inside `canAccess`. That read was never the faulting one. The crashing copy is the `Task.detached` closure capture — and `canAccess` was still `@MainActor`-isolated `async`, so the compiler emits `swift_task_switch` at **function entry**, before any body code runs. Nothing inside the body could be made safe by reordering.

## Root cause

Reached from `CodexAccountSettingsRow`, the account travels through a reabstraction thunk for a stored `(CodexAccount) async -> Bool` closure, so it arrives `@in_guaranteed` — an address the *caller* owns, not storage the callee frame owns. That buffer does not survive the entry actor hop. The outlined value-witness copy then retained a dead `String`, faulting in `swift_retain` at `KERN_INVALID_ADDRESS 0x8`.

This is why only the Settings pane crashed: direct callers and protocol-witness callers hold the value in a live caller coroutine frame; only the thunk for a stored async closure passes a temporary that dies at the hop.

## Fix

- **`canAccess` is now `nonisolated`.** Under `SWIFT_APPROACHABLE_CONCURRENCY` that means `nonisolated(nonsending)` — the body starts on the caller's executor with no entry hop, so `account` is still live.
- **Copy into frame-owned storage** (`let snapshot = account`) before any suspension; every later use goes through the snapshot.
- **Re-enter the main actor explicitly** via `await MainActor.run` to record the result.
- **`CodexUsageProviding.canAccess` is `nonisolated` too**, so the protocol witness thunk does not reintroduce the hop for the refresh legs that call it off the main actor.
- **`refreshConnectionState`** snapshots the account into frame-owned storage before probing.

## Binary verification

Release build, disassembly of `canAccess` (entry `0x1000f5f7c`):

| | 1.8.3 / 1.8.31 (crashing) | this branch |
|---|---|---|
| first | `swift_task_switch` | `CodexAccountVWOc` @ instr #79 |
| then | **`CodexAccountVWOc`** ← faults | `swift_retain`, `Task.detached` |
| then | `swift_retain` / `Task.detached` | first `swift_task_switch` @ instr #169 |

The copy now happens 90 instructions *before* any actor hop — the exact inversion of the crashing order.

## Tests

New regression test probes through a stored closure from a detached task, which only passes if the callee starts on the caller's executor:

```
testProbeFromOffTheMainActorThroughStoredClosureStillRecords
```

- `swift test --filter "CodexAccountAccessTests|CodexCliLocalServiceTests"` → **19 tests, 0 failures**
- Full suite → 1673 tests, 3 failures, all pre-existing and environmental (verified by re-running them on the unmodified tree): live-API auth, headless AppKit animation timing, and a TMPDIR permission error on a lock directory.
- SwiftLint clean on all touched files.

## Known residual

`fetchUsageMetrics(account:)` and `consumeResetCredit(account:)` still read `account` after `await` while main-actor-isolated. They are not reached through a stored-closure thunk today, so they do not crash — but the same hazard applies if a caller ever routes through one. Changing their isolation ripples into `makeCodexRequest` / `usageEndpoint` / `urlSession`, so it is deliberately out of scope here and logged as follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when checking account connection status from background tasks.
  * Ensured connection results are recorded for the correct account after asynchronous checks.

* **Tests**
  * Added coverage for connection checks performed off the main thread through stored asynchronous callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->