### PR TITLE
fix(security): token file/env for serve, CLI path notices, webhook address gate

### DIFF
--- a/MeterBar/Serve/ServeToken.swift
+++ b/MeterBar/Serve/ServeToken.swift
@@ -2,6 +2,100 @@ import Darwin
 import Foundation
 import Security
 
+/// Where the bearer token protecting `meterbar serve` came from. Callers use
+/// this provenance to decide whether startup may reveal the token: only a
+/// freshly generated token has nowhere else for the operator to retrieve it.
+nonisolated public enum ServeTokenOrigin: Sendable, Equatable {
+    case explicitArgument
+    case file
+    case environment
+    case generated
+}
+
+/// A usable bearer token paired with the source that won the documented
+/// precedence chain.
+nonisolated public struct ResolvedServeToken: Sendable, Equatable {
+    public let token: String
+    public let origin: ServeTokenOrigin
+
+    public init(token: String, origin: ServeTokenOrigin) {
+        self.token = token
+        self.origin = origin
+    }
+}
+
+/// Operator-actionable failures from token-source resolution. Keeping these
+/// cases typed lets the CLI translate them into concise `ValidationError`
+/// messages without parsing filesystem error copy or exposing token values.
+nonisolated public enum ServeTokenResolutionError: Error, Sendable, Equatable {
+    case blankExplicitArgument
+    case unreadableTokenFile(path: String)
+    case blankTokenFile(path: String)
+    case blankEnvironment
+}
+
+/// Pure precedence and validation policy for the `meterbar serve` bearer
+/// token. Filesystem reads and token generation are injected so every branch
+/// is deterministic in tests and no test ever needs to place a secret on disk.
+nonisolated public enum ServeTokenSource {
+    public static let environmentVariable = "METERBAR_SERVE_TOKEN"
+
+    public static func resolve(
+        explicitToken: String?,
+        tokenFilePath: String?,
+        environment: [String: String],
+        readFile: (String) throws -> String,
+        generate: () -> String
+    ) throws -> ResolvedServeToken {
+        if let explicitToken {
+            guard ServeToken.isUsable(explicitToken) else {
+                throw ServeTokenResolutionError.blankExplicitArgument
+            }
+            return ResolvedServeToken(token: explicitToken, origin: .explicitArgument)
+        }
+
+        if let tokenFilePath {
+            let contents: String
+            do {
+                contents = try readFile(tokenFilePath)
+            } catch {
+                throw ServeTokenResolutionError.unreadableTokenFile(path: tokenFilePath)
+            }
+            let token = trimmingTrailingWhitespace(from: contents)
+            guard ServeToken.isUsable(token) else {
+                throw ServeTokenResolutionError.blankTokenFile(path: tokenFilePath)
+            }
+            return ResolvedServeToken(token: token, origin: .file)
+        }
+
+        if let environmentToken = environment[environmentVariable] {
+            guard ServeToken.isUsable(environmentToken) else {
+                throw ServeTokenResolutionError.blankEnvironment
+            }
+            return ResolvedServeToken(token: environmentToken, origin: .environment)
+        }
+
+        return ResolvedServeToken(token: generate(), origin: .generated)
+    }
+
+    /// Token files commonly end in a newline because they were written by a
+    /// shell or secret manager. Strip only the suffix: leading and internal
+    /// whitespace may deliberately be part of the bearer token and must remain
+    /// byte-for-byte intact.
+    private static func trimmingTrailingWhitespace(from value: String) -> String {
+        var end = value.endIndex
+        while end > value.startIndex {
+            let previous = value.index(before: end)
+            let character = value[previous]
+            guard character.unicodeScalars.allSatisfy(CharacterSet.whitespacesAndNewlines.contains) else {
+                break
+            }
+            end = previous
+        }
+        return String(value[..<end])
+    }
+}
+
 /// Bearer token generation and comparison for `meterbar serve`. Comparison
 /// runs in constant time so a network caller can't use response latency to
 /// guess the token one byte at a time (docs/cli-json-schema.md security notes).

--- a/MeterBar/Services/CLIBinaryLocator.swift
+++ b/MeterBar/Services/CLIBinaryLocator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Coarse provenance for a resolved provider CLI. This is intentionally an
 /// observability signal rather than an execution gate: developer CLIs are

--- a/MeterBar/Services/CLIBinaryLocator.swift
+++ b/MeterBar/Services/CLIBinaryLocator.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+/// Coarse provenance for a resolved provider CLI. This is intentionally an
+/// observability signal rather than an execution gate: developer CLIs are
+/// routinely installed as unsigned or ad-hoc-signed npm/bun shims.
+nonisolated enum CLIBinaryTrust: Equatable, Sendable {
+    case wellKnown
+    case unexpected
+}
+
 /// Resolves a CLI executable by scanning `PATH` and the common install
 /// locations MeterBar runs from (Homebrew, npm-global, yarn, bun, volta, etc.).
 ///
@@ -7,6 +15,9 @@ import Foundation
 /// out so provider-readiness diagnostics can ask "is `codex` / `claude` / `grok` on
 /// PATH?" without re-deriving the same fallback list.
 nonisolated enum CLIBinaryLocator {
+    private static let systemBinaryDirectories = ["/usr/bin", "/bin", "/usr/sbin", "/sbin"]
+    private static let trustLogState = CLIBinaryTrustLogState()
+
     /// The install directories the fallbacks draw from, in priority order.
     /// Kept in sync with the reconnect script's `export PATH` list.
     static func fallbackDirectories(home: String) -> [String] {
@@ -56,12 +67,21 @@ nonisolated enum CLIBinaryLocator {
         command: String,
         overrideEnvVar: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment,
+        home: String = ServiceSupport.realHomeDirectory(),
         fileManager: FileManager = .default
     ) -> String? {
         if let overrideEnvVar,
            let override = environment[overrideEnvVar]?.trimmingCharacters(in: .whitespacesAndNewlines),
            !override.isEmpty,
            fileManager.isExecutableFile(atPath: override) {
+            // An explicit path is deliberate operator configuration. Its
+            // location carries no surprise signal, regardless of directory.
+            logUnexpectedResolutionIfNeeded(
+                command: command,
+                resolvedPath: override,
+                home: home,
+                isUserOverride: true
+            )
             return override
         }
 
@@ -69,13 +89,120 @@ nonisolated enum CLIBinaryLocator {
             .split(separator: ":")
             .map { "\($0)/\(command)" }
 
-        let fallbacks = fallbackCandidates(for: command, home: ServiceSupport.realHomeDirectory())
+        let fallbacks = fallbackCandidates(for: command, home: home)
 
-        return (pathCandidates + fallbacks).first { fileManager.isExecutableFile(atPath: $0) }
+        guard let resolvedPath = (pathCandidates + fallbacks).first(where: {
+            fileManager.isExecutableFile(atPath: $0)
+        }) else {
+            return nil
+        }
+
+        logUnexpectedResolutionIfNeeded(command: command, resolvedPath: resolvedPath, home: home)
+        return resolvedPath
+    }
+
+    /// Classifies a resolved executable by exact, normalized parent-directory
+    /// equality. Substring matching would incorrectly trust paths such as
+    /// `/tmp/opt/homebrew/bin`, while raw comparison would flag harmless `//`
+    /// and trailing-slash variants.
+    ///
+    /// `isUserOverride` represents a path supplied through the provider's
+    /// override environment variable. Such a path is deliberate user intent
+    /// and is therefore `.wellKnown` regardless of location.
+    ///
+    /// Code-signature enforcement was considered and rejected. Claude, Codex,
+    /// and Grok are frequently unsigned or ad-hoc-signed npm/bun shims, so a
+    /// signature requirement would reject most legitimate installations while
+    /// providing little assurance about the script/runtime ultimately executed.
+    static func trust(
+        forResolvedPath resolvedPath: String,
+        home: String,
+        isUserOverride: Bool = false
+    ) -> CLIBinaryTrust {
+        guard !isUserOverride else { return .wellKnown }
+
+        let parentDirectory = normalizedPath(
+            (normalizedPath(resolvedPath) as NSString).deletingLastPathComponent
+        )
+        let wellKnownDirectories = Set(
+            (fallbackDirectories(home: home) + systemBinaryDirectories).map(normalizedPath)
+        )
+        return wellKnownDirectories.contains(parentDirectory) ? .wellKnown : .unexpected
+    }
+
+    /// Clears process-lifetime notice deduplication so tests remain independent
+    /// of execution order.
+    static func resetTrustLogStateForTesting() {
+        trustLogState.reset()
+    }
+
+    static var trustLogCountForTesting: Int {
+        trustLogState.count
+    }
+
+    private static func logUnexpectedResolutionIfNeeded(
+        command: String,
+        resolvedPath: String,
+        home: String,
+        isUserOverride: Bool = false
+    ) {
+        guard trust(
+            forResolvedPath: resolvedPath,
+            home: home,
+            isUserOverride: isUserOverride
+        ) == .unexpected else {
+            return
+        }
+
+        let normalizedResolvedPath = normalizedPath(resolvedPath)
+        let key = "\(command)\u{0}\(normalizedResolvedPath)"
+        guard trustLogState.insert(key) else { return }
+
+        let redactedPath = ServiceSupport.compactPathForDisplay(
+            normalizedResolvedPath,
+            realHomeDirectory: home
+        )
+        AppLog.app.notice(
+            "Resolved \(command, privacy: .public) CLI from an unexpected path: \(redactedPath, privacy: .public)"
+        )
+    }
+
+    private static func normalizedPath(_ path: String) -> String {
+        var normalized = (path as NSString).standardizingPath
+        while normalized.count > 1, normalized.hasSuffix("/") {
+            normalized.removeLast()
+        }
+        return normalized
     }
 
     /// Whether `command` resolves to an executable.
     static func isAvailable(command: String, overrideEnvVar: String? = nil) -> Bool {
         resolve(command: command, overrideEnvVar: overrideEnvVar) != nil
+    }
+}
+
+/// Lock-protected because provider-readiness polling may resolve the same CLI
+/// concurrently. The set is bounded by the small number of unique command/path
+/// pairs seen during one app process.
+nonisolated private final class CLIBinaryTrustLogState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var keys: Set<String> = []
+
+    func insert(_ key: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return keys.insert(key).inserted
+    }
+
+    func reset() {
+        lock.lock()
+        keys.removeAll()
+        lock.unlock()
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return keys.count
     }
 }

--- a/MeterBar/Services/QuotaEventSettingsStore.swift
+++ b/MeterBar/Services/QuotaEventSettingsStore.swift
@@ -362,6 +362,55 @@ nonisolated enum QuotaWebhookURLPolicy {
         return sawAddress
     }
 
+    /// Whether a transaction metric's remote-address literal belongs to an
+    /// address range the webhook policy forbids. Foundation may include IPv6
+    /// brackets, an interface zone, or a transport port, so normalize those
+    /// presentation details before asking `inet_pton` to parse the address.
+    /// Unknown formats fail open, matching delivery's deliberate behavior when
+    /// URLSession reports no remote address at all.
+    static func isUnsafeAddressLiteral(_ value: String) -> Bool {
+        var candidate = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !candidate.isEmpty else { return false }
+
+        if candidate.hasPrefix("["), let closingBracket = candidate.firstIndex(of: "]") {
+            candidate = String(candidate[candidate.index(after: candidate.startIndex)..<closingBracket])
+        }
+
+        if let zone = candidate.firstIndex(of: "%") {
+            candidate = String(candidate[..<zone])
+        }
+
+        if let result = unsafeAddressParseResult(candidate) {
+            return result
+        }
+
+        // An unbracketed IPv4 address may carry `:port`. Try the complete
+        // literal first above so a valid IPv6 address ending in digits is never
+        // mistaken for a host-plus-port pair.
+        if let colon = candidate.lastIndex(of: ":") {
+            let port = candidate[candidate.index(after: colon)...]
+            let host = String(candidate[..<colon])
+            if !port.isEmpty, port.allSatisfy(\.isNumber), let result = unsafeAddressParseResult(host) {
+                return result
+            }
+        }
+
+        return false
+    }
+
+    private static func unsafeAddressParseResult(_ value: String) -> Bool? {
+        var ipv4 = in_addr()
+        if inet_pton(AF_INET, value, &ipv4) == 1 {
+            return isUnsafeIPv4(UInt32(bigEndian: ipv4.s_addr))
+        }
+
+        var ipv6 = in6_addr()
+        if inet_pton(AF_INET6, value, &ipv6) == 1 {
+            return isUnsafeIPv6(&ipv6)
+        }
+        return nil
+    }
+
     private static func isUnsafeHost(_ host: String) -> Bool {
         if host == "localhost"
             || host.hasSuffix(".localhost")

--- a/MeterBar/Services/QuotaWebhookClient.swift
+++ b/MeterBar/Services/QuotaWebhookClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 nonisolated enum QuotaWebhookPostResult: Equatable, Sendable {
     case succeeded

--- a/MeterBar/Services/QuotaWebhookClient.swift
+++ b/MeterBar/Services/QuotaWebhookClient.swift
@@ -5,9 +5,13 @@ nonisolated enum QuotaWebhookPostResult: Equatable, Sendable {
     case failed(String)
 }
 
-/// Blocks every redirect. A public endpoint cannot redirect the request into a
-/// loopback/private target after the configured URL passed validation.
-nonisolated private final class QuotaWebhookRedirectBlocker: NSObject, URLSessionTaskDelegate {
+/// Blocks redirects and records the address URLSession actually connected to.
+/// The record closes the DNS-rebinding gap between the policy's pre-flight DNS
+/// lookup and URLSession's independent lookup at connection time.
+nonisolated final class QuotaWebhookConnectionDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    private let lock = NSLock()
+    private var remoteAddresses: [Int: String] = [:]
+
     func urlSession(
         _ session: URLSession,
         task: URLSessionTask,
@@ -17,6 +21,37 @@ nonisolated private final class QuotaWebhookRedirectBlocker: NSObject, URLSessio
     ) {
         completionHandler(nil)
     }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didFinishCollecting metrics: URLSessionTaskMetrics
+    ) {
+        guard let remoteAddress = metrics.transactionMetrics.last?.remoteAddress else { return }
+        recordRemoteAddress(remoteAddress, forTaskIdentifier: task.taskIdentifier)
+    }
+
+    /// Removes the entry as part of the read so repeated deliveries and failed
+    /// tasks cannot grow the correlation map without bound.
+    func takeRemoteAddress(forTaskIdentifier taskIdentifier: Int) -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return remoteAddresses.removeValue(forKey: taskIdentifier)
+    }
+
+    /// Internal seam used by deterministic URLProtocol tests, whose synthetic
+    /// loads do not produce transaction metrics or a remote address.
+    func recordRemoteAddress(_ address: String, forTaskIdentifier taskIdentifier: Int) {
+        lock.lock()
+        remoteAddresses[taskIdentifier] = address
+        lock.unlock()
+    }
+
+    var observedAddressCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return remoteAddresses.count
+    }
 }
 
 /// Minimal, ephemeral, cookie-free webhook transport. It discards response
@@ -24,8 +59,9 @@ nonisolated private final class QuotaWebhookRedirectBlocker: NSObject, URLSessio
 nonisolated final class QuotaWebhookClient: @unchecked Sendable {
     private let session: URLSession
     private let timeout: TimeInterval
-    private let redirectBlocker: QuotaWebhookRedirectBlocker
+    private let connectionDelegate: QuotaWebhookConnectionDelegate
     private let hostIsPublic: @Sendable (String) async -> Bool
+    private let taskCreatedForTesting: (@Sendable (URLSessionTask) -> Void)?
 
     init(
         configuration: URLSessionConfiguration = .ephemeral,
@@ -34,7 +70,9 @@ nonisolated final class QuotaWebhookClient: @unchecked Sendable {
             await Task.detached {
                 QuotaWebhookURLPolicy.hostResolvesOnlyToPublicAddresses(host)
             }.value
-        }
+        },
+        connectionDelegate: QuotaWebhookConnectionDelegate = QuotaWebhookConnectionDelegate(),
+        taskCreatedForTesting: (@Sendable (URLSessionTask) -> Void)? = nil
     ) {
         let safeConfiguration = (configuration.copy() as? URLSessionConfiguration) ?? .ephemeral
         safeConfiguration.urlCache = nil
@@ -45,15 +83,15 @@ nonisolated final class QuotaWebhookClient: @unchecked Sendable {
         safeConfiguration.timeoutIntervalForRequest = max(0.01, timeout)
         safeConfiguration.timeoutIntervalForResource = max(0.01, timeout)
 
-        let redirectBlocker = QuotaWebhookRedirectBlocker()
-        self.redirectBlocker = redirectBlocker
+        self.connectionDelegate = connectionDelegate
         session = URLSession(
             configuration: safeConfiguration,
-            delegate: redirectBlocker,
+            delegate: connectionDelegate,
             delegateQueue: nil
         )
         self.timeout = max(0.01, timeout)
         self.hostIsPublic = hostIsPublic
+        self.taskCreatedForTesting = taskCreatedForTesting
     }
 
     func post(
@@ -87,8 +125,23 @@ nonisolated final class QuotaWebhookClient: @unchecked Sendable {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue("MeterBar/\(QuotaEventPayload.currentSchemaVersion)", forHTTPHeaderField: "User-Agent")
 
-        do {
-            let (_, response) = try await session.data(for: request)
+        let transport = await perform(request)
+        let observedAddress = connectionDelegate.takeRemoteAddress(
+            forTaskIdentifier: transport.taskIdentifier
+        )
+
+        // URLProtocol stubs and some non-network/OS-specific loads expose no
+        // `remoteAddress`. Fail open in that case: treating an absent metric as
+        // hostile would break deterministic tests and could disable legitimate
+        // webhook delivery if a future OS stops populating the field.
+        if let observedAddress,
+           QuotaWebhookURLPolicy.isUnsafeAddressLiteral(observedAddress) {
+            AppLog.app.error("Webhook connected to a non-public address; delivery rejected.")
+            return .failed("Webhook connected to a non-public address.")
+        }
+
+        switch transport.result {
+        case .success(let response):
             guard let httpResponse = response as? HTTPURLResponse else {
                 return .failed("Webhook returned an invalid response.")
             }
@@ -96,10 +149,66 @@ nonisolated final class QuotaWebhookClient: @unchecked Sendable {
                 return .failed("Webhook returned HTTP \(httpResponse.statusCode).")
             }
             return .succeeded
-        } catch let error as URLError where error.code == .timedOut {
-            return .failed("Webhook request timed out.")
-        } catch {
+        case .failure(let error):
+            if let urlError = error as? URLError, urlError.code == .timedOut {
+                return .failed("Webhook request timed out.")
+            }
             return .failed("Webhook request failed.")
         }
+    }
+
+    /// Uses an explicit task so its identifier can correlate transaction
+    /// metrics with this awaiting call. Metrics are documented to arrive before
+    /// task completion, so the caller reads once without blocking or polling.
+    ///
+    /// IP pinning was considered and rejected: replacing the URL host with an
+    /// address literal would disable URLSession's normal TLS hostname check and
+    /// require hand-rolled certificate validation against the original host, a
+    /// larger and harder-to-test security regression than this post-flight gate.
+    private func perform(_ request: URLRequest) async -> QuotaWebhookTransport {
+        await withCheckedContinuation { continuation in
+            let taskIdentity = QuotaWebhookTaskIdentity()
+            let task = session.dataTask(with: request) { _, response, error in
+                let result: Result<URLResponse, Error>
+                if let error {
+                    result = .failure(error)
+                } else if let response {
+                    result = .success(response)
+                } else {
+                    result = .failure(URLError(.unknown))
+                }
+                continuation.resume(
+                    returning: QuotaWebhookTransport(taskIdentifier: taskIdentity.value, result: result)
+                )
+            }
+            taskIdentity.store(task.taskIdentifier)
+            taskCreatedForTesting?(task)
+            task.resume()
+        }
+    }
+}
+
+nonisolated private struct QuotaWebhookTransport: @unchecked Sendable {
+    let taskIdentifier: Int
+    let result: Result<URLResponse, Error>
+}
+
+/// Bridges the identifier assigned after `dataTask(with:)` constructs the task
+/// into its concurrently executing completion callback without capturing and
+/// mutating a local variable across isolation domains.
+nonisolated private final class QuotaWebhookTaskIdentity: @unchecked Sendable {
+    private let lock = NSLock()
+    private var taskIdentifier = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return taskIdentifier
+    }
+
+    func store(_ value: Int) {
+        lock.lock()
+        taskIdentifier = value
+        lock.unlock()
     }
 }

--- a/MeterBarCLI/Sources/Serve.swift
+++ b/MeterBarCLI/Sources/Serve.swift
@@ -19,8 +19,16 @@ struct Serve: AsyncParsableCommand {
     @Option(help: "Port to listen on.")
     var port: UInt16 = Serve.defaultPort
 
-    @Option(help: "Bearer token required on every request. If omitted, one is generated and printed once.")
+    @Option(
+        help: ArgumentHelp(
+            "Bearer token required on every request. Visible via ps and shell history; "
+                + "prefer --token-file or METERBAR_SERVE_TOKEN."
+        )
+    )
     var token: String?
+
+    @Option(help: "Read the bearer token from this file, trimming trailing whitespace and newlines.")
+    var tokenFile: String?
 
     @Flag(help: "Bind to all network interfaces instead of loopback only. Exposes usage/cost data to other devices.")
     var allowRemote: Bool = false
@@ -32,21 +40,48 @@ struct Serve: AsyncParsableCommand {
         if maxRequestsPerSecond < 1 {
             throw ValidationError("--max-requests-per-second must be 1 or greater.")
         }
+        if token != nil, tokenFile != nil {
+            throw ValidationError("--token and --token-file cannot be used together.")
+        }
         // `--token ""` survives the `??` below, so reject it here rather than
         // starting a server whose auth check can never reject anything. Omit
         // the flag entirely to get a generated token.
         if let token, !ServeToken.isUsable(token) {
             throw ValidationError("--token must not be blank. Omit it to have one generated.")
         }
+
+        // Validate every external source before `run()` starts installing
+        // signal handlers or constructing a server. The resolver is repeated
+        // in `run()` because a token file can change between argument parsing
+        // and startup; either pass reports a safe ArgumentParser error.
+        do {
+            _ = try resolveToken(generate: { "validation-placeholder" })
+        } catch let error as ServeTokenResolutionError {
+            throw ValidationError(Self.message(for: error))
+        }
     }
 
     func run() async throws {
-        let generatedToken = token == nil
-        let resolvedToken = token ?? ServeToken.generate()
+        let resolvedToken: ResolvedServeToken
+        do {
+            resolvedToken = try resolveToken(generate: ServeToken.generate)
+        } catch let error as ServeTokenResolutionError {
+            throw ValidationError(Self.message(for: error))
+        }
         let bind = ServeBindConfiguration.resolve(allowRemote: allowRemote)
 
         if let warning = bind.warning {
             FileHandle.standardError.write(Data("⚠ \(warning)\n".utf8))
+        }
+        if resolvedToken.origin == .explicitArgument {
+            FileHandle.standardError.write(
+                Data(
+                    (
+                        "⚠ A token passed on the command line is visible to every local process via ps and is "
+                            + "recorded in shell history. Prefer METERBAR_SERVE_TOKEN or --token-file.\n"
+                    ).utf8
+                )
+            )
         }
 
         let cancellation = ServeCancellation()
@@ -56,7 +91,7 @@ struct Serve: AsyncParsableCommand {
         let request = ServeCLI.Request(
             host: bind.host,
             port: port,
-            token: resolvedToken,
+            token: resolvedToken.token,
             maxRequestsPerSecond: maxRequestsPerSecond
         )
 
@@ -66,10 +101,10 @@ struct Serve: AsyncParsableCommand {
             onReady: { info in
                 print("meterbar serve listening on http://\(info.host):\(info.port)")
                 print("Endpoints: GET /usage, GET /cost (Authorization: Bearer <token> required)")
-                if generatedToken {
+                if resolvedToken.origin == .generated {
                     // Printed exactly once, at startup, and never logged again —
                     // this is the only place the token is ever surfaced.
-                    print("Bearer token (generated, shown once): \(resolvedToken)")
+                    print("Bearer token (generated, shown once): \(resolvedToken.token)")
                 }
                 print("Press Ctrl-C to stop.")
             },
@@ -81,6 +116,31 @@ struct Serve: AsyncParsableCommand {
             return
         case .failedToStart(let message):
             throw ValidationError("Failed to start meterbar serve: \(message)")
+        }
+    }
+
+    private func resolveToken(generate: () -> String) throws -> ResolvedServeToken {
+        try ServeTokenSource.resolve(
+            explicitToken: token,
+            tokenFilePath: tokenFile,
+            environment: ProcessInfo.processInfo.environment,
+            readFile: { path in
+                try String(contentsOfFile: path, encoding: .utf8)
+            },
+            generate: generate
+        )
+    }
+
+    private static func message(for error: ServeTokenResolutionError) -> String {
+        switch error {
+        case .blankExplicitArgument:
+            return "--token must not be blank. Omit it to have one generated."
+        case .unreadableTokenFile(let path):
+            return "--token-file could not be read: \(path)"
+        case .blankTokenFile(let path):
+            return "--token-file must contain a non-blank token: \(path)"
+        case .blankEnvironment:
+            return "METERBAR_SERVE_TOKEN must not be blank. Unset it to have a token generated."
         }
     }
 

--- a/MeterBarTests/CLIBinaryLocatorTests.swift
+++ b/MeterBarTests/CLIBinaryLocatorTests.swift
@@ -2,6 +2,11 @@ import XCTest
 @testable import MeterBar
 
 final class CLIBinaryLocatorTests: XCTestCase {
+    override func tearDown() {
+        CLIBinaryLocator.resetTrustLogStateForTesting()
+        super.tearDown()
+    }
+
     // MARK: - augmentedPATH
 
     /// GUI apps inherit launchd's bare PATH; the spawned CLI must still be able
@@ -37,5 +42,122 @@ final class CLIBinaryLocatorTests: XCTestCase {
         XCTAssertFalse(entries.isEmpty)
         XCTAssertEqual(entries.first, "/opt/homebrew/bin")
         XCTAssertFalse(entries.contains(""), "No empty segments from a missing PATH")
+    }
+
+    // MARK: - trust classification
+
+    func testEveryFallbackDirectoryIsWellKnown() {
+        let home = "/Users/tester"
+
+        for directory in CLIBinaryLocator.fallbackDirectories(home: home) {
+            XCTAssertEqual(
+                CLIBinaryLocator.trust(forResolvedPath: "\(directory)/claude", home: home),
+                .wellKnown,
+                directory
+            )
+        }
+    }
+
+    func testStandardSystemBinDirectoriesAreWellKnown() {
+        for directory in ["/usr/bin", "/bin", "/usr/sbin", "/sbin"] {
+            XCTAssertEqual(
+                CLIBinaryLocator.trust(forResolvedPath: "\(directory)/codex", home: "/Users/tester"),
+                .wellKnown,
+                directory
+            )
+        }
+    }
+
+    func testTemporaryAndDownloadsDirectoriesAreUnexpected() {
+        XCTAssertEqual(
+            CLIBinaryLocator.trust(forResolvedPath: "/tmp/evil/claude", home: "/Users/tester"),
+            .unexpected
+        )
+        XCTAssertEqual(
+            CLIBinaryLocator.trust(
+                forResolvedPath: "/Users/tester/Downloads/codex",
+                home: "/Users/tester"
+            ),
+            .unexpected
+        )
+    }
+
+    func testDeliberateEnvironmentOverrideIsWellKnownRegardlessOfLocation() {
+        let fileManager = StubExecutableFileManager(executablePaths: ["/tmp/custom/grok"])
+
+        let resolved = CLIBinaryLocator.resolve(
+            command: "grok",
+            overrideEnvVar: "GROK_CLI_PATH",
+            environment: ["GROK_CLI_PATH": "/tmp/custom/grok"],
+            home: "/Users/tester",
+            fileManager: fileManager
+        )
+
+        XCTAssertEqual(resolved, "/tmp/custom/grok")
+        XCTAssertEqual(
+            CLIBinaryLocator.trust(
+                forResolvedPath: "/tmp/custom/grok",
+                home: "/Users/tester",
+                isUserOverride: true
+            ),
+            .wellKnown
+        )
+    }
+
+    func testTrustClassificationNormalizesRepeatedAndTrailingSlashes() {
+        XCTAssertEqual(
+            CLIBinaryLocator.trust(
+                forResolvedPath: "//opt//homebrew//bin//claude",
+                home: "/Users/tester/"
+            ),
+            .wellKnown
+        )
+        XCTAssertEqual(
+            CLIBinaryLocator.trust(
+                forResolvedPath: "/Users/tester//.local//bin//codex",
+                home: "/Users/tester///"
+            ),
+            .wellKnown
+        )
+    }
+
+    func testUnexpectedResolutionNoticeIsDeduplicatedByCommandAndPath() {
+        let fileManager = StubExecutableFileManager(executablePaths: ["/tmp/evil/claude"])
+        let arguments = (
+            command: "claude",
+            environment: ["PATH": "/tmp/evil"],
+            home: "/Users/tester",
+            fileManager: fileManager
+        )
+
+        _ = CLIBinaryLocator.resolve(
+            command: arguments.command,
+            environment: arguments.environment,
+            home: arguments.home,
+            fileManager: arguments.fileManager
+        )
+        _ = CLIBinaryLocator.resolve(
+            command: arguments.command,
+            environment: arguments.environment,
+            home: arguments.home,
+            fileManager: arguments.fileManager
+        )
+
+        XCTAssertEqual(CLIBinaryLocator.trustLogCountForTesting, 1)
+        CLIBinaryLocator.resetTrustLogStateForTesting()
+        XCTAssertEqual(CLIBinaryLocator.trustLogCountForTesting, 0)
+    }
+}
+
+private final class StubExecutableFileManager: FileManager {
+    private let executablePaths: Set<String>
+
+    init(executablePaths: Set<String>) {
+        self.executablePaths = executablePaths
+        super.init()
+    }
+
+    override func isExecutableFile(atPath path: String) -> Bool {
+        executablePaths.contains(path)
     }
 }

--- a/MeterBarTests/QuotaWebhookClientTests.swift
+++ b/MeterBarTests/QuotaWebhookClientTests.swift
@@ -61,6 +61,37 @@ final class QuotaWebhookClientTests: XCTestCase {
         }
     }
 
+    func testUnsafeAddressLiteralClassification() {
+        let unsafeAddresses = [
+            "127.0.0.1",
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.1.1",
+            "169.254.169.254",
+            "100.64.0.1",
+            "::1",
+            "fd00::1",
+            "fe80::1%en0",
+            "[::1]",
+            "127.0.0.1:443",
+            "[::1]:443",
+            "::ffff:127.0.0.1",
+        ]
+        let safeOrUnknownAddresses = [
+            "93.184.216.34",
+            "2606:2800:220:1:248:1893:25c8:1946",
+            "garbage",
+            "",
+        ]
+
+        for address in unsafeAddresses {
+            XCTAssertTrue(QuotaWebhookURLPolicy.isUnsafeAddressLiteral(address), address)
+        }
+        for address in safeOrUnknownAddresses {
+            XCTAssertFalse(QuotaWebhookURLPolicy.isUnsafeAddressLiteral(address), address)
+        }
+    }
+
     func testPostsOnlyTheVersionedMinimalJSONContractWithoutSecrets() async throws {
         let client = makeClient()
         let url = try XCTUnwrap(QuotaWebhookURLPolicy.validatedURL("https://hooks.example.com/meterbar"))
@@ -160,6 +191,36 @@ final class QuotaWebhookClientTests: XCTestCase {
         )
 
         XCTAssertEqual(result, .failed("Webhook URL is not allowed."))
+    }
+
+    func testPrivateObservedRemoteAddressOverridesSuccessfulHTTPResponseAndIsConsumed() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        let connectionDelegate = QuotaWebhookConnectionDelegate()
+        let client = QuotaWebhookClient(
+            configuration: configuration,
+            timeout: 0.1,
+            hostIsPublic: { _ in true },
+            connectionDelegate: connectionDelegate,
+            taskCreatedForTesting: { task in
+                connectionDelegate.recordRemoteAddress(
+                    "127.0.0.1",
+                    forTaskIdentifier: task.taskIdentifier
+                )
+            }
+        )
+        let url = try XCTUnwrap(QuotaWebhookURLPolicy.validatedURL("https://hooks.example.com/meterbar"))
+        StubURLProtocol.handler = { _ in
+            (
+                try XCTUnwrap(HTTPURLResponse(url: url, statusCode: 204, httpVersion: nil, headerFields: nil)),
+                Data()
+            )
+        }
+
+        let result = await client.post(payload: makePayload(), to: url)
+
+        XCTAssertEqual(result, .failed("Webhook connected to a non-public address."))
+        XCTAssertEqual(connectionDelegate.observedAddressCount, 0)
     }
 
     private func makeClient() -> QuotaWebhookClient {

--- a/MeterBarTests/ServeTokenSourceTests.swift
+++ b/MeterBarTests/ServeTokenSourceTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import XCTest
+@testable import MeterBar
+
+final class ServeTokenSourceTests: XCTestCase {
+    func testExplicitArgumentWinsOverFileEnvironmentAndGeneration() throws {
+        var didReadFile = false
+        var didGenerate = false
+
+        let resolved = try ServeTokenSource.resolve(
+            explicitToken: "argument token with spaces",
+            tokenFilePath: "/ignored/token",
+            environment: ["METERBAR_SERVE_TOKEN": "environment-token"],
+            readFile: { _ in
+                didReadFile = true
+                return "file-token"
+            },
+            generate: {
+                didGenerate = true
+                return "generated-token"
+            }
+        )
+
+        XCTAssertEqual(
+            resolved,
+            ResolvedServeToken(token: "argument token with spaces", origin: .explicitArgument)
+        )
+        XCTAssertFalse(didReadFile)
+        XCTAssertFalse(didGenerate)
+    }
+
+    func testFileWinsOverEnvironmentAndGenerationAndTrimsOnlyTrailingWhitespace() throws {
+        var didGenerate = false
+
+        let resolved = try ServeTokenSource.resolve(
+            explicitToken: nil,
+            tokenFilePath: "/token",
+            environment: ["METERBAR_SERVE_TOKEN": "environment-token"],
+            readFile: { path in
+                XCTAssertEqual(path, "/token")
+                return "  file token with internal spaces \t\n"
+            },
+            generate: {
+                didGenerate = true
+                return "generated-token"
+            }
+        )
+
+        XCTAssertEqual(
+            resolved,
+            ResolvedServeToken(token: "  file token with internal spaces", origin: .file)
+        )
+        XCTAssertFalse(didGenerate)
+    }
+
+    func testEnvironmentWinsOverGenerationAndPreservesTokenVerbatim() throws {
+        var didGenerate = false
+
+        let resolved = try ServeTokenSource.resolve(
+            explicitToken: nil,
+            tokenFilePath: nil,
+            environment: ["METERBAR_SERVE_TOKEN": "environment token with spaces"],
+            readFile: { _ in XCTFail("No file should be read."); return "" },
+            generate: {
+                didGenerate = true
+                return "generated-token"
+            }
+        )
+
+        XCTAssertEqual(
+            resolved,
+            ResolvedServeToken(token: "environment token with spaces", origin: .environment)
+        )
+        XCTAssertFalse(didGenerate)
+    }
+
+    func testGeneratesOnlyWhenNoOtherSourceIsSupplied() throws {
+        var generationCount = 0
+
+        let resolved = try ServeTokenSource.resolve(
+            explicitToken: nil,
+            tokenFilePath: nil,
+            environment: [:],
+            readFile: { _ in XCTFail("No file should be read."); return "" },
+            generate: {
+                generationCount += 1
+                return "generated-token"
+            }
+        )
+
+        XCTAssertEqual(resolved, ResolvedServeToken(token: "generated-token", origin: .generated))
+        XCTAssertEqual(generationCount, 1)
+    }
+
+    func testBlankExplicitArgumentThrowsTypedErrorWithoutConsultingLowerPrecedenceSources() {
+        assertResolutionError(.blankExplicitArgument) {
+            _ = try ServeTokenSource.resolve(
+                explicitToken: " \t\n",
+                tokenFilePath: "/ignored/token",
+                environment: ["METERBAR_SERVE_TOKEN": "environment-token"],
+                readFile: { _ in XCTFail("No file should be read."); return "" },
+                generate: { XCTFail("No token should be generated."); return "" }
+            )
+        }
+    }
+
+    func testUnreadableTokenFileThrowsTypedError() {
+        assertResolutionError(.unreadableTokenFile(path: "/missing/token")) {
+            _ = try ServeTokenSource.resolve(
+                explicitToken: nil,
+                tokenFilePath: "/missing/token",
+                environment: [:],
+                readFile: { _ in throw TestFileError.unreadable },
+                generate: { XCTFail("No token should be generated."); return "" }
+            )
+        }
+    }
+
+    func testBlankTokenFileThrowsTypedErrorAfterTrimming() {
+        assertResolutionError(.blankTokenFile(path: "/blank/token")) {
+            _ = try ServeTokenSource.resolve(
+                explicitToken: nil,
+                tokenFilePath: "/blank/token",
+                environment: [:],
+                readFile: { _ in " \t\n" },
+                generate: { XCTFail("No token should be generated."); return "" }
+            )
+        }
+    }
+
+    func testBlankEnvironmentTokenThrowsTypedErrorInsteadOfGenerating() {
+        assertResolutionError(.blankEnvironment) {
+            _ = try ServeTokenSource.resolve(
+                explicitToken: nil,
+                tokenFilePath: nil,
+                environment: ["METERBAR_SERVE_TOKEN": " \t\n"],
+                readFile: { _ in XCTFail("No file should be read."); return "" },
+                generate: { XCTFail("No token should be generated."); return "" }
+            )
+        }
+    }
+
+    private func assertResolutionError(
+        _ expected: ServeTokenResolutionError,
+        operation: () throws -> Void
+    ) {
+        XCTAssertThrowsError(try operation()) { error in
+            XCTAssertEqual(error as? ServeTokenResolutionError, expected)
+        }
+    }
+}
+
+private enum TestFileError: Error {
+    case unreadable
+}


### PR DESCRIPTION
Closes #382. Three hardening items from the audit. No existing behavior contract changed; `swift test` 2099 passing / 0 failures, `swiftlint --strict` 0 violations.

## 1. `meterbar serve` token sourcing

`--token` put the bearer token in `ps` output for the server's lifetime and in shell history.

- Adds `--token-file <path>` and `METERBAR_SERVE_TOKEN`.
- Precedence: `--token` > `--token-file` > `METERBAR_SERVE_TOKEN` > generated.
- Resolution lives in `ServeTokenSource`, a pure function with injected `environment` / `readFile` / `generate`, so all eight precedence and failure paths are unit-tested without touching the filesystem.
- **A token file is trailing-trimmed; argument and environment values are not.** Files pick up a newline from `echo`/secret managers; whitespace typed into an argument or exported into the environment is deliberate and stays byte-for-byte intact.
- `--token` and `--token-file` together is a validation error. Every blank or unreadable source raises a typed `ServeTokenResolutionError` surfaced as an ArgumentParser failure *before* `run()` installs signal handlers or builds a server.
- `--token` now prints a stderr warning. The generated-token print is gated on the token actually having been generated.

## 2. CLI binary identity

`CLIBinaryLocator` still spawns the first `claude`/`codex`/`grok` found on PATH or in the fallback directories.

**Signature enforcement was considered and rejected.** These CLIs are routinely unsigned or ad-hoc-signed npm/bun shims, so requiring a signature would reject most legitimate installations while saying nothing about the script or runtime ultimately executed.

Instead: a `trust(forResolvedPath:home:)` classifier compares the normalized parent directory against the fallback + system-bin sets by exact equality (substring matching would trust `/tmp/opt/homebrew/bin`). An unexpected location logs one `AppLog.app.notice` per command+path, home-redacted via the existing `ServiceSupport.compactPathForDisplay`. A path supplied through the provider's override env var is deliberate operator config and is always trusted.

## 3. Webhook DNS-rebinding TOCTOU

`QuotaWebhookURLPolicy` resolves the host and rejects private answers, but URLSession resolves independently at connect time — a low-TTL record can answer the check publicly and the connection privately.

**IP pinning was rejected.** Substituting an address literal into the URL disables URLSession's TLS hostname/SNI validation and forces hand-rolled certificate checking against the original host — a larger and harder-to-test regression than the hole it closes.

Instead: `QuotaWebhookConnectionDelegate` (formerly the redirect blocker) records `URLSessionTaskTransactionMetrics.remoteAddress` keyed by task identifier, and delivery fails when the address actually connected to is non-public. The entry is removed as part of the read, so repeated and failed deliveries cannot grow the map. `isUnsafeAddressLiteral` normalizes brackets, IPv6 zones, and `:port` before reusing the existing `isUnsafeIPv4`/`isUnsafeIPv6` range predicates.

**An absent remote address fails open** — URLProtocol stubs produce none, and treating a missing metric as hostile would disable legitimate delivery if a future OS stops populating the field. This converts a silent successful SSRF into a rejected delivery; it is a narrowing, not a proof.

## Tests

`ServeTokenSourceTests` (new, 8 cases) covers each precedence tier, the trim asymmetry, and each typed error. `CLIBinaryLocatorTests` adds trust classification across fallback dirs, system bins, temp/Downloads, slash normalization, override exemption, and notice dedup. `QuotaWebhookClientTests` adds the address-literal table (13 unsafe / 4 safe-or-unknown) and asserts a private observed address overrides an HTTP 204 and consumes the map entry. All four pre-existing webhook tests are unmodified.