### PR TITLE
fix(codex): key usage-fetch errors per account instead of one shared field

### DIFF
--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -39,7 +39,6 @@ class CodexCliLocalService: ObservableObject {
     /// own presentation and for callers that predate multi-account Codex; every
     /// per-account question goes through `accountAccess` instead.
     @Published private(set) var hasAccess: Bool = false
-    @Published private(set) var lastError: ServiceError?
     @Published private(set) var subscriptionType: String?
 
     /// Last observed auth result per Codex profile, keyed by account id.
@@ -49,6 +48,16 @@ class CodexCliLocalService: ObservableObject {
     /// disabled. Probing is a file read plus a JSON/JWT decode, so results are
     /// cached here rather than recomputed on every render.
     @Published private(set) var accountAccess: [UUID: Bool] = [:]
+
+    /// Last fetch failure per Codex profile, keyed by account id.
+    ///
+    /// `UsageDataManager` fans usage fetches out across every enabled profile
+    /// concurrently, so a single shared error would end up describing whichever
+    /// profile happened to finish last — a signed-out secondary profile's
+    /// "Not authenticated" shown beside a healthy default, or a real default
+    /// failure blanked by a later success. Keying by account keeps each fetch
+    /// speaking only for itself.
+    @Published private(set) var accountErrors: [UUID: ServiceError] = [:]
 
     /// Defaults reproduce the production singleton; tests inject a fixture
     /// auth-file provider.
@@ -190,6 +199,13 @@ class CodexCliLocalService: ObservableObject {
         )
     }
 
+    /// Provider-level error across the supplied profiles, in the order given —
+    /// normally `CodexAccountStore.shared.enabledAccounts`, so the default
+    /// profile's failure is the one the UI reports.
+    func firstError(for accounts: [CodexAccount]) -> ServiceError? {
+        accounts.lazy.compactMap { self.accountErrors[$0.id] }.first
+    }
+
     // MARK: - Usage Fetching
 
     func fetchUsageMetrics(account: CodexAccount = .defaultAccount) async throws -> UsageMetrics {
@@ -202,7 +218,7 @@ class CodexCliLocalService: ObservableObject {
         guard let token = auth.token else {
             let error = ServiceError.notAuthenticated
             await MainActor.run {
-                self.lastError = error
+                self.accountErrors[account.id] = error
                 self.record(false, for: account)
             }
             throw error
@@ -229,7 +245,7 @@ class CodexCliLocalService: ObservableObject {
             let usageResponse = try decoder.decode(CodexCliUsageResponse.self, from: data)
 
             await MainActor.run {
-                self.lastError = nil
+                self.accountErrors.removeValue(forKey: account.id)
                 self.record(true, for: account)
                 if account.isDefault {
                     self.subscriptionType = usageResponse.planType
@@ -244,7 +260,7 @@ class CodexCliLocalService: ObservableObject {
             let serviceError = ServiceSupport.serviceError(from: error)
             AppLog.usage.error("Codex usage fetch failed: \(serviceError.localizedDescription)")
             await MainActor.run {
-                self.lastError = serviceError
+                self.accountErrors[account.id] = serviceError
                 if case .notAuthenticated = serviceError {
                     self.record(false, for: account)
                 }

--- a/MeterBar/Services/GrokCLIUsageService.swift
+++ b/MeterBar/Services/GrokCLIUsageService.swift
@@ -10,8 +10,12 @@ final class GrokCLIUsageService: ObservableObject {
     nonisolated static let shared = GrokCLIUsageService()
 
     @Published private(set) var hasAccess = false
-    @Published private(set) var lastError: ServiceError?
     @Published private(set) var subscriptionType: String?
+
+    /// Last fetch failure per Grok profile, keyed by account id. Profiles are
+    /// fetched concurrently, so there is deliberately no provider-wide error
+    /// property: a shared one would describe whichever profile finished last.
+    /// Read it through `firstError(for:)`.
     @Published private(set) var accountErrors: [UUID: ServiceError] = [:]
 
     nonisolated private let binaryPathProvider: @Sendable () -> String?
@@ -65,7 +69,6 @@ final class GrokCLIUsageService: ObservableObject {
             if account.isDefault {
                 hasAccess = false
             }
-            lastError = error
             throw error
         }
 
@@ -77,12 +80,10 @@ final class GrokCLIUsageService: ObservableObject {
                 hasAccess = true
                 subscriptionType = result.subscriptionTier
             }
-            lastError = accountErrors.values.first
             return metrics
         } catch {
             let serviceError = Self.serviceError(from: error)
             accountErrors[account.id] = serviceError
-            lastError = serviceError
             if account.isDefault, case .notAuthenticated = serviceError {
                 hasAccess = false
                 subscriptionType = nil

--- a/MeterBar/Views/DashboardDiagnosticsSection.swift
+++ b/MeterBar/Views/DashboardDiagnosticsSection.swift
@@ -30,6 +30,7 @@ struct DashboardDiagnosticsSection: View {
     @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
     @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
     @StateObject private var codexCliService = CodexCliLocalService.shared
+    @StateObject private var codexAccountStore = CodexAccountStore.shared
     @StateObject private var cursorService = CursorLocalService.shared
     @StateObject private var openRouterService = OpenRouterService.shared
     @StateObject private var grokService = GrokCLIUsageService.shared
@@ -125,7 +126,7 @@ struct DashboardDiagnosticsSection: View {
         let errors = DiagnosticsRunner.refreshErrors(
             claudeDefaultAccountEnabled: claudeAccountStore.defaultAccountIsEnabled,
             claudeError: claudeCodeService.lastError,
-            codexError: codexCliService.lastError,
+            codexError: codexCliService.firstError(for: codexAccountStore.enabledAccounts),
             cursorError: cursorService.lastError,
             openRouterError: openRouterService.lastError,
             grokError: grokService.firstError(for: grokAccountStore.enabledAccounts)

--- a/MeterBar/Views/Settings/ProviderSettingsFacts+Live.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsFacts+Live.swift
@@ -71,11 +71,12 @@ extension ProviderSettingsFacts {
         error: String?
     ) {
         let service = CodexCliLocalService.shared
+        let accounts = CodexAccountStore.shared.enabledAccounts
         return (
-            service.hasAccess(in: CodexAccountStore.shared.enabledAccounts),
+            service.hasAccess(in: accounts),
             service.subscriptionType,
             nil,
-            service.lastError?.localizedDescription
+            service.firstError(for: accounts)?.localizedDescription
         )
     }
 

--- a/MeterBarTests/CodexCliLocalServiceTests.swift
+++ b/MeterBarTests/CodexCliLocalServiceTests.swift
@@ -266,4 +266,175 @@ final class CodexCliLocalServiceTests: XCTestCase {
             "auth-file read ran on the main thread — blocking I/O must hop off main"
         )
     }
+
+    // MARK: - Per-account error attribution
+
+    /// `UsageDataManager` fans usage fetches out across every enabled Codex
+    /// profile concurrently, so a fetch may only ever record its own profile's
+    /// outcome: a shared `lastError` would leave whichever profile finished last
+    /// speaking for all of them.
+
+    private final class StubURLProtocol: URLProtocol {
+        static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+        override func startLoading() {
+            guard let handler = Self.handler else {
+                client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+                return
+            }
+            do {
+                let (response, data) = try handler(request)
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(self, didLoad: data)
+                client?.urlProtocolDidFinishLoading(self)
+            } catch {
+                client?.urlProtocol(self, didFailWithError: error)
+            }
+        }
+
+        override func stopLoading() {}
+    }
+
+    override func tearDown() {
+        StubURLProtocol.handler = nil
+        super.tearDown()
+    }
+
+    private func makeStubSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    /// Smallest body the usage decoder accepts — the window math has its own
+    /// fixtures above, these tests only care about success vs failure.
+    private static let usageBody = Data(#"{"plan_type":"plus","rate_limit":null}"#.utf8)
+
+    /// Serves 200 to the profiles named in `succeeding` and `failureStatus` to
+    /// everyone else, keyed by the per-profile `ChatGPT-Account-Id` header.
+    private func stubUsage(succeeding: Set<String>, failureStatus: Int) {
+        StubURLProtocol.handler = { request in
+            let url = try XCTUnwrap(request.url)
+            let accountID = request.value(forHTTPHeaderField: "ChatGPT-Account-Id") ?? ""
+            let succeeds = succeeding.contains(accountID)
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: url,
+                    statusCode: succeeds ? 200 : failureStatus,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+            return (response, succeeds ? Self.usageBody : Data())
+        }
+    }
+
+    @MainActor
+    func testConcurrentFetchesAttributeFailuresToTheOwningAccount() async {
+        let token = makeJWT(exp: futureExp)
+        let work = CodexAccount(id: UUID(), name: "Work", homeDirectory: "/tmp/codex-work")
+        // Only the default profile is signed in; the work profile has no auth
+        // file, so its fetch fails while the default profile's succeeds.
+        let service = CodexCliLocalService(
+            accountAuthFileDataProvider: { account in
+                account.isDefault
+                    ? self.authFileJSON(accessToken: token, accountId: "account-default")
+                    : nil
+            },
+            urlSession: makeStubSession()
+        )
+        stubUsage(succeeding: ["account-default"], failureStatus: 500)
+        await Task.yield() // let the init-time detached checkAccess drain first
+
+        async let defaultFetch = try? await service.fetchUsageMetrics(account: .defaultAccount)
+        async let workFetch = try? await service.fetchUsageMetrics(account: work)
+        let (defaultMetrics, workMetrics) = await (defaultFetch, workFetch)
+
+        XCTAssertNotNil(defaultMetrics, "the signed-in default profile should have fetched usage")
+        XCTAssertNil(workMetrics, "the signed-out work profile should have failed")
+        XCTAssertEqual(
+            service.firstError(for: [work])?.localizedDescription,
+            ServiceError.notAuthenticated.localizedDescription
+        )
+        XCTAssertNil(
+            service.firstError(for: [.defaultAccount]),
+            "the default profile succeeded — it must not inherit the work profile's error"
+        )
+    }
+
+    @MainActor
+    func testDefaultAccountSuccessDoesNotClearASecondaryAccountsError() async throws {
+        let token = makeJWT(exp: futureExp)
+        let work = CodexAccount(id: UUID(), name: "Work", homeDirectory: "/tmp/codex-work")
+        let service = CodexCliLocalService(
+            accountAuthFileDataProvider: { account in
+                self.authFileJSON(
+                    accessToken: token,
+                    accountId: account.isDefault ? "account-default" : "account-work"
+                )
+            },
+            urlSession: makeStubSession()
+        )
+        stubUsage(succeeding: ["account-default"], failureStatus: 500)
+        await Task.yield()
+
+        // The secondary profile fails first and the default profile succeeds
+        // afterwards — the interleaving that used to blank the shared error.
+        do {
+            _ = try await service.fetchUsageMetrics(account: work)
+            XCTFail("Expected the stubbed HTTP 500 to fail the work profile")
+        } catch {
+            XCTAssertEqual((error as? ServiceError)?.localizedDescription, "HTTP 500")
+        }
+        _ = try await service.fetchUsageMetrics(account: .defaultAccount)
+
+        XCTAssertEqual(
+            service.firstError(for: [work])?.localizedDescription,
+            "HTTP 500",
+            "a later success on another profile must not clear this profile's error"
+        )
+        XCTAssertNil(service.firstError(for: [.defaultAccount]))
+        XCTAssertEqual(service.firstError(for: [.defaultAccount, work])?.localizedDescription, "HTTP 500")
+    }
+
+    @MainActor
+    func testRecoveringAccountClearsOnlyItsOwnError() async throws {
+        let token = makeJWT(exp: futureExp)
+        let work = CodexAccount(id: UUID(), name: "Work", homeDirectory: "/tmp/codex-work")
+        let personal = CodexAccount(id: UUID(), name: "Personal", homeDirectory: "/tmp/codex-personal")
+        let service = CodexCliLocalService(
+            accountAuthFileDataProvider: { account in
+                self.authFileJSON(
+                    accessToken: token,
+                    accountId: account.id == work.id ? "account-work" : "account-personal"
+                )
+            },
+            urlSession: makeStubSession()
+        )
+        stubUsage(succeeding: [], failureStatus: 500)
+        await Task.yield()
+
+        for account in [work, personal] {
+            do {
+                _ = try await service.fetchUsageMetrics(account: account)
+                XCTFail("Expected the stubbed HTTP 500 to fail \(account.name)")
+            } catch {
+                // expected
+            }
+        }
+
+        // Only the work profile recovers.
+        stubUsage(succeeding: ["account-work"], failureStatus: 500)
+        _ = try await service.fetchUsageMetrics(account: work)
+
+        XCTAssertNil(service.firstError(for: [work]), "the recovered profile's error should be cleared")
+        XCTAssertEqual(
+            service.firstError(for: [personal])?.localizedDescription,
+            "HTTP 500",
+            "one profile recovering must not clear another profile's error"
+        )
+    }
 }

--- a/MeterBarTests/GrokCLIUsageServiceTests.swift
+++ b/MeterBarTests/GrokCLIUsageServiceTests.swift
@@ -439,6 +439,38 @@ final class GrokCLIUsageServiceTests: XCTestCase {
         XCTAssertEqual(workMetrics.weeklyLimit?.used, 73)
     }
 
+    /// Profiles are fetched concurrently, so the recorded error has to stay
+    /// keyed to the profile that produced it — a default-profile success that
+    /// lands afterwards must not blank a signed-out profile's error.
+    func testDefaultProfileSuccessKeepsASecondaryProfilesError() async throws {
+        let work = GrokAccount(id: UUID(), name: "Work", homeDirectory: "/tmp/grok-work")
+        let defaultResult = try decodeResult(
+            #"{"config":{"creditUsagePercent":11},"subscription_tier":"Default"}"#
+        )
+        let service = GrokCLIUsageService(
+            binaryPathProvider: { "/usr/local/bin/grok" },
+            authAvailableProvider: { $0.isDefault },
+            billingResultProvider: { _, _ in defaultResult }
+        )
+
+        do {
+            _ = try await service.fetchUsageMetrics(account: work)
+            XCTFail("Expected the signed-out work profile to fail")
+        } catch {
+            XCTAssertEqual(
+                (error as? ServiceError)?.localizedDescription,
+                ServiceError.notAuthenticated.localizedDescription
+            )
+        }
+        _ = try await service.fetchUsageMetrics(account: .defaultAccount)
+
+        XCTAssertEqual(
+            service.firstError(for: [work])?.localizedDescription,
+            ServiceError.notAuthenticated.localizedDescription
+        )
+        XCTAssertNil(service.firstError(for: [.defaultAccount]))
+    }
+
     func testReplayedTranscriptDecodesBillingResult() throws {
         let result = try GrokBillingRPC.result(
             replaying: transcript(


### PR DESCRIPTION
## The bug

`CodexCliLocalService.fetchUsageMetrics(account:)` wrote the shared `self.lastError` on **every** path — auth-missing, success (`nil`), and catch — regardless of which profile it was fetching for.

`UsageDataManager.fetchCodexAccountMetrics` fans those fetches out **concurrently** across every enabled profile (`fanOut` / `withTaskGroup`), so the field ended up describing whichever profile finished last:

- a signed-out secondary profile's *"Not authenticated"* rendered next to a healthy default profile's green status, and
- a real default-profile failure got blanked to `nil` by a later-finishing success on another profile.

The rest of that function already keeps per-account discipline — `record()` gates on `isDefault`, `accountAccess` is keyed by account id. Only the error escaped it.

## The fix

Mirror the shape Grok already ships:

- `CodexCliLocalService` gains `@Published private(set) var accountErrors: [UUID: ServiceError]` and `firstError(for:)`.
- `fetchUsageMetrics` writes per account: set on auth-missing, `removeValue` on success, set in catch.

## Both readers switched, not just the reported one

The report named `ProviderSettingsFacts+Live.codexLiveState()` (Providers page Status row + settings sidebar health dot). There is a **second** reader of the same racy field: `DashboardDiagnosticsSection` feeds it into `DiagnosticsRunner.refreshErrors(codexError:)`, so fixing only `codexLiveState()` would have left the identical race in the Diagnostics report. Both now go through `firstError(for: enabledAccounts)`, matching how Grok is already read at those sites.

With no readers left, `lastError` is **deleted** from `CodexCliLocalService` rather than left behind as a racy-but-authoritative-looking field.

## Landmine removal

`GrokCLIUsageService` still wrote the unscoped `lastError` on all three paths even though nothing has read it since `grokLiveState()` moved to `firstError(for:)` (verified by grep). The writes and the property are gone, so the next UI addition can't pick it up. Both services are now structurally identical.

`UsageDataManager.lastError`, `ApiUsageStore.lastError`, `LaunchAtLoginStore.lastError` and the other providers' `lastError` are unrelated properties with live readers — untouched.

## Tests

Written first; red before the fix (`no member 'firstError'`), green after.

`CodexCliLocalServiceTests`
- `testConcurrentFetchesAttributeFailuresToTheOwningAccount` — default profile succeeds while a signed-out work profile fails, fetched concurrently; the error lands on `work` and the default carries none.
- `testDefaultAccountSuccessDoesNotClearASecondaryAccountsError` — secondary fails (HTTP 500), default succeeds afterwards; the secondary's error survives. This is the exact interleaving that used to blank it.
- `testRecoveringAccountClearsOnlyItsOwnError` — two secondaries fail, one recovers; the other's error is untouched.

`GrokCLIUsageServiceTests`
- `testDefaultProfileSuccessKeepsASecondaryProfilesError` — same regression pinned for Grok, so the deleted `lastError = accountErrors.values.first` line can't come back as a "fix".

Stubbed through the existing `accountAuthFileDataProvider` + `StubURLProtocol` seams — no network, no real `auth.json`.

## Verification

`swift test` — **2182 tests, 0 failures**, 6 skipped.
`swiftlint lint` clean on all four changed production files.