### PR TITLE
feat(popover): show a seven-day usage strip in the hover panel

### DIFF
--- a/MeterBar/Models/ProviderDailyUsageSeries.swift
+++ b/MeterBar/Models/ProviderDailyUsageSeries.swift
@@ -1,0 +1,314 @@
+import Foundation
+import MeterBarShared
+
+/// One provider's trailing-week consumption, bucketed for the hover panel.
+///
+/// The popover card already shows the current window — percent used, pace,
+/// reset. Hovering it used to open a panel showing the same three numbers in a
+/// wider box. This is the dimension the card cannot show: what the last seven
+/// days actually looked like.
+///
+/// Built as a plain value, derived once, for the same reason as
+/// ``TokenActivityGrid``: the panel is hosted in a test without a live
+/// ``CostTracker``, and `body` re-runs on every hover tick, so the bucketing
+/// must not live there.
+///
+/// Two properties are load-bearing:
+///
+/// - **Units never mix.** Claude, Codex and Grok are counted in tokens; Cursor
+///   in requests; OpenRouter in dollars. The metric rides with the series so a
+///   request count can never be printed with a `$` in front of it — the same
+///   guard ``ProviderUsageLedger/dailyUSDSeries(for:)`` enforces upstream.
+/// - **Unobserved days are not zero days.** The ledger providers have no
+///   backfill, so a day before the first poll is unknown. Drawing it as an
+///   empty bar would claim MeterBar watched a week it did not.
+struct ProviderDailyUsageSeries: Equatable {
+    /// What the bars are counted in. Derived from the source, never chosen by
+    /// the view.
+    enum Metric: Equatable {
+        /// Tokens read out of local session logs.
+        case tokens
+        /// US dollars, as published by the provider.
+        case usd
+        /// Requests or credits against a plan allowance — deliberately *not*
+        /// convertible to money, because no rate is published.
+        case requests
+
+        /// Short unit word for the panel's summary line.
+        var summaryNoun: String {
+            switch self {
+            case .tokens: return "tokens"
+            case .usd: return "spent"
+            case .requests: return "requests"
+            }
+        }
+
+        /// Formats one day's figure for a tooltip or accessibility value.
+        func formatted(_ value: Double) -> String {
+            switch self {
+            case .tokens: return UsageFormat.tokens(Int(value.rounded()))
+            case .usd: return UsageFormat.cost(value)
+            case .requests:
+                let count = Int(value.rounded())
+                return "\(count) request\(count == 1 ? "" : "s")"
+            }
+        }
+    }
+
+    /// One bucket. Always a whole day, always present even when empty — the
+    /// panel draws one bar per element and relies on the count being stable.
+    struct Day: Identifiable, Equatable {
+        let date: Date
+
+        /// The day's figure in the series' `metric`. Zero for a measured-quiet
+        /// day and for an unobserved one; `isMeasured` is what tells them apart.
+        let value: Double
+
+        /// False when the source cannot speak for this day at all. Only the
+        /// poll-and-accumulate providers ever produce these.
+        let isMeasured: Bool
+
+        /// Single-letter weekday for the axis, derived here rather than in
+        /// `body` so no `DateFormatter` runs per hover tick.
+        let weekdayLabel: String
+
+        /// Full weekday + date, for the tooltip and the accessibility value.
+        let longLabel: String
+
+        var id: Date { date }
+    }
+
+    let service: ServiceType
+    let metric: Metric
+
+    /// Exactly `dayCount` buckets, oldest first, ending on today.
+    let days: [Day]
+
+    /// The first day the source can speak for, or `nil` when it can speak for
+    /// none of them. Days in the window before this are drawn as unknown.
+    let coverageStart: Date?
+
+    /// True when the figures cover more accounts than the card that opened the
+    /// panel. `DailyTokenUsage` carries no account dimension, but the popover
+    /// shows one card per Claude/Codex/Grok account, so a two-account user's
+    /// panel would silently show both accounts' week under one account's name.
+    let isCombinedAcrossAccounts: Bool
+
+    // MARK: - Sources
+
+    /// Token history, for the providers that write local session logs.
+    ///
+    /// Every day in the window is measured: a scan re-reads the log files, so a
+    /// day with no rows genuinely had no sessions.
+    init(
+        service: ServiceType,
+        dailyUsage: [DailyTokenUsage],
+        accountCount: Int = 1,
+        dayCount: Int = ProviderDailyUsageSeries.defaultDayCount,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) {
+        let window = Self.window(dayCount: dayCount, now: now, calendar: calendar)
+        var totals: [Date: Double] = [:]
+        for row in dailyUsage where row.provider == service {
+            let day = calendar.startOfDay(for: row.date)
+            guard window.contains(day) else { continue }
+            totals[day, default: 0] += Double(max(0, row.totalTokens))
+        }
+
+        self.service = service
+        self.metric = .tokens
+        self.coverageStart = window.first
+        self.isCombinedAcrossAccounts = accountCount > 1
+        self.days = window.map { date in
+            Self.makeDay(
+                date: date,
+                value: totals[date] ?? 0,
+                isMeasured: true,
+                metric: .tokens,
+                calendar: calendar
+            )
+        }
+    }
+
+    /// Polled history, for the providers that keep no local log.
+    ///
+    /// Bucketed in the entry's own day boundary rather than the local one:
+    /// OpenRouter's stored keys are UTC midnights, and re-bucketing them locally
+    /// would shift part of every day's spend into its neighbour.
+    init(
+        service: ServiceType,
+        ledger: ProviderUsageLedger,
+        dayCount: Int = ProviderDailyUsageSeries.defaultDayCount,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) {
+        let entry = ledger.entry(for: service)
+        let bucketCalendar = entry?.dayBoundary.calendar(local: calendar) ?? calendar
+        let window = Self.window(dayCount: dayCount, now: now, calendar: bucketCalendar)
+        // No entry means the provider has never been polled, so nothing in the
+        // window is observed. `.requests` is the non-money default on purpose:
+        // an unknown unit must never render as dollars.
+        let metric: Metric = entry.map { Self.metric(for: $0.unit) } ?? .requests
+        let coverageStart = entry.map { bucketCalendar.startOfDay(for: $0.firstObservedOn) }
+
+        var totals: [Date: Double] = [:]
+        for point in ledger.dailySeries(for: service) {
+            let day = bucketCalendar.startOfDay(for: point.date)
+            guard window.contains(day) else { continue }
+            totals[day, default: 0] += max(0, point.amount)
+        }
+
+        self.service = service
+        self.metric = metric
+        self.coverageStart = coverageStart
+        // The ledger providers are single-account and the ledger is
+        // account-blind, so the caption can never apply here.
+        self.isCombinedAcrossAccounts = false
+        self.days = window.map { date in
+            Self.makeDay(
+                date: date,
+                value: totals[date] ?? 0,
+                isMeasured: coverageStart.map { date >= $0 } ?? false,
+                metric: metric,
+                calendar: bucketCalendar
+            )
+        }
+    }
+
+    /// The front door: picks the source from where the provider actually keeps
+    /// its history.
+    ///
+    /// Getting this wrong is silent rather than loud — Cursor has no token rows
+    /// at all, so a token-sourced Cursor series would draw a permanently empty
+    /// chart telling the user to run a scan that can never fill it.
+    static func make(
+        service: ServiceType,
+        dailyUsage: [DailyTokenUsage],
+        ledger: ProviderUsageLedger,
+        accountCount: Int,
+        dayCount: Int = ProviderDailyUsageSeries.defaultDayCount,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> ProviderDailyUsageSeries {
+        if service.writesLocalTokenLogs {
+            return ProviderDailyUsageSeries(
+                service: service,
+                dailyUsage: dailyUsage,
+                accountCount: accountCount,
+                dayCount: dayCount,
+                now: now,
+                calendar: calendar
+            )
+        }
+        return ProviderDailyUsageSeries(
+            service: service,
+            ledger: ledger,
+            dayCount: dayCount,
+            now: now,
+            calendar: calendar
+        )
+    }
+
+    // MARK: - Derived
+
+    /// The window the panel draws. Seven days is a week the user can hold in
+    /// their head, and it is as many bars as a 340pt panel fits without the
+    /// columns turning into hairlines.
+    static let defaultDayCount = 7
+
+    var totalValue: Double { days.reduce(0) { $0 + $1.value } }
+
+    /// The tallest day, which every bar is scaled against.
+    var peakValue: Double { days.map(\.value).max() ?? 0 }
+
+    /// False when there is nothing worth drawing — either no scan has run or the
+    /// provider has never been polled. The panel shows an empty state instead of
+    /// seven flat bars, which would read as a genuinely quiet week.
+    var hasHistory: Bool { days.contains { $0.isMeasured && $0.value > 0 } }
+
+    /// True when the source could speak for part of the window but not all of
+    /// it, which is worth a one-line caption rather than an empty state.
+    var hasPartialCoverage: Bool { days.contains { !$0.isMeasured } }
+
+    var formattedTotal: String { metric.formatted(totalValue) }
+
+    var accessibilityLabel: String {
+        "\(service.shortName) usage for the last \(days.count) days"
+    }
+
+    var accessibilityValue: String {
+        guard hasHistory else { return "No history yet" }
+        let measured = days.filter(\.isMeasured)
+        return ([formattedTotal + " total"] + measured.map { day in
+            "\(day.longLabel): \(metric.formatted(day.value))"
+        }).joined(separator: ", ")
+    }
+
+    // MARK: - Building
+
+    /// `dayCount` day-starts, oldest first, ending on today.
+    private static func window(dayCount: Int, now: Date, calendar: Calendar) -> [Date] {
+        let normalized = max(1, dayCount)
+        let today = calendar.startOfDay(for: now)
+        return (0..<normalized).reversed().compactMap { offset in
+            calendar.date(byAdding: .day, value: -offset, to: today)
+        }
+    }
+
+    private static func makeDay(
+        date: Date,
+        value: Double,
+        isMeasured: Bool,
+        metric: Metric,
+        calendar: Calendar
+    ) -> Day {
+        Day(
+            date: date,
+            value: value,
+            isMeasured: isMeasured,
+            weekdayLabel: ProviderDailyUsageFormat.weekdayInitial(date, calendar: calendar),
+            longLabel: ProviderDailyUsageFormat.weekdayAndDate(date, calendar: calendar)
+        )
+    }
+
+    private static func metric(for unit: ProviderUsageUnit) -> Metric {
+        switch unit {
+        case .usd: return .usd
+        case .requests: return .requests
+        }
+    }
+}
+
+/// Cached formatters for the sparkline axis.
+///
+/// Same reason the dashboard chart keeps `DashboardDateFormat`: building a
+/// `DateFormatter` is expensive, and these run once per bucket per panel
+/// presentation.
+enum ProviderDailyUsageFormat {
+    private static let weekdayInitialFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("EEEEE")
+        return formatter
+    }()
+
+    private static let weekdayAndDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("EEEEdMMM")
+        return formatter
+    }()
+
+    /// The formatters date in the *user's* zone by default, which is wrong for a
+    /// UTC-bucketed series: a UTC midnight would print as the previous evening's
+    /// weekday for anyone west of Greenwich. Both take the bucket calendar's
+    /// zone so the label always names the day the bar actually is.
+    static func weekdayInitial(_ date: Date, calendar: Calendar) -> String {
+        weekdayInitialFormatter.timeZone = calendar.timeZone
+        return weekdayInitialFormatter.string(from: date)
+    }
+
+    static func weekdayAndDate(_ date: Date, calendar: Calendar) -> String {
+        weekdayAndDateFormatter.timeZone = calendar.timeZone
+        return weekdayAndDateFormatter.string(from: date)
+    }
+}

--- a/MeterBar/Views/Components/ProviderDailyUsageSparkline.swift
+++ b/MeterBar/Views/Components/ProviderDailyUsageSparkline.swift
@@ -1,0 +1,171 @@
+import MeterBarShared
+import SwiftUI
+
+/// The seven-day bar strip in the hover detail panel.
+///
+/// The reason the panel exists. Everything else it draws — the header, the limit
+/// rows — the card underneath already drew; only the row footers get wordier.
+/// This is the one thing the card cannot show, because a card that fits three to
+/// a popover has no room for a week of history.
+///
+/// Deliberately a strip and not ``DailyUsageChart``: that chart is a 30-day
+/// dashboard element with a legend, month labels and stacked per-provider
+/// segments. At 340pt those columns would be hairlines, and the panel is
+/// provider-scoped anyway, so there is nothing to stack.
+///
+/// Takes a fully built ``ProviderDailyUsageSeries`` rather than reaching for
+/// ``CostTracker``, matching ``TokenActivityCard``: the panel is hosted in tests
+/// without standing up the scanner, and the bucketing must not re-run in `body`
+/// on every hover tick.
+struct ProviderDailyUsageSparkline: View {
+    let series: ProviderDailyUsageSeries
+    let accentColor: Color
+
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
+    // Bars grow from the baseline as the panel appears. Gated on Reduce Motion
+    // via `Motion.resolve`, which returns nil and makes `withAnimation` a plain
+    // assignment — the same gate `LimitRow` and `ProviderComponents` use.
+    @State private var isRevealed = false
+
+    private let barHeight: CGFloat = 34
+    private let barCornerRadius: CGFloat = 2.5
+
+    var body: some View {
+        // Spacing and a quiet label, never a rule: the panel is the same card the
+        // pointer is resting on, only wider, so it must not sprout chrome the
+        // card never had.
+        VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.xs) {
+            sectionHeader
+
+            if series.hasHistory {
+                bars
+                if let caption {
+                    Text(caption)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            } else {
+                emptyState
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(series.accessibilityLabel)
+        .accessibilityValue(series.accessibilityValue)
+    }
+
+    // MARK: - Pieces
+
+    private var sectionHeader: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text("Last \(series.days.count) days")
+                .font(.caption2.weight(.semibold))
+                .foregroundColor(.secondary)
+
+            Spacer(minLength: MeterBarTheme.Spacing.sm)
+
+            if series.hasHistory {
+                // The unit noun follows the metric, so a Cursor request count can
+                // never be printed as though it were money.
+                Text("\(series.formattedTotal) \(series.metric.summaryNoun)")
+                    .font(.caption2.monospacedDigit())
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    private var bars: some View {
+        HStack(alignment: .bottom, spacing: 5) {
+            ForEach(series.days) { day in
+                VStack(spacing: 3) {
+                    bar(for: day)
+                    Text(day.weekdayLabel)
+                        .font(.system(size: 9))
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity)
+                .help(helpText(for: day))
+            }
+        }
+        .onAppear {
+            withAnimation(
+                MeterBarTheme.Motion.resolve(MeterBarTheme.Motion.disclosure, reduceMotion: reduceMotion)
+            ) {
+                isRevealed = true
+            }
+        }
+    }
+
+    private func bar(for day: ProviderDailyUsageSeries.Day) -> some View {
+        // The track is always drawn so the strip reads as seven days even when
+        // most of them are quiet. An unobserved day gets the track and no fill —
+        // there is no figure to draw, and a zero-height bar would claim there was.
+        ZStack(alignment: .bottom) {
+            RoundedRectangle(cornerRadius: barCornerRadius, style: .continuous)
+                .fill(Color.secondary.opacity(day.isMeasured ? 0.14 : 0.07))
+
+            if day.isMeasured, day.value > 0 {
+                RoundedRectangle(cornerRadius: barCornerRadius, style: .continuous)
+                    .fill(accentColor.opacity(0.85))
+                    .frame(height: isRevealed ? filledHeight(for: day) : 0)
+            }
+        }
+        .frame(height: barHeight)
+    }
+
+    private var emptyState: some View {
+        EmptyStateCard(
+            systemImage: "chart.bar",
+            title: emptyTitle,
+            message: emptyMessage
+        )
+    }
+
+    // MARK: - Copy
+
+    /// Two genuinely different situations. A log-scanning provider is one scan
+    /// away from a full week of history; a polled provider can only ever be
+    /// waiting, because there is no history to fetch — see
+    /// ``ProviderUsageLedger``.
+    private var emptyTitle: String {
+        series.service.writesLocalTokenLogs ? "No token history yet" : "No usage recorded yet"
+    }
+
+    private var emptyMessage: String {
+        series.service.writesLocalTokenLogs
+            ? "Run a cost scan to load \(series.service.shortName)'s daily usage."
+            : "\(series.service.shortName) publishes no history, so MeterBar builds this from its own refreshes."
+    }
+
+    /// Only shown when the strip is drawing something, so it qualifies the bars
+    /// rather than replacing them.
+    private var caption: String? {
+        if series.isCombinedAcrossAccounts {
+            // The honest version of a limitation that would otherwise be
+            // invisible: the cost cache has no account dimension, so a
+            // per-account card's panel shows every account's usage.
+            return "Across all \(series.service.shortName) accounts"
+        }
+        if series.hasPartialCoverage, let start = series.coverageStart {
+            return "Tracked since \(ProviderDailyUsageFormat.weekdayAndDate(start, calendar: .current))"
+        }
+        return nil
+    }
+
+    private func helpText(for day: ProviderDailyUsageSeries.Day) -> String {
+        guard day.isMeasured else { return "\(day.longLabel): not tracked yet" }
+        return "\(day.longLabel): \(series.metric.formatted(day.value))"
+    }
+
+    // MARK: - Geometry
+
+    /// Scaled against the tallest day in the window, with a floor so a day that
+    /// is small but not empty still reads as a mark rather than nothing.
+    private func filledHeight(for day: ProviderDailyUsageSeries.Day) -> CGFloat {
+        let peak = series.peakValue
+        guard peak > 0 else { return 0 }
+        return max(2, barHeight * CGFloat(day.value / peak))
+    }
+}

--- a/MeterBar/Views/DailyUsageChart.swift
+++ b/MeterBar/Views/DailyUsageChart.swift
@@ -23,15 +23,24 @@ struct DailyUsageChart: View {
     self.days = Self.buildDays(from: dailyUsage, daysToShow: daysToShow)
   }
 
-  private static let providerOrder: [ServiceType] = [.claudeCode, .codexCli, .cursor]
+  // Derived from the enum rather than listed by hand. The hand-written list
+  // stopped at three providers, so Grok and OpenRouter rows were bucketed into
+  // nothing and drew as empty columns — a silent zero, not an error. Internal
+  // (not private) so `DailyUsageChartBucketingTests` can pin it.
+  static let providerOrder: [ServiceType] = ServiceType.allCases.sorted {
+    $0.sortOrder < $1.sortOrder
+  }
 
-  private static func buildDays(
+  // `now`/`calendar` are injected so the bucketing is testable without the test
+  // straddling local midnight. Production always passes the defaults.
+  static func buildDays(
     from dailyUsage: [DailyTokenUsage],
-    daysToShow: Int
+    daysToShow: Int,
+    now: Date = Date(),
+    calendar: Calendar = .current
   ) -> [DailyUsageDay] {
-    let calendar = Calendar.current
     let normalizedDaysToShow = max(1, daysToShow)
-    let endDate = calendar.startOfDay(for: Date())
+    let endDate = calendar.startOfDay(for: now)
     let startDate =
       calendar.date(byAdding: .day, value: -(normalizedDaysToShow - 1), to: endDate) ?? endDate
     let grouped = Dictionary(grouping: dailyUsage) { calendar.startOfDay(for: $0.date) }

--- a/MeterBar/Views/MenuBarDetailPanel.swift
+++ b/MeterBar/Views/MenuBarDetailPanel.swift
@@ -228,10 +228,21 @@ enum MeterBarMenuDetailPanelLayout {
 struct MenuBarProviderDetailContent: View {
   let snapshot: ProviderSnapshot
 
+  /// The hovered provider's trailing week, passed in already bucketed.
+  ///
+  /// A plain value rather than a `CostTracker` lookup, matching
+  /// ``TokenActivityCard``: this panel is hosted directly in
+  /// `MenuBarDetailPanelLayoutTests`, and reaching for the scanner singleton
+  /// would drag it into every one of those tests. `nil` means the caller has no
+  /// series to offer, and the panel simply omits the strip — which is what the
+  /// layout tests exercise.
+  let dailyUsage: ProviderDailyUsageSeries?
+
   @ObservedObject private var menuBarDisplayPreferences = MenuBarDisplayPreferencesStore.shared
 
-  init(snapshot: ProviderSnapshot) {
+  init(snapshot: ProviderSnapshot, dailyUsage: ProviderDailyUsageSeries? = nil) {
     self.snapshot = snapshot
+    self.dailyUsage = dailyUsage
   }
 
   private var detailLimits: [SnapshotLimit] {
@@ -302,6 +313,14 @@ struct MenuBarProviderDetailContent: View {
       let badges = ProviderStatusBadges(snapshot: snapshot, style: .compact)
       if badges.hasContent {
         badges
+      }
+
+      if let dailyUsage {
+        // Last, and separated by a little extra space rather than a rule: the
+        // rows above are the window the card already summarised, and this is the
+        // week behind it. Reading top-to-bottom is now → recent past.
+        ProviderDailyUsageSparkline(series: dailyUsage, accentColor: snapshot.accentColor)
+          .padding(.top, MeterBarTheme.Spacing.xxs)
       }
     }
     .frame(maxWidth: .infinity, alignment: .topLeading)

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -21,6 +21,10 @@ struct MenuBarView: View {
   @StateObject private var providerVisibility = ProviderVisibilityStore.shared
   @StateObject private var sessionWakeStore = SessionWakeSettingsStore.shared
   @StateObject private var menuBarDisplayPreferences = MenuBarDisplayPreferencesStore.shared
+  // Only read for the hover panel's seven-day strip. Safe to hold here: the
+  // tracker's initializer just rehydrates the cached summary and ledger from
+  // disk — observing it never starts a scan.
+  @StateObject private var costTracker = CostTracker.shared
 
   @State private var contentHeight: CGFloat = 320
   @State private var expandedDetailID: String?
@@ -59,6 +63,34 @@ struct MenuBarView: View {
     }
   }
 
+  /// The provider cards the popover draws.
+  ///
+  /// Lifted out of `mainColumn` so the hover handler can read the same list the
+  /// body drew: a Claude/Codex/Grok user with several accounts gets one card per
+  /// account, and the detail panel has to know that to caption its chart
+  /// honestly — the cost cache has no account dimension, so its figures cover
+  /// every account at once.
+  private var snapshots: [ProviderSnapshot] {
+    ProviderSnapshotBuilder.snapshots(
+      ProviderSnapshotBuilder.Input(
+        metrics: dataManager.metrics,
+        codexAccounts: codexAccountStore.accounts,
+        codexAccountMetrics: dataManager.codexAccountMetrics,
+        codexAccountAccess: codexCliService.accountAccess,
+        grokAccounts: grokAccountStore.accounts,
+        grokAccountMetrics: dataManager.grokAccountMetrics,
+        claudeAccounts: claudeAccountStore.accounts,
+        claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
+        enabledServices: providerVisibility.enabledServices,
+        claudeAccountStates: dataManager.claudeCodeAccountStates,
+        claudeCodeHasAccess: claudeCodeService.hasAccess,
+        codexCliHasAccess: codexCliService.hasAccess,
+        cursorHasAccess: cursorService.hasAccess,
+        openRouterHasAccess: openRouterService.hasAccess,
+        grokHasAccess: grokService.hasAccess
+      ))
+  }
+
   private var mainColumn: some View {
     VStack(spacing: 0) {
       popoverHeader
@@ -68,24 +100,7 @@ struct MenuBarView: View {
       ScrollView {
         VStack(spacing: 10) {
           PopoverOverviewPanel(
-            snapshots: ProviderSnapshotBuilder.snapshots(
-              ProviderSnapshotBuilder.Input(
-                metrics: dataManager.metrics,
-                codexAccounts: codexAccountStore.accounts,
-                codexAccountMetrics: dataManager.codexAccountMetrics,
-                codexAccountAccess: codexCliService.accountAccess,
-                grokAccounts: grokAccountStore.accounts,
-                grokAccountMetrics: dataManager.grokAccountMetrics,
-                claudeAccounts: claudeAccountStore.accounts,
-                claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
-                enabledServices: providerVisibility.enabledServices,
-                claudeAccountStates: dataManager.claudeCodeAccountStates,
-                claudeCodeHasAccess: claudeCodeService.hasAccess,
-                codexCliHasAccess: codexCliService.hasAccess,
-                cursorHasAccess: cursorService.hasAccess,
-                openRouterHasAccess: openRouterService.hasAccess,
-                grokHasAccess: grokService.hasAccess
-              )),
+            snapshots: snapshots,
             openDashboard: openDashboard,
             openStatusDetail: openStatusDetail,
             openProviderOverview: openProviderDetail,
@@ -222,8 +237,28 @@ struct MenuBarView: View {
   private func openProviderDetail(_ snapshot: ProviderSnapshot) {
     presentDetail(
       id: snapshot.id,
-      content: AnyView(MenuBarProviderDetailContent(snapshot: snapshot))
+      content: AnyView(
+        MenuBarProviderDetailContent(
+          snapshot: snapshot,
+          // Bucketed here, at hover time, rather than inside the panel: the
+          // panel's `body` re-runs on every hover tick, and it is hosted in
+          // tests that must not stand up the cost scanner.
+          dailyUsage: ProviderDailyUsageSeries.make(
+            service: snapshot.service,
+            dailyUsage: costTracker.costSummary?.dailyUsage ?? [],
+            ledger: costTracker.usageLedger,
+            accountCount: accountCardCount(for: snapshot.service)
+          )
+        )
+      )
     )
+  }
+
+  /// How many cards the popover is currently drawing for one provider. Anything
+  /// above one means the panel's figures are the provider's total, not this
+  /// card's account, which the chart says out loud rather than implying.
+  private func accountCardCount(for service: ServiceType) -> Int {
+    snapshots.filter { $0.service == service }.count
   }
 
   /// Provider-card hover owns the detail panel together with the detail panel's

--- a/MeterBarTests/DailyUsageChartBucketingTests.swift
+++ b/MeterBarTests/DailyUsageChartBucketingTests.swift
@@ -1,0 +1,80 @@
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// Guards the dashboard chart's per-day, per-provider bucketing.
+///
+/// The chart shipped with a hardcoded three-provider order that predated Grok
+/// and OpenRouter, so their rows were bucketed into nothing and their bars drew
+/// empty — a silent zero, not an error. These tests pin the order to the
+/// `ServiceType` enum so adding a sixth provider can never reintroduce that.
+final class DailyUsageChartBucketingTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+    private var calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC") ?? .gmt
+        calendar.locale = Locale(identifier: "en_US_POSIX")
+        return calendar
+    }()
+
+    private func day(_ offset: Int) -> Date {
+        let today = calendar.startOfDay(for: now)
+        return calendar.date(byAdding: .day, value: offset, to: today) ?? today
+    }
+
+    private func row(_ offset: Int, provider: ServiceType, tokens: Int) -> DailyTokenUsage {
+        DailyTokenUsage(
+            date: day(offset).addingTimeInterval(3600 * 5),
+            provider: provider,
+            inputTokens: tokens,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            estimatedCostUSD: Double(tokens) / 1000
+        )
+    }
+
+    /// Every provider MeterBar tracks has to be able to draw. The order itself
+    /// is `ServiceType.sortOrder`, which is already the app's stable provider
+    /// ordering everywhere else.
+    func testProviderOrderCoversEveryTrackedService() {
+        XCTAssertEqual(
+            DailyUsageChart.providerOrder,
+            ServiceType.allCases.sorted { $0.sortOrder < $1.sortOrder }
+        )
+        XCTAssertEqual(Set(DailyUsageChart.providerOrder), Set(ServiceType.allCases))
+    }
+
+    /// The regression itself: Grok and OpenRouter rows used to produce no
+    /// segment, so a day made entirely of Grok usage rendered as a blank column.
+    func testEveryProviderProducesASegment() throws {
+        let rows = ServiceType.allCases.map { row(0, provider: $0, tokens: 1000) }
+        let days = DailyUsageChart.buildDays(from: rows, daysToShow: 3, now: now, calendar: calendar)
+
+        let today = try XCTUnwrap(days.last)
+        XCTAssertEqual(Set(today.segments.map(\.provider)), Set(ServiceType.allCases))
+        XCTAssertEqual(today.totalTokens, 5000)
+    }
+
+    func testWindowEndsOnTodayAndSpansTheRequestedDayCount() {
+        let days = DailyUsageChart.buildDays(from: [], daysToShow: 30, now: now, calendar: calendar)
+
+        XCTAssertEqual(days.count, 30)
+        XCTAssertEqual(days.first?.date, day(-29))
+        XCTAssertEqual(days.last?.date, day(0))
+    }
+
+    /// A provider with nothing that day gets no segment, so the stacked column
+    /// does not draw a zero-height slab in its colour.
+    func testProvidersWithoutUsageAreOmittedFromTheDay() {
+        let days = DailyUsageChart.buildDays(
+            from: [row(-1, provider: .grok, tokens: 42)],
+            daysToShow: 3,
+            now: now,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(days[1].segments.map(\.provider), [.grok])
+        XCTAssertTrue(days[2].segments.isEmpty)
+    }
+}

--- a/MeterBarTests/MenuBarDetailPanelLayoutTests.swift
+++ b/MeterBarTests/MenuBarDetailPanelLayoutTests.swift
@@ -193,6 +193,58 @@ final class MenuBarProviderDetailParityTests: XCTestCase {
         XCTAssertGreaterThan(host.fittingSize.height, 0)
     }
 
+    /// The panel's height is measured from its hosted content, so anything added
+    /// to it grows the window. Seven bars is the reason the size was chosen over
+    /// ``DailyUsageChart``'s thirty, and this pins that it stays a strip: 600pt
+    /// is comfortably inside the visible frame of the smallest display MeterBar
+    /// runs on (1280×800), so the panel never has to fall back to its scrolling
+    /// variant just because the chart is present.
+    func testTheSevenDayStripKeepsThePanelWithinASmallScreen() {
+        let content = MenuBarProviderDetailContent(
+            snapshot: snapshot(),
+            dailyUsage: ProviderDailyUsageSeries(
+                service: .codexCli,
+                dailyUsage: (0..<7).map { offset in
+                    DailyTokenUsage(
+                        date: Date().addingTimeInterval(Double(-offset) * 86_400),
+                        provider: .codexCli,
+                        inputTokens: 900_000,
+                        outputTokens: 0,
+                        cacheReadTokens: 0,
+                        estimatedCostUSD: 12
+                    )
+                }
+            )
+        )
+        let host = NSHostingView(
+            rootView: content.frame(width: MeterBarMenuDetailPanelLayout.detailWidth)
+        )
+        host.layoutSubtreeIfNeeded()
+
+        XCTAssertLessThan(host.fittingSize.height, 600)
+    }
+
+    /// The whole point of the change: hovering has to return something the card
+    /// could not already show. If the strip ever stops rendering, the panel
+    /// silently goes back to being a wider copy of the card.
+    func testTheStripAddsHeightTheCardCopyDidNotHave() {
+        let plain = NSHostingView(
+            rootView: MenuBarProviderDetailContent(snapshot: snapshot())
+                .frame(width: MeterBarMenuDetailPanelLayout.detailWidth)
+        )
+        let charted = NSHostingView(
+            rootView: MenuBarProviderDetailContent(
+                snapshot: snapshot(),
+                dailyUsage: ProviderDailyUsageSeries(service: .codexCli, dailyUsage: [])
+            )
+            .frame(width: MeterBarMenuDetailPanelLayout.detailWidth)
+        )
+        plain.layoutSubtreeIfNeeded()
+        charted.layoutSubtreeIfNeeded()
+
+        XCTAssertGreaterThan(charted.fittingSize.height, plain.fittingSize.height)
+    }
+
     func testHeaderRendersWithAndWithoutTheDisclosureChevron() {
         for showsChevron in [true, false] {
             let header = ProviderCardHeader(snapshot: snapshot(), showsDisclosureChevron: showsChevron)

--- a/MeterBarTests/ProviderDailyUsageSeriesTests.swift
+++ b/MeterBarTests/ProviderDailyUsageSeriesTests.swift
@@ -1,0 +1,353 @@
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// Covers the bucketing behind the hover panel's seven-day sparkline.
+///
+/// The panel is provider-scoped, so every assertion here is about what the
+/// series is allowed to *claim* for one provider: which days land in the
+/// window, which rows belong to it, and — for the poll-and-accumulate
+/// providers — which days it has no right to report at all.
+///
+/// Pixels are deliberately out of scope. The value of this chart is that the
+/// seven numbers under the bars are the right seven numbers; the drawing is
+/// covered by the panel layout tests.
+final class ProviderDailyUsageSeriesTests: XCTestCase {
+    // Pinned so the window arithmetic is reproducible: a run that straddles
+    // local midnight would otherwise shift every bucket by a day.
+    private let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+    private var calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC") ?? .gmt
+        calendar.locale = Locale(identifier: "en_US_POSIX")
+        return calendar
+    }()
+
+    /// `offset` days from the start of `now`'s day. Negative is the past.
+    private func day(_ offset: Int) -> Date {
+        let today = calendar.startOfDay(for: now)
+        return calendar.date(byAdding: .day, value: offset, to: today) ?? today
+    }
+
+    private func tokenRow(
+        _ offset: Int,
+        provider: ServiceType = .claudeCode,
+        tokens: Int,
+        costUSD: Double = 0
+    ) -> DailyTokenUsage {
+        DailyTokenUsage(
+            date: day(offset).addingTimeInterval(3600 * 9),
+            provider: provider,
+            inputTokens: tokens,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            estimatedCostUSD: costUSD
+        )
+    }
+
+    private func tokenSeries(
+        _ rows: [DailyTokenUsage],
+        service: ServiceType = .claudeCode,
+        accountCount: Int = 1
+    ) -> ProviderDailyUsageSeries {
+        ProviderDailyUsageSeries(
+            service: service,
+            dailyUsage: rows,
+            accountCount: accountCount,
+            dayCount: 7,
+            now: now,
+            calendar: calendar
+        )
+    }
+
+    // MARK: - Window boundaries
+
+    /// Seven buckets, oldest first, ending on today. The panel draws one bar
+    /// per element without re-checking the count, so a short array would draw
+    /// a short week rather than a gap.
+    func testSeriesAlwaysCoversExactlySevenTrailingDays() {
+        let series = tokenSeries([tokenRow(0, tokens: 100)])
+
+        XCTAssertEqual(series.days.count, 7)
+        XCTAssertEqual(series.days.first?.date, day(-6))
+        XCTAssertEqual(series.days.last?.date, day(0))
+        XCTAssertEqual(series.days.map(\.date), (-6...0).map { day($0) })
+    }
+
+    /// The seventh day back is outside the window. Folding it into the oldest
+    /// bar is the classic off-by-one here, and it inflates exactly the bar a
+    /// reader uses as their baseline.
+    func testRowsOlderThanTheWindowAreExcluded() {
+        let series = tokenSeries([
+            tokenRow(-7, tokens: 999_999),
+            tokenRow(-6, tokens: 10)
+        ])
+
+        XCTAssertEqual(series.days.first?.value, 10)
+        XCTAssertEqual(series.totalValue, 10)
+    }
+
+    /// A cache written on a machine whose clock ran ahead can carry rows dated
+    /// after today. They have no bar to land in, so they must not be counted
+    /// into the total either — the total would then disagree with the bars.
+    func testFutureDatedRowsAreIgnored() {
+        let series = tokenSeries([
+            tokenRow(1, tokens: 500),
+            tokenRow(0, tokens: 25)
+        ])
+
+        XCTAssertEqual(series.days.last?.value, 25)
+        XCTAssertEqual(series.totalValue, 25)
+    }
+
+    // MARK: - Provider scoping
+
+    /// The panel opens from one provider's card. Summing the whole cache here
+    /// would show Codex's week under Claude's header.
+    func testOtherProvidersAreExcluded() {
+        let series = tokenSeries([
+            tokenRow(-1, provider: .claudeCode, tokens: 30),
+            tokenRow(-1, provider: .codexCli, tokens: 4000),
+            tokenRow(0, provider: .grok, tokens: 4000)
+        ])
+
+        XCTAssertEqual(series.totalValue, 30)
+        XCTAssertEqual(series.days.last?.value, 0)
+    }
+
+    /// Scanners emit one row per day *per source file*, so a single day can
+    /// arrive as several rows.
+    func testMultipleRowsForOneDayAreSummed() {
+        let series = tokenSeries([
+            tokenRow(-2, tokens: 100),
+            tokenRow(-2, tokens: 250)
+        ])
+
+        XCTAssertEqual(series.days[4].value, 350)
+    }
+
+    // MARK: - Sparse and empty history
+
+    /// A quiet day is a measured zero for the token providers: the scan re-reads
+    /// the log files, so silence is evidence, not absence.
+    func testSparseDaysFillAsMeasuredZeros() {
+        let series = tokenSeries([tokenRow(-3, tokens: 60)])
+
+        XCTAssertEqual(series.days.map(\.value), [0, 0, 0, 60, 0, 0, 0])
+        XCTAssertTrue(series.days.allSatisfy(\.isMeasured))
+        XCTAssertTrue(series.hasHistory)
+    }
+
+    /// Before the first scan there is nothing to draw, and the panel shows an
+    /// empty state instead of seven flat bars that read as a quiet week.
+    func testEmptyInputHasNoHistory() {
+        let series = tokenSeries([])
+
+        XCTAssertEqual(series.days.count, 7)
+        XCTAssertFalse(series.hasHistory)
+        XCTAssertEqual(series.totalValue, 0)
+        XCTAssertEqual(series.peakValue, 0)
+    }
+
+    /// The bars are scaled against the tallest day, so the peak has to come
+    /// from the window rather than from the whole cache.
+    func testPeakIsTheTallestDayInTheWindow() {
+        let series = tokenSeries([
+            tokenRow(-8, tokens: 1_000_000),
+            tokenRow(-4, tokens: 700),
+            tokenRow(0, tokens: 120)
+        ])
+
+        XCTAssertEqual(series.peakValue, 700)
+    }
+
+    // MARK: - Units
+
+    func testTokenProvidersAreDenominatedInTokens() {
+        XCTAssertEqual(tokenSeries([], service: .claudeCode).metric, .tokens)
+    }
+
+    /// Cursor publishes a request counter with no currency field anywhere in
+    /// the payload, so its series must never be labelled or formatted as money.
+    func testCursorLedgerSeriesIsDenominatedInRequests() {
+        var ledger = ProviderUsageLedger()
+        ledger.record(
+            ProviderUsageObservation(
+                provider: .cursor,
+                unit: .requests,
+                runningTotal: 0,
+                observedAt: day(-4)
+            ),
+            calendar: calendar
+        )
+        ledger.record(
+            ProviderUsageObservation(
+                provider: .cursor,
+                unit: .requests,
+                runningTotal: 12,
+                observedAt: day(-2)
+            ),
+            calendar: calendar
+        )
+
+        let series = ProviderDailyUsageSeries(
+            service: .cursor,
+            ledger: ledger,
+            dayCount: 7,
+            now: now,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(series.metric, .requests)
+        XCTAssertEqual(series.days[4].value, 12)
+        XCTAssertEqual(series.totalValue, 12)
+    }
+
+    func testOpenRouterLedgerSeriesIsDenominatedInDollars() {
+        var ledger = ProviderUsageLedger()
+        ledger.record(
+            ProviderUsageObservation(
+                provider: .openRouter,
+                unit: .usd,
+                runningTotal: 4,
+                authoritativeDailyTotal: 1.5,
+                dayBoundary: .utc,
+                observedAt: day(-1)
+            ),
+            calendar: calendar
+        )
+
+        let series = ProviderDailyUsageSeries(
+            service: .openRouter,
+            ledger: ledger,
+            dayCount: 7,
+            now: now,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(series.metric, .usd)
+        XCTAssertEqual(series.days[5].value, 1.5, accuracy: 0.0001)
+    }
+
+    // MARK: - Coverage
+
+    /// The ledger is a poll-and-accumulate series with no backfill, so days
+    /// before the first poll were never observed. Drawing them as zero would
+    /// claim MeterBar watched a week it did not.
+    func testLedgerDaysBeforeTheFirstPollAreUnmeasured() {
+        var ledger = ProviderUsageLedger()
+        ledger.record(
+            ProviderUsageObservation(
+                provider: .cursor,
+                unit: .requests,
+                runningTotal: 3,
+                observedAt: day(-2)
+            ),
+            calendar: calendar
+        )
+
+        let series = ProviderDailyUsageSeries(
+            service: .cursor,
+            ledger: ledger,
+            dayCount: 7,
+            now: now,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(series.days.map(\.isMeasured), [false, false, false, false, true, true, true])
+        XCTAssertEqual(series.coverageStart, day(-2))
+    }
+
+    /// A provider MeterBar has never polled has no series at all, which is a
+    /// different empty state from "polled, and the week was quiet".
+    func testLedgerWithoutAnEntryHasNoHistory() {
+        let series = ProviderDailyUsageSeries(
+            service: .cursor,
+            ledger: ProviderUsageLedger(),
+            dayCount: 7,
+            now: now,
+            calendar: calendar
+        )
+
+        XCTAssertFalse(series.hasHistory)
+        XCTAssertNil(series.coverageStart)
+        XCTAssertTrue(series.days.allSatisfy { !$0.isMeasured })
+    }
+
+    // MARK: - Accounts
+
+    /// `DailyTokenUsage` carries no account dimension, but the popover shows one
+    /// card per Claude/Codex/Grok account. The series has to admit that its
+    /// numbers cover every account, not just the hovered card's.
+    func testMultipleAccountsMarkTheSeriesAsCombined() {
+        XCTAssertTrue(tokenSeries([], accountCount: 2).isCombinedAcrossAccounts)
+        XCTAssertFalse(tokenSeries([], accountCount: 1).isCombinedAcrossAccounts)
+        XCTAssertFalse(tokenSeries([], accountCount: 0).isCombinedAcrossAccounts)
+    }
+
+    /// Cursor and OpenRouter are single-account providers, and their ledger is
+    /// account-blind by construction, so the caption never applies to them.
+    func testLedgerSeriesIsNeverMarkedCombined() {
+        let series = ProviderDailyUsageSeries(
+            service: .openRouter,
+            ledger: ProviderUsageLedger(),
+            dayCount: 7,
+            now: now,
+            calendar: calendar
+        )
+
+        XCTAssertFalse(series.isCombinedAcrossAccounts)
+    }
+
+    // MARK: - Source selection
+
+    /// The front door the popover uses. Picking the wrong source is silent:
+    /// Cursor has no token rows, so a token-sourced Cursor series would be a
+    /// permanently empty chart telling the user to run a scan that can never
+    /// populate it.
+    func testSourceIsChosenFromWhereTheProviderKeepsItsHistory() {
+        var ledger = ProviderUsageLedger()
+        ledger.record(
+            ProviderUsageObservation(
+                provider: .cursor,
+                unit: .requests,
+                runningTotal: 5,
+                observedAt: day(-1)
+            ),
+            calendar: calendar
+        )
+
+        let cursor = ProviderDailyUsageSeries.make(
+            service: .cursor,
+            dailyUsage: [tokenRow(-1, provider: .claudeCode, tokens: 900)],
+            ledger: ledger,
+            accountCount: 1,
+            now: now,
+            calendar: calendar
+        )
+        XCTAssertEqual(cursor.metric, .requests)
+
+        let claude = ProviderDailyUsageSeries.make(
+            service: .claudeCode,
+            dailyUsage: [tokenRow(-1, provider: .claudeCode, tokens: 900)],
+            ledger: ledger,
+            accountCount: 1,
+            now: now,
+            calendar: calendar
+        )
+        XCTAssertEqual(claude.metric, .tokens)
+        XCTAssertEqual(claude.totalValue, 900)
+    }
+
+    /// Which providers write local session logs is a fact about the provider,
+    /// not about the chart — it decides the source here and the empty-state
+    /// copy in the panel, so both read it from the same place.
+    func testOnlyLogWritingProvidersReportLocalTokenHistory() {
+        XCTAssertTrue(ServiceType.claudeCode.writesLocalTokenLogs)
+        XCTAssertTrue(ServiceType.codexCli.writesLocalTokenLogs)
+        XCTAssertTrue(ServiceType.grok.writesLocalTokenLogs)
+        XCTAssertFalse(ServiceType.cursor.writesLocalTokenLogs)
+        XCTAssertFalse(ServiceType.openRouter.writesLocalTokenLogs)
+    }
+}

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ServiceType.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ServiceType.swift
@@ -79,6 +79,27 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
         }
     }
 
+    /// Whether the provider's CLI writes per-session logs on disk that MeterBar
+    /// can scan into a dated token series.
+    ///
+    /// The dividing line behind every "where does this provider's history come
+    /// from" decision. Claude, Codex and Grok write session logs, so their
+    /// history is re-readable and a scan can rebuild it. Cursor and OpenRouter
+    /// publish a single running counter and nothing else, so their only dated
+    /// series is the one `ProviderUsageLedger` accumulates from MeterBar's own
+    /// polls — which also means it cannot be backfilled.
+    ///
+    /// Centralized here for the same reason as `weeklyQuotaTitle`: the cost
+    /// scanners, the usage manager and the popover each encode this split, and
+    /// a chart that picks the wrong source draws an empty week rather than an
+    /// error.
+    public var writesLocalTokenLogs: Bool {
+        switch self {
+        case .claudeCode, .codexCli, .grok: return true
+        case .cursor, .openRouter: return false
+        }
+    }
+
     /// Display title for the third ("code review") quota window. For Claude
     /// Code this window is model-scoped: it echoes the parsed model label
     /// (e.g. "Fable", "Sonnet"), falling back to a neutral "Model" when no


### PR DESCRIPTION
## Problem

Hovering a provider card opened a floating detail panel that showed **the same information the card already showed** — same header, same limit rows, only wider.

The entire delta between the two densities is three text fragments: `"% used"`, the pace label, and an untitled reset (`LimitRow.Density.footerStyle`). The panel cost a window, a hosting view and hover-ownership bookkeeping, and returned almost nothing. CodexBar shows a per-day consumption chart on hover; MeterBar showed a second copy of the same numbers.

## Change

The panel now ends with the hovered provider's **last seven days** — history, which is the one dimension a card that fits three to a popover cannot show.

### `ProviderDailyUsageSeries` (new)

A pure bucketing model, derived once and passed in as a plain value. Two properties are load-bearing:

**Sources are picked from where each provider actually keeps its history.** Only Claude, Codex and Grok produce `DailyTokenUsage` — `TokenUsageAggregator.makeDailyUsage` has exactly three call sites. Cursor and OpenRouter publish a single running counter, so their only dated series is the one `ProviderUsageLedger` accumulates from MeterBar's own polls. A token-sourced Cursor chart would have shown a permanent *"run a cost scan"* empty state for a scan that can never populate it. The split is now named once, on `ServiceType.writesLocalTokenLogs`.

**Units never mix.** Tokens for the log-scanning providers, requests for Cursor, dollars for OpenRouter. The metric rides with the series, so a request count can never be printed with a `$` in front of it — the same guard `ProviderUsageLedger.dailyUSDSeries(for:)` enforces upstream. An unknown unit falls back to `.requests`, never money.

Two smaller honesty details fall out of that:

- **Unobserved days are not zero days.** The ledger has no backfill, so a day before the first poll is unknown, not quiet. Those draw a fainter empty track and are excluded from the accessibility value, rather than claiming MeterBar watched a week it did not.
- **`DailyTokenUsage` has no account dimension,** but the popover draws one card per Claude/Codex/Grok account. When more than one card exists for a provider, the strip captions itself *"Across all N accounts"* instead of implying the figures are that account's.

### `ProviderDailyUsageSparkline` (new)

Seven bars, not `DailyUsageChart`'s thirty: at 340pt those columns would be hairlines, and the panel is provider-scoped so there is nothing to stack. Separated from the rows above by spacing and a quiet section label, **never a rule** — the panel is the same card the pointer is resting on, so it must not sprout chrome the card never had. Bars grow from the baseline through `MeterBarTheme.Motion.resolve`, the same Reduce Motion gate `LimitRow` and `ProviderComponents` use, and the strip carries a single accessibility label and value.

Empty states use the established `EmptyStateCard` vocabulary, and distinguish the two genuinely different situations: a log-scanning provider is one scan away from a full week, while a polled provider can only ever be waiting.

### Drive-by fix: `DailyUsageChart` was provider-blind

`providerOrder` was a hand-written list that stopped at three entries, so **Grok and OpenRouter rows were bucketed into nothing and drew as empty columns** — a silent zero, not an error. It is now derived from `ServiceType.allCases`, and `buildDays` takes an injectable `now`/`calendar` so it can be tested without straddling local midnight. The chart had no test coverage at all; it now has four.

## Testing

TDD — the tests were written against the missing types first.

- `ProviderDailyUsageSeriesTests` (17): window boundaries, provider scoping, sparse and empty history, unit selection per source, ledger coverage, the multi-account flag, and source dispatch.
- `DailyUsageChartBucketingTests` (4): pins `providerOrder` to `ServiceType.allCases` and asserts every provider produces a segment.
- `MenuBarDetailPanelLayoutTests` (+2): the strip keeps the panel under 600pt — inside the visible frame of the smallest display MeterBar runs on, so it never has to fall back to the scrolling variant — and the panel with a strip is measurably taller than without, so the change cannot silently revert to a wider copy of the card.

Local: `swift test` **2210 passed, 0 failures**; `swiftlint lint --strict` **0 violations**.

The panel is still hostable without a live `CostTracker` — `dailyUsage` defaults to `nil`, and the existing layout tests construct it unchanged.