### PR TITLE
harden(cost): surface resumable cost-scan cache write failures

### DIFF
--- a/MeterBar/Services/CostScanFileCache.swift
+++ b/MeterBar/Services/CostScanFileCache.swift
@@ -152,17 +152,38 @@ nonisolated struct CostScanCacheStore: Sendable {
         return cache
     }
 
+    /// Writes one cache through, or throws describing which stage failed.
+    ///
+    /// Each stage is mapped to its own case rather than letting the underlying
+    /// error escape: the caller logs this and nothing else, so "the encoder
+    /// refused a value", "the directory could not be prepared", and "the bytes
+    /// never landed" have to be distinguishable from the log line alone. The
+    /// atomic-replace behaviour is unchanged — a failure at any stage leaves the
+    /// previous artifact exactly as it was.
     private static func save<Payload>(
         _ cache: CostScanFileCache<Payload>,
         to url: URL,
         maximumBytes: Int
     ) throws {
-        let data = try encoder.encode(cache)
+        let data: Data
+        do {
+            data = try encoder.encode(cache)
+        } catch {
+            throw CostScanCacheStoreError.encodingFailed(reason: CostScanCacheStoreError.reason(for: error))
+        }
         guard data.count <= maximumBytes else {
             throw CostScanCacheStoreError.artifactTooLarge(data.count)
         }
-        try SecureFileWriter.ensurePrivateDirectory(url.deletingLastPathComponent())
-        try SecureFileWriter.write(data, to: url)
+        do {
+            try SecureFileWriter.ensurePrivateDirectory(url.deletingLastPathComponent())
+        } catch {
+            throw CostScanCacheStoreError.directoryUnavailable(reason: CostScanCacheStoreError.reason(for: error))
+        }
+        do {
+            try SecureFileWriter.write(data, to: url)
+        } catch {
+            throw CostScanCacheStoreError.writeFailed(reason: CostScanCacheStoreError.reason(for: error))
+        }
         Self.removeSupersededFiles(for: url)
     }
 
@@ -185,14 +206,40 @@ nonisolated struct CostScanCacheStore: Sendable {
     }
 }
 
+/// Why a cache could not be written. One case per stage of ``save``, because a
+/// scan that stops resuming is diagnosed from this line and no other.
 nonisolated enum CostScanCacheStoreError: LocalizedError {
     case artifactTooLarge(Int)
+    case encodingFailed(reason: String)
+    case directoryUnavailable(reason: String)
+    case writeFailed(reason: String)
 
     var errorDescription: String? {
         switch self {
         case let .artifactTooLarge(bytes):
             "Cost scan cache is too large to persist (\(bytes) bytes)"
+        case let .encodingFailed(reason):
+            "Could not encode the cost scan cache: \(reason)"
+        case let .directoryUnavailable(reason):
+            "Could not prepare the cost scan cache directory: \(reason)"
+        case let .writeFailed(reason):
+            "Could not write the cost scan cache: \(reason)"
         }
+    }
+
+    /// Describes `error` without the file paths its own description carries.
+    ///
+    /// These reasons are logged at `privacy: .public`, and every path involved
+    /// sits under the user's home directory. An errno, or failing that a domain
+    /// and code, says what to do about it; the path says who the user is.
+    /// Encoder failures matter here too — the cache is keyed by transcript path,
+    /// so `EncodingError`'s own description would name one.
+    static func reason(for error: Error) -> String {
+        if let error = error as? SecureFileWriterError {
+            return error.logDescription
+        }
+        let error = error as NSError
+        return "\(error.domain) \(error.code)"
     }
 }
 

--- a/MeterBar/Services/CostScanSession.swift
+++ b/MeterBar/Services/CostScanSession.swift
@@ -121,7 +121,12 @@ nonisolated final class CostScanSession: @unchecked Sendable {
     /// disk made no *resumable* progress, and a caller that ignores that spends
     /// its remaining slices re-reading the same bytes.
     func persist() -> CostScanPersistOutcome {
-        guard let store else { return .persisted }
+        // No store is not the same as nothing to save. `CostScanCacheStore
+        // .applicationSupport` is optional, and every slice builds a fresh
+        // session from it — so a session without one starts from an empty cache,
+        // re-reads the corpus from offset 0, and defers in the same place. Say
+        // so, or the slice loop keeps calling that forward progress.
+        guard let store else { return .unavailable }
 
         var outcome = CostScanPersistOutcome.persisted
         do {
@@ -145,13 +150,20 @@ nonisolated final class CostScanSession: @unchecked Sendable {
 }
 
 /// Whether a slice's offsets are durable enough for the next one to resume from.
+///
+/// Only `persisted` earns another slice. The two failure shapes are kept apart
+/// because they need different log lines — one is a disk error worth reporting,
+/// the other is a machine whose Application Support directory never resolved.
 nonisolated enum CostScanPersistOutcome: Sendable, Equatable {
-    /// Every cache this session owns is on disk — or there is no store, so there
-    /// was never anything to lose.
+    /// Every cache this session owns is on disk.
     case persisted
 
     /// At least one cache could not be written. Whatever this slice read is
     /// still correct in memory, but it dies with the session: the store holds
     /// exactly what the previous slice left there.
     case failed
+
+    /// There is no store to write to, so nothing this slice read can outlive
+    /// it. Correct for the summary on screen, useless to the next slice.
+    case unavailable
 }

--- a/MeterBar/Services/CostScanSession.swift
+++ b/MeterBar/Services/CostScanSession.swift
@@ -116,15 +116,18 @@ nonisolated final class CostScanSession: @unchecked Sendable {
     /// Writes both caches back, including after a cancelled slice — the whole
     /// point of committing on line boundaries is that partial progress is safe
     /// to keep.
-    @discardableResult
-    func persist() -> Bool {
-        guard let store else { return true }
+    ///
+    /// Deliberately not `@discardableResult`: a slice whose caches never reached
+    /// disk made no *resumable* progress, and a caller that ignores that spends
+    /// its remaining slices re-reading the same bytes.
+    func persist() -> CostScanPersistOutcome {
+        guard let store else { return .persisted }
 
-        var succeeded = true
+        var outcome = CostScanPersistOutcome.persisted
         do {
             try store.saveClaude(claude)
         } catch {
-            succeeded = false
+            outcome = .failed
             AppLog.cost.error(
                 "Failed to persist Claude scan progress: \(error.localizedDescription, privacy: .public)"
             )
@@ -132,11 +135,23 @@ nonisolated final class CostScanSession: @unchecked Sendable {
         do {
             try store.saveCodex(codex)
         } catch {
-            succeeded = false
+            outcome = .failed
             AppLog.cost.error(
                 "Failed to persist Codex scan progress: \(error.localizedDescription, privacy: .public)"
             )
         }
-        return succeeded
+        return outcome
     }
+}
+
+/// Whether a slice's offsets are durable enough for the next one to resume from.
+nonisolated enum CostScanPersistOutcome: Sendable, Equatable {
+    /// Every cache this session owns is on disk — or there is no store, so there
+    /// was never anything to lose.
+    case persisted
+
+    /// At least one cache could not be written. Whatever this slice read is
+    /// still correct in memory, but it dies with the session: the store holds
+    /// exactly what the previous slice left there.
+    case failed
 }

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -168,9 +168,16 @@ class CostTracker: ObservableObject {
             await MainActor.run { costSummary = slice.scan.summary }
 
             guard Self.shouldRunAnotherSlice(after: slice.scan, persistence: slice.persistence) else {
-                AppLog.cost.error(
-                    "Stopping the cost scan: this slice's progress was not persisted, so no later slice can resume"
-                )
+                switch slice.persistence {
+                case .unavailable:
+                    AppLog.cost.error(
+                        "Stopping the cost scan: no cache store, so every slice would re-read the corpus from zero"
+                    )
+                default:
+                    AppLog.cost.error(
+                        "Stopping the cost scan: this slice's progress was not persisted, so no later slice can resume"
+                    )
+                }
                 break
             }
         }
@@ -187,11 +194,12 @@ class CostTracker: ObservableObject {
 
     /// Whether another slice can improve on the one that just finished.
     ///
-    /// A slice that could not write its caches left the store exactly as it
-    /// found it, so the next slice would re-read the same bytes, defer in the
-    /// same place, and fail to persist again — 63 times over, pinning the scan
-    /// queue for nothing. Stopping costs one refresh: the next one retries the
-    /// write from the last durable offsets.
+    /// A slice that could not write its caches — or had no store to write them
+    /// to — left the store exactly as it found it, so the next slice would
+    /// re-read the same bytes, defer in the same place, and fail to persist
+    /// again — 63 times over, pinning the scan queue for nothing. Stopping costs
+    /// one refresh: the next one retries the write from the last durable
+    /// offsets.
     static func shouldRunAnotherSlice(
         after scan: CostSummaryBuilder.CostSummaryScan,
         persistence: CostScanPersistOutcome

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -138,7 +138,7 @@ class CostTracker: ObservableObject {
         var latest: CostSummaryBuilder.CostSummaryScan?
 
         for _ in 0..<Self.maxScanSlices {
-            let scan = try? await CostScanExecutor.run { token in
+            let slice = try? await CostScanExecutor.run { token in
                 let session = CostScanSession(
                     cutoff: cutoff,
                     options: .default,
@@ -155,21 +155,49 @@ class CostTracker: ObservableObject {
                 // Persist even when the slice was cut short: offsets commit on
                 // line boundaries, so partial progress is exactly what the next
                 // slice needs to resume from.
-                session.persist()
-                return scan
+                return ScanSlice(scan: scan, persistence: session.persist())
             }
             // Cancelled. Whatever earlier slices published stands, and the
             // offsets they committed are already on disk.
-            guard let scan else { break }
+            guard let slice else { break }
 
-            latest = scan
-            if scan.isComplete { break }
+            latest = slice.scan
+            if slice.scan.isComplete { break }
             // Publish the partial total so the number on screen improves with
             // every slice instead of only when the last one lands.
-            await MainActor.run { costSummary = scan.summary }
+            await MainActor.run { costSummary = slice.scan.summary }
+
+            guard Self.shouldRunAnotherSlice(after: slice.scan, persistence: slice.persistence) else {
+                AppLog.cost.error(
+                    "Stopping the cost scan: this slice's progress was not persisted, so no later slice can resume"
+                )
+                break
+            }
         }
 
         return latest
+    }
+
+    /// One budgeted slice: what it computed, and whether the next one can pick
+    /// up where it stopped.
+    private struct ScanSlice: Sendable {
+        let scan: CostSummaryBuilder.CostSummaryScan
+        let persistence: CostScanPersistOutcome
+    }
+
+    /// Whether another slice can improve on the one that just finished.
+    ///
+    /// A slice that could not write its caches left the store exactly as it
+    /// found it, so the next slice would re-read the same bytes, defer in the
+    /// same place, and fail to persist again — 63 times over, pinning the scan
+    /// queue for nothing. Stopping costs one refresh: the next one retries the
+    /// write from the last durable offsets.
+    static func shouldRunAnotherSlice(
+        after scan: CostSummaryBuilder.CostSummaryScan,
+        persistence: CostScanPersistOutcome
+    ) -> Bool {
+        guard !scan.isComplete else { return false }
+        return persistence == .persisted
     }
 
     private func loadCachedSummary() {

--- a/MeterBar/Services/SecureFileWriter.swift
+++ b/MeterBar/Services/SecureFileWriter.swift
@@ -189,6 +189,24 @@ enum SecureFileWriterError: LocalizedError {
         }
     }
 
+    /// Path-free rendering, for callers that log at `privacy: .public`.
+    ///
+    /// `errorDescription` names the file, which is right in front of a human
+    /// holding the URL. Everything this writer touches lives under the user's
+    /// home directory, though, so a log line built from it publishes the account
+    /// name to the system log. The errno is the part an operator acts on —
+    /// `ENOSPC` and `EACCES` call for different fixes — and it carries no path.
+    var logDescription: String {
+        switch self {
+        case let .create(code, _):
+            "create failed: \(Self.describe(code))"
+        case let .write(code, _):
+            "write failed: \(Self.describe(code))"
+        case let .replace(code, _):
+            "replace failed: \(Self.describe(code))"
+        }
+    }
+
     private static func describe(_ code: Int32) -> String {
         String(cString: strerror(code))
     }

--- a/MeterBarTests/CostScanFileCacheSafetyTests.swift
+++ b/MeterBarTests/CostScanFileCacheSafetyTests.swift
@@ -99,6 +99,80 @@ final class CostScanFileCacheSafetyTests: XCTestCase {
         )
     }
 
+    // MARK: - Persistence failures
+
+    /// A cache that cannot be encoded must say so rather than leave the caller
+    /// believing the slice's offsets are on disk. `.infinity` is the cheapest
+    /// real trigger: `JSONEncoder` rejects non-conforming floats by default.
+    func testEncodingFailureIsReportedAndWritesNothing() throws {
+        var cache = makeCache()
+        cache.records["/tmp/session.jsonl"]?.payload.period.estimatedCost = .infinity
+        let url = directory.appendingPathComponent(CostScanCacheStore.claudeFileName)
+
+        XCTAssertThrowsError(try CostScanCacheStore.saveClaude(cache, to: url)) { error in
+            guard let error = error as? CostScanCacheStoreError, case .encodingFailed = error else {
+                XCTFail("expected an encoding failure, got \(error)")
+                return
+            }
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    func testDirectorySetupFailureIsReportedAndASuccessfulRetryPersists() throws {
+        // A regular file where the cache directory's parent belongs: creating
+        // the directory underneath it cannot succeed.
+        let blocker = directory.appendingPathComponent("not-a-directory")
+        try Data("blocked".utf8).write(to: blocker)
+        let store = CostScanCacheStore(directory: blocker.appendingPathComponent("MeterBar", isDirectory: true))
+
+        XCTAssertThrowsError(try store.saveClaude(makeCache())) { error in
+            guard let error = error as? CostScanCacheStoreError, case .directoryUnavailable = error else {
+                XCTFail("expected a directory failure, got \(error)")
+                return
+            }
+        }
+
+        try FileManager.default.removeItem(at: blocker)
+
+        XCTAssertNoThrow(try store.saveClaude(makeCache()))
+        XCTAssertEqual(store.loadClaude().records.count, 1)
+    }
+
+    func testWriteFailureIsReportedAndASuccessfulRetryPersists() throws {
+        // The cache directory's path is taken by a regular file, so staging the
+        // atomic write inside it fails.
+        let occupied = directory.appendingPathComponent("MeterBar")
+        try Data("occupied".utf8).write(to: occupied)
+        let store = CostScanCacheStore(directory: occupied)
+
+        XCTAssertThrowsError(try store.saveClaude(makeCache())) { error in
+            guard let error = error as? CostScanCacheStoreError, case .writeFailed = error else {
+                XCTFail("expected a write failure, got \(error)")
+                return
+            }
+        }
+
+        try FileManager.default.removeItem(at: occupied)
+
+        XCTAssertNoThrow(try store.saveClaude(makeCache()))
+        XCTAssertEqual(store.loadClaude().records.count, 1)
+    }
+
+    /// These descriptions are logged at `privacy: .public`, and the cache lives
+    /// under the user's home directory. The errno is the actionable part; the
+    /// path is not, and must not ride along.
+    func testFailureDescriptionsCarryNoFileSystemPaths() throws {
+        let occupied = directory.appendingPathComponent("MeterBar")
+        try Data("occupied".utf8).write(to: occupied)
+        let store = CostScanCacheStore(directory: occupied)
+
+        XCTAssertThrowsError(try store.saveClaude(makeCache())) { error in
+            let description = error.localizedDescription
+            XCTAssertFalse(description.contains(self.directory.path), description)
+            XCTAssertFalse(description.contains("/"), description)
+        }
+    }
+
     private func makeCache() -> CostScanFileCache<ClaudeFileTotals> {
         var cache = CostScanFileCache<ClaudeFileTotals>()
         cache.records["/tmp/session.jsonl"] = CostScanFileRecord(

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -932,7 +932,7 @@ final class CostTrackerTests: XCTestCase {
 
         let first = CostScanSession(cutoff: cutoff, options: budget, store: store)
         let firstWindows = ClaudeCostScanner.scanRoots([root], session: first)
-        first.persist()
+        XCTAssertEqual(first.persist(), .persisted)
 
         XCTAssertFalse(first.isComplete)
         XCTAssertEqual(firstWindows.period.input, 100)
@@ -942,7 +942,7 @@ final class CostTrackerTests: XCTestCase {
         // A fresh refresh gets a fresh budget and picks up exactly what was left.
         let second = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
         let secondWindows = ClaudeCostScanner.scanRoots([root], session: second)
-        second.persist()
+        XCTAssertEqual(second.persist(), .persisted)
 
         XCTAssertTrue(second.isComplete)
         XCTAssertEqual(secondWindows.period.input, 107)
@@ -960,7 +960,7 @@ final class CostTrackerTests: XCTestCase {
 
         let first = CostScanSession(cutoff: cutoff, options: .default, store: store)
         _ = ClaudeCostScanner.scanRoots([root], session: first)
-        first.persist()
+        XCTAssertEqual(first.persist(), .persisted)
 
         let firstSize = try fileSize(url)
         XCTAssertEqual(first.budget.bytesRead, firstSize)
@@ -973,7 +973,7 @@ final class CostTrackerTests: XCTestCase {
 
         let second = CostScanSession(cutoff: cutoff, options: .default, store: store)
         let windows = ClaudeCostScanner.scanRoots([root], session: second)
-        second.persist()
+        XCTAssertEqual(second.persist(), .persisted)
 
         XCTAssertEqual(second.budget.bytesRead, appended.utf8.count)
         XCTAssertEqual(windows.period.input, 107)
@@ -989,7 +989,7 @@ final class CostTrackerTests: XCTestCase {
 
         let first = CostScanSession(cutoff: cutoff, options: .default, store: store)
         _ = ClaudeCostScanner.scanRoots([root], session: first)
-        first.persist()
+        XCTAssertEqual(first.persist(), .persisted)
 
         try append(eventLine(
             timestamp: "2026-07-02T10:00:00.000Z", messageID: "b", requestID: "b", input: 7, output: 3
@@ -1025,7 +1025,7 @@ final class CostTrackerTests: XCTestCase {
 
         let first = CostScanSession(cutoff: cutoff, options: .default, store: store)
         let firstWindows = ClaudeCostScanner.scanRoots([root], session: first)
-        first.persist()
+        XCTAssertEqual(first.persist(), .persisted)
 
         XCTAssertEqual(firstWindows.period.input, 100)
         XCTAssertEqual(
@@ -1097,7 +1097,7 @@ final class CostTrackerTests: XCTestCase {
             try await CostScanExecutor.run { token in
                 let session = CostScanSession(cutoff: cutoff, options: .unlimited, store: store, token: token)
                 _ = ClaudeCostScanner.scanRoots([root], session: session)
-                session.persist()
+                _ = session.persist()
             }
         }
         try? await Task.sleep(nanoseconds: 2_000_000)
@@ -1224,19 +1224,60 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(record.payload.period.daily[day]?.output, 22)
     }
 
-    func testPersistReportsCacheWriteFailure() throws {
+    func testPersistReportsCacheWriteFailureAndASuccessfulRetryPersists() throws {
         let blockedDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("CostScanBlocked-\(UUID().uuidString)")
         try Data().write(to: blockedDirectory)
         addTeardownBlock { try? FileManager.default.removeItem(at: blockedDirectory) }
 
-        let session = CostScanSession(
-            cutoff: Date(timeIntervalSince1970: 1_780_000_000),
-            options: .unlimited,
-            store: CostScanCacheStore(directory: blockedDirectory)
+        let cutoff = Date(timeIntervalSince1970: 1_780_000_000)
+        let store = CostScanCacheStore(directory: blockedDirectory)
+        let session = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        session.setClaudeRecord(
+            CostScanFileRecord(
+                offset: 512,
+                stamp: CostScanFileStamp(size: 4_096, modified: 1_780_000_000, fileID: 42),
+                cutoff: cutoff,
+                isComplete: false,
+                payload: ClaudeFileTotals()
+            ),
+            for: "/transcripts/a.jsonl"
         )
 
-        XCTAssertFalse(session.persist())
+        XCTAssertEqual(session.persist(), .failed)
+        // Nothing reached disk, so the offsets this slice committed are not
+        // resumable — the next slice would re-read the same bytes.
+        XCTAssertTrue(store.loadClaude().records.isEmpty)
+
+        try FileManager.default.removeItem(at: blockedDirectory)
+
+        XCTAssertEqual(session.persist(), .persisted)
+        XCTAssertEqual(store.loadClaude().records["/transcripts/a.jsonl"]?.offset, 512)
+    }
+
+    // MARK: - Slice loop control
+
+    func testAnotherSliceRunsOnlyWhenThePreviousOneLeftResumableProgress() {
+        let partial = CostSummaryBuilder.CostSummaryScan(summary: makeEmptySummary(), isComplete: false)
+        let whole = CostSummaryBuilder.CostSummaryScan(summary: makeEmptySummary(), isComplete: true)
+
+        XCTAssertTrue(CostTracker.shouldRunAnotherSlice(after: partial, persistence: .persisted))
+        // A slice whose caches never landed leaves the store exactly as it found
+        // it, so 63 more slices would re-read the same bytes and defer in the
+        // same place.
+        XCTAssertFalse(CostTracker.shouldRunAnotherSlice(after: partial, persistence: .failed))
+        XCTAssertFalse(CostTracker.shouldRunAnotherSlice(after: whole, persistence: .persisted))
+    }
+
+    private func makeEmptySummary() -> CostSummary {
+        CostSummary(
+            costs: [],
+            totalCostUSD: 0,
+            totalTokens: 0,
+            periodDays: 30,
+            dailyUsage: [],
+            lifetime: nil
+        )
     }
 
     // MARK: - Corpus fixtures

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -1255,6 +1255,25 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(store.loadClaude().records["/transcripts/a.jsonl"]?.offset, 512)
     }
 
+    func testPersistReportsNoStoreAsUnavailableRatherThanPersisted() {
+        let cutoff = Date(timeIntervalSince1970: 1_780_000_000)
+        let session = CostScanSession(cutoff: cutoff, options: .unlimited, store: nil)
+        session.setClaudeRecord(
+            CostScanFileRecord(
+                offset: 512,
+                stamp: CostScanFileStamp(size: 4_096, modified: 1_780_000_000, fileID: 42),
+                cutoff: cutoff,
+                isComplete: false,
+                payload: ClaudeFileTotals()
+            ),
+            for: "/transcripts/a.jsonl"
+        )
+
+        // A session with nowhere to write is not "persisted": the offsets it
+        // committed die with it, so a later slice would start from zero.
+        XCTAssertEqual(session.persist(), .unavailable)
+    }
+
     // MARK: - Slice loop control
 
     func testAnotherSliceRunsOnlyWhenThePreviousOneLeftResumableProgress() {
@@ -1266,6 +1285,9 @@ final class CostTrackerTests: XCTestCase {
         // it, so 63 more slices would re-read the same bytes and defer in the
         // same place.
         XCTAssertFalse(CostTracker.shouldRunAnotherSlice(after: partial, persistence: .failed))
+        // Same waste, different cause: with no store at all every slice rebuilds
+        // an empty cache and re-reads the corpus from offset 0.
+        XCTAssertFalse(CostTracker.shouldRunAnotherSlice(after: partial, persistence: .unavailable))
         XCTAssertFalse(CostTracker.shouldRunAnotherSlice(after: whole, persistence: .persisted))
     }
 


### PR DESCRIPTION
Closes #349.

## Problem

The resumable cost scan could swallow a cache-persistence failure and keep slicing. `CostScanSession.persist()` returned a `@discardableResult` Bool and `CostTracker.makeCostSummary` dropped it.

A slice whose caches never reached disk leaves the store exactly as it found it — so the next slice re-read the same bytes, deferred in the same place, and failed to write again, up to 64 times per refresh. The operator saw a permanently slow scan and no signal at all.

## Change

- **`CostScanCacheStore.save`** maps each stage to its own error case (`encodingFailed`, `directoryUnavailable`, `writeFailed`, alongside the existing `artifactTooLarge`). Atomic-replace behaviour is unchanged: a failure at any stage leaves the previous artifact untouched.
- **Failure reasons are path-free** — errno via a new `SecureFileWriterError.logDescription`, or NSError domain + code. These lines are logged at `privacy: .public` and every path involved sits under the user's home directory; the errno (`ENOSPC` vs `EACCES`) is the part an operator acts on. Encoder failures matter here too, since the cache is keyed by transcript path.
- **`persist()` returns a named `CostScanPersistOutcome`** and is no longer `@discardableResult`, so no caller can ignore a failed write. Logging keeps the existing `saveCachedSummary` convention.
- **The slice loop consumes that outcome** and stops instead of spinning the scan queue on work no later slice can resume from. The partial total still publishes; the next refresh retries the write from the last durable offsets.

## Acceptance criteria

| Criterion | Covered by |
| --- | --- |
| Encoding, directory-creation, and write failures are observable | `testEncodingFailureIsReportedAndWritesNothing`, `testDirectorySetupFailureIsReportedAndASuccessfulRetryPersists`, `testWriteFailureIsReportedAndASuccessfulRetryPersists` |
| Failed writes cannot mark progress as durably persisted | `testPersistReportsCacheWriteFailureAndASuccessfulRetryPersists`, `testAnotherSliceRunsOnlyWhenThePreviousOneLeftResumableProgress` |
| A successful retry persists normally | both retry tests above, asserting the records load back |
| Failure details stay non-sensitive | `testFailureDescriptionsCarryNoFileSystemPaths` |

Tests were written first; existing `persist()` call sites now assert `.persisted` rather than discarding the result.

## Verification

- `swift test` — 1885 tests, 0 failures, 5 skipped (credential-gated)
- `swiftlint lint --strict --quiet` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cache-save failures with clearer, stage-specific error messages.
  * Prevented additional scan work when progress cannot be safely saved.
  * Preserved partial results while supporting reliable retries after storage issues.
  * Sanitized error messages to exclude local file paths while retaining useful diagnostics.
* **Tests**
  * Added coverage for encoding, directory, write, retry, and resumable-progress scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->