### PR TITLE
feat: narrow the recent-activity windows to a week and a month

### DIFF
--- a/MeterBar/Models/SocialShareCardContent.swift
+++ b/MeterBar/Models/SocialShareCardContent.swift
@@ -17,7 +17,7 @@ struct SocialShareCardContent: Equatable {
         self.sessionCount = sessionCount.map { max(0, $0) }
         self.providerNames = Self.uniqueProviderNames(providerNames)
         self.topProviderName = topProviderName?.trimmingCharacters(in: .whitespacesAndNewlines)
-        self.dailyTokenTotals = Array(dailyTokenTotals.suffix(30))
+        self.dailyTokenTotals = Array(dailyTokenTotals.suffix(Self.chartDayCount))
         self.generatedAt = generatedAt
     }
 
@@ -26,6 +26,13 @@ struct SocialShareCardContent: Equatable {
     static let appName = "MeterBar"
     static let websiteURL = "https://meterbar.dev"
     static let websiteDisplay = "meterbar.dev"
+
+    /// Days the sparkline covers. The hero number stays a 30-day total — it
+    /// comes from `CostSummary`, not from these buckets — but a 30-bar chart at
+    /// card width is a texture rather than a trend, so the chart reads the last
+    /// week instead. Every site that slices, pads, or counts the series derives
+    /// from this so the window cannot drift between them.
+    static let chartDayCount = 7
 
     let tokenTotal: Int?
     let sessionCount: Int?
@@ -38,7 +45,7 @@ struct SocialShareCardContent: Equatable {
         tokenTotal != nil
     }
 
-    /// Whether the 30-day chart has any real usage to draw. When this is false
+    /// Whether the chart window has any real usage to draw. When this is false
     /// the share card must render an honest empty state — never fabricated bars.
     /// This is the single source of truth the chart view keys its empty state on.
     var hasDailyChartData: Bool {
@@ -76,7 +83,9 @@ struct SocialShareCardContent: Equatable {
 
     var activeDaysLabel: String {
         let activeDays = dailyTokenTotals.filter { $0 > 0 }.count
-        return "\(activeDays)/30"
+        // Denominator is the window, not `dailyTokenTotals.count`: an unscanned
+        // card carries an empty series and would otherwise read "0/0".
+        return "\(activeDays)/\(Self.chartDayCount)"
     }
 
     var topProviderLabel: String {
@@ -108,7 +117,7 @@ struct SocialShareCardContent: Equatable {
 
     static func dailyTokenTotals(
         from dailyUsage: [DailyTokenUsage],
-        days: Int = 30,
+        days: Int = SocialShareCardContent.chartDayCount,
         now: Date = Date(),
         calendar: Calendar = .current
     ) -> [Int] {

--- a/MeterBar/Models/TokenActivityCalendar.swift
+++ b/MeterBar/Models/TokenActivityCalendar.swift
@@ -137,7 +137,15 @@ struct TokenActivityMonthLabel: Identifiable, Equatable {
 /// Days inside that span with no rows are confirmed zero-usage days; days before
 /// it are unavailable history, not synthetic zeros.
 struct TokenActivityCalendar {
-    static let defaultWeeks = 53
+    /// Columns the dashboard draws: the trailing month. Six is the smallest
+    /// window that always covers the 30 days every other cost surface reports —
+    /// five spans only 29 when today opens its own column — and it leaves the
+    /// cells wide enough to read, which a year-wide grid never was.
+    static let defaultWeeks = 6
+    /// Widest grid the geometry stays honest for. Separate from `defaultWeeks`
+    /// so narrowing the visible window cannot silently cap a caller that asks
+    /// for more.
+    static let maxWeeks = 53
     static let weekdayCount = 7
 
     let requestedWeeks: Int
@@ -163,7 +171,7 @@ struct TokenActivityCalendar {
         now: Date = Date(),
         calendar: Calendar = .current
     ) {
-        let requestedWeeks = min(max(1, weeks), Self.defaultWeeks)
+        let requestedWeeks = min(max(1, weeks), Self.maxWeeks)
         let today = calendar.startOfDay(for: now)
         let weekdayOffset = (calendar.component(.weekday, from: today) - calendar.firstWeekday + Self.weekdayCount)
             % Self.weekdayCount

--- a/MeterBar/Views/SocialShareCard.swift
+++ b/MeterBar/Views/SocialShareCard.swift
@@ -296,8 +296,10 @@ private struct SocialShareTokenChart: View {
     let scale: CGFloat
 
     private var chartValues: [Int] {
-        let visibleValues = Array(values.suffix(30))
-        return visibleValues.isEmpty ? Array(repeating: 0, count: 30) : visibleValues
+        let visibleValues = Array(values.suffix(SocialShareCardContent.chartDayCount))
+        return visibleValues.isEmpty
+            ? Array(repeating: 0, count: SocialShareCardContent.chartDayCount)
+            : visibleValues
     }
 
     private var maxValue: Int {
@@ -316,7 +318,7 @@ private struct SocialShareTokenChart: View {
                         .font(.system(size: 13 * scale, weight: .black, design: .monospaced))
                         .tracking(0.8 * scale)
                         .foregroundStyle(.white)
-                    Text(hasUsage ? "30-day session tokens" : "feed me more sessions")
+                    Text(hasUsage ? "7-day session tokens" : "feed me more sessions")
                         .font(.system(size: 11 * scale, weight: .bold))
                         .foregroundStyle(.white.opacity(0.50))
                 }

--- a/MeterBar/Views/TokenActivityHeatmap.swift
+++ b/MeterBar/Views/TokenActivityHeatmap.swift
@@ -2,12 +2,12 @@ import AppKit
 import MeterBarShared
 import SwiftUI
 
-/// Dashboard card wrapping the trailing contribution calendar.
+/// Dashboard card wrapping the trailing month's contribution calendar.
 ///
 /// Takes plain values rather than reaching for `CostTracker.shared` (same shape
 /// as ``CostOverviewStatusCard``) so the card hosts in a test without standing
 /// up the scanner. The calendar is derived once in `init` — `body` runs on every
-/// hover tick, and re-slicing a year of daily rows there would be wasteful.
+/// hover tick, and re-bucketing the daily rows there would be wasteful.
 struct TokenActivityCard: View {
     private let activity: TokenActivityCalendar
     private let isScanning: Bool
@@ -157,8 +157,9 @@ struct TokenActivityHeatmap: View {
 
             ForEach(activity.weeks) { week in
                 // `fixedSize` before the column-width frame lets the label keep
-                // its natural width and overhang the following columns, which is
-                // the only way a month name fits above an 11pt cell.
+                // its natural width and overhang the following columns. A month
+                // cell is now wide enough for an English abbreviation, but not
+                // for the longer ones other locales use.
                 Text(monthTitles[week.index] ?? "")
                     .fixedSize()
                     .frame(width: TokenActivityMetrics.cell, alignment: .leading)
@@ -171,10 +172,10 @@ struct TokenActivityHeatmap: View {
 
     private var weekdayGutter: some View {
         VStack(spacing: TokenActivityMetrics.spacing) {
-            ForEach(Array(activity.weekdaySymbols.enumerated()), id: \.offset) { index, symbol in
-                // Every other row only — seven stacked labels do not fit beside
-                // 11pt cells, and the alternating ones still orient the reader.
-                Text(index.isMultiple(of: 2) ? "" : symbol)
+            ForEach(Array(activity.weekdaySymbols.enumerated()), id: \.offset) { _, symbol in
+                // Every row is labelled: the month grid's cells are taller than a
+                // 9pt line, which the year-wide grid's were not.
+                Text(symbol)
                     .frame(
                         width: TokenActivityMetrics.gutterWidth,
                         height: TokenActivityMetrics.cell,
@@ -273,14 +274,18 @@ private struct TokenActivitySwatch: View {
 
 /// Grid geometry, kept in one place so the month header, weekday gutter, cells,
 /// and legend stay on the same rhythm.
+/// Sized for the trailing month. Six columns leave room a 53-column year never
+/// had, so the cells are large enough to hover accurately and to carry a legible
+/// weekday label on every row.
 private enum TokenActivityMetrics {
-    static let cell: CGFloat = 11
-    static let spacing: CGFloat = 3
-    static let radius: CGFloat = 2.5
-    static let gutterWidth: CGFloat = 22
+    static let cell: CGFloat = 20
+    static let spacing: CGFloat = 4
+    static let radius: CGFloat = 4
+    static let gutterWidth: CGFloat = 28
     static let focusRingInset: CGFloat = 2
-    /// Placeholder height while a scan runs, matching the loaded grid.
-    static let gridHeight: CGFloat = 132
+    /// Placeholder height while a scan runs, matching the loaded grid: seven
+    /// cell rows plus their gaps, the month header, and the focus-ring inset.
+    static let gridHeight: CGFloat = 186
 }
 
 /// Heatmap band colors.

--- a/MeterBarTests/SocialShareCardContentTests.swift
+++ b/MeterBarTests/SocialShareCardContentTests.swift
@@ -78,7 +78,7 @@ final class SocialShareCardContentTests: XCTestCase {
         XCTAssertEqual(content.tokenHeroCaption, "your 30-day receipts are hiding")
         XCTAssertEqual(content.sessionLabel, "Scan pending")
         XCTAssertEqual(content.averageTokensPerSession, "—")
-        XCTAssertEqual(content.activeDaysLabel, "0/30")
+        XCTAssertEqual(content.activeDaysLabel, "0/7")
         XCTAssertEqual(content.topProviderLabel, "Scan pending")
         XCTAssertEqual(content.usageTier.title, "NO RECEIPTS YET")
     }
@@ -96,7 +96,7 @@ final class SocialShareCardContentTests: XCTestCase {
         XCTAssertEqual(content.providerNames, ["Codex", "Claude"])
         XCTAssertEqual(content.sessionLabel, "24 sessions")
         XCTAssertEqual(content.averageTokensPerSession, "100.0K")
-        XCTAssertEqual(content.activeDaysLabel, "3/30")
+        XCTAssertEqual(content.activeDaysLabel, "3/7")
         XCTAssertEqual(content.topProviderLabel, "Claude")
     }
 
@@ -145,7 +145,38 @@ final class SocialShareCardContentTests: XCTestCase {
         )
     }
 
-    func testDefaultFilenameUsesGeneratedTimestampAndKeepsThirtyDays() {
+    func testDefaultDailyWindowCoversTheChartWeek() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+        let now = Date(timeIntervalSince1970: 86400 * 40)
+        let usage = [
+            DailyTokenUsage(
+                date: Date(timeIntervalSince1970: 86400 * 40),
+                provider: .codexCli,
+                inputTokens: 5,
+                outputTokens: 5,
+                cacheReadTokens: 0,
+                estimatedCostUSD: 0
+            ),
+            // A day inside the old 30-day window but outside the new one, so the
+            // narrowed default is provable rather than merely shorter.
+            DailyTokenUsage(
+                date: Date(timeIntervalSince1970: 86400 * 20),
+                provider: .claudeCode,
+                inputTokens: 900,
+                outputTokens: 100,
+                cacheReadTokens: 0,
+                estimatedCostUSD: 1
+            ),
+        ]
+
+        let totals = SocialShareCardContent.dailyTokenTotals(from: usage, now: now, calendar: calendar)
+
+        XCTAssertEqual(totals.count, SocialShareCardContent.chartDayCount)
+        XCTAssertEqual(totals, [0, 0, 0, 0, 0, 0, 10])
+    }
+
+    func testDefaultFilenameUsesGeneratedTimestampAndKeepsTheChartWeek() {
         let content = SocialShareCardContent(
             tokenTotal: 1,
             sessionCount: 1,
@@ -155,7 +186,11 @@ final class SocialShareCardContentTests: XCTestCase {
             generatedAt: Date(timeIntervalSince1970: 3600)
         )
 
-        XCTAssertEqual(content.dailyTokenTotals.count, 30)
+        XCTAssertEqual(SocialShareCardContent.chartDayCount, 7)
+        XCTAssertEqual(content.dailyTokenTotals.count, SocialShareCardContent.chartDayCount)
+        // The newest days survive the trim — an oldest-first slice would draw a
+        // week-old chart under a fresh timestamp.
+        XCTAssertEqual(content.dailyTokenTotals, Array(33 ..< 40))
         XCTAssertEqual(content.defaultFilename, "meterbar-token-card-19700101-010000.png")
     }
 }

--- a/MeterBarTests/TokenActivityCalendarTests.swift
+++ b/MeterBarTests/TokenActivityCalendarTests.swift
@@ -32,9 +32,14 @@ final class TokenActivityCalendarTests: XCTestCase {
 
     // MARK: - Grid geometry
 
-    func testTrailingGridIsFiftyThreeWeeksOfSevenWeekdaySlots() {
+    func testTrailingGridIsAMonthOfSevenWeekdaySlots() {
         let activity = TokenActivityCalendar(summary: makeSummary(), now: now, calendar: calendar)
 
+        XCTAssertEqual(TokenActivityCalendar.defaultWeeks, 6)
+        // Six columns is the smallest window that always spans the 30 days the
+        // rest of the dashboard reports: five would bottom out at 29 when today
+        // is the first weekday of its column, clipping a day off the scan.
+        XCTAssertGreaterThanOrEqual(activity.days.count, 30)
         XCTAssertEqual(activity.weeks.count, TokenActivityCalendar.defaultWeeks)
         XCTAssertTrue(activity.weeks.allSatisfy { $0.days.count == 7 })
         XCTAssertEqual(activity.weeks.map(\.index), Array(0..<TokenActivityCalendar.defaultWeeks))
@@ -64,7 +69,7 @@ final class TokenActivityCalendarTests: XCTestCase {
         XCTAssertEqual(activity.weeks.last?.days.dropFirst().compactMap { $0 }.count, 0)
         XCTAssertEqual(activity.endDate, today)
         XCTAssertNil(activity.days.first { $0.date > today })
-        XCTAssertEqual(activity.days.count, 52 * 7 + 1)
+        XCTAssertEqual(activity.days.count, (TokenActivityCalendar.defaultWeeks - 1) * 7 + 1)
     }
 
     func testGridHonoursAMondayFirstCalendar() {
@@ -94,13 +99,22 @@ final class TokenActivityCalendarTests: XCTestCase {
         let huge = TokenActivityCalendar(summary: makeSummary(), weeks: 500, now: now, calendar: calendar)
 
         XCTAssertEqual(tiny.weeks.count, 1)
-        XCTAssertEqual(huge.weeks.count, TokenActivityCalendar.defaultWeeks)
+        // The ceiling is its own constant: while it was the default too,
+        // narrowing the visible window would have silently capped every caller
+        // that asks for a longer one.
+        XCTAssertEqual(huge.weeks.count, TokenActivityCalendar.maxWeeks)
+        XCTAssertGreaterThan(TokenActivityCalendar.maxWeeks, TokenActivityCalendar.defaultWeeks)
     }
 
     // MARK: - Month labels
 
     func testMonthLabelsAppearOncePerMonthChangeInWeekOrder() {
-        let activity = TokenActivityCalendar(summary: makeSummary(), now: now, calendar: calendar)
+        let activity = TokenActivityCalendar(
+            summary: makeSummary(),
+            weeks: TokenActivityCalendar.maxWeeks,
+            now: now,
+            calendar: calendar
+        )
         let labels = activity.monthLabels
 
         XCTAssertEqual(labels.map(\.weekIndex), labels.map(\.weekIndex).sorted())
@@ -109,6 +123,15 @@ final class TokenActivityCalendarTests: XCTestCase {
         XCTAssertFalse(labels.contains { $0.weekIndex == 0 }, "the leading partial month stays unlabelled")
         XCTAssertFalse(labels.contains { $0.title.isEmpty })
         XCTAssertEqual(labels.last?.title, "Jun")
+    }
+
+    func testDefaultMonthWindowStillLabelsItsMonthChange() {
+        let activity = TokenActivityCalendar(summary: makeSummary(), now: now, calendar: calendar)
+
+        // Six columns back from Sunday 2025-06-15 open on May 11, so the window
+        // straddles exactly one boundary. A month view that labelled nothing
+        // would leave the header row blank.
+        XCTAssertEqual(activity.monthLabels.map(\.title), ["Jun"])
     }
 
     func testMonthLabelsSurviveTheYearBoundary() {

--- a/MeterBarTests/TokenActivityCardTests.swift
+++ b/MeterBarTests/TokenActivityCardTests.swift
@@ -10,7 +10,7 @@ import XCTest
 final class TokenActivityCardTests: XCTestCase {
     // MARK: - Hosting
 
-    func testLoadedCardHostsWithAFullYearOfCells() {
+    func testLoadedCardHostsWithMoreHistoryThanTheMonthWindowDraws() {
         let card = TokenActivityCard(
             summary: makeSummary(dayCount: 90),
             isScanning: false,


### PR DESCRIPTION
Two dashboard/share surfaces were drawing far wider windows than they could legibly render. Both now match the span a reader can actually parse.

## Share card sparkline: 30 days -> 7

At card width, 30 bars are thinner than the gaps between them — texture, not a trend. The chart now reads the trailing week.

The hero number and its "last 30 days" copy are deliberately untouched: they come from `CostSummary.totalTokens`, not from these buckets. The card still reports a 30-day total above a 7-day chart.

`SocialShareCardContent.chartDayCount` is the single source the window derives from — the default `days:` argument, the constructor's trailing slice, `SocialShareCard`'s zero-padding, and the "active days" denominator all read it, so the window cannot drift between them. That denominator is the constant rather than `dailyTokenTotals.count` on purpose: an unscanned card carries an empty series and would otherwise read `0/0`.

## Token activity heatmap: 53 weeks -> the trailing month

A year-shaped grid over a 30-day scan. It had to scroll horizontally, most of it was "no retained history", and 11pt cells were too small to hover accurately. The grid now draws six week columns.

Six, not five: five spans only 29 days when today opens its own column, which would clip a day off the 30-day window every other cost surface reports. Six always covers 36-42. That is asserted, not just commented.

`TokenActivityCalendar.maxWeeks` splits out from `defaultWeeks`, which was doing double duty as both the init default and the clamp ceiling — lowering `defaultWeeks` alone would have silently capped every caller that asks for a longer window. A regression assertion pins `maxWeeks > defaultWeeks` so the conflation cannot come back.

The reclaimed width pays for readable geometry: 20pt cells, 4pt gaps, and a weekday label on every row instead of alternating ones.

## Verification

- `swiftlint lint --strict` — 0 violations in 261 files
- `swift test` — 1999 tests, 5 skipped, 0 failures