### PR TITLE
fix(cost): speed up scans and clean up cost views

### DIFF
--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -638,7 +638,12 @@ enum CodexCostScanner {
                 FROM logs
             WHERE ts >= ?
               AND target = 'codex_otel.trace_safe'
-              AND feedback_log_body LIKE '%input_token_count=%'
+              AND (
+                    feedback_log_body LIKE '%input_token_count=%'
+                 OR feedback_log_body LIKE '%output_token_count=%'
+                 OR feedback_log_body LIKE '%cached_token_count=%'
+                 OR feedback_log_body LIKE '%reasoning_token_count=%'
+              )
               AND feedback_log_body LIKE '%event.timestamp=%'
             ORDER BY ts ASC, ts_nanos ASC, id ASC
         """

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -34,7 +34,7 @@ enum CodexCostScanner {
         for directory in Self.rolloutDirectories(in: codexDir) {
             Self.scanRollouts(directory: directory, windows: &windows)
         }
-        Self.scanSQLiteLogs(database: logsDatabase, windows: &windows)
+        Self.scanSQLiteLogs(database: logsDatabase, since: cutoffDate, windows: &windows)
 
         return windows
     }
@@ -265,14 +265,18 @@ enum CodexCostScanner {
             directories: Self.rolloutDirectories(in: codexDir),
             session: session
         )
-        // The SQLite log is a single file with no append-only guarantee and no
-        // line structure to resume from, so it is re-read whole every refresh.
-        // It is orders of magnitude smaller than the rollout corpus, so it is
-        // not what the budget exists to bound.
-        Self.scanSQLiteLogs(
-            database: codexDir.appendingPathComponent("logs_2.sqlite"),
-            windows: &windows
-        )
+        // Rollouts are the authoritative lifetime corpus. The SQLite store is
+        // only a recent-session fallback, and it must not escape the slice
+        // budget: a modern Codex database can be multiple gigabytes even when
+        // it contains no usage telemetry at all. Read it once, after the
+        // resumable rollout pass has completed, instead of once per slice.
+        if session.isComplete {
+            Self.scanSQLiteLogs(
+                database: codexDir.appendingPathComponent("logs_2.sqlite"),
+                since: session.cutoff,
+                windows: &windows
+            )
+        }
         return windows
     }
 
@@ -608,8 +612,9 @@ enum CodexCostScanner {
         return payload
     }
 
-    nonisolated private static func scanSQLiteLogs(
+    nonisolated static func scanSQLiteLogs(
         database: URL,
+        since cutoffDate: Date,
         windows: inout ScanWindows<CodexScanContext>
     ) {
         guard FileManager.default.fileExists(atPath: database.path) else { return }
@@ -621,21 +626,30 @@ enum CodexCostScanner {
         defer { sqlite3_close(db) }
         guard openResult == SQLITE_OK else { return }
 
+        // `logs_2.sqlite` now stores the complete Codex diagnostic stream, not
+        // just the old OpenTelemetry cost rows. Restricting the indexed time
+        // range and producer target avoids reading arbitrary prompt/tool bodies
+        // merely because they happen to contain one of the parser's key names.
+        // Recent SQLite rows are enough here: rollouts above own lifetime
+        // history, while this fallback covers a current session before its
+        // rollout is visible.
         let sql = """
             SELECT feedback_log_body
-            FROM logs
-            WHERE feedback_log_body LIKE '%input_token_count=%'
+                FROM logs
+            WHERE ts >= ?
+              AND target = 'codex_otel.trace_safe'
+              AND feedback_log_body LIKE '%input_token_count=%'
               AND feedback_log_body LIKE '%event.timestamp=%'
+            ORDER BY ts ASC, ts_nanos ASC, id ASC
         """
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else { return }
         defer { sqlite3_finalize(statement) }
+        sqlite3_bind_int64(statement, 1, Int64(cutoffDate.timeIntervalSince1970.rounded(.down)))
 
         while sqlite3_step(statement) == SQLITE_ROW {
             guard let bodyPointer = sqlite3_column_text(statement, 0) else { continue }
             let body = String(cString: bodyPointer)
-            // No cutoff skip: the window split now happens per event, and the
-            // lifetime window needs the rows this used to drop.
             guard let timestamp = Self.logDate(in: body) else { continue }
 
             let usage: [String: Any] = [

--- a/MeterBar/Views/DashboardCostCards.swift
+++ b/MeterBar/Views/DashboardCostCards.swift
@@ -10,11 +10,6 @@ struct CostOverviewStatusCard: View {
   let isRefreshingMissingDays: Bool
   let formattedTokens: String
 
-  // Headline sizes scale with Dynamic Type (from their default 34/28pt) instead
-  // of being frozen in pixels, so the cost figure grows for larger accessibility
-  // text sizes. `minimumScaleFactor` + `lineLimit(1)` keep the tile from breaking.
-  @ScaledMetric(relativeTo: .largeTitle)
-  private var headlineSize: CGFloat = 34
   @ScaledMetric(relativeTo: .title)
   private var scanningHeadlineSize: CGFloat = 28
 
@@ -54,7 +49,7 @@ struct CostOverviewStatusCard: View {
   }
 
   var body: some View {
-    DashboardTile {
+    DashboardTile(minHeight: CostHeadlineCardMetrics.minimumHeight) {
       VStack(alignment: .leading, spacing: 12) {
         HStack(alignment: .center, spacing: 9) {
           Image(systemName: "dollarsign.circle.fill")
@@ -124,12 +119,7 @@ struct CostOverviewStatusCard: View {
   @ViewBuilder private var heroValue: some View {
     switch phase {
     case .loaded:
-      Text(summary?.formattedTotalCost ?? "")
-        .font(.system(size: headlineSize, weight: .bold))
-        .foregroundColor(.primary)
-        .lineLimit(1)
-        .minimumScaleFactor(0.75)
-        .contentTransition(.numericText())
+      CostHeadlineAmount(summary?.formattedTotalCost ?? "")
         .id(Phase.loaded)
         .transition(MeterBarTheme.Motion.cardPhase)
     case .scanning:
@@ -146,7 +136,8 @@ struct CostOverviewStatusCard: View {
       .transition(MeterBarTheme.Motion.cardPhase)
     case .needsScan:
       Text("Scan needed")
-        .font(.system(size: headlineSize, weight: .bold))
+        .font(.largeTitle)
+        .fontWeight(.bold)
         .foregroundColor(.primary)
         .lineLimit(1)
         .minimumScaleFactor(0.75)
@@ -161,13 +152,27 @@ struct LifetimeCostSummaryCard: View {
   let isScanning: Bool
 
   var body: some View {
-    DashboardCard(title: "Lifetime Local Cost", trailing: trackedDateRange) {
-      if let summary, summary.hasBillableHistory {
-        VStack(alignment: .leading, spacing: 12) {
-          Text(summary.formattedTotalCost)
-            .font(.largeTitle)
-            .fontWeight(.bold)
-            .contentTransition(.numericText())
+    DashboardTile(minHeight: CostHeadlineCardMetrics.minimumHeight) {
+      VStack(alignment: .leading, spacing: 12) {
+        HStack(alignment: .center, spacing: 9) {
+          Image(systemName: "clock.arrow.circlepath")
+            .font(.system(size: 20, weight: .semibold))
+            .foregroundStyle(MeterBarTheme.appAccent)
+            .accessibilityHidden(true)
+          VStack(alignment: .leading, spacing: 2) {
+            Text("Lifetime Local Cost")
+              .font(.headline)
+              .fontWeight(.semibold)
+            Text("All available history")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+          Spacer()
+          DashboardCardCaption(text: trackedDateRange)
+        }
+
+        if let summary, summary.hasBillableHistory {
+          CostHeadlineAmount(summary.formattedTotalCost)
 
           ForEach(summary.providers) { provider in
             HStack(spacing: 10) {
@@ -186,27 +191,27 @@ struct LifetimeCostSummaryCard: View {
             .accessibilityLabel(provider.provider.displayName)
             .accessibilityValue(provider.formattedCost)
           }
+        } else if isScanning {
+          HStack(spacing: 10) {
+            ProgressView()
+              .controlSize(.small)
+            Text("Scanning all available local history…")
+              .font(.subheadline)
+              .foregroundStyle(.secondary)
+          }
+        } else if summary == nil {
+          EmptyStateCard(
+            systemImage: "magnifyingglass",
+            title: "Lifetime scan needed",
+            message: "Run a local scan to calculate lifetime cost from available history."
+          )
+        } else {
+          EmptyStateCard(
+            systemImage: "clock.arrow.circlepath",
+            title: "No lifetime cost",
+            message: "No billable Claude or Codex history was found in local logs."
+          )
         }
-      } else if isScanning {
-        HStack(spacing: 10) {
-          ProgressView()
-            .controlSize(.small)
-          Text("Scanning all available local history…")
-            .font(.subheadline)
-            .foregroundStyle(.secondary)
-        }
-      } else if summary == nil {
-        EmptyStateCard(
-          systemImage: "magnifyingglass",
-          title: "Lifetime scan needed",
-          message: "Run a local scan to calculate lifetime cost from available history."
-        )
-      } else {
-        EmptyStateCard(
-          systemImage: "clock.arrow.circlepath",
-          title: "No lifetime cost",
-          message: "No billable Claude or Codex history was found in local logs."
-        )
       }
     }
   }
@@ -220,6 +225,32 @@ struct LifetimeCostSummaryCard: View {
     let first = firstDate.formatted(date: .abbreviated, time: .omitted)
     let last = lastDate.formatted(date: .abbreviated, time: .omitted)
     return first == last ? first : "\(first) – \(last)"
+  }
+}
+
+private enum CostHeadlineCardMetrics {
+  static let minimumHeight: CGFloat = 180
+}
+
+/// One typography contract for the two headline cost cards. Keeping the font,
+/// scaling, and digit treatment in one view prevents the 30-day and lifetime
+/// amounts from drifting apart again.
+private struct CostHeadlineAmount: View {
+  let value: String
+
+  init(_ value: String) {
+    self.value = value
+  }
+
+  var body: some View {
+    Text(value)
+      .font(.largeTitle)
+      .fontWeight(.bold)
+      .monospacedDigit()
+      .foregroundStyle(.primary)
+      .lineLimit(1)
+      .minimumScaleFactor(0.75)
+      .contentTransition(.numericText())
   }
 }
 

--- a/MeterBar/Views/Settings/CostSettingsView.swift
+++ b/MeterBar/Views/Settings/CostSettingsView.swift
@@ -18,6 +18,47 @@ enum CostPeriodMode: String, CaseIterable, Identifiable {
     }
 }
 
+/// Human-readable project identity for the settings drill-down. Scanner IDs
+/// stay stable and lossless in the cache; this projection strips storage
+/// scaffolding such as `www/` and `.claude/worktrees/...` from the UI.
+nonisolated struct CostProjectPresentation: Equatable {
+    let title: String
+    let detail: String?
+
+    init(identifier: String) {
+        let components = identifier
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .map(String.init)
+
+        guard identifier != CostProjectAttribution.unknownProjectID, !components.isEmpty else {
+            title = "Unknown project"
+            detail = "No working directory recorded"
+            return
+        }
+
+        if let worktreesIndex = components.firstIndex(of: "worktrees") {
+            let markerIndex = max(0, worktreesIndex - 1)
+            let base = Array(components[..<markerIndex]).last ?? components.first ?? "Worktree"
+            var branch = Array(components.dropFirst(worktreesIndex + 1))
+            if let last = branch.last, Self.looksLikeWorktreeID(last) {
+                branch.removeLast()
+            }
+            title = base
+            detail = branch.isEmpty ? "Worktree" : "Worktree · \(branch.joined(separator: "/"))"
+            return
+        }
+
+        title = components.last ?? identifier
+        let parent = components.dropLast().filter { $0 != "www" }
+        detail = parent.isEmpty ? nil : parent.suffix(2).joined(separator: "/")
+    }
+
+    private static func looksLikeWorktreeID(_ value: String) -> Bool {
+        guard (6...12).contains(value.count) else { return false }
+        return value.allSatisfy { $0.isHexDigit }
+    }
+}
+
 /// Renders one cost-summary period — the rolling 30-day window or the
 /// calendar month-to-date window — plus its per-provider project/worktree
 /// rollup and, when set, a converted-currency caption (issue #270). A pure
@@ -57,39 +98,31 @@ struct CostPeriodContentView: View {
     // MARK: Private
 
     @ViewBuilder private var last30DaysContent: some View {
-        SettingsRowView(title: "Total cost") {
-            VStack(alignment: .trailing, spacing: 2) {
-                Text(summary.formattedTotalCost)
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
-                convertedCaption(summary.totalCostUSD)
-            }
-        }
+        summaryHero(
+            totalCost: summary.formattedTotalCost,
+            totalCostUSD: summary.totalCostUSD,
+            dailyAverage: summary.formattedDailyCost,
+            totalTokens: summary.totalTokens,
+            providerCount: summary.costs.count
+        )
 
-        SettingsRowView(title: "Daily average") {
-            Text(summary.formattedDailyCost)
-                .foregroundColor(.secondary)
-        }
+        Divider()
 
-        ForEach(summary.costs) { cost in
-            SettingsRowView(title: cost.provider.displayName) {
-                VStack(alignment: .trailing, spacing: 2) {
-                    Text(cost.formattedCost)
-                        .font(.caption)
-                        .fontWeight(.semibold)
-                    convertedCaption(cost.estimatedCostUSD)
-                    Text("\(cost.formattedTokens) tokens")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                }
-            }
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Providers")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
 
-            // Per-project/worktree rollup (issue #270): every scanned session
-            // attributes to exactly one row here, including the explicit
-            // "unknown" bucket for anything unattributable — never dropped,
-            // never guessed.
-            if !cost.projectBreakdowns.isEmpty {
-                projectBreakdownRows(cost.projectBreakdowns)
+            ForEach(summary.costs) { cost in
+                CostProviderBreakdownGroup(
+                    provider: cost.provider,
+                    formattedCost: cost.formattedCost,
+                    estimatedCostUSD: cost.estimatedCostUSD,
+                    formattedTokens: "\(cost.formattedTokens) tokens",
+                    projects: cost.projectBreakdowns,
+                    currency: currency
+                )
             }
         }
     }
@@ -119,14 +152,13 @@ struct CostPeriodContentView: View {
     private func monthToDateRows(now: Date) -> some View {
         let window = summary.monthToDateCostWindow(now: now)
 
-        SettingsRowView(title: "Total cost") {
-            VStack(alignment: .trailing, spacing: 2) {
-                Text(window.formattedTotalCost)
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
-                convertedCaption(window.totalCostUSD)
-            }
-        }
+        summaryHero(
+            totalCost: window.formattedTotalCost,
+            totalCostUSD: window.totalCostUSD,
+            dailyAverage: UsageFormat.cost(window.totalCostUSD / Double(max(1, window.coveredDays))),
+            totalTokens: window.totalTokens,
+            providerCount: window.providers.count
+        )
 
         if window.isTruncated {
             SettingsNotice(
@@ -142,68 +174,55 @@ struct CostPeriodContentView: View {
                 message: "No cached daily usage recorded so far this month."
             )
         } else {
-            ForEach(window.providers) { provider in
-                SettingsRowView(title: provider.provider.displayName) {
-                    VStack(alignment: .trailing, spacing: 2) {
-                        Text(provider.formattedCost)
-                            .font(.caption)
-                            .fontWeight(.semibold)
-                        convertedCaption(provider.estimatedCostUSD)
-                        // Daily rows carry no cache-creation tokens or session
-                        // counts, so this reports input+output+cache-read only —
-                        // matching `ProviderDailyTotal.totalTokens` exactly.
-                        Text("\(UsageFormat.groupedTokens(provider.totalTokens)) tokens")
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                    }
-                }
+            Divider()
 
-                if let projects = provider.projectBreakdowns, !projects.isEmpty {
-                    projectBreakdownRows(projects)
-                }
+            Text("Providers")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+
+            ForEach(window.providers) { provider in
+                CostProviderBreakdownGroup(
+                    provider: provider.provider,
+                    formattedCost: provider.formattedCost,
+                    estimatedCostUSD: provider.estimatedCostUSD,
+                    formattedTokens: "\(UsageFormat.groupedTokens(provider.totalTokens)) tokens",
+                    projects: provider.projectBreakdowns ?? [],
+                    currency: currency
+                )
             }
         }
     }
 
-    /// Rollup view plus drill-down to model breakdown (issue #270): each
-    /// project/worktree row expands to the models used within it, without
-    /// duplicating the rollup row's own layout.
     @ViewBuilder
-    private func projectBreakdownRows(_ projects: [TokenUsageBreakdown]) -> some View {
-        ForEach(projects.sorted(by: { $0.estimatedCostUSD > $1.estimatedCostUSD })) { project in
-            DisclosureGroup {
-                ForEach(project.modelBreakdowns) { model in
-                    HStack {
-                        Text(model.name)
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                        Spacer()
-                        Text(model.formattedCost)
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                    }
-                    .padding(.leading, 20)
-                }
-            } label: {
-                HStack(alignment: .top) {
-                    Text(project.name)
+    private func summaryHero(
+        totalCost: String,
+        totalCostUSD: Double,
+        dailyAverage: String,
+        totalTokens: Int,
+        providerCount: Int
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Estimated spend")
                         .font(.caption)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                    Spacer(minLength: 8)
-                    VStack(alignment: .trailing, spacing: 1) {
-                        Text(project.formattedCost)
-                            .font(.caption)
-                            .fontWeight(.semibold)
-                        convertedCaption(project.estimatedCostUSD)
-                        Text("\(project.sessionCount) session\(project.sessionCount == 1 ? "" : "s")")
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                    }
+                        .foregroundStyle(.secondary)
+                    Text(totalCost)
+                        .font(.title)
+                        .fontWeight(.bold)
+                        .monospacedDigit()
+                        .contentTransition(.numericText())
                 }
+                Spacer(minLength: 16)
+                convertedCaption(totalCostUSD)
             }
-            .padding(.leading, 8)
-            .accessibilityIdentifier("project-breakdown-\(project.name)")
+
+            HStack(spacing: MeterBarTheme.Spacing.lg) {
+                CostSettingsMetric(title: "Daily average", value: dailyAverage)
+                CostSettingsMetric(title: "Tokens", value: UsageFormat.tokens(totalTokens))
+                CostSettingsMetric(title: "Providers", value: "\(providerCount)")
+            }
         }
     }
 
@@ -220,6 +239,147 @@ struct CostPeriodContentView: View {
     }
 }
 
+private struct CostSettingsMetric: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct CostProviderBreakdownGroup: View {
+    let provider: ServiceType
+    let formattedCost: String
+    let estimatedCostUSD: Double
+    let formattedTokens: String
+    let projects: [TokenUsageBreakdown]
+    let currency: DisplayCurrency?
+
+    var body: some View {
+        if projects.isEmpty {
+            providerLabel
+        } else {
+            DisclosureGroup {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(projects.sorted(by: { $0.estimatedCostUSD > $1.estimatedCostUSD })) { project in
+                        CostProjectBreakdownRow(project: project, currency: currency)
+                    }
+                }
+                .padding(.top, MeterBarTheme.Spacing.sm)
+                .padding(.leading, MeterBarTheme.Spacing.xxl)
+            } label: {
+                providerLabel
+            }
+            .accessibilityIdentifier("cost-provider-\(provider.rawValue)")
+        }
+    }
+
+    private var providerLabel: some View {
+        HStack(spacing: 10) {
+            ProviderLogoView(
+                kind: .forService(provider),
+                size: 18,
+                foregroundColor: MeterBarTheme.accent(for: provider)
+            )
+            VStack(alignment: .leading, spacing: 2) {
+                Text(provider.displayName)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                Text(formattedTokens)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 12)
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(formattedCost)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .monospacedDigit()
+                if let currency {
+                    Text("≈ \(currency.formattedConverted(usd: estimatedCostUSD))")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+private struct CostProjectBreakdownRow: View {
+    let project: TokenUsageBreakdown
+    let currency: DisplayCurrency?
+
+    private var presentation: CostProjectPresentation {
+        CostProjectPresentation(identifier: project.name)
+    }
+
+    var body: some View {
+        DisclosureGroup {
+            ForEach(project.modelBreakdowns) { model in
+                HStack {
+                    Text(model.name)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 8)
+                    Text(model.formattedCost)
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.leading, MeterBarTheme.Spacing.lg)
+            }
+        } label: {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "folder")
+                    .foregroundStyle(.secondary)
+                    .frame(width: 16)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(presentation.title)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .lineLimit(1)
+                    if let detail = presentation.detail {
+                        Text(detail)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                }
+                Spacer(minLength: 8)
+                VStack(alignment: .trailing, spacing: 1) {
+                    Text(project.formattedCost)
+                        .font(.caption.monospacedDigit())
+                        .fontWeight(.semibold)
+                    if let currency {
+                        Text("≈ \(currency.formattedConverted(usd: project.estimatedCostUSD))")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    Text("\(project.sessionCount) usage events")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .accessibilityIdentifier("project-breakdown-\(project.name)")
+    }
+}
+
 /// The "Cost" settings tab: local session cost scan results, the 30-day scan
 /// control, and (issue #270) the month-to-date period switch and the display
 /// currency preference. Extracted from the SettingsView monolith.
@@ -227,8 +387,10 @@ struct CostSettingsView: View {
     // MARK: Internal
 
     var body: some View {
-        costTrackingSection
-        displayCurrencySection
+        VStack(alignment: .leading, spacing: 14) {
+            costTrackingSection
+            displayCurrencySection
+        }
     }
 
     // MARK: Private
@@ -250,24 +412,23 @@ struct CostSettingsView: View {
     }
 
     private var costTrackingSection: some View {
-        SettingsPanelSection(title: "Cost Tracking", systemImage: "chart.bar.xaxis", color: MeterBarTheme.success) {
-            if costTracker.isScanning {
-                SettingsRowView(title: "Status") {
-                    HStack(spacing: 8) {
-                        ProgressView()
-                            .scaleEffect(0.7)
-                        Text("Scanning sessions...")
-                            .foregroundColor(.secondary)
-                    }
-                }
-            } else if let summary = visibleCostSummary, !summary.costs.isEmpty {
-                periodPicker
+        SettingsPanelSection(title: "Local Cost", systemImage: "dollarsign.circle", color: MeterBarTheme.success) {
+            costToolbar
+
+            if let summary = visibleCostSummary, !summary.costs.isEmpty {
+                Divider()
 
                 CostPeriodContentView(summary: summary, periodMode: periodMode, currency: displayCurrencyStore.currency)
 
                 if let lastScan = costTracker.lastScanDate {
                     SettingsNotice(text: "Last scanned \(formatDate(lastScan)) ago.", color: .secondary)
                 }
+            } else if costTracker.isRefreshInProgress {
+                EmptyStateCard(
+                    systemImage: "magnifyingglass",
+                    title: "Building local cost history",
+                    message: "Recent usage appears first while older local sessions finish in the background."
+                )
             } else if costTracker.costSummary != nil {
                 // Scanned, but nothing landed for the providers that are enabled.
                 EmptyStateCard(
@@ -292,28 +453,36 @@ struct CostSettingsView: View {
                     tone: .warning
                 )
             }
+        }
+    }
 
-            SettingsRowView(title: "Local sessions") {
-                Button {
-                    Task {
-                        await costTracker.scanCosts(days: 30)
-                    }
-                } label: {
-                    HStack(spacing: 7) {
-                        if costTracker.isRefreshInProgress {
-                            ProgressView()
-                                .controlSize(.small)
-                                .scaleEffect(0.75)
-                            Text(costTracker.isRefreshingMissingDays ? "Updating..." : "Scanning...")
-                        } else {
-                            Image(systemName: "magnifyingglass")
-                            Text("Scan 30 Days")
-                        }
+    private var costToolbar: some View {
+        HStack(spacing: 12) {
+            periodPicker
+                .frame(width: 250)
+
+            Spacer(minLength: 12)
+
+            Button {
+                Task {
+                    await costTracker.scanCosts(days: 30)
+                }
+            } label: {
+                HStack(spacing: 7) {
+                    if costTracker.isRefreshInProgress {
+                        ProgressView()
+                            .controlSize(.small)
+                            .scaleEffect(0.75)
+                        Text(costTracker.isRefreshingMissingDays ? "Updating" : "Scanning")
+                    } else {
+                        Image(systemName: "arrow.clockwise")
+                        Text("Refresh")
                     }
                 }
-                .buttonStyle(.glassProminent)
-                .disabled(costTracker.isRefreshInProgress || !canScanCosts)
             }
+            .buttonStyle(.glassProminent)
+            .disabled(costTracker.isRefreshInProgress || !canScanCosts)
+            .accessibilityIdentifier("cost-refresh-button")
         }
     }
 

--- a/MeterBarTests/CostScanCollaboratorTests.swift
+++ b/MeterBarTests/CostScanCollaboratorTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import MeterBar
 import MeterBarShared
+import SQLite3
 
 /// Contract tests for the collaborators split out of `CostTracker` (audit C1d).
 ///
@@ -394,6 +395,60 @@ final class CostScanCollaboratorTests: XCTestCase {
             CodexCostScanner.logDate(in: body),
             FlexibleISO8601.date(from: "2026-07-01T10:00:00Z")
         )
+    }
+
+    func testSQLiteFallbackReadsOnlyRecentOpenTelemetryUsageRows() throws {
+        let database = FileManager.default.temporaryDirectory
+            .appendingPathComponent("meterbar-codex-log-\(UUID().uuidString).sqlite")
+        defer { try? FileManager.default.removeItem(at: database) }
+
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(database.path, &db), SQLITE_OK)
+        guard let db else {
+            return XCTFail("Expected a temporary SQLite database")
+        }
+        defer { sqlite3_close(db) }
+
+        let schema = """
+            CREATE TABLE logs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts INTEGER NOT NULL,
+                ts_nanos INTEGER NOT NULL,
+                target TEXT NOT NULL,
+                feedback_log_body TEXT
+            );
+            CREATE INDEX idx_logs_ts ON logs(ts DESC, ts_nanos DESC, id DESC);
+        """
+        XCTAssertEqual(sqlite3_exec(db, schema, nil, nil, nil), SQLITE_OK)
+
+        let recentUsage = "event.timestamp=2026-07-15T10:00:00Z input_token_count=120 "
+            + "output_token_count=30 cached_token_count=20 reasoning_token_count=5 "
+            + "conversation.id=recent model=gpt-5.6-sol originator=codex_exec}"
+        let oldUsage = recentUsage.replacingOccurrences(of: "2026-07-15", with: "2026-06-01")
+        let inserts = [
+            "INSERT INTO logs(ts, ts_nanos, target, feedback_log_body) "
+                + "VALUES(1784110000, 0, 'codex_otel.trace_safe', '\(recentUsage)');",
+            // Diagnostic bodies can contain copied parser text. A non-OTel
+            // producer must never be interpreted as a usage event.
+            "INSERT INTO logs(ts, ts_nanos, target, feedback_log_body) "
+                + "VALUES(1784110001, 0, 'codex_core::stream_events_utils', '\(recentUsage)');",
+            "INSERT INTO logs(ts, ts_nanos, target, feedback_log_body) "
+                + "VALUES(1780270000, 0, 'codex_otel.trace_safe', '\(oldUsage)');",
+        ]
+        for insert in inserts {
+            XCTAssertEqual(sqlite3_exec(db, insert, nil, nil, nil), SQLITE_OK)
+        }
+
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-07-01T00:00:00Z"))
+        var windows = CodexCostScanner.scanWindows(cutoff: cutoff)
+        CodexCostScanner.scanSQLiteLogs(database: database, since: cutoff, windows: &windows)
+
+        XCTAssertEqual(windows.period.totals.input, 120)
+        XCTAssertEqual(windows.period.totals.output, 30)
+        XCTAssertEqual(windows.period.totals.cacheRead, 20)
+        XCTAssertEqual(windows.period.totals.reasoning, 5)
+        XCTAssertEqual(windows.period.sessionIDs, ["recent"])
+        XCTAssertEqual(windows.lifetime.totals.input, 120)
     }
 
     // MARK: - CostSummaryBuilder

--- a/MeterBarTests/CostScanCollaboratorTests.swift
+++ b/MeterBarTests/CostScanCollaboratorTests.swift
@@ -425,9 +425,13 @@ final class CostScanCollaboratorTests: XCTestCase {
             + "output_token_count=30 cached_token_count=20 reasoning_token_count=5 "
             + "conversation.id=recent model=gpt-5.6-sol originator=codex_exec}"
         let oldUsage = recentUsage.replacingOccurrences(of: "2026-07-15", with: "2026-06-01")
+        let outputOnlyUsage = "event.timestamp=2026-07-16T10:00:00Z output_token_count=7 "
+            + "conversation.id=output-only model=gpt-5.6-sol originator=codex_exec}"
         let inserts = [
             "INSERT INTO logs(ts, ts_nanos, target, feedback_log_body) "
                 + "VALUES(1784110000, 0, 'codex_otel.trace_safe', '\(recentUsage)');",
+            "INSERT INTO logs(ts, ts_nanos, target, feedback_log_body) "
+                + "VALUES(1784196000, 0, 'codex_otel.trace_safe', '\(outputOnlyUsage)');",
             // Diagnostic bodies can contain copied parser text. A non-OTel
             // producer must never be interpreted as a usage event.
             "INSERT INTO logs(ts, ts_nanos, target, feedback_log_body) "
@@ -444,10 +448,10 @@ final class CostScanCollaboratorTests: XCTestCase {
         CodexCostScanner.scanSQLiteLogs(database: database, since: cutoff, windows: &windows)
 
         XCTAssertEqual(windows.period.totals.input, 120)
-        XCTAssertEqual(windows.period.totals.output, 30)
+        XCTAssertEqual(windows.period.totals.output, 37)
         XCTAssertEqual(windows.period.totals.cacheRead, 20)
         XCTAssertEqual(windows.period.totals.reasoning, 5)
-        XCTAssertEqual(windows.period.sessionIDs, ["recent"])
+        XCTAssertEqual(windows.period.sessionIDs, ["output-only", "recent"])
         XCTAssertEqual(windows.lifetime.totals.input, 120)
     }
 

--- a/MeterBarTests/DashboardLayoutTests.swift
+++ b/MeterBarTests/DashboardLayoutTests.swift
@@ -5,7 +5,7 @@ import SwiftUI
 import XCTest
 
 /// Layout-audit coverage: sidebar grouping, header-hosted card controls,
-/// and content-hugging cost card.
+/// and the paired cost headline cards.
 @MainActor
 final class DashboardLayoutTests: XCTestCase {
     // MARK: - Sidebar groups
@@ -99,28 +99,49 @@ final class DashboardLayoutTests: XCTestCase {
         XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
     }
 
-    // MARK: - Cost overview card hugs content
+    // MARK: - Cost headline cards
 
-    func testCostOverviewCardHasNoArtificialMinHeight() {
-        let card = CostOverviewStatusCard(
-            summary: nil,
+    func testLoadedCostHeadlineCardsUseTheSameCompactHeight() {
+        let start = Date(timeIntervalSince1970: 1_765_324_800)
+        let end = Date(timeIntervalSince1970: 1_786_003_200)
+        let cost = TokenCost(
+            provider: .claudeCode,
+            inputTokens: 1_000,
+            outputTokens: 200,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 500,
+            estimatedCostUSD: 5_015.59,
+            sessionCount: 1,
+            periodStart: start,
+            periodEnd: end
+        )
+        let summary = CostSummary(
+            costs: [cost],
+            totalCostUSD: cost.estimatedCostUSD,
+            totalTokens: cost.totalTokens,
+            periodDays: 30,
+            lifetime: LifetimeCostSummary(costs: [cost])
+        )
+        let overview = CostOverviewStatusCard(
+            summary: summary,
             isScanning: false,
             isRefreshingMissingDays: false,
-            formattedTokens: "0"
+            formattedTokens: UsageFormat.tokens(summary.totalTokens)
         )
+        let lifetime = LifetimeCostSummaryCard(summary: summary.lifetime, isScanning: false)
 
-        let hostingView = NSHostingView(rootView: card)
-        hostingView.frame = NSRect(x: 0, y: 0, width: 700, height: 400)
-        hostingView.layoutSubtreeIfNeeded()
+        let overviewHost = NSHostingView(rootView: overview.frame(width: 380))
+        let lifetimeHost = NSHostingView(rootView: lifetime.frame(width: 380))
+        overviewHost.layoutSubtreeIfNeeded()
+        lifetimeHost.layoutSubtreeIfNeeded()
 
-        // 220 was the old overview-grid min-height floor (since removed in favor
-        // of content-driven cards); the costs-page card must hug its content and
-        // stay well under that former floor.
-        XCTAssertLessThan(
-            hostingView.fittingSize.height,
-            220,
-            "costs-page card should hug its content, not pad out to the old grid floor"
+        XCTAssertEqual(
+            overviewHost.fittingSize.height,
+            lifetimeHost.fittingSize.height,
+            accuracy: 0.5,
+            "30-day and lifetime surfaces must end on the same baseline"
         )
+        XCTAssertLessThan(overviewHost.fittingSize.height, 220)
     }
 
     // MARK: - Provider card context-menu commands

--- a/MeterBarTests/SettingsViewSmokeTests.swift
+++ b/MeterBarTests/SettingsViewSmokeTests.swift
@@ -231,6 +231,29 @@ final class SettingsViewSmokeTests: XCTestCase {
         XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
     }
 
+    func testCostProjectPresentationRemovesStorageScaffoldingFromRegularProjects() {
+        let presentation = CostProjectPresentation(identifier: "www/vincentshipsit/public/meterbardev")
+
+        XCTAssertEqual(presentation.title, "meterbardev")
+        XCTAssertEqual(presentation.detail, "vincentshipsit/public")
+    }
+
+    func testCostProjectPresentationNamesWorktreesWithoutOpaqueIDs() {
+        let presentation = CostProjectPresentation(
+            identifier: "www/vincentshipsit/public/meterbardev/.claude/worktrees/loving/kalam/ccb0b4"
+        )
+
+        XCTAssertEqual(presentation.title, "meterbardev")
+        XCTAssertEqual(presentation.detail, "Worktree · loving/kalam")
+    }
+
+    func testCostProjectPresentationExplainsUnknownAttribution() {
+        let presentation = CostProjectPresentation(identifier: CostProjectAttribution.unknownProjectID)
+
+        XCTAssertEqual(presentation.title, "Unknown project")
+        XCTAssertEqual(presentation.detail, "No working directory recorded")
+    }
+
     func testCostSettingsViewRendersDisplayCurrencySectionAlongsideCostTracking() {
         // Hosts the real tab (real singletons, like testGlassCostScanAndRefreshCTAsStillRender
         // above) so a broken Display Currency section or period picker fails to compile/layout


### PR DESCRIPTION
## Summary
- stop rescanning the multi-gigabyte Codex diagnostic database on every transcript slice
- constrain the SQLite fallback to recent indexed OpenTelemetry usage rows
- unify the dashboard cost cards, typography, height, and lifetime icon
- redesign Settings → Cost around a compact summary with collapsed provider/project drill-downs
- replace raw storage paths and the incorrect session label with readable project context and usage events

## Verification
- swift test: 1,880 tests passed, 5 skipped
- focused regression suite: 63 tests passed
- swiftlint lint --strict --quiet
- Debug xcodebuild with code signing disabled
- SwiftUI snapshot inspection for both cost surfaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned cost dashboard cards with consistent sizing, clearer headlines, and improved lifetime usage states.
  - Added richer cost summaries with daily averages, token and provider metrics, and expandable provider/project breakdowns.
  - Added period controls and a refresh action in Cost Settings.
  - Improved project name presentation, including worktrees and unknown projects.

- **Bug Fixes**
  - Cost scans now include only recent, relevant telemetry records and handle incomplete sessions more reliably.

- **Tests**
  - Added coverage for recent usage filtering, card layout consistency, and project name formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->