### PR TITLE
feat(cost): hourly Token Activity heatmap for the 7-day window

### DIFF
--- a/MeterBar/Models/CostWindowSelection.swift
+++ b/MeterBar/Models/CostWindowSelection.swift
@@ -26,11 +26,10 @@ nonisolated enum CostWindowSelection: Int, CaseIterable, Identifiable {
     /// Title of the spend-chart card ("30 Day Spend").
     var spendCardTitle: String { "\(days) Day Spend" }
 
-    /// Token-activity calendar columns covering this window. Two 7-day columns
-    /// are the narrowest grid that always spans the last 7 days (one column
-    /// covers only the part-week up to today); the month keeps the existing
-    /// six-week calendar.
-    var activityWeeks: Int {
+    /// Calendar width used when hourly rows are unavailable. Old seven-day
+    /// caches keep their existing two-week fallback; the month always keeps
+    /// the existing six-week calendar.
+    var fallbackActivityWeeks: Int {
         switch self {
         case .week: return 2
         case .month: return TokenActivityCalendar.defaultWeeks

--- a/MeterBar/Models/TokenActivityCalendar.swift
+++ b/MeterBar/Models/TokenActivityCalendar.swift
@@ -408,6 +408,10 @@ struct TokenActivityHourlyCalendar {
     let days: [TokenActivityHourDay]
     let hours: [TokenActivityHour]
     let scale: TokenActivityIntensityScale
+    /// First local day represented by a retained hourly row. The grid still
+    /// renders all seven rows, but days before this date are layout, not proof
+    /// that MeterBar retained a full week of history.
+    let coverageStartDate: Date?
 
     private let hoursByKey: [TokenActivityHourKey: TokenActivityHour]
     private let calendar: Calendar
@@ -423,6 +427,7 @@ struct TokenActivityHourlyCalendar {
             let day = calendar.startOfDay(for: row.date)
             return day >= startDate && day <= today
         }
+        let coverageStartDate = rows.map { calendar.startOfDay(for: $0.date) }.min()
         let rowsByKey = Dictionary(grouping: rows) { row in
             TokenActivityHourKey(
                 day: calendar.startOfDay(for: row.date),
@@ -469,6 +474,7 @@ struct TokenActivityHourlyCalendar {
         self.days = days
         self.hours = hours
         self.scale = scale
+        self.coverageStartDate = coverageStartDate
         self.hoursByKey = hoursByKey
         self.calendar = calendar
     }
@@ -490,7 +496,12 @@ struct TokenActivityHourlyCalendar {
 
     var busiestHour: TokenActivityHour? { activeHours.max { $0.totalTokens < $1.totalTokens } }
 
-    var coverageSummary: String { "7 days tracked" }
+    var coverageSummary: String? {
+        guard let coverageStartDate else { return nil }
+        let distance = calendar.dateComponents([.day], from: coverageStartDate, to: endDate).day ?? 0
+        let tracked = min(Self.dayCount, max(1, distance + 1))
+        return "\(tracked) day\(tracked == 1 ? "" : "s") tracked"
+    }
 
     var overviewLine: String {
         guard let busiestHour else { return "No tracked usage in this window." }

--- a/MeterBar/Models/TokenActivityCalendar.swift
+++ b/MeterBar/Models/TokenActivityCalendar.swift
@@ -323,3 +323,244 @@ struct TokenActivityCalendar {
         return (0..<weekdayCount).map { symbols[($0 + offset) % weekdayCount] }
     }
 }
+
+// MARK: - Hour × day grid
+
+/// Stable identity for one local day/hour coordinate. The hour component is
+/// explicit so daylight-saving transitions still render exactly 24 columns;
+/// repeated fallback hours aggregate into their shared local-hour column.
+struct TokenActivityHourKey: Hashable {
+    let day: Date
+    let hour: Int
+}
+
+/// One cell in the trailing-seven-day hourly activity grid.
+struct TokenActivityHour: Identifiable, Equatable {
+    var id: TokenActivityHourKey { TokenActivityHourKey(day: day, hour: hour) }
+
+    let day: Date
+    let hour: Int
+    let totalTokens: Int
+    let estimatedCostUSD: Double
+    let providers: [TokenActivityProviderTotal]
+    let level: Int
+
+    var hasUsage: Bool { totalTokens > 0 }
+
+    var accessibilityLabel: String { header }
+
+    var accessibilityValue: String {
+        guard hasUsage else { return "No tracked usage" }
+
+        var parts = [
+            "\(UsageFormat.tokens(totalTokens)) tokens",
+            UsageFormat.cost(estimatedCostUSD),
+            "intensity \(level) of \(TokenActivityIntensityScale.bandCount)",
+        ]
+        parts.append(contentsOf: providers.map {
+            "\($0.provider.displayName) \(UsageFormat.tokens($0.tokens)), \(UsageFormat.cost($0.costUSD))"
+        })
+        return parts.joined(separator: ", ")
+    }
+
+    var detailLine: String {
+        guard hasUsage else { return "\(header) · No tracked usage" }
+
+        var parts = ["\(UsageFormat.tokens(totalTokens)) tokens", UsageFormat.cost(estimatedCostUSD)]
+        parts.append(contentsOf: providers.map {
+            "\($0.provider.displayName) \(UsageFormat.tokens($0.tokens))"
+        })
+        return "\(header) · \(parts.joined(separator: " · "))"
+    }
+
+    var tooltip: String {
+        guard hasUsage else { return "\(header)\nNo tracked usage" }
+
+        var lines = [header, "\(UsageFormat.tokens(totalTokens)) tokens", UsageFormat.cost(estimatedCostUSD)]
+        if !providers.isEmpty {
+            lines.append("")
+            lines.append(contentsOf: providers.map {
+                "\($0.provider.displayName): \(UsageFormat.tokens($0.tokens)) · \(UsageFormat.cost($0.costUSD))"
+            })
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private var header: String {
+        "\(DashboardDateFormat.medium(day)) at \(String(format: "%02d:00", hour))"
+    }
+}
+
+/// One day row, oldest to newest, with a stable cell for each local hour 0–23.
+struct TokenActivityHourDay: Identifiable, Equatable {
+    var id: Date { date }
+    let date: Date
+    let hours: [TokenActivityHour]
+}
+
+/// Pure 7 × 24 model derived once before SwiftUI hover/focus updates begin.
+struct TokenActivityHourlyCalendar {
+    static let dayCount = 7
+    static let hourCount = 24
+
+    let startDate: Date
+    let endDate: Date
+    let days: [TokenActivityHourDay]
+    let hours: [TokenActivityHour]
+    let scale: TokenActivityIntensityScale
+
+    private let hoursByKey: [TokenActivityHourKey: TokenActivityHour]
+    private let calendar: Calendar
+
+    init(
+        hourlyUsage: [HourlyTokenUsage],
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) {
+        let today = calendar.startOfDay(for: now)
+        let startDate = Self.day(today, offsetBy: -(Self.dayCount - 1), calendar: calendar)
+        let rows = hourlyUsage.filter { row in
+            let day = calendar.startOfDay(for: row.date)
+            return day >= startDate && day <= today
+        }
+        let rowsByKey = Dictionary(grouping: rows) { row in
+            TokenActivityHourKey(
+                day: calendar.startOfDay(for: row.date),
+                hour: calendar.component(.hour, from: row.date)
+            )
+        }
+        let coordinates = (0..<Self.dayCount).flatMap { dayOffset in
+            let day = Self.day(startDate, offsetBy: dayOffset, calendar: calendar)
+            return (0..<Self.hourCount).map { TokenActivityHourKey(day: day, hour: $0) }
+        }
+        let totals = coordinates.map { key in
+            let providers = Self.providerTotals(for: rowsByKey[key] ?? [])
+            return (
+                key: key,
+                tokens: providers.reduce(0) { $0 + $1.tokens },
+                cost: providers.reduce(0) { $0 + $1.costUSD },
+                providers: providers
+            )
+        }
+        let scale = TokenActivityIntensityScale(dailyTotals: totals.map(\.tokens))
+        let hours = totals.map { total in
+            TokenActivityHour(
+                day: total.key.day,
+                hour: total.key.hour,
+                totalTokens: total.tokens,
+                estimatedCostUSD: total.cost,
+                providers: total.providers,
+                level: scale.level(for: total.tokens)
+            )
+        }
+        let hoursByKey = Dictionary(uniqueKeysWithValues: hours.map { ($0.id, $0) })
+        let days = (0..<Self.dayCount).map { dayOffset in
+            let day = Self.day(startDate, offsetBy: dayOffset, calendar: calendar)
+            return TokenActivityHourDay(
+                date: day,
+                hours: (0..<Self.hourCount).compactMap {
+                    hoursByKey[TokenActivityHourKey(day: day, hour: $0)]
+                }
+            )
+        }
+
+        self.startDate = startDate
+        self.endDate = today
+        self.days = days
+        self.hours = hours
+        self.scale = scale
+        self.hoursByKey = hoursByKey
+        self.calendar = calendar
+    }
+
+    func hour(at date: Date) -> TokenActivityHour? {
+        hoursByKey[TokenActivityHourKey(
+            day: calendar.startOfDay(for: date),
+            hour: calendar.component(.hour, from: date)
+        )]
+    }
+
+    func hour(for key: TokenActivityHourKey) -> TokenActivityHour? { hoursByKey[key] }
+
+    var activeHours: [TokenActivityHour] { hours.filter(\.hasUsage) }
+
+    var totalTokens: Int { hours.reduce(0) { $0 + $1.totalTokens } }
+
+    var totalCostUSD: Double { hours.reduce(0) { $0 + $1.estimatedCostUSD } }
+
+    var busiestHour: TokenActivityHour? { activeHours.max { $0.totalTokens < $1.totalTokens } }
+
+    var coverageSummary: String { "7 days tracked" }
+
+    var overviewLine: String {
+        guard let busiestHour else { return "No tracked usage in this window." }
+
+        return [
+            "\(UsageFormat.tokens(totalTokens)) tokens",
+            UsageFormat.cost(totalCostUSD),
+            "Busiest \(DashboardDateFormat.medium(busiestHour.day)) at "
+                + String(format: "%02d:00", busiestHour.hour)
+                + " (\(UsageFormat.tokens(busiestHour.totalTokens)))",
+        ].joined(separator: " · ")
+    }
+
+    private static func day(_ date: Date, offsetBy days: Int, calendar: Calendar) -> Date {
+        guard let shifted = calendar.date(byAdding: .day, value: days, to: date) else { return date }
+        return calendar.startOfDay(for: shifted)
+    }
+
+    private static func providerTotals(for rows: [HourlyTokenUsage]) -> [TokenActivityProviderTotal] {
+        Dictionary(grouping: rows, by: \.provider)
+            .map { provider, rows in
+                TokenActivityProviderTotal(
+                    provider: provider,
+                    tokens: rows.reduce(0) { $0 + max(0, $1.totalTokens) },
+                    costUSD: rows.reduce(0) { $0 + max(0, $1.estimatedCostUSD) }
+                )
+            }
+            .filter { $0.tokens > 0 || $0.costUSD > 0 }
+            .sorted {
+                if $0.tokens != $1.tokens { return $0.tokens > $1.tokens }
+                if $0.costUSD != $1.costUSD { return $0.costUSD > $1.costUSD }
+                return $0.provider.displayName < $1.provider.displayName
+            }
+    }
+}
+
+/// Selects the hourly seven-day grid when the new cache field is populated,
+/// otherwise preserving the existing calendar (including the two-week legacy
+/// fallback). Both derived models are built here, never in a hover-driven body.
+struct TokenActivityGrid {
+    let daily: TokenActivityCalendar?
+    let hourly: TokenActivityHourlyCalendar?
+
+    init(
+        summary: CostSummary?,
+        windowSelection: CostWindowSelection,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) {
+        if windowSelection == .week,
+           let hourlyUsage = summary?.hourlyUsage,
+           !hourlyUsage.isEmpty {
+            daily = nil
+            hourly = TokenActivityHourlyCalendar(
+                hourlyUsage: hourlyUsage,
+                now: now,
+                calendar: calendar
+            )
+        } else {
+            daily = TokenActivityCalendar(
+                summary: summary,
+                weeks: windowSelection.fallbackActivityWeeks,
+                now: now,
+                calendar: calendar
+            )
+            hourly = nil
+        }
+    }
+
+    var hasHistory: Bool { hourly != nil || daily?.hasHistory == true }
+
+    var coverageSummary: String? { hourly?.coverageSummary ?? daily?.coverageSummary }
+}

--- a/MeterBar/Models/TokenCost.swift
+++ b/MeterBar/Models/TokenCost.swift
@@ -206,6 +206,42 @@ nonisolated public struct DailyTokenUsage: Codable, Identifiable, Sendable {
     }()
 }
 
+/// One provider's token usage inside a local calendar-hour bucket.
+///
+/// Hourly rows intentionally stop at the same aggregate shape as daily rows:
+/// the seven-day activity heatmap needs provider totals, not model or project
+/// attribution. `date` is always the start of the represented local hour.
+nonisolated public struct HourlyTokenUsage: Codable, Identifiable, Sendable {
+    public var id: String { "\(provider.rawValue)-\(date.timeIntervalSinceReferenceDate)" }
+
+    public let date: Date
+    public let provider: ServiceType
+    public let inputTokens: Int
+    public let outputTokens: Int
+    public let cacheReadTokens: Int
+    public let estimatedCostUSD: Double
+
+    public init(
+        date: Date,
+        provider: ServiceType,
+        inputTokens: Int,
+        outputTokens: Int,
+        cacheReadTokens: Int,
+        estimatedCostUSD: Double
+    ) {
+        self.date = date
+        self.provider = provider
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.cacheReadTokens = cacheReadTokens
+        self.estimatedCostUSD = estimatedCostUSD
+    }
+
+    public var totalTokens: Int {
+        inputTokens + outputTokens + cacheReadTokens
+    }
+}
+
 nonisolated public struct LifetimeProviderCost: Codable, Identifiable, Equatable, Sendable {
     public var id: String { provider.rawValue }
 
@@ -283,6 +319,9 @@ nonisolated public struct CostSummary: Codable, Sendable {
     public let totalTokens: Int
     public let periodDays: Int
     public let dailyUsage: [DailyTokenUsage]
+    /// Provider rows for the trailing seven calendar days, bucketed at each
+    /// local hour start. Optional so caches written before issue #372 decode.
+    public let hourlyUsage: [HourlyTokenUsage]?
     public let lifetime: LifetimeCostSummary?
     /// Which dated rate entries actually priced this scan, and how many events
     /// predated the table (issue #339). Optional so summaries cached by builds
@@ -296,6 +335,7 @@ nonisolated public struct CostSummary: Codable, Sendable {
         totalTokens: Int,
         periodDays: Int,
         dailyUsage: [DailyTokenUsage] = [],
+        hourlyUsage: [HourlyTokenUsage]? = nil,
         lifetime: LifetimeCostSummary? = nil,
         pricing: PricingProvenance? = nil
     ) {
@@ -304,6 +344,7 @@ nonisolated public struct CostSummary: Codable, Sendable {
         self.totalTokens = totalTokens
         self.periodDays = periodDays
         self.dailyUsage = dailyUsage
+        self.hourlyUsage = hourlyUsage
         self.lifetime = lifetime
         self.pricing = pricing
     }
@@ -354,6 +395,26 @@ nonisolated public struct CostSummary: Codable, Sendable {
         })
 
         return populatedDays.count < daysToCheck
+    }
+
+    /// Whether a cache that should cover the seven-day activity window still
+    /// predates hourly rows. A completed scan today is authoritative even when
+    /// it found no hourly usage, preventing an empty week from rescanning on
+    /// every Costs-page appearance.
+    func needsMissingHourlyUsageRefresh(
+        lastScanDate: Date?,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> Bool {
+        guard !costs.isEmpty, totalTokens > 0, periodDays >= 7 else { return false }
+
+        let today = calendar.startOfDay(for: now)
+        if let lastScanDate,
+           calendar.startOfDay(for: lastScanDate) >= today {
+            return false
+        }
+
+        return hourlyUsage?.isEmpty != false
     }
 
     /// Aggregates the cached daily rows into per-provider totals over the last
@@ -445,6 +506,7 @@ nonisolated public struct CostSummary: Codable, Sendable {
     public func filtered(to enabledServices: Set<ServiceType>) -> CostSummary {
         let visibleCosts = costs.filter { enabledServices.contains($0.provider) }
         let visibleDailyUsage = dailyUsage.filter { enabledServices.contains($0.provider) }
+        let visibleHourlyUsage = hourlyUsage?.filter { enabledServices.contains($0.provider) }
 
         return CostSummary(
             costs: visibleCosts,
@@ -452,6 +514,7 @@ nonisolated public struct CostSummary: Codable, Sendable {
             totalTokens: visibleCosts.reduce(0) { $0 + $1.totalTokens },
             periodDays: periodDays,
             dailyUsage: visibleDailyUsage,
+            hourlyUsage: visibleHourlyUsage,
             lifetime: lifetime?.filtered(to: enabledServices)
         )
     }

--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -11,7 +11,7 @@ enum ClaudeCostScanner {
     nonisolated static func makeCost(
         from totals: ClaudeSessionTotals,
         windowStart: Date
-    ) -> (TokenCost, [DailyTokenUsage])? {
+    ) -> (TokenCost, [DailyTokenUsage], [HourlyTokenUsage])? {
         guard totals.hasUsage else { return nil }
 
         let pricing = ModelPricing.claude(for: nil)
@@ -58,6 +58,10 @@ enum ClaudeCostScanner {
             modelsByDay: totals.dailyModels,
             projectsByDay: totals.dailyProjects,
             projectModelsByDay: totals.dailyProjectModels
+        ), TokenUsageAggregator.makeHourlyUsage(
+            from: totals.hourly,
+            provider: .claudeCode,
+            pricing: pricing
         ))
     }
 
@@ -143,6 +147,7 @@ enum ClaudeCostScanner {
     nonisolated static func parseSessionWindows(
         at url: URL,
         since cutoffDate: Date,
+        hourlyCutoff: Date = .distantPast,
         projectID: String = CostProjectAttribution.unknownProjectID
     ) -> ScanWindows<ClaudeSessionTotals> {
         var periodKeyed: [String: ClaudeUsageEvent] = [:]
@@ -169,9 +174,20 @@ enum ClaudeCostScanner {
         truncation.log(url: url)
 
         return ScanWindows(
-            period: Self.tally(keyed: periodKeyed, unkeyed: periodUnkeyed, projectID: projectID),
-            lifetime: Self.tally(keyed: lifetimeKeyed, unkeyed: lifetimeUnkeyed, projectID: projectID),
-            cutoff: cutoffDate
+            period: Self.tally(
+                keyed: periodKeyed,
+                unkeyed: periodUnkeyed,
+                projectID: projectID,
+                hourlyCutoff: hourlyCutoff
+            ),
+            lifetime: Self.tally(
+                keyed: lifetimeKeyed,
+                unkeyed: lifetimeUnkeyed,
+                projectID: projectID,
+                hourlyCutoff: hourlyCutoff
+            ),
+            cutoff: cutoffDate,
+            hourlyCutoff: hourlyCutoff
         )
     }
 
@@ -331,13 +347,19 @@ enum ClaudeCostScanner {
         // Nothing appended since the last pass. This is the steady state once
         // the corpus is warm, and it is why a refresh costs almost no I/O.
         if let record, record.isComplete, record.stamp.matches(file.stamp) {
-            return Self.windows(record.payload, cutoff: session.cutoff)
+            return Self.windows(
+                record.payload,
+                cutoff: session.cutoff,
+                hourlyCutoff: session.hourlyCutoff
+            )
         }
 
         let allowance = session.budget.allowance
         guard allowance > 0 else {
             session.noteDeferred(.claude)
-            return record.map { Self.windows($0.payload, cutoff: session.cutoff) }
+            return record.map {
+                Self.windows($0.payload, cutoff: session.cutoff, hourlyCutoff: session.hourlyCutoff)
+            }
         }
 
         var payload = record?.payload ?? ClaudeFileTotals()
@@ -383,8 +405,18 @@ enum ClaudeCostScanner {
         }
         session.budget.consume(read.bytesRead)
 
-        payload.period.merge(Self.tally(keyed: periodKeyed, unkeyed: periodUnkeyed, projectID: projectID))
-        payload.lifetime.merge(Self.tally(keyed: lifetimeKeyed, unkeyed: lifetimeUnkeyed, projectID: projectID))
+        payload.period.merge(Self.tally(
+            keyed: periodKeyed,
+            unkeyed: periodUnkeyed,
+            projectID: projectID,
+            hourlyCutoff: session.hourlyCutoff
+        ))
+        payload.lifetime.merge(Self.tally(
+            keyed: lifetimeKeyed,
+            unkeyed: lifetimeUnkeyed,
+            projectID: projectID,
+            hourlyCutoff: session.hourlyCutoff
+        ))
         // `merge` sums `sessions`, but one transcript is one session however
         // many slices it took to read.
         payload.period.sessions = payload.period.hasUsage ? 1 : 0
@@ -407,12 +439,13 @@ enum ClaudeCostScanner {
                 offset: read.committedOffset,
                 stamp: file.stamp,
                 cutoff: session.cutoff,
+                hourlyCutoff: session.hourlyCutoff,
                 isComplete: read.reachedEndOfFile,
                 payload: payload
             ),
             for: file.cacheKey
         )
-        return Self.windows(payload, cutoff: session.cutoff)
+        return Self.windows(payload, cutoff: session.cutoff, hourlyCutoff: session.hourlyCutoff)
     }
 
     /// The cached entry to resume from, rebased onto this refresh's cutoff.
@@ -429,6 +462,12 @@ enum ClaudeCostScanner {
         } else {
             guard record.stamp.isSameFile(as: file.stamp),
                   file.size >= record.stamp.size else { return nil }
+        }
+        guard record.hourlyCutoff <= session.hourlyCutoff else { return nil }
+        if record.hourlyCutoff < session.hourlyCutoff {
+            record.payload.period.hourly = record.payload.period.hourly.filter { $0.key >= session.hourlyCutoff }
+            record.payload.lifetime.hourly = record.payload.lifetime.hourly.filter { $0.key >= session.hourlyCutoff }
+            record.hourlyCutoff = session.hourlyCutoff
         }
         guard record.cutoff != session.cutoff else { return record }
 
@@ -455,15 +494,22 @@ enum ClaudeCostScanner {
 
     nonisolated private static func windows(
         _ payload: ClaudeFileTotals,
-        cutoff: Date
+        cutoff: Date,
+        hourlyCutoff: Date = .distantPast
     ) -> ScanWindows<ClaudeSessionTotals> {
-        ScanWindows(period: payload.period, lifetime: payload.lifetime, cutoff: cutoff)
+        ScanWindows(
+            period: payload.period,
+            lifetime: payload.lifetime,
+            cutoff: cutoff,
+            hourlyCutoff: hourlyCutoff
+        )
     }
 
     nonisolated private static func tally(
         keyed: [String: ClaudeUsageEvent],
         unkeyed: [ClaudeUsageEvent],
-        projectID: String
+        projectID: String,
+        hourlyCutoff: Date = .distantPast
     ) -> ClaudeSessionTotals {
         var totals = ClaudeSessionTotals()
         let events = keyed.keys.sorted().compactMap { keyed[$0] } + unkeyed
@@ -502,6 +548,9 @@ enum ClaudeCostScanner {
                 ),
                 at: CostScanEventKeys(
                     day: calendar.startOfDay(for: event.timestamp),
+                    hour: event.timestamp >= hourlyCutoff
+                        ? CostScanHourBucket.start(for: event.timestamp, calendar: calendar)
+                        : nil,
                     model: CostScanValues.displayModelName(event.model),
                     origin: event.origin,
                     project: projectID

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -30,11 +30,15 @@ enum CodexCostScanner {
     /// `earliestDate` starts at now and only decreases, `latestDate` starts at the
     /// window floor (the cutoff for the period, `.distantPast` for lifetime) and
     /// only increases.
-    nonisolated static func scanWindows(cutoff: Date) -> ScanWindows<CostScanWindowContext> {
+    nonisolated static func scanWindows(
+        cutoff: Date,
+        hourlyCutoff: Date = .distantPast
+    ) -> ScanWindows<CostScanWindowContext> {
         ScanWindows(
             period: CostScanWindowContext(earliestDate: Date(), latestDate: cutoff),
             lifetime: CostScanWindowContext(earliestDate: Date(), latestDate: .distantPast),
-            cutoff: cutoff
+            cutoff: cutoff,
+            hourlyCutoff: hourlyCutoff
         )
     }
 
@@ -56,7 +60,7 @@ enum CodexCostScanner {
     nonisolated static func makeCost(
         from context: CostScanWindowContext,
         pricingAt: @escaping (String?, Date) -> TokenPricing = ModelPricing.codex(for:at:)
-    ) -> (TokenCost, [DailyTokenUsage])? {
+    ) -> (TokenCost, [DailyTokenUsage], [HourlyTokenUsage])? {
         let totals = context.totals
         guard totals.input > 0 || totals.output > 0 || totals.cacheRead > 0 else { return nil }
 
@@ -115,6 +119,11 @@ enum CodexCostScanner {
             projectsByDay: context.dailyProjectTotals,
             projectModelsByDay: context.dailyProjectModelTotals,
             pricingAt: pricingAt
+        ), TokenUsageAggregator.makeHourlyUsage(
+            from: context.hourlyTotals,
+            provider: .codexCli,
+            pricing: pricing,
+            pricingAt: { pricingAt(nil, $0) }
         ))
     }
 
@@ -302,7 +311,7 @@ enum CodexCostScanner {
         directories: [URL],
         session: CostScanSession
     ) -> ScanWindows<CostScanWindowContext> {
-        var windows = Self.scanWindows(cutoff: session.cutoff)
+        var windows = Self.scanWindows(cutoff: session.cutoff, hourlyCutoff: session.hourlyCutoff)
         let files = Self.distinctRollouts(in: directories)
         var live: Set<String> = []
 
@@ -360,7 +369,8 @@ enum CodexCostScanner {
         var windows = ScanWindows(
             period: payload.period,
             lifetime: payload.lifetime,
-            cutoff: session.cutoff
+            cutoff: session.cutoff,
+            hourlyCutoff: session.hourlyCutoff
         )
         var rollout = payload.rollout
         var deferred: [CodexDeferredUsage] = []
@@ -434,6 +444,7 @@ enum CodexCostScanner {
                 offset: committed,
                 stamp: file.stamp,
                 cutoff: session.cutoff,
+                hourlyCutoff: session.hourlyCutoff,
                 isComplete: read.reachedEndOfFile,
                 payload: payload
             ),
@@ -547,6 +558,16 @@ enum CodexCostScanner {
         } else {
             guard record.stamp.isSameFile(as: file.stamp),
                   file.size >= record.stamp.size else { return nil }
+        }
+        guard record.hourlyCutoff <= session.hourlyCutoff else { return nil }
+        if record.hourlyCutoff < session.hourlyCutoff {
+            record.payload.period.hourlyTotals = record.payload.period.hourlyTotals.filter {
+                $0.key >= session.hourlyCutoff
+            }
+            record.payload.lifetime.hourlyTotals = record.payload.lifetime.hourlyTotals.filter {
+                $0.key >= session.hourlyCutoff
+            }
+            record.hourlyCutoff = session.hourlyCutoff
         }
         guard record.cutoff != session.cutoff else { return record }
 
@@ -848,6 +869,9 @@ enum CodexCostScanner {
         let key = "\(timestampMillis)-\(sessionID)-\(input)-\(cached)-\(output)-\(reasoning)"
         let keys = CostScanEventKeys(
             day: calendar.startOfDay(for: timestamp),
+            hour: timestamp >= windows.hourlyCutoff
+                ? CostScanHourBucket.start(for: timestamp, calendar: calendar)
+                : nil,
             model: CostScanValues.displayModelName(event.attribution.modelName),
             origin: CostScanValues.displayOriginName(event.attribution.originName),
             project: event.attribution.projectID

--- a/MeterBar/Services/CostScanFileCache.swift
+++ b/MeterBar/Services/CostScanFileCache.swift
@@ -20,6 +20,9 @@ nonisolated struct CostScanFileRecord<Payload: Codable & Sendable>: Codable, Sen
     /// the wrong period today and has to be rebased (or re-read) before use.
     var cutoff: Date
 
+    /// Seven-day hourly boundary used to build `payload`'s hourly buckets.
+    var hourlyCutoff: Date = .distantPast
+
     /// Whether the last pass read this file all the way to end of file.
     var isComplete: Bool
 
@@ -28,8 +31,11 @@ nonisolated struct CostScanFileRecord<Payload: Codable & Sendable>: Codable, Sen
 
 /// Every transcript's record, keyed by standardized path.
 nonisolated struct CostScanFileCache<Payload: Codable & Sendable>: Codable, Sendable {
-    /// Version 3 adds producer/time-zone identity and full per-file stamps.
-    static var currentSchemaVersion: Int { 3 }
+    /// Version 4 adds trailing-seven-day hourly accumulators. This private
+    /// disposable cache intentionally invalidates v3 so the upgrade's first
+    /// background refresh re-reads source events instead of trusting offsets
+    /// whose payload has no hourly totals.
+    static var currentSchemaVersion: Int { 4 }
 
     var schemaVersion = CostScanFileCache.currentSchemaVersion
     var parserVersion = CostScanValues.costCacheParserVersion

--- a/MeterBar/Services/CostScanSession.swift
+++ b/MeterBar/Services/CostScanSession.swift
@@ -14,6 +14,8 @@ nonisolated final class CostScanSession: @unchecked Sendable {
     /// for the cutoff they were tallied against, so this is part of every
     /// cache-hit decision.
     let cutoff: Date
+    /// Start of the seven-calendar-day hour buckets retained by this refresh.
+    let hourlyCutoff: Date
 
     let budget: CostScanBudget
 
@@ -26,11 +28,13 @@ nonisolated final class CostScanSession: @unchecked Sendable {
 
     init(
         cutoff: Date,
+        hourlyCutoff: Date = .distantPast,
         options: CostScanBudgetOptions,
         store: CostScanCacheStore? = nil,
         token: CostScanCancellationToken = .never
     ) {
         self.cutoff = cutoff
+        self.hourlyCutoff = hourlyCutoff
         self.budget = CostScanBudget(options: options, token: token)
         self.store = store
         self.claudeCache = store?.loadClaude() ?? CostScanFileCache<ClaudeFileTotals>()

--- a/MeterBar/Services/CostScanWindows.swift
+++ b/MeterBar/Services/CostScanWindows.swift
@@ -14,6 +14,21 @@ nonisolated struct ScanWindows<Totals> {
     var lifetime: Totals
     /// Events at or after this instant belong to the period window as well.
     let cutoff: Date
+    /// Start of the seven-calendar-day hourly window. Separate from `cutoff`
+    /// because the main cost scan normally retains 30 daily buckets.
+    let hourlyCutoff: Date
+
+    init(
+        period: Totals,
+        lifetime: Totals,
+        cutoff: Date,
+        hourlyCutoff: Date = .distantPast
+    ) {
+        self.period = period
+        self.lifetime = lifetime
+        self.cutoff = cutoff
+        self.hourlyCutoff = hourlyCutoff
+    }
 
     /// Applies `body` to `lifetime` always, and to `period` when the event falls
     /// inside the window.
@@ -35,13 +50,14 @@ nonisolated struct ScanWindows<Totals> {
 // to be `Sendable` just to name `ScanWindows<CostScanResult>`.
 extension ScanWindows: Sendable where Totals: Sendable {}
 
-/// The eight breakdowns every scan folds a usage event into.
+/// The nine breakdowns every scan folds a usage event into.
 ///
-/// Claude and Codex accumulate into different types but the same eight
+/// Claude and Codex accumulate into different types but the same nine
 /// dimensions, so the fold itself lives once in `record(_:at:)` rather than
 /// twice as near-identical stanzas in each scanner.
 nonisolated protocol CostScanBreakdowns {
     var daily: [Date: TokenAccumulator] { get set }
+    var hourly: [Date: TokenAccumulator] { get set }
     var dailyModels: [Date: [String: TokenAccumulator]] { get set }
     var dailyProjects: [Date: [String: TokenAccumulator]] { get set }
     var dailyProjectModels: [Date: [String: [String: TokenAccumulator]]] { get set }
@@ -54,6 +70,8 @@ nonisolated protocol CostScanBreakdowns {
 /// Which bucket of each breakdown one event lands in.
 nonisolated struct CostScanEventKeys {
     let day: Date
+    /// `nil` when the event predates the retained seven-day hourly window.
+    let hour: Date?
     let model: String
     let origin: String
     let project: String
@@ -73,6 +91,9 @@ nonisolated struct CostScanEventTotals {
 nonisolated extension CostScanBreakdowns {
     mutating func record(_ event: CostScanEventTotals, at keys: CostScanEventKeys) {
         daily[keys.day, default: TokenAccumulator()].add(event)
+        if let hour = keys.hour {
+            hourly[hour, default: TokenAccumulator()].add(event)
+        }
         dailyModels[keys.day, default: [:]][keys.model, default: TokenAccumulator()].add(event)
         dailyProjects[keys.day, default: [:]][keys.project, default: TokenAccumulator()].add(event)
         dailyProjectModels[keys.day, default: [:]][keys.project, default: [:]][
@@ -103,6 +124,7 @@ nonisolated struct ClaudeSessionTotals: Sendable, Codable, CostScanBreakdowns {
     var earliest: Date?
     var latest: Date?
     var daily: [Date: TokenAccumulator] = [:]
+    var hourly: [Date: TokenAccumulator] = [:]
     var dailyModels: [Date: [String: TokenAccumulator]] = [:]
     var dailyProjects: [Date: [String: TokenAccumulator]] = [:]
     var dailyProjectModels: [Date: [String: [String: TokenAccumulator]]] = [:]
@@ -138,6 +160,9 @@ nonisolated struct ClaudeSessionTotals: Sendable, Codable, CostScanBreakdowns {
 
         for (day, tokens) in other.daily {
             daily[day, default: TokenAccumulator()].merge(tokens)
+        }
+        for (hour, tokens) in other.hourly {
+            hourly[hour, default: TokenAccumulator()].merge(tokens)
         }
         for (day, modelTotals) in other.dailyModels {
             for (model, tokens) in modelTotals {
@@ -201,13 +226,15 @@ nonisolated struct ClaudeSessionTotals: Sendable, Codable, CostScanBreakdowns {
 nonisolated struct CostScanResult {
     var costs: [TokenCost] = []
     var dailyUsage: [DailyTokenUsage] = []
+    var hourlyUsage: [HourlyTokenUsage] = []
     /// Union of the rate entries every provider in this window priced with.
     var pricing = PricingProvenance()
 
-    mutating func append(_ scan: (TokenCost, [DailyTokenUsage])?) {
+    mutating func append(_ scan: (TokenCost, [DailyTokenUsage], [HourlyTokenUsage])?) {
         guard let scan else { return }
         costs.append(scan.0)
         dailyUsage.append(contentsOf: scan.1)
+        hourlyUsage.append(contentsOf: scan.2)
     }
 
     mutating func record(_ provenance: PricingProvenance) {
@@ -221,7 +248,7 @@ nonisolated struct CostScanResult {
 /// a single `inout` argument.
 ///
 /// Shared by the Codex and Grok scanners rather than duplicated: both fold the
-/// same eight breakdown dimensions plus dedup keys, and a second copy would mean
+/// same nine breakdown dimensions plus dedup keys, and a second copy would mean
 /// a second `merge` and a second set of `_modify` forwarders to keep in step.
 /// Renaming the *type* is safe for the on-disk cache — `Codable` keys come from
 /// the stored property names below, not from the type's name.
@@ -230,6 +257,7 @@ nonisolated struct CostScanResult {
 nonisolated struct CostScanWindowContext: Sendable, Codable {
     var totals = TokenAccumulator()
     var dailyTotals: [Date: TokenAccumulator] = [:]
+    var hourlyTotals: [Date: TokenAccumulator] = [:]
     var dailyModelTotals: [Date: [String: TokenAccumulator]] = [:]
     var dailyProjectTotals: [Date: [String: TokenAccumulator]] = [:]
     var dailyProjectModelTotals: [Date: [String: [String: TokenAccumulator]]] = [:]
@@ -258,6 +286,9 @@ nonisolated struct CostScanWindowContext: Sendable, Codable {
         totals.merge(other.totals)
         for (day, tokens) in other.dailyTotals {
             dailyTotals[day, default: TokenAccumulator()].merge(tokens)
+        }
+        for (hour, tokens) in other.hourlyTotals {
+            hourlyTotals[hour, default: TokenAccumulator()].merge(tokens)
         }
         for (day, modelTotals) in other.dailyModelTotals {
             for (model, tokens) in modelTotals {
@@ -314,6 +345,11 @@ nonisolated extension CostScanWindowContext: CostScanBreakdowns {
         _modify { yield &dailyTotals }
     }
 
+    var hourly: [Date: TokenAccumulator] {
+        get { hourlyTotals }
+        _modify { yield &hourlyTotals }
+    }
+
     var dailyModels: [Date: [String: TokenAccumulator]] {
         get { dailyModelTotals }
         _modify { yield &dailyModelTotals }
@@ -347,6 +383,15 @@ nonisolated extension CostScanWindowContext: CostScanBreakdowns {
     var projectModels: [String: [String: TokenAccumulator]] {
         get { projectModelTotals }
         _modify { yield &projectModelTotals }
+    }
+}
+
+/// Calendar-safe hour normalization shared by all three scanners and the
+/// seven-day grid. `dateInterval` preserves distinct repeated hours at a DST
+/// fallback while still returning the local hour boundary.
+nonisolated enum CostScanHourBucket {
+    static func start(for date: Date, calendar: Calendar) -> Date {
+        calendar.dateInterval(of: .hour, for: date)?.start ?? date
     }
 }
 

--- a/MeterBar/Services/CostSummaryBuilder.swift
+++ b/MeterBar/Services/CostSummaryBuilder.swift
@@ -130,6 +130,10 @@ enum CostSummaryBuilder {
                 totalTokens: costs.reduce(0) { $0 + $1.totalTokens },
                 periodDays: days,
                 dailyUsage: scan.period.dailyUsage.sorted { $0.date < $1.date },
+                hourlyUsage: scan.period.hourlyUsage.sorted { lhs, rhs in
+                    if lhs.date != rhs.date { return lhs.date < rhs.date }
+                    return lhs.provider.rawValue < rhs.provider.rawValue
+                },
                 lifetime: LifetimeCostSummary(costs: scan.lifetime.costs),
                 pricing: scan.period.pricing.isEmpty ? nil : scan.period.pricing
             ),

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -108,11 +108,15 @@ class CostTracker: ObservableObject {
     func refreshMissingDaysInBackground(days: Int = 30) async {
         guard !demoMode else { return }
         let shouldStart = await MainActor.run {
+            let hasEnabledCostScanProvider = Self.hasEnabledCostScanProvider(
+                in: providerVisibilityStore.enabledServices
+            )
             guard !isRefreshInProgress,
                   let visibleSummary = costSummary?.filtered(to: providerVisibilityStore.enabledServices),
                   visibleSummary.lifetime == nil
                     || visibleSummary.needsMissingDailyUsageRefresh(days: days, lastScanDate: lastScanDate)
-                    || visibleSummary.needsMissingHourlyUsageRefresh(lastScanDate: lastScanDate) else {
+                    || (hasEnabledCostScanProvider
+                        && visibleSummary.needsMissingHourlyUsageRefresh(lastScanDate: lastScanDate)) else {
                 return false
             }
             isRefreshingMissingDays = true
@@ -126,6 +130,13 @@ class CostTracker: ObservableObject {
             apply(scan)
             isRefreshingMissingDays = false
         }
+    }
+
+    /// Hourly rows come from local log scanners, not from providers whose
+    /// history is accumulated only by polling. Without this gate a
+    /// Cursor/OpenRouter-only setup would run a fruitless full scan each day.
+    static func hasEnabledCostScanProvider(in enabledServices: Set<ServiceType>) -> Bool {
+        CostScanProvider.allCases.contains { enabledServices.contains($0.service) }
     }
 
     /// Publishes one refresh's result, and records it as authoritative only when

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -102,16 +102,17 @@ class CostTracker: ObservableObject {
         }
     }
 
-    /// Quietly backfills a legacy cache's missing lifetime snapshot or missing
-    /// daily rows when Overview/Costs opens, without the visible "Scanning" UI
-    /// a manual scan shows.
+    /// Quietly backfills a legacy cache's missing lifetime snapshot, daily
+    /// rows, or hourly rows when Overview/Costs opens, without the visible
+    /// "Scanning" UI a manual scan shows.
     func refreshMissingDaysInBackground(days: Int = 30) async {
         guard !demoMode else { return }
         let shouldStart = await MainActor.run {
             guard !isRefreshInProgress,
                   let visibleSummary = costSummary?.filtered(to: providerVisibilityStore.enabledServices),
                   visibleSummary.lifetime == nil
-                    || visibleSummary.needsMissingDailyUsageRefresh(days: days, lastScanDate: lastScanDate) else {
+                    || visibleSummary.needsMissingDailyUsageRefresh(days: days, lastScanDate: lastScanDate)
+                    || visibleSummary.needsMissingHourlyUsageRefresh(lastScanDate: lastScanDate) else {
                 return false
             }
             isRefreshingMissingDays = true
@@ -185,7 +186,9 @@ class CostTracker: ObservableObject {
         // spend was written to, and disabling an account hides its quota gauge
         // without unspending what it already cost.
         let grokAccounts = GrokAccountStore.shared.accounts
-        let cutoff = CostWindow.start(days: days)
+        let scanTime = Date()
+        let cutoff = CostWindow.start(days: days, now: scanTime)
+        let hourlyCutoff = CostWindow.start(days: 7, now: scanTime)
         let store = CostScanCacheStore.applicationSupport
         // Read once, outside the slice loop: polling providers contribute no
         // bytes, so their rows are identical in every slice and re-reading the
@@ -199,6 +202,7 @@ class CostTracker: ObservableObject {
             let slice = try? await CostScanExecutor.run { token in
                 let session = CostScanSession(
                     cutoff: cutoff,
+                    hourlyCutoff: hourlyCutoff,
                     options: .default,
                     store: store,
                     token: token

--- a/MeterBar/Services/GrokCostScanner.swift
+++ b/MeterBar/Services/GrokCostScanner.swift
@@ -69,11 +69,15 @@ enum GrokCostScanner {
 
     /// Seeds both windows: `earliestDate` starts at now and only decreases,
     /// `latestDate` starts at the window floor and only increases.
-    nonisolated static func scanWindows(cutoff: Date) -> ScanWindows<CostScanWindowContext> {
+    nonisolated static func scanWindows(
+        cutoff: Date,
+        hourlyCutoff: Date = .distantPast
+    ) -> ScanWindows<CostScanWindowContext> {
         ScanWindows(
             period: CostScanWindowContext(earliestDate: Date(), latestDate: cutoff),
             lifetime: CostScanWindowContext(earliestDate: Date(), latestDate: .distantPast),
-            cutoff: cutoff
+            cutoff: cutoff,
+            hourlyCutoff: hourlyCutoff
         )
     }
 
@@ -114,7 +118,7 @@ enum GrokCostScanner {
         _ roots: [URL],
         session: CostScanSession
     ) -> ScanWindows<CostScanWindowContext> {
-        var windows = Self.scanWindows(cutoff: session.cutoff)
+        var windows = Self.scanWindows(cutoff: session.cutoff, hourlyCutoff: session.hourlyCutoff)
         var live: Set<String> = []
 
         for root in roots {
@@ -143,7 +147,7 @@ enum GrokCostScanner {
     /// itself billed at $0 — which is the right answer for them.
     nonisolated static func makeCost(
         from context: CostScanWindowContext
-    ) -> (TokenCost, [DailyTokenUsage])? {
+    ) -> (TokenCost, [DailyTokenUsage], [HourlyTokenUsage])? {
         let totals = context.totals
         guard totals.input > 0 || totals.output > 0 || totals.cacheRead > 0 else { return nil }
 
@@ -182,6 +186,10 @@ enum GrokCostScanner {
             modelsByDay: context.dailyModelTotals,
             projectsByDay: context.dailyProjectTotals,
             projectModelsByDay: context.dailyProjectModelTotals
+        ), TokenUsageAggregator.makeHourlyUsage(
+            from: context.hourlyTotals,
+            provider: .grok,
+            pricing: pricing
         ))
     }
 
@@ -214,7 +222,8 @@ enum GrokCostScanner {
         var windows = ScanWindows(
             period: payload.period,
             lifetime: payload.lifetime,
-            cutoff: session.cutoff
+            cutoff: session.cutoff,
+            hourlyCutoff: session.hourlyCutoff
         )
         let attribution = Self.attribution(for: file.url)
         let calendar = Calendar.current
@@ -250,6 +259,7 @@ enum GrokCostScanner {
                 offset: read.committedOffset,
                 stamp: file.stamp,
                 cutoff: session.cutoff,
+                hourlyCutoff: session.hourlyCutoff,
                 isComplete: read.reachedEndOfFile,
                 payload: payload
             ),
@@ -272,6 +282,16 @@ enum GrokCostScanner {
         } else {
             guard record.stamp.isSameFile(as: file.stamp),
                   file.size >= record.stamp.size else { return nil }
+        }
+        guard record.hourlyCutoff <= session.hourlyCutoff else { return nil }
+        if record.hourlyCutoff < session.hourlyCutoff {
+            record.payload.period.hourlyTotals = record.payload.period.hourlyTotals.filter {
+                $0.key >= session.hourlyCutoff
+            }
+            record.payload.lifetime.hourlyTotals = record.payload.lifetime.hourlyTotals.filter {
+                $0.key >= session.hourlyCutoff
+            }
+            record.hourlyCutoff = session.hourlyCutoff
         }
         guard record.cutoff != session.cutoff else { return record }
 
@@ -431,6 +451,9 @@ enum GrokCostScanner {
             """
         let keys = CostScanEventKeys(
             day: calendar.startOfDay(for: timestamp),
+            hour: timestamp >= windows.hourlyCutoff
+                ? CostScanHourBucket.start(for: timestamp, calendar: calendar)
+                : nil,
             model: CostScanValues.displayModelName(event.model),
             origin: CostScanValues.displayOriginName(Self.originName),
             project: event.projectID

--- a/MeterBar/Services/ProviderUsageCostBuilder.swift
+++ b/MeterBar/Services/ProviderUsageCostBuilder.swift
@@ -1,9 +1,10 @@
 import Foundation
 import MeterBarShared
 
-/// Turns the accumulated ledger into the same `(TokenCost, [DailyTokenUsage])`
-/// pair the log scanners produce, so a provider with no local corpus lands in
-/// `costs[]`/`dailyUsage[]` through exactly the same fold.
+/// Turns the accumulated ledger into the same cost/daily/hourly tuple the log
+/// scanners produce, so a provider with no local corpus lands in
+/// `costs[]`/`dailyUsage[]` through exactly the same fold. Poll-only providers
+/// have no event timestamps, so their hourly slice is intentionally empty.
 ///
 /// The counterpart to `ClaudeCostScanner.makeCost` and friends, and deliberately
 /// the *only* path from the ledger into money: it emits nothing for an entry
@@ -28,7 +29,7 @@ nonisolated enum ProviderUsageCostBuilder {
         windowStart: Date,
         now: Date = Date(),
         calendar: Calendar = .current
-    ) -> (TokenCost, [DailyTokenUsage])? {
+    ) -> (TokenCost, [DailyTokenUsage], [HourlyTokenUsage])? {
         let cutoff = calendar.startOfDay(for: windowStart)
         let today = calendar.startOfDay(for: now)
         // Days are only ever written by an observation, so a future-dated one
@@ -66,6 +67,6 @@ nonisolated enum ProviderUsageCostBuilder {
             )
         }
 
-        return (cost, daily)
+        return (cost, daily, [])
     }
 }

--- a/MeterBar/Services/TokenUsageAggregator.swift
+++ b/MeterBar/Services/TokenUsageAggregator.swift
@@ -5,6 +5,36 @@ import MeterBarShared
 /// daily-usage rows and breakdown rows the UI renders.
 /// Split out of `CostTracker` (audit C1d).
 enum TokenUsageAggregator {
+    nonisolated static func makeHourlyUsage(
+        from hourlyTotals: [Date: TokenAccumulator],
+        provider: ServiceType,
+        pricing: TokenPricing,
+        pricingAt: ((Date) -> TokenPricing)? = nil
+    ) -> [HourlyTokenUsage] {
+        hourlyTotals.map { hour, tokens in
+            let rowPricing = pricingAt?(hour) ?? pricing
+            let billableInput = provider == .codexCli ? max(0, tokens.input - tokens.cacheRead) : tokens.input
+            let output = tokens.output + tokens.reasoning
+            let cost = tokens.estimatedCostUSD > 0
+                ? tokens.estimatedCostUSD
+                : TokenCostMath.calculateCost(
+                    input: billableInput,
+                    output: output,
+                    cacheCreation: tokens.cacheCreation,
+                    cacheRead: tokens.cacheRead,
+                    pricing: rowPricing
+                )
+            return HourlyTokenUsage(
+                date: hour,
+                provider: provider,
+                inputTokens: billableInput,
+                outputTokens: output,
+                cacheReadTokens: tokens.cacheRead,
+                estimatedCostUSD: cost
+            )
+        }
+    }
+
     /// `pricingAt` resolves one row's rate from its model name (`nil` for the
     /// day's own flat total) and the day it was recorded, so a dated schedule
     /// prices history at the rate that was in effect then instead of today's

--- a/MeterBar/Views/DashboardCostsSection.swift
+++ b/MeterBar/Views/DashboardCostsSection.swift
@@ -72,7 +72,7 @@ struct DashboardCostsSection: View {
 
             TokenActivityCard(
                 summary: summary,
-                weeks: windowSelection.activityWeeks,
+                windowSelection: windowSelection,
                 isScanning: costTracker.isScanning,
                 isScanDisabled: costTracker.isRefreshInProgress,
                 scan: { Task { await costTracker.scanCosts(days: 30) } }

--- a/MeterBar/Views/TokenActivityHeatmap.swift
+++ b/MeterBar/Views/TokenActivityHeatmap.swift
@@ -2,34 +2,36 @@ import AppKit
 import MeterBarShared
 import SwiftUI
 
-/// Dashboard card wrapping the trailing month's contribution calendar.
+/// Dashboard card wrapping the selected token-activity grid.
 ///
 /// Takes plain values rather than reaching for `CostTracker.shared` (same shape
 /// as ``CostOverviewStatusCard``) so the card hosts in a test without standing
-/// up the scanner. The calendar is derived once in `init` — `body` runs on every
-/// hover tick, and re-bucketing the daily rows there would be wasteful.
+/// up the scanner. The grid is derived once in `init` — `body` runs on every
+/// hover tick, and re-bucketing usage rows there would be wasteful.
 struct TokenActivityCard: View {
-    private let activity: TokenActivityCalendar
+    private let grid: TokenActivityGrid
     private let isScanning: Bool
     private let isScanDisabled: Bool
     private let scan: () -> Void
 
     init(
         summary: CostSummary?,
-        weeks: Int = TokenActivityCalendar.defaultWeeks,
+        windowSelection: CostWindowSelection = .month,
         isScanning: Bool,
         isScanDisabled: Bool,
         scan: @escaping () -> Void
     ) {
-        self.activity = TokenActivityCalendar(summary: summary, weeks: weeks)
+        self.grid = TokenActivityGrid(summary: summary, windowSelection: windowSelection)
         self.isScanning = isScanning
         self.isScanDisabled = isScanDisabled
         self.scan = scan
     }
 
     var body: some View {
-        DashboardCard(title: "Token Activity", trailing: activity.coverageSummary) {
-            if activity.hasHistory {
+        DashboardCard(title: "Token Activity", trailing: grid.coverageSummary) {
+            if let hourly = grid.hourly {
+                TokenActivityHourlyHeatmap(activity: hourly)
+            } else if let activity = grid.daily, activity.hasHistory {
                 TokenActivityHeatmap(activity: activity)
             } else if isScanning {
                 CostScanLoadingChart(compact: true)
@@ -57,6 +59,110 @@ struct TokenActivityCard: View {
             .buttonStyle(.glassProminent)
             .disabled(isScanDisabled)
         }
+    }
+}
+
+/// Seven local-day rows by 24 local-hour columns. The model is already fully
+/// derived, so pointer and keyboard focus updates only select a stable cell.
+struct TokenActivityHourlyHeatmap: View {
+    private let activity: TokenActivityHourlyCalendar
+
+    @State private var hoveredHour: TokenActivityHourKey?
+    @FocusState private var focusedHour: TokenActivityHourKey?
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
+    init(activity: TokenActivityHourlyCalendar) {
+        self.activity = activity
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.sm) {
+            VStack(alignment: .leading, spacing: TokenActivityMetrics.spacing) {
+                hourHeader
+                ForEach(activity.days) { day in
+                    dayRow(day)
+                }
+            }
+            .padding(TokenActivityMetrics.focusRingInset)
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Hourly token activity calendar")
+
+            detail
+            TokenActivityLegend()
+        }
+        .animation(
+            MeterBarTheme.Motion.resolve(MeterBarTheme.Motion.quick, reduceMotion: reduceMotion),
+            value: highlightedHour
+        )
+    }
+
+    private var hourHeader: some View {
+        HStack(spacing: TokenActivityMetrics.hourlySpacing) {
+            Color.clear
+                .frame(width: TokenActivityMetrics.weekLabelWidth, height: 1)
+
+            ForEach(0..<TokenActivityHourlyCalendar.hourCount, id: \.self) { hour in
+                Text(String(format: "%02d", hour))
+                    .monospacedDigit()
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .font(.system(size: 8))
+        .foregroundStyle(.secondary)
+        .accessibilityHidden(true)
+    }
+
+    private func dayRow(_ day: TokenActivityHourDay) -> some View {
+        HStack(spacing: TokenActivityMetrics.hourlySpacing) {
+            Text(DashboardDateFormat.monthDay(day.date))
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .frame(width: TokenActivityMetrics.weekLabelWidth, alignment: .trailing)
+                .accessibilityHidden(true)
+
+            ForEach(day.hours) { hour in
+                cell(for: hour)
+            }
+        }
+    }
+
+    private func cell(for hour: TokenActivityHour) -> some View {
+        TokenActivitySwatch(
+            level: hour.level,
+            isHighlighted: highlightedHour == hour.id,
+            fillsWidth: true
+        )
+        .focusable()
+        .focused($focusedHour, equals: hour.id)
+        .onHover { isHovering in
+            if isHovering {
+                hoveredHour = hour.id
+            } else if hoveredHour == hour.id {
+                hoveredHour = nil
+            }
+        }
+        .help(hour.tooltip)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(hour.accessibilityLabel)
+        .accessibilityValue(hour.accessibilityValue)
+    }
+
+    private var detail: some View {
+        Text(highlightedCell?.detailLine ?? activity.overviewLine)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(2)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityHidden(true)
+    }
+
+    private var highlightedHour: TokenActivityHourKey? { hoveredHour ?? focusedHour }
+
+    private var highlightedCell: TokenActivityHour? {
+        highlightedHour.flatMap(activity.hour(for:))
     }
 }
 
@@ -265,6 +371,8 @@ private enum TokenActivityMetrics {
     /// Leading gutter naming the day each week row starts on.
     static let weekLabelWidth: CGFloat = 52
     static let spacing: CGFloat = 6
+    /// A tighter gap preserves useful hover targets across all 24 hour columns.
+    static let hourlySpacing: CGFloat = 3
     static let radius: CGFloat = 5
     static let focusRingInset: CGFloat = 2
     /// Placeholder height while a scan runs, matching the loaded grid: the

--- a/MeterBar/Views/TokenActivityHeatmap.swift
+++ b/MeterBar/Views/TokenActivityHeatmap.swift
@@ -68,7 +68,8 @@ struct TokenActivityHourlyHeatmap: View {
     private let activity: TokenActivityHourlyCalendar
 
     @State private var hoveredHour: TokenActivityHourKey?
-    @FocusState private var focusedHour: TokenActivityHourKey?
+    @State private var keyboardHour: TokenActivityHourKey?
+    @FocusState private var isGridFocused: Bool
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
 
@@ -85,8 +86,16 @@ struct TokenActivityHourlyHeatmap: View {
                 }
             }
             .padding(TokenActivityMetrics.focusRingInset)
-            .accessibilityElement(children: .contain)
+            .focusable()
+            .focused($isGridFocused)
+            .onChange(of: isGridFocused) { _, focused in
+                guard focused, keyboardHour == nil else { return }
+                keyboardHour = activity.busiestHour?.id ?? activity.hours.last?.id
+            }
+            .onMoveCommand(perform: moveKeyboardSelection)
+            .accessibilityElement(children: .ignore)
             .accessibilityLabel("Hourly token activity calendar")
+            .accessibilityValue(highlightedCell?.accessibilityValue ?? activity.overviewLine)
 
             detail
             TokenActivityLegend()
@@ -128,14 +137,13 @@ struct TokenActivityHourlyHeatmap: View {
         }
     }
 
+    @ViewBuilder
     private func cell(for hour: TokenActivityHour) -> some View {
-        TokenActivitySwatch(
+        let swatch = TokenActivitySwatch(
             level: hour.level,
             isHighlighted: highlightedHour == hour.id,
             fillsWidth: true
         )
-        .focusable()
-        .focused($focusedHour, equals: hour.id)
         .onHover { isHovering in
             if isHovering {
                 hoveredHour = hour.id
@@ -143,10 +151,15 @@ struct TokenActivityHourlyHeatmap: View {
                 hoveredHour = nil
             }
         }
-        .help(hour.tooltip)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(hour.accessibilityLabel)
         .accessibilityValue(hour.accessibilityValue)
+
+        if highlightedHour == hour.id {
+            swatch.help(hour.tooltip)
+        } else {
+            swatch
+        }
     }
 
     private var detail: some View {
@@ -159,10 +172,40 @@ struct TokenActivityHourlyHeatmap: View {
             .accessibilityHidden(true)
     }
 
-    private var highlightedHour: TokenActivityHourKey? { hoveredHour ?? focusedHour }
+    private var highlightedHour: TokenActivityHourKey? {
+        hoveredHour ?? (isGridFocused ? keyboardHour : nil)
+    }
 
     private var highlightedCell: TokenActivityHour? {
         highlightedHour.flatMap(activity.hour(for:))
+    }
+
+    /// The whole 7 × 24 matrix is one tab stop. Arrow keys move the selection
+    /// inside it, avoiding 168 focus stops while keeping every hour reachable.
+    private func moveKeyboardSelection(_ direction: MoveCommandDirection) {
+        guard isGridFocused, !activity.hours.isEmpty else { return }
+        let current = keyboardHour.flatMap { key in activity.hours.firstIndex { $0.id == key } }
+            ?? activity.hours.indices.last
+        guard let current else { return }
+
+        let day = current / TokenActivityHourlyCalendar.hourCount
+        let hour = current % TokenActivityHourlyCalendar.hourCount
+        let target: Int
+        switch direction {
+        case .left:
+            target = day * TokenActivityHourlyCalendar.hourCount + max(0, hour - 1)
+        case .right:
+            target = day * TokenActivityHourlyCalendar.hourCount
+                + min(TokenActivityHourlyCalendar.hourCount - 1, hour + 1)
+        case .up:
+            target = max(0, day - 1) * TokenActivityHourlyCalendar.hourCount + hour
+        case .down:
+            target = min(TokenActivityHourlyCalendar.dayCount - 1, day + 1)
+                * TokenActivityHourlyCalendar.hourCount + hour
+        default:
+            return
+        }
+        keyboardHour = activity.hours[target].id
     }
 }
 

--- a/MeterBarTests/CostScanCollaboratorTests.swift
+++ b/MeterBarTests/CostScanCollaboratorTests.swift
@@ -511,7 +511,7 @@ final class CostScanCollaboratorTests: XCTestCase {
         context.dailyProjectTotals = [day: ["app": tokens]]
         context.dailyProjectModelTotals = [day: ["app": ["gpt-5.6-sol": tokens]]]
 
-        let (cost, dailyRows) = try XCTUnwrap(
+        let (cost, dailyRows, _) = try XCTUnwrap(
             CodexCostScanner.makeCost(from: context) { _, at in
                 schedule.resolve(at: at)?.pricing ?? newRate
             }

--- a/MeterBarTests/CostScanCorpusTests.swift
+++ b/MeterBarTests/CostScanCorpusTests.swift
@@ -91,6 +91,7 @@ final class CostScanCorpusTests: XCTestCase {
         let hourlyCutoff = try date("2025-06-09T00:00:00Z")
         try writeClaudeTranscript(in: root, project: "www/demo", name: "hours.jsonl", lines: [
             claudeEventLine(timestamp: "2025-06-08T23:59:00Z", messageID: "old", requestID: "old", input: 90),
+            claudeEventLine(timestamp: "2025-06-09T00:00:00Z", messageID: "edge", requestID: "edge", input: 50),
             claudeEventLine(timestamp: "2025-06-14T10:59:00Z", messageID: "a", requestID: "a", input: 100),
             claudeEventLine(timestamp: "2025-06-14T11:00:00Z", messageID: "b", requestID: "b", input: 200),
         ])
@@ -105,9 +106,9 @@ final class CostScanCorpusTests: XCTestCase {
             windowStart: periodCutoff
         )?.2)
 
-        XCTAssertEqual(rows.map(\.inputTokens).sorted(), [100, 200])
-        XCTAssertEqual(rows.map(\.provider), [.claudeCode, .claudeCode])
-        XCTAssertEqual(rows.map { calendarHour($0.date) }.sorted(), [10, 11])
+        XCTAssertEqual(rows.map(\.inputTokens).sorted(), [50, 100, 200])
+        XCTAssertEqual(rows.map(\.provider), [.claudeCode, .claudeCode, .claudeCode])
+        XCTAssertEqual(rows.map { calendarHour($0.date) }.sorted(), [0, 10, 11])
     }
 
     // MARK: - Codex
@@ -194,6 +195,7 @@ final class CostScanCorpusTests: XCTestCase {
         let hourlyCutoff = try date("2025-06-09T00:00:00Z")
         try writeCodexRollout(in: directory, path: "hours.jsonl", lines: [
             codexTokenLine(timestamp: "2025-06-08T23:59:00Z", conversationID: "old", input: 90),
+            codexTokenLine(timestamp: "2025-06-09T00:00:00Z", conversationID: "edge", input: 50),
             codexTokenLine(timestamp: "2025-06-14T10:59:00Z", conversationID: "a", input: 100),
             codexTokenLine(timestamp: "2025-06-14T11:00:00Z", conversationID: "b", input: 200),
         ])
@@ -202,10 +204,10 @@ final class CostScanCorpusTests: XCTestCase {
         CostScanFixtureScan.codexRollouts(in: directory, windows: &windows)
         let rows = try XCTUnwrap(CodexCostScanner.makeCost(from: windows.period)?.2)
 
-        XCTAssertEqual(rows.map(\.inputTokens).sorted(), [0, 0])
-        XCTAssertEqual(rows.map(\.cacheReadTokens).sorted(), [200, 200])
-        XCTAssertEqual(rows.map(\.provider), [.codexCli, .codexCli])
-        XCTAssertEqual(rows.map { calendarHour($0.date) }.sorted(), [10, 11])
+        XCTAssertEqual(rows.map(\.inputTokens).sorted(), [0, 0, 0])
+        XCTAssertEqual(rows.map(\.cacheReadTokens).sorted(), [200, 200, 200])
+        XCTAssertEqual(rows.map(\.provider), [.codexCli, .codexCli, .codexCli])
+        XCTAssertEqual(rows.map { calendarHour($0.date) }.sorted(), [0, 10, 11])
     }
 }
 

--- a/MeterBarTests/CostScanCorpusTests.swift
+++ b/MeterBarTests/CostScanCorpusTests.swift
@@ -85,6 +85,31 @@ final class CostScanCorpusTests: XCTestCase {
         XCTAssertEqual(windows.period.sessions, 3)
     }
 
+    func testClaudeScanAccumulatesOnlyTrailingSevenDaysIntoHourlyBuckets() throws {
+        let root = try makeClaudeProjectsRoot()
+        let periodCutoff = try date("2025-05-17T00:00:00Z")
+        let hourlyCutoff = try date("2025-06-09T00:00:00Z")
+        try writeClaudeTranscript(in: root, project: "www/demo", name: "hours.jsonl", lines: [
+            claudeEventLine(timestamp: "2025-06-08T23:59:00Z", messageID: "old", requestID: "old", input: 90),
+            claudeEventLine(timestamp: "2025-06-14T10:59:00Z", messageID: "a", requestID: "a", input: 100),
+            claudeEventLine(timestamp: "2025-06-14T11:00:00Z", messageID: "b", requestID: "b", input: 200),
+        ])
+
+        let session = CostScanSession(
+            cutoff: periodCutoff,
+            hourlyCutoff: hourlyCutoff,
+            options: .unlimited
+        )
+        let rows = try XCTUnwrap(ClaudeCostScanner.makeCost(
+            from: ClaudeCostScanner.scanRoots([root], session: session).period,
+            windowStart: periodCutoff
+        )?.2)
+
+        XCTAssertEqual(rows.map(\.inputTokens).sorted(), [100, 200])
+        XCTAssertEqual(rows.map(\.provider), [.claudeCode, .claudeCode])
+        XCTAssertEqual(rows.map { calendarHour($0.date) }.sorted(), [10, 11])
+    }
+
     // MARK: - Codex
 
     func testCodexDeduplicationStaysGlobalAcrossFiles() throws {
@@ -162,6 +187,26 @@ final class CostScanCorpusTests: XCTestCase {
 
         XCTAssertEqual(windows.lifetime.sessionIDs.count, 5)
     }
+
+    func testCodexScanAccumulatesOnlyTrailingSevenDaysIntoHourlyBuckets() throws {
+        let directory = try makeTemporaryDirectory(named: "CodexHourlyRollouts")
+        let periodCutoff = try date("2025-05-17T00:00:00Z")
+        let hourlyCutoff = try date("2025-06-09T00:00:00Z")
+        try writeCodexRollout(in: directory, path: "hours.jsonl", lines: [
+            codexTokenLine(timestamp: "2025-06-08T23:59:00Z", conversationID: "old", input: 90),
+            codexTokenLine(timestamp: "2025-06-14T10:59:00Z", conversationID: "a", input: 100),
+            codexTokenLine(timestamp: "2025-06-14T11:00:00Z", conversationID: "b", input: 200),
+        ])
+
+        var windows = CodexCostScanner.scanWindows(cutoff: periodCutoff, hourlyCutoff: hourlyCutoff)
+        CostScanFixtureScan.codexRollouts(in: directory, windows: &windows)
+        let rows = try XCTUnwrap(CodexCostScanner.makeCost(from: windows.period)?.2)
+
+        XCTAssertEqual(rows.map(\.inputTokens).sorted(), [0, 0])
+        XCTAssertEqual(rows.map(\.cacheReadTokens).sorted(), [200, 200])
+        XCTAssertEqual(rows.map(\.provider), [.codexCli, .codexCli])
+        XCTAssertEqual(rows.map { calendarHour($0.date) }.sorted(), [10, 11])
+    }
 }
 
 // MARK: - Fixtures
@@ -171,6 +216,16 @@ extension CostScanCorpusTests {
     /// itself is covered by `CostScanCollaboratorTests`.
     private func makeSession(cutoff: Date) -> CostScanSession {
         CostScanSession(cutoff: cutoff, options: .unlimited)
+    }
+
+    private func date(_ value: String) throws -> Date {
+        try XCTUnwrap(FlexibleISO8601.date(from: value))
+    }
+
+    private func calendarHour(_ date: Date) -> Int {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
+        return calendar.component(.hour, from: date)
     }
 
     private func makeTemporaryDirectory(named prefix: String) throws -> URL {

--- a/MeterBarTests/CostScanFileCacheSafetyTests.swift
+++ b/MeterBarTests/CostScanFileCacheSafetyTests.swift
@@ -82,7 +82,7 @@ final class CostScanFileCacheSafetyTests: XCTestCase {
     }
 
     func testVersionedSaveRemovesSupersededSiblings() throws {
-        let oldClaude = directory.appendingPathComponent("cost-scan-claude-v1.json")
+        let oldClaude = directory.appendingPathComponent("cost-scan-claude-v3.json")
         let oldCodex = directory.appendingPathComponent("cost-scan-codex-v2.json")
         try Data("old".utf8).write(to: oldClaude)
         try Data("other-provider".utf8).write(to: oldCodex)
@@ -97,6 +97,16 @@ final class CostScanFileCacheSafetyTests: XCTestCase {
                 atPath: directory.appendingPathComponent(CostScanCacheStore.claudeFileName).path
             )
         )
+    }
+
+    func testHourlyUpgradeReadsFromAFreshV4Artifact() throws {
+        let oldURL = directory.appendingPathComponent("cost-scan-claude-v3.json")
+        try CostScanCacheStore.saveClaude(makeCache(), to: oldURL)
+        let store = CostScanCacheStore(directory: directory)
+
+        XCTAssertEqual(CostScanFileCache<ClaudeFileTotals>.currentSchemaVersion, 4)
+        XCTAssertEqual(CostScanCacheStore.claudeFileName, "cost-scan-claude-v4.json")
+        XCTAssertTrue(store.loadClaude().records.isEmpty)
     }
 
     // MARK: - Persistence failures

--- a/MeterBarTests/CostSummaryStoreTests.swift
+++ b/MeterBarTests/CostSummaryStoreTests.swift
@@ -35,6 +35,7 @@ final class CostSummaryStoreTests: XCTestCase {
         XCTAssertEqual(migrated.summary.dailyUsage.count, 1)
         XCTAssertNil(migrated.summary.dailyUsage[0].modelBreakdowns)
         XCTAssertNil(migrated.summary.dailyUsage[0].projectBreakdowns)
+        XCTAssertNil(migrated.summary.hourlyUsage)
         XCTAssertTrue(
             migrated.summary.needsMissingDailyUsageRefresh(
                 days: 30,
@@ -85,6 +86,38 @@ final class CostSummaryStoreTests: XCTestCase {
 
         XCTAssertEqual(loaded.summary.dailyUsage.first?.inputTokens, 10)
         XCTAssertEqual(loaded.summary.dailyUsage.first?.modelBreakdowns?.count, 0)
+        XCTAssertNil(loaded.summary.hourlyUsage)
+    }
+
+    func testCurrentCacheRoundTripsHourlyUsageWithoutChangingTheDateCodec() throws {
+        let currentURL = tempDirectory.appendingPathComponent("cost-summary-v2.json")
+        let legacyURL = tempDirectory.appendingPathComponent("cost-summary-v1.json")
+        let hour = Date(timeIntervalSince1970: 1_750_000_000)
+        let current = CostSummaryCache(
+            summary: CostSummary(
+                costs: [],
+                totalCostUSD: 0,
+                totalTokens: 0,
+                periodDays: 30,
+                hourlyUsage: [
+                    HourlyTokenUsage(
+                        date: hour,
+                        provider: .codexCli,
+                        inputTokens: 10,
+                        outputTokens: 2,
+                        cacheReadTokens: 1,
+                        estimatedCostUSD: 0.25
+                    ),
+                ]
+            ),
+            lastScanDate: hour
+        )
+
+        try CostSummaryStore.save(current, to: currentURL)
+        let loaded = try XCTUnwrap(CostSummaryStore.load(currentURL: currentURL, legacyURL: legacyURL))
+
+        XCTAssertEqual(loaded.summary.hourlyUsage?.first?.date, hour)
+        XCTAssertEqual(loaded.summary.hourlyUsage?.first?.provider, .codexCli)
     }
 
     private func legacyPayload(inputTokens: Int = 10) throws -> Data {

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -301,7 +301,7 @@ final class CostTrackerTests: XCTestCase {
             7
         )
 
-        let (_, dailyRows) = try XCTUnwrap(
+        let (_, dailyRows, _) = try XCTUnwrap(
             ClaudeCostScanner.makeCost(from: result, windowStart: cutoff)
         )
         let daily = try XCTUnwrap(dailyRows.first)
@@ -631,7 +631,7 @@ final class CostTrackerTests: XCTestCase {
             1_000
         )
 
-        let (_, dailyRows) = try XCTUnwrap(CodexCostScanner.makeCost(from: context))
+        let (_, dailyRows, _) = try XCTUnwrap(CodexCostScanner.makeCost(from: context))
         let daily = try XCTUnwrap(dailyRows.first)
         XCTAssertEqual(daily.modelBreakdowns?.first?.name, "gpt-5.6-sol")
         XCTAssertEqual(daily.projectBreakdowns?.first?.name, "www/genfeed/apps/admin")

--- a/MeterBarTests/CostWindowSelectionTests.swift
+++ b/MeterBarTests/CostWindowSelectionTests.swift
@@ -25,10 +25,10 @@ final class CostWindowSelectionTests: XCTestCase {
         XCTAssertEqual(CostWindowSelection.month.spendCardTitle, "30 Day Spend")
     }
 
-    func testActivityWeeksCoverTheSelectedWindow() {
-        // Two 7-day columns are the narrowest grid that always spans the last
-        // 7 days; the month keeps the existing six-week calendar.
-        XCTAssertEqual(CostWindowSelection.week.activityWeeks, 2)
-        XCTAssertEqual(CostWindowSelection.month.activityWeeks, TokenActivityCalendar.defaultWeeks)
+    func testFallbackActivityWeeksCoverTheSelectedWindow() {
+        // Old summaries without hourly rows keep the existing two-week fallback;
+        // the month keeps the unchanged six-week calendar.
+        XCTAssertEqual(CostWindowSelection.week.fallbackActivityWeeks, 2)
+        XCTAssertEqual(CostWindowSelection.month.fallbackActivityWeeks, TokenActivityCalendar.defaultWeeks)
     }
 }

--- a/MeterBarTests/GrokCostScannerTests.swift
+++ b/MeterBarTests/GrokCostScannerTests.swift
@@ -296,6 +296,57 @@ final class GrokCostScannerTests: XCTestCase {
         XCTAssertEqual(row.estimatedCostUSD, 0.0003, accuracy: 1e-9)
     }
 
+    func testScanAccumulatesOnlyTrailingSevenDaysIntoHourlyBuckets() throws {
+        let root = try makeSessionsRoot()
+        let periodCutoff = Date().addingTimeInterval(-30 * 24 * 60 * 60)
+        let currentHour = try XCTUnwrap(Calendar.current.dateInterval(of: .hour, for: Date())?.start)
+        let hourlyCutoff = currentHour.addingTimeInterval(-7 * 24 * 60 * 60)
+        try writeUpdates(
+            in: root,
+            project: "www/meterbar",
+            session: "session-hourly",
+            lines: [
+                turnCompleted(
+                    at: hourlyCutoff.addingTimeInterval(-60),
+                    input: 90,
+                    cachedRead: 0,
+                    output: 9,
+                    reasoning: 0,
+                    ticks: 900_000
+                ),
+                turnCompleted(
+                    at: hourlyCutoff.addingTimeInterval(3_599),
+                    input: 100,
+                    cachedRead: 10,
+                    output: 10,
+                    reasoning: 0,
+                    ticks: 1_000_000
+                ),
+                turnCompleted(
+                    at: hourlyCutoff.addingTimeInterval(3_600),
+                    input: 200,
+                    cachedRead: 20,
+                    output: 20,
+                    reasoning: 0,
+                    ticks: 2_000_000
+                ),
+            ]
+        )
+        let session = CostScanSession(
+            cutoff: periodCutoff,
+            hourlyCutoff: hourlyCutoff,
+            options: .unlimited
+        )
+
+        let rows = try XCTUnwrap(GrokCostScanner.makeCost(
+            from: GrokCostScanner.scanRoots([root], session: session).period
+        )?.2)
+
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows.map(\.provider), [.grok, .grok])
+        XCTAssertEqual(rows.reduce(0) { $0 + $1.totalTokens }, 330)
+    }
+
     // MARK: - Attribution
 
     /// Grok names each session directory after the URL-encoded absolute project

--- a/MeterBarTests/GrokCostScannerTests.swift
+++ b/MeterBarTests/GrokCostScannerTests.swift
@@ -315,6 +315,14 @@ final class GrokCostScannerTests: XCTestCase {
                     ticks: 900_000
                 ),
                 turnCompleted(
+                    at: hourlyCutoff,
+                    input: 50,
+                    cachedRead: 0,
+                    output: 5,
+                    reasoning: 0,
+                    ticks: 500_000
+                ),
+                turnCompleted(
                     at: hourlyCutoff.addingTimeInterval(3_599),
                     input: 100,
                     cachedRead: 10,
@@ -342,9 +350,9 @@ final class GrokCostScannerTests: XCTestCase {
             from: GrokCostScanner.scanRoots([root], session: session).period
         )?.2)
 
-        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows.count, 2, "the cutoff event shares an hour bucket with the next event")
         XCTAssertEqual(rows.map(\.provider), [.grok, .grok])
-        XCTAssertEqual(rows.reduce(0) { $0 + $1.totalTokens }, 330)
+        XCTAssertEqual(rows.reduce(0) { $0 + $1.totalTokens }, 385)
     }
 
     // MARK: - Attribution

--- a/MeterBarTests/HourlyTokenUsageTests.swift
+++ b/MeterBarTests/HourlyTokenUsageTests.swift
@@ -154,6 +154,13 @@ final class HourlyTokenUsageTests: XCTestCase {
         XCTAssertEqual(filtered.hourlyUsage?.map(\.provider), [.codexCli])
     }
 
+    func testHourlyBackfillOnlyRunsForEnabledLogScanners() {
+        XCTAssertFalse(CostTracker.hasEnabledCostScanProvider(in: [.cursor, .openRouter]))
+        XCTAssertTrue(CostTracker.hasEnabledCostScanProvider(in: [.claudeCode]))
+        XCTAssertTrue(CostTracker.hasEnabledCostScanProvider(in: [.codexCli, .cursor]))
+        XCTAssertTrue(CostTracker.hasEnabledCostScanProvider(in: [.grok]))
+    }
+
     private func makeSummary(
         costs: [TokenCost]? = nil,
         periodDays: Int = 30,

--- a/MeterBarTests/HourlyTokenUsageTests.swift
+++ b/MeterBarTests/HourlyTokenUsageTests.swift
@@ -1,0 +1,201 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+final class HourlyTokenUsageTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+    private var calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
+        calendar.locale = Locale(identifier: "en_US_POSIX")
+        return calendar
+    }()
+
+    func testHourBucketStartsAtTheLocalHourAcrossHourAndDayBoundaries() throws {
+        let beforeHour = try date("2025-06-14T23:59:59Z")
+        let nextDay = try date("2025-06-15T00:00:00Z")
+        let laterHour = try date("2025-06-15T01:42:17Z")
+
+        XCTAssertEqual(
+            CostScanHourBucket.start(for: beforeHour, calendar: calendar),
+            try date("2025-06-14T23:00:00Z")
+        )
+        XCTAssertEqual(
+            CostScanHourBucket.start(for: nextDay, calendar: calendar),
+            try date("2025-06-15T00:00:00Z")
+        )
+        XCTAssertEqual(
+            CostScanHourBucket.start(for: laterHour, calendar: calendar),
+            try date("2025-06-15T01:00:00Z")
+        )
+    }
+
+    func testHourlyAggregatorPreservesBucketMathAndProviderSeparation() throws {
+        let firstHour = try date("2025-06-15T10:00:00Z")
+        let secondHour = try date("2025-06-15T11:00:00Z")
+        var firstTokens = TokenAccumulator()
+        firstTokens.add(input: 100, output: 20, cacheCreation: 0, cacheRead: 5, estimatedCostUSD: 1.25)
+        firstTokens.add(input: 40, output: 8, cacheCreation: 0, cacheRead: 2, estimatedCostUSD: 0.50)
+        var secondTokens = TokenAccumulator()
+        secondTokens.add(input: 70, output: 14, cacheCreation: 0, cacheRead: 3, estimatedCostUSD: 0.75)
+
+        let claude = TokenUsageAggregator.makeHourlyUsage(
+            from: [firstHour: firstTokens, secondHour: secondTokens],
+            provider: .claudeCode,
+            pricing: TokenPricing(input: 0, output: 0, cacheCreation: 0, cacheRead: 0)
+        )
+        let codex = TokenUsageAggregator.makeHourlyUsage(
+            from: [firstHour: firstTokens],
+            provider: .codexCli,
+            pricing: TokenPricing(input: 0, output: 0, cacheCreation: 0, cacheRead: 0)
+        )
+        let rows = claude + codex
+
+        XCTAssertEqual(rows.count, 3)
+        XCTAssertEqual(rows.filter { $0.date == firstHour }.map(\.provider).sorted(by: rawProviderOrder), [
+            .claudeCode,
+            .codexCli,
+        ])
+        let claudeFirst = try XCTUnwrap(rows.first { $0.date == firstHour && $0.provider == .claudeCode })
+        XCTAssertEqual(claudeFirst.inputTokens, 140)
+        XCTAssertEqual(claudeFirst.outputTokens, 28)
+        XCTAssertEqual(claudeFirst.cacheReadTokens, 7)
+        XCTAssertEqual(claudeFirst.estimatedCostUSD, 1.75, accuracy: 0.000_001)
+    }
+
+    func testCostSummaryWithoutHourlyFieldStillDecodes() throws {
+        let summary = makeSummary(hourlyUsage: nil)
+        let encoded = try JSONEncoder().encode(summary)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+
+        XCTAssertNil(object["hourlyUsage"])
+        let decoded = try JSONDecoder().decode(CostSummary.self, from: encoded)
+        XCTAssertNil(decoded.hourlyUsage)
+    }
+
+    func testCostSummaryWithHourlyFieldRoundTrips() throws {
+        let hour = calendar.dateInterval(of: .hour, for: now)?.start ?? now
+        let summary = makeSummary(hourlyUsage: [
+            HourlyTokenUsage(
+                date: hour,
+                provider: .claudeCode,
+                inputTokens: 100,
+                outputTokens: 20,
+                cacheReadTokens: 5,
+                estimatedCostUSD: 1.25
+            ),
+        ])
+
+        let decoded = try JSONDecoder().decode(CostSummary.self, from: JSONEncoder().encode(summary))
+
+        let row = try XCTUnwrap(decoded.hourlyUsage?.first)
+        XCTAssertEqual(row.date, hour)
+        XCTAssertEqual(row.provider, .claudeCode)
+        XCTAssertEqual(row.totalTokens, 125)
+        XCTAssertEqual(row.estimatedCostUSD, 1.25, accuracy: 0.000_001)
+    }
+
+    func testMissingHourlyUsageRefreshTruthTable() {
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: now) ?? now
+        let populated = [
+            HourlyTokenUsage(
+                date: calendar.dateInterval(of: .hour, for: now)?.start ?? now,
+                provider: .claudeCode,
+                inputTokens: 1,
+                outputTokens: 0,
+                cacheReadTokens: 0,
+                estimatedCostUSD: 0
+            ),
+        ]
+
+        XCTAssertFalse(makeSummary(costs: [], hourlyUsage: nil).needsMissingHourlyUsageRefresh(
+            lastScanDate: yesterday,
+            now: now,
+            calendar: calendar
+        ))
+        XCTAssertFalse(makeSummary(periodDays: 1, hourlyUsage: nil).needsMissingHourlyUsageRefresh(
+            lastScanDate: yesterday,
+            now: now,
+            calendar: calendar
+        ))
+        XCTAssertTrue(makeSummary(hourlyUsage: nil).needsMissingHourlyUsageRefresh(
+            lastScanDate: yesterday,
+            now: now,
+            calendar: calendar
+        ))
+        XCTAssertTrue(makeSummary(hourlyUsage: []).needsMissingHourlyUsageRefresh(
+            lastScanDate: yesterday,
+            now: now,
+            calendar: calendar
+        ))
+        XCTAssertFalse(makeSummary(hourlyUsage: nil).needsMissingHourlyUsageRefresh(
+            lastScanDate: now,
+            now: now,
+            calendar: calendar
+        ))
+        XCTAssertFalse(makeSummary(hourlyUsage: populated).needsMissingHourlyUsageRefresh(
+            lastScanDate: yesterday,
+            now: now,
+            calendar: calendar
+        ))
+    }
+
+    func testFilteringSummaryAlsoFiltersHourlyProviders() {
+        let hour = calendar.dateInterval(of: .hour, for: now)?.start ?? now
+        let summary = makeSummary(hourlyUsage: [
+            hourlyUsage(at: hour, provider: .claudeCode),
+            hourlyUsage(at: hour, provider: .codexCli),
+        ])
+
+        let filtered = summary.filtered(to: [.codexCli])
+
+        XCTAssertEqual(filtered.hourlyUsage?.map(\.provider), [.codexCli])
+    }
+
+    private func makeSummary(
+        costs: [TokenCost]? = nil,
+        periodDays: Int = 30,
+        hourlyUsage: [HourlyTokenUsage]?
+    ) -> CostSummary {
+        let defaultCost = TokenCost(
+            provider: .claudeCode,
+            inputTokens: 100,
+            outputTokens: 20,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 5,
+            estimatedCostUSD: 1.25,
+            sessionCount: 1,
+            periodStart: now,
+            periodEnd: now
+        )
+        let costs = costs ?? [defaultCost]
+        return CostSummary(
+            costs: costs,
+            totalCostUSD: costs.reduce(0) { $0 + $1.estimatedCostUSD },
+            totalTokens: costs.reduce(0) { $0 + $1.totalTokens },
+            periodDays: periodDays,
+            hourlyUsage: hourlyUsage
+        )
+    }
+
+    private func date(_ value: String) throws -> Date {
+        try XCTUnwrap(FlexibleISO8601.date(from: value))
+    }
+
+    private func hourlyUsage(at date: Date, provider: ServiceType) -> HourlyTokenUsage {
+        HourlyTokenUsage(
+            date: date,
+            provider: provider,
+            inputTokens: 1,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            estimatedCostUSD: 0
+        )
+    }
+
+    private func rawProviderOrder(_ lhs: ServiceType, _ rhs: ServiceType) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}

--- a/MeterBarTests/ProviderUsageCostBuilderTests.swift
+++ b/MeterBarTests/ProviderUsageCostBuilderTests.swift
@@ -60,6 +60,7 @@ final class ProviderUsageCostBuilderTests: XCTestCase {
         XCTAssertEqual(built.0.periodEnd, day(2))
         XCTAssertEqual(built.1.map(\.date), [day(1), day(2)])
         XCTAssertEqual(built.1.map(\.estimatedCostUSD), [2, 3.5])
+        XCTAssertTrue(built.2.isEmpty, "poll-only providers have no event timestamp for hourly bucketing")
     }
 
     /// OpenRouter's key endpoint reports spend and no token counts whatsoever.

--- a/MeterBarTests/TokenActivityCardTests.swift
+++ b/MeterBarTests/TokenActivityCardTests.swift
@@ -69,6 +69,23 @@ final class TokenActivityCardTests: XCTestCase {
         XCTAssertEqual(activity.weeks.count, TokenActivityCalendar.defaultWeeks)
     }
 
+    func testSevenDayCardHostsTheHourlyHeatmap() {
+        let summary = makeSummaryWithHourlyUsage()
+        let card = TokenActivityCard(
+            summary: summary,
+            windowSelection: .week,
+            isScanning: false,
+            isScanDisabled: false,
+            scan: {}
+        )
+
+        let hostingView = NSHostingView(rootView: card)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 720, height: 400)
+        hostingView.layoutSubtreeIfNeeded()
+
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+    }
+
     // MARK: - Placement regression
 
     func testCostsSectionStillHostsWithTheNewCard() {
@@ -90,7 +107,7 @@ final class TokenActivityCardTests: XCTestCase {
             DashboardCostsSection.refreshStatusText(isScanning: true, isRefreshingMissingDays: true),
             "Scanning..."
         )
-        XCTAssertEqual(CostChartPresentation(summary: summary).hasSpend, true)
+        XCTAssertTrue(CostChartPresentation(summary: summary).hasSpend)
 
         let details = DashboardCard(title: "Daily Details", trailing: "Last 30 days") {
             DailyUsageBreakdownList(dailyUsage: summary.dailyUsage)
@@ -148,6 +165,31 @@ final class TokenActivityCardTests: XCTestCase {
             totalTokens: cost.totalTokens,
             periodDays: 30,
             dailyUsage: dailyUsage
+        )
+    }
+
+    private func makeSummaryWithHourlyUsage() -> CostSummary {
+        let summary = makeSummary(dayCount: 30)
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let hour = calendar.date(byAdding: .hour, value: 10, to: today) ?? today
+
+        return CostSummary(
+            costs: summary.costs,
+            totalCostUSD: summary.totalCostUSD,
+            totalTokens: summary.totalTokens,
+            periodDays: summary.periodDays,
+            dailyUsage: summary.dailyUsage,
+            hourlyUsage: [
+                HourlyTokenUsage(
+                    date: hour,
+                    provider: .claudeCode,
+                    inputTokens: 10_000,
+                    outputTokens: 2_000,
+                    cacheReadTokens: 500,
+                    estimatedCostUSD: 0.75
+                ),
+            ]
         )
     }
 }

--- a/MeterBarTests/TokenActivityHourlyCalendarTests.swift
+++ b/MeterBarTests/TokenActivityHourlyCalendarTests.swift
@@ -53,6 +53,8 @@ final class TokenActivityHourlyCalendarTests: XCTestCase {
         XCTAssertEqual(hourly?.days.first?.date, day(daysAgo: 6))
         XCTAssertEqual(hourly?.hour(at: hour)?.totalTokens, 40)
         XCTAssertEqual(hourly?.activeHours.count, 1)
+        XCTAssertEqual(hourly?.coverageStartDate, day(daysAgo: 2))
+        XCTAssertEqual(hourly?.coverageSummary, "3 days tracked")
     }
 
     func testFullHourlyUsageAggregatesProvidersInEveryCell() throws {
@@ -77,6 +79,7 @@ final class TokenActivityHourlyCalendarTests: XCTestCase {
         XCTAssertEqual(hourly.activeHours.count, 7 * 24)
         XCTAssertTrue(hourly.hours.allSatisfy { $0.totalTokens == 15 })
         XCTAssertTrue(hourly.hours.allSatisfy { $0.providers.map(\.provider) == [.claudeCode, .codexCli] })
+        XCTAssertEqual(hourly.coverageSummary, "7 days tracked")
     }
 
     func testMonthSelectionKeepsTheExistingThirtyDayCalendar() {

--- a/MeterBarTests/TokenActivityHourlyCalendarTests.swift
+++ b/MeterBarTests/TokenActivityHourlyCalendarTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+final class TokenActivityHourlyCalendarTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+    private var calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
+        calendar.locale = Locale(identifier: "en_US_POSIX")
+        return calendar
+    }()
+
+    func testNilHourlyUsageFallsBackToTheExistingTwoWeekCalendar() {
+        let grid = TokenActivityGrid(
+            summary: makeSummary(hourlyUsage: nil),
+            windowSelection: .week,
+            now: now,
+            calendar: calendar
+        )
+
+        XCTAssertNil(grid.hourly)
+        XCTAssertEqual(grid.daily?.weeks.count, 2)
+    }
+
+    func testEmptyHourlyUsageFallsBackToTheExistingTwoWeekCalendar() {
+        let grid = TokenActivityGrid(
+            summary: makeSummary(hourlyUsage: []),
+            windowSelection: .week,
+            now: now,
+            calendar: calendar
+        )
+
+        XCTAssertNil(grid.hourly)
+        XCTAssertEqual(grid.daily?.weeks.count, 2)
+    }
+
+    func testPartialHourlyUsageBuildsSevenOldestToNewestRowsAndTwentyFourColumns() {
+        let hour = hour(daysAgo: 2, hour: 13)
+        let grid = TokenActivityGrid(
+            summary: makeSummary(hourlyUsage: [usage(date: hour, provider: .claudeCode, input: 40)]),
+            windowSelection: .week,
+            now: now,
+            calendar: calendar
+        )
+
+        let hourly = try? XCTUnwrap(grid.hourly)
+        XCTAssertEqual(hourly?.days.count, 7)
+        XCTAssertTrue(hourly?.days.allSatisfy { $0.hours.count == 24 } ?? false)
+        XCTAssertEqual(hourly?.days.last?.date, calendar.startOfDay(for: now))
+        XCTAssertEqual(hourly?.days.first?.date, day(daysAgo: 6))
+        XCTAssertEqual(hourly?.hour(at: hour)?.totalTokens, 40)
+        XCTAssertEqual(hourly?.activeHours.count, 1)
+    }
+
+    func testFullHourlyUsageAggregatesProvidersInEveryCell() throws {
+        let rows = (0..<7).flatMap { dayOffset in
+            (0..<24).flatMap { hourValue in
+                let date = hour(daysAgo: dayOffset, hour: hourValue)
+                return [
+                    usage(date: date, provider: .claudeCode, input: 10),
+                    usage(date: date, provider: .codexCli, input: 5),
+                ]
+            }
+        }
+        let grid = TokenActivityGrid(
+            summary: makeSummary(hourlyUsage: rows),
+            windowSelection: .week,
+            now: now,
+            calendar: calendar
+        )
+
+        let hourly = try XCTUnwrap(grid.hourly)
+        XCTAssertEqual(hourly.hours.count, 7 * 24)
+        XCTAssertEqual(hourly.activeHours.count, 7 * 24)
+        XCTAssertTrue(hourly.hours.allSatisfy { $0.totalTokens == 15 })
+        XCTAssertTrue(hourly.hours.allSatisfy { $0.providers.map(\.provider) == [.claudeCode, .codexCli] })
+    }
+
+    func testMonthSelectionKeepsTheExistingThirtyDayCalendar() {
+        let grid = TokenActivityGrid(
+            summary: makeSummary(hourlyUsage: [
+                usage(date: hour(daysAgo: 0, hour: 1), provider: .claudeCode, input: 1),
+            ]),
+            windowSelection: .month,
+            now: now,
+            calendar: calendar
+        )
+
+        XCTAssertNil(grid.hourly)
+        XCTAssertEqual(grid.daily?.weeks.count, TokenActivityCalendar.defaultWeeks)
+    }
+
+    private func makeSummary(hourlyUsage: [HourlyTokenUsage]?) -> CostSummary {
+        CostSummary(
+            costs: [],
+            totalCostUSD: 0,
+            totalTokens: 0,
+            periodDays: 30,
+            dailyUsage: [
+                DailyTokenUsage(
+                    date: day(daysAgo: 6),
+                    provider: .claudeCode,
+                    inputTokens: 1,
+                    outputTokens: 0,
+                    cacheReadTokens: 0,
+                    estimatedCostUSD: 0
+                ),
+            ],
+            hourlyUsage: hourlyUsage
+        )
+    }
+
+    private func usage(
+        date: Date,
+        provider: ServiceType,
+        input: Int
+    ) -> HourlyTokenUsage {
+        HourlyTokenUsage(
+            date: date,
+            provider: provider,
+            inputTokens: input,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            estimatedCostUSD: 0
+        )
+    }
+
+    private func day(daysAgo: Int) -> Date {
+        let today = calendar.startOfDay(for: now)
+        return calendar.date(byAdding: .day, value: -daysAgo, to: today) ?? today
+    }
+
+    private func hour(daysAgo: Int, hour: Int) -> Date {
+        calendar.date(byAdding: .hour, value: hour, to: day(daysAgo: daysAgo)) ?? now
+    }
+}


### PR DESCRIPTION
Closes #372.

## What

When the Costs-page window toggle is on **7 days**, the Token Activity card now renders an **hour × day heatmap** (7 day rows × 24 hour columns) instead of the shrunken two-week day grid. The 30-day window keeps the existing six-week calendar unchanged.

## Data layer (why this wasn't view-only)

- New `HourlyTokenUsage` model + optional `CostSummary.hourlyUsage` — optional keeps pre-#372 caches decoding (same pattern as `pricing` / `projectBreakdowns`). No date-codec or `CostSummaryCache` schema changes.
- Hour-bucketed accumulation for events inside the trailing 7 days in all three scanners (Claude, Codex, Grok), threaded through `CostScanSession`/`ScanWindows`/`CostSummaryBuilder` alongside the existing daily tallies. Codex billable-input and dated-pricing conventions match the daily aggregation.
- **Backfill:** resumable scan offsets skip already-read bytes, so the cost-scan file cache bumps its private schema v3 → v4 — the first background refresh after upgrade re-reads source events once to materialize hourly rows. `needsMissingHourlyUsageRefresh` (mirroring the daily guard, including the scanned-today short-circuit) is OR'd into `CostTracker.refreshMissingDaysInBackground`.
- Poll-only providers (Cursor, OpenRouter) emit no hourly rows — they have no event timestamps.

## View

- `TokenActivityHourlyHeatmap`: 7×24 grid derived once in `init`, hour header, hover/keyboard-focus detail, shared intensity legend, reduce-motion aware.
- Old caches without hourly rows fall back to the previous two-week day grid (`fallbackActivityWeeks`), so the card never blanks.

## Verification

- TDD: `HourlyTokenUsageTests` (hour boundaries, provider separation, cache decode compat, refresh truth table) and `TokenActivityHourlyCalendarTests` (nil/empty fallback, partial/full grids, ordering, 30-day unchanged) written first, plus scanner fixture tests and cache-contract round-trips.
- Full local suite: **2100 tests, 0 failures** (6 credential-gated skips).
- SwiftLint clean on all changed files.
- CLI decodes caches both with and without the new field (covered by store tests); `MeterBarWidget` does not decode `CostSummary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a seven-day hourly activity heatmap with 24-hour columns, provider breakdowns, tooltips, accessibility labels, and intensity indicators.
  * Added hourly token usage tracking for supported activity-based providers.
  * Preserved daily activity views when hourly data is unavailable, including existing two-week and monthly views.
* **Improvements**
  * Improved background refreshes and cached data handling for hourly activity.
  * Hourly results respect local calendar times and daylight-saving transitions.
* **Bug Fixes**
  * Excluded activity outside the seven-day hourly window from displayed totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->