### PR TITLE
fix(settings): let the row label column use the width it has

### DIFF
--- a/MeterBar/Views/Components/SettingsComponents.swift
+++ b/MeterBar/Views/Components/SettingsComponents.swift
@@ -11,8 +11,23 @@ import SwiftUI
 // MARK: - SettingsRowViewMetrics
 
 enum SettingsRowViewMetrics {
+    /// Fixed width of `SettingsInfoRow`'s label, and the floor `SettingsRowView`
+    /// keeps its label column at so the two line up in a shared panel. Above the
+    /// floor `SettingsRowView`'s column is elastic — it used to be pinned here,
+    /// which wrapped multi-sentence details to six or eight lines while the rest
+    /// of the pane sat empty.
     static let labelWidth: CGFloat = 190
-    static let controlWidth: CGFloat = 240
+
+    /// The control column is a range, not a constant. The floor keeps segmented
+    /// pickers and switches on a common right edge; the ceiling is set by the
+    /// widest control any row actually installs (QuotaEvent's 300pt webhook
+    /// field, then the provider panes' 260pt key field). A control narrower than
+    /// the floor still reserves only the floor, so the label keeps the rest.
+    static let controlMinWidth: CGFloat = 240
+    static let controlMaxWidth: CGFloat = 300
+
+    /// Gutter between the two columns.
+    static let columnSpacing: CGFloat = 16
 }
 
 // MARK: - SettingsInfoRow
@@ -122,7 +137,7 @@ struct SettingsRowView<Content: View>: View {
     let content: Content
 
     var body: some View {
-        HStack(alignment: .center, spacing: 0) {
+        HStack(alignment: .center, spacing: SettingsRowViewMetrics.columnSpacing) {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .font(.subheadline)
@@ -134,16 +149,30 @@ struct SettingsRowView<Content: View>: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
-            .frame(width: SettingsRowViewMetrics.labelWidth, alignment: .leading)
+            .frame(
+                minWidth: SettingsRowViewMetrics.labelWidth,
+                maxWidth: .infinity,
+                alignment: .leading
+            )
             // Read the title and its explanatory detail as one VoiceOver element
             // rather than two adjacent fragments. The trailing control stays a
             // separate focusable element so its own label/actuation are intact.
             .accessibilityElement(children: .combine)
 
-            Spacer(minLength: 16)
-
+            // `fixedSize` is what makes the split work: it resolves the control
+            // to its own ideal width (clamped to the column's range) instead of
+            // leaving it flexible, so the HStack has exactly one greedy child
+            // and hands every remaining point to the label. Without it the two
+            // elastic columns split the slack and the detail still wraps early.
+            // Call sites that set their own `.frame(width:)` or `.fixedSize()`
+            // are unaffected — their ideal is already what they asked for.
             content
-                .frame(width: SettingsRowViewMetrics.controlWidth, alignment: .trailing)
+                .frame(
+                    minWidth: SettingsRowViewMetrics.controlMinWidth,
+                    maxWidth: SettingsRowViewMetrics.controlMaxWidth,
+                    alignment: .trailing
+                )
+                .fixedSize(horizontal: true, vertical: false)
         }
         .frame(maxWidth: .infinity)
     }

--- a/MeterBar/Views/Settings/GeneralSettingsCopy.swift
+++ b/MeterBar/Views/Settings/GeneralSettingsCopy.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+// MARK: - GeneralSettingsCopy
+
+/// The General pane's load-bearing row copy, lifted out of the view so tests can
+/// assert on it directly.
+///
+/// These five details are the ones that carry a constraint a user cannot infer
+/// from the control: the per-account item cap, the fact that pinning and focus
+/// following are mutually exclusive, that rotation stops while the popover is
+/// open, and that focus following never asks for accessibility access. They were
+/// each four to six sentences long, which was survivable only because the row's
+/// label column was a fixed 190pt and nobody noticed the wrap. Shortening them
+/// is fine; dropping one of those facts is not — that is what the tests in
+/// `SettingsRowLayoutTests` are for.
+enum GeneralSettingsCopy {
+    static let autoRefreshInterval = "Adaptive stays between 1 and 30 minutes, "
+        + "reacting to recent activity, quota movement, battery, and thermal state."
+
+    static let menuBarShows = "Auto follows recent activity. "
+        + "Pinning locks one provider, account, and quota window, and turns off focus following and rotation."
+
+    static let rotateProviders = "Cycle the single item through providers that have data. "
+        + "Rotation pauses while the popover is open, and a critical quota holds the item until it recovers."
+
+    static let followFocusedApp = "Show the provider mapped to your frontmost app, "
+        + "matched on its bundle identifier alone — no accessibility permission, window titles, or contents. "
+        + "Turning this on clears the pin and rotation; either one turns it back off."
+
+    /// `itemLimit` is `MenuBarAccountSelection.itemLimit` — the cap on how many
+    /// account items One Per Account will create.
+    static func menuBarLayout(itemLimit: Int) -> String {
+        "One item, one per provider, or one per selected account (up to \(itemLimit)). "
+            + "One Account With Switcher shows a single item you repoint from its right-click menu."
+    }
+}

--- a/MeterBar/Views/Settings/GeneralSettingsView.swift
+++ b/MeterBar/Views/Settings/GeneralSettingsView.swift
@@ -108,8 +108,7 @@ struct GeneralSettingsView: View {
         SettingsPanelSection(title: "Refresh", systemImage: "arrow.clockwise", color: MeterBarTheme.appAccent) {
             SettingsRowView(
                 title: "Auto-refresh interval",
-                detail: "Adaptive stays between 1 and 30 minutes using only recent MeterBar interaction, "
-                    + "quota movement, battery/Low Power Mode, and thermal state."
+                detail: GeneralSettingsCopy.autoRefreshInterval
             ) {
                 Picker("", selection: Binding(
                     get: { dataManager.refreshInterval },
@@ -147,11 +146,7 @@ struct GeneralSettingsView: View {
         ) {
             SettingsRowView(
                 title: "Menu bar layout",
-                detail: "Single Item keeps today’s behavior. "
-                    + "One Per Provider gives every tracked provider its own item. "
-                    + "One Per Account gives each selected account its own item "
-                    + "(up to \(menuBarAccountSelection.itemLimit)). "
-                    + "One Account With Switcher shows a single item you can repoint from its right-click menu."
+                detail: GeneralSettingsCopy.menuBarLayout(itemLimit: menuBarAccountSelection.itemLimit)
             ) {
                 Picker("", selection: Binding(
                     get: { menuBarDisplayPreferences.presentationMode },
@@ -171,8 +166,7 @@ struct GeneralSettingsView: View {
 
             SettingsRowView(
                 title: "Menu bar shows",
-                detail: "Auto follows recent activity. Pinning keeps one provider, account, and quota "
-                    + "window visible, and turns off focus following and rotation."
+                detail: GeneralSettingsCopy.menuBarShows
             ) {
                 Picker("", selection: Binding(
                     get: { menuBarDisplayPreferences.pinnedCandidateKey },
@@ -199,9 +193,7 @@ struct GeneralSettingsView: View {
 
             SettingsRowView(
                 title: "Rotate providers",
-                detail: "Cycle the single item through providers that have data. "
-                    + "Rotation pauses while the popover is open, and a critical quota keeps the item "
-                    + "until it recovers."
+                detail: GeneralSettingsCopy.rotateProviders
             ) {
                 Toggle("", isOn: Binding(
                     get: { menuBarDisplayPreferences.rotatesProviders },
@@ -370,10 +362,7 @@ struct GeneralSettingsView: View {
     @ViewBuilder private var followFocusedAppRows: some View {
         SettingsRowView(
             title: "Follow focused app",
-            detail: "Show the provider mapped to whichever app you are working in. "
-                + "MeterBar reads only the frontmost app’s bundle identifier — no accessibility "
-                + "permission is requested, and no window titles or contents are read. "
-                + "Turning this on clears the pin and rotation; either one turns focus following off."
+            detail: GeneralSettingsCopy.followFocusedApp
         ) {
             Toggle("", isOn: Binding(
                 get: { menuBarDisplayPreferences.followsFocusedApp },

--- a/MeterBarTests/SettingsRowLayoutTests.swift
+++ b/MeterBarTests/SettingsRowLayoutTests.swift
@@ -1,0 +1,160 @@
+import AppKit
+@testable import MeterBar
+import SwiftUI
+import XCTest
+
+/// Guards the settings row's two-column geometry and the copy that column width
+/// was hiding. The row used to pin its label to a fixed 190pt column and its
+/// control to a fixed 240pt one, so a multi-sentence `detail` wrapped to six or
+/// eight lines while ~300pt of the pane sat empty — and a 260pt control (the
+/// provider API-key field) overflowed its 240pt slot. Both directions are
+/// asserted here: the label must grow into free space, and the control must be
+/// sized by what it holds rather than by a constant.
+@MainActor
+final class SettingsRowLayoutTests: XCTestCase {
+    // MARK: - Metrics
+
+    func testControlColumnAccommodatesTheWidestShippedControl() {
+        // ProviderSettingsView's API-key SecureField is 260pt and QuotaEvent's
+        // webhook field caps at 300pt. A ceiling below either clips a real row.
+        XCTAssertGreaterThanOrEqual(SettingsRowViewMetrics.controlMaxWidth, 300)
+        XCTAssertLessThanOrEqual(
+            SettingsRowViewMetrics.controlMinWidth,
+            SettingsRowViewMetrics.controlMaxWidth
+        )
+    }
+
+    func testLabelColumnKeepsAFloorSoNarrowRowsStayReadable() {
+        XCTAssertGreaterThanOrEqual(SettingsRowViewMetrics.labelWidth, 190)
+    }
+
+    // MARK: - Layout
+
+    /// The regression itself. A fixed label column produces the same height at
+    /// every pane width; a flexible one re-wraps and gets shorter as the pane
+    /// grows. `UsageDashboardView`'s settings mode hands panes ~772pt at the
+    /// default window size and more when the user resizes.
+    func testLongDetailReflowsIntoTheExtraWidthOfAWiderPane() {
+        let narrow = measuredHeight(of: longDetailRow, width: 560)
+        let wide = measuredHeight(of: longDetailRow, width: 900)
+
+        XCTAssertLessThan(
+            wide,
+            narrow,
+            "the detail column ignored the extra pane width — it is still fixed"
+        )
+    }
+
+    /// A toggle must not reserve the same slot as a 260pt text field; the space
+    /// it does not need belongs to the label.
+    func testCompactControlReservesLessThanAWideOne() {
+        let toggleWidth = measuredWidth(of: SettingsRowView(title: "Pin") {
+            Toggle("", isOn: .constant(true)).labelsHidden()
+        })
+        let fieldWidth = measuredWidth(of: SettingsRowView(title: "Pin") {
+            Color.clear.frame(width: 260, height: 20)
+        })
+
+        XCTAssertLessThan(
+            toggleWidth,
+            fieldWidth,
+            "every control still reserves one constant width"
+        )
+    }
+
+    /// The 260pt provider key field overflowed the old 240pt slot. The row's
+    /// ideal width has to leave room for the control it was actually given.
+    func testWideControlIsNotClipped() {
+        let width = measuredWidth(of: SettingsRowView(title: "Pin") {
+            Color.clear.frame(width: 260, height: 20)
+        })
+
+        XCTAssertGreaterThanOrEqual(width, SettingsRowViewMetrics.labelWidth + 260)
+    }
+
+    // MARK: - Copy
+
+    func testMenuBarLayoutCopyKeepsTheAccountItemLimit() {
+        let copy = GeneralSettingsCopy.menuBarLayout(itemLimit: 4)
+
+        XCTAssertTrue(copy.contains("4"), copy)
+        XCTAssertTrue(copy.lowercased().contains("right-click"), copy)
+    }
+
+    func testMenuBarShowsCopyKeepsPinExclusivity() {
+        let copy = GeneralSettingsCopy.menuBarShows.lowercased()
+
+        XCTAssertTrue(copy.contains("focus following"), copy)
+        XCTAssertTrue(copy.contains("rotation"), copy)
+    }
+
+    func testRotationCopyKeepsThePopoverPause() {
+        let copy = GeneralSettingsCopy.rotateProviders.lowercased()
+
+        XCTAssertTrue(copy.contains("pauses while the popover is open"), copy)
+        XCTAssertTrue(copy.contains("critical"), copy)
+    }
+
+    func testFollowFocusedAppCopyKeepsPrivacyPostureAndExclusivity() {
+        let copy = GeneralSettingsCopy.followFocusedApp.lowercased()
+
+        XCTAssertTrue(copy.contains("bundle identifier"), copy)
+        XCTAssertTrue(copy.contains("accessibility"), copy)
+        XCTAssertTrue(copy.contains("pin"), copy)
+        XCTAssertTrue(copy.contains("rotation"), copy)
+    }
+
+    func testRefreshIntervalCopyKeepsTheAdaptiveBounds() {
+        let copy = GeneralSettingsCopy.autoRefreshInterval
+
+        XCTAssertTrue(copy.contains("1"), copy)
+        XCTAssertTrue(copy.contains("30"), copy)
+    }
+
+    /// Widening the label column is only half the fix: the copy that filled it
+    /// has to come down to one or two sentences per row.
+    func testEveryTightenedDetailStaysWithinTwoSentences() {
+        let copy = [
+            "autoRefreshInterval": GeneralSettingsCopy.autoRefreshInterval,
+            "menuBarLayout": GeneralSettingsCopy.menuBarLayout(itemLimit: 4),
+            "menuBarShows": GeneralSettingsCopy.menuBarShows,
+            "rotateProviders": GeneralSettingsCopy.rotateProviders,
+            "followFocusedApp": GeneralSettingsCopy.followFocusedApp,
+        ]
+
+        for (name, text) in copy {
+            let sentences = text.split(separator: ".").filter {
+                !$0.trimmingCharacters(in: .whitespaces).isEmpty
+            }
+            XCTAssertLessThanOrEqual(sentences.count, 2, "\(name) is still \(sentences.count) sentences")
+            XCTAssertFalse(text.isEmpty, name)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// A detail long enough that the wrap point moves between 560pt and 900pt.
+    private var longDetailRow: some View {
+        SettingsRowView(
+            title: "Follow focused app",
+            detail: GeneralSettingsCopy.followFocusedApp
+        ) {
+            Toggle("", isOn: .constant(false)).labelsHidden()
+        }
+    }
+
+    private func measuredHeight(of view: some View, width: CGFloat) -> CGFloat {
+        let hostingView = NSHostingView(rootView: view.frame(width: width))
+        hostingView.layoutSubtreeIfNeeded()
+        return hostingView.fittingSize.height
+    }
+
+    /// The row's *ideal* width — what the two columns ask for before a pane
+    /// hands them anything. Short titles keep the label at its floor so the
+    /// difference between two measurements is entirely the control column.
+    private func measuredWidth(of view: some View) -> CGFloat {
+        let hostingView = NSHostingView(rootView: view)
+        hostingView.layoutSubtreeIfNeeded()
+        return hostingView.fittingSize.width
+    }
+}


### PR DESCRIPTION
## Problem

`SettingsRowView` pinned its label to a fixed **190pt** and its control to a fixed **240pt**. Every one of the 78 call sites inherited that, so:

- a multi-sentence `detail` wrapped to six or eight lines while **~300pt of the pane sat empty** beside it;
- a **260pt** control (the provider API-key `SecureField`) overflowed the 240pt slot it was handed;
- a bare `Toggle` reserved the same 240pt as that key field.

## Fix

**The label column is elastic above a 190pt floor. The control column is a 240–300pt range resolved by `.fixedSize(horizontal: true, vertical: false)`.**

`.fixedSize` is the load-bearing part: it pins the control to its *own* ideal width clamped to the range, which leaves the `HStack` exactly **one** greedy child, so every remaining point goes to the label. Two elastic columns would have split the slack and the detail would still wrap early.

Call sites that already set their own `.frame(width: 220)` or `.fixedSize()` are unaffected — their ideal width is precisely what they asked for, so nothing fights and nothing jitters. `SettingsInfoRow` deliberately keeps its fixed label width, so both row types still share a left edge inside a shared panel.

### Copy

The General pane's five load-bearing details move to `GeneralSettingsCopy` (following the `DiagnosticsReportText` precedent) so they are unit-testable, and come down to one or two sentences each. **Every constraint a user cannot infer from the control is preserved and asserted by a test**:

| fact | test |
|---|---|
| per-account item cap (`up to 4`) + right-click switcher | `testMenuBarLayoutCopyKeepsTheAccountItemLimit` |
| pinning turns off focus following **and** rotation | `testMenuBarShowsCopyKeepsPinExclusivity` |
| rotation pauses while the popover is open; critical quota holds the item | `testRotationCopyKeepsThePopoverPause` |
| bundle-identifier matching only, no accessibility permission; clears pin/rotation | `testFollowFocusedAppCopyKeepsPrivacyPostureAndExclusivity` |
| adaptive interval bounds 1–30 min | `testRefreshIntervalCopyKeepsTheAdaptiveBounds` |

The other 20 `detail:` strings in the pane were audited and are already one or two short sentences — left alone.

## Window width: deliberately unchanged

Item 2 of the brief (widen the window "if that measurably improves readability") was investigated and **intentionally not done**. `SettingsView`'s 760pt constant is never what a user sees: the `Settings` scene is replaced by `CommandGroup(replacing: .appSettings)`, which opens `UsageDashboardWindowController.shared.showSettings()`. The real surface is the `NavigationSplitView` dashboard at **1040×700 default, 900 min, user-resizable** — panes get ~772pt. Flexible layout is the whole fix; there was no width to brute-force.

## Verification

Offscreen `NSHostingView` renders of the real pane trees at both the **772pt dashboard width** and the **720pt narrow case**. No clipping, no truncated controls, no horizontal overflow; every trailing control keeps its right edge.

| pane | before | after |
|---|---|---|
| General | 2994px tall | **2344px (−22%)** |
| General @720pt | 3007px | **2409px** |
| Widget | 1452px | 1413px |
| Provider (Claude Code) | 889px | 837px |
| API Usage | 542px | 503px |
| About | 327px | 301px |
| Cost | 556px | **556px (byte-identical)** |

Cost being unchanged is the interesting negative result: it is the pane full of greedy `TextField`s, and the concern was that `.fixedSize` would collapse them. A bare `TextField`'s ideal is below the 240pt floor, so it still renders at 240 — the render is identical byte-for-byte.

Representative reflow — "Follow focused app" went 8 lines → 3, "Menu bar layout" 6 → 2, About's details 2 → 1, with every right-edge control (`Check Now`, `Open`, `StatusPill`, `Manage`) unmoved.

### Before / after

Renders are of the real pane view trees hosted offscreen in `NSHostingView`, at the width the dashboard actually hands a pane. Assets live on the unmerged `assets/pr-366-settings-layout` branch so no binaries enter `master` history.

**General** — the headline. "Follow focused app" 8 lines → 3, "Menu bar layout" 6 → 2; every trailing control keeps its right edge.

![General settings before and after](https://raw.githubusercontent.com/VincentShipsIt/meterbar.dev/assets/pr-366-settings-layout/sbs-general.png)

**Widget** — two-line details collapse to one; nothing else moves.

![Widget settings before and after](https://raw.githubusercontent.com/VincentShipsIt/meterbar.dev/assets/pr-366-settings-layout/sbs-widget.png)

**About** — `Check Now` and the three `Open` buttons are unmoved.

![About settings before and after](https://raw.githubusercontent.com/VincentShipsIt/meterbar.dev/assets/pr-366-settings-layout/sbs-about.png)

**General at the 720pt narrow case** — the check that the elastic column stays sane on a small display: no clipping, no overflow, right edges still aligned.

![General settings at 720pt after the fix](https://raw.githubusercontent.com/VincentShipsIt/meterbar.dev/assets/pr-366-settings-layout/sbs-general-720pt-after.png)


### Checks run locally (Mac Studio)

- `swift build` — clean
- `swift test` — **1976 tests, 0 failures**, 5 skipped
- `xcodebuild -scheme MeterBar -configuration Debug` — **BUILD SUCCEEDED** (CI divergence trap: both paths verified)
- `swiftlint` — **0 violations in 260 files**
- Built `MeterBar Dev.app` launched and ran stably

### TDD

Tests were written first and proven red: reverting `SettingsRowView.body` to the fixed widths failed exactly the three layout tests (`testLongDetailReflowsIntoTheExtraWidthOfAWiderPane`, `testCompactControlReservesLessThanAWideOne`, `testWideControlIsNotClipped`) while the other eight passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved settings-row layout with responsive label and control sizing across different window widths.
  - Added clearer descriptions for General settings, including refresh behavior, menu-bar display, provider rotation, focused-app tracking, and account limits.

- **Bug Fixes**
  - Prevented wide controls from being clipped and improved wrapping of detailed setting descriptions.

- **Tests**
  - Added coverage for responsive settings layouts, control sizing, clipping prevention, and settings description content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
