### PR TITLE
fix(claude): stop the login-password prompt on every launch

### DIFF
--- a/MeterBar/Services/ClaudeCredentialResolver.swift
+++ b/MeterBar/Services/ClaudeCredentialResolver.swift
@@ -285,7 +285,8 @@ nonisolated struct ClaudeCredentialStore: Sendable {
     static func keychainPayload(
         service: String,
         mode: ClaudeKeychainAccessMode,
-        backend: KeychainBackend = SecItemKeychainBackend()
+        backend: KeychainBackend = SecItemKeychainBackend(),
+        interaction: KeychainInteractionGate = LegacyKeychainInteractionGate()
     ) -> ClaudeKeychainReadOutcome<Data> {
         let baseQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -295,8 +296,16 @@ nonisolated struct ClaudeCredentialStore: Sendable {
         ]
         let query = ClaudeKeychainQuery.applyingAccessMode(mode, to: baseQuery)
 
+        // The query flags above cover LocalAuthentication only. The gate is what
+        // keeps securityd's login-keychain ACL dialog off the screen for a
+        // background probe — see `KeychainInteractionGate`. Gated here rather
+        // than inside `SecItemKeychainBackend` so it applies to Claude's
+        // externally-owned items alone; `KeychainManager` reads items MeterBar
+        // wrote itself and is always inside their ACL.
         var result: AnyObject?
-        let status = backend.copyMatching(query: query, result: &result)
+        let status = interaction.withUserInteraction(allowed: mode == .interactive) {
+            backend.copyMatching(query: query, result: &result)
+        }
         return ClaudeKeychainQuery.outcome(
             status: status,
             result: result as? Data,

--- a/MeterBar/Services/KeychainInteractionGate.swift
+++ b/MeterBar/Services/KeychainInteractionGate.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Security
+
+/// Decides whether securityd may put a dialog on screen for one keychain
+/// operation.
+///
+/// This exists because there are **two** independent interaction surfaces on a
+/// keychain read, and MeterBar was only closing one of them:
+///
+/// 1. **LocalAuthentication** — biometrics / passcode for items protected by a
+///    `kSecAccessControl`. Suppressed by `kSecUseAuthenticationUIFail` and
+///    `LAContext.interactionNotAllowed`, which is what
+///    `ClaudeKeychainQuery.applyingAccessMode` already sets.
+/// 2. **The legacy login-keychain ACL dialog** — "MeterBar wants to use the
+///    <item> key in your keychain", raised by securityd whenever a decrypting
+///    read targets a generic password whose trusted-application list does not
+///    include the caller. Claude Code writes its credentials item, so MeterBar
+///    is not in that list. **Nothing in the `SecItem` query dictionary
+///    suppresses this one.** Only the process-level interaction flag does.
+///
+/// That gap is the bug: `ClaudeCodeLocalService.init` probes credentials from a
+/// detached task on every launch, so every launch raised the ACL dialog. Saying
+/// "Always Allow" did not end it, because a *successful* password entry records
+/// no denial and therefore suppresses nothing on the next launch, and because
+/// the walk visits several candidate services, each with an independent ACL.
+///
+/// Measured on the affected machine: with the query flags alone a background
+/// read blocked on the dialog until it was killed; with the process flag it
+/// returned `errSecAuthFailed` in 12 ms and drew nothing.
+///
+/// Suppression blocks **UI, not access**. A caller already in the item's ACL
+/// still gets the data silently, so granting access remains permanent and only
+/// the unsolicited prompt disappears.
+nonisolated protocol KeychainInteractionGate: Sendable {
+    /// Runs `perform` with securityd interaction forced to `allowed`, restoring
+    /// the prior process state afterwards. Deliberately non-generic over
+    /// `OSStatus`: `perform` stays non-escaping so callers can write to an
+    /// `inout` result buffer inside it.
+    func withUserInteraction(allowed: Bool, perform: () -> OSStatus) -> OSStatus
+}
+
+/// Production gate, built on `SecKeychainSetUserInteractionAllowed`.
+///
+/// The API is deprecated (macOS 10.10) and warns at build time, which is
+/// accepted on purpose: it is the only supported way to suppress the legacy ACL
+/// dialog, it still functions on current macOS, and the modern
+/// `kSecUseAuthenticationUI` family does not cover this surface. The warning is
+/// the reminder to revisit if a replacement ever ships.
+nonisolated struct LegacyKeychainInteractionGate: KeychainInteractionGate {
+    /// The flag is process-global, so concurrent reads would otherwise stomp on
+    /// each other's saved state — a background probe could leave interaction
+    /// suppressed for a user-initiated refresh running beside it. Recursive so a
+    /// nested read cannot deadlock against itself.
+    private static let lock = NSRecursiveLock()
+
+    /// Current process state, or nil when securityd will not report it.
+    /// Exposed for tests, which assert the save/restore contract.
+    static func currentUserInteractionAllowed() -> Bool? {
+        var state: DarwinBoolean = true
+        guard SecKeychainGetUserInteractionAllowed(&state) == errSecSuccess else { return nil }
+        return state.boolValue
+    }
+
+    func withUserInteraction(allowed: Bool, perform: () -> OSStatus) -> OSStatus {
+        Self.lock.lock()
+        defer { Self.lock.unlock() }
+
+        // If either half of the save/restore pair is unavailable, run the
+        // operation unwrapped rather than risk leaving the process in a state
+        // that cannot be put back. Worst case is the pre-existing behaviour.
+        guard let previous = Self.currentUserInteractionAllowed(),
+              SecKeychainSetUserInteractionAllowed(allowed) == errSecSuccess else {
+            return perform()
+        }
+        defer { _ = SecKeychainSetUserInteractionAllowed(previous) }
+
+        return perform()
+    }
+}

--- a/MeterBarTests/ClaudeCredentialResolverTests.swift
+++ b/MeterBarTests/ClaudeCredentialResolverTests.swift
@@ -217,6 +217,63 @@ final class ClaudeCredentialResolverTests: XCTestCase {
         XCTAssertNil(backend.lastQuery[kSecUseAuthenticationContext as String])
     }
 
+    /// `kSecUseAuthenticationUIFail` and `LAContext.interactionNotAllowed` gate
+    /// LocalAuthentication only — they say nothing about the legacy login-keychain
+    /// ACL dialog securityd raises for a generic password whose trusted-application
+    /// list omits MeterBar. That dialog is the password prompt on every launch.
+    /// Only the process-level interaction flag suppresses it.
+    func testBackgroundPayloadReadSuppressesTheSecuritydACLDialog() {
+        let backend = RecordingKeychainBackend(
+            status: errSecSuccess,
+            result: Data("payload".utf8) as NSData
+        )
+        let gate = RecordingInteractionGate()
+
+        _ = ClaudeCredentialStore.keychainPayload(
+            service: "Claude Code-credentials-c4394a73",
+            mode: .background,
+            backend: backend,
+            interaction: gate
+        )
+
+        XCTAssertEqual(gate.allowedValues, [false])
+    }
+
+    func testInteractivePayloadReadPermitsTheSecuritydACLDialog() {
+        let backend = RecordingKeychainBackend(
+            status: errSecSuccess,
+            result: Data("payload".utf8) as NSData
+        )
+        let gate = RecordingInteractionGate()
+
+        _ = ClaudeCredentialStore.keychainPayload(
+            service: "Claude Code-credentials-c4394a73",
+            mode: .interactive,
+            backend: backend,
+            interaction: gate
+        )
+
+        XCTAssertEqual(gate.allowedValues, [true])
+    }
+
+    /// Suppressed interaction turns an ungranted ACL into an immediate
+    /// `errSecAuthFailed` instead of a dialog. That is not a denial by the user
+    /// — nobody was asked — so it must read as "interaction required", which is
+    /// what makes the walk fall through to the file fallback and start a cooldown.
+    func testBackgroundAuthFailureIsSurfacedAsInteractionRequired() {
+        let backend = RecordingKeychainBackend(status: errSecAuthFailed)
+
+        XCTAssertEqual(
+            ClaudeCredentialStore.keychainPayload(
+                service: "Claude Code-credentials-c4394a73",
+                mode: .background,
+                backend: backend,
+                interaction: RecordingInteractionGate()
+            ),
+            .interactionRequired
+        )
+    }
+
     func testPayloadQueryPreservesSecurityStatusClasses() {
         let cases: [(OSStatus, ClaudeKeychainReadOutcome<Data>)] = [
             (errSecItemNotFound, .notFound),
@@ -297,6 +354,50 @@ final class ClaudeCredentialResolverTests: XCTestCase {
             .init(service: "Claude Code-credentials-ee16a9f4", mode: .interactive),
             .init(service: ClaudeCredentialResolver.bareKeychainService, mode: .background)
         ])
+    }
+
+    /// The user-visible bug: MeterBar asked for the login password at *every*
+    /// launch, and "Always Allow" never ended it. With interaction suppressed a
+    /// launch-time read fails fast, records a denial, and the next launch inside
+    /// the cooldown never touches the keychain again — so at most one prompt can
+    /// reach the screen, and only from an explicitly user-initiated refresh.
+    func testConsecutiveLaunchReadsTouchTheKeychainOnlyOnce() throws {
+        let fixture = try makeDenialStore()
+        let recorder = KeychainReadRecorder { _, _ in .interactionRequired }
+        let now = Date(timeIntervalSince1970: 10_000)
+        let clock = MutableClock(now)
+        let store = ClaudeCredentialStore(
+            readKeychainResult: { service, mode in recorder.read(service: service, mode: mode) },
+            readFile: { _ in nil },
+            denialStore: fixture.store,
+            isOAuthEnabled: { true },
+            now: { clock.now }
+        )
+        let account = ClaudeCodeAccount(
+            id: UUID(),
+            name: "Work",
+            configDirectory: "/Users/tester/.claude-work"
+        )
+
+        _ = store.credentialsDataResult(
+            for: account,
+            mode: .background,
+            environment: [:],
+            realHomeDirectory: "/Users/tester"
+        )
+        let callsAfterFirstLaunch = recorder.calls
+
+        // A later launch, still well inside the six-hour cooldown.
+        clock.now = now.addingTimeInterval(60)
+        let outcome = store.credentialsDataResult(
+            for: account,
+            mode: .background,
+            environment: [:],
+            realHomeDirectory: "/Users/tester"
+        )
+
+        XCTAssertEqual(recorder.calls, callsAfterFirstLaunch)
+        XCTAssertEqual(outcome, .interactionRequired)
     }
 
     func testBackgroundWalkSkipsCoolingServiceAndStillUsesFileFallback() throws {
@@ -514,6 +615,48 @@ nonisolated private final class PathRecorder: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         storage.append(path)
+    }
+}
+
+/// Advanceable clock for tests that need two reads at different times against
+/// one shared denial store.
+nonisolated private final class MutableClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: Date
+
+    init(_ now: Date) {
+        self.storage = now
+    }
+
+    var now: Date {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            storage = newValue
+        }
+    }
+}
+
+nonisolated private final class RecordingInteractionGate: KeychainInteractionGate, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [Bool] = []
+
+    var allowedValues: [Bool] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func withUserInteraction(allowed: Bool, perform: () -> OSStatus) -> OSStatus {
+        lock.lock()
+        storage.append(allowed)
+        lock.unlock()
+        return perform()
     }
 }
 

--- a/MeterBarTests/KeychainInteractionGateTests.swift
+++ b/MeterBarTests/KeychainInteractionGateTests.swift
@@ -1,0 +1,73 @@
+import Security
+import XCTest
+@testable import MeterBar
+
+/// The real gate touches process-global securityd state, so these tests assert
+/// the two properties that make that safe: the suppression is in force for the
+/// duration of the operation, and the prior state is always put back.
+final class KeychainInteractionGateTests: XCTestCase {
+    func testSuppressionIsInForceForTheDurationOfTheOperation() throws {
+        let gate = LegacyKeychainInteractionGate()
+        var observedInside: Bool?
+
+        let status = gate.withUserInteraction(allowed: false) {
+            observedInside = LegacyKeychainInteractionGate.currentUserInteractionAllowed()
+            return errSecSuccess
+        }
+
+        XCTAssertEqual(status, errSecSuccess)
+        XCTAssertEqual(
+            try XCTUnwrap(observedInside),
+            false,
+            "The keychain operation must run with securityd UI suppressed."
+        )
+    }
+
+    func testAllowedOperationRunsWithInteractionPermitted() throws {
+        let gate = LegacyKeychainInteractionGate()
+        var observedInside: Bool?
+
+        _ = gate.withUserInteraction(allowed: true) {
+            observedInside = LegacyKeychainInteractionGate.currentUserInteractionAllowed()
+            return errSecSuccess
+        }
+
+        XCTAssertEqual(try XCTUnwrap(observedInside), true)
+    }
+
+    func testPreviousProcessStateIsRestoredAfterwards() throws {
+        let gate = LegacyKeychainInteractionGate()
+        let before = try XCTUnwrap(LegacyKeychainInteractionGate.currentUserInteractionAllowed())
+
+        _ = gate.withUserInteraction(allowed: !before) { errSecSuccess }
+
+        XCTAssertEqual(LegacyKeychainInteractionGate.currentUserInteractionAllowed(), before)
+    }
+
+    func testOperationStatusIsReturnedUnchanged() {
+        let gate = LegacyKeychainInteractionGate()
+
+        XCTAssertEqual(
+            gate.withUserInteraction(allowed: false) { errSecAuthFailed },
+            errSecAuthFailed
+        )
+    }
+
+    /// The gate serializes on a process-global flag. A recursive lock is the
+    /// point: a nested read must not deadlock, and the innermost restore must
+    /// not leak out past the outer scope.
+    func testNestedUseRestoresEachScopeInTurn() throws {
+        let gate = LegacyKeychainInteractionGate()
+        let before = try XCTUnwrap(LegacyKeychainInteractionGate.currentUserInteractionAllowed())
+        var observedAfterInnerScope: Bool?
+
+        _ = gate.withUserInteraction(allowed: false) {
+            _ = gate.withUserInteraction(allowed: true) { errSecSuccess }
+            observedAfterInnerScope = LegacyKeychainInteractionGate.currentUserInteractionAllowed()
+            return errSecSuccess
+        }
+
+        XCTAssertEqual(try XCTUnwrap(observedAfterInnerScope), false)
+        XCTAssertEqual(LegacyKeychainInteractionGate.currentUserInteractionAllowed(), before)
+    }
+}


### PR DESCRIPTION
## The bug

MeterBar asks for the login keychain password **every launch** when reading Claude Code credentials, and clicking **Always Allow** never ends it.

## Root cause

A keychain read has **two independent interaction surfaces**. We were only closing one.

| surface | raised by | suppressed by | did we? |
|---|---|---|---|
| LocalAuthentication (biometrics/passcode) | `kSecAccessControl` items | `kSecUseAuthenticationUIFail` + `LAContext.interactionNotAllowed` | ✅ already |
| **Legacy login-keychain ACL dialog** — *"MeterBar wants to use the … key in your keychain"* | securityd, for a generic password whose trusted-application list omits the caller | **only** `SecKeychainSetUserInteractionAllowed(false)` | ❌ **the bug** |

Claude Code writes its own credentials item, so MeterBar is never in that item's ACL. `ClaudeCodeLocalService.init` probes credentials from a detached task on **every launch** → dialog on every launch. **Nothing in the `SecItem` query dictionary suppresses that second surface.**

**Always Allow** didn't help because a *successful* password entry records no denial, so the next launch re-attempts — and the candidate walk visits several services, each with an independent ACL.

## Measured, not reasoned

Two-arm experiment on the affected machine:

| suppression | result |
|---|---|
| our query flags only | **blocked on the password dialog**, killed after 8 s |
| `SecKeychainSetUserInteractionAllowed(false)` | `errSecAuthFailed` in **12 ms**, nothing drawn |

## Suppression blocks UI, not access

The load-bearing claim of the fix, proved with a throwaway probe item created by the caller itself (so the caller *is* in its ACL), read back with interaction suppressed:

```
add: 0
get-prior: 0 prior=true
set-false: 0
read-suppressed: status=0 elapsed=1ms payload=expected-payload
RESULT: authorized read SUCCEEDED with interaction suppressed
```

Probe item deleted afterwards; `security find-generic-password` confirms it's gone.

So granting access stays permanent — only the *unsolicited* prompt disappears.

## The change

- **New** `KeychainInteractionGate` protocol + `LegacyKeychainInteractionGate`: get → set → run → `defer` restore, serialized on a static `NSRecursiveLock` because the flag is process-global (a background probe must not leave interaction suppressed for a user-initiated refresh beside it; recursive so a nested read can't deadlock). If either half of the save/restore pair fails, the operation runs unwrapped rather than risk an unrestorable process state — worst case is the pre-existing behaviour.
- `ClaudeCredentialStore.keychainPayload` takes `interaction:` (defaulted) and wraps the backend call with `allowed: mode == .interactive`.

Gated **there** rather than inside `SecItemKeychainBackend` on purpose: this applies to Claude's *externally-owned* items only. `KeychainManager` reads items MeterBar wrote itself and is always inside their ACL.

## Behaviour after

- **Launch:** silent. Ungranted read fails fast → records a denial → falls through to `~/.claude/.credentials.json` → six-hour cooldown, so a later launch inside it never touches the keychain at all.
- **Explicit user refresh:** at most one prompt.
- **Always Allow:** sticks.

An `errSecAuthFailed` under suppression reads as `.interactionRequired`, not `.denied` — nobody was asked, so it must not be recorded as a user refusal.

## Tests (TDD — written first)

New `KeychainInteractionGateTests` (5): suppression in force for the operation's duration, allowed path permits interaction, prior state restored, status returned unchanged, nested use restores each scope in turn.

`ClaudeCredentialResolverTests` +4: background read routes `allowed: false`, interactive routes `true`, `errSecAuthFailed` surfaces as `.interactionRequired`, and an end-to-end **launch-repeat regression** — two launches 60 s apart touch the keychain exactly once, which is the user-visible complaint encoded as a test.

## Verification

- Filtered: `KeychainInteractionGateTests` + `ClaudeCredentialResolverTests` + `ClaudeKeychainAccessPolicyTests` → **40 executed, 0 failures**
- Full suite: `swift test` → **1702 tests, 5 skipped, 0 failures**
- Release `xcodebuild` of the shipping target → `** BUILD SUCCEEDED **`, **0 errors**

Three warnings, all in the new file, all the documented `SecKeychain*` deprecation. Accepted deliberately: it is the only supported way to suppress this surface, it still functions on current macOS, `kSecUseAuthenticationUI` does not cover it, and the warning is the reminder to revisit if a replacement ships. Grep confirms no `warnings-as-errors` anywhere in the build config.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Background credential checks no longer trigger unexpected login-keychain permission dialogs.
  * Interactive authentication continues to prompt when user approval is required.
  * Authentication failures are surfaced clearly when interaction is needed.
  * Repeated background launches avoid unnecessary credential checks during the cooldown period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->