### PR TITLE
perf(cost): skip oversized transcript lines before parsing

### DIFF
--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MeterBarShared
+import os
 
 /// Reads Claude Code transcripts off disk and turns them into cost totals.
 /// Split out of `CostTracker` (audit C1d) so the transcript parsing, project

--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -186,8 +186,15 @@ enum ClaudeCostScanner {
         var periodUnkeyed: [ClaudeUsageEvent] = []
         var lifetimeKeyed: [String: ClaudeUsageEvent] = [:]
         var lifetimeUnkeyed: [ClaudeUsageEvent] = []
+        var oversizedLines = 0
 
         FileLineReader.forEachLine(in: url) { lineData in
+            // Size first: a pasted file or base64 blob is never a usage record,
+            // and parsing one would cost more than the whole rest of the file.
+            guard CostScanFileSystem.isScannableLine(lineData) else {
+                oversizedLines += 1
+                return
+            }
             guard !lineData.isEmpty,
                   let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
                   let timestampStr = json["timestamp"] as? String,
@@ -219,6 +226,14 @@ enum ClaudeCostScanner {
                 lifetimeUnkeyed.append(event)
                 if inPeriod { periodUnkeyed.append(event) }
             }
+        }
+
+        // One line per file, not per skipped line: a corpus with thousands of
+        // giants must not turn the log into the thing that costs the CPU.
+        if oversizedLines > 0 {
+            AppLog.cost.debug(
+                "Skipped \(oversizedLines, privacy: .public) oversized line(s) in \(url.lastPathComponent)"
+            )
         }
 
         return ScanWindows(

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -164,7 +164,15 @@ enum CodexCostScanner {
             // Per file, like the rollout context: a sibling rollout's model
             // must never name events this file left unexplained.
             var deferred: [CodexDeferredUsage] = []
+            var oversizedLines = 0
             FileLineReader.forEachLine(in: fileURL) { line in
+                // Ahead of even the marker scan: rollouts embed pasted files and
+                // raw tool output, so the biggest lines here are also the ones
+                // guaranteed not to be usage records.
+                guard CostScanFileSystem.isScannableLine(line) else {
+                    oversizedLines += 1
+                    return
+                }
                 guard line.contains(Self.tokenCountMarker) else {
                     Self.updateRolloutContext(&rollout, from: line)
                     // Reaches back only as far as the *first* model the file
@@ -185,6 +193,13 @@ enum CodexCostScanner {
             }
             // Whatever the file never explained is genuinely unattributed.
             Self.flushDeferred(&deferred, modelName: nil, windows: &windows)
+            // One line per file, not per skipped line: rollouts hold hundreds of
+            // oversized records and the log must stay cheaper than the scan.
+            if oversizedLines > 0 {
+                AppLog.cost.debug(
+                    "Skipped \(oversizedLines, privacy: .public) oversized line(s) in \(fileURL.lastPathComponent)"
+                )
+            }
         }
     }
 

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MeterBarShared
+import os
 import SQLite3
 
 /// Reads Codex CLI rollouts and the CLI's SQLite log database and turns them

--- a/MeterBar/Services/CostScanFileSystem.swift
+++ b/MeterBar/Services/CostScanFileSystem.swift
@@ -1,8 +1,29 @@
 import Foundation
 
-/// Filesystem guards the cost scan applies before walking a directory tree.
+/// Guards the cost scan applies to its raw inputs — which trees it will walk,
+/// and which transcript lines are worth parsing.
 /// Split out of `CostTracker` (audit C1d).
 enum CostScanFileSystem {
+    /// Largest transcript line the scanners will hand to `JSONSerialization`.
+    ///
+    /// Both CLIs write pasted files, base64 blobs and raw tool output straight
+    /// into a single `.jsonl` line, so a transcript can carry multi-megabyte
+    /// records that are never usage records. Parsing one costs seconds of CPU
+    /// and a transient allocation the size of the line, and the result is
+    /// always discarded.
+    ///
+    /// 4 MiB is measured, not guessed. On a local corpus of 351k Claude lines
+    /// and 1.44M Codex lines the largest *usage-bearing* line was 150,055 B
+    /// (146.5 KiB) for Claude and 831 B for Codex — the cap leaves roughly 28x
+    /// headroom over the worst real record. It skipped 108 Codex lines and 0
+    /// Claude lines, against a largest line overall of 56.7 MB.
+    nonisolated static let maximumLineBytes = 4 * 1024 * 1024
+
+    /// Whether a transcript line is small enough to be worth parsing.
+    nonisolated static func isScannableLine(_ line: Data) -> Bool {
+        line.count <= maximumLineBytes
+    }
+
     nonisolated static func isLocalDirectory(_ url: URL) -> Bool {
         let standardized = url.standardizedFileURL
         var isDirectory: ObjCBool = false

--- a/MeterBarTests/CostScanCollaboratorTests.swift
+++ b/MeterBarTests/CostScanCollaboratorTests.swift
@@ -89,6 +89,23 @@ final class CostScanCollaboratorTests: XCTestCase {
         XCTAssertFalse(CostScanFileSystem.isLocalDirectory(root.appendingPathComponent("gone", isDirectory: true)))
     }
 
+    func testIsScannableLineAcceptsUpToAndIncludingTheCap() {
+        let cap = CostScanFileSystem.maximumLineBytes
+
+        XCTAssertTrue(CostScanFileSystem.isScannableLine(Data()))
+        XCTAssertTrue(CostScanFileSystem.isScannableLine(Data(count: cap - 1)))
+        XCTAssertTrue(CostScanFileSystem.isScannableLine(Data(count: cap)))
+        XCTAssertFalse(CostScanFileSystem.isScannableLine(Data(count: cap + 1)))
+    }
+
+    func testMaximumLineBytesClearsTheLargestObservedUsageLine() {
+        // 150,055 B is the largest usage-bearing line measured across a local
+        // corpus of 351k Claude and 1.44M Codex transcript lines. Lowering the
+        // cap near it would start dropping real spend.
+        XCTAssertEqual(CostScanFileSystem.maximumLineBytes, 4 * 1024 * 1024)
+        XCTAssertGreaterThan(CostScanFileSystem.maximumLineBytes, 150_055 * 4)
+    }
+
     // MARK: - TokenCostMath
 
     func testCalculateCostPricesEveryTokenClassPerMillion() {

--- a/MeterBarTests/OversizedScanLineTests.swift
+++ b/MeterBarTests/OversizedScanLineTests.swift
@@ -1,0 +1,234 @@
+import XCTest
+@testable import MeterBar
+import MeterBarShared
+
+/// Covers the oversized-line guard both cost scanners apply before handing a
+/// transcript line to `JSONSerialization`.
+///
+/// The fixtures here are deliberately *valid* usage records that are merely too
+/// large: a malformed line was already skipped by the existing parse guards, so
+/// only a well-formed giant proves the size check is what rejected it. Each
+/// oversized fixture sits one byte above `CostScanFileSystem.maximumLineBytes`
+/// and each accepted fixture sits exactly on it, which pins the boundary rather
+/// than testing somewhere vaguely near it.
+final class OversizedScanLineTests: XCTestCase {
+    private var cap: Int { CostScanFileSystem.maximumLineBytes }
+
+    // MARK: - Fixtures
+
+    /// Inflates an ASCII JSON object to exactly `target` bytes by appending a
+    /// top-level padding string. The object stays parseable, so a scanner that
+    /// skips it can only have skipped it on size.
+    private func grown(_ json: String, toBytes target: Int) -> String {
+        let prefix = String(json.dropLast()) + ",\"padding\":\""
+        let suffix = "\"}"
+        let fill = max(0, target - prefix.utf8.count - suffix.utf8.count)
+        return prefix + String(repeating: "x", count: fill) + suffix
+    }
+
+    private func writeTranscript(lines: [String], named name: String = "session.jsonl") throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OversizedScanLineTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent(name)
+        try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        return url
+    }
+
+    /// Writes a rollout into an `archived_sessions` directory and returns that
+    /// directory — the argument `CodexCostScanner.scanRollouts` expects.
+    private func writeCodexArchive(lines: [String]) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OversizedCodexHome-\(UUID().uuidString)", isDirectory: true)
+        let dir = root.appendingPathComponent("archived_sessions", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try lines.joined(separator: "\n").write(
+            to: dir.appendingPathComponent("rollout.jsonl"), atomically: true, encoding: .utf8
+        )
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return dir
+    }
+
+    private func claudeUsageLine(
+        timestamp: String,
+        messageID: String = "msg_1",
+        requestID: String = "req_1",
+        input: Int = 10,
+        output: Int = 5
+    ) -> String {
+        """
+        {"timestamp": "\(timestamp)", "requestId": "\(requestID)", "message": {"id": "\(messageID)", \
+        "model": "claude-sonnet-4-5", "usage": {"input_tokens": \(input), "output_tokens": \(output), \
+        "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}}
+        """
+    }
+
+    private func codexUsageLine(
+        timestamp: String,
+        conversationID: String = "conv-1",
+        input: Int = 1_000,
+        output: Int = 500
+    ) -> String {
+        """
+        {"timestamp": "\(timestamp)", "payload": {"type": "token_count", \
+        "rate_limits": {"conversation_id": "\(conversationID)"}, \
+        "info": {"model": "gpt-5.5", "last_token_usage": \
+        {"input_tokens": \(input), "output_tokens": \(output), \
+        "cached_input_tokens": 0, "reasoning_output_tokens": 0}}}}
+        """
+    }
+
+    private let cutoff = FlexibleISO8601.date(from: "2026-06-01T00:00:00Z") ?? .distantPast
+
+    // MARK: - Claude
+
+    func testClaudeSkipsUsageLinesAboveTheCap() throws {
+        let url = try writeTranscript(lines: [
+            grown(claudeUsageLine(timestamp: "2026-07-01T10:00:00.000Z"), toBytes: cap + 1)
+        ])
+
+        let windows = ClaudeCostScanner.parseSessionWindows(at: url, since: cutoff)
+
+        XCTAssertEqual(windows.period.input, 0)
+        XCTAssertEqual(windows.period.output, 0)
+        XCTAssertEqual(windows.period.estimatedCost, 0, accuracy: 0.0001)
+        // No usage means no session either: a file of nothing but giants is not
+        // a session that spent anything.
+        XCTAssertEqual(windows.period.sessions, 0)
+    }
+
+    func testClaudeParsesUsageLinesExactlyAtTheCap() throws {
+        let url = try writeTranscript(lines: [
+            grown(claudeUsageLine(timestamp: "2026-07-01T10:00:00.000Z"), toBytes: cap)
+        ])
+
+        let result = ClaudeCostScanner.parseSessionFile(at: url, since: cutoff)
+
+        XCTAssertEqual(result.input, 10)
+        XCTAssertEqual(result.output, 5)
+        XCTAssertEqual(result.sessions, 1)
+    }
+
+    func testClaudeOversizedLineDoesNotAbortTheRestOfTheFile() throws {
+        let url = try writeTranscript(lines: [
+            claudeUsageLine(timestamp: "2026-07-01T10:00:00.000Z", messageID: "a", requestID: "a", input: 10),
+            grown(
+                claudeUsageLine(
+                    timestamp: "2026-07-01T10:30:00.000Z", messageID: "big", requestID: "big",
+                    input: 999_999, output: 999_999
+                ),
+                toBytes: cap + 1
+            ),
+            claudeUsageLine(timestamp: "2026-07-01T11:00:00.000Z", messageID: "b", requestID: "b", input: 7, output: 3)
+        ])
+
+        let result = ClaudeCostScanner.parseSessionFile(at: url, since: cutoff)
+
+        // Both normal events survive: the skip is per line, not per file.
+        XCTAssertEqual(result.input, 17)
+        XCTAssertEqual(result.output, 8)
+    }
+
+    func testClaudeCapAppliesToBothWindows() throws {
+        let url = try writeTranscript(lines: [
+            claudeUsageLine(
+                timestamp: "2026-05-01T10:00:00.000Z", messageID: "old", requestID: "old", input: 4, output: 1
+            ),
+            grown(
+                claudeUsageLine(
+                    timestamp: "2026-05-02T10:00:00.000Z", messageID: "old-big", requestID: "old-big",
+                    input: 100_000, output: 100_000
+                ),
+                toBytes: cap + 1
+            ),
+            claudeUsageLine(
+                timestamp: "2026-07-01T10:00:00.000Z", messageID: "new", requestID: "new", input: 10, output: 5
+            ),
+            grown(
+                claudeUsageLine(
+                    timestamp: "2026-07-02T10:00:00.000Z", messageID: "new-big", requestID: "new-big",
+                    input: 200_000, output: 200_000
+                ),
+                toBytes: cap + 1
+            )
+        ])
+
+        let windows = ClaudeCostScanner.parseSessionWindows(at: url, since: cutoff)
+
+        XCTAssertEqual(windows.period.input, 10)
+        XCTAssertEqual(windows.period.output, 5)
+        // The lifetime window reads every line the period window skipped plus
+        // the pre-cutoff ones, so it is where an unguarded giant would show up.
+        XCTAssertEqual(windows.lifetime.input, 14)
+        XCTAssertEqual(windows.lifetime.output, 6)
+    }
+
+    // MARK: - Codex
+
+    func testCodexSkipsUsageLinesAboveTheCap() throws {
+        let dir = try writeCodexArchive(lines: [
+            grown(codexUsageLine(timestamp: "2026-07-01T10:00:00Z"), toBytes: cap + 1)
+        ])
+        var context = CodexScanContext(earliestDate: Date(), latestDate: cutoff)
+
+        CodexCostScanner.scanRollouts(directory: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.totals.input, 0)
+        XCTAssertEqual(context.totals.output, 0)
+        XCTAssertTrue(context.sessionIDs.isEmpty)
+    }
+
+    func testCodexParsesUsageLinesExactlyAtTheCap() throws {
+        let dir = try writeCodexArchive(lines: [
+            grown(codexUsageLine(timestamp: "2026-07-01T10:00:00Z"), toBytes: cap)
+        ])
+        var context = CodexScanContext(earliestDate: Date(), latestDate: cutoff)
+
+        CodexCostScanner.scanRollouts(directory: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.totals.input, 1_000)
+        XCTAssertEqual(context.totals.output, 500)
+        XCTAssertEqual(context.sessionIDs, ["conv-1"])
+    }
+
+    func testCodexOversizedLineDoesNotAbortTheRestOfTheFile() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexUsageLine(timestamp: "2026-07-01T10:00:00Z", input: 1_000, output: 500),
+            grown(
+                codexUsageLine(timestamp: "2026-07-01T10:30:00Z", input: 999_999, output: 999_999),
+                toBytes: cap + 1
+            ),
+            codexUsageLine(timestamp: "2026-07-01T11:00:00Z", input: 7, output: 3)
+        ])
+        var context = CodexScanContext(earliestDate: Date(), latestDate: cutoff)
+
+        CodexCostScanner.scanRollouts(directory: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.totals.input, 1_007)
+        XCTAssertEqual(context.totals.output, 503)
+    }
+
+    func testCodexCapAppliesToBothWindows() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexUsageLine(timestamp: "2026-05-01T10:00:00Z", input: 4, output: 1),
+            grown(
+                codexUsageLine(timestamp: "2026-05-02T10:00:00Z", input: 100_000, output: 100_000),
+                toBytes: cap + 1
+            ),
+            codexUsageLine(timestamp: "2026-07-01T10:00:00Z", input: 10, output: 5),
+            grown(
+                codexUsageLine(timestamp: "2026-07-02T10:00:00Z", input: 200_000, output: 200_000),
+                toBytes: cap + 1
+            )
+        ])
+        var windows = CodexCostScanner.scanWindows(cutoff: cutoff)
+
+        CodexCostScanner.scanRollouts(directory: dir, windows: &windows)
+
+        XCTAssertEqual(windows.period.totals.input, 10)
+        XCTAssertEqual(windows.period.totals.output, 5)
+        XCTAssertEqual(windows.lifetime.totals.input, 14)
+        XCTAssertEqual(windows.lifetime.totals.output, 6)
+    }
+}


### PR DESCRIPTION
## Problem

The cost scan reads every `.jsonl` under `~/.claude*/projects` and `~/.codex/{sessions,archived_sessions}` and hands **every line** to `JSONSerialization.jsonObject`.

Both CLIs write pasted file contents, base64 blobs and raw tool output straight into a single line, so transcript lines get very large — the biggest on my machine is **56,660,520 B (54.04 MiB)** in a `~/.codex/archived_sessions` rollout. Parsing a line that size costs seconds of CPU and a transient allocation as large as the line, and the result is thrown away every time: a line that big is never a usage record.

## Change

- `CostScanFileSystem.maximumLineBytes` (**4 MiB**) + `isScannableLine(_:)` — one shared constant, not a literal duplicated in two files.
- `ClaudeCostScanner.parseSessionWindows` checks it before the parse.
- `CodexCostScanner.scanRollouts` checks it **before even the `token_count` byte-marker scan**, since the biggest lines there are exactly the ones guaranteed not to be usage records.

## Why 4 MiB — measured, not guessed

Scanned the full local corpus: **351,312 Claude lines / 151,089 usage-bearing** and **1,442,275 Codex lines / 372,960 usage-bearing**.

| | Claude | Codex |
|---|---|---|
| **largest usage-bearing line** | **150,055 B (146.5 KiB)** | **831 B** |
| usage-line p50 / p99 | 1,753 / 17,359 B | 722 / 807 B |
| largest line overall | 2,371,526 B (2.26 MiB) | 56,660,520 B (54.04 MiB) |
| lines skipped at 4 MiB | **0** | **108** |

4 MiB sits ~28x above the largest usage-bearing line ever observed, and no usage-bearing line in either corpus comes within an order of magnitude of it. For reference the same corpus has 1,883 lines over 1 MiB and 1,153 over 2 MiB, so a tighter cap would buy more skips at the cost of shrinking that headroom.

## Logging

One `AppLog.cost.debug` **per file that skipped anything**, not per skipped line — on this corpus that is at most ~108 entries and realistically far fewer, so a large corpus can't make the log the new cost. Only the count is `.public`; the filename stays at default redaction.

## Tests (written first)

New `MeterBarTests/OversizedScanLineTests.swift`, 8 cases covering **both** scanners:

- a line above the cap is skipped and contributes zero tokens/cost (and no session)
- a line **exactly at** the cap is still parsed and counted
- a file mixing oversized and normal lines still tallies every normal one — the giant does not abort the rest of the file
- the cap applies to **both** the period and lifetime windows

Fixtures are *valid* usage records padded to an exact byte target, so a skip can only be size-driven — a malformed giant would have been dropped by the pre-existing parse guards and proved nothing. Verified by disabling the guard: 6 of 8 fail without it (the two at-cap tests pass either way by design — they exist to catch over-rejection).

Plus a direct `isScannableLine` boundary assertion in `CostScanCollaboratorTests`.

## Verification

- `swift build` — clean
- `swift test` — **1715 tests, 0 failures** (5 skipped, pre-existing)
- `swiftlint --strict` — 0 violations

`FileLineReader.swift` is untouched, per the parallel quadratic-time fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript scanning by safely skipping excessively large lines instead of attempting to parse them.
  * Continued processing subsequent valid records when oversized lines are encountered.
  * Applied the safeguard consistently across usage periods and supported scanning formats.

* **Tests**
  * Added coverage for line-size boundaries and handling of oversized records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->