### PR TITLE
fix(settings): reconcile account selections for every provider

### DIFF
--- a/MeterBar/Views/Settings/ProviderSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsView.swift
@@ -479,9 +479,12 @@ struct ProviderSettingsView: View {
                                 + "Files and Claude login data are not deleted.",
                             onEnabledChange: { isEnabled in
                                 claudeAccountStore.setEnabled(isEnabled, for: account.id)
-                                SessionWakeSettingsStore.shared.reconcileAccounts(
+                                // Session Wake keeps Claude on its own reconcile
+                                // path; the shared pass only owns the Codex one.
+                                sessionWakeSettings.reconcileAccounts(
                                     available: claudeAccountStore.enabledAccounts.map(\.id)
                                 )
+                                reconcileProviderAccountSelections()
                                 Task { await dataManager.refreshAll() }
                             },
                             onSave: { name, configDirectory in
@@ -493,9 +496,7 @@ struct ProviderSettingsView: View {
                             },
                             onRemove: {
                                 claudeAccountStore.removeAccount(id: account.id)
-                                MenuBarAccountSelectionStore.shared.forget(
-                                    MenuBarAccountKey.make(service: .claudeCode, accountID: account.id)
-                                )
+                                reconcileProviderAccountSelections()
                                 Task { await dataManager.refreshAll() }
                             },
                             onRefresh: { refreshClaudeAccount(account) },
@@ -597,7 +598,7 @@ struct ProviderSettingsView: View {
                                 guard codexAccountStore.setEnabled(isEnabled, for: account.id) == .updated else {
                                     return
                                 }
-                                reconcileCodexAccountSelections()
+                                reconcileProviderAccountSelections()
                                 Task { await dataManager.refreshAll() }
                             },
                             onSave: { name, homeDirectory in
@@ -610,7 +611,7 @@ struct ProviderSettingsView: View {
                             },
                             onRemove: {
                                 guard codexAccountStore.removeAccount(id: account.id) == .updated else { return }
-                                reconcileCodexAccountSelections()
+                                reconcileProviderAccountSelections()
                                 Task { await dataManager.refreshAll() }
                             },
                             onMoveUp: { moveCodexAccount(at: index, down: false) },
@@ -839,6 +840,7 @@ struct ProviderSettingsView: View {
                                 + "Files and Grok login data are not deleted.",
                             onEnabledChange: { isEnabled in
                                 grokAccountStore.setEnabled(isEnabled, for: account.id)
+                                reconcileProviderAccountSelections()
                                 Task { await dataManager.refreshAll() }
                             },
                             onSave: { name, homeDirectory in
@@ -851,9 +853,7 @@ struct ProviderSettingsView: View {
                             },
                             onRemove: {
                                 grokAccountStore.removeAccount(id: account.id)
-                                MenuBarAccountSelectionStore.shared.forget(
-                                    MenuBarAccountKey.make(service: .grok, accountID: account.id)
-                                )
+                                reconcileProviderAccountSelections()
                                 Task { await dataManager.refreshAll() }
                             },
                             onMoveUp: { moveGrokAccount(at: index, down: false) },
@@ -882,9 +882,10 @@ struct ProviderSettingsView: View {
             get: { providerVisibility.isEnabled(service) },
             set: { isEnabled in
                 providerVisibility.set(service, isEnabled: isEnabled)
-                if service == .codexCli {
-                    reconcileCodexAccountSelections()
-                }
+                // Untracking any account-aware provider strands its selections
+                // exactly the way disabling one of its accounts does, so this
+                // runs for every provider rather than Codex alone.
+                reconcileProviderAccountSelections()
                 Task {
                     await dataManager.refreshAll()
                 }
@@ -974,9 +975,15 @@ struct ProviderSettingsView: View {
     }
 
     /// Keep every account-scoped consumer on the same enabled identity set after
-    /// a Codex disable or delete. Session Wake clears and disarms rather than
-    /// silently retargeting; menu-bar and widget preferences prune stale keys.
-    private func reconcileCodexAccountSelections() {
+    /// any provider disable, delete, or untrack. Session Wake clears and disarms
+    /// rather than silently retargeting; menu-bar and widget preferences prune
+    /// stale keys.
+    ///
+    /// The projection covers all three account-aware providers in one pass, so
+    /// every call site gets the same result regardless of which provider was
+    /// mutated — Claude and Grok call sites used to skip it, which left a
+    /// disabled account holding one of the four status-item slots.
+    private func reconcileProviderAccountSelections() {
         ProviderAccountSelectionReconciler.apply(
             ProviderAccountSelectionAvailability(
                 claudeAccounts: claudeAccountStore.accounts,

--- a/MeterBarTests/ProviderAccountSelectionReconcilerTests.swift
+++ b/MeterBarTests/ProviderAccountSelectionReconcilerTests.swift
@@ -113,12 +113,111 @@ final class ProviderAccountSelectionReconcilerTests: XCTestCase {
         XCTAssertEqual(sessionWake.wakeCodexAccountID, codexCustomID)
     }
 
+    // MARK: - Claude and Grok parity (issue #410)
+
+    /// The Codex handlers reconciled on every enable/disable/delete; Claude's and
+    /// Grok's did not, so a disabled Claude profile kept its status-item slot:
+    /// `MenuBarAccountItemPlanner` drops the vanished key while `select()` still
+    /// counts it against `itemLimit`, and the slot cannot be reused until the
+    /// user reselects by hand or relaunches.
+    func testApplyPrunesDisabledClaudeSelectionAndFreesItsStatusItemSlot() throws {
+        let menuBarSelection = MenuBarAccountSelectionStore(userDefaults: try XCTUnwrap(defaults))
+        try fillEverySlot(of: menuBarSelection, lastKey: claudeCustomKey)
+
+        apply(makeAvailability(claudeCustomEnabled: false), menuBarSelection: menuBarSelection)
+
+        XCTAssertFalse(menuBarSelection.selectedAccountKeys.contains(claudeCustomKey))
+        XCTAssertEqual(menuBarSelection.select(grokDefaultKey), .updated)
+    }
+
+    func testApplyPrunesDisabledGrokSelectionAndFreesItsStatusItemSlot() throws {
+        let menuBarSelection = MenuBarAccountSelectionStore(userDefaults: try XCTUnwrap(defaults))
+        try fillEverySlot(of: menuBarSelection, lastKey: grokCustomKey)
+
+        apply(makeAvailability(grokCustomEnabled: false), menuBarSelection: menuBarSelection)
+
+        XCTAssertFalse(menuBarSelection.selectedAccountKeys.contains(grokCustomKey))
+        XCTAssertEqual(menuBarSelection.select(grokDefaultKey), .updated)
+    }
+
+    /// Deleting an account removes it from the store, so the same pass that
+    /// handles a disable also has to clear the switcher binding — otherwise the
+    /// merged status item stays pointed at an account that no longer exists.
+    func testApplyPrunesDeletedClaudeAccountFromSelectionAndMergedKey() throws {
+        let menuBarSelection = MenuBarAccountSelectionStore(userDefaults: try XCTUnwrap(defaults))
+        menuBarSelection.select(claudeCustomKey)
+        menuBarSelection.select(grokDefaultKey)
+        menuBarSelection.setMergedAccountKey(claudeCustomKey)
+
+        apply(makeAvailability(claudeAccountsIncludeCustom: false), menuBarSelection: menuBarSelection)
+
+        XCTAssertEqual(menuBarSelection.selectedAccountKeys, [grokDefaultKey])
+        XCTAssertNil(menuBarSelection.mergedAccountKey)
+    }
+
+    func testApplyPrunesDeletedGrokAccountFromSelectionAndMergedKey() throws {
+        let menuBarSelection = MenuBarAccountSelectionStore(userDefaults: try XCTUnwrap(defaults))
+        menuBarSelection.select(grokCustomKey)
+        menuBarSelection.select(claudeDefaultKey)
+        menuBarSelection.setMergedAccountKey(grokCustomKey)
+
+        apply(makeAvailability(grokAccountsIncludeCustom: false), menuBarSelection: menuBarSelection)
+
+        XCTAssertEqual(menuBarSelection.selectedAccountKeys, [claudeDefaultKey])
+        XCTAssertNil(menuBarSelection.mergedAccountKey)
+    }
+
+    /// Untracking a whole provider leaks exactly like disabling one of its
+    /// accounts: `providerEnabledBinding` used to reconcile for Codex only.
+    func testApplyPrunesEveryProfileOfAnUntrackedProvider() throws {
+        let menuBarSelection = MenuBarAccountSelectionStore(userDefaults: try XCTUnwrap(defaults))
+        menuBarSelection.select(claudeDefaultKey)
+        menuBarSelection.select(claudeCustomKey)
+        menuBarSelection.select(grokDefaultKey)
+
+        apply(
+            makeAvailability(enabledServices: [.codexCli, .grok]),
+            menuBarSelection: menuBarSelection
+        )
+
+        XCTAssertEqual(menuBarSelection.selectedAccountKeys, [grokDefaultKey])
+    }
+
+    func testApplyPrunesExplicitWidgetSelectionForDisabledClaudeProfile() throws {
+        let widgetPreferences = WidgetPreferencesStore(
+            userDefaults: try XCTUnwrap(defaults),
+            reloadTimelines: {}
+        )
+        widgetPreferences.setSelectedAccounts([claudeCustomWidgetID, grokDefaultWidgetID])
+
+        apply(makeAvailability(claudeCustomEnabled: false), widgetPreferences: widgetPreferences)
+
+        XCTAssertEqual(
+            widgetPreferences.preferences.accountSelection.explicitIdentifiers,
+            [grokDefaultWidgetID]
+        )
+    }
+
+    /// Session Wake keeps Claude and Codex on separate reconcile paths
+    /// (`reconcileAccounts` vs `reconcileCodexAccounts`); the shared reconciler
+    /// owns only the Codex one, so a Claude wake target must survive it.
+    func testApplyLeavesClaudeSessionWakeTargetToItsOwnReconcilePath() throws {
+        let sessionWake = SessionWakeSettingsStore(userDefaults: try XCTUnwrap(defaults))
+        sessionWake.setWakeAccountID(claudeCustomID)
+
+        apply(makeAvailability(claudeCustomEnabled: false), sessionWakeSettings: sessionWake)
+
+        XCTAssertEqual(sessionWake.wakeAccountID, claudeCustomID)
+    }
+
     // MARK: Private
 
     private var suiteName: String!
     private var defaults: UserDefaults!
 
     private let codexCustomID = UUID()
+    private let claudeCustomID = UUID()
+    private let grokCustomID = UUID()
 
     private var codexDefaultKey: String {
         MenuBarAccountKey.make(service: .codexCli, accountID: CodexAccount.defaultID)
@@ -136,6 +235,14 @@ final class ProviderAccountSelectionReconcilerTests: XCTestCase {
         MenuBarAccountKey.make(service: .claudeCode, accountID: ClaudeCodeAccount.defaultID)
     }
 
+    private var claudeCustomKey: String {
+        MenuBarAccountKey.make(service: .claudeCode, accountID: claudeCustomID)
+    }
+
+    private var grokCustomKey: String {
+        MenuBarAccountKey.make(service: .grok, accountID: grokCustomID)
+    }
+
     private var codexCustomWidgetID: WidgetAccountIdentifier {
         .account(service: .codexCli, id: codexCustomID)
     }
@@ -148,12 +255,59 @@ final class ProviderAccountSelectionReconcilerTests: XCTestCase {
         .account(service: .claudeCode, id: ClaudeCodeAccount.defaultID)
     }
 
+    private var claudeCustomWidgetID: WidgetAccountIdentifier {
+        .account(service: .claudeCode, id: claudeCustomID)
+    }
+
+    /// Occupies every status-item slot, ending on `lastKey`, so a test can prove
+    /// the cap actually blocks a further selection before reconciliation runs.
+    ///
+    /// The filler keys all stay available across the reconcile under test, so the
+    /// freed slot can only have come from `lastKey` being pruned — not from the
+    /// filler evaporating too.
+    private func fillEverySlot(
+        of store: MenuBarAccountSelectionStore,
+        lastKey: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let filler = [claudeDefaultKey, codexDefaultKey, codexCustomKey]
+        XCTAssertEqual(
+            filler.count + 1,
+            store.itemLimit,
+            "filler no longer fills the cap exactly; the reuse assertion would be vacuous",
+            file: file,
+            line: line
+        )
+        for key in filler + [lastKey] {
+            XCTAssertEqual(store.select(key), .updated, file: file, line: line)
+        }
+        XCTAssertEqual(
+            store.select(grokDefaultKey),
+            .rejectedLimit(store.itemLimit),
+            "the cap must be reached before reconciliation frees a slot",
+            file: file,
+            line: line
+        )
+    }
+
     private func makeAvailability(
         codexCustomEnabled: Bool = true,
+        claudeCustomEnabled: Bool = true,
+        grokCustomEnabled: Bool = true,
+        claudeAccountsIncludeCustom: Bool = true,
+        grokAccountsIncludeCustom: Bool = true,
         enabledServices: Set<ServiceType> = [.claudeCode, .codexCli, .grok]
     ) -> ProviderAccountSelectionAvailability {
         ProviderAccountSelectionAvailability(
-            claudeAccounts: [.defaultAccount],
+            claudeAccounts: [.defaultAccount] + (claudeAccountsIncludeCustom ? [
+                ClaudeCodeAccount(
+                    id: claudeCustomID,
+                    name: "Work",
+                    configDirectory: "/tmp/claude-work",
+                    isEnabled: claudeCustomEnabled
+                )
+            ] : []),
             codexAccounts: [
                 .defaultAccount,
                 CodexAccount(
@@ -163,7 +317,14 @@ final class ProviderAccountSelectionReconcilerTests: XCTestCase {
                     isEnabled: codexCustomEnabled
                 )
             ],
-            grokAccounts: [.defaultAccount],
+            grokAccounts: [.defaultAccount] + (grokAccountsIncludeCustom ? [
+                GrokAccount(
+                    id: grokCustomID,
+                    name: "Work",
+                    homeDirectory: "/tmp/grok-work",
+                    isEnabled: grokCustomEnabled
+                )
+            ] : []),
             enabledServices: enabledServices
         )
     }


### PR DESCRIPTION
## Problem

Only **Codex**'s account handlers called the shared reconciler in `ProviderSettingsView`:

| Call site | Before |
|---|---|
| Claude `onEnabledChange` | `SessionWakeSettingsStore.reconcileAccounts` only |
| Claude `onRemove` | `MenuBarAccountSelectionStore.forget` only |
| Grok `onEnabledChange` | nothing |
| Grok `onRemove` | `forget` only |
| `providerEnabledBinding` | reconciled `if service == .codexCli` |

`MenuBarAccountItemPlanner.perAccountPlan` compactMaps selected keys against **enabled** accounts, while `MenuBarAccountSelectionStore.select()` caps on the **raw** `selectedAccountKeys`. So a disabled-but-still-selected Claude or Grok account loses its status item while still consuming one of the four slots — exactly what that store's doc comment forbids ("Disabled keys must not invisibly consume one of the finite status-item slots"). The user cannot add a replacement item until they manually reselect or relaunch. Toggling a whole Claude/Grok provider off leaked the same way.

## Fix

`ProviderAccountSelectionAvailability` was already provider-agnostic — it builds from all three providers' accounts plus `enabledServices` and applies `ProviderAccountSelectionReconciler` to menu-bar selection, widget preferences, and Session Wake in one pass. So this is pure wiring: every account-mutation call site now runs the shared pass.

- The shared pass **subsumes** the narrower `forget()` calls (it prunes the selection *and* clears a stale merged/switcher key) and additionally prunes widget preferences, which `forget()` never touched.
- `providerEnabledBinding` drops the `codexCli`-only condition.
- Mechanical rename: `reconcileCodexAccountSelections` → `reconcileProviderAccountSelections`.
- Claude's Session Wake reconcile is **preserved, not duplicated**: `SessionWakeSettingsStore` has two distinct methods, and the shared pass owns only `reconcileCodexAccounts`, so Claude keeps its explicit `reconcileAccounts` call.

## Tests

Seven tests added to `ProviderAccountSelectionReconcilerTests`, mirroring the existing Codex coverage: disabled Claude/Grok selections are pruned and the freed slot is provably reusable (filler keys are chosen to survive the reconcile, and the cap is asserted to be hit first, so the reuse assertion can't pass vacuously); deleted accounts clear both selection and merged key; an untracked provider drops all its profiles; widget pruning for Claude; and a guard that the shared pass leaves a Claude Session Wake target to its own reconcile path.

**Honest scope note on TDD:** these tests pass both before and after, because the reconciler itself was never broken — the defect is the missing call sites inside SwiftUI closures, which no unit test can observe without refactoring the view (out of scope here). They lock the mechanism at parity with the existing Codex tests; the wiring change itself is verified by inspection of the diff.

`swift test`: **2185 passed, 0 failures**, 6 skipped. SwiftLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)