### PR TITLE
chore(release): bump MARKETING_VERSION to 1.8.34

### DIFF
--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.33;
+				MARKETING_VERSION = 1.8.34;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -369,7 +369,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.33;
+				MARKETING_VERSION = 1.8.34;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -534,7 +534,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.33;
+				MARKETING_VERSION = 1.8.34;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug;
 				PRODUCT_NAME = "MeterBar Dev";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -580,7 +580,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.33;
+				MARKETING_VERSION = 1.8.34;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
`v1.8.33` is the published **Latest** release (tagged 2026-08-05), so #366, #367, #368 and #369 are all unreleased work sitting on top of a shipped tag. Bumps the marketing version to 1.8.34.

`CURRENT_PROJECT_VERSION` is `$(MARKETING_VERSION)`, so the single value carries the build number too.