### PR TITLE
fix(popover): make the ahead-of-pace band visible in UsageBar

### DIFF
--- a/MeterBar/Views/Components/ProviderComponents.swift
+++ b/MeterBar/Views/Components/ProviderComponents.swift
@@ -197,7 +197,18 @@ struct UsageBar: View {
         clampedRemainingPercentage <= 0 || pace?.isExhausted == true
     }
 
-    private var tooltipText: String? {
+    /// Opacity of the deficit / reserve bands. They stay slightly translucent so
+    /// the accent reads through and the bar still looks like one bar.
+    static let bandOpacity: Double = 0.86
+    /// Opacity of the marker casing — enough to separate the core from whatever
+    /// it overlays without turning into a hard white/black slab.
+    static let markerCasingOpacity: Double = 0.9
+
+    /// The bar's only textual explanation of the overlay: the popover renders
+    /// `LimitRow` at `.compact` density, whose footer is reset-only, so the pace
+    /// labels never appear next to it. Kept internal (not private) so the tests
+    /// can assert both bands are spelled out here.
+    var tooltipText: String? {
         guard let pace else {
             return isExhausted ? "Out of quota\nActual: 100% used\nLeft: 0%" : nil
         }
@@ -215,6 +226,8 @@ struct UsageBar: View {
             lines.append("Quota is exhausted until the reset window opens.")
         } else if pace.stage == .deficit {
             lines.append("Red is quota you should still have at this pace.")
+        } else if pace.stage == .reserve {
+            lines.append("Green is quota you have beyond this pace.")
         }
 
         if let rightLabel = pace.rightLabel(context: paceContext) {
@@ -242,29 +255,53 @@ struct UsageBar: View {
                         .frame(width: 2, height: 13)
                         .offset(x: max(0, proxy.size.width - 2), y: 1)
                 } else if let pace, pace.stage != .onPace {
-                    let expectedRemainingPercent = max(0, 100 - min(max(pace.expectedUsedPercent, 0), 100))
-                    let expectedX = proxy.size.width * expectedRemainingPercent / 100
-                    let actualX = proxy.size.width * clampedRemainingPercentage / 100
+                    let geometry = BarGeometry(
+                        width: proxy.size.width,
+                        usedPercentage: usedPercentage,
+                        pace: pace
+                    )
 
                     ZStack(alignment: .leading) {
                         Rectangle()
                             .fill(accentColor)
-                            .frame(width: actualX, height: 7)
+                            .frame(width: geometry.fillWidth, height: 7)
 
-                        if pace.stage == .deficit {
+                        // Both stages get the same band, on opposite sides of the
+                        // marker: deficit paints the empty track you should still
+                        // have, reserve paints the part of the fill you're ahead
+                        // by. Reserve overlays the accent, so its tint is picked
+                        // for luminance contrast rather than hue — see
+                        // `MeterBarTheme.reserveBand`.
+                        if let band = geometry.band {
                             Rectangle()
-                                .fill(MeterBarTheme.danger.opacity(0.86))
-                                .frame(width: max(0, expectedX - actualX), height: 7)
-                                .offset(x: actualX)
+                                .fill(bandColor(for: band.kind).opacity(Self.bandOpacity))
+                                .frame(width: band.width, height: 7)
+                                .offset(x: band.x)
                         }
                     }
+                    // The band is positioned with `.offset`, which doesn't grow
+                    // the stack, so the painted width has to be stated or the
+                    // capsule clips a deficit band off the end of the fill.
+                    .frame(width: geometry.paintedWidth, alignment: .leading)
                     .clipShape(Capsule())
                     .offset(y: 4)
 
-                    RoundedRectangle(cornerRadius: MeterBarTheme.Radius.small)
-                        .fill(markerColor(for: pace))
-                        .frame(width: 2, height: 13)
-                        .offset(x: min(max(0, expectedX - 1), max(0, proxy.size.width - 2)), y: 1)
+                    if let markerX = geometry.markerX {
+                        // The marker sits inside the fill whenever the user is
+                        // ahead of pace, so the colored core alone can vanish
+                        // against the accent. A casing on each side gives it an
+                        // edge on any background; the core keeps carrying the
+                        // green/red meaning.
+                        RoundedRectangle(cornerRadius: MeterBarTheme.Radius.small)
+                            .fill(MeterBarTheme.paceMarkerCasing.opacity(Self.markerCasingOpacity))
+                            .frame(width: BarGeometry.markerWidth, height: 13)
+                            .overlay {
+                                RoundedRectangle(cornerRadius: MeterBarTheme.Radius.small)
+                                    .fill(markerColor(for: pace))
+                                    .frame(width: BarGeometry.markerCoreWidth, height: 13)
+                            }
+                            .offset(x: markerX, y: 1)
+                    }
                 } else {
                     Rectangle()
                         .fill(accentColor)
@@ -292,6 +329,92 @@ struct UsageBar: View {
             return MeterBarTheme.success
         case .deficit:
             return MeterBarTheme.danger
+        }
+    }
+
+    private func bandColor(for kind: BarGeometry.Band.Kind) -> Color {
+        switch kind {
+        case .reserve:
+            return MeterBarTheme.reserveBand
+        case .deficit:
+            return MeterBarTheme.danger
+        }
+    }
+}
+
+extension UsageBar {
+    /// Pure layout math for the off-pace bar — no SwiftUI, so every stage is
+    /// directly testable (the same reason `LimitRow.RowContent` exists).
+    ///
+    /// Everything is measured from the left in "quota left" space, because the
+    /// colored fill is what's *left*, not what's used: the fill runs from 0 to
+    /// `fillWidth`, and the marker sits where the fill would end if usage were
+    /// exactly on pace. The two are on opposite sides of each other depending on
+    /// the stage, which is what the band spans.
+    struct BarGeometry: Equatable {
+        /// Full width of the marker including its casing.
+        static let markerWidth: CGFloat = 4
+        /// Width of the marker's colored (green/red) core.
+        static let markerCoreWidth: CGFloat = 2
+
+        struct Band: Equatable {
+            enum Kind: Equatable {
+                /// Ahead of pace — spans the marker to the fill's edge, over the accent.
+                case reserve
+                /// Behind pace — spans the fill's edge to the marker, over the empty track.
+                case deficit
+            }
+
+            let kind: Kind
+            let x: CGFloat
+            let width: CGFloat
+        }
+
+        /// Width of the accent fill: the quota still left.
+        let fillWidth: CGFloat
+        /// Width of everything painted on the track — the fill plus a deficit
+        /// band hanging off its end. The band is drawn with `.offset`, which
+        /// doesn't grow a layout, so the stack needs this width explicitly or the
+        /// capsule clip cuts the band off entirely.
+        let paintedWidth: CGFloat
+        /// The off-pace band, or `nil` on pace / with no pace at all.
+        let band: Band?
+        /// Leading edge of the marker, clamped inside the bar. `nil` when no band.
+        let markerX: CGFloat?
+
+        init(width: CGFloat, usedPercentage: Double, pace: UsagePace?) {
+            let width = max(0, width)
+            let usedPercent = min(max(usedPercentage, 0), 100)
+            fillWidth = width * (100 - usedPercent) / 100
+
+            guard let pace, pace.stage != .onPace else {
+                paintedWidth = fillWidth
+                band = nil
+                markerX = nil
+                return
+            }
+
+            let expectedRemainingPercent = max(0, 100 - min(max(pace.expectedUsedPercent, 0), 100))
+            let expectedX = width * expectedRemainingPercent / 100
+
+            switch pace.stage {
+            case .deficit:
+                // Less left than expected, so the fill stops short of the marker
+                // and the band continues the bar out to it.
+                band = Band(kind: .deficit, x: fillWidth, width: max(0, expectedX - fillWidth))
+            case .reserve:
+                // More left than expected, so the fill overshoots the marker and
+                // the band covers the overshoot, inside the fill.
+                band = Band(kind: .reserve, x: expectedX, width: max(0, fillWidth - expectedX))
+            case .onPace:
+                band = nil
+            }
+
+            paintedWidth = max(fillWidth, (band?.x ?? 0) + (band?.width ?? 0))
+
+            // Center the marker on the expected position, then keep it whole
+            // inside the bar so it never hangs off either cap.
+            markerX = min(max(0, expectedX - Self.markerWidth / 2), max(0, width - Self.markerWidth))
         }
     }
 }

--- a/MeterBar/Views/MeterBarTheme.swift
+++ b/MeterBar/Views/MeterBarTheme.swift
@@ -217,6 +217,33 @@ enum MeterBarTheme {
   static let warning = Color(nsColor: .systemOrange)
   static let danger = Color(nsColor: .systemRed)
 
+  // MARK: - Pace overlay (drawn *over* a provider accent, so contrast is by luminance)
+
+  /// The "ahead of pace" band in ``UsageBar``, mirroring the red deficit band.
+  /// It sits on top of the accent fill rather than on the empty track, so plain
+  /// ``success`` is unusable: Cursor (34,150,92) and OpenAI (16,163,127) are
+  /// already green, and a green-on-green band disappears. Both steps are
+  /// therefore *lighter* than every accent in their appearance — a mid mint over
+  /// the mid-dark light accents, a near-white mint over the pastel dark ones —
+  /// which also keeps the band distinct from the track on its other edge, so the
+  /// fill's end stays readable. `UsageBarContrastTests` pins the margin.
+  static let reserveBand = Color.adaptive(
+    light: NSColor(srgbRed: 115 / 255, green: 209 / 255, blue: 143 / 255, alpha: 1),
+    dark: NSColor(srgbRed: 184 / 255, green: 250 / 255, blue: 204 / 255, alpha: 1),
+    lightHighContrast: NSColor(srgbRed: 146 / 255, green: 232 / 255, blue: 172 / 255, alpha: 1),
+    darkHighContrast: NSColor(srgbRed: 208 / 255, green: 255 / 255, blue: 222 / 255, alpha: 1)
+  )
+
+  /// Casing drawn on both sides of the pace marker's colored core. The marker
+  /// lands *inside* the fill whenever the user is ahead of pace, so the core
+  /// alone has no guaranteed contrast against the accent underneath it; the
+  /// casing supplies it in the one direction every accent leaves open — light on
+  /// the dark light-appearance accents, dark on the pale dark-appearance ones.
+  static let paceMarkerCasing = Color.adaptive(
+    light: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 1),
+    dark: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 1)
+  )
+
   static let glassCardStroke = Color.adaptive(
     light: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.08),
     dark: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.10),

--- a/MeterBarTests/UsageBarTests.swift
+++ b/MeterBarTests/UsageBarTests.swift
@@ -1,0 +1,357 @@
+import AppKit
+import MeterBarShared
+import SwiftUI
+import XCTest
+@testable import MeterBar
+
+/// Coverage for `UsageBar`'s off-pace overlay.
+///
+/// The bar's colored fill is quota *left*, so the two off-pace stages sit on
+/// opposite sides of the pace marker: `.deficit` (burning fast) leaves a gap on
+/// the empty track to the marker's left-of-fill side, `.reserve` (ahead of pace)
+/// leaves that same amount *inside* the fill. `.reserve` used to draw no band at
+/// all and a bare 2pt green marker on top of the accent, which made "ahead of
+/// pace" indistinguishable from "on pace" — see the geometry assertions below.
+///
+/// All the math lives in the pure `UsageBar.BarGeometry` value type (the same
+/// reason `LimitRow.RowContent` exists) so every stage is assertable without
+/// hosting the view.
+@MainActor
+final class UsageBarGeometryTests: XCTestCase {
+    private let width: CGFloat = 200
+
+    private func pace(expectedUsed: Double, actualUsed: Double) -> UsagePace {
+        UsagePace(
+            expectedUsedPercent: expectedUsed,
+            deltaPercent: actualUsed - expectedUsed,
+            etaSeconds: nil,
+            willLastToReset: true
+        )
+    }
+
+    private func geometry(expectedUsed: Double, actualUsed: Double) -> UsageBar.BarGeometry {
+        UsageBar.BarGeometry(
+            width: width,
+            usedPercentage: actualUsed,
+            pace: pace(expectedUsed: expectedUsed, actualUsed: actualUsed)
+        )
+    }
+
+    // MARK: - Fill
+
+    func testFillTracksQuotaLeftNotQuotaUsed() {
+        // 65% used → 35% of the bar is filled. The fill is what's left.
+        XCTAssertEqual(geometry(expectedUsed: 67.7, actualUsed: 65).fillWidth, 70, accuracy: 0.001)
+    }
+
+    func testNilPaceDrawsFillOnlyWithNoOverlay() {
+        let geometry = UsageBar.BarGeometry(width: width, usedPercentage: 40, pace: nil)
+        XCTAssertEqual(geometry.fillWidth, 120, accuracy: 0.001)
+        XCTAssertNil(geometry.band)
+        XCTAssertNil(geometry.markerX)
+    }
+
+    // MARK: - Stages
+
+    /// On pace deliberately draws nothing extra — no marker, no band.
+    func testOnPaceDrawsNoMarkerOrBand() {
+        let geometry = geometry(expectedUsed: 50, actualUsed: 51)
+        XCTAssertNil(geometry.band, "on pace must stay a plain fill")
+        XCTAssertNil(geometry.markerX, "on pace must not draw the marker")
+    }
+
+    /// Burning faster than pace: the band spans the empty track between the fill's
+    /// edge and the marker — the quota you *should* still have.
+    func testDeficitBandRunsFromFillEdgeOutToTheMarker() {
+        let geometry = geometry(expectedUsed: 40, actualUsed: 60)
+        // 60% used → fill 80pt. 40% expected-used → marker at 120pt.
+        XCTAssertEqual(geometry.fillWidth, 80, accuracy: 0.001)
+        XCTAssertEqual(geometry.band?.kind, .deficit)
+        XCTAssertEqual(geometry.band?.x ?? -1, 80, accuracy: 0.001)
+        XCTAssertEqual(geometry.band?.width ?? -1, 40, accuracy: 0.001)
+    }
+
+    /// Ahead of pace: the mirror band spans from the marker to the fill's edge —
+    /// the quota you have *beyond* pace. Without it, `.reserve` renders as a bare
+    /// marker buried inside the accent fill and reads as "no marker at all".
+    func testReserveBandRunsFromTheMarkerInToTheFillEdge() {
+        let geometry = geometry(expectedUsed: 60, actualUsed: 40)
+        // 40% used → fill 120pt. 60% expected-used → marker at 80pt.
+        XCTAssertEqual(geometry.fillWidth, 120, accuracy: 0.001)
+        XCTAssertEqual(geometry.band?.kind, .reserve)
+        XCTAssertEqual(geometry.band?.x ?? -1, 80, accuracy: 0.001)
+        XCTAssertEqual(geometry.band?.width ?? -1, 40, accuracy: 0.001)
+    }
+
+    /// The live case that surfaced the bug: a Grok weekly window at 65% used
+    /// against 67.7% expected is `.reserve` by 2.7 points — past the ±2 on-pace
+    /// filter, so it must draw a band rather than silently render as on pace.
+    func testSmallReserveDeltaStillDrawsAVisibleBand() {
+        let geometry = geometry(expectedUsed: 67.69, actualUsed: 65)
+        XCTAssertEqual(geometry.band?.kind, .reserve)
+        XCTAssertEqual(geometry.band?.x ?? -1, 64.62, accuracy: 0.01)
+        XCTAssertEqual(geometry.band?.width ?? -1, 5.38, accuracy: 0.01)
+    }
+
+    /// Mirrored deltas must produce mirrored bands — the reserve band carries the
+    /// same weight as the deficit band it mirrors.
+    func testMirroredDeltasProduceEquallyWideBands() {
+        let deficit = geometry(expectedUsed: 50, actualUsed: 65)
+        let reserve = geometry(expectedUsed: 50, actualUsed: 35)
+
+        XCTAssertEqual(deficit.band?.kind, .deficit)
+        XCTAssertEqual(reserve.band?.kind, .reserve)
+        XCTAssertEqual(deficit.band?.width ?? -1, reserve.band?.width ?? -2, accuracy: 0.001)
+        // Both bands terminate at the same marker, from opposite sides.
+        XCTAssertEqual(deficit.markerX ?? -1, reserve.markerX ?? -2, accuracy: 0.001)
+    }
+
+    /// `.offset` doesn't grow a layout, so the fill + band stack is only as wide
+    /// as its widest *laid-out* child — the fill. The deficit band is offset past
+    /// that edge, so without an explicit painted width the capsule clip swallowed
+    /// it whole and the red block never reached the screen.
+    func testPaintedWidthCoversTheWholeDeficitBand() {
+        let geometry = geometry(expectedUsed: 35, actualUsed: 60)
+        let band = geometry.band
+        XCTAssertGreaterThan(band?.width ?? 0, 0)
+        XCTAssertGreaterThanOrEqual(
+            geometry.paintedWidth,
+            (band?.x ?? 0) + (band?.width ?? 0),
+            "the deficit band must not be clipped off the end of the fill"
+        )
+    }
+
+    /// Reserve paints inside the fill, so the painted region stays the fill.
+    func testPaintedWidthMatchesTheFillWhenAheadOfPace() {
+        let geometry = geometry(expectedUsed: 60, actualUsed: 40)
+        XCTAssertEqual(geometry.paintedWidth, geometry.fillWidth, accuracy: 0.001)
+    }
+
+    // MARK: - Marker placement
+
+    func testMarkerIsCenteredOnTheExpectedPosition() {
+        let geometry = geometry(expectedUsed: 40, actualUsed: 60)
+        let expectedX: CGFloat = 120
+        XCTAssertEqual(
+            (geometry.markerX ?? -1) + UsageBar.BarGeometry.markerWidth / 2,
+            expectedX,
+            accuracy: 0.001
+        )
+    }
+
+    /// The marker is a real shape with width, so it has to stay inside the bar at
+    /// both ends instead of hanging off the cap.
+    func testMarkerStaysInsideTheBarAtBothExtremes() {
+        let markerWidth = UsageBar.BarGeometry.markerWidth
+        let atStart = geometry(expectedUsed: 100, actualUsed: 0)
+        let atEnd = geometry(expectedUsed: 0, actualUsed: 100)
+
+        XCTAssertEqual(atStart.markerX ?? -1, 0, accuracy: 0.001)
+        XCTAssertEqual(atEnd.markerX ?? -1, width - markerWidth, accuracy: 0.001)
+    }
+
+    /// A zero-width bar (first layout pass) must not produce negative geometry.
+    func testZeroWidthBarProducesNoNegativeGeometry() {
+        let geometry = UsageBar.BarGeometry(
+            width: 0,
+            usedPercentage: 40,
+            pace: pace(expectedUsed: 60, actualUsed: 40)
+        )
+        XCTAssertEqual(geometry.fillWidth, 0)
+        XCTAssertGreaterThanOrEqual(geometry.band?.width ?? 0, 0)
+        XCTAssertGreaterThanOrEqual(geometry.markerX ?? 0, 0)
+    }
+
+    /// Percentages arriving out of range (a provider over-reporting) clamp rather
+    /// than painting outside the bar.
+    func testOutOfRangeInputsClamp() {
+        let over = UsageBar.BarGeometry(
+            width: width,
+            usedPercentage: 140,
+            pace: pace(expectedUsed: 180, actualUsed: 140)
+        )
+        XCTAssertEqual(over.fillWidth, 0)
+        XCTAssertGreaterThanOrEqual(over.band?.width ?? 0, 0)
+        XCTAssertLessThanOrEqual(
+            (over.markerX ?? 0) + UsageBar.BarGeometry.markerWidth,
+            width
+        )
+    }
+}
+
+/// The reserve band and the pace marker are drawn *on top of* the provider accent
+/// fill, so hue alone can't carry them: Cursor's and OpenAI's accents are already
+/// green. Both tokens must therefore separate from every accent by luminance, in
+/// light and dark appearance.
+@MainActor
+final class UsageBarContrastTests: XCTestCase {
+    private let accents: [(String, Color)] = [
+        ("codex", MeterBarTheme.codexAccent),
+        ("claude", MeterBarTheme.claudeAccent),
+        ("cursor", MeterBarTheme.cursorAccent),
+        ("openai", MeterBarTheme.openaiAccent),
+        ("openRouter", MeterBarTheme.openRouterAccent),
+        ("grok", MeterBarTheme.grokAccent)
+    ]
+
+    func testReserveBandSeparatesFromEveryAccentInBothAppearances() {
+        assertContrast(
+            overlay: MeterBarTheme.reserveBand,
+            opacity: UsageBar.bandOpacity,
+            minimumLuminanceDelta: 0.15
+        )
+    }
+
+    func testMarkerCasingSeparatesFromEveryAccentInBothAppearances() {
+        assertContrast(
+            overlay: MeterBarTheme.paceMarkerCasing,
+            opacity: UsageBar.markerCasingOpacity,
+            minimumLuminanceDelta: 0.3
+        )
+    }
+
+    /// The casing also has to separate the marker from the reserve band it sits
+    /// against, not just from the raw accent.
+    func testMarkerCasingSeparatesFromTheReserveBand() {
+        for name in [NSAppearance.Name.aqua, .darkAqua] {
+            let band = composite(
+                overlay: MeterBarTheme.reserveBand,
+                opacity: UsageBar.bandOpacity,
+                over: MeterBarTheme.cursorAccent,
+                appearanceName: name
+            )
+            let casing = composite(
+                overlay: MeterBarTheme.paceMarkerCasing,
+                opacity: UsageBar.markerCasingOpacity,
+                over: MeterBarTheme.reserveBand,
+                appearanceName: name
+            )
+            XCTAssertGreaterThan(
+                abs(luminance(casing) - luminance(band)),
+                0.3,
+                "marker casing blends into the reserve band in \(name.rawValue)"
+            )
+        }
+    }
+
+    private func assertContrast(
+        overlay: Color,
+        opacity: Double,
+        minimumLuminanceDelta: Double,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        for name in [NSAppearance.Name.aqua, .darkAqua] {
+            for (label, accent) in accents {
+                let accentLuminance = luminance(resolved(accent, appearanceName: name))
+                let overlayLuminance = luminance(
+                    composite(overlay: overlay, opacity: opacity, over: accent, appearanceName: name)
+                )
+                XCTAssertGreaterThan(
+                    abs(overlayLuminance - accentLuminance),
+                    minimumLuminanceDelta,
+                    "overlay is invisible on the \(label) accent in \(name.rawValue)",
+                    file: file,
+                    line: line
+                )
+            }
+        }
+    }
+
+    /// Source-over composite of `overlay` at `opacity` onto `base`, both resolved
+    /// for the given appearance. The bands are translucent, so contrast has to be
+    /// measured on what actually reaches the screen.
+    private func composite(
+        overlay: Color,
+        opacity: Double,
+        over base: Color,
+        appearanceName: NSAppearance.Name
+    ) -> NSColor {
+        let top = resolved(overlay, appearanceName: appearanceName)
+        let bottom = resolved(base, appearanceName: appearanceName)
+        let alpha = CGFloat(opacity)
+        return NSColor(
+            srgbRed: top.redComponent * alpha + bottom.redComponent * (1 - alpha),
+            green: top.greenComponent * alpha + bottom.greenComponent * (1 - alpha),
+            blue: top.blueComponent * alpha + bottom.blueComponent * (1 - alpha),
+            alpha: 1
+        )
+    }
+
+    private func luminance(_ color: NSColor) -> Double {
+        func linear(_ channel: CGFloat) -> Double {
+            let value = Double(channel)
+            return value <= 0.03928 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * linear(color.redComponent)
+            + 0.7152 * linear(color.greenComponent)
+            + 0.0722 * linear(color.blueComponent)
+    }
+
+    private func resolved(_ color: Color, appearanceName: NSAppearance.Name) -> NSColor {
+        guard let appearance = NSAppearance(named: appearanceName) else {
+            XCTFail("Missing \(appearanceName.rawValue) appearance")
+            return .clear
+        }
+        var resolved: NSColor?
+        appearance.performAsCurrentDrawingAppearance {
+            resolved = NSColor(color).usingColorSpace(.sRGB)
+        }
+        guard let resolved else {
+            XCTFail("Could not resolve color in sRGB")
+            return .clear
+        }
+        return resolved
+    }
+}
+
+/// The bar's only textual explanation is its tooltip — the popover footer is
+/// reset-only at `.compact` density, so hovering is the sole place the overlay is
+/// spelled out. Both bands need a line there, not just the red one.
+@MainActor
+final class UsageBarTooltipTests: XCTestCase {
+    private func bar(expectedUsed: Double, actualUsed: Double) -> UsageBar {
+        UsageBar(
+            usedPercentage: actualUsed,
+            accentColor: .blue,
+            pace: UsagePace(
+                expectedUsedPercent: expectedUsed,
+                deltaPercent: actualUsed - expectedUsed,
+                etaSeconds: nil,
+                willLastToReset: true
+            ),
+            paceContext: .session
+        )
+    }
+
+    func testTooltipExplainsTheDeficitBand() {
+        let tooltip = bar(expectedUsed: 40, actualUsed: 60).tooltipText ?? ""
+        XCTAssertTrue(tooltip.contains("Red is quota you should still have at this pace."), tooltip)
+        XCTAssertFalse(tooltip.contains("Green is"), tooltip)
+    }
+
+    func testTooltipExplainsTheReserveBand() {
+        let tooltip = bar(expectedUsed: 60, actualUsed: 40).tooltipText ?? ""
+        XCTAssertTrue(tooltip.contains("Green is quota you have beyond this pace."), tooltip)
+        XCTAssertFalse(tooltip.contains("Red is"), tooltip)
+    }
+
+    func testOnPaceTooltipExplainsNeitherBand() {
+        let tooltip = bar(expectedUsed: 50, actualUsed: 51).tooltipText ?? ""
+        XCTAssertFalse(tooltip.contains("Green is"), tooltip)
+        XCTAssertFalse(tooltip.contains("Red is"), tooltip)
+    }
+
+    func testEveryStageRenders() {
+        let stages: [(String, Double, Double)] = [
+            ("onPace", 50, 51),
+            ("reserve", 60, 40),
+            ("deficit", 40, 60)
+        ]
+        for (label, expected, actual) in stages {
+            let host = NSHostingView(rootView: bar(expectedUsed: expected, actualUsed: actual).frame(width: 200))
+            host.layoutSubtreeIfNeeded()
+            XCTAssertGreaterThan(host.fittingSize.height, 0, "UsageBar(\(label)) should lay out")
+        }
+    }
+}


### PR DESCRIPTION
## The bug

`UsageBar`'s colored fill represents quota **left**, so the pace marker lands *inside* the saturated accent whenever you're ahead of pace. `.reserve` drew a bare 2pt green line on top of that fill and nothing else — visually identical to `.onPace`, which deliberately draws nothing. `.deficit`, by contrast, got a full band. And the popover renders `LimitRow` at `.compact` density, whose footer is `resetOnly`, so there was no textual fallback either.

Measured live 2026-08-10 — Grok weekly, `used = 65%`, `windowSeconds = 604800`, `resetAt = 2026-08-12T15:05:27Z`:

```
expectedUsedPercent = 67.69   deltaPercent = -2.69   stage = .reserve
```

Past the ±2 on-pace filter, but the marker sits ~2.7% of bar width inside the fill — about 5pt on a 200pt bar.

## The fix

**Symmetric band.** Reserve now gets the mirror image of the deficit band. Deficit paints the empty track from the fill's edge out to the marker; reserve paints the overshoot from the marker in to the fill's edge.

**Contrast by luminance, not hue.** The reserve band overlays a provider accent rather than the empty track, and two of the six accents (Cursor `34,150,92` and OpenAI `16,163,127`) are already green — plain `MeterBarTheme.success` disappears on them. `MeterBarTheme.reserveBand` is therefore *lighter* than every accent in its appearance: a mid mint over the mid-dark light accents, a near-white mint over the pastel dark ones. That also keeps it distinct from the empty track on its other edge, so the fill's end stays readable.

**Marker casing.** The marker's colored core has no guaranteed contrast against whatever it sits on, and at small deltas the ~5pt band alone is too thin to carry the signal. A casing on each side (white in light, black in dark) gives it an edge on any background; the core keeps carrying the green/red meaning. Marker goes 2pt → 4pt total, 2pt core.

**Tooltip.** Added the reserve counterpart to the existing deficit line: *"Green is quota you have beyond this pace."*

## Bug found during visual verification

**The deficit band never reached the screen.** The fill/band `ZStack` sized itself to its widest *laid-out* child — the fill — and the deficit band is positioned with `.offset`, which doesn't grow a SwiftUI layout. The subsequent `.clipShape(Capsule())` swallowed it whole. So the shipped tooltip line *"Red is quota you should still have at this pace."* described something that never rendered. Reserve was unaffected because its band lies inside the fill.

`BarGeometry.paintedWidth` now covers the band and is stated explicitly before the clip. Two regression tests pin it.

## Structure

Geometry math moves out of `body` into `UsageBar.BarGeometry`, a pure `Equatable` value type — mirroring `LimitRow.RowContent` (`LimitRow.swift:158-201`), which exists for exactly this reason. `ProviderComponents.swift` had no test file; `MeterBarTests/UsageBarTests.swift` is new.

## Tests (TDD — written failing first)

- `UsageBarGeometryTests` — all three stages, the live Grok reserve case, mirrored-delta symmetry, marker centering and clamping, zero-width and out-of-range inputs, and the two `paintedWidth` clipping regressions.
- `UsageBarContrastTests` — composites each overlay at its real opacity over all six accents in `.aqua` and `.darkAqua`, then compares WCAG relative luminance. Band Δ > 0.15, casing Δ > 0.3 against both the accents and the reserve band.
- `UsageBarTooltipTests` — both band lines present, neither on `.onPace`, every stage renders.

Full suite: **2198 tests, 6 skipped, 0 failures.** SwiftLint clean.

## Not touched

`UsagePace.stage` thresholds and `UsageLimit.pace()` are unchanged. `.onPace` still draws neither marker nor band.

## Visual check

Rendered all six accents × six pace cases in both appearances via a scratch `NSHostingView` harness (deleted before commit, not in the diff) and inspected the worst case — Cursor's green accent in dark mode — cropped and upscaled. Pale mint band against medium-green accent with a dark-cased green marker reads clearly.