### PR TITLE
fix(cost): stop double-counting duplicated transcripts across files

### DIFF
--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -284,6 +284,15 @@ enum ClaudeCostScanner {
     /// freshly-read files plus every previously-cached one. The number on screen
     /// improves monotonically as the slices land instead of appearing all at
     /// once after a 70-second freeze.
+    ///
+    /// Cache-key dedup only catches the *same* file reached twice. A *copy* —
+    /// a sync client's conflict file, a restored backup, a project directory
+    /// duplicated by hand — is a different path holding the same events, and
+    /// `deduplicationKey` returns the same `messageID:requestID` for it in
+    /// either directory. So each file's totals are folded in the way Codex
+    /// folds a rollout: merged whole when its keys are new, dropped when they
+    /// are all already counted, and re-read event by event when they only
+    /// partly overlap.
     nonisolated static func scanRoots(
         _ roots: [URL],
         session: CostScanSession
@@ -309,11 +318,17 @@ enum ClaudeCostScanner {
                     forTranscriptURL: file.url,
                     root: root
                 )
-                guard let file = Self.totals(for: file, projectID: projectID, session: session) else {
+                guard let totals = Self.totals(for: file, projectID: projectID, session: session) else {
                     continue
                 }
-                windows.period.merge(file.period)
-                windows.lifetime.merge(file.lifetime)
+                guard Self.fold(totals, into: &windows) else {
+                    // This file shares only *some* of its events with one
+                    // already folded in — a stale copy holding a prefix of the
+                    // live transcript. Aggregates cannot be de-overlapped after
+                    // the fact, so it goes back through the event-level path.
+                    Self.foldByEvent(file, projectID: projectID, session: session, windows: &windows)
+                    continue
+                }
             }
         }
 
@@ -323,6 +338,86 @@ enum ClaudeCostScanner {
         // keep contributing their totals forever.
         session.retain(keys: live, provider: .claude)
         return windows
+    }
+
+    /// Merges one transcript's aggregates in, if that can be done without
+    /// double-counting.
+    ///
+    /// - Returns: `false` when the file's events partly overlap what is already
+    ///   folded in, which is the one case aggregates cannot express — the
+    ///   caller has to fall back to ``foldByEvent(_:projectID:session:windows:)``.
+    nonisolated private static func fold(
+        _ totals: ScanWindows<ClaudeSessionTotals>,
+        into windows: inout ScanWindows<ClaudeSessionTotals>
+    ) -> Bool {
+        // Period keys are a subset of lifetime keys by construction (every
+        // in-window event is also a lifetime event), so the lifetime test
+        // answers for both windows.
+        let keys = totals.lifetime.eventKeys
+        if keys.isDisjoint(with: windows.lifetime.eventKeys) {
+            windows.period.merge(totals.period)
+            windows.lifetime.merge(totals.lifetime)
+            return true
+        }
+        // Every event is already counted: a duplicated transcript with nothing
+        // new in it.
+        return keys.isSubset(of: windows.lifetime.eventKeys)
+    }
+
+    /// Re-reads a partly-overlapping transcript from byte zero and folds in only
+    /// the events no other file has contributed yet.
+    ///
+    /// The cache is deliberately left alone. Its record describes this file on
+    /// its own, which stays correct; what is not cacheable is the overlap, since
+    /// which copy got read first can change between refreshes.
+    nonisolated private static func foldByEvent(
+        _ file: CostScanFile,
+        projectID: String,
+        session: CostScanSession,
+        windows: inout ScanWindows<ClaudeSessionTotals>
+    ) {
+        let allowance = session.budget.allowance
+        guard allowance > 0 else {
+            session.noteDeferred(.claude)
+            return
+        }
+
+        var request = FileLineReadRequest()
+        request.maxBytes = allowance
+
+        var periodKeyed: [String: ClaudeUsageEvent] = [:]
+        var lifetimeKeyed: [String: ClaudeUsageEvent] = [:]
+        var truncation = CostScanTruncationTally()
+
+        let read = FileLineReader.readLines(in: file.url, request: request) { line, _ in
+            let event = Self.usageEvent(from: line, url: file.url)
+            truncation.note(line, recovered: event != nil)
+            guard let event else { return }
+
+            let key = event.deduplicationKey(projectID: projectID)
+            guard !windows.lifetime.eventKeys.contains(key) else { return }
+            lifetimeKeyed[key] = event
+            if event.timestamp >= session.cutoff, !windows.period.eventKeys.contains(key) {
+                periodKeyed[key] = event
+            }
+        }
+
+        truncation.log(url: file.url)
+
+        guard let read else { return }
+        session.budget.consume(read.bytesRead)
+        if !read.reachedEndOfFile { session.noteDeferred(.claude) }
+
+        windows.period.merge(Self.tally(
+            keyed: periodKeyed,
+            projectID: projectID,
+            hourlyCutoff: session.hourlyCutoff
+        ))
+        windows.lifetime.merge(Self.tally(
+            keyed: lifetimeKeyed,
+            projectID: projectID,
+            hourlyCutoff: session.hourlyCutoff
+        ))
     }
 
     /// One transcript's contribution: cached, resumed, or skipped.
@@ -374,10 +469,10 @@ enum ClaudeCostScanner {
             // already folded into `payload`, and its bytes are behind the
             // committed offset. Within a single pass the last copy still
             // wins, exactly as a cold scan does.
-            if !payload.lifetimeKeys.contains(key) {
+            if !payload.lifetime.eventKeys.contains(key) {
                 lifetimeKeyed[key] = event
             }
-            if event.timestamp >= session.cutoff, !payload.periodKeys.contains(key) {
+            if event.timestamp >= session.cutoff, !payload.period.eventKeys.contains(key) {
                 periodKeyed[key] = event
             }
         }
@@ -406,17 +501,12 @@ enum ClaudeCostScanner {
         payload.period.sessions = payload.period.hasUsage ? 1 : 0
         payload.lifetime.sessions = payload.lifetime.hasUsage ? 1 : 0
 
-        if read.reachedEndOfFile {
-            // Dedup keys only matter while a read can resume mid-file. Keeping
-            // ~10k files' worth of them on disk forever would cost more to load
-            // than the scan they save.
-            payload.periodKeys = []
-            payload.lifetimeKeys = []
-        } else {
-            payload.periodKeys.formUnion(periodKeyed.keys)
-            payload.lifetimeKeys.formUnion(lifetimeKeyed.keys)
-            session.noteDeferred(.claude)
-        }
+        // The keys ride inside the two windows, so they persist past EOF rather
+        // than being cleared at it. That costs roughly a megabyte on a nine-
+        // megabyte artifact for a thousand-transcript corpus, and it buys the
+        // cross-file check in `fold` — which needs the keys of files the cache
+        // returns without reading, not just of files read this pass.
+        if !read.reachedEndOfFile { session.noteDeferred(.claude) }
 
         session.setRecord(
             CostScanFileRecord(
@@ -474,6 +564,7 @@ enum ClaudeCostScanner {
         hourlyCutoff: Date = .distantPast
     ) -> ClaudeSessionTotals {
         var totals = ClaudeSessionTotals()
+        totals.eventKeys = Set(keyed.keys)
         let events = keyed.keys.sorted().compactMap { keyed[$0] }
         // Resolving the current calendar is not free, and it cannot change
         // mid-fold.

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -876,6 +876,16 @@ enum CodexCostScanner {
         // Use whole-millisecond precision for the dedup key so equivalent events
         // produce a stable, collision-resistant string (raw Double formatting can
         // vary and risks both false matches and false misses).
+        //
+        // Model, origin, and project are deliberately absent. The deferred
+        // back-fill replays a parked event once its rollout finally names a
+        // model, and a budgeted slice that ends with events still parked rolls
+        // its offset back so the next refresh re-reads them — both hand the same
+        // charge to `apply` twice under different attribution, and only an
+        // attribution-free key sees through it. The price is that two distinct
+        // same-millisecond events with identical counts collapse into one.
+        // `CostScanCorpusTests` pins both halves; widen this key only with a
+        // proof that the deferred path still dedups.
         let timestampMillis = Int((timestamp.timeIntervalSince1970 * 1000).rounded())
         let key = "\(timestampMillis)-\(sessionID)-\(input)-\(cached)-\(output)-\(reasoning)"
         let keys = CostScanEventKeys(

--- a/MeterBar/Services/CostScanFileCache.swift
+++ b/MeterBar/Services/CostScanFileCache.swift
@@ -64,11 +64,14 @@ nonisolated protocol CostScanPeriodRebasable: Codable, Sendable {
 
 /// Every transcript's record, keyed by standardized path.
 nonisolated struct CostScanFileCache<Payload: Codable & Sendable>: Codable, Sendable {
-    /// Version 4 adds trailing-seven-day hourly accumulators. This private
-    /// disposable cache intentionally invalidates v3 so the upgrade's first
+    /// Version 5 moves Claude's dedup keys out of the two top-level `periodKeys`
+    /// / `lifetimeKeys` sets and into `eventKeys` on each window, where they
+    /// survive EOF and can be checked across files. Version 4 added
+    /// trailing-seven-day hourly accumulators. This private disposable cache
+    /// intentionally invalidates the previous version so the upgrade's first
     /// background refresh re-reads source events instead of trusting offsets
-    /// whose payload has no hourly totals.
-    static var currentSchemaVersion: Int { 4 }
+    /// whose payload predates the change.
+    static var currentSchemaVersion: Int { 5 }
 
     var schemaVersion = CostScanFileCache.currentSchemaVersion
     var parserVersion = CostScanValues.costCacheParserVersion
@@ -312,22 +315,15 @@ nonisolated enum CostScanCacheStoreError: LocalizedError {
     }
 }
 
-/// One Claude transcript's tally, plus the dedup state a resumed read needs.
+/// One Claude transcript's tally.
+///
+/// The dedup state a resumed read needs lives on the windows themselves, as
+/// `ClaudeSessionTotals.eventKeys` — same shape Codex and Grok get from
+/// `CostScanWindowContext.eventKeys`, and the reason those keys can also answer
+/// "have I already counted this event from a *different* file?".
 nonisolated struct ClaudeFileTotals: Codable, Sendable {
     var period = ClaudeSessionTotals()
     var lifetime = ClaudeSessionTotals()
-
-    /// `messageID:requestID` keys already folded into each window.
-    ///
-    /// Kept only while the file is still being read. Within a single pass the
-    /// scanner keeps the *last* event for a duplicate key; across a resume
-    /// boundary the earlier slice is already tallied, so a duplicate that
-    /// arrives in a later slice is dropped instead — first-wins. The two differ
-    /// only when a transcript repeats a key with different token counts, which
-    /// Claude Code does not do; both are one-copy-counted, which is the property
-    /// that matters.
-    var periodKeys: Set<String> = []
-    var lifetimeKeys: Set<String> = []
 }
 
 /// One Codex rollout's tally, plus the attribution state carried across slices.
@@ -368,13 +364,12 @@ nonisolated extension ClaudeFileTotals: CostScanPeriodRebasable {
         // the only question is whether the cached period tally can be rebased
         // without re-reading the file.
         if (lifetime.latest ?? .distantPast) < cutoff {
-            // Every event predates the new window.
+            // Every event predates the new window. Its keys go with it: they
+            // describe what the period tally counted, and it now counts nothing.
             period = ClaudeSessionTotals()
-            periodKeys = []
         } else if (lifetime.earliest ?? .distantFuture) >= cutoff {
             // Every event falls inside it.
             period = lifetime
-            periodKeys = lifetimeKeys
         } else {
             // The file straddles the cutoff and only its individual events know
             // where. Re-read it — but only files that actually straddle pay.

--- a/MeterBar/Services/CostScanWindows.swift
+++ b/MeterBar/Services/CostScanWindows.swift
@@ -141,6 +141,16 @@ nonisolated struct ClaudeSessionTotals: Sendable, Codable, CostScanBreakdowns {
     /// Which dated rate entries priced these events, and how many predated the
     /// table entirely (issue #339).
     var pricing = PricingProvenance()
+    /// The `messageID:requestID` keys these totals were built from — the same
+    /// role `eventKeys` plays in ``CostScanWindowContext``, and the reason a
+    /// merge can tell "another transcript" from "the same transcript again".
+    ///
+    /// Two things depend on it. Within a file it is the first-wins guard across
+    /// a resume boundary: an event behind the committed offset is already
+    /// tallied, so a later slice must drop its duplicate. Across files it is
+    /// what lets ``ClaudeCostScanner`` refuse a sync conflict copy or a restored
+    /// backup instead of billing its events twice.
+    var eventKeys: Set<String> = []
 
     var hasUsage: Bool {
         input > 0 || output > 0 || cacheCreation > 0 || cacheRead > 0
@@ -149,6 +159,10 @@ nonisolated struct ClaudeSessionTotals: Sendable, Codable, CostScanBreakdowns {
     /// Folds one file's totals in. Empty files are skipped so they never inflate
     /// `sessions`.
     mutating func merge(_ other: ClaudeSessionTotals) {
+        // Ahead of the usage guard: a slice that read only non-usage lines
+        // still has to leave its keys behind, or the next slice would re-count
+        // an event it has already passed.
+        eventKeys.formUnion(other.eventKeys)
         guard other.hasUsage else { return }
 
         input += other.input

--- a/MeterBar/Services/GrokCostScanner.swift
+++ b/MeterBar/Services/GrokCostScanner.swift
@@ -19,10 +19,13 @@ import MeterBarShared
 ///   that scanner parks events until a later line declares one. A Grok
 ///   `turn_completed` names its own model inside `modelUsage`, so every record
 ///   is attributable the moment it is read.
-/// * **No overlap fallback.** Codex stores the same rollout under both
-///   `sessions/` and `archived_sessions/`; Grok writes each session exactly
-///   once, and every dedup key carries its session ID, so two files cannot
-///   describe the same event. A plain `merge` is sufficient.
+///
+/// It does keep Codex's overlap fallback. Grok writes each session exactly
+/// once, but nothing keeps a *copy* of that file off disk: sync clients leave
+/// conflict copies, backups get restored into the tree, and `CostScanCorpus`
+/// matches every `.jsonl` under the root. Because the dedup key carries the
+/// session ID from the payload rather than from the path, a copy produces
+/// identical keys — so a blind `merge` would bill it twice.
 enum GrokCostScanner {
     /// USD per unit of `costUsdTicks`.
     ///
@@ -114,6 +117,11 @@ enum GrokCostScanner {
     /// Roots can overlap — two accounts pointed at one home, or `GROK_HOME` set
     /// to the default — so files are deduplicated by cache key the way the
     /// Claude scanner deduplicates its project roots.
+    ///
+    /// Cache-key dedup only catches the *same* file reached twice. Two distinct
+    /// files describing the same session — a sync conflict copy, a restored
+    /// backup — are caught one level down, by folding each file's tally against
+    /// the events already counted.
     nonisolated static func scanRoots(
         _ roots: [URL],
         session: CostScanSession
@@ -126,13 +134,81 @@ enum GrokCostScanner {
             for file in CostScanCorpus.transcripts(in: root) {
                 guard live.insert(file.cacheKey).inserted else { continue }
                 guard let totals = Self.totals(for: file, session: session) else { continue }
-                windows.period.merge(totals.period)
-                windows.lifetime.merge(totals.lifetime)
+                guard Self.fold(totals, into: &windows) else {
+                    // This file shares only *some* of its events with one
+                    // already folded in — a stale copy holding a prefix of the
+                    // live session. Aggregates cannot be de-overlapped after
+                    // the fact, so it goes back through the event-level path,
+                    // where `apply` drops each duplicate against `eventKeys`.
+                    Self.foldByEvent(file, session: session, windows: &windows)
+                    continue
+                }
             }
         }
 
         session.retain(keys: live, provider: .grok)
         return windows
+    }
+
+    /// Adds one file's tally to the shared windows.
+    ///
+    /// - Returns: `false` when the file's events partly overlap what is already
+    ///   counted, which no aggregate merge can resolve — the caller has to
+    ///   re-read that file event by event.
+    nonisolated private static func fold(
+        _ totals: GrokFileTotals,
+        into windows: inout ScanWindows<CostScanWindowContext>
+    ) -> Bool {
+        // Period keys are a subset of lifetime keys by construction (every
+        // in-window event is also a lifetime event), so the lifetime test
+        // answers for both windows.
+        let keys = totals.lifetime.eventKeys
+        if keys.isDisjoint(with: windows.lifetime.eventKeys) {
+            windows.period.merge(totals.period)
+            windows.lifetime.merge(totals.lifetime)
+            return true
+        }
+        // Every event is already counted: a duplicated session with nothing new.
+        return keys.isSubset(of: windows.lifetime.eventKeys)
+    }
+
+    /// Streams one file straight into the shared windows, under the same budget
+    /// every other read answers to.
+    ///
+    /// The per-file cache is deliberately left alone. This read starts at byte
+    /// zero and produces no tally of its own, so there is nothing here a later
+    /// slice could resume from — the record `totals(for:session:)` already
+    /// committed stays the file's cached state.
+    nonisolated private static func foldByEvent(
+        _ file: CostScanFile,
+        session: CostScanSession,
+        windows: inout ScanWindows<CostScanWindowContext>
+    ) {
+        let allowance = session.budget.allowance
+        guard allowance > 0 else {
+            session.noteDeferred(.grok)
+            return
+        }
+
+        let attribution = Self.attribution(for: file.url)
+        let calendar = Calendar.current
+        var truncation = CostScanTruncationTally()
+        var request = FileLineReadRequest()
+        request.maxBytes = allowance
+
+        let read = FileLineReader.readLines(in: file.url, request: request) { readerLine, _ in
+            // swiftlint:disable:next contains_over_range_nil_comparison
+            guard readerLine.bytes.range(of: Self.turnCompletedMarker) != nil else { return }
+            let event = Self.usageEvent(from: readerLine.bytes, attribution: attribution)
+            truncation.note(readerLine, recovered: event != nil)
+            guard let event else { return }
+            Self.apply(event, windows: &windows, calendar: calendar)
+        }
+        truncation.log(url: file.url)
+
+        guard let read else { return }
+        session.budget.consume(read.bytesRead)
+        if !read.reachedEndOfFile { session.noteDeferred(.grok) }
     }
 
     /// The window's totals as a published cost row plus its daily rows.

--- a/MeterBarTests/CostScanCorpusTests.swift
+++ b/MeterBarTests/CostScanCorpusTests.swift
@@ -7,7 +7,7 @@ import XCTest
 final class CostScanCorpusTests: XCTestCase {
     // MARK: - Claude
 
-    func testClaudeDeduplicationIsPerFileAndPerWindow() throws {
+    func testClaudeDeduplicationIsPerWindowAndSpansFiles() throws {
         let root = try makeClaudeProjectsRoot()
         let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-15T00:00:00Z"))
 
@@ -18,10 +18,28 @@ final class CostScanCorpusTests: XCTestCase {
             claudeEventLine(timestamp: "2026-06-14T23:59:00.000Z", input: 100, output: 50),
             claudeEventLine(timestamp: "2026-06-15T00:01:00.000Z", input: 100, output: 50)
         ])
-        // A duplicate of the same key in a *different* file: Claude dedups per
-        // file, so this is a second billed event.
-        try writeClaudeTranscript(in: root, project: "www/other", name: "copy.jsonl", lines: [
-            claudeEventLine(timestamp: "2026-06-16T00:01:00.000Z", input: 100, output: 50)
+        // A different event in a different project: billed, obviously.
+        try writeClaudeTranscript(in: root, project: "www/other", name: "fresh.jsonl", lines: [
+            claudeEventLine(
+                timestamp: "2026-06-16T00:01:00.000Z",
+                messageID: "msg_2",
+                requestID: "req_2",
+                input: 100,
+                output: 50
+            )
+        ])
+        // That same event again, under a project directory someone restored
+        // from a backup. A `messageID:requestID` pair is unique to one API
+        // call, so a second file carrying it is a copy, not a second charge —
+        // whichever of the two the enumerator happens to reach first.
+        try writeClaudeTranscript(in: root, project: "www/other-backup", name: "fresh.jsonl", lines: [
+            claudeEventLine(
+                timestamp: "2026-06-16T00:01:00.000Z",
+                messageID: "msg_2",
+                requestID: "req_2",
+                input: 100,
+                output: 50
+            )
         ])
 
         let windows = ClaudeCostScanner.scanRoots([root], session: makeSession(cutoff: cutoff))
@@ -136,6 +154,66 @@ final class CostScanCorpusTests: XCTestCase {
         XCTAssertEqual(windows.period.totals.output, 500)
         XCTAssertEqual(windows.lifetime.totals.input, 1_077)
         XCTAssertEqual(windows.lifetime.totals.output, 533)
+    }
+
+    /// Codex's dedup key is `timestamp-session-input-cached-output-reasoning`.
+    /// It deliberately carries no model, origin, or project, and that is what
+    /// makes the deferred back-fill safe: an event parked before its rollout
+    /// declared a model is replayed later with that model filled in, and a
+    /// budgeted slice that ends with events still parked rolls its committed
+    /// offset back so the *next* refresh re-reads them. Both replay the same
+    /// underlying charge under different attribution, and the key has to see
+    /// through that or the event gets billed twice.
+    ///
+    /// The fixture is the extreme version: the same event in two rollouts, one
+    /// of which never names a model, so the two readers attribute it
+    /// differently. If attribution ever enters the key this test doubles.
+    func testCodexDeduplicationIgnoresAttributionSoBackfilledModelsCannotDoubleCount() throws {
+        let directory = try makeTemporaryDirectory(named: "CodexRollouts")
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-15T00:00:00Z"))
+
+        try writeCodexRollout(in: directory, path: "a-attributed.jsonl", lines: [
+            codexTokenLine(timestamp: "2026-06-16T10:00:00Z")
+        ])
+        try writeCodexRollout(in: directory, path: "b-unattributed.jsonl", lines: [
+            codexTokenLine(timestamp: "2026-06-16T10:00:00Z", model: nil)
+        ])
+
+        var windows = CodexCostScanner.scanWindows(cutoff: cutoff)
+        CostScanFixtureScan.codexRollouts(in: directory, windows: &windows)
+
+        XCTAssertEqual(windows.lifetime.totals.input, 1_000)
+        XCTAssertEqual(windows.lifetime.totals.output, 500)
+        // First-event-wins, so the charge keeps the attribution of whichever
+        // reader got there first — and the unattributed replay adds no second
+        // "unknown" row alongside it.
+        XCTAssertEqual(Set(windows.lifetime.models.keys), ["gpt-5.5"])
+    }
+
+    /// The accepted cost of the attribution-free key above: two genuinely
+    /// distinct events that land in the same millisecond, in the same session,
+    /// with identical token counts are indistinguishable to it, so the second
+    /// is dropped and the spend is under-reported. In practice that needs a
+    /// mid-session model switch whose two turns bill identically to the token
+    /// — rare enough to be worth less than the double-count the key prevents.
+    ///
+    /// This test pins the trade-off rather than endorsing the number: it exists
+    /// so that widening the key is a deliberate edit here, made together with a
+    /// proof that the deferred path still dedups, and never a silent one.
+    func testCodexDeduplicationCollapsesASameMillisecondModelSwitchByDesign() throws {
+        let directory = try makeTemporaryDirectory(named: "CodexRollouts")
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-15T00:00:00Z"))
+
+        try writeCodexRollout(in: directory, path: "switch.jsonl", lines: [
+            codexTokenLine(timestamp: "2026-06-16T10:00:00Z", model: "gpt-5.5"),
+            codexTokenLine(timestamp: "2026-06-16T10:00:00Z", model: "gpt-5.5-codex")
+        ])
+
+        var windows = CodexCostScanner.scanWindows(cutoff: cutoff)
+        CostScanFixtureScan.codexRollouts(in: directory, windows: &windows)
+
+        XCTAssertEqual(windows.lifetime.totals.input, 1_000)
+        XCTAssertEqual(Set(windows.lifetime.models.keys), ["gpt-5.5"])
     }
 
     func testCodexScanSurvivesUnreadableAndMalformedRollouts() throws {
@@ -285,18 +363,21 @@ extension CostScanCorpusTests {
         try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
     }
 
-    /// A `token_count` event that names its own model.
+    /// A `token_count` event that names its own model, or — with `model: nil` —
+    /// one that names no model at all, the shape that sends an event down the
+    /// deferred back-fill path.
     private func codexTokenLine(
         timestamp: String,
         conversationID: String = "conv-1",
-        model: String = "gpt-5.5",
+        model: String? = "gpt-5.5",
         input: Int = 1_000,
         output: Int = 500
     ) -> String {
-        """
+        let modelPart = model.map { "\"model\": \"\($0)\", " } ?? ""
+        return """
         {"timestamp": "\(timestamp)", "payload": {"type": "token_count", \
         "rate_limits": {"conversation_id": "\(conversationID)"}, \
-        "info": {"model": "\(model)", "last_token_usage": \
+        "info": {\(modelPart)"last_token_usage": \
         {"input_tokens": \(input), "output_tokens": \(output), \
         "cached_input_tokens": 200, "reasoning_output_tokens": 50}}}}
         """

--- a/MeterBarTests/CostScanFileCacheSafetyTests.swift
+++ b/MeterBarTests/CostScanFileCacheSafetyTests.swift
@@ -99,13 +99,13 @@ final class CostScanFileCacheSafetyTests: XCTestCase {
         )
     }
 
-    func testHourlyUpgradeReadsFromAFreshV4Artifact() throws {
-        let oldURL = directory.appendingPathComponent("cost-scan-claude-v3.json")
+    func testDedupKeyUpgradeReadsFromAFreshV5Artifact() throws {
+        let oldURL = directory.appendingPathComponent("cost-scan-claude-v4.json")
         try CostScanCacheStore.saveClaude(makeCache(), to: oldURL)
         let store = CostScanCacheStore(directory: directory)
 
-        XCTAssertEqual(CostScanFileCache<ClaudeFileTotals>.currentSchemaVersion, 4)
-        XCTAssertEqual(CostScanCacheStore.claudeFileName, "cost-scan-claude-v4.json")
+        XCTAssertEqual(CostScanFileCache<ClaudeFileTotals>.currentSchemaVersion, 5)
+        XCTAssertEqual(CostScanCacheStore.claudeFileName, "cost-scan-claude-v5.json")
         XCTAssertTrue(store.loadClaude().records.isEmpty)
     }
 

--- a/MeterBarTests/CostScanResumptionTests.swift
+++ b/MeterBarTests/CostScanResumptionTests.swift
@@ -36,7 +36,7 @@ final class CostScanResumptionTests: XCTestCase {
         let file = makeFile(size: 100)
         var record = makeRecord(stamp: file.stamp)
         record.cutoff = currentCutoff
-        record.payload.periodKeys = ["unchanged"]
+        record.payload.period.eventKeys = ["unchanged"]
         var didRebase = false
 
         let result = CostScanResumption.resumableRecord(
@@ -49,7 +49,7 @@ final class CostScanResumptionTests: XCTestCase {
         }
 
         XCTAssertFalse(didRebase)
-        XCTAssertEqual(try XCTUnwrap(result).payload.periodKeys, ["unchanged"])
+        XCTAssertEqual(try XCTUnwrap(result).payload.period.eventKeys, ["unchanged"])
     }
 
     func testWindowPayloadRebaseClearsPeriodWhenEveryEventPredatesCutoff() throws {
@@ -131,24 +131,24 @@ final class CostScanResumptionTests: XCTestCase {
     func testClaudeRebasePreservesItsSeparatePeriodAndLifetimeKeySemantics() throws {
         var beforePayload = ClaudeFileTotals()
         beforePayload.period.input = 10
-        beforePayload.periodKeys = ["stale-period"]
+        beforePayload.period.eventKeys = ["stale-period"]
         beforePayload.lifetime.latest = currentCutoff.addingTimeInterval(-100)
-        beforePayload.lifetimeKeys = ["old"]
+        beforePayload.lifetime.eventKeys = ["old"]
 
         let beforeResult = try XCTUnwrap(resumableRecord(makeRecord(payload: beforePayload)))
         XCTAssertFalse(beforeResult.payload.period.hasUsage)
-        XCTAssertTrue(beforeResult.payload.periodKeys.isEmpty)
-        XCTAssertEqual(beforeResult.payload.lifetimeKeys, ["old"])
+        XCTAssertTrue(beforeResult.payload.period.eventKeys.isEmpty)
+        XCTAssertEqual(beforeResult.payload.lifetime.eventKeys, ["old"])
 
         var insidePayload = ClaudeFileTotals()
         insidePayload.lifetime.input = 25
         insidePayload.lifetime.earliest = currentCutoff.addingTimeInterval(100)
         insidePayload.lifetime.latest = currentCutoff.addingTimeInterval(200)
-        insidePayload.lifetimeKeys = ["current"]
+        insidePayload.lifetime.eventKeys = ["current"]
 
         let insideResult = try XCTUnwrap(resumableRecord(makeRecord(payload: insidePayload)))
         XCTAssertEqual(insideResult.payload.period.input, 25)
-        XCTAssertEqual(insideResult.payload.periodKeys, ["current"])
+        XCTAssertEqual(insideResult.payload.period.eventKeys, ["current"])
     }
 
     private func resumableRecord<Payload: CostScanPeriodRebasable>(

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -1524,6 +1524,125 @@ final class CostTrackerTests: XCTestCase {
 
     // MARK: - Budgeted, resumable corpus scan
 
+    /// One event copied into a second project directory — a sync conflict copy,
+    /// a restored backup, a project folder duplicated under a new path — must
+    /// be billed once. `messageID:requestID` identifies the event globally, so
+    /// the second file adds nothing no matter which project it lands under.
+    func testClaudeScanCountsAnEventCopiedIntoASecondProjectOnce() throws {
+        let root = try makeTranscriptRoot()
+        let line = eventLine(
+            timestamp: "2026-07-01T10:00:00.000Z",
+            messageID: "msg_a",
+            requestID: "req_a",
+            input: 100,
+            output: 10
+        )
+        try writeTranscript(
+            in: try makeProjectDirectory(in: root, named: "-Users-me-alpha"),
+            name: "session.jsonl",
+            modifiedAgo: 0,
+            lines: [line]
+        )
+        try writeTranscript(
+            in: try makeProjectDirectory(in: root, named: "-Users-me-alpha-conflict"),
+            name: "session.jsonl",
+            modifiedAgo: 60,
+            lines: [line]
+        )
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+
+        let windows = ClaudeCostScanner.scanRoots(
+            [root],
+            session: CostScanSession(cutoff: cutoff, options: .unlimited)
+        )
+
+        XCTAssertEqual(windows.period.input, 100)
+        XCTAssertEqual(windows.period.output, 10)
+        XCTAssertEqual(windows.period.sessions, 1)
+        XCTAssertEqual(windows.lifetime.input, 100)
+    }
+
+    /// The harder half: a stale copy holds a prefix of the live transcript, so
+    /// the two overlap without either containing the other. No aggregate merge
+    /// can resolve that — the union has to be assembled event by event.
+    func testClaudeScanCountsTheUnionOfPartiallyOverlappingCopiesOnce() throws {
+        let root = try makeTranscriptRoot()
+        let shared = eventLine(
+            timestamp: "2026-07-01T10:00:00.000Z",
+            messageID: "msg_a",
+            requestID: "req_a",
+            input: 100,
+            output: 10
+        )
+        let onlyInLive = eventLine(
+            timestamp: "2026-07-01T11:00:00.000Z",
+            messageID: "msg_b",
+            requestID: "req_b",
+            input: 7,
+            output: 3
+        )
+        try writeTranscript(
+            in: try makeProjectDirectory(in: root, named: "-Users-me-alpha"),
+            name: "session.jsonl",
+            modifiedAgo: 0,
+            lines: [shared, onlyInLive]
+        )
+        try writeTranscript(
+            in: try makeProjectDirectory(in: root, named: "-Users-me-alpha-conflict"),
+            name: "session.jsonl",
+            modifiedAgo: 60,
+            lines: [shared]
+        )
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+
+        let windows = ClaudeCostScanner.scanRoots(
+            [root],
+            session: CostScanSession(cutoff: cutoff, options: .unlimited)
+        )
+
+        XCTAssertEqual(windows.period.input, 107)
+        XCTAssertEqual(windows.period.output, 13)
+        XCTAssertEqual(windows.lifetime.input, 107)
+    }
+
+    /// The overlap guard reads its key sets off the per-file cache, so a warm
+    /// refresh — every file answered from disk, not a single byte re-read —
+    /// has to reject the copy exactly as the cold scan did.
+    func testClaudeScanRejectsACopiedEventOnAWarmCachedRefresh() throws {
+        let root = try makeTranscriptRoot()
+        let line = eventLine(
+            timestamp: "2026-07-01T10:00:00.000Z",
+            messageID: "msg_a",
+            requestID: "req_a",
+            input: 100,
+            output: 10
+        )
+        try writeTranscript(
+            in: try makeProjectDirectory(in: root, named: "-Users-me-alpha"),
+            name: "session.jsonl",
+            modifiedAgo: 0,
+            lines: [line]
+        )
+        try writeTranscript(
+            in: try makeProjectDirectory(in: root, named: "-Users-me-alpha-conflict"),
+            name: "session.jsonl",
+            modifiedAgo: 60,
+            lines: [line]
+        )
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let store = try makeScanCacheStore()
+
+        let cold = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        _ = ClaudeCostScanner.scanRoots([root], session: cold)
+        XCTAssertEqual(cold.persist(), .persisted)
+
+        let warm = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        let windows = ClaudeCostScanner.scanRoots([root], session: warm)
+
+        XCTAssertEqual(windows.period.input, 100)
+        XCTAssertEqual(windows.lifetime.input, 100)
+    }
+
     func testBudgetedClaudeScanMatchesWholeFileForDuplicateUnkeyedEvents() throws {
         let root = try makeTranscriptRoot()
         let line = eventLine(
@@ -2217,6 +2336,15 @@ final class CostTrackerTests: XCTestCase {
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         addTeardownBlock { try? FileManager.default.removeItem(at: root) }
         return root
+    }
+
+    /// One project folder under a transcript root, named the way Claude Code
+    /// encodes them, so `CostProjectAttribution` derives a distinct project ID
+    /// per directory.
+    private func makeProjectDirectory(in root: URL, named name: String) throws -> URL {
+        let directory = root.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
     }
 
     private func makeScanCacheStore() throws -> CostScanCacheStore {

--- a/MeterBarTests/GrokCostScannerTests.swift
+++ b/MeterBarTests/GrokCostScannerTests.swift
@@ -250,6 +250,48 @@ final class GrokCostScannerTests: XCTestCase {
         XCTAssertEqual(cost.inputTokens, 100)
     }
 
+    /// A session directory copied by a sync client — Dropbox/iCloud conflict
+    /// copies, a restored backup, a `cp -r` of `sessions/` — puts the same
+    /// events in two `.jsonl` files. `CostScanCorpus` matches every `.jsonl`
+    /// under the root, so both are read; the dedup key carries the session ID
+    /// from the *payload*, so both files produce identical keys and the second
+    /// must add nothing.
+    func testDuplicatedSessionDirectoryIsCountedOnce() throws {
+        let root = try makeSessionsRoot()
+        let line = turnCompleted(at: Date(), input: 100, cachedRead: 0, output: 10, reasoning: 0, ticks: 1_000_000)
+        try writeUpdates(in: root, project: "www/meterbar", session: "session-a", lines: [line])
+        try writeUpdates(in: root, project: "www/meterbar", session: "session-a-conflict", lines: [line])
+
+        let cost = try XCTUnwrap(scanCost(roots: [root], days: 30))
+
+        XCTAssertEqual(cost.inputTokens, 100)
+        XCTAssertEqual(cost.outputTokens, 10)
+        XCTAssertEqual(cost.sessionCount, 1)
+    }
+
+    /// The harder half: a stale copy holds a prefix of the live file, so the
+    /// two overlap without either containing the other. No aggregate merge can
+    /// resolve that — the union has to be assembled event by event.
+    func testPartiallyOverlappingCopiesCountTheirUnionOnce() throws {
+        let root = try makeSessionsRoot()
+        let now = Date()
+        let shared = turnCompleted(at: now.addingTimeInterval(-120), input: 100, cachedRead: 0, output: 10, reasoning: 0, ticks: 1_000_000)
+        let onlyInLive = turnCompleted(at: now, input: 200, cachedRead: 0, output: 20, reasoning: 0, ticks: 2_000_000)
+        try writeUpdates(in: root, project: "www/meterbar", session: "session-a", lines: [shared])
+        try writeUpdates(
+            in: root,
+            project: "www/meterbar",
+            session: "session-a-conflict",
+            lines: [shared, onlyInLive]
+        )
+
+        let cost = try XCTUnwrap(scanCost(roots: [root], days: 30))
+
+        XCTAssertEqual(cost.inputTokens, 300)
+        XCTAssertEqual(cost.outputTokens, 30)
+        XCTAssertEqual(cost.sessionCount, 1)
+    }
+
     // MARK: - Windowing
 
     /// The period window is the visible 30-day chart; the lifetime window is the


### PR DESCRIPTION
Three cost-correctness findings from a scoped audit. Two MED double-counting bugs, one LOW test gap. TDD throughout — every fix has a regression test that failed first.

## 1. MED — Grok merged every `.jsonl` blind

`GrokCostScanner.scanRoots` merged each distinct file's totals via `CostScanWindowContext.merge`, whose only guard is `!other.eventKeys.isEmpty`. `CostScanCorpus.transcripts(in:)` matches any `.jsonl` recursively, so a sync-conflict copy, a backup, or a duplicated session directory was billed twice. The file's own doc comment asserted "two files cannot describe the same event" — an invariant nothing enforced.

Codex's `fold()` already implements the right pattern with the same primitives. Grok now uses it: disjoint keys → merge both windows; subset → drop; partial overlap → re-read from byte zero and fold event by event. The false doc bullet is gone.

New tests: `testDuplicatedSessionDirectoryIsCountedOnce`, `testPartiallyOverlappingCopiesCountTheirUnionOnce`.

## 2. MED — Claude had no key set to guard with

Structurally worse: `ClaudeSessionTotals` had no `eventKeys` at all, so no guard was possible. The `messageID:requestID` dedup keys lived on `ClaudeFileTotals` as `periodKeys`/`lifetimeKeys`, were rebuilt per file, cleared at EOF, and never checked across files. `deduplicationKey` deliberately omits the project ID when both IDs exist, so the same event in two project directories produces the same key — the collision was there, nothing looked for it.

`eventKeys` now lives on `ClaudeSessionTotals`, **replacing** the two `ClaudeFileTotals` sets rather than adding to them. One set per window serves both jobs:

- **within a file** — the first-wins guard across a resume boundary (unchanged)
- **across files** — the disjointness check `fold` needs

`merge` unions the keys **before** the `hasUsage` guard: a slice that read only non-usage lines still has to leave its keys behind. `rebasePeriod` gains exact parity for free, since the keys now travel inside the window they describe.

**Behavior change:** keys survive EOF. An appended duplicate after a complete read is now dropped — more correct, same first-wins rule. This is what makes the cross-file check work at all: `fold` needs the keys of files the cache returns *without reading*, not only of files read this pass.

New tests in `CostTrackerTests`: `testClaudeScanCountsAnEventCopiedIntoASecondProjectOnce`, `testClaudeScanCountsTheUnionOfPartiallyOverlappingCopiesOnce`, `testClaudeScanRejectsACopiedEventOnAWarmCachedRefresh` (the last forces the keys through serialization).

### Cache schema 4 → 5

The persisted payload shape changed, so `currentSchemaVersion` bumps to 5 and the artifact becomes `cost-scan-claude-v5.json`. `load` drops the v4 file; the first background refresh after upgrade re-reads source events instead of trusting offsets whose payload predates the change. `testDedupKeyUpgradeReadsFromAFreshV5Artifact` covers it.

**Size:** the live `cost-scan-claude-v4.json` is 9,099,087 bytes over 1,058 transcripts (~11,088 keyed events, ~58–61 bytes/key) → roughly **+1.3 MB, ~15%**, against a 64 MiB cap. Comfortable.

**Unrelated, pre-existing, worth knowing:** `cost-scan-codex-v4.json` is currently 66,906,727 bytes — **99.7% of `maximumArtifactBytes`**. This PR does not touch the Codex payload and does not move that number, but it is one refresh away from the save throwing.

## 3. LOW — Codex's key documented, not changed

`CodexCostScanner.apply`'s per-event key omits model, origin, and project, so two same-millisecond events with identical token counts (a mid-session model switch) collapse into one. That is load-bearing, not an oversight: the deferred back-fill replays a parked event once its rollout names a model, and a budgeted slice that ends with events still parked rolls its offset back so the next refresh re-reads them. Both hand the same charge to `apply` twice under different attribution; only an attribution-free key sees through it.

Per the finding, the key is unchanged. It is now commented, and two tests pin both halves so a future widening has to be deliberate:

- `testCodexDeduplicationIgnoresAttributionSoBackfilledModelsCannotDoubleCount` — the property the key protects
- `testCodexDeduplicationCollapsesASameMillisecondModelSwitchByDesign` — the trade-off it costs

The second pins the behavior rather than endorsing the number. Verified non-vacuous: a model-carrying key would score 2,000 across two model rows where the current one scores 1,000 across one.

## Test rewritten, not just added

`testClaudeDeduplicationIsPerFileAndPerWindow` asserted the bug in its name and its numbers ("Claude dedups per file, so this is a second billed event"). It is now `testClaudeDeduplicationIsPerWindowAndSpansFiles` and keeps both properties. The duplicate is deliberately arranged to collide with a *non-straddling* file, so the result does not depend on enumeration order — had it collided with the straddle file, a copy folded first would drop the straddle file as a subset and the per-window assertion would never run.

## Verification

```
swift test        Executed 2185 tests, with 6 skipped and 0 failures in 25.320s
swiftlint --strict  Done linting! Found 0 violations, 0 serious in 270 files.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate Claude and Grok transcript or session events from being counted more than once.
  - Preserved unique events when files partially overlap.
  - Improved deduplication across cached data, refreshed scans, and attribution changes.
  - Updated cached scan data to maintain accurate results after the deduplication improvements.

- **Tests**
  - Added coverage for duplicate files, overlapping events, cache refreshes, and resuming scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->