### PR TITLE
feat(menubar): opt-in timed rotation of providers in merged mode

### DIFF
--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -93,9 +93,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Decides what each menu bar item shows and styles its button. Item
     /// lifecycle stays here; the presenter never creates or removes one.
-    private lazy var statusItemPresenter = StatusItemPresenter { [weak self] descriptors in
-        self?.applyStatusItemDescriptors(descriptors)
-    }
+    private lazy var statusItemPresenter = StatusItemPresenter(
+        isPopoverOpen: { [weak self] in self?.menuPanel?.isShown ?? false },
+        applyDescriptors: { [weak self] descriptors in
+            self?.applyStatusItemDescriptors(descriptors)
+        }
+    )
 
     func applicationWillFinishLaunching(_ notification: Notification) {
         // Apply the persisted Dock visibility as early as possible so users who

--- a/MeterBar/App/StatusItemPresenter.swift
+++ b/MeterBar/App/StatusItemPresenter.swift
@@ -44,7 +44,32 @@ final class StatusItemPresenter {
     /// directory activity probes or performs network work.
     private var countdownTimer: Timer?
 
-    init(applyDescriptors: @escaping ([MenuBarStatusItemDescriptor]) -> Void) {
+    /// The single scheduled source behind opt-in provider rotation (issue #340).
+    /// Like the countdown timer it only re-runs the pure presentation pass over
+    /// the cached candidates — rotation never triggers a refresh. Torn down
+    /// whenever rotation stops applying, so the default (off) build schedules
+    /// nothing at all.
+    private var rotationTimer: Timer?
+
+    /// Interval the live rotation timer was built with, so changing the setting
+    /// reschedules instead of leaving the old cadence running.
+    private var rotationTimerInterval: StatusItemRotationInterval?
+
+    /// Which provider currently has the turn. Reset when rotation stops so
+    /// re-enabling it starts from the top of the cycle rather than mid-list.
+    private var rotationTick = 0
+
+    /// Whether the popover is open, asked at tick time rather than mirrored:
+    /// the panel clears its own presentation flag on paths that never route
+    /// back through the delegate, and a stale mirror would rotate the label out
+    /// from under an open popover.
+    private let isPopoverOpen: () -> Bool
+
+    init(
+        isPopoverOpen: @escaping () -> Bool = { false },
+        applyDescriptors: @escaping ([MenuBarStatusItemDescriptor]) -> Void
+    ) {
+        self.isPopoverOpen = isPopoverOpen
         self.applyDescriptors = applyDescriptors
     }
 
@@ -73,6 +98,11 @@ final class StatusItemPresenter {
         let preferences = MenuBarDisplayPreferencesStore.shared
         let plan = accountPlan(mode: preferences.presentationMode)
         accountItemPlan = plan
+        let rotates = MenuBarRotationSequencer.rotates(
+            mode: preferences.presentationMode,
+            isEnabled: preferences.rotatesProviders,
+            pinnedKey: preferences.pinnedCandidateKey
+        )
         let descriptors = MenuBarStatusItemPlanner.plan(
             mode: preferences.presentationMode,
             accountPlan: plan,
@@ -85,7 +115,8 @@ final class StatusItemPresenter {
             windowMode: preferences.windowMode,
             fontSize: preferences.fontSize,
             highContrast: preferences.highContrast,
-            showsExhaustedResetCountdown: preferences.showsExhaustedResetCountdown
+            showsExhaustedResetCountdown: preferences.showsExhaustedResetCountdown,
+            rotationTick: rotates ? rotationTick : nil
         )
 
         // Rebuilt rather than merged, so an item that just left the plan doesn't
@@ -97,6 +128,7 @@ final class StatusItemPresenter {
 
         applyDescriptors(descriptors)
         updateCountdownTimer(preferences: preferences)
+        updateRotationTimer(preferences: preferences, rotates: rotates)
     }
 
     /// Which accounts own an item right now, so the delegate can build the
@@ -271,6 +303,48 @@ final class StatusItemPresenter {
         timer.tolerance = 2
         RunLoop.main.add(timer, forMode: .common)
         countdownTimer = timer
+    }
+
+    @MainActor
+    private func updateRotationTimer(
+        preferences: MenuBarDisplayPreferencesStore,
+        rotates: Bool
+    ) {
+        guard rotates else {
+            rotationTimer?.invalidate()
+            rotationTimer = nil
+            rotationTimerInterval = nil
+            rotationTick = 0
+            return
+        }
+        // Already running at the chosen cadence; leaving it alone keeps the
+        // current provider's turn from being cut short by an unrelated refresh.
+        guard rotationTimer == nil || rotationTimerInterval != preferences.rotationInterval else {
+            return
+        }
+
+        rotationTimer?.invalidate()
+        let timer = Timer(timeInterval: preferences.rotationInterval.seconds, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.advanceRotation()
+            }
+        }
+        // Generous next to the shortest 5s step, and it lets macOS coalesce the
+        // wakeup with other timers instead of demanding its own.
+        timer.tolerance = 1
+        RunLoop.main.add(timer, forMode: .common)
+        rotationTimer = timer
+        rotationTimerInterval = preferences.rotationInterval
+    }
+
+    @MainActor
+    private func advanceRotation() {
+        let next = MenuBarRotationSequencer.advance(tick: rotationTick, isPaused: isPopoverOpen())
+        // Paused: the tick stands still, so there is nothing to redraw and the
+        // label cannot change while the user is reading the popover it belongs to.
+        guard next != rotationTick else { return }
+        rotationTick = next
+        apply(candidates: latestCandidates)
     }
 
     @MainActor

--- a/MeterBar/App/StatusItemRefreshTrigger.swift
+++ b/MeterBar/App/StatusItemRefreshTrigger.swift
@@ -46,7 +46,12 @@ enum StatusItemRefreshTrigger {
             displayPreferences.$windowMode.map { _ in () }.eraseToAnyPublisher(),
             displayPreferences.$fontSize.map { _ in () }.eraseToAnyPublisher(),
             displayPreferences.$highContrast.map { _ in () }.eraseToAnyPublisher(),
-            displayPreferences.$showsExhaustedResetCountdown.map { _ in () }.eraseToAnyPublisher()
+            displayPreferences.$showsExhaustedResetCountdown.map { _ in () }.eraseToAnyPublisher(),
+            // Rotation reshapes the merged item the moment it is toggled, and a
+            // new interval has to reschedule the timer rather than wait out the
+            // old cadence.
+            displayPreferences.$rotatesProviders.map { _ in () }.eraseToAnyPublisher(),
+            displayPreferences.$rotationInterval.map { _ in () }.eraseToAnyPublisher()
         ])
 
         // Which accounts own items, and which one the switcher shows. Without

--- a/MeterBar/Models/MenuBarRotationSequencer.swift
+++ b/MeterBar/Models/MenuBarRotationSequencer.swift
@@ -1,0 +1,93 @@
+import Foundation
+import MeterBarShared
+
+/// What rotation wants the merged status item to show for the current tick.
+nonisolated enum MenuBarRotationOutcome: Equatable {
+    /// Rotation owns the slot and this provider has the turn.
+    case rotate(StatusLimitCandidate)
+    /// A critical or exhausted quota outranks rotation, so the existing
+    /// auto-selection keeps the slot until the condition clears.
+    case hold(StatusLimitCandidate)
+    /// Rotation does not apply: a pin owns the slot, or no provider has data.
+    /// The caller must fall back to its normal selection.
+    case inactive
+}
+
+/// Opt-in timed rotation for the merged status item (issue #340).
+///
+/// Pure by design: the visible candidate set plus a tick index fully determine
+/// what shows, so ordering, skips, pauses, and the critical hold are all
+/// testable without a run loop. The timer that advances the tick lives in the
+/// controller layer, which is also the only place that knows the popover is
+/// open.
+nonisolated enum MenuBarRotationSequencer {
+    /// Whether a rotation timer should exist at all. Rotation is a merged-mode
+    /// feature, and a pin is a deliberate choice of one window that outranks it,
+    /// so both cases tear the timer down rather than letting it tick unseen.
+    static func rotates(
+        mode: MenuBarPresentationMode,
+        isEnabled: Bool,
+        pinnedKey: String?
+    ) -> Bool {
+        isEnabled && mode == .merged && pinnedKey == nil
+    }
+
+    /// The providers that take a turn: the same auto-selectable windows the
+    /// merged item already competes over, minus the ones whose cached data has
+    /// aged out — rotating onto a "—" would be a turn that says nothing.
+    /// Providers the user hid never reach the candidate list in the first place.
+    ///
+    /// Sorted like the per-provider items so the cycle order stays stable across
+    /// refreshes instead of following probe completion order.
+    static func rotatableCandidates(
+        _ candidates: [StatusLimitCandidate],
+        now: Date
+    ) -> [StatusLimitCandidate] {
+        candidates
+            .filter(\.isAutoSelectable)
+            .filter { now.timeIntervalSince($0.lastUpdated) <= ProviderParseHealthRecord.staleAfter }
+            .sorted { (($0.service.sortOrder, $0.key)) < (($1.service.sortOrder, $1.key)) }
+    }
+
+    static func outcome(
+        candidates: [StatusLimitCandidate],
+        tick: Int,
+        pinnedKey: String?,
+        now: Date
+    ) -> MenuBarRotationOutcome {
+        guard pinnedKey == nil else { return .inactive }
+
+        let rotatable = rotatableCandidates(candidates, now: now)
+        guard !rotatable.isEmpty else { return .inactive }
+
+        // Asking the existing selector what it *would* show keeps the hold rule
+        // honest: it already skips fully spent quotas so the title can't freeze
+        // on 0% for days, and rotation must not reintroduce that freeze through
+        // the back door. No previous key, because the rotated label is not an
+        // auto-selection history and must not anchor the hysteresis.
+        if let selection = StatusItemLimitSelector.select(
+            candidates: rotatable,
+            previousKey: nil,
+            pinnedKey: nil,
+            now: now
+        ), QuotaBand.forLimit(selection.limit).severityRank >= QuotaBand.critical.severityRank {
+            return .hold(selection)
+        }
+
+        return .rotate(rotatable[index(tick: tick, count: rotatable.count)])
+    }
+
+    /// The next tick. A paused tick does not advance, so the label cannot change
+    /// while the user is reading the popover it belongs to.
+    static func advance(tick: Int, isPaused: Bool) -> Int {
+        guard !isPaused else { return tick }
+        return tick == Int.max ? 0 : tick + 1
+    }
+
+    /// Wraps in both directions so a tick restored from anywhere still names a
+    /// real provider instead of trapping on a negative remainder.
+    private static func index(tick: Int, count: Int) -> Int {
+        let remainder = tick % count
+        return remainder < 0 ? remainder + count : remainder
+    }
+}

--- a/MeterBar/Models/MenuBarStatusItemPlanner.swift
+++ b/MeterBar/Models/MenuBarStatusItemPlanner.swift
@@ -41,6 +41,10 @@ enum MenuBarStatusItemPlanner {
     /// - Parameter previousKeys: what each *account* item showed last refresh,
     ///   by item id. Account items each own a slot, so they each need their own
     ///   history; sharing the merged key would hand every item the same anchor.
+    /// - Parameter rotationTick: the merged item's current rotation step, when
+    ///   the user opted into timed rotation. Nil — the default — leaves selection
+    ///   exactly as it was before rotation existed, and the other modes own their
+    ///   items outright so it never applies to them.
     static func plan(
         mode: MenuBarPresentationMode,
         accountPlan: MenuBarAccountItemPlan? = nil,
@@ -54,6 +58,7 @@ enum MenuBarStatusItemPlanner {
         fontSize: StatusItemFontSize = .standard,
         highContrast: Bool = false,
         showsExhaustedResetCountdown: Bool = false,
+        rotationTick: Int? = nil,
         now: Date = Date()
     ) -> [MenuBarStatusItemDescriptor] {
         let context = SelectionContext(
@@ -65,6 +70,7 @@ enum MenuBarStatusItemPlanner {
             windowMode: windowMode,
             visualStyle: StatusItemVisualStyle(fontSize: fontSize, highContrast: highContrast),
             showsExhaustedResetCountdown: showsExhaustedResetCountdown,
+            rotationTick: mode == .merged ? rotationTick : nil,
             now: now
         )
 
@@ -144,6 +150,8 @@ enum MenuBarStatusItemPlanner {
         let windowMode: StatusItemWindowMode
         let visualStyle: StatusItemVisualStyle
         let showsExhaustedResetCountdown: Bool
+        /// Set only when the merged item is rotating; nil everywhere else.
+        let rotationTick: Int?
         let now: Date
 
         /// What the item with this id showed last refresh. The merged slot
@@ -158,6 +166,33 @@ enum MenuBarStatusItemPlanner {
         candidates: [StatusLimitCandidate],
         context: SelectionContext
     ) -> MenuBarStatusItemDescriptor {
+        // Rotation is another way of choosing *which* candidate the one merged
+        // item shows, so it resolves ahead of auto-selection and hands the same
+        // descriptor builder its winner. It stands down for a pin, for a
+        // critical or exhausted quota, and when nothing has fresh data, which
+        // leaves the untouched auto path below in charge.
+        if let rotationTick = context.rotationTick {
+            let outcome = MenuBarRotationSequencer.outcome(
+                candidates: candidates,
+                tick: rotationTick,
+                pinnedKey: context.pinnedKey,
+                now: context.now
+            )
+            switch outcome {
+            case let .rotate(candidate), let .hold(candidate):
+                return descriptor(
+                    id: mergedItemID,
+                    selectionKey: candidate.key,
+                    candidate: candidate,
+                    candidates: candidates,
+                    qualifiedName: false,
+                    context: context
+                )
+            case .inactive:
+                break
+            }
+        }
+
         guard let selection = StatusItemLimitSelector.select(
             candidates: candidates,
             previousKey: context.previousKey(forItem: mergedItemID),

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -40,6 +40,10 @@ nonisolated enum StorageKeys {
     static let statusItemShowsExhaustedResetCountdown = "StatusItemShowsExhaustedResetCountdown"
     /// `ResetTimeFormat` raw value for reset labels in popover cards.
     static let popoverResetTimeFormat = "PopoverResetTimeFormat"
+    /// Opt-in timed rotation of the merged status item through visible providers.
+    static let statusItemRotatesProviders = "StatusItemRotatesProviders"
+    /// `StatusItemRotationInterval` raw value: seconds between rotation steps.
+    static let statusItemRotationInterval = "StatusItemRotationIntervalSeconds"
     /// Accounts that each get their own status item ([String] of MenuBarAccountKey),
     /// in the order the user selected them.
     static let menuBarSelectedAccountKeys = "MenuBarSelectedAccountKeys"

--- a/MeterBar/Services/MenuBarDisplayPreferencesStore.swift
+++ b/MeterBar/Services/MenuBarDisplayPreferencesStore.swift
@@ -147,6 +147,22 @@ nonisolated enum ResetTimeFormat: String, CaseIterable, Identifiable {
     }
 }
 
+/// How long each provider keeps the merged status item when rotation is on.
+/// Raw value is the interval in seconds, so the persisted number stays readable
+/// in `defaults read` and survives renaming a case.
+nonisolated enum StatusItemRotationInterval: Int, CaseIterable, Identifiable, Sendable {
+    case fiveSeconds = 5
+    case fifteenSeconds = 15
+    case thirtySeconds = 30
+    case sixtySeconds = 60
+
+    var id: Int { rawValue }
+
+    var seconds: TimeInterval { TimeInterval(rawValue) }
+
+    var displayName: String { "\(rawValue)s" }
+}
+
 /// Persists the status-item and popover-label choices introduced by issue #142.
 /// Defaults preserve the exact pre-feature presentation: Auto selection, a
 /// compact percentage-left label, and reset countdowns.
@@ -162,6 +178,8 @@ final class MenuBarDisplayPreferencesStore: ObservableObject {
     @Published private(set) var highContrast: Bool
     @Published private(set) var showsExhaustedResetCountdown: Bool
     @Published private(set) var resetTimeFormat: ResetTimeFormat
+    @Published private(set) var rotatesProviders: Bool
+    @Published private(set) var rotationInterval: StatusItemRotationInterval
 
     private let userDefaults: UserDefaults
 
@@ -185,6 +203,10 @@ final class MenuBarDisplayPreferencesStore: ObservableObject {
         )
         resetTimeFormat = userDefaults.string(forKey: StorageKeys.popoverResetTimeFormat)
             .flatMap(ResetTimeFormat.init(rawValue:)) ?? .countdown
+        rotatesProviders = userDefaults.bool(forKey: StorageKeys.statusItemRotatesProviders)
+        rotationInterval = StatusItemRotationInterval(
+            rawValue: userDefaults.integer(forKey: StorageKeys.statusItemRotationInterval)
+        ) ?? .fifteenSeconds
     }
 
     func setPinnedCandidateKey(_ key: String?) {
@@ -244,6 +266,18 @@ final class MenuBarDisplayPreferencesStore: ObservableObject {
         guard format != resetTimeFormat else { return }
         resetTimeFormat = format
         userDefaults.set(format.rawValue, forKey: StorageKeys.popoverResetTimeFormat)
+    }
+
+    func setRotatesProviders(_ enabled: Bool) {
+        guard enabled != rotatesProviders else { return }
+        rotatesProviders = enabled
+        userDefaults.set(enabled, forKey: StorageKeys.statusItemRotatesProviders)
+    }
+
+    func setRotationInterval(_ interval: StatusItemRotationInterval) {
+        guard interval != rotationInterval else { return }
+        rotationInterval = interval
+        userDefaults.set(interval.rawValue, forKey: StorageKeys.statusItemRotationInterval)
     }
 
     nonisolated private static func normalizedPin(_ key: String) -> String? {

--- a/MeterBar/Views/Settings/GeneralSettingsView.swift
+++ b/MeterBar/Views/Settings/GeneralSettingsView.swift
@@ -80,6 +80,26 @@ struct GeneralSettingsView: View {
         providerSnapshots.statusItemPinOptions
     }
 
+    /// Same predicate the presenter uses to decide whether a rotation timer may
+    /// exist, so the controls can never claim rotation is running when it isn't.
+    private var canRotateProviders: Bool {
+        MenuBarRotationSequencer.rotates(
+            mode: menuBarDisplayPreferences.presentationMode,
+            isEnabled: true,
+            pinnedKey: menuBarDisplayPreferences.pinnedCandidateKey
+        )
+    }
+
+    /// Explains a disabled rotation toggle, naming the setting that is standing
+    /// in its way — a pin and rotation are two answers to the same question.
+    private var rotationExclusionNotice: String? {
+        guard !canRotateProviders else { return nil }
+        guard menuBarDisplayPreferences.presentationMode == .merged else {
+            return "Rotation applies to the single menu bar item only."
+        }
+        return "Pinning and rotation are mutually exclusive. Set “Menu bar shows” back to Auto to rotate."
+    }
+
     private var refreshSection: some View {
         SettingsPanelSection(title: "Refresh", systemImage: "arrow.clockwise", color: MeterBarTheme.appAccent) {
             SettingsRowView(
@@ -168,6 +188,43 @@ struct GeneralSettingsView: View {
                 // One-per-provider already shows every account, so there is
                 // nothing left for a pin to choose between.
                 .disabled(menuBarDisplayPreferences.presentationMode == .perProvider)
+            }
+
+            SettingsRowView(
+                title: "Rotate providers",
+                detail: "Cycle the single item through providers that have data. "
+                    + "Rotation pauses while the popover is open, and a critical quota keeps the item "
+                    + "until it recovers."
+            ) {
+                Toggle("", isOn: Binding(
+                    get: { menuBarDisplayPreferences.rotatesProviders },
+                    set: { menuBarDisplayPreferences.setRotatesProviders($0) }
+                ))
+                .labelsHidden()
+                .meterBarSwitch()
+                .disabled(!canRotateProviders)
+            }
+
+            if let notice = rotationExclusionNotice {
+                SettingsNotice(text: notice, color: .secondary)
+            }
+
+            SettingsRowView(
+                title: "Rotation interval",
+                detail: "How long each provider keeps the item."
+            ) {
+                Picker("", selection: Binding(
+                    get: { menuBarDisplayPreferences.rotationInterval },
+                    set: { menuBarDisplayPreferences.setRotationInterval($0) }
+                )) {
+                    ForEach(StatusItemRotationInterval.allCases) { interval in
+                        Text(interval.displayName).tag(interval)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .frame(width: 220)
+                .disabled(!canRotateProviders || !menuBarDisplayPreferences.rotatesProviders)
             }
 
             SettingsRowView(

--- a/MeterBarTests/MenuBarDisplayPreferencesStoreTests.swift
+++ b/MeterBarTests/MenuBarDisplayPreferencesStoreTests.swift
@@ -30,6 +30,8 @@ final class MenuBarDisplayPreferencesStoreTests: XCTestCase {
         XCTAssertFalse(store.highContrast)
         XCTAssertFalse(store.showsExhaustedResetCountdown)
         XCTAssertEqual(store.resetTimeFormat, .countdown)
+        XCTAssertFalse(store.rotatesProviders)
+        XCTAssertEqual(store.rotationInterval, .fifteenSeconds)
     }
 
     func testPreferencesPersistAcrossRelaunch() {
@@ -42,6 +44,8 @@ final class MenuBarDisplayPreferencesStoreTests: XCTestCase {
         store.setHighContrast(true)
         store.setShowsExhaustedResetCountdown(true)
         store.setResetTimeFormat(.clock)
+        store.setRotatesProviders(true)
+        store.setRotationInterval(.sixtySeconds)
 
         let reloaded = MenuBarDisplayPreferencesStore(userDefaults: defaults)
 
@@ -53,6 +57,8 @@ final class MenuBarDisplayPreferencesStoreTests: XCTestCase {
         XCTAssertTrue(reloaded.highContrast)
         XCTAssertTrue(reloaded.showsExhaustedResetCountdown)
         XCTAssertEqual(reloaded.resetTimeFormat, .clock)
+        XCTAssertTrue(reloaded.rotatesProviders)
+        XCTAssertEqual(reloaded.rotationInterval, .sixtySeconds)
     }
 
     func testInvalidPersistedValuesFallBackToExistingDefaults() {
@@ -61,6 +67,7 @@ final class MenuBarDisplayPreferencesStoreTests: XCTestCase {
         defaults.set("invalid", forKey: StorageKeys.statusItemWindowMode)
         defaults.set("invalid", forKey: StorageKeys.statusItemFontSize)
         defaults.set("invalid", forKey: StorageKeys.popoverResetTimeFormat)
+        defaults.set(7, forKey: StorageKeys.statusItemRotationInterval)
 
         let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
 
@@ -69,6 +76,7 @@ final class MenuBarDisplayPreferencesStoreTests: XCTestCase {
         XCTAssertEqual(store.windowMode, .selected)
         XCTAssertEqual(store.fontSize, .standard)
         XCTAssertEqual(store.resetTimeFormat, .countdown)
+        XCTAssertEqual(store.rotationInterval, .fifteenSeconds)
     }
 
     func testBlankPinRestoresAutoAndRemovesPersistence() {

--- a/MeterBarTests/MenuBarRotationSequencerTests.swift
+++ b/MeterBarTests/MenuBarRotationSequencerTests.swift
@@ -1,0 +1,156 @@
+import MeterBarShared
+import XCTest
+
+@testable import MeterBar
+
+/// Covers the pure rotation decision behind the merged status item: which
+/// providers take part, in what order, and when a pin, a critical quota, or an
+/// open popover takes the wheel instead (issue #340).
+final class MenuBarRotationSequencerTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+    private func candidate(
+        key: String,
+        service: ServiceType = .claudeCode,
+        percentUsed: Double,
+        updatedMinutesAgo: Double = 0,
+        isAutoSelectable: Bool = true
+    ) -> StatusLimitCandidate {
+        StatusLimitCandidate(
+            key: key,
+            pinKey: key,
+            service: service,
+            displayName: key,
+            windowName: "Session",
+            limit: UsageLimit(used: percentUsed, total: 100, resetTime: nil),
+            lastUpdated: now.addingTimeInterval(-updatedMinutesAgo * 60),
+            lastActivity: nil,
+            isAutoSelectable: isAutoSelectable
+        )
+    }
+
+    private func outcome(
+        _ candidates: [StatusLimitCandidate],
+        tick: Int,
+        pinnedKey: String? = nil
+    ) -> MenuBarRotationOutcome {
+        MenuBarRotationSequencer.outcome(
+            candidates: candidates,
+            tick: tick,
+            pinnedKey: pinnedKey,
+            now: now
+        )
+    }
+
+    private func rotatedKey(_ candidates: [StatusLimitCandidate], tick: Int) -> String? {
+        guard case let .rotate(candidate) = outcome(candidates, tick: tick) else { return nil }
+        return candidate.key
+    }
+
+    // MARK: - Scheduling
+
+    func testRotationOnlyRunsWhenEnabledInMergedModeWithoutAPin() {
+        XCTAssertTrue(MenuBarRotationSequencer.rotates(mode: .merged, isEnabled: true, pinnedKey: nil))
+        XCTAssertFalse(MenuBarRotationSequencer.rotates(mode: .merged, isEnabled: false, pinnedKey: nil))
+        // A pin is a deliberate choice of one window, so it wins outright.
+        XCTAssertFalse(MenuBarRotationSequencer.rotates(mode: .merged, isEnabled: true, pinnedKey: "codex"))
+        for mode in MenuBarPresentationMode.allCases where mode != .merged {
+            XCTAssertFalse(
+                MenuBarRotationSequencer.rotates(mode: mode, isEnabled: true, pinnedKey: nil),
+                "\(mode) owns its own items and must not rotate"
+            )
+        }
+    }
+
+    // MARK: - Ordering
+
+    func testRotationVisitsEveryProviderInAStableOrderAndWraps() {
+        let claude = candidate(key: "claude", percentUsed: 40)
+        let codex = candidate(key: "codex", service: .codexCli, percentUsed: 30)
+        let cursor = candidate(key: "cursor", service: .cursor, percentUsed: 20)
+        // Deliberately unsorted: the order must come from the sequencer, not
+        // from however the probes happened to emit the candidates.
+        let candidates = [cursor, claude, codex]
+
+        let visited = (0..<5).map { rotatedKey(candidates, tick: $0) }
+
+        XCTAssertEqual(visited, ["claude", "codex", "cursor", "claude", "codex"])
+    }
+
+    func testRotationSkipsProvidersWithoutData() {
+        let fresh = candidate(key: "claude", percentUsed: 40)
+        let stale = candidate(key: "codex", service: .codexCli, percentUsed: 30, updatedMinutesAgo: 180)
+        let pinOnly = candidate(key: "cursor", service: .cursor, percentUsed: 20, isAutoSelectable: false)
+
+        let rotatable = MenuBarRotationSequencer.rotatableCandidates([fresh, stale, pinOnly], now: now)
+
+        XCTAssertEqual(rotatable.map(\.key), ["claude"])
+        XCTAssertEqual(rotatedKey([fresh, stale, pinOnly], tick: 1), "claude")
+    }
+
+    func testRotationStandsDownWhenNoProviderHasData() {
+        let stale = candidate(key: "claude", percentUsed: 40, updatedMinutesAgo: 180)
+
+        XCTAssertEqual(outcome([stale], tick: 0), .inactive)
+        XCTAssertEqual(outcome([], tick: 0), .inactive)
+    }
+
+    // MARK: - Pin exclusion
+
+    func testAPinnedWindowTakesTheSlotInsteadOfRotating() {
+        let claude = candidate(key: "claude", percentUsed: 40)
+        let codex = candidate(key: "codex", service: .codexCli, percentUsed: 30)
+
+        XCTAssertEqual(outcome([claude, codex], tick: 1, pinnedKey: "codex"), .inactive)
+    }
+
+    // MARK: - Critical hold
+
+    func testACriticalQuotaHoldsTheSlotUntilItClears() {
+        let claude = candidate(key: "claude", percentUsed: 40)
+        let critical = candidate(key: "codex", service: .codexCli, percentUsed: 94)
+
+        // Held on every tick, not just the one that would have shown it.
+        XCTAssertEqual(outcome([claude, critical], tick: 0), .hold(critical))
+        XCTAssertEqual(outcome([claude, critical], tick: 1), .hold(critical))
+
+        let recovered = candidate(key: "codex", service: .codexCli, percentUsed: 50)
+        XCTAssertEqual(outcome([claude, recovered], tick: 1), .rotate(recovered))
+    }
+
+    func testASpentQuotaAutoSelectionSkipsDoesNotFreezeRotation() {
+        // Auto-selection drops fully spent quotas so the title can't sit on 0%
+        // for days. Rotation moves on by itself, so the spent provider keeps its
+        // turn instead of holding the slot forever.
+        let claude = candidate(key: "claude", percentUsed: 20)
+        let spent = candidate(key: "codex", service: .codexCli, percentUsed: 100)
+
+        XCTAssertEqual(rotatedKey([claude, spent], tick: 0), "claude")
+        XCTAssertEqual(rotatedKey([claude, spent], tick: 1), "codex")
+    }
+
+    func testEverythingSpentHoldsTheSlotLikeAutoSelectionWould() {
+        let claude = candidate(key: "claude", percentUsed: 100)
+        let codex = candidate(key: "codex", service: .codexCli, percentUsed: 100)
+
+        XCTAssertEqual(outcome([claude, codex], tick: 1), .hold(claude))
+    }
+
+    // MARK: - Pause / resume
+
+    func testPausingHoldsTheTickSoTheLabelCannotChangeUnderTheCursor() {
+        XCTAssertEqual(MenuBarRotationSequencer.advance(tick: 3, isPaused: true), 3)
+        XCTAssertEqual(MenuBarRotationSequencer.advance(tick: 3, isPaused: false), 4)
+    }
+
+    func testTickAdvanceWrapsInsteadOfOverflowing() {
+        XCTAssertEqual(MenuBarRotationSequencer.advance(tick: .max, isPaused: false), 0)
+    }
+
+    func testNegativeTicksStillResolveToARealProvider() {
+        let claude = candidate(key: "claude", percentUsed: 40)
+        let codex = candidate(key: "codex", service: .codexCli, percentUsed: 30)
+
+        XCTAssertEqual(rotatedKey([claude, codex], tick: -1), "codex")
+    }
+}

--- a/MeterBarTests/MenuBarStatusItemPlannerTests.swift
+++ b/MeterBarTests/MenuBarStatusItemPlannerTests.swift
@@ -51,6 +51,23 @@ final class MenuBarStatusItemPlannerTests: XCTestCase {
         )
     }
 
+    private func rotatedPlan(
+        _ candidates: [StatusLimitCandidate],
+        tick: Int,
+        pinnedKey: String? = nil
+    ) -> [MenuBarStatusItemDescriptor] {
+        MenuBarStatusItemPlanner.plan(
+            mode: .merged,
+            candidates: candidates,
+            previousKey: nil,
+            pinnedKey: pinnedKey,
+            metric: .percentLeft,
+            size: .compact,
+            rotationTick: tick,
+            now: now
+        )
+    }
+
     // MARK: - Merged mode
 
     func testMergedModeProducesExactlyOneItemForTheSelectedQuota() {
@@ -118,6 +135,42 @@ final class MenuBarStatusItemPlannerTests: XCTestCase {
         let codex = candidate(key: "codex", service: .codexCli, percentUsed: 50, activeMinutesAgo: 1)
 
         XCTAssertEqual(plan([claude, codex], previousKey: "codex").first?.selectionKey, "codex")
+    }
+
+    // MARK: - Rotation
+
+    func testMergedModeFollowsTheRotationTickWhenRotationIsOn() {
+        let claude = candidate(key: "claude:gen", percentUsed: 48, activeMinutesAgo: 1)
+        let codex = candidate(key: "codex", service: .codexCli, percentUsed: 20, activeMinutesAgo: 1)
+
+        // Auto would stay on the tighter Claude window; rotation overrides it.
+        XCTAssertEqual(rotatedPlan([claude, codex], tick: 0).first?.selectionKey, "claude:gen")
+        let rotated = rotatedPlan([claude, codex], tick: 1).first
+        XCTAssertEqual(rotated?.selectionKey, "codex")
+        XCTAssertEqual(rotated?.service, .codexCli)
+        XCTAssertEqual(rotated?.title, " 80%")
+    }
+
+    func testMergedModeKeepsAutoSelectionWhenRotationIsOff() {
+        let claude = candidate(key: "claude:gen", percentUsed: 48, activeMinutesAgo: 1)
+        let codex = candidate(key: "codex", service: .codexCli, percentUsed: 20, activeMinutesAgo: 1)
+
+        XCTAssertEqual(plan([claude, codex]).first?.selectionKey, "claude:gen")
+    }
+
+    func testRotationNeverOverridesAPin() {
+        let claude = candidate(key: "claude:gen", percentUsed: 48, activeMinutesAgo: 1)
+        let codex = candidate(
+            key: "codex",
+            service: .codexCli,
+            percentUsed: 20,
+            pinKey: "Codex:weekly",
+            activeMinutesAgo: 1
+        )
+
+        let descriptors = rotatedPlan([claude, codex], tick: 0, pinnedKey: "Codex:weekly")
+
+        XCTAssertEqual(descriptors.first?.selectionKey, "codex")
     }
 
     // MARK: - Per-provider mode


### PR DESCRIPTION
Closes #340

Opt-in timed rotation for the single merged status item. Off by default — with the setting off, planning is byte-identical to today.

## What changed

**`MenuBarRotationSequencer` (new, pure).** Visible candidate set + tick index → outcome (`.rotate` / `.hold` / `.inactive`). No run loop, no state, so ordering, stale skips, pin exclusion, pause and the critical hold are all directly testable.

- Cycles only auto-selectable candidates whose data is fresh (`ProviderParseHealthRecord.staleAfter`) — rotating onto a "—" would be a turn that says nothing. Hidden providers never reach the candidate list.
- Stable order (`ServiceType.sortOrder`, then key), so the cycle doesn't follow probe completion order.
- Critical/exhausted holds the slot. The hold asks `StatusItemLimitSelector` what it *would* pick (with `previousKey: nil`, so a rotated label can't anchor hysteresis) rather than scanning for any critical candidate — otherwise one permanently spent quota would freeze rotation forever.

**Planner.** `plan(...)` takes `rotationTick: Int? = nil`, zeroed outside merged mode. Merged selection consults rotation ahead of auto-selection and hands the winner to the same descriptor builder — one path, not two. `.inactive` falls through to the untouched auto path.

**Presenter.** One `Timer` with 1s tolerance on `.common`, invalidated and the tick reset whenever rotation stops applying (disabled, pinned, or leaving merged mode); rescheduled only when the interval actually changes, so an unrelated refresh can't cut a provider's turn short. It re-runs the presentation pass over cached candidates — it never triggers a refresh. Popover state is read at tick time via a closure over `menuPanel?.isShown` rather than mirrored, because the panel clears its own flag on paths that skip the delegate.

**Preferences.** `rotatesProviders` (default `false`) and `StatusItemRotationInterval` (5/15/30/60s, raw value = seconds, default 15s), both fanned into the existing `displayPreferenceChanges` merge so toggling reshapes the item immediately.

**Settings → General → Menu Bar & Popover.** "Rotate providers" toggle + "Rotation interval" segmented picker, placed under "Menu bar shows". The toggle disables under a pin or a non-merged layout, and a notice names the setting standing in the way.

## Tests

`MenuBarRotationSequencerTests` (11): scheduling gate, stable order + wrap, stale/hidden skip, empty ⇒ inactive, pin ⇒ inactive, critical hold + resume, spent-quota non-freeze, all-spent hold, pause/resume, `Int.max` wrap, negative tick. Plus planner tests for tick-follows/off-is-unchanged/pin-wins and store tests for defaults, persistence, and invalid stored intervals.

## Verification

- `swift test` — 1719 tests, 5 skipped, 0 failures
- `xcodebuild -scheme MeterBar -configuration Debug` (unsigned, as CI) — BUILD SUCCEEDED
- `swiftlint` clean on every changed file

## Notes

#341 (follow-focused-app) is still open with no PR, so this lands first and does not wire cross-exclusivity with it; per the issues, whichever lands second owns that.