### PR TITLE
fix(cursor): read team-plan usage instead of falling back to estimates

### DIFF
--- a/MeterBar/Services/CursorLocalService.swift
+++ b/MeterBar/Services/CursorLocalService.swift
@@ -298,7 +298,7 @@ class CursorLocalService: ObservableObject {
         _ summaryData: CursorUsageSummaryResponse,
         at observedAt: Date
     ) -> ProviderUsageObservation? {
-        guard let used = summaryData.individualUsage?.plan?.used else { return nil }
+        guard let used = selectedUsage(from: summaryData).plan?.used else { return nil }
         return ProviderUsageObservation(
             provider: .cursor,
             unit: .requests,
@@ -315,12 +315,13 @@ class CursorLocalService: ObservableObject {
 
     /// Maps a decoded Cursor usage-summary response onto the shared
     /// `UsageMetrics` shape. Pure and side-effect-free so it can be fixture-tested
-    /// without the network or Cursor's SQLite DB: individual plan → billing-cycle
-    /// (long-window) limit, enabled on-demand usage → session limit. The plan
-    /// denominator comes from the server (`plan.limit`, else `plan.breakdown`,
-    /// else the legacy flat `plan.total`); only when the payload carries none of
-    /// those is the assumed quota substituted and flagged `isEstimated`. When
-    /// on-demand has no explicit limit a headroom estimate is used.
+    /// without the network or Cursor's SQLite DB: individual-first plan (falling
+    /// back to team) → billing-cycle (long-window) limit, enabled on-demand usage
+    /// from that same shape → session limit. The plan denominator comes from the
+    /// server (`plan.limit`, else `plan.breakdown`, else the legacy flat
+    /// `plan.total`); only when the selected shape carries none of those is the
+    /// assumed quota substituted and flagged `isEstimated`. When on-demand has
+    /// no explicit limit a headroom estimate is used.
     static func mapSummary(_ summaryData: CursorUsageSummaryResponse) -> UsageMetrics {
         // Parse billing cycle end date for reset time
         var resetTime: Date?
@@ -328,8 +329,8 @@ class CursorLocalService: ObservableObject {
             resetTime = FlexibleISO8601.date(from: billingEnd)
         }
 
-        // Extract usage from individual plan
-        let plan = summaryData.individualUsage?.plan
+        let usage = selectedUsage(from: summaryData)
+        let plan = usage.plan
         let planUsed = Double(plan?.used ?? 0)
         let serverQuota = plan?.serverQuota
         let planTotalIsEstimated = serverQuota == nil
@@ -347,7 +348,7 @@ class CursorLocalService: ObservableObject {
 
         // On-demand usage as secondary metric if enabled
         var sessionLimit: UsageLimit?
-        if let onDemand = summaryData.individualUsage?.onDemand, onDemand.enabled == true {
+        if let onDemand = usage.onDemand, onDemand.enabled == true {
             let onDemandUsed = Double(onDemand.used ?? 0)
             let onDemandLimit = Double(onDemand.limit ?? 0)
             if onDemandUsed > 0 || onDemandLimit > 0 {
@@ -366,6 +367,36 @@ class CursorLocalService: ObservableObject {
             weeklyLimit: weeklyLimit,
             codeReviewLimit: nil
         )
+    }
+
+    /// Resolves the two response shapes once so plan and on-demand usage cannot
+    /// come from different accounts. An explicit individual counter wins even
+    /// when it is zero; team usage is selected only when individual usage has no
+    /// counter. If neither has a counter, retain a server-backed quota or the
+    /// first available shape for the summary mapper, while `observation` still
+    /// rejects the missing counter instead of inventing a reset.
+    private static func selectedUsage(
+        from summaryData: CursorUsageSummaryResponse
+    ) -> (plan: CursorPlanUsage?, onDemand: CursorOnDemandUsage?) {
+        let individual = summaryData.individualUsage
+        let team = summaryData.teamUsage
+
+        if individual?.plan?.used != nil {
+            return (individual?.plan, individual?.onDemand)
+        }
+        if team?.plan?.used != nil {
+            return (team?.plan, team?.onDemand)
+        }
+        if individual?.plan?.serverQuota != nil {
+            return (individual?.plan, individual?.onDemand)
+        }
+        if team?.plan?.serverQuota != nil {
+            return (team?.plan, team?.onDemand)
+        }
+        if individual != nil {
+            return (individual?.plan, individual?.onDemand)
+        }
+        return (team?.plan, team?.onDemand)
     }
 
     // MARK: - API Calls

--- a/MeterBarTests/CursorLocalServiceTests.swift
+++ b/MeterBarTests/CursorLocalServiceTests.swift
@@ -196,6 +196,78 @@ final class CursorLocalServiceTests: XCTestCase {
         XCTAssertNil(metrics.sessionLimit)
     }
 
+    func testMapSummaryFallsBackToTeamUsageWithServerQuota() throws {
+        let json = """
+        {
+          "teamUsage": {
+            "plan": { "used": 340, "limit": 1200, "remaining": 860 }
+          }
+        }
+        """
+        let metrics = CursorLocalService.mapSummary(try decodeSummary(json))
+
+        XCTAssertEqual(metrics.weeklyLimit?.used, 340)
+        XCTAssertEqual(metrics.weeklyLimit?.total, 1200)
+        XCTAssertEqual(metrics.weeklyLimit?.isEstimated, false)
+    }
+
+    func testMapSummaryEstimatesTeamQuotaWhenDenominatorMissing() throws {
+        let json = """
+        {
+          "teamUsage": {
+            "plan": { "used": 85 }
+          }
+        }
+        """
+        let metrics = CursorLocalService.mapSummary(try decodeSummary(json))
+
+        XCTAssertEqual(metrics.weeklyLimit?.used, 85)
+        XCTAssertEqual(metrics.weeklyLimit?.total, 500)
+        XCTAssertEqual(metrics.weeklyLimit?.isEstimated, true)
+    }
+
+    func testMapSummaryPrefersIndividualUsageWhenBothShapesHavePlanCounters() throws {
+        let json = """
+        {
+          "individualUsage": {
+            "plan": { "used": 40, "limit": 500 },
+            "onDemand": { "used": 3, "limit": 15, "enabled": true }
+          },
+          "teamUsage": {
+            "plan": { "used": 900, "limit": 2000 },
+            "onDemand": { "used": 70, "limit": 100, "enabled": true }
+          }
+        }
+        """
+        let metrics = CursorLocalService.mapSummary(try decodeSummary(json))
+
+        XCTAssertEqual(metrics.weeklyLimit?.used, 40)
+        XCTAssertEqual(metrics.weeklyLimit?.total, 500)
+        XCTAssertEqual(metrics.sessionLimit?.used, 3)
+        XCTAssertEqual(metrics.sessionLimit?.total, 15)
+    }
+
+    func testMapSummaryUsesTeamOnDemandWithTeamPlan() throws {
+        let json = """
+        {
+          "individualUsage": {
+            "plan": { "limit": 500 },
+            "onDemand": { "used": 2, "limit": 10, "enabled": true }
+          },
+          "teamUsage": {
+            "plan": { "used": 240, "limit": 1000 },
+            "onDemand": { "used": 18, "limit": 60, "enabled": true }
+          }
+        }
+        """
+        let metrics = CursorLocalService.mapSummary(try decodeSummary(json))
+
+        XCTAssertEqual(metrics.weeklyLimit?.used, 240)
+        XCTAssertEqual(metrics.sessionLimit?.used, 18)
+        XCTAssertEqual(metrics.sessionLimit?.total, 60)
+        XCTAssertEqual(metrics.sessionLimit?.isEstimated, false)
+    }
+
     // MARK: - Poll observations
 
     /// The single most important assertion about Cursor in this codebase.
@@ -263,6 +335,27 @@ final class CursorLocalServiceTests: XCTestCase {
         XCTAssertNil(
             CursorLocalService.observation(try decodeSummary(#"{ "individualUsage": {} }"#), at: Date())
         )
+    }
+
+    func testEmptySummaryStillYieldsNoObservationWithTeamFallback() throws {
+        XCTAssertNil(CursorLocalService.observation(try decodeSummary("{}"), at: Date()))
+    }
+
+    func testSummaryObservesTeamPlanRunningTotal() throws {
+        let json = """
+        {
+          "teamUsage": {
+            "plan": { "used": 612, "limit": 1500 }
+          }
+        }
+        """
+        let observedAt = Date(timeIntervalSince1970: 1_780_000_000)
+
+        let observation = try XCTUnwrap(CursorLocalService.observation(try decodeSummary(json), at: observedAt))
+
+        XCTAssertEqual(observation.runningTotal, 612)
+        XCTAssertEqual(observation.unit, .requests)
+        XCTAssertEqual(observation.observedAt, observedAt)
     }
 
     /// A published zero is a real reading, though — the start of a billing cycle


### PR DESCRIPTION
Fixes #375

## Problem

`CursorLocalService` decodes a summary response that carries **two** usage shapes — `individualUsage` and `teamUsage` — and two separate call sites each reached for `individualUsage` directly:

- `observation` (`:301`) read `individualUsage.plan.used`
- `mapSummary` (`:332`, `:351`) read `individualUsage.plan` and `individualUsage.onDemand`

On a team-plan account `individualUsage` is empty, so the plan counter went missing and the summary quietly fell back to **estimated** numbers. Worse, because the two call sites resolved independently, nothing structurally prevented the plan counter and the on-demand counter from being read out of different branches — one account's usage displayed against another's spend.

## Fix

A single `selectedUsage(from:)` resolver picks the shape once, and both call sites consume its result. Precedence:

1. An explicit **individual** counter wins — *even when it is zero*, since `0 used` is a real answer and must not fall through to the team branch.
2. Otherwise an explicit **team** counter.
3. Otherwise whichever branch carries a server-backed quota, so the summary mapper keeps a real limit to render.
4. Otherwise the first available shape.

Cases 3 and 4 hand `mapSummary` something renderable while `observation` still refuses to publish an observation without a counter — declining rather than inventing a reset.

Because plan and on-demand now come out of one tuple, they cannot diverge.

## Tests

`CursorLocalServiceTests` grows to 25 tests (+93 lines), covering team-plan running totals, zero-valued individual counters beating a populated team branch, on-demand never being folded into the plan count, and a missing counter yielding no observation instead of a fabricated zero.

Full suite: **2089 tests, 0 failures** (6 skipped), 55.5s.