### PR TITLE
fix(settings): remove the Codex probe reabstraction thunk that crashed the Providers pane

### DIFF
--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -113,24 +113,27 @@ class CodexCliLocalService: ObservableObject {
     /// `nonisolated` is load-bearing — see the lifetime note below. Do not
     /// re-isolate this to the main actor.
     nonisolated func canAccess(account: CodexAccount) async -> Bool {
-        // The settings row probes through a stored `(CodexAccount) async -> Bool`
-        // closure, so `account` arrives @in_guaranteed: an address the *caller*
-        // owns, not storage this frame owns. A main-actor-isolated `async`
-        // callee hops to the main actor before its body runs, and that address
-        // does not survive the hop — both 1.8.3 and 1.8.31 faulted in
-        // `swift_retain` while the outlined copy retained the parameter's
-        // `String` fields on the far side of that entry hop. (1.8.31 only moved
-        // the *later* `record` read, which was never the faulting one.)
+        // Callers must not reach this through a stored `(CodexAccount) async ->
+        // Bool` closure. Such a closure is an abstract function type, so the
+        // account is passed indirectly (`@in_guaranteed`) through a
+        // reabstraction thunk and this frame receives an address it does not
+        // own; the copy below then retained a dead `String` and faulted in
+        // `swift_retain` at `0x8`. That was the 1.8.3/1.8.31/1.8.32 crash, and
+        // the fix lives at the call site — `CodexAccountSettingsRow` now binds
+        // the account into a `() async -> Bool` closure so no thunk exists.
         //
-        // Two rules keep this safe, and both are required:
+        // What this function still owes its callers:
         //   1. `nonisolated` — under `SWIFT_APPROACHABLE_CONCURRENCY` that means
         //      `nonisolated(nonsending)`, so the body starts on the caller's
-        //      executor with no entry hop and `account` is still live.
+        //      executor with no entry hop.
         //   2. Copy into frame-owned storage first, then never read `account`
         //      again — every later use goes through `snapshot`.
-        // Verify after any change: in the Release binary, the call to
-        // `outlined init with copy of CodexAccount` inside `canAccess` must come
-        // *before* the first `swift_task_switch`.
+        //
+        // Do *not* re-verify a change here by checking instruction ordering
+        // inside this function: that criterion passed on 1.8.32 and the app
+        // still crashed, because the incoming address was already dead. The
+        // criterion that matters is at the call site (see the note in
+        // `CodexAccountSettingsRow.init`).
         let snapshot = account
         let accountID = snapshot.id
         let isDefault = snapshot.isDefault

--- a/MeterBar/Views/Settings/CodexAccountSettingsRow.swift
+++ b/MeterBar/Views/Settings/CodexAccountSettingsRow.swift
@@ -18,9 +18,7 @@ struct CodexAccountSettingsRow: View {
         onRemove: @escaping () -> Void,
         onMoveUp: @escaping () -> Void,
         onMoveDown: @escaping () -> Void,
-        connectionCheck: @escaping (CodexAccount) async -> Bool = {
-            await CodexCliLocalService.shared.canAccess(account: $0)
-        }
+        connectionCheck: (@Sendable () async -> Bool)? = nil
     ) {
         self.account = account
         self.canDisable = canDisable
@@ -32,7 +30,33 @@ struct CodexAccountSettingsRow: View {
         self.onRemove = onRemove
         self.onMoveUp = onMoveUp
         self.onMoveDown = onMoveDown
-        self.connectionCheck = connectionCheck
+        // Bind the account into the probe closure's heap context *here*, in the
+        // initializer, where it is provably live — rather than passing it as an
+        // argument to a stored async closure later.
+        //
+        // A stored `(CodexAccount) async -> Bool` is an abstract function type,
+        // so every parameter is passed indirectly (`@in_guaranteed`) through a
+        // reabstraction thunk: the callee receives an *address it does not own*.
+        // Reached from `.task`, the buffer behind that address was already dead
+        // by the time `canAccess` copied out of it, and the outlined copy
+        // retained a garbage `String` field — `EXC_BAD_ACCESS` in `swift_retain`
+        // at `0x8`. That is the crash in 1.8.3, 1.8.31 and 1.8.32; all three
+        // fixes reordered work *around* the thunk instead of removing it.
+        //
+        // A `() async -> Bool` seam has no parameter to reabstract. The account
+        // lives in this closure's heap context for the closure's whole lifetime
+        // and `canAccess` becomes a direct call. The thunk is not reordered —
+        // it cannot be emitted at all.
+        //
+        // Acceptance criterion, mechanical and checkable against the shipped
+        // Release binary (not against this reasoning — reasoning is what failed
+        // three times): no reabstraction thunk taking `@in_guaranteed
+        // CodexAccount` may exist in the binary.
+        if let connectionCheck {
+            self.probeConnection = connectionCheck
+        } else {
+            self.probeConnection = { await CodexCliLocalService.shared.canAccess(account: account) }
+        }
         _connectionState = State(initialValue: account.isEnabled ? .checking : .disabled)
     }
 
@@ -74,7 +98,8 @@ struct CodexAccountSettingsRow: View {
     private let onRemove: () -> Void
     private let onMoveUp: () -> Void
     private let onMoveDown: () -> Void
-    private let connectionCheck: (CodexAccount) async -> Bool
+    /// Takes no argument by design — see the note in `init`.
+    private let probeConnection: @Sendable () async -> Bool
 
     @State private var connectionState: ProviderAccountConnectionState
 
@@ -87,17 +112,13 @@ struct CodexAccountSettingsRow: View {
     }
 
     private func refreshConnectionState() async {
-        // Snapshot into frame-owned storage before probing: `connectionCheck` is
-        // a stored async closure, so the account travels through a reabstraction
-        // thunk as an indirect (`@in_guaranteed`) argument. Passing a copy this
-        // frame owns keeps that address valid for the callee's whole lifetime.
-        let account = self.account
+        // No account crosses this call: `probeConnection` already holds it.
         guard account.isEnabled else {
             connectionState = .disabled
             return
         }
         connectionState = .checking
-        let isAuthenticated = await connectionCheck(account)
+        let isAuthenticated = await probeConnection()
         guard !Task.isCancelled else { return }
         connectionState = isAuthenticated ? .authenticated : .loginRequired
     }

--- a/MeterBarTests/CodexAccountProfileRowTests.swift
+++ b/MeterBarTests/CodexAccountProfileRowTests.swift
@@ -108,7 +108,9 @@ final class CodexAccountProfileRowTests: XCTestCase {
             onRemove: {},
             onMoveUp: {},
             onMoveDown: {},
-            connectionCheck: { _ in false }
+            // Zero-argument seam on purpose: the row must never store a
+            // `(CodexAccount) async -> Bool`. See `CodexAccountSettingsRow.init`.
+            connectionCheck: { false }
         )
         let hostingView = NSHostingView(rootView: view.frame(width: 720))
 


### PR DESCRIPTION
Fourth attempt at the Settings → Codex segfault. The first three failed because they reordered work **around** the faulting construct instead of removing it.

## Root cause

`CodexAccountSettingsRow` stored the probe as `(CodexAccount) async -> Bool`. That is an *abstract* function type, so every parameter is passed indirectly (`@in_guaranteed`) through a reabstraction thunk — `canAccess` receives an address it does not own. Reached from `.task`, the buffer behind that address was already dead when `canAccess` copied out of it: the outlined copy retained a garbage `String` and faulted in `swift_retain` at `0x8`.

Frame 4 of every crash report is that thunk, and the symbol names it as **`default argument 10` of `CodexAccountSettingsRow.init`** — the production path. It is the only stored account-parameterized async closure in the app, which is exactly why only this pane crashed.

## Why 1.8.31 and 1.8.32 did not fix it

- **1.8.31** hoisted a post-`await` read of `account` that was never the faulting one.
- **1.8.32** made `canAccess` `nonisolated` to remove the main-actor entry hop. That *worked* — the fault moved off the main thread to `com.apple.root.user-initiated-qos.cooperative` — and the crash survived it, because the incoming address was already garbage before the body ran. Its acceptance criterion measured instruction ordering *inside* `canAccess`, which was never the failing thing.

## Fix

Bind the account into the closure's heap context in `init`, so the stored seam becomes `@Sendable () async -> Bool`. With no parameter to reabstract, the thunk **cannot be emitted**, and `canAccess` becomes a direct call.

## Verification — mechanical, not reasoning

| binary | thunks matching `@async (@guaranteed Builtin.ImplicitActor, @in_guaranteed CodexAccount) -> Bool` |
|---|---|
| shipped 1.8.32 (crashing) | full symbol family present — specialization, async function pointer, 5 suspend-resume + await-resume partials |
| this branch, Release | **0** |

`canAccess` remains present and reachable; only the indirect seam is gone. The criterion is written into the code so the next change is checked the same way — and the row test now constructs the **zero-argument** seam, so reintroducing the parameter fails to compile.

- `swift build` clean, SwiftLint clean
- `CodexAccountAccessTests | CodexCliLocalServiceTests | CodexAccountProfileRowTests` → 28 tests, 0 failures
- Release `xcodebuild` succeeds

Neither Debug nor Release `swift test` reproduces the segfault (it needs the SwiftUI `.task` entry path), which is why the acceptance criterion is symbol absence in the shipped binary rather than a passing test.