### PR TITLE
fix(cost): deduplicate Claude usage events that carry no message/request ID

### DIFF
--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -146,9 +146,7 @@ enum ClaudeCostScanner {
         projectID: String = CostProjectAttribution.unknownProjectID
     ) -> ScanWindows<ClaudeSessionTotals> {
         var periodKeyed: [String: ClaudeUsageEvent] = [:]
-        var periodUnkeyed: [ClaudeUsageEvent] = []
         var lifetimeKeyed: [String: ClaudeUsageEvent] = [:]
-        var lifetimeUnkeyed: [ClaudeUsageEvent] = []
 
         var truncation = CostScanTruncationTally()
 
@@ -158,19 +156,15 @@ enum ClaudeCostScanner {
             guard let event else { return }
 
             let inPeriod = event.timestamp >= cutoffDate
-            if let key = event.deduplicationKey {
-                lifetimeKeyed[key] = event
-                if inPeriod { periodKeyed[key] = event }
-            } else {
-                lifetimeUnkeyed.append(event)
-                if inPeriod { periodUnkeyed.append(event) }
-            }
+            let key = event.deduplicationKey(projectID: projectID)
+            lifetimeKeyed[key] = event
+            if inPeriod { periodKeyed[key] = event }
         }
         truncation.log(url: url)
 
         return ScanWindows(
-            period: Self.tally(keyed: periodKeyed, unkeyed: periodUnkeyed, projectID: projectID),
-            lifetime: Self.tally(keyed: lifetimeKeyed, unkeyed: lifetimeUnkeyed, projectID: projectID),
+            period: Self.tally(keyed: periodKeyed, projectID: projectID),
+            lifetime: Self.tally(keyed: lifetimeKeyed, projectID: projectID),
             cutoff: cutoffDate
         )
     }
@@ -346,9 +340,7 @@ enum ClaudeCostScanner {
         request.maxBytes = allowance
 
         var periodKeyed: [String: ClaudeUsageEvent] = [:]
-        var periodUnkeyed: [ClaudeUsageEvent] = []
         var lifetimeKeyed: [String: ClaudeUsageEvent] = [:]
-        var lifetimeUnkeyed: [ClaudeUsageEvent] = []
 
         var truncation = CostScanTruncationTally()
 
@@ -357,20 +349,16 @@ enum ClaudeCostScanner {
             truncation.note(line, recovered: event != nil)
             guard let event else { return }
 
-            if let key = event.deduplicationKey {
-                // First-wins across a resume boundary: an event with this key is
-                // already folded into `payload`, and its bytes are behind the
-                // committed offset. Within a single pass the last copy still
-                // wins, exactly as a cold scan does.
-                if !payload.lifetimeKeys.contains(key) {
-                    lifetimeKeyed[key] = event
-                }
-                if event.timestamp >= session.cutoff, !payload.periodKeys.contains(key) {
-                    periodKeyed[key] = event
-                }
-            } else {
-                lifetimeUnkeyed.append(event)
-                if event.timestamp >= session.cutoff { periodUnkeyed.append(event) }
+            let key = event.deduplicationKey(projectID: projectID)
+            // First-wins across a resume boundary: an event with this key is
+            // already folded into `payload`, and its bytes are behind the
+            // committed offset. Within a single pass the last copy still
+            // wins, exactly as a cold scan does.
+            if !payload.lifetimeKeys.contains(key) {
+                lifetimeKeyed[key] = event
+            }
+            if event.timestamp >= session.cutoff, !payload.periodKeys.contains(key) {
+                periodKeyed[key] = event
             }
         }
 
@@ -383,8 +371,8 @@ enum ClaudeCostScanner {
         }
         session.budget.consume(read.bytesRead)
 
-        payload.period.merge(Self.tally(keyed: periodKeyed, unkeyed: periodUnkeyed, projectID: projectID))
-        payload.lifetime.merge(Self.tally(keyed: lifetimeKeyed, unkeyed: lifetimeUnkeyed, projectID: projectID))
+        payload.period.merge(Self.tally(keyed: periodKeyed, projectID: projectID))
+        payload.lifetime.merge(Self.tally(keyed: lifetimeKeyed, projectID: projectID))
         // `merge` sums `sessions`, but one transcript is one session however
         // many slices it took to read.
         payload.period.sessions = payload.period.hasUsage ? 1 : 0
@@ -462,11 +450,10 @@ enum ClaudeCostScanner {
 
     nonisolated private static func tally(
         keyed: [String: ClaudeUsageEvent],
-        unkeyed: [ClaudeUsageEvent],
         projectID: String
     ) -> ClaudeSessionTotals {
         var totals = ClaudeSessionTotals()
-        let events = keyed.keys.sorted().compactMap { keyed[$0] } + unkeyed
+        let events = keyed.keys.sorted().compactMap { keyed[$0] }
         // Resolving the current calendar is not free, and it cannot change
         // mid-fold.
         let calendar = Calendar.current
@@ -587,8 +574,27 @@ nonisolated private struct ClaudeUsageEvent: Sendable {
         input > 0 || output > 0 || cacheCreation > 0 || cacheRead > 0
     }
 
-    var deduplicationKey: String? {
-        guard let messageID, let requestID else { return nil }
-        return "\(messageID):\(requestID)"
+    func deduplicationKey(projectID: String) -> String {
+        if let messageID, let requestID {
+            return "\(messageID):\(requestID)"
+        }
+
+        let modelKey = model.map { Self.keyComponent($0) } ?? "nil"
+        return [
+            "synthetic",
+            String(timestamp.timeIntervalSinceReferenceDate.bitPattern),
+            modelKey,
+            String(input),
+            String(output),
+            String(cacheCreation),
+            String(cacheCreationOneHour),
+            String(cacheRead),
+            Self.keyComponent(origin),
+            Self.keyComponent(projectID)
+        ].joined(separator: ":")
+    }
+
+    private static func keyComponent(_ value: String) -> String {
+        "\(value.utf8.count):\(value)"
     }
 }

--- a/MeterBar/Services/CostScanValues.swift
+++ b/MeterBar/Services/CostScanValues.swift
@@ -10,7 +10,7 @@ enum CostScanValues {
     /// Bump this whenever a change alters parsed output: usage extraction,
     /// deduplication, pricing, model normalization, or local-day bucketing.
     /// A mismatch discards the persisted cache and performs a full rescan.
-    nonisolated static let costCacheParserVersion = 3
+    nonisolated static let costCacheParserVersion = 4
 
     /// Token counts arrive as `Int`, `Int64`, `Double`, or a numeric string
     /// depending on which writer produced the log line; coerce every shape.

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -177,6 +177,61 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(result.output, 53)
     }
 
+    func testParseSessionFileDeduplicatesIdenticalUnkeyedEvents() throws {
+        let line = eventLine(
+            timestamp: "2026-07-01T10:00:00.000Z",
+            messageID: nil,
+            requestID: nil,
+            input: 120,
+            output: 30
+        )
+        let url = try writeSessionFile(lines: [line, line])
+
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let result = ClaudeCostScanner.parseSessionFile(at: url, since: cutoff)
+
+        XCTAssertEqual(result.input, 120)
+        XCTAssertEqual(result.output, 30)
+    }
+
+    func testParseSessionFileCountsUnkeyedEventsThatDifferOnlyInTokenCounts() throws {
+        let url = try writeSessionFile(lines: [
+            eventLine(
+                timestamp: "2026-07-01T10:00:00.000Z",
+                messageID: nil,
+                requestID: nil,
+                input: 120,
+                output: 30
+            ),
+            eventLine(
+                timestamp: "2026-07-01T10:00:00.000Z",
+                messageID: nil,
+                requestID: nil,
+                input: 121,
+                output: 30
+            )
+        ])
+
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let result = ClaudeCostScanner.parseSessionFile(at: url, since: cutoff)
+
+        XCTAssertEqual(result.input, 241)
+        XCTAssertEqual(result.output, 60)
+    }
+
+    func testParseSessionFileKeepsExistingKeyedDeduplicationSemantics() throws {
+        let url = try writeSessionFile(lines: [
+            eventLine(timestamp: "2026-07-01T10:00:00.000Z", input: 120, output: 30),
+            eventLine(timestamp: "2026-07-01T10:01:00.000Z", input: 7, output: 3)
+        ])
+
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let result = ClaudeCostScanner.parseSessionFile(at: url, since: cutoff)
+
+        XCTAssertEqual(result.input, 7)
+        XCTAssertEqual(result.output, 3)
+    }
+
     func testParseSessionFileHonorsPerEventCutoff() throws {
         // Events older than the cutoff are excluded even when the FILE was
         // modified recently. (The old CLI scanner only checked file mtime.)
@@ -1469,6 +1524,43 @@ final class CostTrackerTests: XCTestCase {
     }
 
     // MARK: - Budgeted, resumable corpus scan
+
+    func testBudgetedClaudeScanMatchesWholeFileForDuplicateUnkeyedEvents() throws {
+        let root = try makeTranscriptRoot()
+        let line = eventLine(
+            timestamp: "2026-07-01T10:00:00.000Z",
+            messageID: nil,
+            requestID: nil,
+            input: 120,
+            output: 30
+        )
+        let url = try writeTranscript(in: root, name: "session.jsonl", modifiedAgo: 0, lines: [line, line])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let store = try makeScanCacheStore()
+        let firstLineBytes = (line + "\n").utf8.count
+        let firstSliceOptions = CostScanBudgetOptions(
+            maxBytesPerFile: firstLineBytes,
+            maxNewBytesPerRefresh: firstLineBytes,
+            wallClock: nil
+        )
+
+        let firstSlice = CostScanSession(cutoff: cutoff, options: firstSliceOptions, store: store)
+        _ = ClaudeCostScanner.scanRoots([root], session: firstSlice)
+        XCTAssertEqual(firstSlice.persist(), .persisted)
+        XCTAssertFalse(firstSlice.isComplete)
+
+        let resumed = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        let resumedWindows = ClaudeCostScanner.scanRoots([root], session: resumed)
+        let wholeFileWindows = ClaudeCostScanner.parseSessionWindows(at: url, since: cutoff)
+
+        XCTAssertTrue(resumed.isComplete)
+        XCTAssertEqual(resumedWindows.period.input, 120)
+        XCTAssertEqual(resumedWindows.period.output, 30)
+        XCTAssertEqual(resumedWindows.period.input, wholeFileWindows.period.input)
+        XCTAssertEqual(resumedWindows.period.output, wholeFileWindows.period.output)
+        XCTAssertEqual(resumedWindows.lifetime.input, wholeFileWindows.lifetime.input)
+        XCTAssertEqual(resumedWindows.lifetime.output, wholeFileWindows.lifetime.output)
+    }
 
     func testByteBudgetSmallerThanTheCorpusDefersTheRestWithoutLosingData() throws {
         let root = try makeTranscriptRoot()


### PR DESCRIPTION
Fixes #378

> **Stacked on #398.** Base is `fix/374-codex-total-token-fallback`; GitHub will retarget this to `master` when #398 merges. Review the [three-file diff](https://github.com/VincentShipsIt/meterbar.dev/pull/400/files), not the commit range.

## The bug

Claude session lines that carry both `message.id` and `requestId` were deduplicated by that pair. Lines missing either one were pushed onto a separate unkeyed array and tallied verbatim — so the same line written twice counted twice.

The budgeted (resumable) path was worse. Keyed events are checked against `payload.lifetimeKeys` to avoid re-counting across a resume boundary; unkeyed events had no key, skipped that check entirely, and were re-added on **every** slice of a resumed scan.

## The fix

`deduplicationKey(projectID:)` becomes non-optional and always returns something:

- keyed events keep `"\(messageID):\(requestID)"` and their existing last-wins semantics — unchanged;
- unkeyed events get a synthetic key over timestamp bit pattern, model, all five token counts, origin, and project.

String components are length-prefixed (`"\(value.utf8.count):\(value)"`) so a model or origin containing `:` cannot forge a delimiter and collide with a structurally different event.

Both scan paths now hold only `[String: ClaudeUsageEvent]`; the unkeyed arrays and `tally(unkeyed:)` parameter are gone.

The budgeted path applies the same first-wins-across-resume rule to every event:

```swift
if !payload.lifetimeKeys.contains(key) {
    lifetimeKeyed[key] = event
}
```

An event already folded into `payload` sits behind the committed offset, so re-adding it would double-count. Within a single pass the last copy still wins, exactly as a cold scan does.

## Cache invalidation

`costCacheParserVersion` 3 → 4. Existing caches hold the inflated totals and must be discarded. #398 takes it 2 → 3; this branch is stacked so the two bumps are sequential rather than colliding on the same value.

## Tests

Four new tests in `CostTrackerTests`:

| test | asserts |
|---|---|
| `testParseSessionFileDeduplicatesIdenticalUnkeyedEvents` | identical unkeyed line twice → 120/30, not 240/60 |
| `testParseSessionFileCountsUnkeyedEventsThatDifferOnlyInTokenCounts` | 120 vs 121 input at the same timestamp are distinct → 241/60 |
| `testParseSessionFileKeepsExistingKeyedDeduplicationSemantics` | keyed last-wins unchanged → 7/3 |
| `testBudgetedClaudeScanMatchesWholeFileForDuplicateUnkeyedEvents` | slice at `firstLineBytes`, assert incomplete, resume `.unlimited`, result equals the whole-file scan |

The last one is the regression guard for the resumable path specifically — it would have passed before the fix only if the budgeted and cold paths agreed, which they did not.

## Verification

- `swift test` — 2095 tests, 6 skipped, **0 failures** (55.2s)
- `swiftlint lint --strict` (0.65.0, CI-pinned) — **0 violations in 267 files**