### PR TITLE
test: cover audited usage edge cases

### DIFF
--- a/MeterBarTests/ClaudeCodeCLIUsageParserTests.swift
+++ b/MeterBarTests/ClaudeCodeCLIUsageParserTests.swift
@@ -70,6 +70,57 @@ final class ClaudeCodeCLIUsageParserTests: XCTestCase {
         XCTAssertEqual(metrics.modelLimitLabel, "Fable")
     }
 
+    func testParsesResetAcrossYearRollover() throws {
+        let calendar = Calendar.current
+        let now = try XCTUnwrap(calendar.date(from: DateComponents(
+            year: 2026,
+            month: 12,
+            day: 31,
+            hour: 12
+        )))
+        let metrics = try ClaudeCodeCLIUsageParser.parseMetrics(
+            from: "Current session: 10% used · resets Jan 2 at 6pm",
+            now: now
+        )
+        let reset = try XCTUnwrap(metrics.sessionLimit?.resetTime)
+
+        XCTAssertEqual(calendar.component(.year, from: reset), 2027)
+        XCTAssertEqual(calendar.component(.month, from: reset), 1)
+        XCTAssertEqual(calendar.component(.day, from: reset), 2)
+    }
+
+    func testStripsANSICodesBeforeParsing() throws {
+        let output = "\u{001B}[31mCurrent session: 42% used · resets Jul 24 at 6pm\u{001B}[0m"
+
+        let metrics = try ClaudeCodeCLIUsageParser.parseMetrics(from: output)
+
+        XCTAssertEqual(metrics.sessionLimit?.percentage, 42)
+    }
+
+    func testClampsPercentAndIgnoresWindowWithoutPercent() throws {
+        let output = """
+        Current session: 105% used · resets Jul 24 at 6pm
+        Current week (all models): usage unavailable
+        """
+
+        let metrics = try ClaudeCodeCLIUsageParser.parseMetrics(from: output)
+
+        XCTAssertEqual(metrics.sessionLimit?.percentage, 100)
+        XCTAssertNil(metrics.weeklyLimit)
+    }
+
+    func testKeepsCompleteWindowWhenCaptureEndsMidPercent() throws {
+        let output = """
+        Current session: 42% used · resets Jul 24 at 6pm
+        Current week (all models): 9
+        """
+
+        let metrics = try ClaudeCodeCLIUsageParser.parseMetrics(from: output)
+
+        XCTAssertEqual(metrics.sessionLimit?.percentage, 42)
+        XCTAssertNil(metrics.weeklyLimit)
+    }
+
     func testThrowsWhenNoUsageWindowsArePresent() {
         XCTAssertThrowsError(try ClaudeCodeCLIUsageParser.parseMetrics(from: "No usage data"))
     }

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -340,11 +340,10 @@ final class CostTrackerTests: XCTestCase {
         try eventLine(timestamp: "2026-07-01T10:00:00.000Z", input: 10, output: 5)
             .write(to: sessionURL, atomically: true, encoding: .utf8)
 
-        let account = ClaudeCodeAccount(id: UUID(), name: "demo", configDirectory: configDir.path)
         let cutoff = FlexibleISO8601.date(from: "2026-06-01T00:00:00Z")!
         let session = CostScanSession(cutoff: cutoff, options: .unlimited)
         let windows = ClaudeCostScanner.scanRoots(
-            ClaudeCostScanner.projectRoots(accounts: [account]),
+            [configDir.appendingPathComponent("projects", isDirectory: true)],
             session: session
         )
 

--- a/MeterBarTests/OpenRouterServiceTests.swift
+++ b/MeterBarTests/OpenRouterServiceTests.swift
@@ -64,6 +64,27 @@ final class OpenRouterServiceTests: XCTestCase {
         XCTAssertEqual(metrics.sessionLimit?.windowSeconds, 86_400)
     }
 
+    func testWeeklyKeyLimitMapsToNextUTCWeekReset() throws {
+        let credits = try decodeCredits(#"{"data":{"total_credits":20,"total_usage":5}}"#)
+        let key = try decodeKey(
+            #"{"data":{"limit":10,"limit_reset":"weekly","limit_remaining":4,"usage":6,"is_free_tier":false}}"#
+        )
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+        calendar.firstWeekday = 2
+        calendar.minimumDaysInFirstWeek = 4
+
+        let metrics = OpenRouterService.map(
+            credits: credits.data,
+            key: key.data,
+            now: date(2026, 7, 15, 16),
+            calendar: calendar
+        )
+
+        XCTAssertEqual(metrics.sessionLimit?.resetTime, date(2026, 7, 20))
+        XCTAssertEqual(metrics.sessionLimit?.windowSeconds, 604_800)
+    }
+
     // MARK: - Poll observations
 
     /// OpenRouter denominates `usage` and `usage_daily` in dollars, so the

--- a/MeterBarTests/UsageLimitTests.swift
+++ b/MeterBarTests/UsageLimitTests.swift
@@ -73,6 +73,53 @@ final class UsageLimitTests: XCTestCase {
         XCTAssertEqual(deficitPace?.rightLabel(), "Projected empty in 50m")
     }
 
+    func testUsagePaceLabelsOnPaceAndExhausted() throws {
+        let now = Date(timeIntervalSince1970: 0)
+        let resetTime = now.addingTimeInterval(2.5 * 60 * 60)
+
+        let onPace = try XCTUnwrap(UsageLimit(
+            used: 51,
+            total: 100,
+            resetTime: resetTime,
+            windowSeconds: 5 * 60 * 60
+        ).pace(now: now))
+        XCTAssertEqual(onPace.stage, .onPace)
+        XCTAssertEqual(onPace.leftLabel, "On pace")
+        XCTAssertFalse(onPace.willLastToReset)
+
+        let exhausted = try XCTUnwrap(UsageLimit(
+            used: 100,
+            total: 100,
+            resetTime: resetTime,
+            windowSeconds: 5 * 60 * 60
+        ).pace(now: now))
+        XCTAssertTrue(exhausted.isExhausted)
+        XCTAssertEqual(exhausted.leftLabel, "Out of quota")
+        XCTAssertEqual(exhausted.rightLabel(context: .weekly), "Out until reset")
+    }
+
+    func testUsagePaceRejectsInvalidOrNotYetElapsedWindows() {
+        let now = Date(timeIntervalSince1970: 0)
+        let validReset = now.addingTimeInterval(60)
+
+        XCTAssertNil(UsageLimit(used: 1, total: 100, resetTime: nil, windowSeconds: 120).pace(now: now))
+        XCTAssertNil(UsageLimit(used: 1, total: 100, resetTime: validReset).pace(now: now))
+        XCTAssertNil(UsageLimit(used: 1, total: 100, resetTime: validReset, windowSeconds: 0).pace(now: now))
+        XCTAssertNil(UsageLimit(used: 1, total: 100, resetTime: now, windowSeconds: 120).pace(now: now))
+        XCTAssertNil(UsageLimit(
+            used: 1,
+            total: 100,
+            resetTime: now.addingTimeInterval(121),
+            windowSeconds: 120
+        ).pace(now: now))
+        XCTAssertNil(UsageLimit(
+            used: 1,
+            total: 100,
+            resetTime: now.addingTimeInterval(120),
+            windowSeconds: 120
+        ).pace(now: now))
+    }
+
     func testResetCountdownText() throws {
         let now = Date(timeIntervalSince1970: 0)
         let futureReset = UsageLimit(


### PR DESCRIPTION
Closes #386

## Summary
- cover UsageLimit pace states and invalid-window guards
- cover Claude CLI year rollover, ANSI, clamping, missing percent, and truncated capture behavior
- cover OpenRouter weekly UTC reset mapping
- scope the Claude project-attribution fixture to its own root instead of traversing the host transcript corpus

## Verification
- focused suite: 27 tests, 0 failures
- full suite: 2,090 tests, 6 opt-in integration skips, 0 failures
- SwiftLint strict passed