### PR TITLE
fix(menubar): stop the default Claude account borrowing another profile's quota

### DIFF
--- a/MeterBar/App/StatusLimitProbeRequests.swift
+++ b/MeterBar/App/StatusLimitProbeRequests.swift
@@ -40,9 +40,11 @@ nonisolated enum StatusLimitProbeRequestBuilder {
         var requests: [StatusLimitProbeRequest] = []
 
         if visibility.isEnabled(.claudeCode) {
-            for account in ClaudeCodeAccountStore.shared.enabledAccounts {
+            let enabledAccounts = ClaudeCodeAccountStore.shared.enabledAccounts
+            for account in enabledAccounts {
                 guard let accountMetrics = claudeMetrics(
                     for: account,
+                    enabledAccountCount: enabledAccounts.count,
                     accountMetrics: UsageDataManager.shared.claudeCodeAccountMetrics,
                     providerMetrics: metrics[.claudeCode]
                 ) else { continue }
@@ -182,19 +184,31 @@ nonisolated enum StatusLimitProbeRequestBuilder {
     }
 
     /// Per-account metrics win; the provider-wide snapshot only backs the
-    /// default account, which is the one that reads `~/.claude`.
+    /// default account — which is the one that reads `~/.claude` — while it is
+    /// the *only* enabled one and no per-account metrics exist at all. Without
+    /// that guard a multi-profile setup double-counts: `UsageDataManager`'s
+    /// `representativeClaudeCodeMetrics` borrows an arbitrary enabled account's
+    /// snapshot when the default account's fetch failed with no cache, and the
+    /// borrowed numbers would then reach the menu bar under the default
+    /// account's identity. Same rule as Codex and Grok below.
     static func claudeMetrics(
         for account: ClaudeCodeAccount,
+        enabledAccountCount: Int,
         accountMetrics: [UUID: UsageMetrics],
         providerMetrics: UsageMetrics?
     ) -> UsageMetrics? {
-        accountMetrics[account.id] ?? (account.isDefault ? providerMetrics : nil)
+        let fallbackMetrics = account.isDefault
+            && enabledAccountCount == 1
+            && accountMetrics.isEmpty
+            ? providerMetrics
+            : nil
+        return accountMetrics[account.id] ?? fallbackMetrics
     }
 
-    /// Codex is stricter than Claude: the provider-wide snapshot only backs the
-    /// default account while it is the *only* enabled one and no per-account
-    /// metrics exist at all, so a multi-profile setup never double-counts the
-    /// default profile's quota.
+    /// Codex follows the same cache-identity rule as Claude: the provider-wide
+    /// snapshot only backs the default account while it is the *only* enabled
+    /// one and no per-account metrics exist at all, so a multi-profile setup
+    /// never double-counts the default profile's quota.
     static func codexMetrics(
         for account: CodexAccount,
         enabledAccountCount: Int,

--- a/MeterBarTests/AppDelegateSplitTests.swift
+++ b/MeterBarTests/AppDelegateSplitTests.swift
@@ -275,6 +275,7 @@ final class AppDelegateSplitTests: XCTestCase {
 
         let resolved = StatusLimitProbeRequestBuilder.claudeMetrics(
             for: account,
+            enabledAccountCount: 1,
             accountMetrics: [account.id: accountMetrics],
             providerMetrics: providerMetrics
         )
@@ -287,6 +288,7 @@ final class AppDelegateSplitTests: XCTestCase {
 
         let defaultResolved = StatusLimitProbeRequestBuilder.claudeMetrics(
             for: .defaultAccount,
+            enabledAccountCount: 1,
             accountMetrics: [:],
             providerMetrics: providerMetrics
         )
@@ -295,9 +297,62 @@ final class AppDelegateSplitTests: XCTestCase {
         let custom = ClaudeCodeAccount(id: UUID(), name: "Work", configDirectory: "/tmp/work")
         XCTAssertNil(StatusLimitProbeRequestBuilder.claudeMetrics(
             for: custom,
+            enabledAccountCount: 1,
             accountMetrics: [:],
             providerMetrics: providerMetrics
         ))
+    }
+
+    func testClaudeMetricsFallsBackOnlyForASoleDefaultAccountWithoutAccountData() {
+        let providerMetrics = MetricsFixtures.claudeCode(sessionUsedPercent: 90)
+
+        // A second enabled account means the provider-level snapshot is no
+        // longer unambiguously the default account's: `UsageDataManager`
+        // borrows an arbitrary enabled account's metrics when the default
+        // account's own fetch produced nothing.
+        XCTAssertNil(StatusLimitProbeRequestBuilder.claudeMetrics(
+            for: .defaultAccount,
+            enabledAccountCount: 2,
+            accountMetrics: [:],
+            providerMetrics: providerMetrics
+        ))
+
+        // Any account-level data at all wins over the fallback.
+        XCTAssertNil(StatusLimitProbeRequestBuilder.claudeMetrics(
+            for: .defaultAccount,
+            enabledAccountCount: 1,
+            accountMetrics: [UUID(): MetricsFixtures.claudeCode(sessionUsedPercent: 20)],
+            providerMetrics: providerMetrics
+        ))
+    }
+
+    /// The upstream shape of the bug: the default account's fetch failed with no
+    /// cache while a custom account succeeded, so the provider snapshot is the
+    /// *custom* account's numbers. The default account must not emit a probe
+    /// request carrying them under its own identity.
+    func testClaudeDefaultAccountGetsNoMetricsWhenOnlyAnotherAccountHasData() {
+        let custom = ClaudeCodeAccount(id: UUID(), name: "Work", configDirectory: "/tmp/work")
+        let customMetrics = MetricsFixtures.claudeCode(sessionUsedPercent: 90)
+        let accountMetrics = [custom.id: customMetrics]
+        // `representativeClaudeCodeMetrics` hands the custom account's snapshot
+        // up as the provider-wide one when the default account has no entry.
+        let providerMetrics = customMetrics
+
+        XCTAssertNil(StatusLimitProbeRequestBuilder.claudeMetrics(
+            for: .defaultAccount,
+            enabledAccountCount: 2,
+            accountMetrics: accountMetrics,
+            providerMetrics: providerMetrics
+        ))
+        XCTAssertEqual(
+            StatusLimitProbeRequestBuilder.claudeMetrics(
+                for: custom,
+                enabledAccountCount: 2,
+                accountMetrics: accountMetrics,
+                providerMetrics: providerMetrics
+            )?.sessionLimit?.used,
+            90
+        )
     }
 
     func testCodexMetricsFallsBackOnlyForASoleDefaultAccountWithoutAccountData() {


### PR DESCRIPTION
## Problem

`StatusLimitProbeRequestBuilder.claudeMetrics(...)` fell back to the provider-wide snapshot for the default account **unconditionally**:

```swift
accountMetrics[account.id] ?? (account.isDefault ? providerMetrics : nil)
```

The parallel `codexMetrics` and `grokMetrics` in the same file gate the identical fallback behind `account.isDefault && enabledAccountCount == 1 && accountMetrics.isEmpty`, with doc comments explaining that this stops a multi-profile setup from double-counting the default profile's quota. Claude was missing that guard.

It matters because of what feeds `providerMetrics`. `UsageDataManager.representativeClaudeCodeMetrics` borrows an **arbitrary enabled account's** metrics when the default account has no per-account entry — the real-world case being the default account's fetch failing with no cache while a custom account succeeds. Without the guard, that borrowed snapshot was handed to the default account's `StatusLimitProbeRequest`, so two menu-bar candidates carried identical numbers under two different account identities. One of them was wrong.

## Fix

Mirror the Codex/Grok guard exactly — thread `enabledAccountCount` into `claudeMetrics(...)` the same way the other two receive it, and gate the fallback on `isDefault && enabledAccountCount == 1 && accountMetrics.isEmpty`. All three per-provider resolvers now read identically. Doc comments updated so Codex/Grok no longer describe themselves as "stricter than Claude".

## Tests (written first)

Added to `MeterBarTests/AppDelegateSplitTests.swift`, alongside the existing Codex/Grok equivalents:

- `testClaudeMetricsFallsBackOnlyForASoleDefaultAccountWithoutAccountData` — mirrors the Codex/Grok coverage: no fallback with 2 enabled accounts, none when any account-level data exists.
- `testClaudeDefaultAccountGetsNoMetricsWhenOnlyAnotherAccountHasData` — the upstream shape of the bug: 2 enabled accounts, only the non-default has metrics, `providerMetrics` is that borrowed snapshot. The default account resolves to `nil` (no probe request); the custom account still gets its own metrics.

Existing `claudeMetrics` tests updated for the new parameter; their assertions are unchanged and still pass.

Verified red first (compile failure on the new parameter), then green. Full `swift test` suite passes — 2180 tests, 6 skipped, 0 failures across 3 consecutive runs on this branch and 3 on unmodified master.