### PR TITLE
perf(cost): replace generic Data.contains with range(of:) in the rollout scan

### DIFF
--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -135,9 +135,11 @@ enum CodexCostScanner {
         ]
     }
 
+    // swiftlint:disable contains_over_range_nil_comparison
     /// The byte-level equivalent of the old `line.contains("\"token_count\"")`
     /// prefilter. Rollout files are mostly non-usage events, so skipping
     /// `JSONSerialization` on them is what keeps the scan cheap.
+    /// Generic `Data.contains(_:)` runs near 3 MB/s; `range(of:)` reaches 1.8 GB/s, which slice budgets require.
     nonisolated private static let tokenCountMarker = Data("\"token_count\"".utf8)
 
     /// Same prefilter for the two events that carry the attribution a
@@ -203,7 +205,7 @@ enum CodexCostScanner {
 
         FileLineReader.forEachLine(in: fileURL) { readerLine in
             let line = readerLine.bytes
-            guard line.contains(Self.tokenCountMarker) else {
+            guard line.range(of: Self.tokenCountMarker) != nil else {
                 Self.updateRolloutContext(&rollout, from: line)
                 // Reaches back only as far as the *first* model the file
                 // declares — a later mid-session switch must not relabel the
@@ -353,7 +355,7 @@ enum CodexCostScanner {
 
         let read = FileLineReader.readLines(in: file.url, request: request) { readerLine, offset in
             let line = readerLine.bytes
-            guard line.contains(Self.tokenCountMarker) else {
+            guard line.range(of: Self.tokenCountMarker) != nil else {
                 Self.updateRolloutContext(&rollout, from: line)
                 if let model = rollout.turnModel ?? rollout.sessionModel {
                     Self.flushDeferred(&deferred, modelName: model, windows: &windows)
@@ -473,10 +475,10 @@ enum CodexCostScanner {
         _ rollout: inout CodexRolloutContext,
         from line: Data
     ) {
-        if line.contains(Self.turnContextMarker) {
+        if line.range(of: Self.turnContextMarker) != nil {
             guard let payload = Self.eventPayload(in: line, type: "turn_context") else { return }
             rollout.turnModel = (payload["model"] as? String) ?? rollout.turnModel
-        } else if line.contains(Self.sessionMetaMarker) {
+        } else if line.range(of: Self.sessionMetaMarker) != nil {
             guard let payload = Self.eventPayload(in: line, type: "session_meta") else { return }
             // `model` is null on every rollout observed so far, but read it
             // anyway so pre-turn events get named the day Codex populates it.
@@ -485,6 +487,7 @@ enum CodexCostScanner {
             rollout.cwd = (payload["cwd"] as? String) ?? rollout.cwd
         }
     }
+    // swiftlint:enable contains_over_range_nil_comparison
 
     /// Replays the events parked before the file named a model. Each keeps its
     /// own timestamp, so `ScanWindows.update` still places it on its own day.

--- a/MeterBar/Services/CostSummaryBuilder.swift
+++ b/MeterBar/Services/CostSummaryBuilder.swift
@@ -10,7 +10,8 @@ enum CostSummaryBuilder {
         days: Int,
         includeClaudeCode: Bool,
         includeCodexCli: Bool,
-        claudeAccounts: [ClaudeCodeAccount]
+        claudeAccounts: [ClaudeCodeAccount],
+        claudeProjectRoots: [URL]? = nil
     ) -> CostSummary {
         let cutoffDate = CostWindow.start(days: days)
         // One traversal fills both windows. The lifetime scan reads a strict
@@ -20,7 +21,8 @@ enum CostSummaryBuilder {
             since: cutoffDate,
             includeClaudeCode: includeClaudeCode,
             includeCodexCli: includeCodexCli,
-            claudeAccounts: claudeAccounts
+            claudeAccounts: claudeAccounts,
+            claudeProjectRoots: claudeProjectRoots
         )
 
         let costs = scan.period.costs
@@ -42,12 +44,18 @@ enum CostSummaryBuilder {
         since cutoffDate: Date,
         includeClaudeCode: Bool,
         includeCodexCli: Bool,
-        claudeAccounts: [ClaudeCodeAccount]
+        claudeAccounts: [ClaudeCodeAccount],
+        claudeProjectRoots: [URL]?
     ) -> ScanWindows<CostScanResult> {
         var scan = ScanWindows(period: CostScanResult(), lifetime: CostScanResult(), cutoff: cutoffDate)
 
         if includeClaudeCode {
-            let claude = ClaudeCostScanner.scanSessions(since: cutoffDate, claudeAccounts: claudeAccounts)
+            let claude: ScanWindows<ClaudeSessionTotals>
+            if let claudeProjectRoots {
+                claude = ClaudeCostScanner.scanSessions(since: cutoffDate, projectRoots: claudeProjectRoots)
+            } else {
+                claude = ClaudeCostScanner.scanSessions(since: cutoffDate, claudeAccounts: claudeAccounts)
+            }
             scan.period.append(ClaudeCostScanner.makeCost(from: claude.period, windowStart: cutoffDate))
             scan.lifetime.append(ClaudeCostScanner.makeCost(from: claude.lifetime, windowStart: .distantPast))
             scan.period.record(claude.period.pricing)
@@ -97,7 +105,8 @@ enum CostSummaryBuilder {
         includeClaudeCode: Bool,
         includeCodexCli: Bool,
         claudeAccounts: [ClaudeCodeAccount],
-        session: CostScanSession
+        session: CostScanSession,
+        claudeProjectRoots: [URL]? = nil
     ) -> CostSummaryScan {
         var scan = ScanWindows(
             period: CostScanResult(),
@@ -106,16 +115,24 @@ enum CostSummaryBuilder {
         )
 
         if includeClaudeCode {
-            let roots = ClaudeCostScanner.projectRoots(accounts: claudeAccounts)
+            let roots = claudeProjectRoots ?? ClaudeCostScanner.projectRoots(accounts: claudeAccounts)
             let claude = ClaudeCostScanner.scanRoots(roots, session: session)
             scan.period.append(ClaudeCostScanner.makeCost(from: claude.period, windowStart: session.cutoff))
             scan.lifetime.append(ClaudeCostScanner.makeCost(from: claude.lifetime, windowStart: .distantPast))
+            scan.period.record(claude.period.pricing)
+            scan.lifetime.record(claude.lifetime.pricing)
         }
 
         if includeCodexCli {
             let codex = CodexCostScanner.scanSessions(session: session)
             scan.period.append(CodexCostScanner.makeCost(from: codex.period))
             scan.lifetime.append(CodexCostScanner.makeCost(from: codex.lifetime))
+            scan.period.record(codex.period.pricing)
+            scan.lifetime.record(codex.lifetime.pricing)
+        }
+
+        if let note = scan.lifetime.pricing.diagnosticNote {
+            AppLog.cost.warning("Pricing table gap: \(note, privacy: .public)")
         }
 
         let costs = scan.period.costs
@@ -126,7 +143,8 @@ enum CostSummaryBuilder {
                 totalTokens: costs.reduce(0) { $0 + $1.totalTokens },
                 periodDays: days,
                 dailyUsage: scan.period.dailyUsage.sorted { $0.date < $1.date },
-                lifetime: LifetimeCostSummary(costs: scan.lifetime.costs)
+                lifetime: LifetimeCostSummary(costs: scan.lifetime.costs),
+                pricing: scan.period.pricing.isEmpty ? nil : scan.period.pricing
             ),
             isComplete: session.isComplete
         )

--- a/MeterBarTests/CostScanCollaboratorTests.swift
+++ b/MeterBarTests/CostScanCollaboratorTests.swift
@@ -472,6 +472,53 @@ final class CostScanCollaboratorTests: XCTestCase {
         XCTAssertEqual(summary.periodDays, 7)
     }
 
+    func testBudgetedSummaryPreservesFullScanPricingProvenance() throws {
+        let root = try makeCorpusDirectory()
+        let config = root.appendingPathComponent("claude", isDirectory: true)
+        let projects = config.appendingPathComponent("projects", isDirectory: true)
+        let project = projects
+            .appendingPathComponent("fixture", isDirectory: true)
+        let cache = root.appendingPathComponent("cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: cache, withIntermediateDirectories: true)
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        let event = """
+        {"timestamp":"\(timestamp)","requestId":"request","message":{"id":"message",\
+        "model":"claude-sonnet-4-5","usage":{"input_tokens":100,"output_tokens":50,\
+        "cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+        """
+        try event.write(
+            to: project.appendingPathComponent("session.jsonl"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let days = 30
+        let full = CostSummaryBuilder.makeSummary(
+            days: days,
+            includeClaudeCode: true,
+            includeCodexCli: false,
+            claudeAccounts: [],
+            claudeProjectRoots: [projects]
+        )
+        let session = CostScanSession(
+            cutoff: CostWindow.start(days: days),
+            options: .unlimited,
+            store: CostScanCacheStore(directory: cache)
+        )
+
+        let budgeted = CostSummaryBuilder.makeScan(
+            days: days,
+            includeClaudeCode: true,
+            includeCodexCli: false,
+            claudeAccounts: [],
+            session: session,
+            claudeProjectRoots: [projects]
+        )
+
+        XCTAssertNotNil(full.pricing)
+        XCTAssertEqual(budgeted.summary.pricing, full.pricing)
+    }
+
     // MARK: - CostScanBudget
 
     func testProductionBudgetIsBoundedPerFileAndPerRefresh() {


### PR DESCRIPTION
## Summary
- Root cause of the never-ending "Updating…" spinner on Costs/Optimize: the Codex rollout scanner ran up to three `Data.contains(Data)` marker searches per line. Swift routes that through the generic `Collection.firstRange` path — benchmarked on the Mac Studio at **3.2 MB/s vs 1,787 MB/s** for `Data.range(of:)` (~560x). Over ~1 GB of rollouts each 15-second budget slice barely advanced, so `CostScanSession.isComplete` never turned true, `CostTracker.lastScanDate` never stamped (`cost-summary-v2.json` untouched since Aug 3), `needsMissingDailyUsageRefresh` stayed true, and the dashboard backfill re-triggered on every Costs/Optimize visit — endless spinner, one core pinned at 99% CPU.
- Fix: all four hot call sites now use `range(of:)`, with a comment pinning the constraint and a scoped `swiftlint:disable contains_over_range_nil_comparison`.
- Also fixes a #339 regression: the budgeted `makeScan` path silently dropped pricing provenance. It now records period/lifetime pricing from both providers, logs the pricing-table gap note, and carries `pricing` into the returned summary, mirroring `makeSummary`. A new `claudeProjectRoots` seam lets the regression test scan a fixture corpus instead of the real home directories.

## Verification
- `swift test --filter CostScanCollaboratorTests`: 40 passed (includes new `testBudgetedSummaryPreservesFullScanPricingProvenance`)
- `swift test --filter CostTrackerTests`: 56 passed
- Full `swift test` (Codex sandbox run): 1,881 executed, cost-scan suites green; only known sandbox-denied keychain/UI-agent/socket failures
- `swiftlint lint --strict --quiet`: clean
- Micro-benchmark (swiftc -O): `Data.contains` 108.6s vs `range(of:)` 0.20s for 200k searches over a 1.7 KB line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage-event detection for more reliable cost scanning.
  * Ensured budgeted Claude summaries retain accurate pricing information.
  * Added diagnostics when pricing data is unavailable.

* **Improvements**
  * Claude scans can now use specified project locations or automatically discover relevant accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->