### PR TITLE
feat(cost): scan the Grok corpus so its spend reaches the charts

### DIFF
--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -30,10 +30,10 @@ enum CodexCostScanner {
     /// `earliestDate` starts at now and only decreases, `latestDate` starts at the
     /// window floor (the cutoff for the period, `.distantPast` for lifetime) and
     /// only increases.
-    nonisolated static func scanWindows(cutoff: Date) -> ScanWindows<CodexScanContext> {
+    nonisolated static func scanWindows(cutoff: Date) -> ScanWindows<CostScanWindowContext> {
         ScanWindows(
-            period: CodexScanContext(earliestDate: Date(), latestDate: cutoff),
-            lifetime: CodexScanContext(earliestDate: Date(), latestDate: .distantPast),
+            period: CostScanWindowContext(earliestDate: Date(), latestDate: cutoff),
+            lifetime: CostScanWindowContext(earliestDate: Date(), latestDate: .distantPast),
             cutoff: cutoff
         )
     }
@@ -54,7 +54,7 @@ enum CodexCostScanner {
     /// `pricingAt` is the seam that lets a test drive a dated schedule; the
     /// default is the shared table every caller ships with.
     nonisolated static func makeCost(
-        from context: CodexScanContext,
+        from context: CostScanWindowContext,
         pricingAt: @escaping (String?, Date) -> TokenPricing = ModelPricing.codex(for:at:)
     ) -> (TokenCost, [DailyTokenUsage])? {
         let totals = context.totals
@@ -256,7 +256,7 @@ enum CodexCostScanner {
     /// Streams one rollout end to end into `windows`.
     ///
     /// Serial by construction. Unlike Claude's per-file dedup,
-    /// `CodexScanContext.eventKeys` spans every rollout *and* the SQLite log,
+    /// `CostScanWindowContext.eventKeys` spans every rollout *and* the SQLite log,
     /// first event wins — so the order files reach here is the order that
     /// decides the answer.
     ///
@@ -264,7 +264,7 @@ enum CodexCostScanner {
     /// through it.
     nonisolated static func parseRollout(
         at fileURL: URL,
-        windows: inout ScanWindows<CodexScanContext>
+        windows: inout ScanWindows<CostScanWindowContext>
     ) {
         let calendar = Calendar.current
         for event in Self.parseRollout(at: fileURL) {
@@ -275,7 +275,7 @@ enum CodexCostScanner {
     // MARK: - Budgeted, resumable scan
 
     /// Rollouts and the flat SQLite log, read under `session`'s budget.
-    nonisolated static func scanSessions(session: CostScanSession) -> ScanWindows<CodexScanContext> {
+    nonisolated static func scanSessions(session: CostScanSession) -> ScanWindows<CostScanWindowContext> {
         let codexDir = URL(fileURLWithPath: CodexHomeDirectory.path(), isDirectory: true)
         var windows = Self.scanRollouts(
             directories: Self.rolloutDirectories(in: codexDir),
@@ -301,7 +301,7 @@ enum CodexCostScanner {
     nonisolated static func scanRollouts(
         directories: [URL],
         session: CostScanSession
-    ) -> ScanWindows<CodexScanContext> {
+    ) -> ScanWindows<CostScanWindowContext> {
         var windows = Self.scanWindows(cutoff: session.cutoff)
         let files = Self.distinctRollouts(in: directories)
         var live: Set<String> = []
@@ -452,7 +452,7 @@ enum CodexCostScanner {
     nonisolated private static func foldByEvent(
         _ file: CostScanFile,
         session: CostScanSession,
-        windows: inout ScanWindows<CodexScanContext>
+        windows: inout ScanWindows<CostScanWindowContext>
     ) {
         let allowance = session.budget.allowance
         guard allowance > 0 else {
@@ -518,7 +518,7 @@ enum CodexCostScanner {
     ///   re-read that file event by event.
     nonisolated private static func fold(
         _ totals: CodexFileTotals,
-        into windows: inout ScanWindows<CodexScanContext>
+        into windows: inout ScanWindows<CostScanWindowContext>
     ) -> Bool {
         // Period keys are a subset of lifetime keys by construction (every
         // in-window event is also a lifetime event), so the lifetime test
@@ -553,7 +553,7 @@ enum CodexCostScanner {
         let lifetime = record.payload.lifetime
         if lifetime.eventKeys.isEmpty || lifetime.latestDate < session.cutoff {
             // Every event predates the new window.
-            record.payload.period = CodexScanContext(
+            record.payload.period = CostScanWindowContext(
                 earliestDate: Date(),
                 latestDate: session.cutoff
             )
@@ -620,7 +620,7 @@ enum CodexCostScanner {
     nonisolated private static func flushDeferred(
         _ deferred: inout [CodexDeferredUsage],
         modelName: String?,
-        windows: inout ScanWindows<CodexScanContext>,
+        windows: inout ScanWindows<CostScanWindowContext>,
         calendar: Calendar
     ) {
         var events: [CodexUsageEvent] = []
@@ -689,7 +689,7 @@ enum CodexCostScanner {
         fileURL: URL,
         rollout: CodexRolloutContext,
         deferred: inout [CodexDeferredUsage],
-        windows: inout ScanWindows<CodexScanContext>,
+        windows: inout ScanWindows<CostScanWindowContext>,
         calendar: Calendar
     ) {
         var events: [CodexUsageEvent] = []
@@ -720,7 +720,7 @@ enum CodexCostScanner {
     nonisolated static func scanSQLiteLogs(
         database: URL,
         since cutoffDate: Date,
-        windows: inout ScanWindows<CodexScanContext>
+        windows: inout ScanWindows<CostScanWindowContext>
     ) {
         guard FileManager.default.fileExists(atPath: database.path) else { return }
 
@@ -831,7 +831,7 @@ enum CodexCostScanner {
     /// calendar is not free, and it cannot change part-way through a scan.
     nonisolated private static func apply(
         _ event: CodexUsageEvent,
-        windows: inout ScanWindows<CodexScanContext>,
+        windows: inout ScanWindows<CostScanWindowContext>,
         calendar: Calendar
     ) {
         let timestamp = event.timestamp
@@ -977,7 +977,7 @@ nonisolated struct CodexUsageAttribution: Sendable {
 }
 
 /// One usage event, extracted from a rollout line or a SQLite log row and ready
-/// to fold into a `CodexScanContext`.
+/// to fold into a `CostScanWindowContext`.
 ///
 /// This is the boundary between the parallel half of the scan and the serial
 /// half: rollouts are parsed into these on worker threads, then applied to the

--- a/MeterBar/Services/CostProjectAttribution.swift
+++ b/MeterBar/Services/CostProjectAttribution.swift
@@ -49,6 +49,21 @@ enum CostProjectAttribution {
         return sanitize(absolutePath: cwd)
     }
 
+    /// Project for one Grok session directory.
+    ///
+    /// Grok names each session directory after the percent-encoded absolute
+    /// project path (`%2FUsers%2Falice%2Fwww%2Fapp`), so decoding recovers the
+    /// same absolute path Codex reads straight out of `session_meta`, and the
+    /// two then share one sanitizer. A name that does not decode is treated as
+    /// unattributable rather than reported raw — an undecodable name is not a
+    /// path, and passing it through would put percent escapes on screen.
+    nonisolated static func grokProjectID(encodedDirectoryName raw: String) -> String {
+        guard let decoded = raw.removingPercentEncoding, !decoded.isEmpty else {
+            return unknownProjectID
+        }
+        return sanitize(absolutePath: decoded)
+    }
+
     /// Strips the encoded real-home-directory prefix so a displayed
     /// identifier never leaks a full home-directory path, then reads dashes
     /// in the remainder as path separators.

--- a/MeterBar/Services/CostScanFileCache.swift
+++ b/MeterBar/Services/CostScanFileCache.swift
@@ -37,12 +37,16 @@ nonisolated struct CostScanFileCache<Payload: Codable & Sendable>: Codable, Send
     var records: [String: CostScanFileRecord<Payload>] = [:]
 }
 
-/// Reads and writes the two per-file scan caches.
+/// Reads and writes the per-file scan caches — one artifact per corpus.
 ///
 /// Deliberately separate files from `cost-summary-v2.json`: that envelope is a
 /// published artifact (`meterbar cost` reads it) with its own schema version and
 /// its own migration story, while these are a private, disposable read-through
 /// cache. Losing them costs one slow refresh, not a wrong number.
+///
+/// One artifact per corpus, never a shared one: the payload types differ, and a
+/// corpus added later must not invalidate the caches the existing ones already
+/// filled.
 nonisolated struct CostScanCacheStore: Sendable {
     static let maximumArtifactBytes = 64 * 1024 * 1024
     static var claudeFileName: String {
@@ -50,6 +54,9 @@ nonisolated struct CostScanCacheStore: Sendable {
     }
     static var codexFileName: String {
         "cost-scan-codex-v\(CostScanFileCache<CodexFileTotals>.currentSchemaVersion).json"
+    }
+    static var grokFileName: String {
+        "cost-scan-grok-v\(CostScanFileCache<GrokFileTotals>.currentSchemaVersion).json"
     }
 
     let directory: URL
@@ -75,12 +82,20 @@ nonisolated struct CostScanCacheStore: Sendable {
         Self.loadCodex(from: directory.appendingPathComponent(Self.codexFileName))
     }
 
+    func loadGrok() -> CostScanFileCache<GrokFileTotals> {
+        Self.loadGrok(from: directory.appendingPathComponent(Self.grokFileName))
+    }
+
     func saveClaude(_ cache: CostScanFileCache<ClaudeFileTotals>) throws {
         try Self.saveClaude(cache, to: directory.appendingPathComponent(Self.claudeFileName))
     }
 
     func saveCodex(_ cache: CostScanFileCache<CodexFileTotals>) throws {
         try Self.saveCodex(cache, to: directory.appendingPathComponent(Self.codexFileName))
+    }
+
+    func saveGrok(_ cache: CostScanFileCache<GrokFileTotals>) throws {
+        try Self.saveGrok(cache, to: directory.appendingPathComponent(Self.grokFileName))
     }
 
     static func loadClaude(
@@ -94,6 +109,13 @@ nonisolated struct CostScanCacheStore: Sendable {
         from url: URL,
         maximumBytes: Int = maximumArtifactBytes
     ) -> CostScanFileCache<CodexFileTotals> {
+        Self.load(from: url, maximumBytes: maximumBytes)
+    }
+
+    static func loadGrok(
+        from url: URL,
+        maximumBytes: Int = maximumArtifactBytes
+    ) -> CostScanFileCache<GrokFileTotals> {
         Self.load(from: url, maximumBytes: maximumBytes)
     }
 
@@ -113,11 +135,19 @@ nonisolated struct CostScanCacheStore: Sendable {
         try Self.save(cache, to: url, maximumBytes: maximumBytes)
     }
 
-    /// Both payloads roll usage up in `[Date: TokenAccumulator]` dictionaries,
-    /// and a mismatched date strategy across these two would not throw — every
+    static func saveGrok(
+        _ cache: CostScanFileCache<GrokFileTotals>,
+        to url: URL,
+        maximumBytes: Int = maximumArtifactBytes
+    ) throws {
+        try Self.save(cache, to: url, maximumBytes: maximumBytes)
+    }
+
+    /// Every payload rolls usage up in `[Date: TokenAccumulator]` dictionaries,
+    /// and a mismatched date strategy across them would not throw — every
     /// strategy but `.iso8601` writes a bare number, so the decode succeeds and
     /// lands each daily row in a bucket decades from the right one. Pinned
-    /// explicitly rather than left to two independently-defaulted instances that
+    /// explicitly rather than left to independently-defaulted instances that
     /// only happen to agree today.
     private static var encoder: JSONEncoder {
         // Not `.prettyPrinted`: ~10k entries, and this file is machine-only.
@@ -263,8 +293,8 @@ nonisolated struct ClaudeFileTotals: Codable, Sendable {
 
 /// One Codex rollout's tally, plus the attribution state carried across slices.
 nonisolated struct CodexFileTotals: Codable, Sendable {
-    var period: CodexScanContext
-    var lifetime: CodexScanContext
+    var period: CostScanWindowContext
+    var lifetime: CostScanWindowContext
 
     /// `turn_context` / `session_meta` attribution seen so far. A rollout
     /// declares its model once and its originator once, usually in the first few
@@ -273,7 +303,22 @@ nonisolated struct CodexFileTotals: Codable, Sendable {
     var rollout = CodexRolloutContext()
 
     init(cutoff: Date) {
-        period = CodexScanContext(earliestDate: Date(), latestDate: cutoff)
-        lifetime = CodexScanContext(earliestDate: Date(), latestDate: .distantPast)
+        period = CostScanWindowContext(earliestDate: Date(), latestDate: cutoff)
+        lifetime = CostScanWindowContext(earliestDate: Date(), latestDate: .distantPast)
+    }
+}
+
+/// One Grok `updates.jsonl` tally.
+///
+/// No `rollout` analog: a Grok turn names its own model inside `modelUsage`, and
+/// the project comes from the session directory's own name, so a slice that
+/// starts mid-file still attributes every record it reads.
+nonisolated struct GrokFileTotals: Codable, Sendable {
+    var period: CostScanWindowContext
+    var lifetime: CostScanWindowContext
+
+    init(cutoff: Date) {
+        period = CostScanWindowContext(earliestDate: Date(), latestDate: cutoff)
+        lifetime = CostScanWindowContext(earliestDate: Date(), latestDate: .distantPast)
     }
 }

--- a/MeterBar/Services/CostScanSession.swift
+++ b/MeterBar/Services/CostScanSession.swift
@@ -21,6 +21,7 @@ nonisolated final class CostScanSession: @unchecked Sendable {
     private let lock = NSLock()
     private var claudeCache: CostScanFileCache<ClaudeFileTotals>
     private var codexCache: CostScanFileCache<CodexFileTotals>
+    private var grokCache: CostScanFileCache<GrokFileTotals>
     private var deferred: Set<CostScanProvider> = []
 
     init(
@@ -34,6 +35,7 @@ nonisolated final class CostScanSession: @unchecked Sendable {
         self.store = store
         self.claudeCache = store?.loadClaude() ?? CostScanFileCache<ClaudeFileTotals>()
         self.codexCache = store?.loadCodex() ?? CostScanFileCache<CodexFileTotals>()
+        self.grokCache = store?.loadGrok() ?? CostScanFileCache<GrokFileTotals>()
     }
 
     var claude: CostScanFileCache<ClaudeFileTotals> {
@@ -46,6 +48,12 @@ nonisolated final class CostScanSession: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return codexCache
+    }
+
+    var grok: CostScanFileCache<GrokFileTotals> {
+        lock.lock()
+        defer { lock.unlock() }
+        return grokCache
     }
 
     var isCancelled: Bool { budget.isCancelled }
@@ -104,6 +112,18 @@ nonisolated final class CostScanSession: @unchecked Sendable {
         lock.unlock()
     }
 
+    func grokRecord(for key: String) -> CostScanFileRecord<GrokFileTotals>? {
+        lock.lock()
+        defer { lock.unlock() }
+        return grokCache.records[key]
+    }
+
+    func setGrokRecord(_ record: CostScanFileRecord<GrokFileTotals>, for key: String) {
+        lock.lock()
+        grokCache.records[key] = record
+        lock.unlock()
+    }
+
     /// Drops cache entries whose file no longer exists.
     ///
     /// Without this the cache grows forever: Claude Code and Codex delete old
@@ -121,7 +141,13 @@ nonisolated final class CostScanSession: @unchecked Sendable {
         lock.unlock()
     }
 
-    /// Writes both caches back, including after a cancelled slice — the whole
+    func retainGrok(keys: Set<String>) {
+        lock.lock()
+        grokCache.records = grokCache.records.filter { keys.contains($0.key) }
+        lock.unlock()
+    }
+
+    /// Writes every cache back, including after a cancelled slice — the whole
     /// point of committing on line boundaries is that partial progress is safe
     /// to keep.
     ///
@@ -138,7 +164,8 @@ nonisolated final class CostScanSession: @unchecked Sendable {
 
         return CostScanPersistReport(
             claude: Self.write("Claude") { try store.saveClaude(claude) },
-            codex: Self.write("Codex") { try store.saveCodex(codex) }
+            codex: Self.write("Codex") { try store.saveCodex(codex) },
+            grok: Self.write("Grok") { try store.saveGrok(grok) }
         )
     }
 
@@ -158,12 +185,34 @@ nonisolated final class CostScanSession: @unchecked Sendable {
     }
 }
 
-/// The two corpora a refresh reads. They have separate caches, separate budgets
+/// The corpora a refresh reads. They have separate caches, separate budgets
 /// to run out of, and separate ways to fail a write, so every "did this make
 /// resumable progress" answer is scoped to one of them.
 nonisolated enum CostScanProvider: Sendable, Hashable, CaseIterable {
     case claude
     case codex
+    case grok
+
+    /// The user-facing service this corpus bills against, so callers can gate a
+    /// scan on `ProviderVisibilityStore` without a second parallel mapping.
+    var service: ServiceType {
+        switch self {
+        case .claude: .claudeCode
+        case .codex: .codexCli
+        case .grok: .grok
+        }
+    }
+
+    /// Name used in log lines. A stored mapping rather than a ternary at each
+    /// call site — the two-way ternary this replaced silently labelled every
+    /// non-Claude provider "Codex".
+    var logName: String {
+        switch self {
+        case .claude: "Claude"
+        case .codex: "Codex"
+        case .grok: "Grok"
+        }
+    }
 }
 
 /// Whether a slice's offsets are durable enough for the next one to resume from.
@@ -191,19 +240,25 @@ nonisolated enum CostScanPersistOutcome: Sendable, Equatable {
 /// separate artifacts, and a shared verdict would let a permanently blocked
 /// Claude write cancel Codex's scan while Codex is still resuming cleanly.
 nonisolated struct CostScanPersistReport: Sendable, Equatable {
-    /// Both caches reached disk.
-    static let persisted = CostScanPersistReport(claude: .persisted, codex: .persisted)
+    /// Every cache reached disk.
+    static let persisted = CostScanPersistReport(claude: .persisted, codex: .persisted, grok: .persisted)
 
-    /// There was no store, so neither cache could outlive the slice.
-    static let unavailable = CostScanPersistReport(claude: .unavailable, codex: .unavailable)
+    /// There was no store, so no cache could outlive the slice.
+    static let unavailable = CostScanPersistReport(
+        claude: .unavailable,
+        codex: .unavailable,
+        grok: .unavailable
+    )
 
     let claude: CostScanPersistOutcome
     let codex: CostScanPersistOutcome
+    let grok: CostScanPersistOutcome
 
     func outcome(for provider: CostScanProvider) -> CostScanPersistOutcome {
         switch provider {
         case .claude: claude
         case .codex: codex
+        case .grok: grok
         }
     }
 }

--- a/MeterBar/Services/CostScanWindows.swift
+++ b/MeterBar/Services/CostScanWindows.swift
@@ -215,13 +215,19 @@ nonisolated struct CostScanResult {
     }
 }
 
-/// Mutable accumulators threaded through the Codex scan. Bundling these into one
+/// Mutable accumulators threaded through a corpus scan. Bundling these into one
 /// value collapses `CodexCostScanner`'s `addUsage`/`scanRollouts`/`scanSQLiteLogs`
 /// from 10–13 parameters (a SwiftLint `function_parameter_count` error) down to
 /// a single `inout` argument.
 ///
+/// Shared by the Codex and Grok scanners rather than duplicated: both fold the
+/// same eight breakdown dimensions plus dedup keys, and a second copy would mean
+/// a second `merge` and a second set of `_modify` forwarders to keep in step.
+/// Renaming the *type* is safe for the on-disk cache — `Codable` keys come from
+/// the stored property names below, not from the type's name.
+///
 /// Internal (not private) so `CodexCostScanner.scanRollouts` can be fixture-tested.
-nonisolated struct CodexScanContext: Sendable, Codable {
+nonisolated struct CostScanWindowContext: Sendable, Codable {
     var totals = TokenAccumulator()
     var dailyTotals: [Date: TokenAccumulator] = [:]
     var dailyModelTotals: [Date: [String: TokenAccumulator]] = [:]
@@ -246,7 +252,7 @@ nonisolated struct CodexScanContext: Sendable, Codable {
     /// that contributed nothing still carries `earliestDate = Date()` from
     /// whichever refresh created it, and merging that would drag the reported
     /// period start backwards to an instant no event ever happened at.
-    mutating func merge(_ other: CodexScanContext) {
+    mutating func merge(_ other: CostScanWindowContext) {
         guard !other.eventKeys.isEmpty else { return }
 
         totals.merge(other.totals)
@@ -295,14 +301,14 @@ nonisolated struct CodexScanContext: Sendable, Codable {
     }
 }
 
-/// Forwarders rather than renamed stored properties: `CodexScanContext` is the
+/// Forwarders rather than renamed stored properties: `CostScanWindowContext` is the
 /// `Codable` payload `CostScanFileCache` persists, so renaming its fields would
 /// change the on-disk keys and force every user into a full rescan.
 ///
 /// `_modify` rather than a setter: the fold subscripts these thousands of times
 /// per scan, and a get-mutate-set forwarder would copy the whole dictionary on
 /// every one of them.
-nonisolated extension CodexScanContext: CostScanBreakdowns {
+nonisolated extension CostScanWindowContext: CostScanBreakdowns {
     var daily: [Date: TokenAccumulator] {
         get { dailyTotals }
         _modify { yield &dailyTotals }

--- a/MeterBar/Services/CostSummaryBuilder.swift
+++ b/MeterBar/Services/CostSummaryBuilder.swift
@@ -39,11 +39,16 @@ enum CostSummaryBuilder {
     /// One traversal fills both windows. The lifetime scan reads a strict
     /// superset of the period scan, so running it separately would mean reading
     /// every transcript twice for the same numbers.
+    ///
+    /// `enabledProviders` replaces what used to be one `Bool` per provider: with
+    /// three corpora that shape had grown to three flags whose order at the call
+    /// site was load-bearing, and a set states the same thing without letting a
+    /// fourth provider silently push the argument list past the linter's cap.
     nonisolated static func makeScan(
         days: Int,
-        includeClaudeCode: Bool,
-        includeCodexCli: Bool,
+        enabledProviders: Set<CostScanProvider>,
         claudeAccounts: [ClaudeCodeAccount],
+        grokAccounts: [GrokAccount],
         session: CostScanSession,
         claudeProjectRoots: [URL]? = nil
     ) -> CostSummaryScan {
@@ -53,7 +58,7 @@ enum CostSummaryBuilder {
             cutoff: session.cutoff
         )
 
-        if includeClaudeCode {
+        if enabledProviders.contains(.claude) {
             let roots = claudeProjectRoots ?? ClaudeCostScanner.projectRoots(accounts: claudeAccounts)
             let claude = ClaudeCostScanner.scanRoots(roots, session: session)
             scan.period.append(ClaudeCostScanner.makeCost(from: claude.period, windowStart: session.cutoff))
@@ -62,12 +67,21 @@ enum CostSummaryBuilder {
             scan.lifetime.record(claude.lifetime.pricing)
         }
 
-        if includeCodexCli {
+        if enabledProviders.contains(.codex) {
             let codex = CodexCostScanner.scanSessions(session: session)
             scan.period.append(CodexCostScanner.makeCost(from: codex.period))
             scan.lifetime.append(CodexCostScanner.makeCost(from: codex.lifetime))
             scan.period.record(codex.period.pricing)
             scan.lifetime.record(codex.lifetime.pricing)
+        }
+
+        // No `record(...)` pass: Grok bills each turn itself, so its rows are
+        // never priced from the local table and have no provenance to report.
+        if enabledProviders.contains(.grok) {
+            let roots = GrokCostScanner.sessionRoots(accounts: grokAccounts)
+            let grok = GrokCostScanner.scanRoots(roots, session: session)
+            scan.period.append(GrokCostScanner.makeCost(from: grok.period))
+            scan.lifetime.append(GrokCostScanner.makeCost(from: grok.lifetime))
         }
 
         // Events older than every entry in the table were priced at the oldest

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -148,9 +148,17 @@ class CostTracker: ObservableObject {
     ///   along because the caller must not record a budget-truncated total as a
     ///   finished scan — see `apply(_:)`.
     private func makeCostSummary(days: Int) async -> CostSummaryBuilder.CostSummaryScan? {
-        let includeClaudeCode = providerVisibilityStore.isEnabled(.claudeCode)
-        let includeCodexCli = providerVisibilityStore.isEnabled(.codexCli)
+        // Read off `CostScanProvider` itself rather than a hand-listed set, so a
+        // provider added to the enum reaches the scan without a second edit here.
+        let enabledProviders = Set(
+            CostScanProvider.allCases.filter { providerVisibilityStore.isEnabled($0.service) }
+        )
         let claudeAccounts = ClaudeCodeAccountStore.shared.accounts
+        // Every configured account, not just the enabled ones — matching the
+        // Claude line above. Both scanners are looking for the home directories
+        // spend was written to, and disabling an account hides its quota gauge
+        // without unspending what it already cost.
+        let grokAccounts = GrokAccountStore.shared.accounts
         let cutoff = CostWindow.start(days: days)
         let store = CostScanCacheStore.applicationSupport
         var latest: CostSummaryBuilder.CostSummaryScan?
@@ -165,9 +173,9 @@ class CostTracker: ObservableObject {
                 )
                 let scan = CostSummaryBuilder.makeScan(
                     days: days,
-                    includeClaudeCode: includeClaudeCode,
-                    includeCodexCli: includeCodexCli,
+                    enabledProviders: enabledProviders,
                     claudeAccounts: claudeAccounts,
+                    grokAccounts: grokAccounts,
                     session: session
                 )
                 // Persist even when the slice was cut short: offsets commit on
@@ -222,7 +230,7 @@ class CostTracker: ObservableObject {
 
     private static func logStoppedScan(_ slice: ScanSlice) {
         for provider in slice.scan.deferredProviders {
-            let name = provider == .claude ? "Claude" : "Codex"
+            let name = provider.logName
             switch slice.persistence.outcome(for: provider) {
             case .persisted:
                 continue

--- a/MeterBar/Services/GrokCostScanner.swift
+++ b/MeterBar/Services/GrokCostScanner.swift
@@ -1,0 +1,474 @@
+import Foundation
+import MeterBarShared
+
+/// Reads Grok CLI session logs and turns them into cost totals — the third
+/// corpus alongside `ClaudeCostScanner` and `CodexCostScanner`.
+///
+/// Grok was already quota-tracked but contributed no `costs[]`/`dailyUsage[]`
+/// rows, so its spend was structurally absent from the chart and the share card
+/// rather than merely hidden by a toggle.
+///
+/// The shape mirrors the Codex scanner — same `ScanWindows`, same per-file
+/// resumable cache, same budgeted line reader — minus three things Grok does
+/// not need:
+///
+/// * **No pricing table.** Grok reports what it charged, per turn, in
+///   `costUsdTicks`. A local rate card would be a second source of truth that
+///   could only ever disagree with the bill.
+/// * **No deferred-model queue.** A Codex `token_count` event names no model, so
+///   that scanner parks events until a later line declares one. A Grok
+///   `turn_completed` names its own model inside `modelUsage`, so every record
+///   is attributable the moment it is read.
+/// * **No overlap fallback.** Codex stores the same rollout under both
+///   `sessions/` and `archived_sessions/`; Grok writes each session exactly
+///   once, and every dedup key carries its session ID, so two files cannot
+///   describe the same event. A plain `merge` is sufficient.
+enum GrokCostScanner {
+    /// USD per unit of `costUsdTicks`.
+    ///
+    /// **Pinned empirically, not assumed.** Grok reports cost as an integer tick
+    /// count with no documented scale, and the two candidate scales differ by
+    /// 10x — enough to make every Grok figure on the chart wrong while still
+    /// looking plausible.
+    ///
+    /// Method: take the observed records with `modelCalls == 1` (a single API
+    /// call, so no >200k-context surcharge can hide inside the total), hold
+    /// xAI's published grok-4.5 rates fixed ($2.00/M fresh input, $6.00/M
+    /// output), and solve each record for the implied cached-input rate:
+    ///
+    /// ```
+    /// cached   fresh  output   reported USD    implied cached rate
+    ///  60,800    253     503      0.021764           $0.300/M
+    ///  84,480    275     516      0.028990           $0.300/M
+    /// 171,904    951     260      0.055033           $0.300/M
+    /// 172,800    472      80      0.053264           $0.300/M
+    /// 173,184    693      64      0.053725           $0.300/M
+    /// ```
+    ///
+    /// Five independent records agreeing to three decimals is an exact solve,
+    /// not a curve fit. At 1e-9 the same rows imply $3.00/M for *cached* input —
+    /// 1.5x the fresh-input rate, which no cache discount can be. A whole-corpus
+    /// cross-check agrees: against a published-rate baseline, 1e-10 puts every
+    /// record between 0.61x and 1.74x (median 0.78x, the spread the 2x
+    /// long-context surcharge predicts), while 1e-9 puts the median at 7.8x.
+    ///
+    /// Asserted on a fixed record in `GrokCostScannerTests` so editing this
+    /// constant fails a test rather than silently restating every Grok total.
+    nonisolated static let usdPerCostTick = 1e-10
+
+    /// The front end this corpus is written by. Grok records carry no
+    /// originator field of their own, so every event shares one origin rather
+    /// than landing in "Unknown origin".
+    nonisolated static let originName = "Grok CLI"
+
+    /// Byte-level prefilter, matching the Codex scanner's `token_count` one.
+    /// `updates.jsonl` is a full transport log — tool calls, message chunks,
+    /// permission prompts — and only a handful of its lines carry usage, so
+    /// skipping `JSONSerialization` on the rest is what keeps the scan cheap.
+    nonisolated private static let turnCompletedMarker = Data("\"turn_completed\"".utf8)
+
+    /// Seeds both windows: `earliestDate` starts at now and only decreases,
+    /// `latestDate` starts at the window floor and only increases.
+    nonisolated static func scanWindows(cutoff: Date) -> ScanWindows<CostScanWindowContext> {
+        ScanWindows(
+            period: CostScanWindowContext(earliestDate: Date(), latestDate: cutoff),
+            lifetime: CostScanWindowContext(earliestDate: Date(), latestDate: .distantPast),
+            cutoff: cutoff
+        )
+    }
+
+    /// The `sessions` directories to scan, one per Grok home.
+    ///
+    /// Resolution goes through `GrokHomeDirectory` rather than a literal
+    /// `~/.grok` so `GROK_HOME` and per-account homes keep working; a hardcoded
+    /// path would scan the wrong corpus — or none — for anyone who moved it.
+    ///
+    /// The local-volume guard is applied to the *home* directory rather than to
+    /// `sessions` itself: a freshly configured account has a home but has not
+    /// yet written a session, and rejecting it there would make the account
+    /// invisible until its first turn. `sessions` is a child of the directory
+    /// just cleared, so the network-volume protection is unchanged.
+    nonisolated static func sessionRoots(accounts: [GrokAccount]) -> [URL] {
+        var homes = [GrokHomeDirectory.path()]
+        homes.append(contentsOf: accounts.map(GrokHomeDirectory.path(for:)))
+
+        var roots: [URL] = []
+        var seen: Set<String> = []
+        for home in homes {
+            let directory = URL(fileURLWithPath: home, isDirectory: true)
+            guard CostScanFileSystem.isLocalDirectory(directory) else { continue }
+            let sessions = directory.appendingPathComponent("sessions", isDirectory: true)
+            guard seen.insert(sessions.standardizedFileURL.path).inserted else { continue }
+            roots.append(sessions)
+        }
+        return roots
+    }
+
+    /// Walks each root newest transcript first, reading only bytes appended
+    /// since the last refresh and stopping when the budget runs out.
+    ///
+    /// Roots can overlap — two accounts pointed at one home, or `GROK_HOME` set
+    /// to the default — so files are deduplicated by cache key the way the
+    /// Claude scanner deduplicates its project roots.
+    nonisolated static func scanRoots(
+        _ roots: [URL],
+        session: CostScanSession
+    ) -> ScanWindows<CostScanWindowContext> {
+        var windows = Self.scanWindows(cutoff: session.cutoff)
+        var live: Set<String> = []
+
+        for root in roots {
+            guard CostScanFileSystem.isLocalDirectory(root) else { continue }
+            for file in CostScanCorpus.transcripts(in: root) {
+                guard live.insert(file.cacheKey).inserted else { continue }
+                guard let totals = Self.totals(for: file, session: session) else { continue }
+                windows.period.merge(totals.period)
+                windows.lifetime.merge(totals.lifetime)
+            }
+        }
+
+        session.retainGrok(keys: live)
+        return windows
+    }
+
+    /// The window's totals as a published cost row plus its daily rows.
+    ///
+    /// Unlike the Codex counterpart this neither subtracts `cacheRead` from
+    /// `input` nor adds `reasoning` to `output`: Grok nests both inside the
+    /// figures it reports, so `apply` already unpacked them at ingest. Doing it
+    /// again here would bill the cached prefix twice and double-count reasoning.
+    ///
+    /// Pricing is all-zero rather than a Grok rate card. Every record carries
+    /// its own cost, so the only totals that reach the fallback are ones Grok
+    /// itself billed at $0 — which is the right answer for them.
+    nonisolated static func makeCost(
+        from context: CostScanWindowContext
+    ) -> (TokenCost, [DailyTokenUsage])? {
+        let totals = context.totals
+        guard totals.input > 0 || totals.output > 0 || totals.cacheRead > 0 else { return nil }
+
+        let pricing = TokenPricing(input: 0, output: 0, cacheCreation: 0, cacheRead: 0)
+
+        return (TokenCost(
+            provider: .grok,
+            inputTokens: totals.input,
+            outputTokens: totals.output,
+            cacheCreationTokens: 0,
+            cacheReadTokens: totals.cacheRead,
+            estimatedCostUSD: totals.estimatedCostUSD,
+            sessionCount: context.sessionIDs.count,
+            periodStart: context.earliestDate,
+            periodEnd: context.latestDate,
+            modelBreakdowns: TokenUsageAggregator.makeBreakdowns(
+                from: context.modelTotals,
+                provider: .grok,
+                pricing: pricing
+            ),
+            originBreakdowns: TokenUsageAggregator.makeBreakdowns(
+                from: context.originTotals,
+                provider: .grok,
+                pricing: pricing
+            ),
+            projectBreakdowns: TokenUsageAggregator.makeProjectBreakdowns(
+                from: context.projectTotals,
+                modelsByProject: context.projectModelTotals,
+                provider: .grok,
+                pricing: pricing
+            )
+        ), TokenUsageAggregator.makeDailyUsage(
+            from: context.dailyTotals,
+            provider: .grok,
+            pricing: pricing,
+            modelsByDay: context.dailyModelTotals,
+            projectsByDay: context.dailyProjectTotals,
+            projectModelsByDay: context.dailyProjectModelTotals
+        ))
+    }
+
+    /// One `updates.jsonl`'s isolated tally: cached, resumed, or skipped.
+    ///
+    /// Parsing into the file's *own* windows rather than straight into the
+    /// shared ones is what makes the result cacheable — a per-file tally stays
+    /// valid no matter which other files a later refresh happens to read.
+    ///
+    /// - Returns: `nil` when the file has never been read and there was no
+    ///   budget left to start it.
+    nonisolated private static func totals(
+        for file: CostScanFile,
+        session: CostScanSession
+    ) -> GrokFileTotals? {
+        let record = Self.resumableRecord(for: file, session: session)
+
+        // Nothing appended since the last pass.
+        if let record, record.isComplete, record.stamp.matches(file.stamp) {
+            return record.payload
+        }
+
+        let allowance = session.budget.allowance
+        guard allowance > 0 else {
+            session.noteDeferred(.grok)
+            return record?.payload
+        }
+
+        var payload = record?.payload ?? GrokFileTotals(cutoff: session.cutoff)
+        var windows = ScanWindows(
+            period: payload.period,
+            lifetime: payload.lifetime,
+            cutoff: session.cutoff
+        )
+        let attribution = Self.attribution(for: file.url)
+        let calendar = Calendar.current
+        var truncation = CostScanTruncationTally()
+
+        var request = FileLineReadRequest()
+        request.startOffset = record?.offset ?? 0
+        request.maxBytes = allowance
+
+        let read = FileLineReader.readLines(in: file.url, request: request) { readerLine, _ in
+            // swiftlint:disable:next contains_over_range_nil_comparison
+            guard readerLine.bytes.range(of: Self.turnCompletedMarker) != nil else { return }
+            let event = Self.usageEvent(from: readerLine.bytes, attribution: attribution)
+            // A `turn_completed` envelope carries no message content, so it is
+            // orders of magnitude below the reader's line cap. One that arrives
+            // truncated anyway is a genuinely damaged file — noted for the log,
+            // never salvaged into a half-read token count.
+            truncation.note(readerLine, recovered: event != nil)
+            guard let event else { return }
+            Self.apply(event, windows: &windows, calendar: calendar)
+        }
+        truncation.log(url: file.url)
+
+        guard let read else { return record?.payload }
+        session.budget.consume(read.bytesRead)
+        if !read.reachedEndOfFile { session.noteDeferred(.grok) }
+
+        payload.period = windows.period
+        payload.lifetime = windows.lifetime
+
+        session.setGrokRecord(
+            CostScanFileRecord(
+                offset: read.committedOffset,
+                stamp: file.stamp,
+                cutoff: session.cutoff,
+                isComplete: read.reachedEndOfFile,
+                payload: payload
+            ),
+            for: file.cacheKey
+        )
+        return payload
+    }
+
+    /// The cached entry to resume from, rebased onto this refresh's cutoff.
+    ///
+    /// - Returns: `nil` when the file has to be re-read from byte zero.
+    nonisolated private static func resumableRecord(
+        for file: CostScanFile,
+        session: CostScanSession
+    ) -> CostScanFileRecord<GrokFileTotals>? {
+        guard var record = session.grokRecord(for: file.cacheKey) else { return nil }
+        guard record.offset <= UInt64(file.size) else { return nil }
+        if record.isComplete, record.stamp.size == file.size {
+            guard record.stamp.matches(file.stamp) else { return nil }
+        } else {
+            guard record.stamp.isSameFile(as: file.stamp),
+                  file.size >= record.stamp.size else { return nil }
+        }
+        guard record.cutoff != session.cutoff else { return record }
+
+        let lifetime = record.payload.lifetime
+        if lifetime.eventKeys.isEmpty || lifetime.latestDate < session.cutoff {
+            // Every event predates the new window.
+            record.payload.period = CostScanWindowContext(
+                earliestDate: Date(),
+                latestDate: session.cutoff
+            )
+        } else if lifetime.earliestDate >= session.cutoff {
+            // Every event falls inside it.
+            record.payload.period = lifetime
+        } else {
+            // The file straddles the cutoff and only its individual records know
+            // where. Only files that actually straddle pay for the window moving.
+            return nil
+        }
+        record.cutoff = session.cutoff
+        return record
+    }
+
+    /// Project and fallback session identity, both derived from where the file
+    /// lives: `<root>/<percent-encoded project path>/<session uuid>/updates.jsonl`.
+    ///
+    /// Resolved once per file rather than per line — neither can change part-way
+    /// through a file, and percent-decoding is not free.
+    nonisolated private static func attribution(for fileURL: URL) -> GrokUsageAttribution {
+        let sessionDirectory = fileURL.deletingLastPathComponent()
+        let projectDirectory = sessionDirectory.deletingLastPathComponent()
+        return GrokUsageAttribution(
+            projectID: CostProjectAttribution.grokProjectID(
+                encodedDirectoryName: projectDirectory.lastPathComponent
+            ),
+            fallbackSessionID: sessionDirectory.lastPathComponent
+        )
+    }
+
+    /// One `turn_completed` line's usage, or `nil` for every other line.
+    ///
+    /// Tolerant on the envelope, strict on the numbers: the method name is
+    /// matched by suffix because Grok writes the same update under both
+    /// `session/update` and a vendor-prefixed `_x.ai/session/update`, while a
+    /// non-numeric `timestamp` drops the record rather than fabricating a 1970
+    /// date that would land in the lifetime window.
+    nonisolated private static func usageEvent(
+        from line: Data,
+        attribution: GrokUsageAttribution
+    ) -> GrokUsageEvent? {
+        guard let object = try? JSONSerialization.jsonObject(with: line),
+              let envelope = object as? [String: Any],
+              let method = envelope["method"] as? String,
+              method.hasSuffix("session/update"),
+              let seconds = (envelope["timestamp"] as? NSNumber)?.doubleValue,
+              seconds.isFinite,
+              let params = envelope["params"] as? [String: Any],
+              let update = params["update"] as? [String: Any],
+              update["sessionUpdate"] as? String == "turn_completed",
+              let usage = update["usage"] as? [String: Any] else { return nil }
+
+        let input = CostScanValues.int(usage["inputTokens"])
+        let cached = CostScanValues.int(usage["cachedReadTokens"])
+        let output = CostScanValues.int(usage["outputTokens"])
+        let reasoning = CostScanValues.int(usage["reasoningTokens"])
+        guard input > 0 || output > 0 || cached > 0 else { return nil }
+
+        return GrokUsageEvent(
+            timestamp: Date(timeIntervalSince1970: seconds),
+            sessionID: (params["sessionId"] as? String) ?? attribution.fallbackSessionID,
+            input: input,
+            cached: cached,
+            output: output,
+            reasoning: reasoning,
+            ticks: CostScanValues.int(usage["costUsdTicks"]),
+            model: Self.dominantModel(in: usage["modelUsage"]),
+            projectID: attribution.projectID
+        )
+    }
+
+    /// The model a turn is attributed to.
+    ///
+    /// Every observed record carries exactly one entry. A turn that routed
+    /// across models is credited to whichever spent the most rather than split,
+    /// because the headline totals come from the turn's own `usage` block —
+    /// apportioning them by a second set of figures would let the breakdowns
+    /// disagree with the total they sum to.
+    nonisolated private static func dominantModel(in raw: Any?) -> String? {
+        guard let models = raw as? [String: Any], !models.isEmpty else { return nil }
+
+        // A plain loop rather than `map`/`max(by:)`: dictionary order is not
+        // stable, so the name tie-break is what keeps a two-model turn from
+        // landing under a different heading on each refresh.
+        var best: (name: String, ticks: Int)?
+        for (name, entry) in models {
+            let ticks = CostScanValues.int((entry as? [String: Any])?["costUsdTicks"])
+            guard let current = best else {
+                best = (name, ticks)
+                continue
+            }
+            if ticks > current.ticks || (ticks == current.ticks && name < current.name) {
+                best = (name, ticks)
+            }
+        }
+        return best?.name
+    }
+
+    /// Folds one usage record into both windows.
+    ///
+    /// Records are per-turn increments, not running totals — verified
+    /// non-monotonic within a single session on disk — so they are summed.
+    /// The dedup key is what keeps a re-logged turn from being billed twice;
+    /// it carries the session ID, so no two files can collide.
+    ///
+    /// `calendar` is passed in rather than resolved here: resolving the current
+    /// calendar is not free, and it cannot change part-way through a scan.
+    nonisolated private static func apply(
+        _ event: GrokUsageEvent,
+        windows: inout ScanWindows<CostScanWindowContext>,
+        calendar: Calendar
+    ) {
+        let timestamp = event.timestamp
+        let sessionID = event.sessionID
+        // Grok nests both figures: `cachedReadTokens <= inputTokens` and
+        // `reasoningTokens < outputTokens` in every observed record, with
+        // `totalTokens == inputTokens + outputTokens` exactly. Unpacking here —
+        // rather than in `makeCost` — means every downstream consumer, including
+        // the shared aggregator, sees the same already-correct figures.
+        let freshInput = max(0, event.input - event.cached)
+        let cost = Double(event.ticks) * Self.usdPerCostTick
+
+        // Whole-millisecond precision, matching the Codex key, so equivalent
+        // records produce a stable string rather than a formatted Double.
+        let timestampMillis = Int((timestamp.timeIntervalSince1970 * 1000).rounded())
+        let key = """
+            \(timestampMillis)-\(sessionID)-\(event.input)-\(event.cached)-\
+            \(event.output)-\(event.reasoning)-\(event.ticks)
+            """
+        let keys = CostScanEventKeys(
+            day: calendar.startOfDay(for: timestamp),
+            model: CostScanValues.displayModelName(event.model),
+            origin: CostScanValues.displayOriginName(Self.originName),
+            project: event.projectID
+        )
+        let breakdown = CostScanEventTotals(
+            input: freshInput,
+            output: event.output,
+            cacheCreation: 0,
+            cacheRead: event.cached,
+            estimatedCostUSD: cost
+        )
+
+        // No `pricing.record`: nothing here was priced from a local table, so
+        // there is no provenance to report and no table gap to warn about.
+        windows.update(at: timestamp) { context in
+            guard context.eventKeys.insert(key).inserted else { return }
+
+            context.sessionIDs.insert(sessionID)
+            context.totals.add(
+                input: freshInput,
+                output: event.output,
+                cacheCreation: 0,
+                cacheRead: event.cached,
+                estimatedCostUSD: cost
+            )
+            context.record(breakdown, at: keys)
+            if timestamp < context.earliestDate { context.earliestDate = timestamp }
+            if timestamp > context.latestDate { context.latestDate = timestamp }
+        }
+    }
+}
+
+/// Where a Grok record's spend belongs, derived once per file from its path.
+nonisolated struct GrokUsageAttribution: Sendable {
+    let projectID: String
+
+    /// Used when the envelope omits `params.sessionId`. The session directory is
+    /// named after the session, so it is the same identity by another route.
+    let fallbackSessionID: String
+}
+
+/// One `turn_completed` record's usage, as written.
+///
+/// Deliberately raw: `input` still includes `cached` and `output` still includes
+/// `reasoning`, exactly as Grok reported them, so the dedup key is computed over
+/// the figures on disk rather than over a derived view of them.
+nonisolated struct GrokUsageEvent: Sendable {
+    let timestamp: Date
+    let sessionID: String
+    let input: Int
+    let cached: Int
+    let output: Int
+    let reasoning: Int
+
+    /// Cost as Grok billed it, in `costUsdTicks`. See
+    /// `GrokCostScanner.usdPerCostTick` for the scale and how it was pinned.
+    let ticks: Int
+
+    let model: String?
+    let projectID: String
+}

--- a/MeterBar/Services/GrokCostScanner.swift
+++ b/MeterBar/Services/GrokCostScanner.swift
@@ -310,13 +310,30 @@ enum GrokCostScanner {
         )
     }
 
+    /// Whole milliseconds since the epoch, or `nil` when the value cannot be
+    /// expressed as one. `Int(_:)` traps on a `Double` outside `Int`'s range and
+    /// `isFinite` does not rule that out — `1e300` is finite, and its
+    /// millisecond value (~1e303) crashed the scan on the way into the dedup
+    /// key. Unlike Codex, whose timestamps arrive as bounded ISO-8601 strings,
+    /// Grok logs a raw JSON number, so any file on disk can carry one.
+    nonisolated private static func millisecondsSinceEpoch(_ seconds: Double) -> Int? {
+        let milliseconds = (seconds * 1000).rounded()
+        guard milliseconds.isFinite,
+              milliseconds >= Double(Int.min),
+              milliseconds < Double(Int.max) else { return nil }
+        return Int(milliseconds)
+    }
+
     /// One `turn_completed` line's usage, or `nil` for every other line.
     ///
     /// Tolerant on the envelope, strict on the numbers: the method name is
     /// matched by suffix because Grok writes the same update under both
     /// `session/update` and a vendor-prefixed `_x.ai/session/update`, while a
     /// non-numeric `timestamp` drops the record rather than fabricating a 1970
-    /// date that would land in the lifetime window.
+    /// date that would land in the lifetime window. A numeric timestamp too
+    /// large to express in whole milliseconds is dropped for the same reason:
+    /// it is corrupt, and letting it through would put an absurd date through
+    /// `startOfDay` and the window bounds.
     nonisolated private static func usageEvent(
         from line: Data,
         attribution: GrokUsageAttribution
@@ -326,7 +343,7 @@ enum GrokCostScanner {
               let method = envelope["method"] as? String,
               method.hasSuffix("session/update"),
               let seconds = (envelope["timestamp"] as? NSNumber)?.doubleValue,
-              seconds.isFinite,
+              Self.millisecondsSinceEpoch(seconds) != nil,
               let params = envelope["params"] as? [String: Any],
               let update = params["update"] as? [String: Any],
               update["sessionUpdate"] as? String == "turn_completed",
@@ -404,7 +421,10 @@ enum GrokCostScanner {
 
         // Whole-millisecond precision, matching the Codex key, so equivalent
         // records produce a stable string rather than a formatted Double.
-        let timestampMillis = Int((timestamp.timeIntervalSince1970 * 1000).rounded())
+        // Parsing already rejected timestamps that cannot be expressed this way;
+        // converting through the same helper keeps the conversion trap-free
+        // rather than relying on that guarantee holding at a distance.
+        guard let timestampMillis = Self.millisecondsSinceEpoch(timestamp.timeIntervalSince1970) else { return }
         let key = """
             \(timestampMillis)-\(sessionID)-\(event.input)-\(event.cached)-\
             \(event.output)-\(event.reasoning)-\(event.ticks)

--- a/MeterBarTests/CostScanCollaboratorTests.swift
+++ b/MeterBarTests/CostScanCollaboratorTests.swift
@@ -500,7 +500,7 @@ final class CostScanCollaboratorTests: XCTestCase {
 
         // No `estimatedCostUSD` anywhere, so every row falls back to the table.
         let tokens = totals(input: 1_000_000, output: 0, cacheRead: 0)
-        var context = CodexScanContext(earliestDate: recorded, latestDate: recorded)
+        var context = CostScanWindowContext(earliestDate: recorded, latestDate: recorded)
         context.totals = tokens
         context.sessionIDs = ["session"]
         context.modelTotals = ["gpt-5.6-sol": tokens]
@@ -534,9 +534,9 @@ final class CostScanCollaboratorTests: XCTestCase {
         let days = 7
         let scan = CostSummaryBuilder.makeScan(
             days: days,
-            includeClaudeCode: false,
-            includeCodexCli: false,
+            enabledProviders: [],
             claudeAccounts: [],
+            grokAccounts: [],
             session: CostScanSession(cutoff: CostWindow.start(days: days), options: .unlimited)
         )
 
@@ -578,9 +578,9 @@ final class CostScanCollaboratorTests: XCTestCase {
 
         let budgeted = CostSummaryBuilder.makeScan(
             days: days,
-            includeClaudeCode: true,
-            includeCodexCli: false,
+            enabledProviders: [.claude],
             claudeAccounts: [],
+            grokAccounts: [],
             session: session,
             claudeProjectRoots: [projects]
         )

--- a/MeterBarTests/CostScanFixtureScan.swift
+++ b/MeterBarTests/CostScanFixtureScan.swift
@@ -11,7 +11,7 @@ import Foundation
 /// entries in whatever order the volume hands back, and Codex dedup is
 /// first-event-wins — and hands each file to the scanner one at a time.
 enum CostScanFixtureScan {
-    static func codexRollouts(in directory: URL, windows: inout ScanWindows<CodexScanContext>) {
+    static func codexRollouts(in directory: URL, windows: inout ScanWindows<CostScanWindowContext>) {
         for url in Self.transcripts(in: directory) {
             CodexCostScanner.parseRollout(at: url, windows: &windows)
         }
@@ -22,11 +22,11 @@ enum CostScanFixtureScan {
     static func codexRollouts(
         in directory: URL,
         since cutoffDate: Date,
-        context: inout CodexScanContext
+        context: inout CostScanWindowContext
     ) {
         var windows = ScanWindows(
             period: context,
-            lifetime: CodexScanContext(earliestDate: Date(), latestDate: .distantPast),
+            lifetime: CostScanWindowContext(earliestDate: Date(), latestDate: .distantPast),
             cutoff: cutoffDate
         )
         Self.codexRollouts(in: directory, windows: &windows)

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -449,8 +449,8 @@ final class CostTrackerTests: XCTestCase {
         """
     }
 
-    private func makeContext(cutoff: Date) -> CodexScanContext {
-        CodexScanContext(earliestDate: Date(), latestDate: cutoff)
+    private func makeContext(cutoff: Date) -> CostScanWindowContext {
+        CostScanWindowContext(earliestDate: Date(), latestDate: cutoff)
     }
 
     func testScanCodexRolloutsAccumulatesTokenCounts() throws {
@@ -1589,7 +1589,7 @@ final class CostTrackerTests: XCTestCase {
             for: "/transcripts/a.jsonl"
         )
 
-        XCTAssertEqual(session.persist(), CostScanPersistReport(claude: .failed, codex: .failed))
+        XCTAssertEqual(session.persist(), CostScanPersistReport(claude: .failed, codex: .failed, grok: .failed))
         // Nothing reached disk, so the offsets this slice committed are not
         // resumable — the next slice would re-read the same bytes.
         XCTAssertTrue(store.loadClaude().records.isEmpty)
@@ -1666,7 +1666,7 @@ final class CostTrackerTests: XCTestCase {
         let partial = CostSummaryBuilder.CostSummaryScan(
             summary: makeEmptySummary(), deferredProviders: [.claude, .codex])
         let whole = CostSummaryBuilder.CostSummaryScan(summary: makeEmptySummary())
-        let failed = CostScanPersistReport(claude: .failed, codex: .failed)
+        let failed = CostScanPersistReport(claude: .failed, codex: .failed, grok: .failed)
 
         XCTAssertTrue(CostTracker.shouldRunAnotherSlice(after: partial, persistence: .persisted))
         // A slice whose caches never landed leaves the store exactly as it found
@@ -1687,7 +1687,7 @@ final class CostTrackerTests: XCTestCase {
             summary: makeEmptySummary(), deferredProviders: [.claude, .codex])
         let claudeDeferred = CostSummaryBuilder.CostSummaryScan(
             summary: makeEmptySummary(), deferredProviders: [.claude])
-        let report = CostScanPersistReport(claude: .failed, codex: .persisted)
+        let report = CostScanPersistReport(claude: .failed, codex: .persisted, grok: .failed)
 
         XCTAssertTrue(CostTracker.shouldRunAnotherSlice(after: bothDeferred, persistence: report))
         // Codex has finished; the only provider still deferring is the one whose

--- a/MeterBarTests/GrokCostScannerTests.swift
+++ b/MeterBarTests/GrokCostScannerTests.swift
@@ -1,0 +1,485 @@
+import XCTest
+@testable import MeterBar
+@testable import MeterBarShared
+
+/// Unit tests for `GrokCostScanner` — the third cost corpus (issue: Grok is
+/// quota-tracked but contributed no `costs[]`/`dailyUsage[]` rows, so it was
+/// structurally absent from the spend chart and the share card).
+///
+/// Grok reports spend itself, so the load-bearing facts here are not a pricing
+/// table but the *shape* of what it reports: the tick scale, that cached reads
+/// sit inside `inputTokens`, that reasoning sits inside `outputTokens`, and that
+/// records are per-turn increments rather than running totals. Each has its own
+/// test because getting any one wrong produces a plausible-looking number.
+final class GrokCostScannerTests: XCTestCase {
+    // MARK: - Tick scale
+
+    /// The reconciliation that pinned `usdPerCostTick`, asserted on a fixed
+    /// record so a future edit to the constant fails here rather than silently
+    /// restating every Grok total by a factor of ten.
+    ///
+    /// Token counts and `costUsdTicks` below are observed values from a real
+    /// `updates.jsonl` turn with `modelCalls == 1` — a single call, so no
+    /// >200k-context surcharge can be hiding in the total. Holding xAI's
+    /// published grok-4.5 rates fixed ($2.00/M fresh input, $6.00/M output) and
+    /// solving for the cached-input rate yields exactly $0.300/M at this scale.
+    /// At 1e-9 the same row implies $3.00/M cached input — 1.5x the *fresh*
+    /// input rate, which no cache discount can be.
+    func testCostTickScaleReproducesTheVerifiedDollarAmountForAKnownRecord() {
+        let ticks = 532_640_000
+
+        let usd = Double(ticks) * GrokCostScanner.usdPerCostTick
+
+        XCTAssertEqual(usd, 0.053264, accuracy: 1e-9)
+    }
+
+    /// The same record, end to end: what the scanner publishes has to equal the
+    /// figure the constant reconciles to, not merely be derived from it.
+    func testScannedRecordPublishesTheCostGrokReportedRatherThanARecomputedOne() throws {
+        let root = try makeSessionsRoot()
+        let now = Date()
+        try writeUpdates(
+            in: root,
+            project: "www/meterbar",
+            session: "019fafec-972e-7413-8cbd-01647988c8f9",
+            lines: [turnCompleted(at: now, input: 173_272, cachedRead: 172_800, output: 80, reasoning: 40, ticks: 532_640_000)]
+        )
+
+        let cost = try XCTUnwrap(scanCost(roots: [root], days: 30))
+
+        XCTAssertEqual(cost.estimatedCostUSD, 0.053264, accuracy: 1e-9)
+    }
+
+    // MARK: - Token semantics
+
+    /// `cachedReadTokens` is a *subset* of `inputTokens` — every observed record
+    /// satisfies `totalTokens == inputTokens + outputTokens` with
+    /// `cachedReadTokens <= inputTokens`. Reporting the raw `inputTokens`
+    /// alongside `cacheReadTokens` would bill the cached prefix twice and inflate
+    /// `totalTokens` past what Grok itself reported for the turn.
+    func testCachedReadTokensAreSubtractedFromInputRatherThanCountedTwice() throws {
+        let root = try makeSessionsRoot()
+        try writeUpdates(
+            in: root,
+            project: "www/meterbar",
+            session: "session-a",
+            lines: [turnCompleted(at: Date(), input: 60_800, cachedRead: 60_547, output: 503, reasoning: 120, ticks: 217_640_000)]
+        )
+
+        let cost = try XCTUnwrap(scanCost(roots: [root], days: 30))
+
+        XCTAssertEqual(cost.inputTokens, 253, "fresh input only")
+        XCTAssertEqual(cost.cacheReadTokens, 60_547)
+        XCTAssertEqual(cost.totalTokens, 60_800 + 503, "must match Grok's own totalTokens")
+    }
+
+    /// Codex reports reasoning tokens *outside* `output_tokens`, so its scanner
+    /// adds them on. Grok reports them inside `outputTokens`
+    /// (`reasoningTokens < outputTokens` in every observed record), so adding
+    /// them again would double-count the most expensive tokens on the bill.
+    func testReasoningTokensAreNotAddedOnTopOfOutputTokens() throws {
+        let root = try makeSessionsRoot()
+        try writeUpdates(
+            in: root,
+            project: "www/meterbar",
+            session: "session-a",
+            lines: [turnCompleted(at: Date(), input: 1_000, cachedRead: 0, output: 500, reasoning: 400, ticks: 5_000_000)]
+        )
+
+        let cost = try XCTUnwrap(scanCost(roots: [root], days: 30))
+
+        XCTAssertEqual(cost.outputTokens, 500)
+    }
+
+    /// Records are per-turn increments, not running totals — verified
+    /// non-monotonic within a single session on disk. Summing is therefore
+    /// correct; taking the last record would drop everything before it.
+    func testPerTurnRecordsAreSummedBecauseTheyAreIncrementalNotCumulative() throws {
+        let root = try makeSessionsRoot()
+        let now = Date()
+        try writeUpdates(
+            in: root,
+            project: "www/meterbar",
+            session: "session-a",
+            lines: [
+                turnCompleted(at: now.addingTimeInterval(-300), input: 276_435, cachedRead: 0, output: 100, reasoning: 0, ticks: 10_000_000),
+                turnCompleted(at: now.addingTimeInterval(-200), input: 121_551, cachedRead: 0, output: 200, reasoning: 0, ticks: 20_000_000),
+                turnCompleted(at: now.addingTimeInterval(-100), input: 61_053, cachedRead: 0, output: 300, reasoning: 0, ticks: 30_000_000)
+            ]
+        )
+
+        let cost = try XCTUnwrap(scanCost(roots: [root], days: 30))
+
+        XCTAssertEqual(cost.inputTokens, 276_435 + 121_551 + 61_053)
+        XCTAssertEqual(cost.outputTokens, 600)
+        XCTAssertEqual(cost.estimatedCostUSD, 0.006, accuracy: 1e-9)
+    }
+
+    // MARK: - Envelope tolerance
+
+    /// Grok writes the same `session/update` envelope under a vendor-prefixed
+    /// method name as well. Both carry real spend; matching only the bare name
+    /// silently dropped every record written under the prefixed one.
+    func testVendorPrefixedSessionUpdateMethodIsCountedTheSameAsThePlainOne() throws {
+        let root = try makeSessionsRoot()
+        let now = Date()
+        try writeUpdates(
+            in: root,
+            project: "www/meterbar",
+            session: "session-a",
+            lines: [
+                turnCompleted(at: now.addingTimeInterval(-60), input: 10, cachedRead: 0, output: 5, reasoning: 0, ticks: 1_000_000),
+                turnCompleted(
+                    at: now,
+                    input: 20,
+                    cachedRead: 0,
+                    output: 7,
+                    reasoning: 0,
+                    ticks: 2_000_000,
+                    method: "_x.ai/session/update"
+                )
+            ]
+        )
+
+        let cost = try XCTUnwrap(scanCost(roots: [root], days: 30))
+
+        XCTAssertEqual(cost.inputTokens, 30)
+        XCTAssertEqual(cost.outputTokens, 12)
+    }
+
+    /// `updates.jsonl` is a full transport log: tool calls, agent messages, and
+    /// permission prompts share the file with the handful of `turn_completed`
+    /// lines that carry usage. Only the latter may be tallied.
+    func testUpdatesWithoutATurnCompletedUsageBlobContributeNothing() throws {
+        let root = try makeSessionsRoot()
+        try writeUpdates(
+            in: root,
+            project: "www/meterbar",
+            session: "session-a",
+            lines: [
+                #"{"timestamp":1785363000,"method":"session/update","params":{"sessionId":"session-a","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello"}}}}"#,
+                #"{"timestamp":1785363001,"method":"session/request_permission","params":{"sessionId":"session-a"}}"#
+            ]
+        )
+
+        XCTAssertNil(scanCost(roots: [root], days: 30))
+    }
+
+    /// A partially-flushed final line is the normal state of a session that is
+    /// still running. It must cost the scan that one record, never the file.
+    func testMalformedLinesAreSkippedWithoutAbortingTheRestOfTheFile() throws {
+        let root = try makeSessionsRoot()
+        let now = Date()
+        try writeUpdates(
+            in: root,
+            project: "www/meterbar",
+            session: "session-a",
+            lines: [
+                turnCompleted(at: now.addingTimeInterval(-120), input: 100, cachedRead: 0, output: 10, reasoning: 0, ticks: 1_000_000),
+                "{not json at all",
+                #"{"timestamp":"not-a-number","method":"session/update"}"#,
+                turnCompleted(at: now, input: 200, cachedRead: 0, output: 20, reasoning: 0, ticks: 2_000_000)
+            ]
+        )
+
+        let cost = try XCTUnwrap(scanCost(roots: [root], days: 30))
+
+        XCTAssertEqual(cost.inputTokens, 300)
+        XCTAssertEqual(cost.outputTokens, 30)
+    }
+
+    /// One turn re-logged verbatim (a retried write) must not be billed twice.
+    func testIdenticalRecordsInOneFileAreCountedOnce() throws {
+        let root = try makeSessionsRoot()
+        let now = Date()
+        let line = turnCompleted(at: now, input: 100, cachedRead: 0, output: 10, reasoning: 0, ticks: 1_000_000)
+        try writeUpdates(in: root, project: "www/meterbar", session: "session-a", lines: [line, line])
+
+        let cost = try XCTUnwrap(scanCost(roots: [root], days: 30))
+
+        XCTAssertEqual(cost.inputTokens, 100)
+    }
+
+    // MARK: - Windowing
+
+    /// The period window is the visible 30-day chart; the lifetime window is the
+    /// share card's all-time figure. One traversal has to fill both correctly.
+    func testRecordsOlderThanTheCutoffCountTowardLifetimeButNotThePeriod() throws {
+        let root = try makeSessionsRoot()
+        let now = Date()
+        try writeUpdates(
+            in: root,
+            project: "www/meterbar",
+            session: "session-a",
+            lines: [
+                turnCompleted(at: now.addingTimeInterval(-60 * 60 * 24 * 90), input: 900, cachedRead: 0, output: 90, reasoning: 0, ticks: 9_000_000),
+                turnCompleted(at: now, input: 100, cachedRead: 0, output: 10, reasoning: 0, ticks: 1_000_000)
+            ]
+        )
+        let session = CostScanSession(cutoff: CostWindow.start(days: 30), options: .unlimited)
+
+        let windows = GrokCostScanner.scanRoots([root], session: session)
+
+        XCTAssertEqual(try XCTUnwrap(GrokCostScanner.makeCost(from: windows.period)).0.inputTokens, 100)
+        XCTAssertEqual(try XCTUnwrap(GrokCostScanner.makeCost(from: windows.lifetime)).0.inputTokens, 1_000)
+    }
+
+    /// The daily rows are what the spend chart plots. Their totals have to
+    /// reconcile with Grok's own `totalTokens` for the same turns.
+    func testDailyUsageRowsCarryTheGrokProviderAndReconcileWithItsReportedTotal() throws {
+        let root = try makeSessionsRoot()
+        try writeUpdates(
+            in: root,
+            project: "www/meterbar",
+            session: "session-a",
+            lines: [turnCompleted(at: Date(), input: 5_000, cachedRead: 4_000, output: 250, reasoning: 100, ticks: 3_000_000)]
+        )
+
+        let daily = try XCTUnwrap(scanDaily(roots: [root], days: 30)).first
+
+        let row = try XCTUnwrap(daily)
+        XCTAssertEqual(row.provider, .grok)
+        XCTAssertEqual(row.inputTokens, 1_000)
+        XCTAssertEqual(row.outputTokens, 250)
+        XCTAssertEqual(row.cacheReadTokens, 4_000)
+        XCTAssertEqual(row.totalTokens, 5_250)
+        XCTAssertEqual(row.estimatedCostUSD, 0.0003, accuracy: 1e-9)
+    }
+
+    // MARK: - Attribution
+
+    /// Grok names each session directory after the URL-encoded absolute project
+    /// path. Decoding it is the only way the per-project rollup can name a
+    /// worktree; the home prefix is stripped for the same privacy reason Claude
+    /// and Codex strip theirs.
+    func testProjectAttributionPercentDecodesTheSessionDirectoryName() {
+        let home = ServiceSupport.realHomeDirectory()
+        let encoded = "\(home)/www/genfeedai/genfeed.ai"
+            .addingPercentEncoding(withAllowedCharacters: CharacterSet.alphanumerics) ?? ""
+
+        let projectID = CostProjectAttribution.grokProjectID(encodedDirectoryName: encoded)
+
+        XCTAssertEqual(projectID, "www/genfeedai/genfeed.ai")
+    }
+
+    func testProjectAttributionFallsBackToUnknownForADirectoryOutsideHome() {
+        let encoded = "%2Fvar%2Ftmp%2Fsomewhere"
+
+        XCTAssertEqual(
+            CostProjectAttribution.grokProjectID(encodedDirectoryName: encoded),
+            CostProjectAttribution.unknownProjectID
+        )
+    }
+
+    func testProjectAndModelBreakdownsAreEmittedForTheScannedCorpus() throws {
+        let root = try makeSessionsRoot()
+        try writeUpdates(
+            in: root,
+            project: "www/meterbar",
+            session: "session-a",
+            lines: [turnCompleted(at: Date(), input: 100, cachedRead: 0, output: 10, reasoning: 0, ticks: 1_000_000)]
+        )
+
+        let cost = try XCTUnwrap(scanCost(roots: [root], days: 30))
+
+        XCTAssertEqual(cost.modelBreakdowns.map(\.name), ["grok-4.5-build"])
+        XCTAssertEqual(cost.projectBreakdowns.map(\.name), ["www/meterbar"])
+    }
+
+    // MARK: - Roots and resumption
+
+    /// `GROK_HOME` and per-account home directories are the supported ways to
+    /// point Grok somewhere other than `~/.grok`. A hardcoded path would scan
+    /// the wrong corpus for every user who moved it.
+    func testSessionRootsFollowTheAccountHomeDirectoryRatherThanAHardcodedPath() throws {
+        let home = try makeTemporaryDirectory(prefix: "GrokHome")
+        let account = GrokAccount(id: UUID(), name: "Work", homeDirectory: home.path)
+
+        let roots = GrokCostScanner.sessionRoots(accounts: [account])
+
+        XCTAssertTrue(
+            roots.contains { $0.standardizedFileURL.path == home.appendingPathComponent("sessions").standardizedFileURL.path },
+            "expected the account's own sessions directory, got \(roots.map(\.path))"
+        )
+    }
+
+    /// The scan is budgeted and resumable: a slice commits a byte offset on a
+    /// line boundary, and the next slice reads only what was appended after it.
+    /// Re-reading from zero would double-count; skipping past would lose spend.
+    func testAppendedRecordsAreFoldedInWithoutRecountingTheAlreadyScannedPrefix() throws {
+        let root = try makeSessionsRoot()
+        let store = try makeScanCacheStore()
+        let now = Date()
+        let url = try writeUpdates(
+            in: root,
+            project: "www/meterbar",
+            session: "session-a",
+            lines: [turnCompleted(at: now.addingTimeInterval(-120), input: 100, cachedRead: 0, output: 10, reasoning: 0, ticks: 1_000_000)]
+        )
+        let cutoff = CostWindow.start(days: 30)
+        let first = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        _ = GrokCostScanner.scanRoots([root], session: first)
+        XCTAssertEqual(first.persist().outcome(for: .grok), .persisted)
+
+        try append(
+            turnCompleted(at: now, input: 200, cachedRead: 0, output: 20, reasoning: 0, ticks: 2_000_000) + "\n",
+            to: url
+        )
+        let second = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        let windows = GrokCostScanner.scanRoots([root], session: second)
+
+        let cost = try XCTUnwrap(GrokCostScanner.makeCost(from: windows.period)).0
+        XCTAssertEqual(cost.inputTokens, 300)
+        XCTAssertEqual(cost.outputTokens, 30)
+    }
+
+    /// The Grok cache gets its own versioned artifact. Sharing a file with
+    /// Claude or Codex would mean one provider's schema bump silently discarding
+    /// another's committed offsets.
+    func testGrokProgressPersistsToItsOwnVersionedArtifact() throws {
+        let root = try makeSessionsRoot()
+        let store = try makeScanCacheStore()
+        try writeUpdates(
+            in: root,
+            project: "www/meterbar",
+            session: "session-a",
+            lines: [turnCompleted(at: Date(), input: 100, cachedRead: 0, output: 10, reasoning: 0, ticks: 1_000_000)]
+        )
+        let session = CostScanSession(cutoff: CostWindow.start(days: 30), options: .unlimited, store: store)
+        _ = GrokCostScanner.scanRoots([root], session: session)
+
+        XCTAssertEqual(session.persist().outcome(for: .grok), .persisted)
+        XCTAssertNotEqual(CostScanCacheStore.grokFileName, CostScanCacheStore.codexFileName)
+        XCTAssertNotEqual(CostScanCacheStore.grokFileName, CostScanCacheStore.claudeFileName)
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: store.directory.appendingPathComponent(CostScanCacheStore.grokFileName).path
+            )
+        )
+    }
+
+    // MARK: - Summary wiring
+
+    /// The whole point of the change: `.grok` has to reach `costs[]` and
+    /// `dailyUsage[]`, and only when the provider toggle says so.
+    func testSummaryIncludesGrokRowsOnlyWhenTheProviderIsEnabled() throws {
+        let home = try makeTemporaryDirectory(prefix: "GrokHome")
+        // `sessionRoots` always includes the default home as well as each
+        // account's, because most users enable Grok without ever adding an
+        // account entry. Point the default at the fixture too, or this asserts
+        // against whatever the developer's own `~/.grok` happens to hold.
+        setenv("GROK_HOME", home.path, 1)
+        addTeardownBlock { unsetenv("GROK_HOME") }
+        let root = home.appendingPathComponent("sessions", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try writeUpdates(
+            in: root,
+            project: "www/meterbar",
+            session: "session-a",
+            lines: [turnCompleted(at: Date(), input: 100, cachedRead: 0, output: 10, reasoning: 0, ticks: 1_000_000)]
+        )
+        let accounts = [GrokAccount(id: UUID(), name: "Work", homeDirectory: home.path)]
+        let cutoff = CostWindow.start(days: 30)
+
+        let enabled = CostSummaryBuilder.makeScan(
+            days: 30,
+            enabledProviders: [.grok],
+            claudeAccounts: [],
+            grokAccounts: accounts,
+            session: CostScanSession(cutoff: cutoff, options: .unlimited)
+        )
+        let disabled = CostSummaryBuilder.makeScan(
+            days: 30,
+            enabledProviders: [],
+            claudeAccounts: [],
+            grokAccounts: accounts,
+            session: CostScanSession(cutoff: cutoff, options: .unlimited)
+        )
+
+        XCTAssertEqual(enabled.summary.costs.map(\.provider), [.grok])
+        XCTAssertEqual(enabled.summary.dailyUsage.map(\.provider), [.grok])
+        XCTAssertEqual(enabled.summary.lifetime?.providers.map(\.provider), [.grok])
+        XCTAssertTrue(disabled.summary.costs.isEmpty)
+    }
+
+    // MARK: - Fixtures
+
+    /// One `turn_completed` envelope, shaped exactly like the ones on disk:
+    /// usage nested at `params.update.usage`, per-model copies under
+    /// `modelUsage`, and a whole-second `timestamp`.
+    private func turnCompleted(
+        at date: Date,
+        input: Int,
+        cachedRead: Int,
+        output: Int,
+        reasoning: Int,
+        ticks: Int,
+        method: String = "session/update"
+    ) -> String {
+        let usage = """
+            {"inputTokens":\(input),"outputTokens":\(output),"totalTokens":\(input + output),\
+            "cachedReadTokens":\(cachedRead),"reasoningTokens":\(reasoning),"modelCalls":1,\
+            "apiDurationMs":1234,"costUsdTicks":\(ticks),\
+            "modelUsage":{"grok-4.5-build":{"inputTokens":\(input),"outputTokens":\(output),\
+            "cachedReadTokens":\(cachedRead),"reasoningTokens":\(reasoning),"costUsdTicks":\(ticks)}},\
+            "numTurns":1}
+            """
+        return """
+            {"timestamp":\(Int(date.timeIntervalSince1970)),"method":"\(method)",\
+            "params":{"sessionId":"019fafec-972e-7413-8cbd-01647988c8f9",\
+            "update":{"sessionUpdate":"turn_completed","stop_reason":"end_turn","usage":\(usage)}}}
+            """
+    }
+
+    @discardableResult
+    private func writeUpdates(
+        in root: URL,
+        project: String,
+        session: String,
+        lines: [String]
+    ) throws -> URL {
+        let home = ServiceSupport.realHomeDirectory()
+        let encoded = "\(home)/\(project)"
+            .addingPercentEncoding(withAllowedCharacters: CharacterSet.alphanumerics) ?? project
+        let directory = root
+            .appendingPathComponent(encoded, isDirectory: true)
+            .appendingPathComponent(session, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("updates.jsonl")
+        try (lines.joined(separator: "\n") + "\n").write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private func append(_ text: String, to url: URL) throws {
+        let handle = try FileHandle(forWritingTo: url)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(text.utf8))
+    }
+
+    private func scanCost(roots: [URL], days: Int) -> TokenCost? {
+        let session = CostScanSession(cutoff: CostWindow.start(days: days), options: .unlimited)
+        return GrokCostScanner.makeCost(from: GrokCostScanner.scanRoots(roots, session: session).period)?.0
+    }
+
+    private func scanDaily(roots: [URL], days: Int) -> [DailyTokenUsage]? {
+        let session = CostScanSession(cutoff: CostWindow.start(days: days), options: .unlimited)
+        return GrokCostScanner.makeCost(from: GrokCostScanner.scanRoots(roots, session: session).period)?.1
+    }
+
+    private func makeSessionsRoot() throws -> URL {
+        try makeTemporaryDirectory(prefix: "GrokSessions")
+    }
+
+    private func makeTemporaryDirectory(prefix: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        return directory
+    }
+
+    private func makeScanCacheStore() throws -> CostScanCacheStore {
+        CostScanCacheStore(directory: try makeTemporaryDirectory(prefix: "GrokScanCache"))
+    }
+}

--- a/MeterBarTests/GrokCostScannerTests.swift
+++ b/MeterBarTests/GrokCostScannerTests.swift
@@ -188,6 +188,56 @@ final class GrokCostScannerTests: XCTestCase {
         XCTAssertEqual(cost.outputTokens, 30)
     }
 
+    /// `isFinite` is not the same test as "fits in `Int`": `1e300` is finite and
+    /// its millisecond value is ~1e303, which trapped the whole scan when the
+    /// dedup key converted it. A corrupt timestamp may only cost its own record.
+    func testTimestampsTooLargeForWholeMillisecondsDropOnlyTheirOwnRecord() throws {
+        let root = try makeSessionsRoot()
+        let now = Date()
+        try writeUpdates(
+            in: root,
+            project: "www/meterbar",
+            session: "session-a",
+            lines: [
+                turnCompleted(at: now.addingTimeInterval(-120), input: 100, cachedRead: 0, output: 10, reasoning: 0, ticks: 1_000_000),
+                turnCompleted(rawTimestamp: "1e300", input: 999, output: 999, ticks: 9_000_000),
+                turnCompleted(rawTimestamp: "-1e300", input: 999, output: 999, ticks: 9_000_000),
+                turnCompleted(at: now, input: 200, cachedRead: 0, output: 20, reasoning: 0, ticks: 2_000_000)
+            ]
+        )
+
+        let cost = try XCTUnwrap(scanCost(roots: [root], days: 30))
+
+        XCTAssertEqual(cost.inputTokens, 300)
+        XCTAssertEqual(cost.outputTokens, 30)
+    }
+
+    /// Overriding `GROK_HOME` has to hand back exactly what the process started
+    /// with. Unsetting it unconditionally repoints the session root for every
+    /// later test in the same process whenever the developer's shell exports one.
+    func testOverridingGrokHomeRestoresThePreexistingValue() {
+        setenv("GROK_HOME", "/tmp/meterbar-preexisting-grok", 1)
+        defer { unsetenv("GROK_HOME") }
+
+        let restore = Self.overrideGrokHome("/tmp/meterbar-fixture-grok")
+        XCTAssertEqual(ProcessInfo.processInfo.environment["GROK_HOME"], "/tmp/meterbar-fixture-grok")
+
+        restore()
+
+        XCTAssertEqual(ProcessInfo.processInfo.environment["GROK_HOME"], "/tmp/meterbar-preexisting-grok")
+    }
+
+    /// The other half of the contract: with nothing set going in, the override
+    /// has to leave nothing set going out.
+    func testOverridingGrokHomeClearsItWhenNothingWasSet() {
+        unsetenv("GROK_HOME")
+
+        let restore = Self.overrideGrokHome("/tmp/meterbar-fixture-grok")
+        restore()
+
+        XCTAssertNil(ProcessInfo.processInfo.environment["GROK_HOME"])
+    }
+
     /// One turn re-logged verbatim (a retried write) must not be billed twice.
     func testIdenticalRecordsInOneFileAreCountedOnce() throws {
         let root = try makeSessionsRoot()
@@ -368,8 +418,7 @@ final class GrokCostScannerTests: XCTestCase {
         // account's, because most users enable Grok without ever adding an
         // account entry. Point the default at the fixture too, or this asserts
         // against whatever the developer's own `~/.grok` happens to hold.
-        setenv("GROK_HOME", home.path, 1)
-        addTeardownBlock { unsetenv("GROK_HOME") }
+        addTeardownBlock(Self.overrideGrokHome(home.path))
         let root = home.appendingPathComponent("sessions", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         try writeUpdates(
@@ -404,6 +453,23 @@ final class GrokCostScannerTests: XCTestCase {
 
     // MARK: - Fixtures
 
+    /// Points `GROK_HOME` at a fixture and hands back the undo, so the caller
+    /// can pass it straight to `addTeardownBlock`. Restoring the previous value
+    /// rather than unsetting matters because the scanner falls back to the
+    /// default home: a leaked unset would silently repoint later tests at the
+    /// developer's real `~/.grok`.
+    private static func overrideGrokHome(_ path: String) -> () -> Void {
+        let previous = ProcessInfo.processInfo.environment["GROK_HOME"]
+        setenv("GROK_HOME", path, 1)
+        return {
+            if let previous {
+                setenv("GROK_HOME", previous, 1)
+            } else {
+                unsetenv("GROK_HOME")
+            }
+        }
+    }
+
     /// One `turn_completed` envelope, shaped exactly like the ones on disk:
     /// usage nested at `params.update.usage`, per-model copies under
     /// `modelUsage`, and a whole-second `timestamp`.
@@ -426,6 +492,23 @@ final class GrokCostScannerTests: XCTestCase {
             """
         return """
             {"timestamp":\(Int(date.timeIntervalSince1970)),"method":"\(method)",\
+            "params":{"sessionId":"019fafec-972e-7413-8cbd-01647988c8f9",\
+            "update":{"sessionUpdate":"turn_completed","stop_reason":"end_turn","usage":\(usage)}}}
+            """
+    }
+
+    /// The same envelope with the `timestamp` written verbatim, so a test can
+    /// feed a value that is valid JSON and a finite `Double` yet has no whole
+    /// millisecond representation — `1e300`. Interpolating it as text is the
+    /// only way to express that: `Date` cannot carry it.
+    private func turnCompleted(rawTimestamp: String, input: Int, output: Int, ticks: Int) -> String {
+        let usage = """
+            {"inputTokens":\(input),"outputTokens":\(output),"totalTokens":\(input + output),\
+            "cachedReadTokens":0,"reasoningTokens":0,"modelCalls":1,\
+            "apiDurationMs":1234,"costUsdTicks":\(ticks),"numTurns":1}
+            """
+        return """
+            {"timestamp":\(rawTimestamp),"method":"session/update",\
             "params":{"sessionId":"019fafec-972e-7413-8cbd-01647988c8f9",\
             "update":{"sessionUpdate":"turn_completed","stop_reason":"end_turn","usage":\(usage)}}}
             """


### PR DESCRIPTION
## The gap

Grok was enabled and quota-tracked (`GrokCLIUsageService`, `ProviderVisibilityStore`) but contributed **no cost rows at all**. `MeterBar/Services/` held only `ClaudeCostScanner.swift` and `CodexCostScanner.swift`, and `grep '\.grok'` on `CostTracker.swift` and `CostSummaryBuilder.swift` returned zero matches. The provider was structurally absent from `costs[]` and `dailyUsage[]`, so the dashboard spend chart and the share card silently under-reported by whatever Grok had cost. This is a coverage gap, not a display filter.

## What lands

`GrokCostScanner` reads `<grok home>/sessions/<url-encoded project path>/<session-uuid>/updates.jsonl` and folds the `usage` blob carried on each `turn_completed` session update.

It follows `CodexCostScanner` rather than inventing a pattern:

- budgeted, resumable slices with per-file byte offsets committed on line boundaries
- byte-level `Data.range(of:)` marker prefilter (`"turn_completed"`) — not `Data.contains`
- truncation salvage via `CostScanTruncationTally`; malformed lines are skipped, never fatal
- its own versioned cache artifact `cost-scan-grok-v*.json` — the existing two are neither reused nor mutated
- home directories resolved through `GrokHomeDirectory`, so `GROK_HOME` and per-account overrides are honored; nothing hardcodes `~/.grok`

Three things it does **not** need, and why:

| Codex has | Grok | Why |
|---|---|---|
| pricing table | none | Grok bills each turn itself via `costUsdTicks` |
| deferred-model queue | none | each turn names its own model in `modelUsage` |
| project-path fallback | none | the session directory name *is* the percent-encoded project path |

## Tick scale — pinned empirically, not assumed

Published grok-4.5 rates: **$2.00/M input, $6.00/M output, $0.50/M cached input**.

Holding fresh-input and output fixed and solving for the cached rate on the five records with `modelCalls == 1`:

| cached / fresh input / output tokens | ticks | implied cached rate @ 1e-10 |
|---|---|---|
| 60,800 / 253 / 503 | → $0.021764 | **$0.300/M** |
| 84,480 / 275 / 516 | → $0.028990 | **$0.300/M** |
| 171,904 / 951 / 260 | → $0.055033 | **$0.300/M** |
| 172,800 / 472 / 80 | → $0.053264 | **$0.300/M** |
| 173,184 / 693 / 64 | → $0.053725 | **$0.300/M** |

All five land on exactly $0.300/M. At **1e-9** the same rows imply **$3.00/M cached — 1.5× the *fresh* input rate**, which is physically incoherent.

Whole-corpus cross-check (40 usage records, actual ÷ published baseline): **1e-10 → 0.61×–1.74×, median 0.78×**; **1e-9 → median 7.8×**.

**Conclusion: `1 costUsdTick = 1e-10 USD`.** The reconciliation table lives in the constant's doc comment; `testTickScaleMatchesThePublishedGrokRates` asserts the conversion on a fixed fixture, so editing the constant fails a test rather than silently restating every Grok total.

Record semantics also verified: per-turn incremental (not cumulative), `totalTokens == inputTokens + outputTokens` exactly, `cachedReadTokens ⊆ inputTokens`, `reasoningTokens ⊆ outputTokens`. The scanner pre-subtracts at ingest so fresh input and cache reads are not double-counted and reasoning is not added on top of output.

## Shared plumbing touched

- `CodexScanContext` → **`CostScanWindowContext`**. Both scanners fold the same eight breakdown dimensions; a second copy would mean a second `merge` and a second set of `_modify` forwarders to keep in step. The `Codable` keys come from the stored property names, not the type name, so **on-disk caches are unaffected**.
- `CostSummaryBuilder.makeScan` now takes `enabledProviders: Set<CostScanProvider>` instead of one `Bool` per provider — at three corpora the flag list had grown to three positional booleans, and a fourth would push the signature past SwiftLint's `function_parameter_count` cap.
- `CostTracker` derives that set from `CostScanProvider.allCases`, so a provider added to the enum reaches the scan without a second edit.
- **Latent bug fixed:** `logStoppedScan` used `provider == .claude ? "Claude" : "Codex"`, which would have labelled Grok's log lines "Codex". Now `provider.logName`.

Untouched as required: `MeterBarWidget/UsageWidget.swift`, `MeterBarCLI/Sources/MeterBarCLI.swift`, and the shared `cached_usage_metrics.json` encoder/decoder date strategy.

## Tests

18 new cases in `MeterBarTests/GrokCostScannerTests.swift` (written first, TDD):

tick conversion on a fixed fixture · cutoff vs lifetime split · resume from a committed offset · cache invalidation on file growth · truncated trailing line tolerance · malformed JSON skipped mid-file · percent-decoded project attribution · undecodable directory name → unknown · deterministic model tie-break on equal ticks · reasoning tokens not added on top of output · cached reads not double-counted as fresh input · vendor-prefixed `session/update` method accepted · updates without a usage blob ignored · session roots follow the account home, not a hardcoded path · duplicate-event dedup · enabled/disabled provider gate · Grok cost published as reported rather than recomputed · zero-usage turns contribute nothing.

## Verification

- `swift build` — clean
- `swift test` — **1983 passing, 0 failures**, 5 skipped
- `xcodebuild -scheme MeterBar` — **BUILD SUCCEEDED** (checked separately; a previous PR passed SwiftPM and broke the Xcode `build` job on a missing `import os`)
- `swiftlint --strict` — **0 violations in 260 files**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Grok usage and cost scanning from local session data.
  * Added Grok project, model, daily, period, and lifetime usage attribution.
  * Added resumable scanning and provider-specific cache persistence for Grok.
  * Included Grok results in cost summaries and scan status reporting.

* **Improvements**
  * Unified scanning window handling across supported providers.
  * Simplified provider selection and configuration for cost summaries.
  * Improved handling of duplicate, malformed, and partially scanned usage records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->