### PR TITLE
perf(reader): kill the quadratic rescan, then cut lines straight out of the chunk

### DIFF
--- a/MeterBar/Services/FileLineReader.swift
+++ b/MeterBar/Services/FileLineReader.swift
@@ -37,21 +37,38 @@ nonisolated enum FileLineReader {
         // Guards against a caller passing 0 and spinning forever on empty reads.
         let size = max(1, chunkSize)
         var pending = Data()
+        // How much of `pending` has already been searched and proven to hold no
+        // newline. Every byte left in `pending` at the end of an iteration is
+        // part of an unterminated line, so the next chunk resumes from here
+        // instead of rescanning from byte 0. Without it a line spanning N
+        // chunks costs N rescans of a buffer that grows to the line's full
+        // length — O(L^2 / chunkSize). Real Codex rollout transcripts carry
+        // single lines in the tens of megabytes, which turned a one-second scan
+        // into over a minute.
+        var scanned = 0
 
         while let chunk = try? handle.read(upToCount: size), !chunk.isEmpty {
             pending.append(chunk)
-            var searchStart = pending.startIndex
 
-            while let newlineIndex = pending[searchStart...].firstIndex(of: newline) {
-                body(Self.line(pending[searchStart..<newlineIndex]))
-                searchStart = pending.index(after: newlineIndex)
+            // `lineStart` and `searchFrom` are distinct: the line still begins
+            // at the front of the buffer even when the search resumes deeper
+            // in. Conflating them would emit an empty line and drop the real
+            // one whenever a newline landed on the first byte of a chunk.
+            var lineStart = pending.startIndex
+            var searchFrom = pending.index(pending.startIndex, offsetBy: scanned)
+
+            while let newlineIndex = pending[searchFrom...].firstIndex(of: newline) {
+                body(Self.line(pending[lineStart..<newlineIndex]))
+                lineStart = pending.index(after: newlineIndex)
+                searchFrom = lineStart
             }
 
-            if searchStart > pending.startIndex {
+            if lineStart > pending.startIndex {
                 // Re-base rather than `removeSubrange` so the next slice search
                 // starts from index 0 again.
-                pending = Data(pending[searchStart...])
+                pending = Data(pending[lineStart...])
             }
+            scanned = pending.count
         }
 
         if !pending.isEmpty {

--- a/MeterBar/Services/FileLineReader.swift
+++ b/MeterBar/Services/FileLineReader.swift
@@ -16,11 +16,22 @@ nonisolated enum FileLineReader {
     /// small enough that many concurrent scans stay bounded.
     static let defaultChunkSize = 256 * 1024
 
+    private static let newline = UInt8(ascii: "\n")
+    private static let carriageReturn = UInt8(ascii: "\r")
+
     /// Invokes `body` once per line, without the trailing newline.
     ///
     /// `body` is a non-escaping function parameter on purpose: the Codex scan
     /// threads an `inout` accumulator through it, and capturing an `inout`
-    /// parameter is only legal in a non-escaping closure.
+    /// parameter is only legal in a non-escaping closure. It stays non-escaping
+    /// through the nested `withUnsafeBytes` below, whose closure is itself
+    /// non-escaping.
+    ///
+    /// Lines are cut straight out of the chunk the read produced. Nothing is
+    /// buffered unless a line actually straddles two chunks, and the newline
+    /// search runs on `memchr` rather than `Data`'s byte-at-a-time `Collection`
+    /// conformance. On an 820 MB Codex rollout (4754 lines, the longest 56.7 MB)
+    /// that is the difference between 69.8s and 0.4s.
     ///
     /// - Returns: `false` when the file could not be opened, `true` otherwise.
     ///   An empty file opens successfully and yields nothing.
@@ -33,58 +44,67 @@ nonisolated enum FileLineReader {
         guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
         defer { try? handle.close() }
 
-        let newline = UInt8(ascii: "\n")
         // Guards against a caller passing 0 and spinning forever on empty reads.
         let size = max(1, chunkSize)
-        var pending = Data()
-        // How much of `pending` has already been searched and proven to hold no
-        // newline. Every byte left in `pending` at the end of an iteration is
-        // part of an unterminated line, so the next chunk resumes from here
-        // instead of rescanning from byte 0. Without it a line spanning N
-        // chunks costs N rescans of a buffer that grows to the line's full
-        // length — O(L^2 / chunkSize). Real Codex rollout transcripts carry
-        // single lines in the tens of megabytes, which turned a one-second scan
-        // into over a minute.
-        var scanned = 0
+        // Holds only the head of a line whose newline has not arrived yet. A
+        // file of ordinary lines never touches it, so the common path copies
+        // each line exactly once — into the `Data` handed to `body` — and never
+        // re-bases a buffer between chunks.
+        var carry = Data()
 
         while let chunk = try? handle.read(upToCount: size), !chunk.isEmpty {
-            pending.append(chunk)
+            chunk.withUnsafeBytes { raw in
+                guard let base = raw.bindMemory(to: UInt8.self).baseAddress else { return }
+                var cursor = 0
 
-            // `lineStart` and `searchFrom` are distinct: the line still begins
-            // at the front of the buffer even when the search resumes deeper
-            // in. Conflating them would emit an empty line and drop the real
-            // one whenever a newline landed on the first byte of a chunk.
-            var lineStart = pending.startIndex
-            var searchFrom = pending.index(pending.startIndex, offsetBy: scanned)
+                while cursor < raw.count,
+                      let hit = memchr(base + cursor, Int32(newline), raw.count - cursor) {
+                    let newlineOffset = UnsafeRawPointer(hit) - UnsafeRawPointer(base)
+                    if carry.isEmpty {
+                        // Whole line lives in this chunk: emit it in place.
+                        Self.emit(base + cursor, count: newlineOffset - cursor, body)
+                    } else {
+                        // Tail of a straddling line. `carry` is built purely by
+                        // appending onto a fresh `Data`, so it is already
+                        // zero-based and needs no re-copy before `body` — the
+                        // offset-slice hazard that `JSONSerialization` trips on
+                        // cannot arise here.
+                        if newlineOffset > cursor {
+                            carry.append(base + cursor, count: newlineOffset - cursor)
+                        }
+                        if carry.last == Self.carriageReturn { carry.removeLast() }
+                        body(carry)
+                        // Released rather than kept: one 56.7 MB line must not
+                        // pin 56.7 MB for the rest of the scan, least of all
+                        // with several transcripts scanning concurrently.
+                        carry = Data()
+                    }
+                    cursor = newlineOffset + 1
+                }
 
-            while let newlineIndex = pending[searchFrom...].firstIndex(of: newline) {
-                body(Self.line(pending[lineStart..<newlineIndex]))
-                lineStart = pending.index(after: newlineIndex)
-                searchFrom = lineStart
+                if cursor < raw.count {
+                    carry.append(base + cursor, count: raw.count - cursor)
+                }
             }
-
-            if lineStart > pending.startIndex {
-                // Re-base rather than `removeSubrange` so the next slice search
-                // starts from index 0 again.
-                pending = Data(pending[lineStart...])
-            }
-            scanned = pending.count
         }
 
-        if !pending.isEmpty {
-            body(Self.line(pending[...]))
+        if !carry.isEmpty {
+            if carry.last == Self.carriageReturn { carry.removeLast() }
+            body(carry)
         }
         return true
     }
 
-    /// Copies the slice into a zero-based `Data` and drops a CRLF carriage
-    /// return. The copy matters: slicing `Data` keeps the parent's non-zero
-    /// `startIndex`, and `JSONSerialization` has historically mis-read offset
-    /// slices.
-    private static func line(_ slice: Data) -> Data {
-        if slice.last == UInt8(ascii: "\r") {
-            return Data(slice.dropLast())
+    /// Copies `count` bytes into a zero-based `Data` and drops a CRLF carriage
+    /// return. The copy matters: handing out a pointer into the chunk would
+    /// dangle the moment `withUnsafeBytes` returns, and a `Data` slice would
+    /// keep the parent's non-zero `startIndex`, which `JSONSerialization` has
+    /// historically mis-read.
+    private static func emit(_ start: UnsafePointer<UInt8>, count: Int, _ body: (Data) -> Void) {
+        var length = count
+        if length > 0, start[length - 1] == carriageReturn {
+            length -= 1
         }
-        return Data(slice)
+        body(Data(bytes: start, count: length))
     }
 }

--- a/MeterBarTests/FileLineReaderTests.swift
+++ b/MeterBarTests/FileLineReaderTests.swift
@@ -173,6 +173,97 @@ final class FileLineReaderTests: XCTestCase {
         XCTAssertLessThan(elapsed, 5, "32 MiB single line took \(elapsed)s — the scan is not linear")
     }
 
+    /// Splits the whole file in the most obvious way possible. Deliberately
+    /// naive — it is the oracle the chunked reader has to agree with, so it
+    /// must be readable at a glance rather than fast.
+    private func referenceLines(of data: Data) -> [Data] {
+        var out: [Data] = []
+        var current = Data()
+        for byte in data {
+            guard byte == UInt8(ascii: "\n") else {
+                current.append(byte)
+                continue
+            }
+            if current.last == UInt8(ascii: "\r") { current.removeLast() }
+            out.append(current)
+            current = Data()
+        }
+        if !current.isEmpty {
+            if current.last == UInt8(ascii: "\r") { current.removeLast() }
+            out.append(current)
+        }
+        return out
+    }
+
+    private func readerLines(of url: URL, chunkSize: Int) -> [Data] {
+        var collected: [Data] = []
+        FileLineReader.forEachLine(in: url, chunkSize: chunkSize) { collected.append($0) }
+        return collected
+    }
+
+    func testMatchesReferenceSplitterOnPseudoRandomFiles() throws {
+        // Seeded LCG, not `random()`: a differential failure has to be
+        // reproducible from the test name alone.
+        var seed: UInt64 = 0x2545_F491_4F6C_DD1D
+        func nextByte() -> UInt8 {
+            seed = seed &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+            return UInt8((seed >> 33) & 0xFF)
+        }
+
+        for iteration in 0..<40 {
+            var payload = Data()
+            for _ in 0..<(200 + iteration * 13) {
+                let roll = nextByte()
+                // Heavily biased toward \n and \r so boundaries, blank lines and
+                // stray carriage returns actually occur instead of being a
+                // 1-in-256 accident.
+                switch roll % 8 {
+                case 0, 1: payload.append(UInt8(ascii: "\n"))
+                case 2: payload.append(UInt8(ascii: "\r"))
+                default: payload.append(roll)
+                }
+            }
+            let url = try writeData(payload)
+            let expected = referenceLines(of: payload)
+
+            for chunkSize in [1, 2, 3, 4, 5, 7, 8, 13, 16, 31, 64, 255, 1_024] {
+                XCTAssertEqual(
+                    readerLines(of: url, chunkSize: chunkSize),
+                    expected,
+                    "iteration \(iteration), chunkSize \(chunkSize)"
+                )
+            }
+        }
+    }
+
+    func testCarriageReturnSplitAcrossChunkBoundary() throws {
+        // The \r ends one chunk and its \n opens the next, so the trim has to
+        // happen against the reassembled line rather than the current chunk.
+        let chunkSize = 8
+        let url = try writeFile(String(repeating: "x", count: chunkSize - 1) + "\r\n" + "tail")
+
+        XCTAssertEqual(
+            lines(of: url, chunkSize: chunkSize),
+            [String(repeating: "x", count: chunkSize - 1), "tail"]
+        )
+    }
+
+    func testCarriageReturnEndingAnOversizedLine() throws {
+        // Same trim, but the line spans many chunks so it arrives via the
+        // accumulation path rather than straight out of one chunk.
+        let chunkSize = 16
+        let long = String(repeating: "y", count: chunkSize * 6)
+        let url = try writeFile(long + "\r\n" + "tail")
+
+        XCTAssertEqual(lines(of: url, chunkSize: chunkSize), [long, "tail"])
+    }
+
+    func testTrailingCarriageReturnWithoutNewline() throws {
+        let url = try writeFile("a\nbb\r")
+
+        XCTAssertEqual(lines(of: url, chunkSize: 2), ["a", "bb"])
+    }
+
     func testEmptyFileYieldsNothing() throws {
         let url = try writeFile("")
         var count = 0

--- a/MeterBarTests/FileLineReaderTests.swift
+++ b/MeterBarTests/FileLineReaderTests.swift
@@ -17,6 +17,16 @@ final class FileLineReaderTests: XCTestCase {
         return url
     }
 
+    private func writeData(_ contents: Data) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FileLineReaderTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("lines.jsonl")
+        try contents.write(to: url, options: .atomic)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        return url
+    }
+
     private func lines(of url: URL, chunkSize: Int = FileLineReader.defaultChunkSize) -> [String] {
         var collected: [String] = []
         FileLineReader.forEachLine(in: url, chunkSize: chunkSize) { line in
@@ -71,6 +81,96 @@ final class FileLineReaderTests: XCTestCase {
         for chunkSize in [1, 2, 3, 5, 7, 11, 64] {
             XCTAssertEqual(lines(of: url, chunkSize: chunkSize), expected, "chunkSize \(chunkSize)")
         }
+    }
+
+    func testLineManyChunksLongIsDeliveredByteForByte() throws {
+        // The reader must resume the newline search where the previous chunk
+        // left off. Restarting at byte 0 each chunk is what made a long line
+        // quadratic in its own length.
+        let chunkSize = 64
+        // 14...253 so the payload carries no \n to split on and no \r for the
+        // CRLF trim to eat.
+        var payload = Data()
+        for index in 0..<(chunkSize * 50) {
+            payload.append(UInt8(14 + index % 240))
+        }
+        var file = payload
+        file.append(UInt8(ascii: "\n"))
+        file.append(contentsOf: Array("tail".utf8))
+        let url = try writeData(file)
+
+        var collected: [Data] = []
+        FileLineReader.forEachLine(in: url, chunkSize: chunkSize) { collected.append($0) }
+
+        XCTAssertEqual(collected.count, 2)
+        XCTAssertEqual(collected.first, payload)
+        XCTAssertEqual(collected.last, Data("tail".utf8))
+    }
+
+    func testMultipleOversizedLinesInOneFile() throws {
+        let chunkSize = 32
+        let expected = [
+            String(repeating: "a", count: chunkSize * 9),
+            String(repeating: "b", count: chunkSize * 4 + 7),
+            "short",
+            String(repeating: "c", count: chunkSize * 11 + 1),
+        ]
+        let url = try writeFile(expected.joined(separator: "\n") + "\n")
+
+        XCTAssertEqual(lines(of: url, chunkSize: chunkSize), expected)
+    }
+
+    func testNewlineExactlyOnChunkBoundary() throws {
+        let chunkSize = 16
+
+        // Newline is the last byte of a chunk.
+        let atEnd = try writeFile(String(repeating: "x", count: chunkSize - 1) + "\n" + "tail")
+        XCTAssertEqual(
+            lines(of: atEnd, chunkSize: chunkSize),
+            [String(repeating: "x", count: chunkSize - 1), "tail"]
+        )
+
+        // Newline is the first byte of the next chunk — the case where a naive
+        // resume offset would emit an empty line and swallow the real one.
+        let atStart = try writeFile(String(repeating: "x", count: chunkSize) + "\n" + "tail")
+        XCTAssertEqual(
+            lines(of: atStart, chunkSize: chunkSize),
+            [String(repeating: "x", count: chunkSize), "tail"]
+        )
+
+        // And again after several chunks have accumulated into one long line.
+        let deep = try writeFile(String(repeating: "x", count: chunkSize * 5) + "\n" + "tail")
+        XCTAssertEqual(
+            lines(of: deep, chunkSize: chunkSize),
+            [String(repeating: "x", count: chunkSize * 5), "tail"]
+        )
+    }
+
+    func testLongSingleLineReadsInLinearTime() throws {
+        // Regression guard for the quadratic rescan. Real Codex rollout
+        // transcripts carry single lines in the tens of megabytes; at 256 KiB
+        // chunks the old loop rescanned the whole accumulated buffer per chunk
+        // and took tens of seconds for a file this size. Linear scanning does
+        // it in well under a second — 5s is a generous ceiling that only the
+        // quadratic loop can breach.
+        let byteCount = 32 * 1024 * 1024
+        var file = Data(repeating: UInt8(ascii: "x"), count: byteCount)
+        file.append(UInt8(ascii: "\n"))
+        let url = try writeData(file)
+
+        var yielded = 0
+        var lineLength = 0
+        let start = Date()
+        let opened = FileLineReader.forEachLine(in: url) { line in
+            yielded += 1
+            lineLength = line.count
+        }
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertTrue(opened)
+        XCTAssertEqual(yielded, 1)
+        XCTAssertEqual(lineLength, byteCount)
+        XCTAssertLessThan(elapsed, 5, "32 MiB single line took \(elapsed)s — the scan is not linear")
     }
 
     func testEmptyFileYieldsNothing() throws {


### PR DESCRIPTION
Two commits: the quadratic bug, then the per-byte cost it was hiding.

## 1. The quadratic rescan (`a9175c5`)

`FileLineReader.forEachLine` restarted its newline search at byte 0 of the accumulated buffer on every 256 KiB chunk. When a line is longer than the chunk, the inner `while` finds no newline, `searchStart` never advances, and the next chunk rescans everything again — **O(L² / chunkSize)**.

Not theoretical: `~/.codex/archived_sessions/` here holds single lines up to **56.7 MB**. Splitting one 820 MB transcript took **69.8s** warm-cache with no JSON parsing at all.

The fix tracks how far the buffer has been searched and resumes there. The subtlety is that `lineStart` and `searchFrom` must stay **distinct** — a line still begins at the front of the buffer even when the search resumes deeper in. Collapsing them, which is the obvious shape of this fix, emits an empty line and swallows the real one whenever a newline lands on the first byte of a chunk. There is a dedicated test for that.

## 2. The per-byte cost underneath (`200e4bb`)

That got the 820 MB file to ~3s — but `cat` of the same file is **0.06s**, so none of the remainder was I/O. It was `Data.firstIndex(of:)` walking bytes one at a time through `Collection`, plus appending every chunk into a buffer that was then re-based after each line.

So: scan with `memchr`, and emit each line directly out of the chunk the read produced. A buffer is now touched **only when a line actually straddles two chunks**, so the common path copies each line exactly once — into the `Data` handed to `body` — and never re-bases anything.

`body` stays non-escaping. `withUnsafeBytes` takes a non-escaping closure too, so `CodexCostScanner`'s `inout` accumulators (`&rollout`, `&deferred`, `&windows`) still thread through unchanged.

## Measured on the real trees

| | before | after |
|---|---|---|
| 820 MB rollout (4754 lines, longest 56.7 MB) | 69.78s | **0.23s** |
| entire `~/.codex` (2357 files, 1.44 M lines, 8.69 GiB) | 251.73s | **2.49s** |

That second row is why the dashboard sat on "Updating…": **four minutes** of pure line-splitting before a single token was counted. Both readers report the same 2357 files, the same 1,445,144 lines and the same 8.69 GiB, so the speedup is not the new reader quietly skipping work.

For scale, the directory walk the scanners already do costs 5.33s on its own — reading and splitting all 8.69 GiB is now less than half the cost of merely finding the files.

## Output is byte-identical

Hashing every line the **shipping** reader emits from the 820 MB rollout gives the same SHA-256 as an independent Python splitter, along with the same line count, byte count and longest-line length:

```
ORACLE    lines=4754 bytes=820307013 longest=56660520 sha=51cef921…c553c0a2
REALCHECK lines=4754 bytes=820307013 longest=56660520 sha=51cef921…c553c0a2
```

Since the reader's output is provably identical on real data, the cost scanners downstream cannot see any difference. (That check ran from a scratch test against a machine-local 820 MB file; it is deliberately not committed.)

## Behavior preserved

- `body` stays a non-escaping function parameter
- `false` when the file cannot be opened, `true` otherwise; empty file opens and yields nothing
- trailing line with no final newline still delivered
- lines still arrive as a zero-based `Data` (the accumulation buffer is built by appending onto a fresh `Data`, so it is zero-based by construction — the offset-slice hazard `JSONSerialization` trips on cannot arise), trailing `\r` still dropped
- `max(1, chunkSize)` guard kept
- peak memory still chunk size plus longest line. The straddle buffer is **released** after each line rather than kept with capacity: one 56.7 MB line must not pin 56.7 MB for the rest of a scan, least of all with several transcripts scanning concurrently.

Cost scanners and the 256 KiB default are untouched.

## Tests

TDD throughout. For the bug fix, tests written first and confirmed failing (20.5s on the perf guard). For the optimization — a pure refactor — characterization tests first, locking the existing behavior byte-for-byte, then the rewrite under them.

- `testMatchesReferenceSplitterOnPseudoRandomFiles` — differential against a deliberately naive whole-file splitter across 40 seeded pseudo-random files × 13 chunk sizes (**520 comparisons**), with `\n` and `\r` over-represented so boundaries, blank lines and stray carriage returns actually occur rather than being 1-in-256 accidents. Seeded LCG, not `random()`, so a failure reproduces from the test name alone.
- `testNewlineExactlyOnChunkBoundary` — newline as the last byte of a chunk, as the first byte of the next, and again after several chunks accumulate
- `testCarriageReturnSplitAcrossChunkBoundary` / `testCarriageReturnEndingAnOversizedLine` — the `\r` ends one chunk and its `\n` opens the next, so the trim must happen against the reassembled line, not the current chunk
- `testLineManyChunksLongIsDeliveredByteForByte` — a line spanning 50 chunks, compared as `Data`
- `testMultipleOversizedLinesInOneFile`, `testTrailingCarriageReturnWithoutNewline`
- `testLongSingleLineReadsInLinearTime` — generated 32 MiB single-line temp file (no fixture committed), asserts under 5s. Old code **20.5s**, after commit 1 **0.33s**, after commit 2 **~0.05s**. Threshold left generous so it stays a quadratic-regression guard rather than a flaky timing test on shared CI.

`swift build` clean, `xcodebuild` app target **BUILD SUCCEEDED**, `swift test` **1713 tests, 0 failures, 5 skipped**. SwiftLint clean on the reader.
