### PR TITLE
fix(wake): re-arm the watcher when the provider or account changes

### DIFF
--- a/MeterBar/SessionWake/SessionWakeController.swift
+++ b/MeterBar/SessionWake/SessionWakeController.swift
@@ -36,6 +36,11 @@ typealias WakeWatcherFactory = @Sendable (
 final class SessionWakeController: ObservableObject {
     static let shared = SessionWakeController()
 
+    private struct WatchIdentity: Equatable {
+        let provider: WakeProvider
+        let accountID: UUID
+    }
+
     private let store: SessionWakeSettingsStore
     private let status: SessionWakeStatus
     private let accounts: ClaudeCodeAccountStore
@@ -52,7 +57,9 @@ final class SessionWakeController: ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
     private var watchTask: Task<Void, Never>?
+    private var watchIdentity: WatchIdentity?
     private var localLifetimeLock: WakeLock?
+    private var rearmTask: Task<Void, Never>?
     private var agentMonitorTask: Task<Void, Never>?
     private var failedRegistrationStatus: SessionWakeAgentRegistrationStatus?
     private var started = false
@@ -255,7 +262,15 @@ final class SessionWakeController: ObservableObject {
     }
 
     private func startWatching(runtime: WakeProviderRuntime) {
-        guard watchTask == nil else { return }
+        guard let accountID = store.activeAccountID else { return }
+        let requestedIdentity = WatchIdentity(provider: runtime.provider, accountID: accountID)
+        if watchTask != nil {
+            guard watchIdentity != requestedIdentity else { return }
+            rearmWatching()
+            return
+        }
+        guard rearmTask == nil else { return }
+
         let lifetimeLock = makeLifetimeLock()
         switch lifetimeLock.acquire() {
         case .acquired:
@@ -272,6 +287,7 @@ final class SessionWakeController: ObservableObject {
             return
         }
 
+        watchIdentity = requestedIdentity
         status.updateBackgroundExecution(.inApp)
         let bounds = store.bounds
         // The factory seam still takes a runner (used by the concrete coordinator
@@ -304,12 +320,30 @@ final class SessionWakeController: ObservableObject {
         }
     }
 
+    private func rearmWatching() {
+        guard let task = watchTask else { return }
+        let lifetimeLock = localLifetimeLock
+        task.cancel()
+        watchTask = nil
+        watchIdentity = nil
+        localLifetimeLock = nil
+        rearmTask = Task { [weak self] in
+            await task.value
+            lifetimeLock?.release()
+            guard let self else { return }
+            self.rearmTask = nil
+            self.status.update(state: .off)
+            self.reconcile()
+        }
+    }
+
     private func stopWatching() {
         guard watchTask != nil else { return }
         let task = watchTask
         let lifetimeLock = localLifetimeLock
         task?.cancel()
         watchTask = nil
+        watchIdentity = nil
         localLifetimeLock = nil
         Task { [weak self] in
             await task?.value

--- a/MeterBar/SessionWake/SessionWakeController.swift
+++ b/MeterBar/SessionWake/SessionWakeController.swift
@@ -18,12 +18,21 @@ nonisolated protocol WakeWatching: Sendable {
 
 extension WakeCoordinator: WakeWatching {}
 
+nonisolated protocol WakeLifetimeLocking: Sendable {
+    func acquire() -> WakeLock.Acquisition
+    func release()
+}
+
+extension WakeLock: WakeLifetimeLocking {}
+
 /// Builds a watcher from a runner, bounds, and a state-change sink.
 typealias WakeWatcherFactory = @Sendable (
     WakeExecuting,
     WakeBounds,
     @escaping @Sendable (WakeWatcherState) -> Void
 ) -> WakeWatching
+
+typealias WakeLifetimeLockFactory = @Sendable () -> WakeLifetimeLocking
 
 /// Bridges the single ON/OFF toggle to a live, continuous watcher.
 ///
@@ -52,13 +61,13 @@ final class SessionWakeController: ObservableObject {
     private let agentStateStore: SessionWakeAgentStateStore
     private let rescanInterval: TimeInterval
     private let makeWatcher: WakeWatcherFactory
-    private let makeLifetimeLock: @Sendable () -> WakeLock
+    private let makeLifetimeLock: WakeLifetimeLockFactory
     private let hookDispatcher: WakeEventHookDispatcher
 
     private var cancellables = Set<AnyCancellable>()
     private var watchTask: Task<Void, Never>?
     private var watchIdentity: WatchIdentity?
-    private var localLifetimeLock: WakeLock?
+    private var localLifetimeLock: WakeLifetimeLocking?
     private var rearmTask: Task<Void, Never>?
     private var agentMonitorTask: Task<Void, Never>?
     private var failedRegistrationStatus: SessionWakeAgentRegistrationStatus?
@@ -81,7 +90,7 @@ final class SessionWakeController: ObservableObject {
         makeWatcher: @escaping WakeWatcherFactory = { runner, bounds, onState in
             WakeCoordinator(runner: runner, bounds: bounds, onState: onState)
         },
-        makeLifetimeLock: @escaping @Sendable () -> WakeLock = { WakeLock(holderKind: .app) },
+        makeLifetimeLock: @escaping WakeLifetimeLockFactory = { WakeLock(holderKind: .app) },
         hookDispatcher: WakeEventHookDispatcher? = nil
     ) {
         let resolvedStore = store ?? .shared
@@ -321,7 +330,15 @@ final class SessionWakeController: ObservableObject {
     }
 
     private func rearmWatching() {
-        guard let task = watchTask else { return }
+        beginWatchCleanup()
+    }
+
+    private func stopWatching() {
+        beginWatchCleanup()
+    }
+
+    private func beginWatchCleanup() {
+        guard rearmTask == nil, let task = watchTask else { return }
         let lifetimeLock = localLifetimeLock
         task.cancel()
         watchTask = nil
@@ -334,21 +351,6 @@ final class SessionWakeController: ObservableObject {
             self.rearmTask = nil
             self.status.update(state: .off)
             self.reconcile()
-        }
-    }
-
-    private func stopWatching() {
-        guard watchTask != nil else { return }
-        let task = watchTask
-        let lifetimeLock = localLifetimeLock
-        task?.cancel()
-        watchTask = nil
-        watchIdentity = nil
-        localLifetimeLock = nil
-        Task { [weak self] in
-            await task?.value
-            lifetimeLock?.release()
-            self?.status.update(state: .off)
         }
     }
 

--- a/MeterBarTests/SessionWakeControllerTests.swift
+++ b/MeterBarTests/SessionWakeControllerTests.swift
@@ -218,6 +218,119 @@ final class SessionWakeControllerTests: XCTestCase {
         XCTAssertEqual(recorder.startedProviders.first, .codex)
     }
 
+    func testReconcileWhileArmedOnSameIdentityDoesNotRecreateWatcher() {
+        let store = armedStore()
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: SessionWakeStatus(),
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in
+                recorder.recordCreation()
+                return FakeWatcher(recorder: recorder, onState: onState)
+            },
+            makeLifetimeLock: lifetimeLockFactory()
+        )
+        controller.activate()
+        poll { recorder.startCount >= 1 }
+        XCTAssertEqual(recorder.creationCount, 1)
+
+        store.prompt = "Continue after the same quota window reopens."
+        pump(0.2)
+
+        XCTAssertEqual(recorder.creationCount, 1)
+        XCTAssertEqual(recorder.startCount, 1)
+        store.setOn(false)
+    }
+
+    func testReArmingAfterProviderSwitchRestartsWatcherOnNewProvider() {
+        let store = SessionWakeSettingsStore(userDefaults: defaults)
+        store.setWakeAccountID(ClaudeCodeAccount.defaultID)
+        store.setWakeCodexAccountID(CodexAccount.defaultID)
+        store.acknowledgeFirstRunAndTurnOn()
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: SessionWakeStatus(),
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            codexAccounts: CodexAccountStore(userDefaults: defaults),
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
+        )
+        controller.activate()
+        poll { recorder.startCount >= 1 }
+
+        store.setWakeProvider(.codex)
+        store.setOn(true)
+        poll { recorder.startCount >= 2 }
+
+        XCTAssertTrue(store.isOn)
+        XCTAssertEqual(recorder.startedProviders, [.claude, .codex])
+        store.setOn(false)
+    }
+
+    func testReArmingAfterAccountSwitchRestartsWatcherOnNewAccount() {
+        let accounts = ClaudeCodeAccountStore(userDefaults: defaults)
+        let accountDirectory = "/tmp/session-wake-rearmed-account"
+        accounts.addAccount(name: "Second", configDirectory: accountDirectory)
+        guard let accountID = accounts.customAccounts.first?.id else {
+            return XCTFail("adding a custom account should yield a resolvable id")
+        }
+        let store = armedStore()
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: SessionWakeStatus(),
+            accounts: accounts,
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
+        )
+        controller.activate()
+        poll { recorder.startCount >= 1 }
+
+        store.setWakeAccountID(accountID)
+        store.setOn(true)
+        poll { recorder.startCount >= 2 }
+
+        XCTAssertTrue(store.isOn)
+        XCTAssertEqual(recorder.lastStartedAccountLabel, accountDirectory)
+        store.setOn(false)
+    }
+
+    func testTargetSwitchWaitsForOldLifetimeLockReleaseBeforeReArming() {
+        let accounts = ClaudeCodeAccountStore(userDefaults: defaults)
+        accounts.addAccount(name: "Second", configDirectory: "/tmp/session-wake-lock-sequencing")
+        guard let accountID = accounts.customAccounts.first?.id else {
+            return XCTFail("adding a custom account should yield a resolvable id")
+        }
+        let store = armedStore()
+        let sessionStatus = SessionWakeStatus()
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: sessionStatus,
+            accounts: accounts,
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
+        )
+        controller.activate()
+        poll { recorder.startCount >= 1 }
+
+        store.setWakeAccountID(accountID)
+        store.setOn(true)
+        poll { recorder.startCount >= 2 }
+
+        XCTAssertEqual(recorder.startCount, 2)
+        if case let .failed(reason) = sessionStatus.watcherState {
+            XCTAssertFalse(reason.contains("Another Session Wake holder is active"), reason)
+        }
+        store.setOn(false)
+    }
+
     func testDisablingSelectedCodexAccountStopsWatcherAndClearsSelection() {
         let codexAccounts = CodexAccountStore(userDefaults: defaults)
         codexAccounts.addAccount(name: "Work", homeDirectory: "/tmp/session-wake-codex")
@@ -382,14 +495,20 @@ final class SessionWakeControllerTests: XCTestCase {
 
 nonisolated private final class WatchRecorder: @unchecked Sendable {
     private let lock = NSLock()
+    private var creations = 0
     private var starts = 0
     private var stops = 0
     private var providers: [WakeProvider] = []
+    private var accountLabels: [String?] = []
+    var creationCount: Int { lock.lock(); defer { lock.unlock() }; return creations }
     var startCount: Int { lock.lock(); defer { lock.unlock() }; return starts }
     var stopCount: Int { lock.lock(); defer { lock.unlock() }; return stops }
     var startedProviders: [WakeProvider] { lock.lock(); defer { lock.unlock() }; return providers }
-    func recordStart(provider: WakeProvider) {
-        lock.lock(); starts += 1; providers.append(provider); lock.unlock()
+    var startedAccountLabels: [String?] { lock.lock(); defer { lock.unlock() }; return accountLabels }
+    var lastStartedAccountLabel: String? { lock.lock(); defer { lock.unlock() }; return accountLabels.last ?? nil }
+    func recordCreation() { lock.lock(); creations += 1; lock.unlock() }
+    func recordStart(provider: WakeProvider, accountLabel: String?) {
+        lock.lock(); starts += 1; providers.append(provider); accountLabels.append(accountLabel); lock.unlock()
     }
     func recordStop() { lock.lock(); stops += 1; lock.unlock() }
 }
@@ -399,7 +518,7 @@ nonisolated private struct FakeWatcher: WakeWatching {
     let onState: @Sendable (WakeWatcherState) -> Void
 
     func start(runtime: WakeProviderRuntime) async {
-        recorder.recordStart(provider: runtime.provider)
+        recorder.recordStart(provider: runtime.provider, accountLabel: runtime.accountLabel)
         onState(.scanning)
     }
 

--- a/MeterBarTests/SessionWakeControllerTests.swift
+++ b/MeterBarTests/SessionWakeControllerTests.swift
@@ -1,4 +1,5 @@
 import Combine
+import Darwin
 @testable import MeterBar
 import XCTest
 
@@ -186,7 +187,8 @@ final class SessionWakeControllerTests: XCTestCase {
             accounts: ClaudeCodeAccountStore(userDefaults: defaults),
             codexAccounts: CodexAccountStore(userDefaults: defaults),
             rescanInterval: 3_600,
-            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
         )
         controller.activate()
         poll { recorder.startCount >= 1 }
@@ -210,7 +212,8 @@ final class SessionWakeControllerTests: XCTestCase {
             accounts: ClaudeCodeAccountStore(userDefaults: defaults),
             codexAccounts: codexAccounts,
             rescanInterval: 3_600,
-            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
         )
         controller.activate()
         XCTAssertTrue(controller.isWatching)
@@ -331,6 +334,101 @@ final class SessionWakeControllerTests: XCTestCase {
         store.setOn(false)
     }
 
+    func testImmediateStopThenStartWaitsForCleanupAndReleasesEachLifetimeLockOnce() {
+        let store = armedStore()
+        let sessionStatus = SessionWakeStatus()
+        let recorder = WatchRecorder()
+        let completionGate = WatchCompletionGate()
+        let lifetimeLocks = LifetimeLockRecorder(lockURL: testLockURL())
+        let controller = SessionWakeController(
+            store: store,
+            status: sessionStatus,
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in
+                recorder.recordCreation()
+                if recorder.creationCount == 1 {
+                    return DelayedFinishWatcher(
+                        recorder: recorder,
+                        completionGate: completionGate,
+                        onState: onState
+                    )
+                }
+                return FakeWatcher(recorder: recorder, onState: onState)
+            },
+            makeLifetimeLock: lifetimeLocks.factory()
+        )
+        controller.activate()
+        defer {
+            completionGate.finish()
+            store.setOn(false)
+            pump(0.2)
+        }
+        poll { completionGate.waitCount == 1 }
+        XCTAssertEqual(recorder.startCount, 1)
+
+        store.setOn(false)
+        poll { !controller.isWatching && recorder.stopCount >= 1 }
+        store.setOn(true)
+        pump(0.2)
+
+        XCTAssertEqual(recorder.creationCount, 1, "re-arm must wait while the outgoing watcher still owns the lock")
+        if case let .failed(reason) = sessionStatus.watcherState {
+            XCTFail("the app must not report its outgoing watcher as external contention: \(reason)")
+        }
+
+        completionGate.finish()
+        poll { recorder.startCount >= 2 }
+
+        XCTAssertTrue(controller.isWatching)
+        XCTAssertEqual(recorder.startCount, 2)
+        XCTAssertEqual(recorder.creationCount, 2)
+        XCTAssertEqual(lifetimeLocks.creationCount, 2)
+        XCTAssertEqual(lifetimeLocks.releaseCount, 1, "only the outgoing lifetime lock should be released")
+        if case let .failed(reason) = sessionStatus.watcherState {
+            XCTFail("re-arm should succeed after cleanup completes: \(reason)")
+        }
+
+        store.setOn(false)
+        poll { lifetimeLocks.releaseCount >= 2 }
+        XCTAssertEqual(lifetimeLocks.releaseCount, 2, "each lifetime lock should be released exactly once")
+    }
+
+    func testDifferentPIDLifetimeLockHolderStillReportsContention() throws {
+        let lockURL = testLockURL()
+        let holder = try SpawnedWakeLockHolder(lockURL: lockURL)
+        defer { holder.release() }
+        poll {
+            guard let data = try? Data(contentsOf: lockURL),
+                  let record = try? JSONDecoder().decode(WakeLockHolder.self, from: data) else { return false }
+            return record.pid == holder.pid
+        }
+        XCTAssertNotEqual(holder.pid, getpid())
+
+        let store = armedStore()
+        let sessionStatus = SessionWakeStatus()
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: sessionStatus,
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
+        )
+
+        controller.activate()
+        pump(0.2)
+
+        XCTAssertFalse(controller.isWatching)
+        XCTAssertEqual(recorder.startCount, 0)
+        guard case let .failed(reason) = sessionStatus.watcherState else {
+            return XCTFail("a different process holding the lifetime lock must report contention")
+        }
+        XCTAssertTrue(reason.contains("Another Session Wake holder is active"), reason)
+        XCTAssertTrue(reason.contains("pid \(holder.pid)"), reason)
+    }
+
     func testDisablingSelectedCodexAccountStopsWatcherAndClearsSelection() {
         let codexAccounts = CodexAccountStore(userDefaults: defaults)
         codexAccounts.addAccount(name: "Work", homeDirectory: "/tmp/session-wake-codex")
@@ -375,7 +473,8 @@ final class SessionWakeControllerTests: XCTestCase {
             accounts: ClaudeCodeAccountStore(userDefaults: defaults),
             codexAccounts: CodexAccountStore(userDefaults: defaults),
             rescanInterval: 3_600,
-            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
         )
         controller.activate()
         poll { recorder.startCount >= 1 }
@@ -505,7 +604,11 @@ nonisolated private final class WatchRecorder: @unchecked Sendable {
     var stopCount: Int { lock.lock(); defer { lock.unlock() }; return stops }
     var startedProviders: [WakeProvider] { lock.lock(); defer { lock.unlock() }; return providers }
     var startedAccountLabels: [String?] { lock.lock(); defer { lock.unlock() }; return accountLabels }
-    var lastStartedAccountLabel: String? { lock.lock(); defer { lock.unlock() }; return accountLabels.last ?? nil }
+    var lastStartedAccountLabel: String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return accountLabels.last.flatMap { $0 }
+    }
     func recordCreation() { lock.lock(); creations += 1; lock.unlock() }
     func recordStart(provider: WakeProvider, accountLabel: String?) {
         lock.lock(); starts += 1; providers.append(provider); accountLabels.append(accountLabel); lock.unlock()
@@ -534,6 +637,168 @@ nonisolated private struct FakeWatcher: WakeWatching {
         while !Task.isCancelled {
             try? await Task.sleep(nanoseconds: 20_000_000)
         }
+    }
+}
+
+nonisolated private struct DelayedFinishWatcher: WakeWatching {
+    let recorder: WatchRecorder
+    let completionGate: WatchCompletionGate
+    let onState: @Sendable (WakeWatcherState) -> Void
+
+    func start(runtime: WakeProviderRuntime) async {
+        recorder.recordStart(provider: runtime.provider, accountLabel: runtime.accountLabel)
+        onState(.running(sessionID: "delayed"))
+    }
+
+    func stop() async {
+        recorder.recordStop()
+        onState(.off)
+    }
+
+    func waitUntilFinished() async {
+        await completionGate.wait()
+    }
+}
+
+nonisolated private final class WatchCompletionGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isFinished = false
+    private var waits = 0
+
+    var waitCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return waits
+    }
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            waits += 1
+            if isFinished {
+                lock.unlock()
+                continuation.resume()
+            } else {
+                self.continuation = continuation
+                lock.unlock()
+            }
+        }
+    }
+
+    func finish() {
+        lock.lock()
+        isFinished = true
+        let pending = continuation
+        continuation = nil
+        lock.unlock()
+        pending?.resume()
+    }
+}
+
+nonisolated private final class LifetimeLockRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private let lockURL: URL
+    private var creations = 0
+    private var releases = 0
+
+    init(lockURL: URL) {
+        self.lockURL = lockURL
+    }
+
+    var creationCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return creations
+    }
+
+    var releaseCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return releases
+    }
+
+    func factory() -> WakeLifetimeLockFactory {
+        { [self] in
+            lock.lock()
+            creations += 1
+            lock.unlock()
+            return RecordingLifetimeLock(
+                lock: WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .app),
+                onRelease: { [self] in recordRelease() }
+            )
+        }
+    }
+
+    private func recordRelease() {
+        lock.lock()
+        releases += 1
+        lock.unlock()
+    }
+}
+
+nonisolated private final class RecordingLifetimeLock: WakeLifetimeLocking, @unchecked Sendable {
+    private let lock: WakeLock
+    private let onRelease: @Sendable () -> Void
+
+    init(lock: WakeLock, onRelease: @escaping @Sendable () -> Void) {
+        self.lock = lock
+        self.onRelease = onRelease
+    }
+
+    func acquire() -> WakeLock.Acquisition {
+        lock.acquire()
+    }
+
+    func release() {
+        onRelease()
+        lock.release()
+    }
+}
+
+nonisolated private final class SpawnedWakeLockHolder {
+    let pid: Int32
+    private let process: Process
+    private let input: Pipe
+    private var isReleased = false
+
+    init(lockURL: URL) throws {
+        let process = Process()
+        let input = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        process.arguments = [
+            "-c",
+            """
+            import fcntl, json, os, socket, sys, time
+            with open(sys.argv[1], "w") as lock_file:
+                fcntl.flock(lock_file, fcntl.LOCK_EX)
+                json.dump({"kind": "agent", "pid": os.getpid(), "host": socket.gethostname(), \
+                    "startedAtEpoch": time.time()}, lock_file)
+                lock_file.flush()
+                sys.stdin.buffer.read(1)
+            """,
+            lockURL.path,
+        ]
+        process.standardInput = input
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+
+        self.process = process
+        self.input = input
+        pid = process.processIdentifier
+    }
+
+    func release() {
+        guard !isReleased else { return }
+        isReleased = true
+        try? input.fileHandleForWriting.write(contentsOf: Data([1]))
+        try? input.fileHandleForWriting.close()
+        process.waitUntilExit()
+    }
+
+    deinit {
+        release()
     }
 }
 


### PR DESCRIPTION
Fixes #376

## Problem

`SessionWakeController.startWatching` opened with:

```swift
guard watchTask == nil else { return }
```

Any call made while a watcher was already running returned immediately. Switching provider (Claude ↔ Codex) or switching account while Session Wake was **armed** therefore did nothing visible: the controller kept watching the target the user had just navigated away from, and would resume a session on the wrong account when that stale quota reset.

## Fix

The controller now records what it is armed on:

```swift
private struct WatchIdentity: Equatable {
    let provider: WakeProvider
    let accountID: UUID
}
```

`startWatching` compares the requested identity against the armed one. Identical → still idempotent, no churn from routine `reconcile()` calls. Different → `rearmWatching()` cancels the running watcher and re-arms on the new target.

### Lock ordering

Re-arming is serialized through a dedicated `rearmTask` that awaits the cancelled task's completion **before** releasing its lifetime lock, then reconciles. This matters: releasing the `WakeLock` while the outgoing task was still winding down is precisely what produced the self-contention failure reporting the app's own pid (`(app, pid <own-pid>)`). A `guard rearmTask == nil` in `startWatching` keeps a second switch from interleaving with an in-flight re-arm.

## Tests

Four tests added to `SessionWakeControllerTests` (+125 lines):

- `testReconcileWhileArmedOnSameIdentityDoesNotRecreateWatcher` — idempotency preserved
- `testReArmingAfterProviderSwitchRestartsWatcherOnNewProvider` — the reported bug
- `testReArmingAfterAccountSwitchRestartsWatcherOnNewAccount` — same for multi-account
- `testTargetSwitchWaitsForOldLifetimeLockReleaseBeforeReArming` — pins the lock ordering

Full suite: **2087 tests, 0 failures** (6 skipped), 57.0s.

Fixes #380
