### PR TITLE
chore: bump version to 1.8.32

### DIFF
--- a/.agents/SESSIONS/2026-08-05.md
+++ b/.agents/SESSIONS/2026-08-05.md
@@ -1,6 +1,7 @@
 # Sessions: 2026-08-05
 
-**Summary:** Fix 1.8.3 Settings → Codex crash, ship v1.8.31
+**Summary:** Fix 1.8.3 Settings → Codex crash, ship v1.8.31, then fix it for
+real in v1.8.32 after the 1.8.31 fix proved ineffective
 
 ---
 
@@ -132,4 +133,99 @@
 
 ---
 
-**Total sessions today:** 2
+## Session 3: The 1.8.31 fix did not work — real fix for v1.8.32
+
+**Duration:** ~60 min
+**Status:** Complete (PR #328 merged, bump PR open)
+
+### What was done
+
+- User reported Providers → Codex still crashing on 1.8.31. Reproduced at the
+  binary level instead of reasoning statically, which is what exposed the
+  mistake.
+- **Session 1's fix was wrong.** It hoisted `account.id` / `account.isDefault`
+  above the `await` inside `canAccess`. That read was never the faulting one.
+  The crashing copy is the `Task.detached` closure capture, and `canAccess` was
+  still `@MainActor async` — so the compiler emits `swift_task_switch` at
+  *function entry*, before any body code runs. No reordering inside the body
+  could have helped.
+- Root cause, precisely: reached through `CodexAccountSettingsRow`'s stored
+  `(CodexAccount) async -> Bool` closure, the account arrives `@in_guaranteed`
+  — an address the *caller* owns. That buffer does not survive the entry actor
+  hop, so the outlined value-witness copy retained a dead `String` and faulted
+  in `swift_retain` at `KERN_INVALID_ADDRESS 0x8`.
+- Why only the Settings pane crashed: direct callers and protocol-witness
+  callers keep the value in a live caller coroutine frame. Only the
+  reabstraction thunk for a *stored* async closure passes a temporary that dies
+  at the hop.
+- Fix: `canAccess` is `nonisolated` (under `SWIFT_APPROACHABLE_CONCURRENCY`
+  that means `nonisolated(nonsending)`, so no entry hop), snapshots into
+  frame-owned storage before suspending, and re-enters the main actor
+  explicitly via `await MainActor.run` to record. `CodexUsageProviding
+  .canAccess` is `nonisolated` too so the witness thunk does not reintroduce
+  the hop for off-main refresh legs.
+- Added a regression test that probes through a stored closure from a detached
+  task — it only passes if the callee starts on the caller's executor.
+
+### Files changed
+
+- `MeterBar/Services/CodexCliLocalService.swift` — `canAccess` nonisolated,
+  snapshot, explicit `MainActor.run`
+- `MeterBar/Services/UsageDataManager.swift` — `nonisolated` protocol
+  requirement on `CodexUsageProviding`
+- `MeterBar/Views/Settings/CodexAccountSettingsRow.swift` — frame-owned account
+  snapshot in `refreshConnectionState()`
+- `MeterBarTests/CodexAccountAccessTests.swift` —
+  `testProbeFromOffTheMainActorThroughStoredClosureStillRecords`
+
+### Decisions
+
+- **Decision:** Do not add post-hop snapshots to `fetchUsageMetrics(account:)`
+  and `consumeResetCredit(account:)`.
+  - **Context:** Both still read `account` after an `await` while main-actor
+    isolated.
+  - **Rationale:** A snapshot taken *after* the entry hop is theatre — it would
+    create false confidence without changing the codegen. Neither is reached
+    through a stored-closure thunk today, so neither crashes. Changing their
+    isolation ripples into `makeCodexRequest` / `usageEndpoint` / `urlSession`.
+    Logged as an explicit follow-up instead.
+- **Decision:** Verify the fix by disassembly, not by reasoning.
+  - **Context:** The 1.8.31 fix looked correct and was not.
+  - **Rationale:** The acceptance criterion is mechanical and checkable: the
+    call to `outlined init with copy of CodexAccount` must precede the first
+    `swift_task_switch`. That criterion is now written into the code comment so
+    the next change is checked the same way.
+
+### Verification
+
+- Release binary, `canAccess` entry `0x1000f5f7c`: `CodexAccountVWOc` at
+  instruction #79, first `swift_task_switch` at #169 — the copy is 90
+  instructions *before* any actor hop, inverting the crashing order.
+- `swift test --filter "CodexAccountAccessTests|CodexCliLocalServiceTests"` →
+  19 tests, 0 failures.
+- Full suite → 1673 tests, 3 failures, all confirmed pre-existing by re-running
+  them on the unmodified tree: `APIIntegrationTests.testClaudeCodeAPIAccess`
+  (live API, `notAuthenticated`), `LiquidGlassP1RegressionTests
+  .testRapidShowDismissShowLeavesPanelVisibleAndOpaque` (headless AppKit
+  animation timing), `SessionWakeAgentTests
+  .testAgentLifetimeLockExcludesAppAndCLIHolders` (TMPDIR lock-dir permission).
+- SwiftLint clean. All five required checks green on #328 before merge.
+
+### Notes
+
+- Tooling: `otool -tV` + `awk` address-range slicing works on this binary;
+  `objdump --start-address` prints wrong addresses — do not use it here.
+- The Xcode scheme has no test action, so `xcodebuild test` fails. Use
+  `swift test`.
+
+### Next steps
+
+- [ ] Audit `fetchUsageMetrics(account:)` and `consumeResetCredit(account:)`
+      for the same `@in_guaranteed`-across-a-hop hazard if either ever gains a
+      stored-closure caller.
+- [ ] Carry forward from Session 2: repair #324; tighten `/release` step 2's
+      grep to `MARKETING_VERSION = [0-9]`.
+
+---
+
+**Total sessions today:** 3

--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.31;
+				MARKETING_VERSION = 1.8.32;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -369,7 +369,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.31;
+				MARKETING_VERSION = 1.8.32;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -534,7 +534,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.31;
+				MARKETING_VERSION = 1.8.32;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug;
 				PRODUCT_NAME = "MeterBar Dev";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -580,7 +580,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.31;
+				MARKETING_VERSION = 1.8.32;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
Bumps `MARKETING_VERSION` 1.8.31 → 1.8.32 across all four build configurations, and logs Session 3.

Ships the real Settings → Codex crash fix from #328.

**Why a new patch immediately after 1.8.31:** 1.8.31 shipped a fix that did not work. It reordered reads inside `canAccess`, but that function was main-actor-isolated `async`, so the fault happens at the *entry* actor hop before any body code runs. #328 makes the function `nonisolated` so there is no entry hop, and verifies it by disassembly: the `CodexAccount` copy is now 90 instructions before the first `swift_task_switch`.

Tag `v1.8.32` follows once this merges.