### PR TITLE
fix(codex): stop re-offering a reset credit that was already spent

### DIFF
--- a/MeterBar/Services/CodexResetCreditConsumptionStore.swift
+++ b/MeterBar/Services/CodexResetCreditConsumptionStore.swift
@@ -1,0 +1,62 @@
+import Combine
+import Foundation
+
+// MARK: - CodexResetCreditConsumptionStore
+
+/// Tracks Codex reset credits that were spent but are not yet reflected in any
+/// snapshot, keyed by account.
+///
+/// `consumeResetCredit` can succeed and still fail to refetch usage, in which
+/// case the card is left quoting the pre-spend credit count. Offering the action
+/// against that count invites a second, real redemption, so the spend has to be
+/// remembered somewhere until fresher numbers arrive.
+///
+/// It used to be remembered in the card's own `@State`, which was not durable
+/// enough: the dashboard deals cards into columns by array position, so any
+/// change to the snapshot list — another account finishing a poll, a provider
+/// gaining or losing metrics — could move a card, tear down its state, and
+/// re-offer the credit it had just spent. Keying the record by account id puts
+/// it out of reach of view churn.
+///
+/// The record is deliberately not a permanent latch. Each spend is stamped with
+/// the moment it completed, and any snapshot whose metrics were fetched after
+/// that instant supersedes it: those numbers already account for the spend, so
+/// the eligibility rule can be trusted again and an account with a second banked
+/// credit gets its button back. Superseded records are left in place rather than
+/// pruned — reads happen from `body`, which must not mutate — and there is one
+/// entry per Codex account at worst. Nothing is persisted; a relaunch refetches
+/// usage before any card can offer the action.
+final class CodexResetCreditConsumptionStore: ObservableObject {
+    // MARK: Internal
+
+    static let shared = CodexResetCreditConsumptionStore()
+
+    /// Completion instant of the last unconfirmed redemption per account.
+    @Published private(set) var consumedAt: [UUID: Date] = [:]
+
+    /// Records a redemption whose result is not yet visible in any snapshot.
+    func markConsumed(accountID: UUID, at date: Date = Date()) {
+        consumedAt[accountID] = date
+    }
+
+    /// Drops the record because authoritative post-spend numbers arrived — the
+    /// count on screen is now the real remaining balance.
+    func clear(accountID: UUID) {
+        consumedAt.removeValue(forKey: accountID)
+    }
+
+    /// Whether `snapshotUpdatedAt` may still be quoting a credit this account
+    /// has already spent. A pure read: it is called from view bodies.
+    ///
+    /// An undated snapshot has no cached metrics at all, so it can never be the
+    /// newer evidence that clears a record.
+    func hasPendingConsumption(accountID: UUID?, snapshotUpdatedAt: Date?) -> Bool {
+        guard let accountID, let consumedAt = consumedAt[accountID] else { return false }
+        guard let snapshotUpdatedAt else { return true }
+        return snapshotUpdatedAt <= consumedAt
+    }
+
+    func clearAll() {
+        consumedAt.removeAll()
+    }
+}

--- a/MeterBar/Views/Components/ProviderMasonryLayout.swift
+++ b/MeterBar/Views/Components/ProviderMasonryLayout.swift
@@ -1,0 +1,141 @@
+import SwiftUI
+
+// MARK: - ProviderMasonryLayout
+
+/// Round-robin masonry that keeps every card a sibling in one container.
+///
+/// The dashboard used to build this by partitioning the snapshots into per-column
+/// arrays and nesting a `ForEach` inside a `ForEach` over the columns. That made
+/// a card's SwiftUI identity depend on which column it happened to land in, and
+/// columns are dealt by array position: when the snapshot list changed — another
+/// account finishing a background poll, a provider gaining or losing metrics —
+/// every card after the change flipped column, took a different identity path,
+/// and had its `@State` discarded. For the Codex reset-credit button that meant
+/// a spent credit could be silently re-offered.
+///
+/// Placing the cards geometrically fixes the identity, not the arrangement: the
+/// caller keeps one `ForEach` keyed by snapshot id and the layout decides where
+/// each card goes, so a card keeps its state wherever it is placed. The deal is
+/// unchanged — same round robin, same reading order, same balance — so the grid
+/// looks exactly as it did.
+struct ProviderMasonryLayout: Layout {
+    // MARK: Internal
+
+    var columnCount: Int
+    var spacing: CGFloat
+
+    /// Deals items round-robin across `columnCount` independent columns.
+    ///
+    /// `LazyVGrid` locks every card in a row to the tallest card in that row, so
+    /// a provider with two quota windows left a block of dead space beside a
+    /// provider with four. Columns that flow on their own pack tight instead.
+    /// Round-robin keeps reading order running left-to-right across each row
+    /// and keeps the columns balanced to within one card.
+    ///
+    /// Kept as a standalone function (rather than folded into `frames`) so the
+    /// ordering and balance can be unit-tested on their own.
+    nonisolated static func columns<Element>(_ items: [Element], columnCount: Int) -> [[Element]] {
+        let count = max(1, columnCount)
+        var columns = [[Element]](repeating: [], count: count)
+        for (index, item) in items.enumerated() {
+            columns[index % count].append(item)
+        }
+        return columns
+    }
+
+    /// Frames for cards of `heights`, relative to the layout's origin.
+    ///
+    /// Pure so the deal, the column widths, and the independent stacking can be
+    /// asserted without hosting a view.
+    nonisolated static func frames(
+        heights: [CGFloat],
+        containerWidth: CGFloat,
+        columnCount: Int,
+        spacing: CGFloat
+    ) -> [CGRect] {
+        let count = max(1, columnCount)
+        let width = columnWidth(containerWidth: containerWidth, columnCount: count, spacing: spacing)
+        var nextY = [CGFloat](repeating: 0, count: count)
+        var frames = [CGRect](repeating: .zero, count: heights.count)
+
+        for (index, column) in columns(Array(heights.indices), columnCount: count).enumerated() {
+            let x = (width + spacing) * CGFloat(index)
+            for item in column {
+                frames[item] = CGRect(x: x, y: nextY[index], width: width, height: heights[item])
+                nextY[index] += heights[item] + spacing
+            }
+        }
+        return frames
+    }
+
+    /// Height of the tallest column, so a short column never pads the section
+    /// out to a ragged bottom edge.
+    nonisolated static func totalHeight(of frames: [CGRect]) -> CGFloat {
+        frames.map(\.maxY).max() ?? 0
+    }
+
+    /// Width one card occupies: the container minus the gutters between columns.
+    nonisolated static func columnWidth(
+        containerWidth: CGFloat,
+        columnCount: Int,
+        spacing: CGFloat
+    ) -> CGFloat {
+        let count = max(1, columnCount)
+        let gutters = spacing * CGFloat(count - 1)
+        return max(0, (containerWidth - gutters) / CGFloat(count))
+    }
+
+    nonisolated func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) -> CGSize {
+        let width = resolvedWidth(for: proposal)
+        let frames = Self.frames(
+            heights: heights(of: subviews, containerWidth: width),
+            containerWidth: width,
+            columnCount: columnCount,
+            spacing: spacing
+        )
+        return CGSize(width: width, height: Self.totalHeight(of: frames))
+    }
+
+    nonisolated func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) {
+        let frames = Self.frames(
+            heights: heights(of: subviews, containerWidth: bounds.width),
+            containerWidth: bounds.width,
+            columnCount: columnCount,
+            spacing: spacing
+        )
+        for (subview, frame) in zip(subviews, frames) {
+            subview.place(
+                at: CGPoint(x: bounds.minX + frame.minX, y: bounds.minY + frame.minY),
+                proposal: ProposedViewSize(width: frame.width, height: frame.height)
+            )
+        }
+    }
+
+    // MARK: Private
+
+    /// Cards are sized at their column's width before being stacked, so a tall
+    /// wrapping card reports the height it will actually occupy.
+    nonisolated private func heights(of subviews: Subviews, containerWidth: CGFloat) -> [CGFloat] {
+        let width = Self.columnWidth(
+            containerWidth: containerWidth,
+            columnCount: columnCount,
+            spacing: spacing
+        )
+        return subviews.map { $0.sizeThatFits(ProposedViewSize(width: width, height: nil)).height }
+    }
+
+    /// The section always fills the page width; an unspecified proposal only
+    /// happens in sizing passes, where the ideal width is the best answer.
+    nonisolated private func resolvedWidth(for proposal: ProposedViewSize) -> CGFloat {
+        proposal.width ?? proposal.replacingUnspecifiedDimensions().width
+    }
+}

--- a/MeterBar/Views/DashboardOverviewSection.swift
+++ b/MeterBar/Views/DashboardOverviewSection.swift
@@ -37,25 +37,6 @@ struct DashboardOverviewSection: View {
         return ("No data", "Waiting for provider refresh", nil)
     }
 
-    /// Deals items round-robin across `columnCount` independent columns.
-    ///
-    /// `LazyVGrid` locks every card in a row to the tallest card in that row, so
-    /// a provider with two quota windows left a block of dead space beside a
-    /// provider with four. Columns that flow on their own pack tight instead.
-    /// Round-robin keeps reading order running left-to-right across each row
-    /// and keeps the columns balanced to within one card.
-    ///
-    /// Internal (not private) so the ordering and balance can be unit-tested
-    /// without hosting the page.
-    nonisolated static func masonryColumns<Element>(_ items: [Element], columnCount: Int) -> [[Element]] {
-        let count = max(1, columnCount)
-        var columns = [[Element]](repeating: [], count: count)
-        for (index, item) in items.enumerated() {
-            columns[index % count].append(item)
-        }
-        return columns
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             OverviewSummaryStrip(
@@ -65,21 +46,20 @@ struct DashboardOverviewSection: View {
                 formattedTokens: UsageFormat.tokens(costSummary?.totalTokens ?? 0)
             )
 
-            HStack(alignment: .top, spacing: MeterBarTheme.Spacing.sm) {
-                let columns = Self.masonryColumns(snapshots, columnCount: Self.masonryColumnCount)
-                ForEach(Array(columns.enumerated()), id: \.offset) { _, column in
-                    VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.sm) {
-                        ForEach(column) { snapshot in
-                            // Same shared provider card as the popover and the
-                            // Limits page; tapping it jumps to that provider in
-                            // Limits.
-                            ProviderStatusCard(
-                                snapshot: snapshot,
-                                onSelect: { onSelectProvider(snapshot.id) }
-                            )
-                        }
-                    }
-                    .frame(maxWidth: .infinity, alignment: .topLeading)
+            // One container, one ForEach: the layout decides which column each
+            // card lands in, so a card keeps its identity — and any in-flight
+            // state — when the snapshot list changes underneath it.
+            ProviderMasonryLayout(
+                columnCount: Self.masonryColumnCount,
+                spacing: MeterBarTheme.Spacing.sm
+            ) {
+                ForEach(snapshots) { snapshot in
+                    // Same shared provider card as the popover and the Limits
+                    // page; tapping it jumps to that provider in Limits.
+                    ProviderStatusCard(
+                        snapshot: snapshot,
+                        onSelect: { onSelectProvider(snapshot.id) }
+                    )
                 }
             }
             .frame(maxWidth: .infinity)

--- a/MeterBar/Views/ProviderCardPresentation.swift
+++ b/MeterBar/Views/ProviderCardPresentation.swift
@@ -61,17 +61,24 @@ enum ProviderCardPresentation {
             && !collapsesToLoginRow(snapshot: snapshot, now: now)
     }
 
-    /// Reset credits are a Codex CLI concept. `didConsumeResetCredit` suppresses
-    /// the action for the rest of the card's lifetime: the snapshot's credit
-    /// count is only refreshed on the next poll, so without it a spent credit
-    /// stays offered and invites a double redemption.
+    /// Reset credits are a Codex CLI concept. The eligibility rule already hides
+    /// the action once the provider reports no credits left, but the count it
+    /// reads is only as fresh as the last poll: a redemption whose follow-up
+    /// refetch failed leaves the snapshot still claiming the spent credit is
+    /// there. `hasPendingConsumption` covers exactly that window — see
+    /// `CodexResetCreditConsumptionStore`, which drops the record as soon as
+    /// newer metrics arrive.
+    ///
+    /// It is deliberately not a permanent latch. An account can bank several
+    /// credits, and once refreshed numbers land the count is authoritative, so
+    /// the action must come back for the next one.
     static func showsResetCreditAction(
         snapshot: ProviderSnapshot,
-        didConsumeResetCredit: Bool,
+        hasPendingConsumption: Bool,
         isAuthenticated: Bool,
         hasResolvedAccount: Bool
     ) -> Bool {
-        guard snapshot.service == .codexCli, !didConsumeResetCredit else { return false }
+        guard snapshot.service == .codexCli, !hasPendingConsumption else { return false }
         return CodexResetCreditEligibility.isEligible(
             isBlocked: snapshot.hasExhaustedLimit,
             availableCredits: snapshot.resetCreditsAvailable,

--- a/MeterBar/Views/ProviderStatusCard.swift
+++ b/MeterBar/Views/ProviderStatusCard.swift
@@ -15,9 +15,12 @@ struct ProviderStatusCard: View {
     @StateObject private var codexService = CodexCliLocalService.shared
     @StateObject private var codexAccounts = CodexAccountStore.shared
     @StateObject private var dataManager = UsageDataManager.shared
+    // Session-scoped rather than per-card `@State`: this card's identity is not
+    // stable across dashboard re-deals, and losing the record re-offers a credit
+    // that was already spent.
+    @StateObject private var resetCreditConsumptions = CodexResetCreditConsumptionStore.shared
     @State private var isCodexAuthenticated = false
     @State private var isConsumingResetCredit = false
-    @State private var didConsumeResetCredit = false
     @State private var showingResetCreditConfirmation = false
     @State private var resetCreditAlertTitle = ProviderCardResetCreditOutcome.failureTitle
     @State private var resetCreditAlertMessage: String?
@@ -255,7 +258,10 @@ struct ProviderStatusCard: View {
     private var showsResetCreditAction: Bool {
         ProviderCardPresentation.showsResetCreditAction(
             snapshot: snapshot,
-            didConsumeResetCredit: didConsumeResetCredit,
+            hasPendingConsumption: resetCreditConsumptions.hasPendingConsumption(
+                accountID: snapshot.accountID,
+                snapshotUpdatedAt: snapshot.updatedAt
+            ),
             isAuthenticated: isCodexAuthenticated,
             hasResolvedAccount: codexAccount != nil
         )
@@ -287,9 +293,17 @@ struct ProviderStatusCard: View {
         Task {
             do {
                 let result = try await codexService.consumeResetCredit(account: codexAccount)
-                didConsumeResetCredit = true
                 if let refreshedMetrics = result.refreshedMetrics {
+                    // Post-spend numbers straight from the provider: the card is
+                    // about to show the real remaining balance, so eligibility
+                    // alone decides whether another banked credit stays offered.
+                    resetCreditConsumptions.clear(accountID: codexAccount.id)
                     dataManager.applyCodexResetCreditRefresh(refreshedMetrics, accountID: codexAccount.id)
+                } else {
+                    // The credit is gone but the count on screen predates the
+                    // spend. Suppress the action until a later fetch proves the
+                    // balance, or the next press spends a second credit.
+                    resetCreditConsumptions.markConsumed(accountID: codexAccount.id)
                 }
                 if let alert = ProviderCardResetCreditOutcome.alert(for: result) {
                     present(alert)

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -346,20 +346,11 @@ struct UsageDashboardView: View {
                 // was designed at popover width, and stretching its gauges
                 // across the whole detail pane read as one washed-out column.
                 // The focused provider is first in the list, so it lands top-left.
-                HStack(alignment: .top, spacing: MeterBarTheme.Spacing.sm) {
-                    let columns = DashboardOverviewSection.masonryColumns(
-                        orderedProviderSnapshotsForLimits,
-                        columnCount: 2
-                    )
-                    ForEach(Array(columns.enumerated()), id: \.offset) { _, column in
-                        VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.sm) {
-                            ForEach(column) { snapshot in
-                                // The one provider card, shared with the popover, so
-                                // the two surfaces cannot drift.
-                                ProviderStatusCard(snapshot: snapshot)
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .topLeading)
+                ProviderMasonryLayout(columnCount: 2, spacing: MeterBarTheme.Spacing.sm) {
+                    ForEach(orderedProviderSnapshotsForLimits) { snapshot in
+                        // The one provider card, shared with the popover, so
+                        // the two surfaces cannot drift.
+                        ProviderStatusCard(snapshot: snapshot)
                     }
                 }
                 .frame(maxWidth: .infinity)

--- a/MeterBarTests/CardStateTransitionTests.swift
+++ b/MeterBarTests/CardStateTransitionTests.swift
@@ -132,6 +132,48 @@ final class CardStateTransitionTests: XCTestCase {
         )
     }
 
+    // MARK: - Overview masonry build smoke
+
+    /// The overview's provider grid moved from nested per-column `VStack`s to a
+    /// single `ProviderMasonryLayout` container so a card keeps its identity —
+    /// and its in-flight redemption state — when the snapshot list changes
+    /// underneath it. An odd count exercises the uneven-columns path.
+    func testOverviewSectionRendersTheProviderMasonry() {
+        let snapshots = ProviderSnapshotBuilder.snapshots(
+            ProviderSnapshotBuilder.Input(
+                metrics: [
+                    .codexCli: makeMetrics(service: .codexCli, weekly: 10),
+                    .cursor: makeMetrics(service: .cursor, weekly: 30),
+                    .grok: makeMetrics(service: .grok, weekly: 80)
+                ],
+                claudeAccounts: [.defaultAccount],
+                claudeAccountMetrics: [:],
+                enabledServices: [.codexCli, .cursor, .grok]
+            )
+        )
+        XCTAssertEqual(snapshots.count % 2, 1, "fixture must be odd to leave one column short")
+
+        assertRenders(
+            DashboardOverviewSection(
+                snapshots: snapshots,
+                tightestLimit: nil,
+                costSummary: nil,
+                onSelectProvider: { _ in }
+            )
+        )
+
+        // Empty is the other structural state: no cards, no columns to place.
+        assertRenders(
+            DashboardOverviewSection(
+                snapshots: [],
+                tightestLimit: nil,
+                costSummary: nil,
+                onSelectProvider: { _ in }
+            ),
+            minHeight: 0
+        )
+    }
+
     // MARK: - OptimizeInsightsView build smoke
 
     func testOptimizeInsightsViewBuilds() {

--- a/MeterBarTests/CodexResetCreditsTests.swift
+++ b/MeterBarTests/CodexResetCreditsTests.swift
@@ -143,6 +143,149 @@ final class CodexResetCreditsTests: XCTestCase {
         ))
     }
 
+    // MARK: - Post-redemption action visibility
+
+    /// Baseline: a blocked account with banked credits offers the action.
+    func testActionIsOfferedForABlockedCardWithBankedCredits() {
+        let store = CodexResetCreditConsumptionStore()
+        let accountID = UUID()
+
+        XCTAssertTrue(showsAction(blockedSnapshot(accountID: accountID), store: store))
+    }
+
+    /// A redemption whose follow-up refetch failed leaves the snapshot quoting
+    /// the pre-spend count. Offering the action against that count is the
+    /// double-spend: the next press redeems a second, real credit.
+    func testActionIsSuppressedWhileASpentCreditIsUnconfirmed() {
+        let store = CodexResetCreditConsumptionStore()
+        let accountID = UUID()
+        let snapshot = blockedSnapshot(accountID: accountID)
+
+        store.markConsumed(accountID: accountID, at: MetricsFixtures.referenceDate)
+
+        XCTAssertFalse(showsAction(snapshot, store: store))
+    }
+
+    /// Regression, dashboard card churn: the guard used to be per-card `@State`,
+    /// so a card that changed masonry column mid-poll came back with the spent
+    /// credit re-offered. Keyed by account, the record outlives any card.
+    func testSuppressionSurvivesACardBeingRebuilt() {
+        let store = CodexResetCreditConsumptionStore()
+        let accountID = UUID()
+
+        store.markConsumed(accountID: accountID, at: MetricsFixtures.referenceDate)
+
+        // A freshly constructed snapshot for the same account — what a torn-down
+        // and re-created card evaluates against.
+        let rebuilt = blockedSnapshot(accountID: accountID)
+        XCTAssertFalse(showsAction(rebuilt, store: store))
+    }
+
+    /// Spending one account's credit must not disarm another account's button.
+    func testSuppressionIsScopedToTheRedeemingAccount() {
+        let store = CodexResetCreditConsumptionStore()
+        let spender = UUID()
+        let bystander = UUID()
+
+        store.markConsumed(accountID: spender, at: MetricsFixtures.referenceDate)
+
+        XCTAssertTrue(showsAction(blockedSnapshot(accountID: bystander), store: store))
+    }
+
+    /// The suppression covers a stale count, not the account. Once a poll
+    /// delivers metrics fetched after the spend, that count is authoritative and
+    /// eligibility alone decides — an account with a second banked credit gets
+    /// its button back.
+    func testSuppressionLiftsOnceNewerMetricsArrive() {
+        let store = CodexResetCreditConsumptionStore()
+        let accountID = UUID()
+
+        store.markConsumed(accountID: accountID, at: MetricsFixtures.referenceDate)
+
+        let polled = blockedSnapshot(
+            accountID: accountID,
+            resetCreditsAvailable: 1,
+            updatedAt: MetricsFixtures.referenceDate.addingTimeInterval(60)
+        )
+        XCTAssertTrue(showsAction(polled, store: store))
+    }
+
+    /// The redemption's own refresh is the fastest newer-metrics path, and the
+    /// card clears the record explicitly rather than waiting for a poll. With a
+    /// credit still banked the action must come straight back — this is the
+    /// stuck-button bug the permanent latch caused.
+    func testClearingAfterARefreshRestoresTheActionForARemainingCredit() {
+        let store = CodexResetCreditConsumptionStore()
+        let accountID = UUID()
+
+        store.markConsumed(accountID: accountID, at: MetricsFixtures.referenceDate)
+        store.clear(accountID: accountID)
+
+        XCTAssertTrue(showsAction(blockedSnapshot(accountID: accountID, resetCreditsAvailable: 1), store: store))
+    }
+
+    /// The mirror case: refreshed numbers showing the last credit spent must
+    /// leave nothing to press, via the eligibility rule rather than the guard.
+    func testSpendingTheLastCreditHidesTheActionOnRefreshedNumbers() {
+        let store = CodexResetCreditConsumptionStore()
+        let accountID = UUID()
+
+        store.clear(accountID: accountID)
+
+        XCTAssertFalse(showsAction(blockedSnapshot(accountID: accountID, resetCreditsAvailable: 0), store: store))
+    }
+
+    // MARK: - Consumption store
+
+    /// A card with no cached metrics has no count that could postdate the spend,
+    /// so it can never clear the record on its own.
+    func testUndatedSnapshotNeverSupersedesARecordedSpend() {
+        let store = CodexResetCreditConsumptionStore()
+        let accountID = UUID()
+        store.markConsumed(accountID: accountID, at: MetricsFixtures.referenceDate)
+
+        XCTAssertTrue(store.hasPendingConsumption(accountID: accountID, snapshotUpdatedAt: nil))
+    }
+
+    /// Metrics that predate the spend describe the world before it happened.
+    func testOlderMetricsDoNotSupersedeARecordedSpend() {
+        let store = CodexResetCreditConsumptionStore()
+        let accountID = UUID()
+        store.markConsumed(accountID: accountID, at: MetricsFixtures.referenceDate)
+
+        XCTAssertTrue(store.hasPendingConsumption(
+            accountID: accountID,
+            snapshotUpdatedAt: MetricsFixtures.referenceDate.addingTimeInterval(-60)
+        ))
+        // A fetch that completed at the same instant proves nothing either.
+        XCTAssertTrue(store.hasPendingConsumption(
+            accountID: accountID,
+            snapshotUpdatedAt: MetricsFixtures.referenceDate
+        ))
+    }
+
+    /// Snapshots without an account id (the shared non-account providers) can
+    /// never match a record, and must not read as pending.
+    func testAccountlessSnapshotsHaveNoPendingConsumption() {
+        let store = CodexResetCreditConsumptionStore()
+        store.markConsumed(accountID: UUID(), at: MetricsFixtures.referenceDate)
+
+        XCTAssertFalse(store.hasPendingConsumption(accountID: nil, snapshotUpdatedAt: nil))
+    }
+
+    func testClearAllDropsEveryRecordedSpend() {
+        let store = CodexResetCreditConsumptionStore()
+        let first = UUID()
+        let second = UUID()
+        store.markConsumed(accountID: first, at: MetricsFixtures.referenceDate)
+        store.markConsumed(accountID: second, at: MetricsFixtures.referenceDate)
+
+        store.clearAll()
+
+        XCTAssertFalse(store.hasPendingConsumption(accountID: first, snapshotUpdatedAt: nil))
+        XCTAssertFalse(store.hasPendingConsumption(accountID: second, snapshotUpdatedAt: nil))
+    }
+
     // MARK: - Confirmation copy
 
     func testConfirmationNamesTheTargetAccount() {
@@ -394,6 +537,47 @@ final class CodexResetCreditsTests: XCTestCase {
             body.append(buffer, count: count)
         }
         return body
+    }
+
+    /// A Codex card in the only state that offers the reset action: a weekly
+    /// window at its limit with credits still banked.
+    private func blockedSnapshot(
+        accountID: UUID,
+        resetCreditsAvailable: Int? = 2,
+        updatedAt: Date = MetricsFixtures.referenceDate
+    ) -> ProviderSnapshot {
+        let metrics = UsageMetrics(
+            service: .codexCli,
+            weeklyLimit: UsageLimit(
+                used: 100,
+                total: 100,
+                resetTime: updatedAt.addingTimeInterval(24 * 3_600),
+                windowSeconds: 7 * 24 * 3_600
+            ),
+            resetCreditsAvailable: resetCreditsAvailable,
+            lastUpdated: updatedAt
+        )
+        return ProviderSnapshotBuilder.snapshot(
+            title: "Codex CLI",
+            service: .codexCli,
+            metrics: metrics,
+            emptyDetail: "No data",
+            accountID: accountID
+        )
+    }
+
+    /// The presentation rule as the card asks it: authenticated, account
+    /// resolved, with the store answering the pending-spend question.
+    private func showsAction(_ snapshot: ProviderSnapshot, store: CodexResetCreditConsumptionStore) -> Bool {
+        ProviderCardPresentation.showsResetCreditAction(
+            snapshot: snapshot,
+            hasPendingConsumption: store.hasPendingConsumption(
+                accountID: snapshot.accountID,
+                snapshotUpdatedAt: snapshot.updatedAt
+            ),
+            isAuthenticated: true,
+            hasResolvedAccount: true
+        )
     }
 
     /// One available credit, the shape the GET endpoint returns.

--- a/MeterBarTests/DashboardSectionSplitTests.swift
+++ b/MeterBarTests/DashboardSectionSplitTests.swift
@@ -233,7 +233,7 @@ final class DashboardSectionSplitTests: XCTestCase {
     /// columns themselves pack independently, which is the point of the
     /// masonry: a short card no longer pads itself out to a tall neighbour.
     func testMasonryColumnsDealCardsAcrossColumnsInReadingOrder() {
-        let columns = DashboardOverviewSection.masonryColumns(Array(0..<5), columnCount: 2)
+        let columns = ProviderMasonryLayout.columns(Array(0..<5), columnCount: 2)
 
         XCTAssertEqual(columns, [[0, 2, 4], [1, 3]])
     }
@@ -241,7 +241,7 @@ final class DashboardSectionSplitTests: XCTestCase {
     /// Column counts never differ by more than one, so no column runs long
     /// enough to reintroduce the ragged bottom edge.
     func testMasonryColumnsStayBalancedWithinOneCard() {
-        let columns = DashboardOverviewSection.masonryColumns(Array(0..<7), columnCount: 3)
+        let columns = ProviderMasonryLayout.columns(Array(0..<7), columnCount: 3)
 
         let counts = columns.map(\.count)
         XCTAssertEqual(counts, [3, 2, 2])
@@ -251,7 +251,7 @@ final class DashboardSectionSplitTests: XCTestCase {
     /// A single provider must still occupy one column's width rather than
     /// stretching across the page, so empty trailing columns are preserved.
     func testMasonryColumnsKeepEmptyTrailingColumnsForWidth() {
-        let columns = DashboardOverviewSection.masonryColumns([0], columnCount: 2)
+        let columns = ProviderMasonryLayout.columns([0], columnCount: 2)
 
         XCTAssertEqual(columns.count, 2)
         XCTAssertEqual(columns[0], [0])
@@ -259,7 +259,71 @@ final class DashboardSectionSplitTests: XCTestCase {
     }
 
     func testMasonryColumnsClampsNonPositiveColumnCounts() {
-        XCTAssertEqual(DashboardOverviewSection.masonryColumns([1, 2], columnCount: 0), [[1, 2]])
+        XCTAssertEqual(ProviderMasonryLayout.columns([1, 2], columnCount: 0), [[1, 2]])
+    }
+
+    // MARK: - Overview masonry placement
+
+    /// The columns used to be real `VStack`s, which made a card's SwiftUI
+    /// identity depend on which column it was dealt into — a membership change
+    /// anywhere in the list moved cards across columns and discarded their
+    /// `@State`. Placement is geometry now, from one container, so the same
+    /// deal has to come out of the frames instead: even indices stacked down
+    /// the left column, odd down the right, each column packing independently.
+    func testMasonryFramesStackEachColumnIndependently() {
+        let frames = ProviderMasonryLayout.frames(
+            heights: [100, 30, 40, 20, 60],
+            containerWidth: 210,
+            columnCount: 2,
+            spacing: 10
+        )
+
+        XCTAssertEqual(frames.map(\.origin.x), [0, 110, 0, 110, 0])
+        // Left column stacks 100, 40, 60 with a gutter after each. The right
+        // column packs on its own, so index 3 sits directly under index 1's 30
+        // rather than being pushed down by the tall card beside it.
+        XCTAssertEqual(frames.map(\.origin.y), [0, 0, 110, 40, 160])
+    }
+
+    /// Each card gets exactly one column's width; the gutters come out of the
+    /// container, not out of the cards.
+    func testMasonryFramesSplitTheContainerWidthMinusGutters() {
+        let frames = ProviderMasonryLayout.frames(
+            heights: [10, 10, 10],
+            containerWidth: 320,
+            columnCount: 3,
+            spacing: 16
+        )
+
+        XCTAssertEqual(frames.map(\.width), [96, 96, 96])
+        XCTAssertEqual(frames.map(\.origin.x), [0, 112, 224])
+    }
+
+    /// The section is as tall as its tallest column — the short column must not
+    /// pad the layout out to a ragged bottom edge.
+    func testMasonryHeightIsTheTallestColumn() {
+        let frames = ProviderMasonryLayout.frames(
+            heights: [100, 30, 40],
+            containerWidth: 210,
+            columnCount: 2,
+            spacing: 10
+        )
+
+        XCTAssertEqual(ProviderMasonryLayout.totalHeight(of: frames), 150)
+    }
+
+    /// A single card still occupies one column rather than stretching across
+    /// the page, matching the empty-trailing-column rule above.
+    func testMasonryFramesKeepASingleCardAtColumnWidth() {
+        let frames = ProviderMasonryLayout.frames(
+            heights: [42],
+            containerWidth: 210,
+            columnCount: 2,
+            spacing: 10
+        )
+
+        XCTAssertEqual(frames.count, 1)
+        XCTAssertEqual(frames[0], CGRect(x: 0, y: 0, width: 100, height: 42))
     }
 
     // MARK: - Week-row date labels

--- a/MeterBarTests/MenuBarViewSplitTests.swift
+++ b/MeterBarTests/MenuBarViewSplitTests.swift
@@ -161,7 +161,7 @@ final class ProviderCardPresentationTests: XCTestCase {
         XCTAssertTrue(
             ProviderCardPresentation.showsResetCreditAction(
                 snapshot: exhausted,
-                didConsumeResetCredit: false,
+                hasPendingConsumption: false,
                 isAuthenticated: true,
                 hasResolvedAccount: true
             )
@@ -169,16 +169,16 @@ final class ProviderCardPresentationTests: XCTestCase {
         XCTAssertFalse(
             ProviderCardPresentation.showsResetCreditAction(
                 snapshot: exhausted,
-                didConsumeResetCredit: true,
+                hasPendingConsumption: true,
                 isAuthenticated: true,
                 hasResolvedAccount: true
             ),
-            "a credit already spent in this session must not be offered again"
+            "a credit spent but not yet reflected in this count must not be offered again"
         )
         XCTAssertFalse(
             ProviderCardPresentation.showsResetCreditAction(
                 snapshot: exhausted,
-                didConsumeResetCredit: false,
+                hasPendingConsumption: false,
                 isAuthenticated: false,
                 hasResolvedAccount: true
             )
@@ -186,7 +186,7 @@ final class ProviderCardPresentationTests: XCTestCase {
         XCTAssertFalse(
             ProviderCardPresentation.showsResetCreditAction(
                 snapshot: snapshot(used: 100, resetCreditsAvailable: 0),
-                didConsumeResetCredit: false,
+                hasPendingConsumption: false,
                 isAuthenticated: true,
                 hasResolvedAccount: true
             )
@@ -194,7 +194,7 @@ final class ProviderCardPresentationTests: XCTestCase {
         XCTAssertFalse(
             ProviderCardPresentation.showsResetCreditAction(
                 snapshot: snapshot(used: 100, resetCreditsAvailable: 1, service: .claudeCode),
-                didConsumeResetCredit: false,
+                hasPendingConsumption: false,
                 isAuthenticated: true,
                 hasResolvedAccount: true
             ),
@@ -203,7 +203,7 @@ final class ProviderCardPresentationTests: XCTestCase {
         XCTAssertFalse(
             ProviderCardPresentation.showsResetCreditAction(
                 snapshot: exhausted,
-                didConsumeResetCredit: false,
+                hasPendingConsumption: false,
                 isAuthenticated: true,
                 hasResolvedAccount: false
             ),


### PR DESCRIPTION
Two bugs in the Codex reset-credit flow, one root cause: the "already used this" guard lived in `ProviderStatusCard`'s own `@State`, which is not durable enough to protect a spend.

## Bug A — double-spend (HIGH)

`CodexCliLocalService.consumeResetCredit` has a path that redeems the credit **successfully** and then fails to refetch usage, returning `refreshedMetrics: nil`. The card is left quoting the pre-spend count, and `didConsumeResetCredit` was the only thing preventing the next press from redeeming a second, real credit (accounts can bank more than one).

That flag did not survive view churn. `DashboardOverviewSection` partitioned snapshots by `index % columnCount` and nested `ForEach(column)` inside `ForEach(columns.enumerated(), id: \.offset)`, so a card's SwiftUI identity depended on which column slot it landed in. Any change to the snapshot list — another account finishing a background poll, a provider's `hasMetrics` flipping, an account appearing or disappearing — shifted cards across columns, changed their identity path, and discarded the guard. (`isConsumingResetCredit` and the auth/alert state went with it.)

## Bug B — stuck button (MED)

`didConsumeResetCredit = true` was set on **any** success and never reset, and `showsResetCreditAction` short-circuited on it *before* `CodexResetCreditEligibility.isEligible` — which already checks `availableCredits > 0`. An account with several banked credits lost the button until its card happened to be rebuilt.

## The fix

**`ProviderMasonryLayout`** (new) replaces the nested per-column `VStack`s with a single `Layout` container that places cards geometrically. The caller keeps one `ForEach` keyed by `snapshot.id`, so identity no longer depends on column placement. The deal is unchanged — same round robin, same reading order, same balance — so the grid looks exactly as it did. `masonryColumns` moved here from `DashboardOverviewSection`, and `frames(...)` calls it internally so the deal and the placement cannot drift. Both masonry call sites (Overview, Limits) use it.

**`CodexResetCreditConsumptionStore`** (new) keys the pending-spend record by account id rather than by card, putting it out of reach of view churn. It is deliberately **not** a permanent latch: each spend is stamped with the instant it completed, and any snapshot whose metrics were fetched after that instant supersedes it. A successful redemption that *does* return fresh metrics clears the record outright and lets eligibility decide — which is Bug B. Nothing is persisted; reads are pure (they happen from `body`), so superseded records are left inert rather than pruned, bounded by one entry per Codex account.

`showsResetCreditAction`'s `didConsumeResetCredit` parameter is renamed `hasPendingConsumption` to match the narrowed meaning.

## Tests

TDD — presentation-level tests written first for both scenarios.

- `CodexResetCreditsTests` — 11 new: baseline offer, suppression while a spend is unconfirmed, **suppression surviving a card rebuild** (the Bug A regression), per-account scoping, lift once newer metrics arrive, **restoration for a remaining credit** (the Bug B regression), the last-credit case, plus the store's supersession rules (undated and older snapshots never clear; accountless snapshots are inert; `clearAll`).
- `DashboardSectionSplitTests` — the four existing deal tests now target `ProviderMasonryLayout.columns`; 4 new for placement math (independent column stacking, width minus gutters, tallest-column height, single card at column width).
- `CardStateTransitionTests` — render smoke test for the new overview grid, odd card count plus the empty case.

Local: `swift build` clean, `swift test` **2194 tests, 0 failures**, `swiftlint` clean.