### PR TITLE
fix(services): stop persisting provider cookies from usage fetches

### DIFF
--- a/MeterBar/Services/ServiceSupport.swift
+++ b/MeterBar/Services/ServiceSupport.swift
@@ -68,12 +68,22 @@ nonisolated enum ServiceSupport {
         request.timeoutInterval = usageRequestTimeout
     }
 
-    static func makeUsageSession() -> URLSession {
-        let configuration = URLSessionConfiguration.default
-        configuration.timeoutIntervalForRequest = 30
-        configuration.timeoutIntervalForResource = 60
-        configuration.waitsForConnectivity = true
-        return URLSession(configuration: configuration)
+    /// Minimal, ephemeral, cookie-free transport for provider usage requests.
+    /// It keeps credentials in their provider-managed stores and prevents
+    /// responses from persisting cookies, cached data, or credential state.
+    static func makeUsageSession(
+        configuration: URLSessionConfiguration = .ephemeral
+    ) -> URLSession {
+        let safeConfiguration = (configuration.copy() as? URLSessionConfiguration) ?? .ephemeral
+        safeConfiguration.urlCache = nil
+        safeConfiguration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        safeConfiguration.httpCookieStorage = nil
+        safeConfiguration.httpShouldSetCookies = false
+        safeConfiguration.urlCredentialStorage = nil
+        safeConfiguration.timeoutIntervalForRequest = 30
+        safeConfiguration.timeoutIntervalForResource = 60
+        safeConfiguration.waitsForConnectivity = true
+        return URLSession(configuration: safeConfiguration)
     }
 
     /// Validates an HTTP response, mapping 401 to `.notAuthenticated` and any

--- a/MeterBarTests/BrowserRequestHeadersTests.swift
+++ b/MeterBarTests/BrowserRequestHeadersTests.swift
@@ -67,6 +67,24 @@ final class BrowserRequestHeadersTests: XCTestCase {
         )
     }
 
+    func testUsageSessionDoesNotPersistProviderState() {
+        let configuration = ServiceSupport.makeUsageSession().configuration
+
+        XCTAssertNil(configuration.urlCache)
+        XCTAssertEqual(configuration.requestCachePolicy, .reloadIgnoringLocalCacheData)
+        XCTAssertNil(configuration.httpCookieStorage)
+        XCTAssertFalse(configuration.httpShouldSetCookies)
+        XCTAssertNil(configuration.urlCredentialStorage)
+    }
+
+    func testUsageSessionPreservesTimeoutAndConnectivityBehavior() {
+        let configuration = ServiceSupport.makeUsageSession().configuration
+
+        XCTAssertEqual(configuration.timeoutIntervalForRequest, 30)
+        XCTAssertEqual(configuration.timeoutIntervalForResource, 60)
+        XCTAssertTrue(configuration.waitsForConnectivity)
+    }
+
     func testApplyBrowserHeadersWritesEveryFieldOntoTheRequestAndSetsTheTimeout() throws {
         var request = URLRequest(url: try XCTUnwrap(URL(string: "https://chatgpt.com/backend-api/wham/usage")))
         ServiceSupport.applyBrowserHeaders(to: &request, for: .chatGPT, accept: "*/*")


### PR DESCRIPTION
Fixes #377

## Problem

`ServiceSupport.makeUsageSession` returned a session built on the **default** `URLSessionConfiguration`. That configuration persists to disk, so every provider `Set-Cookie` was written to the shared cookie jar and kept indefinitely, and the shared `URLCache` retained response bodies. `QuotaWebhookClient` already used `.ephemeral`; the usage path — the one that talks to five authenticated provider endpoints — never got the same treatment.

## Fix

`makeUsageSession` now defaults to `.ephemeral`, copies the incoming configuration before mutating it (so a caller-supplied configuration is never modified in place), and explicitly clears the three persistence surfaces:

| Surface | Before | After |
|---|---|---|
| `urlCache` | shared on-disk cache | `nil` |
| `httpCookieStorage` | shared on-disk jar | `nil` |
| `urlCredentialStorage` | shared | `nil` |
| `requestCachePolicy` | default | `.reloadIgnoringLocalCacheData` |
| `httpShouldSetCookies` | `true` | `false` |

Quota data is time-sensitive, so ignoring the local cache is a correctness win as well as a privacy one — a cached 200 could otherwise mask a genuinely changed limit.

Timeouts (30s request / 60s resource) and `waitsForConnectivity` are unchanged.

## Tests

Two tests added to `MeterBarTests/BrowserRequestHeadersTests.swift`:

- `testUsageSessionDoesNotPersistProviderState` — asserts all three storages are `nil`, the cache policy is `.reloadIgnoringLocalCacheData`, and cookies are off.
- `testUsageSessionPreservesTimeoutAndConnectivityBehavior` — pins 30/60/`true` so a future edit cannot silently drop them.

Full suite: **2085 tests, 0 failures** (6 skipped), 59.8s.