### PR TITLE
refactor(wake): extract WakeTranscriptScanner from both discovery actors

### DIFF
--- a/MeterBar/SessionWake/CodexSessionDiscovery.swift
+++ b/MeterBar/SessionWake/CodexSessionDiscovery.swift
@@ -8,43 +8,18 @@ import Foundation
 /// `CodexRolloutClassifier`, which keys the block signal on the structured
 /// `rate_limits.rate_limit_reached_type` field rather than any prose.
 actor CodexSessionDiscovery {
-    struct Configuration {
-        var maxTailBytes: Int = 64 * 1024
-        var maxTranscriptAge: TimeInterval = 14 * 24 * 3600
-        var maxTranscripts: Int = 400
-        var fileManager: FileManager = .default
+    typealias Configuration = WakeTranscriptScanner.Configuration
 
-        init(
-            maxTailBytes: Int = 64 * 1024,
-            maxTranscriptAge: TimeInterval = 14 * 24 * 3600,
-            maxTranscripts: Int = 400,
-            fileManager: FileManager = .default
-        ) {
-            self.maxTailBytes = maxTailBytes
-            self.maxTranscriptAge = maxTranscriptAge
-            self.maxTranscripts = maxTranscripts
-            self.fileManager = fileManager
-        }
-    }
-
-    private let configuration: Configuration
+    private let scanner: WakeTranscriptScanner
 
     init(configuration: Configuration = Configuration()) {
-        self.configuration = configuration
+        scanner = WakeTranscriptScanner(configuration: configuration)
     }
 
     /// The `sessions` root for a CODEX_HOME, honoring an explicit override and
     /// otherwise `~/.codex`.
     static func sessionsDirectory(codexHome: String?) -> URL {
-        let trimmed = codexHome?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let base: String
-        if let trimmed, !trimmed.isEmpty {
-            base = (trimmed as NSString).standardizingPath
-        } else {
-            base = "\(ServiceSupport.realHomeDirectory())/.codex"
-        }
-        return URL(fileURLWithPath: base, isDirectory: true)
-            .appendingPathComponent("sessions", isDirectory: true)
+        WakeTranscriptScanner.root(override: codexHome, defaultHome: ".codex", subdirectory: "sessions")
     }
 
     /// Discover blocked Codex sessions under `codexHome`, consulting `ledger` to
@@ -55,12 +30,11 @@ actor CodexSessionDiscovery {
         now: Date = Date()
     ) async -> [WakeSessionCandidate] {
         let sessions = CodexSessionDiscovery.sessionsDirectory(codexHome: codexHome)
-        let rollouts = rolloutURLs(under: sessions, now: now)
-
-        var bySession: [String: WakeSessionCandidate] = [:]
+        let rollouts = scanner.transcriptURLs(under: sessions, now: now, prunesSubagents: false)
+        var candidates = WakeTranscriptScanner.CandidateSet()
 
         for url in rollouts {
-            guard let lines = readTail(of: url) else { continue }
+            guard let lines = scanner.readTail(of: url) else { continue }
             let fallbackID = url.deletingPathExtension().lastPathComponent
             let summary = CodexRolloutClassifier.classify(fallbackID: fallbackID, lines: lines)
 
@@ -72,7 +46,7 @@ actor CodexSessionDiscovery {
                 reason: reason,
                 provider: .codex
             )
-            let (canonicalCwd, cwdSkip) = resolveWorkingDirectory(summary.cwd)
+            let (canonicalCwd, cwdSkip) = scanner.resolveWorkingDirectory(summary.cwd)
             let alreadyHandled = await ledger.contains(fingerprint)
             let skip: WakeSkipReason? = alreadyHandled ? .alreadyHandled : cwdSkip
 
@@ -89,83 +63,9 @@ actor CodexSessionDiscovery {
                 provider: .codex
             )
 
-            if let existing = bySession[summary.sessionID], !supersedes(candidate, existing) {
-                continue
-            }
-            bySession[summary.sessionID] = candidate
+            candidates.insert(candidate)
         }
 
-        return bySession.values.sorted(by: supersedes)
-    }
-
-    private func supersedes(_ candidate: WakeSessionCandidate, _ existing: WakeSessionCandidate) -> Bool {
-        if candidate.blockedAt != existing.blockedAt {
-            return candidate.blockedAt > existing.blockedAt
-        }
-        return candidate.transcriptPath < existing.transcriptPath
-    }
-
-    // MARK: - Filesystem
-
-    private func rolloutURLs(under sessions: URL, now: Date) -> [URL] {
-        guard let enumerator = configuration.fileManager.enumerator(
-            at: sessions,
-            includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            return []
-        }
-        let oldestAllowed = now.addingTimeInterval(-configuration.maxTranscriptAge)
-        var found: [(url: URL, modified: Date)] = []
-        for case let url as URL in enumerator {
-            guard url.pathExtension == "jsonl",
-                  let values = try? url.resourceValues(
-                      forKeys: [.isRegularFileKey, .contentModificationDateKey]
-                  ),
-                  values.isRegularFile == true,
-                  let modified = values.contentModificationDate,
-                  modified >= oldestAllowed else {
-                continue
-            }
-            found.append((url, modified))
-        }
-        return found
-            .sorted {
-                if $0.modified != $1.modified {
-                    return $0.modified > $1.modified
-                }
-                return $0.url.path < $1.url.path
-            }
-            .prefix(configuration.maxTranscripts)
-            .map(\.url)
-    }
-
-    private func readTail(of url: URL) -> [String]? {
-        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
-        defer { try? handle.close() }
-
-        let size = (try? handle.seekToEnd()) ?? 0
-        let start = size > UInt64(configuration.maxTailBytes)
-            ? size - UInt64(configuration.maxTailBytes)
-            : 0
-        try? handle.seek(toOffset: start)
-        let data = (try? handle.readToEnd()) ?? Data()
-        // Lossy decode for the same reason SessionDiscovery uses it: a bounded
-        // tail can split a multibyte character and strict decoding would drop
-        // the whole buffer.
-        // swiftlint:disable:next optional_data_string_conversion
-        let string = String(decoding: data, as: UTF8.self)
-        return string.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
-    }
-
-    private func resolveWorkingDirectory(_ raw: String?) -> (String?, WakeSkipReason?) {
-        guard let raw, !raw.isEmpty else { return (nil, .unknownWorkingDirectory) }
-        let canonical = URL(fileURLWithPath: raw).resolvingSymlinksInPath().path
-        var isDirectory: ObjCBool = false
-        let exists = configuration.fileManager.fileExists(atPath: canonical, isDirectory: &isDirectory)
-        if !exists || !isDirectory.boolValue {
-            return (canonical, .missingWorkingDirectory)
-        }
-        return (canonical, nil)
+        return candidates.sorted
     }
 }

--- a/MeterBar/SessionWake/SessionDiscovery.swift
+++ b/MeterBar/SessionWake/SessionDiscovery.swift
@@ -8,50 +8,18 @@ import Foundation
 /// All work runs on this actor, off the main actor, with a bounded tail read
 /// per transcript so a huge history cannot stall the scan.
 actor SessionDiscovery {
-    struct Configuration {
-        /// Bytes read from the end of each transcript. The decisive tail of a
-        /// session is always near the end, so a bounded window is sufficient
-        /// and keeps scanning incremental.
-        var maxTailBytes: Int = 64 * 1024
-        /// Transcripts whose file was not modified within this window are
-        /// skipped outright — a weeks-old block is history, not a wake target.
-        var maxTranscriptAge: TimeInterval = 14 * 24 * 3600
-        /// Newest-first cap on transcripts classified per scan, so a huge
-        /// projects directory can never make discovery unbounded.
-        var maxTranscripts: Int = 400
-        var fileManager: FileManager = .default
+    typealias Configuration = WakeTranscriptScanner.Configuration
 
-        init(
-            maxTailBytes: Int = 64 * 1024,
-            maxTranscriptAge: TimeInterval = 14 * 24 * 3600,
-            maxTranscripts: Int = 400,
-            fileManager: FileManager = .default
-        ) {
-            self.maxTailBytes = maxTailBytes
-            self.maxTranscriptAge = maxTranscriptAge
-            self.maxTranscripts = maxTranscripts
-            self.fileManager = fileManager
-        }
-    }
-
-    private let configuration: Configuration
+    private let scanner: WakeTranscriptScanner
 
     init(configuration: Configuration = Configuration()) {
-        self.configuration = configuration
+        scanner = WakeTranscriptScanner(configuration: configuration)
     }
 
     /// The `projects` root for an account, honoring an explicit
     /// `CLAUDE_CONFIG_DIR` override and otherwise `~/.claude`.
     static func projectsDirectory(configDirectory: String?) -> URL {
-        let trimmed = configDirectory?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let base: String
-        if let trimmed, !trimmed.isEmpty {
-            base = trimmed
-        } else {
-            base = "\(ServiceSupport.realHomeDirectory())/.claude"
-        }
-        return URL(fileURLWithPath: base, isDirectory: true)
-            .appendingPathComponent("projects", isDirectory: true)
+        WakeTranscriptScanner.root(override: configDirectory, defaultHome: ".claude", subdirectory: "projects")
     }
 
     /// Discover blocked sessions for `configDirectory`, consulting `ledger` to
@@ -67,13 +35,11 @@ actor SessionDiscovery {
         now: Date = Date()
     ) async -> [WakeSessionCandidate] {
         let projects = SessionDiscovery.projectsDirectory(configDirectory: configDirectory)
-        let transcripts = transcriptURLs(under: projects, now: now)
-
-        // Keep the newest block per sessionID (a resumed session can re-block).
-        var bySession: [String: WakeSessionCandidate] = [:]
+        let transcripts = scanner.transcriptURLs(under: projects, now: now, prunesSubagents: true)
+        var candidates = WakeTranscriptScanner.CandidateSet()
 
         for url in transcripts {
-            guard let lines = readTail(of: url) else { continue }
+            guard let lines = scanner.readTail(of: url) else { continue }
             let fallbackID = url.deletingPathExtension().lastPathComponent
             let summary = TranscriptClassifier.classify(sessionID: fallbackID, lines: lines)
 
@@ -87,7 +53,7 @@ actor SessionDiscovery {
                 blockedAt: blockedAt,
                 reason: reason
             )
-            let (canonicalCwd, cwdSkip) = resolveWorkingDirectory(summary.cwd)
+            let (canonicalCwd, cwdSkip) = scanner.resolveWorkingDirectory(summary.cwd)
             let alreadyHandled = await ledger.contains(fingerprint)
 
             let skip: WakeSkipReason? = alreadyHandled ? .alreadyHandled : cwdSkip
@@ -104,107 +70,9 @@ actor SessionDiscovery {
                 skipReason: skip
             )
 
-            if let existing = bySession[summary.sessionID], !supersedes(candidate, existing) {
-                continue
-            }
-            bySession[summary.sessionID] = candidate
+            candidates.insert(candidate)
         }
 
-        // `supersedes` is a strict total order over (blockedAt desc, path asc);
-        // reusing it keeps the dedupe winner and the output order one rule.
-        return bySession.values.sorted(by: supersedes)
-    }
-
-    /// Deterministic dedupe: the latest block wins; equal block instants
-    /// tie-break on the lexicographically first transcript path so the winner
-    /// never depends on filesystem enumeration order.
-    private func supersedes(_ candidate: WakeSessionCandidate, _ existing: WakeSessionCandidate) -> Bool {
-        if candidate.blockedAt != existing.blockedAt {
-            return candidate.blockedAt > existing.blockedAt
-        }
-        return candidate.transcriptPath < existing.transcriptPath
-    }
-
-    // MARK: - Filesystem
-
-    /// Bounded enumeration: recent regular `.jsonl` files outside any
-    /// `subagents/` directory, newest-first, capped at `maxTranscripts`.
-    private func transcriptURLs(under projects: URL, now: Date) -> [URL] {
-        guard let enumerator = configuration.fileManager.enumerator(
-            at: projects,
-            includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            return []
-        }
-        let oldestAllowed = now.addingTimeInterval(-configuration.maxTranscriptAge)
-        var found: [(url: URL, modified: Date)] = []
-        for case let url as URL in enumerator {
-            // Subagent transcripts live under a `subagents/` directory and are
-            // never resume targets — prune the whole subtree so its children
-            // are never even stat'd.
-            if url.lastPathComponent == "subagents", url.hasDirectoryPath {
-                enumerator.skipDescendants()
-                continue
-            }
-            guard url.pathExtension == "jsonl",
-                  !url.pathComponents.contains("subagents"),
-                  let values = try? url.resourceValues(
-                      forKeys: [.isRegularFileKey, .contentModificationDateKey]
-                  ),
-                  values.isRegularFile == true,
-                  let modified = values.contentModificationDate,
-                  modified >= oldestAllowed else {
-                continue
-            }
-            found.append((url, modified))
-        }
-        // Newest-first with a lexicographic path tie-break, so the winners
-        // under the cap never depend on filesystem enumeration order.
-        return found
-            .sorted {
-                if $0.modified != $1.modified {
-                    return $0.modified > $1.modified
-                }
-                return $0.url.path < $1.url.path
-            }
-            .prefix(configuration.maxTranscripts)
-            .map(\.url)
-    }
-
-    /// Read up to `maxTailBytes` from the end of `url`, returned as lines.
-    /// Returns nil only when the file cannot be opened at all.
-    private func readTail(of url: URL) -> [String]? {
-        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
-        defer { try? handle.close() }
-
-        let size = (try? handle.seekToEnd()) ?? 0
-        let start = size > UInt64(configuration.maxTailBytes)
-            ? size - UInt64(configuration.maxTailBytes)
-            : 0
-        try? handle.seek(toOffset: start)
-        let data = (try? handle.readToEnd()) ?? Data()
-        // A bounded tail read can begin mid-multibyte-character. A failable
-        // String(data:encoding:) would reject the whole buffer and silently
-        // drop the transcript's decisive event; lossy decoding turns only the
-        // split leading bytes into U+FFFD (that partial line is skipped as
-        // malformed JSON) and keeps every complete line intact. The lint rule
-        // prefers the failable initializer — exactly the nil-dropping behavior
-        // this fix removes — so it is disabled here deliberately.
-        // swiftlint:disable:next optional_data_string_conversion
-        let string = String(decoding: data, as: UTF8.self)
-        return string.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
-    }
-
-    /// Canonicalize and validate the transcript's working directory.
-    private func resolveWorkingDirectory(_ raw: String?) -> (String?, WakeSkipReason?) {
-        guard let raw, !raw.isEmpty else { return (nil, .unknownWorkingDirectory) }
-        let canonical = URL(fileURLWithPath: raw).resolvingSymlinksInPath().path
-        var isDirectory: ObjCBool = false
-        let exists = configuration.fileManager.fileExists(atPath: canonical, isDirectory: &isDirectory)
-        if !exists || !isDirectory.boolValue {
-            return (canonical, .missingWorkingDirectory)
-        }
-        return (canonical, nil)
+        return candidates.sorted
     }
 }

--- a/MeterBar/SessionWake/WakeTranscriptScanner.swift
+++ b/MeterBar/SessionWake/WakeTranscriptScanner.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+/// Shared bounded filesystem mechanics for provider-specific wake discovery.
+///
+/// Classification stays with each provider so their transcript contracts
+/// cannot bleed together; only their identical read, validation, and ordering
+/// rules live here.
+nonisolated struct WakeTranscriptScanner {
+    struct Configuration {
+        /// Bytes read from the end of each transcript. The decisive tail of a
+        /// session is always near the end, so a bounded window is sufficient
+        /// and keeps scanning incremental.
+        var maxTailBytes: Int = 64 * 1024
+        /// Transcripts whose file was not modified within this window are
+        /// skipped outright — a weeks-old block is history, not a wake target.
+        var maxTranscriptAge: TimeInterval = 14 * 24 * 3600
+        /// Newest-first cap on transcripts classified per scan, so a huge
+        /// transcript directory can never make discovery unbounded.
+        var maxTranscripts: Int = 400
+        var fileManager: FileManager = .default
+    }
+
+    struct CandidateSet {
+        private var bySession: [String: WakeSessionCandidate] = [:]
+
+        mutating func insert(_ candidate: WakeSessionCandidate) {
+            if let existing = bySession[candidate.sessionID],
+               !WakeTranscriptScanner.supersedes(candidate, existing) {
+                return
+            }
+            bySession[candidate.sessionID] = candidate
+        }
+
+        /// `supersedes` is a strict total order over (blockedAt desc, path asc);
+        /// reusing it keeps the dedupe winner and the output order one rule.
+        var sorted: [WakeSessionCandidate] {
+            bySession.values.sorted(by: WakeTranscriptScanner.supersedes)
+        }
+    }
+
+    private let configuration: Configuration
+
+    init(configuration: Configuration = Configuration()) {
+        self.configuration = configuration
+    }
+
+    /// Resolve a provider root consistently across every account layout.
+    ///
+    /// A non-blank override is standardized so tildes expand, `..` components
+    /// collapse, and trailing slashes are removed before the subdirectory is
+    /// appended.
+    static func root(override: String?, defaultHome: String, subdirectory: String) -> URL {
+        let trimmed = override?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let base: String
+        if let trimmed, !trimmed.isEmpty {
+            base = (trimmed as NSString).standardizingPath
+        } else {
+            base = "\(ServiceSupport.realHomeDirectory())/\(defaultHome)"
+        }
+        return URL(fileURLWithPath: base, isDirectory: true)
+            .appendingPathComponent(subdirectory, isDirectory: true)
+    }
+
+    /// Bounded enumeration of recent regular `.jsonl` files, newest first.
+    func transcriptURLs(under root: URL, now: Date, prunesSubagents: Bool) -> [URL] {
+        guard let enumerator = configuration.fileManager.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+        let oldestAllowed = now.addingTimeInterval(-configuration.maxTranscriptAge)
+        var found: [(url: URL, modified: Date)] = []
+        for case let url as URL in enumerator {
+            // Subagent transcripts are never resume targets. Pruning their
+            // directory avoids stat'ing every child before classification.
+            if prunesSubagents, url.lastPathComponent == "subagents", url.hasDirectoryPath {
+                enumerator.skipDescendants()
+                continue
+            }
+            guard url.pathExtension == "jsonl",
+                  !prunesSubagents || !url.pathComponents.contains("subagents"),
+                  let values = try? url.resourceValues(
+                      forKeys: [.isRegularFileKey, .contentModificationDateKey]
+                  ),
+                  values.isRegularFile == true,
+                  let modified = values.contentModificationDate,
+                  modified >= oldestAllowed else {
+                continue
+            }
+            found.append((url, modified))
+        }
+        // A path tie-break keeps the cap independent of filesystem enumeration
+        // order when multiple transcripts share a modification instant.
+        return found
+            .sorted {
+                if $0.modified != $1.modified {
+                    return $0.modified > $1.modified
+                }
+                return $0.url.path < $1.url.path
+            }
+            .prefix(configuration.maxTranscripts)
+            .map(\.url)
+    }
+
+    /// Read up to `maxTailBytes` from the end of `url`, returned as lines.
+    /// Returns nil only when the file cannot be opened at all.
+    func readTail(of url: URL) -> [String]? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+
+        let size = (try? handle.seekToEnd()) ?? 0
+        let start = size > UInt64(configuration.maxTailBytes)
+            ? size - UInt64(configuration.maxTailBytes)
+            : 0
+        try? handle.seek(toOffset: start)
+        let data = (try? handle.readToEnd()) ?? Data()
+        // A bounded tail read can begin mid-multibyte-character. A failable
+        // String(data:encoding:) would reject the whole buffer and silently
+        // drop the transcript's decisive event; lossy decoding turns only the
+        // split leading bytes into U+FFFD (that partial line is skipped as
+        // malformed JSON) and keeps every complete line intact. The lint rule
+        // prefers the failable initializer — exactly the nil-dropping behavior
+        // this fix removes — so it is disabled here deliberately.
+        // swiftlint:disable:next optional_data_string_conversion
+        let string = String(decoding: data, as: UTF8.self)
+        return string.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+    }
+
+    /// Canonicalize and validate the transcript's working directory.
+    func resolveWorkingDirectory(_ raw: String?) -> (String?, WakeSkipReason?) {
+        guard let raw, !raw.isEmpty else { return (nil, .unknownWorkingDirectory) }
+        let canonical = URL(fileURLWithPath: raw).resolvingSymlinksInPath().path
+        var isDirectory: ObjCBool = false
+        let exists = configuration.fileManager.fileExists(atPath: canonical, isDirectory: &isDirectory)
+        if !exists || !isDirectory.boolValue {
+            return (canonical, .missingWorkingDirectory)
+        }
+        return (canonical, nil)
+    }
+
+    /// Deterministic dedupe: the latest block wins; equal block instants
+    /// tie-break on the lexicographically first transcript path so the winner
+    /// never depends on filesystem enumeration order.
+    static func supersedes(_ candidate: WakeSessionCandidate, _ existing: WakeSessionCandidate) -> Bool {
+        if candidate.blockedAt != existing.blockedAt {
+            return candidate.blockedAt > existing.blockedAt
+        }
+        return candidate.transcriptPath < existing.transcriptPath
+    }
+}

--- a/MeterBarTests/WakeTranscriptScannerTests.swift
+++ b/MeterBarTests/WakeTranscriptScannerTests.swift
@@ -1,0 +1,214 @@
+import XCTest
+@testable import MeterBar
+
+final class WakeTranscriptScannerTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WakeTranscriptScannerTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    func testRootExpandsTildePrefixedOverrideForBothProviders() {
+        let standardized = ("~/some-dir" as NSString).standardizingPath
+        let claude = WakeTranscriptScanner.root(
+            override: "~/some-dir",
+            defaultHome: ".claude",
+            subdirectory: "projects"
+        )
+        let codex = WakeTranscriptScanner.root(
+            override: "~/some-dir",
+            defaultHome: ".codex",
+            subdirectory: "sessions"
+        )
+
+        XCTAssertEqual(claude.path, "\(standardized)/projects")
+        XCTAssertEqual(codex.path, "\(standardized)/sessions")
+    }
+
+    func testRootCollapsesParentComponentsAndStripsTrailingSlash() {
+        let override = "\(tempDir.path)/parent/../target/"
+        let root = WakeTranscriptScanner.root(
+            override: override,
+            defaultHome: ".claude",
+            subdirectory: "projects"
+        )
+
+        XCTAssertEqual(root.path, "\(tempDir.path)/target/projects")
+        XCTAssertFalse(root.path.hasSuffix("/"))
+    }
+
+    func testRootFallsBackForNilEmptyAndWhitespaceOnlyOverrides() {
+        let realHome = ServiceSupport.realHomeDirectory()
+        let overrides: [String?] = [nil, "", " \n\t "]
+
+        for override in overrides {
+            XCTAssertEqual(
+                WakeTranscriptScanner.root(
+                    override: override,
+                    defaultHome: ".claude",
+                    subdirectory: "projects"
+                ).path,
+                "\(realHome)/.claude/projects"
+            )
+            XCTAssertEqual(
+                WakeTranscriptScanner.root(
+                    override: override,
+                    defaultHome: ".codex",
+                    subdirectory: "sessions"
+                ).path,
+                "\(realHome)/.codex/sessions"
+            )
+        }
+    }
+
+    func testTranscriptURLsOptionallyPrunesSubagentSubtree() throws {
+        let project = tempDir.appendingPathComponent("project")
+        let subagents = project.appendingPathComponent("subagents")
+        try FileManager.default.createDirectory(at: subagents, withIntermediateDirectories: true)
+        let main = project.appendingPathComponent("main.jsonl")
+        let child = subagents.appendingPathComponent("child.jsonl")
+        try Data("main".utf8).write(to: main)
+        try Data("child".utf8).write(to: child)
+
+        let scanner = WakeTranscriptScanner()
+        let now = Date()
+        let pruned = scanner.transcriptURLs(under: tempDir, now: now, prunesSubagents: true)
+        let unpruned = scanner.transcriptURLs(under: tempDir, now: now, prunesSubagents: false)
+
+        XCTAssertEqual(normalized(pruned), normalized([main]))
+        XCTAssertEqual(Set(normalized(unpruned)), Set(normalized([main, child])))
+    }
+
+    func testTranscriptURLsHonorsAgeCapAndDeterministicOrdering() throws {
+        let now = Date()
+        let a = try writeTranscript(named: "a", modified: now)
+        let b = try writeTranscript(named: "b", modified: now)
+        let older = try writeTranscript(named: "older", modified: now.addingTimeInterval(-50))
+        let stale = try writeTranscript(named: "stale", modified: now.addingTimeInterval(-101))
+
+        let capped = WakeTranscriptScanner(configuration: .init(maxTranscriptAge: 100, maxTranscripts: 2))
+        XCTAssertEqual(
+            normalized(capped.transcriptURLs(under: tempDir, now: now, prunesSubagents: false)),
+            normalized([a, b])
+        )
+
+        let uncapped = WakeTranscriptScanner(configuration: .init(maxTranscriptAge: 100, maxTranscripts: 10))
+        let ageBounded = normalized(
+            uncapped.transcriptURLs(under: tempDir, now: now, prunesSubagents: false)
+        )
+        XCTAssertEqual(ageBounded, normalized([a, b, older]))
+        XCTAssertFalse(ageBounded.contains(normalized(stale)))
+    }
+
+    func testReadTailRespectsByteLimitAndLossilyDecodesSplitMultibyteCharacter() throws {
+        let url = tempDir.appendingPathComponent("tail.jsonl")
+        try Data("prefix🙂\nlast\n".utf8).write(to: url)
+        let scanner = WakeTranscriptScanner(configuration: .init(maxTailBytes: 8))
+
+        let lines = try XCTUnwrap(scanner.readTail(of: url))
+
+        XCTAssertEqual(lines.last, "last")
+        XCTAssertFalse(lines.joined().contains("prefix"))
+        XCTAssertTrue(lines.first?.contains("\u{FFFD}") == true)
+    }
+
+    func testResolveWorkingDirectoryReportsMissingAndResolvesSymlinks() throws {
+        let scanner = WakeTranscriptScanner()
+
+        XCTAssertNil(scanner.resolveWorkingDirectory(nil).0)
+        XCTAssertEqual(scanner.resolveWorkingDirectory(nil).1, .unknownWorkingDirectory)
+        XCTAssertEqual(scanner.resolveWorkingDirectory("").1, .unknownWorkingDirectory)
+
+        let missing = tempDir.appendingPathComponent("missing")
+        XCTAssertEqual(scanner.resolveWorkingDirectory(missing.path).1, .missingWorkingDirectory)
+
+        let file = tempDir.appendingPathComponent("file")
+        try Data().write(to: file)
+        XCTAssertEqual(scanner.resolveWorkingDirectory(file.path).1, .missingWorkingDirectory)
+
+        let real = tempDir.appendingPathComponent("real")
+        let link = tempDir.appendingPathComponent("link")
+        try FileManager.default.createDirectory(at: real, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: real)
+        let resolved = scanner.resolveWorkingDirectory(link.path)
+
+        XCTAssertEqual(resolved.0, real.resolvingSymlinksInPath().path)
+        XCTAssertNil(resolved.1)
+    }
+
+    func testDiscoveryDirectorySeamsAgreeOnTildeHandling() {
+        let standardized = ("~/x" as NSString).standardizingPath
+        let claude = SessionDiscovery.projectsDirectory(configDirectory: "~/x")
+        let codex = CodexSessionDiscovery.sessionsDirectory(codexHome: "~/x")
+
+        XCTAssertEqual(claude.path, "\(standardized)/projects")
+        XCTAssertEqual(codex.path, "\(standardized)/sessions")
+        XCTAssertEqual(claude.deletingLastPathComponent(), codex.deletingLastPathComponent())
+    }
+
+    func testSupersedesAndCandidateSetUseLatestThenLexicographicallyFirstPath() {
+        let instant = Date(timeIntervalSince1970: 1_900_000_000)
+        let earlier = candidate(sessionID: "latest", path: "/a", blockedAt: instant)
+        let later = candidate(sessionID: "latest", path: "/z", blockedAt: instant.addingTimeInterval(1))
+        XCTAssertTrue(WakeTranscriptScanner.supersedes(later, earlier))
+        XCTAssertFalse(WakeTranscriptScanner.supersedes(earlier, later))
+
+        var latest = WakeTranscriptScanner.CandidateSet()
+        latest.insert(later)
+        latest.insert(earlier)
+        XCTAssertEqual(latest.sorted.map(\.transcriptPath), ["/z"])
+
+        let lexicalFirst = candidate(sessionID: "tie", path: "/a", blockedAt: instant)
+        let lexicalLast = candidate(sessionID: "tie", path: "/z", blockedAt: instant)
+        XCTAssertTrue(WakeTranscriptScanner.supersedes(lexicalFirst, lexicalLast))
+
+        var tied = WakeTranscriptScanner.CandidateSet()
+        tied.insert(lexicalLast)
+        tied.insert(lexicalFirst)
+        XCTAssertEqual(tied.sorted.map(\.transcriptPath), ["/a"])
+    }
+
+    /// `FileManager.enumerator` yields canonical `/private/var/...` URLs while
+    /// `temporaryDirectory` yields the `/var/...` symlink form. Both sides go
+    /// through the same resolution so these assertions stay about ordering and
+    /// pruning rather than about macOS path aliasing.
+    private func normalized(_ url: URL) -> String {
+        url.resolvingSymlinksInPath().path
+    }
+
+    private func normalized(_ urls: [URL]) -> [String] {
+        urls.map(normalized)
+    }
+
+    private func writeTranscript(named name: String, modified: Date) throws -> URL {
+        let url = tempDir.appendingPathComponent("\(name).jsonl")
+        try Data(name.utf8).write(to: url)
+        try FileManager.default.setAttributes([.modificationDate: modified], ofItemAtPath: url.path)
+        return url
+    }
+
+    private func candidate(sessionID: String, path: String, blockedAt: Date) -> WakeSessionCandidate {
+        let fingerprint = BlockFingerprint(
+            sessionID: sessionID,
+            blockedAt: blockedAt,
+            reason: .sessionLimit
+        )
+        return WakeSessionCandidate(
+            sessionID: sessionID,
+            transcriptPath: path,
+            workingDirectory: nil,
+            gitBranch: nil,
+            reason: .sessionLimit,
+            blockedAt: blockedAt,
+            resetHint: nil,
+            fingerprint: fingerprint,
+            skipReason: .unknownWorkingDirectory
+        )
+    }
+}


### PR DESCRIPTION
Closes #384

## What

`SessionDiscovery` and `CodexSessionDiscovery` had drifted into near-identical copies of the same bounded-scan mechanics. This extracts them into one `nonisolated struct WakeTranscriptScanner` and leaves each actor holding only the part that is genuinely provider-specific: **classification**.

| | before | after |
|---|---|---|
| `SessionDiscovery.swift` | 210 lines | **78** |
| `CodexSessionDiscovery.swift` | 171 lines | **71** |
| `WakeTranscriptScanner.swift` | — | 152 |

Net **-252 / +20** across the two actors, behind one shared type and 9 new tests.

Shared now: root resolution, newest-first bounded enumeration (age cap + transcript cap), tail reads, working-directory canonicalization, and the dedupe/ordering rule. Classification stays split so the two providers' transcript contracts cannot bleed together.

## ⚠️ Behavior change — read this bit

The duplication was hiding a real bug.

`CodexSessionDiscovery.sessionsDirectory` ran its override through `(trimmed as NSString).standardizingPath`. `SessionDiscovery.projectsDirectory` **did not**. So a `CLAUDE_CONFIG_DIR` containing a `~`, a `..` component, or a trailing slash resolved **relative to the process working directory instead of home** — silently scanning the wrong tree, or nothing at all.

Anyone running more than one Claude config dir (e.g. `~/.claude-work` / `~/.claude-personal`) is in the blast radius, since that is exactly when `CLAUDE_CONFIG_DIR` gets set by hand.

Both seams now standardize. Pinned by `testDiscoveryDirectorySeamsAgreeOnTildeHandling`, which asserts the two entry points agree on the same override.

Two smaller consequences of unifying:
- **Subagent pruning is now an explicit `prunesSubagents:` argument** rather than an implicit difference between two files. Claude passes `true` (Codex rollouts have no `subagents/` subtree), Codex passes `false` — preserving both prior behaviors exactly.
- Each actor keeps `typealias Configuration = WakeTranscriptScanner.Configuration`, so every existing `.init(maxTailBytes:)` call site in the test suite is untouched.

## Tests

9 new tests in `WakeTranscriptScannerTests.swift` covering tilde/`..`/trailing-slash normalization, the nil/empty/whitespace fallback, optional subagent pruning, the age cap and deterministic ordering tie-break, bounded tail reads across a split multibyte character, working-directory resolution, and the `supersedes`/`CandidateSet` total order.

`SessionWakeDiscoveryTests.swift` (809 lines) and `CodexSessionDiscoveryTests.swift` (185 lines) pass **unmodified** — deliberately, as the behavioral proof that the extraction is faithful.

## Verification

Run locally from the worktree root:

- `swiftlint lint --strict` → `Found 0 violations, 0 serious in 268 files`
- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -configuration Debug -destination 'generic/platform=macOS' build` → `** BUILD SUCCEEDED **`
- `swift test` → `Executed 2092 tests, with 6 tests skipped and 0 failures (0 unexpected)`

Branches off `master` (not stacked), so CI runs the full 5 checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved session discovery across transcript sources.
  - Added configurable limits for transcript age, file size, and result count.
  - Improved handling of working directories, symlinks, duplicate sessions, and invalid transcript content.
  - Results are now ordered consistently and irrelevant transcript files are filtered more reliably.

- **Tests**
  - Added comprehensive coverage for transcript discovery, filtering, ordering, path handling, and candidate selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->