### PR TITLE
perf(cost): parse transcripts in parallel, fold them serially in file order

### DIFF
--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -7,39 +7,63 @@ import MeterBarShared
 enum ClaudeCostScanner {
     nonisolated static func scanSessions(
         since cutoffDate: Date,
-        claudeAccounts: [ClaudeCodeAccount]
+        claudeAccounts: [ClaudeCodeAccount],
+        width: Int = CostScanParallel.defaultWidth
+    ) -> ScanWindows<ClaudeSessionTotals> {
+        scanSessions(
+            since: cutoffDate,
+            projectRoots: Self.projectRoots(accounts: claudeAccounts),
+            width: width
+        )
+    }
+
+    /// Roots-explicit seam. The account-based entry point always includes the
+    /// real `~/.claude*/projects` directories, so tests that want to scan a
+    /// fixture tree — and only that tree — go through here.
+    ///
+    /// Deduplication is per file: `parseSessionWindows` keeps its own
+    /// `messageID:requestID` map and throws it away at the end of each
+    /// transcript, so a file's totals depend on nothing outside that file and
+    /// merging them is a plain sum. That is what makes the parse safe to fan
+    /// out. The merge itself stays serial and in sorted-path order because
+    /// summing `Double` costs is not associative.
+    nonisolated static func scanSessions(
+        since cutoffDate: Date,
+        projectRoots: [URL],
+        width: Int = CostScanParallel.defaultWidth
     ) -> ScanWindows<ClaudeSessionTotals> {
         var windows = ScanWindows(
             period: ClaudeSessionTotals(),
             lifetime: ClaudeSessionTotals(),
             cutoff: cutoffDate
         )
-        let projectRoots = Self.projectRoots(accounts: claudeAccounts)
         guard !projectRoots.isEmpty else { return windows }
 
         for root in projectRoots {
-            guard CostScanFileSystem.isLocalDirectory(root) else { continue }
-
-            guard let enumerator = FileManager.default.enumerator(
-                at: root,
-                includingPropertiesForKeys: [.isDirectoryKey],
-                options: [.skipsHiddenFiles, .skipsPackageDescendants]
-            ) else {
-                continue
-            }
-
             // No mtime prefilter: the lifetime window needs every file, and the
             // period window is already bounded by the per-event timestamp check
             // (an event is never newer than the file that holds it).
-            for case let url as URL in enumerator where url.pathExtension == "jsonl" {
-                // Computed once per file, not per event: project identity is a
-                // property of where the transcript lives, unlike `usageOrigin`
-                // which can vary line-to-line within the same file.
-                let projectID = CostProjectAttribution.claudeProjectID(forTranscriptURL: url, root: root)
-                let file = Self.parseSessionWindows(at: url, since: cutoffDate, projectID: projectID)
-                windows.period.merge(file.period)
-                windows.lifetime.merge(file.lifetime)
-            }
+            let files = CostScanFileSystem.transcriptFiles(
+                in: root,
+                options: [.skipsHiddenFiles, .skipsPackageDescendants]
+            )
+
+            CostScanParallel.parseInOrder(
+                files,
+                width: width,
+                parse: { url in
+                    // Computed once per file, not per event: project identity is
+                    // a property of where the transcript lives, unlike
+                    // `usageOrigin` which can vary line-to-line within the same
+                    // file.
+                    let projectID = CostProjectAttribution.claudeProjectID(forTranscriptURL: url, root: root)
+                    return Self.parseSessionWindows(at: url, since: cutoffDate, projectID: projectID)
+                },
+                fold: { file in
+                    windows.period.merge(file.period)
+                    windows.lifetime.merge(file.lifetime)
+                }
+            )
         }
 
         return windows

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -135,57 +135,76 @@ enum CodexCostScanner {
     /// scan streams each file in order and carries the last `turn_context`
     /// model and the opening `session_meta` originator forward. Attribution is
     /// per file: state resets on every rollout.
+    ///
+    /// Unlike Claude's per-file dedup, `CodexScanContext.eventKeys` spans every
+    /// rollout *and* the SQLite log, first event wins. So only the parse fans
+    /// out: each file is turned into an ordered list of usage events on a
+    /// worker, and those lists are applied to the shared windows serially, in
+    /// sorted-path order. Merging per-file contexts instead would have to
+    /// resolve dedup collisions after the fact, and the winner would depend on
+    /// which worker finished first.
     nonisolated static func scanRollouts(
         directory: URL,
-        windows: inout ScanWindows<CodexScanContext>
+        windows: inout ScanWindows<CodexScanContext>,
+        width: Int = CostScanParallel.defaultWidth
     ) {
-        guard CostScanFileSystem.isLocalDirectory(directory) else { return }
-
-        guard let enumerator = FileManager.default.enumerator(
-            at: directory,
-            includingPropertiesForKeys: nil,
-            options: [.skipsHiddenFiles]
-        ) else {
-            return
-        }
-
         // The per-file mtime prefilter is gone on purpose: the lifetime window
         // needs every file, and the period window is still bounded by the
         // per-event timestamp check inside `ScanWindows.update` (an event is
         // never newer than the file holding it).
-        for case let fileURL as URL in enumerator where fileURL.pathExtension == "jsonl" {
-            // Reset per file: attribution carried across rollouts would label
-            // one session's spend with another's model.
-            var rollout = CodexRolloutContext()
-            // Codex emits a session's opening `token_count` events *before* its
-            // first `turn_context`, so forward-only attribution orphaned them
-            // even though the same file names the model seconds later. Park
-            // them here instead and back-fill once the file declares a model.
-            // Per file, like the rollout context: a sibling rollout's model
-            // must never name events this file left unexplained.
-            var deferred: [CodexDeferredUsage] = []
-            FileLineReader.forEachLine(in: fileURL) { line in
-                guard line.contains(Self.tokenCountMarker) else {
-                    Self.updateRolloutContext(&rollout, from: line)
-                    // Reaches back only as far as the *first* model the file
-                    // declares — a later mid-session switch must not relabel
-                    // the events that preceded it.
-                    if let model = rollout.turnModel ?? rollout.sessionModel {
-                        Self.flushDeferred(&deferred, modelName: model, windows: &windows)
-                    }
-                    return
+        let files = CostScanFileSystem.transcriptFiles(in: directory, options: [.skipsHiddenFiles])
+
+        CostScanParallel.parseInOrder(
+            files,
+            width: width,
+            parse: { Self.parseRollout(at: $0) },
+            fold: { events in
+                for event in events {
+                    Self.apply(event, windows: &windows)
                 }
-                Self.addTokenCountLine(
-                    line,
-                    fileURL: fileURL,
-                    rollout: rollout,
-                    deferred: &deferred,
-                    windows: &windows
-                )
             }
-            // Whatever the file never explained is genuinely unattributed.
-            Self.flushDeferred(&deferred, modelName: nil, windows: &windows)
+        )
+    }
+
+    /// Turns one rollout into the usage events it contributes, in the order the
+    /// serial scan would have applied them.
+    ///
+    /// Everything this reads is scoped to the single file — attribution carried
+    /// across rollouts would label one session's spend with another's model —
+    /// which is precisely why it is safe to run on a worker thread.
+    nonisolated static func parseRollout(at fileURL: URL) -> [CodexUsageEvent] {
+        var events: [CodexUsageEvent] = []
+        var rollout = CodexRolloutContext()
+        // Codex emits a session's opening `token_count` events *before* its
+        // first `turn_context`, so forward-only attribution orphaned them even
+        // though the same file names the model seconds later. Park them here
+        // instead and back-fill once the file declares a model. Per file, like
+        // the rollout context: a sibling rollout's model must never name events
+        // this file left unexplained.
+        var deferred: [CodexDeferredUsage] = []
+
+        FileLineReader.forEachLine(in: fileURL) { line in
+            guard line.contains(Self.tokenCountMarker) else {
+                Self.updateRolloutContext(&rollout, from: line)
+                // Reaches back only as far as the *first* model the file
+                // declares — a later mid-session switch must not relabel the
+                // events that preceded it.
+                if let model = rollout.turnModel ?? rollout.sessionModel {
+                    Self.flushDeferred(&deferred, modelName: model, into: &events)
+                }
+                return
+            }
+            Self.addTokenCountLine(
+                line,
+                fileURL: fileURL,
+                rollout: rollout,
+                deferred: &deferred,
+                events: &events
+            )
         }
+        // Whatever the file never explained is genuinely unattributed.
+        Self.flushDeferred(&deferred, modelName: nil, into: &events)
+        return events
     }
 
     /// Single-window entry point kept for callers that only care about one
@@ -193,14 +212,15 @@ enum CodexCostScanner {
     nonisolated static func scanRollouts(
         directory: URL,
         since cutoffDate: Date,
-        context: inout CodexScanContext
+        context: inout CodexScanContext,
+        width: Int = CostScanParallel.defaultWidth
     ) {
         var windows = ScanWindows(
             period: context,
             lifetime: CodexScanContext(earliestDate: Date(), latestDate: .distantPast),
             cutoff: cutoffDate
         )
-        Self.scanRollouts(directory: directory, windows: &windows)
+        Self.scanRollouts(directory: directory, windows: &windows, width: width)
         context = windows.period
     }
 
@@ -227,12 +247,12 @@ enum CodexCostScanner {
     nonisolated private static func flushDeferred(
         _ deferred: inout [CodexDeferredUsage],
         modelName: String?,
-        windows: inout ScanWindows<CodexScanContext>
+        into events: inout [CodexUsageEvent]
     ) {
         guard !deferred.isEmpty else { return }
 
         for pending in deferred {
-            Self.addUsage(
+            guard let event = Self.makeUsageEvent(
                 pending.usage,
                 timestamp: pending.timestamp,
                 sessionID: pending.sessionID,
@@ -240,9 +260,9 @@ enum CodexCostScanner {
                     modelName: modelName,
                     originName: pending.originName,
                     projectID: pending.projectID
-                ),
-                windows: &windows
-            )
+                )
+            ) else { continue }
+            events.append(event)
         }
         deferred.removeAll()
     }
@@ -252,7 +272,7 @@ enum CodexCostScanner {
         fileURL: URL,
         rollout: CodexRolloutContext,
         deferred: inout [CodexDeferredUsage],
-        windows: inout ScanWindows<CodexScanContext>
+        events: inout [CodexUsageEvent]
     ) {
         guard let json = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
               let timestampText = json["timestamp"] as? String,
@@ -288,7 +308,7 @@ enum CodexCostScanner {
             return
         }
 
-        Self.addUsage(
+        guard let event = Self.makeUsageEvent(
             usage,
             timestamp: timestamp,
             sessionID: sessionID,
@@ -296,9 +316,9 @@ enum CodexCostScanner {
                 modelName: modelName,
                 originName: originName,
                 projectID: projectID
-            ),
-            windows: &windows
-        )
+            )
+        ) else { return }
+        events.append(event)
     }
 
     nonisolated private static func eventPayload(
@@ -352,7 +372,7 @@ enum CodexCostScanner {
             let sessionID = Self.logValue("conversation.id", in: body)
                 ?? Self.logValue("thread.id", in: body)
                 ?? "codex"
-            Self.addUsage(
+            guard let event = Self.makeUsageEvent(
                 usage,
                 timestamp: timestamp,
                 sessionID: sessionID,
@@ -363,29 +383,59 @@ enum CodexCostScanner {
                     // all (issue #270) — always the explicit unknown bucket,
                     // never a guess.
                     projectID: CostProjectAttribution.unknownProjectID
-                ),
-                windows: &windows
-            )
+                )
+            ) else { continue }
+            // Same `eventKeys` set the rollouts filled, so a turn recorded in
+            // both places is still billed once.
+            Self.apply(event, windows: &windows)
         }
     }
 
-    /// Stays at five named parameters — SwiftLint's `function_parameter_count`
-    /// warns at seven and CI lints with `--strict` — because the cutoff travels
-    /// inside `ScanWindows` rather than as its own argument, and `modelName`/
+    /// Stays at four named parameters — SwiftLint's `function_parameter_count`
+    /// warns at seven and CI lints with `--strict` — because `modelName`/
     /// `originName`/`projectID` are bundled into one `CodexUsageAttribution`
     /// value instead of three separate parameters.
-    nonisolated private static func addUsage(
+    ///
+    /// Pulling the extraction out of `apply` is what lets a rollout be parsed
+    /// on a worker thread: `[String: Any]` is not `Sendable` and never leaves
+    /// the parse, while `CodexUsageEvent` is a plain value the fold can carry
+    /// back to the shared windows.
+    nonisolated private static func makeUsageEvent(
         _ usage: [String: Any],
         timestamp: Date,
         sessionID: String,
-        attribution: CodexUsageAttribution,
-        windows: inout ScanWindows<CodexScanContext>
-    ) {
+        attribution: CodexUsageAttribution
+    ) -> CodexUsageEvent? {
         let input = CostScanValues.int(usage["input_tokens"])
         let cached = CostScanValues.int(usage["cached_input_tokens"])
         let output = CostScanValues.int(usage["output_tokens"])
         let reasoning = CostScanValues.int(usage["reasoning_output_tokens"])
-        guard input > 0 || output > 0 || cached > 0 || reasoning > 0 else { return }
+        guard input > 0 || output > 0 || cached > 0 || reasoning > 0 else { return nil }
+
+        return CodexUsageEvent(
+            timestamp: timestamp,
+            sessionID: sessionID,
+            input: input,
+            cached: cached,
+            output: output,
+            reasoning: reasoning,
+            attribution: attribution
+        )
+    }
+
+    /// Folds one usage event into both windows. Serial by construction: the
+    /// dedup below is first-event-wins across every file, so the order events
+    /// arrive here is the order that decides the answer.
+    nonisolated private static func apply(
+        _ event: CodexUsageEvent,
+        windows: inout ScanWindows<CodexScanContext>
+    ) {
+        let timestamp = event.timestamp
+        let sessionID = event.sessionID
+        let input = event.input
+        let cached = event.cached
+        let output = event.output
+        let reasoning = event.reasoning
 
         // Use whole-millisecond precision for the dedup key so equivalent events
         // produce a stable, collision-resistant string (raw Double formatting can
@@ -393,9 +443,9 @@ enum CodexCostScanner {
         let timestampMillis = Int((timestamp.timeIntervalSince1970 * 1000).rounded())
         let key = "\(timestampMillis)-\(sessionID)-\(input)-\(cached)-\(output)-\(reasoning)"
         let day = Calendar.current.startOfDay(for: timestamp)
-        let modelKey = CostScanValues.displayModelName(attribution.modelName)
-        let originKey = CostScanValues.displayOriginName(attribution.originName)
-        let projectKey = attribution.projectID
+        let modelKey = CostScanValues.displayModelName(event.attribution.modelName)
+        let originKey = CostScanValues.displayOriginName(event.attribution.originName)
+        let projectKey = event.attribution.projectID
 
         // Each window keeps its own `eventKeys`, so an event that lands in both
         // is deduplicated independently in each — exactly what the two separate
@@ -520,14 +570,10 @@ nonisolated struct CodexRolloutContext: Sendable {
     var cwd: String?
 }
 
-/// Bundles the three "who/what/where" labels a single usage event needs so
-/// `addUsage` can stay under SwiftLint's `function_parameter_count` limit
-/// (issue #270 added `projectID` as the third label alongside the pre-existing
-/// model/origin pair).
 /// A `token_count` event parked because its rollout has not named a model yet.
 ///
 /// Deliberately not `Sendable`: it carries the raw `[String: Any]` usage
-/// payload. It never outlives the single-threaded scan of the file that made
+/// payload. It never outlives the single-threaded parse of the file that made
 /// it, so it does not need to be.
 nonisolated struct CodexDeferredUsage {
     let usage: [String: Any]
@@ -537,8 +583,30 @@ nonisolated struct CodexDeferredUsage {
     let projectID: String
 }
 
+/// Bundles the three "who/what/where" labels a single usage event needs so
+/// `makeUsageEvent` can stay under SwiftLint's `function_parameter_count` limit
+/// (issue #270 added `projectID` as the third label alongside the pre-existing
+/// model/origin pair).
 nonisolated struct CodexUsageAttribution: Sendable {
     let modelName: String?
     let originName: String?
     let projectID: String
+}
+
+/// One usage event, extracted from a rollout line or a SQLite log row and ready
+/// to fold into a `CodexScanContext`.
+///
+/// This is the boundary between the parallel half of the scan and the serial
+/// half: rollouts are parsed into these on worker threads, then applied to the
+/// shared windows one at a time, in file order. It holds only value types so it
+/// can cross that boundary — the raw `[String: Any]` payload it came from stays
+/// behind on the worker.
+nonisolated struct CodexUsageEvent: Sendable {
+    let timestamp: Date
+    let sessionID: String
+    let input: Int
+    let cached: Int
+    let output: Int
+    let reasoning: Int
+    let attribution: CodexUsageAttribution
 }

--- a/MeterBar/Services/CostProjectAttribution.swift
+++ b/MeterBar/Services/CostProjectAttribution.swift
@@ -89,11 +89,23 @@ enum CostProjectAttribution {
     /// Home directory without a trailing separator. Both `sanitize` overloads
     /// append their own boundary character, so a `HOME` that happens to end in
     /// "/" would otherwise never match and send every session to `unknown`.
-    nonisolated private static func homeDirectory() -> String {
+    ///
+    /// Resolved once per process rather than per call. `realHomeDirectory()`
+    /// goes through `getpwuid`, which leaves its result in a shared static
+    /// object and is not safe to call from several threads at once — and both
+    /// scanners now reach this from worker threads, once per Claude transcript
+    /// and once per Codex usage event. The value cannot change while the
+    /// process runs, so a `static let` (initialized exactly once, under the
+    /// runtime's own lock) is both the safe answer and strictly less work.
+    nonisolated private static let cachedHomeDirectory: String = {
         var home = ServiceSupport.realHomeDirectory()
         while home.count > 1, home.hasSuffix("/") {
             home.removeLast()
         }
         return home
+    }()
+
+    nonisolated private static func homeDirectory() -> String {
+        cachedHomeDirectory
     }
 }

--- a/MeterBar/Services/CostScanFileSystem.swift
+++ b/MeterBar/Services/CostScanFileSystem.swift
@@ -17,4 +17,34 @@ enum CostScanFileSystem {
         // fast and avoid surprising remote I/O when users point accounts there.
         return values?.volumeIsLocal != false
     }
+
+    /// Every `.jsonl` transcript under `root`, sorted by path.
+    ///
+    /// The scanners used to parse straight out of the enumerator. Collecting
+    /// first is what lets the parse fan out, and the sort is what keeps the
+    /// answer stable: `FileManager` yields directory entries in whatever order
+    /// the volume hands them back, and both scanners have order-sensitive
+    /// results — Codex deduplicates first-event-wins, and summing `Double`
+    /// costs is not associative. Sorted input means two scans of the same tree
+    /// agree bit for bit, sequential or parallel.
+    ///
+    /// Directory-ness is not checked here. A directory named `foo.jsonl` simply
+    /// fails to open in the reader, the same as any other unreadable file.
+    nonisolated static func transcriptFiles(
+        in root: URL,
+        options: FileManager.DirectoryEnumerationOptions
+    ) -> [URL] {
+        guard isLocalDirectory(root) else { return [] }
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: options
+        ) else { return [] }
+
+        var files: [URL] = []
+        for case let url as URL in enumerator where url.pathExtension == "jsonl" {
+            files.append(url)
+        }
+        return files.sorted { $0.path < $1.path }
+    }
 }

--- a/MeterBar/Services/CostScanParallel.swift
+++ b/MeterBar/Services/CostScanParallel.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+/// Bounded, order-preserving fan-out for the per-file half of a cost scan.
+///
+/// Both scanners walk thousands of transcripts and parse each one in complete
+/// isolation, so the *parse* is embarrassingly parallel. The *fold* is not:
+/// `ClaudeSessionTotals` sums `Double` costs (floating-point addition is not
+/// associative) and `CodexScanContext` deduplicates first-event-wins, so a
+/// different arrival order is a different answer. Parsing concurrently while
+/// handing results back strictly in input order keeps the output identical to
+/// the sequential scan, bit for bit.
+///
+/// The scanners stay synchronous rather than becoming `async`:
+/// `CostSummaryBuilder.makeSummary` calls them straight through, already off the
+/// main actor inside `CostTracker`'s `Task.detached`, and an `async` signature
+/// would push that hop up into every caller.
+nonisolated enum CostScanParallel {
+    /// One worker per core. The scan is file I/O plus JSON parsing, so
+    /// oversubscribing buys nothing, and every in-flight file holds a
+    /// `FileLineReader` chunk resident.
+    static var defaultWidth: Int {
+        max(1, ProcessInfo.processInfo.activeProcessorCount)
+    }
+
+    /// How far ahead of the fold the workers may run, as a multiple of the
+    /// width. Peak memory is `width × lookaheadMultiplier` parsed results plus
+    /// `width` reader chunks — bounded, rather than "one parsed result per file
+    /// in the tree".
+    private static let lookaheadMultiplier = 4
+
+    /// Runs `parse` over `inputs` — at most `width` at a time — and calls
+    /// `fold` once per input, on the calling thread, in input order.
+    ///
+    /// `parse` escapes onto the worker queue, so it must be `@Sendable`.
+    /// `fold` is deliberately neither: it runs serially on the caller's thread,
+    /// which is what lets it capture and mutate an `inout` accumulator.
+    static func parseInOrder<Input: Sendable, Parsed: Sendable>(
+        _ inputs: [Input],
+        width: Int,
+        parse: @escaping @Sendable (Input) -> Parsed,
+        fold: (Parsed) -> Void
+    ) {
+        let width = max(1, width)
+        guard width > 1, inputs.count > 1 else {
+            for input in inputs {
+                fold(parse(input))
+            }
+            return
+        }
+
+        // A pipeline rather than parse-a-batch/fold-a-batch. Transcript sizes
+        // are wildly skewed — a handful carry base64 payloads orders of
+        // magnitude larger than the median — so any batch barrier parks the
+        // whole pool behind one giant file. Here a straggler only stalls the
+        // fold; the other workers keep pulling files until they are
+        // `lookahead` results ahead, which is also what bounds memory.
+        let pipeline = ParsePipeline<Parsed>(
+            count: inputs.count,
+            lookahead: width * Self.lookaheadMultiplier
+        )
+        let queue = DispatchQueue(
+            label: "dev.meterbar.cost-scan.parse",
+            qos: .utility,
+            attributes: .concurrent
+        )
+        let group = DispatchGroup()
+
+        for _ in 0..<min(width, inputs.count) {
+            queue.async(group: group) {
+                while let index = pipeline.claim() {
+                    pipeline.deliver(parse(inputs[index]), at: index)
+                }
+            }
+        }
+
+        for index in 0..<inputs.count {
+            // `take` blocks until index `index` has been parsed, so the fold
+            // sees exactly the sequential order. The optional is a formality —
+            // it only returns after the slot is filled — but it keeps this
+            // free of a force-unwrap.
+            guard let parsed = pipeline.take(index) else { continue }
+            fold(parsed)
+        }
+        group.wait()
+    }
+}
+
+/// Work queue and ordered hand-off between the parsing workers and the folding
+/// caller.
+///
+/// `@unchecked Sendable` over a lock matches the existing pattern in `WakeLock`,
+/// `ManagedProcess.BoundedSink`, and `ServeRateLimiter`; this one uses
+/// `NSCondition` because both sides need to block — workers on the lookahead
+/// limit, the folder on the next result.
+nonisolated private final class ParsePipeline<Value>: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var values: [Value?]
+    private var nextClaim = 0
+    private var nextFold = 0
+    private let lookahead: Int
+
+    init(count: Int, lookahead: Int) {
+        values = Array(repeating: nil, count: count)
+        self.lookahead = max(1, lookahead)
+    }
+
+    /// The next unclaimed index, or `nil` once every input has been handed out.
+    ///
+    /// Blocks while the workers are already `lookahead` results ahead of the
+    /// fold, which is what keeps parsed results from piling up faster than they
+    /// are consumed.
+    func claim() -> Int? {
+        condition.lock()
+        defer { condition.unlock() }
+
+        while true {
+            guard nextClaim < values.count else { return nil }
+            if nextClaim < nextFold + lookahead {
+                let index = nextClaim
+                nextClaim += 1
+                return index
+            }
+            condition.wait()
+        }
+    }
+
+    func deliver(_ value: Value, at index: Int) {
+        condition.lock()
+        defer { condition.unlock() }
+        values[index] = value
+        condition.broadcast()
+    }
+
+    /// Waits for index `index` to be parsed, then removes it.
+    ///
+    /// Dropping the reference here rather than at the end of the scan is what
+    /// makes the lookahead a real memory bound: a folded result is released
+    /// immediately instead of being retained until the last file is done.
+    ///
+    /// Cannot deadlock: the folder only waits on the index it is folding, and
+    /// that index is always inside the lookahead window (`nextFold + lookahead`
+    /// is strictly greater than `nextFold`), so a worker is always free to
+    /// claim it.
+    func take(_ index: Int) -> Value? {
+        condition.lock()
+        defer { condition.unlock() }
+
+        while values[index] == nil {
+            condition.wait()
+        }
+        let value = values[index]
+        values[index] = nil
+        nextFold = index + 1
+        condition.broadcast()
+        return value
+    }
+}

--- a/MeterBarTests/CostScanConcurrencyTests.swift
+++ b/MeterBarTests/CostScanConcurrencyTests.swift
@@ -1,0 +1,594 @@
+import XCTest
+@testable import MeterBar
+
+/// Covers the concurrency layer sitting on top of the two cost scanners: files
+/// are parsed in parallel, but their results are folded serially in input
+/// order.
+///
+/// Every scan here runs twice over the same fixtures — once at `width: 1`
+/// (which takes the plain sequential path) and once wide — and asserts the two
+/// agree exactly, down to the bit pattern of every accumulated `Double`. That
+/// is the property the parallel scan has to preserve: floating-point addition
+/// is not associative, and Codex's dedup is first-event-wins, so "same totals"
+/// is only true if the fold order is pinned.
+final class CostScanConcurrencyTests: XCTestCase {
+    /// Wide enough to interleave on any machine the suite runs on, and not tied
+    /// to `activeProcessorCount` so the test means the same thing on a laptop
+    /// and on CI.
+    private let wide = 8
+
+    // MARK: - Claude
+
+    func testClaudeParallelScanMatchesSequentialScan() throws {
+        let root = try makeClaudeProjectsRoot()
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-15T00:00:00Z"))
+
+        // Enough files to spill past a single batch, spread over several
+        // projects, models, origins, and days — the parallel fold has to
+        // reproduce every one of those breakdowns, not just the grand total.
+        for index in 0..<60 {
+            let project = "www/demo-\(index % 4)"
+            let day = 10 + (index % 12)
+            try writeClaudeTranscript(in: root, project: project, name: "session-\(index).jsonl", lines: [
+                claudeEventLine(
+                    timestamp: "2026-06-\(day)T09:00:00.000Z",
+                    messageID: "msg-\(index)-a",
+                    requestID: "req-\(index)-a",
+                    model: index.isMultiple(of: 2) ? "claude-sonnet-4-5" : "claude-opus-4-1",
+                    input: 100 + index,
+                    output: 7 * index
+                ),
+                claudeEventLine(
+                    timestamp: "2026-06-\(day)T09:05:00.000Z",
+                    messageID: "msg-\(index)-b",
+                    requestID: "req-\(index)-b",
+                    model: "claude-haiku-4-5",
+                    input: 3,
+                    output: 11,
+                    toolName: index.isMultiple(of: 3) ? "Skill" : "Bash"
+                ),
+                // Unkeyed: no messageID/requestID, so it never enters the dedup
+                // map and is tallied in append order.
+                claudeEventLine(
+                    timestamp: "2026-06-\(day)T09:07:00.000Z",
+                    messageID: nil,
+                    requestID: nil,
+                    input: 1,
+                    output: 1
+                )
+            ])
+        }
+
+        let sequential = ClaudeCostScanner.scanSessions(since: cutoff, projectRoots: [root], width: 1)
+        let parallel = ClaudeCostScanner.scanSessions(since: cutoff, projectRoots: [root], width: wide)
+
+        XCTAssertGreaterThan(parallel.lifetime.input, 0, "fixture produced no usage")
+        XCTAssertEqual(snapshot(parallel), snapshot(sequential))
+        XCTAssertEqual(
+            try claudeBreakdownJSON(parallel, cutoff: cutoff),
+            try claudeBreakdownJSON(sequential, cutoff: cutoff)
+        )
+    }
+
+    func testClaudeDeduplicationSurvivesTheParallelFold() throws {
+        let root = try makeClaudeProjectsRoot()
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-15T00:00:00Z"))
+
+        // The same messageID:requestID retried either side of the cutoff. The
+        // two windows keep separate dedup maps, so the period must see only the
+        // in-window copy while lifetime collapses the pair to one event.
+        try writeClaudeTranscript(in: root, project: "www/demo", name: "straddle.jsonl", lines: [
+            claudeEventLine(timestamp: "2026-06-14T23:59:00.000Z", input: 100, output: 50),
+            claudeEventLine(timestamp: "2026-06-15T00:01:00.000Z", input: 100, output: 50)
+        ])
+        // A duplicate of the same key in a *different* file: Claude dedups per
+        // file, so this is a second billed event, and the parallel fold must
+        // not "improve" on that.
+        try writeClaudeTranscript(in: root, project: "www/other", name: "copy.jsonl", lines: [
+            claudeEventLine(timestamp: "2026-06-16T00:01:00.000Z", input: 100, output: 50)
+        ])
+
+        for width in [1, wide] {
+            let windows = ClaudeCostScanner.scanSessions(since: cutoff, projectRoots: [root], width: width)
+            XCTAssertEqual(windows.period.input, 200, "width \(width)")
+            XCTAssertEqual(windows.period.output, 100, "width \(width)")
+            XCTAssertEqual(windows.lifetime.input, 200, "width \(width)")
+            XCTAssertEqual(windows.lifetime.output, 100, "width \(width)")
+        }
+
+        let sequential = ClaudeCostScanner.scanSessions(since: cutoff, projectRoots: [root], width: 1)
+        let parallel = ClaudeCostScanner.scanSessions(since: cutoff, projectRoots: [root], width: wide)
+        XCTAssertEqual(snapshot(parallel), snapshot(sequential))
+    }
+
+    func testClaudeScanSurvivesUnreadableAndMalformedTranscripts() throws {
+        let root = try makeClaudeProjectsRoot()
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+
+        try writeClaudeTranscript(in: root, project: "www/demo", name: "good.jsonl", lines: [
+            claudeEventLine(timestamp: "2026-06-15T10:00:00.000Z", input: 100, output: 50)
+        ])
+        try writeClaudeTranscript(in: root, project: "www/demo", name: "garbage.jsonl", lines: [
+            "not json at all",
+            "{\"timestamp\": \"2026-06-15T10:00:00.000Z\", \"message\": {",
+            ""
+        ])
+        try writeUnreadableFile(at: root.appendingPathComponent("-x/locked.jsonl"))
+        // A *directory* that looks like a transcript: the enumerator hands it
+        // over, the reader can't open it, and the scan has to keep going.
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("-x/folder.jsonl", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        for width in [1, wide] {
+            let windows = ClaudeCostScanner.scanSessions(since: cutoff, projectRoots: [root], width: width)
+            XCTAssertEqual(windows.lifetime.input, 100, "width \(width)")
+            XCTAssertEqual(windows.lifetime.output, 50, "width \(width)")
+            XCTAssertEqual(windows.lifetime.sessions, 1, "width \(width)")
+        }
+    }
+
+    func testClaudeSessionCountsOneSessionPerTranscriptWithUsage() throws {
+        let root = try makeClaudeProjectsRoot()
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+
+        for index in 0..<3 {
+            try writeClaudeTranscript(in: root, project: "www/demo", name: "used-\(index).jsonl", lines: [
+                claudeEventLine(
+                    timestamp: "2026-06-15T10:00:00.000Z",
+                    messageID: "msg-\(index)",
+                    requestID: "req-\(index)",
+                    input: 10,
+                    output: 5
+                )
+            ])
+        }
+        try writeClaudeTranscript(in: root, project: "www/demo", name: "empty.jsonl", lines: [])
+        try writeClaudeTranscript(in: root, project: "www/demo", name: "zero.jsonl", lines: [
+            claudeEventLine(timestamp: "2026-06-15T10:00:00.000Z", messageID: "z", requestID: "z", input: 0, output: 0)
+        ])
+
+        for width in [1, wide] {
+            let windows = ClaudeCostScanner.scanSessions(since: cutoff, projectRoots: [root], width: width)
+            XCTAssertEqual(windows.lifetime.sessions, 3, "width \(width)")
+            XCTAssertEqual(windows.period.sessions, 3, "width \(width)")
+        }
+    }
+
+    // MARK: - Codex
+
+    func testCodexParallelScanMatchesSequentialScan() throws {
+        let directory = try makeTemporaryDirectory(named: "CodexRollouts")
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-15T00:00:00Z"))
+        let home = ServiceSupport.realHomeDirectory()
+
+        for index in 0..<40 {
+            let day = 10 + (index % 12)
+            try writeCodexRollout(in: directory, path: "2026/06/\(day)/rollout-\(index).jsonl", lines: [
+                codexSessionMetaLine(
+                    timestamp: "2026-06-\(day)T08:00:00Z",
+                    conversationID: "conv-\(index)",
+                    originator: index.isMultiple(of: 3) ? "Codex Desktop" : "codex_cli_rs",
+                    cwd: "\(home)/www/demo-\(index % 4)"
+                ),
+                // Lands before the file names a model, so it is parked and
+                // back-filled — order-sensitive state the parallel parse has to
+                // keep strictly inside its own file.
+                codexUsageLine(
+                    timestamp: "2026-06-\(day)T08:30:00Z",
+                    conversationID: "conv-\(index)",
+                    input: 500 + index,
+                    output: 20 + index
+                ),
+                codexTurnContextLine(
+                    timestamp: "2026-06-\(day)T09:00:00Z",
+                    model: index.isMultiple(of: 2) ? "gpt-5.5" : "gpt-5.5-codex"
+                ),
+                codexUsageLine(
+                    timestamp: "2026-06-\(day)T09:30:00Z",
+                    conversationID: "conv-\(index)",
+                    input: 1_000 + index,
+                    output: 500 + index
+                )
+            ])
+        }
+
+        var sequential = CodexCostScanner.scanWindows(cutoff: cutoff)
+        CodexCostScanner.scanRollouts(directory: directory, windows: &sequential, width: 1)
+        var parallel = CodexCostScanner.scanWindows(cutoff: cutoff)
+        CodexCostScanner.scanRollouts(directory: directory, windows: &parallel, width: wide)
+
+        XCTAssertGreaterThan(parallel.lifetime.totals.input, 0, "fixture produced no usage")
+        XCTAssertEqual(snapshot(parallel), snapshot(sequential))
+    }
+
+    func testCodexDeduplicationStaysGlobalAcrossFiles() throws {
+        let directory = try makeTemporaryDirectory(named: "CodexRollouts")
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-15T00:00:00Z"))
+
+        // Codex dedups on timestamp+session+counts across *every* file, unlike
+        // Claude's per-file map, so the same event copied into a sibling
+        // rollout must still be billed once however the files are parsed.
+        let duplicate = codexTokenLine(timestamp: "2026-06-16T10:00:00Z")
+        try writeCodexRollout(in: directory, path: "a.jsonl", lines: [duplicate])
+        try writeCodexRollout(in: directory, path: "b.jsonl", lines: [duplicate])
+        // Before the cutoff: lifetime only, and deduplicated independently of
+        // the period window's own key set.
+        let old = codexTokenLine(timestamp: "2026-06-01T10:00:00Z", input: 77, output: 33)
+        try writeCodexRollout(in: directory, path: "c.jsonl", lines: [old])
+        try writeCodexRollout(in: directory, path: "d.jsonl", lines: [old])
+
+        for width in [1, wide] {
+            var windows = CodexCostScanner.scanWindows(cutoff: cutoff)
+            CodexCostScanner.scanRollouts(directory: directory, windows: &windows, width: width)
+
+            XCTAssertEqual(windows.period.totals.input, 1_000, "width \(width)")
+            XCTAssertEqual(windows.period.totals.output, 500, "width \(width)")
+            XCTAssertEqual(windows.lifetime.totals.input, 1_077, "width \(width)")
+            XCTAssertEqual(windows.lifetime.totals.output, 533, "width \(width)")
+        }
+
+        var sequential = CodexCostScanner.scanWindows(cutoff: cutoff)
+        CodexCostScanner.scanRollouts(directory: directory, windows: &sequential, width: 1)
+        var parallel = CodexCostScanner.scanWindows(cutoff: cutoff)
+        CodexCostScanner.scanRollouts(directory: directory, windows: &parallel, width: wide)
+        XCTAssertEqual(snapshot(parallel), snapshot(sequential))
+    }
+
+    func testCodexScanSurvivesUnreadableAndMalformedRollouts() throws {
+        let directory = try makeTemporaryDirectory(named: "CodexRollouts")
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+
+        try writeCodexRollout(in: directory, path: "good.jsonl", lines: [
+            codexTokenLine(timestamp: "2026-06-15T10:00:00Z")
+        ])
+        try writeCodexRollout(in: directory, path: "garbage.jsonl", lines: [
+            "not json at all",
+            "{\"payload\": {\"type\": \"token_count\"",
+            ""
+        ])
+        try writeUnreadableFile(at: directory.appendingPathComponent("locked.jsonl"))
+        try FileManager.default.createDirectory(
+            at: directory.appendingPathComponent("folder.jsonl", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        for width in [1, wide] {
+            var windows = CodexCostScanner.scanWindows(cutoff: cutoff)
+            CodexCostScanner.scanRollouts(directory: directory, windows: &windows, width: width)
+
+            XCTAssertEqual(windows.lifetime.totals.input, 1_000, "width \(width)")
+            XCTAssertEqual(windows.lifetime.totals.output, 500, "width \(width)")
+            XCTAssertEqual(windows.lifetime.sessionIDs, ["conv-1"], "width \(width)")
+        }
+    }
+
+    func testCodexSessionCountsStayPerConversation() throws {
+        let directory = try makeTemporaryDirectory(named: "CodexRollouts")
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+
+        for index in 0..<5 {
+            try writeCodexRollout(in: directory, path: "rollout-\(index).jsonl", lines: [
+                codexTokenLine(
+                    timestamp: "2026-06-15T10:0\(index):00Z",
+                    conversationID: "conv-\(index)",
+                    input: 100 + index,
+                    output: 10
+                )
+            ])
+        }
+        // Same conversation split across two rollouts: one session, not two.
+        try writeCodexRollout(in: directory, path: "rollout-split.jsonl", lines: [
+            codexTokenLine(timestamp: "2026-06-15T11:00:00Z", conversationID: "conv-0", input: 5, output: 5)
+        ])
+
+        for width in [1, wide] {
+            var windows = CodexCostScanner.scanWindows(cutoff: cutoff)
+            CodexCostScanner.scanRollouts(directory: directory, windows: &windows, width: width)
+            XCTAssertEqual(windows.lifetime.sessionIDs.count, 5, "width \(width)")
+        }
+    }
+
+    // MARK: - Fan-out helper
+
+    func testParseInOrderVisitsEveryInputExactlyOnceInOrder() {
+        let inputs = Array(0..<257)
+
+        for width in [1, 2, 3, wide, 64] {
+            var folded: [Int] = []
+            CostScanParallel.parseInOrder(
+                inputs,
+                width: width,
+                parse: { $0 * 2 },
+                fold: { folded.append($0) }
+            )
+            XCTAssertEqual(folded, inputs.map { $0 * 2 }, "width \(width)")
+        }
+    }
+
+    func testParseInOrderToleratesEmptyInputAndNonPositiveWidth() {
+        var folded: [Int] = []
+        CostScanParallel.parseInOrder([Int](), width: wide, parse: { $0 }, fold: { folded.append($0) })
+        XCTAssertEqual(folded, [])
+
+        CostScanParallel.parseInOrder([1, 2, 3], width: 0, parse: { $0 }, fold: { folded.append($0) })
+        XCTAssertEqual(folded, [1, 2, 3])
+    }
+}
+
+// MARK: - Fixtures
+
+extension CostScanConcurrencyTests {
+    private func makeTemporaryDirectory(named prefix: String) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+
+    private func makeClaudeProjectsRoot() throws -> URL {
+        try makeTemporaryDirectory(named: "ClaudeProjects")
+    }
+
+    /// Claude stores transcripts under `<root>/<encoded-cwd>/<session>.jsonl`,
+    /// and `CostProjectAttribution` only recognizes an encoded directory that
+    /// starts with the real home directory — so the fixture has to encode it
+    /// the same way the CLI does.
+    private func encodedProjectDirectory(for project: String) -> String {
+        let home = ServiceSupport.realHomeDirectory()
+        let encodedHome = "-" + home.split(separator: "/").joined(separator: "-")
+        return encodedHome + "-" + project.replacingOccurrences(of: "/", with: "-")
+    }
+
+    private func writeClaudeTranscript(in root: URL, project: String, name: String, lines: [String]) throws {
+        let directory = root.appendingPathComponent(encodedProjectDirectory(for: project), isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try lines.joined(separator: "\n")
+            .write(to: directory.appendingPathComponent(name), atomically: true, encoding: .utf8)
+    }
+
+    private func claudeEventLine(
+        timestamp: String,
+        messageID: String? = "msg_1",
+        requestID: String? = "req_1",
+        model: String = "claude-sonnet-4-5",
+        input: Int = 100,
+        output: Int = 50,
+        toolName: String? = nil
+    ) -> String {
+        let idPart = messageID.map { "\"id\": \"\($0)\"," } ?? ""
+        let requestPart = requestID.map { "\"requestId\": \"\($0)\"," } ?? ""
+        let contentPart = toolName.map {
+            "\"content\": [{\"type\": \"tool_use\", \"name\": \"\($0)\"}],"
+        } ?? ""
+        return """
+        {"timestamp": "\(timestamp)", \(requestPart) "message": {\(idPart) "model": "\(model)", \
+        \(contentPart) "usage": {"input_tokens": \(input), "output_tokens": \(output), \
+        "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}}
+        """
+    }
+
+    private func writeCodexRollout(in root: URL, path: String, lines: [String]) throws {
+        let url = root.appendingPathComponent(path)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private func codexSessionMetaLine(
+        timestamp: String,
+        conversationID: String = "conv-1",
+        originator: String = "Codex Desktop",
+        cwd: String? = nil
+    ) -> String {
+        let cwdPart = cwd.map { "\"cwd\": \"\($0)\"," } ?? ""
+        return """
+        {"timestamp": "\(timestamp)", "type": "session_meta", "payload": \
+        {"id": "\(conversationID)", "originator": "\(originator)", \(cwdPart) "cli_version": "0.0.0"}}
+        """
+    }
+
+    private func codexTurnContextLine(timestamp: String, model: String) -> String {
+        """
+        {"timestamp": "\(timestamp)", "type": "turn_context", "payload": \
+        {"model": "\(model)", "effort": "high", "summary": "auto"}}
+        """
+    }
+
+    /// A `token_count` event with no model on it — attribution has to come from
+    /// the surrounding rollout.
+    private func codexUsageLine(
+        timestamp: String,
+        conversationID: String = "conv-1",
+        input: Int = 1_000,
+        output: Int = 500
+    ) -> String {
+        """
+        {"timestamp": "\(timestamp)", "type": "event_msg", "payload": {"type": "token_count", \
+        "rate_limits": {"conversation_id": "\(conversationID)"}, \
+        "info": {"last_token_usage": \
+        {"input_tokens": \(input), "output_tokens": \(output), \
+        "cached_input_tokens": 200, "reasoning_output_tokens": 50}}}}
+        """
+    }
+
+    /// A `token_count` event that names its own model.
+    private func codexTokenLine(
+        timestamp: String,
+        conversationID: String = "conv-1",
+        model: String = "gpt-5.5",
+        input: Int = 1_000,
+        output: Int = 500
+    ) -> String {
+        """
+        {"timestamp": "\(timestamp)", "payload": {"type": "token_count", \
+        "rate_limits": {"conversation_id": "\(conversationID)"}, \
+        "info": {"model": "\(model)", "last_token_usage": \
+        {"input_tokens": \(input), "output_tokens": \(output), \
+        "cached_input_tokens": 200, "reasoning_output_tokens": 50}}}}
+        """
+    }
+
+    /// A transcript the scan can see but not open. Restored to readable on
+    /// teardown so the temp directory can be removed.
+    private func writeUnreadableFile(at url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "{\"timestamp\": \"2026-06-15T10:00:00.000Z\"}".write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: url.path)
+        addTeardownBlock {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: url.path)
+        }
+    }
+}
+
+// MARK: - Snapshots
+
+extension CostScanConcurrencyTests {
+    /// Flattens a window pair into plain strings so `XCTAssertEqual` prints a
+    /// usable diff instead of two walls of nested dictionaries.
+    private func snapshot(_ windows: ScanWindows<ClaudeSessionTotals>) -> [String: String] {
+        prefixed("period", snapshot(windows.period))
+            .merging(prefixed("lifetime", snapshot(windows.lifetime))) { lhs, _ in lhs }
+    }
+
+    private func snapshot(_ windows: ScanWindows<CodexScanContext>) -> [String: String] {
+        prefixed("period", snapshot(windows.period))
+            .merging(prefixed("lifetime", snapshot(windows.lifetime))) { lhs, _ in lhs }
+    }
+
+    private func snapshot(_ totals: ClaudeSessionTotals) -> [String: String] {
+        var result: [String: String] = [
+            "input": "\(totals.input)",
+            "output": "\(totals.output)",
+            "cacheCreation": "\(totals.cacheCreation)",
+            "cacheRead": "\(totals.cacheRead)",
+            "estimatedCost": exact(totals.estimatedCost),
+            "sessions": "\(totals.sessions)",
+            "earliest": describe(totals.earliest),
+            "latest": describe(totals.latest)
+        ]
+        merge(&result, "daily", totals.daily)
+        merge(&result, "models", totals.models)
+        merge(&result, "origins", totals.origins)
+        merge(&result, "projects", totals.projects)
+        merge(&result, "dailyModels", totals.dailyModels)
+        merge(&result, "dailyProjects", totals.dailyProjects)
+        merge(&result, "projectModels", totals.projectModels)
+        merge(&result, "dailyProjectModels", totals.dailyProjectModels)
+        return result
+    }
+
+    private func snapshot(_ context: CodexScanContext) -> [String: String] {
+        var result: [String: String] = [
+            "totals": describe(context.totals),
+            "sessionIDs": context.sessionIDs.sorted().joined(separator: ","),
+            "eventKeys": context.eventKeys.sorted().joined(separator: ","),
+            "earliest": describe(context.earliestDate),
+            "latest": describe(context.latestDate)
+        ]
+        merge(&result, "daily", context.dailyTotals)
+        merge(&result, "models", context.modelTotals)
+        merge(&result, "origins", context.originTotals)
+        merge(&result, "projects", context.projectTotals)
+        merge(&result, "dailyModels", context.dailyModelTotals)
+        merge(&result, "dailyProjects", context.dailyProjectTotals)
+        merge(&result, "projectModels", context.projectModelTotals)
+        merge(&result, "dailyProjectModels", context.dailyProjectModelTotals)
+        return result
+    }
+
+    /// The per-model / per-origin / per-project / per-day breakdowns exactly as
+    /// the summary publishes them, not just the accumulators behind them.
+    private func claudeBreakdownJSON(
+        _ windows: ScanWindows<ClaudeSessionTotals>,
+        cutoff: Date
+    ) throws -> String {
+        let scan = try XCTUnwrap(ClaudeCostScanner.makeCost(from: windows.period, windowStart: cutoff))
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let cost = try encoder.encode([
+            scan.0.modelBreakdowns,
+            scan.0.originBreakdowns,
+            scan.0.projectBreakdowns
+        ])
+        let daily = try encoder.encode(scan.1.sorted { $0.date < $1.date })
+        return String(decoding: cost + daily, as: UTF8.self)
+    }
+
+    private func prefixed(_ prefix: String, _ values: [String: String]) -> [String: String] {
+        var result: [String: String] = [:]
+        for (key, value) in values {
+            result["\(prefix).\(key)"] = value
+        }
+        return result
+    }
+
+    private func merge(_ result: inout [String: String], _ label: String, _ values: [String: TokenAccumulator]) {
+        for (name, tokens) in values {
+            result["\(label)|\(name)"] = describe(tokens)
+        }
+    }
+
+    private func merge(_ result: inout [String: String], _ label: String, _ values: [Date: TokenAccumulator]) {
+        for (day, tokens) in values {
+            result["\(label)|\(describe(day))"] = describe(tokens)
+        }
+    }
+
+    private func merge(
+        _ result: inout [String: String],
+        _ label: String,
+        _ values: [String: [String: TokenAccumulator]]
+    ) {
+        for (outer, inner) in values {
+            merge(&result, "\(label)|\(outer)", inner)
+        }
+    }
+
+    private func merge(
+        _ result: inout [String: String],
+        _ label: String,
+        _ values: [Date: [String: TokenAccumulator]]
+    ) {
+        for (day, inner) in values {
+            merge(&result, "\(label)|\(describe(day))", inner)
+        }
+    }
+
+    private func merge(
+        _ result: inout [String: String],
+        _ label: String,
+        _ values: [Date: [String: [String: TokenAccumulator]]]
+    ) {
+        for (day, inner) in values {
+            merge(&result, "\(label)|\(describe(day))", inner)
+        }
+    }
+
+    private func describe(_ tokens: TokenAccumulator) -> String {
+        [
+            "\(tokens.input)", "\(tokens.output)", "\(tokens.cacheCreation)",
+            "\(tokens.cacheRead)", "\(tokens.reasoning)", "\(tokens.events)",
+            exact(tokens.estimatedCostUSD)
+        ].joined(separator: "/")
+    }
+
+    private func describe(_ date: Date?) -> String {
+        guard let date else { return "nil" }
+        return "\(date.timeIntervalSince1970)"
+    }
+
+    /// Bit pattern, not `==`: the whole point of folding in a fixed order is
+    /// that the sums agree to the last ulp, and a tolerance-based comparison
+    /// would pass even if they didn't.
+    private func exact(_ value: Double) -> String {
+        "\(value.bitPattern)"
+    }
+}


### PR DESCRIPTION
Both cost scanners walked their project roots with a single `FileManager.enumerator` and parsed every `.jsonl` sequentially into one accumulator — ~10,000 transcripts, ~10 GB, on one thread while the other nine cores idled. The per-file parse is embarrassingly parallel; this fans it out.

## The shape: parse in parallel, fold serially in input order

`CostScanParallel.parseInOrder` runs `parse` on up to `width` worker threads and calls `fold` once per input **on the calling thread, in input order**. That ordering is not incidental — it is what makes the output bit-identical to the sequential scan:

- `Double` addition is not associative, so a different merge order is a different total.
- Codex deduplicates **first event wins**, so a different arrival order picks a different winner.

## Deduplication: per-file for Claude, global for Codex

This was the decisive question, and the two scanners answer it differently.

**Claude is per-file.** `parseSessionWindows` builds its own `messageID:requestID` map and discards it at the end of each transcript, so a file's totals depend on nothing outside that file. Merging is a plain sum, and the whole parse+tally fans out.

**Codex is global.** `CodexScanContext.eventKeys` spans every rollout *and* the SQLite log — a turn recorded in both is billed once. So only the parse fans out: `parseRollout` turns one file into `[CodexUsageEvent]` (a `Sendable` value type; the raw `[String: Any]` payload never leaves the worker), and `apply` folds those into the shared windows serially with the dedup/day/model/origin/project logic untouched. `addUsage` split into `makeUsageEvent` (pure extraction) + `apply` (serial fold) to make that boundary explicit.

## Determinism, improved

`CostScanFileSystem.transcriptFiles` collects and **sorts by path**. Enumeration order was previously whatever the volume handed back, which — combined with first-wins dedup — meant two scans of an unchanged Codex tree could already disagree. They can't now. Sorted input + in-order fold means sequential and parallel agree bit for bit, and so do repeat runs.

## Bounded concurrency

`ParsePipeline` is an `NSCondition` work queue with a lookahead window of `width × 4`. Workers claim indices dynamically and block once they get that far ahead of the fold; the folder blocks on the index it needs and nils the slot as it takes it. Peak memory is bounded at `width × 4` parsed results plus `width` reader chunks — not one parsed result per file in the tree.

A pipeline rather than a batch barrier on purpose: transcript sizes are heavily skewed (a handful carry base64 payloads orders of magnitude above the median), and any barrier parks the whole pool behind one giant file. Measured — the first cut used `concurrentPerform` over batches and barely beat sequential.

Width defaults to `activeProcessorCount`; `width: 1` is the exact sequential path, which is what the tests compare against.

## Threading

Scanners stay **synchronous** — `CostSummaryBuilder.makeSummary` calls them straight through, already off the main actor inside `CostTracker`'s `Task.detached`. An `async` signature would push that hop into every caller. No new main-actor hops in the hot loop.

One real race surfaced and is fixed: `CostProjectAttribution` reached `ServiceSupport.realHomeDirectory()` once per Claude transcript and once per Codex event. That goes through `getpwuid`, which parks its result in a shared static and is not safe to call concurrently. It is now a `static let`, resolved once per process — safe and strictly less work. The rest of the parse path audited clean: `FlexibleISO8601` uses documented-thread-safe static formatters, `Calendar.current` returns a value snapshot and is only touched in the serial fold, and `logValueRegexes` is an immutable `static let` reached only from the serial SQLite path.

## Benchmark

Real local corpus, release build, Mac Studio, `activeProcessorCount` = 10. `width: 1` is the exact code path this replaced, so both rows are the same binary over the same files in the same process.

| stage | files | before (`width: 1`) | after (`width: 10`) | |
|---|---|---|---|---|
| Claude transcripts | 2,409 sessions | 34.26s | 16.01s | **2.1×** |
| Codex rollouts | 449 sessions | 1010.39s | 313.62s | **3.2×** |

Three things that make these numbers conservative rather than flattering:

- **The wide pass ran first.** Whatever the page cache retained between the two passes benefited the sequential baseline, not the parallel one.
- **Two of ten cores were busy** with an unrelated benchmark in a sibling worktree for the duration, so the wide pass effectively had eight.
- **`archived_sessions` is excluded** (1,883 further Codex rollouts). Those carry the large base64 payloads whose wall clock is dominated by the quadratic rescan #336 fixes; timing them here would mostly measure that bug. The `sessions` directory above is the representative corpus.

Codex parallelizes better than Claude (3.2× vs 2.1×) despite folding its events serially, because its per-file parse is the heavier half.

**Determinism on the real corpus.** Both Codex rows agree exactly — same 12,639 events, same 1,116,153,330 input tokens, same period totals — which is the control worth having, since nothing was writing to that tree during the run.

The Claude rows agree here too, but an earlier pair did *not*, and the cause is worth recording rather than waving away: the Claude corpus grows *while the benchmark runs* — this very session was appending to its own transcript between the two passes — so two passes over it are two passes over different data.

Assuming that would have been the wrong move, so I proved it. A throwaway check APFS-cloned the live Claude roots (near-instant, no extra space) and only then compared `width: 1` against the default:

```
frozen-claude sequential=7515642/16971.232557550007
              parallel=7515642/16971.232557550007
```

Bit-identical on `Double.bitPattern`, over the full 2,409-session corpus. The input total differs from the benchmark row above (7515642 vs 7515619) precisely because the clone was taken minutes later — which is the live-write evidence, stated plainly.

Both the benchmark and that frozen-corpus check lived in a temporary harness that is **not** part of this diff; they read the developer's own `~/.claude*` directories and have no business in the committed suite. The shipped equivalents are the fixture-based determinism tests below, which run everywhere.

## Tests

TDD — `MeterBarTests/CostScanConcurrencyTests.swift`, 10 tests, written before the implementation:

- Parallel and sequential scans over the same fixtures produce identical `CostSummary` values, including per-model, per-origin, per-project and per-day breakdowns (compared via `Double.bitPattern`, so "identical" means exactly that).
- Dedup still collapses duplicate `messageID:requestID` events, including duplicates straddling the period cutoff, and Codex dedup still spans files.
- An unreadable (chmod 000) or malformed transcript does not abort the scan.
- Session counts stay correct — one transcript with usage is one session.
- `parseInOrder` visits every input exactly once, in order, and tolerates empty input and non-positive widths.

`swift build` clean, full `swift test` green — 1715 tests, 5 skipped, 0 failures — and SwiftLint `--strict` clean across 245 files.

Worth noting: `width` defaults everywhere, so every pre-existing scanner test in `CostTrackerTests` now runs against the parallel path without being changed to ask for it. The whole existing suite is a regression net for this.

## Relationship to #344

#344 states the opposite conclusion — that fanning the scan out is the wrong fix — and pins every scan to one serial queue instead. Its two arguments deserve a direct answer, because one is contradicted by measurement and the other does not apply to this implementation.

**"The scan is disk-bound, not CPU-bound."** Measured above on the real corpus, the Claude scan goes from 34.26s to 16.01s on the same files in the same process. A purely disk-bound workload cannot halve when you add workers, and the ordering makes that a floor rather than a flattering case: the wide pass ran *first*, so the page cache favoured the sequential baseline. The scan does plenty of I/O, but it also does `JSONSerialization` and string work per line, and that half was serialized on one core.

**"It starves everything else."** This is a real hazard and the reason the objection names `TaskGroup` and `concurrentPerform` specifically: both land on Swift's cooperative pool, which has one thread per core, so blocking `read(2)` calls there stall unrelated work. This change does not use the cooperative pool. `parseInOrder` owns a private concurrent `DispatchQueue` at `.utility`, so the workers are ordinary Dispatch threads and the cooperative pool is untouched.

The two changes are otherwise complementary rather than exclusive — incremental byte offsets and a per-file cache reduce *how much* gets parsed, and this reduces *how long* parsing what remains takes. They do collide mechanically, though: both rewrite the enumeration in each scanner. Whichever lands first, the second should rebase onto it rather than merge — and if #344's serial executor is kept as the outer boundary, `width` can simply be threaded through it, since these workers are not the pool #344 is protecting.

## Scope

Concurrency layer only. `FileLineReader` and the parse logic are untouched — #336 (quadratic rescan) and #337 (oversized-line cap) own those. Timings above are against the current reader on `master`; once #336 lands the absolute numbers drop and the parallel speedup should widen, since less of the wall clock is one file's pathological rescan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Accelerated Claude and Codex usage scanning through bounded parallel processing.
  * Preserved deterministic totals, ordering, attribution, and deduplication across scans.

* **Reliability**
  * Improved handling of malformed, unreadable, empty, and non-local scan locations.
  * Added consistent discovery of transcript files and session data.

* **Testing**
  * Expanded coverage for concurrency, ordering, deduplication, session counts, edge cases, and exact usage totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->