### PR TITLE
fix(cli): honor the documented contract on cancel, bad input, locks and empty filters

### DIFF
--- a/MeterBar/Guard/QuotaGuardCLI.swift
+++ b/MeterBar/Guard/QuotaGuardCLI.swift
@@ -33,6 +33,10 @@ nonisolated public enum QuotaGuardCLI {
         /// Raw `--refresh-timeout` text, parsed in the core for the same reason
         /// as `minRemaining`. `nil` means `defaultRefreshTimeout`.
         public let refreshTimeout: String?
+        /// Polled by `--refresh` so SIGINT/SIGTERM ends the refresh window
+        /// cooperatively. Guard still evaluates the cached snapshot afterwards
+        /// and exits with a documented guard code.
+        public let shouldCancel: @Sendable () -> Bool
 
         public init(
             provider: String = defaultProvider,
@@ -40,7 +44,8 @@ nonisolated public enum QuotaGuardCLI {
             minRemaining: String? = nil,
             configDirectory: String? = nil,
             refresh: Bool = false,
-            refreshTimeout: String? = nil
+            refreshTimeout: String? = nil,
+            shouldCancel: @escaping @Sendable () -> Bool = { false }
         ) {
             self.provider = provider
             self.window = window
@@ -48,6 +53,7 @@ nonisolated public enum QuotaGuardCLI {
             self.configDirectory = configDirectory
             self.refresh = refresh
             self.refreshTimeout = refreshTimeout
+            self.shouldCancel = shouldCancel
         }
     }
 
@@ -72,7 +78,10 @@ nonisolated public enum QuotaGuardCLI {
         if request.refresh {
             // A failed refresh is not itself a guard failure: the cached
             // snapshot is still evaluated below, and reports its own staleness.
-            await performRefresh(timeout: target.refreshTimeout)
+            await performRefresh(
+                timeout: target.refreshTimeout,
+                shouldCancel: request.shouldCancel
+            )
         }
 
         return result(from: evaluate(target: target))
@@ -81,8 +90,17 @@ nonisolated public enum QuotaGuardCLI {
     /// One bounded refresh through the coordinator the app and `meterbar
     /// refresh` share, so `--refresh` cannot start a second concurrent poll.
     @MainActor
-    private static func performRefresh(timeout: TimeInterval) async {
-        _ = await UsageRefreshCLI.run(UsageRefreshCLI.Request(timeout: timeout))
+    private static func performRefresh(
+        timeout: TimeInterval,
+        shouldCancel: @escaping @Sendable () -> Bool
+    ) async {
+        let result = await UsageRefreshCLI.run(
+            UsageRefreshCLI.Request(timeout: timeout, shouldCancel: shouldCancel)
+        )
+        // Guard keeps running after the refresh, so it must not leave the
+        // cross-process lock held by an abandoned task while it evaluates the
+        // snapshot and exits.
+        await result.awaitPendingCleanup()
     }
 
     private static func evaluate(target: QuotaGuardTarget) -> QuotaGuardEvaluation {

--- a/MeterBar/Models/CLIProviderFilter.swift
+++ b/MeterBar/Models/CLIProviderFilter.swift
@@ -1,0 +1,54 @@
+import Foundation
+import MeterBarShared
+
+/// The `--provider` substring filter shared by `meterbar usage` and
+/// `meterbar doctor`.
+///
+/// Both commands matched providers with their own copy of the same expression,
+/// and only `doctor` said anything when the filter matched nothing. Sharing the
+/// selection — and the message — keeps a typo from reading like "this provider
+/// has no quota data".
+public nonisolated enum CLIProviderFilter {
+    /// Printed by both commands when `--provider` excludes everything.
+    public static let noMatchesMessage = "No matching providers."
+
+    /// Explains an empty report. A filter that names no provider at all is a
+    /// typo; one that names a real provider only means the cache holds nothing
+    /// for it yet, and answering that with "no matching providers" would read
+    /// like the provider does not exist.
+    public static func emptyReportMessage(for filter: String?) -> String {
+        let selected = select(filter)
+        guard !selected.isEmpty else { return noMatchesMessage }
+
+        let names = selected.map(\.displayName).sorted().joined(separator: ", ")
+        return "No cached usage for \(names). Run `meterbar refresh` first."
+    }
+
+    /// Providers whose identifier or display name contains `filter`. A missing
+    /// or blank filter selects every provider; a filter that matches nothing
+    /// selects nothing.
+    public static func select(_ filter: String?) -> Set<ServiceType> {
+        guard let needle = needle(from: filter) else { return Set(ServiceType.allCases) }
+        return Set(ServiceType.allCases.filter { matches($0, needle) })
+    }
+
+    /// The same selection applied to a cached metrics snapshot.
+    public static func apply(
+        _ filter: String?,
+        to metrics: [ServiceType: UsageMetrics]
+    ) -> [ServiceType: UsageMetrics] {
+        guard let needle = needle(from: filter) else { return metrics }
+        return metrics.filter { matches($0.key, needle) }
+    }
+
+    private static func needle(from filter: String?) -> String? {
+        guard let trimmed = filter?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else { return nil }
+        return trimmed.lowercased()
+    }
+
+    private static func matches(_ service: ServiceType, _ needle: String) -> Bool {
+        service.rawValue.lowercased().contains(needle)
+            || service.displayName.lowercased().contains(needle)
+    }
+}

--- a/MeterBar/Models/CLIProviderFilter.swift
+++ b/MeterBar/Models/CLIProviderFilter.swift
@@ -8,7 +8,7 @@ import MeterBarShared
 /// and only `doctor` said anything when the filter matched nothing. Sharing the
 /// selection — and the message — keeps a typo from reading like "this provider
 /// has no quota data".
-public nonisolated enum CLIProviderFilter {
+nonisolated public enum CLIProviderFilter {
     /// Printed by both commands when `--provider` excludes everything.
     public static let noMatchesMessage = "No matching providers."
 

--- a/MeterBar/UsageRefresh/RefreshCLIResponse.swift
+++ b/MeterBar/UsageRefresh/RefreshCLIResponse.swift
@@ -12,6 +12,9 @@ nonisolated public struct RefreshCLIResponse: CLIJSONDocument {
     private let providers: [Provider]
     private let cache: Cache
     let message: String?
+    /// Present only when a caller-supplied input was rejected. Same shape as
+    /// the guard error object so one consumer can read both commands.
+    private let error: ErrorDetail?
 
     var summaryLine: String {
         let counts = [ProviderRefreshState.refreshed, .failed, .skipped]
@@ -26,7 +29,8 @@ nonisolated public struct RefreshCLIResponse: CLIJSONDocument {
         durationSeconds: Double,
         outcomes: [ProviderRefreshOutcome],
         cachedMetrics: [ServiceType: UsageMetrics],
-        message: String? = nil
+        message: String? = nil,
+        failure: RefreshCLIFailure? = nil
     ) {
         self.outcome = outcome
         self.collectedAt = collectedAt
@@ -36,6 +40,40 @@ nonisolated public struct RefreshCLIResponse: CLIJSONDocument {
             .map(Provider.init(outcome:))
         cache = Cache(metrics: cachedMetrics, now: collectedAt)
         self.message = message
+        error = failure.map(ErrorDetail.init(failure:))
+    }
+
+    /// A rejected `--timeout`: no provider was contacted, so the document
+    /// carries the failure rather than an empty provider list that would read
+    /// like a refresh that found nothing to do.
+    init(
+        failure: RefreshCLIFailure,
+        collectedAt: Date,
+        cachedMetrics: [ServiceType: UsageMetrics]
+    ) {
+        self.init(
+            outcome: .refreshFailed,
+            collectedAt: collectedAt,
+            durationSeconds: 0,
+            outcomes: [],
+            cachedMetrics: cachedMetrics,
+            message: failure.message,
+            failure: failure
+        )
+    }
+
+    private struct ErrorDetail: Encodable {
+        let code: String
+        let message: String
+        let flag: String?
+        let value: String?
+
+        init(failure: RefreshCLIFailure) {
+            code = failure.code
+            message = failure.message
+            flag = failure.flag
+            value = failure.value
+        }
     }
 
     private struct Provider: Encodable {

--- a/MeterBar/UsageRefresh/RefreshCLITimeout.swift
+++ b/MeterBar/UsageRefresh/RefreshCLITimeout.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// A caller-supplied `meterbar refresh` input that could not be used, shaped
+/// like the guard failures in `docs/cli-json-schema.md` so both commands report
+/// bad input the same machine-readable way.
+nonisolated struct RefreshCLIFailure: Error, Equatable, Sendable {
+    let code: String
+    let message: String
+    let flag: String?
+    let value: String?
+}
+
+/// Resolves the raw `--timeout` text.
+///
+/// ArgumentParser's own `Double` conversion runs before `validate()` and before
+/// `run()`, so typing the option as `Double` would answer a malformed value
+/// with a usage message and `EX_USAGE` (64) — neither of which is in the
+/// documented refresh contract, and neither of which is JSON. Parsing here
+/// keeps every failure inside the versioned document and the stable exit codes.
+/// `meterbar guard` resolves `--min-remaining` and `--refresh-timeout` the same
+/// way for the same reason.
+nonisolated enum RefreshTimeout {
+    static func resolve(_ raw: String?) -> Result<TimeInterval, RefreshCLIFailure> {
+        guard let raw else { return .success(UsageRefreshCLI.defaultTimeout) }
+
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let parsed = Double(trimmed),
+              parsed.isFinite,
+              (UsageRefreshCLI.minimumTimeout...UsageRefreshCLI.maximumTimeout).contains(parsed) else {
+            return .failure(RefreshCLIFailure(
+                code: "invalid_timeout",
+                message: "Invalid --timeout value '\(trimmed)'. "
+                    + "Expected \(QuotaGuardNumber.text(UsageRefreshCLI.minimumTimeout))"
+                    + "...\(QuotaGuardNumber.text(UsageRefreshCLI.maximumTimeout)) seconds.",
+                flag: "--timeout",
+                value: trimmed
+            ))
+        }
+        return .success(parsed)
+    }
+}

--- a/MeterBar/UsageRefresh/UsageRefreshCLI.swift
+++ b/MeterBar/UsageRefresh/UsageRefreshCLI.swift
@@ -5,15 +5,15 @@ import MeterBarShared
 public enum UsageRefreshCLI {
     // Read from nonisolated parsing and cleanup code, so they cannot inherit
     // the package's MainActor default isolation.
-    public nonisolated static let defaultTimeout: TimeInterval = 60
-    public nonisolated static let minimumTimeout: TimeInterval = 1
-    public nonisolated static let maximumTimeout: TimeInterval = 600
+    nonisolated public static let defaultTimeout: TimeInterval = 60
+    nonisolated public static let minimumTimeout: TimeInterval = 1
+    nonisolated public static let maximumTimeout: TimeInterval = 600
     /// Ceiling on how long a caller waits for an over-running refresh to let go
     /// of the cross-process lock. The JSON is already on standard output by
     /// then, so this only bounds how long the process lingers.
-    public nonisolated static let maximumCleanupWait: TimeInterval = 5
+    nonisolated public static let maximumCleanupWait: TimeInterval = 5
 
-    public nonisolated struct Result: Sendable {
+    nonisolated public struct Result: Sendable {
         public let jsonOutput: String
         public let summaryLine: String
         public let message: String?
@@ -67,7 +67,7 @@ public enum UsageRefreshCLI {
     /// The CLI hands over the text unparsed so a malformed value is reported by
     /// the same JSON contract as every other refresh outcome, instead of by
     /// ArgumentParser's pre-`run()` usage error. See `RefreshTimeout`.
-    public nonisolated enum TimeoutSource: Equatable, Sendable {
+    nonisolated public enum TimeoutSource: Equatable, Sendable {
         case text(String?)
         case resolved(TimeInterval)
 
@@ -79,7 +79,7 @@ public enum UsageRefreshCLI {
         }
     }
 
-    public nonisolated struct Request: Sendable {
+    nonisolated public struct Request: Sendable {
         public let timeout: TimeoutSource
         public let shouldCancel: @Sendable () -> Bool
 

--- a/MeterBar/UsageRefresh/UsageRefreshCLI.swift
+++ b/MeterBar/UsageRefresh/UsageRefreshCLI.swift
@@ -3,32 +3,117 @@ import MeterBarShared
 
 /// Public facade used by the bundled `meterbar refresh` command.
 public enum UsageRefreshCLI {
-    public static let defaultTimeout: TimeInterval = 60
-    public static let minimumTimeout: TimeInterval = 1
-    public static let maximumTimeout: TimeInterval = 600
+    // Read from nonisolated parsing and cleanup code, so they cannot inherit
+    // the package's MainActor default isolation.
+    public nonisolated static let defaultTimeout: TimeInterval = 60
+    public nonisolated static let minimumTimeout: TimeInterval = 1
+    public nonisolated static let maximumTimeout: TimeInterval = 600
+    /// Ceiling on how long a caller waits for an over-running refresh to let go
+    /// of the cross-process lock. The JSON is already on standard output by
+    /// then, so this only bounds how long the process lingers.
+    public nonisolated static let maximumCleanupWait: TimeInterval = 5
 
-    public struct Result: Sendable {
+    public nonisolated struct Result: Sendable {
         public let jsonOutput: String
         public let summaryLine: String
         public let message: String?
         public let exitCode: Int32
+        /// Non-nil when the refresh outlived its deadline and still holds the
+        /// cross-process lock. Await it — bounded — before exiting.
+        public let pendingCleanup: Task<Void, Never>?
+
+        public init(
+            jsonOutput: String,
+            summaryLine: String,
+            message: String?,
+            exitCode: Int32,
+            pendingCleanup: Task<Void, Never>? = nil
+        ) {
+            self.jsonOutput = jsonOutput
+            self.summaryLine = summaryLine
+            self.message = message
+            self.exitCode = exitCode
+            self.pendingCleanup = pendingCleanup
+        }
+
+        /// Waits for the in-flight refresh to release the lock, giving up after
+        /// `timeout`. Giving up leaves the release to process teardown, which is
+        /// the old behaviour — but only for a provider that ignored cancellation
+        /// for a full ceiling, not for every timeout.
+        public func awaitPendingCleanup(
+            timeout: TimeInterval = UsageRefreshCLI.maximumCleanupWait
+        ) async {
+            guard let pendingCleanup else { return }
+            let gate = CleanupGate()
+            // `await someTask.value` ignores the awaiting context's
+            // cancellation, so the ceiling needs its own racing task rather
+            // than a cancelled task group.
+            let observer = Task {
+                _ = await pendingCleanup.value
+                await gate.open()
+            }
+            let deadline = Task {
+                try? await Task.sleep(nanoseconds: UInt64(max(0, timeout) * 1_000_000_000))
+                await gate.open()
+            }
+            await gate.wait()
+            observer.cancel()
+            deadline.cancel()
+        }
     }
 
-    public struct Request: Sendable {
-        public let timeout: TimeInterval
+    /// Either an already-validated timeout or the raw `--timeout` text.
+    ///
+    /// The CLI hands over the text unparsed so a malformed value is reported by
+    /// the same JSON contract as every other refresh outcome, instead of by
+    /// ArgumentParser's pre-`run()` usage error. See `RefreshTimeout`.
+    public nonisolated enum TimeoutSource: Equatable, Sendable {
+        case text(String?)
+        case resolved(TimeInterval)
+
+        func resolve() -> Swift.Result<TimeInterval, RefreshCLIFailure> {
+            switch self {
+            case let .text(raw): return RefreshTimeout.resolve(raw)
+            case let .resolved(value): return .success(value)
+            }
+        }
+    }
+
+    public nonisolated struct Request: Sendable {
+        public let timeout: TimeoutSource
         public let shouldCancel: @Sendable () -> Bool
 
         public init(
             timeout: TimeInterval = defaultTimeout,
             shouldCancel: @escaping @Sendable () -> Bool = { false }
         ) {
-            self.timeout = timeout
+            self.timeout = .resolved(timeout)
+            self.shouldCancel = shouldCancel
+        }
+
+        public init(
+            timeoutText: String?,
+            shouldCancel: @escaping @Sendable () -> Bool = { false }
+        ) {
+            timeout = .text(timeoutText)
             self.shouldCancel = shouldCancel
         }
     }
 
     public static func run(_ request: Request) async -> Result {
         let sharedStore = SharedDataStore.shared
+        let timeout: TimeInterval
+        switch request.timeout.resolve() {
+        case let .success(value):
+            timeout = value
+        case let .failure(failure):
+            return result(from: RefreshCLIResponse(
+                failure: failure,
+                collectedAt: Date(),
+                cachedMetrics: sharedStore.loadMetrics()
+            ))
+        }
+
         guard let configuration = UsageRefreshConfigurationStore.load() else {
             return result(from: RefreshCLIResponse(
                 outcome: .refreshFailed,
@@ -42,7 +127,7 @@ public enum UsageRefreshCLI {
         let manager = makeManager(sharedStore: sharedStore, configuration: configuration)
         let engine = UsageRefreshEngine(
             lock: makeLock(),
-            timeout: request.timeout,
+            timeout: timeout,
             refresh: { await manager.refreshAll(trigger: .userInitiated) },
             cacheSnapshot: {
                 sharedStore.flushPendingWrites()
@@ -50,7 +135,8 @@ public enum UsageRefreshCLI {
             },
             shouldCancel: request.shouldCancel
         )
-        return result(from: await engine.run())
+        let outcome = await engine.run()
+        return result(from: outcome.response, pendingCleanup: outcome.pendingCleanup)
     }
 
     static func makeLock() -> WakeLock {
@@ -78,13 +164,34 @@ public enum UsageRefreshCLI {
         )
     }
 
-    private static func result(from response: RefreshCLIResponse) -> Result {
+    private static func result(
+        from response: RefreshCLIResponse,
+        pendingCleanup: Task<Void, Never>? = nil
+    ) -> Result {
         let json = (try? response.jsonString()) ?? "{}"
         return Result(
             jsonOutput: json,
             summaryLine: response.summaryLine,
             message: response.message,
-            exitCode: response.outcome.exitCode
+            exitCode: response.outcome.exitCode,
+            pendingCleanup: pendingCleanup
         )
+    }
+}
+
+private actor CleanupGate {
+    private var isOpen = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { continuation = $0 }
     }
 }

--- a/MeterBar/UsageRefresh/UsageRefreshEngine.swift
+++ b/MeterBar/UsageRefresh/UsageRefreshEngine.swift
@@ -26,22 +26,33 @@ nonisolated struct UsageRefreshEngine {
         self.shouldCancel = shouldCancel
     }
 
-    func run() async -> RefreshCLIResponse {
+    /// A finished run plus, when work outlived the deadline, the task that
+    /// still owns the cross-process lock.
+    struct RunOutcome {
+        let response: RefreshCLIResponse
+        /// Non-nil only after a timeout or cancellation left the refresh in
+        /// flight. The lock is released when this finishes, so a caller that
+        /// intends to exit should await it — bounded — rather than rely on the
+        /// kernel dropping the `flock` at process death.
+        let pendingCleanup: Task<Void, Never>?
+    }
+
+    func run() async -> RunOutcome {
         switch lock.acquire() {
         case .acquired:
             break
         case let .contended(holder):
             let who = holder.map { " (\($0.shortDescription))" } ?? ""
-            return response(
+            return settled(
                 outcome: .alreadyRunning,
                 duration: 0,
                 outcomes: [],
                 message: "Another MeterBar refresh\(who) is already running; no providers were contacted."
             )
         case let .legacyHeld(guidance):
-            return response(outcome: .alreadyRunning, duration: 0, outcomes: [], message: guidance)
+            return settled(outcome: .alreadyRunning, duration: 0, outcomes: [], message: guidance)
         case let .unavailable(reason):
-            return response(
+            return settled(
                 outcome: .refreshFailed,
                 duration: 0,
                 outcomes: [],
@@ -71,7 +82,7 @@ nonisolated struct UsageRefreshEngine {
         case let .completed(report):
             completionObserver.cancel()
             lock.release()
-            return response(
+            return settled(
                 outcome: outcome(for: report),
                 duration: report.duration,
                 outcomes: report.outcomes,
@@ -82,21 +93,27 @@ nonisolated struct UsageRefreshEngine {
             refreshTask.cancel()
 
             // A cooperative provider normally ends immediately. If it does not,
-            // retain the cross-process lock until the in-flight work really
-            // stops, while allowing the bounded CLI response to return now.
-            Task {
+            // the cross-process lock stays held until the in-flight work really
+            // stops, while the bounded CLI response returns now. The handle is
+            // returned rather than fired and forgotten: the caller decides how
+            // long to wait for it before exiting.
+            let lock = lock
+            let cleanup = Task {
                 _ = await refreshTask.value
                 lock.release()
             }
 
             let timedOut = race == .timedOut
-            return response(
-                outcome: timedOut ? .timedOut : .cancellation,
-                duration: Date().timeIntervalSince(startedAt),
-                outcomes: [],
-                message: timedOut
-                    ? "Refresh did not finish within \(Int(timeout))s; cached metrics remain available."
-                    : "Refresh cancelled; cached metrics remain available."
+            return RunOutcome(
+                response: response(
+                    outcome: timedOut ? .timedOut : .cancellation,
+                    duration: Date().timeIntervalSince(startedAt),
+                    outcomes: [],
+                    message: timedOut
+                        ? "Refresh did not finish within \(Int(timeout))s; cached metrics remain available."
+                        : "Refresh cancelled; cached metrics remain available."
+                ),
+                pendingCleanup: cleanup
             )
         }
     }
@@ -118,6 +135,20 @@ nonisolated struct UsageRefreshEngine {
         let names = failed.map(\.provider.displayName).sorted().joined(separator: ", ")
         return "\(failed.count) provider(s) failed to refresh (\(names)); "
             + "\(preserved) kept last-known-good metrics."
+    }
+
+    /// A run that owes the caller nothing: either the lock was never taken or
+    /// it has already been released.
+    private func settled(
+        outcome: RefreshCLIOutcome,
+        duration: TimeInterval,
+        outcomes: [ProviderRefreshOutcome],
+        message: String?
+    ) -> RunOutcome {
+        RunOutcome(
+            response: response(outcome: outcome, duration: duration, outcomes: outcomes, message: message),
+            pendingCleanup: nil
+        )
     }
 
     private func response(

--- a/MeterBarCLI/Sources/Guard.swift
+++ b/MeterBarCLI/Sources/Guard.swift
@@ -1,4 +1,6 @@
 import ArgumentParser
+import Darwin
+import Dispatch
 import Foundation
 import MeterBar
 
@@ -48,6 +50,10 @@ struct Guard: AsyncParsableCommand {
     var refreshTimeout: String?
 
     func run() async throws {
+        let cancellation = GuardCancellation()
+        let signalSources = installSignalHandlers(cancellation)
+        defer { signalSources.forEach { $0.cancel() } }
+
         let result = await QuotaGuardCLI.run(
             QuotaGuardCLI.Request(
                 provider: provider,
@@ -55,11 +61,27 @@ struct Guard: AsyncParsableCommand {
                 minRemaining: minRemaining,
                 configDirectory: configDir,
                 refresh: refresh,
-                refreshTimeout: refreshTimeout
+                refreshTimeout: refreshTimeout,
+                shouldCancel: { cancellation.isCancelled }
             )
         )
         emit(result)
         throw ExitCode(result.exitCode)
+    }
+
+    /// `--refresh` can hold the process for up to ten minutes. Without these,
+    /// Ctrl-C or a `timeout(1)` wrapper killed guard mid-window with no JSON
+    /// and an exit code outside the documented set. Cancelling ends the refresh
+    /// early; guard still evaluates the cached snapshot and exits 0/10/11/12/13
+    /// — consistent with a refresh that simply failed.
+    private func installSignalHandlers(_ cancellation: GuardCancellation) -> [DispatchSourceSignal] {
+        [SIGINT, SIGTERM].map { signalNumber in
+            signal(signalNumber, SIG_IGN)
+            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global())
+            source.setEventHandler { cancellation.cancel() }
+            source.resume()
+            return source
+        }
     }
 
     private func emit(_ result: QuotaGuardCLI.Result) {
@@ -72,6 +94,23 @@ struct Guard: AsyncParsableCommand {
             var stderr = GuardStandardError()
             Swift.print(message, to: &stderr)
         }
+    }
+}
+
+private final class GuardCancellation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
     }
 }
 

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -102,15 +102,7 @@ struct Usage: ParsableCommand {
             return
         }
 
-        let filtered: [ServiceType: UsageMetrics]
-        if let provider = provider?.lowercased() {
-            filtered = metrics.filter {
-                $0.key.rawValue.lowercased().contains(provider)
-                    || $0.key.displayName.lowercased().contains(provider)
-            }
-        } else {
-            filtered = metrics
-        }
+        let filtered = CLIProviderFilter.apply(provider, to: metrics)
 
         if json {
             try emitJSON(UsageCLIJSONResponse(metrics: filtered))
@@ -124,6 +116,15 @@ struct Usage: ParsableCommand {
         print("│             MeterBar Usage              │")
         print("╰─────────────────────────────────────────╯")
         print()
+
+        // A `--provider` typo used to print the header and nothing else, which
+        // reads like "this provider has no quota data". Say what happened, the
+        // way `meterbar doctor` already does — and distinguish a typo from a
+        // real provider the cache simply has not seen yet.
+        if metrics.isEmpty {
+            print(CLIProviderFilter.emptyReportMessage(for: provider))
+            return
+        }
 
         for (service, metric) in metrics.sorted(by: { $0.key.rawValue < $1.key.rawValue }) {
             print("▸ \(service.displayName)")
@@ -452,13 +453,7 @@ struct Doctor: ParsableCommand {
     }
 
     private func matchingProviders() -> Set<ServiceType> {
-        guard let needle = provider?.lowercased() else {
-            return Set(ServiceType.allCases)
-        }
-        return Set(ServiceType.allCases.filter {
-            $0.rawValue.lowercased().contains(needle)
-                || $0.displayName.lowercased().contains(needle)
-        })
+        CLIProviderFilter.select(provider)
     }
 
     private func printJSON(_ reports: [ProviderReadiness]) throws {
@@ -486,7 +481,7 @@ struct Doctor: ParsableCommand {
         print()
 
         if reports.isEmpty {
-            print("No matching providers.")
+            print(CLIProviderFilter.noMatchesMessage)
             return
         }
 

--- a/MeterBarCLI/Sources/Refresh.swift
+++ b/MeterBarCLI/Sources/Refresh.swift
@@ -13,27 +13,27 @@ struct Refresh: AsyncParsableCommand {
     @Flag(name: .shortAndLong, help: "Emit only the versioned JSON response on stdout.")
     var json: Bool = false
 
+    // Taken as text, not Double: ArgumentParser's own conversion runs before
+    // validate() and before run(), so a malformed value would exit EX_USAGE
+    // with no JSON document — neither the code nor the output the refresh
+    // contract promises. `meterbar guard` takes its thresholds as text for the
+    // same reason.
     @Option(name: .shortAndLong, help: "Seconds to wait before giving up on the refresh.")
-    var timeout: Double = UsageRefreshCLI.defaultTimeout
-
-    func validate() throws {
-        guard timeout >= UsageRefreshCLI.minimumTimeout, timeout <= UsageRefreshCLI.maximumTimeout else {
-            throw ValidationError(
-                "--timeout must be between \(Int(UsageRefreshCLI.minimumTimeout)) "
-                    + "and \(Int(UsageRefreshCLI.maximumTimeout)) seconds."
-            )
-        }
-    }
+    var timeout: String?
 
     func run() async throws {
         let cancelBox = RefreshCancelBox()
-        let signalSource = installSignalHandler(cancelBox)
-        defer { signalSource.cancel() }
+        let signalSources = installSignalHandlers(cancelBox)
+        defer { signalSources.forEach { $0.cancel() } }
 
         let result = await UsageRefreshCLI.run(
-            UsageRefreshCLI.Request(timeout: timeout, shouldCancel: { cancelBox.isCancelled })
+            UsageRefreshCLI.Request(timeoutText: timeout, shouldCancel: { cancelBox.isCancelled })
         )
         emit(result)
+        // The response is already out; wait — bounded — for an over-running
+        // refresh to release the cross-process lock rather than leaving it to
+        // process teardown.
+        await result.awaitPendingCleanup()
         throw ExitCode(result.exitCode)
     }
 
@@ -49,12 +49,17 @@ struct Refresh: AsyncParsableCommand {
         }
     }
 
-    private func installSignalHandler(_ box: RefreshCancelBox) -> DispatchSourceSignal {
-        signal(SIGINT, SIG_IGN)
-        let source = DispatchSource.makeSignalSource(signal: SIGINT, queue: .global())
-        source.setEventHandler { box.cancel() }
-        source.resume()
-        return source
+    /// SIGTERM as well as SIGINT: a refresh started by a script or a timeout
+    /// wrapper is far more likely to be terminated than interrupted, and both
+    /// must still produce the documented JSON and exit code.
+    private func installSignalHandlers(_ box: RefreshCancelBox) -> [DispatchSourceSignal] {
+        [SIGINT, SIGTERM].map { signalNumber in
+            signal(signalNumber, SIG_IGN)
+            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global())
+            source.setEventHandler { box.cancel() }
+            source.resume()
+            return source
+        }
     }
 }
 

--- a/MeterBarTests/CLIProviderFilterTests.swift
+++ b/MeterBarTests/CLIProviderFilterTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// `--provider` is a substring filter shared by `meterbar usage` and
+/// `meterbar doctor`. A filter that matches nothing selects nothing, and both
+/// commands say so — an empty report otherwise reads like "no quota data".
+final class CLIProviderFilterTests: XCTestCase {
+    func testNoFilterSelectsEveryProvider() {
+        XCTAssertEqual(CLIProviderFilter.select(nil), Set(ServiceType.allCases))
+        XCTAssertEqual(CLIProviderFilter.select(""), Set(ServiceType.allCases))
+        XCTAssertEqual(CLIProviderFilter.select("   "), Set(ServiceType.allCases))
+    }
+
+    func testFilterMatchesRawValueOrDisplayNameCaseInsensitively() {
+        XCTAssertEqual(CLIProviderFilter.select("claude"), [.claudeCode])
+        XCTAssertEqual(CLIProviderFilter.select("CLAUDE"), [.claudeCode])
+        XCTAssertEqual(CLIProviderFilter.select(" Cursor "), [.cursor])
+        XCTAssertEqual(CLIProviderFilter.select("router"), [.openRouter])
+    }
+
+    func testAnUnmatchedFilterSelectsNothingRatherThanEverything() {
+        XCTAssertTrue(CLIProviderFilter.select("clod").isEmpty)
+        XCTAssertTrue(CLIProviderFilter.select("gpt-4").isEmpty)
+    }
+
+    func testTheEmptySelectionMessageIsSharedSoBothCommandsAgree() {
+        XCTAssertFalse(CLIProviderFilter.noMatchesMessage.isEmpty)
+    }
+
+    func testAnEmptyReportBlamesTheTypoOnlyWhenTheFilterNamesNoProvider() {
+        XCTAssertEqual(CLIProviderFilter.emptyReportMessage(for: "clod"), CLIProviderFilter.noMatchesMessage)
+        XCTAssertEqual(CLIProviderFilter.emptyReportMessage(for: "gpt-4"), CLIProviderFilter.noMatchesMessage)
+    }
+
+    func testAKnownProviderWithNoCachedDataSaysSoInsteadOfDenyingItExists() {
+        let message = CLIProviderFilter.emptyReportMessage(for: "cursor")
+
+        XCTAssertNotEqual(message, CLIProviderFilter.noMatchesMessage)
+        XCTAssertTrue(message.contains(ServiceType.cursor.displayName), message)
+        XCTAssertTrue(message.contains("meterbar refresh"), message)
+    }
+
+    func testTheEmptyReportMessageNamesEveryProviderTheFilterSelected() {
+        // "code" matches more than one provider, so the advice has to cover
+        // all of them rather than pick one arbitrarily.
+        let selected = CLIProviderFilter.select("code")
+        XCTAssertGreaterThan(selected.count, 1)
+
+        let message = CLIProviderFilter.emptyReportMessage(for: "code")
+        for service in selected {
+            XCTAssertTrue(message.contains(service.displayName), "\(service) missing from: \(message)")
+        }
+    }
+
+    func testSelectionFiltersACachedMetricsSnapshot() {
+        let metrics: [ServiceType: UsageMetrics] = [
+            .claudeCode: metric(.claudeCode),
+            .cursor: metric(.cursor)
+        ]
+
+        XCTAssertEqual(Set(CLIProviderFilter.apply("cursor", to: metrics).keys), [.cursor])
+        XCTAssertEqual(Set(CLIProviderFilter.apply(nil, to: metrics).keys), [.claudeCode, .cursor])
+        XCTAssertTrue(CLIProviderFilter.apply("clod", to: metrics).isEmpty)
+    }
+
+    private func metric(_ service: ServiceType) -> UsageMetrics {
+        UsageMetrics(
+            service: service,
+            weeklyLimit: UsageLimit(used: 1, total: 100, resetTime: nil),
+            lastUpdated: Date()
+        )
+    }
+}

--- a/MeterBarTests/RefreshCLITimeoutTests.swift
+++ b/MeterBarTests/RefreshCLITimeoutTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// `meterbar refresh --timeout` is resolved in the core rather than by
+/// ArgumentParser's `Double` conversion, so a malformed value still produces a
+/// versioned JSON document and one of the exit codes `docs/cli-json-schema.md`
+/// promises (0/10/11/12/13/130) instead of a bare usage message and 64.
+final class RefreshCLITimeoutTests: XCTestCase {
+    func testMissingValueResolvesToTheDocumentedDefault() throws {
+        XCTAssertEqual(try resolve(nil), UsageRefreshCLI.defaultTimeout)
+    }
+
+    func testWellFormedValuesResolveAndToleratePadding() throws {
+        XCTAssertEqual(try resolve("30"), 30)
+        XCTAssertEqual(try resolve(" 45 "), 45)
+        XCTAssertEqual(try resolve("\(Int(UsageRefreshCLI.minimumTimeout))"), UsageRefreshCLI.minimumTimeout)
+        XCTAssertEqual(try resolve("\(Int(UsageRefreshCLI.maximumTimeout))"), UsageRefreshCLI.maximumTimeout)
+    }
+
+    func testMalformedOrOutOfRangeValuesFailWithAStableCodeNamingTheInput() {
+        for raw in ["abc", "", "   ", "0", "0.5", "601", "-1", "nan", "inf"] {
+            let failure = expectFailure(raw)
+            XCTAssertEqual(failure.code, "invalid_timeout", raw)
+            XCTAssertEqual(failure.flag, "--timeout", raw)
+            XCTAssertEqual(failure.value, raw.trimmingCharacters(in: .whitespacesAndNewlines), raw)
+            XCTAssertTrue(failure.message.contains("--timeout"), failure.message)
+        }
+    }
+
+    // MARK: - JSON contract
+
+    func testAnInvalidTimeoutStillEmitsAVersionedDocumentAndADocumentedExitCode() throws {
+        let failure = expectFailure("abc")
+        let response = RefreshCLIResponse(
+            failure: failure,
+            collectedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            cachedMetrics: [:]
+        )
+
+        XCTAssertEqual(response.outcome, .refreshFailed)
+        XCTAssertEqual(response.outcome.exitCode, 13)
+
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: response.jsonData()) as? [String: Any]
+        )
+        XCTAssertEqual(object["schemaVersion"] as? Int, 1)
+        XCTAssertEqual(object["outcome"] as? String, "refreshFailed")
+        XCTAssertNotNil(object["message"])
+
+        let error = try XCTUnwrap(object["error"] as? [String: Any])
+        XCTAssertEqual(error["code"] as? String, "invalid_timeout")
+        XCTAssertEqual(error["flag"] as? String, "--timeout")
+        XCTAssertEqual(error["value"] as? String, "abc")
+        XCTAssertEqual(error["message"] as? String, response.message)
+    }
+
+    func testASuccessfulRefreshCarriesNoErrorObject() throws {
+        let now = Date()
+        let response = RefreshCLIResponse(
+            outcome: .success,
+            collectedAt: now,
+            durationSeconds: 0,
+            outcomes: [ProviderRefreshOutcome(provider: .cursor, state: .refreshed, lastUpdated: now)],
+            cachedMetrics: [:]
+        )
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: response.jsonData()) as? [String: Any]
+        )
+        XCTAssertNil(object["error"])
+    }
+
+    // MARK: - Request wiring
+
+    func testRawTextRequestsCarryTheTextUnparsedSoTheCoreCanReportTheFailure() {
+        XCTAssertEqual(UsageRefreshCLI.Request(timeoutText: "abc").timeout, .text("abc"))
+        XCTAssertEqual(UsageRefreshCLI.Request(timeoutText: nil).timeout, .text(nil))
+        XCTAssertEqual(UsageRefreshCLI.Request(timeout: 20).timeout, .resolved(20))
+    }
+
+    // MARK: - Helpers
+
+    private func resolve(_ raw: String?) throws -> TimeInterval {
+        switch RefreshTimeout.resolve(raw) {
+        case let .success(value):
+            return value
+        case let .failure(failure):
+            throw XCTSkip("unexpected failure: \(failure.message)")
+        }
+    }
+
+    private func expectFailure(
+        _ raw: String?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> RefreshCLIFailure {
+        switch RefreshTimeout.resolve(raw) {
+        case let .success(value):
+            XCTFail("expected \(raw ?? "nil") to fail, resolved to \(value)", file: file, line: line)
+            return RefreshCLIFailure(code: "", message: "", flag: nil, value: nil)
+        case let .failure(failure):
+            return failure
+        }
+    }
+}

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -1167,7 +1167,7 @@ final class UsageDataManagerTests: XCTestCase {
             cacheSnapshot: { [:] }
         )
 
-        let response = await engine.run()
+        let response = await engine.run().response
 
         XCTAssertEqual(response.outcome, .success)
         XCTAssertEqual(cursor.fetchCount, 1)

--- a/MeterBarTests/UsageRefreshEngineTests.swift
+++ b/MeterBarTests/UsageRefreshEngineTests.swift
@@ -25,7 +25,7 @@ final class UsageRefreshEngineTests: XCTestCase {
         let response = await makeEngine(
             refresh: { report },
             cache: [.codexCli: metric(service: .codexCli, lastUpdated: now)]
-        ).run()
+        ).run().response
 
         XCTAssertEqual(response.outcome, .success)
         let object = try jsonObject(response)
@@ -42,7 +42,7 @@ final class UsageRefreshEngineTests: XCTestCase {
             ProviderRefreshOutcome(provider: .cursor, state: .refreshed),
             ProviderRefreshOutcome(provider: .codexCli, state: .failed, servedFromCache: true)
         ])
-        let response = await makeEngine(refresh: { report }).run()
+        let response = await makeEngine(refresh: { report }).run().response
 
         XCTAssertEqual(response.outcome, .partialFailure)
         XCTAssertEqual(response.message?.contains("1 kept last-known-good"), true)
@@ -52,13 +52,13 @@ final class UsageRefreshEngineTests: XCTestCase {
         let report = makeReport([
             ProviderRefreshOutcome(provider: .cursor, state: .failed)
         ])
-        let response = await makeEngine(refresh: { report }).run()
+        let response = await makeEngine(refresh: { report }).run().response
 
         XCTAssertEqual(response.outcome, .refreshFailed)
         XCTAssertEqual(response.outcome.exitCode, 13)
     }
 
-    func testTimeoutReturnsBeforeUncooperativeRefreshAndKeepsLockHeld() async {
+    func testTimeoutReturnsBeforeUncooperativeRefreshAndKeepsLockHeld() async throws {
         let suspended = SuspendedRefresh()
         let lockURL = tempDirectory.appendingPathComponent("refresh.lock")
         let engine = makeEngine(
@@ -68,9 +68,16 @@ final class UsageRefreshEngineTests: XCTestCase {
         )
 
         let startedAt = Date()
-        let response = await engine.run()
-        XCTAssertEqual(response.outcome, .timedOut)
+        let outcome = await engine.run()
+        XCTAssertEqual(outcome.response.outcome, .timedOut)
         XCTAssertLessThan(Date().timeIntervalSince(startedAt), 0.5)
+
+        // The lock is released by the handed-back cleanup task, not by process
+        // death: a caller that keeps running must be able to await it.
+        let cleanup = try XCTUnwrap(
+            outcome.pendingCleanup,
+            "a timeout with work still in flight must hand back a cleanup handle"
+        )
 
         let contender = WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .cli)
         guard case .contended = contender.acquire() else {
@@ -78,12 +85,62 @@ final class UsageRefreshEngineTests: XCTestCase {
         }
 
         await suspended.resume(makeReport([]))
-        for _ in 0..<100 {
-            if contender.acquire() == .acquired { break }
-            try? await Task.sleep(nanoseconds: 2_000_000)
-        }
+        await cleanup.value
         XCTAssertEqual(contender.acquire(), .acquired)
         contender.release()
+    }
+
+    func testCompletedRefreshNeedsNoCleanupBecauseTheLockIsAlreadyReleased() async {
+        let lockURL = tempDirectory.appendingPathComponent("refresh.lock")
+        let outcome = await makeEngine(lockURL: lockURL, refresh: { self.makeReport([]) }).run()
+
+        XCTAssertNil(outcome.pendingCleanup)
+        let contender = WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .cli)
+        XCTAssertEqual(contender.acquire(), .acquired)
+        contender.release()
+    }
+
+    func testCooperativeCancellationReportsTheDocumentedCancellationOutcome() async {
+        let suspended = SuspendedRefresh()
+        let outcome = await makeEngine(
+            timeout: 10,
+            refresh: { await suspended.wait() },
+            shouldCancel: { true }
+        ).run()
+
+        XCTAssertEqual(outcome.response.outcome, .cancellation)
+        XCTAssertEqual(outcome.response.outcome.exitCode, 130)
+        await suspended.resume(makeReport([]))
+        await outcome.pendingCleanup?.value
+    }
+
+    /// The CLI emits its JSON before waiting, so the wait must be bounded: an
+    /// uncooperative provider cannot hold the process open indefinitely.
+    func testAwaitPendingCleanupGivesUpAtItsCeiling() async {
+        let stuck = Task<Void, Never> { try? await Task.sleep(nanoseconds: 30_000_000_000) }
+        defer { stuck.cancel() }
+        let result = UsageRefreshCLI.Result(
+            jsonOutput: "{}",
+            summaryLine: "",
+            message: nil,
+            exitCode: 0,
+            pendingCleanup: stuck
+        )
+
+        let startedAt = Date()
+        await result.awaitPendingCleanup(timeout: 0.05)
+        XCTAssertLessThan(Date().timeIntervalSince(startedAt), 2)
+    }
+
+    func testAwaitPendingCleanupReturnsImmediatelyWhenNothingIsInFlight() async {
+        let result = UsageRefreshCLI.Result(
+            jsonOutput: "{}",
+            summaryLine: "",
+            message: nil,
+            exitCode: 0,
+            pendingCleanup: nil
+        )
+        await result.awaitPendingCleanup(timeout: 30)
     }
 
     func testConcurrentRefreshFailsSafelyWithoutFetching() async {
@@ -99,7 +156,7 @@ final class UsageRefreshEngineTests: XCTestCase {
                 fetchCount.increment()
                 return self.makeReport([])
             }
-        ).run()
+        ).run().response
 
         XCTAssertEqual(response.outcome, .alreadyRunning)
         XCTAssertEqual(fetchCount.value, 0)
@@ -110,7 +167,7 @@ final class UsageRefreshEngineTests: XCTestCase {
         let response = await makeEngine(
             refresh: { self.makeReport([]) },
             cache: [.cursor: metric(service: .cursor, lastUpdated: staleDate)]
-        ).run()
+        ).run().response
         let object = try jsonObject(response)
         let cache = try XCTUnwrap(object["cache"] as? [String: Any])
 
@@ -131,7 +188,8 @@ final class UsageRefreshEngineTests: XCTestCase {
         lockURL: URL? = nil,
         timeout: TimeInterval = 1,
         refresh: @escaping UsageRefreshEngine.RefreshOperation,
-        cache: [ServiceType: UsageMetrics] = [:]
+        cache: [ServiceType: UsageMetrics] = [:],
+        shouldCancel: @escaping @Sendable () -> Bool = { false }
     ) -> UsageRefreshEngine {
         UsageRefreshEngine(
             lock: WakeLock(
@@ -141,7 +199,8 @@ final class UsageRefreshEngineTests: XCTestCase {
             ),
             timeout: timeout,
             refresh: refresh,
-            cacheSnapshot: { cache }
+            cacheSnapshot: { cache },
+            shouldCancel: shouldCancel
         )
     }
 

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -372,6 +372,37 @@ Exit codes are stable for scripting: `0` success, `10` already running, `11` tim
 `12` partial provider failure, `13` complete/configuration failure, and `130` cancellation.
 Non-success JSON remains on standard output; optional human diagnostics use standard error.
 
+A rejected `--timeout` adds an `error` object with a stable `code`, plus the `flag` and `value`
+that were rejected, and reports `refreshFailed` (exit `13`). It is a refresh document like any
+other, so a script parses one shape whether the input or the provider was at fault:
+
+```json
+{
+  "schemaVersion": 1,
+  "outcome": "refreshFailed",
+  "collectedAt": "2026-07-20T17:00:00Z",
+  "durationSeconds": 0,
+  "providers": [],
+  "cache": { "providerCount": 2, "lastUpdated": "2026-07-20T16:45:00Z", "ageSeconds": 900, "isStale": false },
+  "error": {
+    "code": "invalid_timeout",
+    "message": "Invalid --timeout value 'abc'. Expected 1...600 seconds.",
+    "flag": "--timeout",
+    "value": "abc"
+  },
+  "message": "Invalid --timeout value 'abc'. Expected 1...600 seconds."
+}
+```
+
+The stable version 1 refresh error code is `invalid_timeout`; `--timeout` accepts `1`–`600`
+seconds. Malformed input never exits `EX_USAGE` (`64`) and never puts non-JSON on standard output.
+
+`SIGINT` and `SIGTERM` cancel the refresh cooperatively rather than killing the process: in-flight
+provider work stops, the document is still written to standard output, and the command exits `130`
+(`cancellation`). Once that document is out, an over-running refresh is given a bounded grace
+period to release the cross-process refresh lock before the process exits, so a later `meterbar
+refresh` is not answered `alreadyRunning` by an abandoned holder.
+
 ## Guard
 
 ```sh
@@ -469,6 +500,11 @@ Exit codes are stable for scripting:
 The freshness bound is two hours, shared with the provider parse-health model. A snapshot older
 than that is `dataUnavailable` rather than a stale pass. Non-success JSON stays on standard output;
 the human-readable reason uses standard error.
+
+`SIGINT` and `SIGTERM` end a `--refresh` window early instead of killing the process. Guard then
+evaluates the cached snapshot exactly as it would after a refresh that simply failed, and exits
+with one of the codes above — guard has no cancellation code, because an interrupted guard still
+has an answer. Without `--refresh` there is no window to interrupt.
 
 ## Doctor
 


### PR DESCRIPTION
Four verified ways the CLI stepped outside `docs/cli-json-schema.md`. Tests first for each; the doc is updated to match.

## 1 — `guard --refresh` had no signal handling (MED)

`MeterBarCLI/Sources/Guard.swift` installed no `DispatchSourceSignal`, unlike `Refresh`, `Wake`, `WakeAgent`, and `Serve`. During the refresh window — up to 600s — Ctrl-C or a `timeout(1)` wrapper killed the process with **no JSON and an exit code outside the documented 0/10/11/12/13**.

Now `SIGINT`/`SIGTERM` flip a cooperative cancel flag threaded through `QuotaGuardCLI.Request` into the refresh. **Guard has no cancellation code and does not gain one**: an interrupted guard still has an answer, so it evaluates the cached snapshot and exits with a documented guard code — identical to a refresh that simply failed.

```
$ meterbar guard --refresh --refresh-timeout 60 --json   # SIGINT after 2s
{ "schemaVersion": 1, "outcome": "available", ... }
exit=0        # before: killed, no output
```

## 2 — `refresh --timeout` was typed `Double` (MED)

ArgumentParser's own `String`→`Double` conversion runs **before** `validate()` and `run()`, so a malformed value exited `EX_USAGE` (64) with empty stdout — violating both the exit-code table and the "JSON is the only stdout content" guarantee under `--json`. Guard's own comments name this exact trap, which is why its thresholds are typed `String?`.

`--timeout` is now text, resolved in the core, reporting `invalid_timeout` as a `refreshFailed` document:

```
$ meterbar refresh --timeout abc --json
{ ..., "outcome": "refreshFailed", "error": { "code": "invalid_timeout", "flag": "--timeout", "value": "abc", ... } }
exit=13       # before: empty stdout, exit 64
```

`--timeout 601` (out of the documented 1–600 range) takes the same path.

**Deliberately not changed: `cost --days` / `--rate`.** They share the mechanism, but `cost` has **no documented exit-code table**, and `cost --days 0` already exits 64 through its own `validate()`. Changing it would mean inventing a contract rather than honoring one. Flagging it here so the decision is on the record.

## 3 — The refresh lock's timeout safeguard was dead code (MED)

On `.timedOut`/`.cancelled`, `UsageRefreshEngine` released the cross-process lock from a detached `Task { _ = await refreshTask.value; lock.release() }`. But every production caller emits and `throw`s `ExitCode` immediately after, and ArgumentParser's `exit()` tears the process down first — **the task never ran**.

The engine now returns `RunOutcome { response, pendingCleanup }` and hands the cleanup handle to the caller, which awaits it — **bounded at 5s** — *after* the JSON is already on stdout. The bounded-response guarantee is unchanged and asserted (`<0.5s`) in `testTimeoutReturnsBeforeUncooperativeRefreshAndKeepsLockHeld`.

Implementation note: the ceiling uses a gate actor racing a deadline task, not a cancelled `TaskGroup` — `await Task<Void, Never>.value` ignores the awaiting context's cancellation.

## 4 — `usage --provider <typo>` printed only the header box (LOW)

`Doctor.printText` already guarded with `No matching providers.`; `Usage.printText` did not. Both now share one `CLIProviderFilter` instead of two copies of the same expression.

While verifying, the naive mirror surfaced a second inaccuracy: `usage --provider cursor` (a **real** provider with no cached data) would also have said "No matching providers", denying that the provider exists. The two cases are now distinguished:

```
$ meterbar usage --provider bogus     ->  No matching providers.
$ meterbar usage --provider cursor    ->  No cached usage for Cursor. Run `meterbar refresh` first.
$ meterbar usage --provider claude    ->  (unchanged)
$ meterbar doctor --provider bogus    ->  (unchanged)
```

## Also in this PR

- **`refresh` gains `SIGTERM`** alongside its existing `SIGINT` handling — a refresh started by a script or a timeout wrapper is far likelier to be terminated than interrupted, and both owe the caller the documented output. Matches `WakeAgent`/`Serve`.
- **`docs/cli-json-schema.md`**: documents the refresh `error` object, the stable v1 code `invalid_timeout`, the 1–600s range, and the signal-cancellation semantics for both `refresh` and `guard`.

## Verification

- `swift test` — **2196 tests, 6 skipped, 0 failures** (was 2193 before the new tests)
- `swift build` clean on both packages; only pre-existing Swift-6-mode isolation warnings remain
- New coverage: `RefreshCLITimeoutTests` (6), `CLIProviderFilterTests` (8), `UsageRefreshEngineTests` (+5, incl. uncooperative-timeout lock retention and the cleanup ceiling)
- Every behavior above re-verified end-to-end against the rebuilt `meterbar` binary, not just at the library seam