### PR TITLE
feat(pricing): price events at the rate in effect at their timestamp

### DIFF
--- a/MeterBar/Models/CLIJSONOutput.swift
+++ b/MeterBar/Models/CLIJSONOutput.swift
@@ -109,6 +109,10 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
     /// no persisted rate of its own; `--currency`/`--rate` are stateless,
     /// per-invocation flags, never a background exchange-rate fetch.
     private let displayCurrency: DisplayCurrencyJSON?
+    /// Provenance of the dated rate entries the last scan priced with (issue
+    /// #339). Additive and optional, so version 1 stays intact: caches written
+    /// before dated pricing simply omit the key.
+    private let pricing: PricingJSON?
 
     public init(
         cache: CostSummaryCache,
@@ -166,6 +170,26 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
         // property (including `self.displayCurrency` itself) is initialized.
         let finalTotalCostUSD = totalCostUSD
         self.displayCurrency = displayCurrency.map { DisplayCurrencyJSON($0, totalCostUSD: finalTotalCostUSD) }
+        pricing = cache.summary.pricing.flatMap(PricingJSON.init(provenance:))
+    }
+
+    private struct PricingJSON: Encodable {
+        /// Verification date of the oldest rate entry this scan priced with.
+        let verifiedFrom: String
+        /// Verification date of the newest one; equal to `verifiedFrom` when a
+        /// single entry priced everything.
+        let verifiedThrough: String
+        /// Events older than every entry in the table, priced at the oldest
+        /// known rate. Non-zero means those figures are an estimate.
+        let eventsBeforeFirstEntry: Int
+
+        init?(provenance: PricingProvenance) {
+            guard let first = provenance.verificationDates.first,
+                  let last = provenance.verificationDates.last else { return nil }
+            verifiedFrom = first
+            verifiedThrough = last
+            eventsBeforeFirstEntry = provenance.eventsBeforeFirstEntry
+        }
     }
 
     private struct Period: Encodable {

--- a/MeterBar/Models/TokenCost.swift
+++ b/MeterBar/Models/TokenCost.swift
@@ -284,6 +284,11 @@ nonisolated public struct CostSummary: Codable, Sendable {
     public let periodDays: Int
     public let dailyUsage: [DailyTokenUsage]
     public let lifetime: LifetimeCostSummary?
+    /// Which dated rate entries actually priced this scan, and how many events
+    /// predated the table (issue #339). Optional so summaries cached by builds
+    /// that predate dated pricing still decode; readers fall back to
+    /// `ModelPricing.tableProvenance`.
+    public let pricing: PricingProvenance?
 
     public init(
         costs: [TokenCost],
@@ -291,7 +296,8 @@ nonisolated public struct CostSummary: Codable, Sendable {
         totalTokens: Int,
         periodDays: Int,
         dailyUsage: [DailyTokenUsage] = [],
-        lifetime: LifetimeCostSummary? = nil
+        lifetime: LifetimeCostSummary? = nil,
+        pricing: PricingProvenance? = nil
     ) {
         self.costs = costs
         self.totalCostUSD = totalCostUSD
@@ -299,6 +305,7 @@ nonisolated public struct CostSummary: Codable, Sendable {
         self.periodDays = periodDays
         self.dailyUsage = dailyUsage
         self.lifetime = lifetime
+        self.pricing = pricing
     }
 
     public var formattedTotalCost: String {

--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -237,7 +237,11 @@ enum ClaudeCostScanner {
         let events = keyed.keys.sorted().compactMap { keyed[$0] } + unkeyed
 
         for event in events {
-            let pricing = Self.pricing(for: event.model)
+            // Price at the rate in effect when the event was recorded, not
+            // today's (issue #339).
+            let resolved = Self.resolvePricing(for: event.model, at: event.timestamp)
+            let pricing = resolved.pricing
+            totals.pricing.record(resolved)
             let eventCost = TokenCostMath.calculateClaudeCost(
                 input: event.input,
                 output: event.output,
@@ -332,8 +336,12 @@ enum ClaudeCostScanner {
         return min(total, max(0, oneHour))
     }
 
-    nonisolated static func pricing(for model: String?) -> TokenPricing {
-        ModelPricing.claude(for: model)
+    nonisolated static func pricing(for model: String?, at timestamp: Date = Date()) -> TokenPricing {
+        ModelPricing.claude(for: model, at: timestamp)
+    }
+
+    nonisolated static func resolvePricing(for model: String?, at timestamp: Date) -> ResolvedPricing {
+        ModelPricing.resolveClaude(for: model, at: timestamp)
     }
 
     nonisolated static func normalizeModel(_ raw: String) -> String {

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -50,6 +50,19 @@ enum CodexCostScanner {
         )
     }
 
+    /// The rate card in effect for `model` at `timestamp`. Every Codex price
+    /// resolution goes through the shared table so the app, the widget, and the
+    /// CLI cannot drift apart (issues #130 and #339).
+    nonisolated static func pricing(for model: String?, at timestamp: Date = Date()) -> TokenPricing {
+        ModelPricing.codex(for: model, at: timestamp)
+    }
+
+    /// Same lookup, but keeping the entry's verification date and whether the
+    /// event predates the table so the scan can report what it priced with.
+    nonisolated static func resolvePricing(for model: String?, at timestamp: Date) -> ResolvedPricing {
+        ModelPricing.resolveCodex(for: model, at: timestamp)
+    }
+
     nonisolated static func makeCost(
         from context: CodexScanContext
     ) -> (TokenCost, [DailyTokenUsage])? {
@@ -59,13 +72,17 @@ enum CodexCostScanner {
         let pricing = ModelPricing.codex
         let billableInput = max(0, totals.input - totals.cacheRead)
         let output = totals.output + totals.reasoning
-        let cost = TokenCostMath.calculateCost(
+        // Prefer the sum of per-event costs, each priced at its own timestamp's
+        // rate; fall back to today's rate only for totals that carry no per-event
+        // cost (issue #339).
+        let fallbackCost = TokenCostMath.calculateCost(
             input: billableInput,
             output: output,
             cacheCreation: 0,
             cacheRead: totals.cacheRead,
             pricing: pricing
         )
+        let cost = totals.estimatedCostUSD > 0 ? totals.estimatedCostUSD : fallbackCost
 
         return (TokenCost(
             provider: .codexCli,
@@ -397,6 +414,20 @@ enum CodexCostScanner {
         let originKey = CostScanValues.displayOriginName(attribution.originName)
         let projectKey = attribution.projectID
 
+        // Price the event at the rate in effect when it was recorded (issue
+        // #339). Codex used to cost the whole window in one shot at today's
+        // rate, which could not distinguish a session billed under an older
+        // rate card. Cached input is already billed by `cacheRead`, so it is
+        // subtracted from the billable input exactly as the aggregate did.
+        let resolved = Self.resolvePricing(for: attribution.modelName, at: timestamp)
+        let eventCost = TokenCostMath.calculateCost(
+            input: max(0, input - cached),
+            output: output + reasoning,
+            cacheCreation: 0,
+            cacheRead: cached,
+            pricing: resolved.pricing
+        )
+
         // Each window keeps its own `eventKeys`, so an event that lands in both
         // is deduplicated independently in each — exactly what the two separate
         // scans did.
@@ -404,30 +435,35 @@ enum CodexCostScanner {
             guard context.eventKeys.insert(key).inserted else { return }
 
             context.sessionIDs.insert(sessionID)
+            context.pricing.record(resolved)
             context.totals.add(
                 input: input,
                 output: output,
                 cacheCreation: 0,
                 cacheRead: cached,
-                reasoning: reasoning
+                reasoning: reasoning,
+                estimatedCostUSD: eventCost
             )
             context.dailyTotals[day, default: TokenAccumulator()].add(
                 input: input,
                 output: output + reasoning,
                 cacheCreation: 0,
-                cacheRead: cached
+                cacheRead: cached,
+                estimatedCostUSD: eventCost
             )
             context.dailyModelTotals[day, default: [:]][modelKey, default: TokenAccumulator()].add(
                 input: input,
                 output: output + reasoning,
                 cacheCreation: 0,
-                cacheRead: cached
+                cacheRead: cached,
+                estimatedCostUSD: eventCost
             )
             context.dailyProjectTotals[day, default: [:]][projectKey, default: TokenAccumulator()].add(
                 input: input,
                 output: output + reasoning,
                 cacheCreation: 0,
-                cacheRead: cached
+                cacheRead: cached,
+                estimatedCostUSD: eventCost
             )
             var dailyProjectModels = context.dailyProjectModelTotals[day] ?? [:]
             dailyProjectModels[projectKey, default: [:]][
@@ -437,32 +473,37 @@ enum CodexCostScanner {
                 input: input,
                 output: output + reasoning,
                 cacheCreation: 0,
-                cacheRead: cached
+                cacheRead: cached,
+                estimatedCostUSD: eventCost
             )
             context.dailyProjectModelTotals[day] = dailyProjectModels
             context.modelTotals[modelKey, default: TokenAccumulator()].add(
                 input: input,
                 output: output + reasoning,
                 cacheCreation: 0,
-                cacheRead: cached
+                cacheRead: cached,
+                estimatedCostUSD: eventCost
             )
             context.originTotals[originKey, default: TokenAccumulator()].add(
                 input: input,
                 output: output + reasoning,
                 cacheCreation: 0,
-                cacheRead: cached
+                cacheRead: cached,
+                estimatedCostUSD: eventCost
             )
             context.projectTotals[projectKey, default: TokenAccumulator()].add(
                 input: input,
                 output: output + reasoning,
                 cacheCreation: 0,
-                cacheRead: cached
+                cacheRead: cached,
+                estimatedCostUSD: eventCost
             )
             context.projectModelTotals[projectKey, default: [:]][modelKey, default: TokenAccumulator()].add(
                 input: input,
                 output: output + reasoning,
                 cacheCreation: 0,
-                cacheRead: cached
+                cacheRead: cached,
+                estimatedCostUSD: eventCost
             )
             if timestamp < context.earliestDate { context.earliestDate = timestamp }
             if timestamp > context.latestDate { context.latestDate = timestamp }

--- a/MeterBar/Services/CostScanWindows.swift
+++ b/MeterBar/Services/CostScanWindows.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MeterBarShared
 
 /// Two accumulators filled by a single traversal: the reporting period and
 /// all-time.
@@ -60,6 +61,9 @@ nonisolated struct ClaudeSessionTotals: Sendable {
     /// Nested per-project, per-model totals powering the "drill-down to model
     /// breakdown" view under each project's rollup row.
     var projectModels: [String: [String: TokenAccumulator]] = [:]
+    /// Which dated rate entries priced these events, and how many predated the
+    /// table entirely (issue #339).
+    var pricing = PricingProvenance()
 
     var hasUsage: Bool {
         input > 0 || output > 0 || cacheCreation > 0 || cacheRead > 0
@@ -115,6 +119,7 @@ nonisolated struct ClaudeSessionTotals: Sendable {
             }
         }
 
+        pricing.merge(other.pricing)
         earliest = Self.earlier(earliest, other.earliest)
         latest = Self.later(latest, other.latest)
     }
@@ -141,11 +146,17 @@ nonisolated struct ClaudeSessionTotals: Sendable {
 nonisolated struct CostScanResult {
     var costs: [TokenCost] = []
     var dailyUsage: [DailyTokenUsage] = []
+    /// Union of the rate entries every provider in this window priced with.
+    var pricing = PricingProvenance()
 
     mutating func append(_ scan: (TokenCost, [DailyTokenUsage])?) {
         guard let scan else { return }
         costs.append(scan.0)
         dailyUsage.append(contentsOf: scan.1)
+    }
+
+    mutating func record(_ provenance: PricingProvenance) {
+        pricing.merge(provenance)
     }
 }
 
@@ -169,6 +180,8 @@ nonisolated struct CodexScanContext: Sendable {
     var projectModelTotals: [String: [String: TokenAccumulator]] = [:]
     var eventKeys: Set<String> = []
     var sessionIDs: Set<String> = []
+    /// Which dated rate entries priced these events (issue #339).
+    var pricing = PricingProvenance()
     var earliestDate: Date
     var latestDate: Date
 }

--- a/MeterBar/Services/CostSummaryBuilder.swift
+++ b/MeterBar/Services/CostSummaryBuilder.swift
@@ -31,7 +31,8 @@ enum CostSummaryBuilder {
             totalTokens: totalTokens,
             periodDays: days,
             dailyUsage: scan.period.dailyUsage.sorted { $0.date < $1.date },
-            lifetime: LifetimeCostSummary(costs: scan.lifetime.costs)
+            lifetime: LifetimeCostSummary(costs: scan.lifetime.costs),
+            pricing: scan.period.pricing.isEmpty ? nil : scan.period.pricing
         )
     }
 
@@ -47,12 +48,23 @@ enum CostSummaryBuilder {
             let claude = ClaudeCostScanner.scanSessions(since: cutoffDate, claudeAccounts: claudeAccounts)
             scan.period.append(ClaudeCostScanner.makeCost(from: claude.period, windowStart: cutoffDate))
             scan.lifetime.append(ClaudeCostScanner.makeCost(from: claude.lifetime, windowStart: .distantPast))
+            scan.period.record(claude.period.pricing)
+            scan.lifetime.record(claude.lifetime.pricing)
         }
 
         if includeCodexCli {
             let codex = CodexCostScanner.scanSessions(since: cutoffDate)
             scan.period.append(CodexCostScanner.makeCost(from: codex.period))
             scan.lifetime.append(CodexCostScanner.makeCost(from: codex.lifetime))
+            scan.period.record(codex.period.pricing)
+            scan.lifetime.record(codex.lifetime.pricing)
+        }
+
+        // Events older than every entry in the table were priced at the oldest
+        // known rate — a documented guess, so say so rather than let it pass as
+        // a verified figure (issue #339).
+        if let note = scan.lifetime.pricing.diagnosticNote {
+            AppLog.cost.warning("Pricing table gap: \(note, privacy: .public)")
         }
 
         return scan

--- a/MeterBar/Services/CostSummaryBuilder.swift
+++ b/MeterBar/Services/CostSummaryBuilder.swift
@@ -1,4 +1,6 @@
 import Foundation
+import MeterBarShared
+import os
 
 /// Runs the per-provider scanners and folds their windows into the published
 /// `CostSummary`. Split out of `CostTracker` (audit C1d) so the summary shape

--- a/MeterBar/Views/DashboardCostCards.swift
+++ b/MeterBar/Views/DashboardCostCards.swift
@@ -38,6 +38,13 @@ struct CostOverviewStatusCard: View {
     return .needsScan
   }
 
+  /// Verification dates of the rate entries this scan actually priced with, not
+  /// a global table revision (issue #339). Summaries cached before dated
+  /// pricing carry none, so those fall back to the shipped table's own dates.
+  private var pricingProvenance: PricingProvenance {
+    summary?.pricing.flatMap { $0.isEmpty ? nil : $0 } ?? ModelPricing.tableProvenance
+  }
+
   var body: some View {
     DashboardTile {
       VStack(alignment: .leading, spacing: 12) {
@@ -88,9 +95,10 @@ struct CostOverviewStatusCard: View {
               .font(.caption)
               .foregroundColor(.secondary)
             Spacer()
-            Text(ModelPricing.revisionLabel)
+            Text(pricingProvenance.label)
               .font(.caption)
               .fontWeight(.semibold)
+              .help(pricingProvenance.diagnosticNote ?? pricingProvenance.label)
           }
         }
       }

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -300,6 +300,18 @@ struct Cost: ParsableCommand {
         }
     }
 
+    /// The verification dates of the rate entries this scan actually priced
+    /// with, falling back to the shipped table for caches written before dated
+    /// pricing existed (issue #339). Events older than every entry were priced
+    /// at the oldest known rate, so that guess is called out rather than hidden.
+    private func printPricing(_ cache: CostSummaryCache) {
+        let provenance = cache.summary.pricing.flatMap { $0.isEmpty ? nil : $0 } ?? ModelPricing.tableProvenance
+        print("Pricing: \(provenance.label)")
+        if let note = provenance.diagnosticNote {
+            print("⚠ \(note)")
+        }
+    }
+
     /// A USD figure, plus its converted equivalent in parentheses when a
     /// `--currency`/`--rate` pair was supplied — otherwise just the USD text.
     private func costText(_ usd: Double, currency: DisplayCurrency?) -> String {
@@ -319,7 +331,7 @@ struct Cost: ParsableCommand {
         print()
         print("Period: \(periodLabel)")
         print("Scanned: \(UsageFormat.relative(cache.lastScanDate))")
-        print("Pricing: \(ModelPricing.revisionLabel)")
+        printPricing(cache)
         // Printed once, near every converted figure below, so a converted
         // total can never be mistaken for a live quote (issue #270).
         if let currency {
@@ -374,7 +386,7 @@ struct Cost: ParsableCommand {
         print()
         print("Period: Last \(summary.periodDays) days")
         print("Scanned: \(UsageFormat.relative(cache.lastScanDate))")
-        print("Pricing: \(ModelPricing.revisionLabel)")
+        printPricing(cache)
         if let currency {
             print("Currency: \(currency.disclosureText)")
         }

--- a/MeterBarTests/DatedModelPricingTests.swift
+++ b/MeterBarTests/DatedModelPricingTests.swift
@@ -1,0 +1,187 @@
+@testable import MeterBar
+import MeterBarShared
+import XCTest
+
+/// Issue #339 — events are priced at the rate in effect at their timestamp.
+///
+/// The schedule fixtures are built by hand rather than read from the shipped
+/// table: the shipped entries are all open-ended backwards (see
+/// `ModelPricing`), so only a synthetic schedule can exercise a boundary or a
+/// pre-history event today. Locking the behaviour here means the first real
+/// dated entry someone adds is a one-line table edit, not a redesign.
+final class DatedModelPricingTests: XCTestCase {
+    private let oldRate = TokenPricing(
+        input: 2.0, output: 10.0, cacheCreation: 2.5, cacheRead: 0.20, cacheCreationOneHour: 4.0)
+    private let newRate = TokenPricing(
+        input: 4.0, output: 20.0, cacheCreation: 5.0, cacheRead: 0.40, cacheCreationOneHour: 8.0)
+
+    private var firstEffective: Date { DatedTokenPricing.utcDay(2026, 1, 1) }
+    private var secondEffective: Date { DatedTokenPricing.utcDay(2026, 7, 1) }
+
+    private func makeSchedule() -> PricingSchedule {
+        PricingSchedule([
+            DatedTokenPricing(effectiveFrom: firstEffective, verifiedOn: "2026-01-05", pricing: oldRate),
+            DatedTokenPricing(effectiveFrom: secondEffective, verifiedOn: "2026-07-02", pricing: newRate)
+        ])
+    }
+
+    // MARK: - Range boundaries
+
+    func testEventExactlyAtEffectiveFromUsesTheNewEntry() throws {
+        let resolved = try XCTUnwrap(makeSchedule().resolve(at: secondEffective))
+
+        XCTAssertEqual(resolved.pricing, newRate)
+        XCTAssertEqual(resolved.effectiveFrom, secondEffective)
+        XCTAssertEqual(resolved.verifiedOn, "2026-07-02")
+        XCTAssertFalse(resolved.precedesFirstEntry)
+    }
+
+    func testEventOneSecondBeforeEffectiveFromUsesThePreviousEntry() throws {
+        let resolved = try XCTUnwrap(makeSchedule().resolve(at: secondEffective.addingTimeInterval(-1)))
+
+        XCTAssertEqual(resolved.pricing, oldRate)
+        XCTAssertEqual(resolved.effectiveFrom, firstEffective)
+        XCTAssertEqual(resolved.verifiedOn, "2026-01-05")
+        XCTAssertFalse(resolved.precedesFirstEntry)
+    }
+
+    func testEventAfterTheNewestEntryKeepsUsingIt() throws {
+        let resolved = try XCTUnwrap(makeSchedule().resolve(at: DatedTokenPricing.utcDay(2030, 3, 9)))
+
+        XCTAssertEqual(resolved.pricing, newRate)
+        XCTAssertEqual(resolved.verifiedOn, "2026-07-02")
+    }
+
+    func testEntriesResolveRegardlessOfConstructionOrder() throws {
+        let reversed = PricingSchedule([
+            DatedTokenPricing(effectiveFrom: secondEffective, verifiedOn: "2026-07-02", pricing: newRate),
+            DatedTokenPricing(effectiveFrom: firstEffective, verifiedOn: "2026-01-05", pricing: oldRate)
+        ])
+
+        XCTAssertEqual(reversed.entries.map(\.effectiveFrom), [firstEffective, secondEffective])
+        XCTAssertEqual(try XCTUnwrap(reversed.resolve(at: firstEffective)).pricing, oldRate)
+        XCTAssertEqual(try XCTUnwrap(reversed.resolve(at: secondEffective)).pricing, newRate)
+    }
+
+    // MARK: - Pre-history
+
+    func testEventBeforeEveryEntryPricesAtTheOldestEntryAndIsFlagged() throws {
+        let resolved = try XCTUnwrap(makeSchedule().resolve(at: DatedTokenPricing.utcDay(2024, 6, 1)))
+
+        // Not failing, not zero — the oldest known rate, flagged as a guess.
+        XCTAssertEqual(resolved.pricing, oldRate)
+        XCTAssertEqual(resolved.effectiveFrom, firstEffective)
+        XCTAssertTrue(resolved.precedesFirstEntry)
+    }
+
+    func testEmptyScheduleResolvesToNothingRatherThanZeroRates() {
+        XCTAssertNil(PricingSchedule([]).resolve(at: Date()))
+    }
+
+    // MARK: - Regression: a new dated entry must not move historical costs
+
+    func testAddingALaterEntryLeavesEarlierCostsUnchanged() throws {
+        let before = PricingSchedule([
+            DatedTokenPricing(effectiveFrom: firstEffective, verifiedOn: "2026-01-05", pricing: oldRate)
+        ])
+        let after = makeSchedule()
+        let historical = DatedTokenPricing.utcDay(2026, 3, 15)
+
+        let costBefore = Self.cost(using: try XCTUnwrap(before.resolve(at: historical)).pricing)
+        let costAfter = Self.cost(using: try XCTUnwrap(after.resolve(at: historical)).pricing)
+        XCTAssertEqual(costBefore, costAfter, accuracy: 0.000_001)
+
+        // ...and the new entry does apply once its effectiveFrom is reached.
+        let costToday = Self.cost(using: try XCTUnwrap(after.resolve(at: secondEffective)).pricing)
+        XCTAssertNotEqual(costAfter, costToday, accuracy: 0.000_001)
+    }
+
+    private static func cost(using pricing: TokenPricing) -> Double {
+        TokenCostMath.calculateClaudeCost(
+            input: 1_000_000,
+            output: 2_000_000,
+            cacheCreation: 500_000,
+            cacheCreationOneHour: 100_000,
+            cacheRead: 4_000_000,
+            pricing: pricing
+        )
+    }
+
+    // MARK: - Current-rate lookup against the shipped table
+
+    func testShippedTableResolvesTodaysPublishedRates() {
+        let now = Date()
+        XCTAssertEqual(ModelPricing.claude(for: "claude-fable-5", at: now).input, 10.0)
+        XCTAssertEqual(ModelPricing.claude(for: "claude-opus-4-8-20260101", at: now).input, 5.0)
+        XCTAssertEqual(ModelPricing.claude(for: "claude-sonnet-4-6", at: now).cacheCreationOneHour, 6.0)
+        XCTAssertEqual(ModelPricing.claude(for: "mystery-model", at: now).input, 3.0)
+        XCTAssertEqual(ModelPricing.codex(for: "gpt-5.6-sol", at: now).input, 1.25)
+    }
+
+    func testShippedTableHasNoPreHistoryGap() {
+        // Every seeded entry is open-ended backwards on purpose: we never
+        // verified historical Anthropic/OpenAI rates, and inventing effective
+        // dates would silently mis-price old sessions. So no timestamp, however
+        // old, may come back flagged as pre-history from the shipped table.
+        let ancient = DatedTokenPricing.utcDay(2019, 1, 1)
+        for model in ["claude-fable-5", "claude-opus-4-8", "claude-haiku-4-5", "unknown-model", nil] {
+            let resolved = ModelPricing.resolveClaude(for: model, at: ancient)
+            XCTAssertFalse(resolved.precedesFirstEntry, "\(model ?? "nil") reported pre-history")
+            XCTAssertEqual(resolved.pricing, ModelPricing.claude(for: model), "\(model ?? "nil") drifted by date")
+        }
+        XCTAssertFalse(ModelPricing.resolveCodex(for: "gpt-5.6-sol", at: ancient).precedesFirstEntry)
+    }
+
+    func testDefaultTimestampArgumentPricesAtTodaysRate() {
+        XCTAssertEqual(ModelPricing.claude(for: "claude-opus"), ModelPricing.claude(for: "claude-opus", at: Date()))
+        XCTAssertEqual(ModelPricing.codex, ModelPricing.codex(for: nil, at: Date()))
+    }
+
+    // MARK: - Provenance
+
+    func testProvenanceCollectsVerificationDatesAndPreHistoryCount() throws {
+        let schedule = makeSchedule()
+        var provenance = PricingProvenance()
+        provenance.record(try XCTUnwrap(schedule.resolve(at: DatedTokenPricing.utcDay(2024, 6, 1))))
+        provenance.record(try XCTUnwrap(schedule.resolve(at: DatedTokenPricing.utcDay(2026, 3, 1))))
+        provenance.record(try XCTUnwrap(schedule.resolve(at: secondEffective)))
+
+        XCTAssertEqual(provenance.verificationDates, ["2026-01-05", "2026-07-02"])
+        XCTAssertEqual(provenance.eventsBeforeFirstEntry, 1)
+        XCTAssertEqual(provenance.label, "Rates verified 2026-01-05–2026-07-02")
+        XCTAssertNotNil(provenance.diagnosticNote)
+    }
+
+    func testProvenanceLabelUsesASingleDateWhenAllEntriesAgree() throws {
+        var provenance = PricingProvenance()
+        provenance.record(try XCTUnwrap(makeSchedule().resolve(at: secondEffective)))
+
+        XCTAssertEqual(provenance.label, "Rates verified 2026-07-02")
+        XCTAssertNil(provenance.diagnosticNote)
+        XCTAssertFalse(provenance.isEmpty)
+    }
+
+    func testProvenanceMergeUnionsDatesAndSumsPreHistory() {
+        var left = PricingProvenance(verificationDates: ["2026-07-02"], eventsBeforeFirstEntry: 2)
+        let right = PricingProvenance(verificationDates: ["2026-01-05", "2026-07-02"], eventsBeforeFirstEntry: 3)
+        left.merge(right)
+
+        XCTAssertEqual(left.verificationDates, ["2026-01-05", "2026-07-02"])
+        XCTAssertEqual(left.eventsBeforeFirstEntry, 5)
+    }
+
+    func testEmptyProvenanceIsEmptyAndUnlabelled() {
+        // Nothing was priced, so there is no entry to name. Call sites fall back
+        // to `ModelPricing.tableProvenance` rather than showing this label.
+        let provenance = PricingProvenance()
+        XCTAssertTrue(provenance.isEmpty)
+        XCTAssertNil(provenance.diagnosticNote)
+        XCTAssertEqual(provenance.label, "Rates verified —")
+    }
+
+    func testTableProvenanceDescribesTheShippedEntries() {
+        XCTAssertFalse(ModelPricing.tableProvenance.isEmpty)
+        XCTAssertEqual(ModelPricing.tableProvenance.eventsBeforeFirstEntry, 0)
+        XCTAssertEqual(ModelPricing.tableProvenance.label, "Rates verified 2026-07-02")
+    }
+}

--- a/MeterBarTests/ModelPricingTests.swift
+++ b/MeterBarTests/ModelPricingTests.swift
@@ -4,7 +4,9 @@ import XCTest
 
 final class ModelPricingTests: XCTestCase {
     func testSharedTableOwnsRevisionAndProviderRates() {
-        XCTAssertEqual(ModelPricing.revision, "2026-07-02")
+        // Each entry now carries its own verification date (issue #339); the
+        // table's provenance is the span across every shipped entry.
+        XCTAssertEqual(ModelPricing.tableProvenance.verificationDates, ["2026-07-02"])
         XCTAssertEqual(ModelPricing.claude(for: "claude-fable-5").input, 10.0)
         XCTAssertEqual(ModelPricing.claude(for: "claude-opus-4-8-20260101").input, 5.0)
         XCTAssertEqual(ModelPricing.claude(for: "mystery-model").input, 3.0)

--- a/MeterBarTests/PricingScheduleContractTests.swift
+++ b/MeterBarTests/PricingScheduleContractTests.swift
@@ -1,0 +1,201 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// Cross-target contract for the dated pricing table (issues #130 and #339).
+///
+/// The app, the widget extension, and the CLI must price a given (model,
+/// timestamp) pair identically, because all three resolve it through
+/// `MeterBarShared.ModelPricing` — nobody keeps a forked copy. The scan
+/// provenance rides the cost cache the CLI reads, so it has to survive that
+/// exact encode/decode path and stay absent-tolerant for caches written before
+/// this field existed.
+final class PricingScheduleContractTests: XCTestCase {
+    private let referenceDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - Single source of truth (a forked table must break CI)
+
+    func testScannersResolvePricingThroughTheSharedTable() {
+        let timestamps = [
+            DatedTokenPricing.utcDay(2019, 1, 1),
+            DatedTokenPricing.utcDay(2026, 7, 2),
+            Date()
+        ]
+        let claudeModels: [String?] = [nil, "claude-fable-9", "claude-opus-4-7", "claude-haiku-4-5", "unknown"]
+        let codexModels: [String?] = [nil, "gpt-5.6-sol", "gpt-5.6-terra", "  GPT-5.6-Luna  ", "gpt-9-unreleased"]
+
+        for timestamp in timestamps {
+            for model in claudeModels {
+                XCTAssertEqual(
+                    ClaudeCostScanner.pricing(for: model, at: timestamp),
+                    ModelPricing.claude(for: model, at: timestamp)
+                )
+            }
+            for model in codexModels {
+                XCTAssertEqual(
+                    CodexCostScanner.pricing(for: model, at: timestamp),
+                    ModelPricing.codex(for: model, at: timestamp)
+                )
+            }
+        }
+    }
+
+    func testEverySeededScheduleResolvesAtAnyTimestampWithoutZeroRates() {
+        // A schedule that resolves to nothing (or to zero rates) would silently
+        // report $0.00 for a whole provider.
+        for key in ModelPricing.tableKeys {
+            let schedule = ModelPricing.schedule(forKey: key)
+            XCTAssertNotNil(schedule, "no schedule for '\(key)'")
+            XCTAssertFalse(schedule?.entries.isEmpty ?? true, "'\(key)' has no entries")
+            XCTAssertEqual(
+                schedule?.entries.map(\.effectiveFrom).sorted(),
+                schedule?.entries.map(\.effectiveFrom),
+                "'\(key)' entries are not sorted ascending"
+            )
+
+            for timestamp in [Date.distantPast, referenceDate, Date(), Date.distantFuture] {
+                let resolved = schedule?.resolve(at: timestamp)
+                XCTAssertNotNil(resolved, "'\(key)' resolved to nothing at \(timestamp)")
+                XCTAssertGreaterThan(resolved?.pricing.input ?? 0, 0, "'\(key)' priced input at zero")
+                XCTAssertGreaterThan(resolved?.pricing.output ?? 0, 0, "'\(key)' priced output at zero")
+                XCTAssertFalse(resolved?.verifiedOn.isEmpty ?? true, "'\(key)' carries no verification date")
+            }
+        }
+    }
+
+    func testEveryVerificationDateIsAnISO8601Day() {
+        for key in ModelPricing.tableKeys {
+            for entry in ModelPricing.schedule(forKey: key)?.entries ?? [] {
+                XCTAssertNotNil(
+                    entry.verifiedOn.range(of: #"^\d{4}-\d{2}-\d{2}$"#, options: .regularExpression),
+                    "'\(key)' has a malformed verification date '\(entry.verifiedOn)'"
+                )
+            }
+        }
+    }
+
+    // MARK: - The scanner records what it actually priced with
+
+    func testClaudeScanRecordsTheProvenanceOfTheEntriesItUsed() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PricingContractTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("session.jsonl")
+        let line = """
+        {"timestamp": "2026-07-01T10:00:00.000Z", "requestId": "req_1", "message": {"id": "msg_1", \
+        "model": "claude-sonnet-4-5", "usage": {"input_tokens": 1000000, "output_tokens": 0, \
+        "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}}
+        """
+        try line.write(to: url, atomically: true, encoding: .utf8)
+
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let totals = ClaudeCostScanner.parseSessionFile(at: url, since: cutoff)
+
+        let eventDate = try XCTUnwrap(FlexibleISO8601.date(from: "2026-07-01T10:00:00.000Z"))
+        let expected = ModelPricing.resolveClaude(for: "claude-sonnet-4-5", at: eventDate)
+        XCTAssertEqual(totals.pricing.verificationDates, [expected.verifiedOn])
+        XCTAssertEqual(totals.pricing.eventsBeforeFirstEntry, 0)
+        XCTAssertEqual(totals.estimatedCost, expected.pricing.input, accuracy: 0.000_001)
+    }
+
+    // MARK: - Provenance rides the cost cache (app writer ⇄ widget/CLI readers)
+
+    func testProvenanceRoundTripsThroughTheCostCache() throws {
+        let provenance = PricingProvenance(
+            verificationDates: ["2026-07-02", "2026-01-05"],
+            eventsBeforeFirstEntry: 4
+        )
+        let cache = CostSummaryCache(
+            summary: CostSummary(
+                costs: [],
+                totalCostUSD: 0,
+                totalTokens: 0,
+                periodDays: 30,
+                pricing: provenance
+            ),
+            lastScanDate: referenceDate
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(CostSummaryCache.self, from: try encoder.encode(cache))
+
+        let restored = try XCTUnwrap(decoded.summary.pricing)
+        XCTAssertEqual(restored.verificationDates, ["2026-01-05", "2026-07-02"])
+        XCTAssertEqual(restored.eventsBeforeFirstEntry, 4)
+        XCTAssertEqual(restored.label, "Rates verified 2026-01-05–2026-07-02")
+    }
+
+    func testCachesWrittenBeforeDatedPricingStillDecode() throws {
+        // Shape written by builds that had no pricing provenance at all.
+        let legacyJSON = """
+        {
+            "schemaVersion": 2,
+            "lastScanDate": "2023-11-14T22:13:20Z",
+            "summary": {
+                "costs": [],
+                "totalCostUSD": 0,
+                "totalTokens": 0,
+                "periodDays": 30,
+                "dailyUsage": []
+            }
+        }
+        """
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let cache = try decoder.decode(CostSummaryCache.self, from: Data(legacyJSON.utf8))
+
+        XCTAssertNil(cache.summary.pricing)
+        // Readers fall back to the shipped table's own verification dates.
+        XCTAssertEqual(
+            (cache.summary.pricing?.isEmpty == false ? cache.summary.pricing : ModelPricing.tableProvenance)?.label,
+            ModelPricing.tableProvenance.label
+        )
+    }
+
+    // MARK: - CLI JSON stays schema-compatible (docs/cli-json-schema.md, version 1)
+
+    func testCostJSONOmitsPricingWhenTheCacheHasNone() throws {
+        let cache = CostSummaryCache(
+            summary: CostSummary(costs: [], totalCostUSD: 0, totalTokens: 0, periodDays: 30),
+            lastScanDate: referenceDate
+        )
+
+        let object = try Self.jsonObject(CostCLIJSONResponse(cache: cache))
+        XCTAssertEqual(object["schemaVersion"] as? Int, CostCLIJSONResponse.currentSchemaVersion)
+        XCTAssertNil(object["pricing"], "pricing must be omitted, not emitted as null")
+    }
+
+    func testCostJSONPublishesTheProvenanceTheScanRecorded() throws {
+        let cache = CostSummaryCache(
+            summary: CostSummary(
+                costs: [],
+                totalCostUSD: 0,
+                totalTokens: 0,
+                periodDays: 30,
+                pricing: PricingProvenance(
+                    verificationDates: ["2026-07-02", "2026-01-05"],
+                    eventsBeforeFirstEntry: 2
+                )
+            ),
+            lastScanDate: referenceDate
+        )
+
+        let object = try Self.jsonObject(CostCLIJSONResponse(cache: cache))
+        let pricing = try XCTUnwrap(object["pricing"] as? [String: Any])
+        XCTAssertEqual(pricing["verifiedFrom"] as? String, "2026-01-05")
+        XCTAssertEqual(pricing["verifiedThrough"] as? String, "2026-07-02")
+        XCTAssertEqual(pricing["eventsBeforeFirstEntry"] as? Int, 2)
+        // Version 1 permits additive fields; it must not bump the version.
+        XCTAssertEqual(object["schemaVersion"] as? Int, 1)
+    }
+
+    private static func jsonObject(_ document: some CLIJSONDocument) throws -> [String: Any] {
+        try XCTUnwrap(JSONSerialization.jsonObject(with: try document.jsonData()) as? [String: Any])
+    }
+}

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ModelPricing.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ModelPricing.swift
@@ -23,80 +23,257 @@ public struct TokenPricing: Equatable, Sendable {
     }
 }
 
-/// Single source of truth for the app and CLI's local-log cost estimates.
-public enum ModelPricing {
-    /// Date these rates were last checked against provider pricing pages.
-    public static let revision = "2026-07-02"
-    public static let revisionLabel = "Rates verified \(revision)"
+/// One rate card and the date it took effect, so an event recorded months ago
+/// is priced at the rate that was published then rather than today's.
+public struct DatedTokenPricing: Equatable, Sendable {
+    /// Inclusive: an event stamped exactly at this instant uses this entry.
+    public let effectiveFrom: Date
+    /// The day this row was checked against the provider's pricing page.
+    public let verifiedOn: String
+    public let pricing: TokenPricing
 
-    private static let table: [String: TokenPricing] = [
-        "claude-sonnet": TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30),
-        "claude-opus": TokenPricing(input: 15.0, output: 75.0, cacheCreation: 18.75, cacheRead: 1.50),
-        "claude-haiku": TokenPricing(input: 0.25, output: 1.25, cacheCreation: 0.30, cacheRead: 0.03),
-        "claude-fable-5": TokenPricing(
-            input: 10.0, output: 50.0, cacheCreation: 12.5, cacheRead: 1.0, cacheCreationOneHour: 20.0),
-        "claude-opus-4-8": TokenPricing(
-            input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0),
-        "claude-opus-4-7": TokenPricing(
-            input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0),
-        "claude-opus-4-6": TokenPricing(
-            input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0),
-        "claude-sonnet-4-6": TokenPricing(
-            input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30, cacheCreationOneHour: 6.0),
-        "claude-sonnet-4-5": TokenPricing(
-            input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30, cacheCreationOneHour: 6.0),
-        "claude-sonnet-4": TokenPricing(
-            input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30, cacheCreationOneHour: 6.0),
-        "claude-haiku-4-5": TokenPricing(
-            input: 1.0, output: 5.0, cacheCreation: 1.25, cacheRead: 0.10, cacheCreationOneHour: 2.0),
-        "codex": TokenPricing(input: 1.25, output: 10.0, cacheCreation: 0, cacheRead: 0.125),
+    public init(effectiveFrom: Date, verifiedOn: String, pricing: TokenPricing) {
+        self.effectiveFrom = effectiveFrom
+        self.verifiedOn = verifiedOn
+        self.pricing = pricing
+    }
+
+    /// UTC midnight for a table entry, written as `(2026, 7, 2)` so entries read
+    /// like the pricing pages they were copied from.
+    public static func utcDay(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? calendar.timeZone
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        return calendar.date(from: components) ?? .distantPast
+    }
+}
+
+/// The rate that applied to one event, plus where it came from.
+public struct ResolvedPricing: Equatable, Sendable {
+    public let pricing: TokenPricing
+    public let effectiveFrom: Date
+    public let verifiedOn: String
+    /// The event predates every entry we have, so it was priced at the oldest
+    /// known rate. Surfaced in scan diagnostics rather than failing the scan.
+    public let precedesFirstEntry: Bool
+
+    public init(pricing: TokenPricing, effectiveFrom: Date, verifiedOn: String, precedesFirstEntry: Bool) {
+        self.pricing = pricing
+        self.effectiveFrom = effectiveFrom
+        self.verifiedOn = verifiedOn
+        self.precedesFirstEntry = precedesFirstEntry
+    }
+}
+
+/// Date-ranged rates for one model key. Entries are half-open ranges: each one
+/// applies from its `effectiveFrom` until the next entry begins, and the last
+/// entry stays open-ended.
+public struct PricingSchedule: Equatable, Sendable {
+    /// Always sorted ascending by `effectiveFrom`.
+    public let entries: [DatedTokenPricing]
+
+    public init(_ entries: [DatedTokenPricing]) {
+        self.entries = entries.sorted { $0.effectiveFrom < $1.effectiveFrom }
+    }
+
+    /// A rate that has always applied, for models whose historical prices we
+    /// never verified. Open-ended backwards so no event is ever flagged as
+    /// pre-history against a fabricated start date.
+    public static func constant(_ pricing: TokenPricing, verifiedOn: String) -> PricingSchedule {
+        PricingSchedule([
+            DatedTokenPricing(effectiveFrom: .distantPast, verifiedOn: verifiedOn, pricing: pricing)
+        ])
+    }
+
+    /// The entry in effect at `timestamp`, or the oldest entry (flagged) when
+    /// the event predates the whole schedule. `nil` only for an empty schedule —
+    /// callers must fall back rather than price at zero.
+    public func resolve(at timestamp: Date) -> ResolvedPricing? {
+        guard let oldest = entries.first else { return nil }
+
+        var chosen = oldest
+        for entry in entries where entry.effectiveFrom <= timestamp {
+            chosen = entry
+        }
+
+        return ResolvedPricing(
+            pricing: chosen.pricing,
+            effectiveFrom: chosen.effectiveFrom,
+            verifiedOn: chosen.verifiedOn,
+            precedesFirstEntry: timestamp < oldest.effectiveFrom
+        )
+    }
+}
+
+/// Which rate entries a scan actually used, so the UI and CLI can name the
+/// verification date of the entry in play instead of one global revision date.
+public struct PricingProvenance: Codable, Equatable, Sendable {
+    /// Unique and sorted ascending; a scan spanning a rate change carries both.
+    public private(set) var verificationDates: [String]
+    /// Events priced at the oldest known rate because they predate the table.
+    public private(set) var eventsBeforeFirstEntry: Int
+
+    public init(verificationDates: [String] = [], eventsBeforeFirstEntry: Int = 0) {
+        self.verificationDates = Array(Set(verificationDates)).sorted()
+        self.eventsBeforeFirstEntry = max(0, eventsBeforeFirstEntry)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            verificationDates: try container.decodeIfPresent([String].self, forKey: .verificationDates) ?? [],
+            eventsBeforeFirstEntry: try container.decodeIfPresent(Int.self, forKey: .eventsBeforeFirstEntry) ?? 0
+        )
+    }
+
+    public var isEmpty: Bool {
+        verificationDates.isEmpty && eventsBeforeFirstEntry == 0
+    }
+
+    /// "Rates verified 2026-07-02", or a range when the scan crossed entries
+    /// checked on different days.
+    public var label: String {
+        guard let first = verificationDates.first, let last = verificationDates.last else {
+            return "Rates verified —"
+        }
+        return first == last ? "Rates verified \(first)" : "Rates verified \(first)–\(last)"
+    }
+
+    /// Non-nil only when something was priced at the oldest known rate.
+    public var diagnosticNote: String? {
+        guard eventsBeforeFirstEntry > 0 else { return nil }
+        let events = eventsBeforeFirstEntry == 1 ? "1 event" : "\(eventsBeforeFirstEntry) events"
+        return "\(events) predate the pricing table and were priced at the oldest known rate."
+    }
+
+    public mutating func record(_ resolved: ResolvedPricing) {
+        insert(resolved.verifiedOn)
+        if resolved.precedesFirstEntry {
+            eventsBeforeFirstEntry += 1
+        }
+    }
+
+    public mutating func merge(_ other: PricingProvenance) {
+        for date in other.verificationDates {
+            insert(date)
+        }
+        eventsBeforeFirstEntry += other.eventsBeforeFirstEntry
+    }
+
+    private mutating func insert(_ date: String) {
+        guard !verificationDates.contains(date) else { return }
+        verificationDates.append(date)
+        verificationDates.sort()
+    }
+}
+
+/// Single source of truth for the app, widget, and CLI's local-log cost
+/// estimates. Every model key maps to date-ranged rates; look-ups take the
+/// event's timestamp so historical sessions keep the price they were billed at.
+///
+/// Sources, all checked 2026-07-02:
+///   - Anthropic — https://www.anthropic.com/pricing#api
+///   - OpenAI (Codex) — https://openai.com/api/pricing/
+///
+/// The seeded entries are deliberately open-ended backwards: we never verified
+/// what these models cost before that check, and inventing effective dates
+/// would mis-price old sessions while looking authoritative. When a rate
+/// changes, append a dated entry — costs before its `effectiveFrom` stay put.
+public enum ModelPricing {
+    /// Day the seeded entries were checked against the pricing pages above.
+    private static let seedVerification = "2026-07-02"
+
+    private static let table: [String: PricingSchedule] = [
+        "claude-sonnet": .constant(
+            TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30),
+            verifiedOn: seedVerification),
+        "claude-opus": .constant(
+            TokenPricing(input: 15.0, output: 75.0, cacheCreation: 18.75, cacheRead: 1.50),
+            verifiedOn: seedVerification),
+        "claude-haiku": .constant(
+            TokenPricing(input: 0.25, output: 1.25, cacheCreation: 0.30, cacheRead: 0.03),
+            verifiedOn: seedVerification),
+        "claude-fable-5": .constant(
+            TokenPricing(input: 10.0, output: 50.0, cacheCreation: 12.5, cacheRead: 1.0, cacheCreationOneHour: 20.0),
+            verifiedOn: seedVerification),
+        "claude-opus-4-8": .constant(
+            TokenPricing(input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0),
+            verifiedOn: seedVerification),
+        "claude-opus-4-7": .constant(
+            TokenPricing(input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0),
+            verifiedOn: seedVerification),
+        "claude-opus-4-6": .constant(
+            TokenPricing(input: 5.0, output: 25.0, cacheCreation: 6.25, cacheRead: 0.50, cacheCreationOneHour: 10.0),
+            verifiedOn: seedVerification),
+        "claude-sonnet-4-6": .constant(
+            TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30, cacheCreationOneHour: 6.0),
+            verifiedOn: seedVerification),
+        "claude-sonnet-4-5": .constant(
+            TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30, cacheCreationOneHour: 6.0),
+            verifiedOn: seedVerification),
+        "claude-sonnet-4": .constant(
+            TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30, cacheCreationOneHour: 6.0),
+            verifiedOn: seedVerification),
+        "claude-haiku-4-5": .constant(
+            TokenPricing(input: 1.0, output: 5.0, cacheCreation: 1.25, cacheRead: 0.10, cacheCreationOneHour: 2.0),
+            verifiedOn: seedVerification),
+        "codex": .constant(
+            TokenPricing(input: 1.25, output: 10.0, cacheCreation: 0, cacheRead: 0.125),
+            verifiedOn: seedVerification),
         // Every published Codex slug currently bills at the base `codex` rate.
         // They are listed anyway so a future per-slug divergence is a one-line
         // table edit instead of re-plumbing the lookup.
-        "gpt-5.6-sol": TokenPricing(input: 1.25, output: 10.0, cacheCreation: 0, cacheRead: 0.125),
-        "gpt-5.6-terra": TokenPricing(input: 1.25, output: 10.0, cacheCreation: 0, cacheRead: 0.125),
-        "gpt-5.6-luna": TokenPricing(input: 1.25, output: 10.0, cacheCreation: 0, cacheRead: 0.125),
-        "default": TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30)
+        "gpt-5.6-sol": .constant(
+            TokenPricing(input: 1.25, output: 10.0, cacheCreation: 0, cacheRead: 0.125),
+            verifiedOn: seedVerification),
+        "gpt-5.6-terra": .constant(
+            TokenPricing(input: 1.25, output: 10.0, cacheCreation: 0, cacheRead: 0.125),
+            verifiedOn: seedVerification),
+        "gpt-5.6-luna": .constant(
+            TokenPricing(input: 1.25, output: 10.0, cacheCreation: 0, cacheRead: 0.125),
+            verifiedOn: seedVerification),
+        "default": .constant(
+            TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30),
+            verifiedOn: seedVerification)
     ]
 
+    /// Verification dates of the shipped table itself — what the UI and CLI show
+    /// before a scan has recorded which entries it actually used.
+    public static let tableProvenance = PricingProvenance(
+        verificationDates: table.values.flatMap { $0.entries.map(\.verifiedOn) }
+    )
+
+    /// Diagnostic seam for the cross-target contract test.
+    public static var tableKeys: [String] { table.keys.sorted() }
+
+    /// Diagnostic seam for the cross-target contract test.
+    public static func schedule(forKey key: String) -> PricingSchedule? { table[key] }
+
     public static var codex: TokenPricing {
-        table["codex"] ?? fallback
+        codex(for: nil)
     }
 
-    /// Per-model Codex rate, falling back to the flat provider rate for slugs
-    /// the table does not know yet.
-    public static func codex(for model: String?) -> TokenPricing {
-        guard let model else { return codex }
+    /// Per-model Codex rate at `timestamp`, falling back to the flat provider
+    /// rate for slugs the table does not know yet.
+    public static func codex(for model: String?, at timestamp: Date = Date()) -> TokenPricing {
+        resolveCodex(for: model, at: timestamp).pricing
+    }
+
+    public static func resolveCodex(for model: String?, at timestamp: Date = Date()) -> ResolvedPricing {
+        guard let model else { return resolve(key: "codex", at: timestamp) }
         let normalized = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return table[normalized] ?? codex
+        return resolve(key: table[normalized] != nil ? normalized : "codex", at: timestamp)
     }
 
-    public static func claude(for model: String?) -> TokenPricing {
-        guard let model else { return table["claude-sonnet"] ?? fallback }
+    public static func claude(for model: String?, at timestamp: Date = Date()) -> TokenPricing {
+        resolveClaude(for: model, at: timestamp).pricing
+    }
 
-        let normalized = normalizeClaudeModel(model)
-        if let exact = table[normalized] { return exact }
-        if normalized.contains("fable") { return table["claude-fable-5"] ?? fallback }
-        if normalized.contains("opus") {
-            let base = table["claude-opus"] ?? fallback
-            if normalized.contains("4-8") { return table["claude-opus-4-8"] ?? base }
-            if normalized.contains("4-7") { return table["claude-opus-4-7"] ?? base }
-            if normalized.contains("4-6") { return table["claude-opus-4-6"] ?? base }
-            return base
-        }
-        if normalized.contains("haiku") {
-            return normalized.contains("4-5")
-                ? table["claude-haiku-4-5"] ?? (table["claude-haiku"] ?? fallback)
-                : table["claude-haiku"] ?? fallback
-        }
-        if normalized.contains("sonnet") {
-            let base = table["claude-sonnet"] ?? fallback
-            if normalized.contains("4-6") { return table["claude-sonnet-4-6"] ?? base }
-            if normalized.contains("4-5") { return table["claude-sonnet-4-5"] ?? base }
-            if normalized.contains("4") { return table["claude-sonnet-4"] ?? base }
-            return base
-        }
-        return fallback
+    public static func resolveClaude(for model: String?, at timestamp: Date = Date()) -> ResolvedPricing {
+        resolve(key: claudeKey(for: model), at: timestamp)
     }
 
     public static func normalizeClaudeModel(_ raw: String) -> String {
@@ -117,10 +294,40 @@ public enum ModelPricing {
         return trimmed
     }
 
-    private static let fallback = TokenPricing(
-        input: 3.0,
-        output: 15.0,
-        cacheCreation: 3.75,
-        cacheRead: 0.30
+    /// Model name → table key. Split out from the rate lookup so routing stays
+    /// one decision and every key resolves through the same dated path.
+    private static func claudeKey(for model: String?) -> String {
+        guard let model else { return "claude-sonnet" }
+
+        let normalized = normalizeClaudeModel(model)
+        if table[normalized] != nil { return normalized }
+        if normalized.contains("fable") { return "claude-fable-5" }
+        if normalized.contains("opus") {
+            if normalized.contains("4-8") { return "claude-opus-4-8" }
+            if normalized.contains("4-7") { return "claude-opus-4-7" }
+            if normalized.contains("4-6") { return "claude-opus-4-6" }
+            return "claude-opus"
+        }
+        if normalized.contains("haiku") {
+            return normalized.contains("4-5") ? "claude-haiku-4-5" : "claude-haiku"
+        }
+        if normalized.contains("sonnet") {
+            if normalized.contains("4-6") { return "claude-sonnet-4-6" }
+            if normalized.contains("4-5") { return "claude-sonnet-4-5" }
+            if normalized.contains("4") { return "claude-sonnet-4" }
+            return "claude-sonnet"
+        }
+        return "default"
+    }
+
+    private static func resolve(key: String, at timestamp: Date) -> ResolvedPricing {
+        table[key]?.resolve(at: timestamp) ?? fallbackResolution
+    }
+
+    private static let fallbackResolution = ResolvedPricing(
+        pricing: TokenPricing(input: 3.0, output: 15.0, cacheCreation: 3.75, cacheRead: 0.30),
+        effectiveFrom: .distantPast,
+        verifiedOn: seedVerification,
+        precedesFirstEntry: false
     )
 }

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -278,6 +278,30 @@ flags are supplied.
 `source` is always `"manual"` — a marker (not a variant to branch on today) that a future live-rate
 source, if ever added, would need to distinguish itself from.
 
+### Pricing provenance
+
+Added in version 1 as an additive field. Events are priced at the rate in effect at their own
+timestamp, so a scan can span more than one rate entry. The top-level `pricing` object reports
+which entries the cached scan actually used:
+
+```json
+{
+  "pricing": {
+    "verifiedFrom": "2026-01-05",
+    "verifiedThrough": "2026-07-02",
+    "eventsBeforeFirstEntry": 0
+  }
+}
+```
+
+- `verifiedFrom` / `verifiedThrough` — verification dates of the oldest and newest rate entry that
+  priced this scan. Equal when a single entry priced everything.
+- `eventsBeforeFirstEntry` — events older than every entry in the pricing table. Those are priced
+  at the oldest known rate, so a non-zero value means the total is an estimate for that portion.
+
+The object is omitted entirely when the cache predates dated pricing or the scan priced nothing.
+Consumers on version 1 that do not know the field keep working unchanged.
+
 ## Errors
 
 When cached input is unavailable, JSON mode still emits a versioned document:


### PR DESCRIPTION
Closes #339

## What changed

Costs were computed against one flat, undated rate table, so re-verifying a price silently repriced every historical session. Each model key now maps to a `PricingSchedule` of dated entries, and every lookup takes the event's timestamp.

**Shared table** (`Packages/MeterBarShared/.../ModelPricing.swift`)
- `DatedTokenPricing` — `effectiveFrom` (inclusive), its own `verifiedOn`, and the rates. `cacheCreationOneHour` and the Codex slug aliases live per entry.
- `PricingSchedule.resolve(at:)` — returns the entry in force at a timestamp; entries are sorted at construction so declaration order doesn't matter. Events older than every entry resolve to the oldest one with `precedesFirstEntry == true` rather than failing or pricing at zero.
- Lookup ergonomics are unchanged: `ModelPricing.claude(for:at:)` / `ModelPricing.codex(for:at:)` still return a plain `TokenPricing`, with `resolveClaude`/`resolveCodex` alongside for callers that want the provenance too. Call-site churn is one line per scanner.
- `ModelPricing.revision` / `revisionLabel` are removed — a single global date is exactly the thing this issue says is wrong.

**Seeding.** Every shipped entry is open-ended backwards (`effectiveFrom: .distantPast`), seeded from today's table and verified 2026-07-02 against the Anthropic and OpenAI pricing pages (URLs + date in the file's doc comment). Inventing historical effective dates would mis-price old sessions with numbers nobody checked, and backfilling a complete archive is explicitly out of scope. The dated machinery is fully exercised against synthetic schedules in the tests.

**Provenance.** `PricingProvenance` (Codable, mergeable) collects the entries a scan actually priced with, plus a count of pre-history events. It threads from both scanners → `CostScanResult` → `CostSummary.pricing`, so:
- the dashboard shows the verification date of the entry used, with the pre-history note as a tooltip;
- `meterbar cost` prints the same, and a `⚠` line when events predated the table;
- `CostSummaryBuilder` logs a warning so the guess is surfaced in diagnostics rather than passing as a verified figure.

`CostSummary.pricing` is optional, so caches written by earlier builds still decode and fall back to `ModelPricing.tableProvenance`.

## Behaviour note worth a reviewer's eye

Claude already priced per event. Codex priced the whole window once at aggregate time, which by construction cannot be date-aware — so it now computes cost per event inside `addUsage` and sums through `estimatedCostUSD`, with `makeCost` falling back to the aggregate path for totals carrying no per-event cost. The only numeric consequence is that the `max(0, input - cached)` clamp is applied per event instead of per aggregate. It differs only for rows where cached tokens exceed input tokens, and the per-event form is the more correct of the two.

## Compatibility

- App, widget and CLI all still read the one shared table (no regression of #130). `PricingScheduleContractTests` locks scanner lookups to `ModelPricing` across targets, in the spirit of `CachedMetricsContractTests`.
- `meterbar cost --json` stays schema version 1. The new top-level `pricing` object (`verifiedFrom`, `verifiedThrough`, `eventsBeforeFirstEntry`) is additive and omitted entirely when a cache has none — documented in `docs/cli-json-schema.md`. Verified against the real on-disk cache: output is byte-identical to before.
- No network price fetching, no currency-conversion changes.

## Tests (TDD, written first)

`DatedModelPricingTests` (15) — boundary exactly at `effectiveFrom`, one second before, after the newest entry, construction-order independence, pre-history resolution + flag, empty schedule, **regression: adding a later-dated entry leaves a 2026-03-15 cost bit-identical while applying at its own `effectiveFrom`**, shipped current rates, provenance merge/label.

`PricingScheduleContractTests` (8) — scanners resolve through the shared table; every seeded schedule resolves non-zero at `.distantPast`/now/`.distantFuture` and stays sorted; every `verifiedOn` is a well-formed date; provenance survives a real Claude scan, round-trips through `CostSummaryCache`, is absent (not null) for legacy caches, and is published in the JSON document.

## Verification

- `swift build` (root + `MeterBarCLI`) — clean, pre-existing warnings only
- `swift test` — **1728 tests, 5 skipped, 0 failures**
- `swiftlint --strict` — clean
- `meterbar cost` / `meterbar cost --json` smoke-tested against the live cache
