### PR TITLE
chore(release): bump version to 1.8.35

### DIFF
--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.34;
+				MARKETING_VERSION = 1.8.35;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -369,7 +369,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.34;
+				MARKETING_VERSION = 1.8.35;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -534,7 +534,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.34;
+				MARKETING_VERSION = 1.8.35;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug;
 				PRODUCT_NAME = "MeterBar Dev";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -580,7 +580,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.34;
+				MARKETING_VERSION = 1.8.35;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary

- bump app and widget MARKETING_VERSION from 1.8.34 to 1.8.35
- keep CURRENT_PROJECT_VERSION derived from MARKETING_VERSION

## Verification

- scripts/verify-build-identities.sh
- scripts/validate-release-tag.sh v1.8.35
- scripts/test-release-tag.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app and widget extension version to 1.8.35.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->