### PR TITLE
fix(refresh): guard refreshAll with the shared cross-process lock

### DIFF
--- a/MeterBar/Models/CostWindowSelection.swift
+++ b/MeterBar/Models/CostWindowSelection.swift
@@ -26,11 +26,10 @@ nonisolated enum CostWindowSelection: Int, CaseIterable, Identifiable {
     /// Title of the spend-chart card ("30 Day Spend").
     var spendCardTitle: String { "\(days) Day Spend" }
 
-    /// Token-activity calendar columns covering this window. Two 7-day columns
-    /// are the narrowest grid that always spans the last 7 days (one column
-    /// covers only the part-week up to today); the month keeps the existing
-    /// six-week calendar.
-    var activityWeeks: Int {
+    /// Calendar width used when hourly rows are unavailable. Old seven-day
+    /// caches keep their existing two-week fallback; the month always keeps
+    /// the existing six-week calendar.
+    var fallbackActivityWeeks: Int {
         switch self {
         case .week: return 2
         case .month: return TokenActivityCalendar.defaultWeeks

--- a/MeterBar/Models/TokenActivityCalendar.swift
+++ b/MeterBar/Models/TokenActivityCalendar.swift
@@ -323,3 +323,255 @@ struct TokenActivityCalendar {
         return (0..<weekdayCount).map { symbols[($0 + offset) % weekdayCount] }
     }
 }
+
+// MARK: - Hour × day grid
+
+/// Stable identity for one local day/hour coordinate. The hour component is
+/// explicit so daylight-saving transitions still render exactly 24 columns;
+/// repeated fallback hours aggregate into their shared local-hour column.
+struct TokenActivityHourKey: Hashable {
+    let day: Date
+    let hour: Int
+}
+
+/// One cell in the trailing-seven-day hourly activity grid.
+struct TokenActivityHour: Identifiable, Equatable {
+    var id: TokenActivityHourKey { TokenActivityHourKey(day: day, hour: hour) }
+
+    let day: Date
+    let hour: Int
+    let totalTokens: Int
+    let estimatedCostUSD: Double
+    let providers: [TokenActivityProviderTotal]
+    let level: Int
+
+    var hasUsage: Bool { totalTokens > 0 }
+
+    var accessibilityLabel: String { header }
+
+    var accessibilityValue: String {
+        guard hasUsage else { return "No tracked usage" }
+
+        var parts = [
+            "\(UsageFormat.tokens(totalTokens)) tokens",
+            UsageFormat.cost(estimatedCostUSD),
+            "intensity \(level) of \(TokenActivityIntensityScale.bandCount)",
+        ]
+        parts.append(contentsOf: providers.map {
+            "\($0.provider.displayName) \(UsageFormat.tokens($0.tokens)), \(UsageFormat.cost($0.costUSD))"
+        })
+        return parts.joined(separator: ", ")
+    }
+
+    var detailLine: String {
+        guard hasUsage else { return "\(header) · No tracked usage" }
+
+        var parts = ["\(UsageFormat.tokens(totalTokens)) tokens", UsageFormat.cost(estimatedCostUSD)]
+        parts.append(contentsOf: providers.map {
+            "\($0.provider.displayName) \(UsageFormat.tokens($0.tokens))"
+        })
+        return "\(header) · \(parts.joined(separator: " · "))"
+    }
+
+    var tooltip: String {
+        guard hasUsage else { return "\(header)\nNo tracked usage" }
+
+        var lines = [header, "\(UsageFormat.tokens(totalTokens)) tokens", UsageFormat.cost(estimatedCostUSD)]
+        if !providers.isEmpty {
+            lines.append("")
+            lines.append(contentsOf: providers.map {
+                "\($0.provider.displayName): \(UsageFormat.tokens($0.tokens)) · \(UsageFormat.cost($0.costUSD))"
+            })
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private var header: String {
+        "\(DashboardDateFormat.medium(day)) at \(String(format: "%02d:00", hour))"
+    }
+}
+
+/// One day row, oldest to newest, with a stable cell for each local hour 0–23.
+struct TokenActivityHourDay: Identifiable, Equatable {
+    var id: Date { date }
+    let date: Date
+    let hours: [TokenActivityHour]
+}
+
+/// Pure 7 × 24 model derived once before SwiftUI hover/focus updates begin.
+struct TokenActivityHourlyCalendar {
+    static let dayCount = 7
+    static let hourCount = 24
+
+    let startDate: Date
+    let endDate: Date
+    let days: [TokenActivityHourDay]
+    let hours: [TokenActivityHour]
+    let scale: TokenActivityIntensityScale
+    /// First local day represented by a retained hourly row. The grid still
+    /// renders all seven rows, but days before this date are layout, not proof
+    /// that MeterBar retained a full week of history.
+    let coverageStartDate: Date?
+
+    private let hoursByKey: [TokenActivityHourKey: TokenActivityHour]
+    private let calendar: Calendar
+
+    init(
+        hourlyUsage: [HourlyTokenUsage],
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) {
+        let today = calendar.startOfDay(for: now)
+        let startDate = Self.day(today, offsetBy: -(Self.dayCount - 1), calendar: calendar)
+        let rows = hourlyUsage.filter { row in
+            let day = calendar.startOfDay(for: row.date)
+            return day >= startDate && day <= today
+        }
+        let coverageStartDate = rows.map { calendar.startOfDay(for: $0.date) }.min()
+        let rowsByKey = Dictionary(grouping: rows) { row in
+            TokenActivityHourKey(
+                day: calendar.startOfDay(for: row.date),
+                hour: calendar.component(.hour, from: row.date)
+            )
+        }
+        let coordinates = (0..<Self.dayCount).flatMap { dayOffset in
+            let day = Self.day(startDate, offsetBy: dayOffset, calendar: calendar)
+            return (0..<Self.hourCount).map { TokenActivityHourKey(day: day, hour: $0) }
+        }
+        let totals = coordinates.map { key in
+            let providers = Self.providerTotals(for: rowsByKey[key] ?? [])
+            return (
+                key: key,
+                tokens: providers.reduce(0) { $0 + $1.tokens },
+                cost: providers.reduce(0) { $0 + $1.costUSD },
+                providers: providers
+            )
+        }
+        let scale = TokenActivityIntensityScale(dailyTotals: totals.map(\.tokens))
+        let hours = totals.map { total in
+            TokenActivityHour(
+                day: total.key.day,
+                hour: total.key.hour,
+                totalTokens: total.tokens,
+                estimatedCostUSD: total.cost,
+                providers: total.providers,
+                level: scale.level(for: total.tokens)
+            )
+        }
+        let hoursByKey = Dictionary(uniqueKeysWithValues: hours.map { ($0.id, $0) })
+        let days = (0..<Self.dayCount).map { dayOffset in
+            let day = Self.day(startDate, offsetBy: dayOffset, calendar: calendar)
+            return TokenActivityHourDay(
+                date: day,
+                hours: (0..<Self.hourCount).compactMap {
+                    hoursByKey[TokenActivityHourKey(day: day, hour: $0)]
+                }
+            )
+        }
+
+        self.startDate = startDate
+        self.endDate = today
+        self.days = days
+        self.hours = hours
+        self.scale = scale
+        self.coverageStartDate = coverageStartDate
+        self.hoursByKey = hoursByKey
+        self.calendar = calendar
+    }
+
+    func hour(at date: Date) -> TokenActivityHour? {
+        hoursByKey[TokenActivityHourKey(
+            day: calendar.startOfDay(for: date),
+            hour: calendar.component(.hour, from: date)
+        )]
+    }
+
+    func hour(for key: TokenActivityHourKey) -> TokenActivityHour? { hoursByKey[key] }
+
+    var activeHours: [TokenActivityHour] { hours.filter(\.hasUsage) }
+
+    var totalTokens: Int { hours.reduce(0) { $0 + $1.totalTokens } }
+
+    var totalCostUSD: Double { hours.reduce(0) { $0 + $1.estimatedCostUSD } }
+
+    var busiestHour: TokenActivityHour? { activeHours.max { $0.totalTokens < $1.totalTokens } }
+
+    var coverageSummary: String? {
+        guard let coverageStartDate else { return nil }
+        let distance = calendar.dateComponents([.day], from: coverageStartDate, to: endDate).day ?? 0
+        let tracked = min(Self.dayCount, max(1, distance + 1))
+        return "\(tracked) day\(tracked == 1 ? "" : "s") tracked"
+    }
+
+    var overviewLine: String {
+        guard let busiestHour else { return "No tracked usage in this window." }
+
+        return [
+            "\(UsageFormat.tokens(totalTokens)) tokens",
+            UsageFormat.cost(totalCostUSD),
+            "Busiest \(DashboardDateFormat.medium(busiestHour.day)) at "
+                + String(format: "%02d:00", busiestHour.hour)
+                + " (\(UsageFormat.tokens(busiestHour.totalTokens)))",
+        ].joined(separator: " · ")
+    }
+
+    private static func day(_ date: Date, offsetBy days: Int, calendar: Calendar) -> Date {
+        guard let shifted = calendar.date(byAdding: .day, value: days, to: date) else { return date }
+        return calendar.startOfDay(for: shifted)
+    }
+
+    private static func providerTotals(for rows: [HourlyTokenUsage]) -> [TokenActivityProviderTotal] {
+        Dictionary(grouping: rows, by: \.provider)
+            .map { provider, rows in
+                TokenActivityProviderTotal(
+                    provider: provider,
+                    tokens: rows.reduce(0) { $0 + max(0, $1.totalTokens) },
+                    costUSD: rows.reduce(0) { $0 + max(0, $1.estimatedCostUSD) }
+                )
+            }
+            .filter { $0.tokens > 0 || $0.costUSD > 0 }
+            .sorted {
+                if $0.tokens != $1.tokens { return $0.tokens > $1.tokens }
+                if $0.costUSD != $1.costUSD { return $0.costUSD > $1.costUSD }
+                return $0.provider.displayName < $1.provider.displayName
+            }
+    }
+}
+
+/// Selects the hourly seven-day grid when the new cache field is populated,
+/// otherwise preserving the existing calendar (including the two-week legacy
+/// fallback). Both derived models are built here, never in a hover-driven body.
+struct TokenActivityGrid {
+    let daily: TokenActivityCalendar?
+    let hourly: TokenActivityHourlyCalendar?
+
+    init(
+        summary: CostSummary?,
+        windowSelection: CostWindowSelection,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) {
+        if windowSelection == .week,
+           let hourlyUsage = summary?.hourlyUsage,
+           !hourlyUsage.isEmpty {
+            daily = nil
+            hourly = TokenActivityHourlyCalendar(
+                hourlyUsage: hourlyUsage,
+                now: now,
+                calendar: calendar
+            )
+        } else {
+            daily = TokenActivityCalendar(
+                summary: summary,
+                weeks: windowSelection.fallbackActivityWeeks,
+                now: now,
+                calendar: calendar
+            )
+            hourly = nil
+        }
+    }
+
+    var hasHistory: Bool { hourly != nil || daily?.hasHistory == true }
+
+    var coverageSummary: String? { hourly?.coverageSummary ?? daily?.coverageSummary }
+}

--- a/MeterBar/Models/TokenCost.swift
+++ b/MeterBar/Models/TokenCost.swift
@@ -206,6 +206,42 @@ nonisolated public struct DailyTokenUsage: Codable, Identifiable, Sendable {
     }()
 }
 
+/// One provider's token usage inside a local calendar-hour bucket.
+///
+/// Hourly rows intentionally stop at the same aggregate shape as daily rows:
+/// the seven-day activity heatmap needs provider totals, not model or project
+/// attribution. `date` is always the start of the represented local hour.
+nonisolated public struct HourlyTokenUsage: Codable, Identifiable, Sendable {
+    public var id: String { "\(provider.rawValue)-\(date.timeIntervalSinceReferenceDate)" }
+
+    public let date: Date
+    public let provider: ServiceType
+    public let inputTokens: Int
+    public let outputTokens: Int
+    public let cacheReadTokens: Int
+    public let estimatedCostUSD: Double
+
+    public init(
+        date: Date,
+        provider: ServiceType,
+        inputTokens: Int,
+        outputTokens: Int,
+        cacheReadTokens: Int,
+        estimatedCostUSD: Double
+    ) {
+        self.date = date
+        self.provider = provider
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.cacheReadTokens = cacheReadTokens
+        self.estimatedCostUSD = estimatedCostUSD
+    }
+
+    public var totalTokens: Int {
+        inputTokens + outputTokens + cacheReadTokens
+    }
+}
+
 nonisolated public struct LifetimeProviderCost: Codable, Identifiable, Equatable, Sendable {
     public var id: String { provider.rawValue }
 
@@ -283,6 +319,9 @@ nonisolated public struct CostSummary: Codable, Sendable {
     public let totalTokens: Int
     public let periodDays: Int
     public let dailyUsage: [DailyTokenUsage]
+    /// Provider rows for the trailing seven calendar days, bucketed at each
+    /// local hour start. Optional so caches written before issue #372 decode.
+    public let hourlyUsage: [HourlyTokenUsage]?
     public let lifetime: LifetimeCostSummary?
     /// Which dated rate entries actually priced this scan, and how many events
     /// predated the table (issue #339). Optional so summaries cached by builds
@@ -296,6 +335,7 @@ nonisolated public struct CostSummary: Codable, Sendable {
         totalTokens: Int,
         periodDays: Int,
         dailyUsage: [DailyTokenUsage] = [],
+        hourlyUsage: [HourlyTokenUsage]? = nil,
         lifetime: LifetimeCostSummary? = nil,
         pricing: PricingProvenance? = nil
     ) {
@@ -304,6 +344,7 @@ nonisolated public struct CostSummary: Codable, Sendable {
         self.totalTokens = totalTokens
         self.periodDays = periodDays
         self.dailyUsage = dailyUsage
+        self.hourlyUsage = hourlyUsage
         self.lifetime = lifetime
         self.pricing = pricing
     }
@@ -354,6 +395,26 @@ nonisolated public struct CostSummary: Codable, Sendable {
         })
 
         return populatedDays.count < daysToCheck
+    }
+
+    /// Whether a cache that should cover the seven-day activity window still
+    /// predates hourly rows. A completed scan today is authoritative even when
+    /// it found no hourly usage, preventing an empty week from rescanning on
+    /// every Costs-page appearance.
+    func needsMissingHourlyUsageRefresh(
+        lastScanDate: Date?,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> Bool {
+        guard !costs.isEmpty, totalTokens > 0, periodDays >= 7 else { return false }
+
+        let today = calendar.startOfDay(for: now)
+        if let lastScanDate,
+           calendar.startOfDay(for: lastScanDate) >= today {
+            return false
+        }
+
+        return hourlyUsage?.isEmpty != false
     }
 
     /// Aggregates the cached daily rows into per-provider totals over the last
@@ -445,6 +506,7 @@ nonisolated public struct CostSummary: Codable, Sendable {
     public func filtered(to enabledServices: Set<ServiceType>) -> CostSummary {
         let visibleCosts = costs.filter { enabledServices.contains($0.provider) }
         let visibleDailyUsage = dailyUsage.filter { enabledServices.contains($0.provider) }
+        let visibleHourlyUsage = hourlyUsage?.filter { enabledServices.contains($0.provider) }
 
         return CostSummary(
             costs: visibleCosts,
@@ -452,6 +514,7 @@ nonisolated public struct CostSummary: Codable, Sendable {
             totalTokens: visibleCosts.reduce(0) { $0 + $1.totalTokens },
             periodDays: periodDays,
             dailyUsage: visibleDailyUsage,
+            hourlyUsage: visibleHourlyUsage,
             lifetime: lifetime?.filtered(to: enabledServices)
         )
     }

--- a/MeterBar/Models/UsageFormatting.swift
+++ b/MeterBar/Models/UsageFormatting.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MeterBarShared
 
 /// Shared, cached formatting helpers.
 ///
@@ -14,16 +15,6 @@ nonisolated public enum UsageFormat {
         formatter.numberStyle = .decimal
         formatter.usesGroupingSeparator = true
         formatter.maximumFractionDigits = 0
-        return formatter
-    }()
-
-    private static let currencyNumber: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.numberStyle = .decimal
-        formatter.usesGroupingSeparator = true
-        formatter.minimumFractionDigits = 2
-        formatter.maximumFractionDigits = 2
         return formatter
     }()
 
@@ -54,7 +45,7 @@ nonisolated public enum UsageFormat {
 
     /// Currency string, e.g. `$12.34`.
     public static func cost(_ value: Double) -> String {
-        "$\(currencyNumber.string(from: NSNumber(value: value)) ?? String(format: "%.2f", value))"
+        UsageAmountFormat.currency(value)
     }
 
     /// Abbreviated relative time, e.g. `2h ago`, using a cached formatter.

--- a/MeterBar/Serve/ServeToken.swift
+++ b/MeterBar/Serve/ServeToken.swift
@@ -2,6 +2,100 @@ import Darwin
 import Foundation
 import Security
 
+/// Where the bearer token protecting `meterbar serve` came from. Callers use
+/// this provenance to decide whether startup may reveal the token: only a
+/// freshly generated token has nowhere else for the operator to retrieve it.
+nonisolated public enum ServeTokenOrigin: Sendable, Equatable {
+    case explicitArgument
+    case file
+    case environment
+    case generated
+}
+
+/// A usable bearer token paired with the source that won the documented
+/// precedence chain.
+nonisolated public struct ResolvedServeToken: Sendable, Equatable {
+    public let token: String
+    public let origin: ServeTokenOrigin
+
+    public init(token: String, origin: ServeTokenOrigin) {
+        self.token = token
+        self.origin = origin
+    }
+}
+
+/// Operator-actionable failures from token-source resolution. Keeping these
+/// cases typed lets the CLI translate them into concise `ValidationError`
+/// messages without parsing filesystem error copy or exposing token values.
+nonisolated public enum ServeTokenResolutionError: Error, Sendable, Equatable {
+    case blankExplicitArgument
+    case unreadableTokenFile(path: String)
+    case blankTokenFile(path: String)
+    case blankEnvironment
+}
+
+/// Pure precedence and validation policy for the `meterbar serve` bearer
+/// token. Filesystem reads and token generation are injected so every branch
+/// is deterministic in tests and no test ever needs to place a secret on disk.
+nonisolated public enum ServeTokenSource {
+    public static let environmentVariable = "METERBAR_SERVE_TOKEN"
+
+    public static func resolve(
+        explicitToken: String?,
+        tokenFilePath: String?,
+        environment: [String: String],
+        readFile: (String) throws -> String,
+        generate: () -> String
+    ) throws -> ResolvedServeToken {
+        if let explicitToken {
+            guard ServeToken.isUsable(explicitToken) else {
+                throw ServeTokenResolutionError.blankExplicitArgument
+            }
+            return ResolvedServeToken(token: explicitToken, origin: .explicitArgument)
+        }
+
+        if let tokenFilePath {
+            let contents: String
+            do {
+                contents = try readFile(tokenFilePath)
+            } catch {
+                throw ServeTokenResolutionError.unreadableTokenFile(path: tokenFilePath)
+            }
+            let token = trimmingTrailingWhitespace(from: contents)
+            guard ServeToken.isUsable(token) else {
+                throw ServeTokenResolutionError.blankTokenFile(path: tokenFilePath)
+            }
+            return ResolvedServeToken(token: token, origin: .file)
+        }
+
+        if let environmentToken = environment[environmentVariable] {
+            guard ServeToken.isUsable(environmentToken) else {
+                throw ServeTokenResolutionError.blankEnvironment
+            }
+            return ResolvedServeToken(token: environmentToken, origin: .environment)
+        }
+
+        return ResolvedServeToken(token: generate(), origin: .generated)
+    }
+
+    /// Token files commonly end in a newline because they were written by a
+    /// shell or secret manager. Strip only the suffix: leading and internal
+    /// whitespace may deliberately be part of the bearer token and must remain
+    /// byte-for-byte intact.
+    private static func trimmingTrailingWhitespace(from value: String) -> String {
+        var end = value.endIndex
+        while end > value.startIndex {
+            let previous = value.index(before: end)
+            let character = value[previous]
+            guard character.unicodeScalars.allSatisfy(CharacterSet.whitespacesAndNewlines.contains) else {
+                break
+            }
+            end = previous
+        }
+        return String(value[..<end])
+    }
+}
+
 /// Bearer token generation and comparison for `meterbar serve`. Comparison
 /// runs in constant time so a network caller can't use response latency to
 /// guess the token one byte at a time (docs/cli-json-schema.md security notes).

--- a/MeterBar/Services/CLIBinaryLocator.swift
+++ b/MeterBar/Services/CLIBinaryLocator.swift
@@ -1,4 +1,13 @@
 import Foundation
+import os
+
+/// Coarse provenance for a resolved provider CLI. This is intentionally an
+/// observability signal rather than an execution gate: developer CLIs are
+/// routinely installed as unsigned or ad-hoc-signed npm/bun shims.
+nonisolated enum CLIBinaryTrust: Equatable, Sendable {
+    case wellKnown
+    case unexpected
+}
 
 /// Resolves a CLI executable by scanning `PATH` and the common install
 /// locations MeterBar runs from (Homebrew, npm-global, yarn, bun, volta, etc.).
@@ -7,6 +16,9 @@ import Foundation
 /// out so provider-readiness diagnostics can ask "is `codex` / `claude` / `grok` on
 /// PATH?" without re-deriving the same fallback list.
 nonisolated enum CLIBinaryLocator {
+    private static let systemBinaryDirectories = ["/usr/bin", "/bin", "/usr/sbin", "/sbin"]
+    private static let trustLogState = CLIBinaryTrustLogState()
+
     /// The install directories the fallbacks draw from, in priority order.
     /// Kept in sync with the reconnect script's `export PATH` list.
     static func fallbackDirectories(home: String) -> [String] {
@@ -56,12 +68,21 @@ nonisolated enum CLIBinaryLocator {
         command: String,
         overrideEnvVar: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment,
+        home: String = ServiceSupport.realHomeDirectory(),
         fileManager: FileManager = .default
     ) -> String? {
         if let overrideEnvVar,
            let override = environment[overrideEnvVar]?.trimmingCharacters(in: .whitespacesAndNewlines),
            !override.isEmpty,
            fileManager.isExecutableFile(atPath: override) {
+            // An explicit path is deliberate operator configuration. Its
+            // location carries no surprise signal, regardless of directory.
+            logUnexpectedResolutionIfNeeded(
+                command: command,
+                resolvedPath: override,
+                home: home,
+                isUserOverride: true
+            )
             return override
         }
 
@@ -69,13 +90,120 @@ nonisolated enum CLIBinaryLocator {
             .split(separator: ":")
             .map { "\($0)/\(command)" }
 
-        let fallbacks = fallbackCandidates(for: command, home: ServiceSupport.realHomeDirectory())
+        let fallbacks = fallbackCandidates(for: command, home: home)
 
-        return (pathCandidates + fallbacks).first { fileManager.isExecutableFile(atPath: $0) }
+        guard let resolvedPath = (pathCandidates + fallbacks).first(where: {
+            fileManager.isExecutableFile(atPath: $0)
+        }) else {
+            return nil
+        }
+
+        logUnexpectedResolutionIfNeeded(command: command, resolvedPath: resolvedPath, home: home)
+        return resolvedPath
+    }
+
+    /// Classifies a resolved executable by exact, normalized parent-directory
+    /// equality. Substring matching would incorrectly trust paths such as
+    /// `/tmp/opt/homebrew/bin`, while raw comparison would flag harmless `//`
+    /// and trailing-slash variants.
+    ///
+    /// `isUserOverride` represents a path supplied through the provider's
+    /// override environment variable. Such a path is deliberate user intent
+    /// and is therefore `.wellKnown` regardless of location.
+    ///
+    /// Code-signature enforcement was considered and rejected. Claude, Codex,
+    /// and Grok are frequently unsigned or ad-hoc-signed npm/bun shims, so a
+    /// signature requirement would reject most legitimate installations while
+    /// providing little assurance about the script/runtime ultimately executed.
+    static func trust(
+        forResolvedPath resolvedPath: String,
+        home: String,
+        isUserOverride: Bool = false
+    ) -> CLIBinaryTrust {
+        guard !isUserOverride else { return .wellKnown }
+
+        let parentDirectory = normalizedPath(
+            (normalizedPath(resolvedPath) as NSString).deletingLastPathComponent
+        )
+        let wellKnownDirectories = Set(
+            (fallbackDirectories(home: home) + systemBinaryDirectories).map(normalizedPath)
+        )
+        return wellKnownDirectories.contains(parentDirectory) ? .wellKnown : .unexpected
+    }
+
+    /// Clears process-lifetime notice deduplication so tests remain independent
+    /// of execution order.
+    static func resetTrustLogStateForTesting() {
+        trustLogState.reset()
+    }
+
+    static var trustLogCountForTesting: Int {
+        trustLogState.count
+    }
+
+    private static func logUnexpectedResolutionIfNeeded(
+        command: String,
+        resolvedPath: String,
+        home: String,
+        isUserOverride: Bool = false
+    ) {
+        guard trust(
+            forResolvedPath: resolvedPath,
+            home: home,
+            isUserOverride: isUserOverride
+        ) == .unexpected else {
+            return
+        }
+
+        let normalizedResolvedPath = normalizedPath(resolvedPath)
+        let key = "\(command)\u{0}\(normalizedResolvedPath)"
+        guard trustLogState.insert(key) else { return }
+
+        let redactedPath = ServiceSupport.compactPathForDisplay(
+            normalizedResolvedPath,
+            realHomeDirectory: home
+        )
+        AppLog.app.notice(
+            "Resolved \(command, privacy: .public) CLI from an unexpected path: \(redactedPath, privacy: .public)"
+        )
+    }
+
+    private static func normalizedPath(_ path: String) -> String {
+        var normalized = (path as NSString).standardizingPath
+        while normalized.count > 1, normalized.hasSuffix("/") {
+            normalized.removeLast()
+        }
+        return normalized
     }
 
     /// Whether `command` resolves to an executable.
     static func isAvailable(command: String, overrideEnvVar: String? = nil) -> Bool {
         resolve(command: command, overrideEnvVar: overrideEnvVar) != nil
+    }
+}
+
+/// Lock-protected because provider-readiness polling may resolve the same CLI
+/// concurrently. The set is bounded by the small number of unique command/path
+/// pairs seen during one app process.
+nonisolated private final class CLIBinaryTrustLogState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var keys: Set<String> = []
+
+    func insert(_ key: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return keys.insert(key).inserted
+    }
+
+    func reset() {
+        lock.lock()
+        keys.removeAll()
+        lock.unlock()
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return keys.count
     }
 }

--- a/MeterBar/Services/ClaudeCodeLocalService.swift
+++ b/MeterBar/Services/ClaudeCodeLocalService.swift
@@ -396,13 +396,19 @@ class ClaudeCodeLocalService: ObservableObject {
             let (data, response) = try await session.data(for: request)
             try ServiceSupport.validate(response, data: data)
 
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            let usageResponse = try decoder.decode(ClaudeCodeUsageResponse.self, from: data)
+            let usageResponse = try decodeUsageResponse(from: data)
             return metrics(from: usageResponse)
         } catch {
             throw ServiceSupport.serviceError(from: error)
         }
+    }
+
+    /// The OAuth metrics fetch and best-effort extra-usage probe decode the
+    /// same response contract with the same date strategy.
+    nonisolated static func decodeUsageResponse(from data: Data) throws -> ClaudeCodeUsageResponse {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(ClaudeCodeUsageResponse.self, from: data)
     }
 
     /// Reads a non-expired Claude Code OAuth access token for `account`
@@ -575,14 +581,8 @@ class ClaudeCodeLocalService: ObservableObject {
 
         do {
             let (data, response) = try await urlSession.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse,
-                  (200...299).contains(httpResponse.statusCode) else {
-                return .unknown
-            }
-
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            let usageResponse = try decoder.decode(ClaudeCodeUsageResponse.self, from: data)
+            try ServiceSupport.validate(response, data: data)
+            let usageResponse = try Self.decodeUsageResponse(from: data)
             return usageResponse.extraUsageStatus
         } catch {
             return .unknown

--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -11,7 +11,7 @@ enum ClaudeCostScanner {
     nonisolated static func makeCost(
         from totals: ClaudeSessionTotals,
         windowStart: Date
-    ) -> (TokenCost, [DailyTokenUsage])? {
+    ) -> (TokenCost, [DailyTokenUsage], [HourlyTokenUsage])? {
         guard totals.hasUsage else { return nil }
 
         let pricing = ModelPricing.claude(for: nil)
@@ -58,6 +58,10 @@ enum ClaudeCostScanner {
             modelsByDay: totals.dailyModels,
             projectsByDay: totals.dailyProjects,
             projectModelsByDay: totals.dailyProjectModels
+        ), TokenUsageAggregator.makeHourlyUsage(
+            from: totals.hourly,
+            provider: .claudeCode,
+            pricing: pricing
         ))
     }
 
@@ -143,6 +147,7 @@ enum ClaudeCostScanner {
     nonisolated static func parseSessionWindows(
         at url: URL,
         since cutoffDate: Date,
+        hourlyCutoff: Date = .distantPast,
         projectID: String = CostProjectAttribution.unknownProjectID
     ) -> ScanWindows<ClaudeSessionTotals> {
         var periodKeyed: [String: ClaudeUsageEvent] = [:]
@@ -163,9 +168,18 @@ enum ClaudeCostScanner {
         truncation.log(url: url)
 
         return ScanWindows(
-            period: Self.tally(keyed: periodKeyed, projectID: projectID),
-            lifetime: Self.tally(keyed: lifetimeKeyed, projectID: projectID),
-            cutoff: cutoffDate
+            period: Self.tally(
+                keyed: periodKeyed,
+                projectID: projectID,
+                hourlyCutoff: hourlyCutoff
+            ),
+            lifetime: Self.tally(
+                keyed: lifetimeKeyed,
+                projectID: projectID,
+                hourlyCutoff: hourlyCutoff
+            ),
+            cutoff: cutoffDate,
+            hourlyCutoff: hourlyCutoff
         )
     }
 
@@ -325,13 +339,19 @@ enum ClaudeCostScanner {
         // Nothing appended since the last pass. This is the steady state once
         // the corpus is warm, and it is why a refresh costs almost no I/O.
         if let record, record.isComplete, record.stamp.matches(file.stamp) {
-            return Self.windows(record.payload, cutoff: session.cutoff)
+            return Self.windows(
+                record.payload,
+                cutoff: session.cutoff,
+                hourlyCutoff: session.hourlyCutoff
+            )
         }
 
         let allowance = session.budget.allowance
         guard allowance > 0 else {
             session.noteDeferred(.claude)
-            return record.map { Self.windows($0.payload, cutoff: session.cutoff) }
+            return record.map {
+                Self.windows($0.payload, cutoff: session.cutoff, hourlyCutoff: session.hourlyCutoff)
+            }
         }
 
         var payload = record?.payload ?? ClaudeFileTotals()
@@ -371,8 +391,16 @@ enum ClaudeCostScanner {
         }
         session.budget.consume(read.bytesRead)
 
-        payload.period.merge(Self.tally(keyed: periodKeyed, projectID: projectID))
-        payload.lifetime.merge(Self.tally(keyed: lifetimeKeyed, projectID: projectID))
+        payload.period.merge(Self.tally(
+            keyed: periodKeyed,
+            projectID: projectID,
+            hourlyCutoff: session.hourlyCutoff
+        ))
+        payload.lifetime.merge(Self.tally(
+            keyed: lifetimeKeyed,
+            projectID: projectID,
+            hourlyCutoff: session.hourlyCutoff
+        ))
         // `merge` sums `sessions`, but one transcript is one session however
         // many slices it took to read.
         payload.period.sessions = payload.period.hasUsage ? 1 : 0
@@ -395,13 +423,14 @@ enum ClaudeCostScanner {
                 offset: read.committedOffset,
                 stamp: file.stamp,
                 cutoff: session.cutoff,
+                hourlyCutoff: session.hourlyCutoff,
                 isComplete: read.reachedEndOfFile,
                 payload: payload
             ),
             for: file.cacheKey,
             provider: .claude
         )
-        return Self.windows(payload, cutoff: session.cutoff)
+        return Self.windows(payload, cutoff: session.cutoff, hourlyCutoff: session.hourlyCutoff)
     }
 
     /// The cached entry to resume from, rebased onto this refresh's cutoff.
@@ -411,25 +440,38 @@ enum ClaudeCostScanner {
         for file: CostScanFile,
         session: CostScanSession
     ) -> CostScanFileRecord<ClaudeFileTotals>? {
-        CostScanResumption.resumableRecord(
+        guard var record = CostScanResumption.resumableRecord(
             existing: session.record(for: file.cacheKey, provider: .claude),
             file: file,
-            cutoff: session.cutoff
-        ) { payload, cutoff in
-            payload.rebasePeriod(to: cutoff)
+            cutoff: session.cutoff,
+            rebase: { payload, cutoff in payload.rebasePeriod(to: cutoff) }
+        ) else { return nil }
+        guard record.hourlyCutoff <= session.hourlyCutoff else { return nil }
+        if record.hourlyCutoff < session.hourlyCutoff {
+            record.payload.period.hourly = record.payload.period.hourly.filter { $0.key >= session.hourlyCutoff }
+            record.payload.lifetime.hourly = record.payload.lifetime.hourly.filter { $0.key >= session.hourlyCutoff }
+            record.hourlyCutoff = session.hourlyCutoff
         }
+        return record
     }
 
     nonisolated private static func windows(
         _ payload: ClaudeFileTotals,
-        cutoff: Date
+        cutoff: Date,
+        hourlyCutoff: Date = .distantPast
     ) -> ScanWindows<ClaudeSessionTotals> {
-        ScanWindows(period: payload.period, lifetime: payload.lifetime, cutoff: cutoff)
+        ScanWindows(
+            period: payload.period,
+            lifetime: payload.lifetime,
+            cutoff: cutoff,
+            hourlyCutoff: hourlyCutoff
+        )
     }
 
     nonisolated private static func tally(
         keyed: [String: ClaudeUsageEvent],
-        projectID: String
+        projectID: String,
+        hourlyCutoff: Date = .distantPast
     ) -> ClaudeSessionTotals {
         var totals = ClaudeSessionTotals()
         let events = keyed.keys.sorted().compactMap { keyed[$0] }
@@ -468,6 +510,9 @@ enum ClaudeCostScanner {
                 ),
                 at: CostScanEventKeys(
                     day: calendar.startOfDay(for: event.timestamp),
+                    hour: event.timestamp >= hourlyCutoff
+                        ? CostScanHourBucket.start(for: event.timestamp, calendar: calendar)
+                        : nil,
                     model: CostScanValues.displayModelName(event.model),
                     origin: event.origin,
                     project: projectID

--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -146,9 +146,7 @@ enum ClaudeCostScanner {
         projectID: String = CostProjectAttribution.unknownProjectID
     ) -> ScanWindows<ClaudeSessionTotals> {
         var periodKeyed: [String: ClaudeUsageEvent] = [:]
-        var periodUnkeyed: [ClaudeUsageEvent] = []
         var lifetimeKeyed: [String: ClaudeUsageEvent] = [:]
-        var lifetimeUnkeyed: [ClaudeUsageEvent] = []
 
         var truncation = CostScanTruncationTally()
 
@@ -158,19 +156,15 @@ enum ClaudeCostScanner {
             guard let event else { return }
 
             let inPeriod = event.timestamp >= cutoffDate
-            if let key = event.deduplicationKey {
-                lifetimeKeyed[key] = event
-                if inPeriod { periodKeyed[key] = event }
-            } else {
-                lifetimeUnkeyed.append(event)
-                if inPeriod { periodUnkeyed.append(event) }
-            }
+            let key = event.deduplicationKey(projectID: projectID)
+            lifetimeKeyed[key] = event
+            if inPeriod { periodKeyed[key] = event }
         }
         truncation.log(url: url)
 
         return ScanWindows(
-            period: Self.tally(keyed: periodKeyed, unkeyed: periodUnkeyed, projectID: projectID),
-            lifetime: Self.tally(keyed: lifetimeKeyed, unkeyed: lifetimeUnkeyed, projectID: projectID),
+            period: Self.tally(keyed: periodKeyed, projectID: projectID),
+            lifetime: Self.tally(keyed: lifetimeKeyed, projectID: projectID),
             cutoff: cutoffDate
         )
     }
@@ -346,9 +340,7 @@ enum ClaudeCostScanner {
         request.maxBytes = allowance
 
         var periodKeyed: [String: ClaudeUsageEvent] = [:]
-        var periodUnkeyed: [ClaudeUsageEvent] = []
         var lifetimeKeyed: [String: ClaudeUsageEvent] = [:]
-        var lifetimeUnkeyed: [ClaudeUsageEvent] = []
 
         var truncation = CostScanTruncationTally()
 
@@ -357,20 +349,16 @@ enum ClaudeCostScanner {
             truncation.note(line, recovered: event != nil)
             guard let event else { return }
 
-            if let key = event.deduplicationKey {
-                // First-wins across a resume boundary: an event with this key is
-                // already folded into `payload`, and its bytes are behind the
-                // committed offset. Within a single pass the last copy still
-                // wins, exactly as a cold scan does.
-                if !payload.lifetimeKeys.contains(key) {
-                    lifetimeKeyed[key] = event
-                }
-                if event.timestamp >= session.cutoff, !payload.periodKeys.contains(key) {
-                    periodKeyed[key] = event
-                }
-            } else {
-                lifetimeUnkeyed.append(event)
-                if event.timestamp >= session.cutoff { periodUnkeyed.append(event) }
+            let key = event.deduplicationKey(projectID: projectID)
+            // First-wins across a resume boundary: an event with this key is
+            // already folded into `payload`, and its bytes are behind the
+            // committed offset. Within a single pass the last copy still
+            // wins, exactly as a cold scan does.
+            if !payload.lifetimeKeys.contains(key) {
+                lifetimeKeyed[key] = event
+            }
+            if event.timestamp >= session.cutoff, !payload.periodKeys.contains(key) {
+                periodKeyed[key] = event
             }
         }
 
@@ -383,8 +371,8 @@ enum ClaudeCostScanner {
         }
         session.budget.consume(read.bytesRead)
 
-        payload.period.merge(Self.tally(keyed: periodKeyed, unkeyed: periodUnkeyed, projectID: projectID))
-        payload.lifetime.merge(Self.tally(keyed: lifetimeKeyed, unkeyed: lifetimeUnkeyed, projectID: projectID))
+        payload.period.merge(Self.tally(keyed: periodKeyed, projectID: projectID))
+        payload.lifetime.merge(Self.tally(keyed: lifetimeKeyed, projectID: projectID))
         // `merge` sums `sessions`, but one transcript is one session however
         // many slices it took to read.
         payload.period.sessions = payload.period.hasUsage ? 1 : 0
@@ -462,11 +450,10 @@ enum ClaudeCostScanner {
 
     nonisolated private static func tally(
         keyed: [String: ClaudeUsageEvent],
-        unkeyed: [ClaudeUsageEvent],
         projectID: String
     ) -> ClaudeSessionTotals {
         var totals = ClaudeSessionTotals()
-        let events = keyed.keys.sorted().compactMap { keyed[$0] } + unkeyed
+        let events = keyed.keys.sorted().compactMap { keyed[$0] }
         // Resolving the current calendar is not free, and it cannot change
         // mid-fold.
         let calendar = Calendar.current
@@ -587,8 +574,27 @@ nonisolated private struct ClaudeUsageEvent: Sendable {
         input > 0 || output > 0 || cacheCreation > 0 || cacheRead > 0
     }
 
-    var deduplicationKey: String? {
-        guard let messageID, let requestID else { return nil }
-        return "\(messageID):\(requestID)"
+    func deduplicationKey(projectID: String) -> String {
+        if let messageID, let requestID {
+            return "\(messageID):\(requestID)"
+        }
+
+        let modelKey = model.map { Self.keyComponent($0) } ?? "nil"
+        return [
+            "synthetic",
+            String(timestamp.timeIntervalSinceReferenceDate.bitPattern),
+            modelKey,
+            String(input),
+            String(output),
+            String(cacheCreation),
+            String(cacheCreationOneHour),
+            String(cacheRead),
+            Self.keyComponent(origin),
+            Self.keyComponent(projectID)
+        ].joined(separator: ":")
+    }
+
+    private static func keyComponent(_ value: String) -> String {
+        "\(value.utf8.count):\(value)"
     }
 }

--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -307,7 +307,7 @@ enum ClaudeCostScanner {
         // spent, so `live` is every transcript that exists — safe to prune
         // against on a partial refresh. Without it, deleted transcripts would
         // keep contributing their totals forever.
-        session.retainClaude(keys: live)
+        session.retain(keys: live, provider: .claude)
         return windows
     }
 
@@ -390,7 +390,7 @@ enum ClaudeCostScanner {
             session.noteDeferred(.claude)
         }
 
-        session.setClaudeRecord(
+        session.setRecord(
             CostScanFileRecord(
                 offset: read.committedOffset,
                 stamp: file.stamp,
@@ -398,7 +398,8 @@ enum ClaudeCostScanner {
                 isComplete: read.reachedEndOfFile,
                 payload: payload
             ),
-            for: file.cacheKey
+            for: file.cacheKey,
+            provider: .claude
         )
         return Self.windows(payload, cutoff: session.cutoff)
     }
@@ -410,35 +411,13 @@ enum ClaudeCostScanner {
         for file: CostScanFile,
         session: CostScanSession
     ) -> CostScanFileRecord<ClaudeFileTotals>? {
-        guard var record = session.claudeRecord(for: file.cacheKey) else { return nil }
-        guard record.offset <= UInt64(file.size) else { return nil }
-        if record.isComplete, record.stamp.size == file.size {
-            guard record.stamp.matches(file.stamp) else { return nil }
-        } else {
-            guard record.stamp.isSameFile(as: file.stamp),
-                  file.size >= record.stamp.size else { return nil }
+        CostScanResumption.resumableRecord(
+            existing: session.record(for: file.cacheKey, provider: .claude),
+            file: file,
+            cutoff: session.cutoff
+        ) { payload, cutoff in
+            payload.rebasePeriod(to: cutoff)
         }
-        guard record.cutoff != session.cutoff else { return record }
-
-        // The period window slides every day; lifetime totals never expire. So
-        // the only question is whether the cached period tally can be rebased
-        // without re-reading the file.
-        let lifetime = record.payload.lifetime
-        if (lifetime.latest ?? .distantPast) < session.cutoff {
-            // Every event predates the new window.
-            record.payload.period = ClaudeSessionTotals()
-            record.payload.periodKeys = []
-        } else if (lifetime.earliest ?? .distantFuture) >= session.cutoff {
-            // Every event falls inside it.
-            record.payload.period = lifetime
-            record.payload.periodKeys = record.payload.lifetimeKeys
-        } else {
-            // The file straddles the cutoff and only its individual events know
-            // where. Re-read it — but only files that actually straddle pay.
-            return nil
-        }
-        record.cutoff = session.cutoff
-        return record
     }
 
     nonisolated private static func windows(

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -30,11 +30,15 @@ enum CodexCostScanner {
     /// `earliestDate` starts at now and only decreases, `latestDate` starts at the
     /// window floor (the cutoff for the period, `.distantPast` for lifetime) and
     /// only increases.
-    nonisolated static func scanWindows(cutoff: Date) -> ScanWindows<CostScanWindowContext> {
+    nonisolated static func scanWindows(
+        cutoff: Date,
+        hourlyCutoff: Date = .distantPast
+    ) -> ScanWindows<CostScanWindowContext> {
         ScanWindows(
             period: CostScanWindowContext(earliestDate: Date(), latestDate: cutoff),
             lifetime: CostScanWindowContext(earliestDate: Date(), latestDate: .distantPast),
-            cutoff: cutoff
+            cutoff: cutoff,
+            hourlyCutoff: hourlyCutoff
         )
     }
 
@@ -56,7 +60,7 @@ enum CodexCostScanner {
     nonisolated static func makeCost(
         from context: CostScanWindowContext,
         pricingAt: @escaping (String?, Date) -> TokenPricing = ModelPricing.codex(for:at:)
-    ) -> (TokenCost, [DailyTokenUsage])? {
+    ) -> (TokenCost, [DailyTokenUsage], [HourlyTokenUsage])? {
         let totals = context.totals
         guard totals.input > 0 || totals.output > 0 || totals.cacheRead > 0 else { return nil }
 
@@ -115,6 +119,11 @@ enum CodexCostScanner {
             projectsByDay: context.dailyProjectTotals,
             projectModelsByDay: context.dailyProjectModelTotals,
             pricingAt: pricingAt
+        ), TokenUsageAggregator.makeHourlyUsage(
+            from: context.hourlyTotals,
+            provider: .codexCli,
+            pricing: pricing,
+            pricingAt: { pricingAt(nil, $0) }
         ))
     }
 
@@ -302,7 +311,7 @@ enum CodexCostScanner {
         directories: [URL],
         session: CostScanSession
     ) -> ScanWindows<CostScanWindowContext> {
-        var windows = Self.scanWindows(cutoff: session.cutoff)
+        var windows = Self.scanWindows(cutoff: session.cutoff, hourlyCutoff: session.hourlyCutoff)
         let files = Self.distinctRollouts(in: directories)
         var live: Set<String> = []
 
@@ -360,7 +369,8 @@ enum CodexCostScanner {
         var windows = ScanWindows(
             period: payload.period,
             lifetime: payload.lifetime,
-            cutoff: session.cutoff
+            cutoff: session.cutoff,
+            hourlyCutoff: session.hourlyCutoff
         )
         var rollout = payload.rollout
         var deferred: [CodexDeferredUsage] = []
@@ -438,6 +448,7 @@ enum CodexCostScanner {
                 offset: committed,
                 stamp: file.stamp,
                 cutoff: session.cutoff,
+                hourlyCutoff: session.hourlyCutoff,
                 isComplete: read.reachedEndOfFile,
                 payload: payload
             ),
@@ -545,13 +556,23 @@ enum CodexCostScanner {
         for file: CostScanFile,
         session: CostScanSession
     ) -> CostScanFileRecord<CodexFileTotals>? {
-        CostScanResumption.resumableRecord(
+        guard var record = CostScanResumption.resumableRecord(
             existing: session.record(for: file.cacheKey, provider: .codex),
             file: file,
-            cutoff: session.cutoff
-        ) { payload, cutoff in
-            payload.rebasePeriod(to: cutoff)
+            cutoff: session.cutoff,
+            rebase: { payload, cutoff in payload.rebasePeriod(to: cutoff) }
+        ) else { return nil }
+        guard record.hourlyCutoff <= session.hourlyCutoff else { return nil }
+        if record.hourlyCutoff < session.hourlyCutoff {
+            record.payload.period.hourlyTotals = record.payload.period.hourlyTotals.filter {
+                $0.key >= session.hourlyCutoff
+            }
+            record.payload.lifetime.hourlyTotals = record.payload.lifetime.hourlyTotals.filter {
+                $0.key >= session.hourlyCutoff
+            }
+            record.hourlyCutoff = session.hourlyCutoff
         }
+        return record
     }
 
     /// Picks up the model/originator carried by the non-usage rollout events.
@@ -859,6 +880,9 @@ enum CodexCostScanner {
         let key = "\(timestampMillis)-\(sessionID)-\(input)-\(cached)-\(output)-\(reasoning)"
         let keys = CostScanEventKeys(
             day: calendar.startOfDay(for: timestamp),
+            hour: timestamp >= windows.hourlyCutoff
+                ? CostScanHourBucket.start(for: timestamp, calendar: calendar)
+                : nil,
             model: CostScanValues.displayModelName(event.attribution.modelName),
             origin: CostScanValues.displayOriginName(event.attribution.originName),
             project: event.attribution.projectID

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -241,7 +241,7 @@ enum CodexCostScanner {
             Self.addTokenCountLine(
                 line,
                 fileURL: fileURL,
-                rollout: rollout,
+                rollout: &rollout,
                 deferred: &deferred,
                 events: &events
             )
@@ -365,6 +365,7 @@ enum CodexCostScanner {
         var rollout = payload.rollout
         var deferred: [CodexDeferredUsage] = []
         var deferredOffset: UInt64?
+        var deferredRollout: CodexRolloutContext?
         let calendar = Calendar.current
         var truncation = CostScanTruncationTally()
 
@@ -389,10 +390,11 @@ enum CodexCostScanner {
             }
             let parked = deferred.count
             let counted = windows.lifetime.eventKeys.count
+            let rolloutBeforeLine = rollout
             Self.addTokenCountLine(
                 line,
                 fileURL: file.url,
-                rollout: rollout,
+                rollout: &rollout,
                 deferred: &deferred,
                 windows: &windows,
                 calendar: calendar
@@ -403,6 +405,7 @@ enum CodexCostScanner {
             )
             if deferred.count > parked, deferredOffset == nil {
                 deferredOffset = offset
+                deferredRollout = rolloutBeforeLine
             }
         }
         truncation.log(url: file.url)
@@ -422,6 +425,7 @@ enum CodexCostScanner {
                 // is re-read too, and `eventKeys` discards it as the duplicate
                 // it is.
                 committed = deferredOffset
+                if let deferredRollout { rollout = deferredRollout }
             }
         }
 
@@ -486,7 +490,7 @@ enum CodexCostScanner {
             Self.addTokenCountLine(
                 line,
                 fileURL: file.url,
-                rollout: rollout,
+                rollout: &rollout,
                 deferred: &deferred,
                 windows: &windows,
                 calendar: calendar
@@ -633,7 +637,7 @@ enum CodexCostScanner {
     nonisolated private static func addTokenCountLine(
         _ line: Data,
         fileURL: URL,
-        rollout: CodexRolloutContext,
+        rollout: inout CodexRolloutContext,
         deferred: inout [CodexDeferredUsage],
         events: inout [CodexUsageEvent]
     ) {
@@ -642,13 +646,13 @@ enum CodexCostScanner {
               let timestamp = FlexibleISO8601.date(from: timestampText),
               let payload = json["payload"] as? [String: Any],
               payload["type"] as? String == "token_count",
-              let info = payload["info"] as? [String: Any],
-              let usage = (info["last_token_usage"] ?? info["total_token_usage"]) as? [String: Any] else {
+              let info = payload["info"] as? [String: Any] else {
             return
         }
 
         let sessionID = (((payload["rate_limits"] as? [String: Any])?["conversation_id"] as? String)
             ?? fileURL.deletingPathExtension().lastPathComponent)
+        guard let usage = Self.eventUsage(from: info, sessionID: sessionID, rollout: &rollout) else { return }
         // The event's own model wins when present (older rollouts stamped it
         // there); otherwise fall back to the surrounding rollout context.
         let modelName = Self.modelName(from: info, payload: payload)
@@ -687,7 +691,7 @@ enum CodexCostScanner {
     nonisolated private static func addTokenCountLine(
         _ line: Data,
         fileURL: URL,
-        rollout: CodexRolloutContext,
+        rollout: inout CodexRolloutContext,
         deferred: inout [CodexDeferredUsage],
         windows: inout ScanWindows<CostScanWindowContext>,
         calendar: Calendar
@@ -696,13 +700,40 @@ enum CodexCostScanner {
         Self.addTokenCountLine(
             line,
             fileURL: fileURL,
-            rollout: rollout,
+            rollout: &rollout,
             deferred: &deferred,
             events: &events
         )
         for event in events {
             Self.apply(event, windows: &windows, calendar: calendar)
         }
+    }
+
+    /// Codex normally provides a per-turn delta and a cumulative session total.
+    /// Older or interrupted rollouts sometimes omit the delta; only those lines
+    /// are differenced, while any cumulative value still advances the baseline
+    /// the next fallback needs. This runs before model deferral so parked events
+    /// keep their original order and already carry a true per-event delta.
+    nonisolated private static func eventUsage(
+        from info: [String: Any],
+        sessionID: String,
+        rollout: inout CodexRolloutContext
+    ) -> [String: Any]? {
+        let last = info["last_token_usage"] as? [String: Any]
+        let total = info["total_token_usage"] as? [String: Any]
+
+        if let last {
+            let baseline = rollout.cumulativeUsageBySession[sessionID] ?? CodexTokenCounters()
+            rollout.cumulativeUsageBySession[sessionID] = total.map(CodexTokenCounters.init)
+                ?? baseline.adding(CodexTokenCounters(last))
+            return last
+        }
+
+        guard let total else { return nil }
+        let counters = CodexTokenCounters(total)
+        let previous = rollout.cumulativeUsageBySession[sessionID] ?? CodexTokenCounters()
+        rollout.cumulativeUsageBySession[sessionID] = counters
+        return counters.delta(since: previous)
     }
 
     nonisolated private static func eventPayload(
@@ -951,13 +982,65 @@ nonisolated struct CodexRolloutContext: Sendable, Codable {
     /// (issue #270) — the non-prompt-content field project attribution is
     /// derived from. `nil` until (or unless) a `session_meta` event supplies it.
     var cwd: String?
+    /// Session counters observed before the current byte offset. Kept per
+    /// conversation because one rollout can interleave telemetry streams, and
+    /// persisted because resuming with an empty baseline would bill the full
+    /// session total again as if it were newly appended usage.
+    var cumulativeUsageBySession: [String: CodexTokenCounters] = [:]
+}
+
+/// The four cumulative counters Codex reports in `total_token_usage`.
+nonisolated struct CodexTokenCounters: Sendable, Codable {
+    var input = 0
+    var cached = 0
+    var output = 0
+    var reasoning = 0
+
+    init() {}
+
+    init(_ usage: [String: Any]) {
+        input = max(0, CostScanValues.int(usage["input_tokens"]))
+        cached = max(0, CostScanValues.int(usage["cached_input_tokens"]))
+        output = max(0, CostScanValues.int(usage["output_tokens"]))
+        reasoning = max(0, CostScanValues.int(usage["reasoning_output_tokens"]))
+    }
+
+    func delta(since previous: CodexTokenCounters) -> [String: Any] {
+        [
+            "input_tokens": Self.nonnegativeDifference(input, previous.input),
+            "cached_input_tokens": Self.nonnegativeDifference(cached, previous.cached),
+            "output_tokens": Self.nonnegativeDifference(output, previous.output),
+            "reasoning_output_tokens": Self.nonnegativeDifference(reasoning, previous.reasoning)
+        ]
+    }
+
+    func adding(_ other: CodexTokenCounters) -> CodexTokenCounters {
+        CodexTokenCounters(
+            input: input + other.input,
+            cached: cached + other.cached,
+            output: output + other.output,
+            reasoning: reasoning + other.reasoning
+        )
+    }
+
+    private init(input: Int, cached: Int, output: Int, reasoning: Int) {
+        self.input = input
+        self.cached = cached
+        self.output = output
+        self.reasoning = reasoning
+    }
+
+    private static func nonnegativeDifference(_ current: Int, _ previous: Int) -> Int {
+        current >= previous ? current - previous : 0
+    }
 }
 
 /// A `token_count` event parked because its rollout has not named a model yet.
 ///
-/// Deliberately not `Sendable`: it carries the raw `[String: Any]` usage
-/// payload. It never outlives the single-threaded parse of the file that made
-/// it, so it does not need to be.
+/// Its usage is normalized to a per-event delta before parking; delaying
+/// cumulative subtraction until model attribution is known would reorder the
+/// counter stream. Deliberately not `Sendable`: it carries a raw `[String: Any]`
+/// payload and never outlives the single-threaded parse of the file that made it.
 nonisolated struct CodexDeferredUsage {
     let usage: [String: Any]
     let timestamp: Date

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -327,7 +327,7 @@ enum CodexCostScanner {
             }
         }
 
-        session.retainCodex(keys: live)
+        session.retain(keys: live, provider: .codex)
         return windows
     }
 
@@ -433,7 +433,7 @@ enum CodexCostScanner {
         payload.lifetime = windows.lifetime
         payload.rollout = rollout
 
-        session.setCodexRecord(
+        session.setRecord(
             CostScanFileRecord(
                 offset: committed,
                 stamp: file.stamp,
@@ -441,7 +441,8 @@ enum CodexCostScanner {
                 isComplete: read.reachedEndOfFile,
                 payload: payload
             ),
-            for: file.cacheKey
+            for: file.cacheKey,
+            provider: .codex
         )
         return payload
     }
@@ -544,34 +545,13 @@ enum CodexCostScanner {
         for file: CostScanFile,
         session: CostScanSession
     ) -> CostScanFileRecord<CodexFileTotals>? {
-        guard var record = session.codexRecord(for: file.cacheKey) else { return nil }
-        guard record.offset <= UInt64(file.size) else { return nil }
-        if record.isComplete, record.stamp.size == file.size {
-            guard record.stamp.matches(file.stamp) else { return nil }
-        } else {
-            guard record.stamp.isSameFile(as: file.stamp),
-                  file.size >= record.stamp.size else { return nil }
+        CostScanResumption.resumableRecord(
+            existing: session.record(for: file.cacheKey, provider: .codex),
+            file: file,
+            cutoff: session.cutoff
+        ) { payload, cutoff in
+            payload.rebasePeriod(to: cutoff)
         }
-        guard record.cutoff != session.cutoff else { return record }
-
-        let lifetime = record.payload.lifetime
-        if lifetime.eventKeys.isEmpty || lifetime.latestDate < session.cutoff {
-            // Every event predates the new window.
-            record.payload.period = CostScanWindowContext(
-                earliestDate: Date(),
-                latestDate: session.cutoff
-            )
-        } else if lifetime.earliestDate >= session.cutoff {
-            // Every event falls inside it.
-            record.payload.period = lifetime
-        } else {
-            // The rollout straddles the cutoff and only its individual events
-            // know where. Only files that actually straddle pay for the window
-            // moving.
-            return nil
-        }
-        record.cutoff = session.cutoff
-        return record
     }
 
     /// Picks up the model/originator carried by the non-usage rollout events.

--- a/MeterBar/Services/CostScanFileCache.swift
+++ b/MeterBar/Services/CostScanFileCache.swift
@@ -20,6 +20,9 @@ nonisolated struct CostScanFileRecord<Payload: Codable & Sendable>: Codable, Sen
     /// the wrong period today and has to be rebased (or re-read) before use.
     var cutoff: Date
 
+    /// Seven-day hourly boundary used to build `payload`'s hourly buckets.
+    var hourlyCutoff: Date = .distantPast
+
     /// Whether the last pass read this file all the way to end of file.
     var isComplete: Bool
 
@@ -61,8 +64,11 @@ nonisolated protocol CostScanPeriodRebasable: Codable, Sendable {
 
 /// Every transcript's record, keyed by standardized path.
 nonisolated struct CostScanFileCache<Payload: Codable & Sendable>: Codable, Sendable {
-    /// Version 3 adds producer/time-zone identity and full per-file stamps.
-    static var currentSchemaVersion: Int { 3 }
+    /// Version 4 adds trailing-seven-day hourly accumulators. This private
+    /// disposable cache intentionally invalidates v3 so the upgrade's first
+    /// background refresh re-reads source events instead of trusting offsets
+    /// whose payload has no hourly totals.
+    static var currentSchemaVersion: Int { 4 }
 
     var schemaVersion = CostScanFileCache.currentSchemaVersion
     var parserVersion = CostScanValues.costCacheParserVersion

--- a/MeterBar/Services/CostScanFileCache.swift
+++ b/MeterBar/Services/CostScanFileCache.swift
@@ -26,6 +26,39 @@ nonisolated struct CostScanFileRecord<Payload: Codable & Sendable>: Codable, Sen
     var payload: Payload
 }
 
+/// Validates cached file identity and rebases its period payload when the
+/// visible cutoff moves.
+///
+/// The validation order is correctness-critical: offsets are bounded before
+/// any stamp comparison, complete files require an exact stamp, and incomplete
+/// files may resume only when the same inode has grown or stayed the same size.
+nonisolated enum CostScanResumption {
+    static func resumableRecord<Payload>(
+        existing: CostScanFileRecord<Payload>?,
+        file: CostScanFile,
+        cutoff: Date,
+        rebase: (inout Payload, Date) -> Bool
+    ) -> CostScanFileRecord<Payload>? {
+        guard var record = existing else { return nil }
+        guard record.offset <= UInt64(file.size) else { return nil }
+        if record.isComplete, record.stamp.size == file.size {
+            guard record.stamp.matches(file.stamp) else { return nil }
+        } else {
+            guard record.stamp.isSameFile(as: file.stamp),
+                  file.size >= record.stamp.size else { return nil }
+        }
+        guard record.cutoff != cutoff else { return record }
+        guard rebase(&record.payload, cutoff) else { return nil }
+        record.cutoff = cutoff
+        return record
+    }
+}
+
+/// Provider payload behavior injected into ``CostScanResumption``.
+nonisolated protocol CostScanPeriodRebasable: Codable, Sendable {
+    mutating func rebasePeriod(to cutoff: Date) -> Bool
+}
+
 /// Every transcript's record, keyed by standardized path.
 nonisolated struct CostScanFileCache<Payload: Codable & Sendable>: Codable, Sendable {
     /// Version 3 adds producer/time-zone identity and full per-file stamps.
@@ -322,3 +355,54 @@ nonisolated struct GrokFileTotals: Codable, Sendable {
         lifetime = CostScanWindowContext(earliestDate: Date(), latestDate: .distantPast)
     }
 }
+
+nonisolated extension ClaudeFileTotals: CostScanPeriodRebasable {
+    mutating func rebasePeriod(to cutoff: Date) -> Bool {
+        // The period window slides every day; lifetime totals never expire. So
+        // the only question is whether the cached period tally can be rebased
+        // without re-reading the file.
+        if (lifetime.latest ?? .distantPast) < cutoff {
+            // Every event predates the new window.
+            period = ClaudeSessionTotals()
+            periodKeys = []
+        } else if (lifetime.earliest ?? .distantFuture) >= cutoff {
+            // Every event falls inside it.
+            period = lifetime
+            periodKeys = lifetimeKeys
+        } else {
+            // The file straddles the cutoff and only its individual events know
+            // where. Re-read it — but only files that actually straddle pay.
+            return false
+        }
+        return true
+    }
+}
+
+/// The identical period/lifetime shape shared by Codex and Grok payloads.
+nonisolated protocol CostScanWindowPeriodRebasable: CostScanPeriodRebasable {
+    var period: CostScanWindowContext { get set }
+    var lifetime: CostScanWindowContext { get }
+}
+
+nonisolated extension CostScanWindowPeriodRebasable {
+    mutating func rebasePeriod(to cutoff: Date) -> Bool {
+        if lifetime.eventKeys.isEmpty || lifetime.latestDate < cutoff {
+            // Every event predates the new window.
+            period = CostScanWindowContext(
+                earliestDate: Date(),
+                latestDate: cutoff
+            )
+        } else if lifetime.earliestDate >= cutoff {
+            // Every event falls inside it.
+            period = lifetime
+        } else {
+            // The file straddles the cutoff. Only its individual events or
+            // records know where, so only files that straddle pay to re-read.
+            return false
+        }
+        return true
+    }
+}
+
+nonisolated extension CodexFileTotals: CostScanWindowPeriodRebasable {}
+nonisolated extension GrokFileTotals: CostScanWindowPeriodRebasable {}

--- a/MeterBar/Services/CostScanSession.swift
+++ b/MeterBar/Services/CostScanSession.swift
@@ -21,6 +21,8 @@ nonisolated final class CostScanSession: @unchecked Sendable {
     /// for the cutoff they were tallied against, so this is part of every
     /// cache-hit decision.
     let cutoff: Date
+    /// Start of the seven-calendar-day hour buckets retained by this refresh.
+    let hourlyCutoff: Date
 
     let budget: CostScanBudget
 
@@ -34,11 +36,13 @@ nonisolated final class CostScanSession: @unchecked Sendable {
 
     init(
         cutoff: Date,
+        hourlyCutoff: Date = .distantPast,
         options: CostScanBudgetOptions,
         store: CostScanCacheStore? = nil,
         token: CostScanCancellationToken = .never
     ) {
         self.cutoff = cutoff
+        self.hourlyCutoff = hourlyCutoff
         self.budget = CostScanBudget(options: options, token: token)
         self.store = store
         self.claudeCache = store?.loadClaude() ?? CostScanFileCache<ClaudeFileTotals>()

--- a/MeterBar/Services/CostScanSession.swift
+++ b/MeterBar/Services/CostScanSession.swift
@@ -2,6 +2,13 @@ import Foundation
 import MeterBarShared
 import os
 
+/// Type-safe route to one provider's cache inside a scan session.
+nonisolated struct CostScanCacheKey<Payload: Codable & Sendable> {
+    fileprivate let provider: CostScanProvider
+    fileprivate let cache: ReferenceWritableKeyPath<CostScanSession, CostScanFileCache<Payload>>
+    fileprivate let save: (CostScanCacheStore, CostScanFileCache<Payload>) throws -> Void
+}
+
 /// One refresh's worth of scanning: the budget it spends, the per-file caches it
 /// resumes from, and whether it managed to reach the end of the corpus.
 ///
@@ -19,9 +26,10 @@ nonisolated final class CostScanSession: @unchecked Sendable {
 
     private let store: CostScanCacheStore?
     private let lock = NSLock()
-    private var claudeCache: CostScanFileCache<ClaudeFileTotals>
-    private var codexCache: CostScanFileCache<CodexFileTotals>
-    private var grokCache: CostScanFileCache<GrokFileTotals>
+    fileprivate var claudeCache: CostScanFileCache<ClaudeFileTotals>
+    fileprivate var codexCache: CostScanFileCache<CodexFileTotals>
+    fileprivate var grokCache: CostScanFileCache<GrokFileTotals>
+    private var dirtyProviders: Set<CostScanProvider> = []
     private var deferred: Set<CostScanProvider> = []
 
     init(
@@ -39,21 +47,21 @@ nonisolated final class CostScanSession: @unchecked Sendable {
     }
 
     var claude: CostScanFileCache<ClaudeFileTotals> {
-        lock.lock()
-        defer { lock.unlock() }
-        return claudeCache
+        cache(for: .claude)
     }
 
     var codex: CostScanFileCache<CodexFileTotals> {
-        lock.lock()
-        defer { lock.unlock() }
-        return codexCache
+        cache(for: .codex)
     }
 
     var grok: CostScanFileCache<GrokFileTotals> {
+        cache(for: .grok)
+    }
+
+    func cache<Payload>(for provider: CostScanCacheKey<Payload>) -> CostScanFileCache<Payload> {
         lock.lock()
         defer { lock.unlock() }
-        return grokCache
+        return self[keyPath: provider.cache]
     }
 
     var isCancelled: Bool { budget.isCancelled }
@@ -88,40 +96,39 @@ nonisolated final class CostScanSession: @unchecked Sendable {
         lock.unlock()
     }
 
-    func claudeRecord(for key: String) -> CostScanFileRecord<ClaudeFileTotals>? {
+    func record<Payload>(
+        for key: String,
+        provider: CostScanCacheKey<Payload>
+    ) -> CostScanFileRecord<Payload>? {
         lock.lock()
         defer { lock.unlock() }
-        return claudeCache.records[key]
+        return self[keyPath: provider.cache].records[key]
     }
 
-    func setClaudeRecord(_ record: CostScanFileRecord<ClaudeFileTotals>, for key: String) {
+    func setRecord<Payload>(
+        _ record: CostScanFileRecord<Payload>,
+        for key: String,
+        provider: CostScanCacheKey<Payload>
+    ) {
         lock.lock()
-        claudeCache.records[key] = record
+        self[keyPath: provider.cache].records[key] = record
+        dirtyProviders.insert(provider.provider)
         lock.unlock()
     }
 
-    func codexRecord(for key: String) -> CostScanFileRecord<CodexFileTotals>? {
-        lock.lock()
-        defer { lock.unlock() }
-        return codexCache.records[key]
+    // Scanners route through the generic pair above. These named seams stay for
+    // tests, which build a session's starting state directly and read better
+    // naming the provider than spelling out the payload type at every call.
+    func setClaudeRecord(_ record: CostScanFileRecord<ClaudeFileTotals>, for key: String) {
+        setRecord(record, for: key, provider: .claude)
     }
 
     func setCodexRecord(_ record: CostScanFileRecord<CodexFileTotals>, for key: String) {
-        lock.lock()
-        codexCache.records[key] = record
-        lock.unlock()
-    }
-
-    func grokRecord(for key: String) -> CostScanFileRecord<GrokFileTotals>? {
-        lock.lock()
-        defer { lock.unlock() }
-        return grokCache.records[key]
+        setRecord(record, for: key, provider: .codex)
     }
 
     func setGrokRecord(_ record: CostScanFileRecord<GrokFileTotals>, for key: String) {
-        lock.lock()
-        grokCache.records[key] = record
-        lock.unlock()
+        setRecord(record, for: key, provider: .grok)
     }
 
     /// Drops cache entries whose file no longer exists.
@@ -129,27 +136,29 @@ nonisolated final class CostScanSession: @unchecked Sendable {
     /// Without this the cache grows forever: Claude Code and Codex delete old
     /// transcripts, and a stale entry would keep contributing its totals to
     /// every future summary even though the spend it describes is long gone.
-    func retainClaude(keys: Set<String>) {
+    func retain<Payload>(keys: Set<String>, provider: CostScanCacheKey<Payload>) {
         lock.lock()
-        claudeCache.records = claudeCache.records.filter { keys.contains($0.key) }
+        let previousCount = self[keyPath: provider.cache].records.count
+        self[keyPath: provider.cache].records = self[keyPath: provider.cache].records.filter {
+            keys.contains($0.key)
+        }
+        if self[keyPath: provider.cache].records.count != previousCount {
+            dirtyProviders.insert(provider.provider)
+        }
         lock.unlock()
+    }
+
+    func retainClaude(keys: Set<String>) {
+        retain(keys: keys, provider: .claude)
     }
 
     func retainCodex(keys: Set<String>) {
-        lock.lock()
-        codexCache.records = codexCache.records.filter { keys.contains($0.key) }
-        lock.unlock()
+        retain(keys: keys, provider: .codex)
     }
 
-    func retainGrok(keys: Set<String>) {
-        lock.lock()
-        grokCache.records = grokCache.records.filter { keys.contains($0.key) }
-        lock.unlock()
-    }
-
-    /// Writes every cache back, including after a cancelled slice — the whole
-    /// point of committing on line boundaries is that partial progress is safe
-    /// to keep.
+    /// Writes caches with pending changes, including after a cancelled slice —
+    /// the whole point of committing on line boundaries is that partial
+    /// progress is safe to keep.
     ///
     /// Deliberately not `@discardableResult`: a slice whose caches never reached
     /// disk made no *resumable* progress, and a caller that ignores that spends
@@ -163,10 +172,24 @@ nonisolated final class CostScanSession: @unchecked Sendable {
         guard let store else { return .unavailable }
 
         return CostScanPersistReport(
-            claude: Self.write("Claude") { try store.saveClaude(claude) },
-            codex: Self.write("Codex") { try store.saveCodex(codex) },
-            grok: Self.write("Grok") { try store.saveGrok(grok) }
+            claude: persist(provider: .claude, to: store),
+            codex: persist(provider: .codex, to: store),
+            grok: persist(provider: .grok, to: store)
         )
+    }
+
+    private func persist<Payload>(
+        provider: CostScanCacheKey<Payload>,
+        to store: CostScanCacheStore
+    ) -> CostScanPersistOutcome {
+        lock.lock()
+        defer { lock.unlock() }
+        guard dirtyProviders.contains(provider.provider) else { return .persisted }
+        let outcome = Self.write(provider.provider.logName) {
+            try provider.save(store, self[keyPath: provider.cache])
+        }
+        if outcome == .persisted { dirtyProviders.remove(provider.provider) }
+        return outcome
     }
 
     private static func write(_ provider: String, _ save: () throws -> Void) -> CostScanPersistOutcome {
@@ -182,6 +205,36 @@ nonisolated final class CostScanSession: @unchecked Sendable {
             )
             return .failed
         }
+    }
+}
+
+nonisolated extension CostScanCacheKey where Payload == ClaudeFileTotals {
+    static var claude: Self {
+        Self(
+            provider: .claude,
+            cache: \CostScanSession.claudeCache,
+            save: { store, cache in try store.saveClaude(cache) }
+        )
+    }
+}
+
+nonisolated extension CostScanCacheKey where Payload == CodexFileTotals {
+    static var codex: Self {
+        Self(
+            provider: .codex,
+            cache: \CostScanSession.codexCache,
+            save: { store, cache in try store.saveCodex(cache) }
+        )
+    }
+}
+
+nonisolated extension CostScanCacheKey where Payload == GrokFileTotals {
+    static var grok: Self {
+        Self(
+            provider: .grok,
+            cache: \CostScanSession.grokCache,
+            save: { store, cache in try store.saveGrok(cache) }
+        )
     }
 }
 

--- a/MeterBar/Services/CostScanValues.swift
+++ b/MeterBar/Services/CostScanValues.swift
@@ -10,7 +10,7 @@ enum CostScanValues {
     /// Bump this whenever a change alters parsed output: usage extraction,
     /// deduplication, pricing, model normalization, or local-day bucketing.
     /// A mismatch discards the persisted cache and performs a full rescan.
-    nonisolated static let costCacheParserVersion = 2
+    nonisolated static let costCacheParserVersion = 4
 
     /// Token counts arrive as `Int`, `Int64`, `Double`, or a numeric string
     /// depending on which writer produced the log line; coerce every shape.

--- a/MeterBar/Services/CostScanWindows.swift
+++ b/MeterBar/Services/CostScanWindows.swift
@@ -14,6 +14,21 @@ nonisolated struct ScanWindows<Totals> {
     var lifetime: Totals
     /// Events at or after this instant belong to the period window as well.
     let cutoff: Date
+    /// Start of the seven-calendar-day hourly window. Separate from `cutoff`
+    /// because the main cost scan normally retains 30 daily buckets.
+    let hourlyCutoff: Date
+
+    init(
+        period: Totals,
+        lifetime: Totals,
+        cutoff: Date,
+        hourlyCutoff: Date = .distantPast
+    ) {
+        self.period = period
+        self.lifetime = lifetime
+        self.cutoff = cutoff
+        self.hourlyCutoff = hourlyCutoff
+    }
 
     /// Applies `body` to `lifetime` always, and to `period` when the event falls
     /// inside the window.
@@ -35,13 +50,14 @@ nonisolated struct ScanWindows<Totals> {
 // to be `Sendable` just to name `ScanWindows<CostScanResult>`.
 extension ScanWindows: Sendable where Totals: Sendable {}
 
-/// The eight breakdowns every scan folds a usage event into.
+/// The nine breakdowns every scan folds a usage event into.
 ///
-/// Claude and Codex accumulate into different types but the same eight
+/// Claude and Codex accumulate into different types but the same nine
 /// dimensions, so the fold itself lives once in `record(_:at:)` rather than
 /// twice as near-identical stanzas in each scanner.
 nonisolated protocol CostScanBreakdowns {
     var daily: [Date: TokenAccumulator] { get set }
+    var hourly: [Date: TokenAccumulator] { get set }
     var dailyModels: [Date: [String: TokenAccumulator]] { get set }
     var dailyProjects: [Date: [String: TokenAccumulator]] { get set }
     var dailyProjectModels: [Date: [String: [String: TokenAccumulator]]] { get set }
@@ -54,6 +70,8 @@ nonisolated protocol CostScanBreakdowns {
 /// Which bucket of each breakdown one event lands in.
 nonisolated struct CostScanEventKeys {
     let day: Date
+    /// `nil` when the event predates the retained seven-day hourly window.
+    let hour: Date?
     let model: String
     let origin: String
     let project: String
@@ -73,6 +91,9 @@ nonisolated struct CostScanEventTotals {
 nonisolated extension CostScanBreakdowns {
     mutating func record(_ event: CostScanEventTotals, at keys: CostScanEventKeys) {
         daily[keys.day, default: TokenAccumulator()].add(event)
+        if let hour = keys.hour {
+            hourly[hour, default: TokenAccumulator()].add(event)
+        }
         dailyModels[keys.day, default: [:]][keys.model, default: TokenAccumulator()].add(event)
         dailyProjects[keys.day, default: [:]][keys.project, default: TokenAccumulator()].add(event)
         dailyProjectModels[keys.day, default: [:]][keys.project, default: [:]][
@@ -103,6 +124,7 @@ nonisolated struct ClaudeSessionTotals: Sendable, Codable, CostScanBreakdowns {
     var earliest: Date?
     var latest: Date?
     var daily: [Date: TokenAccumulator] = [:]
+    var hourly: [Date: TokenAccumulator] = [:]
     var dailyModels: [Date: [String: TokenAccumulator]] = [:]
     var dailyProjects: [Date: [String: TokenAccumulator]] = [:]
     var dailyProjectModels: [Date: [String: [String: TokenAccumulator]]] = [:]
@@ -138,6 +160,9 @@ nonisolated struct ClaudeSessionTotals: Sendable, Codable, CostScanBreakdowns {
 
         for (day, tokens) in other.daily {
             daily[day, default: TokenAccumulator()].merge(tokens)
+        }
+        for (hour, tokens) in other.hourly {
+            hourly[hour, default: TokenAccumulator()].merge(tokens)
         }
         for (day, modelTotals) in other.dailyModels {
             for (model, tokens) in modelTotals {
@@ -201,13 +226,15 @@ nonisolated struct ClaudeSessionTotals: Sendable, Codable, CostScanBreakdowns {
 nonisolated struct CostScanResult {
     var costs: [TokenCost] = []
     var dailyUsage: [DailyTokenUsage] = []
+    var hourlyUsage: [HourlyTokenUsage] = []
     /// Union of the rate entries every provider in this window priced with.
     var pricing = PricingProvenance()
 
-    mutating func append(_ scan: (TokenCost, [DailyTokenUsage])?) {
+    mutating func append(_ scan: (TokenCost, [DailyTokenUsage], [HourlyTokenUsage])?) {
         guard let scan else { return }
         costs.append(scan.0)
         dailyUsage.append(contentsOf: scan.1)
+        hourlyUsage.append(contentsOf: scan.2)
     }
 
     mutating func record(_ provenance: PricingProvenance) {
@@ -221,7 +248,7 @@ nonisolated struct CostScanResult {
 /// a single `inout` argument.
 ///
 /// Shared by the Codex and Grok scanners rather than duplicated: both fold the
-/// same eight breakdown dimensions plus dedup keys, and a second copy would mean
+/// same nine breakdown dimensions plus dedup keys, and a second copy would mean
 /// a second `merge` and a second set of `_modify` forwarders to keep in step.
 /// Renaming the *type* is safe for the on-disk cache — `Codable` keys come from
 /// the stored property names below, not from the type's name.
@@ -230,6 +257,7 @@ nonisolated struct CostScanResult {
 nonisolated struct CostScanWindowContext: Sendable, Codable {
     var totals = TokenAccumulator()
     var dailyTotals: [Date: TokenAccumulator] = [:]
+    var hourlyTotals: [Date: TokenAccumulator] = [:]
     var dailyModelTotals: [Date: [String: TokenAccumulator]] = [:]
     var dailyProjectTotals: [Date: [String: TokenAccumulator]] = [:]
     var dailyProjectModelTotals: [Date: [String: [String: TokenAccumulator]]] = [:]
@@ -258,6 +286,9 @@ nonisolated struct CostScanWindowContext: Sendable, Codable {
         totals.merge(other.totals)
         for (day, tokens) in other.dailyTotals {
             dailyTotals[day, default: TokenAccumulator()].merge(tokens)
+        }
+        for (hour, tokens) in other.hourlyTotals {
+            hourlyTotals[hour, default: TokenAccumulator()].merge(tokens)
         }
         for (day, modelTotals) in other.dailyModelTotals {
             for (model, tokens) in modelTotals {
@@ -314,6 +345,11 @@ nonisolated extension CostScanWindowContext: CostScanBreakdowns {
         _modify { yield &dailyTotals }
     }
 
+    var hourly: [Date: TokenAccumulator] {
+        get { hourlyTotals }
+        _modify { yield &hourlyTotals }
+    }
+
     var dailyModels: [Date: [String: TokenAccumulator]] {
         get { dailyModelTotals }
         _modify { yield &dailyModelTotals }
@@ -347,6 +383,15 @@ nonisolated extension CostScanWindowContext: CostScanBreakdowns {
     var projectModels: [String: [String: TokenAccumulator]] {
         get { projectModelTotals }
         _modify { yield &projectModelTotals }
+    }
+}
+
+/// Calendar-safe hour normalization shared by all three scanners and the
+/// seven-day grid. `dateInterval` preserves distinct repeated hours at a DST
+/// fallback while still returning the local hour boundary.
+nonisolated enum CostScanHourBucket {
+    static func start(for date: Date, calendar: Calendar) -> Date {
+        calendar.dateInterval(of: .hour, for: date)?.start ?? date
     }
 }
 

--- a/MeterBar/Services/CostSummaryBuilder.swift
+++ b/MeterBar/Services/CostSummaryBuilder.swift
@@ -130,6 +130,10 @@ enum CostSummaryBuilder {
                 totalTokens: costs.reduce(0) { $0 + $1.totalTokens },
                 periodDays: days,
                 dailyUsage: scan.period.dailyUsage.sorted { $0.date < $1.date },
+                hourlyUsage: scan.period.hourlyUsage.sorted { lhs, rhs in
+                    if lhs.date != rhs.date { return lhs.date < rhs.date }
+                    return lhs.provider.rawValue < rhs.provider.rawValue
+                },
                 lifetime: LifetimeCostSummary(costs: scan.lifetime.costs),
                 pricing: scan.period.pricing.isEmpty ? nil : scan.period.pricing
             ),

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -102,16 +102,21 @@ class CostTracker: ObservableObject {
         }
     }
 
-    /// Quietly backfills a legacy cache's missing lifetime snapshot or missing
-    /// daily rows when Overview/Costs opens, without the visible "Scanning" UI
-    /// a manual scan shows.
+    /// Quietly backfills a legacy cache's missing lifetime snapshot, daily
+    /// rows, or hourly rows when Overview/Costs opens, without the visible
+    /// "Scanning" UI a manual scan shows.
     func refreshMissingDaysInBackground(days: Int = 30) async {
         guard !demoMode else { return }
         let shouldStart = await MainActor.run {
+            let hasEnabledCostScanProvider = Self.hasEnabledCostScanProvider(
+                in: providerVisibilityStore.enabledServices
+            )
             guard !isRefreshInProgress,
                   let visibleSummary = costSummary?.filtered(to: providerVisibilityStore.enabledServices),
                   visibleSummary.lifetime == nil
-                    || visibleSummary.needsMissingDailyUsageRefresh(days: days, lastScanDate: lastScanDate) else {
+                    || visibleSummary.needsMissingDailyUsageRefresh(days: days, lastScanDate: lastScanDate)
+                    || (hasEnabledCostScanProvider
+                        && visibleSummary.needsMissingHourlyUsageRefresh(lastScanDate: lastScanDate)) else {
                 return false
             }
             isRefreshingMissingDays = true
@@ -125,6 +130,13 @@ class CostTracker: ObservableObject {
             apply(scan)
             isRefreshingMissingDays = false
         }
+    }
+
+    /// Hourly rows come from local log scanners, not from providers whose
+    /// history is accumulated only by polling. Without this gate a
+    /// Cursor/OpenRouter-only setup would run a fruitless full scan each day.
+    static func hasEnabledCostScanProvider(in enabledServices: Set<ServiceType>) -> Bool {
+        CostScanProvider.allCases.contains { enabledServices.contains($0.service) }
     }
 
     /// Publishes one refresh's result, and records it as authoritative only when
@@ -185,7 +197,9 @@ class CostTracker: ObservableObject {
         // spend was written to, and disabling an account hides its quota gauge
         // without unspending what it already cost.
         let grokAccounts = GrokAccountStore.shared.accounts
-        let cutoff = CostWindow.start(days: days)
+        let scanTime = Date()
+        let cutoff = CostWindow.start(days: days, now: scanTime)
+        let hourlyCutoff = CostWindow.start(days: 7, now: scanTime)
         let store = CostScanCacheStore.applicationSupport
         // Read once, outside the slice loop: polling providers contribute no
         // bytes, so their rows are identical in every slice and re-reading the
@@ -199,6 +213,7 @@ class CostTracker: ObservableObject {
             let slice = try? await CostScanExecutor.run { token in
                 let session = CostScanSession(
                     cutoff: cutoff,
+                    hourlyCutoff: hourlyCutoff,
                     options: .default,
                     store: store,
                     token: token

--- a/MeterBar/Services/GrokCostScanner.swift
+++ b/MeterBar/Services/GrokCostScanner.swift
@@ -69,11 +69,15 @@ enum GrokCostScanner {
 
     /// Seeds both windows: `earliestDate` starts at now and only decreases,
     /// `latestDate` starts at the window floor and only increases.
-    nonisolated static func scanWindows(cutoff: Date) -> ScanWindows<CostScanWindowContext> {
+    nonisolated static func scanWindows(
+        cutoff: Date,
+        hourlyCutoff: Date = .distantPast
+    ) -> ScanWindows<CostScanWindowContext> {
         ScanWindows(
             period: CostScanWindowContext(earliestDate: Date(), latestDate: cutoff),
             lifetime: CostScanWindowContext(earliestDate: Date(), latestDate: .distantPast),
-            cutoff: cutoff
+            cutoff: cutoff,
+            hourlyCutoff: hourlyCutoff
         )
     }
 
@@ -114,7 +118,7 @@ enum GrokCostScanner {
         _ roots: [URL],
         session: CostScanSession
     ) -> ScanWindows<CostScanWindowContext> {
-        var windows = Self.scanWindows(cutoff: session.cutoff)
+        var windows = Self.scanWindows(cutoff: session.cutoff, hourlyCutoff: session.hourlyCutoff)
         var live: Set<String> = []
 
         for root in roots {
@@ -143,7 +147,7 @@ enum GrokCostScanner {
     /// itself billed at $0 — which is the right answer for them.
     nonisolated static func makeCost(
         from context: CostScanWindowContext
-    ) -> (TokenCost, [DailyTokenUsage])? {
+    ) -> (TokenCost, [DailyTokenUsage], [HourlyTokenUsage])? {
         let totals = context.totals
         guard totals.input > 0 || totals.output > 0 || totals.cacheRead > 0 else { return nil }
 
@@ -182,6 +186,10 @@ enum GrokCostScanner {
             modelsByDay: context.dailyModelTotals,
             projectsByDay: context.dailyProjectTotals,
             projectModelsByDay: context.dailyProjectModelTotals
+        ), TokenUsageAggregator.makeHourlyUsage(
+            from: context.hourlyTotals,
+            provider: .grok,
+            pricing: pricing
         ))
     }
 
@@ -214,7 +222,8 @@ enum GrokCostScanner {
         var windows = ScanWindows(
             period: payload.period,
             lifetime: payload.lifetime,
-            cutoff: session.cutoff
+            cutoff: session.cutoff,
+            hourlyCutoff: session.hourlyCutoff
         )
         let attribution = Self.attribution(for: file.url)
         let calendar = Calendar.current
@@ -250,6 +259,7 @@ enum GrokCostScanner {
                 offset: read.committedOffset,
                 stamp: file.stamp,
                 cutoff: session.cutoff,
+                hourlyCutoff: session.hourlyCutoff,
                 isComplete: read.reachedEndOfFile,
                 payload: payload
             ),
@@ -266,13 +276,23 @@ enum GrokCostScanner {
         for file: CostScanFile,
         session: CostScanSession
     ) -> CostScanFileRecord<GrokFileTotals>? {
-        CostScanResumption.resumableRecord(
+        guard var record = CostScanResumption.resumableRecord(
             existing: session.record(for: file.cacheKey, provider: .grok),
             file: file,
-            cutoff: session.cutoff
-        ) { payload, cutoff in
-            payload.rebasePeriod(to: cutoff)
+            cutoff: session.cutoff,
+            rebase: { payload, cutoff in payload.rebasePeriod(to: cutoff) }
+        ) else { return nil }
+        guard record.hourlyCutoff <= session.hourlyCutoff else { return nil }
+        if record.hourlyCutoff < session.hourlyCutoff {
+            record.payload.period.hourlyTotals = record.payload.period.hourlyTotals.filter {
+                $0.key >= session.hourlyCutoff
+            }
+            record.payload.lifetime.hourlyTotals = record.payload.lifetime.hourlyTotals.filter {
+                $0.key >= session.hourlyCutoff
+            }
+            record.hourlyCutoff = session.hourlyCutoff
         }
+        return record
     }
 
     /// Project and fallback session identity, both derived from where the file
@@ -412,6 +432,9 @@ enum GrokCostScanner {
             """
         let keys = CostScanEventKeys(
             day: calendar.startOfDay(for: timestamp),
+            hour: timestamp >= windows.hourlyCutoff
+                ? CostScanHourBucket.start(for: timestamp, calendar: calendar)
+                : nil,
             model: CostScanValues.displayModelName(event.model),
             origin: CostScanValues.displayOriginName(Self.originName),
             project: event.projectID

--- a/MeterBar/Services/GrokCostScanner.swift
+++ b/MeterBar/Services/GrokCostScanner.swift
@@ -127,7 +127,7 @@ enum GrokCostScanner {
             }
         }
 
-        session.retainGrok(keys: live)
+        session.retain(keys: live, provider: .grok)
         return windows
     }
 
@@ -245,7 +245,7 @@ enum GrokCostScanner {
         payload.period = windows.period
         payload.lifetime = windows.lifetime
 
-        session.setGrokRecord(
+        session.setRecord(
             CostScanFileRecord(
                 offset: read.committedOffset,
                 stamp: file.stamp,
@@ -253,7 +253,8 @@ enum GrokCostScanner {
                 isComplete: read.reachedEndOfFile,
                 payload: payload
             ),
-            for: file.cacheKey
+            for: file.cacheKey,
+            provider: .grok
         )
         return payload
     }
@@ -265,33 +266,13 @@ enum GrokCostScanner {
         for file: CostScanFile,
         session: CostScanSession
     ) -> CostScanFileRecord<GrokFileTotals>? {
-        guard var record = session.grokRecord(for: file.cacheKey) else { return nil }
-        guard record.offset <= UInt64(file.size) else { return nil }
-        if record.isComplete, record.stamp.size == file.size {
-            guard record.stamp.matches(file.stamp) else { return nil }
-        } else {
-            guard record.stamp.isSameFile(as: file.stamp),
-                  file.size >= record.stamp.size else { return nil }
+        CostScanResumption.resumableRecord(
+            existing: session.record(for: file.cacheKey, provider: .grok),
+            file: file,
+            cutoff: session.cutoff
+        ) { payload, cutoff in
+            payload.rebasePeriod(to: cutoff)
         }
-        guard record.cutoff != session.cutoff else { return record }
-
-        let lifetime = record.payload.lifetime
-        if lifetime.eventKeys.isEmpty || lifetime.latestDate < session.cutoff {
-            // Every event predates the new window.
-            record.payload.period = CostScanWindowContext(
-                earliestDate: Date(),
-                latestDate: session.cutoff
-            )
-        } else if lifetime.earliestDate >= session.cutoff {
-            // Every event falls inside it.
-            record.payload.period = lifetime
-        } else {
-            // The file straddles the cutoff and only its individual records know
-            // where. Only files that actually straddle pay for the window moving.
-            return nil
-        }
-        record.cutoff = session.cutoff
-        return record
     }
 
     /// Project and fallback session identity, both derived from where the file

--- a/MeterBar/Services/ProviderUsageCostBuilder.swift
+++ b/MeterBar/Services/ProviderUsageCostBuilder.swift
@@ -1,9 +1,10 @@
 import Foundation
 import MeterBarShared
 
-/// Turns the accumulated ledger into the same `(TokenCost, [DailyTokenUsage])`
-/// pair the log scanners produce, so a provider with no local corpus lands in
-/// `costs[]`/`dailyUsage[]` through exactly the same fold.
+/// Turns the accumulated ledger into the same cost/daily/hourly tuple the log
+/// scanners produce, so a provider with no local corpus lands in
+/// `costs[]`/`dailyUsage[]` through exactly the same fold. Poll-only providers
+/// have no event timestamps, so their hourly slice is intentionally empty.
 ///
 /// The counterpart to `ClaudeCostScanner.makeCost` and friends, and deliberately
 /// the *only* path from the ledger into money: it emits nothing for an entry
@@ -28,7 +29,7 @@ nonisolated enum ProviderUsageCostBuilder {
         windowStart: Date,
         now: Date = Date(),
         calendar: Calendar = .current
-    ) -> (TokenCost, [DailyTokenUsage])? {
+    ) -> (TokenCost, [DailyTokenUsage], [HourlyTokenUsage])? {
         let cutoff = calendar.startOfDay(for: windowStart)
         let today = calendar.startOfDay(for: now)
         // Days are only ever written by an observation, so a future-dated one
@@ -66,6 +67,6 @@ nonisolated enum ProviderUsageCostBuilder {
             )
         }
 
-        return (cost, daily)
+        return (cost, daily, [])
     }
 }

--- a/MeterBar/Services/QuotaEventSettingsStore.swift
+++ b/MeterBar/Services/QuotaEventSettingsStore.swift
@@ -362,6 +362,55 @@ nonisolated enum QuotaWebhookURLPolicy {
         return sawAddress
     }
 
+    /// Whether a transaction metric's remote-address literal belongs to an
+    /// address range the webhook policy forbids. Foundation may include IPv6
+    /// brackets, an interface zone, or a transport port, so normalize those
+    /// presentation details before asking `inet_pton` to parse the address.
+    /// Unknown formats fail open, matching delivery's deliberate behavior when
+    /// URLSession reports no remote address at all.
+    static func isUnsafeAddressLiteral(_ value: String) -> Bool {
+        var candidate = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !candidate.isEmpty else { return false }
+
+        if candidate.hasPrefix("["), let closingBracket = candidate.firstIndex(of: "]") {
+            candidate = String(candidate[candidate.index(after: candidate.startIndex)..<closingBracket])
+        }
+
+        if let zone = candidate.firstIndex(of: "%") {
+            candidate = String(candidate[..<zone])
+        }
+
+        if let result = unsafeAddressParseResult(candidate) {
+            return result
+        }
+
+        // An unbracketed IPv4 address may carry `:port`. Try the complete
+        // literal first above so a valid IPv6 address ending in digits is never
+        // mistaken for a host-plus-port pair.
+        if let colon = candidate.lastIndex(of: ":") {
+            let port = candidate[candidate.index(after: colon)...]
+            let host = String(candidate[..<colon])
+            if !port.isEmpty, port.allSatisfy(\.isNumber), let result = unsafeAddressParseResult(host) {
+                return result
+            }
+        }
+
+        return false
+    }
+
+    private static func unsafeAddressParseResult(_ value: String) -> Bool? {
+        var ipv4 = in_addr()
+        if inet_pton(AF_INET, value, &ipv4) == 1 {
+            return isUnsafeIPv4(UInt32(bigEndian: ipv4.s_addr))
+        }
+
+        var ipv6 = in6_addr()
+        if inet_pton(AF_INET6, value, &ipv6) == 1 {
+            return isUnsafeIPv6(&ipv6)
+        }
+        return nil
+    }
+
     private static func isUnsafeHost(_ host: String) -> Bool {
         if host == "localhost"
             || host.hasSuffix(".localhost")

--- a/MeterBar/Services/QuotaWebhookClient.swift
+++ b/MeterBar/Services/QuotaWebhookClient.swift
@@ -1,13 +1,18 @@
 import Foundation
+import os
 
 nonisolated enum QuotaWebhookPostResult: Equatable, Sendable {
     case succeeded
     case failed(String)
 }
 
-/// Blocks every redirect. A public endpoint cannot redirect the request into a
-/// loopback/private target after the configured URL passed validation.
-nonisolated private final class QuotaWebhookRedirectBlocker: NSObject, URLSessionTaskDelegate {
+/// Blocks redirects and records the address URLSession actually connected to.
+/// The record closes the DNS-rebinding gap between the policy's pre-flight DNS
+/// lookup and URLSession's independent lookup at connection time.
+nonisolated final class QuotaWebhookConnectionDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    private let lock = NSLock()
+    private var remoteAddresses: [Int: String] = [:]
+
     func urlSession(
         _ session: URLSession,
         task: URLSessionTask,
@@ -17,6 +22,37 @@ nonisolated private final class QuotaWebhookRedirectBlocker: NSObject, URLSessio
     ) {
         completionHandler(nil)
     }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didFinishCollecting metrics: URLSessionTaskMetrics
+    ) {
+        guard let remoteAddress = metrics.transactionMetrics.last?.remoteAddress else { return }
+        recordRemoteAddress(remoteAddress, forTaskIdentifier: task.taskIdentifier)
+    }
+
+    /// Removes the entry as part of the read so repeated deliveries and failed
+    /// tasks cannot grow the correlation map without bound.
+    func takeRemoteAddress(forTaskIdentifier taskIdentifier: Int) -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return remoteAddresses.removeValue(forKey: taskIdentifier)
+    }
+
+    /// Internal seam used by deterministic URLProtocol tests, whose synthetic
+    /// loads do not produce transaction metrics or a remote address.
+    func recordRemoteAddress(_ address: String, forTaskIdentifier taskIdentifier: Int) {
+        lock.lock()
+        remoteAddresses[taskIdentifier] = address
+        lock.unlock()
+    }
+
+    var observedAddressCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return remoteAddresses.count
+    }
 }
 
 /// Minimal, ephemeral, cookie-free webhook transport. It discards response
@@ -24,8 +60,9 @@ nonisolated private final class QuotaWebhookRedirectBlocker: NSObject, URLSessio
 nonisolated final class QuotaWebhookClient: @unchecked Sendable {
     private let session: URLSession
     private let timeout: TimeInterval
-    private let redirectBlocker: QuotaWebhookRedirectBlocker
+    private let connectionDelegate: QuotaWebhookConnectionDelegate
     private let hostIsPublic: @Sendable (String) async -> Bool
+    private let taskCreatedForTesting: (@Sendable (URLSessionTask) -> Void)?
 
     init(
         configuration: URLSessionConfiguration = .ephemeral,
@@ -34,7 +71,9 @@ nonisolated final class QuotaWebhookClient: @unchecked Sendable {
             await Task.detached {
                 QuotaWebhookURLPolicy.hostResolvesOnlyToPublicAddresses(host)
             }.value
-        }
+        },
+        connectionDelegate: QuotaWebhookConnectionDelegate = QuotaWebhookConnectionDelegate(),
+        taskCreatedForTesting: (@Sendable (URLSessionTask) -> Void)? = nil
     ) {
         let safeConfiguration = (configuration.copy() as? URLSessionConfiguration) ?? .ephemeral
         safeConfiguration.urlCache = nil
@@ -45,15 +84,15 @@ nonisolated final class QuotaWebhookClient: @unchecked Sendable {
         safeConfiguration.timeoutIntervalForRequest = max(0.01, timeout)
         safeConfiguration.timeoutIntervalForResource = max(0.01, timeout)
 
-        let redirectBlocker = QuotaWebhookRedirectBlocker()
-        self.redirectBlocker = redirectBlocker
+        self.connectionDelegate = connectionDelegate
         session = URLSession(
             configuration: safeConfiguration,
-            delegate: redirectBlocker,
+            delegate: connectionDelegate,
             delegateQueue: nil
         )
         self.timeout = max(0.01, timeout)
         self.hostIsPublic = hostIsPublic
+        self.taskCreatedForTesting = taskCreatedForTesting
     }
 
     func post(
@@ -87,8 +126,23 @@ nonisolated final class QuotaWebhookClient: @unchecked Sendable {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue("MeterBar/\(QuotaEventPayload.currentSchemaVersion)", forHTTPHeaderField: "User-Agent")
 
-        do {
-            let (_, response) = try await session.data(for: request)
+        let transport = await perform(request)
+        let observedAddress = connectionDelegate.takeRemoteAddress(
+            forTaskIdentifier: transport.taskIdentifier
+        )
+
+        // URLProtocol stubs and some non-network/OS-specific loads expose no
+        // `remoteAddress`. Fail open in that case: treating an absent metric as
+        // hostile would break deterministic tests and could disable legitimate
+        // webhook delivery if a future OS stops populating the field.
+        if let observedAddress,
+           QuotaWebhookURLPolicy.isUnsafeAddressLiteral(observedAddress) {
+            AppLog.app.error("Webhook connected to a non-public address; delivery rejected.")
+            return .failed("Webhook connected to a non-public address.")
+        }
+
+        switch transport.result {
+        case .success(let response):
             guard let httpResponse = response as? HTTPURLResponse else {
                 return .failed("Webhook returned an invalid response.")
             }
@@ -96,10 +150,66 @@ nonisolated final class QuotaWebhookClient: @unchecked Sendable {
                 return .failed("Webhook returned HTTP \(httpResponse.statusCode).")
             }
             return .succeeded
-        } catch let error as URLError where error.code == .timedOut {
-            return .failed("Webhook request timed out.")
-        } catch {
+        case .failure(let error):
+            if let urlError = error as? URLError, urlError.code == .timedOut {
+                return .failed("Webhook request timed out.")
+            }
             return .failed("Webhook request failed.")
         }
+    }
+
+    /// Uses an explicit task so its identifier can correlate transaction
+    /// metrics with this awaiting call. Metrics are documented to arrive before
+    /// task completion, so the caller reads once without blocking or polling.
+    ///
+    /// IP pinning was considered and rejected: replacing the URL host with an
+    /// address literal would disable URLSession's normal TLS hostname check and
+    /// require hand-rolled certificate validation against the original host, a
+    /// larger and harder-to-test security regression than this post-flight gate.
+    private func perform(_ request: URLRequest) async -> QuotaWebhookTransport {
+        await withCheckedContinuation { continuation in
+            let taskIdentity = QuotaWebhookTaskIdentity()
+            let task = session.dataTask(with: request) { _, response, error in
+                let result: Result<URLResponse, Error>
+                if let error {
+                    result = .failure(error)
+                } else if let response {
+                    result = .success(response)
+                } else {
+                    result = .failure(URLError(.unknown))
+                }
+                continuation.resume(
+                    returning: QuotaWebhookTransport(taskIdentifier: taskIdentity.value, result: result)
+                )
+            }
+            taskIdentity.store(task.taskIdentifier)
+            taskCreatedForTesting?(task)
+            task.resume()
+        }
+    }
+}
+
+nonisolated private struct QuotaWebhookTransport: @unchecked Sendable {
+    let taskIdentifier: Int
+    let result: Result<URLResponse, Error>
+}
+
+/// Bridges the identifier assigned after `dataTask(with:)` constructs the task
+/// into its concurrently executing completion callback without capturing and
+/// mutating a local variable across isolation domains.
+nonisolated private final class QuotaWebhookTaskIdentity: @unchecked Sendable {
+    private let lock = NSLock()
+    private var taskIdentifier = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return taskIdentifier
+    }
+
+    func store(_ value: Int) {
+        lock.lock()
+        taskIdentifier = value
+        lock.unlock()
     }
 }

--- a/MeterBar/Services/TokenUsageAggregator.swift
+++ b/MeterBar/Services/TokenUsageAggregator.swift
@@ -5,6 +5,36 @@ import MeterBarShared
 /// daily-usage rows and breakdown rows the UI renders.
 /// Split out of `CostTracker` (audit C1d).
 enum TokenUsageAggregator {
+    nonisolated static func makeHourlyUsage(
+        from hourlyTotals: [Date: TokenAccumulator],
+        provider: ServiceType,
+        pricing: TokenPricing,
+        pricingAt: ((Date) -> TokenPricing)? = nil
+    ) -> [HourlyTokenUsage] {
+        hourlyTotals.map { hour, tokens in
+            let rowPricing = pricingAt?(hour) ?? pricing
+            let billableInput = provider == .codexCli ? max(0, tokens.input - tokens.cacheRead) : tokens.input
+            let output = tokens.output + tokens.reasoning
+            let cost = tokens.estimatedCostUSD > 0
+                ? tokens.estimatedCostUSD
+                : TokenCostMath.calculateCost(
+                    input: billableInput,
+                    output: output,
+                    cacheCreation: tokens.cacheCreation,
+                    cacheRead: tokens.cacheRead,
+                    pricing: rowPricing
+                )
+            return HourlyTokenUsage(
+                date: hour,
+                provider: provider,
+                inputTokens: billableInput,
+                outputTokens: output,
+                cacheReadTokens: tokens.cacheRead,
+                estimatedCostUSD: cost
+            )
+        }
+    }
+
     /// `pricingAt` resolves one row's rate from its model name (`nil` for the
     /// day's own flat total) and the day it was recorded, so a dated schedule
     /// prices history at the rate that was in effect then instead of today's

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -124,6 +124,8 @@ class UsageDataManager: ObservableObject {
     private let grokAccountStore: GrokAccountStore
     private let providerVisibilityStore: ProviderVisibilityStore
     private let parseHealthStore: ProviderParseHealthStore
+    private let refreshLockMode: UsageRefreshLockMode
+    private let refreshLockFactory: @Sendable () -> WakeLock
 
     /// Where polled running counters are accumulated into a dated series.
     ///
@@ -174,6 +176,10 @@ class UsageDataManager: ObservableObject {
         cacheDefaults: UserDefaults = .standard,
         parseHealthStore: ProviderParseHealthStore? = nil,
         schedulesAutoRefresh: Bool = true,
+        refreshLockMode: UsageRefreshLockMode = .acquirePerRefresh,
+        refreshLockFactory: @escaping @Sendable () -> WakeLock = {
+            UsageRefreshLock.make(holderKind: .app)
+        },
         adaptiveNow: @escaping @Sendable () -> Date = { Date() },
         adaptivePowerState: @escaping @Sendable () -> AdaptiveRefreshPowerState = {
             .current
@@ -194,6 +200,8 @@ class UsageDataManager: ObservableObject {
         self.preferences = preferences
         self.cacheDefaults = cacheDefaults
         self.parseHealthStore = parseHealthStore ?? .shared
+        self.refreshLockMode = refreshLockMode
+        self.refreshLockFactory = refreshLockFactory
         self.adaptiveNow = adaptiveNow
         self.adaptivePowerState = adaptivePowerState
         adaptiveRefreshEngine = AdaptiveRefreshCadenceEngine(now: adaptiveNow)
@@ -261,22 +269,18 @@ class UsageDataManager: ObservableObject {
         }
         defer { rescheduleAdaptiveRefreshIfNeeded() }
         guard !isLoading else {
-            return UsageRefreshReport(
-                startedAt: startedAt,
-                finishedAt: Date(),
-                outcomes: ServiceType.allCases.map {
-                    ProviderRefreshOutcome(
-                        provider: $0,
-                        state: .skipped,
-                        reason: providerVisibilityStore.isEnabled($0)
-                            ? "Another refresh is already running."
-                            : Self.disabledReason,
-                        servedFromCache: metrics[$0] != nil,
-                        lastUpdated: metrics[$0]?.lastUpdated
-                    )
-                }
-            )
+            return skippedRefreshReport(startedAt: startedAt, enabledReason: "Another refresh is already running.")
         }
+
+        let refreshLock: WakeLock?
+        switch await acquireRefreshLock() {
+        case let .acquired(lock):
+            refreshLock = lock
+        case let .skipped(reason):
+            return skippedRefreshReport(startedAt: startedAt, enabledReason: reason)
+        }
+        defer { refreshLock?.release() }
+
         isLoading = true
         defer { isLoading = false }
         lastError = nil
@@ -400,6 +404,54 @@ class UsageDataManager: ObservableObject {
     private static let demoModeReason = "Demo mode is showing sample data."
     private static let notSignedInReason = "No readable credentials for this provider."
     private static let noEnabledAccountsReason = "No enabled accounts for this provider."
+    private static let refreshContendedReason = "Another MeterBar refresh is already running."
+    private static let refreshLockUnavailableReason = "The shared MeterBar refresh lock is unavailable."
+
+    private enum RefreshLockLease {
+        case acquired(WakeLock?)
+        case skipped(reason: String)
+    }
+
+    /// `WakeLock.acquire()` includes filesystem work. Keep that work off the
+    /// main actor even though `LOCK_NB` guarantees it never waits for a holder.
+    private func acquireRefreshLock() async -> RefreshLockLease {
+        guard refreshLockMode == .acquirePerRefresh else { return .acquired(nil) }
+        let makeLock = refreshLockFactory
+        let (lock, acquisition) = await Task.detached(priority: .userInitiated) {
+            let lock = makeLock()
+            return (lock, lock.acquire())
+        }.value
+
+        switch acquisition {
+        case .acquired:
+            return .acquired(lock)
+        case .contended:
+            AppLog.usage.info("Skipping provider refresh because the shared refresh lock is held.")
+            return .skipped(reason: Self.refreshContendedReason)
+        case let .legacyHeld(guidance):
+            AppLog.usage.error("Skipping provider refresh because a legacy lock is held: \(guidance)")
+            return .skipped(reason: Self.refreshLockUnavailableReason)
+        case let .unavailable(reason):
+            AppLog.usage.error("Skipping provider refresh because the lock is unavailable: \(reason)")
+            return .skipped(reason: Self.refreshLockUnavailableReason)
+        }
+    }
+
+    private func skippedRefreshReport(startedAt: Date, enabledReason: String) -> UsageRefreshReport {
+        UsageRefreshReport(
+            startedAt: startedAt,
+            finishedAt: Date(),
+            outcomes: ServiceType.allCases.map {
+                ProviderRefreshOutcome(
+                    provider: $0,
+                    state: .skipped,
+                    reason: providerVisibilityStore.isEnabled($0) ? enabledReason : Self.disabledReason,
+                    servedFromCache: metrics[$0] != nil,
+                    lastUpdated: metrics[$0]?.lastUpdated
+                )
+            }
+        )
+    }
 
     private func claudeCodeSkipReason(hasEnabledAccount: Bool) -> String {
         if !providerVisibilityStore.isEnabled(.claudeCode) { return Self.disabledReason }
@@ -564,6 +616,8 @@ class UsageDataManager: ObservableObject {
         lastMeterBarInteractionAt = adaptiveNow()
         defer { rescheduleAdaptiveRefreshIfNeeded() }
         guard !isLoading else { return }
+        guard case let .acquired(refreshLock) = await acquireRefreshLock() else { return }
+        defer { refreshLock?.release() }
         isLoading = true
         defer { isLoading = false }
         lastError = nil
@@ -642,6 +696,8 @@ class UsageDataManager: ObservableObject {
               let account = claudeCodeAccountStore.enabledAccounts.first(where: { $0.id == id }) else {
             return
         }
+        guard case let .acquired(refreshLock) = await acquireRefreshLock() else { return }
+        defer { refreshLock?.release() }
 
         isLoading = true
         defer { isLoading = false }

--- a/MeterBar/SessionWake/CodexSessionDiscovery.swift
+++ b/MeterBar/SessionWake/CodexSessionDiscovery.swift
@@ -8,43 +8,18 @@ import Foundation
 /// `CodexRolloutClassifier`, which keys the block signal on the structured
 /// `rate_limits.rate_limit_reached_type` field rather than any prose.
 actor CodexSessionDiscovery {
-    struct Configuration {
-        var maxTailBytes: Int = 64 * 1024
-        var maxTranscriptAge: TimeInterval = 14 * 24 * 3600
-        var maxTranscripts: Int = 400
-        var fileManager: FileManager = .default
+    typealias Configuration = WakeTranscriptScanner.Configuration
 
-        init(
-            maxTailBytes: Int = 64 * 1024,
-            maxTranscriptAge: TimeInterval = 14 * 24 * 3600,
-            maxTranscripts: Int = 400,
-            fileManager: FileManager = .default
-        ) {
-            self.maxTailBytes = maxTailBytes
-            self.maxTranscriptAge = maxTranscriptAge
-            self.maxTranscripts = maxTranscripts
-            self.fileManager = fileManager
-        }
-    }
-
-    private let configuration: Configuration
+    private let scanner: WakeTranscriptScanner
 
     init(configuration: Configuration = Configuration()) {
-        self.configuration = configuration
+        scanner = WakeTranscriptScanner(configuration: configuration)
     }
 
     /// The `sessions` root for a CODEX_HOME, honoring an explicit override and
     /// otherwise `~/.codex`.
     static func sessionsDirectory(codexHome: String?) -> URL {
-        let trimmed = codexHome?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let base: String
-        if let trimmed, !trimmed.isEmpty {
-            base = (trimmed as NSString).standardizingPath
-        } else {
-            base = "\(ServiceSupport.realHomeDirectory())/.codex"
-        }
-        return URL(fileURLWithPath: base, isDirectory: true)
-            .appendingPathComponent("sessions", isDirectory: true)
+        WakeTranscriptScanner.root(override: codexHome, defaultHome: ".codex", subdirectory: "sessions")
     }
 
     /// Discover blocked Codex sessions under `codexHome`, consulting `ledger` to
@@ -55,12 +30,11 @@ actor CodexSessionDiscovery {
         now: Date = Date()
     ) async -> [WakeSessionCandidate] {
         let sessions = CodexSessionDiscovery.sessionsDirectory(codexHome: codexHome)
-        let rollouts = rolloutURLs(under: sessions, now: now)
-
-        var bySession: [String: WakeSessionCandidate] = [:]
+        let rollouts = scanner.transcriptURLs(under: sessions, now: now, prunesSubagents: false)
+        var candidates = WakeTranscriptScanner.CandidateSet()
 
         for url in rollouts {
-            guard let lines = readTail(of: url) else { continue }
+            guard let lines = scanner.readTail(of: url) else { continue }
             let fallbackID = url.deletingPathExtension().lastPathComponent
             let summary = CodexRolloutClassifier.classify(fallbackID: fallbackID, lines: lines)
 
@@ -72,7 +46,7 @@ actor CodexSessionDiscovery {
                 reason: reason,
                 provider: .codex
             )
-            let (canonicalCwd, cwdSkip) = resolveWorkingDirectory(summary.cwd)
+            let (canonicalCwd, cwdSkip) = scanner.resolveWorkingDirectory(summary.cwd)
             let alreadyHandled = await ledger.contains(fingerprint)
             let skip: WakeSkipReason? = alreadyHandled ? .alreadyHandled : cwdSkip
 
@@ -89,83 +63,9 @@ actor CodexSessionDiscovery {
                 provider: .codex
             )
 
-            if let existing = bySession[summary.sessionID], !supersedes(candidate, existing) {
-                continue
-            }
-            bySession[summary.sessionID] = candidate
+            candidates.insert(candidate)
         }
 
-        return bySession.values.sorted(by: supersedes)
-    }
-
-    private func supersedes(_ candidate: WakeSessionCandidate, _ existing: WakeSessionCandidate) -> Bool {
-        if candidate.blockedAt != existing.blockedAt {
-            return candidate.blockedAt > existing.blockedAt
-        }
-        return candidate.transcriptPath < existing.transcriptPath
-    }
-
-    // MARK: - Filesystem
-
-    private func rolloutURLs(under sessions: URL, now: Date) -> [URL] {
-        guard let enumerator = configuration.fileManager.enumerator(
-            at: sessions,
-            includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            return []
-        }
-        let oldestAllowed = now.addingTimeInterval(-configuration.maxTranscriptAge)
-        var found: [(url: URL, modified: Date)] = []
-        for case let url as URL in enumerator {
-            guard url.pathExtension == "jsonl",
-                  let values = try? url.resourceValues(
-                      forKeys: [.isRegularFileKey, .contentModificationDateKey]
-                  ),
-                  values.isRegularFile == true,
-                  let modified = values.contentModificationDate,
-                  modified >= oldestAllowed else {
-                continue
-            }
-            found.append((url, modified))
-        }
-        return found
-            .sorted {
-                if $0.modified != $1.modified {
-                    return $0.modified > $1.modified
-                }
-                return $0.url.path < $1.url.path
-            }
-            .prefix(configuration.maxTranscripts)
-            .map(\.url)
-    }
-
-    private func readTail(of url: URL) -> [String]? {
-        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
-        defer { try? handle.close() }
-
-        let size = (try? handle.seekToEnd()) ?? 0
-        let start = size > UInt64(configuration.maxTailBytes)
-            ? size - UInt64(configuration.maxTailBytes)
-            : 0
-        try? handle.seek(toOffset: start)
-        let data = (try? handle.readToEnd()) ?? Data()
-        // Lossy decode for the same reason SessionDiscovery uses it: a bounded
-        // tail can split a multibyte character and strict decoding would drop
-        // the whole buffer.
-        // swiftlint:disable:next optional_data_string_conversion
-        let string = String(decoding: data, as: UTF8.self)
-        return string.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
-    }
-
-    private func resolveWorkingDirectory(_ raw: String?) -> (String?, WakeSkipReason?) {
-        guard let raw, !raw.isEmpty else { return (nil, .unknownWorkingDirectory) }
-        let canonical = URL(fileURLWithPath: raw).resolvingSymlinksInPath().path
-        var isDirectory: ObjCBool = false
-        let exists = configuration.fileManager.fileExists(atPath: canonical, isDirectory: &isDirectory)
-        if !exists || !isDirectory.boolValue {
-            return (canonical, .missingWorkingDirectory)
-        }
-        return (canonical, nil)
+        return candidates.sorted
     }
 }

--- a/MeterBar/SessionWake/SessionDiscovery.swift
+++ b/MeterBar/SessionWake/SessionDiscovery.swift
@@ -8,50 +8,18 @@ import Foundation
 /// All work runs on this actor, off the main actor, with a bounded tail read
 /// per transcript so a huge history cannot stall the scan.
 actor SessionDiscovery {
-    struct Configuration {
-        /// Bytes read from the end of each transcript. The decisive tail of a
-        /// session is always near the end, so a bounded window is sufficient
-        /// and keeps scanning incremental.
-        var maxTailBytes: Int = 64 * 1024
-        /// Transcripts whose file was not modified within this window are
-        /// skipped outright — a weeks-old block is history, not a wake target.
-        var maxTranscriptAge: TimeInterval = 14 * 24 * 3600
-        /// Newest-first cap on transcripts classified per scan, so a huge
-        /// projects directory can never make discovery unbounded.
-        var maxTranscripts: Int = 400
-        var fileManager: FileManager = .default
+    typealias Configuration = WakeTranscriptScanner.Configuration
 
-        init(
-            maxTailBytes: Int = 64 * 1024,
-            maxTranscriptAge: TimeInterval = 14 * 24 * 3600,
-            maxTranscripts: Int = 400,
-            fileManager: FileManager = .default
-        ) {
-            self.maxTailBytes = maxTailBytes
-            self.maxTranscriptAge = maxTranscriptAge
-            self.maxTranscripts = maxTranscripts
-            self.fileManager = fileManager
-        }
-    }
-
-    private let configuration: Configuration
+    private let scanner: WakeTranscriptScanner
 
     init(configuration: Configuration = Configuration()) {
-        self.configuration = configuration
+        scanner = WakeTranscriptScanner(configuration: configuration)
     }
 
     /// The `projects` root for an account, honoring an explicit
     /// `CLAUDE_CONFIG_DIR` override and otherwise `~/.claude`.
     static func projectsDirectory(configDirectory: String?) -> URL {
-        let trimmed = configDirectory?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let base: String
-        if let trimmed, !trimmed.isEmpty {
-            base = trimmed
-        } else {
-            base = "\(ServiceSupport.realHomeDirectory())/.claude"
-        }
-        return URL(fileURLWithPath: base, isDirectory: true)
-            .appendingPathComponent("projects", isDirectory: true)
+        WakeTranscriptScanner.root(override: configDirectory, defaultHome: ".claude", subdirectory: "projects")
     }
 
     /// Discover blocked sessions for `configDirectory`, consulting `ledger` to
@@ -67,13 +35,11 @@ actor SessionDiscovery {
         now: Date = Date()
     ) async -> [WakeSessionCandidate] {
         let projects = SessionDiscovery.projectsDirectory(configDirectory: configDirectory)
-        let transcripts = transcriptURLs(under: projects, now: now)
-
-        // Keep the newest block per sessionID (a resumed session can re-block).
-        var bySession: [String: WakeSessionCandidate] = [:]
+        let transcripts = scanner.transcriptURLs(under: projects, now: now, prunesSubagents: true)
+        var candidates = WakeTranscriptScanner.CandidateSet()
 
         for url in transcripts {
-            guard let lines = readTail(of: url) else { continue }
+            guard let lines = scanner.readTail(of: url) else { continue }
             let fallbackID = url.deletingPathExtension().lastPathComponent
             let summary = TranscriptClassifier.classify(sessionID: fallbackID, lines: lines)
 
@@ -87,7 +53,7 @@ actor SessionDiscovery {
                 blockedAt: blockedAt,
                 reason: reason
             )
-            let (canonicalCwd, cwdSkip) = resolveWorkingDirectory(summary.cwd)
+            let (canonicalCwd, cwdSkip) = scanner.resolveWorkingDirectory(summary.cwd)
             let alreadyHandled = await ledger.contains(fingerprint)
 
             let skip: WakeSkipReason? = alreadyHandled ? .alreadyHandled : cwdSkip
@@ -104,107 +70,9 @@ actor SessionDiscovery {
                 skipReason: skip
             )
 
-            if let existing = bySession[summary.sessionID], !supersedes(candidate, existing) {
-                continue
-            }
-            bySession[summary.sessionID] = candidate
+            candidates.insert(candidate)
         }
 
-        // `supersedes` is a strict total order over (blockedAt desc, path asc);
-        // reusing it keeps the dedupe winner and the output order one rule.
-        return bySession.values.sorted(by: supersedes)
-    }
-
-    /// Deterministic dedupe: the latest block wins; equal block instants
-    /// tie-break on the lexicographically first transcript path so the winner
-    /// never depends on filesystem enumeration order.
-    private func supersedes(_ candidate: WakeSessionCandidate, _ existing: WakeSessionCandidate) -> Bool {
-        if candidate.blockedAt != existing.blockedAt {
-            return candidate.blockedAt > existing.blockedAt
-        }
-        return candidate.transcriptPath < existing.transcriptPath
-    }
-
-    // MARK: - Filesystem
-
-    /// Bounded enumeration: recent regular `.jsonl` files outside any
-    /// `subagents/` directory, newest-first, capped at `maxTranscripts`.
-    private func transcriptURLs(under projects: URL, now: Date) -> [URL] {
-        guard let enumerator = configuration.fileManager.enumerator(
-            at: projects,
-            includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            return []
-        }
-        let oldestAllowed = now.addingTimeInterval(-configuration.maxTranscriptAge)
-        var found: [(url: URL, modified: Date)] = []
-        for case let url as URL in enumerator {
-            // Subagent transcripts live under a `subagents/` directory and are
-            // never resume targets — prune the whole subtree so its children
-            // are never even stat'd.
-            if url.lastPathComponent == "subagents", url.hasDirectoryPath {
-                enumerator.skipDescendants()
-                continue
-            }
-            guard url.pathExtension == "jsonl",
-                  !url.pathComponents.contains("subagents"),
-                  let values = try? url.resourceValues(
-                      forKeys: [.isRegularFileKey, .contentModificationDateKey]
-                  ),
-                  values.isRegularFile == true,
-                  let modified = values.contentModificationDate,
-                  modified >= oldestAllowed else {
-                continue
-            }
-            found.append((url, modified))
-        }
-        // Newest-first with a lexicographic path tie-break, so the winners
-        // under the cap never depend on filesystem enumeration order.
-        return found
-            .sorted {
-                if $0.modified != $1.modified {
-                    return $0.modified > $1.modified
-                }
-                return $0.url.path < $1.url.path
-            }
-            .prefix(configuration.maxTranscripts)
-            .map(\.url)
-    }
-
-    /// Read up to `maxTailBytes` from the end of `url`, returned as lines.
-    /// Returns nil only when the file cannot be opened at all.
-    private func readTail(of url: URL) -> [String]? {
-        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
-        defer { try? handle.close() }
-
-        let size = (try? handle.seekToEnd()) ?? 0
-        let start = size > UInt64(configuration.maxTailBytes)
-            ? size - UInt64(configuration.maxTailBytes)
-            : 0
-        try? handle.seek(toOffset: start)
-        let data = (try? handle.readToEnd()) ?? Data()
-        // A bounded tail read can begin mid-multibyte-character. A failable
-        // String(data:encoding:) would reject the whole buffer and silently
-        // drop the transcript's decisive event; lossy decoding turns only the
-        // split leading bytes into U+FFFD (that partial line is skipped as
-        // malformed JSON) and keeps every complete line intact. The lint rule
-        // prefers the failable initializer — exactly the nil-dropping behavior
-        // this fix removes — so it is disabled here deliberately.
-        // swiftlint:disable:next optional_data_string_conversion
-        let string = String(decoding: data, as: UTF8.self)
-        return string.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
-    }
-
-    /// Canonicalize and validate the transcript's working directory.
-    private func resolveWorkingDirectory(_ raw: String?) -> (String?, WakeSkipReason?) {
-        guard let raw, !raw.isEmpty else { return (nil, .unknownWorkingDirectory) }
-        let canonical = URL(fileURLWithPath: raw).resolvingSymlinksInPath().path
-        var isDirectory: ObjCBool = false
-        let exists = configuration.fileManager.fileExists(atPath: canonical, isDirectory: &isDirectory)
-        if !exists || !isDirectory.boolValue {
-            return (canonical, .missingWorkingDirectory)
-        }
-        return (canonical, nil)
+        return candidates.sorted
     }
 }

--- a/MeterBar/SessionWake/SessionWakeController.swift
+++ b/MeterBar/SessionWake/SessionWakeController.swift
@@ -18,12 +18,21 @@ nonisolated protocol WakeWatching: Sendable {
 
 extension WakeCoordinator: WakeWatching {}
 
+nonisolated protocol WakeLifetimeLocking: Sendable {
+    func acquire() -> WakeLock.Acquisition
+    func release()
+}
+
+extension WakeLock: WakeLifetimeLocking {}
+
 /// Builds a watcher from a runner, bounds, and a state-change sink.
 typealias WakeWatcherFactory = @Sendable (
     WakeExecuting,
     WakeBounds,
     @escaping @Sendable (WakeWatcherState) -> Void
 ) -> WakeWatching
+
+typealias WakeLifetimeLockFactory = @Sendable () -> WakeLifetimeLocking
 
 /// Bridges the single ON/OFF toggle to a live, continuous watcher.
 ///
@@ -36,6 +45,11 @@ typealias WakeWatcherFactory = @Sendable (
 final class SessionWakeController: ObservableObject {
     static let shared = SessionWakeController()
 
+    private struct WatchIdentity: Equatable {
+        let provider: WakeProvider
+        let accountID: UUID
+    }
+
     private let store: SessionWakeSettingsStore
     private let status: SessionWakeStatus
     private let accounts: ClaudeCodeAccountStore
@@ -47,12 +61,14 @@ final class SessionWakeController: ObservableObject {
     private let agentStateStore: SessionWakeAgentStateStore
     private let rescanInterval: TimeInterval
     private let makeWatcher: WakeWatcherFactory
-    private let makeLifetimeLock: @Sendable () -> WakeLock
+    private let makeLifetimeLock: WakeLifetimeLockFactory
     private let hookDispatcher: WakeEventHookDispatcher
 
     private var cancellables = Set<AnyCancellable>()
     private var watchTask: Task<Void, Never>?
-    private var localLifetimeLock: WakeLock?
+    private var watchIdentity: WatchIdentity?
+    private var localLifetimeLock: WakeLifetimeLocking?
+    private var rearmTask: Task<Void, Never>?
     private var agentMonitorTask: Task<Void, Never>?
     private var failedRegistrationStatus: SessionWakeAgentRegistrationStatus?
     private var started = false
@@ -74,7 +90,7 @@ final class SessionWakeController: ObservableObject {
         makeWatcher: @escaping WakeWatcherFactory = { runner, bounds, onState in
             WakeCoordinator(runner: runner, bounds: bounds, onState: onState)
         },
-        makeLifetimeLock: @escaping @Sendable () -> WakeLock = { WakeLock(holderKind: .app) },
+        makeLifetimeLock: @escaping WakeLifetimeLockFactory = { WakeLock(holderKind: .app) },
         hookDispatcher: WakeEventHookDispatcher? = nil
     ) {
         let resolvedStore = store ?? .shared
@@ -255,7 +271,15 @@ final class SessionWakeController: ObservableObject {
     }
 
     private func startWatching(runtime: WakeProviderRuntime) {
-        guard watchTask == nil else { return }
+        guard let accountID = store.activeAccountID else { return }
+        let requestedIdentity = WatchIdentity(provider: runtime.provider, accountID: accountID)
+        if watchTask != nil {
+            guard watchIdentity != requestedIdentity else { return }
+            rearmWatching()
+            return
+        }
+        guard rearmTask == nil else { return }
+
         let lifetimeLock = makeLifetimeLock()
         switch lifetimeLock.acquire() {
         case .acquired:
@@ -272,6 +296,7 @@ final class SessionWakeController: ObservableObject {
             return
         }
 
+        watchIdentity = requestedIdentity
         status.updateBackgroundExecution(.inApp)
         let bounds = store.bounds
         // The factory seam still takes a runner (used by the concrete coordinator
@@ -304,17 +329,28 @@ final class SessionWakeController: ObservableObject {
         }
     }
 
+    private func rearmWatching() {
+        beginWatchCleanup()
+    }
+
     private func stopWatching() {
-        guard watchTask != nil else { return }
-        let task = watchTask
+        beginWatchCleanup()
+    }
+
+    private func beginWatchCleanup() {
+        guard rearmTask == nil, let task = watchTask else { return }
         let lifetimeLock = localLifetimeLock
-        task?.cancel()
+        task.cancel()
         watchTask = nil
+        watchIdentity = nil
         localLifetimeLock = nil
-        Task { [weak self] in
-            await task?.value
+        rearmTask = Task { [weak self] in
+            await task.value
             lifetimeLock?.release()
-            self?.status.update(state: .off)
+            guard let self else { return }
+            self.rearmTask = nil
+            self.status.update(state: .off)
+            self.reconcile()
         }
     }
 

--- a/MeterBar/SessionWake/WakeCLIResponse.swift
+++ b/MeterBar/SessionWake/WakeCLIResponse.swift
@@ -5,7 +5,7 @@ import Foundation
 /// stdout carries only this object; all diagnostics go to stderr/logs. The
 /// `schemaVersion` lets consumers detect breaking changes; new fields are
 /// additive within a version.
-struct WakeCLIResponse: Codable, Equatable, Sendable {
+struct WakeCLIResponse: Codable, Equatable, Sendable, CLIJSONDocument {
     static let currentSchemaVersion = 1
 
     struct Session: Codable, Equatable, Sendable {
@@ -34,13 +34,6 @@ struct WakeCLIResponse: Codable, Equatable, Sendable {
     var summary: Summary
     /// Human-readable, machine-stable reason for a non-success outcome.
     let message: String?
-
-    /// Encode to a single stdout-ready JSON line.
-    func jsonData() throws -> Data {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
-        return try encoder.encode(self)
-    }
 
     static func from(
         candidates: [WakeSessionCandidate],

--- a/MeterBar/SessionWake/WakeLock.swift
+++ b/MeterBar/SessionWake/WakeLock.swift
@@ -35,7 +35,7 @@ nonisolated struct WakeLockHolder: Codable, Equatable, Sendable {
 /// The holder writes a JSON descriptor so a contender can say who is running.
 nonisolated final class WakeLock: @unchecked Sendable {
     /// The outcome of trying to acquire the shared lock.
-    enum Acquisition: Equatable {
+    enum Acquisition: Equatable, Sendable {
         case acquired
         /// Held by another MeterBar/CLI holder; `holder` is present when its
         /// descriptor could be read from the lock file.

--- a/MeterBar/SessionWake/WakeTranscriptScanner.swift
+++ b/MeterBar/SessionWake/WakeTranscriptScanner.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+/// Shared bounded filesystem mechanics for provider-specific wake discovery.
+///
+/// Classification stays with each provider so their transcript contracts
+/// cannot bleed together; only their identical read, validation, and ordering
+/// rules live here.
+nonisolated struct WakeTranscriptScanner {
+    struct Configuration {
+        /// Bytes read from the end of each transcript. The decisive tail of a
+        /// session is always near the end, so a bounded window is sufficient
+        /// and keeps scanning incremental.
+        var maxTailBytes: Int = 64 * 1024
+        /// Transcripts whose file was not modified within this window are
+        /// skipped outright — a weeks-old block is history, not a wake target.
+        var maxTranscriptAge: TimeInterval = 14 * 24 * 3600
+        /// Newest-first cap on transcripts classified per scan, so a huge
+        /// transcript directory can never make discovery unbounded.
+        var maxTranscripts: Int = 400
+        var fileManager: FileManager = .default
+    }
+
+    struct CandidateSet {
+        private var bySession: [String: WakeSessionCandidate] = [:]
+
+        mutating func insert(_ candidate: WakeSessionCandidate) {
+            if let existing = bySession[candidate.sessionID],
+               !WakeTranscriptScanner.supersedes(candidate, existing) {
+                return
+            }
+            bySession[candidate.sessionID] = candidate
+        }
+
+        /// `supersedes` is a strict total order over (blockedAt desc, path asc);
+        /// reusing it keeps the dedupe winner and the output order one rule.
+        var sorted: [WakeSessionCandidate] {
+            bySession.values.sorted(by: WakeTranscriptScanner.supersedes)
+        }
+    }
+
+    private let configuration: Configuration
+
+    init(configuration: Configuration = Configuration()) {
+        self.configuration = configuration
+    }
+
+    /// Resolve a provider root consistently across every account layout.
+    ///
+    /// A non-blank override is standardized so tildes expand, `..` components
+    /// collapse, and trailing slashes are removed before the subdirectory is
+    /// appended.
+    static func root(override: String?, defaultHome: String, subdirectory: String) -> URL {
+        let trimmed = override?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let base: String
+        if let trimmed, !trimmed.isEmpty {
+            base = (trimmed as NSString).standardizingPath
+        } else {
+            base = "\(ServiceSupport.realHomeDirectory())/\(defaultHome)"
+        }
+        return URL(fileURLWithPath: base, isDirectory: true)
+            .appendingPathComponent(subdirectory, isDirectory: true)
+    }
+
+    /// Bounded enumeration of recent regular `.jsonl` files, newest first.
+    func transcriptURLs(under root: URL, now: Date, prunesSubagents: Bool) -> [URL] {
+        guard let enumerator = configuration.fileManager.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+        let oldestAllowed = now.addingTimeInterval(-configuration.maxTranscriptAge)
+        var found: [(url: URL, modified: Date)] = []
+        for case let url as URL in enumerator {
+            // Subagent transcripts are never resume targets. Pruning their
+            // directory avoids stat'ing every child before classification.
+            if prunesSubagents, url.lastPathComponent == "subagents", url.hasDirectoryPath {
+                enumerator.skipDescendants()
+                continue
+            }
+            guard url.pathExtension == "jsonl",
+                  !prunesSubagents || !url.pathComponents.contains("subagents"),
+                  let values = try? url.resourceValues(
+                      forKeys: [.isRegularFileKey, .contentModificationDateKey]
+                  ),
+                  values.isRegularFile == true,
+                  let modified = values.contentModificationDate,
+                  modified >= oldestAllowed else {
+                continue
+            }
+            found.append((url, modified))
+        }
+        // A path tie-break keeps the cap independent of filesystem enumeration
+        // order when multiple transcripts share a modification instant.
+        return found
+            .sorted {
+                if $0.modified != $1.modified {
+                    return $0.modified > $1.modified
+                }
+                return $0.url.path < $1.url.path
+            }
+            .prefix(configuration.maxTranscripts)
+            .map(\.url)
+    }
+
+    /// Read up to `maxTailBytes` from the end of `url`, returned as lines.
+    /// Returns nil only when the file cannot be opened at all.
+    func readTail(of url: URL) -> [String]? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+
+        let size = (try? handle.seekToEnd()) ?? 0
+        let start = size > UInt64(configuration.maxTailBytes)
+            ? size - UInt64(configuration.maxTailBytes)
+            : 0
+        try? handle.seek(toOffset: start)
+        let data = (try? handle.readToEnd()) ?? Data()
+        // A bounded tail read can begin mid-multibyte-character. A failable
+        // String(data:encoding:) would reject the whole buffer and silently
+        // drop the transcript's decisive event; lossy decoding turns only the
+        // split leading bytes into U+FFFD (that partial line is skipped as
+        // malformed JSON) and keeps every complete line intact. The lint rule
+        // prefers the failable initializer — exactly the nil-dropping behavior
+        // this fix removes — so it is disabled here deliberately.
+        // swiftlint:disable:next optional_data_string_conversion
+        let string = String(decoding: data, as: UTF8.self)
+        return string.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+    }
+
+    /// Canonicalize and validate the transcript's working directory.
+    func resolveWorkingDirectory(_ raw: String?) -> (String?, WakeSkipReason?) {
+        guard let raw, !raw.isEmpty else { return (nil, .unknownWorkingDirectory) }
+        let canonical = URL(fileURLWithPath: raw).resolvingSymlinksInPath().path
+        var isDirectory: ObjCBool = false
+        let exists = configuration.fileManager.fileExists(atPath: canonical, isDirectory: &isDirectory)
+        if !exists || !isDirectory.boolValue {
+            return (canonical, .missingWorkingDirectory)
+        }
+        return (canonical, nil)
+    }
+
+    /// Deterministic dedupe: the latest block wins; equal block instants
+    /// tie-break on the lexicographically first transcript path so the winner
+    /// never depends on filesystem enumeration order.
+    static func supersedes(_ candidate: WakeSessionCandidate, _ existing: WakeSessionCandidate) -> Bool {
+        if candidate.blockedAt != existing.blockedAt {
+            return candidate.blockedAt > existing.blockedAt
+        }
+        return candidate.transcriptPath < existing.transcriptPath
+    }
+}

--- a/MeterBar/UsageRefresh/UsageRefreshCLI.swift
+++ b/MeterBar/UsageRefresh/UsageRefreshCLI.swift
@@ -54,16 +54,11 @@ public enum UsageRefreshCLI {
     }
 
     static func makeLock() -> WakeLock {
-        WakeLock(lockURL: lockURL(), legacyLockURLs: [], holderKind: .cli)
+        UsageRefreshLock.make(holderKind: .cli)
     }
 
     static func lockURL() -> URL {
-        let support = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-            ?? URL(fileURLWithPath: "\(ServiceSupport.realHomeDirectory())/Library/Application Support")
-        return support
-            .appendingPathComponent("MeterBar", isDirectory: true)
-            .appendingPathComponent("usage-refresh", isDirectory: true)
-            .appendingPathComponent("refresh.lock")
+        UsageRefreshLock.lockURL()
     }
 
     @MainActor
@@ -78,7 +73,8 @@ public enum UsageRefreshCLI {
             providerVisibilityStore: ProviderVisibilityStore(hiddenServices: configuration.hiddenServices),
             sharedStore: sharedStore,
             cacheDefaults: UserDefaults(suiteName: SharedMetricsStore.appGroupIdentifier) ?? .standard,
-            schedulesAutoRefresh: false
+            schedulesAutoRefresh: false,
+            refreshLockMode: .externallyOwned
         )
     }
 

--- a/MeterBar/UsageRefresh/UsageRefreshLock.swift
+++ b/MeterBar/UsageRefresh/UsageRefreshLock.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Whether a usage manager takes the shared refresh lock itself or runs under
+/// an outer owner such as `UsageRefreshEngine` in the bundled CLI.
+nonisolated enum UsageRefreshLockMode: Equatable, Sendable {
+    case acquirePerRefresh
+    case externallyOwned
+}
+
+/// The one lock path and construction policy shared by the app and CLI.
+nonisolated enum UsageRefreshLock {
+    static func make(holderKind: WakeLockHolder.Kind) -> WakeLock {
+        WakeLock(lockURL: lockURL(), legacyLockURLs: [], holderKind: holderKind)
+    }
+
+    static func lockURL() -> URL {
+        let support = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: "\(ServiceSupport.realHomeDirectory())/Library/Application Support")
+        return support
+            .appendingPathComponent("MeterBar", isDirectory: true)
+            .appendingPathComponent("usage-refresh", isDirectory: true)
+            .appendingPathComponent("refresh.lock")
+    }
+}

--- a/MeterBar/Views/DashboardCostsSection.swift
+++ b/MeterBar/Views/DashboardCostsSection.swift
@@ -72,7 +72,7 @@ struct DashboardCostsSection: View {
 
             TokenActivityCard(
                 summary: summary,
-                weeks: windowSelection.activityWeeks,
+                windowSelection: windowSelection,
                 isScanning: costTracker.isScanning,
                 isScanDisabled: costTracker.isRefreshInProgress,
                 scan: { Task { await costTracker.scanCosts(days: 30) } }

--- a/MeterBar/Views/TokenActivityHeatmap.swift
+++ b/MeterBar/Views/TokenActivityHeatmap.swift
@@ -2,34 +2,36 @@ import AppKit
 import MeterBarShared
 import SwiftUI
 
-/// Dashboard card wrapping the trailing month's contribution calendar.
+/// Dashboard card wrapping the selected token-activity grid.
 ///
 /// Takes plain values rather than reaching for `CostTracker.shared` (same shape
 /// as ``CostOverviewStatusCard``) so the card hosts in a test without standing
-/// up the scanner. The calendar is derived once in `init` — `body` runs on every
-/// hover tick, and re-bucketing the daily rows there would be wasteful.
+/// up the scanner. The grid is derived once in `init` — `body` runs on every
+/// hover tick, and re-bucketing usage rows there would be wasteful.
 struct TokenActivityCard: View {
-    private let activity: TokenActivityCalendar
+    private let grid: TokenActivityGrid
     private let isScanning: Bool
     private let isScanDisabled: Bool
     private let scan: () -> Void
 
     init(
         summary: CostSummary?,
-        weeks: Int = TokenActivityCalendar.defaultWeeks,
+        windowSelection: CostWindowSelection = .month,
         isScanning: Bool,
         isScanDisabled: Bool,
         scan: @escaping () -> Void
     ) {
-        self.activity = TokenActivityCalendar(summary: summary, weeks: weeks)
+        self.grid = TokenActivityGrid(summary: summary, windowSelection: windowSelection)
         self.isScanning = isScanning
         self.isScanDisabled = isScanDisabled
         self.scan = scan
     }
 
     var body: some View {
-        DashboardCard(title: "Token Activity", trailing: activity.coverageSummary) {
-            if activity.hasHistory {
+        DashboardCard(title: "Token Activity", trailing: grid.coverageSummary) {
+            if let hourly = grid.hourly {
+                TokenActivityHourlyHeatmap(activity: hourly)
+            } else if let activity = grid.daily, activity.hasHistory {
                 TokenActivityHeatmap(activity: activity)
             } else if isScanning {
                 CostScanLoadingChart(compact: true)
@@ -57,6 +59,153 @@ struct TokenActivityCard: View {
             .buttonStyle(.glassProminent)
             .disabled(isScanDisabled)
         }
+    }
+}
+
+/// Seven local-day rows by 24 local-hour columns. The model is already fully
+/// derived, so pointer and keyboard focus updates only select a stable cell.
+struct TokenActivityHourlyHeatmap: View {
+    private let activity: TokenActivityHourlyCalendar
+
+    @State private var hoveredHour: TokenActivityHourKey?
+    @State private var keyboardHour: TokenActivityHourKey?
+    @FocusState private var isGridFocused: Bool
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
+    init(activity: TokenActivityHourlyCalendar) {
+        self.activity = activity
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.sm) {
+            VStack(alignment: .leading, spacing: TokenActivityMetrics.spacing) {
+                hourHeader
+                ForEach(activity.days) { day in
+                    dayRow(day)
+                }
+            }
+            .padding(TokenActivityMetrics.focusRingInset)
+            .focusable()
+            .focused($isGridFocused)
+            .onChange(of: isGridFocused) { _, focused in
+                guard focused, keyboardHour == nil else { return }
+                keyboardHour = activity.busiestHour?.id ?? activity.hours.last?.id
+            }
+            .onMoveCommand(perform: moveKeyboardSelection)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Hourly token activity calendar")
+            .accessibilityValue(highlightedCell?.accessibilityValue ?? activity.overviewLine)
+
+            detail
+            TokenActivityLegend()
+        }
+        .animation(
+            MeterBarTheme.Motion.resolve(MeterBarTheme.Motion.quick, reduceMotion: reduceMotion),
+            value: highlightedHour
+        )
+    }
+
+    private var hourHeader: some View {
+        HStack(spacing: TokenActivityMetrics.hourlySpacing) {
+            Color.clear
+                .frame(width: TokenActivityMetrics.weekLabelWidth, height: 1)
+
+            ForEach(0..<TokenActivityHourlyCalendar.hourCount, id: \.self) { hour in
+                Text(String(format: "%02d", hour))
+                    .monospacedDigit()
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .font(.system(size: 8))
+        .foregroundStyle(.secondary)
+        .accessibilityHidden(true)
+    }
+
+    private func dayRow(_ day: TokenActivityHourDay) -> some View {
+        HStack(spacing: TokenActivityMetrics.hourlySpacing) {
+            Text(DashboardDateFormat.monthDay(day.date))
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .frame(width: TokenActivityMetrics.weekLabelWidth, alignment: .trailing)
+                .accessibilityHidden(true)
+
+            ForEach(day.hours) { hour in
+                cell(for: hour)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func cell(for hour: TokenActivityHour) -> some View {
+        let swatch = TokenActivitySwatch(
+            level: hour.level,
+            isHighlighted: highlightedHour == hour.id,
+            fillsWidth: true
+        )
+        .onHover { isHovering in
+            if isHovering {
+                hoveredHour = hour.id
+            } else if hoveredHour == hour.id {
+                hoveredHour = nil
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(hour.accessibilityLabel)
+        .accessibilityValue(hour.accessibilityValue)
+
+        if highlightedHour == hour.id {
+            swatch.help(hour.tooltip)
+        } else {
+            swatch
+        }
+    }
+
+    private var detail: some View {
+        Text(highlightedCell?.detailLine ?? activity.overviewLine)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(2)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityHidden(true)
+    }
+
+    private var highlightedHour: TokenActivityHourKey? {
+        hoveredHour ?? (isGridFocused ? keyboardHour : nil)
+    }
+
+    private var highlightedCell: TokenActivityHour? {
+        highlightedHour.flatMap(activity.hour(for:))
+    }
+
+    /// The whole 7 × 24 matrix is one tab stop. Arrow keys move the selection
+    /// inside it, avoiding 168 focus stops while keeping every hour reachable.
+    private func moveKeyboardSelection(_ direction: MoveCommandDirection) {
+        guard isGridFocused, !activity.hours.isEmpty else { return }
+        let current = keyboardHour.flatMap { key in activity.hours.firstIndex { $0.id == key } }
+            ?? activity.hours.indices.last
+        guard let current else { return }
+
+        let day = current / TokenActivityHourlyCalendar.hourCount
+        let hour = current % TokenActivityHourlyCalendar.hourCount
+        let target: Int
+        switch direction {
+        case .left:
+            target = day * TokenActivityHourlyCalendar.hourCount + max(0, hour - 1)
+        case .right:
+            target = day * TokenActivityHourlyCalendar.hourCount
+                + min(TokenActivityHourlyCalendar.hourCount - 1, hour + 1)
+        case .up:
+            target = max(0, day - 1) * TokenActivityHourlyCalendar.hourCount + hour
+        case .down:
+            target = min(TokenActivityHourlyCalendar.dayCount - 1, day + 1)
+                * TokenActivityHourlyCalendar.hourCount + hour
+        default:
+            return
+        }
+        keyboardHour = activity.hours[target].id
     }
 }
 
@@ -265,6 +414,8 @@ private enum TokenActivityMetrics {
     /// Leading gutter naming the day each week row starts on.
     static let weekLabelWidth: CGFloat = 52
     static let spacing: CGFloat = 6
+    /// A tighter gap preserves useful hover targets across all 24 hour columns.
+    static let hourlySpacing: CGFloat = 3
     static let radius: CGFloat = 5
     static let focusRingInset: CGFloat = 2
     /// Placeholder height while a scan runs, matching the loaded grid: the

--- a/MeterBarCLI/Sources/Serve.swift
+++ b/MeterBarCLI/Sources/Serve.swift
@@ -19,8 +19,16 @@ struct Serve: AsyncParsableCommand {
     @Option(help: "Port to listen on.")
     var port: UInt16 = Serve.defaultPort
 
-    @Option(help: "Bearer token required on every request. If omitted, one is generated and printed once.")
+    @Option(
+        help: ArgumentHelp(
+            "Bearer token required on every request. Visible via ps and shell history; "
+                + "prefer --token-file or METERBAR_SERVE_TOKEN."
+        )
+    )
     var token: String?
+
+    @Option(help: "Read the bearer token from this file, trimming trailing whitespace and newlines.")
+    var tokenFile: String?
 
     @Flag(help: "Bind to all network interfaces instead of loopback only. Exposes usage/cost data to other devices.")
     var allowRemote: Bool = false
@@ -32,21 +40,48 @@ struct Serve: AsyncParsableCommand {
         if maxRequestsPerSecond < 1 {
             throw ValidationError("--max-requests-per-second must be 1 or greater.")
         }
+        if token != nil, tokenFile != nil {
+            throw ValidationError("--token and --token-file cannot be used together.")
+        }
         // `--token ""` survives the `??` below, so reject it here rather than
         // starting a server whose auth check can never reject anything. Omit
         // the flag entirely to get a generated token.
         if let token, !ServeToken.isUsable(token) {
             throw ValidationError("--token must not be blank. Omit it to have one generated.")
         }
+
+        // Validate every external source before `run()` starts installing
+        // signal handlers or constructing a server. The resolver is repeated
+        // in `run()` because a token file can change between argument parsing
+        // and startup; either pass reports a safe ArgumentParser error.
+        do {
+            _ = try resolveToken(generate: { "validation-placeholder" })
+        } catch let error as ServeTokenResolutionError {
+            throw ValidationError(Self.message(for: error))
+        }
     }
 
     func run() async throws {
-        let generatedToken = token == nil
-        let resolvedToken = token ?? ServeToken.generate()
+        let resolvedToken: ResolvedServeToken
+        do {
+            resolvedToken = try resolveToken(generate: ServeToken.generate)
+        } catch let error as ServeTokenResolutionError {
+            throw ValidationError(Self.message(for: error))
+        }
         let bind = ServeBindConfiguration.resolve(allowRemote: allowRemote)
 
         if let warning = bind.warning {
             FileHandle.standardError.write(Data("⚠ \(warning)\n".utf8))
+        }
+        if resolvedToken.origin == .explicitArgument {
+            FileHandle.standardError.write(
+                Data(
+                    (
+                        "⚠ A token passed on the command line is visible to every local process via ps and is "
+                            + "recorded in shell history. Prefer METERBAR_SERVE_TOKEN or --token-file.\n"
+                    ).utf8
+                )
+            )
         }
 
         let cancellation = ServeCancellation()
@@ -56,7 +91,7 @@ struct Serve: AsyncParsableCommand {
         let request = ServeCLI.Request(
             host: bind.host,
             port: port,
-            token: resolvedToken,
+            token: resolvedToken.token,
             maxRequestsPerSecond: maxRequestsPerSecond
         )
 
@@ -66,10 +101,10 @@ struct Serve: AsyncParsableCommand {
             onReady: { info in
                 print("meterbar serve listening on http://\(info.host):\(info.port)")
                 print("Endpoints: GET /usage, GET /cost (Authorization: Bearer <token> required)")
-                if generatedToken {
+                if resolvedToken.origin == .generated {
                     // Printed exactly once, at startup, and never logged again —
                     // this is the only place the token is ever surfaced.
-                    print("Bearer token (generated, shown once): \(resolvedToken)")
+                    print("Bearer token (generated, shown once): \(resolvedToken.token)")
                 }
                 print("Press Ctrl-C to stop.")
             },
@@ -81,6 +116,31 @@ struct Serve: AsyncParsableCommand {
             return
         case .failedToStart(let message):
             throw ValidationError("Failed to start meterbar serve: \(message)")
+        }
+    }
+
+    private func resolveToken(generate: () -> String) throws -> ResolvedServeToken {
+        try ServeTokenSource.resolve(
+            explicitToken: token,
+            tokenFilePath: tokenFile,
+            environment: ProcessInfo.processInfo.environment,
+            readFile: { path in
+                try String(contentsOfFile: path, encoding: .utf8)
+            },
+            generate: generate
+        )
+    }
+
+    private static func message(for error: ServeTokenResolutionError) -> String {
+        switch error {
+        case .blankExplicitArgument:
+            return "--token must not be blank. Omit it to have one generated."
+        case .unreadableTokenFile(let path):
+            return "--token-file could not be read: \(path)"
+        case .blankTokenFile(let path):
+            return "--token-file must contain a non-blank token: \(path)"
+        case .blankEnvironment:
+            return "METERBAR_SERVE_TOKEN must not be blank. Unset it to have a token generated."
         }
     }
 

--- a/MeterBarTests/CLIBinaryLocatorTests.swift
+++ b/MeterBarTests/CLIBinaryLocatorTests.swift
@@ -2,6 +2,11 @@ import XCTest
 @testable import MeterBar
 
 final class CLIBinaryLocatorTests: XCTestCase {
+    override func tearDown() {
+        CLIBinaryLocator.resetTrustLogStateForTesting()
+        super.tearDown()
+    }
+
     // MARK: - augmentedPATH
 
     /// GUI apps inherit launchd's bare PATH; the spawned CLI must still be able
@@ -37,5 +42,122 @@ final class CLIBinaryLocatorTests: XCTestCase {
         XCTAssertFalse(entries.isEmpty)
         XCTAssertEqual(entries.first, "/opt/homebrew/bin")
         XCTAssertFalse(entries.contains(""), "No empty segments from a missing PATH")
+    }
+
+    // MARK: - trust classification
+
+    func testEveryFallbackDirectoryIsWellKnown() {
+        let home = "/Users/tester"
+
+        for directory in CLIBinaryLocator.fallbackDirectories(home: home) {
+            XCTAssertEqual(
+                CLIBinaryLocator.trust(forResolvedPath: "\(directory)/claude", home: home),
+                .wellKnown,
+                directory
+            )
+        }
+    }
+
+    func testStandardSystemBinDirectoriesAreWellKnown() {
+        for directory in ["/usr/bin", "/bin", "/usr/sbin", "/sbin"] {
+            XCTAssertEqual(
+                CLIBinaryLocator.trust(forResolvedPath: "\(directory)/codex", home: "/Users/tester"),
+                .wellKnown,
+                directory
+            )
+        }
+    }
+
+    func testTemporaryAndDownloadsDirectoriesAreUnexpected() {
+        XCTAssertEqual(
+            CLIBinaryLocator.trust(forResolvedPath: "/tmp/evil/claude", home: "/Users/tester"),
+            .unexpected
+        )
+        XCTAssertEqual(
+            CLIBinaryLocator.trust(
+                forResolvedPath: "/Users/tester/Downloads/codex",
+                home: "/Users/tester"
+            ),
+            .unexpected
+        )
+    }
+
+    func testDeliberateEnvironmentOverrideIsWellKnownRegardlessOfLocation() {
+        let fileManager = StubExecutableFileManager(executablePaths: ["/tmp/custom/grok"])
+
+        let resolved = CLIBinaryLocator.resolve(
+            command: "grok",
+            overrideEnvVar: "GROK_CLI_PATH",
+            environment: ["GROK_CLI_PATH": "/tmp/custom/grok"],
+            home: "/Users/tester",
+            fileManager: fileManager
+        )
+
+        XCTAssertEqual(resolved, "/tmp/custom/grok")
+        XCTAssertEqual(
+            CLIBinaryLocator.trust(
+                forResolvedPath: "/tmp/custom/grok",
+                home: "/Users/tester",
+                isUserOverride: true
+            ),
+            .wellKnown
+        )
+    }
+
+    func testTrustClassificationNormalizesRepeatedAndTrailingSlashes() {
+        XCTAssertEqual(
+            CLIBinaryLocator.trust(
+                forResolvedPath: "//opt//homebrew//bin//claude",
+                home: "/Users/tester/"
+            ),
+            .wellKnown
+        )
+        XCTAssertEqual(
+            CLIBinaryLocator.trust(
+                forResolvedPath: "/Users/tester//.local//bin//codex",
+                home: "/Users/tester///"
+            ),
+            .wellKnown
+        )
+    }
+
+    func testUnexpectedResolutionNoticeIsDeduplicatedByCommandAndPath() {
+        let fileManager = StubExecutableFileManager(executablePaths: ["/tmp/evil/claude"])
+        let arguments = (
+            command: "claude",
+            environment: ["PATH": "/tmp/evil"],
+            home: "/Users/tester",
+            fileManager: fileManager
+        )
+
+        _ = CLIBinaryLocator.resolve(
+            command: arguments.command,
+            environment: arguments.environment,
+            home: arguments.home,
+            fileManager: arguments.fileManager
+        )
+        _ = CLIBinaryLocator.resolve(
+            command: arguments.command,
+            environment: arguments.environment,
+            home: arguments.home,
+            fileManager: arguments.fileManager
+        )
+
+        XCTAssertEqual(CLIBinaryLocator.trustLogCountForTesting, 1)
+        CLIBinaryLocator.resetTrustLogStateForTesting()
+        XCTAssertEqual(CLIBinaryLocator.trustLogCountForTesting, 0)
+    }
+}
+
+private final class StubExecutableFileManager: FileManager {
+    private let executablePaths: Set<String>
+
+    init(executablePaths: Set<String>) {
+        self.executablePaths = executablePaths
+        super.init()
+    }
+
+    override func isExecutableFile(atPath path: String) -> Bool {
+        executablePaths.contains(path)
     }
 }

--- a/MeterBarTests/ClaudeCodeCLIUsageParserTests.swift
+++ b/MeterBarTests/ClaudeCodeCLIUsageParserTests.swift
@@ -70,6 +70,57 @@ final class ClaudeCodeCLIUsageParserTests: XCTestCase {
         XCTAssertEqual(metrics.modelLimitLabel, "Fable")
     }
 
+    func testParsesResetAcrossYearRollover() throws {
+        let calendar = Calendar.current
+        let now = try XCTUnwrap(calendar.date(from: DateComponents(
+            year: 2026,
+            month: 12,
+            day: 31,
+            hour: 12
+        )))
+        let metrics = try ClaudeCodeCLIUsageParser.parseMetrics(
+            from: "Current session: 10% used · resets Jan 2 at 6pm",
+            now: now
+        )
+        let reset = try XCTUnwrap(metrics.sessionLimit?.resetTime)
+
+        XCTAssertEqual(calendar.component(.year, from: reset), 2027)
+        XCTAssertEqual(calendar.component(.month, from: reset), 1)
+        XCTAssertEqual(calendar.component(.day, from: reset), 2)
+    }
+
+    func testStripsANSICodesBeforeParsing() throws {
+        let output = "\u{001B}[31mCurrent session: 42% used · resets Jul 24 at 6pm\u{001B}[0m"
+
+        let metrics = try ClaudeCodeCLIUsageParser.parseMetrics(from: output)
+
+        XCTAssertEqual(metrics.sessionLimit?.percentage, 42)
+    }
+
+    func testClampsPercentAndIgnoresWindowWithoutPercent() throws {
+        let output = """
+        Current session: 105% used · resets Jul 24 at 6pm
+        Current week (all models): usage unavailable
+        """
+
+        let metrics = try ClaudeCodeCLIUsageParser.parseMetrics(from: output)
+
+        XCTAssertEqual(metrics.sessionLimit?.percentage, 100)
+        XCTAssertNil(metrics.weeklyLimit)
+    }
+
+    func testKeepsCompleteWindowWhenCaptureEndsMidPercent() throws {
+        let output = """
+        Current session: 42% used · resets Jul 24 at 6pm
+        Current week (all models): 9
+        """
+
+        let metrics = try ClaudeCodeCLIUsageParser.parseMetrics(from: output)
+
+        XCTAssertEqual(metrics.sessionLimit?.percentage, 42)
+        XCTAssertNil(metrics.weeklyLimit)
+    }
+
     func testThrowsWhenNoUsageWindowsArePresent() {
         XCTAssertThrowsError(try ClaudeCodeCLIUsageParser.parseMetrics(from: "No usage data"))
     }

--- a/MeterBarTests/ClaudeCodeOAuthUsageTests.swift
+++ b/MeterBarTests/ClaudeCodeOAuthUsageTests.swift
@@ -215,10 +215,8 @@ final class ClaudeCodeOAuthUsageTests: XCTestCase {
     // MARK: - Helpers
 
     private func decodeUsage(_ json: String) throws -> ClaudeCodeUsageResponse {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
         let data = try XCTUnwrap(json.data(using: .utf8))
-        return try decoder.decode(ClaudeCodeUsageResponse.self, from: data)
+        return try ClaudeCodeLocalService.decodeUsageResponse(from: data)
     }
 
     private func credentials(

--- a/MeterBarTests/CostScanCollaboratorTests.swift
+++ b/MeterBarTests/CostScanCollaboratorTests.swift
@@ -511,7 +511,7 @@ final class CostScanCollaboratorTests: XCTestCase {
         context.dailyProjectTotals = [day: ["app": tokens]]
         context.dailyProjectModelTotals = [day: ["app": ["gpt-5.6-sol": tokens]]]
 
-        let (cost, dailyRows) = try XCTUnwrap(
+        let (cost, dailyRows, _) = try XCTUnwrap(
             CodexCostScanner.makeCost(from: context) { _, at in
                 schedule.resolve(at: at)?.pricing ?? newRate
             }

--- a/MeterBarTests/CostScanCorpusTests.swift
+++ b/MeterBarTests/CostScanCorpusTests.swift
@@ -85,6 +85,32 @@ final class CostScanCorpusTests: XCTestCase {
         XCTAssertEqual(windows.period.sessions, 3)
     }
 
+    func testClaudeScanAccumulatesOnlyTrailingSevenDaysIntoHourlyBuckets() throws {
+        let root = try makeClaudeProjectsRoot()
+        let periodCutoff = try date("2025-05-17T00:00:00Z")
+        let hourlyCutoff = try date("2025-06-09T00:00:00Z")
+        try writeClaudeTranscript(in: root, project: "www/demo", name: "hours.jsonl", lines: [
+            claudeEventLine(timestamp: "2025-06-08T23:59:00Z", messageID: "old", requestID: "old", input: 90),
+            claudeEventLine(timestamp: "2025-06-09T00:00:00Z", messageID: "edge", requestID: "edge", input: 50),
+            claudeEventLine(timestamp: "2025-06-14T10:59:00Z", messageID: "a", requestID: "a", input: 100),
+            claudeEventLine(timestamp: "2025-06-14T11:00:00Z", messageID: "b", requestID: "b", input: 200),
+        ])
+
+        let session = CostScanSession(
+            cutoff: periodCutoff,
+            hourlyCutoff: hourlyCutoff,
+            options: .unlimited
+        )
+        let rows = try XCTUnwrap(ClaudeCostScanner.makeCost(
+            from: ClaudeCostScanner.scanRoots([root], session: session).period,
+            windowStart: periodCutoff
+        )?.2)
+
+        XCTAssertEqual(rows.map(\.inputTokens).sorted(), [50, 100, 200])
+        XCTAssertEqual(rows.map(\.provider), [.claudeCode, .claudeCode, .claudeCode])
+        XCTAssertEqual(rows.map { calendarHour($0.date) }.sorted(), [0, 10, 11])
+    }
+
     // MARK: - Codex
 
     func testCodexDeduplicationStaysGlobalAcrossFiles() throws {
@@ -162,6 +188,27 @@ final class CostScanCorpusTests: XCTestCase {
 
         XCTAssertEqual(windows.lifetime.sessionIDs.count, 5)
     }
+
+    func testCodexScanAccumulatesOnlyTrailingSevenDaysIntoHourlyBuckets() throws {
+        let directory = try makeTemporaryDirectory(named: "CodexHourlyRollouts")
+        let periodCutoff = try date("2025-05-17T00:00:00Z")
+        let hourlyCutoff = try date("2025-06-09T00:00:00Z")
+        try writeCodexRollout(in: directory, path: "hours.jsonl", lines: [
+            codexTokenLine(timestamp: "2025-06-08T23:59:00Z", conversationID: "old", input: 90),
+            codexTokenLine(timestamp: "2025-06-09T00:00:00Z", conversationID: "edge", input: 50),
+            codexTokenLine(timestamp: "2025-06-14T10:59:00Z", conversationID: "a", input: 100),
+            codexTokenLine(timestamp: "2025-06-14T11:00:00Z", conversationID: "b", input: 200),
+        ])
+
+        var windows = CodexCostScanner.scanWindows(cutoff: periodCutoff, hourlyCutoff: hourlyCutoff)
+        CostScanFixtureScan.codexRollouts(in: directory, windows: &windows)
+        let rows = try XCTUnwrap(CodexCostScanner.makeCost(from: windows.period)?.2)
+
+        XCTAssertEqual(rows.map(\.inputTokens).sorted(), [0, 0, 0])
+        XCTAssertEqual(rows.map(\.cacheReadTokens).sorted(), [200, 200, 200])
+        XCTAssertEqual(rows.map(\.provider), [.codexCli, .codexCli, .codexCli])
+        XCTAssertEqual(rows.map { calendarHour($0.date) }.sorted(), [0, 10, 11])
+    }
 }
 
 // MARK: - Fixtures
@@ -171,6 +218,16 @@ extension CostScanCorpusTests {
     /// itself is covered by `CostScanCollaboratorTests`.
     private func makeSession(cutoff: Date) -> CostScanSession {
         CostScanSession(cutoff: cutoff, options: .unlimited)
+    }
+
+    private func date(_ value: String) throws -> Date {
+        try XCTUnwrap(FlexibleISO8601.date(from: value))
+    }
+
+    private func calendarHour(_ date: Date) -> Int {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
+        return calendar.component(.hour, from: date)
     }
 
     private func makeTemporaryDirectory(named prefix: String) throws -> URL {

--- a/MeterBarTests/CostScanFileCacheSafetyTests.swift
+++ b/MeterBarTests/CostScanFileCacheSafetyTests.swift
@@ -82,7 +82,7 @@ final class CostScanFileCacheSafetyTests: XCTestCase {
     }
 
     func testVersionedSaveRemovesSupersededSiblings() throws {
-        let oldClaude = directory.appendingPathComponent("cost-scan-claude-v1.json")
+        let oldClaude = directory.appendingPathComponent("cost-scan-claude-v3.json")
         let oldCodex = directory.appendingPathComponent("cost-scan-codex-v2.json")
         try Data("old".utf8).write(to: oldClaude)
         try Data("other-provider".utf8).write(to: oldCodex)
@@ -97,6 +97,16 @@ final class CostScanFileCacheSafetyTests: XCTestCase {
                 atPath: directory.appendingPathComponent(CostScanCacheStore.claudeFileName).path
             )
         )
+    }
+
+    func testHourlyUpgradeReadsFromAFreshV4Artifact() throws {
+        let oldURL = directory.appendingPathComponent("cost-scan-claude-v3.json")
+        try CostScanCacheStore.saveClaude(makeCache(), to: oldURL)
+        let store = CostScanCacheStore(directory: directory)
+
+        XCTAssertEqual(CostScanFileCache<ClaudeFileTotals>.currentSchemaVersion, 4)
+        XCTAssertEqual(CostScanCacheStore.claudeFileName, "cost-scan-claude-v4.json")
+        XCTAssertTrue(store.loadClaude().records.isEmpty)
     }
 
     // MARK: - Persistence failures

--- a/MeterBarTests/CostScanResumptionTests.swift
+++ b/MeterBarTests/CostScanResumptionTests.swift
@@ -1,0 +1,212 @@
+import Foundation
+import XCTest
+@testable import MeterBar
+
+final class CostScanResumptionTests: XCTestCase {
+    private let originalCutoff = Date(timeIntervalSince1970: 1_780_000_000)
+    private let currentCutoff = Date(timeIntervalSince1970: 1_781_000_000)
+
+    func testRejectsOffsetBeyondCurrentFileSize() {
+        let file = makeFile(size: 100)
+        let record = makeRecord(offset: 101, stamp: file.stamp)
+
+        XCTAssertNil(resumableRecord(record, for: file))
+    }
+
+    func testRejectsCompleteRecordWhenFullStampDoesNotMatch() {
+        let file = makeFile(size: 100, modified: 2_000, fileID: 42)
+        let record = makeRecord(
+            stamp: CostScanFileStamp(size: 100, modified: 1_000, fileID: 42),
+            isComplete: true
+        )
+
+        XCTAssertNil(resumableRecord(record, for: file))
+    }
+
+    func testIncompleteRecordRequiresSameFileAndNondecreasingSize() {
+        let stamp = CostScanFileStamp(size: 80, modified: 1_000, fileID: 42)
+        let record = makeRecord(offset: 70, stamp: stamp, isComplete: false)
+
+        XCTAssertNotNil(resumableRecord(record, for: makeFile(size: 100, modified: 2_000, fileID: 42)))
+        XCTAssertNil(resumableRecord(record, for: makeFile(size: 100, modified: 2_000, fileID: 99)))
+        XCTAssertNil(resumableRecord(record, for: makeFile(size: 70, modified: 2_000, fileID: 42)))
+    }
+
+    func testEqualCutoffReturnsRecordWithoutRebasing() throws {
+        let file = makeFile(size: 100)
+        var record = makeRecord(stamp: file.stamp)
+        record.cutoff = currentCutoff
+        record.payload.periodKeys = ["unchanged"]
+        var didRebase = false
+
+        let result = CostScanResumption.resumableRecord(
+            existing: record,
+            file: file,
+            cutoff: currentCutoff
+        ) { payload, cutoff in
+            didRebase = true
+            return payload.rebasePeriod(to: cutoff)
+        }
+
+        XCTAssertFalse(didRebase)
+        XCTAssertEqual(try XCTUnwrap(result).payload.periodKeys, ["unchanged"])
+    }
+
+    func testWindowPayloadRebaseClearsPeriodWhenEveryEventPredatesCutoff() throws {
+        let oldEvent = currentCutoff.addingTimeInterval(-100)
+        var payload = CodexFileTotals(cutoff: originalCutoff)
+        payload.period.eventKeys = ["stale-period"]
+        payload.lifetime.eventKeys = ["old"]
+        payload.lifetime.earliestDate = oldEvent
+        payload.lifetime.latestDate = oldEvent
+
+        let result = try XCTUnwrap(resumableRecord(makeRecord(payload: payload)))
+
+        XCTAssertTrue(result.payload.period.eventKeys.isEmpty)
+        XCTAssertEqual(result.payload.period.latestDate, currentCutoff)
+        XCTAssertEqual(result.cutoff, currentCutoff)
+    }
+
+    func testWindowPayloadRebaseCopiesLifetimeWhenEveryEventFallsInsideCutoff() throws {
+        let currentEvent = currentCutoff.addingTimeInterval(100)
+        var payload = CodexFileTotals(cutoff: originalCutoff)
+        payload.period.eventKeys = ["stale-period"]
+        payload.lifetime.eventKeys = ["current"]
+        payload.lifetime.earliestDate = currentEvent
+        payload.lifetime.latestDate = currentEvent
+
+        let result = try XCTUnwrap(resumableRecord(makeRecord(payload: payload)))
+
+        XCTAssertEqual(result.payload.period.eventKeys, ["current"])
+        XCTAssertEqual(result.payload.period.earliestDate, currentEvent)
+        XCTAssertEqual(result.payload.period.latestDate, currentEvent)
+        XCTAssertEqual(result.cutoff, currentCutoff)
+    }
+
+    func testWindowPayloadRebaseRejectsRecordWhenEventsStraddleCutoff() {
+        var payload = CodexFileTotals(cutoff: originalCutoff)
+        payload.lifetime.eventKeys = ["old", "current"]
+        payload.lifetime.earliestDate = currentCutoff.addingTimeInterval(-100)
+        payload.lifetime.latestDate = currentCutoff.addingTimeInterval(100)
+
+        XCTAssertNil(resumableRecord(makeRecord(payload: payload)))
+    }
+
+    /// Grok reaches the window rebase through the same shared conformance as
+    /// Codex rather than its own copy, so it is covered explicitly: a missing
+    /// conformance would still compile against the generic seam and silently
+    /// stop rebasing.
+    func testGrokPayloadSharesTheWindowRebaseBehavior() throws {
+        let oldEvent = currentCutoff.addingTimeInterval(-100)
+        var stalePayload = GrokFileTotals(cutoff: originalCutoff)
+        stalePayload.period.eventKeys = ["stale-period"]
+        stalePayload.lifetime.eventKeys = ["old"]
+        stalePayload.lifetime.earliestDate = oldEvent
+        stalePayload.lifetime.latestDate = oldEvent
+
+        let staleResult = try XCTUnwrap(resumableRecord(makeRecord(payload: stalePayload)))
+        XCTAssertTrue(staleResult.payload.period.eventKeys.isEmpty)
+        XCTAssertEqual(staleResult.payload.period.latestDate, currentCutoff)
+        XCTAssertEqual(staleResult.cutoff, currentCutoff)
+
+        let currentEvent = currentCutoff.addingTimeInterval(100)
+        var insidePayload = GrokFileTotals(cutoff: originalCutoff)
+        insidePayload.period.eventKeys = ["stale-period"]
+        insidePayload.lifetime.eventKeys = ["current"]
+        insidePayload.lifetime.earliestDate = currentEvent
+        insidePayload.lifetime.latestDate = currentEvent
+
+        let insideResult = try XCTUnwrap(resumableRecord(makeRecord(payload: insidePayload)))
+        XCTAssertEqual(insideResult.payload.period.eventKeys, ["current"])
+        XCTAssertEqual(insideResult.payload.period.latestDate, currentEvent)
+
+        var straddlePayload = GrokFileTotals(cutoff: originalCutoff)
+        straddlePayload.lifetime.eventKeys = ["old", "current"]
+        straddlePayload.lifetime.earliestDate = oldEvent
+        straddlePayload.lifetime.latestDate = currentEvent
+
+        XCTAssertNil(resumableRecord(makeRecord(payload: straddlePayload)))
+    }
+
+    func testClaudeRebasePreservesItsSeparatePeriodAndLifetimeKeySemantics() throws {
+        var beforePayload = ClaudeFileTotals()
+        beforePayload.period.input = 10
+        beforePayload.periodKeys = ["stale-period"]
+        beforePayload.lifetime.latest = currentCutoff.addingTimeInterval(-100)
+        beforePayload.lifetimeKeys = ["old"]
+
+        let beforeResult = try XCTUnwrap(resumableRecord(makeRecord(payload: beforePayload)))
+        XCTAssertFalse(beforeResult.payload.period.hasUsage)
+        XCTAssertTrue(beforeResult.payload.periodKeys.isEmpty)
+        XCTAssertEqual(beforeResult.payload.lifetimeKeys, ["old"])
+
+        var insidePayload = ClaudeFileTotals()
+        insidePayload.lifetime.input = 25
+        insidePayload.lifetime.earliest = currentCutoff.addingTimeInterval(100)
+        insidePayload.lifetime.latest = currentCutoff.addingTimeInterval(200)
+        insidePayload.lifetimeKeys = ["current"]
+
+        let insideResult = try XCTUnwrap(resumableRecord(makeRecord(payload: insidePayload)))
+        XCTAssertEqual(insideResult.payload.period.input, 25)
+        XCTAssertEqual(insideResult.payload.periodKeys, ["current"])
+    }
+
+    private func resumableRecord<Payload: CostScanPeriodRebasable>(
+        _ record: CostScanFileRecord<Payload>,
+        for file: CostScanFile? = nil
+    ) -> CostScanFileRecord<Payload>? {
+        let file = file ?? makeFile(
+            size: record.stamp.size,
+            modified: record.stamp.modified,
+            fileID: record.stamp.fileID
+        )
+        return CostScanResumption.resumableRecord(
+            existing: record,
+            file: file,
+            cutoff: currentCutoff
+        ) { payload, cutoff in
+            payload.rebasePeriod(to: cutoff)
+        }
+    }
+
+    private func makeFile(
+        size: Int,
+        modified: Double = 1_000,
+        fileID: UInt64? = 42
+    ) -> CostScanFile {
+        CostScanFile(
+            url: URL(fileURLWithPath: "/tmp/cost-scan-resumption.jsonl"),
+            stamp: CostScanFileStamp(size: size, modified: modified, fileID: fileID)
+        )
+    }
+
+    private func makeRecord(
+        offset: UInt64 = 50,
+        stamp: CostScanFileStamp = CostScanFileStamp(size: 100, modified: 1_000, fileID: 42),
+        isComplete: Bool = false,
+        payload: ClaudeFileTotals = ClaudeFileTotals()
+    ) -> CostScanFileRecord<ClaudeFileTotals> {
+        CostScanFileRecord(
+            offset: offset,
+            stamp: stamp,
+            cutoff: originalCutoff,
+            isComplete: isComplete,
+            payload: payload
+        )
+    }
+
+    private func makeRecord<Payload: Codable & Sendable>(
+        offset: UInt64 = 50,
+        stamp: CostScanFileStamp = CostScanFileStamp(size: 100, modified: 1_000, fileID: 42),
+        isComplete: Bool = false,
+        payload: Payload
+    ) -> CostScanFileRecord<Payload> {
+        CostScanFileRecord(
+            offset: offset,
+            stamp: stamp,
+            cutoff: originalCutoff,
+            isComplete: isComplete,
+            payload: payload
+        )
+    }
+}

--- a/MeterBarTests/CostSummaryStoreTests.swift
+++ b/MeterBarTests/CostSummaryStoreTests.swift
@@ -35,6 +35,7 @@ final class CostSummaryStoreTests: XCTestCase {
         XCTAssertEqual(migrated.summary.dailyUsage.count, 1)
         XCTAssertNil(migrated.summary.dailyUsage[0].modelBreakdowns)
         XCTAssertNil(migrated.summary.dailyUsage[0].projectBreakdowns)
+        XCTAssertNil(migrated.summary.hourlyUsage)
         XCTAssertTrue(
             migrated.summary.needsMissingDailyUsageRefresh(
                 days: 30,
@@ -85,6 +86,38 @@ final class CostSummaryStoreTests: XCTestCase {
 
         XCTAssertEqual(loaded.summary.dailyUsage.first?.inputTokens, 10)
         XCTAssertEqual(loaded.summary.dailyUsage.first?.modelBreakdowns?.count, 0)
+        XCTAssertNil(loaded.summary.hourlyUsage)
+    }
+
+    func testCurrentCacheRoundTripsHourlyUsageWithoutChangingTheDateCodec() throws {
+        let currentURL = tempDirectory.appendingPathComponent("cost-summary-v2.json")
+        let legacyURL = tempDirectory.appendingPathComponent("cost-summary-v1.json")
+        let hour = Date(timeIntervalSince1970: 1_750_000_000)
+        let current = CostSummaryCache(
+            summary: CostSummary(
+                costs: [],
+                totalCostUSD: 0,
+                totalTokens: 0,
+                periodDays: 30,
+                hourlyUsage: [
+                    HourlyTokenUsage(
+                        date: hour,
+                        provider: .codexCli,
+                        inputTokens: 10,
+                        outputTokens: 2,
+                        cacheReadTokens: 1,
+                        estimatedCostUSD: 0.25
+                    ),
+                ]
+            ),
+            lastScanDate: hour
+        )
+
+        try CostSummaryStore.save(current, to: currentURL)
+        let loaded = try XCTUnwrap(CostSummaryStore.load(currentURL: currentURL, legacyURL: legacyURL))
+
+        XCTAssertEqual(loaded.summary.hourlyUsage?.first?.date, hour)
+        XCTAssertEqual(loaded.summary.hourlyUsage?.first?.provider, .codexCli)
     }
 
     private func legacyPayload(inputTokens: Int = 10) throws -> Data {

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -356,7 +356,7 @@ final class CostTrackerTests: XCTestCase {
             7
         )
 
-        let (_, dailyRows) = try XCTUnwrap(
+        let (_, dailyRows, _) = try XCTUnwrap(
             ClaudeCostScanner.makeCost(from: result, windowStart: cutoff)
         )
         let daily = try XCTUnwrap(dailyRows.first)
@@ -819,7 +819,7 @@ final class CostTrackerTests: XCTestCase {
             1_000
         )
 
-        let (_, dailyRows) = try XCTUnwrap(CodexCostScanner.makeCost(from: context))
+        let (_, dailyRows, _) = try XCTUnwrap(CodexCostScanner.makeCost(from: context))
         let daily = try XCTUnwrap(dailyRows.first)
         XCTAssertEqual(daily.modelBreakdowns?.first?.name, "gpt-5.6-sol")
         XCTAssertEqual(daily.projectBreakdowns?.first?.name, "www/genfeed/apps/admin")

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -177,6 +177,61 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(result.output, 53)
     }
 
+    func testParseSessionFileDeduplicatesIdenticalUnkeyedEvents() throws {
+        let line = eventLine(
+            timestamp: "2026-07-01T10:00:00.000Z",
+            messageID: nil,
+            requestID: nil,
+            input: 120,
+            output: 30
+        )
+        let url = try writeSessionFile(lines: [line, line])
+
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let result = ClaudeCostScanner.parseSessionFile(at: url, since: cutoff)
+
+        XCTAssertEqual(result.input, 120)
+        XCTAssertEqual(result.output, 30)
+    }
+
+    func testParseSessionFileCountsUnkeyedEventsThatDifferOnlyInTokenCounts() throws {
+        let url = try writeSessionFile(lines: [
+            eventLine(
+                timestamp: "2026-07-01T10:00:00.000Z",
+                messageID: nil,
+                requestID: nil,
+                input: 120,
+                output: 30
+            ),
+            eventLine(
+                timestamp: "2026-07-01T10:00:00.000Z",
+                messageID: nil,
+                requestID: nil,
+                input: 121,
+                output: 30
+            )
+        ])
+
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let result = ClaudeCostScanner.parseSessionFile(at: url, since: cutoff)
+
+        XCTAssertEqual(result.input, 241)
+        XCTAssertEqual(result.output, 60)
+    }
+
+    func testParseSessionFileKeepsExistingKeyedDeduplicationSemantics() throws {
+        let url = try writeSessionFile(lines: [
+            eventLine(timestamp: "2026-07-01T10:00:00.000Z", input: 120, output: 30),
+            eventLine(timestamp: "2026-07-01T10:01:00.000Z", input: 7, output: 3)
+        ])
+
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let result = ClaudeCostScanner.parseSessionFile(at: url, since: cutoff)
+
+        XCTAssertEqual(result.input, 7)
+        XCTAssertEqual(result.output, 3)
+    }
+
     func testParseSessionFileHonorsPerEventCutoff() throws {
         // Events older than the cutoff are excluded even when the FILE was
         // modified recently. (The old CLI scanner only checked file mtime.)
@@ -454,6 +509,29 @@ final class CostTrackerTests: XCTestCase {
         """
     }
 
+    private func codexUsageSelectionLine(
+        timestamp: String,
+        conversationID: String = "conv-1",
+        model: String? = "gpt-5.5",
+        lastInput: Int? = nil,
+        totalInput: Int? = nil
+    ) -> String {
+        var info: [String] = []
+        if let model {
+            info.append("\"model\": \"\(model)\"")
+        }
+        if let lastInput {
+            info.append("\"last_token_usage\": {\"input_tokens\": \(lastInput), \"output_tokens\": 0}")
+        }
+        if let totalInput {
+            info.append("\"total_token_usage\": {\"input_tokens\": \(totalInput), \"output_tokens\": 0}")
+        }
+        return """
+        {"timestamp": "\(timestamp)", "type": "event_msg", "payload": {"type": "token_count", \
+        "rate_limits": {"conversation_id": "\(conversationID)"}, "info": {\(info.joined(separator: ", "))}}}
+        """
+    }
+
     private func makeContext(cutoff: Date) -> CostScanWindowContext {
         CostScanWindowContext(earliestDate: Date(), latestDate: cutoff)
     }
@@ -474,6 +552,116 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(context.totals.reasoning, 50)
         XCTAssertEqual(context.totals.cacheRead, 200)
         XCTAssertEqual(context.sessionIDs, ["conv-1"])
+    }
+
+    func testScanCodexRolloutsKeepsLastTokenUsageAsPerEventDeltas() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:00:00Z", lastInput: 100),
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:01:00Z", lastInput: 25)
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        var context = makeContext(cutoff: cutoff)
+
+        CostScanFixtureScan.codexRollouts(in: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.totals.input, 125)
+    }
+
+    func testScanCodexRolloutsDerivesDeltasFromCumulativeTotals() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:00:00Z", totalInput: 100),
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:01:00Z", totalInput: 150),
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:02:00Z", totalInput: 180)
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        var context = makeContext(cutoff: cutoff)
+
+        CostScanFixtureScan.codexRollouts(in: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.totals.input, 180)
+    }
+
+    func testScanCodexRolloutsKeepsCumulativeBaselineAcrossMixedUsageLines() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:00:00Z", lastInput: 100),
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:01:00Z", totalInput: 140),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T10:02:00Z", lastInput: 10, totalInput: 150
+            )
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        var context = makeContext(cutoff: cutoff)
+
+        CostScanFixtureScan.codexRollouts(in: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.totals.input, 150)
+    }
+
+    func testScanCodexRolloutsClampsCumulativeCounterDecreaseToZero() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:00:00Z", totalInput: 100),
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:01:00Z", totalInput: 90),
+            codexUsageSelectionLine(timestamp: "2026-06-15T10:02:00Z", totalInput: 110)
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        var context = makeContext(cutoff: cutoff)
+
+        CostScanFixtureScan.codexRollouts(in: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.totals.input, 120)
+    }
+
+    func testScanCodexRolloutsKeepsCumulativeBaselinesPerSession() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T10:00:00Z", conversationID: "conv-a", totalInput: 100
+            ),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T10:01:00Z", conversationID: "conv-b", totalInput: 1_000
+            ),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T10:02:00Z", conversationID: "conv-a", totalInput: 150
+            ),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T10:03:00Z", conversationID: "conv-b", totalInput: 1_050
+            )
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        var context = makeContext(cutoff: cutoff)
+
+        CostScanFixtureScan.codexRollouts(in: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.totals.input, 1_200)
+        XCTAssertEqual(context.sessionIDs, ["conv-a", "conv-b"])
+    }
+
+    func testWholeFileAndBudgetedCodexScansMatchForDeferredCumulativeUsage() throws {
+        let root = try makeCodexHome()
+        let directory = root.appendingPathComponent("sessions", isDirectory: true)
+        try writeCodexRollout(in: directory, path: "rollout.jsonl", lines: [
+            codexSessionMetaLine(timestamp: "2026-06-15T09:00:00Z"),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T09:00:30Z", model: nil, totalInput: 100
+            ),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T09:00:45Z", model: nil, totalInput: 150
+            ),
+            codexTurnContextLine(timestamp: "2026-06-15T09:01:00Z", model: "gpt-5.6-sol"),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T09:02:00Z", model: nil, totalInput: 180
+            )
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        var wholeFile = CodexCostScanner.scanWindows(cutoff: cutoff)
+        CostScanFixtureScan.codexRollouts(in: directory, windows: &wholeFile)
+
+        let session = CostScanSession(cutoff: cutoff, options: .unlimited)
+        let budgeted = CodexCostScanner.scanRollouts(directories: [directory], session: session)
+
+        XCTAssertEqual(wholeFile.period.totals.input, 180)
+        XCTAssertEqual(budgeted.period.totals.input, wholeFile.period.totals.input)
+        XCTAssertEqual(budgeted.period.eventKeys, wholeFile.period.eventKeys)
+        XCTAssertEqual(budgeted.period.sessionIDs, wholeFile.period.sessionIDs)
     }
 
     func testScanCodexRolloutsDeduplicatesIdenticalEvents() throws {
@@ -936,6 +1124,79 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(session.codex.records.count, 1)
     }
 
+    func testBudgetedCodexScanResumesCumulativeBaselineWithoutRecounting() throws {
+        let root = try makeCodexHome()
+        let directory = root.appendingPathComponent("sessions", isDirectory: true)
+        let lines = [
+            codexTurnContextLine(timestamp: "2026-06-15T09:00:00Z", model: "gpt-5.6-sol"),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T09:01:00Z", model: nil, totalInput: 100
+            ),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T09:02:00Z", model: nil, totalInput: 150
+            )
+        ]
+        try writeCodexRollout(in: directory, path: "rollout.jsonl", lines: lines)
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        let store = try makeScanCacheStore()
+        let firstSliceBytes = (lines.prefix(2).joined(separator: "\n") + "\n").utf8.count
+        let budget = CostScanBudgetOptions(
+            maxBytesPerFile: .max,
+            maxNewBytesPerRefresh: firstSliceBytes,
+            wallClock: nil
+        )
+
+        let first = CostScanSession(cutoff: cutoff, options: budget, store: store)
+        let firstWindows = CodexCostScanner.scanRollouts(directories: [directory], session: first)
+        XCTAssertEqual(first.persist(), .persisted)
+
+        XCTAssertFalse(first.isComplete)
+        XCTAssertEqual(firstWindows.period.totals.input, 100)
+
+        let second = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        let resumed = CodexCostScanner.scanRollouts(directories: [directory], session: second)
+
+        XCTAssertTrue(second.isComplete)
+        XCTAssertEqual(resumed.period.totals.input, 150)
+    }
+
+    func testBudgetedCodexScanRollsBackCumulativeBaselineWithDeferredUsage() throws {
+        let root = try makeCodexHome()
+        let directory = root.appendingPathComponent("sessions", isDirectory: true)
+        let lines = [
+            codexSessionMetaLine(timestamp: "2026-06-15T09:00:00Z"),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T09:00:30Z", model: nil, totalInput: 100
+            ),
+            codexTurnContextLine(timestamp: "2026-06-15T09:01:00Z", model: "gpt-5.6-sol"),
+            codexUsageSelectionLine(
+                timestamp: "2026-06-15T09:02:00Z", model: nil, totalInput: 150
+            )
+        ]
+        try writeCodexRollout(in: directory, path: "rollout.jsonl", lines: lines)
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        let store = try makeScanCacheStore()
+        let firstSliceBytes = (lines.prefix(2).joined(separator: "\n") + "\n").utf8.count
+        let budget = CostScanBudgetOptions(
+            maxBytesPerFile: .max,
+            maxNewBytesPerRefresh: firstSliceBytes,
+            wallClock: nil
+        )
+
+        let first = CostScanSession(cutoff: cutoff, options: budget, store: store)
+        let firstWindows = CodexCostScanner.scanRollouts(directories: [directory], session: first)
+        XCTAssertEqual(first.persist(), .persisted)
+
+        XCTAssertFalse(first.isComplete)
+        XCTAssertEqual(firstWindows.period.totals.input, 0)
+
+        let second = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        let resumed = CodexCostScanner.scanRollouts(directories: [directory], session: second)
+
+        XCTAssertTrue(second.isComplete)
+        XCTAssertEqual(resumed.period.totals.input, 150)
+    }
+
     /// Deduplication picks one copy per session; it must not also decide the
     /// reading order. `archived_sessions` is enumerated first, so returning
     /// discovery order would put every archived rollout ahead of every live one
@@ -1263,6 +1524,43 @@ final class CostTrackerTests: XCTestCase {
     }
 
     // MARK: - Budgeted, resumable corpus scan
+
+    func testBudgetedClaudeScanMatchesWholeFileForDuplicateUnkeyedEvents() throws {
+        let root = try makeTranscriptRoot()
+        let line = eventLine(
+            timestamp: "2026-07-01T10:00:00.000Z",
+            messageID: nil,
+            requestID: nil,
+            input: 120,
+            output: 30
+        )
+        let url = try writeTranscript(in: root, name: "session.jsonl", modifiedAgo: 0, lines: [line, line])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let store = try makeScanCacheStore()
+        let firstLineBytes = (line + "\n").utf8.count
+        let firstSliceOptions = CostScanBudgetOptions(
+            maxBytesPerFile: firstLineBytes,
+            maxNewBytesPerRefresh: firstLineBytes,
+            wallClock: nil
+        )
+
+        let firstSlice = CostScanSession(cutoff: cutoff, options: firstSliceOptions, store: store)
+        _ = ClaudeCostScanner.scanRoots([root], session: firstSlice)
+        XCTAssertEqual(firstSlice.persist(), .persisted)
+        XCTAssertFalse(firstSlice.isComplete)
+
+        let resumed = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        let resumedWindows = ClaudeCostScanner.scanRoots([root], session: resumed)
+        let wholeFileWindows = ClaudeCostScanner.parseSessionWindows(at: url, since: cutoff)
+
+        XCTAssertTrue(resumed.isComplete)
+        XCTAssertEqual(resumedWindows.period.input, 120)
+        XCTAssertEqual(resumedWindows.period.output, 30)
+        XCTAssertEqual(resumedWindows.period.input, wholeFileWindows.period.input)
+        XCTAssertEqual(resumedWindows.period.output, wholeFileWindows.period.output)
+        XCTAssertEqual(resumedWindows.lifetime.input, wholeFileWindows.lifetime.input)
+        XCTAssertEqual(resumedWindows.lifetime.output, wholeFileWindows.lifetime.output)
+    }
 
     func testByteBudgetSmallerThanTheCorpusDefersTheRestWithoutLosingData() throws {
         let root = try makeTranscriptRoot()

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -1872,6 +1872,183 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(record.payload.period.daily[day]?.output, 22)
     }
 
+    func testPersistDoesNotResaveUntouchedProvidersOnASubsequentPersist() throws {
+        let cutoff = Date(timeIntervalSince1970: 1_780_000_000)
+        let stamp = CostScanFileStamp(size: 4_096, modified: 1_780_000_000, fileID: 42)
+        let store = try makeScanCacheStore()
+        let session = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        session.setClaudeRecord(
+            CostScanFileRecord(
+                offset: 1, stamp: stamp, cutoff: cutoff, isComplete: false, payload: ClaudeFileTotals()
+            ),
+            for: "/transcripts/a.jsonl"
+        )
+        session.setCodexRecord(
+            CostScanFileRecord(
+                offset: 1, stamp: stamp, cutoff: cutoff, isComplete: false, payload: CodexFileTotals(cutoff: cutoff)
+            ),
+            for: "/rollouts/b.jsonl"
+        )
+        session.setGrokRecord(
+            CostScanFileRecord(
+                offset: 1, stamp: stamp, cutoff: cutoff, isComplete: false, payload: GrokFileTotals(cutoff: cutoff)
+            ),
+            for: "/sessions/c/updates.jsonl"
+        )
+        XCTAssertEqual(session.persist(), .persisted)
+
+        let codexURL = store.directory.appendingPathComponent(CostScanCacheStore.codexFileName)
+        let grokURL = store.directory.appendingPathComponent(CostScanCacheStore.grokFileName)
+        let codexArtifact = try cacheArtifactID(at: codexURL)
+        let grokArtifact = try cacheArtifactID(at: grokURL)
+
+        session.setClaudeRecord(
+            CostScanFileRecord(
+                offset: 2, stamp: stamp, cutoff: cutoff, isComplete: false, payload: ClaudeFileTotals()
+            ),
+            for: "/transcripts/a.jsonl"
+        )
+        XCTAssertEqual(session.persist(), .persisted)
+
+        XCTAssertEqual(try cacheArtifactID(at: codexURL), codexArtifact)
+        XCTAssertEqual(try cacheArtifactID(at: grokURL), grokArtifact)
+    }
+
+    func testPersistSavesAProviderTouchedSinceThePreviousPersist() throws {
+        let cutoff = Date(timeIntervalSince1970: 1_780_000_000)
+        let stamp = CostScanFileStamp(size: 4_096, modified: 1_780_000_000, fileID: 42)
+        let store = try makeScanCacheStore()
+        let session = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        session.setClaudeRecord(
+            CostScanFileRecord(
+                offset: 1, stamp: stamp, cutoff: cutoff, isComplete: false, payload: ClaudeFileTotals()
+            ),
+            for: "/transcripts/a.jsonl"
+        )
+        XCTAssertEqual(session.persist(), .persisted)
+
+        let url = store.directory.appendingPathComponent(CostScanCacheStore.claudeFileName)
+        let firstArtifact = try cacheArtifactID(at: url)
+        session.setClaudeRecord(
+            CostScanFileRecord(
+                offset: 2, stamp: stamp, cutoff: cutoff, isComplete: false, payload: ClaudeFileTotals()
+            ),
+            for: "/transcripts/a.jsonl"
+        )
+
+        XCTAssertEqual(session.persist().outcome(for: .claude), .persisted)
+        XCTAssertNotEqual(try cacheArtifactID(at: url), firstArtifact)
+        XCTAssertEqual(store.loadClaude().records["/transcripts/a.jsonl"]?.offset, 2)
+    }
+
+    func testRetentionDirtiesOnlyAProviderWhoseEntriesWereRemoved() throws {
+        let cutoff = Date(timeIntervalSince1970: 1_780_000_000)
+        let stamp = CostScanFileStamp(size: 4_096, modified: 1_780_000_000, fileID: 42)
+        let store = try makeScanCacheStore()
+        let session = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        session.setClaudeRecord(
+            CostScanFileRecord(
+                offset: 1, stamp: stamp, cutoff: cutoff, isComplete: false, payload: ClaudeFileTotals()
+            ),
+            for: "/transcripts/a.jsonl"
+        )
+        session.setCodexRecord(
+            CostScanFileRecord(
+                offset: 1, stamp: stamp, cutoff: cutoff, isComplete: false, payload: CodexFileTotals(cutoff: cutoff)
+            ),
+            for: "/rollouts/b.jsonl"
+        )
+        XCTAssertEqual(session.persist(), .persisted)
+
+        let claudeURL = store.directory.appendingPathComponent(CostScanCacheStore.claudeFileName)
+        let codexURL = store.directory.appendingPathComponent(CostScanCacheStore.codexFileName)
+        let claudeArtifact = try cacheArtifactID(at: claudeURL)
+        let codexArtifact = try cacheArtifactID(at: codexURL)
+
+        session.retainClaude(keys: [])
+        session.retainCodex(keys: ["/rollouts/b.jsonl"])
+        XCTAssertEqual(session.persist(), .persisted)
+
+        XCTAssertNotEqual(try cacheArtifactID(at: claudeURL), claudeArtifact)
+        XCTAssertTrue(store.loadClaude().records.isEmpty)
+        XCTAssertEqual(try cacheArtifactID(at: codexURL), codexArtifact)
+    }
+
+    func testFailedProviderSaveRemainsDirtyAndRetriesOnTheNextPersist() throws {
+        let cutoff = Date(timeIntervalSince1970: 1_780_000_000)
+        let stamp = CostScanFileStamp(size: 4_096, modified: 1_780_000_000, fileID: 42)
+        let store = try makeScanCacheStore()
+        let url = store.directory.appendingPathComponent(CostScanCacheStore.claudeFileName)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        let session = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        session.setClaudeRecord(
+            CostScanFileRecord(
+                offset: 512, stamp: stamp, cutoff: cutoff, isComplete: false, payload: ClaudeFileTotals()
+            ),
+            for: "/transcripts/a.jsonl"
+        )
+
+        XCTAssertEqual(session.persist().outcome(for: .claude), .failed)
+        try FileManager.default.removeItem(at: url)
+
+        XCTAssertEqual(session.persist().outcome(for: .claude), .persisted)
+        XCTAssertEqual(store.loadClaude().records["/transcripts/a.jsonl"]?.offset, 512)
+    }
+
+    func testDirtySaveGatingLeavesEndToEndScanResultsByteForByteIdentical() throws {
+        let root = try makeTranscriptRoot()
+        let newest = try writeTranscript(in: root, name: "newest.jsonl", modifiedAgo: 0, lines: [
+            eventLine(timestamp: "2026-07-01T10:00:00.000Z", messageID: "a", requestID: "a", input: 100, output: 10)
+        ])
+        try writeTranscript(in: root, name: "older.jsonl", modifiedAgo: 3_600, lines: [
+            eventLine(timestamp: "2026-07-02T10:00:00.000Z", messageID: "b", requestID: "b", input: 7, output: 3)
+        ])
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let store = try makeScanCacheStore()
+        let first = CostScanSession(
+            cutoff: cutoff,
+            options: CostScanBudgetOptions(
+                maxBytesPerFile: .max,
+                maxNewBytesPerRefresh: try fileSize(newest),
+                wallClock: nil
+            ),
+            store: store
+        )
+        _ = CostSummaryBuilder.makeScan(
+            days: 30,
+            enabledProviders: [.claude],
+            claudeAccounts: [],
+            grokAccounts: [],
+            session: first,
+            claudeProjectRoots: [root]
+        )
+        XCTAssertEqual(first.persist(), .persisted)
+
+        let resumed = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        let incremental = CostSummaryBuilder.makeScan(
+            days: 30,
+            enabledProviders: [.claude],
+            claudeAccounts: [],
+            grokAccounts: [],
+            session: resumed,
+            claudeProjectRoots: [root]
+        )
+        XCTAssertEqual(resumed.persist(), .persisted)
+
+        let cold = CostSummaryBuilder.makeScan(
+            days: 30,
+            enabledProviders: [.claude],
+            claudeAccounts: [],
+            grokAccounts: [],
+            session: CostScanSession(cutoff: cutoff, options: .unlimited),
+            claudeProjectRoots: [root]
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+
+        XCTAssertEqual(try encoder.encode(incremental.summary), try encoder.encode(cold.summary))
+    }
+
     func testPersistReportsCacheWriteFailureAndASuccessfulRetryPersists() throws {
         let blockedDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("CostScanBlocked-\(UUID().uuidString)")
@@ -1892,7 +2069,7 @@ final class CostTrackerTests: XCTestCase {
             for: "/transcripts/a.jsonl"
         )
 
-        XCTAssertEqual(session.persist(), CostScanPersistReport(claude: .failed, codex: .failed, grok: .failed))
+        XCTAssertEqual(session.persist(), CostScanPersistReport(claude: .failed, codex: .persisted, grok: .persisted))
         // Nothing reached disk, so the offsets this slice committed are not
         // resumable — the next slice would re-read the same bytes.
         XCTAssertTrue(store.loadClaude().records.isEmpty)
@@ -2049,6 +2226,11 @@ final class CostTrackerTests: XCTestCase {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
         return CostScanCacheStore(directory: directory)
+    }
+
+    private func cacheArtifactID(at url: URL) throws -> UInt64 {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return try XCTUnwrap((attributes[.systemFileNumber] as? NSNumber)?.uint64Value)
     }
 
     @discardableResult

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -395,11 +395,10 @@ final class CostTrackerTests: XCTestCase {
         try eventLine(timestamp: "2026-07-01T10:00:00.000Z", input: 10, output: 5)
             .write(to: sessionURL, atomically: true, encoding: .utf8)
 
-        let account = ClaudeCodeAccount(id: UUID(), name: "demo", configDirectory: configDir.path)
         let cutoff = FlexibleISO8601.date(from: "2026-06-01T00:00:00Z")!
         let session = CostScanSession(cutoff: cutoff, options: .unlimited)
         let windows = ClaudeCostScanner.scanRoots(
-            ClaudeCostScanner.projectRoots(accounts: [account]),
+            [configDir.appendingPathComponent("projects", isDirectory: true)],
             session: session
         )
 

--- a/MeterBarTests/CostWindowSelectionTests.swift
+++ b/MeterBarTests/CostWindowSelectionTests.swift
@@ -25,10 +25,10 @@ final class CostWindowSelectionTests: XCTestCase {
         XCTAssertEqual(CostWindowSelection.month.spendCardTitle, "30 Day Spend")
     }
 
-    func testActivityWeeksCoverTheSelectedWindow() {
-        // Two 7-day columns are the narrowest grid that always spans the last
-        // 7 days; the month keeps the existing six-week calendar.
-        XCTAssertEqual(CostWindowSelection.week.activityWeeks, 2)
-        XCTAssertEqual(CostWindowSelection.month.activityWeeks, TokenActivityCalendar.defaultWeeks)
+    func testFallbackActivityWeeksCoverTheSelectedWindow() {
+        // Old summaries without hourly rows keep the existing two-week fallback;
+        // the month keeps the unchanged six-week calendar.
+        XCTAssertEqual(CostWindowSelection.week.fallbackActivityWeeks, 2)
+        XCTAssertEqual(CostWindowSelection.month.fallbackActivityWeeks, TokenActivityCalendar.defaultWeeks)
     }
 }

--- a/MeterBarTests/ExtraUsageStatusTests.swift
+++ b/MeterBarTests/ExtraUsageStatusTests.swift
@@ -14,10 +14,12 @@ final class ExtraUsageStatusTests: XCTestCase {
         XCTAssertEqual(ExtraUsageStatus.formatAmount(5), "$5.00")
         XCTAssertEqual(ExtraUsageStatus.formatAmount(0), "$0.00")
         XCTAssertEqual(ExtraUsageStatus.formatAmount(12.5, currency: "usd"), "$12.50")
+        XCTAssertEqual(ExtraUsageStatus.formatAmount(6_954.07), "$6,954.07")
     }
 
     func testFormatAmountNonUSD() {
         XCTAssertEqual(ExtraUsageStatus.formatAmount(5, currency: "EUR"), "5.00 EUR")
+        XCTAssertEqual(ExtraUsageStatus.formatAmount(6_954.07, currency: "eur"), "6,954.07 EUR")
     }
 
     // MARK: - UsageMetrics integration

--- a/MeterBarTests/GrokCostScannerTests.swift
+++ b/MeterBarTests/GrokCostScannerTests.swift
@@ -296,6 +296,65 @@ final class GrokCostScannerTests: XCTestCase {
         XCTAssertEqual(row.estimatedCostUSD, 0.0003, accuracy: 1e-9)
     }
 
+    func testScanAccumulatesOnlyTrailingSevenDaysIntoHourlyBuckets() throws {
+        let root = try makeSessionsRoot()
+        let periodCutoff = Date().addingTimeInterval(-30 * 24 * 60 * 60)
+        let currentHour = try XCTUnwrap(Calendar.current.dateInterval(of: .hour, for: Date())?.start)
+        let hourlyCutoff = currentHour.addingTimeInterval(-7 * 24 * 60 * 60)
+        try writeUpdates(
+            in: root,
+            project: "www/meterbar",
+            session: "session-hourly",
+            lines: [
+                turnCompleted(
+                    at: hourlyCutoff.addingTimeInterval(-60),
+                    input: 90,
+                    cachedRead: 0,
+                    output: 9,
+                    reasoning: 0,
+                    ticks: 900_000
+                ),
+                turnCompleted(
+                    at: hourlyCutoff,
+                    input: 50,
+                    cachedRead: 0,
+                    output: 5,
+                    reasoning: 0,
+                    ticks: 500_000
+                ),
+                turnCompleted(
+                    at: hourlyCutoff.addingTimeInterval(3_599),
+                    input: 100,
+                    cachedRead: 10,
+                    output: 10,
+                    reasoning: 0,
+                    ticks: 1_000_000
+                ),
+                turnCompleted(
+                    at: hourlyCutoff.addingTimeInterval(3_600),
+                    input: 200,
+                    cachedRead: 20,
+                    output: 20,
+                    reasoning: 0,
+                    ticks: 2_000_000
+                ),
+            ]
+        )
+        let session = CostScanSession(
+            cutoff: periodCutoff,
+            hourlyCutoff: hourlyCutoff,
+            options: .unlimited
+        )
+
+        let rows = try XCTUnwrap(GrokCostScanner.makeCost(
+            from: GrokCostScanner.scanRoots([root], session: session).period
+        )?.2)
+
+        XCTAssertEqual(rows.count, 2, "the cutoff event shares an hour bucket with the next event")
+        XCTAssertEqual(rows.map(\.provider), [.grok, .grok])
+        XCTAssertEqual(rows.reduce(0) { $0 + $1.totalTokens }, 385)
+    }
+
     // MARK: - Attribution
 
     /// Grok names each session directory after the URL-encoded absolute project

--- a/MeterBarTests/HourlyTokenUsageTests.swift
+++ b/MeterBarTests/HourlyTokenUsageTests.swift
@@ -1,0 +1,208 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+final class HourlyTokenUsageTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+    private var calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
+        calendar.locale = Locale(identifier: "en_US_POSIX")
+        return calendar
+    }()
+
+    func testHourBucketStartsAtTheLocalHourAcrossHourAndDayBoundaries() throws {
+        let beforeHour = try date("2025-06-14T23:59:59Z")
+        let nextDay = try date("2025-06-15T00:00:00Z")
+        let laterHour = try date("2025-06-15T01:42:17Z")
+
+        XCTAssertEqual(
+            CostScanHourBucket.start(for: beforeHour, calendar: calendar),
+            try date("2025-06-14T23:00:00Z")
+        )
+        XCTAssertEqual(
+            CostScanHourBucket.start(for: nextDay, calendar: calendar),
+            try date("2025-06-15T00:00:00Z")
+        )
+        XCTAssertEqual(
+            CostScanHourBucket.start(for: laterHour, calendar: calendar),
+            try date("2025-06-15T01:00:00Z")
+        )
+    }
+
+    func testHourlyAggregatorPreservesBucketMathAndProviderSeparation() throws {
+        let firstHour = try date("2025-06-15T10:00:00Z")
+        let secondHour = try date("2025-06-15T11:00:00Z")
+        var firstTokens = TokenAccumulator()
+        firstTokens.add(input: 100, output: 20, cacheCreation: 0, cacheRead: 5, estimatedCostUSD: 1.25)
+        firstTokens.add(input: 40, output: 8, cacheCreation: 0, cacheRead: 2, estimatedCostUSD: 0.50)
+        var secondTokens = TokenAccumulator()
+        secondTokens.add(input: 70, output: 14, cacheCreation: 0, cacheRead: 3, estimatedCostUSD: 0.75)
+
+        let claude = TokenUsageAggregator.makeHourlyUsage(
+            from: [firstHour: firstTokens, secondHour: secondTokens],
+            provider: .claudeCode,
+            pricing: TokenPricing(input: 0, output: 0, cacheCreation: 0, cacheRead: 0)
+        )
+        let codex = TokenUsageAggregator.makeHourlyUsage(
+            from: [firstHour: firstTokens],
+            provider: .codexCli,
+            pricing: TokenPricing(input: 0, output: 0, cacheCreation: 0, cacheRead: 0)
+        )
+        let rows = claude + codex
+
+        XCTAssertEqual(rows.count, 3)
+        XCTAssertEqual(rows.filter { $0.date == firstHour }.map(\.provider).sorted(by: rawProviderOrder), [
+            .claudeCode,
+            .codexCli,
+        ])
+        let claudeFirst = try XCTUnwrap(rows.first { $0.date == firstHour && $0.provider == .claudeCode })
+        XCTAssertEqual(claudeFirst.inputTokens, 140)
+        XCTAssertEqual(claudeFirst.outputTokens, 28)
+        XCTAssertEqual(claudeFirst.cacheReadTokens, 7)
+        XCTAssertEqual(claudeFirst.estimatedCostUSD, 1.75, accuracy: 0.000_001)
+    }
+
+    func testCostSummaryWithoutHourlyFieldStillDecodes() throws {
+        let summary = makeSummary(hourlyUsage: nil)
+        let encoded = try JSONEncoder().encode(summary)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+
+        XCTAssertNil(object["hourlyUsage"])
+        let decoded = try JSONDecoder().decode(CostSummary.self, from: encoded)
+        XCTAssertNil(decoded.hourlyUsage)
+    }
+
+    func testCostSummaryWithHourlyFieldRoundTrips() throws {
+        let hour = calendar.dateInterval(of: .hour, for: now)?.start ?? now
+        let summary = makeSummary(hourlyUsage: [
+            HourlyTokenUsage(
+                date: hour,
+                provider: .claudeCode,
+                inputTokens: 100,
+                outputTokens: 20,
+                cacheReadTokens: 5,
+                estimatedCostUSD: 1.25
+            ),
+        ])
+
+        let decoded = try JSONDecoder().decode(CostSummary.self, from: JSONEncoder().encode(summary))
+
+        let row = try XCTUnwrap(decoded.hourlyUsage?.first)
+        XCTAssertEqual(row.date, hour)
+        XCTAssertEqual(row.provider, .claudeCode)
+        XCTAssertEqual(row.totalTokens, 125)
+        XCTAssertEqual(row.estimatedCostUSD, 1.25, accuracy: 0.000_001)
+    }
+
+    func testMissingHourlyUsageRefreshTruthTable() {
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: now) ?? now
+        let populated = [
+            HourlyTokenUsage(
+                date: calendar.dateInterval(of: .hour, for: now)?.start ?? now,
+                provider: .claudeCode,
+                inputTokens: 1,
+                outputTokens: 0,
+                cacheReadTokens: 0,
+                estimatedCostUSD: 0
+            ),
+        ]
+
+        XCTAssertFalse(makeSummary(costs: [], hourlyUsage: nil).needsMissingHourlyUsageRefresh(
+            lastScanDate: yesterday,
+            now: now,
+            calendar: calendar
+        ))
+        XCTAssertFalse(makeSummary(periodDays: 1, hourlyUsage: nil).needsMissingHourlyUsageRefresh(
+            lastScanDate: yesterday,
+            now: now,
+            calendar: calendar
+        ))
+        XCTAssertTrue(makeSummary(hourlyUsage: nil).needsMissingHourlyUsageRefresh(
+            lastScanDate: yesterday,
+            now: now,
+            calendar: calendar
+        ))
+        XCTAssertTrue(makeSummary(hourlyUsage: []).needsMissingHourlyUsageRefresh(
+            lastScanDate: yesterday,
+            now: now,
+            calendar: calendar
+        ))
+        XCTAssertFalse(makeSummary(hourlyUsage: nil).needsMissingHourlyUsageRefresh(
+            lastScanDate: now,
+            now: now,
+            calendar: calendar
+        ))
+        XCTAssertFalse(makeSummary(hourlyUsage: populated).needsMissingHourlyUsageRefresh(
+            lastScanDate: yesterday,
+            now: now,
+            calendar: calendar
+        ))
+    }
+
+    func testFilteringSummaryAlsoFiltersHourlyProviders() {
+        let hour = calendar.dateInterval(of: .hour, for: now)?.start ?? now
+        let summary = makeSummary(hourlyUsage: [
+            hourlyUsage(at: hour, provider: .claudeCode),
+            hourlyUsage(at: hour, provider: .codexCli),
+        ])
+
+        let filtered = summary.filtered(to: [.codexCli])
+
+        XCTAssertEqual(filtered.hourlyUsage?.map(\.provider), [.codexCli])
+    }
+
+    func testHourlyBackfillOnlyRunsForEnabledLogScanners() {
+        XCTAssertFalse(CostTracker.hasEnabledCostScanProvider(in: [.cursor, .openRouter]))
+        XCTAssertTrue(CostTracker.hasEnabledCostScanProvider(in: [.claudeCode]))
+        XCTAssertTrue(CostTracker.hasEnabledCostScanProvider(in: [.codexCli, .cursor]))
+        XCTAssertTrue(CostTracker.hasEnabledCostScanProvider(in: [.grok]))
+    }
+
+    private func makeSummary(
+        costs: [TokenCost]? = nil,
+        periodDays: Int = 30,
+        hourlyUsage: [HourlyTokenUsage]?
+    ) -> CostSummary {
+        let defaultCost = TokenCost(
+            provider: .claudeCode,
+            inputTokens: 100,
+            outputTokens: 20,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 5,
+            estimatedCostUSD: 1.25,
+            sessionCount: 1,
+            periodStart: now,
+            periodEnd: now
+        )
+        let costs = costs ?? [defaultCost]
+        return CostSummary(
+            costs: costs,
+            totalCostUSD: costs.reduce(0) { $0 + $1.estimatedCostUSD },
+            totalTokens: costs.reduce(0) { $0 + $1.totalTokens },
+            periodDays: periodDays,
+            hourlyUsage: hourlyUsage
+        )
+    }
+
+    private func date(_ value: String) throws -> Date {
+        try XCTUnwrap(FlexibleISO8601.date(from: value))
+    }
+
+    private func hourlyUsage(at date: Date, provider: ServiceType) -> HourlyTokenUsage {
+        HourlyTokenUsage(
+            date: date,
+            provider: provider,
+            inputTokens: 1,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            estimatedCostUSD: 0
+        )
+    }
+
+    private func rawProviderOrder(_ lhs: ServiceType, _ rhs: ServiceType) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}

--- a/MeterBarTests/OpenRouterServiceTests.swift
+++ b/MeterBarTests/OpenRouterServiceTests.swift
@@ -64,6 +64,27 @@ final class OpenRouterServiceTests: XCTestCase {
         XCTAssertEqual(metrics.sessionLimit?.windowSeconds, 86_400)
     }
 
+    func testWeeklyKeyLimitMapsToNextUTCWeekReset() throws {
+        let credits = try decodeCredits(#"{"data":{"total_credits":20,"total_usage":5}}"#)
+        let key = try decodeKey(
+            #"{"data":{"limit":10,"limit_reset":"weekly","limit_remaining":4,"usage":6,"is_free_tier":false}}"#
+        )
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+        calendar.firstWeekday = 2
+        calendar.minimumDaysInFirstWeek = 4
+
+        let metrics = OpenRouterService.map(
+            credits: credits.data,
+            key: key.data,
+            now: date(2026, 7, 15, 16),
+            calendar: calendar
+        )
+
+        XCTAssertEqual(metrics.sessionLimit?.resetTime, date(2026, 7, 20))
+        XCTAssertEqual(metrics.sessionLimit?.windowSeconds, 604_800)
+    }
+
     // MARK: - Poll observations
 
     /// OpenRouter denominates `usage` and `usage_daily` in dollars, so the

--- a/MeterBarTests/ProviderUsageCostBuilderTests.swift
+++ b/MeterBarTests/ProviderUsageCostBuilderTests.swift
@@ -60,6 +60,7 @@ final class ProviderUsageCostBuilderTests: XCTestCase {
         XCTAssertEqual(built.0.periodEnd, day(2))
         XCTAssertEqual(built.1.map(\.date), [day(1), day(2)])
         XCTAssertEqual(built.1.map(\.estimatedCostUSD), [2, 3.5])
+        XCTAssertTrue(built.2.isEmpty, "poll-only providers have no event timestamp for hourly bucketing")
     }
 
     /// OpenRouter's key endpoint reports spend and no token counts whatsoever.

--- a/MeterBarTests/QuotaWebhookClientTests.swift
+++ b/MeterBarTests/QuotaWebhookClientTests.swift
@@ -61,6 +61,37 @@ final class QuotaWebhookClientTests: XCTestCase {
         }
     }
 
+    func testUnsafeAddressLiteralClassification() {
+        let unsafeAddresses = [
+            "127.0.0.1",
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.1.1",
+            "169.254.169.254",
+            "100.64.0.1",
+            "::1",
+            "fd00::1",
+            "fe80::1%en0",
+            "[::1]",
+            "127.0.0.1:443",
+            "[::1]:443",
+            "::ffff:127.0.0.1",
+        ]
+        let safeOrUnknownAddresses = [
+            "93.184.216.34",
+            "2606:2800:220:1:248:1893:25c8:1946",
+            "garbage",
+            "",
+        ]
+
+        for address in unsafeAddresses {
+            XCTAssertTrue(QuotaWebhookURLPolicy.isUnsafeAddressLiteral(address), address)
+        }
+        for address in safeOrUnknownAddresses {
+            XCTAssertFalse(QuotaWebhookURLPolicy.isUnsafeAddressLiteral(address), address)
+        }
+    }
+
     func testPostsOnlyTheVersionedMinimalJSONContractWithoutSecrets() async throws {
         let client = makeClient()
         let url = try XCTUnwrap(QuotaWebhookURLPolicy.validatedURL("https://hooks.example.com/meterbar"))
@@ -160,6 +191,36 @@ final class QuotaWebhookClientTests: XCTestCase {
         )
 
         XCTAssertEqual(result, .failed("Webhook URL is not allowed."))
+    }
+
+    func testPrivateObservedRemoteAddressOverridesSuccessfulHTTPResponseAndIsConsumed() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        let connectionDelegate = QuotaWebhookConnectionDelegate()
+        let client = QuotaWebhookClient(
+            configuration: configuration,
+            timeout: 0.1,
+            hostIsPublic: { _ in true },
+            connectionDelegate: connectionDelegate,
+            taskCreatedForTesting: { task in
+                connectionDelegate.recordRemoteAddress(
+                    "127.0.0.1",
+                    forTaskIdentifier: task.taskIdentifier
+                )
+            }
+        )
+        let url = try XCTUnwrap(QuotaWebhookURLPolicy.validatedURL("https://hooks.example.com/meterbar"))
+        StubURLProtocol.handler = { _ in
+            (
+                try XCTUnwrap(HTTPURLResponse(url: url, statusCode: 204, httpVersion: nil, headerFields: nil)),
+                Data()
+            )
+        }
+
+        let result = await client.post(payload: makePayload(), to: url)
+
+        XCTAssertEqual(result, .failed("Webhook connected to a non-public address."))
+        XCTAssertEqual(connectionDelegate.observedAddressCount, 0)
     }
 
     private func makeClient() -> QuotaWebhookClient {

--- a/MeterBarTests/ServeTokenSourceTests.swift
+++ b/MeterBarTests/ServeTokenSourceTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import XCTest
+@testable import MeterBar
+
+final class ServeTokenSourceTests: XCTestCase {
+    func testExplicitArgumentWinsOverFileEnvironmentAndGeneration() throws {
+        var didReadFile = false
+        var didGenerate = false
+
+        let resolved = try ServeTokenSource.resolve(
+            explicitToken: "argument token with spaces",
+            tokenFilePath: "/ignored/token",
+            environment: ["METERBAR_SERVE_TOKEN": "environment-token"],
+            readFile: { _ in
+                didReadFile = true
+                return "file-token"
+            },
+            generate: {
+                didGenerate = true
+                return "generated-token"
+            }
+        )
+
+        XCTAssertEqual(
+            resolved,
+            ResolvedServeToken(token: "argument token with spaces", origin: .explicitArgument)
+        )
+        XCTAssertFalse(didReadFile)
+        XCTAssertFalse(didGenerate)
+    }
+
+    func testFileWinsOverEnvironmentAndGenerationAndTrimsOnlyTrailingWhitespace() throws {
+        var didGenerate = false
+
+        let resolved = try ServeTokenSource.resolve(
+            explicitToken: nil,
+            tokenFilePath: "/token",
+            environment: ["METERBAR_SERVE_TOKEN": "environment-token"],
+            readFile: { path in
+                XCTAssertEqual(path, "/token")
+                return "  file token with internal spaces \t\n"
+            },
+            generate: {
+                didGenerate = true
+                return "generated-token"
+            }
+        )
+
+        XCTAssertEqual(
+            resolved,
+            ResolvedServeToken(token: "  file token with internal spaces", origin: .file)
+        )
+        XCTAssertFalse(didGenerate)
+    }
+
+    func testEnvironmentWinsOverGenerationAndPreservesTokenVerbatim() throws {
+        var didGenerate = false
+
+        let resolved = try ServeTokenSource.resolve(
+            explicitToken: nil,
+            tokenFilePath: nil,
+            environment: ["METERBAR_SERVE_TOKEN": "environment token with spaces"],
+            readFile: { _ in XCTFail("No file should be read."); return "" },
+            generate: {
+                didGenerate = true
+                return "generated-token"
+            }
+        )
+
+        XCTAssertEqual(
+            resolved,
+            ResolvedServeToken(token: "environment token with spaces", origin: .environment)
+        )
+        XCTAssertFalse(didGenerate)
+    }
+
+    func testGeneratesOnlyWhenNoOtherSourceIsSupplied() throws {
+        var generationCount = 0
+
+        let resolved = try ServeTokenSource.resolve(
+            explicitToken: nil,
+            tokenFilePath: nil,
+            environment: [:],
+            readFile: { _ in XCTFail("No file should be read."); return "" },
+            generate: {
+                generationCount += 1
+                return "generated-token"
+            }
+        )
+
+        XCTAssertEqual(resolved, ResolvedServeToken(token: "generated-token", origin: .generated))
+        XCTAssertEqual(generationCount, 1)
+    }
+
+    func testBlankExplicitArgumentThrowsTypedErrorWithoutConsultingLowerPrecedenceSources() {
+        assertResolutionError(.blankExplicitArgument) {
+            _ = try ServeTokenSource.resolve(
+                explicitToken: " \t\n",
+                tokenFilePath: "/ignored/token",
+                environment: ["METERBAR_SERVE_TOKEN": "environment-token"],
+                readFile: { _ in XCTFail("No file should be read."); return "" },
+                generate: { XCTFail("No token should be generated."); return "" }
+            )
+        }
+    }
+
+    func testUnreadableTokenFileThrowsTypedError() {
+        assertResolutionError(.unreadableTokenFile(path: "/missing/token")) {
+            _ = try ServeTokenSource.resolve(
+                explicitToken: nil,
+                tokenFilePath: "/missing/token",
+                environment: [:],
+                readFile: { _ in throw TestFileError.unreadable },
+                generate: { XCTFail("No token should be generated."); return "" }
+            )
+        }
+    }
+
+    func testBlankTokenFileThrowsTypedErrorAfterTrimming() {
+        assertResolutionError(.blankTokenFile(path: "/blank/token")) {
+            _ = try ServeTokenSource.resolve(
+                explicitToken: nil,
+                tokenFilePath: "/blank/token",
+                environment: [:],
+                readFile: { _ in " \t\n" },
+                generate: { XCTFail("No token should be generated."); return "" }
+            )
+        }
+    }
+
+    func testBlankEnvironmentTokenThrowsTypedErrorInsteadOfGenerating() {
+        assertResolutionError(.blankEnvironment) {
+            _ = try ServeTokenSource.resolve(
+                explicitToken: nil,
+                tokenFilePath: nil,
+                environment: ["METERBAR_SERVE_TOKEN": " \t\n"],
+                readFile: { _ in XCTFail("No file should be read."); return "" },
+                generate: { XCTFail("No token should be generated."); return "" }
+            )
+        }
+    }
+
+    private func assertResolutionError(
+        _ expected: ServeTokenResolutionError,
+        operation: () throws -> Void
+    ) {
+        XCTAssertThrowsError(try operation()) { error in
+            XCTAssertEqual(error as? ServeTokenResolutionError, expected)
+        }
+    }
+}
+
+private enum TestFileError: Error {
+    case unreadable
+}

--- a/MeterBarTests/SessionWakeControllerTests.swift
+++ b/MeterBarTests/SessionWakeControllerTests.swift
@@ -1,4 +1,5 @@
 import Combine
+import Darwin
 @testable import MeterBar
 import XCTest
 
@@ -186,7 +187,8 @@ final class SessionWakeControllerTests: XCTestCase {
             accounts: ClaudeCodeAccountStore(userDefaults: defaults),
             codexAccounts: CodexAccountStore(userDefaults: defaults),
             rescanInterval: 3_600,
-            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
         )
         controller.activate()
         poll { recorder.startCount >= 1 }
@@ -210,12 +212,221 @@ final class SessionWakeControllerTests: XCTestCase {
             accounts: ClaudeCodeAccountStore(userDefaults: defaults),
             codexAccounts: codexAccounts,
             rescanInterval: 3_600,
-            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
         )
         controller.activate()
         XCTAssertTrue(controller.isWatching)
         poll { recorder.startCount >= 1 }
         XCTAssertEqual(recorder.startedProviders.first, .codex)
+    }
+
+    func testReconcileWhileArmedOnSameIdentityDoesNotRecreateWatcher() {
+        let store = armedStore()
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: SessionWakeStatus(),
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in
+                recorder.recordCreation()
+                return FakeWatcher(recorder: recorder, onState: onState)
+            },
+            makeLifetimeLock: lifetimeLockFactory()
+        )
+        controller.activate()
+        poll { recorder.startCount >= 1 }
+        XCTAssertEqual(recorder.creationCount, 1)
+
+        store.prompt = "Continue after the same quota window reopens."
+        pump(0.2)
+
+        XCTAssertEqual(recorder.creationCount, 1)
+        XCTAssertEqual(recorder.startCount, 1)
+        store.setOn(false)
+    }
+
+    func testReArmingAfterProviderSwitchRestartsWatcherOnNewProvider() {
+        let store = SessionWakeSettingsStore(userDefaults: defaults)
+        store.setWakeAccountID(ClaudeCodeAccount.defaultID)
+        store.setWakeCodexAccountID(CodexAccount.defaultID)
+        store.acknowledgeFirstRunAndTurnOn()
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: SessionWakeStatus(),
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            codexAccounts: CodexAccountStore(userDefaults: defaults),
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
+        )
+        controller.activate()
+        poll { recorder.startCount >= 1 }
+
+        store.setWakeProvider(.codex)
+        store.setOn(true)
+        poll { recorder.startCount >= 2 }
+
+        XCTAssertTrue(store.isOn)
+        XCTAssertEqual(recorder.startedProviders, [.claude, .codex])
+        store.setOn(false)
+    }
+
+    func testReArmingAfterAccountSwitchRestartsWatcherOnNewAccount() {
+        let accounts = ClaudeCodeAccountStore(userDefaults: defaults)
+        let accountDirectory = "/tmp/session-wake-rearmed-account"
+        accounts.addAccount(name: "Second", configDirectory: accountDirectory)
+        guard let accountID = accounts.customAccounts.first?.id else {
+            return XCTFail("adding a custom account should yield a resolvable id")
+        }
+        let store = armedStore()
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: SessionWakeStatus(),
+            accounts: accounts,
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
+        )
+        controller.activate()
+        poll { recorder.startCount >= 1 }
+
+        store.setWakeAccountID(accountID)
+        store.setOn(true)
+        poll { recorder.startCount >= 2 }
+
+        XCTAssertTrue(store.isOn)
+        XCTAssertEqual(recorder.lastStartedAccountLabel, accountDirectory)
+        store.setOn(false)
+    }
+
+    func testTargetSwitchWaitsForOldLifetimeLockReleaseBeforeReArming() {
+        let accounts = ClaudeCodeAccountStore(userDefaults: defaults)
+        accounts.addAccount(name: "Second", configDirectory: "/tmp/session-wake-lock-sequencing")
+        guard let accountID = accounts.customAccounts.first?.id else {
+            return XCTFail("adding a custom account should yield a resolvable id")
+        }
+        let store = armedStore()
+        let sessionStatus = SessionWakeStatus()
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: sessionStatus,
+            accounts: accounts,
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
+        )
+        controller.activate()
+        poll { recorder.startCount >= 1 }
+
+        store.setWakeAccountID(accountID)
+        store.setOn(true)
+        poll { recorder.startCount >= 2 }
+
+        XCTAssertEqual(recorder.startCount, 2)
+        if case let .failed(reason) = sessionStatus.watcherState {
+            XCTAssertFalse(reason.contains("Another Session Wake holder is active"), reason)
+        }
+        store.setOn(false)
+    }
+
+    func testImmediateStopThenStartWaitsForCleanupAndReleasesEachLifetimeLockOnce() {
+        let store = armedStore()
+        let sessionStatus = SessionWakeStatus()
+        let recorder = WatchRecorder()
+        let completionGate = WatchCompletionGate()
+        let lifetimeLocks = LifetimeLockRecorder(lockURL: testLockURL())
+        let controller = SessionWakeController(
+            store: store,
+            status: sessionStatus,
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in
+                recorder.recordCreation()
+                if recorder.creationCount == 1 {
+                    return DelayedFinishWatcher(
+                        recorder: recorder,
+                        completionGate: completionGate,
+                        onState: onState
+                    )
+                }
+                return FakeWatcher(recorder: recorder, onState: onState)
+            },
+            makeLifetimeLock: lifetimeLocks.factory()
+        )
+        controller.activate()
+        defer {
+            completionGate.finish()
+            store.setOn(false)
+            pump(0.2)
+        }
+        poll { completionGate.waitCount == 1 }
+        XCTAssertEqual(recorder.startCount, 1)
+
+        store.setOn(false)
+        poll { !controller.isWatching && recorder.stopCount >= 1 }
+        store.setOn(true)
+        pump(0.2)
+
+        XCTAssertEqual(recorder.creationCount, 1, "re-arm must wait while the outgoing watcher still owns the lock")
+        if case let .failed(reason) = sessionStatus.watcherState {
+            XCTFail("the app must not report its outgoing watcher as external contention: \(reason)")
+        }
+
+        completionGate.finish()
+        poll { recorder.startCount >= 2 }
+
+        XCTAssertTrue(controller.isWatching)
+        XCTAssertEqual(recorder.startCount, 2)
+        XCTAssertEqual(recorder.creationCount, 2)
+        XCTAssertEqual(lifetimeLocks.creationCount, 2)
+        XCTAssertEqual(lifetimeLocks.releaseCount, 1, "only the outgoing lifetime lock should be released")
+        if case let .failed(reason) = sessionStatus.watcherState {
+            XCTFail("re-arm should succeed after cleanup completes: \(reason)")
+        }
+
+        store.setOn(false)
+        poll { lifetimeLocks.releaseCount >= 2 }
+        XCTAssertEqual(lifetimeLocks.releaseCount, 2, "each lifetime lock should be released exactly once")
+    }
+
+    func testDifferentPIDLifetimeLockHolderStillReportsContention() throws {
+        let lockURL = testLockURL()
+        let holder = try SpawnedWakeLockHolder(lockURL: lockURL)
+        defer { holder.release() }
+        poll {
+            guard let data = try? Data(contentsOf: lockURL),
+                  let record = try? JSONDecoder().decode(WakeLockHolder.self, from: data) else { return false }
+            return record.pid == holder.pid
+        }
+        XCTAssertNotEqual(holder.pid, getpid())
+
+        let store = armedStore()
+        let sessionStatus = SessionWakeStatus()
+        let recorder = WatchRecorder()
+        let controller = SessionWakeController(
+            store: store,
+            status: sessionStatus,
+            accounts: ClaudeCodeAccountStore(userDefaults: defaults),
+            rescanInterval: 3_600,
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
+        )
+
+        controller.activate()
+        pump(0.2)
+
+        XCTAssertFalse(controller.isWatching)
+        XCTAssertEqual(recorder.startCount, 0)
+        guard case let .failed(reason) = sessionStatus.watcherState else {
+            return XCTFail("a different process holding the lifetime lock must report contention")
+        }
+        XCTAssertTrue(reason.contains("Another Session Wake holder is active"), reason)
+        XCTAssertTrue(reason.contains("pid \(holder.pid)"), reason)
     }
 
     func testDisablingSelectedCodexAccountStopsWatcherAndClearsSelection() {
@@ -262,7 +473,8 @@ final class SessionWakeControllerTests: XCTestCase {
             accounts: ClaudeCodeAccountStore(userDefaults: defaults),
             codexAccounts: CodexAccountStore(userDefaults: defaults),
             rescanInterval: 3_600,
-            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) }
+            makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
+            makeLifetimeLock: lifetimeLockFactory()
         )
         controller.activate()
         poll { recorder.startCount >= 1 }
@@ -382,14 +594,24 @@ final class SessionWakeControllerTests: XCTestCase {
 
 nonisolated private final class WatchRecorder: @unchecked Sendable {
     private let lock = NSLock()
+    private var creations = 0
     private var starts = 0
     private var stops = 0
     private var providers: [WakeProvider] = []
+    private var accountLabels: [String?] = []
+    var creationCount: Int { lock.lock(); defer { lock.unlock() }; return creations }
     var startCount: Int { lock.lock(); defer { lock.unlock() }; return starts }
     var stopCount: Int { lock.lock(); defer { lock.unlock() }; return stops }
     var startedProviders: [WakeProvider] { lock.lock(); defer { lock.unlock() }; return providers }
-    func recordStart(provider: WakeProvider) {
-        lock.lock(); starts += 1; providers.append(provider); lock.unlock()
+    var startedAccountLabels: [String?] { lock.lock(); defer { lock.unlock() }; return accountLabels }
+    var lastStartedAccountLabel: String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return accountLabels.last.flatMap { $0 }
+    }
+    func recordCreation() { lock.lock(); creations += 1; lock.unlock() }
+    func recordStart(provider: WakeProvider, accountLabel: String?) {
+        lock.lock(); starts += 1; providers.append(provider); accountLabels.append(accountLabel); lock.unlock()
     }
     func recordStop() { lock.lock(); stops += 1; lock.unlock() }
 }
@@ -399,7 +621,7 @@ nonisolated private struct FakeWatcher: WakeWatching {
     let onState: @Sendable (WakeWatcherState) -> Void
 
     func start(runtime: WakeProviderRuntime) async {
-        recorder.recordStart(provider: runtime.provider)
+        recorder.recordStart(provider: runtime.provider, accountLabel: runtime.accountLabel)
         onState(.scanning)
     }
 
@@ -415,6 +637,168 @@ nonisolated private struct FakeWatcher: WakeWatching {
         while !Task.isCancelled {
             try? await Task.sleep(nanoseconds: 20_000_000)
         }
+    }
+}
+
+nonisolated private struct DelayedFinishWatcher: WakeWatching {
+    let recorder: WatchRecorder
+    let completionGate: WatchCompletionGate
+    let onState: @Sendable (WakeWatcherState) -> Void
+
+    func start(runtime: WakeProviderRuntime) async {
+        recorder.recordStart(provider: runtime.provider, accountLabel: runtime.accountLabel)
+        onState(.running(sessionID: "delayed"))
+    }
+
+    func stop() async {
+        recorder.recordStop()
+        onState(.off)
+    }
+
+    func waitUntilFinished() async {
+        await completionGate.wait()
+    }
+}
+
+nonisolated private final class WatchCompletionGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isFinished = false
+    private var waits = 0
+
+    var waitCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return waits
+    }
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            waits += 1
+            if isFinished {
+                lock.unlock()
+                continuation.resume()
+            } else {
+                self.continuation = continuation
+                lock.unlock()
+            }
+        }
+    }
+
+    func finish() {
+        lock.lock()
+        isFinished = true
+        let pending = continuation
+        continuation = nil
+        lock.unlock()
+        pending?.resume()
+    }
+}
+
+nonisolated private final class LifetimeLockRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private let lockURL: URL
+    private var creations = 0
+    private var releases = 0
+
+    init(lockURL: URL) {
+        self.lockURL = lockURL
+    }
+
+    var creationCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return creations
+    }
+
+    var releaseCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return releases
+    }
+
+    func factory() -> WakeLifetimeLockFactory {
+        { [self] in
+            lock.lock()
+            creations += 1
+            lock.unlock()
+            return RecordingLifetimeLock(
+                lock: WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .app),
+                onRelease: { [self] in recordRelease() }
+            )
+        }
+    }
+
+    private func recordRelease() {
+        lock.lock()
+        releases += 1
+        lock.unlock()
+    }
+}
+
+nonisolated private final class RecordingLifetimeLock: WakeLifetimeLocking, @unchecked Sendable {
+    private let lock: WakeLock
+    private let onRelease: @Sendable () -> Void
+
+    init(lock: WakeLock, onRelease: @escaping @Sendable () -> Void) {
+        self.lock = lock
+        self.onRelease = onRelease
+    }
+
+    func acquire() -> WakeLock.Acquisition {
+        lock.acquire()
+    }
+
+    func release() {
+        onRelease()
+        lock.release()
+    }
+}
+
+nonisolated private final class SpawnedWakeLockHolder {
+    let pid: Int32
+    private let process: Process
+    private let input: Pipe
+    private var isReleased = false
+
+    init(lockURL: URL) throws {
+        let process = Process()
+        let input = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        process.arguments = [
+            "-c",
+            """
+            import fcntl, json, os, socket, sys, time
+            with open(sys.argv[1], "w") as lock_file:
+                fcntl.flock(lock_file, fcntl.LOCK_EX)
+                json.dump({"kind": "agent", "pid": os.getpid(), "host": socket.gethostname(), \
+                    "startedAtEpoch": time.time()}, lock_file)
+                lock_file.flush()
+                sys.stdin.buffer.read(1)
+            """,
+            lockURL.path,
+        ]
+        process.standardInput = input
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+
+        self.process = process
+        self.input = input
+        pid = process.processIdentifier
+    }
+
+    func release() {
+        guard !isReleased else { return }
+        isReleased = true
+        try? input.fileHandleForWriting.write(contentsOf: Data([1]))
+        try? input.fileHandleForWriting.close()
+        process.waitUntilExit()
+    }
+
+    deinit {
+        release()
     }
 }
 

--- a/MeterBarTests/TokenActivityCardTests.swift
+++ b/MeterBarTests/TokenActivityCardTests.swift
@@ -69,6 +69,23 @@ final class TokenActivityCardTests: XCTestCase {
         XCTAssertEqual(activity.weeks.count, TokenActivityCalendar.defaultWeeks)
     }
 
+    func testSevenDayCardHostsTheHourlyHeatmap() {
+        let summary = makeSummaryWithHourlyUsage()
+        let card = TokenActivityCard(
+            summary: summary,
+            windowSelection: .week,
+            isScanning: false,
+            isScanDisabled: false,
+            scan: {}
+        )
+
+        let hostingView = NSHostingView(rootView: card)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 720, height: 400)
+        hostingView.layoutSubtreeIfNeeded()
+
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+    }
+
     // MARK: - Placement regression
 
     func testCostsSectionStillHostsWithTheNewCard() {
@@ -90,7 +107,7 @@ final class TokenActivityCardTests: XCTestCase {
             DashboardCostsSection.refreshStatusText(isScanning: true, isRefreshingMissingDays: true),
             "Scanning..."
         )
-        XCTAssertEqual(CostChartPresentation(summary: summary).hasSpend, true)
+        XCTAssertTrue(CostChartPresentation(summary: summary).hasSpend)
 
         let details = DashboardCard(title: "Daily Details", trailing: "Last 30 days") {
             DailyUsageBreakdownList(dailyUsage: summary.dailyUsage)
@@ -148,6 +165,31 @@ final class TokenActivityCardTests: XCTestCase {
             totalTokens: cost.totalTokens,
             periodDays: 30,
             dailyUsage: dailyUsage
+        )
+    }
+
+    private func makeSummaryWithHourlyUsage() -> CostSummary {
+        let summary = makeSummary(dayCount: 30)
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let hour = calendar.date(byAdding: .hour, value: 10, to: today) ?? today
+
+        return CostSummary(
+            costs: summary.costs,
+            totalCostUSD: summary.totalCostUSD,
+            totalTokens: summary.totalTokens,
+            periodDays: summary.periodDays,
+            dailyUsage: summary.dailyUsage,
+            hourlyUsage: [
+                HourlyTokenUsage(
+                    date: hour,
+                    provider: .claudeCode,
+                    inputTokens: 10_000,
+                    outputTokens: 2_000,
+                    cacheReadTokens: 500,
+                    estimatedCostUSD: 0.75
+                ),
+            ]
         )
     }
 }

--- a/MeterBarTests/TokenActivityHourlyCalendarTests.swift
+++ b/MeterBarTests/TokenActivityHourlyCalendarTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+final class TokenActivityHourlyCalendarTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+    private var calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
+        calendar.locale = Locale(identifier: "en_US_POSIX")
+        return calendar
+    }()
+
+    func testNilHourlyUsageFallsBackToTheExistingTwoWeekCalendar() {
+        let grid = TokenActivityGrid(
+            summary: makeSummary(hourlyUsage: nil),
+            windowSelection: .week,
+            now: now,
+            calendar: calendar
+        )
+
+        XCTAssertNil(grid.hourly)
+        XCTAssertEqual(grid.daily?.weeks.count, 2)
+    }
+
+    func testEmptyHourlyUsageFallsBackToTheExistingTwoWeekCalendar() {
+        let grid = TokenActivityGrid(
+            summary: makeSummary(hourlyUsage: []),
+            windowSelection: .week,
+            now: now,
+            calendar: calendar
+        )
+
+        XCTAssertNil(grid.hourly)
+        XCTAssertEqual(grid.daily?.weeks.count, 2)
+    }
+
+    func testPartialHourlyUsageBuildsSevenOldestToNewestRowsAndTwentyFourColumns() {
+        let hour = hour(daysAgo: 2, hour: 13)
+        let grid = TokenActivityGrid(
+            summary: makeSummary(hourlyUsage: [usage(date: hour, provider: .claudeCode, input: 40)]),
+            windowSelection: .week,
+            now: now,
+            calendar: calendar
+        )
+
+        let hourly = try? XCTUnwrap(grid.hourly)
+        XCTAssertEqual(hourly?.days.count, 7)
+        XCTAssertTrue(hourly?.days.allSatisfy { $0.hours.count == 24 } ?? false)
+        XCTAssertEqual(hourly?.days.last?.date, calendar.startOfDay(for: now))
+        XCTAssertEqual(hourly?.days.first?.date, day(daysAgo: 6))
+        XCTAssertEqual(hourly?.hour(at: hour)?.totalTokens, 40)
+        XCTAssertEqual(hourly?.activeHours.count, 1)
+        XCTAssertEqual(hourly?.coverageStartDate, day(daysAgo: 2))
+        XCTAssertEqual(hourly?.coverageSummary, "3 days tracked")
+    }
+
+    func testFullHourlyUsageAggregatesProvidersInEveryCell() throws {
+        let rows = (0..<7).flatMap { dayOffset in
+            (0..<24).flatMap { hourValue in
+                let date = hour(daysAgo: dayOffset, hour: hourValue)
+                return [
+                    usage(date: date, provider: .claudeCode, input: 10),
+                    usage(date: date, provider: .codexCli, input: 5),
+                ]
+            }
+        }
+        let grid = TokenActivityGrid(
+            summary: makeSummary(hourlyUsage: rows),
+            windowSelection: .week,
+            now: now,
+            calendar: calendar
+        )
+
+        let hourly = try XCTUnwrap(grid.hourly)
+        XCTAssertEqual(hourly.hours.count, 7 * 24)
+        XCTAssertEqual(hourly.activeHours.count, 7 * 24)
+        XCTAssertTrue(hourly.hours.allSatisfy { $0.totalTokens == 15 })
+        XCTAssertTrue(hourly.hours.allSatisfy { $0.providers.map(\.provider) == [.claudeCode, .codexCli] })
+        XCTAssertEqual(hourly.coverageSummary, "7 days tracked")
+    }
+
+    func testMonthSelectionKeepsTheExistingThirtyDayCalendar() {
+        let grid = TokenActivityGrid(
+            summary: makeSummary(hourlyUsage: [
+                usage(date: hour(daysAgo: 0, hour: 1), provider: .claudeCode, input: 1),
+            ]),
+            windowSelection: .month,
+            now: now,
+            calendar: calendar
+        )
+
+        XCTAssertNil(grid.hourly)
+        XCTAssertEqual(grid.daily?.weeks.count, TokenActivityCalendar.defaultWeeks)
+    }
+
+    private func makeSummary(hourlyUsage: [HourlyTokenUsage]?) -> CostSummary {
+        CostSummary(
+            costs: [],
+            totalCostUSD: 0,
+            totalTokens: 0,
+            periodDays: 30,
+            dailyUsage: [
+                DailyTokenUsage(
+                    date: day(daysAgo: 6),
+                    provider: .claudeCode,
+                    inputTokens: 1,
+                    outputTokens: 0,
+                    cacheReadTokens: 0,
+                    estimatedCostUSD: 0
+                ),
+            ],
+            hourlyUsage: hourlyUsage
+        )
+    }
+
+    private func usage(
+        date: Date,
+        provider: ServiceType,
+        input: Int
+    ) -> HourlyTokenUsage {
+        HourlyTokenUsage(
+            date: date,
+            provider: provider,
+            inputTokens: input,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            estimatedCostUSD: 0
+        )
+    }
+
+    private func day(daysAgo: Int) -> Date {
+        let today = calendar.startOfDay(for: now)
+        return calendar.date(byAdding: .day, value: -daysAgo, to: today) ?? today
+    }
+
+    private func hour(daysAgo: Int, hour: Int) -> Date {
+        calendar.date(byAdding: .hour, value: hour, to: day(daysAgo: daysAgo)) ?? now
+    }
+}

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -204,6 +204,8 @@ final class UsageDataManagerTests: XCTestCase {
         savedRefreshInterval: RefreshInterval? = nil,
         parseHealthStore: ProviderParseHealthStore? = nil,
         schedulesAutoRefresh: Bool = false,
+        refreshLockMode: UsageRefreshLockMode = .acquirePerRefresh,
+        refreshLockFactory: (@Sendable () -> WakeLock)? = nil,
         adaptiveNow: @escaping @Sendable () -> Date = { Date() },
         adaptivePowerState: @escaping @Sendable () -> AdaptiveRefreshPowerState = {
             .unconstrained
@@ -244,6 +246,8 @@ final class UsageDataManagerTests: XCTestCase {
             sharedStore.flushPendingWrites()
         }
 
+        let isolatedLockURL = tempDirectory
+            .appendingPathComponent("refresh-\(UUID().uuidString).lock")
         let manager = UsageDataManager(
             codexCliService: codex,
             cursorService: cursor,
@@ -258,6 +262,10 @@ final class UsageDataManagerTests: XCTestCase {
             cacheDefaults: cacheDefaults,
             parseHealthStore: parseHealthStore,
             schedulesAutoRefresh: schedulesAutoRefresh,
+            refreshLockMode: refreshLockMode,
+            refreshLockFactory: refreshLockFactory ?? {
+                WakeLock(lockURL: isolatedLockURL, legacyLockURLs: [], holderKind: .app)
+            },
             adaptiveNow: adaptiveNow,
             adaptivePowerState: adaptivePowerState,
             demoMode: demoMode
@@ -1057,6 +1065,112 @@ final class UsageDataManagerTests: XCTestCase {
         cursor.resumeFetch()
         _ = await firstRefresh.value
         XCTAssertFalse(manager.isLoading)
+    }
+
+    // MARK: - Cross-process refresh lock
+
+    func testRefreshAllAcquiresSharedLockBeforeFetchAndReleasesAfterSuccess() async {
+        let lockURL = tempDirectory.appendingPathComponent("refresh-success.lock")
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: true, result: .success(MetricsFixtures.cursor()))
+        cursor.suspendsFetch = true
+        let (manager, _) = makeManager(
+            codex: codex,
+            cursor: cursor,
+            refreshLockFactory: {
+                WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .app)
+            }
+        )
+
+        let refresh = Task { await manager.refreshAll() }
+        for _ in 0..<100 where cursor.fetchCount == 0 {
+            await Task.yield()
+        }
+        guard cursor.fetchCount == 1 else {
+            cursor.resumeFetch()
+            _ = await refresh.value
+            return XCTFail("refresh should reach the suspended provider fetch")
+        }
+
+        let contender = WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .cli)
+        guard case .contended = contender.acquire() else {
+            cursor.resumeFetch()
+            _ = await refresh.value
+            return XCTFail("app refresh must hold the shared lock while fetching")
+        }
+
+        cursor.resumeFetch()
+        _ = await refresh.value
+        XCTAssertEqual(contender.acquire(), .acquired)
+        contender.release()
+    }
+
+    func testRefreshAllSkipsWithoutFetchingWhenSharedLockIsHeld() async {
+        let lockURL = tempDirectory.appendingPathComponent("refresh-contended.lock")
+        let holder = WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .cli)
+        XCTAssertEqual(holder.acquire(), .acquired)
+        defer { holder.release() }
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: true, result: .success(MetricsFixtures.cursor()))
+        let (manager, _) = makeManager(
+            codex: codex,
+            cursor: cursor,
+            refreshLockFactory: {
+                WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .app)
+            }
+        )
+
+        let report = await manager.refreshAll(trigger: .userInitiated)
+
+        XCTAssertEqual(cursor.fetchCount, 0)
+        XCTAssertEqual(report.outcome(for: .cursor)?.state, .skipped)
+        XCTAssertEqual(report.outcome(for: .cursor)?.reason, "Another MeterBar refresh is already running.")
+        XCTAssertFalse(manager.isLoading)
+    }
+
+    func testRefreshAllReleasesSharedLockAfterProviderFailure() async {
+        let lockURL = tempDirectory.appendingPathComponent("refresh-failure.lock")
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: true, result: .failure(StubError.fetchFailed))
+        let (manager, _) = makeManager(
+            codex: codex,
+            cursor: cursor,
+            refreshLockFactory: {
+                WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .app)
+            }
+        )
+
+        let report = await manager.refreshAll()
+
+        XCTAssertEqual(report.outcome(for: .cursor)?.state, .failed)
+        let contender = WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .cli)
+        XCTAssertEqual(contender.acquire(), .acquired)
+        contender.release()
+    }
+
+    func testCLIOwnedRefreshLockDoesNotGetReacquiredByManager() async {
+        let lockURL = tempDirectory.appendingPathComponent("refresh-cli-owned.lock")
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: true, result: .success(MetricsFixtures.cursor()))
+        let (manager, _) = makeManager(
+            codex: codex,
+            cursor: cursor,
+            refreshLockMode: .externallyOwned,
+            refreshLockFactory: {
+                WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .app)
+            }
+        )
+        let engine = UsageRefreshEngine(
+            lock: WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .cli),
+            timeout: 1,
+            refresh: { await manager.refreshAll(trigger: .userInitiated) },
+            cacheSnapshot: { [:] }
+        )
+
+        let response = await engine.run()
+
+        XCTAssertEqual(response.outcome, .success)
+        XCTAssertEqual(cursor.fetchCount, 1)
     }
 
     // MARK: - Refresh generation

--- a/MeterBarTests/UsageLimitTests.swift
+++ b/MeterBarTests/UsageLimitTests.swift
@@ -73,6 +73,53 @@ final class UsageLimitTests: XCTestCase {
         XCTAssertEqual(deficitPace?.rightLabel(), "Projected empty in 50m")
     }
 
+    func testUsagePaceLabelsOnPaceAndExhausted() throws {
+        let now = Date(timeIntervalSince1970: 0)
+        let resetTime = now.addingTimeInterval(2.5 * 60 * 60)
+
+        let onPace = try XCTUnwrap(UsageLimit(
+            used: 51,
+            total: 100,
+            resetTime: resetTime,
+            windowSeconds: 5 * 60 * 60
+        ).pace(now: now))
+        XCTAssertEqual(onPace.stage, .onPace)
+        XCTAssertEqual(onPace.leftLabel, "On pace")
+        XCTAssertFalse(onPace.willLastToReset)
+
+        let exhausted = try XCTUnwrap(UsageLimit(
+            used: 100,
+            total: 100,
+            resetTime: resetTime,
+            windowSeconds: 5 * 60 * 60
+        ).pace(now: now))
+        XCTAssertTrue(exhausted.isExhausted)
+        XCTAssertEqual(exhausted.leftLabel, "Out of quota")
+        XCTAssertEqual(exhausted.rightLabel(context: .weekly), "Out until reset")
+    }
+
+    func testUsagePaceRejectsInvalidOrNotYetElapsedWindows() {
+        let now = Date(timeIntervalSince1970: 0)
+        let validReset = now.addingTimeInterval(60)
+
+        XCTAssertNil(UsageLimit(used: 1, total: 100, resetTime: nil, windowSeconds: 120).pace(now: now))
+        XCTAssertNil(UsageLimit(used: 1, total: 100, resetTime: validReset).pace(now: now))
+        XCTAssertNil(UsageLimit(used: 1, total: 100, resetTime: validReset, windowSeconds: 0).pace(now: now))
+        XCTAssertNil(UsageLimit(used: 1, total: 100, resetTime: now, windowSeconds: 120).pace(now: now))
+        XCTAssertNil(UsageLimit(
+            used: 1,
+            total: 100,
+            resetTime: now.addingTimeInterval(121),
+            windowSeconds: 120
+        ).pace(now: now))
+        XCTAssertNil(UsageLimit(
+            used: 1,
+            total: 100,
+            resetTime: now.addingTimeInterval(120),
+            windowSeconds: 120
+        ).pace(now: now))
+    }
+
     func testResetCountdownText() throws {
         let now = Date(timeIntervalSince1970: 0)
         let futureReset = UsageLimit(

--- a/MeterBarTests/WakeCLIEngineTests.swift
+++ b/MeterBarTests/WakeCLIEngineTests.swift
@@ -229,6 +229,8 @@ final class WakeCLIEngineTests: XCTestCase {
         let data = try response.jsonData()
         let text = String(decoding: data, as: UTF8.self)
         XCTAssertTrue(text.contains("\"schemaVersion\" : 1"))
+        XCTAssertTrue(text.contains(#""account" : "/x/.claude""#))
+        XCTAssertFalse(text.contains(#"\/"#))
         let decoded = try JSONDecoder().decode(WakeCLIResponse.self, from: data)
         XCTAssertEqual(decoded, response)
         XCTAssertEqual(decoded.schemaVersion, WakeCLIResponse.currentSchemaVersion)

--- a/MeterBarTests/WakeTranscriptScannerTests.swift
+++ b/MeterBarTests/WakeTranscriptScannerTests.swift
@@ -1,0 +1,214 @@
+import XCTest
+@testable import MeterBar
+
+final class WakeTranscriptScannerTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WakeTranscriptScannerTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    func testRootExpandsTildePrefixedOverrideForBothProviders() {
+        let standardized = ("~/some-dir" as NSString).standardizingPath
+        let claude = WakeTranscriptScanner.root(
+            override: "~/some-dir",
+            defaultHome: ".claude",
+            subdirectory: "projects"
+        )
+        let codex = WakeTranscriptScanner.root(
+            override: "~/some-dir",
+            defaultHome: ".codex",
+            subdirectory: "sessions"
+        )
+
+        XCTAssertEqual(claude.path, "\(standardized)/projects")
+        XCTAssertEqual(codex.path, "\(standardized)/sessions")
+    }
+
+    func testRootCollapsesParentComponentsAndStripsTrailingSlash() {
+        let override = "\(tempDir.path)/parent/../target/"
+        let root = WakeTranscriptScanner.root(
+            override: override,
+            defaultHome: ".claude",
+            subdirectory: "projects"
+        )
+
+        XCTAssertEqual(root.path, "\(tempDir.path)/target/projects")
+        XCTAssertFalse(root.path.hasSuffix("/"))
+    }
+
+    func testRootFallsBackForNilEmptyAndWhitespaceOnlyOverrides() {
+        let realHome = ServiceSupport.realHomeDirectory()
+        let overrides: [String?] = [nil, "", " \n\t "]
+
+        for override in overrides {
+            XCTAssertEqual(
+                WakeTranscriptScanner.root(
+                    override: override,
+                    defaultHome: ".claude",
+                    subdirectory: "projects"
+                ).path,
+                "\(realHome)/.claude/projects"
+            )
+            XCTAssertEqual(
+                WakeTranscriptScanner.root(
+                    override: override,
+                    defaultHome: ".codex",
+                    subdirectory: "sessions"
+                ).path,
+                "\(realHome)/.codex/sessions"
+            )
+        }
+    }
+
+    func testTranscriptURLsOptionallyPrunesSubagentSubtree() throws {
+        let project = tempDir.appendingPathComponent("project")
+        let subagents = project.appendingPathComponent("subagents")
+        try FileManager.default.createDirectory(at: subagents, withIntermediateDirectories: true)
+        let main = project.appendingPathComponent("main.jsonl")
+        let child = subagents.appendingPathComponent("child.jsonl")
+        try Data("main".utf8).write(to: main)
+        try Data("child".utf8).write(to: child)
+
+        let scanner = WakeTranscriptScanner()
+        let now = Date()
+        let pruned = scanner.transcriptURLs(under: tempDir, now: now, prunesSubagents: true)
+        let unpruned = scanner.transcriptURLs(under: tempDir, now: now, prunesSubagents: false)
+
+        XCTAssertEqual(normalized(pruned), normalized([main]))
+        XCTAssertEqual(Set(normalized(unpruned)), Set(normalized([main, child])))
+    }
+
+    func testTranscriptURLsHonorsAgeCapAndDeterministicOrdering() throws {
+        let now = Date()
+        let a = try writeTranscript(named: "a", modified: now)
+        let b = try writeTranscript(named: "b", modified: now)
+        let older = try writeTranscript(named: "older", modified: now.addingTimeInterval(-50))
+        let stale = try writeTranscript(named: "stale", modified: now.addingTimeInterval(-101))
+
+        let capped = WakeTranscriptScanner(configuration: .init(maxTranscriptAge: 100, maxTranscripts: 2))
+        XCTAssertEqual(
+            normalized(capped.transcriptURLs(under: tempDir, now: now, prunesSubagents: false)),
+            normalized([a, b])
+        )
+
+        let uncapped = WakeTranscriptScanner(configuration: .init(maxTranscriptAge: 100, maxTranscripts: 10))
+        let ageBounded = normalized(
+            uncapped.transcriptURLs(under: tempDir, now: now, prunesSubagents: false)
+        )
+        XCTAssertEqual(ageBounded, normalized([a, b, older]))
+        XCTAssertFalse(ageBounded.contains(normalized(stale)))
+    }
+
+    func testReadTailRespectsByteLimitAndLossilyDecodesSplitMultibyteCharacter() throws {
+        let url = tempDir.appendingPathComponent("tail.jsonl")
+        try Data("prefix🙂\nlast\n".utf8).write(to: url)
+        let scanner = WakeTranscriptScanner(configuration: .init(maxTailBytes: 8))
+
+        let lines = try XCTUnwrap(scanner.readTail(of: url))
+
+        XCTAssertEqual(lines.last, "last")
+        XCTAssertFalse(lines.joined().contains("prefix"))
+        XCTAssertTrue(lines.first?.contains("\u{FFFD}") == true)
+    }
+
+    func testResolveWorkingDirectoryReportsMissingAndResolvesSymlinks() throws {
+        let scanner = WakeTranscriptScanner()
+
+        XCTAssertNil(scanner.resolveWorkingDirectory(nil).0)
+        XCTAssertEqual(scanner.resolveWorkingDirectory(nil).1, .unknownWorkingDirectory)
+        XCTAssertEqual(scanner.resolveWorkingDirectory("").1, .unknownWorkingDirectory)
+
+        let missing = tempDir.appendingPathComponent("missing")
+        XCTAssertEqual(scanner.resolveWorkingDirectory(missing.path).1, .missingWorkingDirectory)
+
+        let file = tempDir.appendingPathComponent("file")
+        try Data().write(to: file)
+        XCTAssertEqual(scanner.resolveWorkingDirectory(file.path).1, .missingWorkingDirectory)
+
+        let real = tempDir.appendingPathComponent("real")
+        let link = tempDir.appendingPathComponent("link")
+        try FileManager.default.createDirectory(at: real, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: real)
+        let resolved = scanner.resolveWorkingDirectory(link.path)
+
+        XCTAssertEqual(resolved.0, real.resolvingSymlinksInPath().path)
+        XCTAssertNil(resolved.1)
+    }
+
+    func testDiscoveryDirectorySeamsAgreeOnTildeHandling() {
+        let standardized = ("~/x" as NSString).standardizingPath
+        let claude = SessionDiscovery.projectsDirectory(configDirectory: "~/x")
+        let codex = CodexSessionDiscovery.sessionsDirectory(codexHome: "~/x")
+
+        XCTAssertEqual(claude.path, "\(standardized)/projects")
+        XCTAssertEqual(codex.path, "\(standardized)/sessions")
+        XCTAssertEqual(claude.deletingLastPathComponent(), codex.deletingLastPathComponent())
+    }
+
+    func testSupersedesAndCandidateSetUseLatestThenLexicographicallyFirstPath() {
+        let instant = Date(timeIntervalSince1970: 1_900_000_000)
+        let earlier = candidate(sessionID: "latest", path: "/a", blockedAt: instant)
+        let later = candidate(sessionID: "latest", path: "/z", blockedAt: instant.addingTimeInterval(1))
+        XCTAssertTrue(WakeTranscriptScanner.supersedes(later, earlier))
+        XCTAssertFalse(WakeTranscriptScanner.supersedes(earlier, later))
+
+        var latest = WakeTranscriptScanner.CandidateSet()
+        latest.insert(later)
+        latest.insert(earlier)
+        XCTAssertEqual(latest.sorted.map(\.transcriptPath), ["/z"])
+
+        let lexicalFirst = candidate(sessionID: "tie", path: "/a", blockedAt: instant)
+        let lexicalLast = candidate(sessionID: "tie", path: "/z", blockedAt: instant)
+        XCTAssertTrue(WakeTranscriptScanner.supersedes(lexicalFirst, lexicalLast))
+
+        var tied = WakeTranscriptScanner.CandidateSet()
+        tied.insert(lexicalLast)
+        tied.insert(lexicalFirst)
+        XCTAssertEqual(tied.sorted.map(\.transcriptPath), ["/a"])
+    }
+
+    /// `FileManager.enumerator` yields canonical `/private/var/...` URLs while
+    /// `temporaryDirectory` yields the `/var/...` symlink form. Both sides go
+    /// through the same resolution so these assertions stay about ordering and
+    /// pruning rather than about macOS path aliasing.
+    private func normalized(_ url: URL) -> String {
+        url.resolvingSymlinksInPath().path
+    }
+
+    private func normalized(_ urls: [URL]) -> [String] {
+        urls.map(normalized)
+    }
+
+    private func writeTranscript(named name: String, modified: Date) throws -> URL {
+        let url = tempDir.appendingPathComponent("\(name).jsonl")
+        try Data(name.utf8).write(to: url)
+        try FileManager.default.setAttributes([.modificationDate: modified], ofItemAtPath: url.path)
+        return url
+    }
+
+    private func candidate(sessionID: String, path: String, blockedAt: Date) -> WakeSessionCandidate {
+        let fingerprint = BlockFingerprint(
+            sessionID: sessionID,
+            blockedAt: blockedAt,
+            reason: .sessionLimit
+        )
+        return WakeSessionCandidate(
+            sessionID: sessionID,
+            transcriptPath: path,
+            workingDirectory: nil,
+            gitBranch: nil,
+            reason: .sessionLimit,
+            blockedAt: blockedAt,
+            resetHint: nil,
+            fingerprint: fingerprint,
+            skipReason: .unknownWorkingDirectory
+        )
+    }
+}

--- a/Packages/MeterBarShared/Sources/MeterBarShared/UsageAmountFormatting.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/UsageAmountFormatting.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Stable money formatting shared by the app, widget, CLI, and provider-detail copy.
+public enum UsageAmountFormat {
+    private static let decimal: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.numberStyle = .decimal
+        formatter.usesGroupingSeparator = true
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        return formatter
+    }()
+
+    /// Formats USD with its symbol and other currencies with their ISO code.
+    public static func currency(_ amount: Double, code: String? = "USD") -> String {
+        let normalized = (code ?? "USD").uppercased()
+        let number = decimal.string(from: NSNumber(value: amount)) ?? String(format: "%.2f", amount)
+        return normalized == "USD" ? "$\(number)" : "\(number) \(normalized)"
+    }
+}

--- a/Packages/MeterBarShared/Sources/MeterBarShared/UsageMetrics.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/UsageMetrics.swift
@@ -30,11 +30,7 @@ public struct ExtraUsageStatus: Codable, Equatable, Sendable {
 
     /// Formats an amount as USD ("$5.00"); falls back to "<amount> <currency>" for others.
     public static func formatAmount(_ amount: Double, currency: String? = "USD") -> String {
-        let normalized = (currency ?? "USD").uppercased()
-        if normalized == "USD" {
-            return String(format: "$%.2f", amount)
-        }
-        return String(format: "%.2f %@", amount, normalized)
+        UsageAmountFormat.currency(amount, code: currency)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@
 
 > **Note**: MeterBar is currently in active development. The app is not yet available on the Mac App Store but will be published soon. For now, you can build from source or download pre-built binaries from the Releases page.
 
-A lightweight macOS menu bar app that monitors Claude Code, Codex CLI, Cursor, OpenRouter, and Grok usage at a glance.
+A lightweight macOS menu bar app that monitors Claude Code, Codex CLI, Cursor,
+OpenRouter, and Grok usage at a glance — then tells you which provider still has
+headroom, warns you before you hit a wall, and can resume your blocked sessions
+by itself once a limit resets.
 
 ## Screenshots
 
@@ -37,15 +40,35 @@ A lightweight macOS menu bar app that monitors Claude Code, Codex CLI, Cursor, O
 
 ## Features
 
+### Monitoring
+
 - **Menu Bar App**: Quick access to usage data from your menu bar
 - **Per-Account Menu Bar Items**: Give up to 4 Claude/Codex accounts their own status item, or use one merged item with an in-menu account switcher (Settings → General → Menu Bar Accounts)
-- **Widget Support**: macOS widget for at-a-glance monitoring
 - **Multi-Service Support**: Track Claude Code, Codex CLI, Cursor, OpenRouter, and Grok
+- **Provider Status**: Service-health monitoring for all five providers, so you can tell a provider outage apart from your own exhausted quota
+- **Widget Support**: macOS widget for at-a-glance monitoring
 - **Zero Configuration for CLI Providers**: Reuses local CLI sign-ins without password entry
 - **Real-time Updates**: Background refresh defaults to 10 minutes, with an opt-in 1–30 minute
   adaptive cadence and prompt catch-up after wake
 - **Pace-aware Bars**: Usage bars show quota left with an expected-pace marker and burn-rate projection
 - **Color-coded Status**: Green (healthy), Orange (tight), Red (critical/exhausted)
+
+### Automation
+
+- **Session Wake**: Watch one Claude or Codex account and automatically resume its blocked sessions, one at a time, once the limit resets — the watcher keeps running after MeterBar quits ([details](#session-wake))
+- **Pre-limit Alerts**: Two configurable thresholds — an early heads-up as a quota tightens, and a stronger alert as it runs out ([details](#alerts))
+- **Event Integrations**: Run a local command or POST quota transitions to a webhook ([details](#event-integrations))
+
+### Cost and optimization
+
+- **Local Cost Scan**: 30-day token spend computed from local session logs — nothing is uploaded
+- **Optimize Tab**: See where tokens actually go, and which provider has the most headroom right now
+- **Display Currency**: Show costs in your own currency at a rate you enter (Settings → Costs)
+
+### Scripting
+
+- **CLI Tool**: `meterbar usage` and `meterbar cost`, with a versioned `--json` schema ([details](#cli-tool))
+- **Local HTTP Endpoint**: `meterbar serve` exposes the same cached data read-only over loopback ([details](#http-endpoint))
 
 ## Supported Services
 
@@ -147,7 +170,7 @@ result, and diagnostics check. A failed profile does not block the others.
 
 1. **Launch the app** - It appears in your menu bar with the tightest quota's percent left
 2. **Click the icon** - The popover shows every provider's quota windows
-3. **Open the dashboard** - Full view with limits, 30-day token costs, and settings
+3. **Open the dashboard** - Full view with limits, token costs, optimization, and settings
 4. **Refresh** - Click the refresh icon to update metrics
 
 ### Understanding the Display
@@ -163,6 +186,55 @@ exhausted — a countdown to when usage resumes.
 | Green | more than 25% of the quota left |
 | Orange | 25% or less left - quota is tight |
 | Red | 10% or less left - critical or exhausted |
+
+### Dashboard
+
+| Tab | What it shows |
+|-----|---------------|
+| **Overview** | Current health and local token history |
+| **Limits** | Every tracked quota window |
+| **Costs** | Local 30-day token spend |
+| **Optimize** | Where tokens go, and which provider has headroom right now |
+| **Status** | Provider service health |
+| **Diagnostics** | Provider setup health |
+| **Share** | Social card export |
+
+### Alerts
+
+**Settings → General → Notifications** turns on threshold alerts, with two
+independently configurable levels:
+
+- **Warn me** — the first heads-up as a quota tightens
+- **Alert me** — a stronger alert as the quota runs out
+
+Both are off until you enable notifications. Disabled providers and stale data
+never notify, repeat crossings are deduplicated rather than stacked, and an
+alert only claims a quota is *exhausted* when it actually is — configuring the
+critical level at "10% left" produces a warning at 10%, not a false
+limit-reached banner.
+
+### Session Wake
+
+**Settings → Automation** watches a single Claude or Codex account and, once its
+limit resets, automatically resumes the sessions that limit blocked — one at a
+time, not all at once. A one-time confirmation explains this the first time you
+turn it on.
+
+The watcher runs as a launch agent, so it keeps working after you quit MeterBar.
+Only one watcher runs at a time across the app and the CLI; a cross-process lock
+prevents two from racing each other.
+
+## Cost Tracking
+
+The **Costs** tab computes 30-day token spend by scanning your local Claude,
+Codex, and Grok session logs. The scan is incremental and resumable — it caches
+per-file results and picks up where it left off rather than re-reading the whole
+corpus each time. Nothing is uploaded; the numbers are derived entirely from
+files already on your disk.
+
+Set a **Display Currency** under **Settings → Costs** to show totals in a
+currency other than USD, using a conversion rate you enter yourself. MeterBar
+does not fetch exchange rates.
 
 ## CLI Tool
 
@@ -188,6 +260,29 @@ meterbar cost --json
 `meterbar cost` reports the MeterBar app's cached 30-day scan (run one from
 the app's Costs tab), so the CLI and the app always show the same numbers.
 The [`--json` schema](docs/cli-json-schema.md) is versioned for third-party integrations.
+
+### HTTP Endpoint
+
+`meterbar serve` exposes the same cached data over a local HTTP endpoint, for
+status bars, dashboards, and scripts that would rather poll a URL than shell out.
+
+```bash
+meterbar serve
+# meterbar serve listening on http://127.0.0.1:47663
+# Endpoints: GET /usage, GET /cost (Authorization: Bearer <token> required)
+# Bearer token (generated, shown once): ...
+```
+
+The endpoint is **read-only** — it serves the cache and never triggers a provider
+refresh or mutates state. It binds to loopback only unless you pass
+`--allow-remote`, requires a bearer token on every request (generated and printed
+once at startup if you do not supply `--token`), and rate-limits to 5 requests
+per second by default.
+
+`--allow-remote` exposes a **plaintext HTTP** listener on your network. The
+bearer token and cached usage/cost data are not encrypted in transit, so use it
+only on a trusted private network or place MeterBar behind a TLS-terminating
+reverse proxy. Do not expose the listener directly to the public internet.
 
 ### Event Integrations
 
@@ -229,9 +324,12 @@ Claude Code usage reads the authenticated `/api/oauth/usage` endpoint — the sa
 ## Privacy & Security
 
 - All credentials remain in their original locations (managed by CLI tools)
+- Cost figures are computed locally from session logs already on your disk; no log content leaves the machine
 - No data is sent beyond providers' own usage endpoints by default. An explicitly
   enabled webhook sends only the documented quota event fields to the URL the
   user configured; credentials and config paths are never included.
+- `meterbar serve` is opt-in, read-only, loopback-bound by default, and token-gated.
+  `--allow-remote` is plaintext HTTP; use a trusted private network or a TLS proxy.
 - The main app is **not** sandboxed — it must read other tools' credential/log files
   (`~/.claude`, `~/.codex`, Cursor's local database) and run the `claude` and `grok` binaries. The
   widget extension is sandboxed. Hardened runtime is enabled for both.

--- a/scripts/render-readme-screenshots.sh
+++ b/scripts/render-readme-screenshots.sh
@@ -9,6 +9,12 @@ TMPDIR="$ROOT_DIR/.build/tmp" \
 CLANG_MODULE_CACHE_PATH="$ROOT_DIR/.build/module-cache" \
 SWIFT_MODULE_CACHE_PATH="$ROOT_DIR/.build/module-cache" \
 swiftc -parse-as-library "$ROOT_DIR/scripts/render-readme-screenshots.swift" \
+  "$ROOT_DIR/Packages/MeterBarShared/Sources/MeterBarShared/ServiceType.swift" \
+  "$ROOT_DIR/Packages/MeterBarShared/Sources/MeterBarShared/UsageStatus.swift" \
+  "$ROOT_DIR/Packages/MeterBarShared/Sources/MeterBarShared/QuotaBands.swift" \
+  "$ROOT_DIR/Packages/MeterBarShared/Sources/MeterBarShared/UsageLimit.swift" \
+  "$ROOT_DIR/Packages/MeterBarShared/Sources/MeterBarShared/UsageAmountFormatting.swift" \
+  "$ROOT_DIR/Packages/MeterBarShared/Sources/MeterBarShared/UsageMetrics.swift" \
   -o "$ROOT_DIR/.build/render-readme-screenshots"
 
 "$ROOT_DIR/.build/render-readme-screenshots"

--- a/scripts/render-readme-screenshots.swift
+++ b/scripts/render-readme-screenshots.swift
@@ -2,84 +2,13 @@ import AppKit
 import Foundation
 import SwiftUI
 
-struct UsageLimit: Equatable {
-    let used: Double
-    let total: Double
-    let resetTime: Date?
-
-    var percentage: Double {
-        guard total > 0 else { return 0 }
-        return min(100, max(0, (used / total) * 100))
-    }
-
-    var isNearLimit: Bool {
-        percentage >= 80
-    }
-
-    var isAtLimit: Bool {
-        percentage >= 100
-    }
-
-    var statusColor: UsageStatus {
-        if isAtLimit {
-            return .critical
-        } else if isNearLimit {
-            return .warning
-        }
-        return .good
-    }
-}
-
-enum UsageStatus {
-    case good
-    case warning
-    case critical
-
+private extension UsageStatus {
     var color: Color {
         switch self {
         case .good: return .green
         case .warning: return .orange
         case .critical: return .red
         }
-    }
-}
-
-enum ServiceType: String, CaseIterable, Identifiable {
-    case claudeCode = "Claude Code"
-    case openai = "OpenAI"
-    case cursor = "Cursor"
-
-    var id: String { rawValue }
-
-    var displayName: String { rawValue }
-
-    var iconName: String {
-        switch self {
-        case .claudeCode: return "terminal"
-        case .openai: return "brain"
-        case .cursor: return "cursorarrow.click"
-        }
-    }
-}
-
-struct UsageMetrics: Identifiable {
-    let id = UUID()
-    let service: ServiceType
-    let sessionLimit: UsageLimit?
-    let weeklyLimit: UsageLimit?
-    let codeReviewLimit: UsageLimit?
-    let lastUpdated: Date
-
-    var overallStatus: UsageStatus {
-        let limits = [sessionLimit, weeklyLimit, codeReviewLimit].compactMap { $0 }
-        guard !limits.isEmpty else { return .good }
-
-        if limits.contains(where: { $0.isAtLimit }) {
-            return .critical
-        } else if limits.contains(where: { $0.isNearLimit }) {
-            return .warning
-        }
-        return .good
     }
 }
 
@@ -577,9 +506,8 @@ enum SnapshotRenderer {
 
         let now = Date()
 
-        // This standalone renderer is intentionally self-contained (its own model
-        // copies above) so it compiles with a single `swiftc` invocation and never
-        // links the app. The FIXTURE below, however, must stay in lockstep with the
+        // This standalone renderer compiles the real MeterBarShared models but
+        // never links the app. The fixture below must stay in lockstep with the
         // in-app demo scenario in `MeterBarShared/DemoData.swift` and its cost
         // companion `MeterBar/Models/DemoData+Cost.swift`, so the landing-page
         // screenshots match exactly what `METERBAR_DEMO=1` shows in the app:
@@ -596,7 +524,7 @@ enum SnapshotRenderer {
         )
 
         let openAIMetrics = UsageMetrics(
-            service: .openai,
+            service: .codexCli,
             sessionLimit: UsageLimit(used: 61, total: 100, resetTime: now.addingTimeInterval(2 * 60 * 60)),
             weeklyLimit: UsageLimit(used: 82, total: 100, resetTime: now.addingTimeInterval(24 * 60 * 60)),
             codeReviewLimit: nil,


### PR DESCRIPTION
Fixes #379

## The bug

`UsageDataManager.refreshAll()` guarded re-entrancy with an in-process-only `isLoading` flag. The bundled CLI was the **only** side taking the shared usage-refresh lock at `~/Library/Application Support/MeterBar/usage-refresh/refresh.lock` — and it took it in `UsageRefreshEngine`, outside the manager.

So the app's periodic timer, the menu refresh button, and every provider- or account-scoped refresh took no lock at all. Run `meterbar refresh` while the app is open and both sides fetch every provider concurrently, then race to write the shared cache. Last writer wins; the loser's fetch is wasted API traffic.

## The fix

Every app-side refresh path attempts the shared lock non-blockingly and skips immediately on contention:

```swift
guard case let .acquired(refreshLock) = await acquireRefreshLock() else { return }
defer { refreshLock?.release() }
```

`refreshAll()` surfaces the skip through the existing `UsageRefreshReport` rather than returning silently, so the UI can say why nothing moved. The three non-reporting paths return early.

The acquire runs on a detached task — `WakeLock.acquire()` does filesystem work, and there is no reason to do it on the main actor. `LOCK_NB` means it never waits on a holder, so the hop is the only cost.

### CLI keeps outer ownership

`UsageRefreshCLI` constructs its manager with `refreshLockMode: .externallyOwned`. Without this the CLI would deadlock against itself: `UsageRefreshEngine` already holds the lock, and flock(2) locks **do not merge across separate `open()` calls even inside one process**, so the inner acquisition would report contention and the CLI would skip its own refresh.

### Path consolidation

The lock URL was written out inline in `UsageRefreshCLI`. It moves to a new `UsageRefreshLock` enum that both sides call, so app and CLI resolve the same file by construction rather than by two copies of the same path expression staying in sync.

Worth noting for review: this resolves correctly only because MeterBar is **not** sandboxed — `MeterBar.entitlements` declares app-groups and nothing else, so `.applicationSupportDirectory` gives the real `~/Library/Application Support` for the app exactly as it does for the CLI. If the app ever gains `com.apple.security.app-sandbox`, this path splits into two container-relative files and the exclusion silently stops working.

## Tests

| test | asserts |
|---|---|
| `testRefreshAllAcquiresSharedLockBeforeFetchAndReleasesAfterSuccess` | lock held for the duration of the fetch, released after |
| `testRefreshAllSkipsWithoutFetchingWhenSharedLockIsHeld` | contention → `.skipped`, **zero** provider fetches, `isLoading` false |
| `testRefreshAllReleasesSharedLockAfterProviderFailure` | lock released even when a provider throws |
| `testCLIOwnedRefreshLockDoesNotGetReacquiredByManager` | full `UsageRefreshEngine` + manager stack under one lock succeeds and fetches once |

The last one is the self-deadlock guard — it drives the real engine, not a stub, so a future change that drops `.externallyOwned` fails here.

## Verification

- `swift test` — 2087 tests, 6 skipped, **0 failures** (54.9s)
- `swiftlint lint --strict` (0.65.0, CI-pinned) — **0 violations in 268 files**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added refresh coordination to prevent overlapping usage updates.
  * Refresh operations now safely acquire and release a shared lock.
  * Command-line refreshes can manage the lock externally.

* **Bug Fixes**
  * Prevented duplicate or conflicting fetches when multiple refreshes run simultaneously.
  * Refreshes now stop gracefully when another operation is active or locking is unavailable.
  * Locks are released reliably even when a usage provider fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Integrated audit fixes

This integration PR contains the reviewed and merged work from #373, #395, #398, #399, #403, #404, #406, #407, and #408.

Closes #372
Closes #374
Closes #376
Closes #378
Closes #379
Closes #380
Closes #381
Closes #382
Closes #383
Closes #384
Closes #385
Closes #386
Closes #393