### PR TITLE
fix(popover): honor renamed default account labels

### DIFF
--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -238,7 +238,9 @@ enum ProviderSnapshotBuilder {
             let enabledAccounts = input.codexAccounts.filter(\.isEnabled)
             if !enabledAccounts.isEmpty {
                 for account in enabledAccounts {
-                    let title = account.isDefault && enabledAccounts.count == 1
+                    let title = account.isDefault
+                        && account.name == CodexAccount.defaultName
+                        && enabledAccounts.count == 1
                         ? ServiceType.codexCli.shortName
                         : account.name
                     // A signed-in custom `CODEX_HOME` profile is waiting for a
@@ -272,7 +274,9 @@ enum ProviderSnapshotBuilder {
             let accountMetrics = input.claudeAccountMetrics
             if !enabledAccounts.isEmpty {
                 for account in enabledAccounts {
-                    let title = account.isDefault && enabledAccounts.count == 1
+                    let title = account.isDefault
+                        && account.name == ClaudeCodeAccount.defaultName
+                        && enabledAccounts.count == 1
                         ? ServiceType.claudeCode.shortName
                         : account.name
                     let emptyDetail = account.isDefault && input.claudeCodeHasAccess
@@ -311,7 +315,9 @@ enum ProviderSnapshotBuilder {
         if input.enabledServices.contains(.grok) {
             let enabledAccounts = input.grokAccounts.filter(\.isEnabled)
             for account in enabledAccounts {
-                let title = account.isDefault && enabledAccounts.count == 1
+                let title = account.isDefault
+                    && account.name == GrokAccount.defaultName
+                    && enabledAccounts.count == 1
                     ? ServiceType.grok.shortName
                     : account.name
                 let fallbackMetrics = account.isDefault

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -125,6 +125,33 @@ final class ProviderSnapshotTests: XCTestCase {
         XCTAssertEqual(snapshots.map(\.title), ["Claude"])
     }
 
+    func testRenamedSoleDefaultAccountsUseConfiguredNames() {
+        let codex = CodexAccount(
+            id: CodexAccount.defaultID,
+            name: "Codex Work",
+            homeDirectory: nil
+        )
+        let claude = ClaudeCodeAccount(
+            id: ClaudeCodeAccount.defaultID,
+            name: "Claude Personal",
+            configDirectory: nil
+        )
+        let grok = GrokAccount(
+            id: GrokAccount.defaultID,
+            name: "Grok Studio",
+            homeDirectory: nil
+        )
+
+        let snapshots = ProviderSnapshotBuilder.snapshots(makeInput(
+            codexAccounts: [codex],
+            grokAccounts: [grok],
+            claudeAccounts: [claude],
+            enabledServices: [.codexCli, .claudeCode, .grok]
+        ))
+
+        XCTAssertEqual(snapshots.map(\.title), ["Codex Work", "Claude Personal", "Grok Studio"])
+    }
+
     func testMultipleClaudeAccountsUseAccountNames() {
         let work = ClaudeCodeAccount(id: UUID(), name: "Work", configDirectory: "/tmp/work")
         let accounts = [ClaudeCodeAccount.defaultAccount, work]


### PR DESCRIPTION
## Summary
- show a renamed default account's configured label in popover and dashboard cards
- preserve compact provider names for untouched Default CLI Profile accounts
- cover Claude, Codex, and Grok with one regression test

## Verification
- swift test — 2,178 passed, 6 live-integration tests skipped
- swiftlint lint --strict — 0 violations
- xcodebuild Debug app + widget build — succeeded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider snapshots now display configured custom account names for default Codex, Claude, and Grok accounts when applicable.
  * Standard provider short names continue to appear only when the account uses the provider’s default name and has no enabled sibling accounts.

* **Tests**
  * Added coverage to verify account names are preserved in provider snapshot titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->