### PR TITLE
fix(share): honest share-card freshness, mid-scan export warning, and pin/rotation exclusivity

### DIFF
--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -41,20 +41,38 @@ class CostTracker: ObservableObject {
         loadCachedSummary()
     }
 
-    func scanCosts(days: Int = 30) async {
-        guard !demoMode else { return }
+    /// What a `scanCosts` call actually did, for callers that stamp a timestamp
+    /// or otherwise present the totals as freshly read.
+    enum ScanOutcome: Sendable {
+        /// Demo mode, or another scan/backfill already held the tracker, so no
+        /// log was read and the published totals are exactly as stale as before.
+        case skipped
+        /// Slices ran, but the scan stopped before it saw the whole corpus, so
+        /// the published totals are an undercount that later slices will raise.
+        case partial
+        /// A scan saw the whole corpus.
+        case completed
+
+        /// True only when the published totals came from a scan that finished.
+        var isAuthoritative: Bool { self == .completed }
+    }
+
+    @discardableResult
+    func scanCosts(days: Int = 30) async -> ScanOutcome {
+        guard !demoMode else { return .skipped }
         let shouldStart = await MainActor.run {
             guard !isRefreshInProgress else { return false }
             isScanning = true
             return true
         }
-        guard shouldStart else { return }
+        guard shouldStart else { return .skipped }
 
         let scan = await makeCostSummary(days: days)
 
-        await MainActor.run {
+        return await MainActor.run {
             apply(scan)
             isScanning = false
+            return scan?.isComplete == true ? .completed : .partial
         }
     }
 

--- a/MeterBar/Services/MenuBarDisplayPreferencesStore.swift
+++ b/MeterBar/Services/MenuBarDisplayPreferencesStore.swift
@@ -234,10 +234,12 @@ final class MenuBarDisplayPreferencesStore: ObservableObject {
         pinnedCandidateKey = normalized
         if let normalized {
             userDefaults.set(normalized, forKey: StorageKeys.statusItemPinnedCandidate)
-            // A pin is a deliberate "show exactly this", so it wins over focus
-            // following rather than fighting it on every app switch. Clearing
-            // the pin later does not re-enable the opt-in.
+            // A pin is a deliberate "show exactly this", so it wins over the two
+            // modes that would move the item out from under it rather than
+            // fighting them on every app switch or rotation tick. Clearing the
+            // pin later does not re-enable either opt-in.
             setFollowsFocusedApp(false)
+            setRotatesProviders(false)
         } else {
             userDefaults.removeObject(forKey: StorageKeys.statusItemPinnedCandidate)
         }

--- a/MeterBar/Views/DashboardShareSection.swift
+++ b/MeterBar/Views/DashboardShareSection.swift
@@ -91,8 +91,9 @@ struct DashboardShareSection: View {
                 if costSummary?.dailyUsage.isEmpty ?? true {
                     Button {
                         Task {
-                            await costTracker.scanCosts(days: 30)
-                            generatedAt = Date()
+                            if await costTracker.scanCosts(days: 30).isAuthoritative {
+                                generatedAt = Date()
+                            }
                         }
                     } label: {
                         Label("Scan 30 Days", systemImage: "magnifyingglass")

--- a/MeterBar/Views/DashboardShareSection.swift
+++ b/MeterBar/Views/DashboardShareSection.swift
@@ -56,15 +56,42 @@ struct DashboardShareSection: View {
         return labels
     }
 
+    /// Shared with the Costs cards so the preview and the spend cards announce
+    /// the same scan state in the same words — the same two flags drive both.
+    static func scanStatusText(isScanning: Bool, isRefreshingMissingDays: Bool) -> String? {
+        DashboardCostsSection.refreshStatusText(
+            isScanning: isScanning,
+            isRefreshingMissingDays: isRefreshingMissingDays
+        )
+    }
+
+    /// The budgeted scan publishes partial totals after every slice, so an export
+    /// taken mid-scan bakes an undercount into the PNG and the caption. Only
+    /// successful exports are qualified; a failure toast is about the export
+    /// itself and the caveat would only muddy it.
+    static func exportStatus(_ status: String, isRefreshInProgress: Bool) -> String {
+        isRefreshInProgress ? "\(status) — totals still updating" : status
+    }
+
     var body: some View {
         let previewSize = SocialShareCardLayout.previewSize(
             viewportWidth: viewportWidth,
-            horizontalInsets: horizontalInsets
+            // The preview now sits inside a card, whose own inset eats into the
+            // width the fixed-size artwork can claim.
+            horizontalInsets: horizontalInsets + MeterBarTheme.CardPadding.standard.value * 2
         )
 
         return VStack(alignment: .leading, spacing: 14) {
-            SocialShareCardPreview(content: cardContent, size: previewSize)
-                .accessibilityLabel("MeterBar 30-day token receipt preview")
+            DashboardCard(
+                title: "Share Card",
+                trailing: Self.scanStatusText(
+                    isScanning: costTracker.isScanning,
+                    isRefreshingMissingDays: costTracker.isRefreshingMissingDays
+                )
+            ) {
+                SocialShareCardPreview(content: cardContent, size: previewSize)
+                    .accessibilityLabel("MeterBar 30-day token receipt preview")
+            }
 
             HStack(spacing: 10) {
                 Button {
@@ -153,7 +180,7 @@ struct DashboardShareSection: View {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         if pasteboard.writeObjects([image]) {
-            setShareStatus("PNG copied")
+            setExportStatus("PNG copied")
         } else {
             setShareStatus("Copy failed")
         }
@@ -179,7 +206,7 @@ struct DashboardShareSection: View {
                 // owner-only default the app applies to its own state would be
                 // wrong here. Normal umask semantics are the correct behavior.
                 try pngData.write(to: url, options: .atomic)
-                setShareStatus("PNG saved")
+                setExportStatus("PNG saved")
             } catch {
                 setShareStatus("Save failed")
             }
@@ -192,7 +219,11 @@ struct DashboardShareSection: View {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(content.shareCaption, forType: .string)
-        setShareStatus("Caption copied")
+        setExportStatus("Caption copied")
+    }
+
+    private func setExportStatus(_ status: String) {
+        setShareStatus(Self.exportStatus(status, isRefreshInProgress: costTracker.isRefreshInProgress))
     }
 
     private func setShareStatus(_ status: String) {

--- a/MeterBar/Views/Settings/GeneralSettingsView.swift
+++ b/MeterBar/Views/Settings/GeneralSettingsView.swift
@@ -171,7 +171,8 @@ struct GeneralSettingsView: View {
 
             SettingsRowView(
                 title: "Menu bar shows",
-                detail: "Auto follows recent activity. Pinning keeps one provider, account, and quota window visible."
+                detail: "Auto follows recent activity. Pinning keeps one provider, account, and quota "
+                    + "window visible, and turns off focus following and rotation."
             ) {
                 Picker("", selection: Binding(
                     get: { menuBarDisplayPreferences.pinnedCandidateKey },

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -435,13 +435,19 @@ struct UsageDashboardView: View {
         case .providerStatus:
             await providerStatusMonitor.refreshAll()
         case .costs:
-            await costTracker.scanCosts(days: 30)
+            let outcome = await costTracker.scanCosts(days: 30)
             if activeSection.refreshesApiUsage,
                apiUsageStore.hasAnyAuthenticated,
                !apiUsageStore.isLoading {
                 await apiUsageStore.refresh()
             }
-            socialCardGeneratedAt = Date()
+            // Opening Share starts the background backfill, which makes the
+            // refresh that follows it return without reading anything. Restamp
+            // the card only when a scan actually finished, so the timestamp on
+            // the artwork means what it says.
+            if outcome.isAuthoritative {
+                socialCardGeneratedAt = Date()
+            }
         case .usage:
             await dataManager.refreshForExplicitAction(.manualRefresh)
         }

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -26,6 +26,31 @@ final class CostTrackerTests: XCTestCase {
         }
     }
 
+    // MARK: - Scan outcome
+
+    func testOnlyACompletedScanIsAuthoritative() {
+        XCTAssertTrue(CostTracker.ScanOutcome.completed.isAuthoritative)
+        XCTAssertFalse(CostTracker.ScanOutcome.partial.isAuthoritative)
+        XCTAssertFalse(CostTracker.ScanOutcome.skipped.isAuthoritative)
+    }
+
+    func testDemoModeScanReportsThatItReadNothing() async {
+        let outcome = await CostTracker(demoMode: true).scanCosts(days: 30)
+
+        XCTAssertEqual(outcome, .skipped)
+    }
+
+    @MainActor
+    func testScanReportsSkippedWhileTheBackgroundBackfillHoldsTheTracker() async {
+        let tracker = CostTracker()
+        tracker.isRefreshingMissingDays = true
+
+        let outcome = await tracker.scanCosts(days: 30)
+
+        XCTAssertEqual(outcome, .skipped)
+        XCTAssertFalse(outcome.isAuthoritative)
+    }
+
     // MARK: - Model-id normalization
 
     func testNormalizeClaudeModelStripsDateSuffix() {

--- a/MeterBarTests/DashboardSectionSplitTests.swift
+++ b/MeterBarTests/DashboardSectionSplitTests.swift
@@ -299,6 +299,37 @@ final class DashboardSectionSplitTests: XCTestCase {
         )
     }
 
+    // MARK: - Share card freshness
+
+    func testShareScanStatusMatchesTheCostCardsExactly() {
+        for isScanning in [true, false] {
+            for isRefreshingMissingDays in [true, false] {
+                XCTAssertEqual(
+                    DashboardShareSection.scanStatusText(
+                        isScanning: isScanning,
+                        isRefreshingMissingDays: isRefreshingMissingDays
+                    ),
+                    DashboardCostsSection.refreshStatusText(
+                        isScanning: isScanning,
+                        isRefreshingMissingDays: isRefreshingMissingDays
+                    ),
+                    "share preview and cost cards must announce the same scan state"
+                )
+            }
+        }
+    }
+
+    func testExportStatusWarnsThatTotalsAreStillSettlingDuringAScan() {
+        XCTAssertEqual(
+            DashboardShareSection.exportStatus("PNG copied", isRefreshInProgress: true),
+            "PNG copied — totals still updating"
+        )
+        XCTAssertEqual(
+            DashboardShareSection.exportStatus("Caption copied", isRefreshInProgress: false),
+            "Caption copied"
+        )
+    }
+
     // MARK: - Extracted section views still render
 
     func testOverviewSectionRenders() {

--- a/MeterBarTests/MenuBarDisplayPreferencesStoreTests.swift
+++ b/MeterBarTests/MenuBarDisplayPreferencesStoreTests.swift
@@ -120,6 +120,31 @@ final class MenuBarDisplayPreferencesStoreTests: XCTestCase {
         XCTAssertFalse(store.followsFocusedApp)
     }
 
+    func testPinningTurnsRotationOffAndPersistsIt() {
+        let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+        store.setRotatesProviders(true)
+
+        store.setPinnedCandidateKey("Claude Code:gen:weekly")
+
+        XCTAssertFalse(store.rotatesProviders)
+        XCTAssertFalse(MenuBarDisplayPreferencesStore(userDefaults: defaults).rotatesProviders)
+    }
+
+    func testClearingThePinLeavesRotationOff() {
+        // Rotation is only suppressed at read time while a pin exists, so a pin
+        // that left the stored flag on would hand rotation back the moment the
+        // user returned the menu bar to Auto.
+        let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
+        store.setRotatesProviders(true)
+        store.setPinnedCandidateKey("Claude Code:gen:weekly")
+
+        store.setPinnedCandidateKey(nil)
+
+        XCTAssertFalse(store.rotatesProviders)
+        XCTAssertFalse(store.followsFocusedApp)
+        XCTAssertFalse(MenuBarDisplayPreferencesStore(userDefaults: defaults).rotatesProviders)
+    }
+
     func testEnablingFocusFollowingDisablesRotationAndPersistsBothStates() {
         let store = MenuBarDisplayPreferencesStore(userDefaults: defaults)
         store.setRotatesProviders(true)


### PR DESCRIPTION
Three independent correctness fixes, one commit each.

## A — The share card claimed to be fresh after a refresh that did nothing

**Problem.** `CostTracker.scanCosts` returns silently when `isRefreshInProgress` is true, and opening the Share section is itself what starts the background missing-day backfill (`refreshCostsIfMissingDays` → `refreshMissingDaysInBackground`). `refreshDashboard()` stamped `socialCardGeneratedAt = Date()` unconditionally, so pressing Refresh on the Share page frequently advanced the card's "generated at" with no new data behind it.

**Fix.** `scanCosts` now returns a `ScanOutcome` — `skipped` (demo mode or another refresh held the tracker), `partial` (slices ran but the budget stopped before the whole corpus), `completed`. Both stamping call sites (`UsageDashboardView.refreshDashboard` and the Share page's "Scan 30 Days" button) restamp only when `outcome.isAuthoritative`. `@discardableResult` leaves the other four call sites unchanged.

## B — The Share page exported partial scan totals with no indication

**Problem.** The budgeted scan publishes partial totals after every slice (`makeCostSummary` assigns `costSummary = slice.scan.summary`). A user who previewed or exported mid-scan baked an undercount into the PNG and the copied caption. The Costs cards already surface "Scanning..." / "Updating..." for this exact state; the Share page surfaced nothing.

**Fix.** The preview now sits in a `DashboardCard` whose trailing caption is `DashboardShareSection.scanStatusText`, which delegates straight to `DashboardCostsSection.refreshStatusText` — same component, same wording, same trailing-header placement as the cost cards (matching the existing `CostOverviewStatusCard.headerStatus` reuse precedent). Successful export toasts are qualified with "— totals still updating" while a scan runs; failure toasts stay undecorated because they are about the export, not the numbers. The card's own inset is added to `previewSize`'s `horizontalInsets` so the fixed-size artwork still fits on narrow viewports.

## C — Pinning a provider silently re-armed rotation later

**Problem.** The three menubar display modes are meant to be mutually exclusive, but exclusivity was asymmetric: `setRotatesProviders(true)` cleared `followsFocusedApp`, `setPinnedCandidateKey(_:)` cleared `followsFocusedApp`, and nothing cleared `rotatesProviders` when a pin was set. Rotation was only suppressed at read time while a pin existed (`StatusItemPresenter` passes `rotatesProviders && !followsFocusedApp` into `MenuBarRotationSequencer.rotates`), so a user with rotation on who pinned a provider and later cleared the pin got rotation back without ever re-enabling it.

**Fix.** `setPinnedCandidateKey` clears rotation the same way it clears focus following, extending the intent already documented at that call site — a pin wins over the modes that would move the item out from under it, and clearing the pin later does not re-enable either opt-in. The "Menu bar shows" settings detail now says so, matching the wording the focus-following row already uses.

## Verification

- `swift test` — **1933 tests, 5 skipped, 0 failures.**
- `swiftlint --quiet` — clean on every touched file (the remaining `CostTrackerTests.swift` warnings all predate this branch; the added block is lines 29–53 and is clean).
- New tests:
  - `CostTrackerTests.testOnlyACompletedScanIsAuthoritative`, `testDemoModeScanReportsThatItReadNothing`, `testScanReportsSkippedWhileTheBackgroundBackfillHoldsTheTracker`
  - `DashboardSectionSplitTests.testShareScanStatusMatchesTheCostCardsExactly`, `testExportStatusWarnsThatTotalsAreStillSettlingDuringAScan`
  - `MenuBarDisplayPreferencesStoreTests.testPinningTurnsRotationOffAndPersistsIt`, `testClearingThePinLeavesRotationOff` (the full pin → unpin transition, asserting rotation stays off in memory and after a reload)
- Both C tests were confirmed failing against the old store before the fix landed.