### PR TITLE
fix(costs): move scan status to the card's trailing edge

### DIFF
--- a/MeterBar/Views/DashboardCostCards.swift
+++ b/MeterBar/Views/DashboardCostCards.swift
@@ -21,10 +21,18 @@ struct CostOverviewStatusCard: View {
   @Environment(\.accessibilityReduceMotion)
   private var reduceMotion
 
-  private var subtitle: String {
-    if isScanning { return "Scanning local logs" }
-    if isRefreshingMissingDays { return "Updating…" }
-    return "Last 30 days"
+  /// The subtitle names the reporting window only. Refresh state used to
+  /// replace it, which read as if the window itself had changed; it now sits on
+  /// the trailing edge like the neighbouring "Lifetime Local Cost" date range.
+  static let subtitle = "Last 30 days"
+
+  /// Shared with the "30 Day Spend" card so both trailing captions say the same
+  /// thing at the same time — they are driven by the same two scan flags.
+  static func headerStatus(isScanning: Bool, isRefreshingMissingDays: Bool) -> String? {
+    DashboardCostsSection.refreshStatusText(
+      isScanning: isScanning,
+      isRefreshingMissingDays: isRefreshingMissingDays
+    )
   }
 
   /// The hero value's three mutually-exclusive states. Animate the swap on the
@@ -49,11 +57,17 @@ struct CostOverviewStatusCard: View {
             Text("API-Rate Estimate")
               .font(.headline)
               .fontWeight(.semibold)
-            Text(subtitle)
+            Text(Self.subtitle)
               .font(.caption)
               .foregroundColor(.secondary)
           }
           Spacer()
+          DashboardCardCaption(
+            text: Self.headerStatus(
+              isScanning: isScanning,
+              isRefreshingMissingDays: isRefreshingMissingDays
+            )
+          )
         }
 
         heroValue

--- a/MeterBarTests/DashboardSectionSplitTests.swift
+++ b/MeterBarTests/DashboardSectionSplitTests.swift
@@ -128,6 +128,29 @@ final class DashboardSectionSplitTests: XCTestCase {
         )
     }
 
+    /// The estimate card's subtitle names the window and nothing else: refresh
+    /// state belongs on the trailing edge, matching "Lifetime Local Cost" and
+    /// "30 Day Spend" rather than replacing the card's own caption.
+    func testCostOverviewSubtitleIsWindowOnlyAndStatusMatchesTheOtherCards() {
+        XCTAssertEqual(CostOverviewStatusCard.subtitle, "Last 30 days")
+
+        for isScanning in [true, false] {
+            for isRefreshingMissingDays in [true, false] {
+                XCTAssertEqual(
+                    CostOverviewStatusCard.headerStatus(
+                        isScanning: isScanning,
+                        isRefreshingMissingDays: isRefreshingMissingDays
+                    ),
+                    DashboardCostsSection.refreshStatusText(
+                        isScanning: isScanning,
+                        isRefreshingMissingDays: isRefreshingMissingDays
+                    ),
+                    "estimate card must reuse the page's trailing status wording"
+                )
+            }
+        }
+    }
+
     func testStatusPageSummaryReportsRefreshFirst() {
         XCTAssertEqual(
             DashboardStatusSection.summary(isRefreshing: true, issueCount: 3, reportCount: 0),


### PR DESCRIPTION
## What

The **API-Rate Estimate** card replaced its `Last 30 days` subtitle with the refresh state while a scan ran, so the reporting window disappeared mid-scan and read as if the window itself had changed.

The status now renders on the card's **trailing edge**, matching how the neighbouring **Lifetime Local Cost** card shows its date range. The subtitle is a constant naming the window only.

Both cost cards source the caption from `DashboardCostsSection.refreshStatusText`, so they say the same thing at the same time — they're driven by the same two scan flags.

## Tests

Added `testCostOverviewSubtitleIsWindowOnlyAndStatusMatchesTheOtherCards()` — asserts the subtitle is window-only and that `headerStatus` matches `refreshStatusText` across all four `isScanning` / `isRefreshingMissingDays` combinations.

`swift test --filter "DashboardSectionSplitTests|DashboardLayoutTests"` → 46 tests, 0 failures.

## Not in scope

The long scan itself (~10 GB / ~10k transcript files, 70s+ warm) is tracked separately across four in-flight branches: quadratic line-scan fix, truncated-prefix retention, cache identity hardening, and bounded/resumable scanning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the cost overview card to consistently display the “Last 30 days” reporting period.
  * Improved refresh and scanning status messaging, including states where data for a day is unavailable.
* **Tests**
  * Added coverage to verify reporting-period and refresh-status text across supported states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->