### PR TITLE
feat(optimize): rank providers by remaining headroom

### DIFF
--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -40,6 +40,10 @@ nonisolated enum StorageKeys {
     static let statusItemShowsExhaustedResetCountdown = "StatusItemShowsExhaustedResetCountdown"
     /// `ResetTimeFormat` raw value for reset labels in popover cards.
     static let popoverResetTimeFormat = "PopoverResetTimeFormat"
+    /// Opt-in for the one-line "what to use next" hint at the top of the popover.
+    /// Absent means off: the full ranking already lives in the dashboard's
+    /// Optimize tab, so the popover keeps its pre-feature layout by default.
+    static let popoverShowsRecommendationHint = "PopoverShowsRecommendationHint"
     /// Accounts that each get their own status item ([String] of MenuBarAccountKey),
     /// in the order the user selected them.
     static let menuBarSelectedAccountKeys = "MenuBarSelectedAccountKeys"

--- a/MeterBar/Services/MenuBarDisplayPreferencesStore.swift
+++ b/MeterBar/Services/MenuBarDisplayPreferencesStore.swift
@@ -162,6 +162,7 @@ final class MenuBarDisplayPreferencesStore: ObservableObject {
     @Published private(set) var highContrast: Bool
     @Published private(set) var showsExhaustedResetCountdown: Bool
     @Published private(set) var resetTimeFormat: ResetTimeFormat
+    @Published private(set) var showsRecommendationHint: Bool
 
     private let userDefaults: UserDefaults
 
@@ -185,6 +186,9 @@ final class MenuBarDisplayPreferencesStore: ObservableObject {
         )
         resetTimeFormat = userDefaults.string(forKey: StorageKeys.popoverResetTimeFormat)
             .flatMap(ResetTimeFormat.init(rawValue:)) ?? .countdown
+        // Off unless asked for: the popover's layout stays exactly as it was
+        // before the recommendation shipped.
+        showsRecommendationHint = userDefaults.bool(forKey: StorageKeys.popoverShowsRecommendationHint)
     }
 
     func setPinnedCandidateKey(_ key: String?) {
@@ -244,6 +248,12 @@ final class MenuBarDisplayPreferencesStore: ObservableObject {
         guard format != resetTimeFormat else { return }
         resetTimeFormat = format
         userDefaults.set(format.rawValue, forKey: StorageKeys.popoverResetTimeFormat)
+    }
+
+    func setShowsRecommendationHint(_ enabled: Bool) {
+        guard enabled != showsRecommendationHint else { return }
+        showsRecommendationHint = enabled
+        userDefaults.set(enabled, forKey: StorageKeys.popoverShowsRecommendationHint)
     }
 
     nonisolated private static func normalizedPin(_ key: String) -> String? {

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -20,6 +20,7 @@ struct MenuBarView: View {
   @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
   @StateObject private var providerVisibility = ProviderVisibilityStore.shared
   @StateObject private var sessionWakeStore = SessionWakeSettingsStore.shared
+  @StateObject private var menuBarDisplayPreferences = MenuBarDisplayPreferencesStore.shared
 
   @State private var contentHeight: CGFloat = 320
   @State private var expandedDetailID: String?
@@ -96,7 +97,8 @@ struct MenuBarView: View {
             claudeEnabledAccountMetrics: claudeAccountStore.enabledAccounts.compactMap {
               dataManager.claudeCodeAccountMetrics[$0.id]
             },
-            grokAccounts: grokAccountStore.accounts
+            grokAccounts: grokAccountStore.accounts,
+            showsRecommendationHint: menuBarDisplayPreferences.showsRecommendationHint
           )
 
           if SessionWakeMenuControl.shouldShow(

--- a/MeterBar/Views/OptimizeInsightsView.swift
+++ b/MeterBar/Views/OptimizeInsightsView.swift
@@ -11,6 +11,18 @@ import SwiftUI
 /// nothing uploaded. Lives in its own file (never inside `UsageDashboardView`)
 /// per the dashboard view-split convention.
 struct OptimizeInsightsView: View {
+  /// Every enabled provider/account, *unfiltered* — the recommendation card
+  /// needs the ones without cached usage so it can list them as "no data"
+  /// instead of quietly dropping them.
+  let providerSnapshots: [ProviderSnapshot]
+
+  /// Explicit initializer: the private `@StateObject` storage would lower the
+  /// synthesized memberwise initializer to file-private, so this keeps the page
+  /// constructible from `UsageDashboardView` (and from the test target).
+  init(providerSnapshots: [ProviderSnapshot] = []) {
+    self.providerSnapshots = providerSnapshots
+  }
+
   @StateObject private var costTracker = CostTracker.shared
   @StateObject private var providerVisibility = ProviderVisibilityStore.shared
 
@@ -40,12 +52,78 @@ struct OptimizeInsightsView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 14) {
+      recommendationCard
       phaseContent
         .animation(
           MeterBarTheme.Motion.resolve(MeterBarTheme.Motion.standard, reduceMotion: reduceMotion),
           value: phase
         )
     }
+  }
+
+  // MARK: - What to use next
+
+  /// The ranked "what should I use next?" card.
+  ///
+  /// Sits outside the page's loading/loaded/empty phase on purpose: it reads the
+  /// quota snapshots the app already refreshes, so it answers the question
+  /// before a single token log has been scanned — and keeps answering it while a
+  /// scan runs. Ticks on the shared reset-countdown schedule so the countdowns,
+  /// and the ranking that weighs them, stay current without a clock of its own.
+  @ViewBuilder private var recommendationCard: some View {
+    TimelineView(.periodic(from: ResetCountdownSchedule.anchor, by: ResetCountdownSchedule.interval)) { timeline in
+      let recommendation = providerSnapshots.headroomRecommendation(now: timeline.date)
+      if !recommendation.rows.isEmpty || !recommendation.unavailable.isEmpty {
+        DashboardCard(title: "What To Use Next", trailing: Self.recommendationCaption(for: recommendation)) {
+          VStack(alignment: .leading, spacing: 12) {
+            if let headline = recommendation.headline {
+              Text(headline)
+                .font(.callout)
+                .fontWeight(.semibold)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            ForEach(Array(recommendation.rows.enumerated()), id: \.element.id) { index, row in
+              HeadroomRecommendationRow(rank: index + 1, row: row)
+            }
+
+            if !recommendation.unavailable.isEmpty {
+              Divider()
+              // Named, not hidden: a provider MeterBar cannot read is a fact the
+              // user needs, and guessing a rank for it would be worse than
+              // saying nothing.
+              Text("No data")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundColor(.secondary)
+              ForEach(recommendation.unavailable) { entry in
+                HeadroomUnavailableRow(entry: entry)
+              }
+            }
+
+            Divider()
+
+            Label(
+              "Ranked on your Mac from quota data MeterBar already caches — no extra requests, "
+                + "and nothing switches tools for you.",
+              systemImage: "lock.shield"
+            )
+            .font(.caption2)
+            .foregroundColor(.secondary)
+          }
+        }
+      }
+    }
+  }
+
+  /// Card caption. Names the state instead of restating the headline.
+  ///
+  /// Internal (not private) so the wording can be asserted without hosting the
+  /// page, matching `recentWindowTile(tokens7Day:tokens30Day:)`.
+  static func recommendationCaption(for recommendation: ProviderRecommendation) -> String {
+    if recommendation.isEmpty { return "No usable data" }
+    if recommendation.isFullyExhausted { return "Every window spent" }
+    return "Ranked by remaining headroom"
   }
 
   /// The swapping page body. Each branch is `.id`-tagged and carries the shared
@@ -320,6 +398,100 @@ struct OptimizeInsightsView: View {
     case 0.3..<0.7: return .secondary
     default: return MeterBarTheme.warning
     }
+  }
+}
+
+// MARK: - Headroom recommendation rows
+
+/// One row of the "what to use next" ranking.
+///
+/// Every value on the row is an input to its score — binding window, percent
+/// left, reset countdown, pace — so the ordering can be read off the row rather
+/// than taken on faith. Deliberately plain: this is arithmetic over cached
+/// quota numbers, not a prediction.
+private struct HeadroomRecommendationRow: View {
+  let rank: Int
+  let row: ProviderRecommendationRow
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 5) {
+      HStack(spacing: 8) {
+        Text("\(rank)")
+          .font(.caption)
+          .fontWeight(.semibold)
+          .monospacedDigit()
+          .foregroundColor(.secondary)
+          .frame(width: 14, alignment: .trailing)
+
+        Circle()
+          .fill(MeterBarTheme.accent(for: row.service))
+          .frame(width: 8, height: 8)
+
+        Text(row.name)
+          .font(.callout)
+          .fontWeight(.medium)
+          .lineLimit(1)
+          .truncationMode(.middle)
+
+        MeterBarChip(row.windowTitle, tint: row.band.color, style: .flat)
+
+        Spacer(minLength: 8)
+
+        Text(row.isExhausted ? "Spent" : row.headroomText)
+          .font(.callout)
+          .monospacedDigit()
+          .foregroundColor(row.band.color)
+      }
+
+      ShareBar(fraction: Double(row.percentLeft) / 100, tint: row.band.color)
+
+      if !detailParts.isEmpty {
+        Text(detailParts.joined(separator: " · "))
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .lineLimit(1)
+      }
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Rank \(rank)")
+    .accessibilityValue(row.summary)
+  }
+
+  /// The score inputs that don't fit the headline row, in weighting order: when
+  /// the window refills, then how the burn compares to the clock.
+  private var detailParts: [String] {
+    if row.isExhausted {
+      return [row.availabilityText].compactMap { $0 }
+    }
+    return [row.resetText, row.paceText].compactMap { $0 }
+  }
+}
+
+/// A provider left out of the ranking, with the reason in place of a rank.
+private struct HeadroomUnavailableRow: View {
+  let entry: ProviderRecommendationUnavailableRow
+
+  var body: some View {
+    HStack(spacing: 8) {
+      Circle()
+        .fill(MeterBarTheme.accent(for: entry.service))
+        .frame(width: 8, height: 8)
+
+      Text(entry.name)
+        .font(.callout)
+        .lineLimit(1)
+        .truncationMode(.middle)
+
+      Spacer(minLength: 8)
+
+      Text(entry.detail)
+        .font(.caption)
+        .foregroundColor(.secondary)
+        .lineLimit(1)
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(entry.name)
+    .accessibilityValue(entry.detail)
   }
 }
 

--- a/MeterBar/Views/PopoverOverviewPanel.swift
+++ b/MeterBar/Views/PopoverOverviewPanel.swift
@@ -18,6 +18,9 @@ struct PopoverOverviewPanel: View {
     let claudeEnabledCustomAccountIDs: [UUID]
     let claudeEnabledAccountMetrics: [UsageMetrics]
     let grokAccounts: [GrokAccount]
+    /// Opt-in one-line "what to use next" hint. Defaults to off so the popover
+    /// keeps its pre-feature layout; the full ranking lives in the dashboard.
+    let showsRecommendationHint: Bool
 
     @State private var setupReports: [ProviderReadiness] = []
     @StateObject private var onboarding = FirstRunOnboardingStore.shared
@@ -36,7 +39,8 @@ struct PopoverOverviewPanel: View {
         claudeDefaultAccountEnabled: Bool = true,
         claudeEnabledCustomAccountIDs: [UUID] = [],
         claudeEnabledAccountMetrics: [UsageMetrics] = [],
-        grokAccounts: [GrokAccount] = [.defaultAccount]
+        grokAccounts: [GrokAccount] = [.defaultAccount],
+        showsRecommendationHint: Bool = false
     ) {
         self.snapshots = snapshots
         self.openDashboard = openDashboard
@@ -47,6 +51,7 @@ struct PopoverOverviewPanel: View {
         self.claudeEnabledCustomAccountIDs = claudeEnabledCustomAccountIDs
         self.claudeEnabledAccountMetrics = claudeEnabledAccountMetrics
         self.grokAccounts = grokAccounts
+        self.showsRecommendationHint = showsRecommendationHint
     }
 
     /// The enabled providers currently shown in the popover.
@@ -71,6 +76,7 @@ struct PopoverOverviewPanel: View {
     /// separately via the cards' own `.numericText()` content transitions.
     private struct StructuralKey: Equatable {
         let showsFirstRun: Bool
+        let showsRecommendationHint: Bool
         let isEmpty: Bool
         let setupProviders: [ServiceType]
         let snapshotIDs: [String]
@@ -87,6 +93,7 @@ struct PopoverOverviewPanel: View {
     private var structuralKey: StructuralKey {
         StructuralKey(
             showsFirstRun: onboarding.shouldPresent,
+            showsRecommendationHint: showsRecommendationHint,
             isEmpty: snapshots.isEmpty,
             setupProviders: providersNeedingSetup.map(\.provider),
             snapshotIDs: snapshots.map(\.id)
@@ -118,6 +125,11 @@ struct PopoverOverviewPanel: View {
                     .transition(MeterBarTheme.Motion.popoverTile)
             }
 
+            if showsRecommendationHint {
+                recommendationHint
+                    .transition(MeterBarTheme.Motion.popoverTile)
+            }
+
             if !providersNeedingSetup.isEmpty {
                 setupChecklist
                     .transition(MeterBarTheme.Motion.popoverTile)
@@ -141,6 +153,41 @@ struct PopoverOverviewPanel: View {
         )
         .task(id: readinessInputKey) {
             await loadSetupReports()
+        }
+    }
+
+    /// The opt-in one-line "what to use next" row.
+    ///
+    /// Deliberately the same sentence the dashboard card leads with — the popover
+    /// is the glanceable copy of that ranking, not a second opinion. Ticks on the
+    /// shared reset-countdown schedule so its countdown, and the ranking that
+    /// weighs it, stay current without a clock of its own. Renders nothing when
+    /// nothing is rankable rather than guessing a pick.
+    @ViewBuilder private var recommendationHint: some View {
+        TimelineView(
+            .periodic(from: ResetCountdownSchedule.anchor, by: ResetCountdownSchedule.interval)
+        ) { timeline in
+            let recommendation = snapshots.headroomRecommendation(now: timeline.date)
+            if let headline = recommendation.headline, let top = recommendation.top {
+                DashboardTile(padding: .popover) {
+                    HStack(alignment: .center, spacing: 9) {
+                        Image(systemName: "arrow.forward.circle.fill")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(MeterBarTheme.accent(for: top.service))
+                            .accessibilityHidden(true)
+
+                        Text(headline)
+                            .font(.caption)
+                            .fontWeight(.medium)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        Spacer(minLength: 0)
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("Recommended next")
+                    .accessibilityValue(top.summary)
+                }
+            }
         }
     }
 

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -420,4 +420,32 @@ extension Array where Element == ProviderSnapshot {
     var tightestLimit: SnapshotLimit? {
         compactMap(\.primaryLimit).min { $0.percentLeft < $1.percentLeft }
     }
+
+    /// Ranks these providers by remaining headroom — the "what should I use
+    /// next?" answer. Pass the *unfiltered* snapshot list: the planner needs the
+    /// providers with no cached usage in order to list them under its no-data
+    /// state instead of silently dropping them. Hidden providers never appear
+    /// here because `ProviderSnapshotBuilder` only emits enabled services, so
+    /// they are omitted from every recommendation surface for free.
+    func headroomRecommendation(now: Date = Date()) -> ProviderRecommendation {
+        var displayOrderByService: [ServiceType: Int] = [:]
+        let candidates = map { snapshot -> ProviderRecommendationCandidate in
+            let displayOrder = displayOrderByService[snapshot.service, default: 0]
+            displayOrderByService[snapshot.service] = displayOrder + 1
+            return ProviderRecommendationCandidate(
+                id: snapshot.id,
+                name: snapshot.title,
+                service: snapshot.service,
+                displayOrder: displayOrder,
+                sessionLimit: snapshot.limits.first { $0.kind == .session }?.usageLimit,
+                weeklyLimit: snapshot.limits.first { $0.kind == .weekly }?.usageLimit,
+                lastUpdated: snapshot.updatedAt,
+                // A signed-out or unreachable account can still hold a fresh,
+                // healthy-looking cache. Recommending it would send the user to
+                // a tool they cannot actually run.
+                unavailableReason: snapshot.authNotice.map { .blocked($0.shortLabel) }
+            )
+        }
+        return ProviderRecommendationPlanner.rank(candidates: candidates, now: now)
+    }
 }

--- a/MeterBar/Views/Settings/GeneralSettingsView.swift
+++ b/MeterBar/Views/Settings/GeneralSettingsView.swift
@@ -282,6 +282,19 @@ struct GeneralSettingsView: View {
                 .pickerStyle(.segmented)
                 .frame(width: 180)
             }
+
+            SettingsRowView(
+                title: "What to use next",
+                detail: "Show the top provider by remaining headroom at the top of the popover. "
+                    + "The full ranking stays in the dashboard’s Optimize tab."
+            ) {
+                Toggle("", isOn: Binding(
+                    get: { menuBarDisplayPreferences.showsRecommendationHint },
+                    set: { menuBarDisplayPreferences.setShowsRecommendationHint($0) }
+                ))
+                .labelsHidden()
+                .meterBarSwitch()
+            }
         }
     }
 

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -283,7 +283,10 @@ struct UsageDashboardView: View {
                 quotaSnapshot: providerSnapshot(for:)
             )
         case .optimize:
-            OptimizeInsightsView()
+            // Unfiltered on purpose: the recommendation card lists the enabled
+            // providers with no cached usage under its own "no data" state, so
+            // filtering them out here would hide them instead.
+            OptimizeInsightsView(providerSnapshots: allProviderSnapshots)
         case .diagnostics:
             DashboardDiagnosticsSection(
                 reports: $readinessReports,
@@ -351,8 +354,15 @@ struct UsageDashboardView: View {
     }
 
     private var providerSnapshots: [ProviderSnapshot] {
-        // Same builder the popover uses; the dashboard only renders providers
-        // that have reported metrics.
+        // Same builder the popover uses; most dashboard sections only render
+        // providers that have reported metrics.
+        allProviderSnapshots.filter(\.hasMetrics)
+    }
+
+    /// Every enabled provider/account, including the ones with no cached usage.
+    /// Sections that must *name* a silent provider — the Optimize page's
+    /// recommendation card — read this instead of the filtered list.
+    private var allProviderSnapshots: [ProviderSnapshot] {
         ProviderSnapshotBuilder.snapshots(ProviderSnapshotBuilder.Input(
             metrics: dataManager.metrics,
             codexAccounts: codexAccountStore.accounts,
@@ -370,7 +380,6 @@ struct UsageDashboardView: View {
             openRouterHasAccess: openRouterService.hasAccess,
             grokHasAccess: grokService.hasAccess
         ))
-        .filter(\.hasMetrics)
     }
 
     private var orderedProviderSnapshotsForLimits: [ProviderSnapshot] {

--- a/MeterBarTests/CardStateTransitionTests.swift
+++ b/MeterBarTests/CardStateTransitionTests.swift
@@ -119,6 +119,17 @@ final class CardStateTransitionTests: XCTestCase {
                 openProviderOverview: { _ in }
             )
         )
+
+        // Hint enabled: the opt-in "what to use next" row joins the stack.
+        assertRenders(
+            PopoverOverviewPanel(
+                snapshots: snapshots,
+                openDashboard: {},
+                openStatusDetail: {},
+                openProviderOverview: { _ in },
+                showsRecommendationHint: true
+            )
+        )
     }
 
     // MARK: - OptimizeInsightsView build smoke
@@ -128,6 +139,21 @@ final class CardStateTransitionTests: XCTestCase {
         // this asserts the phase-switched body lays out rather than a specific
         // branch.
         assertRenders(OptimizeInsightsView(), minHeight: 0)
+
+        // With snapshots the recommendation card renders above the phase content,
+        // including its "no data" section for the provider without metrics.
+        let snapshots = ProviderSnapshotBuilder.snapshots(
+            ProviderSnapshotBuilder.Input(
+                metrics: [
+                    .codexCli: makeMetrics(service: .codexCli, weekly: 10),
+                    .cursor: makeMetrics(service: .cursor, weekly: 30)
+                ],
+                claudeAccounts: [.defaultAccount],
+                claudeAccountMetrics: [:],
+                enabledServices: [.codexCli, .cursor, .claudeCode]
+            )
+        )
+        assertRenders(OptimizeInsightsView(providerSnapshots: snapshots), minHeight: 0)
     }
 
     // MARK: - Helpers

--- a/MeterBarTests/MenuBarDisplayPreferencesStoreTests.swift
+++ b/MeterBarTests/MenuBarDisplayPreferencesStoreTests.swift
@@ -30,6 +30,8 @@ final class MenuBarDisplayPreferencesStoreTests: XCTestCase {
         XCTAssertFalse(store.highContrast)
         XCTAssertFalse(store.showsExhaustedResetCountdown)
         XCTAssertEqual(store.resetTimeFormat, .countdown)
+        // The popover keeps its pre-feature layout until the hint is asked for.
+        XCTAssertFalse(store.showsRecommendationHint)
     }
 
     func testPreferencesPersistAcrossRelaunch() {
@@ -42,6 +44,7 @@ final class MenuBarDisplayPreferencesStoreTests: XCTestCase {
         store.setHighContrast(true)
         store.setShowsExhaustedResetCountdown(true)
         store.setResetTimeFormat(.clock)
+        store.setShowsRecommendationHint(true)
 
         let reloaded = MenuBarDisplayPreferencesStore(userDefaults: defaults)
 
@@ -53,6 +56,7 @@ final class MenuBarDisplayPreferencesStoreTests: XCTestCase {
         XCTAssertTrue(reloaded.highContrast)
         XCTAssertTrue(reloaded.showsExhaustedResetCountdown)
         XCTAssertEqual(reloaded.resetTimeFormat, .clock)
+        XCTAssertTrue(reloaded.showsRecommendationHint)
     }
 
     func testInvalidPersistedValuesFallBackToExistingDefaults() {

--- a/MeterBarTests/ProviderRecommendationTests.swift
+++ b/MeterBarTests/ProviderRecommendationTests.swift
@@ -1,0 +1,420 @@
+import Foundation
+import MeterBarShared
+import XCTest
+
+final class ProviderRecommendationTests: XCTestCase {
+    private let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
+
+    // MARK: - Ordering
+
+    func testRanksCandidatesByBindingWindowHeadroom() {
+        let recommendation = rank([
+            makeCandidate(id: "tight", service: .grok, session: limit(used: 90)),
+            makeCandidate(id: "roomy", service: .cursor, session: limit(used: 20)),
+            makeCandidate(id: "middling", service: .codexCli, session: limit(used: 60))
+        ])
+
+        XCTAssertEqual(recommendation.rows.map(\.id), ["roomy", "middling", "tight"])
+        XCTAssertEqual(recommendation.rows.map(\.percentLeft), [80, 40, 10])
+        XCTAssertEqual(recommendation.top?.id, "roomy")
+        XCTAssertTrue(recommendation.unavailable.isEmpty)
+    }
+
+    func testBindingWindowIsTheTightestProviderBlockingWindow() {
+        let recommendation = rank([
+            makeCandidate(
+                id: "weekly-bound",
+                service: .claudeCode,
+                session: limit(used: 10),
+                weekly: limit(used: 70)
+            ),
+            makeCandidate(id: "session-only", service: .codexCli, session: limit(used: 50))
+        ])
+
+        XCTAssertEqual(recommendation.rows.map(\.id), ["session-only", "weekly-bound"])
+        XCTAssertEqual(recommendation.rows.map(\.window), [.session, .weekly])
+        XCTAssertEqual(recommendation.rows.map(\.percentLeft), [50, 30])
+        XCTAssertEqual(recommendation.rows.map(\.windowTitle), ["Session", "Weekly"])
+    }
+
+    func testWindowTitleFollowsTheProviderVocabulary() {
+        let recommendation = rank([
+            makeCandidate(id: "credits", service: .openRouter, weekly: limit(used: 10)),
+            makeCandidate(id: "monthly", service: .cursor, weekly: limit(used: 20)),
+            makeCandidate(id: "key", service: .openRouter, displayOrder: 1, session: limit(used: 30))
+        ])
+
+        XCTAssertEqual(
+            recommendation.rows.map(\.windowTitle),
+            ["Account credits", "Monthly", "Key limit"]
+        )
+    }
+
+    func testEqualScoresFallBackToStableProviderOrder() {
+        let recommendation = rank([
+            makeCandidate(id: "grok", service: .grok, session: limit(used: 40)),
+            makeCandidate(id: "claude-b", service: .claudeCode, displayOrder: 1, session: limit(used: 40)),
+            makeCandidate(id: "claude-a", service: .claudeCode, displayOrder: 0, session: limit(used: 40))
+        ])
+
+        XCTAssertEqual(recommendation.rows.map(\.id), ["claude-a", "claude-b", "grok"])
+        XCTAssertEqual(Set(recommendation.rows.map(\.score)), [60])
+    }
+
+    // MARK: - Pace weighting
+
+    func testReserveOutranksDeficitAtEqualHeadroom() {
+        // Both candidates have half their quota left; only the elapsed share of
+        // the window differs, so pace is the sole tiebreaker.
+        let recommendation = rank([
+            makeCandidate(
+                id: "deficit",
+                service: .claudeCode,
+                session: limit(used: 50, resetIn: 8 * 3_600, windowSeconds: 10 * 3_600)
+            ),
+            makeCandidate(
+                id: "reserve",
+                service: .codexCli,
+                session: limit(used: 50, resetIn: 2 * 3_600, windowSeconds: 10 * 3_600)
+            )
+        ])
+
+        XCTAssertEqual(recommendation.rows.map(\.id), ["reserve", "deficit"])
+        XCTAssertEqual(recommendation.rows.map(\.score), [62, 38])
+        XCTAssertEqual(recommendation.rows.map(\.paceText), ["30% in reserve", "30% in deficit"])
+    }
+
+    func testPaceAdjustmentIsCappedSoHeadroomStaysDominant() {
+        // "reserve" runs a 30-point reserve — worth 12 points, not 12 × 0.4 × 30 —
+        // so the candidate with genuinely more quota left still wins.
+        let recommendation = rank([
+            makeCandidate(
+                id: "reserve",
+                service: .claudeCode,
+                session: limit(used: 60, resetIn: 3_600, windowSeconds: 10 * 3_600)
+            ),
+            makeCandidate(
+                id: "roomier",
+                service: .codexCli,
+                session: limit(used: 45, resetIn: 5_400 + 14_400, windowSeconds: 10 * 3_600)
+            )
+        ])
+
+        XCTAssertEqual(recommendation.rows.map(\.id), ["roomier", "reserve"])
+        XCTAssertEqual(recommendation.rows.map(\.score), [55, 52])
+    }
+
+    func testImminentResetLiftsANearlyRefilledWindow() {
+        let recommendation = rank([
+            makeCandidate(id: "refills-soon", service: .claudeCode, session: limit(used: 70, resetIn: 600)),
+            makeCandidate(id: "no-reset", service: .codexCli, session: limit(used: 68))
+        ])
+
+        XCTAssertEqual(recommendation.rows.map(\.id), ["refills-soon", "no-reset"])
+        XCTAssertEqual(recommendation.rows.map(\.score), [34, 32])
+        XCTAssertEqual(recommendation.rows.first?.resetText, "Resets in 10m")
+    }
+
+    // MARK: - Exhaustion
+
+    func testExhaustedCandidatesRankLastOrderedBySoonestReset() {
+        let recommendation = rank([
+            makeCandidate(id: "late", service: .claudeCode, session: limit(used: 100, resetIn: 3 * 3_600)),
+            makeCandidate(id: "unknown-reset", service: .codexCli, session: limit(used: 120)),
+            makeCandidate(id: "healthy", service: .cursor, session: limit(used: 50)),
+            makeCandidate(id: "soon", service: .grok, session: limit(used: 100, resetIn: 1_800))
+        ])
+
+        XCTAssertEqual(recommendation.rows.map(\.id), ["healthy", "soon", "late", "unknown-reset"])
+        XCTAssertEqual(recommendation.rows.map(\.isExhausted), [false, true, true, true])
+        XCTAssertEqual(recommendation.rows.dropFirst().map(\.score), [0, 0, 0])
+        XCTAssertEqual(
+            recommendation.rows.map(\.availabilityText),
+            [nil, "Available in 30m", "Available in 3h", nil]
+        )
+    }
+
+    func testAnExhaustedWindowNeverBorrowsTheImminentResetBonus() {
+        let recommendation = rank([
+            makeCandidate(id: "exhausted", service: .claudeCode, session: limit(used: 100, resetIn: 300)),
+            makeCandidate(id: "barely-left", service: .codexCli, session: limit(used: 99.5))
+        ])
+
+        XCTAssertEqual(recommendation.rows.map(\.id), ["barely-left", "exhausted"])
+        XCTAssertEqual(recommendation.rows.map(\.score), [1, 0])
+    }
+
+    func testEveryWindowExhaustedStillNamesTheSoonestReturn() {
+        let recommendation = rank([
+            makeCandidate(id: "later", service: .claudeCode, session: limit(used: 100, resetIn: 4 * 3_600)),
+            makeCandidate(id: "sooner", service: .codexCli, session: limit(used: 100, resetIn: 90 * 60))
+        ])
+
+        XCTAssertTrue(recommendation.isFullyExhausted)
+        XCTAssertEqual(recommendation.top?.id, "sooner")
+        XCTAssertEqual(recommendation.top?.availabilityText, "Available in 1h 30m")
+    }
+
+    // MARK: - Staleness and missing data
+
+    func testStaleCandidatesAreExcludedWithTheirAgeInsteadOfRanked() {
+        let recommendation = rank([
+            makeCandidate(id: "fresh", service: .claudeCode, session: limit(used: 40)),
+            makeCandidate(
+                id: "stale",
+                service: .codexCli,
+                session: limit(used: 5),
+                updatedSecondsAgo: 3 * 3_600
+            )
+        ])
+
+        XCTAssertEqual(recommendation.rows.map(\.id), ["fresh"])
+        XCTAssertEqual(recommendation.unavailable.map(\.id), ["stale"])
+        XCTAssertEqual(recommendation.unavailable.first?.reason, .stale(age: 3 * 3_600))
+        XCTAssertEqual(recommendation.unavailable.first?.detail, "Last updated 3h ago")
+    }
+
+    func testStalenessThresholdIsInjectable() {
+        let candidates = [
+            makeCandidate(id: "fresh", service: .claudeCode, session: limit(used: 40)),
+            makeCandidate(
+                id: "older",
+                service: .codexCli,
+                session: limit(used: 5),
+                updatedSecondsAgo: 30 * 60
+            )
+        ]
+
+        XCTAssertEqual(rank(candidates).rows.map(\.id), ["older", "fresh"])
+        XCTAssertEqual(
+            rank(candidates, stalenessThreshold: 10 * 60).rows.map(\.id),
+            ["fresh"]
+        )
+    }
+
+    func testMissingSnapshotsAndMissingBindingWindowsListAsNoData() {
+        let recommendation = rank([
+            makeCandidate(id: "ranked", service: .cursor, session: limit(used: 40)),
+            makeCandidate(id: "never-fetched", service: .claudeCode, updatedSecondsAgo: nil),
+            makeCandidate(id: "no-window", service: .codexCli)
+        ])
+
+        XCTAssertEqual(recommendation.rows.map(\.id), ["ranked"])
+        XCTAssertEqual(recommendation.unavailable.map(\.id), ["never-fetched", "no-window"])
+        XCTAssertEqual(
+            recommendation.unavailable.map(\.reason),
+            [.noSnapshot, .noBindingWindow]
+        )
+        XCTAssertEqual(
+            recommendation.unavailable.map(\.detail),
+            ["No usage cached yet", "No session or weekly window reported"]
+        )
+    }
+
+    func testCallerSuppliedBlockersOutrankOtherwiseHealthyNumbers() {
+        let signedOut = ProviderRecommendationCandidate(
+            id: "signed-out",
+            name: "Claude",
+            service: .claudeCode,
+            displayOrder: 0,
+            sessionLimit: limit(used: 5),
+            weeklyLimit: nil,
+            lastUpdated: now,
+            unavailableReason: .blocked("Login required")
+        )
+        let recommendation = rank([
+            signedOut,
+            makeCandidate(id: "usable", service: .codexCli, session: limit(used: 80))
+        ])
+
+        XCTAssertEqual(recommendation.rows.map(\.id), ["usable"])
+        XCTAssertEqual(recommendation.unavailable.map(\.detail), ["Login required"])
+    }
+
+    func testHeadroomIsNeverGuessedFromAnEmptyQuotaTotal() {
+        let recommendation = rank([
+            makeCandidate(
+                id: "zero-total",
+                service: .claudeCode,
+                session: UsageLimit(used: 0, total: 0, resetTime: nil)
+            )
+        ])
+
+        XCTAssertTrue(recommendation.rows.isEmpty)
+        XCTAssertEqual(recommendation.unavailable.map(\.reason), [.noBindingWindow])
+    }
+
+    // MARK: - Degenerate inputs
+
+    func testSingleCandidateIsItsOwnTopRecommendation() {
+        let recommendation = rank([
+            makeCandidate(id: "solo", service: .cursor, weekly: limit(used: 18, resetIn: 3 * 86_400))
+        ])
+
+        XCTAssertEqual(recommendation.rows.count, 1)
+        XCTAssertEqual(recommendation.top?.id, "solo")
+        XCTAssertFalse(recommendation.isEmpty)
+        XCTAssertFalse(recommendation.isFullyExhausted)
+        XCTAssertEqual(recommendation.top?.summary, "Cursor — 82% left on Monthly, resets in 3d")
+    }
+
+    func testHeadlineNamesTheTopPickAndItsNumbers() {
+        let recommendation = rank([
+            makeCandidate(id: "solo", service: .cursor, weekly: limit(used: 18, resetIn: 3 * 86_400))
+        ])
+
+        XCTAssertEqual(recommendation.headline, "Use Cursor next — 82% left on monthly, resets in 3d")
+    }
+
+    func testHeadlineSaysSoWhenEveryWindowIsSpent() {
+        let recommendation = rank([
+            makeCandidate(id: "late", service: .codexCli, session: limit(used: 100, resetIn: 3 * 3_600)),
+            makeCandidate(id: "soon", service: .claudeCode, session: limit(used: 100, resetIn: 45 * 60))
+        ])
+
+        XCTAssertEqual(
+            recommendation.headline,
+            "Every window is spent — Claude is back first, available in 45m"
+        )
+    }
+
+    func testHeadlineIsAbsentWithNothingToRank() {
+        XCTAssertNil(rank([]).headline)
+    }
+
+    func testEmptyCandidateListProducesAnEmptyRecommendation() {
+        let recommendation = rank([])
+
+        XCTAssertTrue(recommendation.rows.isEmpty)
+        XCTAssertTrue(recommendation.unavailable.isEmpty)
+        XCTAssertTrue(recommendation.isEmpty)
+        XCTAssertFalse(recommendation.isFullyExhausted)
+        XCTAssertNil(recommendation.top)
+    }
+
+    func testOnlyUnavailableCandidatesStillCountAsEmptyRanking() {
+        let recommendation = rank([
+            makeCandidate(id: "never-fetched", service: .claudeCode, updatedSecondsAgo: nil)
+        ])
+
+        XCTAssertTrue(recommendation.isEmpty)
+        XCTAssertFalse(recommendation.isFullyExhausted)
+        XCTAssertEqual(recommendation.unavailable.count, 1)
+    }
+
+    // MARK: - Explainability
+
+    func testEstimatedTotalsRankButStayMarkedAsEstimates() {
+        let recommendation = rank([
+            makeCandidate(
+                id: "estimated",
+                service: .claudeCode,
+                session: limit(used: 60, isEstimated: true)
+            )
+        ])
+
+        XCTAssertEqual(recommendation.top?.headroomText, "~40% left")
+        XCTAssertEqual(recommendation.top?.limit.isEstimated, true)
+    }
+
+    func testRowsCarryTheInputsThatProducedTheirScore() {
+        let recommendation = rank([
+            makeCandidate(
+                id: "explained",
+                service: .claudeCode,
+                session: limit(used: 50, resetIn: 2 * 3_600, windowSeconds: 10 * 3_600)
+            )
+        ])
+
+        let row = recommendation.rows.first
+        XCTAssertEqual(row?.percentLeft, 50)
+        XCTAssertEqual(row?.band, .healthy)
+        XCTAssertEqual(row?.window, .session)
+        XCTAssertEqual(row?.secondsUntilReset, 2 * 3_600)
+        XCTAssertEqual(row?.resetText, "Resets in 2h")
+        XCTAssertEqual(row?.paceText, "30% in reserve")
+        XCTAssertEqual(row?.pace?.stage, .reserve)
+    }
+
+    func testCandidateFromMetricsIgnoresTheModelScopedWindow() {
+        let metrics = UsageMetrics(
+            service: .claudeCode,
+            sessionLimit: limit(used: 30),
+            weeklyLimit: limit(used: 40),
+            codeReviewLimit: limit(used: 99),
+            lastUpdated: now
+        )
+        let candidate = ProviderRecommendationCandidate(
+            id: "claude",
+            name: "Claude Code",
+            service: .claudeCode,
+            displayOrder: 0,
+            metrics: metrics
+        )
+
+        XCTAssertEqual(candidate.sessionLimit, metrics.sessionLimit)
+        XCTAssertEqual(candidate.weeklyLimit, metrics.weeklyLimit)
+        XCTAssertEqual(candidate.lastUpdated, now)
+        XCTAssertEqual(rank([candidate]).top?.percentLeft, 60)
+    }
+
+    func testCandidateFromAMissingSnapshotHasNoTimestamp() {
+        let candidate = ProviderRecommendationCandidate(
+            id: "grok",
+            name: "Grok",
+            service: .grok,
+            displayOrder: 0,
+            metrics: nil
+        )
+
+        XCTAssertNil(candidate.lastUpdated)
+        XCTAssertEqual(rank([candidate]).unavailable.map(\.reason), [.noSnapshot])
+    }
+
+    // MARK: - Helpers
+
+    private func rank(
+        _ candidates: [ProviderRecommendationCandidate],
+        stalenessThreshold: TimeInterval = ProviderRecommendationPlanner.defaultStalenessThreshold
+    ) -> ProviderRecommendation {
+        ProviderRecommendationPlanner.rank(
+            candidates: candidates,
+            now: now,
+            stalenessThreshold: stalenessThreshold
+        )
+    }
+
+    private func limit(
+        used: Double,
+        resetIn: TimeInterval? = nil,
+        windowSeconds: TimeInterval? = nil,
+        isEstimated: Bool = false
+    ) -> UsageLimit {
+        UsageLimit(
+            used: used,
+            total: 100,
+            resetTime: resetIn.map { now.addingTimeInterval($0) },
+            windowSeconds: windowSeconds,
+            isEstimated: isEstimated
+        )
+    }
+
+    private func makeCandidate(
+        id: String,
+        service: ServiceType,
+        displayOrder: Int = 0,
+        session: UsageLimit? = nil,
+        weekly: UsageLimit? = nil,
+        updatedSecondsAgo: TimeInterval? = 0
+    ) -> ProviderRecommendationCandidate {
+        ProviderRecommendationCandidate(
+            id: id,
+            name: service.shortName,
+            service: service,
+            displayOrder: displayOrder,
+            sessionLimit: session,
+            weeklyLimit: weekly,
+            lastUpdated: updatedSecondsAgo.map { now.addingTimeInterval(-$0) }
+        )
+    }
+}

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ProviderRecommendation.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ProviderRecommendation.swift
@@ -1,0 +1,438 @@
+import Foundation
+
+/// One provider or account the recommendation considers.
+///
+/// The candidate carries only the two provider-blocking windows because those
+/// are the ones that stop work: a model-scoped or code-review window can be
+/// spent while the provider itself stays perfectly usable, so ranking on it
+/// would recommend against a tool that is in fact free. `lastUpdated` is
+/// `nil` when no snapshot has ever been cached for this provider, which is
+/// what separates "never fetched" from "fetched but empty".
+public struct ProviderRecommendationCandidate: Equatable, Sendable {
+    public let id: String
+    public let name: String
+    public let service: ServiceType
+    /// Position of this account within its provider, so multi-account
+    /// providers keep the order the rest of the app shows them in.
+    public let displayOrder: Int
+    public let sessionLimit: UsageLimit?
+    public let weeklyLimit: UsageLimit?
+    public let lastUpdated: Date?
+    /// Set when the caller already knows the provider is unusable for a reason
+    /// the planner cannot see in the numbers — a signed-out account, say, whose
+    /// last cached reading is fresh and healthy but no longer reachable. It
+    /// short-circuits ranking so those percentages never become a suggestion.
+    public let unavailableReason: ProviderRecommendationUnavailability?
+
+    public init(
+        id: String,
+        name: String,
+        service: ServiceType,
+        displayOrder: Int,
+        sessionLimit: UsageLimit?,
+        weeklyLimit: UsageLimit?,
+        lastUpdated: Date?,
+        unavailableReason: ProviderRecommendationUnavailability? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.service = service
+        self.displayOrder = displayOrder
+        self.sessionLimit = sessionLimit
+        self.weeklyLimit = weeklyLimit
+        self.lastUpdated = lastUpdated
+        self.unavailableReason = unavailableReason
+    }
+
+    /// Convenience for callers that already hold a cached snapshot. Drops the
+    /// model-scoped window on purpose — see the type's note.
+    public init(
+        id: String,
+        name: String,
+        service: ServiceType,
+        displayOrder: Int,
+        metrics: UsageMetrics?,
+        unavailableReason: ProviderRecommendationUnavailability? = nil
+    ) {
+        self.init(
+            id: id,
+            name: name,
+            service: service,
+            displayOrder: displayOrder,
+            sessionLimit: metrics?.sessionLimit,
+            weeklyLimit: metrics?.weeklyLimit,
+            lastUpdated: metrics?.lastUpdated,
+            unavailableReason: unavailableReason
+        )
+    }
+}
+
+/// The provider-blocking window a recommendation row is constrained by.
+///
+/// Deliberately narrower than `WidgetQuotaWindow`, which also carries
+/// `codeReview`: that window never blocks a provider, so it can never be the
+/// reason to pick a different tool.
+public enum ProviderRecommendationWindow: String, Equatable, Sendable {
+    case session
+    case weekly
+
+    public func title(for service: ServiceType) -> String {
+        switch (self, service) {
+        case (.session, .openRouter):
+            return "Key limit"
+        case (.session, _):
+            return "Session"
+        case (.weekly, _):
+            return service.weeklyQuotaTitle
+        }
+    }
+}
+
+/// Why a candidate could not be ranked. Every case is a statement about the
+/// cache, never an estimate of the quota behind it — a provider MeterBar
+/// cannot currently measure is listed, not guessed at.
+public enum ProviderRecommendationUnavailability: Equatable, Sendable {
+    /// No usage has ever been cached for this provider or account.
+    case noSnapshot
+    /// A snapshot exists but reports no usable session or weekly window.
+    case noBindingWindow
+    /// The snapshot is older than the staleness threshold.
+    case stale(age: TimeInterval)
+    /// The caller knows the provider is unusable for a reason outside the
+    /// numbers — signed out, not connected, needs attention — and supplies the
+    /// wording, so provider auth vocabulary stays out of the shared planner.
+    case blocked(String)
+
+    public var detail: String {
+        switch self {
+        case .noSnapshot:
+            return "No usage cached yet"
+        case .noBindingWindow:
+            return "No session or weekly window reported"
+        case let .stale(age):
+            return "Last updated \(UsageDurationText.short(seconds: age)) ago"
+        case let .blocked(detail):
+            return detail
+        }
+    }
+}
+
+/// A ranked provider, carrying every input that produced its score so the row
+/// can show its own reasoning rather than assert a verdict.
+public struct ProviderRecommendationRow: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let name: String
+    public let service: ServiceType
+    public let window: ProviderRecommendationWindow
+    public let limit: UsageLimit
+    public let percentLeft: Int
+    public let band: QuotaBand
+    public let secondsUntilReset: TimeInterval?
+    public let pace: UsagePace?
+    public let score: Int
+
+    public var isExhausted: Bool {
+        band == .exhausted
+    }
+
+    public var windowTitle: String {
+        window.title(for: service)
+    }
+
+    public var headroomText: String {
+        limit.percentLeftText
+    }
+
+    /// "Resets in 3h 20m" — or "Resets now" once the countdown has run out but
+    /// the provider has not yet reported the refill.
+    public var resetText: String? {
+        guard let secondsUntilReset else { return nil }
+        guard secondsUntilReset > 0 else { return "Resets now" }
+        return "Resets in \(UsageDurationText.short(seconds: secondsUntilReset))"
+    }
+
+    public var paceText: String? {
+        pace?.leftLabel
+    }
+
+    /// When this provider becomes usable again. Only meaningful for a spent
+    /// window, and `nil` when the provider reports no reset time — the row says
+    /// nothing rather than inventing a return.
+    public var availabilityText: String? {
+        guard isExhausted, let secondsUntilReset else { return nil }
+        guard secondsUntilReset > 0 else { return "Available now" }
+        return "Available in \(UsageDurationText.short(seconds: secondsUntilReset))"
+    }
+
+    /// One-line form for compact surfaces (the popover hint).
+    public var summary: String {
+        if isExhausted {
+            let suffix = availabilityText.map { ", \($0.lowercased())" } ?? ""
+            return "\(name) — out of \(windowTitle.lowercased()) quota\(suffix)"
+        }
+        let suffix = resetText.map { ", \($0.lowercased())" } ?? ""
+        return "\(name) — \(headroomText) on \(windowTitle)\(suffix)"
+    }
+}
+
+public struct ProviderRecommendationUnavailableRow: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let name: String
+    public let service: ServiceType
+    public let reason: ProviderRecommendationUnavailability
+
+    public var detail: String {
+        reason.detail
+    }
+}
+
+public struct ProviderRecommendation: Equatable, Sendable {
+    /// Rankable providers, best headroom first, spent windows last.
+    public let rows: [ProviderRecommendationRow]
+    /// Providers deliberately left out of the ranking, with the reason.
+    public let unavailable: [ProviderRecommendationUnavailableRow]
+
+    public var top: ProviderRecommendationRow? {
+        rows.first
+    }
+
+    public var isEmpty: Bool {
+        rows.isEmpty
+    }
+
+    /// True when every rankable provider is spent — the case where the honest
+    /// answer is "none of them, and here is when the first one returns".
+    public var isFullyExhausted: Bool {
+        !rows.isEmpty && rows.allSatisfy(\.isExhausted)
+    }
+
+    /// The one-line answer, shared by the dashboard card's lead and the popover
+    /// hint so the two surfaces cannot phrase the same ranking differently.
+    /// `nil` when nothing is rankable — no headline is better than a hedge.
+    public var headline: String? {
+        guard let top else { return nil }
+        if isFullyExhausted {
+            let availability = top.availabilityText.map { ", \($0.lowercased())" } ?? ""
+            return "Every window is spent — \(top.name) is back first\(availability)"
+        }
+        let reset = top.resetText.map { ", \($0.lowercased())" } ?? ""
+        return "Use \(top.name) next — \(top.headroomText) on \(top.windowTitle.lowercased())\(reset)"
+    }
+}
+
+/// Weights for the headroom score, in score points.
+///
+/// The score answers one question — "how much room does this provider have
+/// left right now?" — so percent-left is the base and everything else is a
+/// bounded adjustment on top of it. Keeping the weights named and capped is
+/// what makes a row's ordering explainable from the values the row already
+/// shows; a bare tuned constant would not be.
+public enum ProviderRecommendationWeights {
+    /// Each percentage point left of the binding window is worth one point, so
+    /// an unadjusted score reads as "percent left".
+    public static let headroomPointsPerPercentLeft = 1.0
+
+    /// How much one point of pace delta moves the score. Burning slower than
+    /// the window elapses (reserve) adds; burning faster (deficit) subtracts.
+    public static let pacePointsPerDeltaPercent = 0.4
+
+    /// Ceiling on the pace adjustment in either direction. Pace is a
+    /// short-horizon projection off a partially elapsed window, so it may
+    /// nudge the order but must never out-vote the headroom it is measured
+    /// against — twelve points cannot flip a provider past one with a quarter
+    /// more quota left.
+    public static let maximumPaceAdjustment = 12.0
+
+    /// Bonus for a window that refills within `imminentResetWindow`. A quota
+    /// that is about to be replaced is worth more than its current percentage
+    /// suggests, but only slightly — it is still spent until it resets.
+    public static let imminentResetBonus = 4.0
+
+    /// How soon a reset has to be to earn `imminentResetBonus`.
+    public static let imminentResetWindow: TimeInterval = 30 * 60
+}
+
+/// Pure ranking policy for "which provider should I use next?".
+///
+/// The planner reads no global state and owns no clock: `now` is injected and
+/// every input comes from snapshots the app has already cached, so the answer
+/// is deterministic and directly testable — and so this makes no network
+/// requests and collects nothing new. Callers decide *which* providers are
+/// eligible (hidden providers simply never become candidates); the planner
+/// only orders what it is given and says why.
+public enum ProviderRecommendationPlanner {
+    /// Matches the widget's staleness precedent: past two hours a snapshot
+    /// describes a quota window that has likely moved on.
+    public static let defaultStalenessThreshold: TimeInterval = 2 * 60 * 60
+
+    public static func rank(
+        candidates: [ProviderRecommendationCandidate],
+        now: Date,
+        stalenessThreshold: TimeInterval = defaultStalenessThreshold
+    ) -> ProviderRecommendation {
+        var rows: [ProviderRecommendationRow] = []
+        var unavailable: [ProviderRecommendationUnavailableRow] = []
+
+        for candidate in candidates.sorted(by: { order($0) < order($1) }) {
+            switch evaluate(candidate: candidate, now: now, stalenessThreshold: stalenessThreshold) {
+            case let .ranked(row):
+                rows.append(row)
+            case let .unavailable(reason):
+                unavailable.append(
+                    ProviderRecommendationUnavailableRow(
+                        id: candidate.id,
+                        name: candidate.name,
+                        service: candidate.service,
+                        reason: reason
+                    )
+                )
+            }
+        }
+
+        return ProviderRecommendation(rows: sorted(rows, candidates: candidates), unavailable: unavailable)
+    }
+
+    // MARK: - Evaluation
+
+    private enum Evaluation {
+        case ranked(ProviderRecommendationRow)
+        case unavailable(ProviderRecommendationUnavailability)
+    }
+
+    private static func evaluate(
+        candidate: ProviderRecommendationCandidate,
+        now: Date,
+        stalenessThreshold: TimeInterval
+    ) -> Evaluation {
+        if let unavailableReason = candidate.unavailableReason {
+            return .unavailable(unavailableReason)
+        }
+
+        guard let lastUpdated = candidate.lastUpdated else {
+            return .unavailable(.noSnapshot)
+        }
+
+        let age = now.timeIntervalSince(lastUpdated)
+        guard age <= stalenessThreshold else {
+            return .unavailable(.stale(age: age))
+        }
+
+        guard let binding = bindingWindow(for: candidate) else {
+            return .unavailable(.noBindingWindow)
+        }
+
+        let percentLeft = QuotaMath.percentLeft(for: binding.limit)
+        let band = QuotaBand.forPercentLeft(percentLeft)
+        let secondsUntilReset = binding.limit.secondsUntilReset(now: now)
+        let pace = binding.limit.pace(now: now)
+
+        return .ranked(
+            ProviderRecommendationRow(
+                id: candidate.id,
+                name: candidate.name,
+                service: candidate.service,
+                window: binding.window,
+                limit: binding.limit,
+                percentLeft: percentLeft,
+                band: band,
+                secondsUntilReset: secondsUntilReset,
+                pace: pace,
+                score: band == .exhausted
+                    ? 0
+                    : score(percentLeft: percentLeft, pace: pace, secondsUntilReset: secondsUntilReset)
+            )
+        )
+    }
+
+    /// The tightest window that can block the provider. Ties keep the session
+    /// window, matching the provider card's own primary-limit rule so the
+    /// recommendation never explains itself with a different number than the
+    /// card beside it.
+    private static func bindingWindow(
+        for candidate: ProviderRecommendationCandidate
+    ) -> (window: ProviderRecommendationWindow, limit: UsageLimit)? {
+        let windows: [(ProviderRecommendationWindow, UsageLimit)] = [
+            (.session, candidate.sessionLimit),
+            (.weekly, candidate.weeklyLimit)
+        ].compactMap { window, limit in
+            // A zero total carries no headroom information — reading it as
+            // "100% left" would recommend a provider MeterBar cannot measure.
+            guard let limit, limit.total > 0 else { return nil }
+            return (window, limit)
+        }
+
+        return windows.min { QuotaMath.percentLeft(for: $0.1) < QuotaMath.percentLeft(for: $1.1) }
+    }
+
+    private static func score(
+        percentLeft: Int,
+        pace: UsagePace?,
+        secondsUntilReset: TimeInterval?
+    ) -> Int {
+        let headroom = Double(percentLeft) * ProviderRecommendationWeights.headroomPointsPerPercentLeft
+
+        // `deltaPercent` is positive when the provider is *behind* on quota, so
+        // negating it turns a reserve into a bonus and a deficit into a penalty.
+        let paceAdjustment = pace.map { pace -> Double in
+            let raw = -pace.deltaPercent * ProviderRecommendationWeights.pacePointsPerDeltaPercent
+            return min(
+                ProviderRecommendationWeights.maximumPaceAdjustment,
+                max(-ProviderRecommendationWeights.maximumPaceAdjustment, raw)
+            )
+        } ?? 0
+
+        let resetBonus: Double
+        if let secondsUntilReset,
+           secondsUntilReset > 0,
+           secondsUntilReset <= ProviderRecommendationWeights.imminentResetWindow {
+            resetBonus = ProviderRecommendationWeights.imminentResetBonus
+        } else {
+            resetBonus = 0
+        }
+
+        return Int(max(0, headroom + paceAdjustment + resetBonus).rounded())
+    }
+
+    // MARK: - Ordering
+
+    private static func sorted(
+        _ rows: [ProviderRecommendationRow],
+        candidates: [ProviderRecommendationCandidate]
+    ) -> [ProviderRecommendationRow] {
+        let orderByID = Dictionary(
+            candidates.map { ($0.id, order($0)) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let fallback = (Int.max, Int.max, "")
+
+        return rows.sorted { lhs, rhs in
+            // A spent window is never a recommendation, however soon it refills.
+            if lhs.isExhausted != rhs.isExhausted {
+                return rhs.isExhausted
+            }
+
+            if lhs.isExhausted {
+                // Among spent providers the only useful ordering is which one
+                // comes back first; an unknown reset sorts last.
+                let lhsReset = lhs.secondsUntilReset ?? .greatestFiniteMagnitude
+                let rhsReset = rhs.secondsUntilReset ?? .greatestFiniteMagnitude
+                if lhsReset != rhsReset {
+                    return lhsReset < rhsReset
+                }
+            } else {
+                if lhs.score != rhs.score {
+                    return lhs.score > rhs.score
+                }
+                if lhs.percentLeft != rhs.percentLeft {
+                    return lhs.percentLeft > rhs.percentLeft
+                }
+            }
+
+            return orderByID[lhs.id, default: fallback] < orderByID[rhs.id, default: fallback]
+        }
+    }
+
+    private static func order(_ candidate: ProviderRecommendationCandidate) -> (Int, Int, String) {
+        (candidate.service.sortOrder, candidate.displayOrder, candidate.id)
+    }
+}


### PR DESCRIPTION
Closes #338

## What

Answers **"what should I use next?"** from the quota snapshots MeterBar already caches. No new network requests, no log scanning, no stored data, no automatic tool switching, no CLI surface.

### Ranking function — `Packages/MeterBarShared/Sources/MeterBarShared/ProviderRecommendation.swift`

`ProviderRecommendationPlanner.rank(candidates:now:stalenessThreshold:)` is pure: `now` is injected, there is no clock or global, and it lives in the shared package so a future CLI/widget surface reuses the same ordering rather than reimplementing it.

- **Binding window** = session or weekly only (session wins ties, matching `ProviderSnapshot.primaryLimit`). Model-scoped and code-review windows never collapse a provider, so they never bind.
- **Score** = percent left, adjusted by pace (reserve up, deficit down, bounded), plus a small bonus for a window about to refill. Weights are named constants on `ProviderRecommendationWeights` with a doc comment — no magic numbers.
- **Exhausted** windows score 0 and sort into a separate last partition, carrying when they become usable again.
- **Not ranked, and said so:** no snapshot, no binding window, stale (>2h, the existing `WidgetPresentationPlanner` precedent), or a blocked/signed-out account — each with its reason.

### Dashboard — `OptimizeInsightsView.swift`

A "What To Use Next" card above the page's cost-scan phase content, so it answers before any token log has been scanned and keeps answering during a scan. Each row shows every input to its score — window, percent left, reset countdown, pace — so the ordering can be read off the row instead of taken on faith. Excluded providers are named under an explicit **No data** section. No "AI" framing anywhere; the footnote states plainly that this is arithmetic over cached numbers and that nothing switches tools for you.

`UsageDashboardView.providerSnapshots` was `.filter(\.hasMetrics)`-filtered, which would have silently dropped exactly the providers the "no data" state must name — split into a new unfiltered `allProviderSnapshots` for this page, with every other section unchanged.

### Popover — `PopoverOverviewPanel.swift`

Optional one-line hint, **off by default**, toggled from Settings › General ("What to use next"). It renders `ProviderRecommendation.headline` — the same sentence the dashboard card leads with — so the two surfaces cannot phrase one ranking two different ways. Disabled leaves the popover byte-for-byte as it was.

Both surfaces tick on the shared `ResetCountdownSchedule`, so the countdowns *and* the ranking that weighs them stay current without a private timer.

Hidden providers reach neither surface: both read snapshots built from `providerVisibility.enabledServices`.

## Tests

TDD — the ranking tests were written before the planner. 25 cases in `MeterBarTests/ProviderRecommendationTests.swift` cover ordering, the single-provider case, exhaustion (last, with reset time), staleness/missing data, blocked accounts, zero-total limits, tie-breaking, and the headline wording. Preference default + persistence covered in `MenuBarDisplayPreferencesStoreTests`; both new surfaces get render smoke coverage in `CardStateTransitionTests`.

Local: `swift test` → **1730 tests, 0 failures** (5 skipped). `swiftlint lint --strict` → 0 violations. `swift build` clean. PR CI is the gate.