### PR TITLE
refactor(providers): source every provider name from ServiceType

### DIFF
--- a/MeterBar/SessionWake/WakeProvider.swift
+++ b/MeterBar/SessionWake/WakeProvider.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MeterBarShared
 
 /// The AI coding assistant a Session Wake run targets.
 ///
@@ -10,11 +11,17 @@ nonisolated enum WakeProvider: String, Codable, Equatable, Sendable, CaseIterabl
     case claude
     case codex
 
-    /// User-facing name for menus, notifications, and status copy.
+    /// User-facing name for menus, notifications, and status copy, sourced from
+    /// `ServiceType` so a provider rename is a single edit there rather than a
+    /// hunt through every enum that names the same five products.
+    ///
+    /// The two cases deliberately pick different name concepts: this string
+    /// lands mid-sentence ("Resumed 2 of 3 … sessions"), where Codex's full
+    /// product name ("OpenAI Codex") reads as boilerplate.
     var displayName: String {
         switch self {
-        case .claude: return "Claude Code"
-        case .codex: return "Codex"
+        case .claude: return ServiceType.claudeCode.displayName
+        case .codex: return ServiceType.codexCli.shortName
         }
     }
 

--- a/MeterBar/Views/DailyUsageChart.swift
+++ b/MeterBar/Views/DailyUsageChart.swift
@@ -580,20 +580,7 @@ struct DailyProviderUsageSummaryRow: View {
     .padding(.vertical, MeterBarTheme.Spacing.xs)
   }
 
-  private var providerShortName: String {
-    switch provider.provider {
-    case .claudeCode:
-      return "Claude"
-    case .codexCli:
-      return "Codex"
-    case .cursor:
-      return "Cursor"
-    case .openRouter:
-      return "OpenRouter"
-    case .grok:
-      return "Grok"
-    }
-  }
+  private var providerShortName: String { provider.provider.shortName }
 }
 
 private struct DailyUsageMetricCell: View {

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -238,7 +238,9 @@ enum ProviderSnapshotBuilder {
             let enabledAccounts = input.codexAccounts.filter(\.isEnabled)
             if !enabledAccounts.isEmpty {
                 for account in enabledAccounts {
-                    let title = account.isDefault && enabledAccounts.count == 1 ? "Codex" : account.name
+                    let title = account.isDefault && enabledAccounts.count == 1
+                        ? ServiceType.codexCli.shortName
+                        : account.name
                     // A signed-in custom `CODEX_HOME` profile is waiting for a
                     // refresh, not for a login — only ask for one when this
                     // account's own probe says it has no usable token.
@@ -270,7 +272,9 @@ enum ProviderSnapshotBuilder {
             let accountMetrics = input.claudeAccountMetrics
             if !enabledAccounts.isEmpty {
                 for account in enabledAccounts {
-                    let title = account.isDefault && enabledAccounts.count == 1 ? "Claude" : account.name
+                    let title = account.isDefault && enabledAccounts.count == 1
+                        ? ServiceType.claudeCode.shortName
+                        : account.name
                     let emptyDetail = account.isDefault && input.claudeCodeHasAccess
                         ? "Waiting for refresh"
                         : "Run claude login"
@@ -288,7 +292,7 @@ enum ProviderSnapshotBuilder {
 
         if input.enabledServices.contains(.cursor) {
             result.append(snapshot(
-                title: "Cursor",
+                title: ServiceType.cursor.shortName,
                 service: .cursor,
                 metrics: input.metrics[.cursor],
                 emptyDetail: input.cursorHasAccess ? "Waiting for refresh" : "Log in to Cursor"
@@ -297,7 +301,7 @@ enum ProviderSnapshotBuilder {
 
         if input.enabledServices.contains(.openRouter) {
             result.append(snapshot(
-                title: "OpenRouter",
+                title: ServiceType.openRouter.shortName,
                 service: .openRouter,
                 metrics: input.metrics[.openRouter],
                 emptyDetail: input.openRouterHasAccess ? "Waiting for refresh" : "Add an OpenRouter API key"
@@ -307,7 +311,9 @@ enum ProviderSnapshotBuilder {
         if input.enabledServices.contains(.grok) {
             let enabledAccounts = input.grokAccounts.filter(\.isEnabled)
             for account in enabledAccounts {
-                let title = account.isDefault && enabledAccounts.count == 1 ? "Grok" : account.name
+                let title = account.isDefault && enabledAccounts.count == 1
+                    ? ServiceType.grok.shortName
+                    : account.name
                 let fallbackMetrics = account.isDefault
                     && enabledAccounts.count == 1
                     && input.grokAccountMetrics.isEmpty

--- a/MeterBar/Views/Settings/ApiUsageSettingsView.swift
+++ b/MeterBar/Views/Settings/ApiUsageSettingsView.swift
@@ -51,7 +51,7 @@ struct ApiUsageSettingsView: View {
             if providerVisibility.isEnabled(.claudeCode) {
                 if let claudeExtraUsageStatus {
                     ExtraUsageRow(
-                        title: "Claude Code",
+                        title: ServiceType.claudeCode.displayName,
                         status: claudeExtraUsageStatus,
                         manageURL: "https://claude.ai/settings"
                     )
@@ -60,7 +60,7 @@ struct ApiUsageSettingsView: View {
 
             if providerVisibility.isEnabled(.codexCli) {
                 ExtraUsageRow(
-                    title: "OpenAI Codex",
+                    title: ServiceType.codexCli.displayName,
                     status: dataManager.metrics[.codexCli]?.extraUsage,
                     manageURL: "https://chatgpt.com"
                 )
@@ -68,7 +68,7 @@ struct ApiUsageSettingsView: View {
 
             if providerVisibility.isEnabled(.grok) {
                 ExtraUsageRow(
-                    title: "Grok",
+                    title: ServiceType.grok.displayName,
                     status: dataManager.metrics[.grok]?.extraUsage,
                     manageURL: "https://grok.com/?_s=usage"
                 )

--- a/MeterBar/Views/Settings/ProviderAccountProfileModels.swift
+++ b/MeterBar/Views/Settings/ProviderAccountProfileModels.swift
@@ -242,7 +242,7 @@ enum ClaudeReconnectConfirmation {
     static func message(for account: ClaudeCodeAccount) -> String {
         ProviderAccountReconnectConfirmation.message(
             accountName: account.name,
-            providerDisplayName: "Claude"
+            providerDisplayName: ServiceType.claudeCode.shortName
         )
     }
 }

--- a/MeterBar/Views/Settings/ProviderSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsView.swift
@@ -510,7 +510,11 @@ struct ProviderSettingsView: View {
     }
 
     private var codexCliSection: some View {
-        SettingsPanelSection(title: ServiceType.codexCli.displayName, logoKind: .codex, color: MeterBarTheme.codexAccent) {
+        SettingsPanelSection(
+            title: ServiceType.codexCli.displayName,
+            logoKind: .codex,
+            color: MeterBarTheme.codexAccent
+        ) {
             SettingsRowView(
                 title: "Default connection",
                 detail: "Reads the OAuth session from \(codexAuthFileDisplayPath)."
@@ -619,7 +623,11 @@ struct ProviderSettingsView: View {
     }
 
     private var cursorSection: some View {
-        SettingsPanelSection(title: ServiceType.cursor.displayName, logoKind: .cursor, color: MeterBarTheme.cursorAccent) {
+        SettingsPanelSection(
+            title: ServiceType.cursor.displayName,
+            logoKind: .cursor,
+            color: MeterBarTheme.cursorAccent
+        ) {
             SettingsRowView(title: "Connection") {
                 HStack(spacing: 8) {
                     StatusPill(
@@ -666,7 +674,11 @@ struct ProviderSettingsView: View {
     }
 
     private var openRouterSection: some View {
-        SettingsPanelSection(title: ServiceType.openRouter.displayName, logoKind: .openRouter, color: MeterBarTheme.openRouterAccent) {
+        SettingsPanelSection(
+            title: ServiceType.openRouter.displayName,
+            logoKind: .openRouter,
+            color: MeterBarTheme.openRouterAccent
+        ) {
             SettingsNotice(
                 text: "The key is stored in macOS Keychain and sent only to OpenRouter's credits and key APIs.",
                 color: .secondary

--- a/MeterBar/Views/Settings/ProviderSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsView.swift
@@ -41,7 +41,7 @@ struct ProviderSettingsView: View {
         }
         .sheet(isPresented: $isAddingClaudeAccount) {
             AddProviderAccountSheet(
-                providerName: "Claude",
+                providerName: ServiceType.claudeCode.shortName,
                 logoKind: .claude,
                 accent: MeterBarTheme.claudeAccent,
                 subtitle: "Use a separate CLAUDE_CONFIG_DIR for this profile.",
@@ -54,7 +54,7 @@ struct ProviderSettingsView: View {
         }
         .sheet(isPresented: $isAddingCodexAccount) {
             AddProviderAccountSheet(
-                providerName: "Codex",
+                providerName: ServiceType.codexCli.shortName,
                 logoKind: .codex,
                 accent: MeterBarTheme.codexAccent,
                 subtitle: "Use a separate CODEX_HOME containing its own auth.json.",
@@ -68,7 +68,7 @@ struct ProviderSettingsView: View {
         }
         .sheet(isPresented: $isAddingGrokAccount) {
             AddProviderAccountSheet(
-                providerName: "Grok",
+                providerName: ServiceType.grok.shortName,
                 logoKind: .grok,
                 accent: MeterBarTheme.grokAccent,
                 subtitle: "Use a separate GROK_HOME containing its CLI-managed auth.json.",
@@ -329,7 +329,7 @@ struct ProviderSettingsView: View {
             if let claudeExtraUsageStatus {
                 SettingsPanelSection(title: "Extra Usage", systemImage: "creditcard", color: MeterBarTheme.warning) {
                     ExtraUsageRow(
-                        title: "Claude Code",
+                        title: ServiceType.claudeCode.displayName,
                         status: claudeExtraUsageStatus,
                         manageURL: "https://claude.ai/settings"
                     )
@@ -338,7 +338,7 @@ struct ProviderSettingsView: View {
         case .codexCli:
             SettingsPanelSection(title: "Credits", systemImage: "creditcard", color: MeterBarTheme.warning) {
                 ExtraUsageRow(
-                    title: "OpenAI Codex",
+                    title: ServiceType.codexCli.displayName,
                     status: dataManager.metrics[.codexCli]?.extraUsage,
                     manageURL: "https://chatgpt.com"
                 )
@@ -350,7 +350,7 @@ struct ProviderSettingsView: View {
         case .grok:
             SettingsPanelSection(title: "Extra Usage", systemImage: "creditcard", color: MeterBarTheme.warning) {
                 ExtraUsageRow(
-                    title: "Grok",
+                    title: ServiceType.grok.displayName,
                     status: dataManager.metrics[.grok]?.extraUsage,
                     manageURL: "https://grok.com/?_s=usage"
                 )
@@ -473,7 +473,7 @@ struct ProviderSettingsView: View {
                             isRefreshing: refreshingClaudeAccountIDs.contains(account.id),
                             showsRefresh: true,
                             showsReconnect: true,
-                            reconnectProviderName: "Claude",
+                            reconnectProviderName: ServiceType.claudeCode.shortName,
                             deleteMessage:
                                 "MeterBar will stop tracking this CLAUDE_CONFIG_DIR. "
                                 + "Files and Claude login data are not deleted.",
@@ -510,7 +510,7 @@ struct ProviderSettingsView: View {
     }
 
     private var codexCliSection: some View {
-        SettingsPanelSection(title: "OpenAI Codex", logoKind: .codex, color: MeterBarTheme.codexAccent) {
+        SettingsPanelSection(title: ServiceType.codexCli.displayName, logoKind: .codex, color: MeterBarTheme.codexAccent) {
             SettingsRowView(
                 title: "Default connection",
                 detail: "Reads the OAuth session from \(codexAuthFileDisplayPath)."
@@ -619,7 +619,7 @@ struct ProviderSettingsView: View {
     }
 
     private var cursorSection: some View {
-        SettingsPanelSection(title: "Cursor", logoKind: .cursor, color: MeterBarTheme.cursorAccent) {
+        SettingsPanelSection(title: ServiceType.cursor.displayName, logoKind: .cursor, color: MeterBarTheme.cursorAccent) {
             SettingsRowView(title: "Connection") {
                 HStack(spacing: 8) {
                     StatusPill(
@@ -666,7 +666,7 @@ struct ProviderSettingsView: View {
     }
 
     private var openRouterSection: some View {
-        SettingsPanelSection(title: "OpenRouter", logoKind: .openRouter, color: MeterBarTheme.openRouterAccent) {
+        SettingsPanelSection(title: ServiceType.openRouter.displayName, logoKind: .openRouter, color: MeterBarTheme.openRouterAccent) {
             SettingsNotice(
                 text: "The key is stored in macOS Keychain and sent only to OpenRouter's credits and key APIs.",
                 color: .secondary

--- a/MeterBarTests/ServiceTypeTests.swift
+++ b/MeterBarTests/ServiceTypeTests.swift
@@ -35,6 +35,32 @@ final class ServiceTypeTests: XCTestCase {
         XCTAssertEqual(ServiceType.grok.id, "Grok")
     }
 
+    /// The compact brand form, for places where the full product name would
+    /// crowd the layout: chart legends, popover provider cards, "Add account"
+    /// sheets. It is a second *name*, not a second source of truth — the views
+    /// that used to spell these out inline (three separate switches over the
+    /// same five cases) now read them from here.
+    func testShortNames() {
+        XCTAssertEqual(ServiceType.claudeCode.shortName, "Claude")
+        XCTAssertEqual(ServiceType.codexCli.shortName, "Codex")
+        XCTAssertEqual(ServiceType.cursor.shortName, "Cursor")
+        XCTAssertEqual(ServiceType.openRouter.shortName, "OpenRouter")
+        XCTAssertEqual(ServiceType.grok.shortName, "Grok")
+    }
+
+    /// Both names must exist and be usable for every case, including any added
+    /// later — an empty label renders as a blank row rather than failing loudly.
+    func testEveryServiceHasBothNames() {
+        for service in ServiceType.allCases {
+            XCTAssertFalse(service.displayName.isEmpty, "\(service) has no display name")
+            XCTAssertFalse(service.shortName.isEmpty, "\(service) has no short name")
+            XCTAssertFalse(
+                service.shortName.count > service.displayName.count,
+                "\(service): the short name must not be longer than the full one"
+            )
+        }
+    }
+
     func testAllCasesCount() {
         XCTAssertEqual(ServiceType.allCases.count, 5)
     }

--- a/MeterBarTests/SessionWakeSettingsTests.swift
+++ b/MeterBarTests/SessionWakeSettingsTests.swift
@@ -1,3 +1,4 @@
+import MeterBarShared
 import XCTest
 @testable import MeterBar
 
@@ -204,6 +205,18 @@ final class SessionWakeSettingsTests: XCTestCase {
     }
 
     // MARK: - Provider dimension
+
+    /// Session Wake's own two-case provider enum names itself out of
+    /// `ServiceType` rather than carrying its own copies, so renaming a provider
+    /// is one edit. The two cases pick different name concepts on purpose: this
+    /// string lands mid-sentence ("Resumed 2 of 3 … sessions"), where Codex's
+    /// full product name reads as boilerplate.
+    func testWakeProviderNamesComeFromServiceType() {
+        XCTAssertEqual(WakeProvider.claude.displayName, ServiceType.claudeCode.displayName)
+        XCTAssertEqual(WakeProvider.codex.displayName, ServiceType.codexCli.shortName)
+        XCTAssertEqual(WakeProvider.claude.displayName, "Claude Code")
+        XCTAssertEqual(WakeProvider.codex.displayName, "Codex")
+    }
 
     func testDefaultProviderIsClaude() {
         let store = makeStore()

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ServiceType.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ServiceType.swift
@@ -12,10 +12,33 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
 
     public var id: String { rawValue }
 
+    /// The full product name. Use it wherever a provider is being *named*:
+    /// settings section headers, sidebar rows, notification titles, CLI JSON,
+    /// share cards.
     public var displayName: String {
         switch self {
         case .claudeCode: return "Claude Code"
         case .codexCli: return "OpenAI Codex"
+        case .cursor: return "Cursor"
+        case .openRouter: return "OpenRouter"
+        case .grok: return "Grok"
+        }
+    }
+
+    /// The compact brand form, for places where the full product name would
+    /// crowd the layout: chart legends, popover provider cards, "Add account"
+    /// sheet copy.
+    ///
+    /// Centralized here for the same reason as `codeReviewQuotaTitle`: the
+    /// dashboard chart, the popover snapshot builder, and the settings sheets
+    /// each used to switch over these five cases inline, so renaming a provider
+    /// meant finding every copy. Note this is *not* the status-page operator
+    /// name — Codex's status page belongs to "OpenAI", which is why
+    /// `statusPageDisplayName` stays separate.
+    public var shortName: String {
+        switch self {
+        case .claudeCode: return "Claude"
+        case .codexCli: return "Codex"
         case .cursor: return "Cursor"
         case .openRouter: return "OpenRouter"
         case .grok: return "Grok"


### PR DESCRIPTION
## Why

Renaming a provider meant hunting literals. "OpenAI Codex" lived in the settings section header, "Codex" in the chart legend, the popover card, the Add-account sheet, and Session Wake's own enum — five copies of one fact, each free to drift.

## What

Provider naming is really **two** concepts, so `ServiceType` now carries both:

| property | value for Codex | used by |
|---|---|---|
| `displayName` | `OpenAI Codex` | settings section headers, sidebar rows, notification titles, CLI JSON, share cards |
| `shortName` *(new)* | `Codex` | chart legends, popover provider cards, Add-account sheet copy |

Call sites converted: `DailyUsageChart`, `ProviderSnapshot`, `ApiUsageSettingsView`, `ProviderSettingsView`, `ProviderAccountProfileModels`, `WakeProvider`.

## Deliberately not touched

- **`statusPageDisplayName`** — Codex's status page belongs to *OpenAI*, which is neither name above. Different concept, already centralized.
- **`rawValue`** (`"Codex CLI"`) — persistence identity.
- **`CodexCostScanner`'s `?? "Codex CLI"`** — a rollout-log originator fallback, not display copy.
- **`scripts/render-readme-screenshots.swift`** — standalone duplicate enum outside the app target.

`WakeProvider` keeps its own two cases but now names itself out of `ServiceType`. The cases pick different concepts on purpose: that string lands mid-sentence ("Resumed 2 of 3 Codex sessions"), where the full product name reads as boilerplate.

**No user-visible copy changes.** Every rendered string is byte-identical to before.

## Tests

Written first, confirmed RED before implementation:
- `shortName`'s five values.
- An invariant that every case — including any added later — has both names non-empty, and that the short one is never longer than the full one.
- `WakeProvider.displayName` asserted against both the `ServiceType` source *and* its literal current value, so the indirection can't silently change the copy.

`swift test`: **1705 tests, 5 skipped, 0 failures.**