### PR TITLE
perf(cost): scan the corpus in resumable, budgeted slices on one serial queue

### DIFF
--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -100,7 +100,9 @@ enum ClaudeCostScanner {
         ))
     }
 
-    nonisolated private static func projectRoots(accounts: [ClaudeCodeAccount]) -> [URL] {
+    /// Internal (not private) so the budgeted scan can enumerate the same roots
+    /// the whole-corpus scan walks.
+    nonisolated static func projectRoots(accounts: [ClaudeCodeAccount]) -> [URL] {
         let fileManager = FileManager.default
         // realHomeDirectory, not homeDirectoryForCurrentUser: in sandboxed
         // builds the latter is the app container, and the scan would silently
@@ -188,30 +190,9 @@ enum ClaudeCostScanner {
         var lifetimeUnkeyed: [ClaudeUsageEvent] = []
 
         FileLineReader.forEachLine(in: url) { lineData in
-            guard !lineData.isEmpty,
-                  let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
-                  let timestampStr = json["timestamp"] as? String,
-                  let timestamp = FlexibleISO8601.date(from: timestampStr),
-                  let message = json["message"] as? [String: Any],
-                  let usage = message["usage"] as? [String: Any] else {
-                return
-            }
+            guard let event = Self.usageEvent(from: lineData, url: url) else { return }
 
-            let event = ClaudeUsageEvent(
-                timestamp: timestamp,
-                model: message["model"] as? String,
-                messageID: message["id"] as? String,
-                requestID: json["requestId"] as? String,
-                input: CostScanValues.int(usage["input_tokens"]),
-                output: CostScanValues.int(usage["output_tokens"]),
-                cacheCreation: CostScanValues.int(usage["cache_creation_input_tokens"]),
-                cacheCreationOneHour: Self.oneHourCacheCreationTokens(in: usage),
-                cacheRead: CostScanValues.int(usage["cache_read_input_tokens"]),
-                origin: Self.usageOrigin(json: json, message: message, url: url)
-            )
-            guard event.hasUsage else { return }
-
-            let inPeriod = timestamp >= cutoffDate
+            let inPeriod = event.timestamp >= cutoffDate
             if let key = event.deduplicationKey {
                 lifetimeKeyed[key] = event
                 if inPeriod { periodKeyed[key] = event }
@@ -226,6 +207,217 @@ enum ClaudeCostScanner {
             lifetime: Self.tally(keyed: lifetimeKeyed, unkeyed: lifetimeUnkeyed, projectID: projectID),
             cutoff: cutoffDate
         )
+    }
+
+    /// Decodes one transcript line into a usage event, or `nil` when the line is
+    /// not one (blank, malformed, or a non-usage record).
+    nonisolated private static func usageEvent(from lineData: Data, url: URL) -> ClaudeUsageEvent? {
+        guard !lineData.isEmpty,
+              let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+              let timestampStr = json["timestamp"] as? String,
+              let timestamp = FlexibleISO8601.date(from: timestampStr),
+              let message = json["message"] as? [String: Any],
+              let usage = message["usage"] as? [String: Any] else {
+            return nil
+        }
+
+        let event = ClaudeUsageEvent(
+            timestamp: timestamp,
+            model: message["model"] as? String,
+            messageID: message["id"] as? String,
+            requestID: json["requestId"] as? String,
+            input: CostScanValues.int(usage["input_tokens"]),
+            output: CostScanValues.int(usage["output_tokens"]),
+            cacheCreation: CostScanValues.int(usage["cache_creation_input_tokens"]),
+            cacheCreationOneHour: Self.oneHourCacheCreationTokens(in: usage),
+            cacheRead: CostScanValues.int(usage["cache_read_input_tokens"]),
+            origin: Self.usageOrigin(json: json, message: message, url: url)
+        )
+        return event.hasUsage ? event : nil
+    }
+
+    // MARK: - Budgeted, resumable scan
+
+    /// Walks `roots` newest transcript first, reading only bytes appended since
+    /// the last refresh and stopping when `session`'s budget runs out.
+    ///
+    /// Every file's tally lives on its own cache entry, so a refresh that only
+    /// gets through the newest handful still returns the *whole* corpus total —
+    /// freshly-read files plus every previously-cached one. The number on screen
+    /// improves monotonically as the slices land instead of appearing all at
+    /// once after a 70-second freeze.
+    nonisolated static func scanRoots(
+        _ roots: [URL],
+        session: CostScanSession
+    ) -> ScanWindows<ClaudeSessionTotals> {
+        var windows = ScanWindows(
+            period: ClaudeSessionTotals(),
+            lifetime: ClaudeSessionTotals(),
+            cutoff: session.cutoff
+        )
+        var live: Set<String> = []
+
+        for root in roots {
+            guard CostScanFileSystem.isLocalDirectory(root) else { continue }
+
+            for file in CostScanCorpus.transcripts(in: root) {
+                // `projectRoots` can name the same directory twice (an account's
+                // configured path is often just `~/.claude`), and the cache is
+                // keyed by standardized path — counting a file once per root
+                // would double its spend.
+                guard live.insert(file.cacheKey).inserted else { continue }
+
+                let projectID = CostProjectAttribution.claudeProjectID(
+                    forTranscriptURL: file.url,
+                    root: root
+                )
+                guard let file = Self.totals(for: file, projectID: projectID, session: session) else {
+                    continue
+                }
+                windows.period.merge(file.period)
+                windows.lifetime.merge(file.lifetime)
+            }
+        }
+
+        // Enumeration always runs to completion even when the read budget is
+        // spent, so `live` is every transcript that exists — safe to prune
+        // against on a partial refresh. Without it, deleted transcripts would
+        // keep contributing their totals forever.
+        session.retainClaude(keys: live)
+        return windows
+    }
+
+    /// One transcript's contribution: cached, resumed, or skipped.
+    ///
+    /// - Returns: `nil` when the file has never been read and there was no
+    ///   budget left to start it, so it contributes nothing this refresh.
+    nonisolated private static func totals(
+        for file: CostScanFile,
+        projectID: String,
+        session: CostScanSession
+    ) -> ScanWindows<ClaudeSessionTotals>? {
+        let record = Self.resumableRecord(for: file, session: session)
+
+        // Nothing appended since the last pass. This is the steady state once
+        // the corpus is warm, and it is why a refresh costs almost no I/O.
+        if let record, record.isComplete, record.size == file.size {
+            return Self.windows(record.payload, cutoff: session.cutoff)
+        }
+
+        let allowance = session.budget.allowance
+        guard allowance > 0 else {
+            session.noteDeferred()
+            return record.map { Self.windows($0.payload, cutoff: session.cutoff) }
+        }
+
+        var payload = record?.payload ?? ClaudeFileTotals()
+        var request = FileLineReadRequest()
+        request.startOffset = record?.offset ?? 0
+        request.maxBytes = allowance
+
+        var periodKeyed: [String: ClaudeUsageEvent] = [:]
+        var periodUnkeyed: [ClaudeUsageEvent] = []
+        var lifetimeKeyed: [String: ClaudeUsageEvent] = [:]
+        var lifetimeUnkeyed: [ClaudeUsageEvent] = []
+
+        let read = FileLineReader.readLines(in: file.url, request: request) { lineData, _ in
+            guard let event = Self.usageEvent(from: lineData, url: file.url) else { return }
+
+            if let key = event.deduplicationKey {
+                // First-wins across a resume boundary: an event with this key is
+                // already folded into `payload`, and its bytes are behind the
+                // committed offset. Within a single pass the last copy still
+                // wins, exactly as a cold scan does.
+                if !payload.lifetimeKeys.contains(key) {
+                    lifetimeKeyed[key] = event
+                }
+                if event.timestamp >= session.cutoff, !payload.periodKeys.contains(key) {
+                    periodKeyed[key] = event
+                }
+            } else {
+                lifetimeUnkeyed.append(event)
+                if event.timestamp >= session.cutoff { periodUnkeyed.append(event) }
+            }
+        }
+
+        guard let read else {
+            // Unreadable (permissions, deleted mid-scan). Keep whatever the
+            // cache already had rather than dropping the file's history.
+            return record.map { Self.windows($0.payload, cutoff: session.cutoff) }
+        }
+        session.budget.consume(read.bytesRead)
+
+        payload.period.merge(Self.tally(keyed: periodKeyed, unkeyed: periodUnkeyed, projectID: projectID))
+        payload.lifetime.merge(Self.tally(keyed: lifetimeKeyed, unkeyed: lifetimeUnkeyed, projectID: projectID))
+        // `merge` sums `sessions`, but one transcript is one session however
+        // many slices it took to read.
+        payload.period.sessions = payload.period.hasUsage ? 1 : 0
+        payload.lifetime.sessions = payload.lifetime.hasUsage ? 1 : 0
+
+        if read.reachedEndOfFile {
+            // Dedup keys only matter while a read can resume mid-file. Keeping
+            // ~10k files' worth of them on disk forever would cost more to load
+            // than the scan they save.
+            payload.periodKeys = []
+            payload.lifetimeKeys = []
+        } else {
+            payload.periodKeys.formUnion(periodKeyed.keys)
+            payload.lifetimeKeys.formUnion(lifetimeKeyed.keys)
+            session.noteDeferred()
+        }
+
+        session.setClaudeRecord(
+            CostScanFileRecord(
+                offset: read.committedOffset,
+                size: file.size,
+                cutoff: session.cutoff,
+                isComplete: read.reachedEndOfFile,
+                payload: payload
+            ),
+            for: file.cacheKey
+        )
+        return Self.windows(payload, cutoff: session.cutoff)
+    }
+
+    /// The cached entry to resume from, rebased onto this refresh's cutoff.
+    ///
+    /// - Returns: `nil` when the file has to be re-read from byte zero.
+    nonisolated private static func resumableRecord(
+        for file: CostScanFile,
+        session: CostScanSession
+    ) -> CostScanFileRecord<ClaudeFileTotals>? {
+        guard var record = session.claudeRecord(for: file.cacheKey) else { return nil }
+        // A file that shrank was rotated or replaced, so the cached tally
+        // describes bytes that no longer exist.
+        guard record.offset <= UInt64(file.size) else { return nil }
+        guard record.cutoff != session.cutoff else { return record }
+
+        // The period window slides every day; lifetime totals never expire. So
+        // the only question is whether the cached period tally can be rebased
+        // without re-reading the file.
+        let lifetime = record.payload.lifetime
+        if (lifetime.latest ?? .distantPast) < session.cutoff {
+            // Every event predates the new window.
+            record.payload.period = ClaudeSessionTotals()
+            record.payload.periodKeys = []
+        } else if (lifetime.earliest ?? .distantFuture) >= session.cutoff {
+            // Every event falls inside it.
+            record.payload.period = lifetime
+            record.payload.periodKeys = record.payload.lifetimeKeys
+        } else {
+            // The file straddles the cutoff and only its individual events know
+            // where. Re-read it — but only files that actually straddle pay.
+            return nil
+        }
+        record.cutoff = session.cutoff
+        return record
+    }
+
+    nonisolated private static func windows(
+        _ payload: ClaudeFileTotals,
+        cutoff: Date
+    ) -> ScanWindows<ClaudeSessionTotals> {
+        ScanWindows(period: payload.period, lifetime: payload.lifetime, cutoff: cutoff)
     }
 
     nonisolated private static func tally(

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -154,38 +154,47 @@ enum CodexCostScanner {
         // per-event timestamp check inside `ScanWindows.update` (an event is
         // never newer than the file holding it).
         for case let fileURL as URL in enumerator where fileURL.pathExtension == "jsonl" {
-            // Reset per file: attribution carried across rollouts would label
-            // one session's spend with another's model.
-            var rollout = CodexRolloutContext()
-            // Codex emits a session's opening `token_count` events *before* its
-            // first `turn_context`, so forward-only attribution orphaned them
-            // even though the same file names the model seconds later. Park
-            // them here instead and back-fill once the file declares a model.
-            // Per file, like the rollout context: a sibling rollout's model
-            // must never name events this file left unexplained.
-            var deferred: [CodexDeferredUsage] = []
-            FileLineReader.forEachLine(in: fileURL) { line in
-                guard line.contains(Self.tokenCountMarker) else {
-                    Self.updateRolloutContext(&rollout, from: line)
-                    // Reaches back only as far as the *first* model the file
-                    // declares — a later mid-session switch must not relabel
-                    // the events that preceded it.
-                    if let model = rollout.turnModel ?? rollout.sessionModel {
-                        Self.flushDeferred(&deferred, modelName: model, windows: &windows)
-                    }
-                    return
-                }
-                Self.addTokenCountLine(
-                    line,
-                    fileURL: fileURL,
-                    rollout: rollout,
-                    deferred: &deferred,
-                    windows: &windows
-                )
-            }
-            // Whatever the file never explained is genuinely unattributed.
-            Self.flushDeferred(&deferred, modelName: nil, windows: &windows)
+            Self.parseRollout(at: fileURL, windows: &windows)
         }
+    }
+
+    /// Streams one rollout end to end into `windows`.
+    ///
+    /// Attribution state is created here and dies here: carried across rollouts
+    /// it would label one session's spend with another's model.
+    nonisolated private static func parseRollout(
+        at fileURL: URL,
+        windows: inout ScanWindows<CodexScanContext>
+    ) {
+        var rollout = CodexRolloutContext()
+        // Codex emits a session's opening `token_count` events *before* its
+        // first `turn_context`, so forward-only attribution orphaned them
+        // even though the same file names the model seconds later. Park
+        // them here instead and back-fill once the file declares a model.
+        // Per file, like the rollout context: a sibling rollout's model
+        // must never name events this file left unexplained.
+        var deferred: [CodexDeferredUsage] = []
+        FileLineReader.forEachLine(in: fileURL) { line in
+            guard line.contains(Self.tokenCountMarker) else {
+                Self.updateRolloutContext(&rollout, from: line)
+                // Reaches back only as far as the *first* model the file
+                // declares — a later mid-session switch must not relabel
+                // the events that preceded it.
+                if let model = rollout.turnModel ?? rollout.sessionModel {
+                    Self.flushDeferred(&deferred, modelName: model, windows: &windows)
+                }
+                return
+            }
+            Self.addTokenCountLine(
+                line,
+                fileURL: fileURL,
+                rollout: rollout,
+                deferred: &deferred,
+                windows: &windows
+            )
+        }
+        // Whatever the file never explained is genuinely unattributed.
+        Self.flushDeferred(&deferred, modelName: nil, windows: &windows)
     }
 
     /// Single-window entry point kept for callers that only care about one
@@ -202,6 +211,209 @@ enum CodexCostScanner {
         )
         Self.scanRollouts(directory: directory, windows: &windows)
         context = windows.period
+    }
+
+    // MARK: - Budgeted, resumable scan
+
+    /// Rollouts and the flat SQLite log, read under `session`'s budget.
+    nonisolated static func scanSessions(session: CostScanSession) -> ScanWindows<CodexScanContext> {
+        let codexDir = URL(fileURLWithPath: CodexHomeDirectory.path(), isDirectory: true)
+        var windows = Self.scanRollouts(
+            directories: Self.rolloutDirectories(in: codexDir),
+            session: session
+        )
+        // The SQLite log is a single file with no append-only guarantee and no
+        // line structure to resume from, so it is re-read whole every refresh.
+        // It is orders of magnitude smaller than the rollout corpus, so it is
+        // not what the budget exists to bound.
+        Self.scanSQLiteLogs(
+            database: codexDir.appendingPathComponent("logs_2.sqlite"),
+            windows: &windows
+        )
+        return windows
+    }
+
+    /// Walks `directories` newest rollout first, reading only bytes appended
+    /// since the last refresh and stopping when the budget runs out.
+    nonisolated static func scanRollouts(
+        directories: [URL],
+        session: CostScanSession
+    ) -> ScanWindows<CodexScanContext> {
+        var windows = Self.scanWindows(cutoff: session.cutoff)
+        var live: Set<String> = []
+
+        for directory in directories {
+            guard CostScanFileSystem.isLocalDirectory(directory) else { continue }
+
+            for file in CostScanCorpus.transcripts(in: directory) {
+                guard live.insert(file.cacheKey).inserted else { continue }
+                guard let totals = Self.totals(for: file, session: session) else { continue }
+                guard Self.fold(totals, into: &windows) else {
+                    // This rollout shares events with one already folded in —
+                    // in practice a session that exists in both `sessions/` and
+                    // `archived_sessions/` at once. Aggregates cannot be
+                    // de-overlapped after the fact, so this one file goes back
+                    // through the live path, where `addUsage` drops the
+                    // duplicates event by event.
+                    Self.parseRollout(at: file.url, windows: &windows)
+                    continue
+                }
+            }
+        }
+
+        session.retainCodex(keys: live)
+        return windows
+    }
+
+    /// One rollout's isolated tally: cached, resumed, or skipped.
+    ///
+    /// Parsing into the file's *own* windows rather than straight into the
+    /// shared ones is what makes the result cacheable — a per-file tally stays
+    /// valid no matter which other files a later refresh happens to read.
+    ///
+    /// - Returns: `nil` when the file has never been read and there was no
+    ///   budget left to start it.
+    nonisolated private static func totals(
+        for file: CostScanFile,
+        session: CostScanSession
+    ) -> CodexFileTotals? {
+        let record = Self.resumableRecord(for: file, session: session)
+
+        // Nothing appended since the last pass.
+        if let record, record.isComplete, record.size == file.size {
+            return record.payload
+        }
+
+        let allowance = session.budget.allowance
+        guard allowance > 0 else {
+            session.noteDeferred()
+            return record?.payload
+        }
+
+        var payload = record?.payload ?? CodexFileTotals(cutoff: session.cutoff)
+        var windows = ScanWindows(
+            period: payload.period,
+            lifetime: payload.lifetime,
+            cutoff: session.cutoff
+        )
+        var rollout = payload.rollout
+        var deferred: [CodexDeferredUsage] = []
+        var deferredOffset: UInt64?
+
+        var request = FileLineReadRequest()
+        request.startOffset = record?.offset ?? 0
+        request.maxBytes = allowance
+
+        let read = FileLineReader.readLines(in: file.url, request: request) { line, offset in
+            guard line.contains(Self.tokenCountMarker) else {
+                Self.updateRolloutContext(&rollout, from: line)
+                if let model = rollout.turnModel ?? rollout.sessionModel {
+                    Self.flushDeferred(&deferred, modelName: model, windows: &windows)
+                    deferredOffset = nil
+                }
+                return
+            }
+            let parked = deferred.count
+            Self.addTokenCountLine(
+                line,
+                fileURL: file.url,
+                rollout: rollout,
+                deferred: &deferred,
+                windows: &windows
+            )
+            if deferred.count > parked, deferredOffset == nil {
+                deferredOffset = offset
+            }
+        }
+
+        guard let read else { return record?.payload }
+        session.budget.consume(read.bytesRead)
+
+        var committed = read.committedOffset
+        if read.reachedEndOfFile {
+            Self.flushDeferred(&deferred, modelName: nil, windows: &windows)
+        } else {
+            session.noteDeferred()
+            if let deferredOffset {
+                // Events still waiting on a model the *next* slice may yet
+                // declare. Rolling the offset back re-reads them rather than
+                // stranding them as unattributed; every event already counted
+                // is re-read too, and `eventKeys` discards it as the duplicate
+                // it is.
+                committed = deferredOffset
+            }
+        }
+
+        payload.period = windows.period
+        payload.lifetime = windows.lifetime
+        payload.rollout = rollout
+
+        session.setCodexRecord(
+            CostScanFileRecord(
+                offset: committed,
+                size: file.size,
+                cutoff: session.cutoff,
+                isComplete: read.reachedEndOfFile,
+                payload: payload
+            ),
+            for: file.cacheKey
+        )
+        return payload
+    }
+
+    /// Adds one rollout's tally to the shared windows.
+    ///
+    /// - Returns: `false` when the file's events partly overlap what is already
+    ///   counted, which no aggregate merge can resolve — the caller has to
+    ///   re-read that file event by event.
+    nonisolated private static func fold(
+        _ totals: CodexFileTotals,
+        into windows: inout ScanWindows<CodexScanContext>
+    ) -> Bool {
+        // Period keys are a subset of lifetime keys by construction (every
+        // in-window event is also a lifetime event), so the lifetime test
+        // answers for both windows.
+        let keys = totals.lifetime.eventKeys
+        if keys.isDisjoint(with: windows.lifetime.eventKeys) {
+            windows.period.merge(totals.period)
+            windows.lifetime.merge(totals.lifetime)
+            return true
+        }
+        // Every event is already counted: a duplicated rollout with nothing new.
+        return keys.isSubset(of: windows.lifetime.eventKeys)
+    }
+
+    /// The cached entry to resume from, rebased onto this refresh's cutoff.
+    ///
+    /// - Returns: `nil` when the rollout has to be re-read from byte zero.
+    nonisolated private static func resumableRecord(
+        for file: CostScanFile,
+        session: CostScanSession
+    ) -> CostScanFileRecord<CodexFileTotals>? {
+        guard var record = session.codexRecord(for: file.cacheKey) else { return nil }
+        // A file that shrank was rotated or replaced, so the cached tally
+        // describes bytes that no longer exist.
+        guard record.offset <= UInt64(file.size) else { return nil }
+        guard record.cutoff != session.cutoff else { return record }
+
+        let lifetime = record.payload.lifetime
+        if lifetime.eventKeys.isEmpty || lifetime.latestDate < session.cutoff {
+            // Every event predates the new window.
+            record.payload.period = CodexScanContext(
+                earliestDate: Date(),
+                latestDate: session.cutoff
+            )
+        } else if lifetime.earliestDate >= session.cutoff {
+            // Every event falls inside it.
+            record.payload.period = lifetime
+        } else {
+            // The rollout straddles the cutoff and only its individual events
+            // know where. Only files that actually straddle pay for the window
+            // moving.
+            return nil
+        }
+        record.cutoff = session.cutoff
+        return record
     }
 
     /// Picks up the model/originator carried by the non-usage rollout events.
@@ -510,7 +722,10 @@ enum CodexCostScanner {
 /// `token_count` events name neither the model nor the front end: the model is
 /// declared once per turn in `turn_context`, the front end once per session in
 /// `session_meta`. Reset per file so one rollout never labels another's spend.
-nonisolated struct CodexRolloutContext: Sendable {
+/// `Codable` because `CodexFileTotals` persists it: a slice that resumes past a
+/// rollout's opening `session_meta`/`turn_context` would attribute every
+/// remaining event to "unknown" without the labels the previous slice read.
+nonisolated struct CodexRolloutContext: Sendable, Codable {
     var turnModel: String?
     var sessionModel: String?
     var originator: String?

--- a/MeterBar/Services/CostScanBudget.swift
+++ b/MeterBar/Services/CostScanBudget.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// How much a single refresh is allowed to read.
+///
+/// A cold corpus is ~10 GB; reading all of it in one pass is the 70-second
+/// freeze this budget exists to prevent. A refresh instead takes a bounded bite
+/// of whatever is still unread, persists its byte offsets, and leaves the rest
+/// for the next pass.
+nonisolated struct CostScanBudgetOptions: Sendable {
+    /// 256 MiB. Caps the damage one pathological transcript can do: without it a
+    /// single multi-gigabyte `.jsonl` would consume an entire refresh and starve
+    /// every other file behind it, so the newest-first ordering would stop
+    /// buying anything.
+    var maxBytesPerFile: Int
+
+    /// 512 MiB. The whole-refresh ceiling, and the knob that actually sets the
+    /// slice length — roughly a second of warm sequential reads on an internal
+    /// SSD, and ~20 slices to walk a 10 GB corpus from cold. Raising it makes a
+    /// cold start converge in fewer passes at the cost of a longer stretch with
+    /// the scan queue busy.
+    var maxNewBytesPerRefresh: Int
+
+    /// Wall-clock ceiling, in seconds. Bytes are a poor proxy for time on a
+    /// spinning disk, an encrypted external volume, or a machine under memory
+    /// pressure, so this bounds the slice even when the byte budget is nowhere
+    /// near spent. `nil` disables it.
+    var wallClock: TimeInterval?
+
+    init(maxBytesPerFile: Int, maxNewBytesPerRefresh: Int, wallClock: TimeInterval?) {
+        self.maxBytesPerFile = maxBytesPerFile
+        self.maxNewBytesPerRefresh = maxNewBytesPerRefresh
+        self.wallClock = wallClock
+    }
+
+    /// The only options production uses. The scan is never unbounded in the app.
+    static let `default` = CostScanBudgetOptions(
+        maxBytesPerFile: 256 * 1024 * 1024,
+        maxNewBytesPerRefresh: 512 * 1024 * 1024,
+        wallClock: 15
+    )
+
+    /// Tests only — fixtures are a few hundred bytes, and a test that asserts on
+    /// a whole corpus must not depend on how the production slice happens to
+    /// fall. Never use this from app code.
+    static let unlimited = CostScanBudgetOptions(
+        maxBytesPerFile: .max,
+        maxNewBytesPerRefresh: .max,
+        wallClock: nil
+    )
+
+    var isUnbounded: Bool {
+        maxBytesPerFile == .max && maxNewBytesPerRefresh == .max && wallClock == nil
+    }
+}
+
+/// Tracks one refresh's spend against `CostScanBudgetOptions`.
+///
+/// A reference type because the scan threads it through per-file helpers that
+/// are already at SwiftLint's `function_parameter_count` limit; passing it
+/// `inout` alongside the accumulators would push several of them over.
+nonisolated final class CostScanBudget: @unchecked Sendable {
+    let options: CostScanBudgetOptions
+    private let token: CostScanCancellationToken
+    private let deadline: Date?
+    private let lock = NSLock()
+    private var spent = 0
+
+    init(
+        options: CostScanBudgetOptions,
+        token: CostScanCancellationToken = .never,
+        startedAt: Date = Date()
+    ) {
+        self.options = options
+        self.token = token
+        self.deadline = options.wallClock.map { startedAt.addingTimeInterval($0) }
+    }
+
+    /// Bytes actually pulled off disk this refresh — cached files contribute
+    /// nothing, which is the whole point of the per-file offsets.
+    var bytesRead: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return spent
+    }
+
+    var isCancelled: Bool { token.isCancelled }
+
+    var isExhausted: Bool { allowance == 0 }
+
+    /// The most the next file may read: whichever of the per-file cap and the
+    /// refresh remainder is smaller, and zero once time is up or the refresh was
+    /// cancelled.
+    var allowance: Int {
+        guard !token.isCancelled else { return 0 }
+        if let deadline, Date() >= deadline { return 0 }
+        guard options.maxNewBytesPerRefresh != .max else { return options.maxBytesPerFile }
+
+        lock.lock()
+        let remaining = max(0, options.maxNewBytesPerRefresh - spent)
+        lock.unlock()
+        return min(options.maxBytesPerFile, remaining)
+    }
+
+    func consume(_ bytes: Int) {
+        guard bytes > 0 else { return }
+        lock.lock()
+        // Saturating: an unbounded refresh reading a huge corpus must not trap
+        // on overflow just because nothing was ever going to check the total.
+        spent = spent.addingReportingOverflow(bytes).overflow ? .max : spent + bytes
+        lock.unlock()
+    }
+}

--- a/MeterBar/Services/CostScanCorpus.swift
+++ b/MeterBar/Services/CostScanCorpus.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// One transcript on disk, with the metadata the scan needs before deciding
+/// whether to open it.
+nonisolated struct CostScanFile: Sendable {
+    let url: URL
+    let size: Int
+    let modified: Date
+
+    /// The per-file cache key. Standardized so `/tmp/...` and `/private/tmp/...`
+    /// resolve to one entry rather than two half-read ones.
+    var cacheKey: String { url.standardizedFileURL.path }
+}
+
+/// Enumerates the `.jsonl` transcripts under a provider root, newest first.
+nonisolated enum CostScanCorpus {
+    /// Newest modification date first.
+    ///
+    /// Ordering is what makes a budgeted refresh useful rather than arbitrary.
+    /// The visible summary is a 30-day window, and the transcripts that fall in
+    /// it are exactly the recently-written ones — so spending the budget newest
+    /// first makes the number on screen correct after the first pass, while the
+    /// older archive (which only moves the lifetime total) catches up over
+    /// subsequent refreshes.
+    static func transcripts(in root: URL) -> [CostScanFile] {
+        let keys: [URLResourceKey] = [.isRegularFileKey, .fileSizeKey, .contentModificationDateKey]
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: keys,
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+        ) else { return [] }
+
+        var files: [CostScanFile] = []
+        for case let url as URL in enumerator where url.pathExtension == "jsonl" {
+            guard let values = try? url.resourceValues(forKeys: Set(keys)),
+                  values.isRegularFile == true else { continue }
+            files.append(
+                CostScanFile(
+                    url: url,
+                    size: values.fileSize ?? 0,
+                    modified: values.contentModificationDate ?? .distantPast
+                )
+            )
+        }
+
+        // Path breaks ties so a corpus written in one burst still enumerates
+        // deterministically — otherwise a budgeted test would be a coin flip.
+        return files.sorted {
+            $0.modified == $1.modified ? $0.url.path < $1.url.path : $0.modified > $1.modified
+        }
+    }
+}

--- a/MeterBar/Services/CostScanExecutor.swift
+++ b/MeterBar/Services/CostScanExecutor.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+/// The one thread every cost scan runs on.
+///
+/// ## Why one serial queue and not a fan-out
+///
+/// The obvious "make the scan faster" change is to parallelize it — a
+/// `TaskGroup` or `concurrentPerform` over the transcript files, one worker per
+/// core. That is the wrong fix here, for two independent reasons:
+///
+/// 1. **The scan is disk-bound, not CPU-bound.** A working corpus is roughly
+///    10 GB across ~10k `.jsonl` transcripts. Fanning reads out across cores
+///    multiplies I/O contention — more seeks, more page-cache churn, more
+///    read-ahead thrash — and buys no wall time back, because no core was ever
+///    waiting on arithmetic.
+/// 2. **It starves everything else.** Swift's cooperative pool has one thread
+///    per core. A fan-out of blocking `read(2)` calls occupies all of them, so
+///    every other `async` task in the app — menu rendering, provider polling,
+///    status refreshes — queues behind a scan that is itself just waiting on the
+///    disk. The symptom is the menu freezing while the main thread sits idle.
+///
+/// steipete/CodexBar hit exactly this and went the other way: its
+/// `CostUsageScanExecutor` pins all cost scans to a single serial
+/// `DispatchQueue` at `.utility` off the cooperative pool. This is the same
+/// shape, for the same reason.
+///
+/// Wall time comes from `CostScanBudget` and the resumable byte offsets on
+/// `CostScanFileCache` instead: a refresh reads only what was appended since the
+/// last one, newest transcript first, and stops at a byte ceiling. That turns a
+/// 70-second cold scan into bounded slices without touching a second core.
+nonisolated enum CostScanExecutor {
+    /// Serial, `.utility`, and deliberately *not* on the cooperative pool: a
+    /// `DispatchQueue` thread is allowed to block in `read(2)` without costing
+    /// the rest of the app a concurrency slot.
+    private static let queue = DispatchQueue(label: "dev.meterbar.app.CostScan.io", qos: .utility)
+
+    /// Runs `work` on the scan queue and bridges Swift task cancellation into it.
+    ///
+    /// Cancellation has two shapes, and both matter:
+    /// - **Before the work starts** (still queued behind an in-flight scan) it
+    ///   resumes immediately with `CancellationError` rather than waiting out the
+    ///   scan ahead of it, and the closure never runs at all.
+    /// - **While the work runs**, the token flips and the scan notices at its
+    ///   next file boundary: it persists what it has read and returns. The caller
+    ///   still sees `CancellationError`; the progress is already on disk.
+    static func run<Value: Sendable>(
+        _ work: @escaping @Sendable (CostScanCancellationToken) -> Value
+    ) async throws -> Value {
+        let handoff = CostScanHandoff<Value>()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                handoff.store(continuation)
+                queue.async {
+                    guard handoff.beginWork() else { return }
+                    handoff.finish(work(handoff.token))
+                }
+            }
+        } onCancel: {
+            handoff.cancel()
+        }
+    }
+}
+
+/// A cancellation flag the scan can poll from a non-`async` context.
+///
+/// `Task.isCancelled` is meaningless inside a `DispatchQueue` block, so the
+/// executor hands the work an explicit token instead.
+nonisolated final class CostScanCancellationToken: @unchecked Sendable {
+    /// For call sites that scan outside the executor — tests, and the unbounded
+    /// convenience paths — where nothing can ever cancel.
+    static let never = CostScanCancellationToken()
+
+    private let lock = NSLock()
+    private var cancelled = false
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+}
+
+/// Guarantees the continuation handed to `CostScanExecutor.run` is resumed
+/// exactly once, whichever of "cancelled" and "work finished" happens first.
+private final class CostScanHandoff<Value: Sendable>: @unchecked Sendable {
+    let token = CostScanCancellationToken()
+
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Value, Error>?
+    private var settled = false
+
+    /// Parks the continuation, or resumes it straight away when cancellation
+    /// already arrived.
+    ///
+    /// The `isCancelled` check may not be qualified with `!settled`: `cancel()`
+    /// running before `store()` finds no continuation to resume, so if `store()`
+    /// then treated the call as already settled the continuation would be parked
+    /// forever and the caller would hang.
+    func store(_ continuation: CheckedContinuation<Value, Error>) {
+        if token.isCancelled {
+            continuation.resume(throwing: CancellationError())
+            lock.lock()
+            settled = true
+            lock.unlock()
+            return
+        }
+        lock.lock()
+        if settled {
+            lock.unlock()
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+        self.continuation = continuation
+        lock.unlock()
+    }
+
+    /// - Returns: `false` when the caller already gave up, so the queue can drop
+    ///   the block instead of reading the corpus for a result nobody wants.
+    func beginWork() -> Bool {
+        !token.isCancelled
+    }
+
+    func finish(_ value: Value) {
+        guard let continuation = take() else { return }
+        continuation.resume(returning: value)
+    }
+
+    func cancel() {
+        token.cancel()
+        guard let continuation = take() else { return }
+        continuation.resume(throwing: CancellationError())
+    }
+
+    private func take() -> CheckedContinuation<Value, Error>? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !settled else { return nil }
+        settled = true
+        let pending = continuation
+        continuation = nil
+        return pending
+    }
+}

--- a/MeterBar/Services/CostScanFileCache.swift
+++ b/MeterBar/Services/CostScanFileCache.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// What one transcript contributed, and where to pick its reading back up.
+///
+/// The byte offset lives on the same entry as the totals on purpose. Two stores
+/// — "offsets here, totals there" — can disagree after a crash or a partial
+/// write, and the failure is silent: the scan seeks past bytes whose totals were
+/// never persisted, so that spend disappears from the summary until the file is
+/// rewritten. One entry, written once, cannot drift.
+nonisolated struct CostScanFileRecord<Payload: Codable & Sendable>: Codable, Sendable {
+    /// Byte offset one past the last *complete* line folded into `payload`.
+    var offset: UInt64
+
+    /// The file's size when `offset` was written. A file that has since shrunk
+    /// was rotated or replaced, so the cached totals describe bytes that no
+    /// longer exist — the entry is discarded rather than resumed.
+    var size: Int
+
+    /// The period cutoff `payload`'s period window was computed against. The
+    /// 30-day window slides every day, so a record written yesterday describes
+    /// the wrong period today and has to be rebased (or re-read) before use.
+    var cutoff: Date
+
+    /// Whether the last pass read this file all the way to end of file.
+    var isComplete: Bool
+
+    var payload: Payload
+}
+
+/// Every transcript's record, keyed by standardized path.
+nonisolated struct CostScanFileCache<Payload: Codable & Sendable>: Codable, Sendable {
+    static var currentSchemaVersion: Int { 1 }
+
+    var schemaVersion = CostScanFileCache.currentSchemaVersion
+    var records: [String: CostScanFileRecord<Payload>] = [:]
+}
+
+/// Reads and writes the two per-file scan caches.
+///
+/// Deliberately separate files from `cost-summary-v2.json`: that envelope is a
+/// published artifact (`meterbar cost` reads it) with its own schema version and
+/// its own migration story, while these are a private, disposable read-through
+/// cache. Losing them costs one slow refresh, not a wrong number.
+nonisolated struct CostScanCacheStore: Sendable {
+    static let claudeFileName = "cost-scan-claude-v1.json"
+    static let codexFileName = "cost-scan-codex-v1.json"
+
+    let directory: URL
+
+    /// `~/Library/Application Support/MeterBar`, alongside the summary cache.
+    static var applicationSupport: CostScanCacheStore? {
+        guard let support = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            return nil
+        }
+        return CostScanCacheStore(
+            directory: support.appendingPathComponent("MeterBar", isDirectory: true)
+        )
+    }
+
+    func loadClaude() -> CostScanFileCache<ClaudeFileTotals> {
+        Self.load(from: directory.appendingPathComponent(Self.claudeFileName))
+    }
+
+    func loadCodex() -> CostScanFileCache<CodexFileTotals> {
+        Self.load(from: directory.appendingPathComponent(Self.codexFileName))
+    }
+
+    func saveClaude(_ cache: CostScanFileCache<ClaudeFileTotals>) {
+        Self.save(cache, to: directory.appendingPathComponent(Self.claudeFileName))
+    }
+
+    func saveCodex(_ cache: CostScanFileCache<CodexFileTotals>) {
+        Self.save(cache, to: directory.appendingPathComponent(Self.codexFileName))
+    }
+
+    private static func load<Payload>(from url: URL) -> CostScanFileCache<Payload> {
+        guard let data = try? Data(contentsOf: url),
+              let cache = try? JSONDecoder().decode(CostScanFileCache<Payload>.self, from: data),
+              cache.schemaVersion == CostScanFileCache<Payload>.currentSchemaVersion else {
+            // A cache from a future or unreadable build is dropped, not
+            // migrated: a full re-scan is slow, but a mis-decoded offset would
+            // silently under-count forever.
+            return CostScanFileCache<Payload>()
+        }
+        return cache
+    }
+
+    private static func save<Payload>(_ cache: CostScanFileCache<Payload>, to url: URL) {
+        // Not `.prettyPrinted`: ~10k entries, and this file is machine-only.
+        // Pretty printing roughly doubles it for nobody's benefit.
+        guard let data = try? JSONEncoder().encode(cache) else { return }
+        let directory = url.deletingLastPathComponent()
+        try? SecureFileWriter.ensurePrivateDirectory(directory)
+        try? SecureFileWriter.write(data, to: url)
+    }
+}
+
+/// One Claude transcript's tally, plus the dedup state a resumed read needs.
+nonisolated struct ClaudeFileTotals: Codable, Sendable {
+    var period = ClaudeSessionTotals()
+    var lifetime = ClaudeSessionTotals()
+
+    /// `messageID:requestID` keys already folded into each window.
+    ///
+    /// Kept only while the file is still being read. Within a single pass the
+    /// scanner keeps the *last* event for a duplicate key; across a resume
+    /// boundary the earlier slice is already tallied, so a duplicate that
+    /// arrives in a later slice is dropped instead — first-wins. The two differ
+    /// only when a transcript repeats a key with different token counts, which
+    /// Claude Code does not do; both are one-copy-counted, which is the property
+    /// that matters.
+    var periodKeys: Set<String> = []
+    var lifetimeKeys: Set<String> = []
+}
+
+/// One Codex rollout's tally, plus the attribution state carried across slices.
+nonisolated struct CodexFileTotals: Codable, Sendable {
+    var period: CodexScanContext
+    var lifetime: CodexScanContext
+
+    /// `turn_context` / `session_meta` attribution seen so far. A rollout
+    /// declares its model once and its originator once, usually in the first few
+    /// hundred bytes, so a slice that starts past them would attribute every
+    /// remaining event to "unknown" without this.
+    var rollout = CodexRolloutContext()
+
+    init(cutoff: Date) {
+        period = CodexScanContext(earliestDate: Date(), latestDate: cutoff)
+        lifetime = CodexScanContext(earliestDate: Date(), latestDate: .distantPast)
+    }
+}

--- a/MeterBar/Services/CostScanFileCache.swift
+++ b/MeterBar/Services/CostScanFileCache.swift
@@ -1,5 +1,4 @@
 import Foundation
-import os
 
 /// What one transcript contributed, and where to pick its reading back up.
 ///
@@ -77,12 +76,12 @@ nonisolated struct CostScanCacheStore: Sendable {
         Self.load(from: directory.appendingPathComponent(Self.codexFileName))
     }
 
-    func saveClaude(_ cache: CostScanFileCache<ClaudeFileTotals>) {
-        Self.save(cache, to: directory.appendingPathComponent(Self.claudeFileName))
+    func saveClaude(_ cache: CostScanFileCache<ClaudeFileTotals>) throws {
+        try Self.save(cache, to: directory.appendingPathComponent(Self.claudeFileName))
     }
 
-    func saveCodex(_ cache: CostScanFileCache<CodexFileTotals>) {
-        Self.save(cache, to: directory.appendingPathComponent(Self.codexFileName))
+    func saveCodex(_ cache: CostScanFileCache<CodexFileTotals>) throws {
+        try Self.save(cache, to: directory.appendingPathComponent(Self.codexFileName))
     }
 
     /// Both payloads roll usage up in `[Date: TokenAccumulator]` dictionaries,
@@ -117,27 +116,10 @@ nonisolated struct CostScanCacheStore: Sendable {
         return cache
     }
 
-    /// Failures are logged, not propagated. This cache is an optimisation — the
-    /// next refresh re-reads from offset 0 and produces the same number, just
-    /// slowly — so there is nothing for a caller to do about a failed write and
-    /// no reason to fail a scan that otherwise succeeded. The log line is what
-    /// distinguishes "cold corpus" from "this write has been failing for weeks",
-    /// which is otherwise invisible: both look like a permanently slow refresh.
-    private static func save<Payload>(_ cache: CostScanFileCache<Payload>, to url: URL) {
-        do {
-            let data = try encoder.encode(cache)
-            try SecureFileWriter.ensurePrivateDirectory(url.deletingLastPathComponent())
-            try SecureFileWriter.write(data, to: url)
-        } catch {
-            // The file name is one of two compile-time constants, so it carries
-            // nothing about the user's projects.
-            AppLog.cost.error(
-                """
-                Failed to save scan cache \(url.lastPathComponent, privacy: .public): \
-                \(error.localizedDescription, privacy: .public)
-                """
-            )
-        }
+    private static func save<Payload>(_ cache: CostScanFileCache<Payload>, to url: URL) throws {
+        let data = try encoder.encode(cache)
+        try SecureFileWriter.ensurePrivateDirectory(url.deletingLastPathComponent())
+        try SecureFileWriter.write(data, to: url)
     }
 }
 

--- a/MeterBar/Services/CostScanFileCache.swift
+++ b/MeterBar/Services/CostScanFileCache.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// What one transcript contributed, and where to pick its reading back up.
 ///
@@ -29,7 +30,12 @@ nonisolated struct CostScanFileRecord<Payload: Codable & Sendable>: Codable, Sen
 
 /// Every transcript's record, keyed by standardized path.
 nonisolated struct CostScanFileCache<Payload: Codable & Sendable>: Codable, Sendable {
-    static var currentSchemaVersion: Int { 1 }
+    /// Bumped to 2 when the date strategy was pinned to `.secondsSince1970`: a
+    /// v1 file's dates were written against `.deferredToDate`'s 2001 epoch, and
+    /// decoding those numbers as Unix seconds succeeds while landing every daily
+    /// row 31 years early. Dropping the file costs one slow refresh; reading it
+    /// would be silently wrong.
+    static var currentSchemaVersion: Int { 2 }
 
     var schemaVersion = CostScanFileCache.currentSchemaVersion
     var records: [String: CostScanFileRecord<Payload>] = [:]
@@ -42,6 +48,9 @@ nonisolated struct CostScanFileCache<Payload: Codable & Sendable>: Codable, Send
 /// its own migration story, while these are a private, disposable read-through
 /// cache. Losing them costs one slow refresh, not a wrong number.
 nonisolated struct CostScanCacheStore: Sendable {
+    /// The `v1` in the file names is the *path* generation, not the schema —
+    /// `schemaVersion` inside the file is what gates a read. Bumping the name
+    /// too would strand the old file on disk forever with nothing to delete it.
     static let claudeFileName = "cost-scan-claude-v1.json"
     static let codexFileName = "cost-scan-codex-v1.json"
 
@@ -76,9 +85,29 @@ nonisolated struct CostScanCacheStore: Sendable {
         Self.save(cache, to: directory.appendingPathComponent(Self.codexFileName))
     }
 
+    /// Both payloads roll usage up in `[Date: TokenAccumulator]` dictionaries,
+    /// and a mismatched date strategy across these two would not throw — every
+    /// strategy but `.iso8601` writes a bare number, so the decode succeeds and
+    /// lands each daily row in a bucket decades from the right one. Pinned
+    /// explicitly rather than left to two independently-defaulted instances that
+    /// only happen to agree today.
+    private static var encoder: JSONEncoder {
+        // Not `.prettyPrinted`: ~10k entries, and this file is machine-only.
+        // Pretty printing roughly doubles it for nobody's benefit.
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        return encoder
+    }
+
+    private static var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        return decoder
+    }
+
     private static func load<Payload>(from url: URL) -> CostScanFileCache<Payload> {
         guard let data = try? Data(contentsOf: url),
-              let cache = try? JSONDecoder().decode(CostScanFileCache<Payload>.self, from: data),
+              let cache = try? decoder.decode(CostScanFileCache<Payload>.self, from: data),
               cache.schemaVersion == CostScanFileCache<Payload>.currentSchemaVersion else {
             // A cache from a future or unreadable build is dropped, not
             // migrated: a full re-scan is slow, but a mis-decoded offset would
@@ -88,13 +117,27 @@ nonisolated struct CostScanCacheStore: Sendable {
         return cache
     }
 
+    /// Failures are logged, not propagated. This cache is an optimisation — the
+    /// next refresh re-reads from offset 0 and produces the same number, just
+    /// slowly — so there is nothing for a caller to do about a failed write and
+    /// no reason to fail a scan that otherwise succeeded. The log line is what
+    /// distinguishes "cold corpus" from "this write has been failing for weeks",
+    /// which is otherwise invisible: both look like a permanently slow refresh.
     private static func save<Payload>(_ cache: CostScanFileCache<Payload>, to url: URL) {
-        // Not `.prettyPrinted`: ~10k entries, and this file is machine-only.
-        // Pretty printing roughly doubles it for nobody's benefit.
-        guard let data = try? JSONEncoder().encode(cache) else { return }
-        let directory = url.deletingLastPathComponent()
-        try? SecureFileWriter.ensurePrivateDirectory(directory)
-        try? SecureFileWriter.write(data, to: url)
+        do {
+            let data = try encoder.encode(cache)
+            try SecureFileWriter.ensurePrivateDirectory(url.deletingLastPathComponent())
+            try SecureFileWriter.write(data, to: url)
+        } catch {
+            // The file name is one of two compile-time constants, so it carries
+            // nothing about the user's projects.
+            AppLog.cost.error(
+                """
+                Failed to save scan cache \(url.lastPathComponent, privacy: .public): \
+                \(error.localizedDescription, privacy: .public)
+                """
+            )
+        }
     }
 }
 

--- a/MeterBar/Services/CostScanSession.swift
+++ b/MeterBar/Services/CostScanSession.swift
@@ -1,4 +1,6 @@
 import Foundation
+import MeterBarShared
+import os
 
 /// One refresh's worth of scanning: the budget it spends, the per-file caches it
 /// resumes from, and whether it managed to reach the end of the corpus.
@@ -114,9 +116,27 @@ nonisolated final class CostScanSession: @unchecked Sendable {
     /// Writes both caches back, including after a cancelled slice — the whole
     /// point of committing on line boundaries is that partial progress is safe
     /// to keep.
-    func persist() {
-        guard let store else { return }
-        store.saveClaude(claude)
-        store.saveCodex(codex)
+    @discardableResult
+    func persist() -> Bool {
+        guard let store else { return true }
+
+        var succeeded = true
+        do {
+            try store.saveClaude(claude)
+        } catch {
+            succeeded = false
+            AppLog.cost.error(
+                "Failed to persist Claude scan progress: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+        do {
+            try store.saveCodex(codex)
+        } catch {
+            succeeded = false
+            AppLog.cost.error(
+                "Failed to persist Codex scan progress: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+        return succeeded
     }
 }

--- a/MeterBar/Services/CostScanSession.swift
+++ b/MeterBar/Services/CostScanSession.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// One refresh's worth of scanning: the budget it spends, the per-file caches it
+/// resumes from, and whether it managed to reach the end of the corpus.
+///
+/// A reference type on purpose. The scanners hand it down through per-file
+/// helpers and mutate its caches as they go; a value type would mean either
+/// `inout` on already-wide signatures or copying two dictionaries of ~10k
+/// entries per file.
+nonisolated final class CostScanSession: @unchecked Sendable {
+    /// Start of the visible period window. Cached period totals are only valid
+    /// for the cutoff they were tallied against, so this is part of every
+    /// cache-hit decision.
+    let cutoff: Date
+
+    let budget: CostScanBudget
+
+    private let store: CostScanCacheStore?
+    private let lock = NSLock()
+    private var claudeCache: CostScanFileCache<ClaudeFileTotals>
+    private var codexCache: CostScanFileCache<CodexFileTotals>
+    private var deferred = false
+
+    init(
+        cutoff: Date,
+        options: CostScanBudgetOptions,
+        store: CostScanCacheStore? = nil,
+        token: CostScanCancellationToken = .never
+    ) {
+        self.cutoff = cutoff
+        self.budget = CostScanBudget(options: options, token: token)
+        self.store = store
+        self.claudeCache = store?.loadClaude() ?? CostScanFileCache<ClaudeFileTotals>()
+        self.codexCache = store?.loadCodex() ?? CostScanFileCache<CodexFileTotals>()
+    }
+
+    var claude: CostScanFileCache<ClaudeFileTotals> {
+        lock.lock()
+        defer { lock.unlock() }
+        return claudeCache
+    }
+
+    var codex: CostScanFileCache<CodexFileTotals> {
+        lock.lock()
+        defer { lock.unlock() }
+        return codexCache
+    }
+
+    var isCancelled: Bool { budget.isCancelled }
+
+    /// `true` when this refresh walked the whole corpus. `false` means the
+    /// budget ran out or the refresh was cancelled and some files were skipped
+    /// entirely or read only partway — the caller should schedule another slice
+    /// rather than treat the summary as final.
+    var isComplete: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !deferred
+    }
+
+    /// Records that at least one file was left unfinished.
+    ///
+    /// Deliberately *not* driven by "did we reach EOF": a transcript that is
+    /// being appended to right now ends in a half-written line the scan
+    /// legitimately withholds, and treating that as incomplete would keep the
+    /// refresh loop spinning forever on a live session.
+    func noteDeferred() {
+        lock.lock()
+        deferred = true
+        lock.unlock()
+    }
+
+    func claudeRecord(for key: String) -> CostScanFileRecord<ClaudeFileTotals>? {
+        lock.lock()
+        defer { lock.unlock() }
+        return claudeCache.records[key]
+    }
+
+    func setClaudeRecord(_ record: CostScanFileRecord<ClaudeFileTotals>, for key: String) {
+        lock.lock()
+        claudeCache.records[key] = record
+        lock.unlock()
+    }
+
+    func codexRecord(for key: String) -> CostScanFileRecord<CodexFileTotals>? {
+        lock.lock()
+        defer { lock.unlock() }
+        return codexCache.records[key]
+    }
+
+    func setCodexRecord(_ record: CostScanFileRecord<CodexFileTotals>, for key: String) {
+        lock.lock()
+        codexCache.records[key] = record
+        lock.unlock()
+    }
+
+    /// Drops cache entries whose file no longer exists.
+    ///
+    /// Without this the cache grows forever: Claude Code and Codex delete old
+    /// transcripts, and a stale entry would keep contributing its totals to
+    /// every future summary even though the spend it describes is long gone.
+    func retainClaude(keys: Set<String>) {
+        lock.lock()
+        claudeCache.records = claudeCache.records.filter { keys.contains($0.key) }
+        lock.unlock()
+    }
+
+    func retainCodex(keys: Set<String>) {
+        lock.lock()
+        codexCache.records = codexCache.records.filter { keys.contains($0.key) }
+        lock.unlock()
+    }
+
+    /// Writes both caches back, including after a cancelled slice — the whole
+    /// point of committing on line boundaries is that partial progress is safe
+    /// to keep.
+    func persist() {
+        guard let store else { return }
+        store.saveClaude(claude)
+        store.saveCodex(codex)
+    }
+}

--- a/MeterBar/Services/CostScanWindows.swift
+++ b/MeterBar/Services/CostScanWindows.swift
@@ -35,7 +35,11 @@ nonisolated struct ScanWindows<Totals> {
 extension ScanWindows: Sendable where Totals: Sendable {}
 
 /// Per-window tally for one Claude Code transcript, or many merged together.
-nonisolated struct ClaudeSessionTotals: Sendable {
+///
+/// `Codable` because a single file's tally is what `CostScanFileCache` persists
+/// between refreshes — the byte offset alone would be worthless without the
+/// totals the already-read bytes produced.
+nonisolated struct ClaudeSessionTotals: Sendable, Codable {
     var input = 0
     var output = 0
     var cacheCreation = 0
@@ -155,7 +159,7 @@ nonisolated struct CostScanResult {
 /// a single `inout` argument.
 ///
 /// Internal (not private) so `CodexCostScanner.scanRollouts` can be fixture-tested.
-nonisolated struct CodexScanContext: Sendable {
+nonisolated struct CodexScanContext: Sendable, Codable {
     var totals = TokenAccumulator()
     var dailyTotals: [Date: TokenAccumulator] = [:]
     var dailyModelTotals: [Date: [String: TokenAccumulator]] = [:]
@@ -171,9 +175,63 @@ nonisolated struct CodexScanContext: Sendable {
     var sessionIDs: Set<String> = []
     var earliestDate: Date
     var latestDate: Date
+
+    /// Folds a cached rollout's tally into this window.
+    ///
+    /// The `eventKeys` guard is not an optimization. A cached context for a file
+    /// that contributed nothing still carries `earliestDate = Date()` from
+    /// whichever refresh created it, and merging that would drag the reported
+    /// period start backwards to an instant no event ever happened at.
+    mutating func merge(_ other: CodexScanContext) {
+        guard !other.eventKeys.isEmpty else { return }
+
+        totals.merge(other.totals)
+        for (day, tokens) in other.dailyTotals {
+            dailyTotals[day, default: TokenAccumulator()].merge(tokens)
+        }
+        for (day, modelTotals) in other.dailyModelTotals {
+            for (model, tokens) in modelTotals {
+                dailyModelTotals[day, default: [:]][model, default: TokenAccumulator()].merge(tokens)
+            }
+        }
+        for (day, projectTotals) in other.dailyProjectTotals {
+            for (project, tokens) in projectTotals {
+                dailyProjectTotals[day, default: [:]][project, default: TokenAccumulator()].merge(tokens)
+            }
+        }
+        for (day, projectTotals) in other.dailyProjectModelTotals {
+            for (project, modelTotals) in projectTotals {
+                for (model, tokens) in modelTotals {
+                    dailyProjectModelTotals[day, default: [:]][project, default: [:]][
+                        model,
+                        default: TokenAccumulator()
+                    ].merge(tokens)
+                }
+            }
+        }
+        for (name, tokens) in other.modelTotals {
+            modelTotals[name, default: TokenAccumulator()].merge(tokens)
+        }
+        for (name, tokens) in other.originTotals {
+            originTotals[name, default: TokenAccumulator()].merge(tokens)
+        }
+        for (project, tokens) in other.projectTotals {
+            projectTotals[project, default: TokenAccumulator()].merge(tokens)
+        }
+        for (project, modelTotals) in other.projectModelTotals {
+            for (model, tokens) in modelTotals {
+                projectModelTotals[project, default: [:]][model, default: TokenAccumulator()].merge(tokens)
+            }
+        }
+
+        eventKeys.formUnion(other.eventKeys)
+        sessionIDs.formUnion(other.sessionIDs)
+        earliestDate = min(earliestDate, other.earliestDate)
+        latestDate = max(latestDate, other.latestDate)
+    }
 }
 
-nonisolated struct TokenAccumulator: Sendable {
+nonisolated struct TokenAccumulator: Sendable, Codable {
     var input = 0
     var output = 0
     var cacheCreation = 0

--- a/MeterBar/Services/CostSummaryBuilder.swift
+++ b/MeterBar/Services/CostSummaryBuilder.swift
@@ -57,4 +57,64 @@ enum CostSummaryBuilder {
 
         return scan
     }
+
+    // MARK: - Budgeted, resumable scan
+
+    /// A summary plus whether the refresh that produced it saw the whole corpus.
+    nonisolated struct CostSummaryScan: Sendable {
+        let summary: CostSummary
+
+        /// `false` when the budget ran out (or the refresh was cancelled) with
+        /// files still unread. The summary is correct as far as it goes — every
+        /// number in it comes from bytes actually accounted for — but it is not
+        /// yet the whole corpus, so the caller should run another slice.
+        let isComplete: Bool
+    }
+
+    /// One budgeted slice of the corpus scan.
+    ///
+    /// Unlike `makeSummary`, this reads only what `session`'s budget allows,
+    /// resuming each transcript from the byte offset the last slice committed.
+    /// Files it does not reach still contribute their cached totals, so the
+    /// summary is complete-as-of-what-has-been-read from the very first slice
+    /// rather than only after the last one.
+    nonisolated static func makeScan(
+        days: Int,
+        includeClaudeCode: Bool,
+        includeCodexCli: Bool,
+        claudeAccounts: [ClaudeCodeAccount],
+        session: CostScanSession
+    ) -> CostSummaryScan {
+        var scan = ScanWindows(
+            period: CostScanResult(),
+            lifetime: CostScanResult(),
+            cutoff: session.cutoff
+        )
+
+        if includeClaudeCode {
+            let roots = ClaudeCostScanner.projectRoots(accounts: claudeAccounts)
+            let claude = ClaudeCostScanner.scanRoots(roots, session: session)
+            scan.period.append(ClaudeCostScanner.makeCost(from: claude.period, windowStart: session.cutoff))
+            scan.lifetime.append(ClaudeCostScanner.makeCost(from: claude.lifetime, windowStart: .distantPast))
+        }
+
+        if includeCodexCli {
+            let codex = CodexCostScanner.scanSessions(session: session)
+            scan.period.append(CodexCostScanner.makeCost(from: codex.period))
+            scan.lifetime.append(CodexCostScanner.makeCost(from: codex.lifetime))
+        }
+
+        let costs = scan.period.costs
+        return CostSummaryScan(
+            summary: CostSummary(
+                costs: costs,
+                totalCostUSD: costs.reduce(0) { $0 + $1.estimatedCostUSD },
+                totalTokens: costs.reduce(0) { $0 + $1.totalTokens },
+                periodDays: days,
+                dailyUsage: scan.period.dailyUsage.sorted { $0.date < $1.date },
+                lifetime: LifetimeCostSummary(costs: scan.lifetime.costs)
+            ),
+            isComplete: session.isComplete
+        )
+    }
 }

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -50,12 +50,10 @@ class CostTracker: ObservableObject {
         }
         guard shouldStart else { return }
 
-        let summary = await makeCostSummary(days: days)
+        let scan = await makeCostSummary(days: days)
 
         await MainActor.run {
-            if let summary { costSummary = summary }
-            lastScanDate = Date()
-            saveCachedSummary()
+            apply(scan)
             isScanning = false
         }
     }
@@ -77,14 +75,35 @@ class CostTracker: ObservableObject {
         }
         guard shouldStart else { return }
 
-        let summary = await makeCostSummary(days: days)
+        let scan = await makeCostSummary(days: days)
 
         await MainActor.run {
-            if let summary { costSummary = summary }
-            lastScanDate = Date()
-            saveCachedSummary()
+            apply(scan)
             isRefreshingMissingDays = false
         }
+    }
+
+    /// Publishes one refresh's result, and records it as authoritative only when
+    /// it saw the whole corpus.
+    ///
+    /// An incomplete scan still publishes its partial total — the number on
+    /// screen should improve as slices land — but must not touch `lastScanDate`
+    /// or the cache. Both are read elsewhere as "a full scan finished":
+    /// `saveCachedSummary` makes the partial survive relaunch, and
+    /// `needsMissingDailyUsageRefresh` returns `false` for the rest of the
+    /// calendar day once `lastScanDate` is today. Stamping a budget-truncated
+    /// slice would therefore freeze an undercount on screen until tomorrow —
+    /// exactly the failure the resumable offsets exist to avoid.
+    ///
+    /// `nil` means no slice completed at all, so there is nothing to publish and
+    /// nothing has been learned.
+    @MainActor
+    func apply(_ scan: CostSummaryBuilder.CostSummaryScan?) {
+        guard let scan else { return }
+        costSummary = scan.summary
+        guard scan.isComplete else { return }
+        lastScanDate = Date()
+        saveCachedSummary()
     }
 
     /// Backstop against a refresh that never reports completion.
@@ -106,15 +125,17 @@ class CostTracker: ObservableObject {
     /// menu, or a second scan starting — stops at the next file boundary
     /// instead of after the whole corpus.
     ///
-    /// - Returns: the last summary produced, or `nil` when the refresh was
-    ///   cancelled before a single slice completed.
-    private func makeCostSummary(days: Int) async -> CostSummary? {
+    /// - Returns: the last slice's result, or `nil` when the refresh was
+    ///   cancelled before a single slice finished. The `isComplete` flag rides
+    ///   along because the caller must not record a budget-truncated total as a
+    ///   finished scan — see `apply(_:)`.
+    private func makeCostSummary(days: Int) async -> CostSummaryBuilder.CostSummaryScan? {
         let includeClaudeCode = providerVisibilityStore.isEnabled(.claudeCode)
         let includeCodexCli = providerVisibilityStore.isEnabled(.codexCli)
         let claudeAccounts = ClaudeCodeAccountStore.shared.accounts
         let cutoff = CostWindow.start(days: days)
         let store = CostScanCacheStore.applicationSupport
-        var latest: CostSummary?
+        var latest: CostSummaryBuilder.CostSummaryScan?
 
         for _ in 0..<Self.maxScanSlices {
             let scan = try? await CostScanExecutor.run { token in
@@ -141,7 +162,7 @@ class CostTracker: ObservableObject {
             // offsets they committed are already on disk.
             guard let scan else { break }
 
-            latest = scan.summary
+            latest = scan
             if scan.isComplete { break }
             // Publish the partial total so the number on screen improves with
             // every slice instead of only when the last one lands.

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -50,10 +50,10 @@ class CostTracker: ObservableObject {
         }
         guard shouldStart else { return }
 
-        let summary = await makeCostSummary(days: days, priority: .userInitiated)
+        let summary = await makeCostSummary(days: days)
 
         await MainActor.run {
-            costSummary = summary
+            if let summary { costSummary = summary }
             lastScanDate = Date()
             saveCachedSummary()
             isScanning = false
@@ -77,28 +77,78 @@ class CostTracker: ObservableObject {
         }
         guard shouldStart else { return }
 
-        let summary = await makeCostSummary(days: days, priority: .utility)
+        let summary = await makeCostSummary(days: days)
 
         await MainActor.run {
-            costSummary = summary
+            if let summary { costSummary = summary }
             lastScanDate = Date()
             saveCachedSummary()
             isRefreshingMissingDays = false
         }
     }
 
-    private func makeCostSummary(days: Int, priority: TaskPriority) async -> CostSummary {
+    /// Backstop against a refresh that never reports completion.
+    ///
+    /// Every slice that defers work has, by construction, spent budget reading
+    /// bytes — so the loop terminates on its own after ~20 slices on a cold
+    /// 10 GB corpus. This bound only exists so a corrupted cache or a
+    /// pathological transcript cannot pin the scan queue indefinitely; hitting
+    /// it costs nothing but a later refresh finishing the remainder.
+    private static let maxScanSlices = 64
+
+    /// Scans the corpus in budgeted slices, publishing after each one.
+    ///
+    /// The slices run on `CostScanExecutor`'s serial queue rather than a
+    /// detached `Task`: the work is blocking disk I/O, and a detached task
+    /// holds a cooperative-pool thread hostage while it waits on `read(2)`
+    /// (see the header of `CostScanExecutor` for the full rationale). Between
+    /// slices the queue is free, so a cancelled refresh — the user closing the
+    /// menu, or a second scan starting — stops at the next file boundary
+    /// instead of after the whole corpus.
+    ///
+    /// - Returns: the last summary produced, or `nil` when the refresh was
+    ///   cancelled before a single slice completed.
+    private func makeCostSummary(days: Int) async -> CostSummary? {
         let includeClaudeCode = providerVisibilityStore.isEnabled(.claudeCode)
         let includeCodexCli = providerVisibilityStore.isEnabled(.codexCli)
         let claudeAccounts = ClaudeCodeAccountStore.shared.accounts
-        return await Task.detached(priority: priority) {
-            CostSummaryBuilder.makeSummary(
-                days: days,
-                includeClaudeCode: includeClaudeCode,
-                includeCodexCli: includeCodexCli,
-                claudeAccounts: claudeAccounts
-            )
-        }.value
+        let cutoff = CostWindow.start(days: days)
+        let store = CostScanCacheStore.applicationSupport
+        var latest: CostSummary?
+
+        for _ in 0..<Self.maxScanSlices {
+            let scan = try? await CostScanExecutor.run { token in
+                let session = CostScanSession(
+                    cutoff: cutoff,
+                    options: .default,
+                    store: store,
+                    token: token
+                )
+                let scan = CostSummaryBuilder.makeScan(
+                    days: days,
+                    includeClaudeCode: includeClaudeCode,
+                    includeCodexCli: includeCodexCli,
+                    claudeAccounts: claudeAccounts,
+                    session: session
+                )
+                // Persist even when the slice was cut short: offsets commit on
+                // line boundaries, so partial progress is exactly what the next
+                // slice needs to resume from.
+                session.persist()
+                return scan
+            }
+            // Cancelled. Whatever earlier slices published stands, and the
+            // offsets they committed are already on disk.
+            guard let scan else { break }
+
+            latest = scan.summary
+            if scan.isComplete { break }
+            // Publish the partial total so the number on screen improves with
+            // every slice instead of only when the last one lands.
+            await MainActor.run { costSummary = scan.summary }
+        }
+
+        return latest
     }
 
     private func loadCachedSummary() {

--- a/MeterBar/Services/FileLineReader.swift
+++ b/MeterBar/Services/FileLineReader.swift
@@ -1,5 +1,44 @@
 import Foundation
 
+/// Where to start reading, and how much to read.
+nonisolated struct FileLineReadRequest {
+    /// Byte offset to seek to before reading. Comes from the previous refresh's
+    /// `FileLineReadResult.committedOffset`, so a resumed read sees only bytes
+    /// appended since.
+    var startOffset: UInt64 = 0
+
+    /// Ceiling on bytes pulled off disk in this call. The reader stops at the
+    /// last complete line inside the ceiling; the rest of the file is left for
+    /// the next refresh.
+    var maxBytes: Int = .max
+
+    var chunkSize: Int = FileLineReader.defaultChunkSize
+
+    /// Yield the final line even when it has no trailing newline and is not
+    /// structurally complete JSON.
+    ///
+    /// Only `forEachLine` sets this, to preserve its whole-file semantics. The
+    /// resumable path must not: transcripts are appended to while being read, so
+    /// a trailing fragment there is a record still being written.
+    var commitsUnterminatedTrailingLine = false
+}
+
+/// Where the next read should pick up, and why this one stopped.
+nonisolated struct FileLineReadResult {
+    /// One past the last line handed to `body`. Safe to persist: every byte
+    /// before it has been accounted for exactly once.
+    var committedOffset: UInt64
+
+    /// Bytes actually read from disk, which is what the refresh budget spends.
+    /// Larger than `committedOffset - startOffset` whenever the read stopped
+    /// mid-line.
+    var bytesRead: Int
+
+    /// `true` only when a read came back empty. `false` means the byte ceiling
+    /// stopped the read with more file left.
+    var reachedEndOfFile: Bool
+}
+
 /// Streams a newline-delimited file one line at a time.
 ///
 /// The cost scanners used to read each transcript with `Data(contentsOf:)` and
@@ -30,20 +69,70 @@ nonisolated enum FileLineReader {
         chunkSize: Int = defaultChunkSize,
         _ body: (Data) -> Void
     ) -> Bool {
-        guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+        var request = FileLineReadRequest()
+        request.chunkSize = chunkSize
+        // Whole-file reads have no budget and no follow-up pass, so a trailing
+        // fragment is all the caller will ever get — yield it.
+        request.commitsUnterminatedTrailingLine = true
+        return readLines(in: url, request: request) { line, _ in body(line) } != nil
+    }
+
+    /// Reads lines from `request.startOffset` up to `request.maxBytes`.
+    ///
+    /// `body` receives each line's payload and the byte offset the line *starts*
+    /// at, which is what the Codex scan needs to roll its committed offset back
+    /// to the first event it had to defer.
+    ///
+    /// - Returns: `nil` when the file could not be opened or sought.
+    static func readLines(
+        in url: URL,
+        request: FileLineReadRequest,
+        _ body: (Data, UInt64) -> Void
+    ) -> FileLineReadResult? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
         defer { try? handle.close() }
+        if request.startOffset > 0 {
+            do {
+                try handle.seek(toOffset: request.startOffset)
+            } catch {
+                return nil
+            }
+        }
 
         let newline = UInt8(ascii: "\n")
         // Guards against a caller passing 0 and spinning forever on empty reads.
-        let size = max(1, chunkSize)
+        let chunkSize = max(1, request.chunkSize)
+        let budget = max(0, request.maxBytes)
+        var committed = request.startOffset
+        var bytesRead = 0
+        var reachedEnd = false
         var pending = Data()
 
-        while let chunk = try? handle.read(upToCount: size), !chunk.isEmpty {
+        while bytesRead < budget {
+            // `read(upToCount:)` signals end of file by returning `nil` *or* an
+            // empty `Data` depending on the handle, and only a thrown error means
+            // the read actually failed. Collapsing the two with `try?` would
+            // report EOF as a failure, and the caller reads `reachedEndOfFile` to
+            // decide whether a file is done — a false negative there re-reads
+            // every transcript from its offset on every refresh, forever.
+            let chunk: Data?
+            do {
+                chunk = try handle.read(upToCount: min(chunkSize, budget - bytesRead))
+            } catch {
+                break
+            }
+            guard let chunk, !chunk.isEmpty else {
+                reachedEnd = true
+                break
+            }
+            bytesRead += chunk.count
             pending.append(chunk)
             var searchStart = pending.startIndex
 
             while let newlineIndex = pending[searchStart...].firstIndex(of: newline) {
-                body(Self.line(pending[searchStart..<newlineIndex]))
+                let slice = pending[searchStart..<newlineIndex]
+                body(Self.line(slice), committed)
+                committed += UInt64(slice.count) + 1
                 searchStart = pending.index(after: newlineIndex)
             }
 
@@ -54,10 +143,71 @@ nonisolated enum FileLineReader {
             }
         }
 
-        if !pending.isEmpty {
-            body(Self.line(pending[...]))
+        // A residual left behind because the budget ran out is a line the file
+        // continues past — never commit it, even when the bytes read so far
+        // happen to look like complete JSON.
+        let stoppedForBudget = !reachedEnd && bytesRead >= budget
+        if !pending.isEmpty, !stoppedForBudget,
+           request.commitsUnterminatedTrailingLine || isStructurallyCompleteJSONLine(pending) {
+            body(Self.line(pending[...]), committed)
+            committed += UInt64(pending.count)
         }
-        return true
+
+        return FileLineReadResult(
+            committedOffset: committed,
+            bytesRead: bytesRead,
+            reachedEndOfFile: reachedEnd
+        )
+    }
+
+    /// Cheap structural check for a trailing line with no newline yet.
+    ///
+    /// Claude Code and Codex append to transcripts while the scan reads them, so
+    /// the last line is routinely half-written. Committing one would double-count
+    /// the record once the rest lands, and re-reading from before it every
+    /// refresh would give up the offsets entirely — so the reader commits a
+    /// newline-less line only when its brackets balance outside of strings.
+    ///
+    /// This is not validation: `{"a":}` passes, and the parser rejects it
+    /// harmlessly a moment later. It only has to catch a write that stopped
+    /// mid-record, which always leaves an unclosed bracket or an open string.
+    static func isStructurallyCompleteJSONLine(_ data: Data) -> Bool {
+        var expected: [UInt8] = []
+        var inString = false
+        var escaped = false
+        var sawContent = false
+
+        for byte in data {
+            if escaped {
+                escaped = false
+                continue
+            }
+            if inString {
+                switch byte {
+                case UInt8(ascii: "\\"): escaped = true
+                case UInt8(ascii: "\""): inString = false
+                default: break
+                }
+                continue
+            }
+            switch byte {
+            case UInt8(ascii: " "), UInt8(ascii: "\t"), UInt8(ascii: "\r"), UInt8(ascii: "\n"):
+                continue
+            case UInt8(ascii: "\""):
+                inString = true
+            case UInt8(ascii: "{"):
+                expected.append(UInt8(ascii: "}"))
+            case UInt8(ascii: "["):
+                expected.append(UInt8(ascii: "]"))
+            case UInt8(ascii: "}"), UInt8(ascii: "]"):
+                guard expected.popLast() == byte else { return false }
+            default:
+                break
+            }
+            sawContent = true
+        }
+
+        return sawContent && !inString && !escaped && expected.isEmpty
     }
 
     /// Copies the slice into a zero-based `Data` and drops a CRLF carriage

--- a/MeterBarTests/CostScanCollaboratorTests.swift
+++ b/MeterBarTests/CostScanCollaboratorTests.swift
@@ -412,4 +412,199 @@ final class CostScanCollaboratorTests: XCTestCase {
         XCTAssertEqual(summary.totalTokens, 0)
         XCTAssertEqual(summary.periodDays, 7)
     }
+
+    // MARK: - CostScanBudget
+
+    func testProductionBudgetIsBoundedPerFileAndPerRefresh() {
+        let options = CostScanBudgetOptions.default
+
+        XCTAssertEqual(options.maxBytesPerFile, 256 * 1024 * 1024)
+        XCTAssertEqual(options.maxNewBytesPerRefresh, 512 * 1024 * 1024)
+        XCTAssertNotNil(options.wallClock)
+        XCTAssertFalse(options.isUnbounded)
+        XCTAssertTrue(CostScanBudgetOptions.unlimited.isUnbounded)
+    }
+
+    func testAllowanceIsTheSmallerOfThePerFileAndRemainingRefreshBudgets() {
+        let budget = CostScanBudget(
+            options: CostScanBudgetOptions(maxBytesPerFile: 100, maxNewBytesPerRefresh: 250, wallClock: nil)
+        )
+
+        XCTAssertEqual(budget.allowance, 100)
+        budget.consume(180)
+        XCTAssertEqual(budget.bytesRead, 180)
+        XCTAssertEqual(budget.allowance, 70)
+        XCTAssertFalse(budget.isExhausted)
+
+        budget.consume(70)
+        XCTAssertEqual(budget.allowance, 0)
+        XCTAssertTrue(budget.isExhausted)
+    }
+
+    func testUnlimitedBudgetIsNeverExhausted() {
+        let budget = CostScanBudget(options: .unlimited)
+
+        budget.consume(4 * 1024 * 1024 * 1024)
+
+        XCTAssertFalse(budget.isExhausted)
+        XCTAssertEqual(budget.allowance, Int.max)
+    }
+
+    func testWallClockBudgetExpiresIndependentlyOfBytes() {
+        let options = CostScanBudgetOptions(maxBytesPerFile: .max, maxNewBytesPerRefresh: .max, wallClock: 5)
+        let budget = CostScanBudget(options: options, startedAt: Date(timeIntervalSinceNow: -10))
+
+        XCTAssertTrue(budget.isExhausted)
+        XCTAssertEqual(budget.allowance, 0)
+    }
+
+    func testCancellingTheTokenExhaustsTheBudget() {
+        let token = CostScanCancellationToken()
+        let budget = CostScanBudget(options: .unlimited, token: token)
+
+        XCTAssertFalse(budget.isExhausted)
+        token.cancel()
+        XCTAssertTrue(budget.isExhausted)
+        XCTAssertTrue(budget.isCancelled)
+    }
+
+    // MARK: - CostScanCorpus
+
+    func testTranscriptsAreOrderedNewestModifiedFirst() throws {
+        let root = try makeCorpusDirectory()
+        let now = Date(timeIntervalSince1970: 1_780_000_000)
+        try writeCorpusFile(in: root, name: "middle.jsonl", bytes: 10, modified: now.addingTimeInterval(-60))
+        try writeCorpusFile(in: root, name: "oldest.jsonl", bytes: 10, modified: now.addingTimeInterval(-120))
+        try writeCorpusFile(in: root, name: "newest.jsonl", bytes: 10, modified: now)
+        // Only `.jsonl` transcripts participate in the scan.
+        try writeCorpusFile(in: root, name: "notes.txt", bytes: 10, modified: now)
+
+        let files = CostScanCorpus.transcripts(in: root)
+
+        XCTAssertEqual(files.map { $0.url.lastPathComponent }, ["newest.jsonl", "middle.jsonl", "oldest.jsonl"])
+        XCTAssertEqual(files.first?.size, 10)
+    }
+
+    func testCorpusOfAMissingDirectoryIsEmpty() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CostScanCorpus-missing-\(UUID().uuidString)", isDirectory: true)
+
+        XCTAssertTrue(CostScanCorpus.transcripts(in: missing).isEmpty)
+    }
+
+    // MARK: - CostScanExecutor
+
+    func testExecutorReturnsTheWorkResult() async throws {
+        let value = try await CostScanExecutor.run { _ in 42 }
+
+        XCTAssertEqual(value, 42)
+    }
+
+    func testCancelledWorkDoesNotWaitBehindAnInFlightScan() async throws {
+        // The whole point of the serial queue is that a stale refresh can be
+        // abandoned instantly: work still queued must fail fast rather than sit
+        // behind a scan that is already reading the corpus.
+        let gate = DispatchSemaphore(value: 0)
+        let running = CostScanFlag()
+        let blocker = Task {
+            try await CostScanExecutor.run { _ in
+                running.set()
+                gate.wait()
+            }
+        }
+        try await waitUntil(running.isSet, "the blocking scan to occupy the queue")
+
+        let queued = Task { try await CostScanExecutor.run { _ in true } }
+        queued.cancel()
+
+        do {
+            _ = try await queued.value
+            XCTFail("expected the queued scan to be cancelled")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+
+        gate.signal()
+        _ = try await blocker.value
+    }
+
+    func testCancellingAnInFlightScanSignalsItsToken() async throws {
+        let started = CostScanFlag()
+        let observed = CostScanFlag()
+        let task = Task {
+            try await CostScanExecutor.run { token in
+                started.set()
+                while !token.isCancelled {
+                    usleep(1_000)
+                }
+                observed.set()
+                return true
+            }
+        }
+        // Polled rather than waited on a semaphore: this method runs on the main
+        // actor, and `task` is enqueued to it too, so blocking here would starve
+        // the very work we are waiting to start.
+        try await waitUntil(started.isSet, "the scan to reach the queue")
+
+        task.cancel()
+        _ = try? await task.value
+        // The queue is serial, so this only runs once the cancelled work returned.
+        _ = try await CostScanExecutor.run { _ in true }
+
+        XCTAssertTrue(observed.isSet)
+    }
+
+    /// Yields until `condition` holds, or fails after five seconds.
+    ///
+    /// Every wait in these tests has to suspend rather than block: the test
+    /// methods are main-actor isolated, and so are the `Task`s they spawn, so a
+    /// `DispatchSemaphore.wait` on this thread deadlocks against the work it is
+    /// waiting for.
+    private func waitUntil(
+        _ condition: @autoclosure () -> Bool,
+        _ description: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        for _ in 0..<5_000 {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        XCTFail("timed out waiting for \(description)", file: file, line: line)
+    }
+
+    // MARK: - Corpus fixtures
+
+    private func makeCorpusDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CostScanCorpus-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+
+    private func writeCorpusFile(in root: URL, name: String, bytes: Int, modified: Date) throws {
+        let url = root.appendingPathComponent(name)
+        try Data(repeating: UInt8(ascii: "x"), count: bytes).write(to: url)
+        try FileManager.default.setAttributes([.modificationDate: modified], ofItemAtPath: url.path)
+    }
+}
+
+/// Lock-guarded boolean so a scan closure running on the serial queue can report
+/// back to the test without tripping `Sendable` checking.
+private final class CostScanFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = false
+
+    var isSet: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    func set() {
+        lock.lock()
+        value = true
+        lock.unlock()
+    }
 }

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -834,4 +834,261 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(windows.period.totals.input, 1_000)
         XCTAssertEqual(windows.lifetime.totals.input, 1_000)
     }
+
+    // MARK: - Budgeted, resumable corpus scan
+
+    func testByteBudgetSmallerThanTheCorpusDefersTheRestWithoutLosingData() throws {
+        let root = try makeTranscriptRoot()
+        let newest = try writeTranscript(in: root, name: "newest.jsonl", modifiedAgo: 0, lines: [
+            eventLine(timestamp: "2026-07-01T10:00:00.000Z", messageID: "a", requestID: "a", input: 100, output: 10)
+        ])
+        let older = try writeTranscript(in: root, name: "older.jsonl", modifiedAgo: 3_600, lines: [
+            eventLine(timestamp: "2026-07-02T10:00:00.000Z", messageID: "b", requestID: "b", input: 7, output: 3)
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let store = try makeScanCacheStore()
+        let budget = CostScanBudgetOptions(
+            maxBytesPerFile: .max,
+            maxNewBytesPerRefresh: try fileSize(newest),
+            wallClock: nil
+        )
+
+        let first = CostScanSession(cutoff: cutoff, options: budget, store: store)
+        let firstWindows = ClaudeCostScanner.scanRoots([root], session: first)
+        first.persist()
+
+        XCTAssertFalse(first.isComplete)
+        XCTAssertEqual(firstWindows.period.input, 100)
+        XCTAssertEqual(firstWindows.period.sessions, 1)
+        XCTAssertNil(first.claude.records[older.standardizedFileURL.path])
+
+        // A fresh refresh gets a fresh budget and picks up exactly what was left.
+        let second = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        let secondWindows = ClaudeCostScanner.scanRoots([root], session: second)
+        second.persist()
+
+        XCTAssertTrue(second.isComplete)
+        XCTAssertEqual(secondWindows.period.input, 107)
+        XCTAssertEqual(secondWindows.period.output, 13)
+        XCTAssertEqual(secondWindows.period.sessions, 2)
+    }
+
+    func testSecondRefreshResumesFromThePersistedOffsetAndReadsOnlyAppendedBytes() throws {
+        let root = try makeTranscriptRoot()
+        let url = try writeTranscript(in: root, name: "session.jsonl", modifiedAgo: 0, lines: [
+            eventLine(timestamp: "2026-07-01T10:00:00.000Z", messageID: "a", requestID: "a", input: 100, output: 10)
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let store = try makeScanCacheStore()
+
+        let first = CostScanSession(cutoff: cutoff, options: .default, store: store)
+        _ = ClaudeCostScanner.scanRoots([root], session: first)
+        first.persist()
+
+        let firstSize = try fileSize(url)
+        XCTAssertEqual(first.budget.bytesRead, firstSize)
+        XCTAssertEqual(first.claude.records[url.standardizedFileURL.path]?.offset, UInt64(firstSize))
+
+        let appended = eventLine(
+            timestamp: "2026-07-02T10:00:00.000Z", messageID: "b", requestID: "b", input: 7, output: 3
+        ) + "\n"
+        try append(appended, to: url)
+
+        let second = CostScanSession(cutoff: cutoff, options: .default, store: store)
+        let windows = ClaudeCostScanner.scanRoots([root], session: second)
+        second.persist()
+
+        XCTAssertEqual(second.budget.bytesRead, appended.utf8.count)
+        XCTAssertEqual(windows.period.input, 107)
+    }
+
+    func testAppendingBetweenScansCountsTheNewRecordsExactlyOnce() throws {
+        let root = try makeTranscriptRoot()
+        let url = try writeTranscript(in: root, name: "session.jsonl", modifiedAgo: 0, lines: [
+            eventLine(timestamp: "2026-07-01T10:00:00.000Z", messageID: "a", requestID: "a", input: 100, output: 10)
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let store = try makeScanCacheStore()
+
+        let first = CostScanSession(cutoff: cutoff, options: .default, store: store)
+        _ = ClaudeCostScanner.scanRoots([root], session: first)
+        first.persist()
+
+        try append(eventLine(
+            timestamp: "2026-07-02T10:00:00.000Z", messageID: "b", requestID: "b", input: 7, output: 3
+        ) + "\n", to: url)
+
+        let second = CostScanSession(cutoff: cutoff, options: .default, store: store)
+        let incremental = ClaudeCostScanner.scanRoots([root], session: second)
+
+        // A cold scan of the finished file is the reference: incremental reads
+        // must land on exactly the same totals, not double the appended event.
+        let cold = ClaudeCostScanner.parseSessionWindows(at: url, since: cutoff)
+
+        XCTAssertEqual(incremental.period.input, cold.period.input)
+        XCTAssertEqual(incremental.period.output, cold.period.output)
+        XCTAssertEqual(incremental.period.estimatedCost, cold.period.estimatedCost, accuracy: 0.000_001)
+        XCTAssertEqual(incremental.period.sessions, 1)
+        XCTAssertEqual(incremental.lifetime.input, cold.lifetime.input)
+    }
+
+    func testHalfWrittenTrailingLineIsNotCommittedUntilItIsComplete() throws {
+        let root = try makeTranscriptRoot()
+        let complete = eventLine(
+            timestamp: "2026-07-01T10:00:00.000Z", messageID: "a", requestID: "a", input: 100, output: 10
+        )
+        let tail = eventLine(
+            timestamp: "2026-07-02T10:00:00.000Z", messageID: "b", requestID: "b", input: 7, output: 3
+        )
+        let url = root.appendingPathComponent("session.jsonl")
+        let head = String(tail.prefix(20))
+        try (complete + "\n" + head).write(to: url, atomically: true, encoding: .utf8)
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let store = try makeScanCacheStore()
+
+        let first = CostScanSession(cutoff: cutoff, options: .default, store: store)
+        let firstWindows = ClaudeCostScanner.scanRoots([root], session: first)
+        first.persist()
+
+        XCTAssertEqual(firstWindows.period.input, 100)
+        XCTAssertEqual(
+            first.claude.records[url.standardizedFileURL.path]?.offset,
+            UInt64((complete + "\n").utf8.count)
+        )
+
+        try append(String(tail.dropFirst(head.count)) + "\n", to: url)
+
+        let second = CostScanSession(cutoff: cutoff, options: .default, store: store)
+        let secondWindows = ClaudeCostScanner.scanRoots([root], session: second)
+
+        XCTAssertEqual(secondWindows.period.input, 107)
+        XCTAssertEqual(secondWindows.period.output, 13)
+    }
+
+    func testNewestTranscriptsAreScannedFirstWhenTheBudgetCoversOnlySome() throws {
+        let root = try makeTranscriptRoot()
+        let oldest = try writeTranscript(in: root, name: "oldest.jsonl", modifiedAgo: 7_200, lines: [
+            eventLine(timestamp: "2026-07-01T10:00:00.000Z", messageID: "c", requestID: "c", input: 1, output: 1)
+        ])
+        let middle = try writeTranscript(in: root, name: "middle.jsonl", modifiedAgo: 3_600, lines: [
+            eventLine(timestamp: "2026-07-01T10:00:00.000Z", messageID: "b", requestID: "b", input: 10, output: 1)
+        ])
+        let newest = try writeTranscript(in: root, name: "newest.jsonl", modifiedAgo: 0, lines: [
+            eventLine(timestamp: "2026-07-01T10:00:00.000Z", messageID: "a", requestID: "a", input: 100, output: 1)
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let budget = CostScanBudgetOptions(
+            maxBytesPerFile: .max,
+            maxNewBytesPerRefresh: try fileSize(newest),
+            wallClock: nil
+        )
+
+        let session = CostScanSession(cutoff: cutoff, options: budget)
+        let windows = ClaudeCostScanner.scanRoots([root], session: session)
+
+        XCTAssertFalse(session.isComplete)
+        XCTAssertEqual(windows.period.input, 100)
+        XCTAssertNotNil(session.claude.records[newest.standardizedFileURL.path])
+        XCTAssertNil(session.claude.records[middle.standardizedFileURL.path])
+        XCTAssertNil(session.claude.records[oldest.standardizedFileURL.path])
+    }
+
+    func testCancellationMidScanLeavesPersistedOffsetsOnLineBoundaries() async throws {
+        let root = try makeTranscriptRoot()
+        let fileCount = 40
+        let linesPerFile = 40
+        for file in 0..<fileCount {
+            try writeTranscript(
+                in: root,
+                name: "session-\(file).jsonl",
+                modifiedAgo: TimeInterval(file),
+                lines: (0..<linesPerFile).map { line in
+                    eventLine(
+                        timestamp: "2026-07-01T10:00:00.000Z",
+                        messageID: "m-\(file)-\(line)",
+                        requestID: "r-\(file)-\(line)",
+                        input: 10,
+                        output: 1
+                    )
+                }
+            )
+        }
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let store = try makeScanCacheStore()
+
+        let scan = Task {
+            try await CostScanExecutor.run { token in
+                let session = CostScanSession(cutoff: cutoff, options: .unlimited, store: store, token: token)
+                _ = ClaudeCostScanner.scanRoots([root], session: session)
+                session.persist()
+            }
+        }
+        try? await Task.sleep(nanoseconds: 2_000_000)
+        scan.cancel()
+        _ = try? await scan.value
+        // The scan queue is serial, so this only returns once the cancelled work
+        // has finished persisting whatever it managed to read.
+        _ = try await CostScanExecutor.run { _ in true }
+
+        for (path, record) in store.loadClaude().records {
+            let bytes = try Data(contentsOf: URL(fileURLWithPath: path))
+            XCTAssertLessThanOrEqual(Int(record.offset), bytes.count, path)
+            if record.offset > 0 {
+                XCTAssertEqual(bytes[Int(record.offset) - 1], UInt8(ascii: "\n"), path)
+            }
+        }
+
+        let resumed = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        let windows = ClaudeCostScanner.scanRoots([root], session: resumed)
+
+        XCTAssertTrue(resumed.isComplete)
+        XCTAssertEqual(windows.period.input, fileCount * linesPerFile * 10)
+        XCTAssertEqual(windows.period.output, fileCount * linesPerFile)
+        XCTAssertEqual(windows.period.sessions, fileCount)
+    }
+
+    // MARK: - Corpus fixtures
+
+    private func makeTranscriptRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CostScanRoot-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+
+    private func makeScanCacheStore() throws -> CostScanCacheStore {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CostScanCache-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        return CostScanCacheStore(directory: directory)
+    }
+
+    @discardableResult
+    private func writeTranscript(
+        in root: URL,
+        name: String,
+        modifiedAgo: TimeInterval,
+        lines: [String]
+    ) throws -> URL {
+        let url = root.appendingPathComponent(name)
+        try (lines.joined(separator: "\n") + "\n").write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 1_780_000_000 - modifiedAgo)],
+            ofItemAtPath: url.path
+        )
+        return url
+    }
+
+    private func append(_ text: String, to url: URL) throws {
+        let handle = try FileHandle(forWritingTo: url)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(text.utf8))
+    }
+
+    private func fileSize(_ url: URL) throws -> Int {
+        try url.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
+    }
 }

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -1047,6 +1047,106 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(windows.period.sessions, fileCount)
     }
 
+    // MARK: - Applying a slice's result
+
+    /// Demo mode is the vehicle rather than the subject: it stubs out the cache
+    /// write, so these assert the publish/stamp decision without touching the
+    /// real `~/Library/Application Support` summary.
+    @MainActor
+    private func makeApplyTracker(lastScan: Date) -> CostTracker {
+        let tracker = CostTracker(demoMode: true)
+        tracker.lastScanDate = lastScan
+        return tracker
+    }
+
+    @MainActor
+    func testIncompleteScanPublishesItsPartialTotalWithoutStampingTheScanClock() {
+        let previous = Date(timeIntervalSince1970: 1_000)
+        let tracker = makeApplyTracker(lastScan: previous)
+        let partial = CostSummary(
+            costs: [],
+            totalCostUSD: 4,
+            totalTokens: 40,
+            periodDays: 30,
+            dailyUsage: [],
+            lifetime: nil
+        )
+
+        tracker.apply(CostSummaryBuilder.CostSummaryScan(summary: partial, isComplete: false))
+
+        // The number on screen improves with every slice...
+        XCTAssertEqual(tracker.costSummary?.totalCostUSD, 4)
+        // ...but an undercount must not be recorded as a finished scan: a
+        // `lastScanDate` of today suppresses the background backfill for the
+        // rest of the calendar day.
+        XCTAssertEqual(tracker.lastScanDate, previous)
+    }
+
+    @MainActor
+    func testCompleteScanStampsTheScanClock() {
+        let previous = Date(timeIntervalSince1970: 1_000)
+        let tracker = makeApplyTracker(lastScan: previous)
+        let whole = CostSummary(
+            costs: [],
+            totalCostUSD: 9,
+            totalTokens: 90,
+            periodDays: 30,
+            dailyUsage: [],
+            lifetime: nil
+        )
+
+        tracker.apply(CostSummaryBuilder.CostSummaryScan(summary: whole, isComplete: true))
+
+        XCTAssertEqual(tracker.costSummary?.totalCostUSD, 9)
+        XCTAssertNotEqual(tracker.lastScanDate, previous)
+    }
+
+    @MainActor
+    func testCancelledScanLeavesBothTheSummaryAndTheScanClockAlone() {
+        let previous = Date(timeIntervalSince1970: 1_000)
+        let tracker = makeApplyTracker(lastScan: previous)
+        let before = tracker.costSummary?.totalCostUSD
+
+        // No slice completed, so there is nothing to publish and nothing learned.
+        tracker.apply(nil)
+
+        XCTAssertEqual(tracker.costSummary?.totalCostUSD, before)
+        XCTAssertEqual(tracker.lastScanDate, previous)
+    }
+
+    // MARK: - Cache round-trip
+
+    /// The persisted payloads roll usage up in `[Date: TokenAccumulator]`
+    /// dictionaries, and a `Date` key survives a round trip only while the
+    /// encoder and decoder agree on a date strategy. They fail *silently* when
+    /// they drift: every strategy but `.iso8601` writes a bare number, so a
+    /// mismatched pair still decodes — into the wrong day. Every daily row would
+    /// land in a bucket decades away with nothing thrown, so pin the invariant
+    /// here rather than trusting two defaults to stay matched.
+    func testDateKeyedDailyRollupsSurviveACacheRoundTrip() throws {
+        let store = try makeScanCacheStore()
+        let day = Calendar.current.startOfDay(for: Date(timeIntervalSince1970: 1_780_000_000))
+        var totals = ClaudeFileTotals()
+        totals.period.daily[day] = TokenAccumulator(input: 11, output: 22)
+
+        var cache = CostScanFileCache<ClaudeFileTotals>()
+        cache.records["/transcripts/a.jsonl"] = CostScanFileRecord(
+            offset: 512,
+            size: 4_096,
+            cutoff: day,
+            isComplete: false,
+            payload: totals
+        )
+        store.saveClaude(cache)
+
+        let loaded = store.loadClaude()
+        let record = try XCTUnwrap(loaded.records["/transcripts/a.jsonl"])
+        XCTAssertEqual(record.cutoff, day)
+        XCTAssertEqual(record.offset, 512)
+        XCTAssertEqual(record.payload.period.daily[day]?.input, 11)
+        XCTAssertEqual(record.payload.period.daily[day]?.output, 22)
+    }
+
     // MARK: - Corpus fixtures
 
     private func makeTranscriptRoot() throws -> URL {

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -1137,7 +1137,7 @@ final class CostTrackerTests: XCTestCase {
             isComplete: false,
             payload: totals
         )
-        store.saveClaude(cache)
+        try store.saveClaude(cache)
 
         let loaded = store.loadClaude()
         let record = try XCTUnwrap(loaded.records["/transcripts/a.jsonl"])
@@ -1145,6 +1145,21 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(record.offset, 512)
         XCTAssertEqual(record.payload.period.daily[day]?.input, 11)
         XCTAssertEqual(record.payload.period.daily[day]?.output, 22)
+    }
+
+    func testPersistReportsCacheWriteFailure() throws {
+        let blockedDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CostScanBlocked-\(UUID().uuidString)")
+        try Data().write(to: blockedDirectory)
+        addTeardownBlock { try? FileManager.default.removeItem(at: blockedDirectory) }
+
+        let session = CostScanSession(
+            cutoff: Date(timeIntervalSince1970: 1_780_000_000),
+            options: .unlimited,
+            store: CostScanCacheStore(directory: blockedDirectory)
+        )
+
+        XCTAssertFalse(session.persist())
     }
 
     // MARK: - Corpus fixtures

--- a/MeterBarTests/FileLineReaderTests.swift
+++ b/MeterBarTests/FileLineReaderTests.swift
@@ -93,4 +93,101 @@ final class FileLineReaderTests: XCTestCase {
         XCTAssertFalse(opened)
         XCTAssertEqual(count, 0)
     }
+
+    // MARK: - Resumable reads
+
+    private func read(
+        _ url: URL,
+        startOffset: UInt64 = 0,
+        maxBytes: Int = .max,
+        chunkSize: Int = FileLineReader.defaultChunkSize
+    ) -> (lines: [String], offsets: [UInt64], result: FileLineReadResult?) {
+        var collected: [String] = []
+        var offsets: [UInt64] = []
+        var request = FileLineReadRequest()
+        request.startOffset = startOffset
+        request.maxBytes = maxBytes
+        request.chunkSize = chunkSize
+        let result = FileLineReader.readLines(in: url, request: request) { line, offset in
+            collected.append(String(decoding: line, as: UTF8.self))
+            offsets.append(offset)
+        }
+        return (collected, offsets, result)
+    }
+
+    func testReadLinesReportsTheByteOffsetOfEachLine() throws {
+        let url = try writeFile("a\nbb\nccc\n")
+
+        let read = self.read(url)
+
+        XCTAssertEqual(read.lines, ["a", "bb", "ccc"])
+        XCTAssertEqual(read.offsets, [0, 2, 5])
+        XCTAssertEqual(read.result?.committedOffset, 9)
+        XCTAssertEqual(read.result?.bytesRead, 9)
+        XCTAssertEqual(read.result?.reachedEndOfFile, true)
+    }
+
+    func testReadLinesResumesFromAPersistedOffset() throws {
+        let url = try writeFile("a\nbb\nccc\n")
+
+        let read = self.read(url, startOffset: 2)
+
+        XCTAssertEqual(read.lines, ["bb", "ccc"])
+        XCTAssertEqual(read.result?.bytesRead, 7)
+        XCTAssertEqual(read.result?.committedOffset, 9)
+    }
+
+    func testReadLinesStopsAtTheByteBudgetOnTheLastCompleteLine() throws {
+        let url = try writeFile("a\nbb\nccc\n")
+
+        // Four bytes covers "a\n" plus the first half of "bb\n".
+        let read = self.read(url, maxBytes: 4, chunkSize: 1)
+
+        XCTAssertEqual(read.lines, ["a"])
+        XCTAssertEqual(read.result?.committedOffset, 2)
+        XCTAssertEqual(read.result?.bytesRead, 4)
+        XCTAssertEqual(read.result?.reachedEndOfFile, false)
+    }
+
+    func testReadLinesCommitsAStructurallyCompleteTrailingLineWithoutNewline() throws {
+        let url = try writeFile("{\"a\":1}\n{\"b\":2}")
+
+        let read = self.read(url)
+
+        XCTAssertEqual(read.lines, ["{\"a\":1}", "{\"b\":2}"])
+        XCTAssertEqual(read.result?.committedOffset, 15)
+    }
+
+    func testReadLinesWithholdsAHalfWrittenTrailingLine() throws {
+        // The scanners read files that Claude Code and Codex are still appending
+        // to. Committing a half-written record would double-count it once the
+        // rest of the line lands.
+        let url = try writeFile("{\"a\":1}\n{\"b\":")
+
+        let read = self.read(url)
+
+        XCTAssertEqual(read.lines, ["{\"a\":1}"])
+        XCTAssertEqual(read.result?.committedOffset, 8)
+        XCTAssertEqual(read.result?.reachedEndOfFile, true)
+    }
+
+    func testReadLinesNeverCommitsATrailingLineCutShortByTheBudget() throws {
+        // The bytes look like complete JSON only because the budget stopped
+        // reading there; the file itself continues.
+        let url = try writeFile("{\"a\":1}{\"b\":2}\n")
+
+        let read = self.read(url, maxBytes: 7, chunkSize: 1)
+
+        XCTAssertTrue(read.lines.isEmpty)
+        XCTAssertEqual(read.result?.committedOffset, 0)
+    }
+
+    func testStructuralCompletenessIgnoresBracesInsideStrings() {
+        XCTAssertTrue(FileLineReader.isStructurallyCompleteJSONLine(Data(#"{"a":"}"}"#.utf8)))
+        XCTAssertFalse(FileLineReader.isStructurallyCompleteJSONLine(Data(#"{"a":"}"#.utf8)))
+        XCTAssertTrue(FileLineReader.isStructurallyCompleteJSONLine(Data(#"{"a":"\""}"#.utf8)))
+        XCTAssertFalse(FileLineReader.isStructurallyCompleteJSONLine(Data(#"{"a":[1,2}"#.utf8)))
+        XCTAssertFalse(FileLineReader.isStructurallyCompleteJSONLine(Data("".utf8)))
+        XCTAssertFalse(FileLineReader.isStructurallyCompleteJSONLine(Data("   ".utf8)))
+    }
 }


### PR DESCRIPTION
## What

The cost scan read the entire corpus — ~10 GB across ~10k `.jsonl` transcripts — on every refresh, blocking for roughly 70 seconds from cold. This makes the scan **incremental** rather than merely faster: each refresh reads only the bytes appended since the last one, newest transcript first, and stops at a byte ceiling.

## Why not parallelize

The obvious fix — a `TaskGroup` or `concurrentPerform` over the files — is the wrong one, for two independent reasons:

1. **The scan is disk-bound, not CPU-bound.** Fanning reads across cores multiplies I/O contention (more seeks, more page-cache churn, more read-ahead thrash) and buys back no wall time, because no core was ever waiting on arithmetic.
2. **It starves everything else.** Swift's cooperative pool has one thread per core. A fan-out of blocking `read(2)` calls occupies all of them, so menu rendering, provider polling and status refreshes queue behind a scan that is itself just waiting on the disk. The symptom is the menu freezing while the main thread sits idle.

`CostScanExecutor` pins every scan to one serial `DispatchQueue` at `.utility`, off the cooperative pool — the same shape [steipete/CodexBar](https://github.com/steipete/CodexBar) arrived at with its `CostUsageScanExecutor`. The full rationale is written into that file's header so the next person to reach for a `TaskGroup` finds it first.

No parallelization had landed on this branch — nothing to revert. `withTaskGroup` appears only in `UsageDataManager`, `ProviderStatusMonitor` and `SessionWakeAgent`, none of which are cost scanners.

## How

| File | Role |
|---|---|
| `CostScanExecutor` | Serial `.utility` queue + cancellation bridge. Work still **queued** when cancelled resumes immediately with `CancellationError` instead of waiting out the scan ahead of it; work already **running** polls a token from its non-`async` context and stops at the next file boundary. |
| `CostScanBudget` | 256 MiB per file, 512 MiB per refresh, 15 s wall clock — each number's reasoning is a comment on the property. Exhaustion finishes the current chunk, persists, and defers the rest. Production is never unbounded; `.unlimited` is tests-only and says so. |
| `CostScanFileCache` | Byte offset, file size and cutoff live on the **same** per-file entry as the totals. Two stores could disagree after a crash, and the failure is silent: the scan seeks past bytes whose totals were never persisted and that spend vanishes. |
| `FileLineReader.readLines` | Seeks to the persisted offset, commits only on line boundaries. A trailing line with no newline is committed only when its brackets balance outside strings — transcripts are appended to *while being read*, so committing a half-written record would double-count it on the next pass. Cheap structural check, not validation. |
| `CostScanCorpus` | Newest-mtime-first, so the visible 30-day window is correct after the first pass while the older archive catches up behind it. Path breaks ties for determinism. |
| `CostTracker` | Runs slices in a loop on the executor and publishes after each one, so the number on screen improves monotonically instead of only when the last slice lands. |

## Bug found along the way

`FileHandle.read(upToCount:)` signals end of file by returning `nil`, which `try?` collapsed into the failure path. No file ever reported `reachedEndOfFile`, so every transcript would have been re-read from its offset on every refresh forever — the offsets would have worked and the completion tracking would not. Caught by the new tests; fixed by distinguishing a thrown error from a `nil` return.

## Tests (written first)

Extending `CostTrackerTests`, `CostScanCollaboratorTests` and `FileLineReaderTests`:

- a byte budget smaller than the corpus stops the scan and defers the rest, with no data loss
- a second refresh resumes from the persisted offset and reads only the appended bytes
- appending between two scans counts the new records exactly once
- a file whose final line is incomplete JSON does not commit it, and picks it up next scan once complete
- newest-first ordering: under a partial budget, the newest files are the ones scanned
- cancellation mid-scan leaves every persisted offset on a line boundary
- cancelled-while-queued work does not wait behind an in-flight scan

One trap worth recording: `Package.swift` sets `.defaultIsolation(MainActor.self)`, so an XCTest `async` method **and** the `Task { }` it spawns are both main-actor isolated. A `DispatchSemaphore.wait()` on the test thread starves the very Task it is waiting for. The collaborator tests poll with `Task.sleep` via a `waitUntil` helper instead, and the helper's doc comment explains why.

## Verification

```
swift build                                             # exit 0
swiftlint lint --strict --quiet                          # exit 0
swift test --filter "CostTrackerTests|CostScanCollaboratorTests|FileLineReaderTests|CostSummaryStoreTests"
# Executed 103 tests, with 0 failures (0 unexpected) in 50.805 seconds
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cost scanning now supports resumable, budget-limited processing for faster refreshes.
  * Progress is saved between refreshes, allowing scans to continue without rereading completed files.
  * Claude and Codex results are deduplicated and remain accurate across partial scans and changing date ranges.
  * Partial summaries can be displayed while scanning continues.

* **Bug Fixes**
  * Improved handling of cancellation, incomplete transcript lines, inaccessible files, and deferred data.
  * Prevented duplicate usage records and preserved the previous summary when no new result is available.

* **Tests**
  * Added coverage for scanning limits, resumption, caching, cancellation, ordering, and incomplete files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->