### PR TITLE
refactor(cost): share one resumable-record gate across the cost scanners

### DIFF
--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -313,7 +313,7 @@ enum ClaudeCostScanner {
         // spent, so `live` is every transcript that exists — safe to prune
         // against on a partial refresh. Without it, deleted transcripts would
         // keep contributing their totals forever.
-        session.retainClaude(keys: live)
+        session.retain(keys: live, provider: .claude)
         return windows
     }
 
@@ -402,7 +402,7 @@ enum ClaudeCostScanner {
             session.noteDeferred(.claude)
         }
 
-        session.setClaudeRecord(
+        session.setRecord(
             CostScanFileRecord(
                 offset: read.committedOffset,
                 stamp: file.stamp,
@@ -410,7 +410,8 @@ enum ClaudeCostScanner {
                 isComplete: read.reachedEndOfFile,
                 payload: payload
             ),
-            for: file.cacheKey
+            for: file.cacheKey,
+            provider: .claude
         )
         return Self.windows(payload, cutoff: session.cutoff)
     }
@@ -422,35 +423,13 @@ enum ClaudeCostScanner {
         for file: CostScanFile,
         session: CostScanSession
     ) -> CostScanFileRecord<ClaudeFileTotals>? {
-        guard var record = session.claudeRecord(for: file.cacheKey) else { return nil }
-        guard record.offset <= UInt64(file.size) else { return nil }
-        if record.isComplete, record.stamp.size == file.size {
-            guard record.stamp.matches(file.stamp) else { return nil }
-        } else {
-            guard record.stamp.isSameFile(as: file.stamp),
-                  file.size >= record.stamp.size else { return nil }
+        CostScanResumption.resumableRecord(
+            existing: session.record(for: file.cacheKey, provider: .claude),
+            file: file,
+            cutoff: session.cutoff
+        ) { payload, cutoff in
+            payload.rebasePeriod(to: cutoff)
         }
-        guard record.cutoff != session.cutoff else { return record }
-
-        // The period window slides every day; lifetime totals never expire. So
-        // the only question is whether the cached period tally can be rebased
-        // without re-reading the file.
-        let lifetime = record.payload.lifetime
-        if (lifetime.latest ?? .distantPast) < session.cutoff {
-            // Every event predates the new window.
-            record.payload.period = ClaudeSessionTotals()
-            record.payload.periodKeys = []
-        } else if (lifetime.earliest ?? .distantFuture) >= session.cutoff {
-            // Every event falls inside it.
-            record.payload.period = lifetime
-            record.payload.periodKeys = record.payload.lifetimeKeys
-        } else {
-            // The file straddles the cutoff and only its individual events know
-            // where. Re-read it — but only files that actually straddle pay.
-            return nil
-        }
-        record.cutoff = session.cutoff
-        return record
     }
 
     nonisolated private static func windows(

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -327,7 +327,7 @@ enum CodexCostScanner {
             }
         }
 
-        session.retainCodex(keys: live)
+        session.retain(keys: live, provider: .codex)
         return windows
     }
 
@@ -429,7 +429,7 @@ enum CodexCostScanner {
         payload.lifetime = windows.lifetime
         payload.rollout = rollout
 
-        session.setCodexRecord(
+        session.setRecord(
             CostScanFileRecord(
                 offset: committed,
                 stamp: file.stamp,
@@ -437,7 +437,8 @@ enum CodexCostScanner {
                 isComplete: read.reachedEndOfFile,
                 payload: payload
             ),
-            for: file.cacheKey
+            for: file.cacheKey,
+            provider: .codex
         )
         return payload
     }
@@ -540,34 +541,13 @@ enum CodexCostScanner {
         for file: CostScanFile,
         session: CostScanSession
     ) -> CostScanFileRecord<CodexFileTotals>? {
-        guard var record = session.codexRecord(for: file.cacheKey) else { return nil }
-        guard record.offset <= UInt64(file.size) else { return nil }
-        if record.isComplete, record.stamp.size == file.size {
-            guard record.stamp.matches(file.stamp) else { return nil }
-        } else {
-            guard record.stamp.isSameFile(as: file.stamp),
-                  file.size >= record.stamp.size else { return nil }
+        CostScanResumption.resumableRecord(
+            existing: session.record(for: file.cacheKey, provider: .codex),
+            file: file,
+            cutoff: session.cutoff
+        ) { payload, cutoff in
+            payload.rebasePeriod(to: cutoff)
         }
-        guard record.cutoff != session.cutoff else { return record }
-
-        let lifetime = record.payload.lifetime
-        if lifetime.eventKeys.isEmpty || lifetime.latestDate < session.cutoff {
-            // Every event predates the new window.
-            record.payload.period = CostScanWindowContext(
-                earliestDate: Date(),
-                latestDate: session.cutoff
-            )
-        } else if lifetime.earliestDate >= session.cutoff {
-            // Every event falls inside it.
-            record.payload.period = lifetime
-        } else {
-            // The rollout straddles the cutoff and only its individual events
-            // know where. Only files that actually straddle pay for the window
-            // moving.
-            return nil
-        }
-        record.cutoff = session.cutoff
-        return record
     }
 
     /// Picks up the model/originator carried by the non-usage rollout events.

--- a/MeterBar/Services/CostScanFileCache.swift
+++ b/MeterBar/Services/CostScanFileCache.swift
@@ -26,6 +26,39 @@ nonisolated struct CostScanFileRecord<Payload: Codable & Sendable>: Codable, Sen
     var payload: Payload
 }
 
+/// Validates cached file identity and rebases its period payload when the
+/// visible cutoff moves.
+///
+/// The validation order is correctness-critical: offsets are bounded before
+/// any stamp comparison, complete files require an exact stamp, and incomplete
+/// files may resume only when the same inode has grown or stayed the same size.
+nonisolated enum CostScanResumption {
+    static func resumableRecord<Payload>(
+        existing: CostScanFileRecord<Payload>?,
+        file: CostScanFile,
+        cutoff: Date,
+        rebase: (inout Payload, Date) -> Bool
+    ) -> CostScanFileRecord<Payload>? {
+        guard var record = existing else { return nil }
+        guard record.offset <= UInt64(file.size) else { return nil }
+        if record.isComplete, record.stamp.size == file.size {
+            guard record.stamp.matches(file.stamp) else { return nil }
+        } else {
+            guard record.stamp.isSameFile(as: file.stamp),
+                  file.size >= record.stamp.size else { return nil }
+        }
+        guard record.cutoff != cutoff else { return record }
+        guard rebase(&record.payload, cutoff) else { return nil }
+        record.cutoff = cutoff
+        return record
+    }
+}
+
+/// Provider payload behavior injected into ``CostScanResumption``.
+nonisolated protocol CostScanPeriodRebasable: Codable, Sendable {
+    mutating func rebasePeriod(to cutoff: Date) -> Bool
+}
+
 /// Every transcript's record, keyed by standardized path.
 nonisolated struct CostScanFileCache<Payload: Codable & Sendable>: Codable, Sendable {
     /// Version 3 adds producer/time-zone identity and full per-file stamps.
@@ -322,3 +355,54 @@ nonisolated struct GrokFileTotals: Codable, Sendable {
         lifetime = CostScanWindowContext(earliestDate: Date(), latestDate: .distantPast)
     }
 }
+
+extension ClaudeFileTotals: CostScanPeriodRebasable {
+    mutating func rebasePeriod(to cutoff: Date) -> Bool {
+        // The period window slides every day; lifetime totals never expire. So
+        // the only question is whether the cached period tally can be rebased
+        // without re-reading the file.
+        if (lifetime.latest ?? .distantPast) < cutoff {
+            // Every event predates the new window.
+            period = ClaudeSessionTotals()
+            periodKeys = []
+        } else if (lifetime.earliest ?? .distantFuture) >= cutoff {
+            // Every event falls inside it.
+            period = lifetime
+            periodKeys = lifetimeKeys
+        } else {
+            // The file straddles the cutoff and only its individual events know
+            // where. Re-read it — but only files that actually straddle pay.
+            return false
+        }
+        return true
+    }
+}
+
+/// The identical period/lifetime shape shared by Codex and Grok payloads.
+nonisolated protocol CostScanWindowPeriodRebasable: CostScanPeriodRebasable {
+    var period: CostScanWindowContext { get set }
+    var lifetime: CostScanWindowContext { get }
+}
+
+extension CostScanWindowPeriodRebasable {
+    mutating func rebasePeriod(to cutoff: Date) -> Bool {
+        if lifetime.eventKeys.isEmpty || lifetime.latestDate < cutoff {
+            // Every event predates the new window.
+            period = CostScanWindowContext(
+                earliestDate: Date(),
+                latestDate: cutoff
+            )
+        } else if lifetime.earliestDate >= cutoff {
+            // Every event falls inside it.
+            period = lifetime
+        } else {
+            // The file straddles the cutoff. Only its individual events or
+            // records know where, so only files that straddle pay to re-read.
+            return false
+        }
+        return true
+    }
+}
+
+extension CodexFileTotals: CostScanWindowPeriodRebasable {}
+extension GrokFileTotals: CostScanWindowPeriodRebasable {}

--- a/MeterBar/Services/CostScanFileCache.swift
+++ b/MeterBar/Services/CostScanFileCache.swift
@@ -356,7 +356,7 @@ nonisolated struct GrokFileTotals: Codable, Sendable {
     }
 }
 
-extension ClaudeFileTotals: CostScanPeriodRebasable {
+nonisolated extension ClaudeFileTotals: CostScanPeriodRebasable {
     mutating func rebasePeriod(to cutoff: Date) -> Bool {
         // The period window slides every day; lifetime totals never expire. So
         // the only question is whether the cached period tally can be rebased
@@ -384,7 +384,7 @@ nonisolated protocol CostScanWindowPeriodRebasable: CostScanPeriodRebasable {
     var lifetime: CostScanWindowContext { get }
 }
 
-extension CostScanWindowPeriodRebasable {
+nonisolated extension CostScanWindowPeriodRebasable {
     mutating func rebasePeriod(to cutoff: Date) -> Bool {
         if lifetime.eventKeys.isEmpty || lifetime.latestDate < cutoff {
             // Every event predates the new window.
@@ -404,5 +404,5 @@ extension CostScanWindowPeriodRebasable {
     }
 }
 
-extension CodexFileTotals: CostScanWindowPeriodRebasable {}
-extension GrokFileTotals: CostScanWindowPeriodRebasable {}
+nonisolated extension CodexFileTotals: CostScanWindowPeriodRebasable {}
+nonisolated extension GrokFileTotals: CostScanWindowPeriodRebasable {}

--- a/MeterBar/Services/CostScanSession.swift
+++ b/MeterBar/Services/CostScanSession.swift
@@ -2,6 +2,13 @@ import Foundation
 import MeterBarShared
 import os
 
+/// Type-safe route to one provider's cache inside a scan session.
+nonisolated struct CostScanCacheKey<Payload: Codable & Sendable> {
+    fileprivate let provider: CostScanProvider
+    fileprivate let cache: ReferenceWritableKeyPath<CostScanSession, CostScanFileCache<Payload>>
+    fileprivate let save: (CostScanCacheStore, CostScanFileCache<Payload>) throws -> Void
+}
+
 /// One refresh's worth of scanning: the budget it spends, the per-file caches it
 /// resumes from, and whether it managed to reach the end of the corpus.
 ///
@@ -19,12 +26,10 @@ nonisolated final class CostScanSession: @unchecked Sendable {
 
     private let store: CostScanCacheStore?
     private let lock = NSLock()
-    private var claudeCache: CostScanFileCache<ClaudeFileTotals>
-    private var codexCache: CostScanFileCache<CodexFileTotals>
-    private var grokCache: CostScanFileCache<GrokFileTotals>
-    private var isClaudeDirty = false
-    private var isCodexDirty = false
-    private var isGrokDirty = false
+    fileprivate var claudeCache: CostScanFileCache<ClaudeFileTotals>
+    fileprivate var codexCache: CostScanFileCache<CodexFileTotals>
+    fileprivate var grokCache: CostScanFileCache<GrokFileTotals>
+    private var dirtyProviders: Set<CostScanProvider> = []
     private var deferred: Set<CostScanProvider> = []
 
     init(
@@ -42,21 +47,21 @@ nonisolated final class CostScanSession: @unchecked Sendable {
     }
 
     var claude: CostScanFileCache<ClaudeFileTotals> {
-        lock.lock()
-        defer { lock.unlock() }
-        return claudeCache
+        cache(for: .claude)
     }
 
     var codex: CostScanFileCache<CodexFileTotals> {
-        lock.lock()
-        defer { lock.unlock() }
-        return codexCache
+        cache(for: .codex)
     }
 
     var grok: CostScanFileCache<GrokFileTotals> {
+        cache(for: .grok)
+    }
+
+    func cache<Payload>(for provider: CostScanCacheKey<Payload>) -> CostScanFileCache<Payload> {
         lock.lock()
         defer { lock.unlock() }
-        return grokCache
+        return self[keyPath: provider.cache]
     }
 
     var isCancelled: Bool { budget.isCancelled }
@@ -91,43 +96,39 @@ nonisolated final class CostScanSession: @unchecked Sendable {
         lock.unlock()
     }
 
-    func claudeRecord(for key: String) -> CostScanFileRecord<ClaudeFileTotals>? {
+    func record<Payload>(
+        for key: String,
+        provider: CostScanCacheKey<Payload>
+    ) -> CostScanFileRecord<Payload>? {
         lock.lock()
         defer { lock.unlock() }
-        return claudeCache.records[key]
+        return self[keyPath: provider.cache].records[key]
     }
 
-    func setClaudeRecord(_ record: CostScanFileRecord<ClaudeFileTotals>, for key: String) {
+    func setRecord<Payload>(
+        _ record: CostScanFileRecord<Payload>,
+        for key: String,
+        provider: CostScanCacheKey<Payload>
+    ) {
         lock.lock()
-        claudeCache.records[key] = record
-        isClaudeDirty = true
+        self[keyPath: provider.cache].records[key] = record
+        dirtyProviders.insert(provider.provider)
         lock.unlock()
     }
 
-    func codexRecord(for key: String) -> CostScanFileRecord<CodexFileTotals>? {
-        lock.lock()
-        defer { lock.unlock() }
-        return codexCache.records[key]
+    // Scanners route through the generic pair above. These named seams stay for
+    // tests, which build a session's starting state directly and read better
+    // naming the provider than spelling out the payload type at every call.
+    func setClaudeRecord(_ record: CostScanFileRecord<ClaudeFileTotals>, for key: String) {
+        setRecord(record, for: key, provider: .claude)
     }
 
     func setCodexRecord(_ record: CostScanFileRecord<CodexFileTotals>, for key: String) {
-        lock.lock()
-        codexCache.records[key] = record
-        isCodexDirty = true
-        lock.unlock()
-    }
-
-    func grokRecord(for key: String) -> CostScanFileRecord<GrokFileTotals>? {
-        lock.lock()
-        defer { lock.unlock() }
-        return grokCache.records[key]
+        setRecord(record, for: key, provider: .codex)
     }
 
     func setGrokRecord(_ record: CostScanFileRecord<GrokFileTotals>, for key: String) {
-        lock.lock()
-        grokCache.records[key] = record
-        isGrokDirty = true
-        lock.unlock()
+        setRecord(record, for: key, provider: .grok)
     }
 
     /// Drops cache entries whose file no longer exists.
@@ -135,28 +136,24 @@ nonisolated final class CostScanSession: @unchecked Sendable {
     /// Without this the cache grows forever: Claude Code and Codex delete old
     /// transcripts, and a stale entry would keep contributing its totals to
     /// every future summary even though the spend it describes is long gone.
-    func retainClaude(keys: Set<String>) {
+    func retain<Payload>(keys: Set<String>, provider: CostScanCacheKey<Payload>) {
         lock.lock()
-        let previousCount = claudeCache.records.count
-        claudeCache.records = claudeCache.records.filter { keys.contains($0.key) }
-        if claudeCache.records.count != previousCount { isClaudeDirty = true }
+        let previousCount = self[keyPath: provider.cache].records.count
+        self[keyPath: provider.cache].records = self[keyPath: provider.cache].records.filter {
+            keys.contains($0.key)
+        }
+        if self[keyPath: provider.cache].records.count != previousCount {
+            dirtyProviders.insert(provider.provider)
+        }
         lock.unlock()
+    }
+
+    func retainClaude(keys: Set<String>) {
+        retain(keys: keys, provider: .claude)
     }
 
     func retainCodex(keys: Set<String>) {
-        lock.lock()
-        let previousCount = codexCache.records.count
-        codexCache.records = codexCache.records.filter { keys.contains($0.key) }
-        if codexCache.records.count != previousCount { isCodexDirty = true }
-        lock.unlock()
-    }
-
-    func retainGrok(keys: Set<String>) {
-        lock.lock()
-        let previousCount = grokCache.records.count
-        grokCache.records = grokCache.records.filter { keys.contains($0.key) }
-        if grokCache.records.count != previousCount { isGrokDirty = true }
-        lock.unlock()
+        retain(keys: keys, provider: .codex)
     }
 
     /// Writes caches with pending changes, including after a cancelled slice —
@@ -175,36 +172,23 @@ nonisolated final class CostScanSession: @unchecked Sendable {
         guard let store else { return .unavailable }
 
         return CostScanPersistReport(
-            claude: persistClaude(to: store),
-            codex: persistCodex(to: store),
-            grok: persistGrok(to: store)
+            claude: persist(provider: .claude, to: store),
+            codex: persist(provider: .codex, to: store),
+            grok: persist(provider: .grok, to: store)
         )
     }
 
-    private func persistClaude(to store: CostScanCacheStore) -> CostScanPersistOutcome {
+    private func persist<Payload>(
+        provider: CostScanCacheKey<Payload>,
+        to store: CostScanCacheStore
+    ) -> CostScanPersistOutcome {
         lock.lock()
         defer { lock.unlock() }
-        guard isClaudeDirty else { return .persisted }
-        let outcome = Self.write("Claude") { try store.saveClaude(claudeCache) }
-        if outcome == .persisted { isClaudeDirty = false }
-        return outcome
-    }
-
-    private func persistCodex(to store: CostScanCacheStore) -> CostScanPersistOutcome {
-        lock.lock()
-        defer { lock.unlock() }
-        guard isCodexDirty else { return .persisted }
-        let outcome = Self.write("Codex") { try store.saveCodex(codexCache) }
-        if outcome == .persisted { isCodexDirty = false }
-        return outcome
-    }
-
-    private func persistGrok(to store: CostScanCacheStore) -> CostScanPersistOutcome {
-        lock.lock()
-        defer { lock.unlock() }
-        guard isGrokDirty else { return .persisted }
-        let outcome = Self.write("Grok") { try store.saveGrok(grokCache) }
-        if outcome == .persisted { isGrokDirty = false }
+        guard dirtyProviders.contains(provider.provider) else { return .persisted }
+        let outcome = Self.write(provider.provider.logName) {
+            try provider.save(store, self[keyPath: provider.cache])
+        }
+        if outcome == .persisted { dirtyProviders.remove(provider.provider) }
         return outcome
     }
 
@@ -221,6 +205,36 @@ nonisolated final class CostScanSession: @unchecked Sendable {
             )
             return .failed
         }
+    }
+}
+
+extension CostScanCacheKey where Payload == ClaudeFileTotals {
+    static var claude: Self {
+        Self(
+            provider: .claude,
+            cache: \CostScanSession.claudeCache,
+            save: { store, cache in try store.saveClaude(cache) }
+        )
+    }
+}
+
+extension CostScanCacheKey where Payload == CodexFileTotals {
+    static var codex: Self {
+        Self(
+            provider: .codex,
+            cache: \CostScanSession.codexCache,
+            save: { store, cache in try store.saveCodex(cache) }
+        )
+    }
+}
+
+extension CostScanCacheKey where Payload == GrokFileTotals {
+    static var grok: Self {
+        Self(
+            provider: .grok,
+            cache: \CostScanSession.grokCache,
+            save: { store, cache in try store.saveGrok(cache) }
+        )
     }
 }
 

--- a/MeterBar/Services/CostScanSession.swift
+++ b/MeterBar/Services/CostScanSession.swift
@@ -208,7 +208,7 @@ nonisolated final class CostScanSession: @unchecked Sendable {
     }
 }
 
-extension CostScanCacheKey where Payload == ClaudeFileTotals {
+nonisolated extension CostScanCacheKey where Payload == ClaudeFileTotals {
     static var claude: Self {
         Self(
             provider: .claude,
@@ -218,7 +218,7 @@ extension CostScanCacheKey where Payload == ClaudeFileTotals {
     }
 }
 
-extension CostScanCacheKey where Payload == CodexFileTotals {
+nonisolated extension CostScanCacheKey where Payload == CodexFileTotals {
     static var codex: Self {
         Self(
             provider: .codex,
@@ -228,7 +228,7 @@ extension CostScanCacheKey where Payload == CodexFileTotals {
     }
 }
 
-extension CostScanCacheKey where Payload == GrokFileTotals {
+nonisolated extension CostScanCacheKey where Payload == GrokFileTotals {
     static var grok: Self {
         Self(
             provider: .grok,

--- a/MeterBar/Services/GrokCostScanner.swift
+++ b/MeterBar/Services/GrokCostScanner.swift
@@ -127,7 +127,7 @@ enum GrokCostScanner {
             }
         }
 
-        session.retainGrok(keys: live)
+        session.retain(keys: live, provider: .grok)
         return windows
     }
 
@@ -245,7 +245,7 @@ enum GrokCostScanner {
         payload.period = windows.period
         payload.lifetime = windows.lifetime
 
-        session.setGrokRecord(
+        session.setRecord(
             CostScanFileRecord(
                 offset: read.committedOffset,
                 stamp: file.stamp,
@@ -253,7 +253,8 @@ enum GrokCostScanner {
                 isComplete: read.reachedEndOfFile,
                 payload: payload
             ),
-            for: file.cacheKey
+            for: file.cacheKey,
+            provider: .grok
         )
         return payload
     }
@@ -265,33 +266,13 @@ enum GrokCostScanner {
         for file: CostScanFile,
         session: CostScanSession
     ) -> CostScanFileRecord<GrokFileTotals>? {
-        guard var record = session.grokRecord(for: file.cacheKey) else { return nil }
-        guard record.offset <= UInt64(file.size) else { return nil }
-        if record.isComplete, record.stamp.size == file.size {
-            guard record.stamp.matches(file.stamp) else { return nil }
-        } else {
-            guard record.stamp.isSameFile(as: file.stamp),
-                  file.size >= record.stamp.size else { return nil }
+        CostScanResumption.resumableRecord(
+            existing: session.record(for: file.cacheKey, provider: .grok),
+            file: file,
+            cutoff: session.cutoff
+        ) { payload, cutoff in
+            payload.rebasePeriod(to: cutoff)
         }
-        guard record.cutoff != session.cutoff else { return record }
-
-        let lifetime = record.payload.lifetime
-        if lifetime.eventKeys.isEmpty || lifetime.latestDate < session.cutoff {
-            // Every event predates the new window.
-            record.payload.period = CostScanWindowContext(
-                earliestDate: Date(),
-                latestDate: session.cutoff
-            )
-        } else if lifetime.earliestDate >= session.cutoff {
-            // Every event falls inside it.
-            record.payload.period = lifetime
-        } else {
-            // The file straddles the cutoff and only its individual records know
-            // where. Only files that actually straddle pay for the window moving.
-            return nil
-        }
-        record.cutoff = session.cutoff
-        return record
     }
 
     /// Project and fallback session identity, both derived from where the file

--- a/MeterBarTests/CostScanResumptionTests.swift
+++ b/MeterBarTests/CostScanResumptionTests.swift
@@ -1,0 +1,212 @@
+import Foundation
+import XCTest
+@testable import MeterBar
+
+final class CostScanResumptionTests: XCTestCase {
+    private let originalCutoff = Date(timeIntervalSince1970: 1_780_000_000)
+    private let currentCutoff = Date(timeIntervalSince1970: 1_781_000_000)
+
+    func testRejectsOffsetBeyondCurrentFileSize() {
+        let file = makeFile(size: 100)
+        let record = makeRecord(offset: 101, stamp: file.stamp)
+
+        XCTAssertNil(resumableRecord(record, for: file))
+    }
+
+    func testRejectsCompleteRecordWhenFullStampDoesNotMatch() {
+        let file = makeFile(size: 100, modified: 2_000, fileID: 42)
+        let record = makeRecord(
+            stamp: CostScanFileStamp(size: 100, modified: 1_000, fileID: 42),
+            isComplete: true
+        )
+
+        XCTAssertNil(resumableRecord(record, for: file))
+    }
+
+    func testIncompleteRecordRequiresSameFileAndNondecreasingSize() {
+        let stamp = CostScanFileStamp(size: 80, modified: 1_000, fileID: 42)
+        let record = makeRecord(offset: 70, stamp: stamp, isComplete: false)
+
+        XCTAssertNotNil(resumableRecord(record, for: makeFile(size: 100, modified: 2_000, fileID: 42)))
+        XCTAssertNil(resumableRecord(record, for: makeFile(size: 100, modified: 2_000, fileID: 99)))
+        XCTAssertNil(resumableRecord(record, for: makeFile(size: 70, modified: 2_000, fileID: 42)))
+    }
+
+    func testEqualCutoffReturnsRecordWithoutRebasing() throws {
+        let file = makeFile(size: 100)
+        var record = makeRecord(stamp: file.stamp)
+        record.cutoff = currentCutoff
+        record.payload.periodKeys = ["unchanged"]
+        var didRebase = false
+
+        let result = CostScanResumption.resumableRecord(
+            existing: record,
+            file: file,
+            cutoff: currentCutoff
+        ) { payload, cutoff in
+            didRebase = true
+            return payload.rebasePeriod(to: cutoff)
+        }
+
+        XCTAssertFalse(didRebase)
+        XCTAssertEqual(try XCTUnwrap(result).payload.periodKeys, ["unchanged"])
+    }
+
+    func testWindowPayloadRebaseClearsPeriodWhenEveryEventPredatesCutoff() throws {
+        let oldEvent = currentCutoff.addingTimeInterval(-100)
+        var payload = CodexFileTotals(cutoff: originalCutoff)
+        payload.period.eventKeys = ["stale-period"]
+        payload.lifetime.eventKeys = ["old"]
+        payload.lifetime.earliestDate = oldEvent
+        payload.lifetime.latestDate = oldEvent
+
+        let result = try XCTUnwrap(resumableRecord(makeRecord(payload: payload)))
+
+        XCTAssertTrue(result.payload.period.eventKeys.isEmpty)
+        XCTAssertEqual(result.payload.period.latestDate, currentCutoff)
+        XCTAssertEqual(result.cutoff, currentCutoff)
+    }
+
+    func testWindowPayloadRebaseCopiesLifetimeWhenEveryEventFallsInsideCutoff() throws {
+        let currentEvent = currentCutoff.addingTimeInterval(100)
+        var payload = CodexFileTotals(cutoff: originalCutoff)
+        payload.period.eventKeys = ["stale-period"]
+        payload.lifetime.eventKeys = ["current"]
+        payload.lifetime.earliestDate = currentEvent
+        payload.lifetime.latestDate = currentEvent
+
+        let result = try XCTUnwrap(resumableRecord(makeRecord(payload: payload)))
+
+        XCTAssertEqual(result.payload.period.eventKeys, ["current"])
+        XCTAssertEqual(result.payload.period.earliestDate, currentEvent)
+        XCTAssertEqual(result.payload.period.latestDate, currentEvent)
+        XCTAssertEqual(result.cutoff, currentCutoff)
+    }
+
+    func testWindowPayloadRebaseRejectsRecordWhenEventsStraddleCutoff() {
+        var payload = CodexFileTotals(cutoff: originalCutoff)
+        payload.lifetime.eventKeys = ["old", "current"]
+        payload.lifetime.earliestDate = currentCutoff.addingTimeInterval(-100)
+        payload.lifetime.latestDate = currentCutoff.addingTimeInterval(100)
+
+        XCTAssertNil(resumableRecord(makeRecord(payload: payload)))
+    }
+
+    /// Grok reaches the window rebase through the same shared conformance as
+    /// Codex rather than its own copy, so it is covered explicitly: a missing
+    /// conformance would still compile against the generic seam and silently
+    /// stop rebasing.
+    func testGrokPayloadSharesTheWindowRebaseBehavior() throws {
+        let oldEvent = currentCutoff.addingTimeInterval(-100)
+        var stalePayload = GrokFileTotals(cutoff: originalCutoff)
+        stalePayload.period.eventKeys = ["stale-period"]
+        stalePayload.lifetime.eventKeys = ["old"]
+        stalePayload.lifetime.earliestDate = oldEvent
+        stalePayload.lifetime.latestDate = oldEvent
+
+        let staleResult = try XCTUnwrap(resumableRecord(makeRecord(payload: stalePayload)))
+        XCTAssertTrue(staleResult.payload.period.eventKeys.isEmpty)
+        XCTAssertEqual(staleResult.payload.period.latestDate, currentCutoff)
+        XCTAssertEqual(staleResult.cutoff, currentCutoff)
+
+        let currentEvent = currentCutoff.addingTimeInterval(100)
+        var insidePayload = GrokFileTotals(cutoff: originalCutoff)
+        insidePayload.period.eventKeys = ["stale-period"]
+        insidePayload.lifetime.eventKeys = ["current"]
+        insidePayload.lifetime.earliestDate = currentEvent
+        insidePayload.lifetime.latestDate = currentEvent
+
+        let insideResult = try XCTUnwrap(resumableRecord(makeRecord(payload: insidePayload)))
+        XCTAssertEqual(insideResult.payload.period.eventKeys, ["current"])
+        XCTAssertEqual(insideResult.payload.period.latestDate, currentEvent)
+
+        var straddlePayload = GrokFileTotals(cutoff: originalCutoff)
+        straddlePayload.lifetime.eventKeys = ["old", "current"]
+        straddlePayload.lifetime.earliestDate = oldEvent
+        straddlePayload.lifetime.latestDate = currentEvent
+
+        XCTAssertNil(resumableRecord(makeRecord(payload: straddlePayload)))
+    }
+
+    func testClaudeRebasePreservesItsSeparatePeriodAndLifetimeKeySemantics() throws {
+        var beforePayload = ClaudeFileTotals()
+        beforePayload.period.input = 10
+        beforePayload.periodKeys = ["stale-period"]
+        beforePayload.lifetime.latest = currentCutoff.addingTimeInterval(-100)
+        beforePayload.lifetimeKeys = ["old"]
+
+        let beforeResult = try XCTUnwrap(resumableRecord(makeRecord(payload: beforePayload)))
+        XCTAssertFalse(beforeResult.payload.period.hasUsage)
+        XCTAssertTrue(beforeResult.payload.periodKeys.isEmpty)
+        XCTAssertEqual(beforeResult.payload.lifetimeKeys, ["old"])
+
+        var insidePayload = ClaudeFileTotals()
+        insidePayload.lifetime.input = 25
+        insidePayload.lifetime.earliest = currentCutoff.addingTimeInterval(100)
+        insidePayload.lifetime.latest = currentCutoff.addingTimeInterval(200)
+        insidePayload.lifetimeKeys = ["current"]
+
+        let insideResult = try XCTUnwrap(resumableRecord(makeRecord(payload: insidePayload)))
+        XCTAssertEqual(insideResult.payload.period.input, 25)
+        XCTAssertEqual(insideResult.payload.periodKeys, ["current"])
+    }
+
+    private func resumableRecord<Payload: CostScanPeriodRebasable>(
+        _ record: CostScanFileRecord<Payload>,
+        for file: CostScanFile? = nil
+    ) -> CostScanFileRecord<Payload>? {
+        let file = file ?? makeFile(
+            size: record.stamp.size,
+            modified: record.stamp.modified,
+            fileID: record.stamp.fileID
+        )
+        return CostScanResumption.resumableRecord(
+            existing: record,
+            file: file,
+            cutoff: currentCutoff
+        ) { payload, cutoff in
+            payload.rebasePeriod(to: cutoff)
+        }
+    }
+
+    private func makeFile(
+        size: Int,
+        modified: Double = 1_000,
+        fileID: UInt64? = 42
+    ) -> CostScanFile {
+        CostScanFile(
+            url: URL(fileURLWithPath: "/tmp/cost-scan-resumption.jsonl"),
+            stamp: CostScanFileStamp(size: size, modified: modified, fileID: fileID)
+        )
+    }
+
+    private func makeRecord(
+        offset: UInt64 = 50,
+        stamp: CostScanFileStamp = CostScanFileStamp(size: 100, modified: 1_000, fileID: 42),
+        isComplete: Bool = false,
+        payload: ClaudeFileTotals = ClaudeFileTotals()
+    ) -> CostScanFileRecord<ClaudeFileTotals> {
+        CostScanFileRecord(
+            offset: offset,
+            stamp: stamp,
+            cutoff: originalCutoff,
+            isComplete: isComplete,
+            payload: payload
+        )
+    }
+
+    private func makeRecord<Payload: Codable & Sendable>(
+        offset: UInt64 = 50,
+        stamp: CostScanFileStamp = CostScanFileStamp(size: 100, modified: 1_000, fileID: 42),
+        isComplete: Bool = false,
+        payload: Payload
+    ) -> CostScanFileRecord<Payload> {
+        CostScanFileRecord(
+            offset: offset,
+            stamp: stamp,
+            cutoff: originalCutoff,
+            isComplete: isComplete,
+            payload: payload
+        )
+    }
+}


### PR DESCRIPTION
Closes #383. Stacked on #403 (`fix/381`) — retarget to `master` once that lands.

## What

All three cost scanners carried their own copy of the same cache-resumption check: offset bounds, stamp matching, then a period rebase against the current cutoff. ~25 lines each, already drifting, and a fourth provider would have meant a fourth copy.

- **`CostScanResumption.resumableRecord`** now owns the invariant part and takes the payload rebase as a closure.
- **`CostScanPeriodRebasable`** expresses the rebase. Codex and Grok share one default implementation via `CostScanWindowPeriodRebasable`; Claude keeps its own because it tracks period and lifetime key sets separately.
- **`CostScanSession`** routes through a generic `CostScanCacheKey` instead of nine hand-written per-provider accessors, and the three dirty-flag bools collapse into a `Set<CostScanProvider>`.
- `CostScanProvider.logName` replaces a two-way ternary that silently labelled every non-Claude provider "Codex" in the persist-failure log line.

Named seams the tests still use stay in place — tests build a session's starting state directly and read better naming the provider than spelling out the payload type. The four with no callers left (`claudeRecord`, `codexRecord`, `grokRecord`, `retainGrok`) are removed.

No behaviour change. No parser-version bump, so no cache invalidation.

## Tests

New `MeterBarTests/CostScanResumptionTests.swift` — nine cases covering the shared gate directly: offset-beyond-size rejection, complete-record stamp mismatch, incomplete-record same-file/non-decreasing-size, equal-cutoff short circuit (asserts the rebase closure is never entered), and the three window-rebase outcomes for both Codex and Grok plus Claude's separate key semantics.

Grok gets its own test rather than riding on Codex's: it reaches the rebase through a shared conformance, so a missing `extension GrokFileTotals: CostScanWindowPeriodRebasable {}` would still compile against the generic seam and silently stop rebasing.

## Verification

| gate | result |
|---|---|
| `swift test` | 2097 tests, 6 skipped, **0 failures** |
| `swiftlint lint --strict` | **0 violations**, 267 files |
| Xcode build (CI invocation) | `** BUILD SUCCEEDED **` |

Note that CI does not run on stacked PRs — `.github/workflows/ci.yml` triggers on `master` only — so the three gates above were run locally with the exact CI commands.