### PR TITLE
fix(cost): budget the Codex fold fallback, recover usage past the truncation cap, and surface dropped records

### DIFF
--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -214,12 +214,12 @@ enum ClaudeCostScanner {
         var lifetimeKeyed: [String: ClaudeUsageEvent] = [:]
         var lifetimeUnkeyed: [ClaudeUsageEvent] = []
 
-        // A line the reader had to truncate is parsed like any other: the usage
-        // block sits near the front of a transcript record, so the retained
-        // prefix often still decodes. Only a prefix that fails to parse is
-        // skipped — never the line for being long.
+        var truncation = CostScanTruncationTally()
+
         FileLineReader.forEachLine(in: url) { line in
-            guard let event = Self.usageEvent(from: line.bytes, url: url) else { return }
+            let event = Self.usageEvent(from: line, url: url)
+            truncation.note(line, recovered: event != nil)
+            guard let event else { return }
 
             let inPeriod = event.timestamp >= cutoffDate
             if let key = event.deduplicationKey {
@@ -230,6 +230,7 @@ enum ClaudeCostScanner {
                 if inPeriod { periodUnkeyed.append(event) }
             }
         }
+        truncation.log(url: url)
 
         return ScanWindows(
             period: Self.tally(keyed: periodKeyed, unkeyed: periodUnkeyed, projectID: projectID),
@@ -240,10 +241,74 @@ enum ClaudeCostScanner {
 
     /// Decodes one transcript line into a usage event, or `nil` when the line is
     /// not one (blank, malformed, or a non-usage record).
-    nonisolated private static func usageEvent(from lineData: Data, url: URL) -> ClaudeUsageEvent? {
-        guard !lineData.isEmpty,
-              let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
-              let timestampStr = json["timestamp"] as? String,
+    ///
+    /// A line the reader had to truncate gets a second attempt through the
+    /// salvage path. `content` precedes `usage` inside a Claude record and the
+    /// top-level `timestamp` trails the whole message object, so a line made
+    /// oversized by its content leaves nothing decodable in the retained prefix
+    /// — every token in it used to be lost silently.
+    nonisolated private static func usageEvent(from line: FileLineReader.Line, url: URL) -> ClaudeUsageEvent? {
+        if !line.bytes.isEmpty,
+           let json = try? JSONSerialization.jsonObject(with: line.bytes) as? [String: Any],
+           let event = Self.usageEvent(json: json, url: url) {
+            return event
+        }
+        guard line.wasTruncated else { return nil }
+        return Self.usageEvent(json: Self.salvagedJSON(from: line), url: url)
+    }
+
+    /// Reassembles the fields a usage event needs from the two windows a
+    /// truncated line carries.
+    ///
+    /// Which occurrence to trust follows from the record's field order: `model`
+    /// and `id` sit ahead of `content`, so the head prefix's first match is the
+    /// record's own, while `usage`, `timestamp` and `requestId` all trail it and
+    /// the tail's last match is. Anything a matching key finds earlier came from
+    /// inside `content` and is not the record speaking.
+    ///
+    /// `origin` cannot be salvaged: it is derived from the `tool_use` blocks in
+    /// `content`, which is exactly the part that was cut. A salvaged event lands
+    /// in "Main chat" unless the record declared itself a sidechain.
+    nonisolated private static func salvagedJSON(from line: FileLineReader.Line) -> [String: Any] {
+        var message: [String: Any] = [:]
+        if let usage = Self.salvagedUsage(in: line.truncatedTail) {
+            message["usage"] = usage
+        }
+        if let model = TruncatedJSONLineSalvage.firstValue(forKey: "model", in: line.bytes) as? String {
+            message["model"] = model
+        }
+        if let messageID = TruncatedJSONLineSalvage.firstValue(forKey: "id", in: line.bytes) as? String {
+            message["id"] = messageID
+        }
+
+        var json: [String: Any] = ["message": message]
+        if let timestamp = TruncatedJSONLineSalvage.lastValue(forKey: "timestamp", in: line.truncatedTail) as? String {
+            json["timestamp"] = timestamp
+        }
+        if let requestID = TruncatedJSONLineSalvage.lastValue(forKey: "requestId", in: line.truncatedTail) as? String {
+            json["requestId"] = requestID
+        }
+        if let isSidechain = TruncatedJSONLineSalvage.firstValue(forKey: "isSidechain", in: line.bytes) as? Bool {
+            json["isSidechain"] = isSidechain
+        }
+        return json
+    }
+
+    /// The last `usage` object in the tail that actually carries token fields.
+    ///
+    /// The filter is what separates the record's own accounting from a `"usage"`
+    /// that happens to appear inside a transcript's prose.
+    nonisolated private static func salvagedUsage(in tail: Data) -> [String: Any]? {
+        let tokenKeys = ["input_tokens", "output_tokens", "cache_creation_input_tokens", "cache_read_input_tokens"]
+        return TruncatedJSONLineSalvage.values(forKey: "usage", in: tail)
+            .reversed()
+            .lazy
+            .compactMap { $0 as? [String: Any] }
+            .first { candidate in tokenKeys.contains(where: { candidate[$0] != nil }) }
+    }
+
+    nonisolated private static func usageEvent(json: [String: Any], url: URL) -> ClaudeUsageEvent? {
+        guard let timestampStr = json["timestamp"] as? String,
               let timestamp = FlexibleISO8601.date(from: timestampStr),
               let message = json["message"] as? [String: Any],
               let usage = message["usage"] as? [String: Any] else {
@@ -349,8 +414,12 @@ enum ClaudeCostScanner {
         var lifetimeKeyed: [String: ClaudeUsageEvent] = [:]
         var lifetimeUnkeyed: [ClaudeUsageEvent] = []
 
+        var truncation = CostScanTruncationTally()
+
         let read = FileLineReader.readLines(in: file.url, request: request) { line, _ in
-            guard let event = Self.usageEvent(from: line.bytes, url: file.url) else { return }
+            let event = Self.usageEvent(from: line, url: file.url)
+            truncation.note(line, recovered: event != nil)
+            guard let event else { return }
 
             if let key = event.deduplicationKey {
                 // First-wins across a resume boundary: an event with this key is
@@ -368,6 +437,8 @@ enum ClaudeCostScanner {
                 if event.timestamp >= session.cutoff { periodUnkeyed.append(event) }
             }
         }
+
+        truncation.log(url: file.url)
 
         guard let read else {
             // Unreadable (permissions, deleted mid-scan). Keep whatever the

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -135,6 +135,53 @@ enum CodexCostScanner {
         ]
     }
 
+    /// The conversation a rollout belongs to, taken from its file name.
+    ///
+    /// Codex names rollouts `rollout-<ISO timestamp>-<session uuid>.jsonl` and
+    /// keeps the whole name when it archives one, so the trailing UUID is what
+    /// ties the copy in `archived_sessions/` to the one still being written in
+    /// `sessions/`. Anything that does not end in a UUID — an older layout, a
+    /// hand-placed file — is its own session under its full stem.
+    nonisolated static func rolloutSessionID(for url: URL) -> String {
+        let stem = url.deletingPathExtension().lastPathComponent
+        let uuidLength = 36
+        guard stem.count > uuidLength else { return stem }
+        let suffix = String(stem.suffix(uuidLength))
+        guard UUID(uuidString: suffix) != nil else { return stem }
+        return suffix.lowercased()
+    }
+
+    /// One file per conversation, in the order the scan should read them.
+    ///
+    /// A session that exists in both `sessions/` and `archived_sessions/` is the
+    /// same bytes twice. Reading both and reconciling them afterwards is what
+    /// used to force a whole rollout back through an unbudgeted re-parse on
+    /// every slice; picking a copy up front removes that case instead of paying
+    /// for it. The larger copy wins because archiving happens while a session is
+    /// still live, so the archived snapshot can be short — and a tie goes to the
+    /// copy found last, which is the one under `sessions/` that may still grow.
+    nonisolated static func distinctRollouts(in directories: [URL]) -> [CostScanFile] {
+        var order: [String] = []
+        var chosen: [String: CostScanFile] = [:]
+        var seen: Set<String> = []
+
+        for directory in directories {
+            guard CostScanFileSystem.isLocalDirectory(directory) else { continue }
+
+            for file in CostScanCorpus.transcripts(in: directory) {
+                guard seen.insert(file.cacheKey).inserted else { continue }
+                let sessionID = Self.rolloutSessionID(for: file.url)
+                guard let incumbent = chosen[sessionID] else {
+                    chosen[sessionID] = file
+                    order.append(sessionID)
+                    continue
+                }
+                if file.size >= incumbent.size { chosen[sessionID] = file }
+            }
+        }
+        return order.compactMap { chosen[$0] }
+    }
+
     // swiftlint:disable contains_over_range_nil_comparison
     /// The byte-level equivalent of the old `line.contains("\"token_count\"")`
     /// prefilter. Rollout files are mostly non-usage events, so skipping
@@ -202,6 +249,7 @@ enum CodexCostScanner {
         // the rollout context: a sibling rollout's model must never name events
         // this file left unexplained.
         var deferred: [CodexDeferredUsage] = []
+        var truncation = CostScanTruncationTally()
 
         FileLineReader.forEachLine(in: fileURL) { readerLine in
             let line = readerLine.bytes
@@ -215,6 +263,12 @@ enum CodexCostScanner {
                 }
                 return
             }
+            // Counted only past this guard, and so only for usage lines. Codex
+            // rollouts are full of oversized `function_call_output` records that
+            // carry no accounting; calling their truncation a dropped record
+            // would bury the one case that costs tokens under thousands that
+            // cost nothing.
+            let produced = events.count + deferred.count
             Self.addTokenCountLine(
                 line,
                 fileURL: fileURL,
@@ -222,23 +276,12 @@ enum CodexCostScanner {
                 deferred: &deferred,
                 events: &events
             )
+            truncation.note(readerLine, recovered: events.count + deferred.count > produced)
         }
         // Whatever the file never explained is genuinely unattributed.
         Self.flushDeferred(&deferred, modelName: nil, into: &events)
+        truncation.log(url: fileURL)
         return events
-    }
-
-    /// Streams one rollout end to end into `windows`.
-    ///
-    /// Attribution state is created here and dies here: carried across rollouts
-    /// it would label one session's spend with another's model.
-    nonisolated private static func parseRollout(
-        at fileURL: URL,
-        windows: inout ScanWindows<CodexScanContext>
-    ) {
-        for event in Self.parseRollout(at: fileURL) {
-            Self.apply(event, windows: &windows)
-        }
     }
 
     /// Single-window entry point kept for callers that only care about one
@@ -289,24 +332,27 @@ enum CodexCostScanner {
         session: CostScanSession
     ) -> ScanWindows<CodexScanContext> {
         var windows = Self.scanWindows(cutoff: session.cutoff)
+        let files = Self.distinctRollouts(in: directories)
         var live: Set<String> = []
 
-        for directory in directories {
-            guard CostScanFileSystem.isLocalDirectory(directory) else { continue }
-
-            for file in CostScanCorpus.transcripts(in: directory) {
-                guard live.insert(file.cacheKey).inserted else { continue }
-                guard let totals = Self.totals(for: file, session: session) else { continue }
-                guard Self.fold(totals, into: &windows) else {
-                    // This rollout shares events with one already folded in —
-                    // in practice a session that exists in both `sessions/` and
-                    // `archived_sessions/` at once. Aggregates cannot be
-                    // de-overlapped after the fact, so this one file goes back
-                    // through the live path, where `addUsage` drops the
-                    // duplicates event by event.
-                    Self.parseRollout(at: file.url, windows: &windows)
-                    continue
-                }
+        for file in files {
+            live.insert(file.cacheKey)
+            guard let totals = Self.totals(for: file, session: session) else { continue }
+            guard Self.fold(totals, into: &windows) else {
+                // This rollout shares only *some* of its events with one already
+                // folded in. Aggregates cannot be de-overlapped after the fact,
+                // so the file goes back through the event-level path, where
+                // `apply` drops each duplicate against the window's `eventKeys`.
+                //
+                // Rollouts duplicated across `sessions/` and
+                // `archived_sessions/` no longer reach here at all — only one
+                // copy is ever read. What is left is two genuinely different
+                // conversations that recorded the same event, which still costs
+                // a re-read on every slice; it is budgeted and cancellable, but
+                // it is not cached, because a tally that overlaps the shared
+                // windows is not one a later refresh can reuse.
+                Self.foldByEvent(file, session: session, windows: &windows)
+                continue
             }
         }
 
@@ -348,6 +394,7 @@ enum CodexCostScanner {
         var rollout = payload.rollout
         var deferred: [CodexDeferredUsage] = []
         var deferredOffset: UInt64?
+        var truncation = CostScanTruncationTally()
 
         var request = FileLineReadRequest()
         request.startOffset = record?.offset ?? 0
@@ -364,6 +411,7 @@ enum CodexCostScanner {
                 return
             }
             let parked = deferred.count
+            let counted = windows.lifetime.eventKeys.count
             Self.addTokenCountLine(
                 line,
                 fileURL: file.url,
@@ -371,10 +419,15 @@ enum CodexCostScanner {
                 deferred: &deferred,
                 windows: &windows
             )
+            truncation.note(
+                readerLine,
+                recovered: deferred.count > parked || windows.lifetime.eventKeys.count > counted
+            )
             if deferred.count > parked, deferredOffset == nil {
                 deferredOffset = offset
             }
         }
+        truncation.log(url: file.url)
 
         guard let read else { return record?.payload }
         session.budget.consume(read.bytesRead)
@@ -409,6 +462,68 @@ enum CodexCostScanner {
             for: file.cacheKey
         )
         return payload
+    }
+
+    /// Streams one rollout straight into the shared windows, under the same
+    /// budget every other read answers to.
+    ///
+    /// The per-file cache is deliberately left alone. This read starts at byte
+    /// zero and produces no tally of its own, so there is nothing here a later
+    /// slice could resume from — the record `totals(for:session:)` already
+    /// committed stays the file's cached state.
+    nonisolated private static func foldByEvent(
+        _ file: CostScanFile,
+        session: CostScanSession,
+        windows: inout ScanWindows<CodexScanContext>
+    ) {
+        let allowance = session.budget.allowance
+        guard allowance > 0 else {
+            session.noteDeferred()
+            return
+        }
+
+        var rollout = CodexRolloutContext()
+        var deferred: [CodexDeferredUsage] = []
+        var truncation = CostScanTruncationTally()
+        var request = FileLineReadRequest()
+        request.maxBytes = allowance
+
+        let read = FileLineReader.readLines(in: file.url, request: request) { readerLine, _ in
+            let line = readerLine.bytes
+            guard line.range(of: Self.tokenCountMarker) != nil else {
+                Self.updateRolloutContext(&rollout, from: line)
+                if let model = rollout.turnModel ?? rollout.sessionModel {
+                    Self.flushDeferred(&deferred, modelName: model, windows: &windows)
+                }
+                return
+            }
+            let parked = deferred.count
+            let counted = windows.lifetime.eventKeys.count
+            Self.addTokenCountLine(
+                line,
+                fileURL: file.url,
+                rollout: rollout,
+                deferred: &deferred,
+                windows: &windows
+            )
+            truncation.note(
+                readerLine,
+                recovered: deferred.count > parked || windows.lifetime.eventKeys.count > counted
+            )
+        }
+        truncation.log(url: file.url)
+
+        guard let read else { return }
+        session.budget.consume(read.bytesRead)
+
+        if read.reachedEndOfFile {
+            Self.flushDeferred(&deferred, modelName: nil, windows: &windows)
+        } else {
+            // Whatever is still parked belongs to a model the unread remainder
+            // may yet name. Dropping it as unattributed would be worse than
+            // letting the next slice read the file again.
+            session.noteDeferred()
+        }
     }
 
     /// Adds one rollout's tally to the shared windows.

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -167,8 +167,15 @@ enum CodexCostScanner {
     /// for it. The larger copy wins because archiving happens while a session is
     /// still live, so the archived snapshot can be short — and a tie goes to the
     /// copy found last, which is the one under `sessions/` that may still grow.
+    ///
+    /// The result is re-sorted rather than returned in discovery order.
+    /// `CostScanCorpus.transcripts` only orders within one directory, and
+    /// `archived_sessions` is enumerated first, so discovery order would put
+    /// every archived rollout ahead of every live one — handing a slice's whole
+    /// budget to the oldest conversations on disk. The comparator is the
+    /// corpus's own, so a rollout's position does not depend on which directory
+    /// its surviving copy came from.
     nonisolated static func distinctRollouts(in directories: [URL]) -> [CostScanFile] {
-        var order: [String] = []
         var chosen: [String: CostScanFile] = [:]
         var seen: Set<String> = []
 
@@ -180,13 +187,14 @@ enum CodexCostScanner {
                 let sessionID = Self.rolloutSessionID(for: file.url)
                 guard let incumbent = chosen[sessionID] else {
                     chosen[sessionID] = file
-                    order.append(sessionID)
                     continue
                 }
                 if file.size >= incumbent.size { chosen[sessionID] = file }
             }
         }
-        return order.compactMap { chosen[$0] }
+        return chosen.values.sorted {
+            $0.modified == $1.modified ? $0.url.path < $1.url.path : $0.modified > $1.modified
+        }
     }
 
     // swiftlint:disable contains_over_range_nil_comparison

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -485,7 +485,7 @@ enum CodexCostScanner {
     ) {
         let allowance = session.budget.allowance
         guard allowance > 0 else {
-            session.noteDeferred()
+            session.noteDeferred(.codex)
             return
         }
 
@@ -529,7 +529,7 @@ enum CodexCostScanner {
             // Whatever is still parked belongs to a model the unread remainder
             // may yet name. Dropping it as unattributed would be worse than
             // letting the next slice read the file again.
-            session.noteDeferred()
+            session.noteDeferred(.codex)
         }
     }
 

--- a/MeterBar/Services/CostScanTruncationTally.swift
+++ b/MeterBar/Services/CostScanTruncationTally.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Counts the lines a scan could not retain whole, and how many of them still
+/// yielded usage.
+///
+/// A truncated line that salvage cannot decode is a record whose tokens are
+/// missing from the totals. Nothing in the pipeline surfaced that before: the
+/// reader flagged the line, the scanner dropped it through a `try?`, and the
+/// number the menu bar showed was quietly short. One line per affected file is
+/// enough to make that visible without turning a 10 GB corpus into a log flood.
+///
+/// Only counts and the file's path are ever logged — never a byte of the line.
+nonisolated struct CostScanTruncationTally {
+    private(set) var truncated = 0
+    private(set) var recovered = 0
+
+    var unrecovered: Int { truncated - recovered }
+    var isEmpty: Bool { truncated == 0 }
+
+    mutating func note(_ line: FileLineReader.Line, recovered: Bool) {
+        guard line.wasTruncated else { return }
+        truncated += 1
+        if recovered { self.recovered += 1 }
+    }
+
+    /// Emits at most one line per file. Silent when the file had no truncation,
+    /// which is the overwhelming majority of them.
+    func log(url: URL) {
+        guard !isEmpty else { return }
+        if unrecovered == 0 {
+            AppLog.cost.notice(
+                """
+                Recovered usage from \(recovered, privacy: .public) oversized line(s) \
+                in \(url.path, privacy: .private)
+                """
+            )
+        } else {
+            AppLog.cost.warning(
+                """
+                Dropped \(unrecovered, privacy: .public) of \(truncated, privacy: .public) oversized line(s), \
+                recovered \(recovered, privacy: .public), in \(url.path, privacy: .private)
+                """
+            )
+        }
+    }
+}

--- a/MeterBar/Services/CostScanTruncationTally.swift
+++ b/MeterBar/Services/CostScanTruncationTally.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Counts the lines a scan could not retain whole, and how many of them still
 /// yielded usage.

--- a/MeterBar/Services/CostScanValues.swift
+++ b/MeterBar/Services/CostScanValues.swift
@@ -10,7 +10,7 @@ enum CostScanValues {
     /// Bump this whenever a change alters parsed output: usage extraction,
     /// deduplication, pricing, model normalization, or local-day bucketing.
     /// A mismatch discards the persisted cache and performs a full rescan.
-    nonisolated static let costCacheParserVersion = 1
+    nonisolated static let costCacheParserVersion = 2
 
     /// Token counts arrive as `Int`, `Int64`, `Double`, or a numeric string
     /// depending on which writer produced the log line; coerce every shape.

--- a/MeterBar/Services/FileLineReader.swift
+++ b/MeterBar/Services/FileLineReader.swift
@@ -21,6 +21,9 @@ nonisolated struct FileLineReadRequest {
     /// Leading bytes of an oversized line passed to the parser.
     var prefixBytes: Int = FileLineReader.defaultPrefixBytes
 
+    /// Trailing bytes of an oversized line kept alongside the prefix.
+    var salvageTailBytes: Int = FileLineReader.defaultSalvageTailBytes
+
     /// Yield the final line even when it has no trailing newline and is not
     /// structurally complete JSON.
     ///
@@ -74,6 +77,15 @@ nonisolated enum FileLineReader {
     /// usage record and under-report spend, which is the failure this avoids.
     static let defaultPrefixBytes = 1024 * 1024
 
+    /// 256 KiB — the trailing window of an oversized line kept for salvage.
+    ///
+    /// A Claude transcript record orders `content` before `usage` and puts the
+    /// top-level `timestamp` after the whole message object, so a line made
+    /// oversized by its content strands both fields the accounting needs past
+    /// the prefix cut. They sit within the last few hundred bytes of the record;
+    /// this window reaches them without retention ever tracking line length.
+    static let defaultSalvageTailBytes = 256 * 1024
+
     /// One line of the file, carrying enough context for a caller to tell a
     /// whole record from a salvaged prefix.
     struct Line {
@@ -87,6 +99,17 @@ nonisolated enum FileLineReader {
         /// Callers should still try to parse it: a truncated record whose usage
         /// fields survived is real spend and must be counted.
         let wasTruncated: Bool
+        /// The last `salvageTailBytes` of a truncated line, cut at an arbitrary
+        /// byte. Empty whenever `wasTruncated` is `false`. It is not valid JSON
+        /// on its own — only ``TruncatedJSONLineSalvage`` should read it.
+        let truncatedTail: Data
+
+        init(bytes: Data, byteCount: Int, wasTruncated: Bool, truncatedTail: Data = Data()) {
+            self.bytes = bytes
+            self.byteCount = byteCount
+            self.wasTruncated = wasTruncated
+            self.truncatedTail = truncatedTail
+        }
     }
 
     private static let newline = UInt8(ascii: "\n")
@@ -112,6 +135,8 @@ nonisolated enum FileLineReader {
     ///     only keeps counting, so peak retention never tracks line length.
     ///   - prefixBytes: Bytes of an oversized line handed to `body`. Clamped to
     ///     `maxLineBytes`, since nothing beyond that was ever buffered.
+    ///   - salvageTailBytes: Trailing bytes of an oversized line kept alongside
+    ///     the prefix, for the fields that sit past the cut.
     /// - Returns: `false` when the file could not be opened, `true` otherwise.
     ///   An empty file opens successfully and yields nothing.
     @discardableResult
@@ -120,12 +145,14 @@ nonisolated enum FileLineReader {
         chunkSize: Int = defaultChunkSize,
         maxLineBytes: Int = defaultMaxLineBytes,
         prefixBytes: Int = defaultPrefixBytes,
+        salvageTailBytes: Int = defaultSalvageTailBytes,
         _ body: (Line) -> Void
     ) -> Bool {
         var request = FileLineReadRequest()
         request.chunkSize = chunkSize
         request.maxLineBytes = maxLineBytes
         request.prefixBytes = prefixBytes
+        request.salvageTailBytes = salvageTailBytes
         // Whole-file reads have no budget and no follow-up pass, so a trailing
         // fragment is all the caller will ever get — yield it.
         request.commitsUnterminatedTrailingLine = true
@@ -158,25 +185,41 @@ nonisolated enum FileLineReader {
         let chunkSize = max(1, request.chunkSize)
         let cap = max(0, request.maxLineBytes)
         let prefix = min(max(0, request.prefixBytes), cap)
+        let tail = max(0, request.salvageTailBytes)
         let budget = max(0, request.maxBytes)
         var committed = request.startOffset
         var bytesRead = 0
         var reachedEnd = false
         var retained = Data()
+        var overflow = Data()
         var byteCount = 0
 
         // Counts every byte of the line but stops copying once the cap is hit.
+        // Past the cap a rolling window of the most recent bytes is kept, halved
+        // back to `tail` whenever it doubles, so both buffers stay flat no matter
+        // how long the line runs.
         func absorb(_ start: UnsafePointer<UInt8>, count: Int) {
             byteCount += count
-            guard retained.count < cap else { return }
-            let room = cap - retained.count
-            retained.append(start, count: min(count, room))
+            var consumed = 0
+            if retained.count < cap {
+                consumed = min(count, cap - retained.count)
+                retained.append(start, count: consumed)
+            }
+            guard tail > 0, consumed < count else { return }
+            overflow.append(start + consumed, count: count - consumed)
+            if overflow.count > 2 * tail {
+                overflow = Data(overflow.suffix(tail))
+            }
         }
 
         func emitRetained(hasNewline: Bool) {
-            body(Self.line(retained, byteCount: byteCount, prefixBytes: prefix), committed)
+            let line = Self.line(
+                retained, overflow: overflow, byteCount: byteCount, prefixBytes: prefix, tailBytes: tail
+            )
+            body(line, committed)
             committed += UInt64(byteCount + (hasNewline ? 1 : 0))
             retained = Data()
+            overflow = Data()
             byteCount = 0
         }
 
@@ -230,7 +273,9 @@ nonisolated enum FileLineReader {
         // happen to look like complete JSON.
         let stoppedForBudget = !reachedEnd && bytesRead >= budget
         if byteCount > 0, !stoppedForBudget {
-            let line = Self.line(retained, byteCount: byteCount, prefixBytes: prefix)
+            let line = Self.line(
+                retained, overflow: overflow, byteCount: byteCount, prefixBytes: prefix, tailBytes: tail
+            )
             if request.commitsUnterminatedTrailingLine
                 || (!line.wasTruncated && isStructurallyCompleteJSONLine(line.bytes)) {
                 emitRetained(hasNewline: false)
@@ -295,16 +340,27 @@ nonisolated enum FileLineReader {
     }
 
     /// Builds the emitted line: trims an oversized buffer down to the salvage
-    /// prefix, and drops a CRLF carriage return.
+    /// prefix and its trailing window, and drops a CRLF carriage return.
     ///
     /// The copies matter: slicing `Data` keeps the parent's non-zero
     /// `startIndex`, and `JSONSerialization` has historically mis-read offset
     /// slices. The carriage return is only stripped from a complete line — on a
     /// truncated one the last byte is an arbitrary mid-line byte, not a
     /// terminator.
-    private static func line(_ retained: Data, byteCount: Int, prefixBytes: Int) -> Line {
+    private static func line(
+        _ retained: Data,
+        overflow: Data,
+        byteCount: Int,
+        prefixBytes: Int,
+        tailBytes: Int
+    ) -> Line {
         guard byteCount <= retained.count else {
-            return Line(bytes: Data(retained.prefix(prefixBytes)), byteCount: byteCount, wasTruncated: true)
+            return Line(
+                bytes: Data(retained.prefix(prefixBytes)),
+                byteCount: byteCount,
+                wasTruncated: true,
+                truncatedTail: Data(overflow.suffix(tailBytes))
+            )
         }
         if retained.last == UInt8(ascii: "\r") {
             return Line(bytes: Data(retained.dropLast()), byteCount: byteCount, wasTruncated: false)

--- a/MeterBar/Services/TruncatedJSONLineSalvage.swift
+++ b/MeterBar/Services/TruncatedJSONLineSalvage.swift
@@ -1,0 +1,191 @@
+import Foundation
+
+/// Pulls individual JSON values out of a window cut from a line too long to
+/// retain whole.
+///
+/// Neither window a truncated line carries is parseable JSON: the prefix stops
+/// mid-record and the tail starts mid-record. `JSONSerialization` rejects both,
+/// so the fields a usage event needs have to be lifted out one at a time.
+///
+/// This is a heuristic and cannot be anything else. A tail begins at an
+/// arbitrary byte, so there is no way to know from inside the window whether a
+/// given quote opens or closes a string — a `"usage":` sequence appearing inside
+/// a `content` string is indistinguishable from the real one. Two things keep it
+/// honest: an extracted value must parse on its own, and the caller decides
+/// which occurrence to trust (`usage` sits after `content` in every Claude
+/// record, so the last match in the tail is the record's own). Both are why the
+/// output is only ever used to recover accounting from a line that would
+/// otherwise be dropped outright, never to override a line that parsed.
+nonisolated enum TruncatedJSONLineSalvage {
+    /// 64 KiB. Every field worth salvaging — a usage object, a timestamp, a
+    /// model name — is orders of magnitude smaller; a candidate this large is a
+    /// false positive that ran off into the record's content.
+    static let maximumValueBytes = 64 * 1024
+
+    /// Ceiling on candidates considered for one key, so a window full of
+    /// `"usage"` occurrences cannot turn salvage into a quadratic scan.
+    static let maximumMatches = 64
+
+    /// Every value found for `key`, in the order they appear in `window`.
+    static func values(forKey key: String, in window: Data, maximumMatches: Int = maximumMatches) -> [Any] {
+        guard !window.isEmpty, !key.isEmpty else { return [] }
+        let needle = Data("\"\(key)\"".utf8)
+        var found: [Any] = []
+        var searchStart = window.startIndex
+
+        while found.count < maximumMatches, searchStart < window.endIndex,
+              let match = window.range(of: needle, in: searchStart..<window.endIndex) {
+            searchStart = match.upperBound
+            guard let colon = Self.index(ofColonAfter: match.upperBound, in: window),
+                  let value = Self.value(startingAfter: colon, in: window) else { continue }
+            found.append(value)
+        }
+        return found
+    }
+
+    static func firstValue(forKey key: String, in window: Data) -> Any? {
+        Self.values(forKey: key, in: window, maximumMatches: 1).first
+    }
+
+    static func lastValue(forKey key: String, in window: Data) -> Any? {
+        Self.values(forKey: key, in: window).last
+    }
+
+    /// Index of the `:` that follows a key, or `nil` if anything but whitespace
+    /// sits between the two — which means the match was a string, not a key.
+    private static func index(ofColonAfter start: Data.Index, in window: Data) -> Data.Index? {
+        var cursor = start
+        while cursor < window.endIndex {
+            switch window[cursor] {
+            case UInt8(ascii: " "), UInt8(ascii: "\t"), UInt8(ascii: "\r"), UInt8(ascii: "\n"):
+                cursor = window.index(after: cursor)
+            case UInt8(ascii: ":"):
+                return cursor
+            default:
+                return nil
+            }
+        }
+        return nil
+    }
+
+    /// Decodes the value that begins after `colon`, bounded by
+    /// ``maximumValueBytes`` and by the end of the window.
+    private static func value(startingAfter colon: Data.Index, in window: Data) -> Any? {
+        var cursor = window.index(after: colon)
+        while cursor < window.endIndex, Self.isWhitespace(window[cursor]) {
+            cursor = window.index(after: cursor)
+        }
+        guard cursor < window.endIndex else { return nil }
+        let limit = window.index(cursor, offsetBy: maximumValueBytes, limitedBy: window.endIndex) ?? window.endIndex
+
+        let end: Data.Index?
+        switch window[cursor] {
+        case UInt8(ascii: "{"):
+            end = Self.balanced(
+                from: cursor,
+                to: limit,
+                in: window,
+                open: UInt8(ascii: "{"),
+                close: UInt8(ascii: "}")
+            )
+        case UInt8(ascii: "["):
+            end = Self.balanced(
+                from: cursor,
+                to: limit,
+                in: window,
+                open: UInt8(ascii: "["),
+                close: UInt8(ascii: "]")
+            )
+        case UInt8(ascii: "\""):
+            end = Self.quoted(from: cursor, to: limit, in: window)
+        default:
+            end = Self.literal(from: cursor, to: limit, in: window)
+        }
+        guard let end else { return nil }
+
+        // Zero-based copy: `JSONSerialization` has historically mis-read slices
+        // that carry a non-zero `startIndex`.
+        let bytes = Data(window[cursor..<end])
+        return try? JSONSerialization.jsonObject(with: bytes, options: [.fragmentsAllowed])
+    }
+
+    private static func balanced(
+        from start: Data.Index,
+        to limit: Data.Index,
+        in window: Data,
+        open: UInt8,
+        close: UInt8
+    ) -> Data.Index? {
+        var depth = 0
+        var inString = false
+        var escaped = false
+        var cursor = start
+
+        while cursor < limit {
+            let byte = window[cursor]
+            cursor = window.index(after: cursor)
+            if escaped {
+                escaped = false
+                continue
+            }
+            if inString {
+                switch byte {
+                case UInt8(ascii: "\\"): escaped = true
+                case UInt8(ascii: "\""): inString = false
+                default: break
+                }
+                continue
+            }
+            switch byte {
+            case UInt8(ascii: "\""): inString = true
+            case open: depth += 1
+            case close:
+                depth -= 1
+                if depth == 0 { return cursor }
+            default: break
+            }
+        }
+        return nil
+    }
+
+    private static func quoted(from start: Data.Index, to limit: Data.Index, in window: Data) -> Data.Index? {
+        var escaped = false
+        var cursor = window.index(after: start)
+
+        while cursor < limit {
+            let byte = window[cursor]
+            cursor = window.index(after: cursor)
+            if escaped {
+                escaped = false
+                continue
+            }
+            switch byte {
+            case UInt8(ascii: "\\"): escaped = true
+            case UInt8(ascii: "\""): return cursor
+            default: break
+            }
+        }
+        return nil
+    }
+
+    /// End of a bare `true` / `false` / `null` / number. A literal running to the
+    /// edge of the window was cut by the truncation and is not trustworthy, so
+    /// only one terminated by a delimiter counts.
+    private static func literal(from start: Data.Index, to limit: Data.Index, in window: Data) -> Data.Index? {
+        var cursor = start
+        while cursor < limit {
+            let byte = window[cursor]
+            if byte == UInt8(ascii: ",") || byte == UInt8(ascii: "}") || byte == UInt8(ascii: "]")
+                || Self.isWhitespace(byte) {
+                return cursor > start ? cursor : nil
+            }
+            cursor = window.index(after: cursor)
+        }
+        return nil
+    }
+
+    private static func isWhitespace(_ byte: UInt8) -> Bool {
+        byte == UInt8(ascii: " ") || byte == UInt8(ascii: "\t")
+            || byte == UInt8(ascii: "\r") || byte == UInt8(ascii: "\n")
+    }
+}

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -819,6 +819,154 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(context.modelTotals["gpt-5.6-sol"]?.input, 100)
     }
 
+    // MARK: - Budgeted Codex rollout scan
+
+    /// Names a rollout the way Codex does: the session UUID trails an ISO
+    /// timestamp, and the archived copy keeps the whole name.
+    private func codexRolloutName(sessionID: UUID, stamp: String = "2026-06-15T09-00-00") -> String {
+        "rollout-\(stamp)-\(sessionID.uuidString.lowercased()).jsonl"
+    }
+
+    func testRolloutSessionIDIdentifiesTheArchivedCopyOfALiveRollout() {
+        let id = UUID()
+        let live = URL(fileURLWithPath: "/codex/sessions/2026/06/15/\(codexRolloutName(sessionID: id))")
+        let archived = URL(fileURLWithPath: "/codex/archived_sessions/\(codexRolloutName(sessionID: id))")
+
+        XCTAssertEqual(
+            CodexCostScanner.rolloutSessionID(for: live),
+            CodexCostScanner.rolloutSessionID(for: archived)
+        )
+        XCTAssertEqual(CodexCostScanner.rolloutSessionID(for: live), id.uuidString.lowercased())
+    }
+
+    func testRolloutSessionIDFallsBackToTheWholeStemWithoutAUUIDSuffix() {
+        let legacy = URL(fileURLWithPath: "/codex/archived_sessions/rollout-conv-x.jsonl")
+
+        XCTAssertEqual(CodexCostScanner.rolloutSessionID(for: legacy), "rollout-conv-x")
+    }
+
+    /// The duplicate the fold fallback exists for. Reading only one copy is what
+    /// keeps the fallback — and its unbudgeted re-parse — off the hot path
+    /// entirely.
+    func testBudgetedCodexScanReadsOnlyOneCopyOfADuplicatedRollout() throws {
+        let root = try makeCodexHome()
+        let name = codexRolloutName(sessionID: UUID())
+        let lines = [
+            codexTurnContextLine(timestamp: "2026-06-15T09:01:00Z", model: "gpt-5.6-sol"),
+            codexUsageLine(timestamp: "2026-06-15T09:02:00Z", conversationID: "conv-x", input: 100)
+        ]
+        try writeCodexRollout(in: root, path: "archived_sessions/\(name)", modifiedAgo: 60, lines: lines)
+        let live = try writeCodexRollout(
+            in: root, path: "sessions/2026/06/15/\(name)", modifiedAgo: 0, lines: lines
+        )
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        let session = CostScanSession(cutoff: cutoff, options: .unlimited)
+
+        let windows = CodexCostScanner.scanRollouts(
+            directories: CodexCostScanner.rolloutDirectories(in: root), session: session
+        )
+
+        XCTAssertTrue(session.isComplete)
+        XCTAssertEqual(windows.period.totals.input, 100)
+        // The copy still being appended to is the one worth caching an offset
+        // against.
+        XCTAssertEqual(Set(session.codex.records.keys), [live.standardizedFileURL.path])
+    }
+
+    /// A live rollout keeps growing after it is archived, so the longer copy is
+    /// the one that carries every event.
+    func testBudgetedCodexScanKeepsTheLongerCopyOfADuplicatedRollout() throws {
+        let root = try makeCodexHome()
+        let name = codexRolloutName(sessionID: UUID())
+        let shared = [
+            codexTurnContextLine(timestamp: "2026-06-15T09:01:00Z", model: "gpt-5.6-sol"),
+            codexUsageLine(timestamp: "2026-06-15T09:02:00Z", conversationID: "conv-x", input: 100)
+        ]
+        try writeCodexRollout(in: root, path: "archived_sessions/\(name)", modifiedAgo: 60, lines: shared)
+        try writeCodexRollout(
+            in: root,
+            path: "sessions/2026/06/15/\(name)",
+            modifiedAgo: 0,
+            lines: shared + [
+                codexUsageLine(timestamp: "2026-06-15T09:03:00Z", conversationID: "conv-x", input: 25)
+            ]
+        )
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        let session = CostScanSession(cutoff: cutoff, options: .unlimited)
+
+        let windows = CodexCostScanner.scanRollouts(
+            directories: CodexCostScanner.rolloutDirectories(in: root), session: session
+        )
+
+        XCTAssertEqual(windows.period.totals.input, 125)
+        XCTAssertEqual(session.codex.records.count, 1)
+    }
+
+    /// Two rollouts that are not copies of one session but still share events.
+    /// Aggregates cannot be de-overlapped, so the shorter one is re-read event
+    /// by event — and that read has to answer to the same budget as every other.
+    func testCodexFoldFallbackCountsTheOverlappingRolloutOnce() throws {
+        let root = try makeCodexHome()
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        try writeOverlappingCodexRollouts(in: root)
+        let session = CostScanSession(cutoff: cutoff, options: .unlimited)
+
+        let windows = CodexCostScanner.scanRollouts(
+            directories: CodexCostScanner.rolloutDirectories(in: root), session: session
+        )
+
+        XCTAssertTrue(session.isComplete)
+        XCTAssertEqual(windows.period.totals.input, 150)
+    }
+
+    func testCodexFoldFallbackDefersRatherThanReadingPastTheBudget() throws {
+        let root = try makeCodexHome()
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        let sizes = try writeOverlappingCodexRollouts(in: root)
+        // Exactly enough to read both files once. The fallback re-read of the
+        // second one has to come out of a budget that is already spent.
+        let budget = CostScanBudgetOptions(
+            maxBytesPerFile: .max,
+            maxNewBytesPerRefresh: sizes.reduce(0, +),
+            wallClock: nil
+        )
+        let session = CostScanSession(cutoff: cutoff, options: budget)
+
+        let windows = CodexCostScanner.scanRollouts(
+            directories: CodexCostScanner.rolloutDirectories(in: root), session: session
+        )
+
+        // 150 would mean the fallback read the overlapping rollout anyway.
+        XCTAssertEqual(windows.period.totals.input, 100)
+        XCTAssertFalse(session.isComplete)
+    }
+
+    /// Two distinct sessions whose events overlap: the newer file holds one
+    /// event, the older holds that same event plus one more. Returns each file's
+    /// size in scan order.
+    @discardableResult
+    private func writeOverlappingCodexRollouts(in root: URL) throws -> [Int] {
+        let shared = codexUsageLine(timestamp: "2026-06-15T09:02:00Z", conversationID: "conv-x", input: 100)
+        let context = codexTurnContextLine(timestamp: "2026-06-15T09:01:00Z", model: "gpt-5.6-sol")
+        let newer = try writeCodexRollout(
+            in: root,
+            path: "sessions/2026/06/15/\(codexRolloutName(sessionID: UUID()))",
+            modifiedAgo: 0,
+            lines: [context, shared]
+        )
+        let older = try writeCodexRollout(
+            in: root,
+            path: "sessions/2026/06/15/\(codexRolloutName(sessionID: UUID(), stamp: "2026-06-15T08-00-00"))",
+            modifiedAgo: 60,
+            lines: [
+                context,
+                shared,
+                codexUsageLine(timestamp: "2026-06-15T09:05:00Z", conversationID: "conv-x", input: 50)
+            ]
+        )
+        return try [newer, older].map { try fileSize($0) }
+    }
+
     // MARK: - Period/lifetime windows (single-pass scan)
 
     func testParseSessionWindowsSplitsPeriodFromLifetime() throws {

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -343,12 +343,28 @@ final class CostTrackerTests: XCTestCase {
 
     /// Writes a rollout at an arbitrary path under a Codex home, creating the
     /// intermediate `sessions/YYYY/MM/DD` folders Codex nests live rollouts in.
-    private func writeCodexRollout(in root: URL, path: String, lines: [String]) throws {
+    ///
+    /// The trailing newline is not decoration: the budgeted scan withholds an
+    /// unterminated last line, so a fixture without one loses its final event.
+    @discardableResult
+    private func writeCodexRollout(
+        in root: URL,
+        path: String,
+        modifiedAgo: TimeInterval? = nil,
+        lines: [String]
+    ) throws -> URL {
         let url = root.appendingPathComponent(path)
         try FileManager.default.createDirectory(
             at: url.deletingLastPathComponent(), withIntermediateDirectories: true
         )
-        try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+        try (lines.joined(separator: "\n") + "\n").write(to: url, atomically: true, encoding: .utf8)
+        if let modifiedAgo {
+            try FileManager.default.setAttributes(
+                [.modificationDate: Date(timeIntervalSince1970: 1_780_000_000 - modifiedAgo)],
+                ofItemAtPath: url.path
+            )
+        }
+        return url
     }
 
     /// Real rollouts open with a `session_meta` event; the model field there is
@@ -882,6 +898,124 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(windows.period.earliest, FlexibleISO8601.date(from: "2026-07-01T10:00:00.000Z"))
         XCTAssertEqual(windows.lifetime.earliest, FlexibleISO8601.date(from: "2026-05-01T10:00:00.000Z"))
         XCTAssertEqual(windows.lifetime.latest, FlexibleISO8601.date(from: "2026-07-01T10:00:00.000Z"))
+    }
+
+    /// Mirrors the key order of a real Claude transcript record: `content` sits
+    /// ahead of `usage` inside `message`, and the top-level `timestamp` trails
+    /// the whole message object. Both fields a usage event needs are therefore
+    /// past the prefix cut once `content` is large. Nothing pads the line after
+    /// its closing brace — padding is what made the older truncation fixtures
+    /// salvageable by accident.
+    private func oversizedEventLine(
+        timestamp: String,
+        contentBytes: Int,
+        messageID: String = "msg_big",
+        requestID: String = "req_big",
+        model: String = "claude-sonnet-4-5",
+        input: Int = 100,
+        output: Int = 50
+    ) -> String {
+        let blob = String(repeating: "a", count: contentBytes)
+        return """
+        {"parentUuid": "p-1", "isSidechain": false, "message": {"model": "\(model)", "id": "\(messageID)", \
+        "type": "message", "role": "assistant", "content": [{"type": "text", "text": "\(blob)"}], \
+        "stop_reason": "end_turn", "stop_sequence": null, \
+        "usage": {"input_tokens": \(input), "output_tokens": \(output), \
+        "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}, \
+        "requestId": "\(requestID)", "type": "assistant", "uuid": "u-1", "timestamp": "\(timestamp)"}
+        """
+    }
+
+    func testParseSessionWindowsCountsUsageStrandedPastTheTruncationCap() throws {
+        let url = try writeSessionFile(lines: [
+            oversizedEventLine(
+                timestamp: "2026-07-01T10:00:00.000Z",
+                contentBytes: FileLineReader.defaultMaxLineBytes + 4_096,
+                input: 900,
+                output: 90
+            ),
+            eventLine(
+                timestamp: "2026-07-01T11:00:00.000Z",
+                messageID: "small",
+                requestID: "small",
+                input: 100,
+                output: 10
+            )
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+
+        let windows = ClaudeCostScanner.parseSessionWindows(at: url, since: cutoff)
+
+        XCTAssertEqual(windows.period.input, 1_000)
+        XCTAssertEqual(windows.period.output, 100)
+        XCTAssertEqual(windows.lifetime.input, 1_000)
+        XCTAssertEqual(windows.period.models["claude-sonnet-4-5"]?.input, 1_000)
+    }
+
+    func testSalvagedUsageIsDeduplicatedAgainstItsUntruncatedCopy() throws {
+        // A retried record can land once small and once oversized. The salvage
+        // path has to recover the same `messageID:requestID` key, or the spend
+        // is counted twice.
+        let url = try writeSessionFile(lines: [
+            eventLine(
+                timestamp: "2026-07-01T10:00:00.000Z",
+                messageID: "msg_big",
+                requestID: "req_big",
+                input: 900,
+                output: 90
+            ),
+            oversizedEventLine(
+                timestamp: "2026-07-01T10:00:01.000Z",
+                contentBytes: FileLineReader.defaultMaxLineBytes + 4_096,
+                input: 900,
+                output: 90
+            )
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+
+        let windows = ClaudeCostScanner.parseSessionWindows(at: url, since: cutoff)
+
+        XCTAssertEqual(windows.period.input, 900)
+        XCTAssertEqual(windows.period.output, 90)
+    }
+
+    func testTruncatedLineWithNoRecoverableUsageIsSkippedWithoutDisturbingTheScan() throws {
+        let blob = String(repeating: "a", count: FileLineReader.defaultMaxLineBytes + 4_096)
+        let url = try writeSessionFile(lines: [
+            #"{"type": "user", "message": {"role": "user", "content": "\#(blob)"}}"#,
+            eventLine(
+                timestamp: "2026-07-01T11:00:00.000Z",
+                messageID: "after",
+                requestID: "after",
+                input: 12,
+                output: 3
+            )
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+
+        let windows = ClaudeCostScanner.parseSessionWindows(at: url, since: cutoff)
+
+        XCTAssertEqual(windows.period.input, 12)
+        XCTAssertEqual(windows.period.output, 3)
+    }
+
+    func testBudgetedScanCountsUsageStrandedPastTheTruncationCap() throws {
+        let root = try makeTranscriptRoot()
+        try writeTranscript(in: root, name: "session.jsonl", modifiedAgo: 0, lines: [
+            oversizedEventLine(
+                timestamp: "2026-07-01T10:00:00.000Z",
+                contentBytes: FileLineReader.defaultMaxLineBytes + 4_096,
+                input: 900,
+                output: 90
+            )
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let session = CostScanSession(cutoff: cutoff, options: .unlimited)
+
+        let windows = ClaudeCostScanner.scanRoots([root], session: session)
+
+        XCTAssertEqual(windows.period.input, 900)
+        XCTAssertEqual(windows.period.output, 90)
     }
 
     func testScanCodexRolloutWindowsSplitPeriodFromLifetime() throws {

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -902,6 +902,40 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(session.codex.records.count, 1)
     }
 
+    /// Deduplication picks one copy per session; it must not also decide the
+    /// reading order. `archived_sessions` is enumerated first, so returning
+    /// discovery order would put every archived rollout ahead of every live one
+    /// and spend a slice's whole budget on the oldest conversations on disk —
+    /// the exact inversion of the newest-first walk the budget assumes.
+    func testDistinctRolloutsOrdersNewestFirstAcrossDirectories() throws {
+        let root = try makeCodexHome()
+        let lines = [
+            codexTurnContextLine(timestamp: "2026-06-15T09:01:00Z", model: "gpt-5.6-sol"),
+            codexUsageLine(timestamp: "2026-06-15T09:02:00Z", conversationID: "conv-x", input: 100)
+        ]
+        let old = try writeCodexRollout(
+            in: root,
+            path: "archived_sessions/\(codexRolloutName(sessionID: UUID()))",
+            modifiedAgo: 6000,
+            lines: lines
+        )
+        let recent = try writeCodexRollout(
+            in: root,
+            path: "sessions/2026/06/15/\(codexRolloutName(sessionID: UUID()))",
+            modifiedAgo: 60,
+            lines: lines
+        )
+
+        let files = CodexCostScanner.distinctRollouts(
+            in: CodexCostScanner.rolloutDirectories(in: root)
+        )
+
+        XCTAssertEqual(
+            files.map(\.url.standardizedFileURL.path),
+            [recent.standardizedFileURL.path, old.standardizedFileURL.path]
+        )
+    }
+
     /// Two rollouts that are not copies of one session but still share events.
     /// Aggregates cannot be de-overlapped, so the shorter one is re-read event
     /// by event — and that read has to answer to the same budget as every other.

--- a/MeterBarTests/FileLineReaderTests.swift
+++ b/MeterBarTests/FileLineReaderTests.swift
@@ -35,14 +35,16 @@ final class FileLineReaderTests: XCTestCase {
         of url: URL,
         chunkSize: Int = FileLineReader.defaultChunkSize,
         maxLineBytes: Int = FileLineReader.defaultMaxLineBytes,
-        prefixBytes: Int = FileLineReader.defaultPrefixBytes
+        prefixBytes: Int = FileLineReader.defaultPrefixBytes,
+        salvageTailBytes: Int = FileLineReader.defaultSalvageTailBytes
     ) -> [FileLineReader.Line] {
         var collected: [FileLineReader.Line] = []
         FileLineReader.forEachLine(
             in: url,
             chunkSize: chunkSize,
             maxLineBytes: maxLineBytes,
-            prefixBytes: prefixBytes
+            prefixBytes: prefixBytes,
+            salvageTailBytes: salvageTailBytes
         ) { line in
             collected.append(line)
         }
@@ -370,6 +372,62 @@ final class FileLineReaderTests: XCTestCase {
         XCTAssertEqual(collected[0].bytes.count, 200)
         XCTAssertTrue(collected[1].wasTruncated)
         XCTAssertEqual(collected[1].bytes.count, 64)
+    }
+
+    // MARK: - Salvage tail
+
+    func testOversizedLineKeepsATrailingWindowForSalvage() throws {
+        // In a Claude transcript `usage` follows `content`, so a line made
+        // oversized by a large `content` strands its accounting past the prefix
+        // cut. The tail is the only window that can reach it.
+        let url = try writeFile(String(repeating: "x", count: 4_000) + "TAILTAIL")
+
+        let collected = records(of: url, chunkSize: 64, maxLineBytes: 128, prefixBytes: 128, salvageTailBytes: 8)
+
+        XCTAssertEqual(collected.count, 1)
+        XCTAssertTrue(collected[0].wasTruncated)
+        XCTAssertEqual(collected[0].byteCount, 4_008)
+        XCTAssertEqual(String(bytes: collected[0].truncatedTail, encoding: .utf8), "TAILTAIL")
+    }
+
+    func testTruncatedTailDoesNotGrowWithLineLength() throws {
+        // The tail is the second retention window, so it needs the same flat
+        // ceiling the prefix has: an 800 MB line must not be held to reach its
+        // last 64 bytes.
+        for length in [1_000, 10_000, 1_000_000] {
+            let url = try writeFile(String(repeating: "y", count: length) + "END")
+
+            let collected = records(
+                of: url, chunkSize: 4_096, maxLineBytes: 256, prefixBytes: 256, salvageTailBytes: 64
+            )
+
+            XCTAssertEqual(collected.count, 1, "length \(length)")
+            XCTAssertEqual(collected[0].bytes.count, 256, "length \(length)")
+            XCTAssertEqual(collected[0].truncatedTail.count, 64, "length \(length)")
+            XCTAssertEqual(collected[0].byteCount, length + 3, "length \(length)")
+            XCTAssertEqual(
+                String(bytes: collected[0].truncatedTail.suffix(3), encoding: .utf8), "END", "length \(length)"
+            )
+        }
+    }
+
+    func testLinesWithinTheCapCarryNoSalvageTail() throws {
+        let url = try writeFile("alpha\nbeta\n")
+
+        let collected = records(of: url, maxLineBytes: 128, prefixBytes: 128, salvageTailBytes: 64)
+
+        XCTAssertEqual(collected.map(\.wasTruncated), [false, false])
+        XCTAssertEqual(collected.map(\.truncatedTail), [Data(), Data()])
+    }
+
+    func testSalvageTailSurvivesALineSpanningManyChunks() throws {
+        let url = try writeFile(String(repeating: "z", count: 10_000) + "FINISH\ntail\n")
+
+        let collected = records(of: url, chunkSize: 7, maxLineBytes: 32, prefixBytes: 32, salvageTailBytes: 6)
+
+        XCTAssertEqual(collected.count, 2)
+        XCTAssertEqual(String(bytes: collected[0].truncatedTail, encoding: .utf8), "FINISH")
+        XCTAssertEqual(String(bytes: collected[1].bytes, encoding: .utf8), "tail")
     }
 
     func testMissingFileReturnsFalseAndYieldsNothing() {

--- a/MeterBarTests/TruncatedJSONLineSalvageTests.swift
+++ b/MeterBarTests/TruncatedJSONLineSalvageTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import MeterBar
+
+/// Covers the key-scoped extractor the scanners fall back to when a transcript
+/// line was too long to retain whole. Its input is a window cut at an arbitrary
+/// byte, so every case here starts or ends mid-record on purpose.
+final class TruncatedJSONLineSalvageTests: XCTestCase {
+    private func data(_ text: String) -> Data { Data(text.utf8) }
+
+    func testExtractsAnObjectValue() throws {
+        let window = data(#"tail","usage":{"input_tokens":5,"output_tokens":7}},"requestId":"req_1"}"#)
+
+        let usage = try XCTUnwrap(TruncatedJSONLineSalvage.lastValue(forKey: "usage", in: window) as? [String: Any])
+
+        XCTAssertEqual(usage["input_tokens"] as? Int, 5)
+        XCTAssertEqual(usage["output_tokens"] as? Int, 7)
+    }
+
+    func testExtractsAStringValue() throws {
+        let window = data(#""stop_reason":null,"timestamp":"2026-07-01T10:00:00.000Z","type":"assistant"}"#)
+
+        XCTAssertEqual(
+            TruncatedJSONLineSalvage.lastValue(forKey: "timestamp", in: window) as? String,
+            "2026-07-01T10:00:00.000Z"
+        )
+    }
+
+    func testExtractsBooleanAndNumericLiterals() {
+        let window = data(#"{"isSidechain":true,"cost":1.5,"depth":3}"#)
+
+        XCTAssertEqual(TruncatedJSONLineSalvage.firstValue(forKey: "isSidechain", in: window) as? Bool, true)
+        XCTAssertEqual(TruncatedJSONLineSalvage.firstValue(forKey: "cost", in: window) as? Double, 1.5)
+        XCTAssertEqual(TruncatedJSONLineSalvage.firstValue(forKey: "depth", in: window) as? Int, 3)
+    }
+
+    func testIgnoresAValueTheWindowCutsShort() {
+        let window = data(#""model":"claude-sonnet-4-5","usage":{"input_tokens":5,"outp"#)
+
+        XCTAssertNil(TruncatedJSONLineSalvage.lastValue(forKey: "usage", in: window))
+        XCTAssertEqual(
+            TruncatedJSONLineSalvage.lastValue(forKey: "model", in: window) as? String, "claude-sonnet-4-5"
+        )
+    }
+
+    func testIgnoresAKeyWithNoColonAfterIt() {
+        let window = data(#"{"content":"the word \"usage\" appears here","other":1}"#)
+
+        XCTAssertNil(TruncatedJSONLineSalvage.firstValue(forKey: "usage", in: window))
+    }
+
+    func testReturnsEveryOccurrenceInDocumentOrder() throws {
+        let window = data(#"{"usage":{"input_tokens":1},"b":{"usage":{"input_tokens":2}}}"#)
+
+        let usages = TruncatedJSONLineSalvage.values(forKey: "usage", in: window)
+
+        XCTAssertEqual(usages.count, 2)
+        XCTAssertEqual((usages.first as? [String: Any])?["input_tokens"] as? Int, 1)
+        XCTAssertEqual((usages.last as? [String: Any])?["input_tokens"] as? Int, 2)
+    }
+
+    func testStopsExtractingBeyondTheValueCeiling() {
+        let blob = String(repeating: "a", count: TruncatedJSONLineSalvage.maximumValueBytes + 64)
+        let window = data(#"{"content":"\#(blob)","input_tokens":9}"#)
+
+        XCTAssertNil(TruncatedJSONLineSalvage.firstValue(forKey: "content", in: window))
+        XCTAssertEqual(TruncatedJSONLineSalvage.firstValue(forKey: "input_tokens", in: window) as? Int, 9)
+    }
+
+    func testHandlesNestedBracketsAndEscapedQuotesInsideTheValue() throws {
+        let window = data(#"x,"usage":{"detail":"a \"quoted\" }brace{","input_tokens":4}}"#)
+
+        let usage = try XCTUnwrap(TruncatedJSONLineSalvage.lastValue(forKey: "usage", in: window) as? [String: Any])
+
+        XCTAssertEqual(usage["input_tokens"] as? Int, 4)
+    }
+
+    func testEmptyWindowYieldsNothing() {
+        XCTAssertNil(TruncatedJSONLineSalvage.firstValue(forKey: "usage", in: Data()))
+        XCTAssertTrue(TruncatedJSONLineSalvage.values(forKey: "usage", in: Data()).isEmpty)
+    }
+}


### PR DESCRIPTION
Three correctness defects in the budgeted cost-scan pipeline. Each is a separate commit.

## 1. The Codex fold fallback bypassed the entire budget system

**Problem.** Inside the budgeted scan loop, the fold fallback called an unbudgeted `parseRollout`, which read the whole file with no `maxBytes` and no cancellation token — the only call site in the budgeted path that ignored all three `CostScanBudget` ceilings (per-file bytes, per-refresh bytes, wall clock). Compounding it: the per-file cache record was committed *before* the fold check and the fallback's own result was never cached, so a rollout duplicated across `sessions/` and `archived_sessions/` — precisely the case the fallback exists for — forced a full unbounded re-parse on **every** subsequent slice, for as long as the duplicate pair existed.

**Fix.** Rollouts are deduplicated by session id (the trailing UUID in `rollout-<stamp>-<uuid>.jsonl`) before anything is read, so the duplicate-copy case never reaches the fallback at all. The larger copy wins, because archiving happens while a session is still live and the archived snapshot can be short. What remains — two genuinely different conversations that recorded the same event, which no aggregate merge can de-overlap — goes through the new `foldByEvent`, which streams into the shared windows under the same budget and cancellation token every other read answers to, and calls `noteDeferred()` rather than overrunning. The unbudgeted `parseRollout(at:windows:)` is deleted; it had no other caller. A stale comment naming `addUsage` (split into `makeUsageEvent` / `apply` some time ago) is corrected.

## 2. The 1 MiB prefix salvage could not recover the thing it exists to recover

**Problem.** When a JSONL line exceeded the byte cap, the reader salvaged only its first 1 MiB. In Claude Code transcripts `content` precedes `usage` in the overwhelming majority of usage-bearing lines (6,082 of 6,125 on a real corpus), so a line made oversized by a large `content` has its `usage` object sitting past the cut. The truncated JSON then failed to parse — silently, through a `try?` — and every token in the record was lost.

The existing truncation tests never caught this because their fixtures pad with trailing whitespace *after* the JSON object closes, so the salvaged prefix still held complete, parseable JSON. The new fixtures do not.

**Fix.** `FileLineReader` keeps a bounded rolling tail (256 KiB) alongside the prefix. Peak retention stays flat at `cap + 2 * tail + chunkSize` regardless of line length — an 800 MB line is still never held in memory. `TruncatedJSONLineSalvage` lifts individual JSON values out of a window cut at an arbitrary byte, itself bounded (64 KiB per value, 64 matches). `ClaudeCostScanner` reassembles an event from the head prefix (`model`, `id`, `isSidechain` — first match) and the tail (`timestamp`, `requestId`, `usage` — last match, since a forged `"usage":` inside `content` necessarily precedes the real one), reusing the same `messageID:requestID` key so a salvaged record dedups against an untruncated copy of itself.

Codex is deliberately given no salvage path: `token_count` events are small, and oversized Codex lines are `function_call_output` records that carry no accounting.

`costCacheParserVersion` is bumped to 2 so cached digests are rescanned under the new rules.

## 3. Zero observability on dropped records

**Problem.** `Line.wasTruncated` was set but read by nothing outside the tests. Neither scanner reported it, and the per-file skip logging removed with `isScannableLine` was never carried over to the salvage path. Defect 2 was therefore undetectable in production.

**Fix.** `CostScanTruncationTally` counts truncated lines per file and how many still yielded usage, emitting at most one `AppLog.cost` line per affected file — `notice` when everything was recovered, `warning` when records were dropped. Wired into both Claude paths and all three Codex paths. On the Codex side truncation is counted only past the `token_count` marker guard, so thousands of oversized `function_call_output` lines that cost no tokens do not bury the one case that does. Counts are logged at `.public`, paths at `.private`; no line content is ever logged.

## Verification

- `swift test` — **1949 tests, 5 skipped, 0 failures.**
- `swiftlint --quiet` on all nine touched files — **zero net-new violations** versus the `master` baseline (35 force-unwrap / 23 multiline-arguments / 6 optional-data-string / 2 line-length, all pre-existing in `CostTrackerTests.swift` and `FileLineReaderTests.swift`).
- New tests, all written failing first:
  - `MeterBarTests/FileLineReaderTests.swift` — salvage tail: capture past the prefix, flat ceiling across 1 KB → 1 MB lines, no tail for lines within the cap, survival across many chunks.
  - `MeterBarTests/TruncatedJSONLineSalvageTests.swift` — 9 tests over the value extractor.
  - `MeterBarTests/CostTrackerTests.swift` — oversized-line usage recovery, salvage/untruncated dedup, unrecoverable line skipped without disturbing the scan; duplicated-rollout single read, longer-copy preference, fallback counts overlap once, fallback defers rather than reading past the budget.
- Budget test proved real by temporarily forcing `allowance = Int.max` in `foldByEvent`, which fails the deferral test with `("150") is not equal to ("100")`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery of usage data from truncated Claude and Codex transcript lines.
  - Prevented duplicate session counting when multiple transcript copies exist.
  - Improved budgeted and resumable scans across partially overlapping files.
  - Preserved usage details when complete transcript records are unavailable.

- **Reliability**
  - Added clearer scan statistics for recovered and unrecoverable records.
  - Updated cached cost data handling to reflect the improved scanning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->