### PR TITLE
fix(decode): stop one unreadable entry from wiping persisted usage data

### DIFF
--- a/MeterBar/Models/ProviderUsageLedger.swift
+++ b/MeterBar/Models/ProviderUsageLedger.swift
@@ -177,6 +177,29 @@ nonisolated struct ProviderUsageLedger: Codable, Sendable, Equatable {
         self.entries = entries
     }
 
+    /// Decodes entries tolerantly so one unreadable provider costs only that
+    /// provider's history.
+    ///
+    /// `ProviderUsageLedgerEntry.provider` is a closed `ServiceType`: a raw value
+    /// written by a newer build, or a provider since removed, throws. Under the
+    /// synthesized decoder that threw the array, which threw the ledger, which
+    /// `ProviderUsageLedgerStore.load` turned into an empty one — discarding
+    /// every other provider's days. Nothing re-serves them: Cursor and
+    /// OpenRouter publish a running counter and no history, so a dropped day is
+    /// gone permanently.
+    ///
+    /// `schemaVersion` and `timeZoneIdentifier` stay strict. A payload missing
+    /// them is not a ledger this build can reason about, and the store already
+    /// drops on a version mismatch rather than half-decoding a changed shape.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+        timeZoneIdentifier = try container.decode(String.self, forKey: .timeZoneIdentifier)
+        entries = try container
+            .decode([FailableBox<ProviderUsageLedgerEntry>].self, forKey: .entries)
+            .compactMap(\.value)
+    }
+
     // MARK: - Reading
 
     func entry(for provider: ServiceType) -> ProviderUsageLedgerEntry? {

--- a/MeterBar/Services/SharedDataStore.swift
+++ b/MeterBar/Services/SharedDataStore.swift
@@ -75,7 +75,7 @@ nonisolated public final class SharedDataStore: @unchecked Sendable {
 
     func saveAccountMetrics(_ snapshots: [AccountUsageSnapshot]) {
         guard let fileURL = accountMetricsFileURL,
-              let data = try? JSONEncoder().encode(snapshots) else {
+              let data = MetricsCodec.encodeAccounts(snapshots) else {
             AppLog.storage.error("Failed to prepare shared account metrics")
             return
         }
@@ -107,9 +107,8 @@ nonisolated public final class SharedDataStore: @unchecked Sendable {
     public func loadAccountMetrics() -> [AccountUsageSnapshot] {
         guard directoryOverride == nil else {
             guard let fileURL = accountMetricsFileURL,
-                  let data = try? Data(contentsOf: fileURL),
-                  let decoded = try? JSONDecoder().decode([AccountUsageSnapshot].self, from: data) else { return [] }
-            return decoded
+                  let data = try? Data(contentsOf: fileURL) else { return [] }
+            return MetricsCodec.decodeAccounts(data)
         }
         return SharedMetricsStore.loadAccountMetrics()
     }

--- a/MeterBarTests/MetricsCodecTests.swift
+++ b/MeterBarTests/MetricsCodecTests.swift
@@ -77,4 +77,60 @@ final class MetricsCodecTests: XCTestCase {
     func testGarbageDataDecodesToEmpty() {
         XCTAssertTrue(MetricsCodec.decode(Data("not json".utf8)).isEmpty)
     }
+
+    func testAccountRoundTripPreservesLabelsAndUsage() throws {
+        let snapshots = [
+            AccountUsageSnapshot(
+                id: UUID(),
+                name: "Personal",
+                metrics: UsageMetrics(
+                    service: .codexCli,
+                    sessionLimit: UsageLimit(used: 30, total: 100, resetTime: nil)
+                )
+            )
+        ]
+
+        let data = try XCTUnwrap(MetricsCodec.encodeAccounts(snapshots))
+        let decoded = MetricsCodec.decodeAccounts(data)
+
+        XCTAssertEqual(decoded.map(\.name), ["Personal"])
+        XCTAssertEqual(decoded.first?.metrics.sessionLimit?.used, 30)
+    }
+
+    /// The account cache is decoded by the widget and the CLI as well as the
+    /// app, so one snapshot naming a provider this build does not know must cost
+    /// that snapshot only — never every account's widget row.
+    func testUnknownAccountServiceIsDroppedNotFatal() throws {
+        let json = """
+        [
+          {"id": "00000000-0000-0000-0000-000000000003", "name": "Future",
+           "metrics": {"id": "00000000-0000-0000-0000-000000000004", "service": "Fusion",
+                       "lastUpdated": 700000000}},
+          {"id": "00000000-0000-0000-0000-000000000005", "name": "Personal",
+           "metrics": {"id": "00000000-0000-0000-0000-000000000006", "service": "Codex CLI",
+                       "lastUpdated": 700000000,
+                       "weeklyLimit": {"used": 7, "total": 100, "resetTime": null, "windowSeconds": null}}}
+        ]
+        """
+        let decoded = MetricsCodec.decodeAccounts(Data(json.utf8))
+
+        XCTAssertEqual(decoded.map(\.name), ["Personal"])
+        XCTAssertEqual(decoded.first?.metrics.weeklyLimit?.used, 7)
+    }
+
+    func testMalformedAccountSnapshotIsDroppedNotFatal() {
+        let json = """
+        [
+          {"totally": "wrong shape"},
+          {"id": "00000000-0000-0000-0000-000000000007", "name": "Work",
+           "metrics": {"id": "00000000-0000-0000-0000-000000000008", "service": "Cursor",
+                       "lastUpdated": 700000000}}
+        ]
+        """
+        XCTAssertEqual(MetricsCodec.decodeAccounts(Data(json.utf8)).map(\.name), ["Work"])
+    }
+
+    func testGarbageAccountDataDecodesToEmpty() {
+        XCTAssertTrue(MetricsCodec.decodeAccounts(Data("not json".utf8)).isEmpty)
+    }
 }

--- a/MeterBarTests/ProviderUsageLedgerStoreTests.swift
+++ b/MeterBarTests/ProviderUsageLedgerStoreTests.swift
@@ -92,6 +92,51 @@ final class ProviderUsageLedgerStoreTests: XCTestCase {
         XCTAssertEqual(loaded.timeZoneIdentifier, TimeZone.current.identifier)
     }
 
+    /// One unreadable entry costs that provider's history, never the file's.
+    ///
+    /// `ProviderUsageLedgerEntry.provider` is a closed `ServiceType`, so a raw
+    /// value this build does not know — a payload written by a newer version, a
+    /// provider since removed — fails that entry's decode. Failing the entry
+    /// used to fail the array, which failed the ledger, which returned an empty
+    /// one and re-baselined from the next poll. Unlike the scan caches there is
+    /// nothing to re-read: neither Cursor nor OpenRouter will re-serve a day
+    /// once it has passed, so the surviving providers' days must survive.
+    func testUnknownProviderDropsOnlyThatEntryNotTheWholeLedger() throws {
+        let url = directory.appendingPathComponent(ProviderUsageLedgerStore.fileName)
+        let saved = makeLedger()
+        try ProviderUsageLedgerStore.save(saved, to: url)
+
+        try rewriteEntries(url) { entry in
+            var entry = entry
+            if entry["provider"] as? String == ServiceType.cursor.rawValue {
+                entry["provider"] = "Fusion"
+            }
+            return entry
+        }
+
+        let loaded = ProviderUsageLedgerStore.load(from: url)
+
+        XCTAssertEqual(loaded.entries.map(\.provider), [.openRouter])
+        XCTAssertEqual(loaded.entries.first, saved.entry(for: .openRouter))
+        XCTAssertTrue(loaded.dailySeries(for: .cursor).isEmpty)
+    }
+
+    /// A structurally broken entry degrades the same way an unknown provider
+    /// does — it drops alone.
+    func testMalformedEntryDropsOnlyThatEntry() throws {
+        let url = directory.appendingPathComponent(ProviderUsageLedgerStore.fileName)
+        let saved = makeLedger()
+        try ProviderUsageLedgerStore.save(saved, to: url)
+
+        try rewriteEntries(url) { entry in
+            entry["provider"] as? String == ServiceType.openRouter.rawValue
+                ? ["totally": "wrong shape"]
+                : entry
+        }
+
+        XCTAssertEqual(ProviderUsageLedgerStore.load(from: url).entries.map(\.provider), [.cursor])
+    }
+
     /// Truncated or hand-edited JSON must not crash the poll that reads it.
     func testCorruptPayloadLoadsAnEmptyLedger() throws {
         let url = directory.appendingPathComponent(ProviderUsageLedgerStore.fileName)
@@ -168,6 +213,13 @@ final class ProviderUsageLedgerStoreTests: XCTestCase {
         at date: Date
     ) -> ProviderUsageObservation {
         ProviderUsageObservation(provider: provider, unit: unit, runningTotal: total, observedAt: date)
+    }
+
+    private func rewriteEntries(_ url: URL, _ mutate: ([String: Any]) -> [String: Any]) throws {
+        try rewrite(url) { object in
+            guard let entries = object["entries"] as? [[String: Any]] else { return }
+            object["entries"] = entries.map(mutate)
+        }
     }
 
     private func rewrite(_ url: URL, _ mutate: (inout [String: Any]) -> Void) throws {

--- a/MeterBarTests/SharedDataStoreTests.swift
+++ b/MeterBarTests/SharedDataStoreTests.swift
@@ -91,6 +91,49 @@ final class SharedDataStoreTests: XCTestCase {
         XCTAssertEqual(loaded.map { $0.metrics.sessionLimit?.used }, [30, 90])
     }
 
+    /// One snapshot this build cannot read must not erase every account's widget
+    /// data.
+    ///
+    /// `AccountUsageSnapshot.metrics.service` is a closed `ServiceType`. A raw
+    /// value written by a newer app version — or left behind by a provider since
+    /// removed — fails that snapshot's decode, and a single non-tolerant decode
+    /// of the array turned that into an empty widget for every account. The
+    /// provider-keyed cache next door has tolerated this since `MetricsCodec`;
+    /// the account cache must too.
+    func testUnknownAccountServiceDropsOnlySnapshotNotEveryAccount() throws {
+        let store = SharedDataStore(directoryOverride: tempDirectory) {}
+        let healthy = AccountUsageSnapshot(
+            id: CodexAccount.defaultID,
+            name: "Personal",
+            metrics: MetricsFixtures.codexCli()
+        )
+        store.saveAccountMetrics([healthy])
+        store.flushPendingWrites()
+
+        try prependSnapshotWithUnknownService()
+
+        let loaded = store.loadAccountMetrics()
+
+        XCTAssertEqual(loaded.map(\.name), ["Personal"])
+        XCTAssertEqual(loaded.first?.metrics.sessionLimit?.used, healthy.metrics.sessionLimit?.used)
+    }
+
+    /// A structurally broken snapshot degrades the same way an unknown provider
+    /// does: it drops, the rest survive.
+    func testMalformedAccountSnapshotDropsOnlyThatEntry() throws {
+        let store = SharedDataStore(directoryOverride: tempDirectory) {}
+        store.saveAccountMetrics([
+            AccountUsageSnapshot(id: UUID(), name: "Work", metrics: MetricsFixtures.codexCli())
+        ])
+        store.flushPendingWrites()
+
+        try rewriteAccountMetrics { snapshots in
+            [["totally": "wrong shape"]] + snapshots
+        }
+
+        XCTAssertEqual(store.loadAccountMetrics().map(\.name), ["Work"])
+    }
+
     func testSharedMetricsLocationPrefersEntitledContainer() {
         let entitled = URL(fileURLWithPath: "/entitled/group", isDirectory: true)
         let resolved = SharedMetricsStore.resolvedContainerURL(
@@ -125,5 +168,30 @@ final class SharedDataStoreTests: XCTestCase {
         )
 
         XCTAssertNil(resolved)
+    }
+
+    // MARK: - Helpers
+
+    /// Copies the stored snapshot and stamps the copy with a `ServiceType` raw
+    /// value this build does not know, reproducing a cache written by a newer
+    /// app version.
+    private func prependSnapshotWithUnknownService() throws {
+        try rewriteAccountMetrics { snapshots in
+            guard var future = snapshots.first,
+                  var metrics = future["metrics"] as? [String: Any] else { return snapshots }
+            metrics["service"] = "Fusion"
+            future["metrics"] = metrics
+            future["name"] = "Future"
+            return [future] + snapshots
+        }
+    }
+
+    private func rewriteAccountMetrics(_ mutate: ([[String: Any]]) -> [[String: Any]]) throws {
+        let url = tempDirectory
+            .appendingPathComponent("\(SharedMetricsStore.accountMetricsKey).json")
+        let snapshots = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [[String: Any]]
+        )
+        try JSONSerialization.data(withJSONObject: mutate(snapshots)).write(to: url)
     }
 }

--- a/MeterBarTests/WidgetPreferencesStoreTests.swift
+++ b/MeterBarTests/WidgetPreferencesStoreTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import MeterBarShared
 import XCTest
+@testable import MeterBarShared
 
 final class WidgetPreferencesStoreTests: XCTestCase {
     private var suiteName: String!
@@ -216,6 +216,115 @@ final class WidgetPreferencesStoreTests: XCTestCase {
         let decoded = try JSONDecoder().decode(WidgetPreferences.self, from: legacyData)
 
         XCTAssertEqual(decoded, .defaults)
+    }
+
+    /// An enum case this build does not know degrades that one field, never the
+    /// whole preference set.
+    ///
+    /// The app and the widget extension read the same App Group value, so the
+    /// two sides are only ever as aligned as the user's last update let them be.
+    /// `decodeIfPresent` tolerates a *missing* key; a present key holding a
+    /// future raw value still threw, the store's `try?` swallowed it into
+    /// `.defaults`, and the next `update(_:)` wrote that reset back to disk —
+    /// turning a one-field skew into a silent wipe of every preference.
+    func testUnknownEnumCaseDegradesOnlyTheUnrecognizedField() throws {
+        let account = WidgetAccountIdentifier.account(service: .claudeCode, id: UUID())
+        var written = WidgetPreferences.defaults
+        written.accountSelection = .explicit([account])
+        written.displayMode = .remaining
+        written.visibleQuotaWindows = [.weekly, .session]
+        written.showsResetTime = true
+        written.accountOrdering = .urgency
+
+        let data = try encoded(written) { object in
+            object["accountOrdering"] = "leastRecentlyUsed"
+            object["visibleQuotaWindows"] = [
+                WidgetQuotaWindow.weekly.rawValue,
+                "monthlyRollup"
+            ]
+        }
+
+        let decoded = try JSONDecoder().decode(WidgetPreferences.self, from: data)
+
+        XCTAssertEqual(decoded.accountSelection.explicitIdentifiers, [account])
+        XCTAssertEqual(decoded.displayMode, .remaining)
+        XCTAssertEqual(decoded.visibleQuotaWindows, [.weekly])
+        XCTAssertTrue(decoded.showsResetTime)
+        XCTAssertEqual(decoded.accountOrdering, WidgetPreferences.defaults.accountOrdering)
+    }
+
+    /// An unknown display mode falls back to the default; every other field the
+    /// user chose is still theirs.
+    func testUnknownDisplayModeFallsBackWithoutDiscardingOtherPreferences() throws {
+        var written = WidgetPreferences.defaults
+        written.displayMode = .remaining
+        written.showsFreshness = true
+        written.accountOrdering = .urgency
+
+        let data = try encoded(written) { $0["displayMode"] = "perAccountAverage" }
+
+        let decoded = try JSONDecoder().decode(WidgetPreferences.self, from: data)
+
+        XCTAssertEqual(decoded.displayMode, WidgetPreferences.defaults.displayMode)
+        XCTAssertTrue(decoded.showsFreshness)
+        XCTAssertEqual(decoded.accountOrdering, .urgency)
+    }
+
+    /// An unknown selection mode must not throw away the identifiers stored
+    /// beside it — the selection is the one field here the user typed by hand.
+    /// Identifiers present imply an explicit selection; none imply `.all`.
+    func testUnknownAccountSelectionModeKeepsTheStoredIdentifiers() throws {
+        let account = WidgetAccountIdentifier.account(service: .codexCli, id: UUID())
+        var written = WidgetPreferences.defaults
+        written.accountSelection = .explicit([account])
+
+        let data = try encoded(written) { object in
+            guard var selection = object["accountSelection"] as? [String: Any] else { return }
+            selection["mode"] = "urgentOnly"
+            object["accountSelection"] = selection
+        }
+
+        let decoded = try JSONDecoder().decode(WidgetPreferences.self, from: data)
+
+        XCTAssertEqual(decoded.accountSelection.mode, .explicit)
+        XCTAssertEqual(decoded.accountSelection.explicitIdentifiers, [account])
+    }
+
+    /// The store must not reset on a future enum case, and the next mutation
+    /// must persist the preferences that survived rather than the wipe.
+    func testStoredPreferencesSurviveAFutureEnumCaseAcrossTheNextUpdate() throws {
+        var written = WidgetPreferences.defaults
+        written.displayMode = .remaining
+        written.showsFreshness = true
+        written.accountOrdering = .urgency
+        let data = try encoded(written) { $0["accountOrdering"] = "leastRecentlyUsed" }
+        defaults.set(data, forKey: WidgetPreferencesStore.storageKey)
+
+        let store = makeStore()
+
+        XCTAssertEqual(store.preferences.displayMode, .remaining)
+        XCTAssertTrue(store.preferences.showsFreshness)
+        XCTAssertEqual(store.preferences.accountOrdering, WidgetPreferences.defaults.accountOrdering)
+
+        store.setShowsResetTime(true)
+        let reloaded = makeStore()
+
+        XCTAssertEqual(reloaded.preferences.displayMode, .remaining)
+        XCTAssertTrue(reloaded.preferences.showsFreshness)
+        XCTAssertTrue(reloaded.preferences.showsResetTime)
+    }
+
+    /// Re-encodes a known-good value and edits the JSON, so the fixture can
+    /// never drift from the real wire format.
+    private func encoded(
+        _ preferences: WidgetPreferences,
+        _ mutate: (inout [String: Any]) -> Void
+    ) throws -> Data {
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(preferences)) as? [String: Any]
+        )
+        mutate(&object)
+        return try JSONSerialization.data(withJSONObject: object)
     }
 
     private func makeStore() -> WidgetPreferencesStore {

--- a/Packages/MeterBarShared/Sources/MeterBarShared/FailableBox.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/FailableBox.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Wraps a decodable value so one bad element degrades to `nil` instead of
+/// failing the containing collection's decode.
+///
+/// Swift's keyed and unkeyed containers advance past an element whose nested
+/// decode throws, so wrapping the element type is enough to make an array or
+/// dictionary tolerant: the unreadable entries become `nil` and every entry the
+/// running build understands survives. Persisted caches read across app
+/// versions — the App Group blobs, the provider usage ledger — decode through
+/// this rather than an all-or-nothing `try?`.
+public struct FailableBox<T: Decodable>: Decodable {
+    public let value: T?
+
+    public init(from decoder: Decoder) throws {
+        value = try? T(from: decoder)
+    }
+}

--- a/Packages/MeterBarShared/Sources/MeterBarShared/MetricsCodec.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/MetricsCodec.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-/// Single owner of the `[ServiceType: UsageMetrics]` ⇄ JSON wire format shared
+/// Single owner of the cached-usage ⇄ JSON wire formats — provider-keyed
+/// `[ServiceType: UsageMetrics]` and the account-scoped `[AccountUsageSnapshot]` — shared
 /// by the app's UserDefaults cache, the app-group file read by the widget and
 /// CLI, and any future consumer. Previously this mapping was re-implemented in
 /// four places (UsageDataManager, SharedDataStore, the widget, the CLI).
@@ -30,14 +31,22 @@ public enum MetricsCodec {
             result[service] = metrics
         }
     }
-}
 
-/// Wraps a decodable value so one bad element degrades to `nil` instead of
-/// failing the containing collection's decode.
-private struct FailableBox<T: Decodable>: Decodable {
-    let value: T?
+    public static func encodeAccounts(_ snapshots: [AccountUsageSnapshot]) -> Data? {
+        try? JSONEncoder().encode(snapshots)
+    }
 
-    init(from decoder: Decoder) throws {
-        value = try? T(from: decoder)
+    /// Decodes the account-scoped cache with the same per-entry tolerance the
+    /// provider-keyed cache has.
+    ///
+    /// One snapshot whose `service` raw value this build does not know — a cache
+    /// written by a newer version, a provider since removed, a half-written
+    /// array — drops alone. Failing the array here would blank the widget for
+    /// every account, not just the unreadable one.
+    public static func decodeAccounts(_ data: Data) -> [AccountUsageSnapshot] {
+        guard let boxed = try? JSONDecoder().decode([FailableBox<AccountUsageSnapshot>].self, from: data) else {
+            return []
+        }
+        return boxed.compactMap(\.value)
     }
 }

--- a/Packages/MeterBarShared/Sources/MeterBarShared/SharedMetricsStore.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/SharedMetricsStore.swift
@@ -79,12 +79,15 @@ public enum SharedMetricsStore {
         return MetricsCodec.decode(data)
     }
 
+    /// Decode the cached account snapshots, tolerating a missing file or
+    /// malformed entries the same way `loadMetrics` does (an unknown service
+    /// raw value drops that snapshot, not every account — see
+    /// `MetricsCodec.decodeAccounts`).
     public static func loadAccountMetrics() -> [AccountUsageSnapshot] {
         guard let accountMetricsFileURL,
-              let data = try? Data(contentsOf: accountMetricsFileURL),
-              let decoded = try? JSONDecoder().decode([AccountUsageSnapshot].self, from: data) else {
+              let data = try? Data(contentsOf: accountMetricsFileURL) else {
             return []
         }
-        return decoded
+        return MetricsCodec.decodeAccounts(data)
     }
 }

--- a/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPreferences.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPreferences.swift
@@ -68,6 +68,28 @@ public struct WidgetAccountSelection: Codable, Equatable, Sendable {
     public var explicitIdentifiers: Set<WidgetAccountIdentifier> {
         Set(accountIdentifiers)
     }
+
+    /// Keeps the stored identifiers when the mode is a case this build does not
+    /// know.
+    ///
+    /// A newer app version writing a future selection mode into the shared App
+    /// Group must not cost the user the accounts they picked, so an unreadable
+    /// mode degrades to `.explicit` whenever identifiers survived — and to
+    /// `.all` only when there was nothing to keep, which is what `.all` already
+    /// means.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let identifiers = (container.decodeTolerantly(
+            [FailableBox<WidgetAccountIdentifier>].self,
+            forKey: .accountIdentifiers
+        ) ?? []).compactMap(\.value)
+        let mode = container.decodeCaseTolerantly(
+            WidgetAccountSelectionMode.self,
+            forKey: .mode
+        ) ?? (identifiers.isEmpty ? .all : .explicit)
+
+        self.init(mode: mode, accountIdentifiers: identifiers)
+    }
 }
 
 public enum WidgetUsageDisplayMode: String, Codable, CaseIterable, Sendable {
@@ -128,36 +150,64 @@ public struct WidgetPreferences: Codable, Equatable, Sendable {
         self.preservesLegacyOpenRouterBalance = preservesLegacyOpenRouterBalance
     }
 
+    /// Decodes field by field so an unreadable one degrades alone.
+    ///
+    /// Tolerating only *missing* keys was enough while the app and the widget
+    /// extension always shipped together, but they read this value out of the
+    /// same App Group across versions. A key that is present carrying an enum
+    /// case this build does not know used to throw, the store's `try?` then
+    /// fell back to `.defaults`, and the next `update(_:)` wrote that fallback
+    /// over the user's real settings. So every field is read independently: a
+    /// value this build cannot recognize costs that field its default and
+    /// nothing else, and unknown quota windows are simply not shown.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        accountSelection = try container.decodeIfPresent(
+        accountSelection = container.decodeTolerantly(
             WidgetAccountSelection.self,
             forKey: .accountSelection
         ) ?? Self.defaults.accountSelection
-        displayMode = try container.decodeIfPresent(
+        displayMode = container.decodeCaseTolerantly(
             WidgetUsageDisplayMode.self,
             forKey: .displayMode
         ) ?? Self.defaults.displayMode
-        visibleQuotaWindows = try container.decodeIfPresent(
-            Set<WidgetQuotaWindow>.self,
-            forKey: .visibleQuotaWindows
-        ) ?? Self.defaults.visibleQuotaWindows
-        showsResetTime = try container.decodeIfPresent(
+        let rawWindows = container.decodeTolerantly([String].self, forKey: .visibleQuotaWindows)
+        visibleQuotaWindows = rawWindows
+            .map { Set($0.compactMap(WidgetQuotaWindow.init(rawValue:))) }
+            ?? Self.defaults.visibleQuotaWindows
+        showsResetTime = container.decodeTolerantly(
             Bool.self,
             forKey: .showsResetTime
         ) ?? Self.defaults.showsResetTime
-        showsFreshness = try container.decodeIfPresent(
+        showsFreshness = container.decodeTolerantly(
             Bool.self,
             forKey: .showsFreshness
         ) ?? Self.defaults.showsFreshness
-        accountOrdering = try container.decodeIfPresent(
+        accountOrdering = container.decodeCaseTolerantly(
             WidgetAccountOrdering.self,
             forKey: .accountOrdering
         ) ?? Self.defaults.accountOrdering
-        preservesLegacyOpenRouterBalance = try container.decodeIfPresent(
+        preservesLegacyOpenRouterBalance = container.decodeTolerantly(
             Bool.self,
             forKey: .preservesLegacyOpenRouterBalance
         ) ?? Self.defaults.preservesLegacyOpenRouterBalance
+    }
+}
+
+private extension KeyedDecodingContainer {
+    /// Decodes a value, treating one this build cannot read as absent so the
+    /// caller can substitute its own default.
+    func decodeTolerantly<T: Decodable>(_ type: T.Type, forKey key: Key) -> T? {
+        guard let value = try? decodeIfPresent(T.self, forKey: key) else { return nil }
+        return value
+    }
+
+    /// Decodes an enum through its raw value so a case written by a different
+    /// app version degrades to `nil` instead of failing the whole payload.
+    func decodeCaseTolerantly<T: RawRepresentable>(
+        _ type: T.Type,
+        forKey key: Key
+    ) -> T? where T.RawValue: Decodable {
+        decodeTolerantly(T.RawValue.self, forKey: key).flatMap(T.init(rawValue:))
     }
 }
 
@@ -243,7 +293,9 @@ public final class WidgetPreferencesStore: ObservableObject {
 
     @Published public private(set) var preferences: WidgetPreferences
 
-    private static let storageKey = "WidgetPreferences"
+    /// Internal rather than private so a test can plant a payload written by a
+    /// different app version at the exact key the store reads.
+    static let storageKey = "WidgetPreferences"
 
     private let userDefaults: UserDefaults
     private let reloadTimelines: () -> Void


### PR DESCRIPTION
## Problem

Three persisted payloads decoded all-or-nothing. A single entry the running build could not read discarded every other entry with it. All three are read across app versions through the shared App Group (app, widget extension, CLI), so a value written by a newer build is a normal condition, not an exceptional one.

| | File | Blast radius |
|---|---|---|
| **High** | `SharedMetricsStore.loadAccountMetrics` | One snapshot with an unknown `ServiceType` blanked the widget for **every** account |
| **High** | `ProviderUsageLedger` / `ProviderUsageLedgerStore.load` | One bad entry emptied the **only** copy of Cursor + OpenRouter history — irrecoverable |
| **Medium** | `WidgetPreferences.init(from:)` | A present key with an unknown enum case reset **all** preferences, and the next `update(_:)` persisted the wipe |

## Fix

- **Account metrics cache** — decodes through a new `MetricsCodec.decodeAccounts`, giving it the per-entry tolerance the provider-keyed cache has had since `MetricsCodec`. `SharedDataStore` now encodes/decodes through the codec too, so both readers share one wire-format owner.
- **Provider usage ledger** — `entries` decodes per entry via `FailableBox`. `schemaVersion` and `timeZoneIdentifier` stay strict, so the existing schema-mismatch drop (and its test) is unchanged; only the entry array degrades. This artifact matters most: neither provider re-serves a day once it has passed, so a dropped ledger is permanent loss, not a re-fetchable cache.
- **Widget preferences** — every field decodes independently. An unrecognized enum case costs that field its default and nothing else; unknown quota windows are dropped rather than shown; an unknown account-selection mode keeps the identifiers the user picked (degrading to `.explicit` when any survived, `.all` only when none did).
- `FailableBox` moves out of `MetricsCodec` into its own file as shared API, since the ledger lives in the app target.

## Tests

TDD — each test was written first and observed failing against the old decoders (13 assertion failures across the three suites), then green after the fix.

- `MetricsCodecTests` — account round-trip, unknown service dropped, malformed snapshot dropped, garbage → empty
- `SharedDataStoreTests` — unknown service drops only that snapshot; malformed snapshot drops alone
- `ProviderUsageLedgerStoreTests` — unknown provider drops only that entry (surviving entry compared to the saved one); malformed entry drops alone
- `WidgetPreferencesStoreTests` — unknown ordering/quota window, unknown display mode, unknown selection mode, and one end-to-end test proving the next `update(_:)` persists the survivors rather than a wipe

Fixtures are generated by encoding a real value and mutating the JSON object, so they cannot drift from the actual wire format.

**Full suite: 2190 tests, 0 failures.** SwiftLint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resilience when loading saved usage data: malformed, outdated, or unrecognized entries are skipped while valid information remains available.
  - Invalid account metrics now safely fall back to an empty result instead of preventing other data from loading.
  - Widget preferences now preserve saved account selections and default only affected settings when unknown values are encountered.
  - Unrecognized quota-window options are ignored without invalidating the entire preferences file.

- **Reliability**
  - Improved compatibility with future data formats and partially corrupted stored data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->