### PR TITLE
fix(costs): keep pricing provenance when filtering a summary

### DIFF
--- a/MeterBar/Models/TokenCost.swift
+++ b/MeterBar/Models/TokenCost.swift
@@ -515,7 +515,12 @@ nonisolated public struct CostSummary: Codable, Sendable {
             periodDays: periodDays,
             dailyUsage: visibleDailyUsage,
             hourlyUsage: visibleHourlyUsage,
-            lifetime: lifetime?.filtered(to: enabledServices)
+            lifetime: lifetime?.filtered(to: enabledServices),
+            // Provenance describes which rate entries priced the scan, not a
+            // provider subset, so it is forwarded unfiltered. Dropping it here
+            // would strand every dashboard consumer — they all filter first —
+            // on `ModelPricing.tableProvenance`'s static date (issue #339).
+            pricing: pricing
         )
     }
 }

--- a/MeterBarTests/DatedModelPricingTests.swift
+++ b/MeterBarTests/DatedModelPricingTests.swift
@@ -206,4 +206,56 @@ final class DatedModelPricingTests: XCTestCase {
         XCTAssertEqual(ModelPricing.tableProvenance.eventsBeforeFirstEntry, 0)
         XCTAssertEqual(ModelPricing.tableProvenance.label, "Rates verified 2026-07-02")
     }
+
+    /// Every dashboard consumer filters the summary to the enabled services
+    /// before rendering, so dropping provenance in `filtered(to:)` would mean no
+    /// view ever sees the live scan's dates — the "Rates verified" label would
+    /// silently fall back to the shipped table and `diagnosticNote` could never
+    /// surface. Provenance describes the whole scan, not a provider subset, so
+    /// it must survive filtering unchanged.
+    func testFilteringSummaryKeepsTheScanPricingProvenance() {
+        let provenance = PricingProvenance(
+            verificationDates: ["2026-01-05", "2026-07-02"],
+            eventsBeforeFirstEntry: 4
+        )
+        let summary = CostSummary(
+            costs: [tokenCost(provider: .claudeCode), tokenCost(provider: .codexCli)],
+            totalCostUSD: 2.50,
+            totalTokens: 240,
+            periodDays: 30,
+            pricing: provenance
+        )
+
+        let filtered = summary.filtered(to: [.codexCli])
+
+        XCTAssertEqual(filtered.costs.map(\.provider), [.codexCli])
+        XCTAssertEqual(filtered.pricing, summary.pricing)
+        XCTAssertEqual(filtered.pricing?.eventsBeforeFirstEntry, 4)
+        XCTAssertNotNil(filtered.pricing?.diagnosticNote)
+    }
+
+    func testFilteringSummaryWithoutProvenanceStaysNil() {
+        let summary = CostSummary(
+            costs: [tokenCost(provider: .claudeCode)],
+            totalCostUSD: 1.25,
+            totalTokens: 120,
+            periodDays: 30
+        )
+
+        XCTAssertNil(summary.filtered(to: [.claudeCode]).pricing)
+    }
+
+    private func tokenCost(provider: ServiceType) -> TokenCost {
+        TokenCost(
+            provider: provider,
+            inputTokens: 100,
+            outputTokens: 20,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 0,
+            estimatedCostUSD: 1.25,
+            sessionCount: 1,
+            periodStart: firstEffective,
+            periodEnd: secondEffective
+        )
+    }
 }


### PR DESCRIPTION
## Problem

[`CostSummary.filtered(to:)`](MeterBar/Models/TokenCost.swift:506) rebuilt the summary but never forwarded `pricing:`, so the memberwise init defaulted it to `nil`.

The field is genuinely populated on real scans (`CostSummaryBuilder.swift:138` → `CostTracker.swift:159/242/305`), but **every** dashboard consumer filters before rendering — [UsageDashboardView.swift:417](MeterBar/Views/UsageDashboardView.swift:417), [OptimizeInsightsView.swift:43](MeterBar/Views/OptimizeInsightsView.swift:43), [CostSettingsView.swift:417](MeterBar/Views/CostSettingsView.swift:417) — so no view ever saw a live scan's provenance.

`CostOverviewStatusCard.pricingProvenance` falls back to `ModelPricing.tableProvenance` when `pricing` is nil, which made the bug silent rather than visible:

- The **"Rates verified &lt;date&gt;"** label always showed the shipped table's static date instead of the dates the scan actually priced with.
- `PricingProvenance.diagnosticNote` — the only warning that N events predate the pricing table — could **never** surface (issue #339).

## Fix

Pass `pricing: pricing` through in the reconstruction. Provenance describes the whole scan, not a provider subset, so it is forwarded **unchanged** rather than filtered.

## Tests

Written first, confirmed red against the old code (`filtered.pricing` was nil), green after:

- `testFilteringSummaryKeepsTheScanPricingProvenance` — `summary.filtered(to: subset).pricing == summary.pricing`, including `eventsBeforeFirstEntry` and a non-nil `diagnosticNote`.
- `testFilteringSummaryWithoutProvenanceStaysNil` — no false positive when a legacy cache carries no provenance.

No prior test guarded this; `HourlyTokenUsageTests.swift:143-152` and `LifetimeCostSummaryTests.swift:64` only cover row filtering.

Full local suite: **2180 tests, 6 skipped, 0 failures**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Filtered cost summaries now retain pricing information when available.
  * Summaries without pricing information continue to display correctly without it.

* **Tests**
  * Added coverage for preserving pricing details during filtering.
  * Added validation for summaries with and without pricing provenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->