### PR TITLE
feat(menubar): follow the focused app in merged mode

### DIFF
--- a/MeterBar/App/FrontmostAppMonitor.swift
+++ b/MeterBar/App/FrontmostAppMonitor.swift
@@ -1,0 +1,127 @@
+import AppKit
+import Combine
+import Foundation
+
+/// Publishes which app the user is currently working in, for merged-mode focus
+/// following (issue #341).
+///
+/// Privacy posture, deliberately narrow: the monitor reads the frontmost app's
+/// **bundle identifier and nothing else**. No polling, no accessibility APIs, no
+/// window titles, no document paths, no inspection of what runs inside a
+/// terminal. It also stays completely dormant until the user opts in — the
+/// workspace subscription is created when the preference turns on and torn down
+/// when it turns off, so "off" means "not observing", not "observing quietly".
+@MainActor
+final class FrontmostAppMonitor: ObservableObject {
+    // MARK: Lifecycle
+
+    init(
+        preferences: MenuBarDisplayPreferencesStore = .shared,
+        interval: TimeInterval = MenuBarFocusDebouncer.defaultInterval
+    ) {
+        self.preferences = preferences
+        debouncer = MenuBarFocusDebouncer(interval: interval)
+    }
+
+    // MARK: Internal
+
+    static let shared = FrontmostAppMonitor()
+
+    /// Bundle identifier of the settled frontmost app, or nil while the feature
+    /// is off (or the frontmost app has none).
+    @Published private(set) var bundleIdentifier: String?
+
+    /// Starts watching the opt-in preference. Safe to call more than once.
+    func activate() {
+        guard !isActivated else { return }
+        isActivated = true
+
+        preferences.$followsFocusedApp
+            .removeDuplicates()
+            .sink { [weak self] enabled in
+                // `@Published` fires on `willSet`; hop once so the store is
+                // committed before the monitor reacts to it.
+                Task { @MainActor in
+                    self?.setFollowing(enabled)
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: Private
+
+    private let preferences: MenuBarDisplayPreferencesStore
+
+    /// Coalesces a cmd-tab sweep into the app the user actually landed on.
+    private var debouncer: MenuBarFocusDebouncer
+
+    private var cancellables = Set<AnyCancellable>()
+
+    /// Held separately from `cancellables` so following can be switched off
+    /// without also dropping the preference subscription that turns it back on.
+    private var workspaceObservation: AnyCancellable?
+
+    /// Supersedes an in-flight debounce window instead of cancelling a timer —
+    /// same idiom as the presenter's update generation.
+    private var flushGeneration = 0
+
+    private var isActivated = false
+    private var isFollowing = false
+
+    private func setFollowing(_ enabled: Bool) {
+        guard enabled != isFollowing else { return }
+        isFollowing = enabled
+        if enabled {
+            startObserving()
+        } else {
+            stopObserving()
+        }
+    }
+
+    private func startObserving() {
+        // Seed from whatever is already frontmost, without a debounce window:
+        // there is no burst to sit out at the moment the user opts in.
+        debouncer = MenuBarFocusDebouncer(bundleID: NSWorkspace.shared.frontmostApplication?.bundleIdentifier)
+        bundleIdentifier = debouncer.bundleID
+
+        workspaceObservation = NSWorkspace.shared.notificationCenter
+            .publisher(for: NSWorkspace.didActivateApplicationNotification)
+            .sink { [weak self] notification in
+                let application = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+                // Bundle identifier only — the rest of `NSRunningApplication` is
+                // never read.
+                let bundleID = application?.bundleIdentifier
+                Task { @MainActor in
+                    self?.record(bundleID)
+                }
+            }
+    }
+
+    private func stopObserving() {
+        workspaceObservation = nil
+        flushGeneration += 1
+        debouncer = MenuBarFocusDebouncer(interval: debouncer.interval)
+        bundleIdentifier = nil
+    }
+
+    private func record(_ bundleID: String?, at now: Date = Date()) {
+        // Bumping first cancels any pending flush, including the case where the
+        // debouncer reports "nothing to do" because the user came straight back
+        // to the app already on screen.
+        flushGeneration += 1
+        guard let deadline = debouncer.record(bundleID, at: now) else { return }
+
+        let generation = flushGeneration
+        let delay = max(0, deadline.timeIntervalSince(now))
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            guard let self, generation == self.flushGeneration else { return }
+            self.commit()
+        }
+    }
+
+    private func commit() {
+        guard debouncer.flush() else { return }
+        bundleIdentifier = debouncer.bundleID
+    }
+}

--- a/MeterBar/App/MeterBarApp.swift
+++ b/MeterBar/App/MeterBarApp.swift
@@ -156,6 +156,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             // Bring the Session Wake watcher online: it re-arms if the toggle was
             // left on and starts/stops as the user flips it.
             SessionWakeController.shared.activate()
+            // Watches the follow-focused-app opt-in; observes NSWorkspace only
+            // while that preference is on (issue #341).
+            FrontmostAppMonitor.shared.activate()
             // The managed agent owns completion banners while it is available,
             // including when the GUI is quit. Development builds without the
             // embedded helper retain the in-app notification observer.

--- a/MeterBar/App/StatusItemPresenter.swift
+++ b/MeterBar/App/StatusItemPresenter.swift
@@ -100,7 +100,7 @@ final class StatusItemPresenter {
         accountItemPlan = plan
         let rotates = MenuBarRotationSequencer.rotates(
             mode: preferences.presentationMode,
-            isEnabled: preferences.rotatesProviders,
+            isEnabled: preferences.rotatesProviders && !preferences.followsFocusedApp,
             pinnedKey: preferences.pinnedCandidateKey
         )
         let descriptors = MenuBarStatusItemPlanner.plan(

--- a/MeterBar/App/StatusItemPresenter.swift
+++ b/MeterBar/App/StatusItemPresenter.swift
@@ -85,7 +85,8 @@ final class StatusItemPresenter {
             windowMode: preferences.windowMode,
             fontSize: preferences.fontSize,
             highContrast: preferences.highContrast,
-            showsExhaustedResetCountdown: preferences.showsExhaustedResetCountdown
+            showsExhaustedResetCountdown: preferences.showsExhaustedResetCountdown,
+            focus: focusContext(preferences: preferences)
         )
 
         // Rebuilt rather than merged, so an item that just left the plan doesn't
@@ -97,6 +98,19 @@ final class StatusItemPresenter {
 
         applyDescriptors(descriptors)
         updateCountdownTimer(preferences: preferences)
+    }
+
+    /// The frontmost-app input to the merged selection, or nil when the user has
+    /// not opted into focus following — in which case the planner behaves
+    /// exactly as it did before the feature existed.
+    @MainActor
+    private func focusContext(preferences: MenuBarDisplayPreferencesStore) -> MenuBarFocusContext? {
+        guard preferences.followsFocusedApp else { return nil }
+        return MenuBarFocusContext(
+            bundleID: FrontmostAppMonitor.shared.bundleIdentifier,
+            mapping: preferences.focusAppMapping,
+            visibleServices: ProviderVisibilityStore.shared.enabledServices
+        )
     }
 
     /// Which accounts own an item right now, so the delegate can build the

--- a/MeterBar/App/StatusItemRefreshTrigger.swift
+++ b/MeterBar/App/StatusItemRefreshTrigger.swift
@@ -46,8 +46,15 @@ enum StatusItemRefreshTrigger {
             displayPreferences.$windowMode.map { _ in () }.eraseToAnyPublisher(),
             displayPreferences.$fontSize.map { _ in () }.eraseToAnyPublisher(),
             displayPreferences.$highContrast.map { _ in () }.eraseToAnyPublisher(),
-            displayPreferences.$showsExhaustedResetCountdown.map { _ in () }.eraseToAnyPublisher()
+            displayPreferences.$showsExhaustedResetCountdown.map { _ in () }.eraseToAnyPublisher(),
+            displayPreferences.$followsFocusedApp.map { _ in () }.eraseToAnyPublisher(),
+            displayPreferences.$focusAppMapping.map { _ in () }.eraseToAnyPublisher()
         ])
+
+        // Which app the user is working in, when focus following is on. The
+        // monitor publishes nil (and observes nothing) while the feature is off,
+        // so this upstream is inert until the user opts in.
+        let focusedAppChanges = FrontmostAppMonitor.shared.$bundleIdentifier.map { _ in () }
 
         // Which accounts own items, and which one the switcher shows. Without
         // these, picking an account from the switcher submenu (or toggling one
@@ -76,7 +83,8 @@ enum StatusItemRefreshTrigger {
             accountSelectionChanges.eraseToAnyPublisher(),
             visibilityChanges.eraseToAnyPublisher(),
             parseHealthChanges.eraseToAnyPublisher(),
-            displayPreferenceChanges.eraseToAnyPublisher()
+            displayPreferenceChanges.eraseToAnyPublisher(),
+            focusedAppChanges.eraseToAnyPublisher()
         ]
     }
 

--- a/MeterBar/Models/MenuBarFocusAppCatalog.swift
+++ b/MeterBar/Models/MenuBarFocusAppCatalog.swift
@@ -1,0 +1,65 @@
+import Foundation
+import MeterBarShared
+
+/// One app the user can map to a provider in Settings (issue #341).
+nonisolated struct MenuBarFocusApp: Identifiable, Equatable, Sendable {
+    let bundleID: String
+    let displayName: String
+
+    var id: String { bundleID }
+}
+
+/// The small, editable starting list of apps offered for focus mapping, and the
+/// default mapping shipped with the feature.
+///
+/// The catalog is a convenience, not a whitelist: any app the user has already
+/// mapped shows up in Settings whether or not it is listed here, and an app that
+/// is listed but not installed simply never becomes frontmost.
+nonisolated enum MenuBarFocusAppCatalog {
+    static let cursorBundleID = "com.todesktop.230313mzl4w4u92"
+
+    /// Editors first, then terminals, matching the Settings row order.
+    static let apps: [MenuBarFocusApp] = [
+        MenuBarFocusApp(bundleID: cursorBundleID, displayName: "Cursor"),
+        MenuBarFocusApp(bundleID: "com.microsoft.VSCode", displayName: "Visual Studio Code"),
+        MenuBarFocusApp(bundleID: "com.exafunction.windsurf", displayName: "Windsurf"),
+        MenuBarFocusApp(bundleID: "dev.zed.Zed", displayName: "Zed"),
+        MenuBarFocusApp(bundleID: "com.apple.dt.Xcode", displayName: "Xcode"),
+        MenuBarFocusApp(bundleID: "com.apple.Terminal", displayName: "Terminal"),
+        MenuBarFocusApp(bundleID: "com.googlecode.iterm2", displayName: "iTerm2"),
+        MenuBarFocusApp(bundleID: "com.mitchellh.ghostty", displayName: "Ghostty"),
+        MenuBarFocusApp(bundleID: "dev.warp.Warp-Stable", displayName: "Warp"),
+        MenuBarFocusApp(bundleID: "net.kovidgoyal.kitty", displayName: "kitty"),
+        MenuBarFocusApp(bundleID: "org.alacritty", displayName: "Alacritty"),
+        MenuBarFocusApp(bundleID: "com.github.wez.wezterm", displayName: "WezTerm")
+    ]
+
+    /// Apps that host a CLI rather than being one. Called out in Settings so the
+    /// blank default reads as a deliberate choice, not an oversight.
+    static let terminalBundleIDs: Set<String> = [
+        "com.apple.Terminal",
+        "com.googlecode.iterm2",
+        "com.mitchellh.ghostty",
+        "dev.warp.Warp-Stable",
+        "net.kovidgoyal.kitty",
+        "org.alacritty",
+        "com.github.wez.wezterm"
+    ]
+
+    /// Only apps whose provider is unambiguous ship mapped. Terminals are left
+    /// to the user on purpose: a terminal window says nothing about which CLI is
+    /// running in it, and MeterBar does not look.
+    static let defaultMapping: [String: ServiceType] = [cursorBundleID: .cursor]
+
+    /// Settings rows: the catalog plus anything the user has already mapped,
+    /// so a mapping never becomes invisible (and un-editable) just because the
+    /// app is not one MeterBar knows by name.
+    static func rows(for mapping: [String: ServiceType]) -> [MenuBarFocusApp] {
+        let known = Set(apps.map(\.bundleID))
+        let extras = mapping.keys
+            .filter { !known.contains($0) }
+            .sorted()
+            .map { MenuBarFocusApp(bundleID: $0, displayName: $0) }
+        return apps + extras
+    }
+}

--- a/MeterBar/Models/MenuBarFocusDebouncer.swift
+++ b/MeterBar/Models/MenuBarFocusDebouncer.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Coalesces a burst of app activations into one settled frontmost app.
+///
+/// A cmd-tab sweep activates every app it passes, and publishing each one would
+/// flicker the menu bar through three providers before landing. The caller owns
+/// the timer — `record` returns the deadline to schedule and `flush` commits —
+/// so the whole decision stays pure and testable without wall-clock waits.
+nonisolated struct MenuBarFocusDebouncer {
+    // MARK: Lifecycle
+
+    init(interval: TimeInterval = MenuBarFocusDebouncer.defaultInterval, bundleID: String? = nil) {
+        self.interval = interval
+        self.bundleID = bundleID
+    }
+
+    // MARK: Internal
+
+    /// Long enough to sit out a cmd-tab sweep, short enough that switching to an
+    /// app and reading the menu bar feels immediate.
+    static let defaultInterval: TimeInterval = 0.5
+
+    let interval: TimeInterval
+
+    /// The frontmost app the menu bar is currently following.
+    private(set) var bundleID: String?
+
+    /// When the pending change becomes eligible to commit, nil when nothing is
+    /// pending.
+    var pendingDeadline: Date? { pending?.deadline }
+
+    /// Records an activation.
+    ///
+    /// - Returns: the deadline the caller should schedule `flush()` for, or nil
+    ///   when the activation changes nothing — either it names the app already
+    ///   settled on, or it cancels a pending change by returning to it.
+    mutating func record(_ bundleID: String?, at now: Date) -> Date? {
+        guard bundleID != self.bundleID else {
+            pending = nil
+            return nil
+        }
+        let deadline = now.addingTimeInterval(interval)
+        pending = Pending(bundleID: bundleID, deadline: deadline)
+        return deadline
+    }
+
+    /// Commits the pending change, if any.
+    ///
+    /// - Returns: true when the settled app actually changed, so the caller only
+    ///   republishes on a real transition.
+    @discardableResult
+    mutating func flush() -> Bool {
+        guard let pending else { return false }
+        self.pending = nil
+        guard pending.bundleID != bundleID else { return false }
+        bundleID = pending.bundleID
+        return true
+    }
+
+    // MARK: Private
+
+    private struct Pending {
+        let bundleID: String?
+        let deadline: Date
+    }
+
+    private var pending: Pending?
+}

--- a/MeterBar/Models/MenuBarFocusSelector.swift
+++ b/MeterBar/Models/MenuBarFocusSelector.swift
@@ -1,0 +1,72 @@
+import Foundation
+import MeterBarShared
+
+/// Everything the focus resolver knows about the frontmost app (issue #341).
+///
+/// Deliberately only a bundle identifier: MeterBar never asks for accessibility
+/// permission, never reads window titles or documents, and never inspects which
+/// CLI is running inside a terminal. The user's mapping is the only link between
+/// an app and a provider.
+nonisolated struct MenuBarFocusContext: Equatable, Sendable {
+    /// Bundle identifier of the frontmost app, nil when it has none or when
+    /// nothing has been observed yet.
+    let bundleID: String?
+    /// User-editable bundle identifier → provider mapping.
+    let mapping: [String: ServiceType]
+    /// Providers the user has not hidden. A mapping onto a hidden provider is
+    /// treated as no mapping at all.
+    let visibleServices: Set<ServiceType>
+}
+
+/// Resolves "the frontmost app is X, so show provider Y" into one candidate.
+///
+/// Returning nil is the normal, load-bearing outcome: it means *this input has
+/// no opinion*, and the caller falls through to `StatusItemLimitSelector` so
+/// Auto behaves exactly as it did before the feature existed.
+nonisolated enum MenuBarFocusSelector {
+    /// Bands at or above this rank take the menu bar back from focus following.
+    /// A quota the user cannot see running out is more urgent than the quota
+    /// belonging to the app they are looking at.
+    private static let overridingBand = QuotaBand.critical
+
+    static func select(
+        candidates: [StatusLimitCandidate],
+        context: MenuBarFocusContext
+    ) -> StatusLimitCandidate? {
+        guard let bundleID = context.bundleID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !bundleID.isEmpty,
+              let service = context.mapping[bundleID],
+              context.visibleServices.contains(service) else { return nil }
+
+        // Same Auto-window rule as the default selector: other windows exist
+        // only so the user can pin them explicitly.
+        let autoCandidates = candidates.filter {
+            $0.isAutoSelectable && context.visibleServices.contains($0.service)
+        }
+        let focused = autoCandidates.filter { $0.service == service }
+        // No data for the mapped provider is indistinguishable from no mapping.
+        guard let selection = tightest(in: focused) else { return nil }
+
+        let urgentElsewhere = autoCandidates.contains {
+            $0.service != service
+                && QuotaBand.forLimit($0.limit).severityRank >= overridingBand.severityRank
+        }
+        guard !urgentElsewhere else { return nil }
+
+        return selection
+    }
+
+    /// Tightest quota with anything left, falling back to the whole pool when
+    /// every window of the focused provider is spent — mirrors the spent-account
+    /// rule in `StatusItemLimitSelector` so the two inputs never disagree about
+    /// which window of a provider represents it.
+    private static func tightest(in candidates: [StatusLimitCandidate]) -> StatusLimitCandidate? {
+        let withQuotaLeft = candidates.filter { QuotaMath.percentLeft(for: $0.limit) > 0 }
+        let pool = withQuotaLeft.isEmpty ? candidates : withQuotaLeft
+        return pool.min { lhs, rhs in
+            // Tie-break on key so equal quotas resolve deterministically.
+            (QuotaMath.percentLeft(for: lhs.limit), lhs.key)
+                < (QuotaMath.percentLeft(for: rhs.limit), rhs.key)
+        }
+    }
+}

--- a/MeterBar/Models/MenuBarStatusItemPlanner.swift
+++ b/MeterBar/Models/MenuBarStatusItemPlanner.swift
@@ -41,6 +41,10 @@ enum MenuBarStatusItemPlanner {
     /// - Parameter previousKeys: what each *account* item showed last refresh,
     ///   by item id. Account items each own a slot, so they each need their own
     ///   history; sharing the merged key would hand every item the same anchor.
+    /// - Parameter focus: the frontmost app and its provider mapping (#341).
+    ///   Nil whenever the opt-in is off, which is the default; the parameter is
+    ///   honored in merged mode only, since the account-scoped and per-provider
+    ///   modes already show every provider at once.
     static func plan(
         mode: MenuBarPresentationMode,
         accountPlan: MenuBarAccountItemPlan? = nil,
@@ -54,6 +58,7 @@ enum MenuBarStatusItemPlanner {
         fontSize: StatusItemFontSize = .standard,
         highContrast: Bool = false,
         showsExhaustedResetCountdown: Bool = false,
+        focus: MenuBarFocusContext? = nil,
         now: Date = Date()
     ) -> [MenuBarStatusItemDescriptor] {
         let context = SelectionContext(
@@ -65,6 +70,7 @@ enum MenuBarStatusItemPlanner {
             windowMode: windowMode,
             visualStyle: StatusItemVisualStyle(fontSize: fontSize, highContrast: highContrast),
             showsExhaustedResetCountdown: showsExhaustedResetCountdown,
+            focus: mode == .merged ? focus : nil,
             now: now
         )
 
@@ -144,6 +150,9 @@ enum MenuBarStatusItemPlanner {
         let windowMode: StatusItemWindowMode
         let visualStyle: StatusItemVisualStyle
         let showsExhaustedResetCountdown: Bool
+        /// Nil unless the user opted into focus following *and* the mode is
+        /// merged, so every other path is byte-identical to pre-#341 behavior.
+        let focus: MenuBarFocusContext?
         let now: Date
 
         /// What the item with this id showed last refresh. The merged slot
@@ -158,7 +167,14 @@ enum MenuBarStatusItemPlanner {
         candidates: [StatusLimitCandidate],
         context: SelectionContext
     ) -> MenuBarStatusItemDescriptor {
-        guard let selection = StatusItemLimitSelector.select(
+        // A pin is an explicit "show exactly this", so it outranks the focused
+        // app; when the focus resolver has no opinion (unmapped app, hidden or
+        // dataless provider, critical quota elsewhere) Auto decides as before.
+        let focused = context.pinnedKey == nil
+            ? context.focus.flatMap { MenuBarFocusSelector.select(candidates: candidates, context: $0) }
+            : nil
+
+        guard let selection = focused ?? StatusItemLimitSelector.select(
             candidates: candidates,
             previousKey: context.previousKey(forItem: mergedItemID),
             pinnedKey: context.pinnedKey,

--- a/MeterBar/Models/MenuBarStatusItemPlanner.swift
+++ b/MeterBar/Models/MenuBarStatusItemPlanner.swift
@@ -185,9 +185,9 @@ enum MenuBarStatusItemPlanner {
         // Rotation is another way of choosing *which* candidate the one merged
         // item shows, so it resolves ahead of auto-selection and hands the same
         // descriptor builder its winner. It stands down for a pin, for a
-        // critical or exhausted quota, when focus already selected a provider,
-        // and when nothing has fresh data.
-        if focused == nil, let rotationTick = context.rotationTick {
+        // critical or exhausted quota, whenever focus following is active, and
+        // when nothing has fresh data. An unmapped focused app must keep Auto.
+        if context.focus == nil, let rotationTick = context.rotationTick {
             let outcome = MenuBarRotationSequencer.outcome(
                 candidates: candidates,
                 tick: rotationTick,

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -38,6 +38,18 @@ nonisolated enum StorageKeys {
     static let statusItemHighContrast = "StatusItemHighContrast"
     /// Replaces an exhausted quota value with its reset countdown when available.
     static let statusItemShowsExhaustedResetCountdown = "StatusItemShowsExhaustedResetCountdown"
+
+    // MARK: - Follow Focused App (#341)
+
+    /// Explicit opt-in for merged-mode focus following (Bool, default off).
+    /// Mutually exclusive with pinning: enabling it clears the pin, and pinning
+    /// turns it back off.
+    static let statusItemFollowsFocusedApp = "StatusItemFollowsFocusedApp"
+    /// JSON-encoded `[String: ServiceType]` mapping app bundle identifiers to
+    /// providers. Missing means "never edited" and yields
+    /// `MenuBarFocusAppCatalog.defaultMapping`; an empty dictionary is a
+    /// deliberate "nothing mapped" and is preserved as written.
+    static let statusItemFocusAppMapping = "StatusItemFocusAppMapping"
     /// `ResetTimeFormat` raw value for reset labels in popover cards.
     static let popoverResetTimeFormat = "PopoverResetTimeFormat"
     /// Accounts that each get their own status item ([String] of MenuBarAccountKey),

--- a/MeterBar/Services/MenuBarDisplayPreferencesStore.swift
+++ b/MeterBar/Services/MenuBarDisplayPreferencesStore.swift
@@ -162,6 +162,12 @@ final class MenuBarDisplayPreferencesStore: ObservableObject {
     @Published private(set) var highContrast: Bool
     @Published private(set) var showsExhaustedResetCountdown: Bool
     @Published private(set) var resetTimeFormat: ResetTimeFormat
+    /// Opt-in merged-mode focus following (#341). Off by default, and mutually
+    /// exclusive with pinning.
+    @Published private(set) var followsFocusedApp: Bool
+    /// App bundle identifier → provider, the only link between a focused app and
+    /// a quota. MeterBar never infers this from window contents.
+    @Published private(set) var focusAppMapping: [String: ServiceType]
 
     private let userDefaults: UserDefaults
 
@@ -185,6 +191,8 @@ final class MenuBarDisplayPreferencesStore: ObservableObject {
         )
         resetTimeFormat = userDefaults.string(forKey: StorageKeys.popoverResetTimeFormat)
             .flatMap(ResetTimeFormat.init(rawValue:)) ?? .countdown
+        followsFocusedApp = userDefaults.bool(forKey: StorageKeys.statusItemFollowsFocusedApp)
+        focusAppMapping = Self.loadFocusMapping(from: userDefaults)
     }
 
     func setPinnedCandidateKey(_ key: String?) {
@@ -193,8 +201,36 @@ final class MenuBarDisplayPreferencesStore: ObservableObject {
         pinnedCandidateKey = normalized
         if let normalized {
             userDefaults.set(normalized, forKey: StorageKeys.statusItemPinnedCandidate)
+            // A pin is a deliberate "show exactly this", so it wins over focus
+            // following rather than fighting it on every app switch. Clearing
+            // the pin later does not re-enable the opt-in.
+            setFollowsFocusedApp(false)
         } else {
             userDefaults.removeObject(forKey: StorageKeys.statusItemPinnedCandidate)
+        }
+    }
+
+    func setFollowsFocusedApp(_ enabled: Bool) {
+        guard enabled != followsFocusedApp else { return }
+        followsFocusedApp = enabled
+        userDefaults.set(enabled, forKey: StorageKeys.statusItemFollowsFocusedApp)
+        if enabled {
+            setPinnedCandidateKey(nil)
+        }
+    }
+
+    /// Maps one app to a provider, or removes its mapping when `service` is nil.
+    func setFocusMapping(_ service: ServiceType?, forBundleID bundleID: String) {
+        let trimmed = bundleID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        var updated = focusAppMapping
+        updated[trimmed] = service
+        guard updated != focusAppMapping else { return }
+        focusAppMapping = updated
+        // Always written, even when empty: "the user cleared every mapping" must
+        // survive relaunch instead of being read back as "never edited".
+        if let data = try? JSONEncoder().encode(updated) {
+            userDefaults.set(data, forKey: StorageKeys.statusItemFocusAppMapping)
         }
     }
 
@@ -249,6 +285,16 @@ final class MenuBarDisplayPreferencesStore: ObservableObject {
     nonisolated private static func normalizedPin(_ key: String) -> String? {
         let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Unreadable payloads fall back to the shipped defaults rather than to an
+    /// empty mapping, so a corrupt value leaves the feature usable.
+    nonisolated private static func loadFocusMapping(from userDefaults: UserDefaults) -> [String: ServiceType] {
+        guard let data = userDefaults.data(forKey: StorageKeys.statusItemFocusAppMapping),
+              let decoded = try? JSONDecoder().decode([String: ServiceType].self, from: data) else {
+            return MenuBarFocusAppCatalog.defaultMapping
+        }
+        return decoded
     }
 }
 

--- a/MeterBar/Services/MenuBarDisplayPreferencesStore.swift
+++ b/MeterBar/Services/MenuBarDisplayPreferencesStore.swift
@@ -215,6 +215,13 @@ final class MenuBarDisplayPreferencesStore: ObservableObject {
         rotationInterval = StatusItemRotationInterval(
             rawValue: userDefaults.integer(forKey: StorageKeys.statusItemRotationInterval)
         ) ?? .fifteenSeconds
+        // Both features independently predated their integration. If a local
+        // development build persisted both, focus wins and rotation is repaired
+        // once so an unmapped focused app still falls back to Auto.
+        if followsFocusedApp, rotatesProviders {
+            rotatesProviders = false
+            userDefaults.set(false, forKey: StorageKeys.statusItemRotatesProviders)
+        }
     }
 
     func setPinnedCandidateKey(_ key: String?) {
@@ -233,12 +240,13 @@ final class MenuBarDisplayPreferencesStore: ObservableObject {
     }
 
     func setFollowsFocusedApp(_ enabled: Bool) {
+        if enabled {
+            setPinnedCandidateKey(nil)
+            setRotatesProviders(false)
+        }
         guard enabled != followsFocusedApp else { return }
         followsFocusedApp = enabled
         userDefaults.set(enabled, forKey: StorageKeys.statusItemFollowsFocusedApp)
-        if enabled {
-            setPinnedCandidateKey(nil)
-        }
     }
 
     /// Maps one app to a provider, or removes its mapping when `service` is nil.
@@ -305,6 +313,9 @@ final class MenuBarDisplayPreferencesStore: ObservableObject {
     }
 
     func setRotatesProviders(_ enabled: Bool) {
+        if enabled {
+            setFollowsFocusedApp(false)
+        }
         guard enabled != rotatesProviders else { return }
         rotatesProviders = enabled
         userDefaults.set(enabled, forKey: StorageKeys.statusItemRotatesProviders)

--- a/MeterBar/Views/Settings/GeneralSettingsView.swift
+++ b/MeterBar/Views/Settings/GeneralSettingsView.swift
@@ -170,6 +170,8 @@ struct GeneralSettingsView: View {
                 .disabled(menuBarDisplayPreferences.presentationMode == .perProvider)
             }
 
+            followFocusedAppRows
+
             SettingsRowView(
                 title: "Label metric",
                 detail: "Pace shows reserve or deficit. Icon Only keeps the status item minimal."
@@ -283,6 +285,91 @@ struct GeneralSettingsView: View {
                 .frame(width: 180)
             }
         }
+    }
+
+    /// Opt-in merged-mode focus following and its per-app mapping (issue #341).
+    ///
+    /// Off by default, and mutually exclusive with pinning: turning it on clears
+    /// the pin, and pinning turns it back off. The privacy posture is stated in
+    /// the row copy because it is the whole reason this can be a plain toggle
+    /// rather than a permission prompt.
+    @ViewBuilder private var followFocusedAppRows: some View {
+        SettingsRowView(
+            title: "Follow focused app",
+            detail: "Show the provider mapped to whichever app you are working in. "
+                + "MeterBar reads only the frontmost app’s bundle identifier — no accessibility "
+                + "permission is requested, and no window titles or contents are read. "
+                + "Turning this on clears the pin above; pinning turns it back off."
+        ) {
+            Toggle("", isOn: Binding(
+                get: { menuBarDisplayPreferences.followsFocusedApp },
+                set: { menuBarDisplayPreferences.setFollowsFocusedApp($0) }
+            ))
+            .labelsHidden()
+            .meterBarSwitch()
+            // Focus following only decides the single merged item; the other
+            // layouts already show every provider or account.
+            .disabled(menuBarDisplayPreferences.presentationMode != .merged)
+        }
+
+        if menuBarDisplayPreferences.presentationMode != .merged {
+            SettingsNotice(
+                text: "Switch the menu bar layout to Single Item to follow the focused app.",
+                color: .secondary
+            )
+        } else if menuBarDisplayPreferences.followsFocusedApp {
+            if focusMappableServices.isEmpty {
+                SettingsNotice(text: "No tracked providers to map yet.", color: .secondary)
+            } else {
+                SettingsNotice(
+                    text: "Unmapped apps keep Auto. A provider that is hidden, has no data, "
+                        + "or is out of quota is treated as unmapped, and a critical or exhausted "
+                        + "quota anywhere still takes over the menu bar.",
+                    color: .secondary
+                )
+                focusMappingRows
+            }
+        }
+    }
+
+    private var focusMappingRows: some View {
+        ForEach(MenuBarFocusAppCatalog.rows(for: menuBarDisplayPreferences.focusAppMapping)) { app in
+            SettingsRowView(
+                title: app.displayName,
+                detail: focusMappingDetail(for: app)
+            ) {
+                Picker("", selection: Binding(
+                    get: { menuBarDisplayPreferences.focusAppMapping[app.bundleID] },
+                    set: { menuBarDisplayPreferences.setFocusMapping($0, forBundleID: app.bundleID) }
+                )) {
+                    Text("None").tag(ServiceType?.none)
+                    ForEach(focusMappableServices) { service in
+                        Text(service.displayName).tag(ServiceType?.some(service))
+                    }
+                    // A mapping to a provider the user has since hidden stays
+                    // selectable so it can be changed rather than stranded.
+                    if let mapped = menuBarDisplayPreferences.focusAppMapping[app.bundleID],
+                       !focusMappableServices.contains(mapped) {
+                        Text("\(mapped.displayName) — hidden").tag(ServiceType?.some(mapped))
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .fixedSize()
+            }
+        }
+    }
+
+    /// Providers a mapping can point at: the tracked ones, in their usual order.
+    private var focusMappableServices: [ServiceType] {
+        ServiceType.allCases.filter { providerVisibility.isEnabled($0) }
+    }
+
+    private func focusMappingDetail(for app: MenuBarFocusApp) -> String? {
+        guard MenuBarFocusAppCatalog.terminalBundleIDs.contains(app.bundleID) else { return nil }
+        // Deliberately unmapped by default: MeterBar never inspects what runs
+        // inside a terminal, so only the user knows which CLI this one means.
+        return "MeterBar does not detect which CLI runs in a terminal — pick the one you use here."
     }
 
     /// Which Claude/Codex accounts own a menu-bar status item (issue #266).

--- a/MeterBar/Views/Settings/GeneralSettingsView.swift
+++ b/MeterBar/Views/Settings/GeneralSettingsView.swift
@@ -83,7 +83,8 @@ struct GeneralSettingsView: View {
     /// Same predicate the presenter uses to decide whether a rotation timer may
     /// exist, so the controls can never claim rotation is running when it isn't.
     private var canRotateProviders: Bool {
-        MenuBarRotationSequencer.rotates(
+        guard !menuBarDisplayPreferences.followsFocusedApp else { return false }
+        return MenuBarRotationSequencer.rotates(
             mode: menuBarDisplayPreferences.presentationMode,
             isEnabled: true,
             pinnedKey: menuBarDisplayPreferences.pinnedCandidateKey
@@ -96,6 +97,9 @@ struct GeneralSettingsView: View {
         guard !canRotateProviders else { return nil }
         guard menuBarDisplayPreferences.presentationMode == .merged else {
             return "Rotation applies to the single menu bar item only."
+        }
+        if menuBarDisplayPreferences.followsFocusedApp {
+            return "Focus following and rotation are mutually exclusive. Turn off focus following to rotate."
         }
         return "Pinning and rotation are mutually exclusive. Set “Menu bar shows” back to Auto to rotate."
     }
@@ -346,17 +350,16 @@ struct GeneralSettingsView: View {
 
     /// Opt-in merged-mode focus following and its per-app mapping (issue #341).
     ///
-    /// Off by default, and mutually exclusive with pinning: turning it on clears
-    /// the pin, and pinning turns it back off. The privacy posture is stated in
-    /// the row copy because it is the whole reason this can be a plain toggle
-    /// rather than a permission prompt.
+    /// Off by default, and mutually exclusive with pinning and rotation. The
+    /// privacy posture is stated in the row copy because it is the whole reason
+    /// this can be a plain toggle rather than a permission prompt.
     @ViewBuilder private var followFocusedAppRows: some View {
         SettingsRowView(
             title: "Follow focused app",
             detail: "Show the provider mapped to whichever app you are working in. "
                 + "MeterBar reads only the frontmost app’s bundle identifier — no accessibility "
                 + "permission is requested, and no window titles or contents are read. "
-                + "Turning this on clears the pin above; pinning turns it back off."
+                + "Turning this on clears the pin and rotation; either one turns focus following off."
         ) {
             Toggle("", isOn: Binding(
                 get: { menuBarDisplayPreferences.followsFocusedApp },
@@ -366,7 +369,10 @@ struct GeneralSettingsView: View {
             .meterBarSwitch()
             // Focus following only decides the single merged item; the other
             // layouts already show every provider or account.
-            .disabled(menuBarDisplayPreferences.presentationMode != .merged)
+            .disabled(
+                menuBarDisplayPreferences.presentationMode != .merged
+                    || menuBarDisplayPreferences.rotatesProviders
+            )
         }
 
         if menuBarDisplayPreferences.presentationMode != .merged {
@@ -374,12 +380,18 @@ struct GeneralSettingsView: View {
                 text: "Switch the menu bar layout to Single Item to follow the focused app.",
                 color: .secondary
             )
+        } else if menuBarDisplayPreferences.rotatesProviders {
+            SettingsNotice(
+                text: "Focus following and rotation are mutually exclusive. "
+                    + "Turn off rotation to follow the focused app.",
+                color: .secondary
+            )
         } else if menuBarDisplayPreferences.followsFocusedApp {
             if focusMappableServices.isEmpty {
                 SettingsNotice(text: "No tracked providers to map yet.", color: .secondary)
             } else {
                 SettingsNotice(
-                    text: "Unmapped apps keep the normal selection behavior. A provider that is hidden, has no data, "
+                    text: "Unmapped apps keep Auto. A provider that is hidden, has no data, "
                         + "or is out of quota is treated as unmapped, and a critical or exhausted "
                         + "quota anywhere still takes over the menu bar.",
                     color: .secondary

--- a/MeterBarTests/AppDelegateSplitTests.swift
+++ b/MeterBarTests/AppDelegateSplitTests.swift
@@ -248,9 +248,9 @@ final class AppDelegateSplitTests: XCTestCase {
     func testRefreshTriggerFansInEverySource() {
         // One publisher per input that can change the menu-bar title: metrics,
         // the three account-metric maps, Claude/Codex/Grok accounts, the
-        // menu-bar account selection, provider visibility, parse health, and the
-        // label preferences.
-        XCTAssertEqual(StatusItemRefreshTrigger.sources().count, 11)
+        // menu-bar account selection, provider visibility, parse health, the
+        // label preferences, and the frontmost app.
+        XCTAssertEqual(StatusItemRefreshTrigger.sources().count, 12)
     }
 
     func testRefreshTriggerPublisherEmitsOnSubscribe() {

--- a/MeterBarTests/MenuBarDisplayPreferencesStoreTests.swift
+++ b/MeterBarTests/MenuBarDisplayPreferencesStoreTests.swift
@@ -118,6 +118,43 @@ final class MenuBarDisplayPreferencesStoreTests: XCTestCase {
         XCTAssertFalse(store.followsFocusedApp)
     }
 
+    func testEnablingFocusFollowingDisablesRotationAndPersistsBothStates() {
+        let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+        store.setRotatesProviders(true)
+
+        store.setFollowsFocusedApp(true)
+
+        XCTAssertTrue(store.followsFocusedApp)
+        XCTAssertFalse(store.rotatesProviders)
+        let reloaded = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+        XCTAssertTrue(reloaded.followsFocusedApp)
+        XCTAssertFalse(reloaded.rotatesProviders)
+    }
+
+    func testEnablingRotationDisablesFocusFollowingAndPersistsBothStates() {
+        let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+        store.setFollowsFocusedApp(true)
+
+        store.setRotatesProviders(true)
+
+        XCTAssertFalse(store.followsFocusedApp)
+        XCTAssertTrue(store.rotatesProviders)
+        let reloaded = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+        XCTAssertFalse(reloaded.followsFocusedApp)
+        XCTAssertTrue(reloaded.rotatesProviders)
+    }
+
+    func testPersistedFocusFollowingRepairsAnOldConflictingRotationValue() {
+        defaults.set(true, forKey: StorageKeys.statusItemFollowsFocusedApp)
+        defaults.set(true, forKey: StorageKeys.statusItemRotatesProviders)
+
+        let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+
+        XCTAssertTrue(store.followsFocusedApp)
+        XCTAssertFalse(store.rotatesProviders)
+        XCTAssertFalse(defaults.bool(forKey: StorageKeys.statusItemRotatesProviders))
+    }
+
     func testPreferencesPersistAcrossRelaunch() {
         let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
         store.setPinnedCandidateKey("codex:account-id:weekly")

--- a/MeterBarTests/MenuBarDisplayPreferencesStoreTests.swift
+++ b/MeterBarTests/MenuBarDisplayPreferencesStoreTests.swift
@@ -30,6 +30,90 @@ final class MenuBarDisplayPreferencesStoreTests: XCTestCase {
         XCTAssertFalse(store.highContrast)
         XCTAssertFalse(store.showsExhaustedResetCountdown)
         XCTAssertEqual(store.resetTimeFormat, .countdown)
+        XCTAssertFalse(store.followsFocusedApp)
+    }
+
+    // MARK: - Follow focused app (#341)
+
+    func testFocusMappingStartsWithTheEditableDefaultAppList() {
+        let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+
+        // Only unambiguous editors ship mapped. Terminals stay unmapped because
+        // MeterBar never guesses which CLI is running inside one.
+        XCTAssertEqual(store.focusAppMapping, MenuBarFocusAppCatalog.defaultMapping)
+        XCTAssertEqual(store.focusAppMapping[MenuBarFocusAppCatalog.cursorBundleID], .cursor)
+        XCTAssertNil(store.focusAppMapping["com.apple.Terminal"])
+    }
+
+    func testFocusPreferencesPersistAcrossRelaunch() {
+        let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+        store.setFollowsFocusedApp(true)
+        store.setFocusMapping(.claudeCode, forBundleID: "com.apple.Terminal")
+
+        let reloaded = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+
+        XCTAssertTrue(reloaded.followsFocusedApp)
+        XCTAssertEqual(reloaded.focusAppMapping["com.apple.Terminal"], .claudeCode)
+        XCTAssertEqual(reloaded.focusAppMapping[MenuBarFocusAppCatalog.cursorBundleID], .cursor)
+    }
+
+    func testClearingEveryMappingSurvivesRelaunchInsteadOfRestoringDefaults() {
+        let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+        for bundleID in store.focusAppMapping.keys {
+            store.setFocusMapping(nil, forBundleID: bundleID)
+        }
+
+        XCTAssertTrue(store.focusAppMapping.isEmpty)
+        XCTAssertTrue(MenuBarDisplayPreferencesStore(userDefaults: defaults).focusAppMapping.isEmpty)
+    }
+
+    func testCorruptPersistedMappingFallsBackToTheDefaultMapping() {
+        defaults.set(Data("not json".utf8), forKey: StorageKeys.statusItemFocusAppMapping)
+
+        let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+
+        XCTAssertEqual(store.focusAppMapping, MenuBarFocusAppCatalog.defaultMapping)
+    }
+
+    func testBlankBundleIdentifiersAreNotMapped() {
+        let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+
+        store.setFocusMapping(.grok, forBundleID: "   ")
+
+        XCTAssertNil(store.focusAppMapping["   "])
+        XCTAssertNil(store.focusAppMapping[""])
+    }
+
+    func testEnablingFollowFocusedAppClearsThePin() {
+        let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+        store.setPinnedCandidateKey("Claude Code:gen:weekly")
+
+        store.setFollowsFocusedApp(true)
+
+        XCTAssertNil(store.pinnedCandidateKey)
+        XCTAssertNil(defaults.string(forKey: StorageKeys.statusItemPinnedCandidate))
+    }
+
+    func testPinningTurnsFollowFocusedAppOff() {
+        let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+        store.setFollowsFocusedApp(true)
+
+        store.setPinnedCandidateKey("Claude Code:gen:weekly")
+
+        XCTAssertFalse(store.followsFocusedApp)
+        XCTAssertEqual(store.pinnedCandidateKey, "Claude Code:gen:weekly")
+        XCTAssertFalse(MenuBarDisplayPreferencesStore(userDefaults: defaults).followsFocusedApp)
+    }
+
+    func testClearingThePinLeavesFollowFocusedAppOff() {
+        // Returning the menu bar to Auto must not silently re-enable an opt-in.
+        let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+        store.setFollowsFocusedApp(true)
+        store.setPinnedCandidateKey("Claude Code:gen:weekly")
+
+        store.setPinnedCandidateKey(nil)
+
+        XCTAssertFalse(store.followsFocusedApp)
     }
 
     func testPreferencesPersistAcrossRelaunch() {

--- a/MeterBarTests/MenuBarFocusDebouncerTests.swift
+++ b/MeterBarTests/MenuBarFocusDebouncerTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+
+@testable import MeterBar
+
+/// Covers the debounce that keeps a cmd-tab sweep from flickering the menu bar
+/// through every app it passes (issue #341). Deliberately free of wall-clock
+/// waits: the caller owns the timer, this type only owns the decision.
+final class MenuBarFocusDebouncerTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+    func testDefaultIntervalMatchesTheDocumentedHalfSecond() {
+        XCTAssertEqual(MenuBarFocusDebouncer.defaultInterval, 0.5)
+    }
+
+    func testRapidSwitchesSettleOnTheFinalApp() {
+        var debouncer = MenuBarFocusDebouncer(interval: 0.5)
+
+        XCTAssertEqual(debouncer.record("com.apple.Terminal", at: now), now.addingTimeInterval(0.5))
+        XCTAssertEqual(
+            debouncer.record("com.apple.Safari", at: now.addingTimeInterval(0.1)),
+            now.addingTimeInterval(0.6)
+        )
+        XCTAssertEqual(
+            debouncer.record("com.microsoft.VSCode", at: now.addingTimeInterval(0.2)),
+            now.addingTimeInterval(0.7)
+        )
+        // Nothing is published until the sweep stops.
+        XCTAssertNil(debouncer.bundleID)
+
+        XCTAssertTrue(debouncer.flush())
+        XCTAssertEqual(debouncer.bundleID, "com.microsoft.VSCode")
+        XCTAssertNil(debouncer.pendingDeadline)
+    }
+
+    func testDeadlineIsMeasuredFromTheLastActivation() {
+        var debouncer = MenuBarFocusDebouncer(interval: 0.25)
+
+        _ = debouncer.record("com.apple.Terminal", at: now)
+        _ = debouncer.record("com.apple.Safari", at: now.addingTimeInterval(2))
+
+        XCTAssertEqual(debouncer.pendingDeadline, now.addingTimeInterval(2.25))
+    }
+
+    func testReactivatingTheSettledAppIsANoOp() {
+        var debouncer = MenuBarFocusDebouncer(interval: 0.5)
+        _ = debouncer.record("com.apple.Terminal", at: now)
+        XCTAssertTrue(debouncer.flush())
+
+        XCTAssertNil(debouncer.record("com.apple.Terminal", at: now.addingTimeInterval(1)))
+        XCTAssertFalse(debouncer.flush())
+        XCTAssertEqual(debouncer.bundleID, "com.apple.Terminal")
+    }
+
+    func testReturningToTheSettledAppCancelsThePendingChange() {
+        var debouncer = MenuBarFocusDebouncer(interval: 0.5)
+        _ = debouncer.record("com.apple.Terminal", at: now)
+        XCTAssertTrue(debouncer.flush())
+
+        _ = debouncer.record("com.apple.Safari", at: now.addingTimeInterval(1))
+        XCTAssertNil(debouncer.record("com.apple.Terminal", at: now.addingTimeInterval(1.1)))
+
+        XCTAssertNil(debouncer.pendingDeadline)
+        XCTAssertFalse(debouncer.flush())
+        XCTAssertEqual(debouncer.bundleID, "com.apple.Terminal")
+    }
+
+    func testFlushingWithoutAPendingChangeReportsNoChange() {
+        var debouncer = MenuBarFocusDebouncer(interval: 0.5)
+
+        XCTAssertFalse(debouncer.flush())
+        XCTAssertNil(debouncer.bundleID)
+    }
+
+    func testLosingFocusToAnUnknownAppSettlesOnNoApp() {
+        var debouncer = MenuBarFocusDebouncer(interval: 0.5)
+        _ = debouncer.record("com.apple.Terminal", at: now)
+        XCTAssertTrue(debouncer.flush())
+
+        XCTAssertEqual(debouncer.record(nil, at: now.addingTimeInterval(1)), now.addingTimeInterval(1.5))
+        XCTAssertTrue(debouncer.flush())
+        XCTAssertNil(debouncer.bundleID)
+    }
+}

--- a/MeterBarTests/MenuBarFocusSelectionTests.swift
+++ b/MeterBarTests/MenuBarFocusSelectionTests.swift
@@ -1,0 +1,331 @@
+import MeterBarShared
+import XCTest
+
+@testable import MeterBar
+
+/// Covers the pure "follow the focused app" selection input (issue #341): a
+/// frontmost bundle identifier plus the user's mapping resolves to one quota,
+/// and every case that must hand the decision back to existing Auto selection.
+final class MenuBarFocusSelectionTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_750_000_000)
+    private let cursorBundleID = "com.todesktop.230313mzl4w4u92"
+    private let terminalBundleID = "com.apple.Terminal"
+    private let unknownBundleID = "com.example.SomethingElse"
+
+    private func candidate(
+        key: String,
+        service: ServiceType = .claudeCode,
+        accountKey: String? = nil,
+        percentUsed: Double,
+        displayName: String? = nil,
+        windowName: String = "Session",
+        pinKey: String? = nil,
+        activeMinutesAgo: Double? = nil,
+        isAutoSelectable: Bool = true
+    ) -> StatusLimitCandidate {
+        StatusLimitCandidate(
+            key: key,
+            pinKey: pinKey ?? key,
+            service: service,
+            accountKey: accountKey,
+            displayName: displayName ?? key,
+            windowName: windowName,
+            limit: UsageLimit(used: percentUsed, total: 100, resetTime: nil),
+            lastUpdated: now,
+            lastActivity: activeMinutesAgo.map { now.addingTimeInterval(-$0 * 60) },
+            isAutoSelectable: isAutoSelectable
+        )
+    }
+
+    private func context(
+        bundleID: String?,
+        mapping: [String: ServiceType]? = nil,
+        visibleServices: Set<ServiceType> = Set(ServiceType.allCases)
+    ) -> MenuBarFocusContext {
+        MenuBarFocusContext(
+            bundleID: bundleID,
+            mapping: mapping ?? [cursorBundleID: .cursor, terminalBundleID: .claudeCode],
+            visibleServices: visibleServices
+        )
+    }
+
+    private func select(
+        _ candidates: [StatusLimitCandidate],
+        bundleID: String?,
+        mapping: [String: ServiceType]? = nil,
+        visibleServices: Set<ServiceType> = Set(ServiceType.allCases)
+    ) -> StatusLimitCandidate? {
+        MenuBarFocusSelector.select(
+            candidates: candidates,
+            context: context(bundleID: bundleID, mapping: mapping, visibleServices: visibleServices)
+        )
+    }
+
+    // MARK: - Mapping
+
+    func testMappedFrontmostAppSelectsThatProvidersQuota() {
+        let claude = candidate(key: "claude:gen", percentUsed: 20, activeMinutesAgo: 1)
+        let cursor = candidate(key: "cursor", service: .cursor, percentUsed: 40)
+
+        let selection = select([claude, cursor], bundleID: cursorBundleID)
+
+        XCTAssertEqual(selection?.key, "cursor")
+        XCTAssertEqual(selection?.service, .cursor)
+    }
+
+    func testMappedTerminalFollowsTheProviderTheUserChoseForIt() {
+        // The mapping is the whole story: MeterBar never inspects which CLI is
+        // running inside the terminal.
+        let claude = candidate(key: "claude:gen", percentUsed: 20)
+        let cursor = candidate(key: "cursor", service: .cursor, percentUsed: 40)
+
+        XCTAssertEqual(select([claude, cursor], bundleID: terminalBundleID)?.service, .claudeCode)
+    }
+
+    func testMappedProviderWithSeveralWindowsPicksTheTightestAutoWindow() {
+        let session = candidate(key: "claude:gen", percentUsed: 30, windowName: "Session")
+        let weekly = candidate(
+            key: "Claude Code:gen:weekly",
+            percentUsed: 80,
+            windowName: "Weekly",
+            isAutoSelectable: false
+        )
+
+        let selection = select([session, weekly], bundleID: terminalBundleID)
+
+        // Only Auto windows compete, exactly like `StatusItemLimitSelector`.
+        XCTAssertEqual(selection?.key, "claude:gen")
+    }
+
+    func testMappedProviderWithSeveralAccountsPicksTheTightestOne() {
+        let gen = candidate(key: "claude:gen", accountKey: "gen", percentUsed: 30)
+        let ship = candidate(key: "claude:ship", accountKey: "ship", percentUsed: 70)
+
+        XCTAssertEqual(select([gen, ship], bundleID: terminalBundleID)?.key, "claude:ship")
+    }
+
+    func testMappedProviderWithEveryAccountSpentStillResolves() {
+        let gen = candidate(key: "claude:gen", accountKey: "gen", percentUsed: 100)
+        let ship = candidate(key: "claude:ship", accountKey: "ship", percentUsed: 100)
+
+        XCTAssertNotNil(select([gen, ship], bundleID: terminalBundleID))
+    }
+
+    func testMappedProviderSkipsSpentAccountsWhileAnotherHasQuotaLeft() {
+        let gen = candidate(key: "claude:gen", accountKey: "gen", percentUsed: 100)
+        let ship = candidate(key: "claude:ship", accountKey: "ship", percentUsed: 60)
+
+        XCTAssertEqual(select([gen, ship], bundleID: terminalBundleID)?.key, "claude:ship")
+    }
+
+    // MARK: - Fallback to Auto
+
+    func testUnmappedFrontmostAppFallsBackToAutoSelection() {
+        let claude = candidate(key: "claude:gen", percentUsed: 20)
+        let cursor = candidate(key: "cursor", service: .cursor, percentUsed: 40)
+
+        XCTAssertNil(select([claude, cursor], bundleID: unknownBundleID))
+    }
+
+    func testUnknownFrontmostAppFallsBackToAutoSelection() {
+        let claude = candidate(key: "claude:gen", percentUsed: 20)
+
+        XCTAssertNil(select([claude], bundleID: nil))
+        XCTAssertNil(select([claude], bundleID: "   "))
+    }
+
+    func testMappingToAHiddenProviderIsTreatedAsUnmapped() {
+        let claude = candidate(key: "claude:gen", percentUsed: 20)
+        let cursor = candidate(key: "cursor", service: .cursor, percentUsed: 40)
+
+        let selection = select(
+            [claude, cursor],
+            bundleID: cursorBundleID,
+            visibleServices: [.claudeCode, .codexCli]
+        )
+
+        XCTAssertNil(selection)
+    }
+
+    func testMappingToAProviderWithNoDataIsTreatedAsUnmapped() {
+        let claude = candidate(key: "claude:gen", percentUsed: 20)
+
+        XCTAssertNil(select([claude], bundleID: cursorBundleID))
+    }
+
+    func testMappingToAProviderWithNoAutoSelectableWindowIsTreatedAsUnmapped() {
+        let cursorReview = candidate(
+            key: "Cursor:default:codeReview",
+            service: .cursor,
+            percentUsed: 10,
+            windowName: "Code Review",
+            isAutoSelectable: false
+        )
+
+        XCTAssertNil(select([cursorReview], bundleID: cursorBundleID))
+    }
+
+    // MARK: - Critical priority
+
+    func testCriticalQuotaElsewhereOverridesTheFocusMapping() {
+        let claude = candidate(key: "claude:gen", percentUsed: 92)
+        let cursor = candidate(key: "cursor", service: .cursor, percentUsed: 40)
+
+        XCTAssertEqual(QuotaBand.forLimit(claude.limit), .critical)
+        XCTAssertNil(select([claude, cursor], bundleID: cursorBundleID))
+    }
+
+    func testExhaustedQuotaElsewhereOverridesTheFocusMapping() {
+        let claude = candidate(key: "claude:gen", percentUsed: 100)
+        let cursor = candidate(key: "cursor", service: .cursor, percentUsed: 40)
+
+        XCTAssertNil(select([claude, cursor], bundleID: cursorBundleID))
+    }
+
+    func testFocusFollowingResumesOnceTheCriticalQuotaClears() {
+        let recovered = candidate(key: "claude:gen", percentUsed: 60)
+        let cursor = candidate(key: "cursor", service: .cursor, percentUsed: 40)
+
+        XCTAssertEqual(select([recovered, cursor], bundleID: cursorBundleID)?.key, "cursor")
+    }
+
+    func testTightQuotaElsewhereDoesNotOverrideTheFocusMapping() {
+        // Only the critical/exhausted bands take priority; "tight" is normal.
+        let claude = candidate(key: "claude:gen", percentUsed: 80)
+        let cursor = candidate(key: "cursor", service: .cursor, percentUsed: 40)
+
+        XCTAssertEqual(QuotaBand.forLimit(claude.limit), .tight)
+        XCTAssertEqual(select([claude, cursor], bundleID: cursorBundleID)?.key, "cursor")
+    }
+
+    func testFocusedProviderInCriticalStaysSelected() {
+        // The override exists to surface a quota the user cannot see; when the
+        // focused provider is the critical one there is nothing to surface.
+        let cursor = candidate(key: "cursor", service: .cursor, percentUsed: 95)
+        let claude = candidate(key: "claude:gen", percentUsed: 20)
+
+        XCTAssertEqual(select([cursor, claude], bundleID: cursorBundleID)?.key, "cursor")
+    }
+
+    func testHiddenProviderInCriticalDoesNotOverrideTheFocusMapping() {
+        let hiddenClaude = candidate(key: "claude:gen", percentUsed: 95)
+        let cursor = candidate(key: "cursor", service: .cursor, percentUsed: 40)
+
+        let selection = select(
+            [hiddenClaude, cursor],
+            bundleID: cursorBundleID,
+            visibleServices: [.cursor]
+        )
+
+        XCTAssertEqual(selection?.key, "cursor")
+    }
+
+    // MARK: - Planner integration
+
+    private func plan(
+        _ candidates: [StatusLimitCandidate],
+        mode: MenuBarPresentationMode = .merged,
+        pinnedKey: String? = nil,
+        focus: MenuBarFocusContext? = nil
+    ) -> [MenuBarStatusItemDescriptor] {
+        MenuBarStatusItemPlanner.plan(
+            mode: mode,
+            candidates: candidates,
+            previousKey: nil,
+            pinnedKey: pinnedKey,
+            metric: .percentLeft,
+            size: .compact,
+            focus: focus,
+            now: now
+        )
+    }
+
+    func testMergedModeShowsTheFocusedProvider() {
+        let claude = candidate(key: "claude:gen", percentUsed: 20, activeMinutesAgo: 1)
+        let cursor = candidate(
+            key: "cursor",
+            service: .cursor,
+            percentUsed: 40,
+            displayName: "Cursor",
+            windowName: "Monthly"
+        )
+
+        let descriptors = plan([claude, cursor], focus: context(bundleID: cursorBundleID))
+
+        XCTAssertEqual(descriptors.count, 1)
+        XCTAssertEqual(descriptors.first?.service, .cursor)
+        XCTAssertEqual(descriptors.first?.selectionKey, "cursor")
+        XCTAssertEqual(descriptors.first?.title, " 60%")
+        // Focus behaves like Auto, not like a pin: no window qualifier.
+        XCTAssertEqual(descriptors.first?.tooltip, "MeterBar: 60% left on Cursor")
+    }
+
+    func testMergedModeWithoutFocusBehavesExactlyAsBefore() {
+        let claude = candidate(key: "claude:gen", percentUsed: 20, activeMinutesAgo: 1)
+        let cursor = candidate(key: "cursor", service: .cursor, percentUsed: 40)
+
+        let baseline = plan([claude, cursor])
+
+        XCTAssertEqual(plan([claude, cursor], focus: nil), baseline)
+        // Toggle on but nothing mapped is still the untouched Auto behavior.
+        XCTAssertEqual(
+            plan([claude, cursor], focus: context(bundleID: unknownBundleID)),
+            baseline
+        )
+        XCTAssertEqual(baseline.first?.selectionKey, "claude:gen")
+    }
+
+    func testPinBeatsTheFocusMapping() {
+        let claude = candidate(key: "claude:gen", percentUsed: 20, pinKey: "Claude Code:gen:session")
+        let cursor = candidate(key: "cursor", service: .cursor, percentUsed: 40)
+
+        let descriptors = plan(
+            [claude, cursor],
+            pinnedKey: "Claude Code:gen:session",
+            focus: context(bundleID: cursorBundleID)
+        )
+
+        XCTAssertEqual(descriptors.first?.selectionKey, "claude:gen")
+    }
+
+    func testFocusIsIgnoredOutsideMergedMode() {
+        let claude = candidate(key: "claude:gen", percentUsed: 20)
+        let cursor = candidate(key: "cursor", service: .cursor, percentUsed: 40)
+
+        let focused = plan([claude, cursor], mode: .perProvider, focus: context(bundleID: cursorBundleID))
+
+        XCTAssertEqual(focused, plan([claude, cursor], mode: .perProvider))
+        XCTAssertEqual(focused.count, 2)
+    }
+
+    // MARK: - Catalog
+
+    func testEveryTerminalIsOfferedButNoneShipsMapped() {
+        let offered = Set(MenuBarFocusAppCatalog.apps.map(\.bundleID))
+        for terminal in MenuBarFocusAppCatalog.terminalBundleIDs {
+            XCTAssertTrue(offered.contains(terminal), "\(terminal) is flagged a terminal but never offered")
+            // MeterBar does not look inside a terminal, so it cannot guess.
+            XCTAssertNil(MenuBarFocusAppCatalog.defaultMapping[terminal])
+        }
+    }
+
+    func testDefaultMappingOnlyCoversUnambiguousApps() {
+        XCTAssertEqual(MenuBarFocusAppCatalog.defaultMapping, [MenuBarFocusAppCatalog.cursorBundleID: .cursor])
+    }
+
+    func testCatalogRowsIncludeAppsTheUserMappedThemselves() {
+        let rows = MenuBarFocusAppCatalog.rows(for: [unknownBundleID: .claudeCode])
+
+        XCTAssertEqual(rows.count, MenuBarFocusAppCatalog.apps.count + 1)
+        XCTAssertEqual(rows.last?.bundleID, unknownBundleID)
+        // No display name is known for an app MeterBar does not ship, so the
+        // identifier itself has to stand in — an unlabelled row is unusable.
+        XCTAssertEqual(rows.last?.displayName, unknownBundleID)
+    }
+
+    func testCatalogRowsDoNotDuplicateKnownApps() {
+        let rows = MenuBarFocusAppCatalog.rows(for: MenuBarFocusAppCatalog.defaultMapping)
+
+        XCTAssertEqual(rows.map(\.bundleID), MenuBarFocusAppCatalog.apps.map(\.bundleID))
+    }
+}

--- a/MeterBarTests/MenuBarFocusSelectionTests.swift
+++ b/MeterBarTests/MenuBarFocusSelectionTests.swift
@@ -303,7 +303,7 @@ final class MenuBarFocusSelectionTests: XCTestCase {
         XCTAssertEqual(descriptors.first?.selectionKey, "cursor")
     }
 
-    func testRotationRemainsTheFallbackForAnUnmappedFocusedApp() {
+    func testUnmappedFocusedAppKeepsAutoEvenWithADefensiveRotationTick() {
         let claude = candidate(key: "claude:gen", percentUsed: 20, activeMinutesAgo: 1)
         let cursor = candidate(key: "cursor", service: .cursor, percentUsed: 40)
 
@@ -313,7 +313,7 @@ final class MenuBarFocusSelectionTests: XCTestCase {
             rotationTick: 1
         )
 
-        XCTAssertEqual(descriptors.first?.selectionKey, "cursor")
+        XCTAssertEqual(descriptors.first?.selectionKey, "claude:gen")
     }
 
     func testFocusIsIgnoredOutsideMergedMode() {


### PR DESCRIPTION
Closes #341

Opt-in "follow focused app" for merged mode. Off by default; with the toggle off every code path is byte-identical to before.

## What it does

When enabled, the merged status item shows the provider mapped to whichever app is frontmost. Cursor → Cursor ships mapped; everything else is the user's call.

## Shape

- **`MenuBarFocusSelector`** — pure resolver, a new input to `MenuBarStatusItemPlanner`: frontmost bundle id + mapping + quota state in, one candidate (or *no opinion*) out. Nil is load-bearing — unmapped app, mapping onto a hidden/dataless provider, or a critical/exhausted quota elsewhere all fall through to the existing auto-selection.
- **`MenuBarFocusDebouncer`** — deterministic, time-comparison-free. The caller owns the timer (`record` returns a deadline, `flush` commits), so a cmd-tab sweep settles on the final app and the ~500ms behaviour is testable without wall-clock waits.
- **`FrontmostAppMonitor`** (controller layer) — `NSWorkspace.didActivateApplicationNotification`, subscribed **only while the preference is on**.
- **`MenuBarDisplayPreferencesStore`** — the toggle plus a codable `[String: ServiceType]` mapping. An empty mapping is persisted as written, so "I cleared everything" survives relaunch instead of resurrecting the defaults; a corrupt payload falls back to the shipped mapping.

## Precedence

pin > critical/exhausted quota anywhere > focused app > auto. Focus selections read like Auto in the tooltip, not like a pin.

Pinning and focus following are mutually exclusive in the store, both directions: enabling the toggle clears the pin, pinning turns the toggle back off. Clearing a pin does not re-enable the opt-in.

## Privacy

Bundle identifier only. No polling, no accessibility permission, no window titles or contents, and no attempt to detect which CLI runs inside a terminal — which is why terminals ship unmapped and Settings says so. The posture is stated in the Settings copy.

## Tests

30 new focused tests (1745 total, 0 failures locally): mapping, unmapped fallback, debounce, critical/exhausted override and its clearing, hidden/dataless provider handling, pin precedence, non-merged modes untouched, persistence, mutual exclusivity, and catalog consistency.

## Note on #340

Timed rotation (#340, PR #350) is still open. Per the issue, whichever of the two lands second wires their mutual exclusivity in Settings — this PR does not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in setting to make the menu-bar status display follow the currently focused application.
  * Added configurable application-to-provider mappings, with sensible defaults and support for previously mapped apps.
  * Focus-based selection now respects pinned items, provider availability, quotas, and existing rotation behavior.
  * Added clear notices for unsupported layouts, unmapped applications, unavailable providers, and terminal applications.
* **Bug Fixes**
  * Prevented conflicts between pinned status items and focused-app following.
* **Tests**
  * Added coverage for preferences, app switching, mappings, quotas, and selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->