### PR TITLE
feat(dashboard): stale-login one-liners, 7/30-day cost window, cleaner status rows

### DIFF
--- a/MeterBar/Models/CostChartPresentation.swift
+++ b/MeterBar/Models/CostChartPresentation.swift
@@ -91,18 +91,35 @@ nonisolated struct CostChartPresentation: Sendable {
                 return $0.date < $1.date
             }
 
-        let modelResult = Self.makeModelPoints(from: summary.costs)
-        modelPoints = modelResult.points
-        hasUnattributedModelSpend = modelResult.hasUnattributed
+        let windowTotalUSD = windowRows.reduce(0) { $0 + max(0, $1.estimatedCostUSD) }
+
+        // A window narrower than the scan re-derives model spend from the daily
+        // rows' own attribution, so "Spend by model" describes the same days as
+        // the daily chart above it. Rows from a v1 cache carry no attribution,
+        // so those fall back to the scan-period detail and the mismatch caption.
+        if let windowed = Self.makeModelPoints(
+            fromWindowRows: windowRows,
+            requestedDays: normalizedDays,
+            periodDays: summary.periodDays
+        ) {
+            modelPoints = windowed.points
+            hasUnattributedModelSpend = windowed.hasUnattributed
+            modelWindowDays = normalizedDays
+            selectedPeriodTotalUSD = windowTotalUSD
+        } else {
+            let modelResult = Self.makeModelPoints(from: summary.costs)
+            modelPoints = modelResult.points
+            hasUnattributedModelSpend = modelResult.hasUnattributed
+            modelWindowDays = max(0, summary.periodDays)
+            selectedPeriodTotalUSD = max(0, summary.totalCostUSD)
+        }
 
         self.requestedDays = normalizedDays
         coveredDays = costWindow.coveredDays
         self.startDate = startDate
         endDate = today
         chartDomainEndDate = calendar.date(byAdding: .day, value: 1, to: today) ?? today
-        modelWindowDays = max(0, summary.periodDays)
-        selectedPeriodTotalUSD = max(0, summary.totalCostUSD)
-        dailyTotalUSD = windowRows.reduce(0) { $0 + max(0, $1.estimatedCostUSD) }
+        dailyTotalUSD = windowTotalUSD
         modelTotalUSD = modelPoints.reduce(0) { $0 + $1.costUSD }
     }
 
@@ -130,6 +147,42 @@ nonisolated struct CostChartPresentation: Sendable {
         modelWindowDays == requestedDays
     }
 
+    /// Model points for a window narrower than the scan, cut from the daily
+    /// rows' own model attribution. `nil` when the request *is* the scan window
+    /// (the scan's totals are authoritative there), when the window holds no
+    /// rows, or when any row predates attribution — the callers fall back to
+    /// the scan-period detail plus the mismatch caption in all three cases.
+    private static func makeModelPoints(
+        fromWindowRows windowRows: [DailyTokenUsage],
+        requestedDays: Int,
+        periodDays: Int
+    ) -> (points: [CostModelSpendPoint], hasUnattributed: Bool)? {
+        guard requestedDays < periodDays,
+              !windowRows.isEmpty,
+              windowRows.allSatisfy({ $0.modelBreakdowns != nil })
+        else { return nil }
+
+        var totals: [CostModelKey: Double] = [:]
+        var hasUnattributed = false
+
+        for row in windowRows {
+            let rowTotal = max(0, row.estimatedCostUSD)
+            let attributedTotal = (row.modelBreakdowns ?? []).reduce(0) { result, breakdown in
+                let amount = max(0, breakdown.estimatedCostUSD)
+                guard amount > 0 else { return result }
+                totals[CostModelKey(provider: row.provider, name: breakdown.name), default: 0] += amount
+                return result + amount
+            }
+            let unattributed = rowTotal - attributedTotal
+            if unattributed > Self.reconciliationToleranceUSD {
+                totals[CostModelKey(provider: row.provider, name: "Unattributed"), default: 0] += unattributed
+                hasUnattributed = true
+            }
+        }
+
+        return (labelledModelPoints(from: totals), hasUnattributed)
+    }
+
     private static func makeModelPoints(
         from costs: [TokenCost]
     ) -> (points: [CostModelSpendPoint], hasUnattributed: Bool) {
@@ -152,6 +205,15 @@ nonisolated struct CostChartPresentation: Sendable {
             }
         }
 
+        return (labelledModelPoints(from: totals), hasUnattributed)
+    }
+
+    /// Sorts the accumulated totals and disambiguates model names shared across
+    /// providers — one implementation for the scan-period and windowed makers so
+    /// the chart's ordering and labels cannot depend on the selected window.
+    private static func labelledModelPoints(
+        from totals: [CostModelKey: Double]
+    ) -> [CostModelSpendPoint] {
         let rawPoints = totals
             .compactMap { key, costUSD -> CostModelSpendPoint? in
                 guard costUSD > 0 else { return nil }
@@ -173,7 +235,7 @@ nonisolated struct CostChartPresentation: Sendable {
             }
 
         let duplicateNames = Dictionary(grouping: rawPoints, by: \.model)
-        let points = rawPoints.map { point in
+        return rawPoints.map { point in
             let label = duplicateNames[point.model, default: []].count > 1
                 ? "\(point.model) · \(point.provider.displayName)"
                 : point.model
@@ -184,7 +246,6 @@ nonisolated struct CostChartPresentation: Sendable {
                 costUSD: point.costUSD
             )
         }
-        return (points, hasUnattributed)
     }
 }
 

--- a/MeterBar/Models/CostWindowSelection.swift
+++ b/MeterBar/Models/CostWindowSelection.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// The Costs page's reporting-window toggle: the same cards over the last 7 or
+/// the last 30 days.
+///
+/// Presentation-only — both windows are cut from the one cached 30-day scan
+/// (`CostSummary.dailyCostWindow` / `CostChartPresentation.requestedDays`), so
+/// switching never triggers a rescan; the 7-day view just renders a quarter of
+/// the marks. The raw value *is* the day count, which is what
+/// `UserDefaults` persists — an unknown stored count falls back to the month.
+nonisolated enum CostWindowSelection: Int, CaseIterable, Identifiable {
+    case week = 7
+    case month = 30
+
+    var id: Int { rawValue }
+
+    var days: Int { rawValue }
+
+    /// Segment title in the window picker.
+    var pickerLabel: String { "\(days) days" }
+
+    /// Card subtitle naming the window ("Last 30 days"), shared by the estimate
+    /// card and the Daily Details trailing caption so they cannot drift.
+    var subtitle: String { "Last \(days) days" }
+
+    /// Title of the spend-chart card ("30 Day Spend").
+    var spendCardTitle: String { "\(days) Day Spend" }
+
+    /// Token-activity calendar columns covering this window. Two 7-day columns
+    /// are the narrowest grid that always spans the last 7 days (one column
+    /// covers only the part-week up to today); the month keeps the existing
+    /// six-week calendar.
+    var activityWeeks: Int {
+        switch self {
+        case .week: return 2
+        case .month: return TokenActivityCalendar.defaultWeeks
+        }
+    }
+}

--- a/MeterBar/Models/DemoData+Cost.swift
+++ b/MeterBar/Models/DemoData+Cost.swift
@@ -9,12 +9,74 @@ import MeterBarShared
 /// scanning real CLI logs when demo mode is active.
 ///
 /// The summary is deliberately **non-alarming** — a ~$205 30-day estimate split
-/// across three providers — and carries **no origin or model breakdowns**, so
-/// it never surfaces the owner's real project paths or private model routing.
+/// across three providers. Model and origin breakdowns are **fully synthetic**,
+/// drawn from `syntheticBreakdownNames` only (public model ids and generic
+/// origin labels), so the model-spend and origin charts render in screenshots
+/// without ever surfacing the owner's real project paths or private routing.
 /// Daily rows are a smooth, deterministic weekly rhythm so the cost chart reads
 /// as populated and healthy in screenshots. Everything is a pure function of
 /// `now`.
 extension DemoData {
+    /// The only names demo breakdowns may carry — public model identifiers and
+    /// generic origin labels. Internal (not private) so the leak test can pin
+    /// every rendered breakdown row to this vocabulary.
+    static let syntheticBreakdownNames: Set<String> = [
+        "claude-fable-5", "claude-opus-5", "claude-haiku-4-5",
+        "gpt-5.6-sol", "gpt-5.6-luna",
+        "Main chat", "Agents", "Code review",
+    ]
+
+    /// One named slice of a provider's synthetic spend. Fractions per provider
+    /// sum to 1 so the breakdown reconciles exactly — a demo chart must never
+    /// show an "Unattributed" remainder.
+    private struct DemoSplit {
+        let name: String
+        let fraction: Double
+    }
+
+    private static let demoModelSplits: [ServiceType: [DemoSplit]] = [
+        .claudeCode: [
+            DemoSplit(name: "claude-fable-5", fraction: 0.52),
+            DemoSplit(name: "claude-opus-5", fraction: 0.31),
+            DemoSplit(name: "claude-haiku-4-5", fraction: 0.17),
+        ],
+        .codexCli: [
+            DemoSplit(name: "gpt-5.6-sol", fraction: 0.72),
+            DemoSplit(name: "gpt-5.6-luna", fraction: 0.28),
+        ],
+    ]
+
+    private static let demoOriginSplits: [ServiceType: [DemoSplit]] = [
+        .claudeCode: [
+            DemoSplit(name: "Main chat", fraction: 0.44),
+            DemoSplit(name: "Agents", fraction: 0.38),
+            DemoSplit(name: "Code review", fraction: 0.18),
+        ],
+        .codexCli: [
+            DemoSplit(name: "Main chat", fraction: 0.57),
+            DemoSplit(name: "Agents", fraction: 0.43),
+        ],
+    ]
+
+    /// Slices token/cost totals along `splits`. Token counts truncate — nothing
+    /// asserts on their sums — but the dollar fractions add back to the total.
+    private static func syntheticBreakdowns(
+        splits: [DemoSplit],
+        of totals: DemoProviderCost
+    ) -> [TokenUsageBreakdown] {
+        splits.map { split in
+            TokenUsageBreakdown(
+                provider: totals.provider,
+                name: split.name,
+                inputTokens: Int(Double(totals.inputTokens) * split.fraction),
+                outputTokens: Int(Double(totals.outputTokens) * split.fraction),
+                cacheCreationTokens: Int(Double(totals.cacheCreationTokens) * split.fraction),
+                cacheReadTokens: Int(Double(totals.cacheReadTokens) * split.fraction),
+                estimatedCostUSD: totals.costUSD * split.fraction,
+                sessionCount: max(1, Int(Double(totals.sessionCount) * split.fraction))
+            )
+        }
+    }
     /// Per-provider 30-day totals (USD) and token magnitudes for the demo cost
     /// summary. Sums to $204.90 ≈ "$205".
     private struct DemoProviderCost {
@@ -76,8 +138,14 @@ extension DemoData {
                 sessionCount: provider.sessionCount,
                 periodStart: periodStart,
                 periodEnd: periodEnd,
-                modelBreakdowns: [],
-                originBreakdowns: []
+                modelBreakdowns: syntheticBreakdowns(
+                    splits: demoModelSplits[provider.provider] ?? [],
+                    of: provider
+                ),
+                originBreakdowns: syntheticBreakdowns(
+                    splits: demoOriginSplits[provider.provider] ?? [],
+                    of: provider
+                )
             )
         }
 
@@ -116,13 +184,33 @@ extension DemoData {
                     ) else { return nil }
                     let weight = Double(weeklyWeights[index % weeklyWeights.count])
                     let fraction = weight / Double(weightTotal)
+                    let dayInput = Int(Double(provider.inputTokens) * fraction)
+                    let dayOutput = Int(Double(provider.outputTokens) * fraction)
+                    let dayCacheRead = Int(Double(provider.cacheReadTokens) * fraction)
+                    let dayCost = provider.costUSD * fraction
                     return DailyTokenUsage(
                         date: date,
                         provider: provider.provider,
-                        inputTokens: Int(Double(provider.inputTokens) * fraction),
-                        outputTokens: Int(Double(provider.outputTokens) * fraction),
-                        cacheReadTokens: Int(Double(provider.cacheReadTokens) * fraction),
-                        estimatedCostUSD: provider.costUSD * fraction
+                        inputTokens: dayInput,
+                        outputTokens: dayOutput,
+                        cacheReadTokens: dayCacheRead,
+                        estimatedCostUSD: dayCost,
+                        // Per-day model attribution, so the 7-day window's model
+                        // chart re-derives from these rows like it does for a
+                        // real v2 cache instead of falling back to the
+                        // scan-period detail and the mismatch caption.
+                        modelBreakdowns: syntheticBreakdowns(
+                            splits: demoModelSplits[provider.provider] ?? [],
+                            of: DemoProviderCost(
+                                provider: provider.provider,
+                                inputTokens: dayInput,
+                                outputTokens: dayOutput,
+                                cacheCreationTokens: 0,
+                                cacheReadTokens: dayCacheRead,
+                                costUSD: dayCost,
+                                sessionCount: 1
+                            )
+                        )
                     )
                 }
             }

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -155,6 +155,10 @@ nonisolated enum StorageKeys {
     /// reads `sessionWakeEventHooks` once, then this key becomes authoritative.
     static let quotaEventIntegrations = "QuotaEventIntegrationsV1"
 
+    /// `CostWindowSelection` raw value (7 or 30): the Costs page reporting
+    /// window. Missing or unknown means the 30-day view.
+    static let costsWindowDays = "CostsWindowDays"
+
     // MARK: - Display Currency (#270)
 
     /// User-typed currency code/label (e.g. "EUR"). Presentation only — stored

--- a/MeterBar/Views/Components/ReadinessComponents.swift
+++ b/MeterBar/Views/Components/ReadinessComponents.swift
@@ -131,7 +131,7 @@ struct ReadinessBadge: View {
   }
 }
 
-/// Renders readiness reports as a plain-text block for the "Copy report" button.
+/// Renders readiness reports as a plain-text block for the Diagnostics Copy button.
 /// Mirrors the `meterbar doctor` layout so a pasted report reads the same whether
 /// it came from the CLI or the app. Every string is already redacted upstream.
 enum DiagnosticsReportText {

--- a/MeterBar/Views/CostSpendCharts.swift
+++ b/MeterBar/Views/CostSpendCharts.swift
@@ -5,6 +5,23 @@ import SwiftUI
 struct CostSpendCharts: View {
     let presentation: CostChartPresentation
 
+    /// The model list opens on the biggest spenders and hides the long tail —
+    /// a dozen sub-$200 rows were most of the card's height.
+    @State private var showsAllModels = false
+
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
+    /// Models shown before the reader asks for the rest.
+    static let compactModelLimit = 3
+
+    /// Title for the expand/collapse control, or `nil` when the list already
+    /// fits within the compact limit and a control would toggle nothing.
+    static func modelToggleTitle(showingAll: Bool, totalCount: Int) -> String? {
+        guard totalCount > compactModelLimit else { return nil }
+        return showingAll ? "Show top \(compactModelLimit)" : "Show all \(totalCount) models"
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.xl) {
             if presentation.hasDailyCoverage {
@@ -95,7 +112,7 @@ struct CostSpendCharts: View {
                 value: UsageFormat.cost(presentation.modelTotalUSD)
             )
 
-            Chart(presentation.modelPoints) { point in
+            Chart(displayedModelPoints) { point in
                 BarMark(
                     x: .value("Spend", point.costUSD),
                     y: .value("Model", point.chartLabel)
@@ -112,12 +129,31 @@ struct CostSpendCharts: View {
                 currencyXAxisMarks
             }
             .chartLegend(position: .top, alignment: .leading, spacing: MeterBarTheme.Spacing.sm)
-            .frame(height: max(180, CGFloat(presentation.modelPoints.count) * 30))
+            .frame(height: max(110, CGFloat(displayedModelPoints.count) * 30))
             .accessibilityElement(children: .contain)
             .accessibilityLabel("Spend by model")
             .accessibilityValue(
                 "\(presentation.modelPoints.count) models totaling \(UsageFormat.cost(presentation.modelTotalUSD))"
             )
+
+            if let toggleTitle = Self.modelToggleTitle(
+                showingAll: showsAllModels,
+                totalCount: presentation.modelPoints.count
+            ) {
+                Button {
+                    withAnimation(MeterBarTheme.Motion.resolve(
+                        MeterBarTheme.Motion.disclosure,
+                        reduceMotion: reduceMotion
+                    )) {
+                        showsAllModels.toggle()
+                    }
+                } label: {
+                    Label(toggleTitle, systemImage: showsAllModels ? "chevron.up" : "chevron.down")
+                        .font(.caption)
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+            }
 
             if presentation.hasUnattributedModelSpend {
                 Text("Spend without model metadata is shown as Unattributed.")
@@ -149,6 +185,15 @@ struct CostSpendCharts: View {
     private var dailyProviders: [ServiceType] {
         Set(presentation.dailyProviderPoints.map(\.provider))
             .sorted { $0.rawValue < $1.rawValue }
+    }
+
+    /// The rows the chart draws: the top spenders, or everything on request.
+    /// `modelPoints` is already sorted by descending spend, so a prefix *is*
+    /// the top of the list. The heading total always reports every model.
+    private var displayedModelPoints: [CostModelSpendPoint] {
+        showsAllModels
+            ? presentation.modelPoints
+            : Array(presentation.modelPoints.prefix(Self.compactModelLimit))
     }
 
     private var modelProviders: [ServiceType] {

--- a/MeterBar/Views/CostSpendCharts.swift
+++ b/MeterBar/Views/CostSpendCharts.swift
@@ -196,8 +196,10 @@ struct CostSpendCharts: View {
             : Array(presentation.modelPoints.prefix(Self.compactModelLimit))
     }
 
+    /// Legend/scale providers come from the rows actually drawn, so the
+    /// compact top-3 view never lists a provider with no visible bar.
     private var modelProviders: [ServiceType] {
-        Set(presentation.modelPoints.map(\.provider))
+        Set(displayedModelPoints.map(\.provider))
             .sorted { $0.rawValue < $1.rawValue }
     }
 

--- a/MeterBar/Views/DailyUsageChart.swift
+++ b/MeterBar/Views/DailyUsageChart.swift
@@ -622,7 +622,14 @@ enum DashboardDateFormat {
     return formatter
   }()
 
+  private static let monthDay: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.setLocalizedDateFormatFromTemplate("MMMd")
+    return formatter
+  }()
+
   static func medium(_ date: Date) -> String { mediumDate.string(from: date) }
   static func month(_ date: Date) -> String { month.string(from: date) }
   static func weekdayMonthDay(_ date: Date) -> String { weekdayMonthDay.string(from: date) }
+  static func monthDay(_ date: Date) -> String { monthDay.string(from: date) }
 }

--- a/MeterBar/Views/DashboardCard.swift
+++ b/MeterBar/Views/DashboardCard.swift
@@ -11,6 +11,7 @@ struct DashboardTile<Content: View>: View {
   let cornerRadius: CGFloat
   let padding: MeterBarTheme.CardPadding
   let minHeight: CGFloat?
+  let maxHeight: CGFloat?
   let alignment: Alignment
   @ViewBuilder let content: Content
 
@@ -18,12 +19,14 @@ struct DashboardTile<Content: View>: View {
     cornerRadius: CGFloat = MeterBarTheme.Radius.card,
     padding: MeterBarTheme.CardPadding = .standard,
     minHeight: CGFloat? = nil,
+    maxHeight: CGFloat? = nil,
     alignment: Alignment = .topLeading,
     @ViewBuilder content: () -> Content
   ) {
     self.cornerRadius = cornerRadius
     self.padding = padding
     self.minHeight = minHeight
+    self.maxHeight = maxHeight
     self.alignment = alignment
     self.content = content()
   }
@@ -31,7 +34,7 @@ struct DashboardTile<Content: View>: View {
   var body: some View {
     content
       .padding(padding.value)
-      .frame(maxWidth: .infinity, minHeight: minHeight, alignment: alignment)
+      .frame(maxWidth: .infinity, minHeight: minHeight, maxHeight: maxHeight, alignment: alignment)
       .meterBarCardSurface(cornerRadius: cornerRadius)
   }
 }

--- a/MeterBar/Views/DashboardCostCards.swift
+++ b/MeterBar/Views/DashboardCostCards.swift
@@ -9,17 +9,17 @@ struct CostOverviewStatusCard: View {
   let isScanning: Bool
   let isRefreshingMissingDays: Bool
   let formattedTokens: String
+  /// The page's 7/30-day toggle. The month keeps the scan's own totals
+  /// (authoritative, cache-creation tokens included); the week is cut from the
+  /// cached daily rows — no rescan. Defaulted so existing hosts and tests keep
+  /// meaning "the full scan window".
+  var windowSelection: CostWindowSelection = .month
 
   @ScaledMetric(relativeTo: .title)
   private var scanningHeadlineSize: CGFloat = 28
 
   @Environment(\.accessibilityReduceMotion)
   private var reduceMotion
-
-  /// The subtitle names the reporting window only. Refresh state used to
-  /// replace it, which read as if the window itself had changed; it now sits on
-  /// the trailing edge like the neighbouring "Lifetime Local Cost" date range.
-  static let subtitle = "Last 30 days"
 
   /// Shared with the "30 Day Spend" card so both trailing captions say the same
   /// thing at the same time — they are driven by the same two scan flags.
@@ -41,6 +41,23 @@ struct CostOverviewStatusCard: View {
     return .needsScan
   }
 
+  /// The figures the card renders for the selected window. The month view keeps
+  /// the scan's own totals; the week view aggregates the cached daily rows,
+  /// which carry input/output/cache-read tokens but not cache-creation tokens —
+  /// the same basis every daily chart on this page already reports.
+  private var figures: (cost: String, tokens: String, providers: Int) {
+    guard let summary else { return ("", formattedTokens, 0) }
+    guard windowSelection != .month else {
+      return (summary.formattedTotalCost, formattedTokens, summary.costs.count)
+    }
+    let window = summary.dailyCostWindow(lastDays: windowSelection.days)
+    return (
+      UsageFormat.cost(window.totalCostUSD),
+      UsageFormat.tokens(window.totalTokens),
+      window.providers.count
+    )
+  }
+
   /// Verification dates of the rate entries this scan actually priced with, not
   /// a global table revision (issue #339). Summaries cached before dated
   /// pricing carry none, so those fall back to the shipped table's own dates.
@@ -59,7 +76,7 @@ struct CostOverviewStatusCard: View {
             Text("API-Rate Estimate")
               .font(.headline)
               .fontWeight(.semibold)
-            Text(Self.subtitle)
+            Text(windowSelection.subtitle)
               .font(.caption)
               .foregroundColor(.secondary)
           }
@@ -84,20 +101,20 @@ struct CostOverviewStatusCard: View {
               .font(.caption)
               .foregroundColor(.secondary)
             Spacer()
-            Text(formattedTokens)
+            Text(figures.tokens)
               .font(.caption)
               .fontWeight(.semibold)
-              .numericRefreshTransition(value: formattedTokens, reduceMotion: reduceMotion)
+              .numericRefreshTransition(value: figures.tokens, reduceMotion: reduceMotion)
           }
           HStack {
             Text("Providers")
               .font(.caption)
               .foregroundColor(.secondary)
             Spacer()
-            Text("\(summary?.costs.count ?? 0)")
+            Text("\(figures.providers)")
               .font(.caption)
               .fontWeight(.semibold)
-              .numericRefreshTransition(value: summary?.costs.count ?? 0, reduceMotion: reduceMotion)
+              .numericRefreshTransition(value: figures.providers, reduceMotion: reduceMotion)
           }
           HStack {
             Text("Pricing")
@@ -119,7 +136,7 @@ struct CostOverviewStatusCard: View {
   @ViewBuilder private var heroValue: some View {
     switch phase {
     case .loaded:
-      CostHeadlineAmount(summary?.formattedTotalCost ?? "")
+      CostHeadlineAmount(figures.cost)
         .id(Phase.loaded)
         .transition(MeterBarTheme.Motion.cardPhase)
     case .scanning:

--- a/MeterBar/Views/DashboardCostCards.swift
+++ b/MeterBar/Views/DashboardCostCards.swift
@@ -66,7 +66,11 @@ struct CostOverviewStatusCard: View {
   }
 
   var body: some View {
-    DashboardTile(minHeight: CostHeadlineCardMetrics.minimumHeight) {
+    // `maxHeight: .infinity` lets the card *surface* stretch to the paired
+    // Lifetime card's height — the section already offers the row height, but
+    // without this the tile kept its intrinsic size and the shorter card ended
+    // mid-air beside the taller one.
+    DashboardTile(minHeight: CostHeadlineCardMetrics.minimumHeight, maxHeight: .infinity) {
       VStack(alignment: .leading, spacing: 12) {
         HStack(alignment: .center, spacing: 9) {
           Image(systemName: "dollarsign.circle.fill")
@@ -169,7 +173,9 @@ struct LifetimeCostSummaryCard: View {
   let isScanning: Bool
 
   var body: some View {
-    DashboardTile(minHeight: CostHeadlineCardMetrics.minimumHeight) {
+    // Same stretch as the estimate card — both surfaces must end on the same
+    // baseline whichever one is intrinsically taller.
+    DashboardTile(minHeight: CostHeadlineCardMetrics.minimumHeight, maxHeight: .infinity) {
       VStack(alignment: .leading, spacing: 12) {
         HStack(alignment: .center, spacing: 9) {
           Image(systemName: "clock.arrow.circlepath")
@@ -393,6 +399,13 @@ struct CostScanProgressBadge: View {
 struct ProviderCostBreakdown: View {
   let cost: TokenCost
   var quotaSnapshot: ProviderSnapshot?
+  /// Windowed totals for this provider when the page's 7-day window is active.
+  /// `nil` renders the scan-period card exactly as before. Daily rows carry no
+  /// session counts or origin split, so the windowed card reports cache-read
+  /// tokens and the project rollup in their place.
+  var window: ProviderDailyTotal?
+  /// Caption naming the window the figures cover, shown only when windowed.
+  var windowSubtitle: String?
 
   @Environment(\.accessibilityReduceMotion)
   private var reduceMotion
@@ -405,6 +418,14 @@ struct ProviderCostBreakdown: View {
     MeterBarTheme.accent(for: cost.provider)
   }
 
+  private var formattedCost: String {
+    window?.formattedCost ?? cost.formattedCost
+  }
+
+  private var modelBreakdowns: [TokenUsageBreakdown] {
+    window.map { $0.modelBreakdowns ?? [] } ?? cost.modelBreakdowns
+  }
+
   var body: some View {
     DashboardTile {
       VStack(alignment: .leading, spacing: 10) {
@@ -415,11 +436,14 @@ struct ProviderCostBreakdown: View {
             color: logoColor,
             font: .headline
           )
+          if let windowSubtitle {
+            DashboardCardCaption(text: windowSubtitle)
+          }
           Spacer()
-          Text(cost.formattedCost)
+          Text(formattedCost)
             .font(.title3)
             .bold()
-            .numericRefreshTransition(value: cost.formattedCost, reduceMotion: reduceMotion)
+            .numericRefreshTransition(value: formattedCost, reduceMotion: reduceMotion)
         }
 
         if let quotaSnapshot, quotaSnapshot.hasExhaustedLimit {
@@ -429,18 +453,31 @@ struct ProviderCostBreakdown: View {
           )
         }
 
-        HStack(spacing: 14) {
-          CostMetric(label: "Tokens", value: cost.formattedTokens)
-          CostMetric(label: "Input", value: UsageFormat.tokens(cost.inputTokens))
-          CostMetric(label: "Output", value: UsageFormat.tokens(cost.outputTokens))
-          CostMetric(label: "Sessions", value: "\(cost.sessionCount)")
+        if let window {
+          HStack(spacing: 14) {
+            CostMetric(label: "Tokens", value: UsageFormat.groupedTokens(window.totalTokens))
+            CostMetric(label: "Input", value: UsageFormat.tokens(window.inputTokens))
+            CostMetric(label: "Output", value: UsageFormat.tokens(window.outputTokens))
+            CostMetric(label: "Cache", value: UsageFormat.tokens(window.cacheReadTokens))
+          }
+        } else {
+          HStack(spacing: 14) {
+            CostMetric(label: "Tokens", value: cost.formattedTokens)
+            CostMetric(label: "Input", value: UsageFormat.tokens(cost.inputTokens))
+            CostMetric(label: "Output", value: UsageFormat.tokens(cost.outputTokens))
+            CostMetric(label: "Sessions", value: "\(cost.sessionCount)")
+          }
         }
 
-        if !cost.modelBreakdowns.isEmpty {
-          CostBreakdownSection(title: "Models", items: Array(cost.modelBreakdowns.prefix(6)))
+        if !modelBreakdowns.isEmpty {
+          CostBreakdownSection(title: "Models", items: Array(modelBreakdowns.prefix(6)))
         }
 
-        if !cost.originBreakdowns.isEmpty {
+        if let window {
+          if let projects = window.projectBreakdowns, !projects.isEmpty {
+            CostBreakdownSection(title: "Projects", items: Array(projects.prefix(6)))
+          }
+        } else if !cost.originBreakdowns.isEmpty {
           CostBreakdownSection(title: "Usage Origin", items: Array(cost.originBreakdowns.prefix(6)))
         }
       }

--- a/MeterBar/Views/DashboardCostsSection.swift
+++ b/MeterBar/Views/DashboardCostsSection.swift
@@ -82,7 +82,10 @@ struct DashboardCostsSection: View {
             // the chart's absence of Cursor raises. Hidden entirely when no
             // request-denominated provider has been polled — an empty card
             // would read as "measured nothing".
-            let polledUsage = PolledRequestSeriesPresentation(ledger: costTracker.usageLedger)
+            let polledUsage = PolledRequestSeriesPresentation(
+                ledger: costTracker.usageLedger,
+                requestedDays: windowSelection.days
+            )
             if !polledUsage.isEmpty {
                 PolledUsageCard(presentation: polledUsage)
             }
@@ -98,11 +101,23 @@ struct DashboardCostsSection: View {
             }
 
             if let summary, !summary.costs.isEmpty {
+                // In the 7-day window the per-provider cards re-cut to the same
+                // days as every chart above; a provider with no spend inside
+                // the window drops out instead of showing 30-day numbers under
+                // a 7-day heading.
+                let weekWindow = windowSelection == .week
+                    ? summary.dailyCostWindow(lastDays: windowSelection.days)
+                    : nil
                 ForEach(summary.costs) { cost in
-                    ProviderCostBreakdown(
-                        cost: cost,
-                        quotaSnapshot: quotaSnapshot(cost.provider)
-                    )
+                    let providerWindow = weekWindow?.providers.first { $0.provider == cost.provider }
+                    if weekWindow == nil || providerWindow != nil {
+                        ProviderCostBreakdown(
+                            cost: cost,
+                            quotaSnapshot: quotaSnapshot(cost.provider),
+                            window: providerWindow,
+                            windowSubtitle: providerWindow != nil ? windowSelection.subtitle : nil
+                        )
+                    }
                 }
             } else {
                 DashboardCard(title: "No Local Logs Found") {

--- a/MeterBar/Views/DashboardCostsSection.swift
+++ b/MeterBar/Views/DashboardCostsSection.swift
@@ -12,6 +12,16 @@ struct DashboardCostsSection: View {
     @StateObject private var costTracker = CostTracker.shared
     @StateObject private var apiUsageStore = ApiUsageStore.shared
 
+    /// The page-wide 7/30-day reporting window. Presentation-only: both windows
+    /// are cut from the same cached 30-day scan, so flipping never rescans —
+    /// the 7-day view just draws a quarter of the marks.
+    @AppStorage(StorageKeys.costsWindowDays)
+    private var costsWindowDays = CostWindowSelection.month.rawValue
+
+    private var windowSelection: CostWindowSelection {
+        CostWindowSelection(rawValue: costsWindowDays) ?? .month
+    }
+
     init(
         summary: CostSummary?,
         quotaSnapshot: @escaping (ServiceType) -> ProviderSnapshot?
@@ -34,6 +44,8 @@ struct DashboardCostsSection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
+            windowPicker
+
             // The two headline figures answer the same question over different
             // windows, so they read as a pair. `maxHeight: .infinity` on both,
             // with the row fixed to its intrinsic height, stretches the shorter
@@ -43,7 +55,8 @@ struct DashboardCostsSection: View {
                     summary: summary,
                     isScanning: costTracker.isScanning,
                     isRefreshingMissingDays: costTracker.isRefreshingMissingDays,
-                    formattedTokens: UsageFormat.tokens(summary?.totalTokens ?? 0)
+                    formattedTokens: UsageFormat.tokens(summary?.totalTokens ?? 0),
+                    windowSelection: windowSelection
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
@@ -59,6 +72,7 @@ struct DashboardCostsSection: View {
 
             TokenActivityCard(
                 summary: summary,
+                weeks: windowSelection.activityWeeks,
                 isScanning: costTracker.isScanning,
                 isScanDisabled: costTracker.isRefreshInProgress,
                 scan: { Task { await costTracker.scanCosts(days: 30) } }
@@ -74,8 +88,12 @@ struct DashboardCostsSection: View {
             }
 
             if let summary, !summary.dailyUsage.isEmpty {
-                DashboardCard(title: "Daily Details", trailing: "Last 30 days") {
-                    DailyUsageBreakdownList(dailyUsage: summary.dailyUsage)
+                let windowStart = CostWindow.start(days: windowSelection.days)
+                let windowRows = summary.dailyUsage.filter { $0.date >= windowStart }
+                if !windowRows.isEmpty {
+                    DashboardCard(title: "Daily Details", trailing: windowSelection.subtitle) {
+                        DailyUsageBreakdownList(dailyUsage: windowRows)
+                    }
                 }
             }
 
@@ -111,9 +129,27 @@ struct DashboardCostsSection: View {
         }
     }
 
+    /// One page-wide window control, trailing-aligned above the cards it
+    /// governs. A segmented picker rather than per-card toggles so every cost
+    /// surface below always reports the same days.
+    private var windowPicker: some View {
+        HStack {
+            Spacer()
+            Picker("Reporting window", selection: $costsWindowDays) {
+                ForEach(CostWindowSelection.allCases) { window in
+                    Text(window.pickerLabel).tag(window.rawValue)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .fixedSize()
+            .accessibilityLabel("Reporting window")
+        }
+    }
+
     private var costTrendCard: some View {
         DashboardCard(
-            title: "30 Day Spend",
+            title: windowSelection.spendCardTitle,
             trailing: Self.refreshStatusText(
                 isScanning: costTracker.isScanning,
                 isRefreshingMissingDays: costTracker.isRefreshingMissingDays
@@ -128,7 +164,10 @@ struct DashboardCostsSection: View {
                     .foregroundColor(.secondary)
 
                 if let summary {
-                    let presentation = CostChartPresentation(summary: summary)
+                    let presentation = CostChartPresentation(
+                        summary: summary,
+                        requestedDays: windowSelection.days
+                    )
                     ZStack {
                         if presentation.hasSpend {
                             CostSpendCharts(presentation: presentation)
@@ -137,7 +176,7 @@ struct DashboardCostsSection: View {
                             EmptyStateCard(
                                 systemImage: "chart.bar.xaxis",
                                 title: "No spend in this window",
-                                message: "No billable usage was found in the last 30 days."
+                                message: "No billable usage was found in the \(windowSelection.subtitle.lowercased())."
                             )
                         }
 

--- a/MeterBar/Views/DashboardDiagnosticsSection.swift
+++ b/MeterBar/Views/DashboardDiagnosticsSection.swift
@@ -37,25 +37,9 @@ struct DashboardDiagnosticsSection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            DashboardCard(
-                title: "Refresh Cadence",
-                trailing: refreshCadenceDiagnostic.effectiveInterval
-            ) {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Selected: \(refreshCadenceDiagnostic.selection)")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                    Text(refreshCadenceDiagnostic.reason)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                    if dataManager.refreshInterval == .adaptive {
-                        Text("Adaptive range: 1–30 minutes. Activity signals stay in memory and are never sent.")
-                            .font(.caption)
-                            .foregroundStyle(.tertiary)
-                    }
-                }
-            }
-
+            // No Refresh Cadence card here: cadence is configured in Settings
+            // and restating it on this page was pure duplication. The copied
+            // report still includes it — it is genuinely diagnostic there.
             DashboardCard(
                 title: "Provider Diagnostics",
                 trailing: DiagnosticsRunner.summary(for: readinessReports)
@@ -69,16 +53,18 @@ struct DashboardDiagnosticsSection: View {
                         Button {
                             Task { await runDiagnostics() }
                         } label: {
-                            Label("Re-run checks", systemImage: "arrow.clockwise")
+                            Label("Refresh", systemImage: "arrow.clockwise")
                         }
                         .disabled(isRunningDiagnostics)
+                        .help("Re-run every provider readiness check")
 
                         Button {
                             copyDiagnosticsToClipboard()
                         } label: {
-                            Label("Copy report", systemImage: "doc.on.doc")
+                            Label("Copy", systemImage: "doc.on.doc")
                         }
                         .disabled(readinessReports.isEmpty)
+                        .help("Copy the redacted diagnostics report")
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)

--- a/MeterBar/Views/DashboardNavigation.swift
+++ b/MeterBar/Views/DashboardNavigation.swift
@@ -225,25 +225,6 @@ enum SettingsSidebarModel {
     }
 }
 
-enum EnabledQuotaSourceCounter {
-    static func count(
-        enabledServices: Set<ServiceType>,
-        codexAccountCount: Int,
-        claudeAccountCount: Int
-    ) -> Int {
-        enabledServices.reduce(into: 0) { count, service in
-            switch service {
-            case .codexCli:
-                count += codexAccountCount
-            case .claudeCode:
-                count += claudeAccountCount
-            case .cursor, .openRouter, .grok:
-                count += 1
-            }
-        }
-    }
-}
-
 @MainActor
 final class DashboardNavigationStore: ObservableObject {
     static let shared = DashboardNavigationStore()

--- a/MeterBar/Views/DashboardOverviewSection.swift
+++ b/MeterBar/Views/DashboardOverviewSection.swift
@@ -8,11 +8,33 @@ import SwiftUI
 struct DashboardOverviewSection: View {
     let snapshots: [ProviderSnapshot]
     let tightestLimit: SnapshotLimit?
-    let enabledSourceCount: Int
     let costSummary: CostSummary?
     let onSelectProvider: (ProviderSnapshot.ID) -> Void
 
     private static let masonryColumnCount = 2
+
+    /// Copy for the "Use next" tile — the Optimize ranking's top pick, boiled
+    /// down to one glance. Replaces the old "Tracked sources" tile, which was a
+    /// Settings fact that almost always read "all reporting".
+    ///
+    /// Internal (not private) so the three states can be asserted without
+    /// hosting the page, matching `OptimizeInsightsView.recentWindowTile`.
+    static func useNextTile(
+        for recommendation: ProviderRecommendation
+    ) -> (value: String, caption: String, band: QuotaBand?) {
+        if let top = recommendation.rows.first, !recommendation.isFullyExhausted {
+            var parts = ["\(top.headroomText) of \(top.windowTitle) left"]
+            if let resetText = top.resetText {
+                parts.append(resetText)
+            }
+            return (top.name, parts.joined(separator: " · "), top.band)
+        }
+        if recommendation.isFullyExhausted {
+            let caption = recommendation.rows.first?.availabilityText ?? "Waiting for the next reset"
+            return ("Every window spent", caption, .exhausted)
+        }
+        return ("No data", "Waiting for provider refresh", nil)
+    }
 
     /// Deals items round-robin across `columnCount` independent columns.
     ///
@@ -36,9 +58,8 @@ struct DashboardOverviewSection: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             OverviewSummaryStrip(
+                snapshots: snapshots,
                 tightestLimit: tightestLimit,
-                sourceCount: snapshots.count,
-                enabledSourceCount: enabledSourceCount,
                 estimatedCost: costSummary?.formattedTotalCost,
                 formattedTokens: UsageFormat.tokens(costSummary?.totalTokens ?? 0)
             )
@@ -66,9 +87,8 @@ struct DashboardOverviewSection: View {
 }
 
 private struct OverviewSummaryStrip: View {
+    let snapshots: [ProviderSnapshot]
     let tightestLimit: SnapshotLimit?
-    let sourceCount: Int
-    let enabledSourceCount: Int
     let estimatedCost: String?
     let formattedTokens: String
 
@@ -105,13 +125,26 @@ private struct OverviewSummaryStrip: View {
                 style: .compact
             )
 
-            DashboardMetricTile(
-                title: "Tracked sources",
-                value: "\(sourceCount)",
-                caption: sourceCaption,
-                systemImage: "checklist.checked",
-                style: .compact
-            )
+            // The Optimize ranking's top pick, on the same countdown clock as
+            // the tightest-window tile so its reset caption stays current.
+            TimelineView(
+                .periodic(
+                    from: ResetCountdownSchedule.anchor,
+                    by: ResetCountdownSchedule.interval
+                )
+            ) { timeline in
+                let tile = DashboardOverviewSection.useNextTile(
+                    for: snapshots.headroomRecommendation(now: timeline.date)
+                )
+                DashboardMetricTile(
+                    title: "Use next",
+                    value: tile.value,
+                    caption: tile.caption,
+                    systemImage: "arrow.forward.circle",
+                    indicatorTint: tile.band?.color ?? .secondary,
+                    style: .compact
+                )
+            }
         }
     }
 
@@ -130,16 +163,6 @@ private struct OverviewSummaryStrip: View {
     private var tightestCaption: String {
         guard let tightestLimit else { return "Waiting for provider refresh" }
         return "\(tightestLimit.title) quota"
-    }
-
-    private var sourceCaption: String {
-        if enabledSourceCount == 0 {
-            return "Enable providers in Settings"
-        }
-        if sourceCount == enabledSourceCount {
-            return "All enabled sources reporting"
-        }
-        return "\(sourceCount) of \(enabledSourceCount) enabled reporting"
     }
 
     private func tightestValue(now: Date) -> String {

--- a/MeterBar/Views/DashboardOverviewSection.swift
+++ b/MeterBar/Views/DashboardOverviewSection.swift
@@ -23,7 +23,8 @@ struct DashboardOverviewSection: View {
         for recommendation: ProviderRecommendation
     ) -> (value: String, caption: String, band: QuotaBand?) {
         if let top = recommendation.rows.first, !recommendation.isFullyExhausted {
-            var parts = ["\(top.headroomText) of \(top.windowTitle) left"]
+            // `headroomText` already reads "44% left", so the window name leads.
+            var parts = ["\(top.windowTitle) · \(top.headroomText)"]
             if let resetText = top.resetText {
                 parts.append(resetText)
             }

--- a/MeterBar/Views/DashboardShareSection.swift
+++ b/MeterBar/Views/DashboardShareSection.swift
@@ -89,53 +89,58 @@ struct DashboardShareSection: View {
                     isRefreshingMissingDays: costTracker.isRefreshingMissingDays
                 )
             ) {
-                SocialShareCardPreview(content: cardContent, size: previewSize)
-                    .accessibilityLabel("MeterBar 30-day token receipt preview")
-            }
+                VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.md) {
+                    SocialShareCardPreview(content: cardContent, size: previewSize)
+                        .accessibilityLabel("MeterBar 30-day token receipt preview")
 
-            HStack(spacing: 10) {
-                Button {
-                    copyCardImage()
-                } label: {
-                    Label("Copy PNG", systemImage: "doc.on.doc")
-                }
-                .buttonStyle(.glassProminent)
-
-                Button {
-                    saveCardImage()
-                } label: {
-                    Label("Save PNG", systemImage: "square.and.arrow.down")
-                }
-                .buttonStyle(.bordered)
-
-                Button {
-                    copyCaption()
-                } label: {
-                    Label("Copy Caption", systemImage: "text.quote")
-                }
-                .buttonStyle(.bordered)
-
-                if costSummary?.dailyUsage.isEmpty ?? true {
-                    Button {
-                        Task {
-                            if await costTracker.scanCosts(days: 30).isAuthoritative {
-                                generatedAt = Date()
-                            }
+                    // The export actions live with the artifact they export —
+                    // as a bare row between two cards they were anchored to
+                    // neither.
+                    HStack(spacing: 10) {
+                        Button {
+                            copyCardImage()
+                        } label: {
+                            Label("Copy PNG", systemImage: "doc.on.doc")
                         }
-                    } label: {
-                        Label("Scan 30 Days", systemImage: "magnifyingglass")
+                        .buttonStyle(.glassProminent)
+
+                        Button {
+                            saveCardImage()
+                        } label: {
+                            Label("Save PNG", systemImage: "square.and.arrow.down")
+                        }
+                        .buttonStyle(.bordered)
+
+                        Button {
+                            copyCaption()
+                        } label: {
+                            Label("Copy Caption", systemImage: "text.quote")
+                        }
+                        .buttonStyle(.bordered)
+
+                        if costSummary?.dailyUsage.isEmpty ?? true {
+                            Button {
+                                Task {
+                                    if await costTracker.scanCosts(days: 30).isAuthoritative {
+                                        generatedAt = Date()
+                                    }
+                                }
+                            } label: {
+                                Label("Scan 30 Days", systemImage: "magnifyingglass")
+                            }
+                            .buttonStyle(.bordered)
+                            .disabled(costTracker.isRefreshInProgress)
+                        }
+
+                        Spacer()
+
+                        if let shareStatus {
+                            Text(shareStatus)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .transition(.opacity)
+                        }
                     }
-                    .buttonStyle(.bordered)
-                    .disabled(costTracker.isRefreshInProgress)
-                }
-
-                Spacer()
-
-                if let shareStatus {
-                    Text(shareStatus)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .transition(.opacity)
                 }
             }
 

--- a/MeterBar/Views/OptimizeInsightsView.swift
+++ b/MeterBar/Views/OptimizeInsightsView.swift
@@ -29,8 +29,15 @@ struct OptimizeInsightsView: View {
   @Environment(\.accessibilityReduceMotion)
   private var reduceMotion
 
-  /// 7/30-day window for the token-burn chart.
-  @State private var chartDays = 30
+  /// The same persisted 7/30-day window the Costs page uses — one preference,
+  /// two pages. Replaces the picker that used to hide inside the Token Burn
+  /// card and the fixed "Last 7 days" tile beside it.
+  @AppStorage(StorageKeys.costsWindowDays)
+  private var costsWindowDays = CostWindowSelection.month.rawValue
+
+  private var windowSelection: CostWindowSelection {
+    CostWindowSelection(rawValue: costsWindowDays) ?? .month
+  }
 
   private var visibleSummary: CostSummary? {
     costTracker.costSummary?.filtered(to: providerVisibility.enabledServices)
@@ -52,12 +59,30 @@ struct OptimizeInsightsView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 14) {
+      windowPicker
       recommendationCard
       phaseContent
         .animation(
           MeterBarTheme.Motion.resolve(MeterBarTheme.Motion.standard, reduceMotion: reduceMotion),
           value: phase
         )
+    }
+  }
+
+  /// The page-level window control, in the same position and style as the
+  /// Costs page's — the two pages share the persisted selection.
+  private var windowPicker: some View {
+    HStack {
+      Spacer()
+      Picker("Reporting window", selection: $costsWindowDays) {
+        ForEach(CostWindowSelection.allCases) { window in
+          Text(window.pickerLabel).tag(window.rawValue)
+        }
+      }
+      .pickerStyle(.segmented)
+      .labelsHidden()
+      .fixedSize()
+      .accessibilityLabel("Reporting window")
     }
   }
 
@@ -201,6 +226,26 @@ struct OptimizeInsightsView: View {
     )
   }
 
+  /// The window KPI tile, following the page's 7/30-day toggle. The week keeps
+  /// `recentWindowTile`'s empty-week wording; the month reports the 30-day
+  /// total the rest of the page's insights are computed over.
+  static func windowTile(
+    selection: CostWindowSelection,
+    tokens7Day: Int,
+    tokens30Day: Int
+  ) -> (title: String, value: String, caption: String) {
+    switch selection {
+    case .week:
+      let tile = recentWindowTile(tokens7Day: tokens7Day, tokens30Day: tokens30Day)
+      return (selection.subtitle, tile.value, tile.caption)
+    case .month:
+      guard tokens30Day > 0 else {
+        return (selection.subtitle, "None", "no tokens recorded in the last 30 days")
+      }
+      return (selection.subtitle, UsageFormat.tokens(tokens30Day), "tokens in the last 30 days")
+    }
+  }
+
   private func kpiGrid(for insights: OptimizationInsights) -> some View {
     LazyVGrid(columns: Self.kpiColumns, alignment: .leading, spacing: 12) {
       DashboardMetricTile(
@@ -223,12 +268,13 @@ struct OptimizeInsightsView: View {
         caption: "context sent vs generated",
         systemImage: "text.append"
       )
-      let recentWindow = Self.recentWindowTile(
+      let recentWindow = Self.windowTile(
+        selection: windowSelection,
         tokens7Day: insights.tokens7Day,
         tokens30Day: insights.tokens30Day
       )
       DashboardMetricTile(
-        title: "Last 7 days",
+        title: recentWindow.title,
         value: recentWindow.value,
         caption: recentWindow.caption,
         systemImage: "calendar"
@@ -238,17 +284,11 @@ struct OptimizeInsightsView: View {
   }
 
   private var tokenBurnCard: some View {
-    DashboardCard(title: "Token Burn") {
-      Picker("Window", selection: $chartDays) {
-        Text("7 days").tag(7)
-        Text("30 days").tag(30)
-      }
-      .pickerStyle(.segmented)
-      .labelsHidden()
-      .fixedSize()
-    } content: {
+    // No in-card picker: the page-level window toggle above governs this chart
+    // (and the window tile), matching the Costs page's pattern.
+    DashboardCard(title: "Token Burn", trailing: windowSelection.subtitle) {
       if let summary = visibleSummary, !summary.dailyUsage.isEmpty {
-        DailyUsageChart(dailyUsage: summary.dailyUsage, daysToShow: chartDays)
+        DailyUsageChart(dailyUsage: summary.dailyUsage, daysToShow: windowSelection.days)
           .frame(height: 200)
       } else {
         Text("No daily token history yet.")

--- a/MeterBar/Views/ProviderCardPresentation.swift
+++ b/MeterBar/Views/ProviderCardPresentation.swift
@@ -29,11 +29,36 @@ enum ProviderCardPresentation {
         return snapshot.band?.shortLabel ?? "Offline"
     }
 
+    /// How long a login-required card may keep showing its cached gauges before
+    /// they stop being useful context and start being noise. Two hours is past
+    /// any session window the cache could still be describing.
+    static let loginCollapseStaleInterval: TimeInterval = 2 * 60 * 60
+
+    /// A logged-out account whose cache has aged past
+    /// ``loginCollapseStaleInterval`` collapses to a one-line "Login required"
+    /// row: the bars underneath describe a session that ended hours ago, and the
+    /// only action that changes anything is logging back in. A *fresh* cache
+    /// stays expanded — those numbers were true minutes ago and still orient the
+    /// user. Cards with no cache at all belong to the offline row instead.
+    static func collapsesToLoginRow(snapshot: ProviderSnapshot, now: Date = Date()) -> Bool {
+        guard snapshot.authNotice == .loginRequired, let updatedAt = snapshot.updatedAt else { return false }
+        return now.timeIntervalSince(updatedAt) > loginCollapseStaleInterval
+    }
+
     /// Cards without usage data and exhausted cards are terminal summaries. A
     /// login/waiting card has no quota detail to reveal, while an exhausted card
-    /// already shows its only actionable reset information inline.
-    static func allowsDetailNavigation(hasSelectionHandler: Bool, snapshot: ProviderSnapshot) -> Bool {
-        hasSelectionHandler && snapshot.hasMetrics && !snapshot.hasExhaustedLimit
+    /// already shows its only actionable reset information inline. A collapsed
+    /// stale-login row is terminal too: its detail panel would present hours-old
+    /// gauges as if they were live.
+    static func allowsDetailNavigation(
+        hasSelectionHandler: Bool,
+        snapshot: ProviderSnapshot,
+        now: Date = Date()
+    ) -> Bool {
+        hasSelectionHandler
+            && snapshot.hasMetrics
+            && !snapshot.hasExhaustedLimit
+            && !collapsesToLoginRow(snapshot: snapshot, now: now)
     }
 
     /// Reset credits are a Codex CLI concept. `didConsumeResetCredit` suppresses

--- a/MeterBar/Views/ProviderStatusCard.swift
+++ b/MeterBar/Views/ProviderStatusCard.swift
@@ -103,6 +103,8 @@ struct ProviderStatusCard: View {
     @ViewBuilder private var cardBody: some View {
         if !snapshot.hasMetrics {
             offlineRow
+        } else if ProviderCardPresentation.collapsesToLoginRow(snapshot: snapshot) {
+            staleLoginRow
         } else if snapshot.hasExhaustedWeeklyLimit {
             weeklyExhaustedRow
         } else {
@@ -125,6 +127,26 @@ struct ProviderStatusCard: View {
                 .fontWeight(.semibold)
                 .foregroundStyle(.secondary)
         }
+    }
+
+    /// A logged-out card whose cache has aged past the collapse threshold —
+    /// see `ProviderCardPresentation.collapsesToLoginRow`. One line: the gauges
+    /// below described a session that ended hours ago, so the only thing worth
+    /// stating is the provider and the way back in.
+    private var staleLoginRow: some View {
+        HStack(spacing: 7) {
+            ProviderLogoView(kind: snapshot.logoKind, size: 17, foregroundColor: snapshot.accentColor)
+            Text(snapshot.title)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .lineLimit(1)
+            Spacer(minLength: 8)
+            Text(ProviderAuthNotice.loginRequired.shortLabel)
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .foregroundStyle(MeterBarTheme.warning)
+        }
+        .help("\(snapshot.updatedText) — log in to resume tracking")
     }
 
     /// A weekly block makes every shorter/model-specific gauge non-actionable.

--- a/MeterBar/Views/ProviderStatusViews.swift
+++ b/MeterBar/Views/ProviderStatusViews.swift
@@ -56,32 +56,25 @@ struct ProviderStatusTable: View {
     private var reduceMotion
 
     var body: some View {
-        DashboardTile(padding: .nested) {
-            VStack(spacing: 0) {
-                ForEach(Array(ServiceType.allCases.enumerated()), id: \.element) { index, service in
-                    if index > 0 {
-                        Divider()
-                            .padding(.horizontal, MeterBarTheme.Spacing.sm)
-                    }
-
-                    ProviderStatusDisclosureRow(
-                        service: service,
-                        report: reports[service],
-                        error: errors[service],
-                        isExpanded: expandedServices.contains(service),
-                        toggle: { toggleExpansion(for: service) },
-                        openStatusPage: { openStatusPage(service) }
-                    )
-                }
+        // One tile per provider, like the popover's status detail sections —
+        // the previous single divider-separated tile read as one blurred list,
+        // and its unclipped move-in transition drew the expanding content on
+        // top of the row above it.
+        VStack(spacing: MeterBarTheme.Spacing.sm) {
+            ForEach(ServiceType.allCases) { service in
+                ProviderStatusDisclosureRow(
+                    service: service,
+                    report: reports[service],
+                    error: errors[service],
+                    isExpanded: expandedServices.contains(service),
+                    toggle: { toggleExpansion(for: service) },
+                    openStatusPage: { openStatusPage(service) }
+                )
             }
         }
     }
 
     private func toggleExpansion(for service: ServiceType) {
-        // These rows sit on a shared flat tile (divider-separated), with no
-        // per-row glass surface, so a `glassEffectID` morph would read wrong —
-        // they keep the in-place move/opacity transition, now on a shared token
-        // and gated by Reduce Motion.
         withAnimation(reduceMotion ? nil : MeterBarTheme.Motion.disclosure) {
             if expandedServices.contains(service) {
                 expandedServices.remove(service)
@@ -112,60 +105,63 @@ private struct ProviderStatusDisclosureRow: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack(alignment: .center, spacing: 10) {
-                Button(action: toggle) {
-                    HStack(alignment: .center, spacing: 10) {
-                        Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                            .font(.caption2)
-                            .fontWeight(.bold)
-                            .foregroundColor(.secondary)
-                            .frame(width: 12)
-                            .contentTransition(.symbolEffect(.replace))
-                            .animation(MeterBarTheme.Motion.snappy(reduceMotion: reduceMotion), value: isExpanded)
+        DashboardTile(padding: .popover) {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(alignment: .center, spacing: 10) {
+                    Button(action: toggle) {
+                        HStack(alignment: .center, spacing: 10) {
+                            Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                                .font(.caption2)
+                                .fontWeight(.bold)
+                                .foregroundColor(.secondary)
+                                .frame(width: 12)
+                                .contentTransition(.symbolEffect(.replace))
+                                .animation(MeterBarTheme.Motion.snappy(reduceMotion: reduceMotion), value: isExpanded)
 
-                        ProviderLogoView(
-                            kind: .forService(service),
-                            size: 17,
-                            foregroundColor: MeterBarTheme.accent(for: service)
-                        )
+                            ProviderLogoView(
+                                kind: .forService(service),
+                                size: 17,
+                                foregroundColor: MeterBarTheme.accent(for: service)
+                            )
 
-                        VStack(alignment: .leading, spacing: 1) {
-                            Text(service.statusPageDisplayName)
-                                .font(.subheadline)
-                                .fontWeight(.semibold)
-                            Text(subtitle)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
+                            VStack(alignment: .leading, spacing: 1) {
+                                Text(service.statusPageDisplayName)
+                                    .font(.subheadline)
+                                    .fontWeight(.semibold)
+                                Text(subtitle)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                            }
+
+                            Spacer(minLength: 10)
+
+                            ProviderStatusBadge(indicator: indicator, label: headline)
                         }
-
-                        Spacer(minLength: 10)
-
-                        ProviderStatusBadge(indicator: indicator, label: headline)
+                        .contentShape(Rectangle())
                     }
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityHint(isExpanded ? "Collapse status details" : "Show status details")
+                    .buttonStyle(.plain)
+                    .accessibilityHint(isExpanded ? "Collapse status details" : "Show status details")
 
-                Button(action: openStatusPage) {
-                    Image(systemName: "arrow.up.right.square")
+                    Button(action: openStatusPage) {
+                        Image(systemName: "arrow.up.right.square")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Open \(service.statusPageDisplayName) status page")
                 }
-                .buttonStyle(.borderless)
-                .help("Open \(service.statusPageDisplayName) status page")
-            }
-            .padding(.horizontal, MeterBarTheme.Spacing.sm)
-            .padding(.vertical, MeterBarTheme.Spacing.sm)
 
-            if isExpanded {
-                expandedDetails
-                    .padding(.leading, MeterBarTheme.Spacing.xxl)
-                    .padding(.trailing, MeterBarTheme.Spacing.sm)
-                    .padding(.bottom, MeterBarTheme.Spacing.md)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
+                if isExpanded {
+                    // Fade only: the tile's height change carries the motion.
+                    // The old `.move(edge: .top)` slid the incoming rows over
+                    // the header because nothing clipped them mid-flight.
+                    expandedDetails
+                        .padding(.top, MeterBarTheme.Spacing.md)
+                        .padding(.leading, MeterBarTheme.Spacing.xxl)
+                        .transition(.opacity)
+                }
             }
         }
+        .clipShape(RoundedRectangle(cornerRadius: MeterBarTheme.Radius.card, style: .continuous))
     }
 
     @ViewBuilder private var expandedDetails: some View {

--- a/MeterBar/Views/TokenActivityHeatmap.swift
+++ b/MeterBar/Views/TokenActivityHeatmap.swift
@@ -60,11 +60,14 @@ struct TokenActivityCard: View {
     }
 }
 
-/// The grid itself: month headers, weekday gutter, cells, hover/focus detail,
-/// and the intensity legend.
+/// The grid itself: weekday header, one full-width row per week, hover/focus
+/// detail, and the intensity legend.
+///
+/// Weeks run as *rows* with the weekday columns stretched across the card —
+/// the transposed month grid was anchored to one edge and left half the card
+/// empty, and its 20pt cells were fiddly hover targets.
 struct TokenActivityHeatmap: View {
     private let activity: TokenActivityCalendar
-    private let monthTitles: [Int: String]
 
     @State private var hoveredDate: Date?
     @FocusState private var focusedDate: Date?
@@ -73,28 +76,21 @@ struct TokenActivityHeatmap: View {
 
     init(activity: TokenActivityCalendar) {
         self.activity = activity
-        self.monthTitles = Dictionary(
-            activity.monthLabels.map { ($0.weekIndex, $0.title) },
-            uniquingKeysWith: { first, _ in first }
-        )
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.sm) {
-            ScrollView(.horizontal) {
-                VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.xs) {
-                    monthHeader
-                    HStack(alignment: .top, spacing: TokenActivityMetrics.spacing) {
-                        weekdayGutter
-                        grid
-                    }
+            VStack(alignment: .leading, spacing: TokenActivityMetrics.spacing) {
+                weekdayHeader
+                ForEach(activity.weeks) { week in
+                    weekRow(week)
                 }
-                // Focus rings sit just outside a cell; without the inset the
-                // leading and trailing columns clip theirs against the card.
-                .padding(TokenActivityMetrics.focusRingInset)
             }
-            .scrollIndicators(.hidden)
-            .defaultScrollAnchor(.trailing)
+            // Focus rings sit just outside a cell; without the inset the
+            // leading and trailing columns clip theirs against the card.
+            .padding(TokenActivityMetrics.focusRingInset)
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Token activity calendar")
 
             detail
             TokenActivityLegend()
@@ -107,32 +103,52 @@ struct TokenActivityHeatmap: View {
 
     // MARK: - Grid
 
-    private var grid: some View {
-        HStack(alignment: .top, spacing: TokenActivityMetrics.spacing) {
-            ForEach(activity.weeks) { week in
-                VStack(spacing: TokenActivityMetrics.spacing) {
-                    ForEach(Array(week.days.enumerated()), id: \.offset) { _, day in
-                        if let day {
-                            cell(for: day)
-                        } else {
-                            // A future weekday in the current column: the slot
-                            // still holds the grid's shape, it just has no cell.
-                            Color.clear
-                                .frame(width: TokenActivityMetrics.cell, height: TokenActivityMetrics.cell)
-                        }
-                    }
+    private var weekdayHeader: some View {
+        HStack(spacing: TokenActivityMetrics.spacing) {
+            Color.clear
+                .frame(width: TokenActivityMetrics.weekLabelWidth, height: 1)
+
+            ForEach(Array(activity.weekdaySymbols.enumerated()), id: \.offset) { _, symbol in
+                Text(symbol)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .font(.system(size: 9))
+        .foregroundStyle(.secondary)
+        .accessibilityHidden(true)
+    }
+
+    private func weekRow(_ week: TokenActivityWeek) -> some View {
+        HStack(spacing: TokenActivityMetrics.spacing) {
+            // Each row names the day it starts on; a single month header can't
+            // label rows that all begin mid-month.
+            Text(DashboardDateFormat.monthDay(week.startDate))
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .frame(width: TokenActivityMetrics.weekLabelWidth, alignment: .trailing)
+                .accessibilityHidden(true)
+
+            ForEach(Array(week.days.enumerated()), id: \.offset) { _, day in
+                if let day {
+                    cell(for: day)
+                } else {
+                    // A future weekday in the current row: the slot still holds
+                    // the grid's shape, it just has no cell.
+                    Color.clear
+                        .frame(maxWidth: .infinity)
+                        .frame(height: TokenActivityMetrics.rowHeight)
                 }
             }
         }
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Token activity calendar")
     }
 
     private func cell(for day: TokenActivityDay) -> some View {
         TokenActivitySwatch(
             level: day.level,
             isCovered: day.isCovered,
-            isHighlighted: highlightedDate == day.date
+            isHighlighted: highlightedDate == day.date,
+            fillsWidth: true
         )
         .focusable()
         .focused($focusedDate, equals: day.date)
@@ -147,46 +163,6 @@ struct TokenActivityHeatmap: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(day.accessibilityLabel)
         .accessibilityValue(day.accessibilityValue)
-    }
-
-    // MARK: - Headers
-
-    private var monthHeader: some View {
-        HStack(alignment: .bottom, spacing: TokenActivityMetrics.spacing) {
-            Color.clear
-                .frame(width: TokenActivityMetrics.gutterWidth, height: 1)
-
-            ForEach(activity.weeks) { week in
-                // `fixedSize` before the column-width frame lets the label keep
-                // its natural width and overhang the following columns. A month
-                // cell is now wide enough for an English abbreviation, but not
-                // for the longer ones other locales use.
-                Text(monthTitles[week.index] ?? "")
-                    .fixedSize()
-                    .frame(width: TokenActivityMetrics.cell, alignment: .leading)
-            }
-        }
-        .font(.system(size: 9))
-        .foregroundStyle(.secondary)
-        .accessibilityHidden(true)
-    }
-
-    private var weekdayGutter: some View {
-        VStack(spacing: TokenActivityMetrics.spacing) {
-            ForEach(Array(activity.weekdaySymbols.enumerated()), id: \.offset) { _, symbol in
-                // Every row is labelled: the month grid's cells are taller than a
-                // 9pt line, which the year-wide grid's were not.
-                Text(symbol)
-                    .frame(
-                        width: TokenActivityMetrics.gutterWidth,
-                        height: TokenActivityMetrics.cell,
-                        alignment: .leading
-                    )
-            }
-        }
-        .font(.system(size: 9))
-        .foregroundStyle(.secondary)
-        .accessibilityHidden(true)
     }
 
     // MARK: - Detail line
@@ -242,11 +218,13 @@ private struct TokenActivityLegend: View {
 // MARK: - Cell chrome
 
 /// One rounded tile, shared by the grid and the legend so a swatch can never
-/// drift from the cells it explains.
+/// drift from the cells it explains. Grid cells stretch to their column's
+/// width; legend swatches stay fixed squares.
 private struct TokenActivitySwatch: View {
     let level: Int
     var isCovered = true
     var isHighlighted = false
+    var fillsWidth = false
 
     var body: some View {
         RoundedRectangle(cornerRadius: TokenActivityMetrics.radius, style: .continuous)
@@ -255,7 +233,11 @@ private struct TokenActivitySwatch: View {
                 RoundedRectangle(cornerRadius: TokenActivityMetrics.radius, style: .continuous)
                     .strokeBorder(borderColor, style: borderStyle)
             }
-            .frame(width: TokenActivityMetrics.cell, height: TokenActivityMetrics.cell)
+            .frame(
+                minWidth: fillsWidth ? nil : TokenActivityMetrics.cell,
+                maxWidth: fillsWidth ? .infinity : TokenActivityMetrics.cell
+            )
+            .frame(height: fillsWidth ? TokenActivityMetrics.rowHeight : TokenActivityMetrics.cell)
     }
 
     private var borderColor: Color {
@@ -273,20 +255,21 @@ private struct TokenActivitySwatch: View {
 
 // MARK: - Metrics and palette
 
-/// Grid geometry, kept in one place so the month header, weekday gutter, cells,
-/// and legend stay on the same rhythm.
-/// Sized for the trailing month. Six columns leave room a 53-column year never
-/// had, so the cells are large enough to hover accurately and to carry a legible
-/// weekday label on every row.
+/// Grid geometry, kept in one place so the weekday header, week rows, and
+/// legend stay on the same rhythm.
 private enum TokenActivityMetrics {
-    static let cell: CGFloat = 20
-    static let spacing: CGFloat = 4
-    static let radius: CGFloat = 4
-    static let gutterWidth: CGFloat = 28
+    /// Fixed square used by the legend swatches.
+    static let cell: CGFloat = 14
+    /// Height of a full-width week-row cell.
+    static let rowHeight: CGFloat = 26
+    /// Leading gutter naming the day each week row starts on.
+    static let weekLabelWidth: CGFloat = 52
+    static let spacing: CGFloat = 6
+    static let radius: CGFloat = 5
     static let focusRingInset: CGFloat = 2
-    /// Placeholder height while a scan runs, matching the loaded grid: seven
-    /// cell rows plus their gaps, the month header, and the focus-ring inset.
-    static let gridHeight: CGFloat = 186
+    /// Placeholder height while a scan runs, matching the loaded grid: the
+    /// weekday header plus six week rows and their gaps.
+    static let gridHeight: CGFloat = 204
 }
 
 /// Heatmap band colors.

--- a/MeterBar/Views/TokenActivityHeatmap.swift
+++ b/MeterBar/Views/TokenActivityHeatmap.swift
@@ -16,11 +16,12 @@ struct TokenActivityCard: View {
 
     init(
         summary: CostSummary?,
+        weeks: Int = TokenActivityCalendar.defaultWeeks,
         isScanning: Bool,
         isScanDisabled: Bool,
         scan: @escaping () -> Void
     ) {
-        self.activity = TokenActivityCalendar(summary: summary)
+        self.activity = TokenActivityCalendar(summary: summary, weeks: weeks)
         self.isScanning = isScanning
         self.isScanDisabled = isScanDisabled
         self.scan = scan

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -267,7 +267,6 @@ struct UsageDashboardView: View {
             DashboardOverviewSection(
                 snapshots: providerSnapshots,
                 tightestLimit: tightestLimit,
-                enabledSourceCount: enabledQuotaSourceCount,
                 costSummary: visibleCostSummary,
                 onSelectProvider: { providerID in
                     navigation.navigate(to: .limits, focusedProviderID: providerID)
@@ -343,11 +342,27 @@ struct UsageDashboardView: View {
                         .foregroundColor(.secondary)
                 }
             } else {
-                ForEach(orderedProviderSnapshotsForLimits) { snapshot in
-                    // The one provider card, shared with the popover, so the two
-                    // surfaces are physically the same component and cannot drift.
-                    ProviderStatusCard(snapshot: snapshot)
+                // Same two-column masonry as Overview: the shared provider card
+                // was designed at popover width, and stretching its gauges
+                // across the whole detail pane read as one washed-out column.
+                // The focused provider is first in the list, so it lands top-left.
+                HStack(alignment: .top, spacing: MeterBarTheme.Spacing.sm) {
+                    let columns = DashboardOverviewSection.masonryColumns(
+                        orderedProviderSnapshotsForLimits,
+                        columnCount: 2
+                    )
+                    ForEach(Array(columns.enumerated()), id: \.offset) { _, column in
+                        VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.sm) {
+                            ForEach(column) { snapshot in
+                                // The one provider card, shared with the popover, so
+                                // the two surfaces cannot drift.
+                                ProviderStatusCard(snapshot: snapshot)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .topLeading)
+                    }
                 }
+                .frame(maxWidth: .infinity)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -400,14 +415,6 @@ struct UsageDashboardView: View {
 
     private var visibleCostSummary: CostSummary? {
         costTracker.costSummary?.filtered(to: providerVisibility.enabledServices)
-    }
-
-    private var enabledQuotaSourceCount: Int {
-        EnabledQuotaSourceCounter.count(
-            enabledServices: providerVisibility.enabledServices,
-            codexAccountCount: codexAccountStore.enabledAccounts.count,
-            claudeAccountCount: claudeAccountStore.enabledAccounts.count
-        )
     }
 
     private var tightestLimit: SnapshotLimit? {

--- a/MeterBarTests/ClaudeAccountAuthStateTests.swift
+++ b/MeterBarTests/ClaudeAccountAuthStateTests.swift
@@ -216,7 +216,82 @@ final class ClaudeAccountAuthStateTests: XCTestCase {
         XCTAssertNil(cursor.authNotice)
     }
 
+    // MARK: - Stale login collapse (dashboard/popover one-liner)
+
+    func testLoginRequiredCardCollapsesOnceItsCacheIsOlderThanTwoHours() {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let threeHoursAgo = now.addingTimeInterval(-3 * 60 * 60)
+        let card = makeCard(notice: .loginRequired, updatedAt: threeHoursAgo)
+
+        XCTAssertTrue(ProviderCardPresentation.collapsesToLoginRow(snapshot: card, now: now))
+    }
+
+    func testLoginRequiredCardKeepsItsGaugesWhileTheCacheIsStillFresh() {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let oneHourAgo = now.addingTimeInterval(-60 * 60)
+        let card = makeCard(notice: .loginRequired, updatedAt: oneHourAgo)
+
+        XCTAssertFalse(ProviderCardPresentation.collapsesToLoginRow(snapshot: card, now: now))
+    }
+
+    func testOnlyTheLoginNoticeCollapsesAnAgedCard() {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let yesterday = now.addingTimeInterval(-24 * 60 * 60)
+
+        for notice: ProviderAuthNotice? in [nil, .stale(since: yesterday), .attention("boom"), .notConnected] {
+            let card = makeCard(notice: notice, updatedAt: yesterday)
+            XCTAssertFalse(
+                ProviderCardPresentation.collapsesToLoginRow(snapshot: card, now: now),
+                "\(String(describing: notice)) must not collapse to the login one-liner"
+            )
+        }
+    }
+
+    func testCardWithoutMetricsNeverCollapsesToTheLoginRow() {
+        // No cache at all is the offline row's territory, not the login row's.
+        let card = makeCard(notice: .loginRequired, updatedAt: nil)
+
+        XCTAssertFalse(ProviderCardPresentation.collapsesToLoginRow(snapshot: card, now: Date()))
+    }
+
+    func testCollapsedLoginCardOffersNoDetailNavigation() {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let collapsed = makeCard(notice: .loginRequired, updatedAt: now.addingTimeInterval(-3 * 60 * 60))
+        let fresh = makeCard(notice: .loginRequired, updatedAt: now.addingTimeInterval(-60 * 60))
+
+        XCTAssertFalse(
+            ProviderCardPresentation.allowsDetailNavigation(hasSelectionHandler: true, snapshot: collapsed, now: now),
+            "A collapsed login row is terminal; its stale detail would mislead"
+        )
+        XCTAssertTrue(
+            ProviderCardPresentation.allowsDetailNavigation(hasSelectionHandler: true, snapshot: fresh, now: now),
+            "A fresh login-required card keeps its recent detail reachable"
+        )
+    }
+
     // MARK: - Helpers
+
+    private func makeCard(notice: ProviderAuthNotice?, updatedAt: Date?) -> ProviderSnapshot {
+        ProviderSnapshot(
+            id: "claude-work-collapse",
+            title: "Work",
+            service: .claudeCode,
+            updatedAt: updatedAt,
+            limits: [
+                SnapshotLimit(
+                    id: "session",
+                    kind: .session,
+                    title: "Session",
+                    usageLimit: UsageLimit(used: 12, total: 100, resetTime: nil)
+                ),
+            ],
+            emptyDetail: "Run claude login",
+            extraUsage: nil,
+            resetCreditsAvailable: nil,
+            accountID: nil,
+            authNotice: notice
+        )
+    }
 
     private func makeSnapshot(sessionUsedPercent: Double, notice: ProviderAuthNotice?) -> ProviderSnapshot {
         ProviderSnapshotBuilder.snapshot(

--- a/MeterBarTests/CostChartPresentationTests.swift
+++ b/MeterBarTests/CostChartPresentationTests.swift
@@ -161,6 +161,143 @@ final class CostChartPresentationTests: XCTestCase {
         XCTAssertTrue(presentation.modelPoints.allSatisfy { $0.chartLabel.contains($0.provider.displayName) })
     }
 
+    func testSevenDayWindowDerivesModelSpendFromAttributedDailyRows() {
+        let summary = makeSummary(
+            costs: [
+                tokenCost(
+                    provider: .claudeCode,
+                    totalCost: 40,
+                    models: [model(provider: .claudeCode, name: "claude-fable-5", cost: 40)]
+                ),
+            ],
+            dailyUsage: [
+                dailyRow(
+                    daysAgo: 2,
+                    provider: .claudeCode,
+                    cost: 4,
+                    models: [model(provider: .claudeCode, name: "claude-fable-5", cost: 4)]
+                ),
+                dailyRow(
+                    daysAgo: 5,
+                    provider: .codexCli,
+                    cost: 3,
+                    models: [model(provider: .codexCli, name: "gpt-5.6-sol", cost: 3)]
+                ),
+                // Outside the 7-day window: must not leak into the model chart.
+                dailyRow(
+                    daysAgo: 20,
+                    provider: .claudeCode,
+                    cost: 33,
+                    models: [model(provider: .claudeCode, name: "claude-fable-5", cost: 33)]
+                ),
+            ]
+        )
+
+        let presentation = CostChartPresentation(
+            summary: summary,
+            requestedDays: 7,
+            now: now,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(presentation.modelWindowDays, 7)
+        XCTAssertTrue(presentation.modelWindowMatchesRequested)
+        XCTAssertEqual(presentation.modelPoints.count, 2)
+        XCTAssertEqual(
+            presentation.modelPoints.first { $0.model == "claude-fable-5" }?.costUSD ?? 0,
+            4,
+            accuracy: 0.000_001
+        )
+        XCTAssertEqual(presentation.modelTotalUSD, 7, accuracy: 0.000_001)
+        XCTAssertEqual(presentation.selectedPeriodTotalUSD, 7, accuracy: 0.000_001)
+        XCTAssertTrue(presentation.modelTotalReconciles)
+    }
+
+    func testSevenDayWindowReportsUnattributedRemainderPerDay() {
+        let summary = makeSummary(
+            dailyUsage: [
+                dailyRow(
+                    daysAgo: 1,
+                    provider: .claudeCode,
+                    cost: 5,
+                    models: [model(provider: .claudeCode, name: "claude-fable-5", cost: 3)]
+                ),
+            ]
+        )
+
+        let presentation = CostChartPresentation(
+            summary: summary,
+            requestedDays: 7,
+            now: now,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(
+            presentation.modelPoints.first { $0.model == "Unattributed" }?.costUSD ?? 0,
+            2,
+            accuracy: 0.000_001
+        )
+        XCTAssertTrue(presentation.hasUnattributedModelSpend)
+        XCTAssertTrue(presentation.modelTotalReconciles)
+    }
+
+    func testSevenDayWindowFallsBackToPeriodModelDetailWhenRowsPredateAttribution() {
+        let summary = makeSummary(
+            costs: [
+                tokenCost(
+                    provider: .claudeCode,
+                    totalCost: 40,
+                    models: [model(provider: .claudeCode, name: "claude-fable-5", cost: 40)]
+                ),
+            ],
+            dailyUsage: [
+                // v1 cache rows: no model attribution to re-window from.
+                dailyRow(daysAgo: 1, provider: .claudeCode, cost: 4),
+            ]
+        )
+
+        let presentation = CostChartPresentation(
+            summary: summary,
+            requestedDays: 7,
+            now: now,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(presentation.modelWindowDays, 30, "period detail is the honest fallback")
+        XCTAssertFalse(presentation.modelWindowMatchesRequested)
+        XCTAssertEqual(presentation.modelTotalUSD, 40, accuracy: 0.000_001)
+    }
+
+    func testFullWindowKeepsTheAuthoritativePeriodModelDetail() {
+        let summary = makeSummary(
+            costs: [
+                tokenCost(
+                    provider: .claudeCode,
+                    totalCost: 40,
+                    models: [model(provider: .claudeCode, name: "claude-fable-5", cost: 40)]
+                ),
+            ],
+            dailyUsage: [
+                dailyRow(
+                    daysAgo: 1,
+                    provider: .claudeCode,
+                    cost: 4,
+                    models: [model(provider: .claudeCode, name: "claude-fable-5", cost: 4)]
+                ),
+            ]
+        )
+
+        let presentation = CostChartPresentation(summary: summary, now: now, calendar: calendar)
+
+        XCTAssertEqual(presentation.modelWindowDays, 30)
+        XCTAssertEqual(
+            presentation.modelTotalUSD,
+            40,
+            accuracy: 0.000_001,
+            "a 30-day request must keep the scan's own totals, not re-derive them from daily rows"
+        )
+    }
+
     func testNegativeCostsDoNotProduceChartMarks() {
         let summary = makeSummary(
             costs: [
@@ -259,7 +396,8 @@ final class CostChartPresentationTests: XCTestCase {
     private func dailyRow(
         daysAgo: Int,
         provider: ServiceType,
-        cost: Double
+        cost: Double,
+        models: [TokenUsageBreakdown]? = nil
     ) -> DailyTokenUsage {
         DailyTokenUsage(
             date: dailyDate(daysAgo: daysAgo),
@@ -267,7 +405,8 @@ final class CostChartPresentationTests: XCTestCase {
             inputTokens: 1,
             outputTokens: 0,
             cacheReadTokens: 0,
-            estimatedCostUSD: cost
+            estimatedCostUSD: cost,
+            modelBreakdowns: models
         )
     }
 

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -19,10 +19,15 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertNotNil(tracker.lastScanDate)
         XCTAssertFalse(tracker.isScanning)
 
-        // Never leaks real project paths or private model routing.
+        // Breakdowns are synthetic-only: every name comes from the fixture's
+        // fixed vocabulary, so no real project path or routing can leak.
         for cost in summary?.costs ?? [] {
-            XCTAssertTrue(cost.modelBreakdowns.isEmpty)
-            XCTAssertTrue(cost.originBreakdowns.isEmpty)
+            for breakdown in cost.modelBreakdowns + cost.originBreakdowns {
+                XCTAssertTrue(
+                    DemoData.syntheticBreakdownNames.contains(breakdown.name),
+                    "unexpected demo breakdown name: \(breakdown.name)"
+                )
+            }
         }
     }
 

--- a/MeterBarTests/CostWindowSelectionTests.swift
+++ b/MeterBarTests/CostWindowSelectionTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import MeterBar
+
+/// The Costs page window toggle (7 vs 30 days). Pure value rules only — the
+/// picker itself is a plain segmented control over `allCases`.
+final class CostWindowSelectionTests: XCTestCase {
+    func testRawValuesAreTheDayCounts() {
+        XCTAssertEqual(CostWindowSelection.week.days, 7)
+        XCTAssertEqual(CostWindowSelection.month.days, 30)
+        XCTAssertEqual(CostWindowSelection(rawValue: 7), .week)
+        XCTAssertEqual(CostWindowSelection(rawValue: 30), .month)
+        XCTAssertNil(CostWindowSelection(rawValue: 14), "unknown persisted day counts must fall back, not crash")
+    }
+
+    func testPickerRunsShortWindowFirst() {
+        XCTAssertEqual(CostWindowSelection.allCases, [.week, .month])
+    }
+
+    func testDisplayStringsNameTheWindow() {
+        XCTAssertEqual(CostWindowSelection.week.pickerLabel, "7 days")
+        XCTAssertEqual(CostWindowSelection.month.pickerLabel, "30 days")
+        XCTAssertEqual(CostWindowSelection.week.subtitle, "Last 7 days")
+        XCTAssertEqual(CostWindowSelection.month.subtitle, "Last 30 days")
+        XCTAssertEqual(CostWindowSelection.week.spendCardTitle, "7 Day Spend")
+        XCTAssertEqual(CostWindowSelection.month.spendCardTitle, "30 Day Spend")
+    }
+
+    func testActivityWeeksCoverTheSelectedWindow() {
+        // Two 7-day columns are the narrowest grid that always spans the last
+        // 7 days; the month keeps the existing six-week calendar.
+        XCTAssertEqual(CostWindowSelection.week.activityWeeks, 2)
+        XCTAssertEqual(CostWindowSelection.month.activityWeeks, TokenActivityCalendar.defaultWeeks)
+    }
+}

--- a/MeterBarTests/CostsPageSnapshotRenderTests.swift
+++ b/MeterBarTests/CostsPageSnapshotRenderTests.swift
@@ -14,6 +14,7 @@ final class CostsPageSnapshotRenderTests: XCTestCase {
             throw XCTSkip("render only when SNAPSHOT_DIR is set")
         }
         let outputDir = URL(fileURLWithPath: dir, isDirectory: true)
+        try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
         let summary = DemoData.costSummary()
 
         try render(width: 1000, name: "0-overview", into: outputDir) {

--- a/MeterBarTests/CostsPageSnapshotRenderTests.swift
+++ b/MeterBarTests/CostsPageSnapshotRenderTests.swift
@@ -16,6 +16,15 @@ final class CostsPageSnapshotRenderTests: XCTestCase {
         let outputDir = URL(fileURLWithPath: dir, isDirectory: true)
         let summary = DemoData.costSummary()
 
+        try render(width: 1000, name: "0-overview", into: outputDir) {
+            DashboardOverviewSection(
+                snapshots: overviewSnapshots(),
+                tightestLimit: overviewSnapshots().first?.limits.first,
+                costSummary: summary,
+                onSelectProvider: { _ in }
+            )
+        }
+
         try render(width: 1000, name: "1-headline-row", into: outputDir) {
             HStack(alignment: .top, spacing: MeterBarTheme.Spacing.sm) {
                 CostOverviewStatusCard(
@@ -46,6 +55,41 @@ final class CostsPageSnapshotRenderTests: XCTestCase {
                 scan: {}
             )
         }
+    }
+
+    /// One healthy provider and one logged-out stale one, so the render shows
+    /// both the "Use next" tile and the collapsed login one-liner.
+    private func overviewSnapshots() -> [ProviderSnapshot] {
+        let healthy = ProviderSnapshotBuilder.snapshot(
+            title: "Codex",
+            service: .codexCli,
+            metrics: UsageMetrics(
+                service: .codexCli,
+                sessionLimit: UsageLimit(used: 56, total: 100, resetTime: Date().addingTimeInterval(9_000)),
+                weeklyLimit: UsageLimit(used: 8, total: 100, resetTime: Date().addingTimeInterval(345_600))
+            ),
+            emptyDetail: "Run codex login"
+        )
+        let staleLogin = ProviderSnapshot(
+            id: "claude-shipshitdev",
+            title: "shipshitdev",
+            service: .claudeCode,
+            updatedAt: Date().addingTimeInterval(-3 * 60 * 60),
+            limits: [
+                SnapshotLimit(
+                    id: "session",
+                    kind: .session,
+                    title: "Session",
+                    usageLimit: UsageLimit(used: 56, total: 100, resetTime: nil)
+                ),
+            ],
+            emptyDetail: "Run claude login",
+            extraUsage: nil,
+            resetCreditsAvailable: nil,
+            accountID: nil,
+            authNotice: .loginRequired
+        )
+        return [staleLogin, healthy]
     }
 
     private func render<V: View>(

--- a/MeterBarTests/CostsPageSnapshotRenderTests.swift
+++ b/MeterBarTests/CostsPageSnapshotRenderTests.swift
@@ -1,0 +1,90 @@
+import AppKit
+import MeterBarShared
+import SwiftUI
+import XCTest
+@testable import MeterBar
+
+/// Offscreen PNG renders of the redesigned Costs-page cards, for visual
+/// verification without driving the running app. Skipped unless SNAPSHOT_DIR
+/// is set, so the normal suite never writes artifacts.
+@MainActor
+final class CostsPageSnapshotRenderTests: XCTestCase {
+    func testRenderCostsPageCards() throws {
+        guard let dir = ProcessInfo.processInfo.environment["SNAPSHOT_DIR"] else {
+            throw XCTSkip("render only when SNAPSHOT_DIR is set")
+        }
+        let outputDir = URL(fileURLWithPath: dir, isDirectory: true)
+        let summary = DemoData.costSummary()
+
+        try render(width: 1000, name: "1-headline-row", into: outputDir) {
+            HStack(alignment: .top, spacing: MeterBarTheme.Spacing.sm) {
+                CostOverviewStatusCard(
+                    summary: summary,
+                    isScanning: false,
+                    isRefreshingMissingDays: false,
+                    formattedTokens: UsageFormat.tokens(summary.totalTokens)
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+                LifetimeCostSummaryCard(summary: summary.lifetime, isScanning: false)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            }
+            .fixedSize(horizontal: false, vertical: true)
+        }
+
+        try render(width: 1000, name: "2-spend-charts", into: outputDir) {
+            DashboardCard(title: "30 Day Spend") {
+                CostSpendCharts(presentation: CostChartPresentation(summary: summary))
+            }
+        }
+
+        try render(width: 1000, name: "3-token-activity", into: outputDir) {
+            TokenActivityCard(
+                summary: summary,
+                isScanning: false,
+                isScanDisabled: false,
+                scan: {}
+            )
+        }
+    }
+
+    private func render<V: View>(
+        width: CGFloat,
+        name: String,
+        into outputDir: URL,
+        @ViewBuilder content: () -> V
+    ) throws {
+        let host = NSHostingView(
+            rootView: content()
+                .frame(width: width)
+                .padding(20)
+                .background(Color(nsColor: NSColor(calibratedWhite: 0.11, alpha: 1)))
+                .environment(\.colorScheme, .dark)
+        )
+        host.appearance = NSAppearance(named: .darkAqua)
+        let size = host.fittingSize
+        host.frame = NSRect(origin: .zero, size: size)
+
+        // A window backs the view hierarchy so layers materialize; it is never
+        // ordered onto the screen — the capture is an offscreen cacheDisplay.
+        let window = NSWindow(
+            contentRect: host.frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.appearance = NSAppearance(named: .darkAqua)
+        window.contentView = host
+        host.layoutSubtreeIfNeeded()
+
+        guard let rep = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+            return XCTFail("no bitmap rep for \(name)")
+        }
+        host.cacheDisplay(in: host.bounds, to: rep)
+        guard let data = rep.representation(using: .png, properties: [:]) else {
+            return XCTFail("no png data for \(name)")
+        }
+        try data.write(to: outputDir.appendingPathComponent("\(name).png"))
+    }
+}

--- a/MeterBarTests/DashboardLayoutTests.swift
+++ b/MeterBarTests/DashboardLayoutTests.swift
@@ -32,41 +32,6 @@ final class DashboardLayoutTests: XCTestCase {
         )
     }
 
-    // MARK: - Enabled quota-source count
-
-    func testEnabledQuotaSourceCountIncludesEveryEnabledAccount() {
-        XCTAssertEqual(
-            EnabledQuotaSourceCounter.count(
-                enabledServices: [.codexCli, .claudeCode, .cursor],
-                codexAccountCount: 3,
-                claudeAccountCount: 2
-            ),
-            6
-        )
-    }
-
-    func testEnabledQuotaSourceCountIncludesSingleAccountProviders() {
-        XCTAssertEqual(
-            EnabledQuotaSourceCounter.count(
-                enabledServices: Set(ServiceType.allCases),
-                codexAccountCount: 2,
-                claudeAccountCount: 3
-            ),
-            8
-        )
-    }
-
-    func testEnabledQuotaSourceCountIgnoresAccountsForHiddenProviders() {
-        XCTAssertEqual(
-            EnabledQuotaSourceCounter.count(
-                enabledServices: [.cursor],
-                codexAccountCount: 3,
-                claudeAccountCount: 2
-            ),
-            1
-        )
-    }
-
     // MARK: - DashboardCard trailing view slot
 
     func testDashboardCardAcceptsTrailingControl() {

--- a/MeterBarTests/DashboardSectionSplitTests.swift
+++ b/MeterBarTests/DashboardSectionSplitTests.swift
@@ -130,9 +130,11 @@ final class DashboardSectionSplitTests: XCTestCase {
 
     /// The estimate card's subtitle names the window and nothing else: refresh
     /// state belongs on the trailing edge, matching "Lifetime Local Cost" and
-    /// "30 Day Spend" rather than replacing the card's own caption.
+    /// the spend card rather than replacing the card's own caption. The window
+    /// now follows the page's 7/30-day toggle.
     func testCostOverviewSubtitleIsWindowOnlyAndStatusMatchesTheOtherCards() {
-        XCTAssertEqual(CostOverviewStatusCard.subtitle, "Last 30 days")
+        XCTAssertEqual(CostWindowSelection.month.subtitle, "Last 30 days")
+        XCTAssertEqual(CostWindowSelection.week.subtitle, "Last 7 days")
 
         for isScanning in [true, false] {
             for isRefreshingMissingDays in [true, false] {

--- a/MeterBarTests/DashboardSectionSplitTests.swift
+++ b/MeterBarTests/DashboardSectionSplitTests.swift
@@ -262,6 +262,22 @@ final class DashboardSectionSplitTests: XCTestCase {
         XCTAssertEqual(DashboardOverviewSection.masonryColumns([1, 2], columnCount: 0), [[1, 2]])
     }
 
+    // MARK: - Week-row date labels
+
+    /// The week-row gutter label is locale-templated ("MMMd"), so the exact
+    /// ordering varies by machine locale — but the day number must survive in
+    /// every arrangement ("10 Jul", "Jul 10", "7月10日").
+    func testMonthDayLabelCarriesTheDayNumberInAnyLocale() {
+        let date = Date(timeIntervalSince1970: 1_750_000_000)
+        let label = DashboardDateFormat.monthDay(date)
+
+        XCTAssertFalse(label.isEmpty)
+        XCTAssertTrue(
+            label.contains("\(Calendar.current.component(.day, from: date))"),
+            "label must include the day of month: \(label)"
+        )
+    }
+
     // MARK: - Overview "Use next" tile
 
     private func rankedRecommendation(

--- a/MeterBarTests/DashboardSectionSplitTests.swift
+++ b/MeterBarTests/DashboardSectionSplitTests.swift
@@ -153,6 +153,22 @@ final class DashboardSectionSplitTests: XCTestCase {
         }
     }
 
+    /// The model list leads with the three biggest spenders; the rest live
+    /// behind an explicit control. No control at all when nothing is hidden.
+    func testModelSpendListCompactsPastTheTopThree() {
+        XCTAssertEqual(CostSpendCharts.compactModelLimit, 3)
+        XCTAssertNil(CostSpendCharts.modelToggleTitle(showingAll: false, totalCount: 3))
+        XCTAssertNil(CostSpendCharts.modelToggleTitle(showingAll: false, totalCount: 0))
+        XCTAssertEqual(
+            CostSpendCharts.modelToggleTitle(showingAll: false, totalCount: 12),
+            "Show all 12 models"
+        )
+        XCTAssertEqual(
+            CostSpendCharts.modelToggleTitle(showingAll: true, totalCount: 12),
+            "Show top 3"
+        )
+    }
+
     func testStatusPageSummaryReportsRefreshFirst() {
         XCTAssertEqual(
             DashboardStatusSection.summary(isRefreshing: true, issueCount: 3, reportCount: 0),

--- a/MeterBarTests/DashboardSectionSplitTests.swift
+++ b/MeterBarTests/DashboardSectionSplitTests.swift
@@ -262,6 +262,60 @@ final class DashboardSectionSplitTests: XCTestCase {
         XCTAssertEqual(DashboardOverviewSection.masonryColumns([1, 2], columnCount: 0), [[1, 2]])
     }
 
+    // MARK: - Overview "Use next" tile
+
+    private func rankedRecommendation(
+        sessionUsed: Double = 8,
+        weeklyUsed: Double = 8
+    ) -> ProviderRecommendation {
+        ProviderRecommendationPlanner.rank(
+            candidates: [
+                ProviderRecommendationCandidate(
+                    id: "codex",
+                    name: "Codex",
+                    service: .codexCli,
+                    displayOrder: 0,
+                    sessionLimit: UsageLimit(used: sessionUsed, total: 100, resetTime: nil),
+                    weeklyLimit: UsageLimit(used: weeklyUsed, total: 100, resetTime: nil),
+                    lastUpdated: Date(timeIntervalSince1970: 1_750_000_000)
+                ),
+            ],
+            now: Date(timeIntervalSince1970: 1_750_000_100)
+        )
+    }
+
+    func testUseNextTileLeadsWithTheTopRankedProvider() throws {
+        let recommendation = rankedRecommendation()
+        let tile = DashboardOverviewSection.useNextTile(for: recommendation)
+        let top = try XCTUnwrap(recommendation.rows.first)
+
+        XCTAssertEqual(tile.value, top.name)
+        XCTAssertTrue(
+            tile.caption.contains(top.headroomText),
+            "the caption must carry the headroom that earned the rank: \(tile.caption)"
+        )
+        XCTAssertTrue(tile.caption.contains(top.windowTitle))
+        XCTAssertEqual(tile.band, top.band)
+    }
+
+    func testUseNextTileSaysSoWhenEveryWindowIsSpent() {
+        let recommendation = rankedRecommendation(sessionUsed: 100, weeklyUsed: 100)
+        let tile = DashboardOverviewSection.useNextTile(for: recommendation)
+
+        XCTAssertEqual(tile.value, "Every window spent")
+        XCTAssertEqual(tile.band, .exhausted)
+    }
+
+    func testUseNextTileFallsBackWhenNothingIsRankable() {
+        let tile = DashboardOverviewSection.useNextTile(
+            for: ProviderRecommendationPlanner.rank(candidates: [], now: Date())
+        )
+
+        XCTAssertEqual(tile.value, "No data")
+        XCTAssertEqual(tile.caption, "Waiting for provider refresh")
+        XCTAssertNil(tile.band)
+    }
+
     // MARK: - Optimize KPI tiles
 
     /// The four KPI tiles are one glanceable band of headline numbers, not a
@@ -298,6 +352,32 @@ final class DashboardSectionSplitTests: XCTestCase {
 
         XCTAssertEqual(busy.value, UsageFormat.tokens(1_200_000))
         XCTAssertEqual(busy.caption, "\(UsageFormat.tokens(9_000_000)) over 30 days")
+    }
+
+    /// The window KPI tile follows the page's 7/30-day toggle: the week keeps
+    /// the empty-week wording above; the month reports the 30-day total.
+    func testWindowTileFollowsTheSelectedWindow() {
+        let week = OptimizeInsightsView.windowTile(
+            selection: .week,
+            tokens7Day: 1_200_000,
+            tokens30Day: 9_000_000
+        )
+        XCTAssertEqual(week.title, "Last 7 days")
+        XCTAssertEqual(week.value, UsageFormat.tokens(1_200_000))
+        XCTAssertEqual(week.caption, "\(UsageFormat.tokens(9_000_000)) over 30 days")
+
+        let month = OptimizeInsightsView.windowTile(
+            selection: .month,
+            tokens7Day: 1_200_000,
+            tokens30Day: 9_000_000
+        )
+        XCTAssertEqual(month.title, "Last 30 days")
+        XCTAssertEqual(month.value, UsageFormat.tokens(9_000_000))
+        XCTAssertEqual(month.caption, "tokens in the last 30 days")
+
+        let emptyMonth = OptimizeInsightsView.windowTile(selection: .month, tokens7Day: 0, tokens30Day: 0)
+        XCTAssertEqual(emptyMonth.value, "None")
+        XCTAssertEqual(emptyMonth.caption, "no tokens recorded in the last 30 days")
     }
 
     // MARK: - Share card sources
@@ -354,7 +434,6 @@ final class DashboardSectionSplitTests: XCTestCase {
         let view = DashboardOverviewSection(
             snapshots: [snapshot()],
             tightestLimit: snapshot().limits.first,
-            enabledSourceCount: 2,
             costSummary: nil,
             onSelectProvider: { _ in }
         )

--- a/MeterBarTests/DemoDataTests.swift
+++ b/MeterBarTests/DemoDataTests.swift
@@ -95,9 +95,9 @@ final class DemoDataTests: XCTestCase {
         XCTAssertNil(metrics[.cursor]?.weeklyLimit?.pace(now: now))
     }
 
-    // MARK: - Cost summary: non-alarming, no project/model leakage
+    // MARK: - Cost summary: non-alarming, synthetic breakdowns only
 
-    func testCostSummaryIsNonAlarmingAndLeaksNoOriginOrModelBreakdowns() {
+    func testCostSummaryIsNonAlarmingAndCarriesOnlySyntheticBreakdowns() {
         let summary = DemoData.costSummary(now: now)
 
         XCTAssertEqual(summary.totalCostUSD, 204.90, accuracy: 0.001, "~$205, deliberately modest")
@@ -112,10 +112,52 @@ final class DemoDataTests: XCTestCase {
         )
         XCTAssertGreaterThan(summary.totalTokens, 0)
 
-        // Never surface real project paths or private model routing.
-        for cost in summary.costs {
-            XCTAssertTrue(cost.modelBreakdowns.isEmpty, "\(cost.provider) must carry no model breakdown")
-            XCTAssertTrue(cost.originBreakdowns.isEmpty, "\(cost.provider) must carry no origin breakdown")
+        // Breakdowns exist so demo screenshots show the model/origin charts —
+        // but only from the fixture's fixed synthetic vocabulary. Nothing here
+        // may ever look like a real project path or leak private routing.
+        for cost in summary.costs where cost.provider != .cursor {
+            XCTAssertFalse(cost.modelBreakdowns.isEmpty, "\(cost.provider) demo needs model rows")
+            XCTAssertFalse(cost.originBreakdowns.isEmpty, "\(cost.provider) demo needs origin rows")
+
+            let attributed = cost.modelBreakdowns.reduce(0) { $0 + $1.estimatedCostUSD }
+            XCTAssertEqual(
+                attributed,
+                cost.estimatedCostUSD,
+                accuracy: 0.005,
+                "\(cost.provider) model rows must reconcile — no Unattributed remainder in demo"
+            )
+
+            for breakdown in cost.modelBreakdowns + cost.originBreakdowns {
+                XCTAssertTrue(
+                    DemoData.syntheticBreakdownNames.contains(breakdown.name),
+                    "unexpected demo breakdown name: \(breakdown.name)"
+                )
+                XCTAssertFalse(breakdown.name.contains("/"), "no path-like names in demo data")
+            }
+        }
+
+        // Cursor is dollar-billed with no token telemetry; it stays plain.
+        let cursor = summary.costs.first { $0.provider == .cursor }
+        XCTAssertEqual(cursor?.modelBreakdowns.isEmpty, true)
+    }
+
+    /// Daily rows carry per-model attribution so the 7-day window's model chart
+    /// derives from them instead of falling back to the mismatch caption.
+    func testDemoDailyRowsCarryReconcilingModelAttribution() {
+        let summary = DemoData.costSummary(now: now)
+
+        for row in summary.dailyUsage {
+            let models = row.modelBreakdowns ?? []
+            XCTAssertFalse(models.isEmpty, "daily rows need model attribution for windowed charts")
+            XCTAssertEqual(
+                models.reduce(0) { $0 + $1.estimatedCostUSD },
+                row.estimatedCostUSD,
+                accuracy: 0.005,
+                "daily model rows must reconcile to the day's cost"
+            )
+            for model in models {
+                XCTAssertTrue(DemoData.syntheticBreakdownNames.contains(model.name))
+            }
         }
     }
 


### PR DESCRIPTION
Implements five of the six dashboard feedback items (the Token Activity redesign is a separate follow-up pending a design pick).

## Changes

### Provider cards — stale login collapse
- A `.loginRequired` card whose cache is **older than 2 hours** collapses to a one-line "Login required" row (`ProviderCardPresentation.collapsesToLoginRow`). A fresh cache keeps its gauges — those numbers were true minutes ago.
- Collapsed rows drop detail navigation: the detail panel would present hours-old gauges as live.

### Costs — 7/30-day window toggle
- New `CostWindowSelection` (raw value = day count) persisted at `StorageKeys.costsWindowDays`; segmented picker at the top of the Costs page governs every windowed card.
- Presentation-only: both windows are cut from the one cached 30-day scan, so flipping never rescans and the 7-day view draws a quarter of the marks.
  - Headline estimate + tokens + provider count via `CostSummary.dailyCostWindow`.
  - Spend chart via `CostChartPresentation.requestedDays`; **Spend by model is re-derived from the daily rows' own model attribution** for narrow windows, with an honest fallback to scan-period detail (plus the existing mismatch caption) for v1 caches without attribution.
  - Daily Details filtered to the window; Token Activity narrows to two columns.

### Status page
- One tile per provider instead of a single divider-separated list, matching the popover's per-provider status sections.
- Expand animation: fade-only content transition while the tile's height change carries the motion. The old unclipped `.move(edge: .top)` slid incoming rows over the header row above — the artifact in the report.

### Diagnostics
- Removed the Refresh Cadence card (cadence is configured in Settings; the copied report still includes it).
- Action labels shortened: "Re-run checks" → **Refresh**, "Copy report" → **Copy**, each with a tooltip.

## Testing
- TDD: new tests for the collapse rule (`ClaudeAccountAuthStateTests`), `CostWindowSelectionTests`, and windowed model-spend derivation/fallback (`CostChartPresentationTests`).
- `swift test`: **2078 tests, 0 failures** (5 skipped, credential-gated).
- swiftlint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a saved Costs dashboard selector for 7-day and 30-day reporting windows.
  * Updated cost cards, charts, token activity, provider totals, labels, and empty states for the selected window.
  * Improved short-period model cost attribution.
  * Added expandable model charts, a recommendation-based “Use next” tile, and compact stale-login prompts.

* **UI Improvements**
  * Refined provider layouts, activity heatmaps, diagnostics actions, and share-card presentation.
  * Removed the duplicate refresh-cadence card.

* **Tests**
  * Added coverage for reporting windows, cost attribution, layouts, and stale-login behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->