### PR TITLE
fix(cost): five correctness fixes across pricing, scan persistence, and menu-bar selection

### DIFF
--- a/MeterBar/Models/MenuBarFocusSelector.swift
+++ b/MeterBar/Models/MenuBarFocusSelector.swift
@@ -56,13 +56,19 @@ nonisolated enum MenuBarFocusSelector {
         return selection
     }
 
-    /// Tightest quota with anything left, falling back to the whole pool when
-    /// every window of the focused provider is spent — mirrors the spent-account
-    /// rule in `StatusItemLimitSelector` so the two inputs never disagree about
+    /// Tightest measurable quota with anything left, falling back to the spent
+    /// ones when every window of the focused provider is spent — mirrors the
+    /// spent-account rule in `StatusItemLimitSelector` so the two never disagree about
     /// which window of a provider represents it.
     private static func tightest(in candidates: [StatusLimitCandidate]) -> StatusLimitCandidate? {
-        let withQuotaLeft = candidates.filter { QuotaMath.percentLeft(for: $0.limit) > 0 }
-        let pool = withQuotaLeft.isEmpty ? candidates : withQuotaLeft
+        // A zero total carries no headroom information — reading it as "100%
+        // left" would put the one window MeterBar cannot measure in the menu
+        // bar, and ahead of the provider's spent windows at that. Dropped
+        // outright rather than kept as a fallback pool: with nothing measurable
+        // for the focused provider this input has no opinion, so Auto decides.
+        let measurable = candidates.filter { $0.limit.total > 0 }
+        let withQuotaLeft = measurable.filter { QuotaMath.percentLeft(for: $0.limit) > 0 }
+        let pool = withQuotaLeft.isEmpty ? measurable : withQuotaLeft
         return pool.min { lhs, rhs in
             // Tie-break on key so equal quotas resolve deterministically.
             (QuotaMath.percentLeft(for: lhs.limit), lhs.key)

--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -335,7 +335,7 @@ enum ClaudeCostScanner {
 
         let allowance = session.budget.allowance
         guard allowance > 0 else {
-            session.noteDeferred()
+            session.noteDeferred(.claude)
             return record.map { Self.windows($0.payload, cutoff: session.cutoff) }
         }
 
@@ -392,7 +392,7 @@ enum ClaudeCostScanner {
         } else {
             payload.periodKeys.formUnion(periodKeyed.keys)
             payload.lifetimeKeys.formUnion(lifetimeKeyed.keys)
-            session.noteDeferred()
+            session.noteDeferred(.claude)
         }
 
         session.setClaudeRecord(

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -342,7 +342,7 @@ enum CodexCostScanner {
 
         let allowance = session.budget.allowance
         guard allowance > 0 else {
-            session.noteDeferred()
+            session.noteDeferred(.codex)
             return record?.payload
         }
 
@@ -390,7 +390,7 @@ enum CodexCostScanner {
         if read.reachedEndOfFile {
             Self.flushDeferred(&deferred, modelName: nil, windows: &windows)
         } else {
-            session.noteDeferred()
+            session.noteDeferred(.codex)
             if let deferredOffset {
                 // Events still waiting on a model the *next* slice may yet
                 // declare. Rolling the offset back re-reads them rather than

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -64,18 +64,25 @@ enum CodexCostScanner {
         ModelPricing.resolveCodex(for: model, at: timestamp)
     }
 
+    /// `pricingAt` is the seam that lets a test drive a dated schedule; the
+    /// default is the shared table every caller ships with.
     nonisolated static func makeCost(
-        from context: CodexScanContext
+        from context: CodexScanContext,
+        pricingAt: @escaping (String?, Date) -> TokenPricing = ModelPricing.codex(for:at:)
     ) -> (TokenCost, [DailyTokenUsage])? {
         let totals = context.totals
         guard totals.input > 0 || totals.output > 0 || totals.cacheRead > 0 else { return nil }
 
-        let pricing = ModelPricing.codex
+        // A window aggregates many events, so it has no single event time; its
+        // newest event is the closest defensible stand-in, and it is already
+        // what the window reports as `periodEnd`. Daily rows resolve per day.
+        let windowEnd = context.latestDate
+        let pricing = pricingAt(nil, windowEnd)
         let billableInput = max(0, totals.input - totals.cacheRead)
         let output = totals.output + totals.reasoning
         // Prefer the sum of per-event costs, each priced at its own timestamp's
-        // rate; fall back to today's rate only for totals that carry no per-event
-        // cost (issue #339).
+        // rate; fall back to the rate in effect when the tokens were recorded
+        // only for totals that carry no per-event cost (issue #339).
         let fallbackCost = TokenCostMath.calculateCost(
             input: billableInput,
             output: output,
@@ -99,7 +106,7 @@ enum CodexCostScanner {
                 from: context.modelTotals,
                 provider: .codexCli,
                 pricing: pricing,
-                pricingForName: { ModelPricing.codex(for: $0) }
+                pricingForName: { pricingAt($0, windowEnd) }
             ),
             originBreakdowns: TokenUsageAggregator.makeBreakdowns(
                 from: context.originTotals,
@@ -111,7 +118,7 @@ enum CodexCostScanner {
                 modelsByProject: context.projectModelTotals,
                 provider: .codexCli,
                 pricing: pricing,
-                pricingForName: { ModelPricing.codex(for: $0) }
+                pricingForName: { pricingAt($0, windowEnd) }
             )
         ), TokenUsageAggregator.makeDailyUsage(
             from: context.dailyTotals,
@@ -120,7 +127,7 @@ enum CodexCostScanner {
             modelsByDay: context.dailyModelTotals,
             projectsByDay: context.dailyProjectTotals,
             projectModelsByDay: context.dailyProjectModelTotals,
-            pricingForName: { ModelPricing.codex(for: $0) }
+            pricingAt: pricingAt
         ))
     }
 

--- a/MeterBar/Services/CostScanSession.swift
+++ b/MeterBar/Services/CostScanSession.swift
@@ -21,7 +21,7 @@ nonisolated final class CostScanSession: @unchecked Sendable {
     private let lock = NSLock()
     private var claudeCache: CostScanFileCache<ClaudeFileTotals>
     private var codexCache: CostScanFileCache<CodexFileTotals>
-    private var deferred = false
+    private var deferred: Set<CostScanProvider> = []
 
     init(
         cutoff: Date,
@@ -54,21 +54,29 @@ nonisolated final class CostScanSession: @unchecked Sendable {
     /// budget ran out or the refresh was cancelled and some files were skipped
     /// entirely or read only partway — the caller should schedule another slice
     /// rather than treat the summary as final.
-    var isComplete: Bool {
+    var isComplete: Bool { deferredProviders.isEmpty }
+
+    /// Which corpora were left unfinished.
+    ///
+    /// Tracked per provider rather than as one flag because the slice loop's
+    /// stop condition pairs each of these with that provider's own persist
+    /// outcome: a provider that still has work but cannot write its offsets is
+    /// the one case where another slice buys nothing.
+    var deferredProviders: Set<CostScanProvider> {
         lock.lock()
         defer { lock.unlock() }
-        return !deferred
+        return deferred
     }
 
-    /// Records that at least one file was left unfinished.
+    /// Records that at least one of `provider`'s files was left unfinished.
     ///
     /// Deliberately *not* driven by "did we reach EOF": a transcript that is
     /// being appended to right now ends in a half-written line the scan
     /// legitimately withholds, and treating that as incomplete would keep the
     /// refresh loop spinning forever on a live session.
-    func noteDeferred() {
+    func noteDeferred(_ provider: CostScanProvider) {
         lock.lock()
-        deferred = true
+        deferred.insert(provider)
         lock.unlock()
     }
 
@@ -120,7 +128,7 @@ nonisolated final class CostScanSession: @unchecked Sendable {
     /// Deliberately not `@discardableResult`: a slice whose caches never reached
     /// disk made no *resumable* progress, and a caller that ignores that spends
     /// its remaining slices re-reading the same bytes.
-    func persist() -> CostScanPersistOutcome {
+    func persist() -> CostScanPersistReport {
         // No store is not the same as nothing to save. `CostScanCacheStore
         // .applicationSupport` is optional, and every slice builds a fresh
         // session from it — so a session without one starts from an empty cache,
@@ -128,25 +136,34 @@ nonisolated final class CostScanSession: @unchecked Sendable {
         // so, or the slice loop keeps calling that forward progress.
         guard let store else { return .unavailable }
 
-        var outcome = CostScanPersistOutcome.persisted
-        do {
-            try store.saveClaude(claude)
-        } catch {
-            outcome = .failed
-            AppLog.cost.error(
-                "Failed to persist Claude scan progress: \(error.localizedDescription, privacy: .public)"
-            )
-        }
-        do {
-            try store.saveCodex(codex)
-        } catch {
-            outcome = .failed
-            AppLog.cost.error(
-                "Failed to persist Codex scan progress: \(error.localizedDescription, privacy: .public)"
-            )
-        }
-        return outcome
+        return CostScanPersistReport(
+            claude: Self.write("Claude") { try store.saveClaude(claude) },
+            codex: Self.write("Codex") { try store.saveCodex(codex) }
+        )
     }
+
+    private static func write(_ provider: String, _ save: () throws -> Void) -> CostScanPersistOutcome {
+        do {
+            try save()
+            return .persisted
+        } catch {
+            AppLog.cost.error(
+                """
+                Failed to persist \(provider, privacy: .public) scan progress: \
+                \(error.localizedDescription, privacy: .public)
+                """
+            )
+            return .failed
+        }
+    }
+}
+
+/// The two corpora a refresh reads. They have separate caches, separate budgets
+/// to run out of, and separate ways to fail a write, so every "did this make
+/// resumable progress" answer is scoped to one of them.
+nonisolated enum CostScanProvider: Sendable, Hashable, CaseIterable {
+    case claude
+    case codex
 }
 
 /// Whether a slice's offsets are durable enough for the next one to resume from.
@@ -155,15 +172,38 @@ nonisolated final class CostScanSession: @unchecked Sendable {
 /// because they need different log lines — one is a disk error worth reporting,
 /// the other is a machine whose Application Support directory never resolved.
 nonisolated enum CostScanPersistOutcome: Sendable, Equatable {
-    /// Every cache this session owns is on disk.
+    /// This provider's cache is on disk.
     case persisted
 
-    /// At least one cache could not be written. Whatever this slice read is
-    /// still correct in memory, but it dies with the session: the store holds
-    /// exactly what the previous slice left there.
+    /// The cache could not be written. Whatever this slice read is still correct
+    /// in memory, but it dies with the session: the store holds exactly what the
+    /// previous slice left there.
     case failed
 
     /// There is no store to write to, so nothing this slice read can outlive
     /// it. Correct for the summary on screen, useless to the next slice.
     case unavailable
+}
+
+/// One slice's persist result, per provider.
+///
+/// Kept apart rather than reduced to a single worst-case verdict: the caches are
+/// separate artifacts, and a shared verdict would let a permanently blocked
+/// Claude write cancel Codex's scan while Codex is still resuming cleanly.
+nonisolated struct CostScanPersistReport: Sendable, Equatable {
+    /// Both caches reached disk.
+    static let persisted = CostScanPersistReport(claude: .persisted, codex: .persisted)
+
+    /// There was no store, so neither cache could outlive the slice.
+    static let unavailable = CostScanPersistReport(claude: .unavailable, codex: .unavailable)
+
+    let claude: CostScanPersistOutcome
+    let codex: CostScanPersistOutcome
+
+    func outcome(for provider: CostScanProvider) -> CostScanPersistOutcome {
+        switch provider {
+        case .claude: claude
+        case .codex: codex
+        }
+    }
 }

--- a/MeterBar/Services/CostSummaryBuilder.swift
+++ b/MeterBar/Services/CostSummaryBuilder.swift
@@ -86,11 +86,22 @@ enum CostSummaryBuilder {
     nonisolated struct CostSummaryScan: Sendable {
         let summary: CostSummary
 
-        /// `false` when the budget ran out (or the refresh was cancelled) with
-        /// files still unread. The summary is correct as far as it goes — every
-        /// number in it comes from bytes actually accounted for — but it is not
-        /// yet the whole corpus, so the caller should run another slice.
-        let isComplete: Bool
+        /// The providers whose corpus still has unread files, because the budget
+        /// ran out or the refresh was cancelled. The summary is correct as far
+        /// as it goes — every number in it comes from bytes actually accounted
+        /// for — but it is not yet the whole corpus.
+        ///
+        /// Named per provider rather than as one flag so the caller can pair
+        /// each with that provider's own persist outcome; see
+        /// `CostTracker.shouldRunAnotherSlice`.
+        let deferredProviders: Set<CostScanProvider>
+
+        var isComplete: Bool { deferredProviders.isEmpty }
+
+        init(summary: CostSummary, deferredProviders: Set<CostScanProvider> = []) {
+            self.summary = summary
+            self.deferredProviders = deferredProviders
+        }
     }
 
     /// One budgeted slice of the corpus scan.
@@ -146,7 +157,7 @@ enum CostSummaryBuilder {
                 lifetime: LifetimeCostSummary(costs: scan.lifetime.costs),
                 pricing: scan.period.pricing.isEmpty ? nil : scan.period.pricing
             ),
-            isComplete: session.isComplete
+            deferredProviders: session.deferredProviders
         )
     }
 }

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -168,16 +168,7 @@ class CostTracker: ObservableObject {
             await MainActor.run { costSummary = slice.scan.summary }
 
             guard Self.shouldRunAnotherSlice(after: slice.scan, persistence: slice.persistence) else {
-                switch slice.persistence {
-                case .unavailable:
-                    AppLog.cost.error(
-                        "Stopping the cost scan: no cache store, so every slice would re-read the corpus from zero"
-                    )
-                default:
-                    AppLog.cost.error(
-                        "Stopping the cost scan: this slice's progress was not persisted, so no later slice can resume"
-                    )
-                }
+                Self.logStoppedScan(slice)
                 break
             }
         }
@@ -189,23 +180,50 @@ class CostTracker: ObservableObject {
     /// up where it stopped.
     private struct ScanSlice: Sendable {
         let scan: CostSummaryBuilder.CostSummaryScan
-        let persistence: CostScanPersistOutcome
+        let persistence: CostScanPersistReport
     }
 
     /// Whether another slice can improve on the one that just finished.
     ///
-    /// A slice that could not write its caches — or had no store to write them
-    /// to — left the store exactly as it found it, so the next slice would
+    /// A provider that could not write its cache — or had no store to write it
+    /// to — left that artifact exactly as it found it, so the next slice would
     /// re-read the same bytes, defer in the same place, and fail to persist
-    /// again — 63 times over, pinning the scan queue for nothing. Stopping costs
-    /// one refresh: the next one retries the write from the last durable
-    /// offsets.
+    /// again — 63 times over, pinning the scan queue for nothing.
+    ///
+    /// Asked per provider because the two caches fail independently: a blocked
+    /// Claude write must neither end Codex's scan while Codex is still resuming,
+    /// nor keep the loop alive once Codex has finished and Claude is the only
+    /// one still deferring. Stopping costs one refresh — the next one retries
+    /// the write from the last durable offsets.
     static func shouldRunAnotherSlice(
         after scan: CostSummaryBuilder.CostSummaryScan,
-        persistence: CostScanPersistOutcome
+        persistence: CostScanPersistReport
     ) -> Bool {
-        guard !scan.isComplete else { return false }
-        return persistence == .persisted
+        scan.deferredProviders.contains { persistence.outcome(for: $0) == .persisted }
+    }
+
+    private static func logStoppedScan(_ slice: ScanSlice) {
+        for provider in slice.scan.deferredProviders {
+            let name = provider == .claude ? "Claude" : "Codex"
+            switch slice.persistence.outcome(for: provider) {
+            case .persisted:
+                continue
+            case .unavailable:
+                AppLog.cost.error(
+                    """
+                    Stopping the \(name, privacy: .public) cost scan: no cache store, \
+                    so every slice would re-read the corpus from zero
+                    """
+                )
+            case .failed:
+                AppLog.cost.error(
+                    """
+                    Stopping the \(name, privacy: .public) cost scan: this slice's progress \
+                    was not persisted, so no later slice can resume
+                    """
+                )
+            }
+        }
     }
 
     private func loadCachedSummary() {

--- a/MeterBar/Services/TokenUsageAggregator.swift
+++ b/MeterBar/Services/TokenUsageAggregator.swift
@@ -5,6 +5,10 @@ import MeterBarShared
 /// daily-usage rows and breakdown rows the UI renders.
 /// Split out of `CostTracker` (audit C1d).
 enum TokenUsageAggregator {
+    /// `pricingAt` resolves one row's rate from its model name (`nil` for the
+    /// day's own flat total) and the day it was recorded, so a dated schedule
+    /// prices history at the rate that was in effect then instead of today's
+    /// (issue #339). Without it every row falls back to `pricing`.
     nonisolated static func makeDailyUsage(
         from dailyTotals: [Date: TokenAccumulator],
         provider: ServiceType,
@@ -12,9 +16,11 @@ enum TokenUsageAggregator {
         modelsByDay: [Date: [String: TokenAccumulator]] = [:],
         projectsByDay: [Date: [String: TokenAccumulator]] = [:],
         projectModelsByDay: [Date: [String: [String: TokenAccumulator]]] = [:],
-        pricingForName: ((String) -> TokenPricing)? = nil
+        pricingAt: ((String?, Date) -> TokenPricing)? = nil
     ) -> [DailyTokenUsage] {
         dailyTotals.map { day, tokens in
+            let dayPricing = pricingAt?(nil, day) ?? pricing
+            let pricingForName = pricingAt.map { resolve in { (name: String) in resolve(name, day) } }
             let billableInput = provider == .codexCli ? max(0, tokens.input - tokens.cacheRead) : tokens.input
             let cost = tokens.estimatedCostUSD > 0
                 ? tokens.estimatedCostUSD
@@ -23,7 +29,7 @@ enum TokenUsageAggregator {
                     output: tokens.output + tokens.reasoning,
                     cacheCreation: tokens.cacheCreation,
                     cacheRead: tokens.cacheRead,
-                    pricing: pricing
+                    pricing: dayPricing
                 )
             return DailyTokenUsage(
                 date: day,
@@ -36,7 +42,7 @@ enum TokenUsageAggregator {
                     makeBreakdowns(
                         from: $0,
                         provider: provider,
-                        pricing: pricing,
+                        pricing: dayPricing,
                         pricingForName: pricingForName
                     )
                 },
@@ -45,7 +51,7 @@ enum TokenUsageAggregator {
                         from: $0,
                         modelsByProject: projectModelsByDay[day] ?? [:],
                         provider: provider,
-                        pricing: pricing,
+                        pricing: dayPricing,
                         pricingForName: pricingForName
                     )
                 }

--- a/MeterBar/Views/Settings/CostSettingsView.swift
+++ b/MeterBar/Views/Settings/CostSettingsView.swift
@@ -53,10 +53,20 @@ nonisolated struct CostProjectPresentation: Equatable {
         detail = parent.isEmpty ? nil : parent.suffix(2).joined(separator: "/")
     }
 
+    /// Width and a digit, not the character class alone.
+    ///
+    /// The IDs this drops are the fixed 6-character lowercase-hex suffix a
+    /// worktree tool appends; anything of another length is a name someone
+    /// chose. `deadbeef` and `cafe123` are hex too, and a branch losing its
+    /// last segment is worse than an ID surviving on screen — which is also
+    /// why the all-letter hex words (`decade`, `facade`, `accede`) are spared
+    /// at the cost of the 1-in-360 real IDs that draw no digit.
     private static func looksLikeWorktreeID(_ value: String) -> Bool {
-        guard (6...12).contains(value.count) else { return false }
-        return value.allSatisfy { $0.isHexDigit }
+        guard value.count == generatedWorktreeIDLength, value.contains(where: \.isNumber) else { return false }
+        return value.allSatisfy { $0.isHexDigit && !$0.isUppercase }
     }
+
+    private static let generatedWorktreeIDLength = 6
 }
 
 /// Renders one cost-summary period — the rolling 30-day window or the

--- a/MeterBarTests/CostScanCollaboratorTests.swift
+++ b/MeterBarTests/CostScanCollaboratorTests.swift
@@ -274,6 +274,33 @@ final class CostScanCollaboratorTests: XCTestCase {
         XCTAssertEqual(unbilled, 0.0, accuracy: 0.0001)
     }
 
+    func testDailyUsageResolvesEachDaysRateFromThatDayRatherThanOneSharedRate() throws {
+        let cheapDay = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-10T00:00:00Z"))
+        let dearDay = try XCTUnwrap(FlexibleISO8601.date(from: "2026-09-10T00:00:00Z"))
+        let source = [
+            cheapDay: totals(input: 1_000_000, output: 0, cacheRead: 0),
+            dearDay: totals(input: 1_000_000, output: 0, cacheRead: 0)
+        ]
+        let cheap = TokenPricing(input: 1.0, output: 0, cacheCreation: 0, cacheRead: 0)
+        let dear = TokenPricing(input: 5.0, output: 0, cacheCreation: 0, cacheRead: 0)
+
+        let rows = TokenUsageAggregator.makeDailyUsage(
+            from: source,
+            provider: .codexCli,
+            pricing: dear,
+            modelsByDay: [cheapDay: ["sol": totals(input: 1_000_000, output: 0, cacheRead: 0)]],
+            pricingAt: { _, at in at < dearDay ? cheap : dear }
+        )
+
+        XCTAssertEqual(rows.first { $0.date == cheapDay }?.estimatedCostUSD ?? -1, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(rows.first { $0.date == dearDay }?.estimatedCostUSD ?? -1, 5.0, accuracy: 0.0001)
+        XCTAssertEqual(
+            rows.first { $0.date == cheapDay }?.modelBreakdowns?.first?.estimatedCostUSD ?? -1,
+            1.0,
+            accuracy: 0.0001
+        )
+    }
+
     func testProjectBreakdownsNestTheirOwnModelSliceUnderEachRollupRow() {
         let projectTotals: [String: TokenAccumulator] = [
             "app-a": totals(input: 100, output: 0, cacheRead: 0, cost: 5),
@@ -453,6 +480,52 @@ final class CostScanCollaboratorTests: XCTestCase {
         XCTAssertEqual(windows.period.totals.reasoning, 5)
         XCTAssertEqual(windows.period.sessionIDs, ["output-only", "recent"])
         XCTAssertEqual(windows.lifetime.totals.input, 120)
+    }
+
+    /// Issue #339's invariant reaches the fallback path too: totals that carry
+    /// no per-event cost must be priced at the rate in effect when they were
+    /// recorded, not at today's. Exercised through an injected dated schedule
+    /// because every entry in the shipped table is still open-ended backwards.
+    func testCodexFallbackPricingUsesTheRateInEffectWhenTheTokensWereRecorded() throws {
+        let recorded = try XCTUnwrap(FlexibleISO8601.date(from: "2026-02-10T10:00:00Z"))
+        let day = Calendar.current.startOfDay(for: recorded)
+        let oldRate = TokenPricing(input: 3.0, output: 0, cacheCreation: 0, cacheRead: 0)
+        let newRate = TokenPricing(input: 30.0, output: 0, cacheCreation: 0, cacheRead: 0)
+        let schedule = PricingSchedule([
+            DatedTokenPricing(
+                effectiveFrom: DatedTokenPricing.utcDay(2026, 1, 1), verifiedOn: "2026-01-05", pricing: oldRate),
+            DatedTokenPricing(
+                effectiveFrom: DatedTokenPricing.utcDay(2026, 6, 1), verifiedOn: "2026-06-02", pricing: newRate)
+        ])
+
+        // No `estimatedCostUSD` anywhere, so every row falls back to the table.
+        let tokens = totals(input: 1_000_000, output: 0, cacheRead: 0)
+        var context = CodexScanContext(earliestDate: recorded, latestDate: recorded)
+        context.totals = tokens
+        context.sessionIDs = ["session"]
+        context.modelTotals = ["gpt-5.6-sol": tokens]
+        context.projectTotals = ["app": tokens]
+        context.projectModelTotals = ["app": ["gpt-5.6-sol": tokens]]
+        context.dailyTotals = [day: tokens]
+        context.dailyModelTotals = [day: ["gpt-5.6-sol": tokens]]
+        context.dailyProjectTotals = [day: ["app": tokens]]
+        context.dailyProjectModelTotals = [day: ["app": ["gpt-5.6-sol": tokens]]]
+
+        let (cost, dailyRows) = try XCTUnwrap(
+            CodexCostScanner.makeCost(from: context) { _, at in
+                schedule.resolve(at: at)?.pricing ?? newRate
+            }
+        )
+        let daily = try XCTUnwrap(dailyRows.first)
+
+        XCTAssertEqual(cost.estimatedCostUSD, 3.0, accuracy: 0.0001)
+        XCTAssertEqual(cost.modelBreakdowns.first?.estimatedCostUSD ?? -1, 3.0, accuracy: 0.0001)
+        XCTAssertEqual(
+            cost.projectBreakdowns.first?.modelBreakdowns.first?.estimatedCostUSD ?? -1, 3.0, accuracy: 0.0001)
+        XCTAssertEqual(daily.estimatedCostUSD, 3.0, accuracy: 0.0001)
+        XCTAssertEqual(daily.modelBreakdowns?.first?.estimatedCostUSD ?? -1, 3.0, accuracy: 0.0001)
+        XCTAssertEqual(
+            daily.projectBreakdowns?.first?.modelBreakdowns.first?.estimatedCostUSD ?? -1, 3.0, accuracy: 0.0001)
     }
 
     // MARK: - CostSummaryBuilder

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -1149,7 +1149,7 @@ final class CostTrackerTests: XCTestCase {
             lifetime: nil
         )
 
-        tracker.apply(CostSummaryBuilder.CostSummaryScan(summary: partial, isComplete: false))
+        tracker.apply(CostSummaryBuilder.CostSummaryScan(summary: partial, deferredProviders: [.claude]))
 
         // The number on screen improves with every slice...
         XCTAssertEqual(tracker.costSummary?.totalCostUSD, 4)
@@ -1172,7 +1172,7 @@ final class CostTrackerTests: XCTestCase {
             lifetime: nil
         )
 
-        tracker.apply(CostSummaryBuilder.CostSummaryScan(summary: whole, isComplete: true))
+        tracker.apply(CostSummaryBuilder.CostSummaryScan(summary: whole))
 
         XCTAssertEqual(tracker.costSummary?.totalCostUSD, 9)
         XCTAssertNotEqual(tracker.lastScanDate, previous)
@@ -1244,7 +1244,7 @@ final class CostTrackerTests: XCTestCase {
             for: "/transcripts/a.jsonl"
         )
 
-        XCTAssertEqual(session.persist(), .failed)
+        XCTAssertEqual(session.persist(), CostScanPersistReport(claude: .failed, codex: .failed))
         // Nothing reached disk, so the offsets this slice committed are not
         // resumable — the next slice would re-read the same bytes.
         XCTAssertTrue(store.loadClaude().records.isEmpty)
@@ -1253,6 +1253,47 @@ final class CostTrackerTests: XCTestCase {
 
         XCTAssertEqual(session.persist(), .persisted)
         XCTAssertEqual(store.loadClaude().records["/transcripts/a.jsonl"]?.offset, 512)
+    }
+
+    /// The two caches are separate artifacts with separate failure modes, so one
+    /// provider's blocked write says nothing about the other's. Reporting a
+    /// shared verdict costs the healthy provider its resumable offsets: the
+    /// slice loop stops, and its next slice re-reads bytes it already paid for.
+    func testPersistIsolatesOneProvidersWriteFailureFromTheOthersProgress() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CostScanSplit-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        // A directory standing where the Claude artifact belongs: that write
+        // fails while the Codex artifact beside it lands normally.
+        try FileManager.default.createDirectory(
+            at: directory.appendingPathComponent(CostScanCacheStore.claudeFileName),
+            withIntermediateDirectories: true
+        )
+
+        let cutoff = Date(timeIntervalSince1970: 1_780_000_000)
+        let stamp = CostScanFileStamp(size: 4_096, modified: 1_780_000_000, fileID: 42)
+        let store = CostScanCacheStore(directory: directory)
+        let session = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        session.setClaudeRecord(
+            CostScanFileRecord(
+                offset: 512, stamp: stamp, cutoff: cutoff, isComplete: false, payload: ClaudeFileTotals()
+            ),
+            for: "/transcripts/a.jsonl"
+        )
+        session.setCodexRecord(
+            CostScanFileRecord(
+                offset: 512, stamp: stamp, cutoff: cutoff, isComplete: false, payload: CodexFileTotals(cutoff: cutoff)
+            ),
+            for: "/rollouts/b.jsonl"
+        )
+
+        let report = session.persist()
+
+        XCTAssertEqual(report.outcome(for: .claude), .failed)
+        XCTAssertEqual(report.outcome(for: .codex), .persisted)
+        XCTAssertTrue(store.loadClaude().records.isEmpty)
+        XCTAssertEqual(store.loadCodex().records["/rollouts/b.jsonl"]?.offset, 512)
     }
 
     func testPersistReportsNoStoreAsUnavailableRatherThanPersisted() {
@@ -1277,18 +1318,60 @@ final class CostTrackerTests: XCTestCase {
     // MARK: - Slice loop control
 
     func testAnotherSliceRunsOnlyWhenThePreviousOneLeftResumableProgress() {
-        let partial = CostSummaryBuilder.CostSummaryScan(summary: makeEmptySummary(), isComplete: false)
-        let whole = CostSummaryBuilder.CostSummaryScan(summary: makeEmptySummary(), isComplete: true)
+        let partial = CostSummaryBuilder.CostSummaryScan(
+            summary: makeEmptySummary(), deferredProviders: [.claude, .codex])
+        let whole = CostSummaryBuilder.CostSummaryScan(summary: makeEmptySummary())
+        let failed = CostScanPersistReport(claude: .failed, codex: .failed)
 
         XCTAssertTrue(CostTracker.shouldRunAnotherSlice(after: partial, persistence: .persisted))
         // A slice whose caches never landed leaves the store exactly as it found
         // it, so 63 more slices would re-read the same bytes and defer in the
         // same place.
-        XCTAssertFalse(CostTracker.shouldRunAnotherSlice(after: partial, persistence: .failed))
+        XCTAssertFalse(CostTracker.shouldRunAnotherSlice(after: partial, persistence: failed))
         // Same waste, different cause: with no store at all every slice rebuilds
         // an empty cache and re-reads the corpus from offset 0.
         XCTAssertFalse(CostTracker.shouldRunAnotherSlice(after: partial, persistence: .unavailable))
         XCTAssertFalse(CostTracker.shouldRunAnotherSlice(after: whole, persistence: .persisted))
+    }
+
+    /// The stop condition is per provider, not per slice: one provider that
+    /// cannot write must not end the other's scan, and must not keep the loop
+    /// alive once it is the only one left with work.
+    func testAnotherSliceRunsWhileAnyDeferringProviderStillPersistsItsProgress() {
+        let bothDeferred = CostSummaryBuilder.CostSummaryScan(
+            summary: makeEmptySummary(), deferredProviders: [.claude, .codex])
+        let claudeDeferred = CostSummaryBuilder.CostSummaryScan(
+            summary: makeEmptySummary(), deferredProviders: [.claude])
+        let report = CostScanPersistReport(claude: .failed, codex: .persisted)
+
+        XCTAssertTrue(CostTracker.shouldRunAnotherSlice(after: bothDeferred, persistence: report))
+        // Codex has finished; the only provider still deferring is the one whose
+        // offsets never reach disk, so another slice would read the same bytes.
+        XCTAssertFalse(CostTracker.shouldRunAnotherSlice(after: claudeDeferred, persistence: report))
+        // ...and the mirror image: Codex still has work and can still resume it.
+        XCTAssertTrue(
+            CostTracker.shouldRunAnotherSlice(
+                after: CostSummaryBuilder.CostSummaryScan(
+                    summary: makeEmptySummary(), deferredProviders: [.codex]),
+                persistence: report
+            )
+        )
+    }
+
+    /// Each scanner defers its own corpus. A shared flag would report Claude as
+    /// unfinished because Codex ran out of budget, and the slice loop's
+    /// per-provider stop condition reads this set.
+    func testDeferringOneProviderLeavesTheOtherReportedAsFinished() {
+        let session = CostScanSession(
+            cutoff: Date(timeIntervalSince1970: 1_780_000_000), options: .unlimited, store: nil)
+
+        XCTAssertTrue(session.isComplete)
+        XCTAssertEqual(session.deferredProviders, [])
+
+        session.noteDeferred(.codex)
+
+        XCTAssertFalse(session.isComplete)
+        XCTAssertEqual(session.deferredProviders, [.codex])
     }
 
     private func makeEmptySummary() -> CostSummary {

--- a/MeterBarTests/DatedModelPricingTests.swift
+++ b/MeterBarTests/DatedModelPricingTests.swift
@@ -52,6 +52,28 @@ final class DatedModelPricingTests: XCTestCase {
         XCTAssertEqual(resolved.verifiedOn, "2026-07-02")
     }
 
+    /// `resolve(at:)` stops at the first entry that starts after the requested
+    /// date. With more than two entries that shortcut has to land on the newest
+    /// applicable one — stopping an iteration early would return its predecessor.
+    func testResolvePicksTheNewestApplicableEntryAcrossALongSchedule() throws {
+        let rates = (1...5).map { step in
+            DatedTokenPricing(
+                effectiveFrom: DatedTokenPricing.utcDay(2026, step, 1),
+                verifiedOn: "2026-0\(step)-02",
+                pricing: TokenPricing(
+                    input: Double(step), output: 0, cacheCreation: 0, cacheRead: 0)
+            )
+        }
+        let schedule = PricingSchedule(rates)
+
+        for step in 1...5 {
+            let midMonth = DatedTokenPricing.utcDay(2026, step, 15)
+            let resolved = try XCTUnwrap(schedule.resolve(at: midMonth))
+            XCTAssertEqual(resolved.pricing.input, Double(step), "resolved the wrong entry for month \(step)")
+            XCTAssertEqual(resolved.verifiedOn, "2026-0\(step)-02")
+        }
+    }
+
     func testEntriesResolveRegardlessOfConstructionOrder() throws {
         let reversed = PricingSchedule([
             DatedTokenPricing(effectiveFrom: secondEffective, verifiedOn: "2026-07-02", pricing: newRate),

--- a/MeterBarTests/MenuBarFocusSelectionTests.swift
+++ b/MeterBarTests/MenuBarFocusSelectionTests.swift
@@ -17,6 +17,7 @@ final class MenuBarFocusSelectionTests: XCTestCase {
         service: ServiceType = .claudeCode,
         accountKey: String? = nil,
         percentUsed: Double,
+        total: Double = 100,
         displayName: String? = nil,
         windowName: String = "Session",
         pinKey: String? = nil,
@@ -30,7 +31,7 @@ final class MenuBarFocusSelectionTests: XCTestCase {
             accountKey: accountKey,
             displayName: displayName ?? key,
             windowName: windowName,
-            limit: UsageLimit(used: percentUsed, total: 100, resetTime: nil),
+            limit: UsageLimit(used: percentUsed, total: total, resetTime: nil),
             lastUpdated: now,
             lastActivity: activeMinutesAgo.map { now.addingTimeInterval(-$0 * 60) },
             isAutoSelectable: isAutoSelectable
@@ -163,6 +164,26 @@ final class MenuBarFocusSelectionTests: XCTestCase {
         )
 
         XCTAssertNil(select([cursorReview], bundleID: cursorBundleID))
+    }
+
+    /// A zero total reads as 100% left, which makes the window MeterBar can
+    /// measure least look like the one with the most headroom.
+    func testMappingToAProviderWithOnlyAnUnmeasurableWindowIsTreatedAsUnmapped() {
+        let cursorSession = candidate(key: "Cursor:default:session", service: .cursor, percentUsed: 0, total: 0)
+
+        XCTAssertNil(select([cursorSession], bundleID: cursorBundleID))
+    }
+
+    func testUnmeasurableWindowNeverStandsInForTheFocusedProvidersSpentOne() {
+        let cursorSession = candidate(key: "Cursor:default:session", service: .cursor, percentUsed: 0, total: 0)
+        let cursorWeekly = candidate(
+            key: "Cursor:default:weekly",
+            service: .cursor,
+            percentUsed: 100,
+            windowName: "Weekly"
+        )
+
+        XCTAssertEqual(select([cursorSession, cursorWeekly], bundleID: cursorBundleID)?.key, cursorWeekly.key)
     }
 
     // MARK: - Critical priority

--- a/MeterBarTests/SettingsViewSmokeTests.swift
+++ b/MeterBarTests/SettingsViewSmokeTests.swift
@@ -247,6 +247,36 @@ final class SettingsViewSmokeTests: XCTestCase {
         XCTAssertEqual(presentation.detail, "Worktree · loving/kalam")
     }
 
+    func testCostProjectPresentationStripsGeneratedWorktreeIDsFromEveryBranchDepth() {
+        for identifier in [
+            "www/vincentshipsit/public/meterbardev/.claude/worktrees/loving/kalam/ccb0b4",
+            "www/vincentshipsit/public/meterbardev/.claude/worktrees/nice/taussig/b68029",
+            "www/vincentshipsit/public/meterbardev/.claude/worktrees/0f1e2d"
+        ] {
+            let presentation = CostProjectPresentation(identifier: identifier)
+
+            XCTAssertEqual(presentation.title, "meterbardev", "\(identifier)")
+            XCTAssertFalse(
+                presentation.detail?.contains(identifier.split(separator: "/").last ?? "") ?? false,
+                "\(identifier) kept its generated ID"
+            )
+        }
+    }
+
+    /// Every one of these is valid hex, so the character class alone cannot tell
+    /// them from a generated ID — and a branch someone named `deadbeef` losing
+    /// its last segment is a worse failure than an ID surviving on screen.
+    func testCostProjectPresentationKeepsWorktreeNamesThatOnlyLookLikeIDs() {
+        for name in ["deadbeef", "cafe123", "decade", "facade", "accede"] {
+            let presentation = CostProjectPresentation(
+                identifier: "www/vincentshipsit/public/meterbardev/.claude/worktrees/loving/\(name)"
+            )
+
+            XCTAssertEqual(presentation.title, "meterbardev", "\(name)")
+            XCTAssertEqual(presentation.detail, "Worktree · loving/\(name)", "\(name) was mistaken for an ID")
+        }
+    }
+
     func testCostProjectPresentationExplainsUnknownAttribution() {
         let presentation = CostProjectPresentation(identifier: CostProjectAttribution.unknownProjectID)
 

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ModelPricing.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ModelPricing.swift
@@ -95,7 +95,10 @@ public struct PricingSchedule: Equatable, Sendable {
         guard let oldest = entries.first else { return nil }
 
         var chosen = oldest
-        for entry in entries where entry.effectiveFrom <= timestamp {
+        for entry in entries {
+            // Ascending order means the first entry that starts after the
+            // requested date ends the search — nothing later can apply.
+            guard entry.effectiveFrom <= timestamp else { break }
             chosen = entry
         }
 


### PR DESCRIPTION
Five independent correctness and performance fixes found while reading the cost
and menu-bar paths. One commit each.

## 1. Codex pricing fallback ignored the event's timestamp

**Problem.** `CodexCostScanner.makeCost` passed `pricingForName: { ModelPricing.codex(for: $0) }`,
whose `at:` defaults to `Date()`. Every fallback row was therefore priced at
today's rate, contradicting the invariant established in 84866cb that a pricing
event resolves at the rate in effect at its own timestamp. Dormant only because
the Codex cache-creation rate is currently $0.

**Fix.** `TokenUsageAggregator.makeDailyUsage` gained a date-aware resolver
(`pricingAt: ((String?, Date) -> TokenPricing)?`) that the scanner feeds with the
row's own day; window-level rows anchor on `context.latestDate`. The shape
matches `ModelPricing.codex(for:at:)` so it passes by function reference.
`makeBreakdowns`/`makeProjectBreakdowns` are unchanged.

**Verification.** Every entry in the shipped table is `.constant`, so a test
against real data proves nothing — the new test injects a synthetic dated
schedule with a non-zero historical rate and pins that a historical event is
priced at the old rate, not today's.

## 2. `PricingSchedule.resolve(at:)` scanned past its answer

**Problem.** Entries are sorted ascending, but the loop walked all of them.

**Fix.** `break` on the first entry newer than the requested date.

**Verification.** Behaviour-neutral, so the new test pins what an off-by-one
`break` would break: a five-entry schedule probed mid-month for every month must
return the newest applicable entry each time, never its predecessor.

## 3. One provider's cache-write failure stopped the other's scan

**Problem.** `CostScanSession.persist()` collapsed both cache writes into one
verdict, and `deferred` was a single flag. A blocked Claude write ended Codex's
scan while Codex was still resuming cleanly.

**Fix.** Both halves are now per provider: `deferredProviders: Set<CostScanProvider>`
and `CostScanPersistReport`. The slice loop's stop condition stays coherent by
pairing them — run another slice iff some provider *both* still has deferred work
*and* persisted its progress. That is what keeps the loop from spinning 64 times
writing nothing once the only provider still deferring is the one that cannot
write.

**Verification.** New tests cover the isolation (a directory planted at the
Claude artifact's path fails that write while the Codex artifact beside it lands)
and the four corners of the stop condition, including the case where one provider
finishes and the other is permanently blocked.

## 4. `looksLikeWorktreeID` mangled ordinary names

**Problem.** Any 6–12 character all-hex string was stripped from the displayed
project name, so `deadbeef`, `cafe123`, `decade`, `facade`, and `accede` lost
their last path segment.

**Fix.** Require the generated ID's exact 6-character width, all lowercase hex,
and at least one decimal digit. That costs the 1-in-360 real IDs that draw no
digit — cheaper than mangling a directory someone named.

**Verification.** New tests cover both directions: generated IDs at three branch
depths are still stripped, and each of the five hex-looking words survives.

## 5. `tightest` could pick a zero-total limit

**Problem.** A zero total yields `rawPercentage == 0`, so `QuotaMath.percentLeft`
reads it as 100% left. `MenuBarFocusSelector.tightest` had no zero-total filter,
so the one window MeterBar cannot measure could represent the focused provider —
ahead of that provider's spent windows.

**Fix.** Filter `limit.total > 0` first, matching `ProviderRecommendation.bindingWindow`.
No fallback pool: with nothing measurable for the focused provider, focus has no
opinion and Auto decides — the selector's existing "no data is indistinguishable
from no mapping" contract.

**Verification.** New tests pin that an unmeasurable-only provider falls through
to Auto, and that a spent measurable window is preferred over an unmeasurable one.

## Verification

- `swift test` — 1936 tests, 5 skipped, 0 failures.
- `swiftlint --quiet` — clean.
