### PR TITLE
fix(cost): keep cached offsets when a transcript walk is incomplete

### DIFF
--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -293,17 +293,20 @@ enum ClaudeCostScanner {
             lifetime: ClaudeSessionTotals(),
             cutoff: session.cutoff
         )
-        var live: Set<String> = []
+        var coverage = CostScanCorpusCoverage()
 
         for root in roots {
             guard CostScanFileSystem.isLocalDirectory(root) else { continue }
 
-            for file in CostScanCorpus.transcripts(in: root) {
+            let listing = CostScanCorpus.listing(in: root)
+            coverage.add(listing)
+
+            for file in listing.files {
                 // `projectRoots` can name the same directory twice (an account's
                 // configured path is often just `~/.claude`), and the cache is
                 // keyed by standardized path — counting a file once per root
                 // would double its spend.
-                guard live.insert(file.cacheKey).inserted else { continue }
+                guard coverage.keep(file.cacheKey) else { continue }
 
                 let projectID = CostProjectAttribution.claudeProjectID(
                     forTranscriptURL: file.url,
@@ -318,10 +321,11 @@ enum ClaudeCostScanner {
         }
 
         // Enumeration always runs to completion even when the read budget is
-        // spent, so `live` is every transcript that exists — safe to prune
-        // against on a partial refresh. Without it, deleted transcripts would
-        // keep contributing their totals forever.
-        session.retain(keys: live, provider: .claude)
+        // spent, so a partial refresh is still safe to prune against — the
+        // budget limits reads, not the walk. Without pruning, deleted
+        // transcripts would keep contributing their totals forever. `coverage`
+        // withholds the prune when the walk itself came up short.
+        session.retain(coverage: coverage, provider: .claude)
         return windows
     }
 

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -165,20 +165,30 @@ enum CodexCostScanner {
     /// copy found last, which is the one under `sessions/` that may still grow.
     ///
     /// The result is re-sorted rather than returned in discovery order.
-    /// `CostScanCorpus.transcripts` only orders within one directory, and
+    /// `CostScanCorpus.listing` only orders within one directory, and
     /// `archived_sessions` is enumerated first, so discovery order would put
     /// every archived rollout ahead of every live one — handing a slice's whole
     /// budget to the oldest conversations on disk. The comparator is the
     /// corpus's own, so a rollout's position does not depend on which directory
     /// its surviving copy came from.
-    nonisolated static func distinctRollouts(in directories: [URL]) -> [CostScanFile] {
+    ///
+    /// A directory that is missing or non-local is a complete answer, not a
+    /// failed walk: `archived_sessions/` routinely does not exist, and treating
+    /// that as incomplete would disable pruning forever.
+    nonisolated static func distinctRollouts(in directories: [URL]) -> CostScanCorpusListing {
         var chosen: [String: CostScanFile] = [:]
         var seen: Set<String> = []
+        var unreadableKeys: Set<String> = []
+        var isComplete = true
 
         for directory in directories {
             guard CostScanFileSystem.isLocalDirectory(directory) else { continue }
 
-            for file in CostScanCorpus.transcripts(in: directory) {
+            let listing = CostScanCorpus.listing(in: directory)
+            unreadableKeys.formUnion(listing.unreadableKeys)
+            isComplete = isComplete && listing.isComplete
+
+            for file in listing.files {
                 guard seen.insert(file.cacheKey).inserted else { continue }
                 let sessionID = Self.rolloutSessionID(for: file.url)
                 guard let incumbent = chosen[sessionID] else {
@@ -188,9 +198,13 @@ enum CodexCostScanner {
                 if file.size >= incumbent.size { chosen[sessionID] = file }
             }
         }
-        return chosen.values.sorted {
-            $0.modified == $1.modified ? $0.url.path < $1.url.path : $0.modified > $1.modified
-        }
+        return CostScanCorpusListing(
+            files: chosen.values.sorted {
+                $0.modified == $1.modified ? $0.url.path < $1.url.path : $0.modified > $1.modified
+            },
+            unreadableKeys: unreadableKeys,
+            isComplete: isComplete
+        )
     }
 
     // swiftlint:disable contains_over_range_nil_comparison
@@ -312,11 +326,12 @@ enum CodexCostScanner {
         session: CostScanSession
     ) -> ScanWindows<CostScanWindowContext> {
         var windows = Self.scanWindows(cutoff: session.cutoff, hourlyCutoff: session.hourlyCutoff)
-        let files = Self.distinctRollouts(in: directories)
-        var live: Set<String> = []
+        let listing = Self.distinctRollouts(in: directories)
+        var coverage = CostScanCorpusCoverage()
+        coverage.add(listing)
 
-        for file in files {
-            live.insert(file.cacheKey)
+        for file in listing.files {
+            coverage.keep(file.cacheKey)
             guard let totals = Self.totals(for: file, session: session) else { continue }
             guard Self.fold(totals, into: &windows) else {
                 // This rollout shares only *some* of its events with one already
@@ -336,7 +351,10 @@ enum CodexCostScanner {
             }
         }
 
-        session.retain(keys: live, provider: .codex)
+        // The duplicate copy of a rollout that lost the size comparison is
+        // deliberately absent here: only the winner is ever read, so the loser
+        // has no progress worth keeping.
+        session.retain(coverage: coverage, provider: .codex)
         return windows
     }
 

--- a/MeterBar/Services/CostScanCorpus.swift
+++ b/MeterBar/Services/CostScanCorpus.swift
@@ -43,13 +43,67 @@ nonisolated struct CostScanFile: Sendable {
     var size: Int { stamp.size }
     var modified: Date { Date(timeIntervalSince1970: stamp.modified) }
 
-    /// The per-file cache key. Standardized so `/tmp/...` and `/private/tmp/...`
-    /// resolve to one entry rather than two half-read ones.
-    var cacheKey: String { url.standardizedFileURL.path }
+    var cacheKey: String { CostScanCorpus.cacheKey(for: url) }
+}
+
+/// The result of walking one provider root: the transcripts the walk could
+/// stamp, plus what it could *not* see.
+///
+/// Callers prune their cache against the keys a walk produced, so a walk has to
+/// say how much of the tree it actually covered. Silently dropping an entry
+/// makes a live transcript indistinguishable from a deleted one, and pruning
+/// against that discards its resumable offset.
+nonisolated struct CostScanCorpusListing: Sendable {
+    /// Stamped regular files, newest modification date first.
+    let files: [CostScanFile]
+    /// Cache keys for `.jsonl` files the walk listed but could not stamp. They
+    /// exist; this lookup simply failed. They keep their cache records and are
+    /// retried on the next refresh.
+    let unreadableKeys: Set<String>
+    /// `false` when part of the tree was never walked — an unreadable
+    /// directory, or an enumerator that could not be created. Nothing may be
+    /// pruned against a listing that is not complete.
+    let isComplete: Bool
+
+    static let empty = CostScanCorpusListing(files: [], unreadableKeys: [], isComplete: true)
+}
+
+/// Accumulates listings across the several roots one provider scans, and the
+/// keys the scan actually visited, into the single retention set the session
+/// prunes against.
+nonisolated struct CostScanCorpusCoverage {
+    /// Keys the scan reached. Doubles as the dedup set for overlapping roots.
+    private var scanned: Set<String> = []
+    /// Kept separately from `scanned`: one root failing to stat a path says
+    /// nothing about a sibling root that reads it fine, so an unreadable key
+    /// must never make the file look already-visited.
+    private var unreadable: Set<String> = []
+    private(set) var isComplete = true
+
+    /// Everything the provider's cache is allowed to keep.
+    var retainedKeys: Set<String> { scanned.union(unreadable) }
+
+    mutating func add(_ listing: CostScanCorpusListing) {
+        unreadable.formUnion(listing.unreadableKeys)
+        isComplete = isComplete && listing.isComplete
+    }
+
+    /// Records a key as visited.
+    ///
+    /// - Returns: `false` when this scan already visited the key, so callers can
+    ///   skip transcripts reached twice through overlapping roots.
+    @discardableResult
+    mutating func keep(_ key: String) -> Bool {
+        scanned.insert(key).inserted
+    }
 }
 
 /// Enumerates the `.jsonl` transcripts under a provider root, newest first.
 nonisolated enum CostScanCorpus {
+    /// The per-file cache key. Standardized so `/tmp/...` and `/private/tmp/...`
+    /// resolve to one entry rather than two half-read ones.
+    static func cacheKey(for url: URL) -> String { url.standardizedFileURL.path }
+
     /// Newest modification date first.
     ///
     /// Ordering is what makes a budgeted refresh useful rather than arbitrary.
@@ -58,19 +112,46 @@ nonisolated enum CostScanCorpus {
     /// first makes the number on screen correct after the first pass, while the
     /// older archive (which only moves the lifetime total) catches up over
     /// subsequent refreshes.
-    static func transcripts(in root: URL) -> [CostScanFile] {
+    ///
+    /// - Parameter stamp: injectable so tests can fail one lookup inside an
+    ///   otherwise healthy tree. A stat race cannot be staged on a real file
+    ///   system. Production callers use the default.
+    static func listing(
+        in root: URL,
+        stamp: (URL) -> CostScanFileStamp? = { CostScanFileStamp.read(at: $0) }
+    ) -> CostScanCorpusListing {
         let keys: [URLResourceKey] = [.isRegularFileKey]
+        // A subtree the walk cannot descend into still holds transcripts. The
+        // handler keeps the walk going — the rest of the corpus is worth
+        // scanning — but the listing can no longer claim to be the whole truth.
+        let walk = WalkStatus()
         guard let enumerator = FileManager.default.enumerator(
             at: root,
             includingPropertiesForKeys: keys,
-            options: [.skipsHiddenFiles, .skipsPackageDescendants]
-        ) else { return [] }
+            options: [.skipsHiddenFiles, .skipsPackageDescendants],
+            errorHandler: { _, _ in
+                walk.markIncomplete()
+                return true
+            }
+        ) else {
+            return CostScanCorpusListing(files: [], unreadableKeys: [], isComplete: false)
+        }
 
         var files: [CostScanFile] = []
+        var unreadableKeys: Set<String> = []
         for case let url as URL in enumerator where url.pathExtension == "jsonl" {
-            guard let values = try? url.resourceValues(forKeys: Set(keys)),
-                  values.isRegularFile == true,
-                  let stamp = CostScanFileStamp.read(at: url) else { continue }
+            // A directory or dangling symlink named `*.jsonl` is a definite
+            // answer, not a failed lookup: it is not a transcript and never was,
+            // so it must stay prunable rather than pin a phantom cache key.
+            guard let values = try? url.resourceValues(forKeys: Set(keys)) else {
+                unreadableKeys.insert(cacheKey(for: url))
+                continue
+            }
+            guard values.isRegularFile == true else { continue }
+            guard let stamp = stamp(url) else {
+                unreadableKeys.insert(cacheKey(for: url))
+                continue
+            }
             files.append(
                 CostScanFile(
                     url: url,
@@ -81,8 +162,31 @@ nonisolated enum CostScanCorpus {
 
         // Path breaks ties so a corpus written in one burst still enumerates
         // deterministically — otherwise a budgeted test would be a coin flip.
-        return files.sorted {
-            $0.modified == $1.modified ? $0.url.path < $1.url.path : $0.modified > $1.modified
+        return CostScanCorpusListing(
+            files: files.sorted {
+                $0.modified == $1.modified ? $0.url.path < $1.url.path : $0.modified > $1.modified
+            },
+            unreadableKeys: unreadableKeys,
+            isComplete: walk.isComplete
+        )
+    }
+
+    /// The enumerator's error handler outlives this call's stack frame, so the
+    /// flag it sets cannot be a captured local.
+    private final class WalkStatus: @unchecked Sendable {
+        private let lock = NSLock()
+        private var incomplete = false
+
+        var isComplete: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return !incomplete
+        }
+
+        func markIncomplete() {
+            lock.lock()
+            incomplete = true
+            lock.unlock()
         }
     }
 }

--- a/MeterBar/Services/CostScanSession.swift
+++ b/MeterBar/Services/CostScanSession.swift
@@ -152,6 +152,24 @@ nonisolated final class CostScanSession: @unchecked Sendable {
         lock.unlock()
     }
 
+    /// Prunes against a completed walk of the provider's roots, and against
+    /// nothing at all when part of the corpus could not be listed.
+    ///
+    /// Absence only means deletion when the walk saw everything. An unreadable
+    /// directory hides live transcripts, and dropping their records throws away
+    /// resumable offsets — the refresh undercounts and the next one re-reads the
+    /// files end to end. Skipping the prune leaves the cache a little stale
+    /// instead, which the next complete walk cleans up.
+    func retain<Payload>(coverage: CostScanCorpusCoverage, provider: CostScanCacheKey<Payload>) {
+        guard coverage.isComplete else {
+            AppLog.cost.notice(
+                "\(provider.provider.logName, privacy: .public) corpus listing incomplete; skipping cache prune"
+            )
+            return
+        }
+        retain(keys: coverage.retainedKeys, provider: provider)
+    }
+
     func retainClaude(keys: Set<String>) {
         retain(keys: keys, provider: .claude)
     }

--- a/MeterBar/Services/GrokCostScanner.swift
+++ b/MeterBar/Services/GrokCostScanner.swift
@@ -119,19 +119,22 @@ enum GrokCostScanner {
         session: CostScanSession
     ) -> ScanWindows<CostScanWindowContext> {
         var windows = Self.scanWindows(cutoff: session.cutoff, hourlyCutoff: session.hourlyCutoff)
-        var live: Set<String> = []
+        var coverage = CostScanCorpusCoverage()
 
         for root in roots {
             guard CostScanFileSystem.isLocalDirectory(root) else { continue }
-            for file in CostScanCorpus.transcripts(in: root) {
-                guard live.insert(file.cacheKey).inserted else { continue }
+            let listing = CostScanCorpus.listing(in: root)
+            coverage.add(listing)
+
+            for file in listing.files {
+                guard coverage.keep(file.cacheKey) else { continue }
                 guard let totals = Self.totals(for: file, session: session) else { continue }
                 windows.period.merge(totals.period)
                 windows.lifetime.merge(totals.lifetime)
             }
         }
 
-        session.retain(keys: live, provider: .grok)
+        session.retain(coverage: coverage, provider: .grok)
         return windows
     }
 

--- a/MeterBarTests/CostScanCollaboratorTests.swift
+++ b/MeterBarTests/CostScanCollaboratorTests.swift
@@ -658,17 +658,23 @@ final class CostScanCollaboratorTests: XCTestCase {
         // Only `.jsonl` transcripts participate in the scan.
         try writeCorpusFile(in: root, name: "notes.txt", bytes: 10, modified: now)
 
-        let files = CostScanCorpus.transcripts(in: root)
+        let files = CostScanCorpus.listing(in: root).files
 
         XCTAssertEqual(files.map { $0.url.lastPathComponent }, ["newest.jsonl", "middle.jsonl", "oldest.jsonl"])
         XCTAssertEqual(files.first?.size, 10)
     }
 
-    func testCorpusOfAMissingDirectoryIsEmpty() {
+    /// A root that is not there yields nothing, and says so: the walk never
+    /// happened, so its emptiness is no evidence that the cached transcripts
+    /// were deleted.
+    func testCorpusOfAMissingDirectoryIsEmptyAndIncomplete() {
         let missing = FileManager.default.temporaryDirectory
             .appendingPathComponent("CostScanCorpus-missing-\(UUID().uuidString)", isDirectory: true)
 
-        XCTAssertTrue(CostScanCorpus.transcripts(in: missing).isEmpty)
+        let listing = CostScanCorpus.listing(in: missing)
+
+        XCTAssertTrue(listing.files.isEmpty)
+        XCTAssertFalse(listing.isComplete)
     }
 
     // MARK: - CostScanExecutor

--- a/MeterBarTests/CostScanFileCacheSafetyTests.swift
+++ b/MeterBarTests/CostScanFileCacheSafetyTests.swift
@@ -43,6 +43,35 @@ final class CostScanFileCacheSafetyTests: XCTestCase {
         XCTAssertFalse(before.isSameFile(as: after))
     }
 
+    /// The branch `testAtomicReplacementWithSameSizeAndMtimeChangesFileIdentity`
+    /// skips over on volumes without file identifiers, pinned down directly.
+    ///
+    /// A missing identifier is a gap in what the volume reports, not evidence of
+    /// a different file, so `matches` falls back to size and mtime alone and
+    /// resumption stays available. `isSameFile` makes the opposite call: it
+    /// gates resuming a *changed* file, where guessing wrong means appending
+    /// another file's events to this one's tally, so it demands proof.
+    func testStampComparisonsWithoutFileIdentifiersFavorReuseButRefuseResumption() {
+        let anonymous = CostScanFileStamp(size: 4, modified: 1_780_000_000, fileID: nil)
+        let identified = CostScanFileStamp(size: 4, modified: 1_780_000_000, fileID: 42)
+        let grown = CostScanFileStamp(size: 8, modified: 1_780_000_000, fileID: nil)
+        let touched = CostScanFileStamp(size: 4, modified: 1_780_000_001, fileID: nil)
+
+        XCTAssertTrue(anonymous.matches(anonymous))
+        // One side reporting an identifier is not a mismatch: the other side
+        // never claimed a different one.
+        XCTAssertTrue(anonymous.matches(identified))
+        XCTAssertTrue(identified.matches(anonymous))
+        // Size and mtime still decide on their own.
+        XCTAssertFalse(anonymous.matches(grown))
+        XCTAssertFalse(anonymous.matches(touched))
+
+        XCTAssertFalse(anonymous.isSameFile(as: anonymous))
+        XCTAssertFalse(anonymous.isSameFile(as: identified))
+        XCTAssertFalse(identified.isSameFile(as: anonymous))
+        XCTAssertTrue(identified.isSameFile(as: identified))
+    }
+
     func testCacheRejectsParserAndTimeZoneMismatches() throws {
         let url = directory.appendingPathComponent(CostScanCacheStore.claudeFileName)
         try CostScanCacheStore.saveClaude(makeCache(), to: url)

--- a/MeterBarTests/CostScanPruneSafetyTests.swift
+++ b/MeterBarTests/CostScanPruneSafetyTests.swift
@@ -1,0 +1,301 @@
+import Foundation
+import XCTest
+@testable import MeterBar
+
+/// What the cost scan is allowed to conclude from *not* seeing a transcript.
+///
+/// `CostScanSession.retain` treats an absent cache key as a deleted file and
+/// drops its record. That is correct only when the walk that produced the key
+/// set actually saw the whole corpus: a walk that skipped a subtree it could
+/// not read, or an entry it could not stat, has no evidence of deletion at all.
+/// Pruning against that partial view discards a live transcript's resumable
+/// offset — the refresh undercounts, and the next one pays for a full re-read.
+final class CostScanPruneSafetyTests: XCTestCase {
+    private let cutoff = Date(timeIntervalSince1970: 1_780_000_000)
+
+    // MARK: - Corpus listing
+
+    func testListingOfAReadableTreeIsComplete() throws {
+        let root = try makeTemporaryDirectory(named: "CostScanPruneComplete")
+        try writeTranscript(at: root.appendingPathComponent("a.jsonl"))
+        try writeTranscript(at: root.appendingPathComponent("nested/b.jsonl"))
+
+        let listing = CostScanCorpus.listing(in: root)
+
+        XCTAssertTrue(listing.isComplete)
+        XCTAssertTrue(listing.unreadableKeys.isEmpty)
+        XCTAssertEqual(
+            Set(listing.files.map(\.url.lastPathComponent)),
+            ["a.jsonl", "b.jsonl"]
+        )
+    }
+
+    /// A subtree the walk cannot descend into is the realistic shape of this
+    /// bug: the transcripts under it still exist, they are simply unlisted.
+    func testListingOfATreeWithAnUnreadableDirectoryIsIncomplete() throws {
+        let root = try makeTemporaryDirectory(named: "CostScanPruneLockedDir")
+        try writeTranscript(at: root.appendingPathComponent("visible.jsonl"))
+        try lockDirectory(at: root.appendingPathComponent("locked", isDirectory: true), holding: "hidden.jsonl")
+
+        let listing = CostScanCorpus.listing(in: root)
+
+        XCTAssertFalse(listing.isComplete)
+        XCTAssertEqual(listing.files.map(\.url.lastPathComponent), ["visible.jsonl"])
+    }
+
+    /// A `.jsonl` the walk lists but cannot stamp. `EINTR` and friends make this
+    /// a transient property of one lookup, not of the file, so it is reported
+    /// rather than dropped — the caller keeps its cache record and tries again.
+    func testListingReportsEntriesItCannotStamp() throws {
+        let root = try makeTemporaryDirectory(named: "CostScanPruneStatFailure")
+        let unstampable = root.appendingPathComponent("racy.jsonl")
+        try writeTranscript(at: unstampable)
+        try writeTranscript(at: root.appendingPathComponent("stable.jsonl"))
+
+        let listing = CostScanCorpus.listing(in: root) { url in
+            url.lastPathComponent == "racy.jsonl" ? nil : CostScanFileStamp.read(at: url)
+        }
+
+        XCTAssertEqual(listing.files.map(\.url.lastPathComponent), ["stable.jsonl"])
+        XCTAssertEqual(listing.unreadableKeys, [CostScanCorpus.cacheKey(for: unstampable)])
+        // The tree itself was walked end to end. Only one lookup inside it
+        // failed, and the grace period covers exactly that key.
+        XCTAssertTrue(listing.isComplete)
+    }
+
+    /// A directory named `x.jsonl`, or a symlink to nowhere, is a definite
+    /// answer: it is not a transcript, and never was one. Reporting it as
+    /// unreadable would keep a phantom cache key alive forever.
+    func testListingDoesNotReportNonRegularEntriesAsUnreadable() throws {
+        let root = try makeTemporaryDirectory(named: "CostScanPruneNonRegular")
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("folder.jsonl", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createSymbolicLink(
+            atPath: root.appendingPathComponent("dangling.jsonl").path,
+            withDestinationPath: root.appendingPathComponent("missing.jsonl").path
+        )
+
+        let listing = CostScanCorpus.listing(in: root)
+
+        XCTAssertTrue(listing.files.isEmpty)
+        XCTAssertTrue(listing.unreadableKeys.isEmpty)
+        XCTAssertTrue(listing.isComplete)
+    }
+
+    // MARK: - Coverage
+
+    func testCoverageRetainsScannedAndUnreadableKeysAndFoldsCompleteness() {
+        var coverage = CostScanCorpusCoverage()
+        XCTAssertTrue(coverage.isComplete)
+
+        coverage.add(CostScanCorpusListing(files: [], unreadableKeys: ["/tmp/a.jsonl"], isComplete: true))
+        XCTAssertTrue(coverage.keep("/tmp/b.jsonl"))
+        // Overlapping roots hand the same transcript over twice; the second
+        // sighting is not a second file to scan.
+        XCTAssertFalse(coverage.keep("/tmp/b.jsonl"))
+        XCTAssertEqual(coverage.retainedKeys, ["/tmp/a.jsonl", "/tmp/b.jsonl"])
+        XCTAssertTrue(coverage.isComplete)
+
+        coverage.add(CostScanCorpusListing(files: [], unreadableKeys: [], isComplete: false))
+        XCTAssertFalse(coverage.isComplete)
+    }
+
+    /// An unreadable key must not make the file look already-scanned: one root
+    /// failing to stat a path says nothing about the root that reads it fine.
+    func testUnreadableKeysDoNotSuppressScanningTheSamePathFromAnotherRoot() {
+        var coverage = CostScanCorpusCoverage()
+        coverage.add(CostScanCorpusListing(files: [], unreadableKeys: ["/tmp/a.jsonl"], isComplete: true))
+
+        XCTAssertTrue(coverage.keep("/tmp/a.jsonl"))
+    }
+
+    // MARK: - Claude
+
+    func testClaudeKeepsCachedRecordsWhenPartOfTheCorpusCouldNotBeListed() throws {
+        let root = try makeTemporaryDirectory(named: "ClaudePruneProjects")
+        try writeTranscript(at: root.appendingPathComponent("project/visible.jsonl"), line: claudeEventLine())
+        let hidden = try lockDirectory(
+            at: root.appendingPathComponent("locked", isDirectory: true),
+            holding: "hidden.jsonl"
+        )
+        let session = makeSession()
+        session.setClaudeRecord(makeClaudeRecord(offset: 4_096), for: CostScanCorpus.cacheKey(for: hidden))
+        // A transcript that really is gone. An incomplete walk cannot tell it
+        // apart from `hidden.jsonl`, so it survives too — one refresh of stale
+        // totals is recoverable, a discarded offset is not.
+        session.setClaudeRecord(makeClaudeRecord(), for: "/tmp/deleted-\(UUID().uuidString).jsonl")
+
+        _ = ClaudeCostScanner.scanRoots([root], session: session)
+
+        XCTAssertEqual(session.claude.records.count, 3)
+        XCTAssertEqual(session.claude.records[CostScanCorpus.cacheKey(for: hidden)]?.offset, 4_096)
+    }
+
+    /// The other half of the contract: a walk that saw everything still prunes,
+    /// or the cache would grow without bound.
+    func testClaudeStillPrunesDeletedTranscriptsWhenTheWalkIsComplete() throws {
+        let root = try makeTemporaryDirectory(named: "ClaudePruneComplete")
+        let visible = root.appendingPathComponent("project/visible.jsonl")
+        try writeTranscript(at: visible, line: claudeEventLine())
+        let session = makeSession()
+        session.setClaudeRecord(makeClaudeRecord(), for: "/tmp/deleted-\(UUID().uuidString).jsonl")
+
+        _ = ClaudeCostScanner.scanRoots([root], session: session)
+
+        XCTAssertEqual(
+            Set(session.claude.records.keys),
+            [CostScanCorpus.cacheKey(for: visible)]
+        )
+    }
+
+    // MARK: - Codex
+
+    func testCodexKeepsCachedRecordsWhenPartOfTheCorpusCouldNotBeListed() throws {
+        let root = try makeTemporaryDirectory(named: "CodexPruneRollouts")
+        try writeTranscript(at: root.appendingPathComponent("visible.jsonl"), line: codexTokenLine())
+        let hidden = try lockDirectory(
+            at: root.appendingPathComponent("locked", isDirectory: true),
+            holding: "hidden.jsonl"
+        )
+        let session = makeSession()
+        session.setCodexRecord(makeCodexRecord(offset: 4_096), for: CostScanCorpus.cacheKey(for: hidden))
+
+        _ = CodexCostScanner.scanRollouts(directories: [root], session: session)
+
+        XCTAssertEqual(session.codex.records[CostScanCorpus.cacheKey(for: hidden)]?.offset, 4_096)
+    }
+
+    func testCodexStillPrunesDeletedRolloutsWhenTheWalkIsComplete() throws {
+        let root = try makeTemporaryDirectory(named: "CodexPruneComplete")
+        let visible = root.appendingPathComponent("visible.jsonl")
+        try writeTranscript(at: visible, line: codexTokenLine())
+        let session = makeSession()
+        session.setCodexRecord(makeCodexRecord(), for: "/tmp/deleted-\(UUID().uuidString).jsonl")
+
+        _ = CodexCostScanner.scanRollouts(directories: [root], session: session)
+
+        XCTAssertEqual(Set(session.codex.records.keys), [CostScanCorpus.cacheKey(for: visible)])
+    }
+
+    // MARK: - Grok
+
+    func testGrokKeepsCachedRecordsWhenPartOfTheCorpusCouldNotBeListed() throws {
+        let root = try makeTemporaryDirectory(named: "GrokPruneSessions")
+        try writeTranscript(at: root.appendingPathComponent("session-a/updates.jsonl"), line: grokTurnLine())
+        let hidden = try lockDirectory(
+            at: root.appendingPathComponent("locked", isDirectory: true),
+            holding: "updates.jsonl"
+        )
+        let session = makeSession()
+        session.setGrokRecord(makeGrokRecord(offset: 4_096), for: CostScanCorpus.cacheKey(for: hidden))
+
+        _ = GrokCostScanner.scanRoots([root], session: session)
+
+        XCTAssertEqual(session.grok.records[CostScanCorpus.cacheKey(for: hidden)]?.offset, 4_096)
+    }
+
+    func testGrokStillPrunesDeletedSessionsWhenTheWalkIsComplete() throws {
+        let root = try makeTemporaryDirectory(named: "GrokPruneComplete")
+        let visible = root.appendingPathComponent("session-a/updates.jsonl")
+        try writeTranscript(at: visible, line: grokTurnLine())
+        let session = makeSession()
+        session.setGrokRecord(makeGrokRecord(), for: "/tmp/deleted-\(UUID().uuidString).jsonl")
+
+        _ = GrokCostScanner.scanRoots([root], session: session)
+
+        XCTAssertEqual(Set(session.grok.records.keys), [CostScanCorpus.cacheKey(for: visible)])
+    }
+}
+
+// MARK: - Fixtures
+
+extension CostScanPruneSafetyTests {
+    private func makeSession() -> CostScanSession {
+        CostScanSession(cutoff: cutoff, options: .unlimited)
+    }
+
+    private func makeClaudeRecord(offset: UInt64 = 0) -> CostScanFileRecord<ClaudeFileTotals> {
+        makeRecord(offset: offset, payload: ClaudeFileTotals())
+    }
+
+    private func makeCodexRecord(offset: UInt64 = 0) -> CostScanFileRecord<CodexFileTotals> {
+        makeRecord(offset: offset, payload: CodexFileTotals(cutoff: cutoff))
+    }
+
+    private func makeGrokRecord(offset: UInt64 = 0) -> CostScanFileRecord<GrokFileTotals> {
+        makeRecord(offset: offset, payload: GrokFileTotals(cutoff: cutoff))
+    }
+
+    private func makeRecord<Payload>(offset: UInt64, payload: Payload) -> CostScanFileRecord<Payload> {
+        CostScanFileRecord(
+            offset: offset,
+            stamp: CostScanFileStamp(size: Int(offset), modified: cutoff.timeIntervalSince1970, fileID: 42),
+            cutoff: cutoff,
+            isComplete: true,
+            payload: payload
+        )
+    }
+
+    private func makeTemporaryDirectory(named prefix: String) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+
+    private func writeTranscript(at url: URL, line: String = "{}") throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try (line + "\n").write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    /// A subdirectory holding a transcript that the walk can neither list nor
+    /// stat. Restored to searchable on teardown so the temp tree can be removed.
+    ///
+    /// - Returns: the URL of the transcript now hidden behind it.
+    @discardableResult
+    private func lockDirectory(at directory: URL, holding name: String) throws -> URL {
+        let transcript = directory.appendingPathComponent(name)
+        try writeTranscript(at: transcript)
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: directory.path)
+        addTeardownBlock {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: directory.path)
+        }
+        return transcript
+    }
+
+    private func claudeEventLine() -> String {
+        """
+        {"timestamp": "2026-06-15T10:00:00.000Z", "requestId": "req_1", \
+        "message": {"id": "msg_1", "model": "claude-sonnet-4-5", \
+        "usage": {"input_tokens": 100, "output_tokens": 50, \
+        "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}}
+        """
+    }
+
+    private func codexTokenLine() -> String {
+        """
+        {"timestamp": "2026-06-15T10:00:00Z", "payload": {"type": "token_count", \
+        "rate_limits": {"conversation_id": "conv-1"}, \
+        "info": {"model": "gpt-5.5", "last_token_usage": \
+        {"input_tokens": 1000, "output_tokens": 500, \
+        "cached_input_tokens": 200, "reasoning_output_tokens": 50}}}}
+        """
+    }
+
+    private func grokTurnLine() -> String {
+        """
+        {"timestamp":"2026-06-15T10:00:00.000Z","method":"session/update",\
+        "params":{"sessionId":"019fafec-972e-7413-8cbd-01647988c8f9",\
+        "update":{"sessionUpdate":"turn_completed","stop_reason":"end_turn",\
+        "usage":{"inputTokens":100,"outputTokens":10,"totalTokens":110,\
+        "cachedReadTokens":0,"reasoningTokens":0,"modelCalls":1,\
+        "apiDurationMs":1234,"costUsdTicks":1000000,"numTurns":1}}}}
+        """
+    }
+}

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -1222,7 +1222,7 @@ final class CostTrackerTests: XCTestCase {
 
         let files = CodexCostScanner.distinctRollouts(
             in: CodexCostScanner.rolloutDirectories(in: root)
-        )
+        ).files
 
         XCTAssertEqual(
             files.map(\.url.standardizedFileURL.path),


### PR DESCRIPTION
## The bug

`CostScanCorpus.transcripts(in:)` dropped any `.jsonl` whose `resourceValues` or `CostScanFileStamp.read` failed, with no way to tell that from "the file isn't there". Its `FileManager.enumerator` was built with **no `errorHandler`**, so an unreadable subdirectory was skipped in silence, and a nil enumerator returned `[]` — a corpus of zero.

All three scanners built their retention set solely from that listing:

```swift
session.retain(keys: live, provider: .claude)   // ...and .codex, .grok
```

`CostScanSession.retain` treats an absent key as a deleted file, marks the provider dirty, and the next `persist()` writes the prune to disk. So one transient ENOENT/EINTR-class stat race on a live, actively-written transcript:

1. contributed nothing to that refresh — **undercount**, and
2. **permanently discarded its resumable byte offset**, forcing a full re-scan of the file.

`retain()` itself was correct; the bug was entirely in what fed `keys`.

## The fix

The walk now reports what it could not see.

- **`CostScanCorpusListing`** — stamped `files`, `unreadableKeys` (listed but unstampable), and `isComplete`.
- **An `errorHandler`** on the enumerator: keep walking the rest of the corpus, but mark the listing incomplete. A nil enumerator is incomplete, not empty.
- **`CostScanCorpusCoverage`** — folds listings across a provider's several roots. `scanned` and `unreadable` are tracked separately so an unreadable key from one root can't make the file look already-visited to a sibling root that reads it fine. Its `keep(_:)` replaces the scanners' hand-rolled dedup guard.
- **`CostScanSession.retain(coverage:provider:)`** — prunes only against a complete walk; otherwise logs and skips, leaving the cache slightly stale until the next complete walk cleans it up.
- **`CostScanCorpus.cacheKey(for:)`** — one definition of the key, so the unreadable-key path can't drift from `CostScanFile.cacheKey`.

`transcripts(in:)` is **deleted** rather than kept as a wrapper — returning a bare array with no completeness signal is the footgun that caused this.

### Deliberately unchanged

- **Non-regular entries stay prunable.** A directory or dangling symlink named `*.jsonl` is a definite answer, not a failed lookup; reporting it as unreadable would pin a phantom cache key forever.
- **A missing or non-local root stays complete.** Codex's `archived_sessions/` routinely doesn't exist; marking that incomplete would disable pruning permanently.
- **Codex still prunes the losing duplicate** of a rollout found in both `sessions/` and `archived_sessions/` — only the winner is ever read, so the loser has no progress worth keeping.

### Trade-off

While a root contains a *permanently* unreadable subdirectory, that provider's cache is never pruned. That is bounded, logged, and non-corrupting — strictly better than deleting live offsets.

## Tests (TDD)

New `MeterBarTests/CostScanPruneSafetyTests.swift`. The three scanner tests were written first and use **only pre-existing API**, so they failed against unmodified production code:

```
testClaudeKeepsCachedRecordsWhenPartOfTheCorpusCouldNotBeListed  FAILED ("1" is not equal to "3" / "nil" is not equal to "Optional(4096)")
testCodexKeepsCachedRecordsWhenPartOfTheCorpusCouldNotBeListed   FAILED ("nil" is not equal to "Optional(4096)")
testGrokKeepsCachedRecordsWhenPartOfTheCorpusCouldNotBeListed    FAILED ("nil" is not equal to "Optional(4096)")
```

Each seeds a cache record for a transcript hidden behind a mode-`000` directory, runs the scanner, and asserts the record and its `offset: 4096` survive. A paired `…StillPrunes…` test per provider asserts a complete walk still drops a genuinely deleted key — those passed before and after, so the fix withholds pruning without disabling it.

Per-file stat failure can't be staged on a real file system, so `listing(in:stamp:)` takes an injectable stamp closure, following the existing seam precedent in `ProviderReadinessInspector` and `AuthenticationManager`.

Also adds `testStampComparisonsWithoutFileIdentifiersFavorReuseButRefuseResumption`, covering the nil-`fileID` branch of `matches()`/`isSameFile(as:)` that `testAtomicReplacementWithSameSizeAndMtimeChangesFileIdentity` `XCTSkip`s on volumes without file identifiers.

## Verification

`swift test` — **2191 tests, 0 failures**, 6 pre-existing skips.