### PR TITLE
fix(serve): key rate limiting per source and bound the response write

### DIFF
--- a/MeterBar/Serve/ServeHTTPServer.swift
+++ b/MeterBar/Serve/ServeHTTPServer.swift
@@ -26,13 +26,22 @@ nonisolated public final class ServeHTTPServer: @unchecked Sendable {
         public let dataSource: ServeRouter.DataSource
         public let requestTimeout: TimeInterval
 
+        /// Rate-limit bucket a connection is charged to, derived from the
+        /// accepted descriptor. Injectable only so tests can drive a
+        /// loopback-only listener as if requests came from several hosts;
+        /// nothing on the CLI surface exposes it.
+        public let sourceKey: @Sendable (Int32) -> String
+
         public init(
             host: String,
             port: UInt16,
             token: String,
             maxRequestsPerSecond: Int,
             dataSource: ServeRouter.DataSource,
-            requestTimeout: TimeInterval = ServeHTTPServer.defaultRequestTimeout
+            requestTimeout: TimeInterval = ServeHTTPServer.defaultRequestTimeout,
+            // A closure rather than an unapplied `peerAddress(of:)` reference,
+            // which is not itself `@Sendable` under strict concurrency.
+            sourceKey: @escaping @Sendable (Int32) -> String = { ServeHTTPServer.peerAddress(of: $0) }
         ) {
             self.host = host
             self.port = port
@@ -40,6 +49,7 @@ nonisolated public final class ServeHTTPServer: @unchecked Sendable {
             self.maxRequestsPerSecond = maxRequestsPerSecond
             self.dataSource = dataSource
             self.requestTimeout = requestTimeout
+            self.sourceKey = sourceKey
         }
     }
 
@@ -163,7 +173,7 @@ nonisolated public final class ServeHTTPServer: @unchecked Sendable {
                 continue
             }
 
-            configureTimeouts(clientFD)
+            configureSocketOptions(clientFD)
             DispatchQueue.global(qos: .utility).async { [weak self] in
                 self?.handle(connection: clientFD)
             }
@@ -178,16 +188,64 @@ nonisolated public final class ServeHTTPServer: @unchecked Sendable {
             || code == EWOULDBLOCK || code == EMFILE || code == ENFILE
     }
 
-    private func configureTimeouts(_ fd: Int32) {
+    private func configureSocketOptions(_ fd: Int32) {
         var timeout = timeval(tv_sec: Self.socketPollSeconds, tv_usec: 0)
         setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
         setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+
+        // Without this, a peer that vanishes mid-response turns a `write` into
+        // SIGPIPE, whose default disposition kills the whole process rather
+        // than failing the one connection.
+        var noSigPipe: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size))
     }
+
+    /// The address a connection is charged to. Falls back to a shared key
+    /// rather than a per-connection one when `getpeername` fails: an
+    /// unidentifiable caller must not get an uncounted request.
+    public static func peerAddress(of fd: Int32) -> String {
+        var storage = sockaddr_storage()
+        var length = socklen_t(MemoryLayout<sockaddr_storage>.size)
+        let result = withUnsafeMutablePointer(to: &storage) { pointer -> Int32 in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                getpeername(fd, sockaddrPointer, &length)
+            }
+        }
+        guard result == 0 else { return unknownSourceKey }
+
+        let family = Int32(storage.ss_family)
+        var text = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+        let converted: UnsafePointer<CChar>? = withUnsafePointer(to: &storage) { pointer in
+            switch family {
+            case AF_INET:
+                return pointer.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { ipv4 in
+                    var address = ipv4.pointee.sin_addr
+                    return inet_ntop(AF_INET, &address, &text, socklen_t(text.count))
+                }
+            case AF_INET6:
+                return pointer.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { ipv6 in
+                    var address = ipv6.pointee.sin6_addr
+                    return inet_ntop(AF_INET6, &address, &text, socklen_t(text.count))
+                }
+            default:
+                return nil
+            }
+        }
+        guard converted != nil else { return unknownSourceKey }
+        return String(cString: text)
+    }
+
+    /// Deliberately one shared bucket, not a unique key per unidentified
+    /// connection — the latter would hand every such caller a full budget.
+    private static let unknownSourceKey = "unknown"
 
     private func handle(connection fd: Int32) {
         defer { Darwin.close(fd) }
 
-        guard rateLimiter.allow() else {
+        // Charged before parsing, so an invalid or unauthenticated request
+        // still costs its sender. Keyed by source so that cost lands on the
+        // sender alone and can't starve the token holder (ServeRateLimiter).
+        guard rateLimiter.allow(source: configuration.sourceKey(fd)) else {
             write(response: ServeRouter.tooManyRequestsResponse(), to: fd)
             return
         }
@@ -202,17 +260,35 @@ nonisolated public final class ServeHTTPServer: @unchecked Sendable {
         write(response: response, to: fd)
     }
 
-    private func write(response: ServeHTTPResponse, to fd: Int32) {
+    /// Bounded by its own deadline for the same reason `readRequest` is:
+    /// `SO_SNDTIMEO` bounds one `write`, not the drain. A client that stops
+    /// reading part-way through a large `/cost` body makes the next `write`
+    /// fail with `EAGAIN`, and giving up there would hand the caller a
+    /// truncated document under a correct `Content-Length` — a corruption only
+    /// a parse would reveal. Retry until the deadline instead.
+    @discardableResult
+    private func write(response: ServeHTTPResponse, to fd: Int32) -> Bool {
         let data = Self.serialize(response)
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
+        let deadline = Date().addingTimeInterval(configuration.requestTimeout)
+        return data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Bool in
             var remaining = buffer.count
             var pointer = buffer.baseAddress
             while remaining > 0, let base = pointer {
+                guard Date() < deadline else { return false }
+
                 let written = Darwin.write(fd, base, remaining)
-                guard written > 0 else { return }
-                remaining -= written
-                pointer = base + written
+                if written > 0 {
+                    remaining -= written
+                    pointer = base + written
+                    continue
+                }
+
+                // 0 can't make progress and anything other than a blocked or
+                // interrupted write is fatal for this connection; both leave
+                // the peer with a short body it will detect via Content-Length.
+                guard written < 0, errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR else { return false }
             }
+            return true
         }
     }
 

--- a/MeterBar/Serve/ServeRateLimiter.swift
+++ b/MeterBar/Serve/ServeRateLimiter.swift
@@ -1,39 +1,89 @@
 import Foundation
 
-/// Bounds how many requests `meterbar serve` answers per second. Even a
-/// loopback-only, token-gated listener can be pointed at repeatedly by a
-/// misbehaving script; this keeps a single caller from turning polling into
-/// an unbounded CPU/encoding cost.
+/// Bounds how many requests `meterbar serve` answers per second, **per source
+/// address**. Even a loopback-only, token-gated listener can be pointed at
+/// repeatedly by a misbehaving script; this keeps a single caller from turning
+/// polling into an unbounded CPU/encoding cost.
+///
+/// The budget is per source rather than process-wide because the limit is
+/// charged before a request is parsed or authenticated: with `--allow-remote`,
+/// one global window would let any unauthenticated device on the LAN keep the
+/// listener saturated and hold the token holder at `429` indefinitely. Keying
+/// by source bounds what an invalid request costs to the source that sent it.
 nonisolated public final class ServeRateLimiter: @unchecked Sendable {
+    /// How many distinct sources carry their own window before the table starts
+    /// evicting. Bounds the memory a remote caller can make the server hold:
+    /// each entry is a date and a count, so 1024 sources is a few tens of KB.
+    public static let defaultMaxTrackedSources = 1_024
+
+    private struct Window {
+        var start: Date
+        var count: Int
+    }
+
     private let maxPerSecond: Int
+    private let maxTrackedSources: Int
     private let clock: @Sendable () -> Date
     private let lock = NSLock()
-    private var windowStart: Date
-    private var countInWindow = 0
+    private var windows: [String: Window] = [:]
 
     // The default is a closure rather than the `Date.init` reference: an
     // unapplied initializer reference is not itself `@Sendable`, so passing it
     // directly warns under Swift 6 strict concurrency.
-    public init(maxPerSecond: Int, clock: @escaping @Sendable () -> Date = { Date() }) {
+    public init(
+        maxPerSecond: Int,
+        maxTrackedSources: Int = ServeRateLimiter.defaultMaxTrackedSources,
+        clock: @escaping @Sendable () -> Date = { Date() }
+    ) {
         self.maxPerSecond = max(1, maxPerSecond)
+        self.maxTrackedSources = max(1, maxTrackedSources)
         self.clock = clock
-        self.windowStart = clock()
     }
 
-    /// Sliding-by-reset (not sliding-window) counter: cheap, thread-safe, and
-    /// precise enough for a bounded local endpoint.
-    public func allow() -> Bool {
+    /// Number of sources currently holding a window. Exposed for tests that
+    /// assert the table stays bounded.
+    public var trackedSourceCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return windows.count
+    }
+
+    /// Sliding-by-reset (not sliding-window) counter per source: cheap,
+    /// thread-safe, and precise enough for a bounded local endpoint.
+    public func allow(source: String) -> Bool {
         lock.lock()
         defer { lock.unlock() }
 
         let now = clock()
-        if now.timeIntervalSince(windowStart) >= 1 {
-            windowStart = now
-            countInWindow = 0
+        var window = windows[source] ?? Window(start: now, count: 0)
+        if now.timeIntervalSince(window.start) >= 1 {
+            window = Window(start: now, count: 0)
         }
 
-        guard countInWindow < maxPerSecond else { return false }
-        countInWindow += 1
+        guard window.count < maxPerSecond else {
+            windows[source] = window
+            return false
+        }
+
+        window.count += 1
+        if windows[source] == nil {
+            makeRoomForANewSource(now: now)
+        }
+        windows[source] = window
         return true
+    }
+
+    /// Eviction fails open: dropping a window only ever hands its source a
+    /// fresh budget, so a caller that floods the table with new addresses can
+    /// never use eviction to starve anyone. Elapsed windows go first — they are
+    /// already spent — and only then the least recently started live one.
+    private func makeRoomForANewSource(now: Date) {
+        guard windows.count >= maxTrackedSources else { return }
+
+        windows = windows.filter { now.timeIntervalSince($0.value.start) < 1 }
+        while windows.count >= maxTrackedSources {
+            guard let oldest = windows.min(by: { $0.value.start < $1.value.start })?.key else { return }
+            windows.removeValue(forKey: oldest)
+        }
     }
 }

--- a/MeterBarTests/ServeHTTPServerTests.swift
+++ b/MeterBarTests/ServeHTTPServerTests.swift
@@ -26,15 +26,18 @@ final class ServeHTTPServerTests: XCTestCase {
 
     private func startServer(
         maxRequestsPerSecond: Int = 100,
-        requestTimeout: TimeInterval = 5
+        requestTimeout: TimeInterval = 5,
+        dataSource: ServeRouter.DataSource? = nil,
+        sourceKey: (@Sendable (Int32) -> String)? = nil
     ) throws -> ServeHTTPServer {
         let server = ServeHTTPServer(configuration: ServeHTTPServer.Configuration(
             host: ServeBindConfiguration.loopbackHost,
             port: 0,
             token: token,
             maxRequestsPerSecond: maxRequestsPerSecond,
-            dataSource: makeDataSource(),
-            requestTimeout: requestTimeout
+            dataSource: dataSource ?? makeDataSource(),
+            requestTimeout: requestTimeout,
+            sourceKey: sourceKey ?? { ServeHTTPServer.peerAddress(of: $0) }
         ))
         try server.start()
         server.runAcceptLoop()
@@ -107,6 +110,92 @@ final class ServeHTTPServerTests: XCTestCase {
         let (second, _) = try await get("/usage", port: server.boundPort, bearerToken: token)
 
         XCTAssertEqual(second.statusCode, 429)
+    }
+
+    /// `--allow-remote` puts the listener in front of every device on the LAN.
+    /// With one process-wide window charged before auth, any of them could keep
+    /// the limiter saturated and hold the token holder at 429 indefinitely, so
+    /// the budget an unauthenticated burst can spend must be its own source's.
+    func testUnauthenticatedBurstFromOneAddressDoesNotStarveTheTokenHolder() async throws {
+        let caller = ScriptedSource(address: "203.0.113.7")
+        let server = try startServer(maxRequestsPerSecond: 2, sourceKey: { _ in caller.address })
+        defer { server.stop() }
+
+        var burstStatuses: [Int] = []
+        for _ in 0..<4 {
+            let (response, _) = try await get("/usage", port: server.boundPort, bearerToken: nil)
+            burstStatuses.append(response.statusCode)
+        }
+
+        caller.address = "127.0.0.1"
+        let (legitimate, _) = try await get("/usage", port: server.boundPort, bearerToken: token)
+
+        XCTAssertEqual(
+            legitimate.statusCode,
+            200,
+            "an unauthenticated burst from another address consumed the token holder's budget"
+        )
+        XCTAssertEqual(Array(burstStatuses.prefix(2)), [401, 401], "got \(burstStatuses)")
+        XCTAssertTrue(
+            burstStatuses.contains(429),
+            "the bursting source was never rate limited, so its pre-auth cost is unbounded: \(burstStatuses)"
+        )
+    }
+
+    // MARK: Response delivery
+
+    /// `SO_SNDTIMEO` bounds one `write`, not the whole drain: a client that
+    /// stops reading part-way through a large `/cost` body makes the next
+    /// `write` fail with `EAGAIN`. Giving up there hands the client a truncated
+    /// JSON document under a correct `Content-Length` — a silent corruption the
+    /// caller can only detect by parsing. The write path must retry against a
+    /// deadline the way the read path already does.
+    func testServerDeliversTheWholeResponseToAClientThatStallsMidDrain() throws {
+        // The write deadline is not what this test is about: give the drain
+        // plenty of room so a failure means the loop gave up, not that it ran
+        // out of time.
+        let server = try startServer(requestTimeout: 20, dataSource: makeLargeCostDataSource())
+        defer { server.stop() }
+
+        // A small receive buffer keeps the in-flight window well under the
+        // response size, so the server is guaranteed to block mid-body.
+        let fd = try connectRawClient(
+            port: server.boundPort,
+            receiveTimeoutMicroseconds: 500_000,
+            receiveBufferBytes: 4_096
+        )
+        defer { Darwin.close(fd) }
+
+        try sendRaw("GET /cost HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer \(token)\r\n\r\n", to: fd)
+
+        // Stall only once bytes are actually arriving. Sleeping straight after
+        // the request would spend the stall while the server is still encoding
+        // the body, and the drain would then start before any `write` blocked.
+        var received = readSome(fd, timeout: 15)
+        XCTAssertFalse(received.isEmpty, "the server sent nothing at all")
+
+        // Comfortably longer than *two* of the socket's 1s send timeouts. The
+        // first `write` spends one of them and still returns the partial count
+        // it managed before the buffer filled; only a whole timeout with zero
+        // bytes moved yields the EAGAIN this test is about.
+        Thread.sleep(forTimeInterval: 3)
+
+        received.append(contentsOf: drainToEOF(fd, timeout: 15))
+        let (head, body) = try splitHTTPMessage(received)
+
+        let contentLength = try XCTUnwrap(
+            headerValue(named: "Content-Length", in: head).flatMap(Int.init),
+            "response carried no Content-Length"
+        )
+        XCTAssertEqual(
+            body.count,
+            contentLength,
+            "the response body was truncated after the client stalled (\(body.count) of \(contentLength) bytes)"
+        )
+        XCTAssertNotNil(
+            try? JSONSerialization.jsonObject(with: Data(body)),
+            "the delivered body is not parseable JSON"
+        )
     }
 
     func testStopClosesTheListeningSocketSoNewConnectionsAreRefused() async throws {
@@ -198,9 +287,78 @@ final class ServeHTTPServerTests: XCTestCase {
         XCTAssertEqual(response.statusCode, 200, "the accept loop stopped after abrupt disconnects")
     }
 
+    // MARK: Fixtures
+
+    /// A `/cost` payload far larger than any socket buffer, so one `write` can
+    /// never drain it — the shape that exposes a short-write bug.
+    private func makeLargeCostDataSource(modelRows: Int = 40_000) -> ServeRouter.DataSource {
+        let breakdowns = (0..<modelRows).map { index in
+            TokenUsageBreakdown(
+                provider: .claudeCode,
+                name: "meterbar-large-response-fixture-model-\(index)",
+                inputTokens: 1_000,
+                outputTokens: 250,
+                cacheCreationTokens: 50,
+                cacheReadTokens: 500,
+                estimatedCostUSD: 1.25,
+                sessionCount: 3
+            )
+        }
+        let cache = CostSummaryCache(
+            summary: CostSummary(
+                costs: [
+                    TokenCost(
+                        provider: .claudeCode,
+                        inputTokens: 1_000,
+                        outputTokens: 250,
+                        cacheCreationTokens: 50,
+                        cacheReadTokens: 500,
+                        estimatedCostUSD: 1.25,
+                        sessionCount: 3,
+                        periodStart: referenceDate.addingTimeInterval(-86_400),
+                        periodEnd: referenceDate,
+                        modelBreakdowns: breakdowns
+                    ),
+                ],
+                totalCostUSD: 1.25,
+                totalTokens: 1_800,
+                periodDays: 30
+            ),
+            lastScanDate: referenceDate
+        )
+        return ServeRouter.DataSource(loadUsageMetrics: { [:] }, loadCostCache: { cache })
+    }
+
+    /// Stands in for `getpeername` so a loopback-only listener can be driven as
+    /// if requests arrived from different hosts. The test flips `address`
+    /// between phases; connections are keyed with whatever it holds at accept.
+    nonisolated private final class ScriptedSource: @unchecked Sendable {
+        private let lock = NSLock()
+        private var current: String
+
+        init(address: String) { current = address }
+
+        var address: String {
+            get {
+                lock.lock()
+                defer { lock.unlock() }
+                return current
+            }
+            set {
+                lock.lock()
+                current = newValue
+                lock.unlock()
+            }
+        }
+    }
+
     // MARK: Raw socket helpers
 
-    private func connectRawClient(port: UInt16, receiveTimeoutMicroseconds: Int32 = 50_000) throws -> Int32 {
+    private func connectRawClient(
+        port: UInt16,
+        receiveTimeoutMicroseconds: Int32 = 50_000,
+        receiveBufferBytes: Int32? = nil
+    ) throws -> Int32 {
         let fd = Darwin.socket(AF_INET, SOCK_STREAM, 0)
         guard fd >= 0 else { throw RawClientError.socketFailed }
 
@@ -208,6 +366,10 @@ final class ServeHTTPServerTests: XCTestCase {
         setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &enabled, socklen_t(MemoryLayout<Int32>.size))
         var timeout = timeval(tv_sec: 0, tv_usec: receiveTimeoutMicroseconds)
         setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+        if var receiveBufferBytes {
+            // Must be set before `connect`: the window is negotiated at handshake.
+            setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &receiveBufferBytes, socklen_t(MemoryLayout<Int32>.size))
+        }
 
         var address = sockaddr_in()
         address.sin_family = sa_family_t(AF_INET)
@@ -226,6 +388,59 @@ final class ServeHTTPServerTests: XCTestCase {
         return fd
     }
 
+    /// Polls until the first bytes arrive, so a test can tell "the server is
+    /// mid-response" apart from "the server has not started writing yet".
+    private func readSome(_ fd: Int32, timeout: TimeInterval) -> [UInt8] {
+        var buffer = [UInt8](repeating: 0, count: 16_384)
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            let count = Darwin.recv(fd, &buffer, buffer.count, 0)
+            if count > 0 { return Array(buffer[0..<count]) }
+            if count == 0 { return [] }
+            if errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR { continue }
+            return []
+        }
+        return []
+    }
+
+    /// Reads until the server closes the connection or `timeout` elapses. The
+    /// client socket carries a receive timeout, so an empty read is a poll miss,
+    /// not end of stream — only `0` means the peer hung up.
+    private func drainToEOF(_ fd: Int32, timeout: TimeInterval) -> [UInt8] {
+        var received: [UInt8] = []
+        var buffer = [UInt8](repeating: 0, count: 16_384)
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            let count = Darwin.recv(fd, &buffer, buffer.count, 0)
+            if count > 0 {
+                received.append(contentsOf: buffer[0..<count])
+                continue
+            }
+            if count == 0 { break }
+            if errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR { continue }
+            break
+        }
+        return received
+    }
+
+    private func splitHTTPMessage(_ message: [UInt8]) throws -> (head: String, body: [UInt8]) {
+        let separator = Array("\r\n\r\n".utf8)
+        guard let range = message.firstRange(of: separator) else {
+            throw RawClientError.malformedResponse
+        }
+        let head = try XCTUnwrap(String(bytes: message[..<range.lowerBound], encoding: .utf8))
+        return (head, Array(message[range.upperBound...]))
+    }
+
+    private func headerValue(named name: String, in head: String) -> String? {
+        head
+            .split(separator: "\r\n")
+            .first { $0.lowercased().hasPrefix("\(name.lowercased()):") }
+            .map { $0.drop { $0 != ":" }.dropFirst().trimmingCharacters(in: .whitespaces) }
+    }
+
     private func sendRaw(_ text: String, to fd: Int32) throws {
         let bytes = Array(text.utf8)
         let sent = bytes.withUnsafeBytes { Darwin.send(fd, $0.baseAddress, $0.count, 0) }
@@ -236,5 +451,6 @@ final class ServeHTTPServerTests: XCTestCase {
         case socketFailed
         case connectFailed
         case sendFailed
+        case malformedResponse
     }
 }

--- a/MeterBarTests/ServeRateLimiterTests.swift
+++ b/MeterBarTests/ServeRateLimiterTests.swift
@@ -2,33 +2,89 @@ import XCTest
 @testable import MeterBar
 
 final class ServeRateLimiterTests: XCTestCase {
+    private let source = "127.0.0.1"
+
     func testAllowsUpToTheConfiguredLimitWithinAWindow() {
         var now = Date(timeIntervalSince1970: 0)
         let limiter = ServeRateLimiter(maxPerSecond: 3, clock: { now })
 
-        XCTAssertTrue(limiter.allow())
-        XCTAssertTrue(limiter.allow())
-        XCTAssertTrue(limiter.allow())
-        XCTAssertFalse(limiter.allow())
+        XCTAssertTrue(limiter.allow(source: source))
+        XCTAssertTrue(limiter.allow(source: source))
+        XCTAssertTrue(limiter.allow(source: source))
+        XCTAssertFalse(limiter.allow(source: source))
 
         now = now.addingTimeInterval(0.5)
-        XCTAssertFalse(limiter.allow(), "still inside the same one-second window")
+        XCTAssertFalse(limiter.allow(source: source), "still inside the same one-second window")
     }
 
     func testResetsAfterTheWindowElapses() {
         var now = Date(timeIntervalSince1970: 0)
         let limiter = ServeRateLimiter(maxPerSecond: 1, clock: { now })
 
-        XCTAssertTrue(limiter.allow())
-        XCTAssertFalse(limiter.allow())
+        XCTAssertTrue(limiter.allow(source: source))
+        XCTAssertFalse(limiter.allow(source: source))
 
         now = now.addingTimeInterval(1.1)
-        XCTAssertTrue(limiter.allow(), "a new window should allow requests again")
+        XCTAssertTrue(limiter.allow(source: source), "a new window should allow requests again")
     }
 
     func testTreatsNonPositiveLimitsAsAtLeastOne() {
         let limiter = ServeRateLimiter(maxPerSecond: 0, clock: { Date(timeIntervalSince1970: 0) })
 
-        XCTAssertTrue(limiter.allow())
+        XCTAssertTrue(limiter.allow(source: source))
+    }
+
+    // MARK: Per-source isolation
+
+    /// The whole point of keying by source: one caller exhausting its window
+    /// must not spend anybody else's budget. A single global window let one
+    /// unauthenticated LAN host keep `meterbar serve --allow-remote` at 429 for
+    /// the legitimate token holder.
+    func testOneSourceExhaustingItsWindowDoesNotSpendAnother() {
+        let now = Date(timeIntervalSince1970: 0)
+        let limiter = ServeRateLimiter(maxPerSecond: 2, clock: { now })
+
+        XCTAssertTrue(limiter.allow(source: "192.168.1.50"))
+        XCTAssertTrue(limiter.allow(source: "192.168.1.50"))
+        XCTAssertFalse(limiter.allow(source: "192.168.1.50"))
+
+        XCTAssertTrue(limiter.allow(source: "127.0.0.1"), "a burst from one address consumed another's budget")
+        XCTAssertTrue(limiter.allow(source: "127.0.0.1"))
+        XCTAssertFalse(limiter.allow(source: "127.0.0.1"), "each source still gets exactly its own cap")
+    }
+
+    // MARK: Table bounding
+
+    /// Per-source buckets must not become an unbounded, remotely growable map.
+    /// Sources whose window has elapsed are dropped once the table is full.
+    func testDropsElapsedSourcesInsteadOfGrowingTheTableWithoutBound() {
+        var now = Date(timeIntervalSince1970: 0)
+        let limiter = ServeRateLimiter(maxPerSecond: 1, maxTrackedSources: 4, clock: { now })
+
+        for index in 0..<4 {
+            XCTAssertTrue(limiter.allow(source: "10.0.0.\(index)"))
+        }
+        XCTAssertEqual(limiter.trackedSourceCount, 4)
+
+        now = now.addingTimeInterval(1.1)
+        XCTAssertTrue(limiter.allow(source: "10.0.0.99"))
+        XCTAssertLessThanOrEqual(limiter.trackedSourceCount, 4, "the source table grew past its bound")
+    }
+
+    /// With every tracked window still live, admitting a new source has to
+    /// evict an existing one. Eviction only ever hands budget back, so it can
+    /// never be used to starve the caller that gets dropped.
+    func testEvictsTheOldestLiveSourceWhenTheTableIsFull() {
+        var now = Date(timeIntervalSince1970: 0)
+        let limiter = ServeRateLimiter(maxPerSecond: 1, maxTrackedSources: 2, clock: { now })
+
+        XCTAssertTrue(limiter.allow(source: "10.0.0.1"))
+        now = now.addingTimeInterval(0.1)
+        XCTAssertTrue(limiter.allow(source: "10.0.0.2"))
+        now = now.addingTimeInterval(0.1)
+
+        XCTAssertTrue(limiter.allow(source: "10.0.0.3"), "a new source must still be admitted")
+        XCTAssertLessThanOrEqual(limiter.trackedSourceCount, 2)
+        XCTAssertFalse(limiter.allow(source: "10.0.0.3"), "the newest source still carries its own cap")
     }
 }

--- a/README.md
+++ b/README.md
@@ -277,7 +277,8 @@ The endpoint is **read-only** — it serves the cache and never triggers a provi
 refresh or mutates state. It binds to loopback only unless you pass
 `--allow-remote`, requires a bearer token on every request (generated and printed
 once at startup if you do not supply `--token`), and rate-limits to 5 requests
-per second by default.
+per second per client address by default, so one noisy caller cannot starve
+another.
 
 `--allow-remote` exposes a **plaintext HTTP** listener on your network. The
 bearer token and cached usage/cost data are not encrypted in transit, so use it

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -556,9 +556,12 @@ empty (no metrics yet, or no cost scan yet), the endpoint returns `200` with the
 `Content-Type: application/json; charset=utf-8`. Responses are never cached by clients or
 intermediaries.
 
-**Rate limiting.** Requests are bounded to `--max-requests-per-second` (default 5) per server
-instance; requests beyond that return `429` with the standard error envelope (`too_many_requests`).
-A malformed HTTP request returns `400` (`bad_request`).
+**Rate limiting.** Requests are bounded to `--max-requests-per-second` (default 5) **per client
+address**; requests beyond that return `429` with the standard error envelope (`too_many_requests`).
+The budget is charged before a request is parsed or authenticated, so keying it by source is what
+keeps an unauthenticated burst — the risk `--allow-remote` introduces — from consuming the token
+holder's allowance. A local client still sees exactly the documented default: every loopback caller
+shares the `127.0.0.1` bucket. A malformed HTTP request returns `400` (`bad_request`).
 
 **Lifecycle.** `meterbar serve` runs until it receives `SIGINT` or `SIGTERM` (for example, Ctrl-C),
 at which point it stops accepting new connections, closes its listening socket, and exits cleanly.


### PR DESCRIPTION
Fixes two verified MED issues in the `meterbar serve` HTTP server.

## 1. Pre-auth rate limiting was process-wide (security)

`handle(connection:)` charged `rateLimiter.allow()` before parsing or auth (auth happens later in `ServeRouter.handle`), against a single `ServeRateLimiter` shared by every connection. With `--allow-remote`, any LAN device could send an unauthenticated burst that kept the global window (default 5/s) saturated and hold the legitimate token holder at `429` indefinitely.

The charge stays before parsing — an invalid request must still cost its sender — but the window is now **keyed by peer address** (`getpeername` on the accepted descriptor), so that cost lands on the sender alone. Per-connection cost remains bounded by the existing 8 KiB head cap and 5 s read deadline.

- **Loopback behaviour and the documented 5/s default are unchanged**: every local caller shares the `127.0.0.1` bucket.
- The source table is bounded (1024 entries). Eviction **fails open** — spent windows first, then the oldest live one — so flooding it with fresh addresses can only hand budget back, never starve anyone.
- A peer that can't be identified falls back to one shared `"unknown"` bucket, not a fresh key per connection, so an unidentifiable caller can't get an uncounted request.

## 2. Short writes silently truncated large responses (bug)

`write(response:to:)` looped on `Darwin.write` but returned on the first `written <= 0` — no EAGAIN/EWOULDBLOCK/EINTR retry and no deadline — while `readRequest` already retries against a tracked 5 s deadline. Since `SO_SNDTIMEO` (1 s) bounds a single `write` rather than the whole drain, a client that stalled mid-body received **truncated JSON under a correct `Content-Length`** — a corruption only a parse would reveal.

The write path now mirrors the read path: a tracked deadline plus retry on EAGAIN/EWOULDBLOCK/EINTR. Accepted sockets also set `SO_NOSIGPIPE`, so a peer vanishing mid-response fails that one connection instead of killing the process.

## Tests (written first)

- `testOneSourceExhaustingItsWindowDoesNotSpendAnother` — per-source isolation.
- `testDropsElapsedSourcesInsteadOfGrowingTheTableWithoutBound`, `testEvictsTheOldestLiveSourceWhenTheTableIsFull` — the table stays bounded and eviction never starves.
- `testUnauthenticatedBurstFromOneAddressDoesNotStarveTheTokenHolder` — an unauthenticated burst gets `401`s then its own `429`, and the token holder still gets `200`.
- `testServerDeliversTheWholeResponseToAClientThatStallsMidDrain` — stalls 3 s mid-drain of a 12.9 MB `/cost` body, then asserts the full `Content-Length` arrives and parses.

Both new integration tests were confirmed red against the pre-fix code: the starvation test 429s the token holder, and the slow-reader test received **678,292 of 12,869,448 bytes** with an unparseable body.

## Verification

- `swift test` — **2183 tests, 0 failures** (6 skipped).
- `swiftlint` clean on the changed files.
- README and `docs/cli-json-schema.md` updated to describe the per-address budget while keeping the 5/s default contract explicit.