### PR TITLE
fix(cost): stop double-counting Codex turns that omit last_token_usage

### DIFF
--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -146,9 +146,7 @@ enum ClaudeCostScanner {
         projectID: String = CostProjectAttribution.unknownProjectID
     ) -> ScanWindows<ClaudeSessionTotals> {
         var periodKeyed: [String: ClaudeUsageEvent] = [:]
-        var periodUnkeyed: [ClaudeUsageEvent] = []
         var lifetimeKeyed: [String: ClaudeUsageEvent] = [:]
-        var lifetimeUnkeyed: [ClaudeUsageEvent] = []
 
         var truncation = CostScanTruncationTally()
 
@@ -158,19 +156,15 @@ enum ClaudeCostScanner {
             guard let event else { return }
 
             let inPeriod = event.timestamp >= cutoffDate
-            if let key = event.deduplicationKey {
-                lifetimeKeyed[key] = event
-                if inPeriod { periodKeyed[key] = event }
-            } else {
-                lifetimeUnkeyed.append(event)
-                if inPeriod { periodUnkeyed.append(event) }
-            }
+            let key = event.deduplicationKey(projectID: projectID)
+            lifetimeKeyed[key] = event
+            if inPeriod { periodKeyed[key] = event }
         }
         truncation.log(url: url)
 
         return ScanWindows(
-            period: Self.tally(keyed: periodKeyed, unkeyed: periodUnkeyed, projectID: projectID),
-            lifetime: Self.tally(keyed: lifetimeKeyed, unkeyed: lifetimeUnkeyed, projectID: projectID),
+            period: Self.tally(keyed: periodKeyed, projectID: projectID),
+            lifetime: Self.tally(keyed: lifetimeKeyed, projectID: projectID),
             cutoff: cutoffDate
         )
     }
@@ -346,9 +340,7 @@ enum ClaudeCostScanner {
         request.maxBytes = allowance
 
         var periodKeyed: [String: ClaudeUsageEvent] = [:]
-        var periodUnkeyed: [ClaudeUsageEvent] = []
         var lifetimeKeyed: [String: ClaudeUsageEvent] = [:]
-        var lifetimeUnkeyed: [ClaudeUsageEvent] = []
 
         var truncation = CostScanTruncationTally()
 
@@ -357,20 +349,16 @@ enum ClaudeCostScanner {
             truncation.note(line, recovered: event != nil)
             guard let event else { return }
 
-            if let key = event.deduplicationKey {
-                // First-wins across a resume boundary: an event with this key is
-                // already folded into `payload`, and its bytes are behind the
-                // committed offset. Within a single pass the last copy still
-                // wins, exactly as a cold scan does.
-                if !payload.lifetimeKeys.contains(key) {
-                    lifetimeKeyed[key] = event
-                }
-                if event.timestamp >= session.cutoff, !payload.periodKeys.contains(key) {
-                    periodKeyed[key] = event
-                }
-            } else {
-                lifetimeUnkeyed.append(event)
-                if event.timestamp >= session.cutoff { periodUnkeyed.append(event) }
+            let key = event.deduplicationKey(projectID: projectID)
+            // First-wins across a resume boundary: an event with this key is
+            // already folded into `payload`, and its bytes are behind the
+            // committed offset. Within a single pass the last copy still
+            // wins, exactly as a cold scan does.
+            if !payload.lifetimeKeys.contains(key) {
+                lifetimeKeyed[key] = event
+            }
+            if event.timestamp >= session.cutoff, !payload.periodKeys.contains(key) {
+                periodKeyed[key] = event
             }
         }
 
@@ -383,8 +371,8 @@ enum ClaudeCostScanner {
         }
         session.budget.consume(read.bytesRead)
 
-        payload.period.merge(Self.tally(keyed: periodKeyed, unkeyed: periodUnkeyed, projectID: projectID))
-        payload.lifetime.merge(Self.tally(keyed: lifetimeKeyed, unkeyed: lifetimeUnkeyed, projectID: projectID))
+        payload.period.merge(Self.tally(keyed: periodKeyed, projectID: projectID))
+        payload.lifetime.merge(Self.tally(keyed: lifetimeKeyed, projectID: projectID))
         // `merge` sums `sessions`, but one transcript is one session however
         // many slices it took to read.
         payload.period.sessions = payload.period.hasUsage ? 1 : 0
@@ -462,11 +450,10 @@ enum ClaudeCostScanner {
 
     nonisolated private static func tally(
         keyed: [String: ClaudeUsageEvent],
-        unkeyed: [ClaudeUsageEvent],
         projectID: String
     ) -> ClaudeSessionTotals {
         var totals = ClaudeSessionTotals()
-        let events = keyed.keys.sorted().compactMap { keyed[$0] } + unkeyed
+        let events = keyed.keys.sorted().compactMap { keyed[$0] }
         // Resolving the current calendar is not free, and it cannot change
         // mid-fold.
         let calendar = Calendar.current
@@ -587,8 +574,27 @@ nonisolated private struct ClaudeUsageEvent: Sendable {
         input > 0 || output > 0 || cacheCreation > 0 || cacheRead > 0
     }
 
-    var deduplicationKey: String? {
-        guard let messageID, let requestID else { return nil }
-        return "\(messageID):\(requestID)"
+    func deduplicationKey(projectID: String) -> String {
+        if let messageID, let requestID {
+            return "\(messageID):\(requestID)"
+        }
+
+        let modelKey = model.map { Self.keyComponent($0) } ?? "nil"
+        return [
+            "synthetic",
+            String(timestamp.timeIntervalSinceReferenceDate.bitPattern),
+            modelKey,
+            String(input),
+            String(output),
+            String(cacheCreation),
+            String(cacheCreationOneHour),
+            String(cacheRead),
+            Self.keyComponent(origin),
+            Self.keyComponent(projectID)
+        ].joined(separator: ":")
+    }
+
+    private static func keyComponent(_ value: String) -> String {
+        "\(value.utf8.count):\(value)"
     }
 }

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -241,7 +241,7 @@ enum CodexCostScanner {
             Self.addTokenCountLine(
                 line,
                 fileURL: fileURL,
-                rollout: rollout,
+                rollout: &rollout,
                 deferred: &deferred,
                 events: &events
             )
@@ -365,6 +365,7 @@ enum CodexCostScanner {
         var rollout = payload.rollout
         var deferred: [CodexDeferredUsage] = []
         var deferredOffset: UInt64?
+        var deferredRollout: CodexRolloutContext?
         let calendar = Calendar.current
         var truncation = CostScanTruncationTally()
 
@@ -389,10 +390,11 @@ enum CodexCostScanner {
             }
             let parked = deferred.count
             let counted = windows.lifetime.eventKeys.count
+            let rolloutBeforeLine = rollout
             Self.addTokenCountLine(
                 line,
                 fileURL: file.url,
-                rollout: rollout,
+                rollout: &rollout,
                 deferred: &deferred,
                 windows: &windows,
                 calendar: calendar
@@ -403,6 +405,7 @@ enum CodexCostScanner {
             )
             if deferred.count > parked, deferredOffset == nil {
                 deferredOffset = offset
+                deferredRollout = rolloutBeforeLine
             }
         }
         truncation.log(url: file.url)
@@ -422,6 +425,7 @@ enum CodexCostScanner {
                 // is re-read too, and `eventKeys` discards it as the duplicate
                 // it is.
                 committed = deferredOffset
+                if let deferredRollout { rollout = deferredRollout }
             }
         }
 
@@ -486,7 +490,7 @@ enum CodexCostScanner {
             Self.addTokenCountLine(
                 line,
                 fileURL: file.url,
-                rollout: rollout,
+                rollout: &rollout,
                 deferred: &deferred,
                 windows: &windows,
                 calendar: calendar
@@ -633,7 +637,7 @@ enum CodexCostScanner {
     nonisolated private static func addTokenCountLine(
         _ line: Data,
         fileURL: URL,
-        rollout: CodexRolloutContext,
+        rollout: inout CodexRolloutContext,
         deferred: inout [CodexDeferredUsage],
         events: inout [CodexUsageEvent]
     ) {
@@ -642,13 +646,13 @@ enum CodexCostScanner {
               let timestamp = FlexibleISO8601.date(from: timestampText),
               let payload = json["payload"] as? [String: Any],
               payload["type"] as? String == "token_count",
-              let info = payload["info"] as? [String: Any],
-              let usage = (info["last_token_usage"] ?? info["total_token_usage"]) as? [String: Any] else {
+              let info = payload["info"] as? [String: Any] else {
             return
         }
 
         let sessionID = (((payload["rate_limits"] as? [String: Any])?["conversation_id"] as? String)
             ?? fileURL.deletingPathExtension().lastPathComponent)
+        guard let usage = Self.eventUsage(from: info, sessionID: sessionID, rollout: &rollout) else { return }
         // The event's own model wins when present (older rollouts stamped it
         // there); otherwise fall back to the surrounding rollout context.
         let modelName = Self.modelName(from: info, payload: payload)
@@ -687,7 +691,7 @@ enum CodexCostScanner {
     nonisolated private static func addTokenCountLine(
         _ line: Data,
         fileURL: URL,
-        rollout: CodexRolloutContext,
+        rollout: inout CodexRolloutContext,
         deferred: inout [CodexDeferredUsage],
         windows: inout ScanWindows<CostScanWindowContext>,
         calendar: Calendar
@@ -696,13 +700,40 @@ enum CodexCostScanner {
         Self.addTokenCountLine(
             line,
             fileURL: fileURL,
-            rollout: rollout,
+            rollout: &rollout,
             deferred: &deferred,
             events: &events
         )
         for event in events {
             Self.apply(event, windows: &windows, calendar: calendar)
         }
+    }
+
+    /// Codex normally provides a per-turn delta and a cumulative session total.
+    /// Older or interrupted rollouts sometimes omit the delta; only those lines
+    /// are differenced, while any cumulative value still advances the baseline
+    /// the next fallback needs. This runs before model deferral so parked events
+    /// keep their original order and already carry a true per-event delta.
+    nonisolated private static func eventUsage(
+        from info: [String: Any],
+        sessionID: String,
+        rollout: inout CodexRolloutContext
+    ) -> [String: Any]? {
+        let last = info["last_token_usage"] as? [String: Any]
+        let total = info["total_token_usage"] as? [String: Any]
+
+        if let last {
+            let baseline = rollout.cumulativeUsageBySession[sessionID] ?? CodexTokenCounters()
+            rollout.cumulativeUsageBySession[sessionID] = total.map(CodexTokenCounters.init)
+                ?? baseline.adding(CodexTokenCounters(last))
+            return last
+        }
+
+        guard let total else { return nil }
+        let counters = CodexTokenCounters(total)
+        let previous = rollout.cumulativeUsageBySession[sessionID] ?? CodexTokenCounters()
+        rollout.cumulativeUsageBySession[sessionID] = counters
+        return counters.delta(since: previous)
     }
 
     nonisolated private static func eventPayload(
@@ -951,13 +982,65 @@ nonisolated struct CodexRolloutContext: Sendable, Codable {
     /// (issue #270) — the non-prompt-content field project attribution is
     /// derived from. `nil` until (or unless) a `session_meta` event supplies it.
     var cwd: String?
+    /// Session counters observed before the current byte offset. Kept per
+    /// conversation because one rollout can interleave telemetry streams, and
+    /// persisted because resuming with an empty baseline would bill the full
+    /// session total again as if it were newly appended usage.
+    var cumulativeUsageBySession: [String: CodexTokenCounters] = [:]
+}
+
+/// The four cumulative counters Codex reports in `total_token_usage`.
+nonisolated struct CodexTokenCounters: Sendable, Codable {
+    var input = 0
+    var cached = 0
+    var output = 0
+    var reasoning = 0
+
+    init() {}
+
+    init(_ usage: [String: Any]) {
+        input = max(0, CostScanValues.int(usage["input_tokens"]))
+        cached = max(0, CostScanValues.int(usage["cached_input_tokens"]))
+        output = max(0, CostScanValues.int(usage["output_tokens"]))
+        reasoning = max(0, CostScanValues.int(usage["reasoning_output_tokens"]))
+    }
+
+    func delta(since previous: CodexTokenCounters) -> [String: Any] {
+        [
+            "input_tokens": Self.nonnegativeDifference(input, previous.input),
+            "cached_input_tokens": Self.nonnegativeDifference(cached, previous.cached),
+            "output_tokens": Self.nonnegativeDifference(output, previous.output),
+            "reasoning_output_tokens": Self.nonnegativeDifference(reasoning, previous.reasoning)
+        ]
+    }
+
+    func adding(_ other: CodexTokenCounters) -> CodexTokenCounters {
+        CodexTokenCounters(
+            input: input + other.input,
+            cached: cached + other.cached,
+            output: output + other.output,
+            reasoning: reasoning + other.reasoning
+        )
+    }
+
+    private init(input: Int, cached: Int, output: Int, reasoning: Int) {
+        self.input = input
+        self.cached = cached
+        self.output = output
+        self.reasoning = reasoning
+    }
+
+    private static func nonnegativeDifference(_ current: Int, _ previous: Int) -> Int {
+        current >= previous ? current - previous : 0
+    }
 }
 
 /// A `token_count` event parked because its rollout has not named a model yet.
 ///
-/// Deliberately not `Sendable`: it carries the raw `[String: Any]` usage
-/// payload. It never outlives the single-threaded parse of the file that made
-/// it, so it does not need to be.
+/// Its usage is normalized to a per-event delta before parking; delaying
+/// cumulative subtraction until model attribution is known would reorder the
+/// counter stream. Deliberately not `Sendable`: it carries a raw `[String: Any]`
+/// payload and never outlives the single-threaded parse of the file that made it.
 nonisolated struct CodexDeferredUsage {
     let usage: [String: Any]
     let timestamp: Date

--- a/MeterBar/Services/CostScanValues.swift
+++ b/MeterBar/Services/CostScanValues.swift
@@ -10,7 +10,7 @@ enum CostScanValues {
     /// Bump this whenever a change alters parsed output: usage extraction,
     /// deduplication, pricing, model normalization, or local-day bucketing.
     /// A mismatch discards the persisted cache and performs a full rescan.
-    nonisolated static let costCacheParserVersion = 3
+    nonisolated static let costCacheParserVersion = 4
 
     /// Token counts arrive as `Int`, `Int64`, `Double`, or a numeric string
     /// depending on which writer produced the log line; coerce every shape.

--- a/MeterBar/Services/CostScanValues.swift
+++ b/MeterBar/Services/CostScanValues.swift
@@ -10,7 +10,7 @@ enum CostScanValues {
     /// Bump this whenever a change alters parsed output: usage extraction,
     /// deduplication, pricing, model normalization, or local-day bucketing.
     /// A mismatch discards the persisted cache and performs a full rescan.
-    nonisolated static let costCacheParserVersion = 2
+    nonisolated static let costCacheParserVersion = 3
 
     /// Token counts arrive as `Int`, `Int64`, `Double`, or a numeric string
     /// depending on which writer produced the log line; coerce every shape.

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -177,6 +177,61 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(result.output, 53)
     }
 
+    func testParseSessionFileDeduplicatesIdenticalUnkeyedEvents() throws {
+        let line = eventLine(
+            timestamp: "2026-07-01T10:00:00.000Z",
+            messageID: nil,
+            requestID: nil,
+            input: 120,
+            output: 30
+        )
+        let url = try writeSessionFile(lines: [line, line])
+
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let result = ClaudeCostScanner.parseSessionFile(at: url, since: cutoff)
+
+        XCTAssertEqual(result.input, 120)
+        XCTAssertEqual(result.output, 30)
+    }
+
+    func testParseSessionFileCountsUnkeyedEventsThatDifferOnlyInTokenCounts() throws {
+        let url = try writeSessionFile(lines: [
+            eventLine(
+                timestamp: "2026-07-01T10:00:00.000Z",
+                messageID: nil,
+                requestID: nil,
+                input: 120,
+                output: 30
+            ),
+            eventLine(
+                timestamp: "2026-07-01T10:00:00.000Z",
+                messageID: nil,
+                requestID: nil,
+                input: 121,
+                output: 30
+            )
+        ])
+
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let result = ClaudeCostScanner.parseSessionFile(at: url, since: cutoff)
+
+        XCTAssertEqual(result.input, 241)
+        XCTAssertEqual(result.output, 60)
+    }
+
+    func testParseSessionFileKeepsExistingKeyedDeduplicationSemantics() throws {
+        let url = try writeSessionFile(lines: [
+            eventLine(timestamp: "2026-07-01T10:00:00.000Z", input: 120, output: 30),
+            eventLine(timestamp: "2026-07-01T10:01:00.000Z", input: 7, output: 3)
+        ])
+
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let result = ClaudeCostScanner.parseSessionFile(at: url, since: cutoff)
+
+        XCTAssertEqual(result.input, 7)
+        XCTAssertEqual(result.output, 3)
+    }
+
     func testParseSessionFileHonorsPerEventCutoff() throws {
         // Events older than the cutoff are excluded even when the FILE was
         // modified recently. (The old CLI scanner only checked file mtime.)
@@ -1469,6 +1524,43 @@ final class CostTrackerTests: XCTestCase {
     }
 
     // MARK: - Budgeted, resumable corpus scan
+
+    func testBudgetedClaudeScanMatchesWholeFileForDuplicateUnkeyedEvents() throws {
+        let root = try makeTranscriptRoot()
+        let line = eventLine(
+            timestamp: "2026-07-01T10:00:00.000Z",
+            messageID: nil,
+            requestID: nil,
+            input: 120,
+            output: 30
+        )
+        let url = try writeTranscript(in: root, name: "session.jsonl", modifiedAgo: 0, lines: [line, line])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let store = try makeScanCacheStore()
+        let firstLineBytes = (line + "\n").utf8.count
+        let firstSliceOptions = CostScanBudgetOptions(
+            maxBytesPerFile: firstLineBytes,
+            maxNewBytesPerRefresh: firstLineBytes,
+            wallClock: nil
+        )
+
+        let firstSlice = CostScanSession(cutoff: cutoff, options: firstSliceOptions, store: store)
+        _ = ClaudeCostScanner.scanRoots([root], session: firstSlice)
+        XCTAssertEqual(firstSlice.persist(), .persisted)
+        XCTAssertFalse(firstSlice.isComplete)
+
+        let resumed = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        let resumedWindows = ClaudeCostScanner.scanRoots([root], session: resumed)
+        let wholeFileWindows = ClaudeCostScanner.parseSessionWindows(at: url, since: cutoff)
+
+        XCTAssertTrue(resumed.isComplete)
+        XCTAssertEqual(resumedWindows.period.input, 120)
+        XCTAssertEqual(resumedWindows.period.output, 30)
+        XCTAssertEqual(resumedWindows.period.input, wholeFileWindows.period.input)
+        XCTAssertEqual(resumedWindows.period.output, wholeFileWindows.period.output)
+        XCTAssertEqual(resumedWindows.lifetime.input, wholeFileWindows.lifetime.input)
+        XCTAssertEqual(resumedWindows.lifetime.output, wholeFileWindows.lifetime.output)
+    }
 
     func testByteBudgetSmallerThanTheCorpusDefersTheRestWithoutLosingData() throws {
         let root = try makeTranscriptRoot()

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -454,6 +454,29 @@ final class CostTrackerTests: XCTestCase {
         """
     }
 
+    private func codexUsageSelectionLine(
+        timestamp: String,
+        conversationID: String = "conv-1",
+        model: String? = "gpt-5.5",
+        lastInput: Int? = nil,
+        totalInput: Int? = nil
+    ) -> String {
+        var info: [String] = []
+        if let model {
+            info.append("\"model\": \"\(model)\"")
+        }
+        if let lastInput {
+            info.append("\"last_token_usage\": {\"input_tokens\": \(lastInput), \"output_tokens\": 0}")
+        }
+        if let totalInput {
+            info.append("\"total_token_usage\": {\"input_tokens\": \(totalInput), \"output_tokens\": 0}")
+        }
+        return """
+        {"timestamp": "\(timestamp)", "type": "event_msg", "payload": {"type": "token_count", \
+        "rate_limits": {"conversation_id": "\(conversationID)"}, "info": {\(info.joined(separator: ", "))}}}
+        """
+    }
+
     private func makeContext(cutoff: Date) -> CostScanWindowContext {
         CostScanWindowContext(earliestDate: Date(), latestDate: cutoff)
     }
@@ -474,6 +497,116 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(context.totals.reasoning, 50)
         XCTAssertEqual(context.totals.cacheRead, 200)
         XCTAssertEqual(context.sessionIDs, ["conv-1"])
+    }
+
+    func testScanCodexRolloutsKeepsLastTokenUsageAsPerEventDeltas() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:00:00Z", lastInput: 100),
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:01:00Z", lastInput: 25)
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        var context = makeContext(cutoff: cutoff)
+
+        CostScanFixtureScan.codexRollouts(in: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.totals.input, 125)
+    }
+
+    func testScanCodexRolloutsDerivesDeltasFromCumulativeTotals() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:00:00Z", totalInput: 100),
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:01:00Z", totalInput: 150),
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:02:00Z", totalInput: 180)
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        var context = makeContext(cutoff: cutoff)
+
+        CostScanFixtureScan.codexRollouts(in: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.totals.input, 180)
+    }
+
+    func testScanCodexRolloutsKeepsCumulativeBaselineAcrossMixedUsageLines() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:00:00Z", lastInput: 100),
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:01:00Z", totalInput: 140),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T10:02:00Z", lastInput: 10, totalInput: 150
+            )
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        var context = makeContext(cutoff: cutoff)
+
+        CostScanFixtureScan.codexRollouts(in: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.totals.input, 150)
+    }
+
+    func testScanCodexRolloutsClampsCumulativeCounterDecreaseToZero() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:00:00Z", totalInput: 100),
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:01:00Z", totalInput: 90),
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:02:00Z", totalInput: 110)
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        var context = makeContext(cutoff: cutoff)
+
+        CostScanFixtureScan.codexRollouts(in: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.totals.input, 120)
+    }
+
+    func testScanCodexRolloutsKeepsCumulativeBaselinesPerSession() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T10:00:00Z", conversationID: "conv-a", totalInput: 100
+            ),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T10:01:00Z", conversationID: "conv-b", totalInput: 1_000
+            ),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T10:02:00Z", conversationID: "conv-a", totalInput: 150
+            ),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T10:03:00Z", conversationID: "conv-b", totalInput: 1_050
+            )
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        var context = makeContext(cutoff: cutoff)
+
+        CostScanFixtureScan.codexRollouts(in: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.totals.input, 1_200)
+        XCTAssertEqual(context.sessionIDs, ["conv-a", "conv-b"])
+    }
+
+    func testWholeFileAndBudgetedCodexScansMatchForDeferredCumulativeUsage() throws {
+        let root = try makeCodexHome()
+        let directory = root.appendingPathComponent("sessions", isDirectory: true)
+        try writeCodexRollout(in: directory, path: "rollout.jsonl", lines: [
+            codexSessionMetaLine(timestamp: "2026-06-15T09:00:00Z"),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T09:00:30Z", model: nil, totalInput: 100
+            ),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T09:00:45Z", model: nil, totalInput: 150
+            ),
+            codexTurnContextLine(timestamp: "2026-06-15T09:01:00Z", model: "gpt-5.6-sol"),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T09:02:00Z", model: nil, totalInput: 180
+            )
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        var wholeFile = CodexCostScanner.scanWindows(cutoff: cutoff)
+        CostScanFixtureScan.codexRollouts(in: directory, windows: &wholeFile)
+
+        let session = CostScanSession(cutoff: cutoff, options: .unlimited)
+        let budgeted = CodexCostScanner.scanRollouts(directories: [directory], session: session)
+
+        XCTAssertEqual(wholeFile.period.totals.input, 180)
+        XCTAssertEqual(budgeted.period.totals.input, wholeFile.period.totals.input)
+        XCTAssertEqual(budgeted.period.eventKeys, wholeFile.period.eventKeys)
+        XCTAssertEqual(budgeted.period.sessionIDs, wholeFile.period.sessionIDs)
     }
 
     func testScanCodexRolloutsDeduplicatesIdenticalEvents() throws {
@@ -934,6 +1067,79 @@ final class CostTrackerTests: XCTestCase {
 
         XCTAssertEqual(windows.period.totals.input, 125)
         XCTAssertEqual(session.codex.records.count, 1)
+    }
+
+    func testBudgetedCodexScanResumesCumulativeBaselineWithoutRecounting() throws {
+        let root = try makeCodexHome()
+        let directory = root.appendingPathComponent("sessions", isDirectory: true)
+        let lines = [
+            codexTurnContextLine(timestamp: "2026-06-15T09:00:00Z", model: "gpt-5.6-sol"),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T09:01:00Z", model: nil, totalInput: 100
+            ),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T09:02:00Z", model: nil, totalInput: 150
+            )
+        ]
+        try writeCodexRollout(in: directory, path: "rollout.jsonl", lines: lines)
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        let store = try makeScanCacheStore()
+        let firstSliceBytes = (lines.prefix(2).joined(separator: "\n") + "\n").utf8.count
+        let budget = CostScanBudgetOptions(
+            maxBytesPerFile: .max,
+            maxNewBytesPerRefresh: firstSliceBytes,
+            wallClock: nil
+        )
+
+        let first = CostScanSession(cutoff: cutoff, options: budget, store: store)
+        let firstWindows = CodexCostScanner.scanRollouts(directories: [directory], session: first)
+        XCTAssertEqual(first.persist(), .persisted)
+
+        XCTAssertFalse(first.isComplete)
+        XCTAssertEqual(firstWindows.period.totals.input, 100)
+
+        let second = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        let resumed = CodexCostScanner.scanRollouts(directories: [directory], session: second)
+
+        XCTAssertTrue(second.isComplete)
+        XCTAssertEqual(resumed.period.totals.input, 150)
+    }
+
+    func testBudgetedCodexScanRollsBackCumulativeBaselineWithDeferredUsage() throws {
+        let root = try makeCodexHome()
+        let directory = root.appendingPathComponent("sessions", isDirectory: true)
+        let lines = [
+            codexSessionMetaLine(timestamp: "2026-06-15T09:00:00Z"),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T09:00:30Z", model: nil, totalInput: 100
+            ),
+            codexTurnContextLine(timestamp: "2026-06-15T09:01:00Z", model: "gpt-5.6-sol"),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T09:02:00Z", model: nil, totalInput: 150
+            )
+        ]
+        try writeCodexRollout(in: directory, path: "rollout.jsonl", lines: lines)
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        let store = try makeScanCacheStore()
+        let firstSliceBytes = (lines.prefix(2).joined(separator: "\n") + "\n").utf8.count
+        let budget = CostScanBudgetOptions(
+            maxBytesPerFile: .max,
+            maxNewBytesPerRefresh: firstSliceBytes,
+            wallClock: nil
+        )
+
+        let first = CostScanSession(cutoff: cutoff, options: budget, store: store)
+        let firstWindows = CodexCostScanner.scanRollouts(directories: [directory], session: first)
+        XCTAssertEqual(first.persist(), .persisted)
+
+        XCTAssertFalse(first.isComplete)
+        XCTAssertEqual(firstWindows.period.totals.input, 0)
+
+        let second = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        let resumed = CodexCostScanner.scanRollouts(directories: [directory], session: second)
+
+        XCTAssertTrue(second.isComplete)
+        XCTAssertEqual(resumed.period.totals.input, 150)
     }
 
     /// Deduplication picks one copy per session; it must not also decide the


### PR DESCRIPTION
Fixes #374

## Problem

`CodexCostScanner.addTokenCountLine` treated two different quantities as interchangeable:

```swift
let usage = (info["last_token_usage"] ?? info["total_token_usage"]) as? [String: Any]
```

`last_token_usage` is a **per-turn delta**. `total_token_usage` is the **session running total**. When a rollout omitted the delta — older writers, interrupted sessions — the scanner summed the entire cumulative total on top of every delta it had already counted. Codex spend inflated for the remainder of that session, and the error compounded with each subsequent cumulative-only line.

## Fix

Usage resolution moves into `eventUsage(from:sessionID:rollout:)`, which maintains a per-session baseline of counters seen so far:

- **Delta line** → used as-is; the baseline advances to the reported total, or to `baseline + delta` when no total accompanies it.
- **Cumulative-only line** → differenced against the baseline, and the baseline advances.
- **Counter decrease** → clamped to zero rather than producing a negative charge.

Normalization happens *before* model deferral, so events parked awaiting model attribution keep their original order and are already carrying a true per-event delta — deferring the subtraction instead would reorder the counter stream.

### Resume correctness

The baseline lives on `CodexRolloutContext`, keyed by conversation, because a single rollout file can interleave telemetry streams. It is **persisted**: resuming a scan with an empty baseline would difference the next cumulative line against zero and bill an entire session total again as freshly appended usage.

Budgeted scans that stop mid-file already roll the committed offset back to the first deferred line. That rollback now carries the baseline with it (`deferredRollout`), so the resumed scan re-reads those lines from exactly the state a whole-file scan would have been in. `testWholeFileAndBudgetedCodexScansMatchForDeferredCumulativeUsage` pins that equivalence directly.

`costCacheParserVersion` 2 → 3 discards caches written by the old arithmetic. Stale-shape decode is already `try?`-guarded in `CostScanFileCache.load`, so an older cache falls back to empty rather than throwing.

## Tests

Eight tests added to `CostTrackerTests` (+206 lines):

| Test | Covers |
|---|---|
| `KeepsLastTokenUsageAsPerEventDeltas` | delta lines unchanged |
| `DerivesDeltasFromCumulativeTotals` | the actual bug |
| `KeepsCumulativeBaselineAcrossMixedUsageLines` | interleaved shapes |
| `ClampsCumulativeCounterDecreaseToZero` | no negative charges |
| `KeepsCumulativeBaselinesPerSession` | per-conversation isolation |
| `WholeFileAndBudgetedCodexScansMatch…` | budgeted ≡ whole-file |
| `BudgetedCodexScanResumesCumulativeBaseline…` | no recount on resume |
| `BudgetedCodexScanRollsBackCumulativeBaseline…` | deferred rollback |

Full suite: **2091 tests, 0 failures** (6 skipped), 56.2s.

Fixes #378
