### PR TITLE
feat(cost): give Cursor and OpenRouter a dated series by polling

### DIFF
--- a/MeterBar/Models/PolledRequestSeriesPresentation.swift
+++ b/MeterBar/Models/PolledRequestSeriesPresentation.swift
@@ -1,0 +1,99 @@
+import Foundation
+import MeterBarShared
+
+/// The view-facing shape of every polled series that is *not* denominated in
+/// dollars.
+///
+/// `ProviderUsageCostBuilder` bars these from `costs[]` and `dailyUsage[]`,
+/// because those arrays carry `estimatedCostUSD` and a request count is not
+/// money — Cursor's `/api/usage-summary` publishes no currency field and no
+/// per-request rate, so any dollar figure derived from it would be invented.
+/// Dropping the series entirely would trade one wrong number for no number,
+/// so it surfaces here instead, labelled in the unit it was measured in.
+///
+/// Mirrors `CostChartPresentation`: a value type computed from the model, with
+/// all windowing and ordering resolved before the view sees it.
+nonisolated struct PolledRequestSeriesPresentation: Sendable, Equatable {
+    static let defaultRequestedDays = 30
+
+    /// One provider's windowed series.
+    nonisolated struct ProviderSeries: Sendable, Equatable {
+        let provider: ServiceType
+        let unit: ProviderUsageUnit
+
+        /// Days inside the window that carry a measured amount, oldest first.
+        ///
+        /// Never padded: a day the ledger has no entry for is a day MeterBar did
+        /// not measure, and a zero-amount bar would claim it measured one and
+        /// found nothing.
+        let days: [ProviderUsageDay]
+
+        /// The window's total, summed from `days` alone.
+        let total: Double
+
+        /// The day of the first successful poll.
+        ///
+        /// The series cannot reach back past it — neither provider serves dated
+        /// history — so the view states it rather than letting the empty stretch
+        /// before it read as measured inactivity.
+        let trackingStartedOn: Date
+
+        /// True when the provider has been polled but no increase has yet been
+        /// observed inside the window.
+        var hasNoMeasuredDays: Bool { days.isEmpty }
+
+        /// The window total with its unit spelled out, e.g. "1,204 requests".
+        ///
+        /// The unit is written into the string rather than left to the caller,
+        /// because the label is the last place it can be lost: a user reads
+        /// "$1,204", not `ProviderUsageUnit.requests`.
+        var formattedTotal: String {
+            let rounded = Int(total.rounded())
+            switch unit {
+            case .usd:
+                return UsageFormat.cost(total)
+            case .requests:
+                return "\(UsageFormat.groupedTokens(rounded)) \(rounded == 1 ? "request" : "requests")"
+            }
+        }
+    }
+
+    let requestedDays: Int
+    let providers: [ProviderSeries]
+
+    var isEmpty: Bool { providers.isEmpty }
+
+    init(
+        ledger: ProviderUsageLedger,
+        requestedDays: Int = PolledRequestSeriesPresentation.defaultRequestedDays,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) {
+        let normalizedDays = max(1, requestedDays)
+        let today = calendar.startOfDay(for: now)
+        let windowStart = calendar.date(byAdding: .day, value: -(normalizedDays - 1), to: today) ?? today
+
+        self.requestedDays = normalizedDays
+        // `nonUSDProviders` is already sorted by raw value, so the card order is
+        // stable across refreshes instead of following dictionary iteration.
+        providers = ledger.nonUSDProviders.compactMap { provider in
+            guard let unit = ledger.unit(for: provider),
+                  let trackingStartedOn = ledger.firstObservedDate(for: provider) else {
+                return nil
+            }
+            // Future-dated days are dropped rather than clamped: a backwards
+            // clock jump should lose one bar, not move it onto a day it did not
+            // happen.
+            let days = ledger.dailySeries(for: provider).filter { day in
+                day.amount > 0 && day.date >= windowStart && day.date <= today
+            }
+            return ProviderSeries(
+                provider: provider,
+                unit: unit,
+                days: days,
+                total: days.reduce(0) { $0 + $1.amount },
+                trackingStartedOn: trackingStartedOn
+            )
+        }
+    }
+}

--- a/MeterBar/Models/ProviderUsageLedger.swift
+++ b/MeterBar/Models/ProviderUsageLedger.swift
@@ -18,6 +18,39 @@ nonisolated enum ProviderUsageUnit: String, Codable, Sendable {
     case requests
 }
 
+/// Which day boundary a provider's figures are dated against.
+///
+/// Not cosmetic. OpenRouter documents `usage_daily` as the credits spent since
+/// midnight *UTC*, so filing it under the user's local day would hand part of
+/// one local day's spend to another for every user who is not on UTC — and the
+/// authoritative path writes the bucket absolutely, so the misfiled figure also
+/// erases the delta sum that was correctly there. Cursor publishes no daily
+/// figure at all; its deltas are dated when MeterBar observed them, which is a
+/// local-calendar notion. The boundary rides with the observation and is stored
+/// on the entry so one provider's buckets can never be extended against the
+/// other's calendar.
+nonisolated enum ProviderUsageDayBoundary: String, Codable, Sendable {
+    /// Dated in the user's own calendar, matching every other MeterBar surface.
+    case local
+
+    /// Dated in UTC, because the provider's published day is.
+    case utc
+
+    /// The calendar this boundary's day buckets are computed in. `local` defers
+    /// to the caller's so a test can pin one; `utc` is fixed, because the
+    /// provider's own day is fixed.
+    func calendar(local: Calendar) -> Calendar {
+        switch self {
+        case .local:
+            return local
+        case .utc:
+            var utc = Calendar(identifier: .gregorian)
+            utc.timeZone = .gmt
+            return utc
+        }
+    }
+}
+
 /// One poll's reading of a provider's running counter.
 ///
 /// Deliberately not a `UsageMetrics`: that type is serialized into the shared
@@ -33,11 +66,14 @@ nonisolated struct ProviderUsageObservation: Sendable, Equatable {
     /// that it moves monotonically until it resets.
     let runningTotal: Double
 
-    /// The provider's own figure for the whole of `observedAt`'s calendar day,
-    /// when it publishes one (OpenRouter's `usage_daily`). Authoritative for
-    /// that day: it covers the hours MeterBar was not running, which a delta
-    /// between two polls cannot.
+    /// The provider's own figure for the whole of `observedAt`'s day, when it
+    /// publishes one (OpenRouter's `usage_daily`). Authoritative for that day:
+    /// it covers the hours MeterBar was not running, which a delta between two
+    /// polls cannot. Which day it means is `dayBoundary`, not the user's.
     let authoritativeDailyTotal: Double?
+
+    /// The calendar this provider's figures are dated against.
+    let dayBoundary: ProviderUsageDayBoundary
 
     let observedAt: Date
 
@@ -46,12 +82,14 @@ nonisolated struct ProviderUsageObservation: Sendable, Equatable {
         unit: ProviderUsageUnit,
         runningTotal: Double,
         authoritativeDailyTotal: Double? = nil,
+        dayBoundary: ProviderUsageDayBoundary = .local,
         observedAt: Date
     ) {
         self.provider = provider
         self.unit = unit
         self.runningTotal = runningTotal
         self.authoritativeDailyTotal = authoritativeDailyTotal
+        self.dayBoundary = dayBoundary
         self.observedAt = observedAt
     }
 }
@@ -66,6 +104,11 @@ nonisolated struct ProviderUsageDay: Sendable, Equatable, Codable {
 nonisolated struct ProviderUsageLedgerEntry: Codable, Sendable, Equatable {
     var provider: ServiceType
     var unit: ProviderUsageUnit
+
+    /// The calendar `daily`'s keys were computed in. Stored so a later poll can
+    /// tell whether it is about to extend the map against the same boundary, the
+    /// same way `unit` guards against extending it in the wrong denomination.
+    var dayBoundary: ProviderUsageDayBoundary
 
     /// The counter as of `lastObservedAt`, i.e. the baseline the next reading is
     /// differenced against.
@@ -104,7 +147,7 @@ nonisolated struct ProviderUsageLedger: Codable, Sendable, Equatable {
     /// Bumped whenever the stored shape changes. A mismatch drops the artifact
     /// rather than migrating it — the cost is one lost baseline, and the series
     /// resumes from the next poll.
-    static var currentSchemaVersion: Int { 1 }
+    static var currentSchemaVersion: Int { 2 }
 
     /// How much history the ledger keeps, in days.
     ///
@@ -117,9 +160,12 @@ nonisolated struct ProviderUsageLedger: Codable, Sendable, Equatable {
 
     var schemaVersion = ProviderUsageLedger.currentSchemaVersion
 
-    /// The time zone the day buckets were computed in. Days are a local-calendar
-    /// notion, so a ledger accumulated in one zone cannot be extended in another
-    /// without silently mixing boundaries.
+    /// The zone the most recent `.local` buckets were computed in.
+    ///
+    /// Recorded for provenance, not as a validity check: this ledger is the only
+    /// copy of its providers' history, so `ProviderUsageLedgerStore.load`
+    /// re-anchors it on a zone change rather than discarding days that can never
+    /// be fetched again.
     var timeZoneIdentifier = TimeZone.current.identifier
 
     /// An array rather than a dictionary keyed by provider, matching
@@ -195,10 +241,15 @@ nonisolated struct ProviderUsageLedger: Codable, Sendable, Equatable {
     /// worse than useless if accepted: a `NaN` baseline makes every later
     /// comparison read as a reset, and a stale reading re-baselines downwards so
     /// that the next real poll charges the entire counter as one day's usage.
+    ///
+    /// `calendar` is the *local* calendar. A provider that dates its figures in
+    /// UTC is bucketed in UTC regardless of what is passed here — see
+    /// `ProviderUsageDayBoundary`.
     mutating func record(_ observation: ProviderUsageObservation, calendar: Calendar = .current) {
         guard observation.runningTotal.isFinite, observation.runningTotal >= 0 else { return }
 
-        let day = calendar.startOfDay(for: observation.observedAt)
+        let bucketCalendar = observation.dayBoundary.calendar(local: calendar)
+        let day = bucketCalendar.startOfDay(for: observation.observedAt)
         // A non-finite published total is dropped rather than stored: it would
         // propagate through every `reduce` downstream until the headline reads
         // "$nan".
@@ -214,7 +265,11 @@ nonisolated struct ProviderUsageLedger: Codable, Sendable, Equatable {
         // A unit change means the counter now measures something else, so the
         // old baseline is not comparable. Restarting costs one poll interval;
         // differencing dollars against requests yields a number in neither unit.
-        guard entries[index].unit == observation.unit else {
+        // A boundary change is the same problem one axis over: the existing keys
+        // are midnights in a different calendar, so adding to them would sum two
+        // definitions of "day" into one bucket.
+        guard entries[index].unit == observation.unit,
+              entries[index].dayBoundary == observation.dayBoundary else {
             entries[index] = Self.makeEntry(from: observation, day: day, authoritative: authoritative)
             return
         }
@@ -245,7 +300,7 @@ nonisolated struct ProviderUsageLedger: Codable, Sendable, Equatable {
         // the last non-authoritative reading.
         entries[index].lastObservedTotal = observation.runningTotal
         entries[index].lastObservedAt = observation.observedAt
-        Self.prune(&entries[index], calendar: calendar)
+        Self.prune(&entries[index], calendar: bucketCalendar)
     }
 
     /// The first entry for a provider: a baseline, and nothing more.
@@ -265,6 +320,7 @@ nonisolated struct ProviderUsageLedger: Codable, Sendable, Equatable {
         return ProviderUsageLedgerEntry(
             provider: observation.provider,
             unit: observation.unit,
+            dayBoundary: observation.dayBoundary,
             lastObservedTotal: observation.runningTotal,
             lastObservedAt: observation.observedAt,
             firstObservedOn: day,

--- a/MeterBar/Models/ProviderUsageLedger.swift
+++ b/MeterBar/Models/ProviderUsageLedger.swift
@@ -1,0 +1,284 @@
+import Foundation
+import MeterBarShared
+
+/// What a provider's running counter is denominated in.
+///
+/// Claude, Codex and Grok all write per-session logs with token counts and a
+/// price, so their rows are dollars by construction. Cursor and OpenRouter
+/// publish a single running scalar instead — and only one of the two is money.
+/// The unit rides with every observation and every stored entry so a request
+/// count can never be folded into a dollar total on the way to the chart.
+nonisolated enum ProviderUsageUnit: String, Codable, Sendable {
+    /// US dollars, as reported by the provider. Safe to fold into `costs[]`.
+    case usd
+
+    /// Requests or credits against a plan allowance. Cursor's usage-summary
+    /// payload carries no currency field at all, so there is no rate to convert
+    /// with — a dollar figure derived from this would be invented, not measured.
+    case requests
+}
+
+/// One poll's reading of a provider's running counter.
+///
+/// Deliberately not a `UsageMetrics`: that type is serialized into the shared
+/// app-group cache read by the widget and the CLI, and widening it to carry
+/// accumulation state would drag two other codebases into this change for data
+/// neither of them wants.
+nonisolated struct ProviderUsageObservation: Sendable, Equatable {
+    let provider: ServiceType
+    let unit: ProviderUsageUnit
+
+    /// The provider's counter as of `observedAt`. Lifetime for OpenRouter,
+    /// current-billing-cycle for Cursor — the ledger does not care which, only
+    /// that it moves monotonically until it resets.
+    let runningTotal: Double
+
+    /// The provider's own figure for the whole of `observedAt`'s calendar day,
+    /// when it publishes one (OpenRouter's `usage_daily`). Authoritative for
+    /// that day: it covers the hours MeterBar was not running, which a delta
+    /// between two polls cannot.
+    let authoritativeDailyTotal: Double?
+
+    let observedAt: Date
+
+    init(
+        provider: ServiceType,
+        unit: ProviderUsageUnit,
+        runningTotal: Double,
+        authoritativeDailyTotal: Double? = nil,
+        observedAt: Date
+    ) {
+        self.provider = provider
+        self.unit = unit
+        self.runningTotal = runningTotal
+        self.authoritativeDailyTotal = authoritativeDailyTotal
+        self.observedAt = observedAt
+    }
+}
+
+/// One day's accumulated contribution, in the entry's unit.
+nonisolated struct ProviderUsageDay: Sendable, Equatable, Codable {
+    let date: Date
+    let amount: Double
+}
+
+/// Everything the ledger knows about one provider.
+nonisolated struct ProviderUsageLedgerEntry: Codable, Sendable, Equatable {
+    var provider: ServiceType
+    var unit: ProviderUsageUnit
+
+    /// The counter as of `lastObservedAt`, i.e. the baseline the next reading is
+    /// differenced against.
+    var lastObservedTotal: Double
+    var lastObservedAt: Date
+
+    /// The day of the first poll. Everything before it is genuinely unknown —
+    /// MeterBar was not watching, and neither provider offers history to fill it
+    /// in — so it bounds what the series is allowed to claim coverage of.
+    var firstObservedOn: Date
+
+    /// Day (start-of-day) to that day's accumulated amount.
+    ///
+    /// A day with no entry has no data *or* had nothing to report; a stored `0`
+    /// would be a claim that the day was measured and empty, which is a stronger
+    /// statement than the ledger can make. So zero is never written — see
+    /// `ProviderUsageLedger.record`.
+    var daily: [Date: Double]
+}
+
+/// A persisted poll-and-accumulate series for providers that keep no local log.
+///
+/// Cursor and OpenRouter both expose a running counter and nothing else: no
+/// per-session records, no history endpoint, no dated breakdown to scan. The
+/// only way either can appear in a dated series is for MeterBar to difference
+/// that counter across its own polls, which is what this type does.
+///
+/// Two properties are load-bearing and easy to lose:
+///
+/// - **No backfill.** The series starts the day of the first poll. OpenRouter's
+///   `usage` is a lifetime figure; treating the first reading as a delta against
+///   zero would dump a year of history onto install day.
+/// - **No zero rows.** A day is absent when nothing was observed for it. A
+///   stored zero reads downstream as a measured, confirmed-empty day.
+nonisolated struct ProviderUsageLedger: Codable, Sendable, Equatable {
+    /// Bumped whenever the stored shape changes. A mismatch drops the artifact
+    /// rather than migrating it — the cost is one lost baseline, and the series
+    /// resumes from the next poll.
+    static var currentSchemaVersion: Int { 1 }
+
+    /// How much history the ledger keeps, in days.
+    ///
+    /// The file is rewritten on every successful poll for the life of the
+    /// install, so an unbounded dictionary would grow forever and eventually
+    /// trip the store's size guard — which fails the write, which freezes the
+    /// baseline. 400 days comfortably covers the 30-day window the UI draws and
+    /// the year-long activity calendar.
+    static let retainedDays = 400
+
+    var schemaVersion = ProviderUsageLedger.currentSchemaVersion
+
+    /// The time zone the day buckets were computed in. Days are a local-calendar
+    /// notion, so a ledger accumulated in one zone cannot be extended in another
+    /// without silently mixing boundaries.
+    var timeZoneIdentifier = TimeZone.current.identifier
+
+    /// An array rather than a dictionary keyed by provider, matching
+    /// `LifetimeCostSummary.providers`: the entry carries its own provider, and
+    /// the JSON stays readable with a `ServiceType` raw value in it.
+    var entries: [ProviderUsageLedgerEntry] = []
+
+    init(entries: [ProviderUsageLedgerEntry] = []) {
+        self.entries = entries
+    }
+
+    // MARK: - Reading
+
+    func entry(for provider: ServiceType) -> ProviderUsageLedgerEntry? {
+        entries.first { $0.provider == provider }
+    }
+
+    func unit(for provider: ServiceType) -> ProviderUsageUnit? {
+        entry(for: provider)?.unit
+    }
+
+    /// The day of the first poll, or `nil` when the provider has never been
+    /// observed. Callers use it to bound coverage rather than implying the
+    /// series covers everything before it.
+    func firstObservedDate(for provider: ServiceType) -> Date? {
+        entry(for: provider)?.firstObservedOn
+    }
+
+    /// The provider's accumulated series, oldest first, in its own unit.
+    func dailySeries(for provider: ServiceType) -> [ProviderUsageDay] {
+        guard let entry = entry(for: provider) else { return [] }
+        return entry.daily
+            .map { ProviderUsageDay(date: $0.key, amount: $0.value) }
+            .sorted { $0.date < $1.date }
+    }
+
+    /// The provider's series only when it is denominated in dollars.
+    ///
+    /// The single guard between a Cursor request count and `estimatedCostUSD`.
+    /// Every caller that produces money goes through here.
+    func dailyUSDSeries(for provider: ServiceType) -> [ProviderUsageDay] {
+        guard entry(for: provider)?.unit == .usd else { return [] }
+        return dailySeries(for: provider)
+    }
+
+    /// Providers whose series can honestly be reported as money, in a stable
+    /// order so the folded `costs[]` rows don't reshuffle between refreshes.
+    var usdProviders: [ServiceType] {
+        entries.filter { $0.unit == .usd }
+            .map(\.provider)
+            .sorted { $0.rawValue < $1.rawValue }
+    }
+
+    /// Providers whose series is a plan allowance rather than money.
+    var nonUSDProviders: [ServiceType] {
+        entries.filter { $0.unit != .usd }
+            .map(\.provider)
+            .sorted { $0.rawValue < $1.rawValue }
+    }
+
+    /// Drops entries for providers the user has hidden, matching
+    /// `CostSummary.filtered(to:)`.
+    func filtered(to enabledServices: Set<ServiceType>) -> ProviderUsageLedger {
+        ProviderUsageLedger(entries: entries.filter { enabledServices.contains($0.provider) })
+    }
+
+    // MARK: - Accumulating
+
+    /// Folds one poll into the series.
+    ///
+    /// Silently ignores readings it cannot trust — a non-finite or negative
+    /// counter, or one stamped earlier than the last reading recorded. Both are
+    /// worse than useless if accepted: a `NaN` baseline makes every later
+    /// comparison read as a reset, and a stale reading re-baselines downwards so
+    /// that the next real poll charges the entire counter as one day's usage.
+    mutating func record(_ observation: ProviderUsageObservation, calendar: Calendar = .current) {
+        guard observation.runningTotal.isFinite, observation.runningTotal >= 0 else { return }
+
+        let day = calendar.startOfDay(for: observation.observedAt)
+        // A non-finite published total is dropped rather than stored: it would
+        // propagate through every `reduce` downstream until the headline reads
+        // "$nan".
+        let authoritative = observation.authoritativeDailyTotal.flatMap {
+            $0.isFinite && $0 >= 0 ? $0 : nil
+        }
+
+        guard let index = entries.firstIndex(where: { $0.provider == observation.provider }) else {
+            entries.append(Self.makeEntry(from: observation, day: day, authoritative: authoritative))
+            return
+        }
+
+        // A unit change means the counter now measures something else, so the
+        // old baseline is not comparable. Restarting costs one poll interval;
+        // differencing dollars against requests yields a number in neither unit.
+        guard entries[index].unit == observation.unit else {
+            entries[index] = Self.makeEntry(from: observation, day: day, authoritative: authoritative)
+            return
+        }
+
+        guard observation.observedAt >= entries[index].lastObservedAt else { return }
+
+        if let authoritative {
+            // Sets the day absolutely — it replaces whatever the delta path had
+            // accumulated, and is never added on top of this poll's own delta.
+            entries[index].daily[day] = authoritative > 0 ? authoritative : nil
+        } else {
+            // A counter that dropped has reset (Cursor zeroes at
+            // `billingCycleStart`), so the post-reset value *is* the new
+            // contribution. Never `runningTotal - last`, which would be negative
+            // and would cancel out spend already attributed to earlier days.
+            let previous = entries[index].lastObservedTotal
+            let delta = observation.runningTotal >= previous
+                ? observation.runningTotal - previous
+                : observation.runningTotal
+            if delta > 0 {
+                entries[index].daily[day, default: 0] += delta
+            }
+        }
+
+        // Re-baseline on both paths. The published daily total is optional in
+        // OpenRouter's payload, so the delta path can resume at any poll — and
+        // it would resume against a stale baseline, re-charging everything since
+        // the last non-authoritative reading.
+        entries[index].lastObservedTotal = observation.runningTotal
+        entries[index].lastObservedAt = observation.observedAt
+        Self.prune(&entries[index], calendar: calendar)
+    }
+
+    /// The first entry for a provider: a baseline, and nothing more.
+    ///
+    /// The running counter is history the ledger has no right to date, so it is
+    /// recorded as a starting point only. A published *daily* total is different
+    /// — it claims today alone, so it is not backfill and is kept.
+    private static func makeEntry(
+        from observation: ProviderUsageObservation,
+        day: Date,
+        authoritative: Double?
+    ) -> ProviderUsageLedgerEntry {
+        var daily: [Date: Double] = [:]
+        if let authoritative, authoritative > 0 {
+            daily[day] = authoritative
+        }
+        return ProviderUsageLedgerEntry(
+            provider: observation.provider,
+            unit: observation.unit,
+            lastObservedTotal: observation.runningTotal,
+            lastObservedAt: observation.observedAt,
+            firstObservedOn: day,
+            daily: daily
+        )
+    }
+
+    private static func prune(_ entry: inout ProviderUsageLedgerEntry, calendar: Calendar) {
+        guard let newest = entry.daily.keys.max(),
+              let cutoff = calendar.date(byAdding: .day, value: -retainedDays, to: newest) else { return }
+        entry.daily = entry.daily.filter { $0.key >= cutoff }
+        // Coverage cannot start earlier than the oldest day still retained,
+        // otherwise the UI would draw a gap where data was pruned as if it were
+        // a measured quiet stretch.
+        entry.firstObservedOn = max(entry.firstObservedOn, cutoff)
+    }
+}

--- a/MeterBar/Services/CostSummaryBuilder.swift
+++ b/MeterBar/Services/CostSummaryBuilder.swift
@@ -44,13 +44,22 @@ enum CostSummaryBuilder {
     /// three corpora that shape had grown to three flags whose order at the call
     /// site was load-bearing, and a set states the same thing without letting a
     /// fourth provider silently push the argument list past the linter's cap.
+    ///
+    /// `usageLedger` carries the providers that have no corpus to scan at all.
+    /// Cursor and OpenRouter publish a running counter and no session log, so
+    /// their rows come from MeterBar's own poll history rather than from disk —
+    /// see `ProviderUsageLedger`. It arrives pre-filtered to the enabled
+    /// services (there is no `CostScanProvider` case to test against, and adding
+    /// one would drag a poll into the byte-offset deferral machinery it has no
+    /// use for).
     nonisolated static func makeScan(
         days: Int,
         enabledProviders: Set<CostScanProvider>,
         claudeAccounts: [ClaudeCodeAccount],
         grokAccounts: [GrokAccount],
         session: CostScanSession,
-        claudeProjectRoots: [URL]? = nil
+        claudeProjectRoots: [URL]? = nil,
+        usageLedger: ProviderUsageLedger = ProviderUsageLedger()
     ) -> CostSummaryScan {
         var scan = ScanWindows(
             period: CostScanResult(),
@@ -82,6 +91,28 @@ enum CostSummaryBuilder {
             let grok = GrokCostScanner.scanRoots(roots, session: session)
             scan.period.append(GrokCostScanner.makeCost(from: grok.period))
             scan.lifetime.append(GrokCostScanner.makeCost(from: grok.lifetime))
+        }
+
+        // No pricing pass either: these totals arrive already denominated in
+        // dollars by the provider, so no local rate priced them and there is no
+        // provenance to report. Providers denominated in requests never reach
+        // here — `usdProviders` is the guard, and it is the only one between a
+        // Cursor request count and `estimatedCostUSD`.
+        for provider in usageLedger.usdProviders {
+            scan.period.append(
+                ProviderUsageCostBuilder.makeCost(
+                    from: usageLedger,
+                    provider: provider,
+                    windowStart: session.cutoff
+                )
+            )
+            scan.lifetime.append(
+                ProviderUsageCostBuilder.makeCost(
+                    from: usageLedger,
+                    provider: provider,
+                    windowStart: .distantPast
+                )
+            )
         }
 
         // Events older than every entry in the table were priced at the oldest

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -17,6 +17,18 @@ class CostTracker: ObservableObject {
     @Published var isRefreshingMissingDays: Bool = false
     @Published var lastScanDate: Date?
 
+    /// Polled running counters, accumulated into a dated series.
+    ///
+    /// Published separately from `costSummary` because it refreshes on a
+    /// different clock: `UsageDataManager` appends to the artifact on every
+    /// provider poll, while `costSummary` is rebuilt only by a scan. Folding
+    /// this into the scan alone would leave the request series days stale.
+    ///
+    /// Its dollar-denominated entries still travel through `costSummary` — see
+    /// `ProviderUsageCostBuilder`. What only lives here is the part that has no
+    /// honest place in `costs[]`: Cursor's request counter.
+    @Published private(set) var usageLedger = ProviderUsageLedger()
+
     private let providerVisibilityStore = ProviderVisibilityStore.shared
 
     /// When true, the tracker publishes the synthetic `DemoData.costSummary`
@@ -39,6 +51,20 @@ class CostTracker: ObservableObject {
             return
         }
         loadCachedSummary()
+        refreshUsageLedger()
+    }
+
+    /// Re-reads the polled series from disk.
+    ///
+    /// Cheap enough to call on every Costs view appearance: one small JSON read,
+    /// no log scan. Called from there rather than only at init because
+    /// `UsageDataManager` writes the artifact from its own refresh cycle, so the
+    /// copy loaded at launch goes stale within a poll interval.
+    func refreshUsageLedger() {
+        guard !demoMode else { return }
+        usageLedger = ProviderUsageLedgerStore.applicationSupport?
+            .load()
+            .filtered(to: providerVisibilityStore.enabledServices) ?? ProviderUsageLedger()
     }
 
     /// What a `scanCosts` call actually did, for callers that stamp a timestamp
@@ -161,6 +187,12 @@ class CostTracker: ObservableObject {
         let grokAccounts = GrokAccountStore.shared.accounts
         let cutoff = CostWindow.start(days: days)
         let store = CostScanCacheStore.applicationSupport
+        // Read once, outside the slice loop: polling providers contribute no
+        // bytes, so their rows are identical in every slice and re-reading the
+        // artifact 64 times would buy nothing. Refreshed here rather than
+        // reused as-is so a scan never folds in a ledger older than itself.
+        refreshUsageLedger()
+        let usageLedger = usageLedger
         var latest: CostSummaryBuilder.CostSummaryScan?
 
         for _ in 0..<Self.maxScanSlices {
@@ -176,7 +208,8 @@ class CostTracker: ObservableObject {
                     enabledProviders: enabledProviders,
                     claudeAccounts: claudeAccounts,
                     grokAccounts: grokAccounts,
-                    session: session
+                    session: session,
+                    usageLedger: usageLedger
                 )
                 // Persist even when the slice was cut short: offsets commit on
                 // line boundaries, so partial progress is exactly what the next

--- a/MeterBar/Services/CursorLocalService.swift
+++ b/MeterBar/Services/CursorLocalService.swift
@@ -288,17 +288,27 @@ class CursorLocalService: ObservableObject {
     /// The counter zeroes at `billingCycleStart`; the ledger reads a drop as a
     /// reset rather than a negative delta, so no cycle rollover emits a negative
     /// day.
+    ///
+    /// Returns `nil` when the payload carries no plan counter at all. Defaulting
+    /// the absent field to `0` would be indistinguishable from a real reset to
+    /// the ledger, which reads a drop as a new billing cycle and re-baselines to
+    /// zero — so the next complete poll would charge the entire cycle-to-date
+    /// count to a single day as a phantom spike.
     static func observation(
         _ summaryData: CursorUsageSummaryResponse,
         at observedAt: Date
-    ) -> ProviderUsageObservation {
-        ProviderUsageObservation(
+    ) -> ProviderUsageObservation? {
+        guard let used = summaryData.individualUsage?.plan?.used else { return nil }
+        return ProviderUsageObservation(
             provider: .cursor,
             unit: .requests,
-            runningTotal: Double(summaryData.individualUsage?.plan?.used ?? 0),
+            runningTotal: Double(used),
             // Cursor publishes no per-day figure, so there is nothing
             // authoritative to prefer over the poll-to-poll delta.
             authoritativeDailyTotal: nil,
+            // Deltas are dated when MeterBar observed them, so the user's own
+            // calendar is the right one.
+            dayBoundary: .local,
             observedAt: observedAt
         )
     }

--- a/MeterBar/Services/CursorLocalService.swift
+++ b/MeterBar/Services/CursorLocalService.swift
@@ -32,6 +32,14 @@ class CursorLocalService: ObservableObject {
     @Published private(set) var subscriptionType: String?
     @Published private(set) var lastError: ServiceError?
 
+    /// The running request counter from the last successful poll.
+    ///
+    /// Cursor keeps no per-session usage log on disk — `~/.cursor` holds an
+    /// auth/state database and an AI-authored-lines tracker, neither of which
+    /// records tokens or spend — so differencing this scalar across polls is the
+    /// only way Cursor can appear in a dated series. See `ProviderUsageLedger`.
+    private(set) var latestUsageObservation: ProviderUsageObservation?
+
     private init() {
         // Defer I/O off main thread; only @Published mutations land on main actor
         Task.detached(priority: .utility) { [weak self] in self?.checkAccess(forceRescan: false) }
@@ -251,13 +259,48 @@ class CursorLocalService: ObservableObject {
         // Fetch usage summary data (uses /api/usage-summary endpoint)
         let summaryData = try await fetchUsageSummary(userId: userId, token: token)
 
+        let metrics = CursorLocalService.mapSummary(summaryData)
+
         // Clear any previous errors on success
         await MainActor.run {
             self.lastError = nil
             self.subscriptionType = summaryData.membershipType
+            self.latestUsageObservation = CursorLocalService.observation(summaryData, at: metrics.lastUpdated)
         }
 
-        return CursorLocalService.mapSummary(summaryData)
+        return metrics
+    }
+
+    /// One poll's reading of the plan counter, in requests.
+    ///
+    /// `.requests`, never `.usd`: `/api/usage-summary` publishes no currency
+    /// field — `plan.used`, `plan.limit` and the on-demand figures are integer
+    /// counts against a plan allowance, and Cursor publishes no per-request rate
+    /// anywhere MeterBar can read. Any dollar figure derived here would be
+    /// invented, so this counter is barred from `costs[]` by
+    /// `ProviderUsageLedger.dailyUSDSeries(for:)` and surfaces as a request
+    /// series instead.
+    ///
+    /// On-demand usage is billed and counted separately, so it is deliberately
+    /// not summed in: the total would then be in neither unit. No token counts
+    /// ride along either — the endpoint reports none.
+    ///
+    /// The counter zeroes at `billingCycleStart`; the ledger reads a drop as a
+    /// reset rather than a negative delta, so no cycle rollover emits a negative
+    /// day.
+    static func observation(
+        _ summaryData: CursorUsageSummaryResponse,
+        at observedAt: Date
+    ) -> ProviderUsageObservation {
+        ProviderUsageObservation(
+            provider: .cursor,
+            unit: .requests,
+            runningTotal: Double(summaryData.individualUsage?.plan?.used ?? 0),
+            // Cursor publishes no per-day figure, so there is nothing
+            // authoritative to prefer over the poll-to-poll delta.
+            authoritativeDailyTotal: nil,
+            observedAt: observedAt
+        )
     }
 
     /// Maps a decoded Cursor usage-summary response onto the shared

--- a/MeterBar/Services/OpenRouterService.swift
+++ b/MeterBar/Services/OpenRouterService.swift
@@ -12,6 +12,15 @@ final class OpenRouterService: ObservableObject {
     @Published private(set) var hasAccess: Bool
     @Published private(set) var lastError: ServiceError?
 
+    /// The running spend counter from the last successful poll.
+    ///
+    /// OpenRouter writes no session log and serves no dated history, so
+    /// differencing this scalar across polls is the only way its spend can reach
+    /// the chart at all — see `ProviderUsageLedger`. Held here rather than
+    /// returned inside `UsageMetrics`, which is serialized into the app-group
+    /// cache the widget and the CLI decode.
+    private(set) var latestUsageObservation: ProviderUsageObservation?
+
     private let keychain: KeychainManager
     private let fetchData: (URLRequest) async throws -> Data
 
@@ -60,6 +69,7 @@ final class OpenRouterService: ObservableObject {
             let credits = try decoder.decode(OpenRouterCreditsResponse.self, from: await creditsData)
             let key = try decoder.decode(OpenRouterKeyResponse.self, from: await keyData)
             let metrics = Self.map(credits: credits.data, key: key.data)
+            latestUsageObservation = Self.observation(key: key.data, at: metrics.lastUpdated)
             hasAccess = true
             lastError = nil
             return metrics
@@ -102,6 +112,30 @@ final class OpenRouterService: ObservableObject {
             sessionLimit: keyLimit,
             weeklyLimit: accountCredits,
             lastUpdated: now
+        )
+    }
+
+    /// One poll's reading of the key's running spend, in dollars.
+    ///
+    /// Both fields are already USD — OpenRouter bills in dollars and publishes
+    /// them as such — so nothing is converted here and no rate is guessed. No
+    /// token counts ride along because the endpoint reports none; see
+    /// `ProviderUsageCostBuilder`.
+    ///
+    /// Key-scoped rather than account-scoped: `usage` and `usage_daily` both
+    /// describe the key MeterBar authenticates with, while `/credits` reports
+    /// the whole account. Mixing the two would have the delta path and the
+    /// authoritative-today path measuring different things and contradicting
+    /// each other on alternating polls.
+    static func observation(key: OpenRouterKey, at observedAt: Date) -> ProviderUsageObservation {
+        ProviderUsageObservation(
+            provider: .openRouter,
+            unit: .usd,
+            runningTotal: key.usage,
+            // Authoritative for the whole of today, including the hours MeterBar
+            // was not running — which a delta between two polls cannot see.
+            authoritativeDailyTotal: key.usageDaily,
+            observedAt: observedAt
         )
     }
 

--- a/MeterBar/Services/OpenRouterService.swift
+++ b/MeterBar/Services/OpenRouterService.swift
@@ -135,6 +135,11 @@ final class OpenRouterService: ObservableObject {
             // Authoritative for the whole of today, including the hours MeterBar
             // was not running — which a delta between two polls cannot see.
             authoritativeDailyTotal: key.usageDaily,
+            // `usage_daily` is documented as spend since midnight UTC, and it is
+            // written into its day's bucket absolutely. Filing it under a local
+            // day would both misdate it and overwrite the delta sum that day had
+            // legitimately accumulated, for every user not already on UTC.
+            dayBoundary: .utc,
             observedAt: observedAt
         )
     }

--- a/MeterBar/Services/ProviderUsageCostBuilder.swift
+++ b/MeterBar/Services/ProviderUsageCostBuilder.swift
@@ -1,0 +1,71 @@
+import Foundation
+import MeterBarShared
+
+/// Turns the accumulated ledger into the same `(TokenCost, [DailyTokenUsage])`
+/// pair the log scanners produce, so a provider with no local corpus lands in
+/// `costs[]`/`dailyUsage[]` through exactly the same fold.
+///
+/// The counterpart to `ClaudeCostScanner.makeCost` and friends, and deliberately
+/// the *only* path from the ledger into money: it emits nothing for an entry
+/// that is not denominated in dollars.
+nonisolated enum ProviderUsageCostBuilder {
+    /// One provider's window, or `nil` when it has nothing to contribute.
+    ///
+    /// Every token count is zero, and that is the honest answer rather than a
+    /// missing one: OpenRouter's key endpoint reports spend and no token counts
+    /// at all, so any figure here would be invented. Breakdowns are `[]` for the
+    /// same reason — the provider publishes no per-model or per-project split —
+    /// and emphatically not `nil`, which `CostSummary.needsMissingDailyUsageRefresh`
+    /// reads as "this row predates attribution, rescan", re-triggering a full
+    /// corpus scan on every refresh forever.
+    ///
+    /// - Parameter windowStart: the reporting cutoff; `.distantPast` for the
+    ///   lifetime window, which for these providers means "everything MeterBar
+    ///   has observed" and never the provider's own pre-install total.
+    static func makeCost(
+        from ledger: ProviderUsageLedger,
+        provider: ServiceType,
+        windowStart: Date,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> (TokenCost, [DailyTokenUsage])? {
+        let cutoff = calendar.startOfDay(for: windowStart)
+        let today = calendar.startOfDay(for: now)
+        // Days are only ever written by an observation, so a future-dated one
+        // means the clock moved backwards; it is dropped rather than drawn off
+        // the right edge of the chart.
+        let days = ledger.dailyUSDSeries(for: provider)
+            .filter { $0.date >= cutoff && $0.date <= today && $0.amount > 0 }
+        guard let periodStart = days.first?.date, let periodEnd = days.last?.date else { return nil }
+
+        let total = days.reduce(0) { $0 + $1.amount }
+        let cost = TokenCost(
+            provider: provider,
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 0,
+            estimatedCostUSD: total,
+            // No session data exists: the provider reports a running total, not
+            // a list of sessions. Zero states that plainly.
+            sessionCount: 0,
+            periodStart: periodStart,
+            periodEnd: periodEnd
+        )
+
+        let daily = days.map { day in
+            DailyTokenUsage(
+                date: day.date,
+                provider: provider,
+                inputTokens: 0,
+                outputTokens: 0,
+                cacheReadTokens: 0,
+                estimatedCostUSD: day.amount,
+                modelBreakdowns: [],
+                projectBreakdowns: []
+            )
+        }
+
+        return (cost, daily)
+    }
+}

--- a/MeterBar/Services/ProviderUsageLedgerStore.swift
+++ b/MeterBar/Services/ProviderUsageLedgerStore.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Reads and writes the poll-and-accumulate ledger — one artifact, separate from
+/// every scanner cache.
+///
+/// Its own file on purpose. The `cost-scan-*` caches are a disposable
+/// read-through cache over logs that still exist on disk: losing one costs a
+/// slow re-scan and no data. This ledger is the *only* copy of Cursor's and
+/// OpenRouter's history — neither provider will re-serve a day once it has
+/// passed — so it must not be invalidated by a parser-version bump or a schema
+/// change that has nothing to do with it.
+nonisolated struct ProviderUsageLedgerStore: Sendable {
+    /// Far smaller than the scan caches need: at most a few hundred days times a
+    /// couple of providers. A file past this is corrupt, not large.
+    static let maximumArtifactBytes = 1 * 1024 * 1024
+
+    static var fileName: String {
+        "provider-usage-observations-v\(ProviderUsageLedger.currentSchemaVersion).json"
+    }
+
+    let directory: URL
+
+    /// `~/Library/Application Support/MeterBar`, alongside the cost caches.
+    static var applicationSupport: ProviderUsageLedgerStore? {
+        guard let support = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            return nil
+        }
+        return ProviderUsageLedgerStore(
+            directory: support.appendingPathComponent("MeterBar", isDirectory: true)
+        )
+    }
+
+    var fileURL: URL { directory.appendingPathComponent(Self.fileName) }
+
+    func load() -> ProviderUsageLedger {
+        Self.load(from: fileURL)
+    }
+
+    func save(_ ledger: ProviderUsageLedger) throws {
+        try Self.save(ledger, to: fileURL)
+    }
+
+    /// Matches `CostScanCacheStore`: the payload keys dictionaries by `Date`, and
+    /// a mismatched strategy would not throw — every strategy but `.iso8601`
+    /// writes a bare number, so the decode succeeds and lands each day decades
+    /// from where it belongs. Pinned rather than left to independently
+    /// defaulted instances that only happen to agree today.
+    private static var encoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        return encoder
+    }
+
+    private static var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        return decoder
+    }
+
+    static func load(from url: URL, maximumBytes: Int = maximumArtifactBytes) -> ProviderUsageLedger {
+        guard let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+              size <= maximumBytes,
+              let data = try? Data(contentsOf: url),
+              let ledger = try? decoder.decode(ProviderUsageLedger.self, from: data),
+              ledger.schemaVersion == ProviderUsageLedger.currentSchemaVersion,
+              ledger.timeZoneIdentifier == TimeZone.current.identifier else {
+            // Dropped rather than migrated. Losing the baseline costs one poll
+            // interval of accumulation; a day bucket decoded against the wrong
+            // calendar would misdate spend with no way to tell afterwards.
+            return ProviderUsageLedger()
+        }
+        return ledger
+    }
+
+    /// Writes the ledger through, or throws describing which stage failed.
+    ///
+    /// Reuses `CostScanCacheStoreError` rather than declaring a parallel set: the
+    /// stages are identical, and the reasons are already reduced to errno or
+    /// domain+code so a `privacy: .public` log line cannot leak a home-directory
+    /// path.
+    static func save(_ ledger: ProviderUsageLedger, to url: URL, maximumBytes: Int = maximumArtifactBytes) throws {
+        let data: Data
+        do {
+            data = try encoder.encode(ledger)
+        } catch {
+            throw CostScanCacheStoreError.encodingFailed(reason: CostScanCacheStoreError.reason(for: error))
+        }
+        guard data.count <= maximumBytes else {
+            throw CostScanCacheStoreError.artifactTooLarge(data.count)
+        }
+        do {
+            try SecureFileWriter.ensurePrivateDirectory(url.deletingLastPathComponent())
+        } catch {
+            throw CostScanCacheStoreError.directoryUnavailable(reason: CostScanCacheStoreError.reason(for: error))
+        }
+        do {
+            try SecureFileWriter.write(data, to: url)
+        } catch {
+            throw CostScanCacheStoreError.writeFailed(reason: CostScanCacheStoreError.reason(for: error))
+        }
+    }
+}

--- a/MeterBar/Services/ProviderUsageLedgerStore.swift
+++ b/MeterBar/Services/ProviderUsageLedgerStore.swift
@@ -43,11 +43,15 @@ nonisolated struct ProviderUsageLedgerStore: Sendable {
         try Self.save(ledger, to: fileURL)
     }
 
-    /// Matches `CostScanCacheStore`: the payload keys dictionaries by `Date`, and
-    /// a mismatched strategy would not throw — every strategy but `.iso8601`
-    /// writes a bare number, so the decode succeeds and lands each day decades
-    /// from where it belongs. Pinned rather than left to independently
-    /// defaulted instances that only happen to agree today.
+    /// `.secondsSince1970`, pinned on both sides, matching `CostScanCacheStore`.
+    ///
+    /// Pinned rather than left to independently defaulted instances that only
+    /// happen to agree today, because a mismatch here would not throw: the
+    /// payload keys dictionaries by `Date`, and Foundation's own default
+    /// (`.deferredToDate`) also writes a bare number — just one counted from
+    /// 2001 rather than 1970. Reading one as the other decodes cleanly and lands
+    /// every day thirty-one years from where it belongs. Change one of these two
+    /// and you must change the other.
     private static var encoder: JSONEncoder {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .secondsSince1970
@@ -60,18 +64,32 @@ nonisolated struct ProviderUsageLedgerStore: Sendable {
         return decoder
     }
 
+    /// Loads the ledger, or an empty one when the artifact is missing, oversized,
+    /// unreadable, or written by a different schema.
+    ///
+    /// A schema mismatch drops rather than migrates: the cost is one poll
+    /// interval of accumulation, and `fileName` is schema-versioned so the two
+    /// generations never share a path. A *time-zone* change is deliberately not
+    /// grounds to drop. Moving zones is routine — travel, a corrected system
+    /// setting, DST on a machine configured by offset — and discarding here would
+    /// silently destroy up to `retainedDays` of the only copy of Cursor's and
+    /// OpenRouter's history, which neither provider will re-serve.
+    ///
+    /// So the days already recorded keep the boundary they were recorded
+    /// against, and the ledger is re-anchored to the current zone for the days
+    /// still to come. That leaves a bounded error on the one or two days
+    /// straddling the move — strictly better than total, irreversible loss.
+    /// Entries dated in UTC are unaffected either way; their boundary never
+    /// depended on the system zone.
     static func load(from url: URL, maximumBytes: Int = maximumArtifactBytes) -> ProviderUsageLedger {
         guard let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
               size <= maximumBytes,
               let data = try? Data(contentsOf: url),
-              let ledger = try? decoder.decode(ProviderUsageLedger.self, from: data),
-              ledger.schemaVersion == ProviderUsageLedger.currentSchemaVersion,
-              ledger.timeZoneIdentifier == TimeZone.current.identifier else {
-            // Dropped rather than migrated. Losing the baseline costs one poll
-            // interval of accumulation; a day bucket decoded against the wrong
-            // calendar would misdate spend with no way to tell afterwards.
+              var ledger = try? decoder.decode(ProviderUsageLedger.self, from: data),
+              ledger.schemaVersion == ProviderUsageLedger.currentSchemaVersion else {
             return ProviderUsageLedger()
         }
+        ledger.timeZoneIdentifier = TimeZone.current.identifier
         return ledger
     }
 

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -11,6 +11,23 @@ import os
 protocol SimpleUsageProviding: AnyObject {
     var hasAccess: Bool { get }
     func fetchUsageMetrics() async throws -> UsageMetrics
+
+    /// The running counter this provider reported on its last successful poll,
+    /// or nil if it has not polled successfully or publishes no such counter.
+    ///
+    /// Both providers behind this seam serve running scalars and no history —
+    /// neither will re-serve a day once it has passed — so this is the only
+    /// point at which their spend can be captured for a dated series. Read
+    /// after `fetchUsageMetrics()` rather than returned from it, because that
+    /// return value is serialized into the app-group cache the widget and the
+    /// CLI decode.
+    var latestUsageObservation: ProviderUsageObservation? { get }
+}
+
+/// Defaulted so stub providers in tests, which have no counter to publish,
+/// keep conforming without restating this.
+extension SimpleUsageProviding {
+    var latestUsageObservation: ProviderUsageObservation? { nil }
 }
 
 extension CursorLocalService: SimpleUsageProviding {}
@@ -107,6 +124,14 @@ class UsageDataManager: ObservableObject {
     private let grokAccountStore: GrokAccountStore
     private let providerVisibilityStore: ProviderVisibilityStore
     private let parseHealthStore: ProviderParseHealthStore
+
+    /// Where polled running counters are accumulated into a dated series.
+    ///
+    /// Its own artifact, not shared with the scan caches: those are derived
+    /// from log files that can be re-read, while this ledger is the only copy
+    /// of Cursor's and OpenRouter's history that will ever exist. `CostTracker`
+    /// reads the same file back when it builds the published summary.
+    private let usageLedgerStore = ProviderUsageLedgerStore.applicationSupport
 
     /// When true, the manager publishes the synthetic `DemoData` fixture and
     /// performs no real fetches, cache reads, or shared-store writes. Gated at
@@ -474,10 +499,12 @@ class UsageDataManager: ObservableObject {
         // Fold in the original provider order so the reported failure stays
         // deterministic rather than reflecting whichever leg finished last.
         var firstFailure: Error?
+        var refreshed: [ServiceType] = []
         for (service, leg) in zip(pending, legs) {
             if let fetched = leg.metrics {
                 metrics[service] = fetched
                 states[service] = (.refreshed, nil)
+                refreshed.append(service)
             } else if let error = leg.error {
                 if firstFailure == nil { firstFailure = error }
                 let safeMessage = ServiceSupport.safeErrorMessage(for: error)
@@ -487,7 +514,49 @@ class UsageDataManager: ObservableObject {
             }
         }
 
+        recordUsageObservations(for: refreshed)
+
         return SimpleProviderRefresh(metrics: metrics, states: states, firstFailure: firstFailure)
+    }
+
+    /// Folds this refresh's polled counters into the persisted ledger.
+    ///
+    /// A poll that is not recorded here is spend that can never reach the
+    /// chart: neither provider serves dated history, so the delta between two
+    /// consecutive polls is the only measurement of a day that exists, and it
+    /// is gone once the next poll overwrites the counter in memory.
+    ///
+    /// Failure to persist is logged, not surfaced: the refresh itself
+    /// succeeded, and the counters are running totals, so the next poll's delta
+    /// spans the gap and no spend is lost — only its attribution to a
+    /// particular day.
+    private func recordUsageObservations(for services: [ServiceType]) {
+        guard !demoMode, let store = usageLedgerStore else { return }
+        let observations = services.compactMap { simpleProvider(for: $0)?.latestUsageObservation }
+        guard !observations.isEmpty else { return }
+
+        var ledger = store.load()
+        for observation in observations {
+            ledger.record(observation)
+        }
+        do {
+            try store.save(ledger)
+        } catch {
+            AppLog.usage.error(
+                "Failed to persist provider usage observations: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    private func simpleProvider(for service: ServiceType) -> SimpleUsageProviding? {
+        switch service {
+        case .cursor:
+            return cursorService
+        case .openRouter:
+            return openRouterService
+        case .claudeCode, .codexCli, .grok:
+            return nil
+        }
     }
 
     func refresh(service: ServiceType) async {

--- a/MeterBar/Views/DashboardCostCards.swift
+++ b/MeterBar/Views/DashboardCostCards.swift
@@ -209,7 +209,7 @@ struct LifetimeCostSummaryCard: View {
           EmptyStateCard(
             systemImage: "clock.arrow.circlepath",
             title: "No lifetime cost",
-            message: "No billable Claude or Codex history was found in local logs."
+            message: "No billable history was found for any enabled provider."
           )
         }
       }

--- a/MeterBar/Views/DashboardCostsSection.swift
+++ b/MeterBar/Views/DashboardCostsSection.swift
@@ -64,6 +64,15 @@ struct DashboardCostsSection: View {
                 scan: { Task { await costTracker.scanCosts(days: 30) } }
             )
 
+            // Directly under the spend chart, because it answers the question
+            // the chart's absence of Cursor raises. Hidden entirely when no
+            // request-denominated provider has been polled — an empty card
+            // would read as "measured nothing".
+            let polledUsage = PolledRequestSeriesPresentation(ledger: costTracker.usageLedger)
+            if !polledUsage.isEmpty {
+                PolledUsageCard(presentation: polledUsage)
+            }
+
             if let summary, !summary.dailyUsage.isEmpty {
                 DashboardCard(title: "Daily Details", trailing: "Last 30 days") {
                     DailyUsageBreakdownList(dailyUsage: summary.dailyUsage)
@@ -92,6 +101,10 @@ struct DashboardCostsSection: View {
             }
         }
         .task {
+            // One small JSON read, no log scan. The provider refresh cycle
+            // appends to this artifact between scans, so the copy loaded at
+            // launch is stale by the time the Costs page opens.
+            costTracker.refreshUsageLedger()
             if apiUsageStore.hasAnyAuthenticated, !apiUsageStore.isLoading {
                 await apiUsageStore.refresh()
             }
@@ -124,7 +137,7 @@ struct DashboardCostsSection: View {
                             EmptyStateCard(
                                 systemImage: "chart.bar.xaxis",
                                 title: "No spend in this window",
-                                message: "No billable Claude or Codex usage was found in the last 30 days."
+                                message: "No billable usage was found in the last 30 days."
                             )
                         }
 

--- a/MeterBar/Views/PolledUsageCard.swift
+++ b/MeterBar/Views/PolledUsageCard.swift
@@ -1,0 +1,104 @@
+import Charts
+import MeterBarShared
+import SwiftUI
+
+/// The dashboard home for polled series that are not denominated in dollars.
+///
+/// Cursor reports a request counter against a plan allowance and publishes no
+/// rate to price it with, so it is barred from the spend chart, the cost total
+/// and the share card — all three are money. This card is where it appears
+/// instead, counted in requests and captioned with the date tracking began, so
+/// the stretch before MeterBar's first poll reads as unmeasured rather than as
+/// a quiet run of zeroes.
+struct PolledUsageCard: View {
+    let presentation: PolledRequestSeriesPresentation
+
+    var body: some View {
+        DashboardCard(title: "Polled Usage", trailing: "Last \(presentation.requestedDays) days") {
+            VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.md) {
+                Text(
+                    "These providers report a running counter, not a cost, and keep no local logs. "
+                        + "MeterBar counts the change between its own polls, so this is usage, not spend."
+                )
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+                ForEach(presentation.providers, id: \.provider) { series in
+                    PolledUsageProviderRow(series: series)
+                }
+            }
+        }
+    }
+}
+
+private struct PolledUsageProviderRow: View {
+    let series: PolledRequestSeriesPresentation.ProviderSeries
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.sm) {
+            HStack(spacing: 10) {
+                ProviderTitle(
+                    title: series.provider.displayName,
+                    logoKind: .forService(series.provider),
+                    color: MeterBarTheme.accent(for: series.provider),
+                    font: .subheadline
+                )
+                Spacer()
+                Text(series.formattedTotal)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .monospacedDigit()
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(series.provider.displayName)
+            .accessibilityValue(series.formattedTotal)
+
+            if series.hasNoMeasuredDays {
+                EmptyStateCard(
+                    systemImage: "dot.radiowaves.left.and.right",
+                    title: "No change observed yet",
+                    message: "The counter has not moved since MeterBar started watching it."
+                )
+            } else {
+                chart
+            }
+
+            DashboardCardCaption(text: trackingCaption)
+        }
+    }
+
+    /// Bars only for days that were measured. The x-scale deliberately spans
+    /// just the observed range instead of the full window, so unmeasured days
+    /// are absent from the axis rather than drawn as empty ground.
+    private var chart: some View {
+        Chart(series.days, id: \.date) { day in
+            BarMark(
+                x: .value("Day", day.date, unit: .day),
+                y: .value("Requests", day.amount)
+            )
+            .foregroundStyle(MeterBarTheme.accent(for: series.provider))
+            .accessibilityLabel(day.date.formatted(date: .abbreviated, time: .omitted))
+            .accessibilityValue("\(UsageFormat.groupedTokens(Int(day.amount.rounded()))) requests")
+        }
+        .chartXAxis {
+            AxisMarks(values: .automatic(desiredCount: 5)) {
+                AxisGridLine()
+                AxisTick()
+                AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+            }
+        }
+        .chartYAxis {
+            AxisMarks(values: .automatic(desiredCount: 4)) {
+                AxisGridLine()
+                AxisTick()
+                AxisValueLabel()
+            }
+        }
+        .frame(height: 130)
+    }
+
+    private var trackingCaption: String {
+        let started = series.trackingStartedOn.formatted(date: .abbreviated, time: .omitted)
+        return "Counted since \(started). Earlier days were never polled, so they are not shown."
+    }
+}

--- a/MeterBarTests/CursorLocalServiceTests.swift
+++ b/MeterBarTests/CursorLocalServiceTests.swift
@@ -196,6 +196,73 @@ final class CursorLocalServiceTests: XCTestCase {
         XCTAssertNil(metrics.sessionLimit)
     }
 
+    // MARK: - Poll observations
+
+    /// The single most important assertion about Cursor in this codebase.
+    /// `/api/usage-summary` carries no currency field anywhere — `plan.used`,
+    /// `plan.limit` and the on-demand figures are all integer counts against a
+    /// plan allowance — so the observation is `.requests`. Flipping this to
+    /// `.usd` would publish a request count as dollars in the spend chart, the
+    /// dashboard total, and the share card.
+    func testSummaryObservesPlanUsageAsRequestsNotDollars() throws {
+        let json = """
+        {
+          "billingCycleStart": "2026-07-01T00:00:00Z",
+          "billingCycleEnd": "2026-08-01T00:00:00Z",
+          "individualUsage": {
+            "plan": { "used": 137, "limit": 750 },
+            "onDemand": { "used": 4, "limit": 20, "enabled": true }
+          }
+        }
+        """
+        let observedAt = Date(timeIntervalSince1970: 1_780_000_000)
+
+        let observation = CursorLocalService.observation(try decodeSummary(json), at: observedAt)
+
+        XCTAssertEqual(observation.provider, .cursor)
+        XCTAssertEqual(observation.unit, .requests)
+        XCTAssertEqual(observation.runningTotal, 137)
+        XCTAssertEqual(observation.observedAt, observedAt)
+    }
+
+    /// On-demand spend is billed separately and counted separately, so adding it
+    /// to the plan count would produce a number in neither unit. It is left out
+    /// rather than folded in.
+    func testOnDemandUsageIsNotAddedToThePlanCount() throws {
+        let json = """
+        {
+          "individualUsage": {
+            "plan": { "used": 100, "limit": 500 },
+            "onDemand": { "used": 25, "limit": 50, "enabled": true }
+          }
+        }
+        """
+
+        let observation = CursorLocalService.observation(try decodeSummary(json), at: Date())
+
+        XCTAssertEqual(observation.runningTotal, 100)
+    }
+
+    /// Cursor publishes no per-day figure at all, so there is nothing
+    /// authoritative to prefer over the poll-to-poll delta.
+    func testSummaryPublishesNoAuthoritativeDailyTotal() throws {
+        let json = #"{ "individualUsage": { "plan": { "used": 3, "limit": 500 } } }"#
+
+        let observation = CursorLocalService.observation(try decodeSummary(json), at: Date())
+
+        XCTAssertNil(observation.authoritativeDailyTotal)
+    }
+
+    /// A payload with no individual usage at all still yields a well-formed
+    /// baseline. Zero here is the counter's value, not a claim about a day —
+    /// the ledger writes no row for an unchanged counter.
+    func testMissingIndividualUsageObservesZeroRatherThanFailing() throws {
+        let observation = CursorLocalService.observation(try decodeSummary("{}"), at: Date())
+
+        XCTAssertEqual(observation.runningTotal, 0)
+        XCTAssertEqual(observation.unit, .requests)
+    }
+
     // MARK: - JWT userId extraction
 
     func testExtractUserIdSplitsAuth0PrefixedSub() {

--- a/MeterBarTests/CursorLocalServiceTests.swift
+++ b/MeterBarTests/CursorLocalServiceTests.swift
@@ -217,12 +217,13 @@ final class CursorLocalServiceTests: XCTestCase {
         """
         let observedAt = Date(timeIntervalSince1970: 1_780_000_000)
 
-        let observation = CursorLocalService.observation(try decodeSummary(json), at: observedAt)
+        let observation = try XCTUnwrap(CursorLocalService.observation(try decodeSummary(json), at: observedAt))
 
         XCTAssertEqual(observation.provider, .cursor)
         XCTAssertEqual(observation.unit, .requests)
         XCTAssertEqual(observation.runningTotal, 137)
         XCTAssertEqual(observation.observedAt, observedAt)
+        XCTAssertEqual(observation.dayBoundary, .local, "deltas are dated when MeterBar saw them")
     }
 
     /// On-demand spend is billed separately and counted separately, so adding it
@@ -238,7 +239,7 @@ final class CursorLocalServiceTests: XCTestCase {
         }
         """
 
-        let observation = CursorLocalService.observation(try decodeSummary(json), at: Date())
+        let observation = try XCTUnwrap(CursorLocalService.observation(try decodeSummary(json), at: Date()))
 
         XCTAssertEqual(observation.runningTotal, 100)
     }
@@ -248,16 +249,28 @@ final class CursorLocalServiceTests: XCTestCase {
     func testSummaryPublishesNoAuthoritativeDailyTotal() throws {
         let json = #"{ "individualUsage": { "plan": { "used": 3, "limit": 500 } } }"#
 
-        let observation = CursorLocalService.observation(try decodeSummary(json), at: Date())
+        let observation = try XCTUnwrap(CursorLocalService.observation(try decodeSummary(json), at: Date()))
 
         XCTAssertNil(observation.authoritativeDailyTotal)
     }
 
-    /// A payload with no individual usage at all still yields a well-formed
-    /// baseline. Zero here is the counter's value, not a claim about a day —
-    /// the ledger writes no row for an unchanged counter.
-    func testMissingIndividualUsageObservesZeroRatherThanFailing() throws {
-        let observation = CursorLocalService.observation(try decodeSummary("{}"), at: Date())
+    /// A payload with no plan counter is not a reading of zero, and must not be
+    /// reported as one: the ledger reads a drop as a billing-cycle reset and
+    /// re-baselines, so the next complete poll would charge the whole
+    /// cycle-to-date count to a single day.
+    func testMissingPlanCounterYieldsNoObservationRatherThanZero() throws {
+        XCTAssertNil(CursorLocalService.observation(try decodeSummary("{}"), at: Date()))
+        XCTAssertNil(
+            CursorLocalService.observation(try decodeSummary(#"{ "individualUsage": {} }"#), at: Date())
+        )
+    }
+
+    /// A published zero is a real reading, though — the start of a billing cycle
+    /// — and still establishes the baseline the next poll differences against.
+    func testExplicitZeroPlanCounterIsStillObserved() throws {
+        let json = #"{ "individualUsage": { "plan": { "used": 0, "limit": 500 } } }"#
+
+        let observation = try XCTUnwrap(CursorLocalService.observation(try decodeSummary(json), at: Date()))
 
         XCTAssertEqual(observation.runningTotal, 0)
         XCTAssertEqual(observation.unit, .requests)

--- a/MeterBarTests/OpenRouterServiceTests.swift
+++ b/MeterBarTests/OpenRouterServiceTests.swift
@@ -64,6 +64,54 @@ final class OpenRouterServiceTests: XCTestCase {
         XCTAssertEqual(metrics.sessionLimit?.windowSeconds, 86_400)
     }
 
+    // MARK: - Poll observations
+
+    /// OpenRouter denominates `usage` and `usage_daily` in dollars, so the
+    /// observation is `.usd` and no conversion is involved. If this ever became
+    /// `.requests` the ledger would stop folding OpenRouter into `costs[]`
+    /// entirely; if a request-denominated provider were ever marked `.usd`, its
+    /// counter would be published as money.
+    func testKeyResponseObservesRunningSpendInDollars() throws {
+        let key = try decodeKey(
+            #"{"data":{"limit":40,"limit_reset":"monthly","usage":27.5,"usage_daily":1.25,"is_free_tier":false}}"#
+        )
+        let now = date(2026, 7, 13)
+
+        let observation = OpenRouterService.observation(key: key.data, at: now)
+
+        XCTAssertEqual(observation.provider, .openRouter)
+        XCTAssertEqual(observation.unit, .usd)
+        XCTAssertEqual(observation.runningTotal, 27.5)
+        XCTAssertEqual(observation.authoritativeDailyTotal, 1.25)
+        XCTAssertEqual(observation.observedAt, now)
+    }
+
+    /// `usage_daily` is optional in the payload. Its absence must leave the
+    /// authoritative slot empty so the ledger falls back to differencing polls,
+    /// rather than being read as a published zero that erases the day.
+    func testMissingDailyTotalLeavesTheAuthoritativeSlotEmpty() throws {
+        let key = try decodeKey(#"{"data":{"limit":null,"limit_reset":null,"usage":9,"is_free_tier":true}}"#)
+
+        let observation = OpenRouterService.observation(key: key.data, at: date(2026, 7, 13))
+
+        XCTAssertEqual(observation.runningTotal, 9)
+        XCTAssertNil(observation.authoritativeDailyTotal)
+    }
+
+    /// The running total and the published daily total must describe the same
+    /// scope, or the delta path and the authoritative path contradict each other
+    /// on alternating polls. Both are key-scoped, so the account-wide
+    /// `total_usage` from `/credits` is deliberately not the counter.
+    func testObservationUsesKeyScopedUsageNotAccountWideCredits() throws {
+        let credits = try decodeCredits(#"{"data":{"total_credits":100,"total_usage":80}}"#)
+        let key = try decodeKey(#"{"data":{"limit":null,"limit_reset":null,"usage":12,"usage_daily":2}}"#)
+
+        let observation = OpenRouterService.observation(key: key.data, at: date(2026, 7, 13))
+
+        XCTAssertEqual(observation.runningTotal, 12)
+        XCTAssertNotEqual(observation.runningTotal, credits.data.totalUsage)
+    }
+
     private func decodeCredits(_ json: String) throws -> OpenRouterCreditsResponse {
         try JSONDecoder().decode(OpenRouterCreditsResponse.self, from: Data(json.utf8))
     }

--- a/MeterBarTests/OpenRouterServiceTests.swift
+++ b/MeterBarTests/OpenRouterServiceTests.swift
@@ -86,6 +86,18 @@ final class OpenRouterServiceTests: XCTestCase {
         XCTAssertEqual(observation.observedAt, now)
     }
 
+    /// `usage_daily` is spend since midnight UTC, and the ledger writes it into
+    /// its day absolutely. Dated against a local calendar it would land in the
+    /// wrong day for every user off UTC — and overwrite whatever that day had
+    /// legitimately accumulated from deltas.
+    func testDailyTotalIsDatedAgainstUTCNotTheUsersCalendar() throws {
+        let key = try decodeKey(#"{"data":{"limit":40,"limit_reset":"monthly","usage":27.5,"usage_daily":1.25}}"#)
+
+        let observation = OpenRouterService.observation(key: key.data, at: date(2026, 7, 13))
+
+        XCTAssertEqual(observation.dayBoundary, .utc)
+    }
+
     /// `usage_daily` is optional in the payload. Its absence must leave the
     /// authoritative slot empty so the ledger falls back to differencing polls,
     /// rather than being read as a published zero that erases the day.

--- a/MeterBarTests/PolledRequestSeriesPresentationTests.swift
+++ b/MeterBarTests/PolledRequestSeriesPresentationTests.swift
@@ -1,0 +1,255 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// Coverage for the only view-facing surface a request-denominated provider
+/// gets.
+///
+/// `ProviderUsageCostBuilder` deliberately refuses to give Cursor a row in
+/// `costs[]`, because its counter is not money. This presentation is the other
+/// half of that decision: the series still exists and is still shown, labelled
+/// in the unit it was actually measured in.
+final class PolledRequestSeriesPresentationTests: XCTestCase {
+    private let calendar = Calendar(identifier: .gregorian)
+
+    // MARK: - Units
+
+    /// A dollar provider already appears in the spend chart, the dashboard total
+    /// and the share card. Repeating it here would double-count it on screen.
+    func testDollarProvidersAreExcluded() {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.openRouter, unit: .usd, total: 1, at: day(-2)))
+        ledger.record(observation(.openRouter, unit: .usd, total: 9, at: day(-1)))
+
+        let presentation = PolledRequestSeriesPresentation(ledger: ledger, now: day(0))
+
+        XCTAssertTrue(presentation.providers.isEmpty)
+        XCTAssertTrue(presentation.isEmpty)
+    }
+
+    /// The unit travels with the series so the view can never render a request
+    /// count behind a currency symbol.
+    func testRequestProviderCarriesItsOwnUnit() throws {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.cursor, unit: .requests, total: 40, at: day(-2)))
+        ledger.record(observation(.cursor, unit: .requests, total: 190, at: day(-1)))
+
+        let presentation = PolledRequestSeriesPresentation(ledger: ledger, now: day(0))
+        let series = try XCTUnwrap(presentation.providers.first)
+
+        XCTAssertEqual(presentation.providers.map(\.provider), [.cursor])
+        XCTAssertEqual(series.unit, .requests)
+        XCTAssertEqual(series.days.map(\.amount), [150])
+        XCTAssertEqual(series.total, 150, accuracy: 0.000_001)
+        XCTAssertFalse(presentation.isEmpty)
+    }
+
+    // MARK: - Window boundaries
+
+    /// The card is captioned with a window, so it must honour one. Retained
+    /// history reaches back 400 days; drawing all of it under a "Last 30 days"
+    /// heading would misstate the total.
+    func testDaysOutsideTheRequestedWindowAreExcluded() throws {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.cursor, unit: .requests, total: 0, at: day(-60)))
+        ledger.record(observation(.cursor, unit: .requests, total: 500, at: day(-59)))
+        ledger.record(observation(.cursor, unit: .requests, total: 520, at: day(-3)))
+
+        let series = try XCTUnwrap(
+            PolledRequestSeriesPresentation(ledger: ledger, requestedDays: 30, now: day(0)).providers.first
+        )
+
+        XCTAssertEqual(series.days.map(\.date), [day(-3)])
+        XCTAssertEqual(series.total, 20, accuracy: 0.000_001)
+    }
+
+    /// If the clock moves backwards a stored day can sit ahead of today. Drawing
+    /// it would put a bar off the right edge of the chart.
+    func testFutureDatedDaysAreExcluded() throws {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.cursor, unit: .requests, total: 5, at: day(-1)))
+        ledger.record(observation(.cursor, unit: .requests, total: 11, at: day(0)))
+        ledger.record(observation(.cursor, unit: .requests, total: 99, at: day(4)))
+
+        let series = try XCTUnwrap(
+            PolledRequestSeriesPresentation(ledger: ledger, requestedDays: 30, now: day(0)).providers.first
+        )
+
+        XCTAssertEqual(series.days.map(\.date), [day(0)])
+        XCTAssertEqual(series.total, 6, accuracy: 0.000_001)
+    }
+
+    func testDaysAreOrderedOldestFirst() throws {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.cursor, unit: .requests, total: 0, at: day(-3)))
+        ledger.record(observation(.cursor, unit: .requests, total: 3, at: day(-1)))
+        ledger.record(observation(.cursor, unit: .requests, total: 4, at: day(-2)))
+        ledger.record(observation(.cursor, unit: .requests, total: 10, at: day(0)))
+
+        let series = try XCTUnwrap(
+            PolledRequestSeriesPresentation(ledger: ledger, now: day(0)).providers.first
+        )
+
+        XCTAssertEqual(series.days.map(\.date), series.days.map(\.date).sorted())
+    }
+
+    // MARK: - What the series may and may not claim
+
+    /// The tracking-start date is the whole honesty story for this card: it is
+    /// what lets the view say the series begins at the first poll instead of
+    /// implying the empty stretch before it was a stretch of zero usage.
+    func testTrackingStartDateIsCarried() throws {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.cursor, unit: .requests, total: 400, at: day(-5)))
+        ledger.record(observation(.cursor, unit: .requests, total: 410, at: day(-1)))
+
+        let series = try XCTUnwrap(
+            PolledRequestSeriesPresentation(ledger: ledger, now: day(0)).providers.first
+        )
+
+        XCTAssertEqual(series.trackingStartedOn, day(-5))
+    }
+
+    /// A first poll is a baseline, never a day's usage — so a provider polled
+    /// once shows an empty series rather than a spike the size of the user's
+    /// whole billing cycle.
+    func testFirstPollAloneProducesAnEmptySeriesNotASpike() throws {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.cursor, unit: .requests, total: 431, at: day(0)))
+
+        let series = try XCTUnwrap(
+            PolledRequestSeriesPresentation(ledger: ledger, now: day(0)).providers.first
+        )
+
+        XCTAssertTrue(series.days.isEmpty)
+        XCTAssertEqual(series.total, 0)
+        XCTAssertEqual(series.trackingStartedOn, day(0))
+    }
+
+    /// Days before the first poll must be absent, not zero. A zero bar asserts
+    /// that nothing was spent that day, which MeterBar has no way to know.
+    func testDaysBeforeTrackingBeganAreAbsentRatherThanZero() throws {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.cursor, unit: .requests, total: 100, at: day(-1)))
+        ledger.record(observation(.cursor, unit: .requests, total: 130, at: day(0)))
+
+        let series = try XCTUnwrap(
+            PolledRequestSeriesPresentation(ledger: ledger, requestedDays: 30, now: day(0)).providers.first
+        )
+
+        XCTAssertEqual(series.days.count, 1)
+        XCTAssertEqual(series.days.map(\.date), [day(0)])
+    }
+
+    /// A provider that has never been polled has no card at all — an empty card
+    /// reads as "measured nothing", which is a different claim from "not
+    /// measured".
+    func testNeverPolledProviderIsAbsentEntirely() {
+        let presentation = PolledRequestSeriesPresentation(ledger: ProviderUsageLedger(), now: day(0))
+
+        XCTAssertTrue(presentation.providers.isEmpty)
+        XCTAssertTrue(presentation.isEmpty)
+    }
+
+    /// A counter that has not moved since tracking began is a real observation,
+    /// so the provider keeps its card and its start date — only the series is
+    /// empty.
+    func testUnchangedCounterKeepsTheProviderButNotTheDays() throws {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.cursor, unit: .requests, total: 7, at: day(-2)))
+        ledger.record(observation(.cursor, unit: .requests, total: 7, at: day(-1)))
+
+        let series = try XCTUnwrap(
+            PolledRequestSeriesPresentation(ledger: ledger, now: day(0)).providers.first
+        )
+
+        XCTAssertTrue(series.days.isEmpty)
+        XCTAssertEqual(series.trackingStartedOn, day(-2))
+    }
+
+    /// Cycle rollover zeroes Cursor's counter. The ledger reads the drop as a
+    /// reset, and the card must show the post-reset usage rather than a hole.
+    func testCounterResetShowsPostResetUsageAndNeverANegativeDay() throws {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.cursor, unit: .requests, total: 740, at: day(-2)))
+        ledger.record(observation(.cursor, unit: .requests, total: 12, at: day(-1)))
+
+        let series = try XCTUnwrap(
+            PolledRequestSeriesPresentation(ledger: ledger, now: day(0)).providers.first
+        )
+
+        XCTAssertEqual(series.days.map(\.amount), [12])
+        XCTAssertTrue(series.days.allSatisfy { $0.amount > 0 })
+    }
+
+    // MARK: - Labelling
+
+    /// The label is the last place the unit can be lost. A currency symbol here
+    /// would undo every guard upstream, because a user reads the label, not the
+    /// enum.
+    func testTotalIsLabelledInRequestsAndCarriesNoCurrencySymbol() throws {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.cursor, unit: .requests, total: 0, at: day(-2)))
+        ledger.record(observation(.cursor, unit: .requests, total: 1_204, at: day(-1)))
+
+        let series = try XCTUnwrap(
+            PolledRequestSeriesPresentation(ledger: ledger, now: day(0)).providers.first
+        )
+
+        XCTAssertTrue(series.formattedTotal.hasSuffix("requests"), series.formattedTotal)
+        XCTAssertFalse(series.formattedTotal.contains("$"))
+    }
+
+    /// One request is one request, not "1 requests".
+    func testSingleRequestIsLabelledInTheSingular() throws {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.cursor, unit: .requests, total: 8, at: day(-2)))
+        ledger.record(observation(.cursor, unit: .requests, total: 9, at: day(-1)))
+
+        let series = try XCTUnwrap(
+            PolledRequestSeriesPresentation(ledger: ledger, now: day(0)).providers.first
+        )
+
+        XCTAssertEqual(series.formattedTotal, "1 request")
+    }
+
+    // MARK: - Ordering
+
+    func testProvidersAreOrderedDeterministically() {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.cursor, unit: .requests, total: 1, at: day(-2)))
+        ledger.record(observation(.cursor, unit: .requests, total: 5, at: day(-1)))
+        ledger.record(observation(.grok, unit: .requests, total: 1, at: day(-2)))
+        ledger.record(observation(.grok, unit: .requests, total: 3, at: day(-1)))
+
+        let first = PolledRequestSeriesPresentation(ledger: ledger, now: day(0)).providers.map(\.provider)
+        let second = PolledRequestSeriesPresentation(ledger: ledger, now: day(0)).providers.map(\.provider)
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(first.count, 2)
+    }
+
+    // MARK: - Helpers
+
+    private func observation(
+        _ provider: ServiceType,
+        unit: ProviderUsageUnit,
+        total: Double,
+        at date: Date
+    ) -> ProviderUsageObservation {
+        ProviderUsageObservation(provider: provider, unit: unit, runningTotal: total, observedAt: date)
+    }
+
+    /// Start of the day `offset` days after a fixed epoch.
+    private func day(_ offset: Int) -> Date {
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 5
+        components.day = 20
+        components.hour = 12
+        let base = calendar.date(from: components) ?? Date(timeIntervalSince1970: 0)
+        let shifted = calendar.date(byAdding: .day, value: offset, to: base) ?? base
+        return calendar.startOfDay(for: shifted)
+    }
+}

--- a/MeterBarTests/ProviderUsageCostBuilderTests.swift
+++ b/MeterBarTests/ProviderUsageCostBuilderTests.swift
@@ -1,0 +1,239 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// Coverage for the one path from the poll ledger into money.
+///
+/// `costs[]` and `dailyUsage[]` are denominated in dollars and tokens. Cursor's
+/// counter is neither — it is a count of requests against a plan allowance, with
+/// no rate published anywhere to convert it. These tests pin the boundary: what
+/// the ledger is allowed to claim, and what it must refuse to claim.
+final class ProviderUsageCostBuilderTests: XCTestCase {
+    private let calendar = Calendar(identifier: .gregorian)
+
+    // MARK: - Units
+
+    /// The load-bearing test of the whole change. Cursor's usage-summary payload
+    /// carries no currency field at all, so a dollar figure derived from
+    /// `plan.used` would be invented rather than measured. The builder must emit
+    /// nothing for it — not a zero row, not a converted one.
+    func testRequestDenominatedProviderProducesNoCostRowAtAll() {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.cursor, unit: .requests, total: 40, at: day(0)))
+        ledger.record(observation(.cursor, unit: .requests, total: 190, at: day(1)))
+
+        XCTAssertNil(
+            ProviderUsageCostBuilder.makeCost(from: ledger, provider: .cursor, windowStart: day(-30), now: day(1))
+        )
+    }
+
+    /// A request series still exists and is still readable — it is only barred
+    /// from the dollar fold. Losing it entirely would trade one wrong number for
+    /// no number.
+    func testRequestDenominatedProviderKeepsItsOwnSeries() {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.cursor, unit: .requests, total: 40, at: day(0)))
+        ledger.record(observation(.cursor, unit: .requests, total: 190, at: day(1)))
+
+        XCTAssertEqual(ledger.dailySeries(for: .cursor).map(\.amount), [150])
+        XCTAssertTrue(ledger.dailyUSDSeries(for: .cursor).isEmpty)
+        XCTAssertEqual(ledger.usdProviders, [])
+        XCTAssertEqual(ledger.nonUSDProviders, [.cursor])
+    }
+
+    // MARK: - Dollar-denominated rows
+
+    func testDollarDenominatedProviderProducesOneCostAndOneRowPerDay() throws {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.openRouter, unit: .usd, total: 10, at: day(0)))
+        ledger.record(observation(.openRouter, unit: .usd, total: 12, at: day(1)))
+        ledger.record(observation(.openRouter, unit: .usd, total: 15.5, at: day(2)))
+
+        let built = try XCTUnwrap(
+            ProviderUsageCostBuilder.makeCost(from: ledger, provider: .openRouter, windowStart: day(-30), now: day(2))
+        )
+
+        XCTAssertEqual(built.0.provider, .openRouter)
+        XCTAssertEqual(built.0.estimatedCostUSD, 5.5, accuracy: 0.000_001)
+        XCTAssertEqual(built.0.periodStart, day(1))
+        XCTAssertEqual(built.0.periodEnd, day(2))
+        XCTAssertEqual(built.1.map(\.date), [day(1), day(2)])
+        XCTAssertEqual(built.1.map(\.estimatedCostUSD), [2, 3.5])
+    }
+
+    /// OpenRouter's key endpoint reports spend and no token counts whatsoever.
+    /// Zero states that plainly; any other figure would be fabricated, and a
+    /// fabricated token count would flow straight into the headline "tokens"
+    /// number on the dashboard.
+    func testNoTokenCountsAreInventedForAProviderThatReportsNone() throws {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.openRouter, unit: .usd, total: 1, at: day(0)))
+        ledger.record(observation(.openRouter, unit: .usd, total: 4, at: day(1)))
+
+        let built = try XCTUnwrap(
+            ProviderUsageCostBuilder.makeCost(from: ledger, provider: .openRouter, windowStart: day(-30), now: day(1))
+        )
+
+        XCTAssertEqual(built.0.totalTokens, 0)
+        XCTAssertEqual(built.0.sessionCount, 0)
+        XCTAssertEqual(built.1.map(\.inputTokens), [0])
+        XCTAssertEqual(built.1.map(\.outputTokens), [0])
+    }
+
+    /// Breakdowns must be empty arrays, never `nil`. `nil` means "this row
+    /// predates attribution" to `needsMissingDailyUsageRefresh`, which would
+    /// kick off a full corpus re-scan on every single Costs view open, forever —
+    /// and no re-scan can ever fill them, because there is no corpus.
+    func testEmptyBreakdownsDoNotTriggerAPerpetualRescan() throws {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.openRouter, unit: .usd, total: 1, at: day(0)))
+        ledger.record(observation(.openRouter, unit: .usd, total: 4, at: day(1)))
+
+        let built = try XCTUnwrap(
+            ProviderUsageCostBuilder.makeCost(from: ledger, provider: .openRouter, windowStart: day(-30), now: day(1))
+        )
+        for row in built.1 {
+            XCTAssertEqual(row.modelBreakdowns?.count, 0)
+            XCTAssertEqual(row.projectBreakdowns?.count, 0)
+        }
+
+        let summary = CostSummary(
+            costs: [built.0],
+            totalCostUSD: built.0.estimatedCostUSD,
+            totalTokens: built.0.totalTokens,
+            periodDays: 30,
+            dailyUsage: built.1
+        )
+        XCTAssertFalse(summary.needsMissingDailyUsageRefresh(days: 30, lastScanDate: day(1)))
+    }
+
+    // MARK: - Window boundaries
+
+    /// The 30-day window must not drag the whole retained history into the
+    /// period totals just because these rows arrive outside the scanners.
+    func testDaysOutsideTheWindowAreExcluded() throws {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.openRouter, unit: .usd, total: 0, at: day(0)))
+        ledger.record(observation(.openRouter, unit: .usd, total: 100, at: day(1)))
+        ledger.record(observation(.openRouter, unit: .usd, total: 103, at: day(40)))
+
+        let period = try XCTUnwrap(
+            ProviderUsageCostBuilder.makeCost(from: ledger, provider: .openRouter, windowStart: day(11), now: day(40))
+        )
+        XCTAssertEqual(period.0.estimatedCostUSD, 3, accuracy: 0.000_001)
+
+        let lifetime = try XCTUnwrap(
+            ProviderUsageCostBuilder.makeCost(
+                from: ledger,
+                provider: .openRouter,
+                windowStart: .distantPast,
+                now: day(40)
+            )
+        )
+        XCTAssertEqual(lifetime.0.estimatedCostUSD, 103, accuracy: 0.000_001)
+    }
+
+    /// A provider that has never been polled has no history to report, and the
+    /// absence must stay an absence: a zero-dollar `TokenCost` would put an
+    /// empty provider row on the dashboard claiming a measured $0.00.
+    func testNeverObservedProviderContributesNothing() {
+        let ledger = ProviderUsageLedger()
+
+        XCTAssertNil(
+            ProviderUsageCostBuilder.makeCost(from: ledger, provider: .openRouter, windowStart: day(-30), now: day(0))
+        )
+    }
+
+    /// The first poll is a baseline only, so a freshly installed app shows no
+    /// OpenRouter row rather than a spike equal to the user's lifetime spend.
+    func testFirstPollAloneContributesNothing() {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.openRouter, unit: .usd, total: 812.44, at: day(0)))
+
+        XCTAssertNil(
+            ProviderUsageCostBuilder.makeCost(from: ledger, provider: .openRouter, windowStart: day(-30), now: day(0))
+        )
+    }
+
+    /// If the clock moves backwards, a stored day can end up ahead of "today".
+    /// Drawing it would put a bar off the right edge of the chart.
+    func testFutureDatedDaysAreExcluded() throws {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.openRouter, unit: .usd, total: 1, at: day(0)))
+        ledger.record(observation(.openRouter, unit: .usd, total: 3, at: day(1)))
+        ledger.record(observation(.openRouter, unit: .usd, total: 99, at: day(5)))
+
+        let built = try XCTUnwrap(
+            ProviderUsageCostBuilder.makeCost(from: ledger, provider: .openRouter, windowStart: day(-30), now: day(1))
+        )
+        XCTAssertEqual(built.1.map(\.date), [day(1)])
+        XCTAssertEqual(built.0.estimatedCostUSD, 2, accuracy: 0.000_001)
+    }
+
+    // MARK: - The fold into the published summary
+
+    /// End-to-end through the same builder `CostTracker` calls: a dollar
+    /// provider reaches `costs[]`/`dailyUsage[]`, and a request provider in the
+    /// very same ledger does not.
+    func testMakeScanFoldsDollarProvidersAndSkipsRequestProviders() {
+        var ledger = ProviderUsageLedger()
+        ledger.record(observation(.openRouter, unit: .usd, total: 2, at: day(0)))
+        ledger.record(observation(.openRouter, unit: .usd, total: 6, at: day(1)))
+        ledger.record(observation(.cursor, unit: .requests, total: 10, at: day(0)))
+        ledger.record(observation(.cursor, unit: .requests, total: 300, at: day(1)))
+
+        let scan = CostSummaryBuilder.makeScan(
+            days: 30,
+            enabledProviders: [],
+            claudeAccounts: [],
+            grokAccounts: [],
+            session: CostScanSession(cutoff: day(-30), options: .unlimited),
+            usageLedger: ledger
+        )
+
+        XCTAssertEqual(scan.summary.costs.map(\.provider), [.openRouter])
+        XCTAssertEqual(scan.summary.totalCostUSD, 4, accuracy: 0.000_001)
+        XCTAssertEqual(scan.summary.totalTokens, 0)
+        XCTAssertEqual(scan.summary.dailyUsage.map(\.provider), [.openRouter])
+        XCTAssertEqual(scan.summary.lifetime?.providers.map(\.provider), [.openRouter])
+    }
+
+    /// The default keeps every existing call site — and the scanners' own
+    /// tests — producing exactly what they did before the ledger existed.
+    func testMakeScanWithoutALedgerProducesNoPolledRows() {
+        let scan = CostSummaryBuilder.makeScan(
+            days: 30,
+            enabledProviders: [],
+            claudeAccounts: [],
+            grokAccounts: [],
+            session: CostScanSession(cutoff: day(-30), options: .unlimited)
+        )
+
+        XCTAssertTrue(scan.summary.costs.isEmpty)
+        XCTAssertTrue(scan.summary.dailyUsage.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func observation(
+        _ provider: ServiceType,
+        unit: ProviderUsageUnit,
+        total: Double,
+        at date: Date
+    ) -> ProviderUsageObservation {
+        ProviderUsageObservation(provider: provider, unit: unit, runningTotal: total, observedAt: date)
+    }
+
+    /// Start of the day `offset` days after a fixed epoch.
+    private func day(_ offset: Int) -> Date {
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 3
+        components.day = 15
+        components.hour = 12
+        let base = calendar.date(from: components) ?? Date(timeIntervalSince1970: 0)
+        let shifted = calendar.date(byAdding: .day, value: offset, to: base) ?? base
+        return calendar.startOfDay(for: shifted)
+    }
+}

--- a/MeterBarTests/ProviderUsageLedgerStoreTests.swift
+++ b/MeterBarTests/ProviderUsageLedgerStoreTests.swift
@@ -1,0 +1,170 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// Persistence coverage for `ProviderUsageLedgerStore`.
+///
+/// This artifact is not a cache. The scan caches can be deleted at any time and
+/// cost nothing but a re-read of logs that are still on disk; this file is the
+/// only copy of Cursor's and OpenRouter's history, because neither provider will
+/// re-serve a day once it has passed. Every test here pins a way that history
+/// could be silently corrupted or thrown away.
+final class ProviderUsageLedgerStoreTests: XCTestCase {
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ProviderUsageLedgerStore-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let directory {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        directory = nil
+        try super.tearDownWithError()
+    }
+
+    /// Round-trip must preserve day boundaries exactly. The payload keys its
+    /// daily buckets by `Date`, and an encoder/decoder pair that disagreed on
+    /// the date strategy would not throw — it would decode every bucket decades
+    /// from where it belongs, silently.
+    func testRoundTripPreservesDayKeysAndAmounts() throws {
+        let url = directory.appendingPathComponent(ProviderUsageLedgerStore.fileName)
+        var ledger = ProviderUsageLedger()
+        let first = Date(timeIntervalSince1970: 1_780_000_000)
+        ledger.record(observation(.openRouter, unit: .usd, total: 10, at: first))
+        ledger.record(
+            observation(.openRouter, unit: .usd, total: 12.5, at: first.addingTimeInterval(86_400))
+        )
+
+        try ProviderUsageLedgerStore.save(ledger, to: url)
+        let loaded = ProviderUsageLedgerStore.load(from: url)
+
+        XCTAssertEqual(loaded, ledger)
+        XCTAssertEqual(loaded.dailySeries(for: .openRouter).count, 1)
+        XCTAssertEqual(loaded.dailySeries(for: .openRouter).first?.amount ?? 0, 2.5, accuracy: 0.000_001)
+    }
+
+    /// A missing file is a first run, not a failure: the ledger starts empty and
+    /// the next poll establishes the baseline.
+    func testMissingFileLoadsAnEmptyLedgerRatherThanFailing() {
+        let url = directory.appendingPathComponent("does-not-exist.json")
+
+        XCTAssertTrue(ProviderUsageLedgerStore.load(from: url).entries.isEmpty)
+    }
+
+    /// A ledger written under a different schema version is dropped, never
+    /// half-decoded. Losing the baseline costs one poll interval; decoding a
+    /// changed shape against the current one would misattribute real spend with
+    /// no way to detect it afterwards.
+    func testSchemaVersionMismatchDropsTheArtifact() throws {
+        let url = directory.appendingPathComponent(ProviderUsageLedgerStore.fileName)
+        try ProviderUsageLedgerStore.save(makeLedger(), to: url)
+
+        try rewrite(url) { $0["schemaVersion"] = ProviderUsageLedger.currentSchemaVersion + 1 }
+
+        XCTAssertTrue(ProviderUsageLedgerStore.load(from: url).entries.isEmpty)
+    }
+
+    /// Days are a local-calendar notion. A ledger accumulated in one time zone
+    /// cannot be extended in another without mixing day boundaries, so the
+    /// mismatch restarts the series instead of appending to it.
+    func testTimeZoneMismatchDropsTheArtifact() throws {
+        let url = directory.appendingPathComponent(ProviderUsageLedgerStore.fileName)
+        try ProviderUsageLedgerStore.save(makeLedger(), to: url)
+
+        try rewrite(url) { $0["timeZoneIdentifier"] = "Antarctica/Troll" }
+
+        XCTAssertTrue(ProviderUsageLedgerStore.load(from: url).entries.isEmpty)
+    }
+
+    /// Truncated or hand-edited JSON must not crash the poll that reads it.
+    func testCorruptPayloadLoadsAnEmptyLedger() throws {
+        let url = directory.appendingPathComponent(ProviderUsageLedgerStore.fileName)
+        try Data("{ not json".utf8).write(to: url)
+
+        XCTAssertTrue(ProviderUsageLedgerStore.load(from: url).entries.isEmpty)
+    }
+
+    /// The file is rewritten on every successful poll for the life of the
+    /// install, so an unbounded payload would eventually trip the size guard on
+    /// write — which would freeze the baseline. A file past the cap is corrupt,
+    /// and is refused on read rather than parsed.
+    func testOversizedArtifactIsRefusedOnLoadAndOnSave() throws {
+        let url = directory.appendingPathComponent(ProviderUsageLedgerStore.fileName)
+        try ProviderUsageLedgerStore.save(makeLedger(), to: url)
+        let size = try XCTUnwrap(url.resourceValues(forKeys: [.fileSizeKey]).fileSize)
+
+        XCTAssertTrue(ProviderUsageLedgerStore.load(from: url, maximumBytes: size - 1).entries.isEmpty)
+        XCTAssertThrowsError(try ProviderUsageLedgerStore.save(makeLedger(), to: url, maximumBytes: 1)) { error in
+            guard case CostScanCacheStoreError.artifactTooLarge = error else {
+                return XCTFail("expected artifactTooLarge, got \(error)")
+            }
+        }
+    }
+
+    /// The ledger records what the user spends. It is written through
+    /// `SecureFileWriter`, which chmods before the first byte lands, so it can
+    /// never be briefly world-readable in the user's home directory.
+    func testSavedFileIsOwnerReadableOnly() throws {
+        let url = directory.appendingPathComponent(ProviderUsageLedgerStore.fileName)
+        try ProviderUsageLedgerStore.save(makeLedger(), to: url)
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        let permissions = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber)
+        XCTAssertEqual(permissions.int16Value & 0o077, 0)
+    }
+
+    /// The file name carries the schema version, so a future shape lands beside
+    /// the old one rather than being decoded as if it were compatible.
+    func testFileNameCarriesTheSchemaVersion() {
+        XCTAssertEqual(
+            ProviderUsageLedgerStore.fileName,
+            "provider-usage-observations-v\(ProviderUsageLedger.currentSchemaVersion).json"
+        )
+    }
+
+    /// The ledger must never share an artifact with the disposable scan caches:
+    /// a parser-version bump there would take this history with it.
+    func testLedgerDoesNotShareAFileWithTheScanCaches() {
+        let names = [
+            CostScanCacheStore.claudeFileName,
+            CostScanCacheStore.codexFileName,
+            CostScanCacheStore.grokFileName
+        ]
+        XCTAssertFalse(names.contains(ProviderUsageLedgerStore.fileName))
+    }
+
+    // MARK: - Helpers
+
+    private func makeLedger() -> ProviderUsageLedger {
+        var ledger = ProviderUsageLedger()
+        let start = Date(timeIntervalSince1970: 1_780_000_000)
+        ledger.record(observation(.openRouter, unit: .usd, total: 4, at: start))
+        ledger.record(observation(.openRouter, unit: .usd, total: 9, at: start.addingTimeInterval(86_400)))
+        ledger.record(observation(.cursor, unit: .requests, total: 40, at: start))
+        ledger.record(observation(.cursor, unit: .requests, total: 61, at: start.addingTimeInterval(86_400)))
+        return ledger
+    }
+
+    private func observation(
+        _ provider: ServiceType,
+        unit: ProviderUsageUnit,
+        total: Double,
+        at date: Date
+    ) -> ProviderUsageObservation {
+        ProviderUsageObservation(provider: provider, unit: unit, runningTotal: total, observedAt: date)
+    }
+
+    private func rewrite(_ url: URL, _ mutate: (inout [String: Any]) -> Void) throws {
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any]
+        )
+        mutate(&object)
+        try JSONSerialization.data(withJSONObject: object).write(to: url)
+    }
+}

--- a/MeterBarTests/ProviderUsageLedgerStoreTests.swift
+++ b/MeterBarTests/ProviderUsageLedgerStoreTests.swift
@@ -70,16 +70,26 @@ final class ProviderUsageLedgerStoreTests: XCTestCase {
         XCTAssertTrue(ProviderUsageLedgerStore.load(from: url).entries.isEmpty)
     }
 
-    /// Days are a local-calendar notion. A ledger accumulated in one time zone
-    /// cannot be extended in another without mixing day boundaries, so the
-    /// mismatch restarts the series instead of appending to it.
-    func testTimeZoneMismatchDropsTheArtifact() throws {
+    /// A time-zone change re-anchors the ledger; it never discards it.
+    ///
+    /// Moving zones is routine — travel, a corrected system setting, DST on a
+    /// machine configured by offset — and this file is the only copy of these
+    /// providers' history. Dropping here would silently destroy up to
+    /// `retainedDays` of days neither provider will re-serve. The recorded days
+    /// keep the boundary they were recorded against and the zone is updated for
+    /// the days still to come, which costs a bounded error on the one day
+    /// straddling the move instead of the lot.
+    func testTimeZoneMismatchReanchorsInsteadOfDiscardingHistory() throws {
         let url = directory.appendingPathComponent(ProviderUsageLedgerStore.fileName)
-        try ProviderUsageLedgerStore.save(makeLedger(), to: url)
+        let saved = makeLedger()
+        try ProviderUsageLedgerStore.save(saved, to: url)
 
         try rewrite(url) { $0["timeZoneIdentifier"] = "Antarctica/Troll" }
 
-        XCTAssertTrue(ProviderUsageLedgerStore.load(from: url).entries.isEmpty)
+        let loaded = ProviderUsageLedgerStore.load(from: url)
+        XCTAssertFalse(loaded.entries.isEmpty)
+        XCTAssertEqual(loaded.entries, saved.entries)
+        XCTAssertEqual(loaded.timeZoneIdentifier, TimeZone.current.identifier)
     }
 
     /// Truncated or hand-edited JSON must not crash the poll that reads it.

--- a/MeterBarTests/ProviderUsageObservationTests.swift
+++ b/MeterBarTests/ProviderUsageObservationTests.swift
@@ -330,6 +330,54 @@ final class ProviderUsageObservationTests: XCTestCase {
         XCTAssertEqual(ledger.unit(for: .cursor), .usd)
     }
 
+    // MARK: - Day boundaries
+
+    /// A provider that dates its figures in UTC is bucketed in UTC, whatever the
+    /// user's calendar says.
+    ///
+    /// OpenRouter documents `usage_daily` as spend since midnight *UTC*, and the
+    /// authoritative path writes its bucket absolutely. Filing it under the local
+    /// day would therefore do two things at once for every user off UTC: date the
+    /// figure to the wrong day, and overwrite whatever that day had legitimately
+    /// accumulated from deltas.
+    func testUTCBoundaryBucketsAgainstUTCRatherThanTheLocalCalendar() {
+        var utc = Calendar(identifier: .gregorian)
+        utc.timeZone = .gmt
+        var pacific = Calendar(identifier: .gregorian)
+        pacific.timeZone = TimeZone(secondsFromGMT: -8 * 3600) ?? .gmt
+        // 02:00 UTC on the 2nd is still 18:00 on the 1st in the local calendar,
+        // so the two boundaries disagree about which day this instant is in.
+        let instant = utc.date(from: DateComponents(year: 2026, month: 1, day: 2, hour: 2)) ?? Date()
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(
+            observation(.openRouter, unit: .usd, total: 100, authoritativeDaily: 7, boundary: .utc, at: instant),
+            calendar: pacific
+        )
+
+        let series = ledger.dailySeries(for: .openRouter)
+        XCTAssertEqual(series.map(\.date), [utc.startOfDay(for: instant)])
+        XCTAssertNotEqual(series.first?.date, pacific.startOfDay(for: instant))
+    }
+
+    /// A provider whose day boundary changes starts a fresh baseline.
+    ///
+    /// This is the unit-change guard one axis over: the keys already in the map
+    /// are midnights in a different calendar, so extending it would sum two
+    /// definitions of "day" into one bucket and shift part of one day's spend
+    /// onto its neighbour.
+    func testDayBoundaryChangeRestartsTheBaselineInsteadOfMixingCalendars() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.openRouter, unit: .usd, total: 100, at: day(1)), calendar: calendar)
+        ledger.record(
+            observation(.openRouter, unit: .usd, total: 140, boundary: .utc, at: day(2)),
+            calendar: calendar
+        )
+
+        XCTAssertEqual(ledger.dailySeries(for: .openRouter), [])
+    }
+
     // MARK: - Malformed input
 
     /// Non-finite and negative readings are ignored, baseline included.
@@ -414,6 +462,7 @@ final class ProviderUsageObservationTests: XCTestCase {
         unit: ProviderUsageUnit,
         total: Double,
         authoritativeDaily: Double? = nil,
+        boundary: ProviderUsageDayBoundary = .local,
         at date: Date
     ) -> ProviderUsageObservation {
         ProviderUsageObservation(
@@ -421,6 +470,7 @@ final class ProviderUsageObservationTests: XCTestCase {
             unit: unit,
             runningTotal: total,
             authoritativeDailyTotal: authoritativeDaily,
+            dayBoundary: boundary,
             observedAt: date
         )
     }

--- a/MeterBarTests/ProviderUsageObservationTests.swift
+++ b/MeterBarTests/ProviderUsageObservationTests.swift
@@ -1,0 +1,439 @@
+import XCTest
+@testable import MeterBar
+@testable import MeterBarShared
+
+/// Unit tests for `ProviderUsageLedger` — the poll-and-accumulate series for the
+/// two providers that keep no local session log (issue: Cursor and OpenRouter
+/// contributed no `costs[]`/`dailyUsage[]` rows at all, so they were
+/// structurally absent from the spend chart, the dashboard cost section, and the
+/// share card).
+///
+/// Neither provider reports per-session usage. Both report a *running counter*
+/// that MeterBar has to differentiate into a dated series, and every load-bearing
+/// fact here is about that conversion: which day a delta belongs to, what a
+/// counter going backwards means, which figure wins when the provider publishes
+/// its own daily total, and — most of all — what the series is not allowed to
+/// claim about days it never observed. Getting any one wrong produces a
+/// plausible-looking number that is simply false.
+final class ProviderUsageObservationTests: XCTestCase {
+    private let calendar = Calendar(identifier: .gregorian)
+
+    // MARK: - Baseline and backfill
+
+    /// The first poll establishes a baseline and nothing else.
+    ///
+    /// OpenRouter's `usage` is a *lifetime* total. Treating the first reading as
+    /// a delta against zero would land a user's entire account history — possibly
+    /// hundreds of dollars accrued over a year — on the single day they installed
+    /// MeterBar, and that spike would then anchor the chart's y-axis forever.
+    func testFirstObservationEstablishesABaselineWithoutEmittingARow() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(
+            observation(.openRouter, unit: .usd, total: 412.50, at: day(1)),
+            calendar: calendar
+        )
+
+        XCTAssertEqual(ledger.dailySeries(for: .openRouter), [])
+    }
+
+    /// Days before the first poll must be absent from the series, not zero.
+    ///
+    /// A zero row is an affirmative claim that nothing was spent that day. For a
+    /// day MeterBar was not running, that claim is false — and `CostChartPresentation`
+    /// draws a covered zero differently from an uncovered gap, so a fabricated
+    /// zero would render as a confirmed quiet day.
+    func testDaysBeforeTheFirstObservationAreAbsentRatherThanZero() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.openRouter, unit: .usd, total: 10, at: day(5)), calendar: calendar)
+        ledger.record(observation(.openRouter, unit: .usd, total: 13, at: day(6)), calendar: calendar)
+
+        let dates = ledger.dailySeries(for: .openRouter).map(\.date)
+        XCTAssertEqual(dates, [day(6)])
+        XCTAssertEqual(ledger.firstObservedDate(for: .openRouter), day(5))
+    }
+
+    // MARK: - Delta attribution
+
+    /// A delta belongs to the day the observation was taken.
+    ///
+    /// Attributing it to the *previous* observation's day — the other obvious
+    /// reading of "spend between two polls" — back-dates every row by one poll
+    /// interval and, across a midnight boundary, moves today's spend to
+    /// yesterday.
+    func testDeltaIsAttributedToTheObservationDayNotThePreviousObservationDay() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.openRouter, unit: .usd, total: 100, at: day(1)), calendar: calendar)
+        ledger.record(observation(.openRouter, unit: .usd, total: 107.25, at: day(2)), calendar: calendar)
+
+        let series = ledger.dailySeries(for: .openRouter)
+        XCTAssertEqual(series.count, 1)
+        XCTAssertEqual(series.first?.date, day(2))
+        XCTAssertEqual(series.first?.amount ?? 0, 7.25, accuracy: 1e-9)
+    }
+
+    /// Several polls on one day accumulate into that day's single row.
+    ///
+    /// Overwriting instead of summing would report only the last poll interval,
+    /// silently discarding everything spent earlier in the day.
+    func testMultiplePollsOnTheSameDayAccumulateIntoOneRow() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.openRouter, unit: .usd, total: 100, at: day(1)), calendar: calendar)
+        ledger.record(observation(.openRouter, unit: .usd, total: 101, at: day(2, hour: 9)), calendar: calendar)
+        ledger.record(observation(.openRouter, unit: .usd, total: 104, at: day(2, hour: 17)), calendar: calendar)
+
+        let series = ledger.dailySeries(for: .openRouter)
+        XCTAssertEqual(series.count, 1)
+        XCTAssertEqual(series.first?.amount ?? 0, 4, accuracy: 1e-9)
+    }
+
+    /// An unchanged counter emits no row at all.
+    ///
+    /// A zero-delta poll means "nothing new since last time", which is already
+    /// expressed by the day's absence. Writing a `0` row would make an idle day
+    /// indistinguishable from a day that was measured and confirmed empty, and
+    /// would drag a meaningless entry into the "Daily Details" list.
+    func testUnchangedCounterEmitsNoRowForThatDay() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.openRouter, unit: .usd, total: 100, at: day(1)), calendar: calendar)
+        ledger.record(observation(.openRouter, unit: .usd, total: 100, at: day(2)), calendar: calendar)
+
+        XCTAssertEqual(ledger.dailySeries(for: .openRouter), [])
+    }
+
+    // MARK: - Counter resets
+
+    /// A counter that drops is a reset, not negative spend.
+    ///
+    /// Cursor's `plan.used` zeroes at `billingCycleStart`. Subtracting the old
+    /// baseline would emit a large negative row that cancels out real earlier
+    /// spend, making a month-boundary refresh *reduce* the reported total.
+    func testDroppingCounterIsTreatedAsAResetAndNeverEmitsANegativeRow() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.cursor, unit: .requests, total: 480, at: day(1)), calendar: calendar)
+        ledger.record(observation(.cursor, unit: .requests, total: 12, at: day(2)), calendar: calendar)
+
+        let series = ledger.dailySeries(for: .cursor)
+        XCTAssertEqual(series.count, 1)
+        XCTAssertEqual(series.first?.date, day(2))
+        XCTAssertEqual(series.first?.amount ?? 0, 12, accuracy: 1e-9)
+        XCTAssertFalse(series.contains { $0.amount < 0 })
+    }
+
+    /// After a reset the post-reset value is the day's contribution, and the new
+    /// baseline is the post-reset counter.
+    ///
+    /// Leaving the pre-reset baseline in place would swallow the whole next
+    /// cycle: every reading below the old high-water mark would keep re-reading
+    /// as another reset, and the series would repeat the running total instead
+    /// of differentiating it.
+    func testBaselineFollowsThePostResetCounterSoTheNextDeltaIsCorrect() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.cursor, unit: .requests, total: 480, at: day(1)), calendar: calendar)
+        ledger.record(observation(.cursor, unit: .requests, total: 12, at: day(2)), calendar: calendar)
+        ledger.record(observation(.cursor, unit: .requests, total: 30, at: day(3)), calendar: calendar)
+
+        let series = ledger.dailySeries(for: .cursor)
+        XCTAssertEqual(series.map(\.date), [day(2), day(3)])
+        XCTAssertEqual(series.last?.amount ?? 0, 18, accuracy: 1e-9)
+    }
+
+    /// Spend across a billing-cycle reset is conserved, not double-counted.
+    ///
+    /// Treating the post-reset value as a delta against zero is only correct
+    /// because the pre-reset consumption was already attributed on earlier days.
+    /// This pins the arithmetic end to end so a "fix" that also re-adds the
+    /// pre-reset high-water mark fails here.
+    func testTotalAcrossAResetEqualsTheSumOfBothCycles() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.cursor, unit: .requests, total: 0, at: day(1)), calendar: calendar)
+        ledger.record(observation(.cursor, unit: .requests, total: 200, at: day(2)), calendar: calendar)
+        ledger.record(observation(.cursor, unit: .requests, total: 500, at: day(3)), calendar: calendar)
+        // Cycle rolls over: the counter zeroes and climbs again.
+        ledger.record(observation(.cursor, unit: .requests, total: 40, at: day(4)), calendar: calendar)
+
+        let total = ledger.dailySeries(for: .cursor).reduce(0) { $0 + $1.amount }
+        XCTAssertEqual(total, 540, accuracy: 1e-9)
+    }
+
+    // MARK: - Provider-published daily totals
+
+    /// OpenRouter's own `usage_daily` wins over the computed delta for today.
+    ///
+    /// The delta only knows what happened between two polls. `usage_daily` is
+    /// the provider's figure for the whole calendar day, so preferring it is
+    /// what lets a day survive a laptop that was asleep for most of it.
+    func testAuthoritativeDailyTotalOverridesTheComputedDeltaForToday() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.openRouter, unit: .usd, total: 100, at: day(1)), calendar: calendar)
+        ledger.record(
+            observation(.openRouter, unit: .usd, total: 102, authoritativeDaily: 9.5, at: day(2)),
+            calendar: calendar
+        )
+
+        let series = ledger.dailySeries(for: .openRouter)
+        XCTAssertEqual(series.count, 1)
+        XCTAssertEqual(series.first?.amount ?? 0, 9.5, accuracy: 1e-9)
+    }
+
+    /// Applying `usage_daily` must not also apply that poll's delta.
+    ///
+    /// Adding both is the natural implementation slip — record the delta, then
+    /// "correct" the row — and it inflates every day the provider publishes a
+    /// total by exactly one poll interval.
+    func testAuthoritativeDailyTotalIsNotAddedOnTopOfTheDelta() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.openRouter, unit: .usd, total: 100, at: day(1)), calendar: calendar)
+        ledger.record(
+            observation(.openRouter, unit: .usd, total: 105, authoritativeDaily: 5, at: day(2)),
+            calendar: calendar
+        )
+
+        XCTAssertEqual(ledger.dailySeries(for: .openRouter).first?.amount ?? 0, 5, accuracy: 1e-9)
+    }
+
+    /// A later `usage_daily` replaces an earlier delta-derived row for the same
+    /// day rather than adding to it.
+    ///
+    /// This is the self-heal path: the morning poll had no published total and
+    /// fell back to a delta; the evening poll has one and is authoritative. Summing
+    /// would count the morning twice.
+    func testAuthoritativeDailyTotalReplacesAnEarlierDeltaRowForTheSameDay() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.openRouter, unit: .usd, total: 100, at: day(1)), calendar: calendar)
+        ledger.record(observation(.openRouter, unit: .usd, total: 103, at: day(2, hour: 9)), calendar: calendar)
+        ledger.record(
+            observation(.openRouter, unit: .usd, total: 108, authoritativeDaily: 8, at: day(2, hour: 21)),
+            calendar: calendar
+        )
+
+        let series = ledger.dailySeries(for: .openRouter)
+        XCTAssertEqual(series.count, 1)
+        XCTAssertEqual(series.first?.amount ?? 0, 8, accuracy: 1e-9)
+    }
+
+    /// After an authoritative poll the running baseline still advances.
+    ///
+    /// `usage_daily` is optional in OpenRouter's payload. If the field goes away
+    /// on the next poll, the delta path resumes — and it resumes against a stale
+    /// baseline unless the authoritative branch re-baselines too, re-charging
+    /// every dollar since the last non-authoritative poll.
+    func testAuthoritativePollStillRebaselinesSoALaterDeltaIsNotInflated() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.openRouter, unit: .usd, total: 100, at: day(1)), calendar: calendar)
+        ledger.record(
+            observation(.openRouter, unit: .usd, total: 110, authoritativeDaily: 10, at: day(2)),
+            calendar: calendar
+        )
+        ledger.record(observation(.openRouter, unit: .usd, total: 112, at: day(3)), calendar: calendar)
+
+        XCTAssertEqual(ledger.dailySeries(for: .openRouter).last?.amount ?? 0, 2, accuracy: 1e-9)
+    }
+
+    /// A published daily total of zero clears the day instead of writing `0`.
+    ///
+    /// The provider saying "nothing today" is still not a reason to persist a
+    /// zero row — the day's absence already says that, and a stored zero would
+    /// leak into the "Daily Details" list as an empty entry.
+    func testZeroAuthoritativeDailyTotalRemovesTheRowRatherThanStoringZero() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.openRouter, unit: .usd, total: 100, at: day(1)), calendar: calendar)
+        ledger.record(observation(.openRouter, unit: .usd, total: 103, at: day(2, hour: 9)), calendar: calendar)
+        ledger.record(
+            observation(.openRouter, unit: .usd, total: 103, authoritativeDaily: 0, at: day(2, hour: 21)),
+            calendar: calendar
+        )
+
+        XCTAssertEqual(ledger.dailySeries(for: .openRouter), [])
+    }
+
+    /// The very first poll may still use its published daily total.
+    ///
+    /// `usage_daily` claims only today, so unlike the lifetime `usage` scalar it
+    /// is not a backfill and does not violate the no-history rule. Suppressing
+    /// it would throw away the one real figure available on install day.
+    func testFirstObservationMayUseItsPublishedDailyTotal() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(
+            observation(.openRouter, unit: .usd, total: 412.50, authoritativeDaily: 3.25, at: day(1)),
+            calendar: calendar
+        )
+
+        let series = ledger.dailySeries(for: .openRouter)
+        XCTAssertEqual(series.count, 1)
+        XCTAssertEqual(series.first?.amount ?? 0, 3.25, accuracy: 1e-9)
+    }
+
+    // MARK: - Units
+
+    /// Providers are accumulated independently and keep their own unit.
+    ///
+    /// Cursor counts requests and OpenRouter counts dollars. A shared bucket, or
+    /// a series that forgets which unit it is in, is exactly how a request count
+    /// ends up rendered with a dollar sign.
+    func testEachProviderKeepsItsOwnUnitAndSeries() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.openRouter, unit: .usd, total: 10, at: day(1)), calendar: calendar)
+        ledger.record(observation(.cursor, unit: .requests, total: 100, at: day(1)), calendar: calendar)
+        ledger.record(observation(.openRouter, unit: .usd, total: 12, at: day(2)), calendar: calendar)
+        ledger.record(observation(.cursor, unit: .requests, total: 140, at: day(2)), calendar: calendar)
+
+        XCTAssertEqual(ledger.unit(for: .openRouter), .usd)
+        XCTAssertEqual(ledger.unit(for: .cursor), .requests)
+        XCTAssertEqual(ledger.dailySeries(for: .openRouter).first?.amount ?? 0, 2, accuracy: 1e-9)
+        XCTAssertEqual(ledger.dailySeries(for: .cursor).first?.amount ?? 0, 40, accuracy: 1e-9)
+    }
+
+    /// Only dollar-denominated entries can produce cost rows.
+    ///
+    /// This is the guard against the single worst outcome available here:
+    /// Cursor's request count reaching `estimatedCostUSD` and being printed as
+    /// money. Cursor's usage-summary payload carries no currency field at all,
+    /// so there is no rate to convert with and no honest dollar figure to emit.
+    func testRequestDenominatedEntriesProduceNoUSDRows() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.cursor, unit: .requests, total: 100, at: day(1)), calendar: calendar)
+        ledger.record(observation(.cursor, unit: .requests, total: 140, at: day(2)), calendar: calendar)
+
+        XCTAssertEqual(ledger.dailyUSDSeries(for: .cursor), [])
+        XCTAssertFalse(ledger.usdProviders.contains(.cursor))
+        XCTAssertFalse(ledger.dailySeries(for: .cursor).isEmpty)
+    }
+
+    /// A provider whose reported unit changes starts a fresh baseline.
+    ///
+    /// Differencing a dollar figure against a request count would emit a number
+    /// in neither unit. Dropping the stale baseline costs one poll interval;
+    /// keeping it produces silent nonsense.
+    func testUnitChangeRestartsTheBaselineInsteadOfDifferencingAcrossUnits() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.cursor, unit: .requests, total: 400, at: day(1)), calendar: calendar)
+        ledger.record(observation(.cursor, unit: .usd, total: 5, at: day(2)), calendar: calendar)
+
+        XCTAssertEqual(ledger.dailySeries(for: .cursor), [])
+        XCTAssertEqual(ledger.unit(for: .cursor), .usd)
+    }
+
+    // MARK: - Malformed input
+
+    /// Non-finite and negative readings are ignored, baseline included.
+    ///
+    /// A `NaN` reaching the baseline poisons every later comparison — `NaN >= x`
+    /// is false, so every subsequent poll would read as a reset and re-charge the
+    /// full running total, every time.
+    func testNonFiniteOrNegativeReadingsAreIgnoredEntirely() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.openRouter, unit: .usd, total: 100, at: day(1)), calendar: calendar)
+        ledger.record(observation(.openRouter, unit: .usd, total: .nan, at: day(2)), calendar: calendar)
+        ledger.record(observation(.openRouter, unit: .usd, total: -5, at: day(2)), calendar: calendar)
+        ledger.record(observation(.openRouter, unit: .usd, total: 103, at: day(2)), calendar: calendar)
+
+        let series = ledger.dailySeries(for: .openRouter)
+        XCTAssertEqual(series.count, 1)
+        XCTAssertEqual(series.first?.amount ?? 0, 3, accuracy: 1e-9)
+    }
+
+    /// A non-finite published daily total falls back to the delta.
+    ///
+    /// Storing it would make the day's amount `NaN`, and a `NaN` row propagates
+    /// through every `reduce` in the cost summary until the headline total reads
+    /// "$nan".
+    func testNonFiniteAuthoritativeDailyTotalFallsBackToTheDelta() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.openRouter, unit: .usd, total: 100, at: day(1)), calendar: calendar)
+        ledger.record(
+            observation(.openRouter, unit: .usd, total: 104, authoritativeDaily: .infinity, at: day(2)),
+            calendar: calendar
+        )
+
+        XCTAssertEqual(ledger.dailySeries(for: .openRouter).first?.amount ?? 0, 4, accuracy: 1e-9)
+    }
+
+    /// An observation older than the last one recorded is dropped.
+    ///
+    /// A stale reading would re-baseline *downwards*, and the drop reads as a
+    /// reset — so the next poll re-charges the entire running counter as one
+    /// day's spend. Clock adjustments and out-of-order concurrent refreshes both
+    /// produce this.
+    func testObservationOlderThanTheLastRecordedOneIsDropped() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.openRouter, unit: .usd, total: 100, at: day(1)), calendar: calendar)
+        ledger.record(observation(.openRouter, unit: .usd, total: 150, at: day(5)), calendar: calendar)
+        ledger.record(observation(.openRouter, unit: .usd, total: 120, at: day(3)), calendar: calendar)
+        ledger.record(observation(.openRouter, unit: .usd, total: 155, at: day(6)), calendar: calendar)
+
+        let series = ledger.dailySeries(for: .openRouter)
+        XCTAssertEqual(series.map(\.date), [day(5), day(6)])
+        XCTAssertEqual(series.last?.amount ?? 0, 5, accuracy: 1e-9)
+    }
+
+    // MARK: - Retention
+
+    /// The ledger keeps a bounded window of days.
+    ///
+    /// This file is rewritten on every poll for the life of the install. Without
+    /// a bound it grows without limit, and the store's own size guard would
+    /// eventually start refusing writes — which silently freezes the baseline.
+    func testDaysOlderThanTheRetentionWindowArePruned() {
+        var ledger = ProviderUsageLedger()
+
+        ledger.record(observation(.openRouter, unit: .usd, total: 10, at: day(0)), calendar: calendar)
+        ledger.record(observation(.openRouter, unit: .usd, total: 20, at: day(1)), calendar: calendar)
+        ledger.record(
+            observation(.openRouter, unit: .usd, total: 30, at: day(ProviderUsageLedger.retainedDays + 5)),
+            calendar: calendar
+        )
+
+        let series = ledger.dailySeries(for: .openRouter)
+        XCTAssertEqual(series.map(\.date), [day(ProviderUsageLedger.retainedDays + 5)])
+    }
+
+    // MARK: - Helpers
+
+    private func observation(
+        _ provider: ServiceType,
+        unit: ProviderUsageUnit,
+        total: Double,
+        authoritativeDaily: Double? = nil,
+        at date: Date
+    ) -> ProviderUsageObservation {
+        ProviderUsageObservation(
+            provider: provider,
+            unit: unit,
+            runningTotal: total,
+            authoritativeDailyTotal: authoritativeDaily,
+            observedAt: date
+        )
+    }
+
+    /// Day `offset` after a fixed epoch, at `hour` local time.
+    private func day(_ offset: Int, hour: Int = 12) -> Date {
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 1
+        components.day = 1
+        components.hour = hour
+        let base = calendar.date(from: components) ?? Date(timeIntervalSince1970: 0)
+        let shifted = calendar.date(byAdding: .day, value: offset, to: base) ?? base
+        return hour == 12 ? calendar.startOfDay(for: shifted) : shifted
+    }
+}


### PR DESCRIPTION
`ServiceType` has five cases, but only three of them — Claude, Codex, Grok — could ever appear in the spend chart, the dashboard cost section, or the share card. Those three write per-session logs to disk, so a scanner can read them. Cursor and OpenRouter write nothing, so they contributed nothing to `costs[]` or `dailyUsage[]` and were structurally absent from every historical view.

This adds the only mechanism those two can support: **poll and accumulate**. On each successful poll, MeterBar records the provider's running counter. The next poll's delta becomes that day's row. There is no scanner because there is nothing to scan.

## What each provider actually reports

Verified against the live payloads and the local state directories, not assumed.

### OpenRouter — dollars, no tokens, no local corpus

`GET /api/v1/key` returns `usage` (running USD for the authenticated key) and optionally `usage_daily` / `usage_weekly` / `usage_monthly`. There is no session log, no history endpoint, and no local corpus of any kind.

- **The series claims:** dollars spent per day, from the first poll onward. These rows land in `costs[]` and `dailyUsage[]` and appear in the spend chart, the 30-day and lifetime totals, and the share card.
- **It does not claim:** any token count. The endpoint reports none, so every token field on the emitted `TokenCost` and `DailyTokenUsage` is `0` rather than a number derived from a rate. It also claims no model or project attribution — the breakdowns are empty arrays (not `nil`, which `needsMissingDailyUsageRefresh` reads as "re-scan me", and no re-scan could ever fill them).
- **Scope:** the observation is key-scoped (`/key`), not account-scoped (`/credits`). `usage` and `usage_daily` describe the same key, so the delta path and the authoritative-today path measure the same thing.
- **`usage_daily` wins when present.** It covers the whole day including hours MeterBar was not running, which a poll-to-poll delta cannot see, so it self-heals a missed poll. The delta is the fallback when the field is absent.

### Cursor — requests, not dollars

`CursorLocalService` reads an auth token out of Cursor's SQLite state and calls `https://cursor.com/api/usage-summary`. That payload carries `individualUsage.plan.used/limit`, `individualUsage.onDemand.used/limit`, and the billing-cycle bounds. **It carries no currency field anywhere** — every usage figure is an integer count against a plan allowance, and Cursor publishes no per-request rate that MeterBar can read. `~/.cursor` has no per-session usage log either: a sweep of every `*.json`/`*.jsonl` for token or cost keys returned nothing, and `ai-tracking/ai-code-tracking.db` tracks AI-authored lines of code with no token or cost column.

- **The series claims:** requests consumed per day against the plan allowance, from the first poll onward.
- **It does not claim, and deliberately never will, a dollar figure.** `plan.used` is a request count. Multiplying it by a guessed rate would put an invented number in the spend chart, the dashboard total, and the share card — three places a user reads as measured. `ProviderUsageLedger.dailyUSDSeries(for:)` is the single guard: it returns nothing unless the entry's unit is `.usd`, and `ProviderUsageCostBuilder` returns `nil` rather than a converted or zeroed row.
- **It does not claim token counts** for the same reason.
- **On-demand usage is not summed into the plan count.** It is billed and counted separately; adding them would produce a number in neither unit.
- Cursor surfaces instead in a new **Polled Usage** card on the Costs page, counted in requests and labelled as such.

## What the series cannot claim, for either provider

- **No backfill.** The series starts the day of the first poll. OpenRouter's `usage` is a lifetime figure — treating the first reading as a delta against zero would dump a year of spend onto install day, so the first poll is a baseline only.
- **No zero rows for unmeasured days.** A day with no observation is absent from the series. A stored `0` reads downstream as "measured, and empty" — a claim MeterBar cannot support for a day it wasn't watching. Each card is captioned with the date tracking began so the gap before it reads as unmeasured rather than as quiet.
- **No negative days.** Cursor's counter zeroes at `billingCycleStart`, and OpenRouter's lifetime figure is only supposed to be monotonic. A drop is treated as a reset — the new value is the day's contribution — never as a negative delta.

## Implementation

- `ProviderUsageLedger` (`MeterBar/Models/`) — the observation → daily-series fold, with reset detection, the authoritative-daily override, no-backfill baselining, and 400-day retention.
- `ProviderUsageLedgerStore` (`MeterBar/Services/`) — its own versioned artifact, `provider-usage-observations-v1.json`, alongside the scan caches in `~/Library/Application Support/MeterBar/`. Deliberately **not** shared with `cost-scan-*-v3.json`: those are derived from logs that can be re-read, while this ledger is the only copy of either provider's history that will ever exist. Written through `SecureFileWriter` (owner-only, atomic), pinned to `.secondsSince1970`, size-guarded, and dropped rather than migrated on a schema or time-zone mismatch.
- `ProviderUsageCostBuilder` — the one path from ledger to money, and the one place the USD guard is applied.
- `PolledRequestSeriesPresentation` + `PolledUsageCard` — the request-denominated surface, mirroring `CostChartPresentation`/`CostSpendCharts`.
- Capture points: `OpenRouterService.observation(key:at:)` and `CursorLocalService.observation(_:at:)`, held on the service and folded into the ledger by `UsageDataManager.recordUsageObservations(for:)` after each successful refresh. Held on the service rather than returned inside `UsageMetrics`, because that value is serialized into the app-group cache the widget and the CLI decode — **no shared-cache serialization changed in this PR.**

Also corrects two dashboard empty-state strings that named only Claude and Codex.

## Verification

- TDD throughout: 57 new tests across five suites, each doc-commented with the bug it prevents.
- `swift test` — **2059 tests, 0 failures** (5 pre-existing skips).
- `swiftlint lint --strict` — clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added usage tracking for request-based and dollar-based provider activity.
- Added a dashboard card showing polled request totals and daily trends.
- Added persistent usage history across app launches.
- Included eligible provider usage in cost summaries.
- Improved empty-state messaging for broader provider coverage.

## Bug Fixes
- Improved handling of counter resets, missing readings, date ranges, and daily totals.
- Ensured usage data is validated and safely persisted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->