### PR TITLE
feat(dashboard): add token activity heatmap

### DIFF
--- a/MeterBar/Models/TokenActivityCalendar.swift
+++ b/MeterBar/Models/TokenActivityCalendar.swift
@@ -1,0 +1,317 @@
+import Foundation
+import MeterBarShared
+
+/// Graduated intensity bands for the token-activity heatmap.
+///
+/// Scaling linearly against the busiest day collapses a normal week into the
+/// lightest band as soon as one outlier lands in the window, so the bands are
+/// cut on the *rank* of the distinct daily totals instead of their magnitude.
+/// Every band therefore carries roughly the same share of active days, and a
+/// single 10M-token day only ever claims the top band for itself.
+struct TokenActivityIntensityScale: Equatable {
+    /// Non-zero bands. Level `0` is reserved for confirmed zero-usage days.
+    static let bandCount = 4
+
+    /// Ascending inclusive lower bound of each band in use.
+    let lowerBounds: [Int]
+
+    init(dailyTotals: [Int]) {
+        let distinct = Set(dailyTotals.filter { $0 > 0 }).sorted()
+        guard !distinct.isEmpty else {
+            lowerBounds = []
+            return
+        }
+
+        // Fewer distinct totals than bands means the extra bands would be empty;
+        // a flat history should read as one quiet tone, not as saturated.
+        let bands = min(Self.bandCount, distinct.count)
+        lowerBounds = (0..<bands).map { band in
+            distinct[min(distinct.count - 1, band * distinct.count / bands)]
+        }
+    }
+
+    /// Bands this history actually populates (`0` when nothing was used).
+    var usedBandCount: Int { lowerBounds.count }
+
+    /// `0` for confirmed-zero days, otherwise `1...usedBandCount`.
+    func level(for tokens: Int) -> Int {
+        guard tokens > 0 else { return 0 }
+        guard let index = lowerBounds.lastIndex(where: { $0 <= tokens }) else { return 1 }
+        return index + 1
+    }
+}
+
+/// One provider's contribution to a single calendar day.
+struct TokenActivityProviderTotal: Identifiable, Equatable {
+    var id: ServiceType { provider }
+    let provider: ServiceType
+    let tokens: Int
+    let costUSD: Double
+}
+
+/// One cell of the contribution calendar.
+///
+/// `isCovered == false` means MeterBar has no retained history for the day —
+/// deliberately distinct from a covered day that simply saw no usage, so the
+/// grid never implies continuous coverage it cannot back up.
+struct TokenActivityDay: Identifiable, Equatable {
+    var id: Date { date }
+    let date: Date
+    let isCovered: Bool
+    let totalTokens: Int
+    let estimatedCostUSD: Double
+    let providers: [TokenActivityProviderTotal]
+    let level: Int
+
+    var hasUsage: Bool { totalTokens > 0 }
+
+    var accessibilityLabel: String { DashboardDateFormat.medium(date) }
+
+    var accessibilityValue: String {
+        guard isCovered else { return "No retained history" }
+        guard hasUsage else { return "No tracked usage" }
+
+        var parts = [
+            "\(UsageFormat.tokens(totalTokens)) tokens",
+            UsageFormat.cost(estimatedCostUSD),
+            "intensity \(level) of \(TokenActivityIntensityScale.bandCount)",
+        ]
+        parts.append(contentsOf: providers.map {
+            "\($0.provider.displayName) \(UsageFormat.tokens($0.tokens)), \(UsageFormat.cost($0.costUSD))"
+        })
+        return parts.joined(separator: ", ")
+    }
+
+    /// Single-line hover/focus detail rendered under the grid, where the
+    /// multi-line tooltip shape would push the card's height around.
+    var detailLine: String {
+        let header = DashboardDateFormat.medium(date)
+        guard isCovered else { return "\(header) · No retained history" }
+        guard hasUsage else { return "\(header) · No tracked usage" }
+
+        var parts = ["\(UsageFormat.tokens(totalTokens)) tokens", UsageFormat.cost(estimatedCostUSD)]
+        parts.append(contentsOf: providers.map {
+            "\($0.provider.displayName) \(UsageFormat.tokens($0.tokens))"
+        })
+        return "\(header) · \(parts.joined(separator: " · "))"
+    }
+
+    /// Multi-line hover text, mirroring the stacked daily chart's tooltip shape.
+    var tooltip: String {
+        let header = DashboardDateFormat.medium(date)
+        guard isCovered else { return "\(header)\nNo retained history" }
+        guard hasUsage else { return "\(header)\nNo tracked usage" }
+
+        var lines = [header, "\(UsageFormat.tokens(totalTokens)) tokens", UsageFormat.cost(estimatedCostUSD)]
+        if !providers.isEmpty {
+            lines.append("")
+            lines.append(contentsOf: providers.map {
+                "\($0.provider.displayName): \(UsageFormat.tokens($0.tokens)) · \(UsageFormat.cost($0.costUSD))"
+            })
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+/// One column of the grid. `days` always holds seven weekday slots starting at
+/// the calendar's `firstWeekday`; `nil` marks a future date with no cell.
+struct TokenActivityWeek: Identifiable, Equatable {
+    var id: Date { startDate }
+    let index: Int
+    let startDate: Date
+    let days: [TokenActivityDay?]
+}
+
+/// A month header pinned to the column that opens the month.
+struct TokenActivityMonthLabel: Identifiable, Equatable {
+    var id: Int { weekIndex }
+    let weekIndex: Int
+    let title: String
+}
+
+/// Pure, deterministic contribution-calendar input derived from one reviewed
+/// `CostSummary`.
+///
+/// Coverage policy (matching `CostChartPresentation`): the earliest `dailyUsage`
+/// row on or before today opens the covered span, which runs through today.
+/// Days inside that span with no rows are confirmed zero-usage days; days before
+/// it are unavailable history, not synthetic zeros.
+struct TokenActivityCalendar {
+    static let defaultWeeks = 53
+    static let weekdayCount = 7
+
+    let requestedWeeks: Int
+    /// First day of the grid — always the calendar's `firstWeekday`.
+    let startDate: Date
+    /// Last day of the grid — always today; the grid never renders the future.
+    let endDate: Date
+    /// First day MeterBar has retained history for, or `nil` when it has none.
+    let coverageStartDate: Date?
+    let weeks: [TokenActivityWeek]
+    let monthLabels: [TokenActivityMonthLabel]
+    let scale: TokenActivityIntensityScale
+    /// Short weekday names ordered from the calendar's `firstWeekday`.
+    let weekdaySymbols: [String]
+    /// Every rendered cell, oldest first.
+    let days: [TokenActivityDay]
+
+    private let daysByDate: [Date: TokenActivityDay]
+
+    init(
+        summary: CostSummary?,
+        weeks: Int = TokenActivityCalendar.defaultWeeks,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) {
+        let requestedWeeks = min(max(1, weeks), Self.defaultWeeks)
+        let today = calendar.startOfDay(for: now)
+        let weekdayOffset = (calendar.component(.weekday, from: today) - calendar.firstWeekday + Self.weekdayCount)
+            % Self.weekdayCount
+        let currentWeekStart = Self.day(today, offsetBy: -weekdayOffset, calendar: calendar)
+        let gridStart = Self.day(
+            currentWeekStart,
+            offsetBy: -(requestedWeeks - 1) * Self.weekdayCount,
+            calendar: calendar
+        )
+
+        // Future-dated rows never open or extend the covered span.
+        let rows = (summary?.dailyUsage ?? []).filter { calendar.startOfDay(for: $0.date) <= today }
+        let rowsByDay = Dictionary(grouping: rows) { calendar.startOfDay(for: $0.date) }
+        let coverageStartDate = rowsByDay.keys.min()
+
+        let slots: [(date: Date, isFuture: Bool)] = (0..<(requestedWeeks * Self.weekdayCount)).map { offset in
+            let date = Self.day(gridStart, offsetBy: offset, calendar: calendar)
+            return (date, date > today)
+        }
+
+        let totals: [(date: Date, isCovered: Bool, tokens: Int, cost: Double, providers: [TokenActivityProviderTotal])]
+        totals = slots.filter { !$0.isFuture }.map { slot in
+            let providers = Self.providerTotals(for: rowsByDay[slot.date] ?? [])
+            return (
+                slot.date,
+                coverageStartDate.map { slot.date >= $0 } ?? false,
+                providers.reduce(0) { $0 + $1.tokens },
+                providers.reduce(0) { $0 + $1.costUSD },
+                providers
+            )
+        }
+
+        let scale = TokenActivityIntensityScale(dailyTotals: totals.map(\.tokens))
+        let days = totals.map { total in
+            TokenActivityDay(
+                date: total.date,
+                isCovered: total.isCovered,
+                totalTokens: total.tokens,
+                estimatedCostUSD: total.cost,
+                providers: total.providers,
+                level: scale.level(for: total.tokens)
+            )
+        }
+
+        let daysByDate = Dictionary(uniqueKeysWithValues: days.map { ($0.date, $0) })
+        let weeks = (0..<requestedWeeks).map { index in
+            let slice = slots[(index * Self.weekdayCount)..<((index + 1) * Self.weekdayCount)]
+            return TokenActivityWeek(
+                index: index,
+                startDate: slice.first?.date ?? gridStart,
+                days: slice.map { $0.isFuture ? nil : daysByDate[$0.date] }
+            )
+        }
+
+        self.requestedWeeks = requestedWeeks
+        self.startDate = gridStart
+        self.endDate = today
+        self.coverageStartDate = coverageStartDate
+        self.weeks = weeks
+        self.monthLabels = Self.monthLabels(for: weeks, calendar: calendar)
+        self.scale = scale
+        self.weekdaySymbols = Self.weekdaySymbols(calendar: calendar)
+        self.days = days
+        self.daysByDate = daysByDate
+    }
+
+    /// The rendered cell for `date`, or `nil` when the date falls outside the
+    /// grid (before it starts, or in the future).
+    func day(on date: Date) -> TokenActivityDay? { daysByDate[date] }
+
+    /// Days MeterBar has retained history for, whether or not they saw usage.
+    var trackedDays: [TokenActivityDay] { days.filter(\.isCovered) }
+
+    /// Days that actually consumed tokens.
+    var activeDays: [TokenActivityDay] { days.filter(\.hasUsage) }
+
+    var hasHistory: Bool { coverageStartDate != nil }
+
+    var hasActivity: Bool { !activeDays.isEmpty }
+
+    var totalTokens: Int { days.reduce(0) { $0 + $1.totalTokens } }
+
+    var totalCostUSD: Double { days.reduce(0) { $0 + $1.estimatedCostUSD } }
+
+    var busiestDay: TokenActivityDay? { activeDays.max { $0.totalTokens < $1.totalTokens } }
+
+    /// Short caption naming how much of the window is backed by real history.
+    var coverageSummary: String? {
+        guard hasHistory else { return nil }
+        let tracked = trackedDays.count
+        return "\(tracked) day\(tracked == 1 ? "" : "s") tracked"
+    }
+
+    /// Caption shown under the grid while nothing is hovered or focused.
+    var overviewLine: String {
+        guard hasActivity else { return "No tracked usage in this window." }
+
+        var parts = ["\(UsageFormat.tokens(totalTokens)) tokens", UsageFormat.cost(totalCostUSD)]
+        if let busiest = busiestDay {
+            parts.append("Busiest \(DashboardDateFormat.medium(busiest.date))"
+                + " (\(UsageFormat.tokens(busiest.totalTokens)))")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    // MARK: - Construction helpers
+
+    private static func day(_ date: Date, offsetBy days: Int, calendar: Calendar) -> Date {
+        guard let shifted = calendar.date(byAdding: .day, value: days, to: date) else { return date }
+        // Zones that shift at midnight can return 01:00; re-normalise every hop.
+        return calendar.startOfDay(for: shifted)
+    }
+
+    private static func providerTotals(for rows: [DailyTokenUsage]) -> [TokenActivityProviderTotal] {
+        Dictionary(grouping: rows, by: \.provider)
+            .map { provider, rows in
+                TokenActivityProviderTotal(
+                    provider: provider,
+                    tokens: rows.reduce(0) { $0 + max(0, $1.totalTokens) },
+                    costUSD: rows.reduce(0) { $0 + max(0, $1.estimatedCostUSD) }
+                )
+            }
+            .filter { $0.tokens > 0 || $0.costUSD > 0 }
+            .sorted {
+                if $0.tokens != $1.tokens { return $0.tokens > $1.tokens }
+                if $0.costUSD != $1.costUSD { return $0.costUSD > $1.costUSD }
+                return $0.provider.displayName < $1.provider.displayName
+            }
+    }
+
+    private static func monthLabels(
+        for weeks: [TokenActivityWeek],
+        calendar: Calendar
+    ) -> [TokenActivityMonthLabel] {
+        // The leading column is almost always mid-month and has no room for a
+        // header, so labels start at the first column that opens a new month.
+        weeks.dropFirst().compactMap { week in
+            let previous = weeks[week.index - 1].startDate
+            guard calendar.component(.month, from: week.startDate) != calendar.component(.month, from: previous)
+            else { return nil }
+            return TokenActivityMonthLabel(weekIndex: week.index, title: DashboardDateFormat.month(week.startDate))
+        }
+    }
+
+    private static func weekdaySymbols(calendar: Calendar) -> [String] {
+        let symbols = calendar.shortWeekdaySymbols
+        guard symbols.count == weekdayCount else { return symbols }
+        let offset = calendar.firstWeekday - 1
+        return (0..<weekdayCount).map { symbols[($0 + offset) % weekdayCount] }
+    }
+}

--- a/MeterBar/Views/DashboardCostsSection.swift
+++ b/MeterBar/Views/DashboardCostsSection.swift
@@ -57,6 +57,13 @@ struct DashboardCostsSection: View {
 
             costTrendCard
 
+            TokenActivityCard(
+                summary: summary,
+                isScanning: costTracker.isScanning,
+                isScanDisabled: costTracker.isRefreshInProgress,
+                scan: { Task { await costTracker.scanCosts(days: 30) } }
+            )
+
             if let summary, !summary.dailyUsage.isEmpty {
                 DashboardCard(title: "Daily Details", trailing: "Last 30 days") {
                     DailyUsageBreakdownList(dailyUsage: summary.dailyUsage)

--- a/MeterBar/Views/TokenActivityHeatmap.swift
+++ b/MeterBar/Views/TokenActivityHeatmap.swift
@@ -1,0 +1,317 @@
+import AppKit
+import MeterBarShared
+import SwiftUI
+
+/// Dashboard card wrapping the trailing contribution calendar.
+///
+/// Takes plain values rather than reaching for `CostTracker.shared` (same shape
+/// as ``CostOverviewStatusCard``) so the card hosts in a test without standing
+/// up the scanner. The calendar is derived once in `init` — `body` runs on every
+/// hover tick, and re-slicing a year of daily rows there would be wasteful.
+struct TokenActivityCard: View {
+    private let activity: TokenActivityCalendar
+    private let isScanning: Bool
+    private let isScanDisabled: Bool
+    private let scan: () -> Void
+
+    init(
+        summary: CostSummary?,
+        isScanning: Bool,
+        isScanDisabled: Bool,
+        scan: @escaping () -> Void
+    ) {
+        self.activity = TokenActivityCalendar(summary: summary)
+        self.isScanning = isScanning
+        self.isScanDisabled = isScanDisabled
+        self.scan = scan
+    }
+
+    var body: some View {
+        DashboardCard(title: "Token Activity", trailing: activity.coverageSummary) {
+            if activity.hasHistory {
+                TokenActivityHeatmap(activity: activity)
+            } else if isScanning {
+                CostScanLoadingChart(compact: true)
+                    .frame(height: TokenActivityMetrics.gridHeight)
+            } else {
+                emptyState
+            }
+        }
+    }
+
+    /// The heatmap is empty for exactly the reason the 30-day chart is, so it
+    /// reuses that explanation and its scan action rather than inventing a
+    /// second wording for the same state.
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.sm) {
+            EmptyStateCard(
+                systemImage: "square.grid.3x3",
+                title: "No daily history yet",
+                message: "Run a local scan to load 30-day token history."
+            )
+
+            Button(action: scan) {
+                Label("Scan 30 Days", systemImage: "magnifyingglass")
+            }
+            .buttonStyle(.glassProminent)
+            .disabled(isScanDisabled)
+        }
+    }
+}
+
+/// The grid itself: month headers, weekday gutter, cells, hover/focus detail,
+/// and the intensity legend.
+struct TokenActivityHeatmap: View {
+    private let activity: TokenActivityCalendar
+    private let monthTitles: [Int: String]
+
+    @State private var hoveredDate: Date?
+    @FocusState private var focusedDate: Date?
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
+    init(activity: TokenActivityCalendar) {
+        self.activity = activity
+        self.monthTitles = Dictionary(
+            activity.monthLabels.map { ($0.weekIndex, $0.title) },
+            uniquingKeysWith: { first, _ in first }
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.sm) {
+            ScrollView(.horizontal) {
+                VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.xs) {
+                    monthHeader
+                    HStack(alignment: .top, spacing: TokenActivityMetrics.spacing) {
+                        weekdayGutter
+                        grid
+                    }
+                }
+                // Focus rings sit just outside a cell; without the inset the
+                // leading and trailing columns clip theirs against the card.
+                .padding(TokenActivityMetrics.focusRingInset)
+            }
+            .scrollIndicators(.hidden)
+            .defaultScrollAnchor(.trailing)
+
+            detail
+            TokenActivityLegend()
+        }
+        .animation(
+            MeterBarTheme.Motion.resolve(MeterBarTheme.Motion.quick, reduceMotion: reduceMotion),
+            value: highlightedDate
+        )
+    }
+
+    // MARK: - Grid
+
+    private var grid: some View {
+        HStack(alignment: .top, spacing: TokenActivityMetrics.spacing) {
+            ForEach(activity.weeks) { week in
+                VStack(spacing: TokenActivityMetrics.spacing) {
+                    ForEach(Array(week.days.enumerated()), id: \.offset) { _, day in
+                        if let day {
+                            cell(for: day)
+                        } else {
+                            // A future weekday in the current column: the slot
+                            // still holds the grid's shape, it just has no cell.
+                            Color.clear
+                                .frame(width: TokenActivityMetrics.cell, height: TokenActivityMetrics.cell)
+                        }
+                    }
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Token activity calendar")
+    }
+
+    private func cell(for day: TokenActivityDay) -> some View {
+        TokenActivitySwatch(
+            level: day.level,
+            isCovered: day.isCovered,
+            isHighlighted: highlightedDate == day.date
+        )
+        .focusable()
+        .focused($focusedDate, equals: day.date)
+        .onHover { isHovering in
+            if isHovering {
+                hoveredDate = day.date
+            } else if hoveredDate == day.date {
+                hoveredDate = nil
+            }
+        }
+        .help(day.tooltip)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(day.accessibilityLabel)
+        .accessibilityValue(day.accessibilityValue)
+    }
+
+    // MARK: - Headers
+
+    private var monthHeader: some View {
+        HStack(alignment: .bottom, spacing: TokenActivityMetrics.spacing) {
+            Color.clear
+                .frame(width: TokenActivityMetrics.gutterWidth, height: 1)
+
+            ForEach(activity.weeks) { week in
+                // `fixedSize` before the column-width frame lets the label keep
+                // its natural width and overhang the following columns, which is
+                // the only way a month name fits above an 11pt cell.
+                Text(monthTitles[week.index] ?? "")
+                    .fixedSize()
+                    .frame(width: TokenActivityMetrics.cell, alignment: .leading)
+            }
+        }
+        .font(.system(size: 9))
+        .foregroundStyle(.secondary)
+        .accessibilityHidden(true)
+    }
+
+    private var weekdayGutter: some View {
+        VStack(spacing: TokenActivityMetrics.spacing) {
+            ForEach(Array(activity.weekdaySymbols.enumerated()), id: \.offset) { index, symbol in
+                // Every other row only — seven stacked labels do not fit beside
+                // 11pt cells, and the alternating ones still orient the reader.
+                Text(index.isMultiple(of: 2) ? "" : symbol)
+                    .frame(
+                        width: TokenActivityMetrics.gutterWidth,
+                        height: TokenActivityMetrics.cell,
+                        alignment: .leading
+                    )
+            }
+        }
+        .font(.system(size: 9))
+        .foregroundStyle(.secondary)
+        .accessibilityHidden(true)
+    }
+
+    // MARK: - Detail line
+
+    private var detail: some View {
+        Text(highlightedDay?.detailLine ?? activity.overviewLine)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(2)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityHidden(true)
+    }
+
+    /// Hover wins over focus: the pointer is the more recent intent when both
+    /// are live.
+    private var highlightedDate: Date? { hoveredDate ?? focusedDate }
+
+    private var highlightedDay: TokenActivityDay? { highlightedDate.flatMap(activity.day(on:)) }
+}
+
+// MARK: - Legend
+
+/// Intensity key. The bands are also spelled out in every cell's accessibility
+/// value, so the grid never depends on color alone.
+private struct TokenActivityLegend: View {
+    var body: some View {
+        HStack(spacing: MeterBarTheme.Spacing.xs) {
+            Text("Less")
+            HStack(spacing: TokenActivityMetrics.spacing) {
+                ForEach(0...TokenActivityIntensityScale.bandCount, id: \.self) { level in
+                    TokenActivitySwatch(level: level)
+                }
+            }
+            Text("More")
+
+            Spacer(minLength: MeterBarTheme.Spacing.sm)
+
+            TokenActivitySwatch(level: 0, isCovered: false)
+            Text("No history")
+        }
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Intensity legend")
+        .accessibilityValue(
+            "Cells run from no tracked usage through \(TokenActivityIntensityScale.bandCount) busier bands. "
+                + "Outlined cells are days with no retained history."
+        )
+    }
+}
+
+// MARK: - Cell chrome
+
+/// One rounded tile, shared by the grid and the legend so a swatch can never
+/// drift from the cells it explains.
+private struct TokenActivitySwatch: View {
+    let level: Int
+    var isCovered = true
+    var isHighlighted = false
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: TokenActivityMetrics.radius, style: .continuous)
+            .fill(TokenActivityPalette.fill(level: level, isCovered: isCovered))
+            .overlay {
+                RoundedRectangle(cornerRadius: TokenActivityMetrics.radius, style: .continuous)
+                    .strokeBorder(borderColor, style: borderStyle)
+            }
+            .frame(width: TokenActivityMetrics.cell, height: TokenActivityMetrics.cell)
+    }
+
+    private var borderColor: Color {
+        if isHighlighted { return MeterBarTheme.appAccent }
+        return isCovered ? Color.clear : TokenActivityPalette.unavailableBorder
+    }
+
+    /// Unavailable days get a dashed outline so "no retained history" survives
+    /// grayscale, Increase Contrast, and a screenshot.
+    private var borderStyle: StrokeStyle {
+        if isHighlighted { return StrokeStyle(lineWidth: 1.5) }
+        return StrokeStyle(lineWidth: 1, dash: isCovered ? [] : [1.5, 1.5])
+    }
+}
+
+// MARK: - Metrics and palette
+
+/// Grid geometry, kept in one place so the month header, weekday gutter, cells,
+/// and legend stay on the same rhythm.
+private enum TokenActivityMetrics {
+    static let cell: CGFloat = 11
+    static let spacing: CGFloat = 3
+    static let radius: CGFloat = 2.5
+    static let gutterWidth: CGFloat = 22
+    static let focusRingInset: CGFloat = 2
+    /// Placeholder height while a scan runs, matching the loaded grid.
+    static let gridHeight: CGFloat = 132
+}
+
+/// Heatmap band colors.
+///
+/// The active bands are an opacity ramp on the app accent, so the grid picks up
+/// the user's accent like the rest of the dashboard. The neutral tones are
+/// explicit adaptive colors instead: an opacity ramp alone all but vanishes
+/// under Increase Contrast, and the empty band has to stay legible against both
+/// the light and dark card fill.
+private enum TokenActivityPalette {
+    static let quiet = Color.adaptive(
+        light: NSColor(white: 0, alpha: 0.08),
+        dark: NSColor(white: 1, alpha: 0.10),
+        lightHighContrast: NSColor(white: 0, alpha: 0.18),
+        darkHighContrast: NSColor(white: 1, alpha: 0.22)
+    )
+
+    static let unavailable = Color.clear
+
+    static let unavailableBorder = Color.adaptive(
+        light: NSColor(white: 0, alpha: 0.16),
+        dark: NSColor(white: 1, alpha: 0.20),
+        lightHighContrast: NSColor(white: 0, alpha: 0.34),
+        darkHighContrast: NSColor(white: 1, alpha: 0.40)
+    )
+
+    private static let bandOpacity: [Double] = [0.32, 0.54, 0.77, 1.0]
+
+    static func fill(level: Int, isCovered: Bool) -> Color {
+        guard isCovered else { return unavailable }
+        guard level > 0 else { return quiet }
+        return MeterBarTheme.appAccent.opacity(bandOpacity[min(level, bandOpacity.count) - 1])
+    }
+}

--- a/MeterBarTests/TokenActivityCalendarTests.swift
+++ b/MeterBarTests/TokenActivityCalendarTests.swift
@@ -1,0 +1,529 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// Covers the pure geometry, aggregation, coverage and banding math behind the
+/// `Token Activity` contribution calendar.
+///
+/// Everything asserted here runs without a rendered view: the card only draws
+/// what `TokenActivityCalendar` already decided, so grid alignment, future-date
+/// suppression, known-zero vs unavailable days, and outlier-resistant intensity
+/// bands are all provable from this harness.
+final class TokenActivityCalendarTests: XCTestCase {
+    /// Sunday, 2025-06-15 in UTC — a week boundary under `firstWeekday == 1`
+    /// and the last weekday of the week under `firstWeekday == 2`, so the same
+    /// instant exercises both a one-day and a full trailing week.
+    private let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+    private var calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
+        calendar.locale = Locale(identifier: "en_US_POSIX")
+        calendar.firstWeekday = 1
+        return calendar
+    }()
+
+    private var mondayFirstCalendar: Calendar {
+        var mondayFirst = calendar
+        mondayFirst.firstWeekday = 2
+        return mondayFirst
+    }
+
+    // MARK: - Grid geometry
+
+    func testTrailingGridIsFiftyThreeWeeksOfSevenWeekdaySlots() {
+        let activity = TokenActivityCalendar(summary: makeSummary(), now: now, calendar: calendar)
+
+        XCTAssertEqual(activity.weeks.count, TokenActivityCalendar.defaultWeeks)
+        XCTAssertTrue(activity.weeks.allSatisfy { $0.days.count == 7 })
+        XCTAssertEqual(activity.weeks.map(\.index), Array(0..<TokenActivityCalendar.defaultWeeks))
+    }
+
+    func testEveryColumnStartsOnTheCalendarsFirstWeekday() {
+        let activity = TokenActivityCalendar(summary: makeSummary(), now: now, calendar: calendar)
+
+        for week in activity.weeks {
+            XCTAssertEqual(calendar.component(.weekday, from: week.startDate), calendar.firstWeekday)
+        }
+
+        // Row N is always the same weekday, which is what makes the grid readable.
+        for row in 0..<7 {
+            let weekdays = activity.weeks.compactMap { $0.days[row]?.date }
+                .map { calendar.component(.weekday, from: $0) }
+            XCTAssertEqual(Set(weekdays).count, 1, "row \(row) mixed weekdays")
+        }
+    }
+
+    func testGridEndsOnTodayAndLeavesFutureCellsEmpty() {
+        let today = calendar.startOfDay(for: now)
+        let activity = TokenActivityCalendar(summary: makeSummary(), now: now, calendar: calendar)
+
+        // Sunday-first: today is Sunday, so the current column holds a single day.
+        XCTAssertEqual(activity.weeks.last?.days.first??.date, today)
+        XCTAssertEqual(activity.weeks.last?.days.dropFirst().compactMap { $0 }.count, 0)
+        XCTAssertEqual(activity.endDate, today)
+        XCTAssertNil(activity.days.first { $0.date > today })
+        XCTAssertEqual(activity.days.count, 52 * 7 + 1)
+    }
+
+    func testGridHonoursAMondayFirstCalendar() {
+        let mondayFirst = mondayFirstCalendar
+        let activity = TokenActivityCalendar(summary: makeSummary(), now: now, calendar: mondayFirst)
+
+        // Today is a Sunday, the final slot of a Monday-first week: no gaps at all.
+        XCTAssertEqual(activity.weeks.last?.days.compactMap { $0 }.count, 7)
+        XCTAssertEqual(activity.weeks.last?.days.last??.date, mondayFirst.startOfDay(for: now))
+        XCTAssertEqual(activity.days.count, TokenActivityCalendar.defaultWeeks * 7)
+        XCTAssertEqual(mondayFirst.component(.weekday, from: activity.startDate), 2)
+    }
+
+    func testDaysAreContiguousAndStrictlyIncreasing() {
+        let activity = TokenActivityCalendar(summary: makeSummary(), now: now, calendar: calendar)
+        let dates = activity.days.map(\.date)
+
+        XCTAssertEqual(dates, dates.sorted())
+        XCTAssertEqual(Set(dates).count, dates.count)
+        for (previous, next) in zip(dates, dates.dropFirst()) {
+            XCTAssertEqual(calendar.dateComponents([.day], from: previous, to: next).day, 1)
+        }
+    }
+
+    func testRequestedWeeksAreClampedToASensibleRange() {
+        let tiny = TokenActivityCalendar(summary: makeSummary(), weeks: 0, now: now, calendar: calendar)
+        let huge = TokenActivityCalendar(summary: makeSummary(), weeks: 500, now: now, calendar: calendar)
+
+        XCTAssertEqual(tiny.weeks.count, 1)
+        XCTAssertEqual(huge.weeks.count, TokenActivityCalendar.defaultWeeks)
+    }
+
+    // MARK: - Month labels
+
+    func testMonthLabelsAppearOncePerMonthChangeInWeekOrder() {
+        let activity = TokenActivityCalendar(summary: makeSummary(), now: now, calendar: calendar)
+        let labels = activity.monthLabels
+
+        XCTAssertEqual(labels.map(\.weekIndex), labels.map(\.weekIndex).sorted())
+        XCTAssertEqual(Set(labels.map(\.weekIndex)).count, labels.count)
+        XCTAssertEqual(labels.count, 12, "a 53-week window changes month twelve times")
+        XCTAssertFalse(labels.contains { $0.weekIndex == 0 }, "the leading partial month stays unlabelled")
+        XCTAssertFalse(labels.contains { $0.title.isEmpty })
+        XCTAssertEqual(labels.last?.title, "Jun")
+    }
+
+    func testMonthLabelsSurviveTheYearBoundary() {
+        let newYear = Date(timeIntervalSince1970: 1_767_700_000) // 2026-01-06
+        let activity = TokenActivityCalendar(summary: makeSummary(), weeks: 8, now: newYear, calendar: calendar)
+
+        let titles = activity.monthLabels.map(\.title)
+        XCTAssertTrue(titles.contains("Dec"), "December label missing: \(titles)")
+        XCTAssertTrue(titles.contains("Jan"), "January label missing: \(titles)")
+        XCTAssertEqual(activity.days.map(\.date), activity.days.map(\.date).sorted())
+    }
+
+    // MARK: - Aggregation
+
+    func testSameDayProviderRowsAggregateIntoOneCell() {
+        let today = calendar.startOfDay(for: now)
+        let midday = calendar.date(byAdding: .hour, value: 13, to: today) ?? today
+        let summary = makeSummary(dailyUsage: [
+            usage(date: today, provider: .claudeCode, input: 300, output: 100, cacheRead: 200, cost: 2),
+            usage(date: midday, provider: .claudeCode, input: 100, output: 0, cacheRead: 0, cost: 1),
+            usage(date: today, provider: .codexCli, input: 50, output: 25, cacheRead: 0, cost: 0.5),
+        ])
+
+        let activity = TokenActivityCalendar(summary: summary, now: now, calendar: calendar)
+        let cell = try? XCTUnwrap(activity.days.last)
+
+        XCTAssertEqual(cell?.totalTokens, 775)
+        XCTAssertEqual(cell?.estimatedCostUSD ?? 0, 3.5, accuracy: 0.000_001)
+        XCTAssertEqual(cell?.providers.map(\.provider), [.claudeCode, .codexCli], "biggest provider leads")
+        XCTAssertEqual(cell?.providers.first?.tokens, 700)
+        XCTAssertEqual(cell?.providers.last?.tokens, 75)
+    }
+
+    func testTotalsIgnoreNegativeRows() {
+        let summary = makeSummary(dailyUsage: [
+            usage(daysAgo: 0, provider: .claudeCode, input: -500, output: -10, cacheRead: 0, cost: -4),
+        ])
+
+        let activity = TokenActivityCalendar(summary: summary, now: now, calendar: calendar)
+
+        XCTAssertEqual(activity.totalTokens, 0)
+        XCTAssertEqual(activity.totalCostUSD, 0, accuracy: 0.000_001)
+        XCTAssertTrue(activity.activeDays.isEmpty)
+        XCTAssertEqual(activity.days.last?.level, 0)
+    }
+
+    func testRowsOlderThanTheGridAreExcluded() {
+        let summary = makeSummary(dailyUsage: [
+            usage(daysAgo: 400, provider: .claudeCode, input: 9_999, output: 0, cacheRead: 0, cost: 99),
+            usage(daysAgo: 0, provider: .claudeCode, input: 10, output: 0, cacheRead: 0, cost: 1),
+        ])
+
+        let activity = TokenActivityCalendar(summary: summary, now: now, calendar: calendar)
+
+        XCTAssertEqual(activity.totalTokens, 10)
+        XCTAssertEqual(activity.activeDays.count, 1)
+    }
+
+    // MARK: - Coverage
+
+    func testConfirmedZeroDaysAreDistinctFromUnavailableHistory() {
+        let summary = makeSummary(dailyUsage: [
+            usage(daysAgo: 2, provider: .claudeCode, input: 100, output: 0, cacheRead: 0, cost: 1),
+            usage(daysAgo: 0, provider: .claudeCode, input: 200, output: 0, cacheRead: 0, cost: 2),
+        ])
+
+        let activity = TokenActivityCalendar(summary: summary, now: now, calendar: calendar)
+
+        XCTAssertEqual(activity.coverageStartDate, day(daysAgo: 2))
+        XCTAssertEqual(activity.trackedDays.count, 3)
+
+        let quietDay = activity.days.first { $0.date == day(daysAgo: 1) }
+        XCTAssertEqual(quietDay?.isCovered, true)
+        XCTAssertEqual(quietDay?.totalTokens, 0)
+        XCTAssertEqual(quietDay?.level, 0)
+
+        let unknownDay = activity.days.first { $0.date == day(daysAgo: 3) }
+        XCTAssertEqual(unknownDay?.isCovered, false)
+        XCTAssertEqual(unknownDay?.totalTokens, 0)
+
+        XCTAssertEqual(activity.days.filter { !$0.isCovered }.count, activity.days.count - 3)
+    }
+
+    func testFutureDatedRowsNeverExtendCoverage() {
+        let tomorrow = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now)) ?? now
+        let summary = makeSummary(dailyUsage: [
+            usage(date: tomorrow, provider: .claudeCode, input: 10, output: 0, cacheRead: 0, cost: 1),
+            usage(daysAgo: 1, provider: .claudeCode, input: 20, output: 0, cacheRead: 0, cost: 2),
+        ])
+
+        let activity = TokenActivityCalendar(summary: summary, now: now, calendar: calendar)
+
+        XCTAssertEqual(activity.coverageStartDate, day(daysAgo: 1))
+        XCTAssertEqual(activity.trackedDays.count, 2)
+        XCTAssertEqual(activity.totalTokens, 20)
+    }
+
+    func testEmptyHistoryProducesNoCoverageAndNoFabricatedZeros() {
+        let activity = TokenActivityCalendar(summary: makeSummary(), now: now, calendar: calendar)
+
+        XCTAssertFalse(activity.hasHistory)
+        XCTAssertNil(activity.coverageStartDate)
+        XCTAssertTrue(activity.trackedDays.isEmpty)
+        XCTAssertTrue(activity.activeDays.isEmpty)
+        XCTAssertTrue(activity.days.allSatisfy { !$0.isCovered })
+        XCTAssertNil(activity.coverageSummary)
+    }
+
+    func testMissingSummaryBehavesLikeEmptyHistory() {
+        let activity = TokenActivityCalendar(summary: nil, now: now, calendar: calendar)
+
+        XCTAssertFalse(activity.hasHistory)
+        XCTAssertEqual(activity.weeks.count, TokenActivityCalendar.defaultWeeks)
+        XCTAssertTrue(activity.days.allSatisfy { !$0.isCovered })
+    }
+
+    func testCoverageSummaryNamesTheFirstTrackedDay() {
+        let summary = makeSummary(dailyUsage: [
+            usage(daysAgo: 4, provider: .codexCli, input: 10, output: 0, cacheRead: 0, cost: 1),
+        ])
+
+        let activity = TokenActivityCalendar(summary: summary, now: now, calendar: calendar)
+
+        XCTAssertEqual(activity.coverageSummary, "5 days tracked")
+    }
+
+    // MARK: - Intensity bands
+
+    func testZeroTokensAlwaysLandOnTheEmptyBand() {
+        let scale = TokenActivityIntensityScale(dailyTotals: [10, 20, 30, 40])
+
+        XCTAssertEqual(scale.level(for: 0), 0)
+        XCTAssertEqual(scale.level(for: -5), 0)
+        XCTAssertGreaterThanOrEqual(scale.level(for: 1), 1)
+    }
+
+    func testBandsStayGraduatedWhenOneDayDwarfsTheRest() {
+        let ordinary = Array(1...20).map { $0 * 1_000 }
+        let scale = TokenActivityIntensityScale(dailyTotals: ordinary + [10_000_000])
+
+        let ordinaryLevels = Set(ordinary.map { scale.level(for: $0) })
+        XCTAssertGreaterThanOrEqual(
+            ordinaryLevels.count,
+            3,
+            "a single outlier must not flatten the rest of the range into one band"
+        )
+        XCTAssertEqual(scale.level(for: 10_000_000), TokenActivityIntensityScale.bandCount)
+        XCTAssertEqual(scale.level(for: 1_000), 1)
+        XCTAssertGreaterThan(scale.level(for: 20_000), scale.level(for: 1_000))
+    }
+
+    func testLevelsAreMonotonicInTokenCount() {
+        let totals = [5, 12, 90, 400, 400, 7_000, 88_000, 1_000_000]
+        let scale = TokenActivityIntensityScale(dailyTotals: totals)
+
+        let levels = totals.sorted().map { scale.level(for: $0) }
+        XCTAssertEqual(levels, levels.sorted())
+        XCTAssertEqual(scale.level(for: totals.max() ?? 0), scale.usedBandCount)
+    }
+
+    func testUniformHistoryUsesASingleQuietBand() {
+        let scale = TokenActivityIntensityScale(dailyTotals: [500, 500, 500, 500])
+
+        XCTAssertEqual(scale.usedBandCount, 1)
+        XCTAssertEqual(scale.level(for: 500), 1)
+    }
+
+    func testTwoDistinctTotalsUseTwoBands() {
+        let scale = TokenActivityIntensityScale(dailyTotals: [100, 100, 900])
+
+        XCTAssertEqual(scale.usedBandCount, 2)
+        XCTAssertEqual(scale.level(for: 100), 1)
+        XCTAssertEqual(scale.level(for: 900), 2)
+    }
+
+    func testEmptyHistoryScaleStillClassifiesUsage() {
+        let scale = TokenActivityIntensityScale(dailyTotals: [])
+
+        XCTAssertEqual(scale.usedBandCount, 0)
+        XCTAssertEqual(scale.level(for: 0), 0)
+        XCTAssertEqual(scale.level(for: 5), 1)
+    }
+
+    func testCalendarAssignsTheTopBandToItsBusiestDay() {
+        let summary = makeSummary(dailyUsage: (0..<8).map { offset in
+            usage(
+                daysAgo: offset,
+                provider: .claudeCode,
+                input: (offset + 1) * 1_000,
+                output: 0,
+                cacheRead: 0,
+                cost: Double(offset + 1)
+            )
+        })
+
+        let activity = TokenActivityCalendar(summary: summary, now: now, calendar: calendar)
+        let busiest = activity.activeDays.max { $0.totalTokens < $1.totalTokens }
+
+        XCTAssertEqual(busiest?.level, TokenActivityIntensityScale.bandCount)
+        XCTAssertEqual(activity.activeDays.count, 8)
+        XCTAssertEqual(Set(activity.activeDays.map(\.level)).count, TokenActivityIntensityScale.bandCount)
+    }
+
+    // MARK: - Time zones
+
+    func testGridSurvivesADaylightSavingTransition() {
+        var losAngeles = Calendar(identifier: .gregorian)
+        losAngeles.timeZone = TimeZone(identifier: "America/Los_Angeles") ?? .current
+        losAngeles.locale = Locale(identifier: "en_US_POSIX")
+        losAngeles.firstWeekday = 1
+        let formatter = ISO8601DateFormatter()
+        let dstNow = formatter.date(from: "2026-03-09T12:00:00Z") ?? now
+
+        let activity = TokenActivityCalendar(summary: makeSummary(), weeks: 4, now: dstNow, calendar: losAngeles)
+        let dates = activity.days.map(\.date)
+
+        XCTAssertTrue(activity.weeks.allSatisfy { $0.days.count == 7 })
+        XCTAssertTrue(dates.allSatisfy { losAngeles.startOfDay(for: $0) == $0 })
+        for (previous, next) in zip(dates, dates.dropFirst()) {
+            XCTAssertEqual(losAngeles.dateComponents([.day], from: previous, to: next).day, 1)
+        }
+        XCTAssertEqual(activity.endDate, losAngeles.startOfDay(for: dstNow))
+    }
+
+    func testDaysAreGroupedInTheSuppliedTimeZone() {
+        var tokyo = Calendar(identifier: .gregorian)
+        tokyo.timeZone = TimeZone(identifier: "Asia/Tokyo") ?? .current
+        tokyo.locale = Locale(identifier: "en_US_POSIX")
+        tokyo.firstWeekday = 1
+        let formatter = ISO8601DateFormatter()
+        // 22:00 UTC is already the next calendar day in Tokyo.
+        let lateUTC = formatter.date(from: "2025-06-14T22:00:00Z") ?? now
+        let summary = makeSummary(dailyUsage: [
+            usage(date: lateUTC, provider: .claudeCode, input: 42, output: 0, cacheRead: 0, cost: 1),
+        ])
+
+        let activity = TokenActivityCalendar(summary: summary, now: now, calendar: tokyo)
+
+        XCTAssertEqual(activity.activeDays.count, 1)
+        XCTAssertEqual(activity.activeDays.first?.date, tokyo.startOfDay(for: lateUTC))
+        XCTAssertEqual(tokyo.component(.day, from: activity.activeDays.first?.date ?? now), 15)
+    }
+
+    // MARK: - Accessibility and tooltips
+
+    func testTrackedDayDescribesTokensCostAndProviders() {
+        let today = calendar.startOfDay(for: now)
+        let summary = makeSummary(dailyUsage: [
+            usage(date: today, provider: .claudeCode, input: 1_000_000, output: 200_000, cacheRead: 0, cost: 12.5),
+            usage(date: today, provider: .codexCli, input: 300_000, output: 0, cacheRead: 0, cost: 4),
+        ])
+
+        let activity = TokenActivityCalendar(summary: summary, now: now, calendar: calendar)
+        let cell = activity.days.last
+
+        XCTAssertEqual(cell?.accessibilityLabel, DashboardDateFormat.medium(today))
+        let value = cell?.accessibilityValue ?? ""
+        XCTAssertTrue(value.contains("1.5M tokens"), value)
+        XCTAssertTrue(value.contains("$16.50"), value)
+        XCTAssertTrue(value.contains(ServiceType.claudeCode.displayName), value)
+        XCTAssertTrue(value.contains(ServiceType.codexCli.displayName), value)
+        XCTAssertTrue(value.contains("intensity"), "non-colour intensity must be spoken: \(value)")
+
+        let tooltip = cell?.tooltip ?? ""
+        XCTAssertTrue(tooltip.hasPrefix(DashboardDateFormat.medium(today)), tooltip)
+        XCTAssertTrue(tooltip.contains("$16.50"), tooltip)
+        XCTAssertTrue(tooltip.contains(ServiceType.codexCli.displayName), tooltip)
+    }
+
+    func testQuietAndUnknownDaysReadDifferently() {
+        let summary = makeSummary(dailyUsage: [
+            usage(daysAgo: 1, provider: .claudeCode, input: 10, output: 0, cacheRead: 0, cost: 1),
+        ])
+
+        let activity = TokenActivityCalendar(summary: summary, now: now, calendar: calendar)
+        let quiet = activity.days.first { $0.date == day(daysAgo: 0) }
+        let unknown = activity.days.first { $0.date == day(daysAgo: 5) }
+
+        XCTAssertEqual(quiet?.accessibilityValue, "No tracked usage")
+        XCTAssertEqual(unknown?.accessibilityValue, "No retained history")
+        XCTAssertNotEqual(quiet?.accessibilityValue, unknown?.accessibilityValue)
+        XCTAssertTrue(unknown?.tooltip.contains("No retained history") ?? false)
+    }
+
+    func testWeekdaySymbolsFollowTheCalendarsFirstWeekday() {
+        let sundayFirst = TokenActivityCalendar(summary: makeSummary(), weeks: 4, now: now, calendar: calendar)
+        let mondayFirst = TokenActivityCalendar(
+            summary: makeSummary(),
+            weeks: 4,
+            now: now,
+            calendar: mondayFirstCalendar
+        )
+
+        XCTAssertEqual(sundayFirst.weekdaySymbols.count, 7)
+        XCTAssertEqual(sundayFirst.weekdaySymbols.first, calendar.shortWeekdaySymbols.first)
+        XCTAssertEqual(mondayFirst.weekdaySymbols.first, calendar.shortWeekdaySymbols[1])
+        XCTAssertEqual(mondayFirst.weekdaySymbols.last, calendar.shortWeekdaySymbols[0])
+    }
+
+    // MARK: - Hover / focus detail
+
+    func testDetailLineNamesTheDateTokensCostAndProviders() {
+        let summary = makeSummary(dailyUsage: [
+            usage(daysAgo: 2, provider: .claudeCode, input: 1_000_000, output: 400_000, cacheRead: 100_000, cost: 16.5),
+            usage(daysAgo: 2, provider: .codexCli, input: 20_000, output: 0, cacheRead: 0, cost: 0.5),
+        ])
+
+        let activity = TokenActivityCalendar(summary: summary, now: now, calendar: calendar)
+        let detail = activity.day(on: day(daysAgo: 2))?.detailLine ?? ""
+
+        XCTAssertTrue(detail.contains(DashboardDateFormat.medium(day(daysAgo: 2))))
+        XCTAssertTrue(detail.contains("1.5M tokens"))
+        XCTAssertTrue(detail.contains("$17.00"))
+        XCTAssertTrue(detail.contains(ServiceType.claudeCode.displayName))
+        XCTAssertTrue(detail.contains(ServiceType.codexCli.displayName))
+        XCTAssertFalse(detail.contains("\n"), "the detail line sits on a single row under the grid")
+    }
+
+    func testDetailLineDistinguishesQuietDaysFromUnavailableDays() {
+        let summary = makeSummary(dailyUsage: [
+            usage(daysAgo: 3, provider: .claudeCode, input: 10, output: 0, cacheRead: 0, cost: 1),
+        ])
+
+        let activity = TokenActivityCalendar(summary: summary, now: now, calendar: calendar)
+
+        XCTAssertEqual(activity.day(on: day(daysAgo: 0))?.detailLine.hasSuffix("No tracked usage"), true)
+        XCTAssertEqual(activity.day(on: day(daysAgo: 9))?.detailLine.hasSuffix("No retained history"), true)
+    }
+
+    func testDayLookupOnlyResolvesRenderedCells() {
+        let activity = TokenActivityCalendar(summary: makeSummary(), weeks: 4, now: now, calendar: calendar)
+
+        XCTAssertNotNil(activity.day(on: day(daysAgo: 0)))
+        XCTAssertNil(activity.day(on: day(daysAgo: -1)), "tomorrow has no cell")
+        XCTAssertNil(activity.day(on: day(daysAgo: 400)), "dates before the grid have no cell")
+    }
+
+    func testOverviewLineSummarisesTheWindowAndItsBusiestDay() {
+        let summary = makeSummary(dailyUsage: [
+            usage(daysAgo: 1, provider: .claudeCode, input: 1_000_000, output: 0, cacheRead: 0, cost: 10),
+            usage(daysAgo: 4, provider: .codexCli, input: 500_000, output: 0, cacheRead: 0, cost: 5),
+        ])
+
+        let overview = TokenActivityCalendar(summary: summary, now: now, calendar: calendar).overviewLine
+
+        XCTAssertTrue(overview.contains("1.5M tokens"))
+        XCTAssertTrue(overview.contains("$15.00"))
+        XCTAssertTrue(overview.contains(DashboardDateFormat.medium(day(daysAgo: 1))), "names the busiest day")
+    }
+
+    func testOverviewLineReportsATrackedButQuietWindow() {
+        let summary = makeSummary(dailyUsage: [
+            usage(daysAgo: 2, provider: .claudeCode, input: 0, output: 0, cacheRead: 0, cost: 0),
+        ])
+
+        let activity = TokenActivityCalendar(summary: summary, now: now, calendar: calendar)
+
+        XCTAssertTrue(activity.hasHistory)
+        XCTAssertFalse(activity.hasActivity)
+        XCTAssertEqual(activity.overviewLine, "No tracked usage in this window.")
+    }
+
+    // MARK: - Fixtures
+
+    private func makeSummary(
+        dailyUsage: [DailyTokenUsage] = [],
+        periodDays: Int = 30
+    ) -> CostSummary {
+        CostSummary(
+            costs: [],
+            totalCostUSD: 0,
+            totalTokens: 0,
+            periodDays: periodDays,
+            dailyUsage: dailyUsage
+        )
+    }
+
+    private func day(daysAgo: Int) -> Date {
+        let today = calendar.startOfDay(for: now)
+        return calendar.date(byAdding: .day, value: -daysAgo, to: today) ?? today
+    }
+
+    private func usage(
+        daysAgo: Int,
+        provider: ServiceType,
+        input: Int,
+        output: Int,
+        cacheRead: Int,
+        cost: Double
+    ) -> DailyTokenUsage {
+        usage(
+            date: day(daysAgo: daysAgo),
+            provider: provider,
+            input: input,
+            output: output,
+            cacheRead: cacheRead,
+            cost: cost
+        )
+    }
+
+    private func usage(
+        date: Date,
+        provider: ServiceType,
+        input: Int,
+        output: Int,
+        cacheRead: Int,
+        cost: Double
+    ) -> DailyTokenUsage {
+        DailyTokenUsage(
+            date: date,
+            provider: provider,
+            inputTokens: input,
+            outputTokens: output,
+            cacheReadTokens: cacheRead,
+            estimatedCostUSD: cost
+        )
+    }
+}

--- a/MeterBarTests/TokenActivityCardTests.swift
+++ b/MeterBarTests/TokenActivityCardTests.swift
@@ -1,0 +1,153 @@
+import AppKit
+@testable import MeterBar
+import MeterBarShared
+import SwiftUI
+import XCTest
+
+/// Hosting smoke tests for the Token Activity card, plus the regression that
+/// adding it left the 30-day chart and Daily Details surfaces untouched.
+@MainActor
+final class TokenActivityCardTests: XCTestCase {
+    // MARK: - Hosting
+
+    func testLoadedCardHostsWithAFullYearOfCells() {
+        let card = TokenActivityCard(
+            summary: makeSummary(dayCount: 90),
+            isScanning: false,
+            isScanDisabled: false,
+            scan: {}
+        )
+
+        let hostingView = NSHostingView(rootView: card)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 720, height: 400)
+        hostingView.layoutSubtreeIfNeeded()
+
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+    }
+
+    func testEmptyCardHostsAndOffersTheLocalScan() {
+        var scans = 0
+        let card = TokenActivityCard(
+            summary: nil,
+            isScanning: false,
+            isScanDisabled: false,
+            scan: { scans += 1 }
+        )
+
+        let hostingView = NSHostingView(rootView: card)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 720, height: 400)
+        hostingView.layoutSubtreeIfNeeded()
+
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+        XCTAssertEqual(scans, 0, "the scan only runs when the button is pressed")
+    }
+
+    func testScanningCardHosts() {
+        let card = TokenActivityCard(
+            summary: nil,
+            isScanning: true,
+            isScanDisabled: true,
+            scan: {}
+        )
+
+        let hostingView = NSHostingView(rootView: card)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 720, height: 400)
+        hostingView.layoutSubtreeIfNeeded()
+
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+    }
+
+    func testHeatmapHostsOnItsOwn() {
+        let activity = TokenActivityCalendar(summary: makeSummary(dayCount: 400))
+        let heatmap = TokenActivityHeatmap(activity: activity)
+
+        let hostingView = NSHostingView(rootView: heatmap)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 720, height: 240)
+        hostingView.layoutSubtreeIfNeeded()
+
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+        XCTAssertEqual(activity.weeks.count, TokenActivityCalendar.defaultWeeks)
+    }
+
+    // MARK: - Placement regression
+
+    func testCostsSectionStillHostsWithTheNewCard() {
+        let section = DashboardCostsSection(summary: makeSummary(dayCount: 30)) { _ in nil }
+
+        let hostingView = NSHostingView(rootView: section)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 720, height: 900)
+        hostingView.layoutSubtreeIfNeeded()
+
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+    }
+
+    func testThirtyDayChartAndDailyDetailsAreUnchanged() {
+        let summary = makeSummary(dayCount: 30)
+
+        // The heatmap reads the same `dailyUsage` contract but must not narrow
+        // or reshape what the existing surfaces receive.
+        XCTAssertEqual(
+            DashboardCostsSection.refreshStatusText(isScanning: true, isRefreshingMissingDays: true),
+            "Scanning..."
+        )
+        XCTAssertEqual(CostChartPresentation(summary: summary).hasSpend, true)
+
+        let details = DashboardCard(title: "Daily Details", trailing: "Last 30 days") {
+            DailyUsageBreakdownList(dailyUsage: summary.dailyUsage)
+        }
+        let hostingView = NSHostingView(rootView: details)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 720, height: 600)
+        hostingView.layoutSubtreeIfNeeded()
+
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+    }
+
+    // MARK: - Fixtures
+
+    private func makeSummary(dayCount: Int) -> CostSummary {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let dailyUsage: [DailyTokenUsage] = (0..<dayCount).flatMap { offset -> [DailyTokenUsage] in
+            let date = calendar.date(byAdding: .day, value: -offset, to: today) ?? today
+            // Every third day is a confirmed zero so the fixture exercises the
+            // empty band as well as the graduated ones.
+            guard !offset.isMultiple(of: 3) else { return [] }
+            return [
+                DailyTokenUsage(
+                    date: date,
+                    provider: .claudeCode,
+                    inputTokens: 10_000 * (offset + 1),
+                    outputTokens: 2_000,
+                    cacheReadTokens: 500,
+                    estimatedCostUSD: Double(offset + 1) * 0.75
+                ),
+                DailyTokenUsage(
+                    date: date,
+                    provider: .codexCli,
+                    inputTokens: 4_000,
+                    outputTokens: 900,
+                    cacheReadTokens: 0,
+                    estimatedCostUSD: 0.25
+                ),
+            ]
+        }
+        let cost = TokenCost(
+            provider: .claudeCode,
+            inputTokens: 1_000_000,
+            outputTokens: 200_000,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 50_000,
+            estimatedCostUSD: 42.5,
+            sessionCount: 12,
+            periodStart: calendar.date(byAdding: .day, value: -dayCount, to: today) ?? today,
+            periodEnd: today
+        )
+        return CostSummary(
+            costs: [cost],
+            totalCostUSD: cost.estimatedCostUSD,
+            totalTokens: cost.totalTokens,
+            periodDays: 30,
+            dailyUsage: dailyUsage
+        )
+    }
+}


### PR DESCRIPTION
Closes #356.

Adds a **Token Activity** card to the Costs page: a trailing contribution calendar (up to 53 weeks, weekday-aligned, month labels, no future cells) derived from the existing `CostSummary.dailyUsage` contract.

## What's here

**`MeterBar/Models/TokenActivityCalendar.swift`** — all the grid, aggregation, and banding math as a pure value type, so it's assertable without hosting a view (same shape as `CostChartPresentation`).

- Multiple provider rows for the same local calendar day fold into one cell. Negative totals clamp to zero; providers contributing nothing are dropped.
- Every date hop is re-normalised through `calendar.startOfDay(for:)`, so the grid survives DST transitions (including midnight-shift zones) and year boundaries in the user's own calendar and time zone — including a non-Sunday `firstWeekday`.
- **Intensity bands cut on the _rank_ of distinct daily totals, not their magnitude.** Linear scaling against the busiest day collapses a normal week into the lightest band as soon as one outlier lands in the window; rank-based cuts keep the ordinary days spread across all four bands and give the outlier the top band alone. A history with fewer distinct totals than bands uses only the bands it can fill, so a flat window reads as one quiet tone instead of saturating.
- **Coverage follows the existing `CostChartPresentation` policy**: the earliest `dailyUsage` row on or before today opens the covered span, which runs through today. Days inside it with no rows are confirmed zeros; days before it are unavailable history, not fabricated zeros. Future-dated rows never open or extend coverage.

**`MeterBar/Views/TokenActivityHeatmap.swift`** — the card and grid.

- Hover (`.help` tooltip + live detail line) and focus both surface the exact date, total tokens, estimated cost, and provider breakdown.
- Every cell carries an accessibility label (the date) and value (tokens, cost, band, per-provider split), so the intensity legend is readable without color. Unavailable days additionally get a dashed outline, which survives grayscale, Increase Contrast, and a screenshot.
- Band colors ride the app accent as an opacity ramp; the neutral tones are explicit `Color.adaptive` values with high-contrast variants, since an opacity ramp alone vanishes under Increase Contrast.
- Cell highlight animation goes through `MeterBarTheme.Motion.resolve(_:reduceMotion:)`.
- With no history the card reuses the 30-day chart's own local-scan explanation and `Scan 30 Days` action rather than inventing a second wording for the same state. It never triggers a synchronous rescan — the button calls the existing background `scanCosts(days:)` path.

The calendar is built once in the view's `init` (as `DailyUsageChart` does) rather than per-`body`.

## Verification

- `swift test` — **1919 tests, 0 failures** (5 pre-existing skips).
- `swiftlint lint --strict --quiet` — clean.
- 39 tests cover the new code: 33 on the calendar (grid geometry, month labels, same-day aggregation, known-zero vs unavailable, band graduation under an outlier, DST and time-zone grouping, empty/partial history, accessibility strings) and 6 hosting/regression tests.
- `testThirtyDayChartAndDailyDetailsAreUnchanged` guards that the 30-day chart and Daily Details surfaces are untouched.

No network, no analytics — everything is on-device.