### PR TITLE
refactor: consolidate remaining shared helpers

### DIFF
--- a/MeterBar/Models/UsageFormatting.swift
+++ b/MeterBar/Models/UsageFormatting.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MeterBarShared
 
 /// Shared, cached formatting helpers.
 ///
@@ -14,16 +15,6 @@ nonisolated public enum UsageFormat {
         formatter.numberStyle = .decimal
         formatter.usesGroupingSeparator = true
         formatter.maximumFractionDigits = 0
-        return formatter
-    }()
-
-    private static let currencyNumber: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.numberStyle = .decimal
-        formatter.usesGroupingSeparator = true
-        formatter.minimumFractionDigits = 2
-        formatter.maximumFractionDigits = 2
         return formatter
     }()
 
@@ -54,7 +45,7 @@ nonisolated public enum UsageFormat {
 
     /// Currency string, e.g. `$12.34`.
     public static func cost(_ value: Double) -> String {
-        "$\(currencyNumber.string(from: NSNumber(value: value)) ?? String(format: "%.2f", value))"
+        UsageAmountFormat.currency(value)
     }
 
     /// Abbreviated relative time, e.g. `2h ago`, using a cached formatter.

--- a/MeterBar/Services/ClaudeCodeLocalService.swift
+++ b/MeterBar/Services/ClaudeCodeLocalService.swift
@@ -396,13 +396,19 @@ class ClaudeCodeLocalService: ObservableObject {
             let (data, response) = try await session.data(for: request)
             try ServiceSupport.validate(response, data: data)
 
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            let usageResponse = try decoder.decode(ClaudeCodeUsageResponse.self, from: data)
+            let usageResponse = try decodeUsageResponse(from: data)
             return metrics(from: usageResponse)
         } catch {
             throw ServiceSupport.serviceError(from: error)
         }
+    }
+
+    /// The OAuth metrics fetch and best-effort extra-usage probe decode the
+    /// same response contract with the same date strategy.
+    nonisolated static func decodeUsageResponse(from data: Data) throws -> ClaudeCodeUsageResponse {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(ClaudeCodeUsageResponse.self, from: data)
     }
 
     /// Reads a non-expired Claude Code OAuth access token for `account`
@@ -575,14 +581,8 @@ class ClaudeCodeLocalService: ObservableObject {
 
         do {
             let (data, response) = try await urlSession.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse,
-                  (200...299).contains(httpResponse.statusCode) else {
-                return .unknown
-            }
-
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            let usageResponse = try decoder.decode(ClaudeCodeUsageResponse.self, from: data)
+            try ServiceSupport.validate(response, data: data)
+            let usageResponse = try Self.decodeUsageResponse(from: data)
             return usageResponse.extraUsageStatus
         } catch {
             return .unknown

--- a/MeterBar/SessionWake/WakeCLIResponse.swift
+++ b/MeterBar/SessionWake/WakeCLIResponse.swift
@@ -5,7 +5,7 @@ import Foundation
 /// stdout carries only this object; all diagnostics go to stderr/logs. The
 /// `schemaVersion` lets consumers detect breaking changes; new fields are
 /// additive within a version.
-struct WakeCLIResponse: Codable, Equatable, Sendable {
+struct WakeCLIResponse: Codable, Equatable, Sendable, CLIJSONDocument {
     static let currentSchemaVersion = 1
 
     struct Session: Codable, Equatable, Sendable {
@@ -34,13 +34,6 @@ struct WakeCLIResponse: Codable, Equatable, Sendable {
     var summary: Summary
     /// Human-readable, machine-stable reason for a non-success outcome.
     let message: String?
-
-    /// Encode to a single stdout-ready JSON line.
-    func jsonData() throws -> Data {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
-        return try encoder.encode(self)
-    }
 
     static func from(
         candidates: [WakeSessionCandidate],

--- a/MeterBarTests/ClaudeCodeOAuthUsageTests.swift
+++ b/MeterBarTests/ClaudeCodeOAuthUsageTests.swift
@@ -215,10 +215,8 @@ final class ClaudeCodeOAuthUsageTests: XCTestCase {
     // MARK: - Helpers
 
     private func decodeUsage(_ json: String) throws -> ClaudeCodeUsageResponse {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
         let data = try XCTUnwrap(json.data(using: .utf8))
-        return try decoder.decode(ClaudeCodeUsageResponse.self, from: data)
+        return try ClaudeCodeLocalService.decodeUsageResponse(from: data)
     }
 
     private func credentials(

--- a/MeterBarTests/ExtraUsageStatusTests.swift
+++ b/MeterBarTests/ExtraUsageStatusTests.swift
@@ -14,10 +14,12 @@ final class ExtraUsageStatusTests: XCTestCase {
         XCTAssertEqual(ExtraUsageStatus.formatAmount(5), "$5.00")
         XCTAssertEqual(ExtraUsageStatus.formatAmount(0), "$0.00")
         XCTAssertEqual(ExtraUsageStatus.formatAmount(12.5, currency: "usd"), "$12.50")
+        XCTAssertEqual(ExtraUsageStatus.formatAmount(6_954.07), "$6,954.07")
     }
 
     func testFormatAmountNonUSD() {
         XCTAssertEqual(ExtraUsageStatus.formatAmount(5, currency: "EUR"), "5.00 EUR")
+        XCTAssertEqual(ExtraUsageStatus.formatAmount(6_954.07, currency: "eur"), "6,954.07 EUR")
     }
 
     // MARK: - UsageMetrics integration

--- a/MeterBarTests/WakeCLIEngineTests.swift
+++ b/MeterBarTests/WakeCLIEngineTests.swift
@@ -229,6 +229,8 @@ final class WakeCLIEngineTests: XCTestCase {
         let data = try response.jsonData()
         let text = String(decoding: data, as: UTF8.self)
         XCTAssertTrue(text.contains("\"schemaVersion\" : 1"))
+        XCTAssertTrue(text.contains(#""account" : "/x/.claude""#))
+        XCTAssertFalse(text.contains(#"\/"#))
         let decoded = try JSONDecoder().decode(WakeCLIResponse.self, from: data)
         XCTAssertEqual(decoded, response)
         XCTAssertEqual(decoded.schemaVersion, WakeCLIResponse.currentSchemaVersion)

--- a/Packages/MeterBarShared/Sources/MeterBarShared/UsageAmountFormatting.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/UsageAmountFormatting.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Stable money formatting shared by the app, widget, CLI, and provider-detail copy.
+public enum UsageAmountFormat {
+    private static let decimal: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.numberStyle = .decimal
+        formatter.usesGroupingSeparator = true
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        return formatter
+    }()
+
+    /// Formats USD with its symbol and other currencies with their ISO code.
+    public static func currency(_ amount: Double, code: String? = "USD") -> String {
+        let normalized = (code ?? "USD").uppercased()
+        let number = decimal.string(from: NSNumber(value: amount)) ?? String(format: "%.2f", amount)
+        return normalized == "USD" ? "$\(number)" : "\(number) \(normalized)"
+    }
+}

--- a/Packages/MeterBarShared/Sources/MeterBarShared/UsageMetrics.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/UsageMetrics.swift
@@ -30,11 +30,7 @@ public struct ExtraUsageStatus: Codable, Equatable, Sendable {
 
     /// Formats an amount as USD ("$5.00"); falls back to "<amount> <currency>" for others.
     public static func formatAmount(_ amount: Double, currency: String? = "USD") -> String {
-        let normalized = (currency ?? "USD").uppercased()
-        if normalized == "USD" {
-            return String(format: "$%.2f", amount)
-        }
-        return String(format: "%.2f %@", amount, normalized)
+        UsageAmountFormat.currency(amount, code: currency)
     }
 }
 

--- a/scripts/render-readme-screenshots.sh
+++ b/scripts/render-readme-screenshots.sh
@@ -9,6 +9,12 @@ TMPDIR="$ROOT_DIR/.build/tmp" \
 CLANG_MODULE_CACHE_PATH="$ROOT_DIR/.build/module-cache" \
 SWIFT_MODULE_CACHE_PATH="$ROOT_DIR/.build/module-cache" \
 swiftc -parse-as-library "$ROOT_DIR/scripts/render-readme-screenshots.swift" \
+  "$ROOT_DIR/Packages/MeterBarShared/Sources/MeterBarShared/ServiceType.swift" \
+  "$ROOT_DIR/Packages/MeterBarShared/Sources/MeterBarShared/UsageStatus.swift" \
+  "$ROOT_DIR/Packages/MeterBarShared/Sources/MeterBarShared/QuotaBands.swift" \
+  "$ROOT_DIR/Packages/MeterBarShared/Sources/MeterBarShared/UsageLimit.swift" \
+  "$ROOT_DIR/Packages/MeterBarShared/Sources/MeterBarShared/UsageAmountFormatting.swift" \
+  "$ROOT_DIR/Packages/MeterBarShared/Sources/MeterBarShared/UsageMetrics.swift" \
   -o "$ROOT_DIR/.build/render-readme-screenshots"
 
 "$ROOT_DIR/.build/render-readme-screenshots"

--- a/scripts/render-readme-screenshots.swift
+++ b/scripts/render-readme-screenshots.swift
@@ -2,84 +2,13 @@ import AppKit
 import Foundation
 import SwiftUI
 
-struct UsageLimit: Equatable {
-    let used: Double
-    let total: Double
-    let resetTime: Date?
-
-    var percentage: Double {
-        guard total > 0 else { return 0 }
-        return min(100, max(0, (used / total) * 100))
-    }
-
-    var isNearLimit: Bool {
-        percentage >= 80
-    }
-
-    var isAtLimit: Bool {
-        percentage >= 100
-    }
-
-    var statusColor: UsageStatus {
-        if isAtLimit {
-            return .critical
-        } else if isNearLimit {
-            return .warning
-        }
-        return .good
-    }
-}
-
-enum UsageStatus {
-    case good
-    case warning
-    case critical
-
+private extension UsageStatus {
     var color: Color {
         switch self {
         case .good: return .green
         case .warning: return .orange
         case .critical: return .red
         }
-    }
-}
-
-enum ServiceType: String, CaseIterable, Identifiable {
-    case claudeCode = "Claude Code"
-    case openai = "OpenAI"
-    case cursor = "Cursor"
-
-    var id: String { rawValue }
-
-    var displayName: String { rawValue }
-
-    var iconName: String {
-        switch self {
-        case .claudeCode: return "terminal"
-        case .openai: return "brain"
-        case .cursor: return "cursorarrow.click"
-        }
-    }
-}
-
-struct UsageMetrics: Identifiable {
-    let id = UUID()
-    let service: ServiceType
-    let sessionLimit: UsageLimit?
-    let weeklyLimit: UsageLimit?
-    let codeReviewLimit: UsageLimit?
-    let lastUpdated: Date
-
-    var overallStatus: UsageStatus {
-        let limits = [sessionLimit, weeklyLimit, codeReviewLimit].compactMap { $0 }
-        guard !limits.isEmpty else { return .good }
-
-        if limits.contains(where: { $0.isAtLimit }) {
-            return .critical
-        } else if limits.contains(where: { $0.isNearLimit }) {
-            return .warning
-        }
-        return .good
     }
 }
 
@@ -577,9 +506,8 @@ enum SnapshotRenderer {
 
         let now = Date()
 
-        // This standalone renderer is intentionally self-contained (its own model
-        // copies above) so it compiles with a single `swiftc` invocation and never
-        // links the app. The FIXTURE below, however, must stay in lockstep with the
+        // This standalone renderer compiles the real MeterBarShared models but
+        // never links the app. The fixture below must stay in lockstep with the
         // in-app demo scenario in `MeterBarShared/DemoData.swift` and its cost
         // companion `MeterBar/Models/DemoData+Cost.swift`, so the landing-page
         // screenshots match exactly what `METERBAR_DEMO=1` shows in the app:
@@ -596,7 +524,7 @@ enum SnapshotRenderer {
         )
 
         let openAIMetrics = UsageMetrics(
-            service: .openai,
+            service: .codexCli,
             sessionLimit: UsageLimit(used: 61, total: 100, resetTime: now.addingTimeInterval(2 * 60 * 60)),
             weeklyLimit: UsageLimit(used: 82, total: 100, resetTime: now.addingTimeInterval(24 * 60 * 60)),
             codeReviewLimit: nil,


### PR DESCRIPTION
Closes #385

## Summary
- route Claude extra-usage validation and decoding through shared service support
- reuse the CLI JSON document encoder for wake responses
- centralize currency formatting in MeterBarShared
- compile the screenshot renderer against the real shared usage models

## Verification
- 53 focused tests passed
- SwiftLint strict passed (268 files)
- screenshot renderer compiled against shared models
- screenshot shell script syntax passed
- MeterBar app + widget Xcode build succeeded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent currency formatting with two decimal places and thousands separators.
  * USD amounts display with a dollar sign; other currencies use uppercase currency codes.
  * Missing currency information defaults to USD.

* **Bug Fixes**
  * Improved handling and validation of usage data from Claude Code.
  * Improved command-line response serialization consistency.

* **Tests**
  * Expanded coverage for large currency values and serialized response formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->