### PR TITLE
feat(cost): automate display currency conversion

### DIFF
--- a/MeterBar/Models/CLIJSONOutput.swift
+++ b/MeterBar/Models/CLIJSONOutput.swift
@@ -255,21 +255,21 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
     }
 
     /// Presentation-only currency conversion of `totalCostUSD` (issue #270).
-    /// `source` is always `"manual"`: the CLI never persists or fetches a
-    /// rate, so every emission is a fresh, explicit `--currency`/`--rate` pair
-    /// the caller typed for this one invocation — never a cached snapshot.
+    /// CLI-created values remain `manual`; the field also keeps the model
+    /// honest if an app-generated automatic value is encoded in tests.
     private struct DisplayCurrencyJSON: Encodable {
         let code: String
         let unitsPerUSD: Double
         let enteredAt: Date
         let totalCostConverted: Double
-        let source = "manual"
+        let source: String
 
         init(_ currency: DisplayCurrency, totalCostUSD: Double) {
             code = currency.code
             unitsPerUSD = currency.unitsPerUSD
             enteredAt = currency.enteredAt
             totalCostConverted = currency.convert(usd: totalCostUSD)
+            source = currency.source.rawValue
         }
     }
 

--- a/MeterBar/Models/DisplayCurrency.swift
+++ b/MeterBar/Models/DisplayCurrency.swift
@@ -1,29 +1,37 @@
 import Foundation
 
-/// A user-supplied, presentation-only currency conversion for cost views and
-/// the CLI (issue #270). MeterBar NEVER fetches a live exchange rate — the
-/// rate is exactly what the user typed, and every converted figure must show
-/// both the rate and the date it was entered so it can't be mistaken for a
-/// live quote. Stored and exported cost data (JSON, daily usage, breakdowns)
-/// always stays USD; this type only affects what is rendered on screen.
-nonisolated public struct DisplayCurrency: Equatable, Sendable {
-    /// Free-form currency code/label the user types (e.g. "EUR", "JPY",
-    /// "credits"). Not validated against ISO 4217 or any live list — MeterBar
-    /// has no way to look one up without a network call, which is explicitly
-    /// out of scope for this feature.
-    public let code: String
-    /// User-supplied units of `code` per 1 USD. `convert` treats a
-    /// non-positive rate as an identity fallback; the store that persists
-    /// this value is responsible for rejecting one before it's saved.
-    public let unitsPerUSD: Double
-    /// When the user entered this rate — shown alongside every converted
-    /// figure so it reads as a manual snapshot, never a live quote.
-    public let enteredAt: Date
+nonisolated public enum DisplayCurrencySource: String, Equatable, Sendable {
+    case manual
+    case europeanCentralBank = "ecb"
+    case system
+}
 
-    public init(code: String, unitsPerUSD: Double, enteredAt: Date) {
+/// A presentation-only currency conversion for cost views and the CLI.
+/// Stored and exported cost data (JSON, daily usage, breakdowns) always stays
+/// USD; this type only affects what is rendered on screen. App-generated
+/// conversions carry their official reference date, while CLI conversions
+/// remain explicit manual snapshots.
+nonisolated public struct DisplayCurrency: Equatable, Sendable {
+    /// ISO currency code for automatic rates, or the user's free-form label
+    /// for a manual conversion.
+    public let code: String
+    /// Units of `code` per 1 USD. `convert` treats a non-positive rate as an
+    /// identity fallback; the store rejects one before it is saved.
+    public let unitsPerUSD: Double
+    /// Manual entry time or the official reference date for an automatic rate.
+    public let enteredAt: Date
+    public let source: DisplayCurrencySource
+
+    public init(
+        code: String,
+        unitsPerUSD: Double,
+        enteredAt: Date,
+        source: DisplayCurrencySource = .manual
+    ) {
         self.code = code
         self.unitsPerUSD = unitsPerUSD
         self.enteredAt = enteredAt
+        self.source = source
     }
 
     /// Converts a USD amount to `code`, rounded to 2 decimal places (the same
@@ -44,11 +52,31 @@ nonisolated public struct DisplayCurrency: Equatable, Sendable {
         return formatter
     }()
 
-    /// Disclosure text shown next to every converted figure, e.g.
-    /// "1 USD = 0.92 EUR, entered 2026-07-20" — the fixed pairing of rate and
-    /// entry date that keeps a converted number from reading as a live quote.
+    /// ECB dates are calendar dates, parsed at midnight UTC. Formatting them
+    /// in a negative local offset would otherwise display the previous day.
+    private static let referenceDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    /// Disclosure text shown next to every converted figure. Automatic quotes
+    /// name their source and reference day; manual snapshots retain the entry
+    /// date so neither can be mistaken for a transaction-grade live quote.
     public var disclosureText: String {
-        "1 USD = \(formattedRate) \(code), entered \(Self.enteredAtFormatter.string(from: enteredAt))"
+        switch source {
+        case .manual:
+            let day = Self.enteredAtFormatter.string(from: enteredAt)
+            return "1 USD = \(formattedRate) \(code), entered \(day)"
+        case .europeanCentralBank:
+            let day = Self.referenceDateFormatter.string(from: enteredAt)
+            return "1 USD = \(formattedRate) \(code), ECB reference rate \(day)"
+        case .system:
+            return "1 USD = \(formattedRate) \(code), from Mac region settings"
+        }
     }
 
     /// Trims insignificant trailing zeros (e.g. `150` not `150.0000`,

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -161,14 +161,17 @@ nonisolated enum StorageKeys {
 
     // MARK: - Display Currency (#270)
 
-    /// User-typed currency code/label (e.g. "EUR"). Presentation only — stored
-    /// and exported cost data always stays USD. Missing means "no conversion,
-    /// show USD" — the default.
+    /// Display currency code/label. Presentation only — stored and exported
+    /// cost data always stays USD.
     static let displayCurrencyCode = "DisplayCurrencyCode"
-    /// User-supplied units of `displayCurrencyCode` per 1 USD. MeterBar never
-    /// fetches this from a live/network source.
+    /// Units of `displayCurrencyCode` per 1 USD.
     static let displayCurrencyRate = "DisplayCurrencyRate"
-    /// When the user entered the rate above. Shown next to every converted
-    /// figure so it can never be mistaken for a live quote.
+    /// Manual entry time or official reference date for the saved rate.
     static let displayCurrencyEnteredAt = "DisplayCurrencyEnteredAt"
+    /// `DisplayCurrencySource` raw value. Missing migrates to `.manual`.
+    static let displayCurrencySource = "DisplayCurrencySource"
+    /// Whether the app should detect the Mac's currency and refresh its rate.
+    static let displayCurrencyAutomatic = "DisplayCurrencyAutomatic"
+    /// Last successful automatic refresh, used to cap fetches at once per day.
+    static let displayCurrencyLastRefreshAt = "DisplayCurrencyLastRefreshAt"
 }

--- a/MeterBar/Services/DisplayCurrencyRateClient.swift
+++ b/MeterBar/Services/DisplayCurrencyRateClient.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// One official reference-rate snapshot converted into the app's
+/// "target-currency units per 1 USD" representation.
+nonisolated struct DisplayCurrencyRateQuote: Equatable, Sendable {
+    let code: String
+    let unitsPerUSD: Double
+    let referenceDate: Date
+}
+
+nonisolated enum DisplayCurrencyRateError: LocalizedError {
+    case invalidResponse
+    case invalidPayload
+    case unsupportedCurrency(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            "The exchange-rate service returned an invalid response."
+        case .invalidPayload:
+            "The exchange-rate service returned unreadable data."
+        case .unsupportedCurrency(let code):
+            "The ECB does not publish a reference rate for \(code)."
+        }
+    }
+}
+
+/// Fetches the European Central Bank's keyless daily reference-rate feed.
+///
+/// The ECB quotes every published currency as units per EUR. MeterBar stores
+/// units per USD, so a target rate is `targetPerEUR / usdPerEUR`. The service
+/// is deliberately stateless; `DisplayCurrencyStore` owns refresh cadence and
+/// the last-known-good offline cache.
+nonisolated struct DisplayCurrencyRateClient {
+    typealias FetchData = (URLRequest) async throws -> (Data, URLResponse)
+
+    private static let feedURL = URL(
+        string: "https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml"
+    )!
+
+    private let fetchData: FetchData
+
+    init(fetchData: FetchData? = nil) {
+        self.fetchData = fetchData ?? { request in
+            try await ServiceSupport.session.data(for: request)
+        }
+    }
+
+    func fetchRate(for rawCode: String) async throws -> DisplayCurrencyRateQuote {
+        let code = rawCode.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        guard !code.isEmpty else {
+            throw DisplayCurrencyRateError.unsupportedCurrency(rawCode)
+        }
+
+        var request = URLRequest(url: Self.feedURL)
+        request.timeoutInterval = 15
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.setValue("application/xml", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await fetchData(request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw DisplayCurrencyRateError.invalidResponse
+        }
+        return try Self.parse(data, targetCode: code)
+    }
+
+    static func parse(_ data: Data, targetCode: String) throws -> DisplayCurrencyRateQuote {
+        let delegate = ECBReferenceRateParser()
+        let parser = XMLParser(data: data)
+        parser.delegate = delegate
+        guard parser.parse(), let rawReferenceDate = delegate.referenceDate else {
+            throw DisplayCurrencyRateError.invalidPayload
+        }
+
+        let code = targetCode.uppercased()
+        guard let usdPerEUR = delegate.ratesPerEUR["USD"], usdPerEUR > 0 else {
+            throw DisplayCurrencyRateError.invalidPayload
+        }
+
+        let targetPerEUR: Double
+        if code == "EUR" {
+            targetPerEUR = 1
+        } else if code == "USD" {
+            targetPerEUR = usdPerEUR
+        } else if let publishedRate = delegate.ratesPerEUR[code], publishedRate > 0 {
+            targetPerEUR = publishedRate
+        } else {
+            throw DisplayCurrencyRateError.unsupportedCurrency(code)
+        }
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.calendar = Calendar(identifier: .gregorian)
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        guard let referenceDate = dateFormatter.date(from: rawReferenceDate) else {
+            throw DisplayCurrencyRateError.invalidPayload
+        }
+
+        return DisplayCurrencyRateQuote(
+            code: code,
+            unitsPerUSD: targetPerEUR / usdPerEUR,
+            referenceDate: referenceDate
+        )
+    }
+}
+
+nonisolated private final class ECBReferenceRateParser: NSObject, XMLParserDelegate {
+    private(set) var referenceDate: String?
+    private(set) var ratesPerEUR: [String: Double] = [:]
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        if let time = attributeDict["time"] {
+            referenceDate = time
+        }
+        guard let currency = attributeDict["currency"],
+              let rawRate = attributeDict["rate"],
+              let rate = Double(rawRate),
+              rate > 0,
+              rate.isFinite else {
+            return
+        }
+        ratesPerEUR[currency.uppercased()] = rate
+    }
+}

--- a/MeterBar/Services/DisplayCurrencyStore.swift
+++ b/MeterBar/Services/DisplayCurrencyStore.swift
@@ -1,67 +1,187 @@
 import Combine
 import Foundation
 
-/// Persists the user's optional presentation-only currency conversion
-/// (issue #270). MeterBar never fetches a live exchange rate: `currency` is
-/// exactly what the user typed, paired with the moment they entered it, so a
-/// converted figure is never mistaken for a live quote. `nil` means "no
-/// conversion, show USD" — the default and the only state that ships out of
-/// the box.
+/// Persists the optional presentation-only currency conversion.
+///
+/// Automatic mode detects the currency configured in macOS Region settings,
+/// refreshes it from the ECB at most once per day, and keeps the last
+/// successful quote for offline use. Manual mode remains available for a
+/// currency the ECB does not publish. Stored and exported cost data stays USD.
 final class DisplayCurrencyStore: ObservableObject {
     static let shared = DisplayCurrencyStore()
 
     @Published private(set) var currency: DisplayCurrency?
+    @Published private(set) var isAutomatic: Bool
+    @Published private(set) var isRefreshingAutomaticRate = false
+    @Published private(set) var automaticRateError: String?
+
+    var detectedCurrencyCode: String? {
+        Self.normalizedCode(localeCurrencyCode())
+    }
+
+    private static let automaticRefreshInterval: TimeInterval = 24 * 60 * 60
 
     private let userDefaults: UserDefaults
+    private let fetchAutomaticRate: (String) async throws -> DisplayCurrencyRateQuote
+    private let localeCurrencyCode: () -> String?
+    private let now: () -> Date
 
-    /// Internal (not private) so tests can construct an instance backed by an
-    /// isolated `UserDefaults` suite; production code uses `shared`.
-    init(userDefaults: UserDefaults = .standard) {
+    /// Internal seams keep locale, time, networking, and persistence fully
+    /// deterministic in tests. Production uses the official ECB client.
+    init(
+        userDefaults: UserDefaults = .standard,
+        fetchAutomaticRate: ((String) async throws -> DisplayCurrencyRateQuote)? = nil,
+        localeCurrencyCode: @escaping () -> String? = { Locale.autoupdatingCurrent.currency?.identifier },
+        now: @escaping () -> Date = Date.init
+    ) {
         self.userDefaults = userDefaults
+        self.fetchAutomaticRate = fetchAutomaticRate ?? { code in
+            try await DisplayCurrencyRateClient().fetchRate(for: code)
+        }
+        self.localeCurrencyCode = localeCurrencyCode
+        self.now = now
+        currency = nil
+        isAutomatic = false
         load()
+
+        if userDefaults.object(forKey: StorageKeys.displayCurrencyAutomatic) != nil {
+            isAutomatic = userDefaults.bool(forKey: StorageKeys.displayCurrencyAutomatic)
+        } else {
+            // Preserve an existing manual conversion during migration. Fresh
+            // installs have no conversion and opt into the useful default.
+            isAutomatic = currency == nil
+        }
     }
 
-    /// Read-only projection for the CLI, mirroring `ProviderVisibilityStore`'s
-    /// second initializer — no `UserDefaults` access, just the decoded value.
+    /// Read-only projection used by CLI-oriented call sites and tests.
     init(currency: DisplayCurrency?) {
         userDefaults = .standard
+        fetchAutomaticRate = { code in
+            throw DisplayCurrencyRateError.unsupportedCurrency(code)
+        }
+        localeCurrencyCode = { nil }
+        now = Date.init
         self.currency = currency
+        isAutomatic = false
     }
 
-    /// Saves a new rate. `code` is trimmed and uppercased for display
-    /// consistency. A rate that is non-positive, infinite, or NaN can never
-    /// produce a meaningful converted figure, so it clears the conversion
-    /// instead of saving one. (`Double.infinity` passes `> 0`, so the finite
-    /// check has to be explicit or every converted total becomes "inf".)
+    /// Saves an explicit manual rate and disables background replacement.
     func set(code: String, rate: Double) {
-        let trimmedCode = code.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        let trimmedCode = Self.normalizedCode(code) ?? ""
         guard !trimmedCode.isEmpty, rate > 0, rate.isFinite else {
             clear()
             return
         }
-        let next = DisplayCurrency(code: trimmedCode, unitsPerUSD: rate, enteredAt: Date())
+        let next = DisplayCurrency(
+            code: trimmedCode,
+            unitsPerUSD: rate,
+            enteredAt: now(),
+            source: .manual
+        )
+        isAutomatic = false
+        automaticRateError = nil
+        userDefaults.set(false, forKey: StorageKeys.displayCurrencyAutomatic)
+        userDefaults.removeObject(forKey: StorageKeys.displayCurrencyLastRefreshAt)
         currency = next
         persist(next)
     }
 
-    /// Removes any saved conversion, reverting cost views to plain USD.
+    func setAutomaticEnabled(_ enabled: Bool) {
+        isAutomatic = enabled
+        automaticRateError = nil
+        userDefaults.set(enabled, forKey: StorageKeys.displayCurrencyAutomatic)
+    }
+
+    /// Refreshes only when automatic mode is enabled and the cached fetch is
+    /// stale, unless the user explicitly requested `force` from Settings.
+    /// Failures never discard the last-known-good quote.
+    func refreshAutomaticCurrency(force: Bool = false) async {
+        guard isAutomatic, !isRefreshingAutomaticRate else { return }
+        guard let code = detectedCurrencyCode else {
+            automaticRateError = "Choose a currency in macOS Region settings or enter a manual rate."
+            return
+        }
+
+        let refreshDate = userDefaults.object(forKey: StorageKeys.displayCurrencyLastRefreshAt) as? Date
+        let cacheMatches = currency?.code == code && currency?.source != .manual
+        if !force,
+           cacheMatches,
+           let refreshDate,
+           now().timeIntervalSince(refreshDate) < Self.automaticRefreshInterval {
+            return
+        }
+
+        isRefreshingAutomaticRate = true
+        automaticRateError = nil
+        defer { isRefreshingAutomaticRate = false }
+
+        do {
+            let next: DisplayCurrency
+            if code == "USD" {
+                next = DisplayCurrency(
+                    code: "USD",
+                    unitsPerUSD: 1,
+                    enteredAt: now(),
+                    source: .system
+                )
+            } else {
+                let quote = try await fetchAutomaticRate(code)
+                guard quote.unitsPerUSD > 0, quote.unitsPerUSD.isFinite else {
+                    throw DisplayCurrencyRateError.invalidPayload
+                }
+                next = DisplayCurrency(
+                    code: quote.code,
+                    unitsPerUSD: quote.unitsPerUSD,
+                    enteredAt: quote.referenceDate,
+                    source: .europeanCentralBank
+                )
+            }
+
+            currency = next
+            persist(next)
+            userDefaults.set(true, forKey: StorageKeys.displayCurrencyAutomatic)
+            userDefaults.set(now(), forKey: StorageKeys.displayCurrencyLastRefreshAt)
+        } catch let error as DisplayCurrencyRateError {
+            automaticRateError = error.localizedDescription + offlineFallbackSuffix
+        } catch {
+            automaticRateError = "The automatic exchange rate could not be updated." + offlineFallbackSuffix
+        }
+    }
+
+    /// Removes the saved conversion and disables automatic mode so choosing
+    /// "Show USD" remains stable across view appearances.
     func clear() {
         currency = nil
+        isAutomatic = false
+        automaticRateError = nil
+        userDefaults.set(false, forKey: StorageKeys.displayCurrencyAutomatic)
         userDefaults.removeObject(forKey: StorageKeys.displayCurrencyCode)
         userDefaults.removeObject(forKey: StorageKeys.displayCurrencyRate)
         userDefaults.removeObject(forKey: StorageKeys.displayCurrencyEnteredAt)
+        userDefaults.removeObject(forKey: StorageKeys.displayCurrencySource)
+        userDefaults.removeObject(forKey: StorageKeys.displayCurrencyLastRefreshAt)
+    }
+
+    private var offlineFallbackSuffix: String {
+        currency == nil ? " Enter a manual rate instead." : " The last saved rate is still in use."
+    }
+
+    private static func normalizedCode(_ code: String?) -> String? {
+        guard let code else { return nil }
+        let normalized = code.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        return normalized.isEmpty ? nil : normalized
     }
 
     private func persist(_ currency: DisplayCurrency) {
         userDefaults.set(currency.code, forKey: StorageKeys.displayCurrencyCode)
         userDefaults.set(currency.unitsPerUSD, forKey: StorageKeys.displayCurrencyRate)
         userDefaults.set(currency.enteredAt, forKey: StorageKeys.displayCurrencyEnteredAt)
+        userDefaults.set(currency.source.rawValue, forKey: StorageKeys.displayCurrencySource)
     }
 
     private func load() {
         guard
-            let code = userDefaults.string(forKey: StorageKeys.displayCurrencyCode),
-            !code.isEmpty,
+            let code = Self.normalizedCode(userDefaults.string(forKey: StorageKeys.displayCurrencyCode)),
             userDefaults.object(forKey: StorageKeys.displayCurrencyRate) != nil
         else {
             currency = nil
@@ -72,7 +192,14 @@ final class DisplayCurrencyStore: ObservableObject {
             currency = nil
             return
         }
-        let enteredAt = userDefaults.object(forKey: StorageKeys.displayCurrencyEnteredAt) as? Date ?? Date()
-        currency = DisplayCurrency(code: code, unitsPerUSD: rate, enteredAt: enteredAt)
+        let enteredAt = userDefaults.object(forKey: StorageKeys.displayCurrencyEnteredAt) as? Date ?? now()
+        let source = userDefaults.string(forKey: StorageKeys.displayCurrencySource)
+            .flatMap(DisplayCurrencySource.init(rawValue:)) ?? .manual
+        currency = DisplayCurrency(
+            code: code,
+            unitsPerUSD: rate,
+            enteredAt: enteredAt,
+            source: source
+        )
     }
 }

--- a/MeterBar/Views/Settings/CostSettingsView.swift
+++ b/MeterBar/Views/Settings/CostSettingsView.swift
@@ -510,46 +510,86 @@ struct CostSettingsView: View {
         .accessibilityIdentifier("cost-period-picker")
     }
 
-    /// Presentation-only currency preference entry (issue #270). MeterBar
-    /// never fetches a live rate — this only accepts what the user types —
-    /// and the disclosure notice below always pairs the stored rate with the
-    /// date it was entered so a converted figure can't read as a live quote.
-    /// Shown regardless of scan state: entering a rate ahead of the first
-    /// scan is harmless, since it only affects how future totals render.
+    /// Presentation-only currency preference. Automatic mode uses the Mac's
+    /// region currency and the ECB's daily reference feed; manual entry remains
+    /// available for unsupported currencies. Stored/exported data stays USD.
     private var displayCurrencySection: some View {
         SettingsPanelSection(title: "Display Currency", systemImage: "banknote", color: MeterBarTheme.warning) {
-            Text("Converts the totals above for display only. Stored and exported cost data always stays USD.")
+            Text("Converts totals for display only. Stored and exported cost data always stays USD.")
                 .font(.caption)
                 .foregroundColor(.secondary)
 
-            SettingsRowView(title: "Currency code") {
-                TextField("e.g. EUR", text: $currencyCodeInput)
-                    .textFieldStyle(.roundedBorder)
-                    .accessibilityIdentifier("display-currency-code-field")
-            }
-
-            SettingsRowView(title: "Units per 1 USD") {
-                TextField("e.g. 0.92", text: $currencyRateInput)
-                    .textFieldStyle(.roundedBorder)
-                    .accessibilityIdentifier("display-currency-rate-field")
-            }
-
-            HStack(spacing: 8) {
-                Spacer(minLength: 0)
-
-                Button("Save") {
-                    guard let rate = parsedCurrencyRate else { return }
-                    displayCurrencyStore.set(code: currencyCodeInput, rate: rate)
+            SettingsRowView(title: "Automatic rate") {
+                HStack(spacing: 8) {
+                    if displayCurrencyStore.isRefreshingAutomaticRate {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                    Toggle("Automatic rate", isOn: automaticCurrencyBinding)
+                        .labelsHidden()
+                        .accessibilityIdentifier("display-currency-automatic-toggle")
                 }
-                .buttonStyle(.bordered)
-                .disabled(
-                    currencyCodeInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                        || parsedCurrencyRate == nil
-                )
-                .accessibilityIdentifier("display-currency-save-button")
+            }
 
-                if displayCurrencyStore.currency != nil {
-                    Button("Clear", role: .destructive) {
+            if displayCurrencyStore.isAutomatic {
+                Text("Uses the currency in macOS Region settings and ECB reference rates, refreshed daily.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                SettingsRowView(title: "Currency") {
+                    HStack(spacing: 10) {
+                        Text(displayCurrencyStore.detectedCurrencyCode ?? "Not configured")
+                            .foregroundStyle(.secondary)
+
+                        Button("Refresh Now") {
+                            refreshAutomaticCurrency(force: true)
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(displayCurrencyStore.isRefreshingAutomaticRate)
+                        .accessibilityIdentifier("display-currency-refresh-button")
+                    }
+                }
+
+                if let error = displayCurrencyStore.automaticRateError {
+                    SettingsNotice(text: error, color: MeterBarTheme.warning)
+                }
+            } else {
+                Text("Enter a manual rate only if you do not want to use the currency from your Mac's region.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                SettingsRowView(title: "Currency code") {
+                    TextField("e.g. EUR", text: $currencyCodeInput)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityIdentifier("display-currency-code-field")
+                }
+
+                SettingsRowView(title: "Units per 1 USD") {
+                    TextField("e.g. 0.92", text: $currencyRateInput)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityIdentifier("display-currency-rate-field")
+                }
+
+                HStack(spacing: 8) {
+                    Spacer(minLength: 0)
+
+                    Button("Save Manual Rate") {
+                        guard let rate = parsedCurrencyRate else { return }
+                        displayCurrencyStore.set(code: currencyCodeInput, rate: rate)
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(
+                        currencyCodeInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            || parsedCurrencyRate == nil
+                    )
+                    .accessibilityIdentifier("display-currency-save-button")
+                }
+            }
+
+            if displayCurrencyStore.currency != nil {
+                HStack {
+                    Spacer(minLength: 0)
+                    Button("Show USD", role: .destructive) {
                         displayCurrencyStore.clear()
                         currencyCodeInput = ""
                         currencyRateInput = ""
@@ -563,7 +603,24 @@ struct CostSettingsView: View {
                 SettingsNotice(text: currency.disclosureText, color: .secondary)
             }
         }
-        .onAppear(perform: syncCurrencyInputsFromStore)
+        .onAppear {
+            syncCurrencyInputsFromStore()
+            refreshAutomaticCurrency()
+        }
+    }
+
+    private var automaticCurrencyBinding: Binding<Bool> {
+        Binding(
+            get: { displayCurrencyStore.isAutomatic },
+            set: { enabled in
+                displayCurrencyStore.setAutomaticEnabled(enabled)
+                if enabled {
+                    refreshAutomaticCurrency(force: true)
+                } else {
+                    syncCurrencyInputsFromStore()
+                }
+            }
+        )
     }
 
     /// `Double("inf")` and `Double("nan")` both parse, so plain
@@ -578,6 +635,13 @@ struct CostSettingsView: View {
         guard let currency = displayCurrencyStore.currency else { return }
         currencyCodeInput = currency.code
         currencyRateInput = String(currency.unitsPerUSD)
+    }
+
+    private func refreshAutomaticCurrency(force: Bool = false) {
+        Task {
+            await displayCurrencyStore.refreshAutomaticCurrency(force: force)
+            syncCurrencyInputsFromStore()
+        }
     }
 
     private func formatDate(_ date: Date) -> String {

--- a/MeterBarTests/DisplayCurrencyRateClientTests.swift
+++ b/MeterBarTests/DisplayCurrencyRateClientTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+@testable import MeterBar
+import XCTest
+
+final class DisplayCurrencyRateClientTests: XCTestCase {
+    private let feed = Data(
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <gesmes:Envelope xmlns:gesmes="http://www.gesmes.org/xml/2002-08-01"
+            xmlns="http://www.ecb.int/vocabulary/2002-08-01/eurofxref">
+          <Cube>
+            <Cube time="2026-08-08">
+              <Cube currency="USD" rate="1.2000"/>
+              <Cube currency="JPY" rate="150.0000"/>
+              <Cube currency="GBP" rate="0.8400"/>
+            </Cube>
+          </Cube>
+        </gesmes:Envelope>
+        """.utf8
+    )
+
+    func testParsesEuroRateAsTheReciprocalOfUSDPerEuro() throws {
+        let quote = try DisplayCurrencyRateClient.parse(feed, targetCode: "EUR")
+
+        XCTAssertEqual(quote.code, "EUR")
+        XCTAssertEqual(quote.unitsPerUSD, 1 / 1.2, accuracy: 0.000_001)
+        XCTAssertEqual(day(quote.referenceDate), "2026-08-08")
+    }
+
+    func testConvertsAnotherEuroQuoteIntoUnitsPerUSD() throws {
+        let quote = try DisplayCurrencyRateClient.parse(feed, targetCode: "jpy")
+
+        XCTAssertEqual(quote.code, "JPY")
+        XCTAssertEqual(quote.unitsPerUSD, 125, accuracy: 0.000_001)
+    }
+
+    func testUSDIsAnIdentityRate() throws {
+        let quote = try DisplayCurrencyRateClient.parse(feed, targetCode: "USD")
+
+        XCTAssertEqual(quote.unitsPerUSD, 1, accuracy: 0.000_001)
+    }
+
+    func testUnsupportedCurrencyFailsInsteadOfInventingARate() {
+        XCTAssertThrowsError(try DisplayCurrencyRateClient.parse(feed, targetCode: "BTC")) { error in
+            guard case DisplayCurrencyRateError.unsupportedCurrency("BTC") = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testFetchUsesTheOfficialECBFeedAndRejectsHTTPFailure() async throws {
+        var requestedURL: URL?
+        let client = DisplayCurrencyRateClient { request in
+            requestedURL = request.url
+            let response = try XCTUnwrap(
+                HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 503, httpVersion: nil, headerFields: nil)
+            )
+            return (Data(), response)
+        }
+
+        do {
+            _ = try await client.fetchRate(for: "EUR")
+            XCTFail("Expected the HTTP failure to be rejected")
+        } catch DisplayCurrencyRateError.invalidResponse {
+            // Expected.
+        }
+
+        XCTAssertEqual(
+            requestedURL?.absoluteString,
+            "https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml"
+        )
+    }
+
+    private func day(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+}

--- a/MeterBarTests/DisplayCurrencyStoreTests.swift
+++ b/MeterBarTests/DisplayCurrencyStoreTests.swift
@@ -1,15 +1,15 @@
 import XCTest
 @testable import MeterBar
 
-/// Unit tests for `DisplayCurrencyStore` — the `UserDefaults`-backed
-/// persistence layer for the presentation-only currency conversion behind
-/// issue #270, modeled on `ProviderVisibilityStore`'s test conventions.
+/// Unit tests for the UserDefaults-backed manual and automatic conversion
+/// modes, with locale, clock, and networking injected.
 final class DisplayCurrencyStoreTests: XCTestCase {
     func testDefaultsToNoConversionWhenNothingHasBeenSaved() {
         withIsolatedDefaults { defaults in
             let store = DisplayCurrencyStore(userDefaults: defaults)
 
             XCTAssertNil(store.currency)
+            XCTAssertTrue(store.isAutomatic)
         }
     }
 
@@ -19,9 +19,13 @@ final class DisplayCurrencyStoreTests: XCTestCase {
 
             store.set(code: "eur", rate: 0.92)
 
-            let currency = try! XCTUnwrap(store.currency)
+            guard let currency = store.currency else {
+                return XCTFail("Expected the manual currency to be saved")
+            }
             XCTAssertEqual(currency.code, "EUR")
             XCTAssertEqual(currency.unitsPerUSD, 0.92, accuracy: 0.0001)
+            XCTAssertEqual(currency.source, .manual)
+            XCTAssertFalse(store.isAutomatic)
             XCTAssertLessThan(abs(currency.enteredAt.timeIntervalSinceNow), 5)
 
             let reloaded = DisplayCurrencyStore(userDefaults: defaults)
@@ -93,7 +97,114 @@ final class DisplayCurrencyStoreTests: XCTestCase {
             store.clear()
 
             XCTAssertNil(store.currency)
+            XCTAssertFalse(store.isAutomatic)
             XCTAssertNil(DisplayCurrencyStore(userDefaults: defaults).currency)
+        }
+    }
+
+    func testExistingSavedRateMigratesAsManualWithoutAutomaticReplacement() {
+        withIsolatedDefaults { defaults in
+            defaults.set("EUR", forKey: StorageKeys.displayCurrencyCode)
+            defaults.set(0.92, forKey: StorageKeys.displayCurrencyRate)
+            defaults.set(Date(timeIntervalSince1970: 1_784_000_000), forKey: StorageKeys.displayCurrencyEnteredAt)
+
+            let store = DisplayCurrencyStore(userDefaults: defaults)
+
+            XCTAssertEqual(store.currency?.source, .manual)
+            XCTAssertFalse(store.isAutomatic)
+        }
+    }
+
+    func testAutomaticRefreshDetectsLocaleFetchesAndPersistsOfficialRate() async {
+        await withIsolatedDefaults { defaults in
+            let now = Date(timeIntervalSince1970: 1_786_000_000)
+            let referenceDate = Date(timeIntervalSince1970: 1_785_888_000)
+            var requestedCodes: [String] = []
+            let store = DisplayCurrencyStore(
+                userDefaults: defaults,
+                fetchAutomaticRate: { code in
+                    requestedCodes.append(code)
+                    return DisplayCurrencyRateQuote(
+                        code: code,
+                        unitsPerUSD: 0.8645,
+                        referenceDate: referenceDate
+                    )
+                },
+                localeCurrencyCode: { "eur" },
+                now: { now }
+            )
+
+            await store.refreshAutomaticCurrency()
+
+            XCTAssertEqual(requestedCodes, ["EUR"])
+            XCTAssertEqual(store.currency?.code, "EUR")
+            XCTAssertEqual(store.currency?.unitsPerUSD ?? 0, 0.8645, accuracy: 0.000_001)
+            XCTAssertEqual(store.currency?.enteredAt, referenceDate)
+            XCTAssertEqual(store.currency?.source, .europeanCentralBank)
+            XCTAssertTrue(defaults.bool(forKey: StorageKeys.displayCurrencyAutomatic))
+
+            let reloaded = DisplayCurrencyStore(userDefaults: defaults)
+            XCTAssertEqual(reloaded.currency, store.currency)
+            XCTAssertTrue(reloaded.isAutomatic)
+        }
+    }
+
+    func testFreshAutomaticCacheDoesNotFetchAgain() async {
+        await withIsolatedDefaults { defaults in
+            let now = Date(timeIntervalSince1970: 1_786_000_000)
+            var fetchCount = 0
+            let store = DisplayCurrencyStore(
+                userDefaults: defaults,
+                fetchAutomaticRate: { code in
+                    fetchCount += 1
+                    return DisplayCurrencyRateQuote(code: code, unitsPerUSD: 0.86, referenceDate: now)
+                },
+                localeCurrencyCode: { "EUR" },
+                now: { now }
+            )
+
+            await store.refreshAutomaticCurrency()
+            await store.refreshAutomaticCurrency()
+
+            XCTAssertEqual(fetchCount, 1)
+        }
+    }
+
+    func testAutomaticFailureKeepsLastSavedRate() async {
+        await withIsolatedDefaults { defaults in
+            let store = DisplayCurrencyStore(
+                userDefaults: defaults,
+                fetchAutomaticRate: { _ in throw URLError(.notConnectedToInternet) },
+                localeCurrencyCode: { "EUR" }
+            )
+            store.set(code: "EUR", rate: 0.91)
+            let saved = store.currency
+            store.setAutomaticEnabled(true)
+
+            await store.refreshAutomaticCurrency(force: true)
+
+            XCTAssertEqual(store.currency, saved)
+            XCTAssertEqual(store.automaticRateError?.contains("last saved rate"), true)
+        }
+    }
+
+    func testUSDAutomaticModeUsesIdentityWithoutNetwork() async {
+        await withIsolatedDefaults { defaults in
+            var didFetch = false
+            let store = DisplayCurrencyStore(
+                userDefaults: defaults,
+                fetchAutomaticRate: { code in
+                    didFetch = true
+                    throw DisplayCurrencyRateError.unsupportedCurrency(code)
+                },
+                localeCurrencyCode: { "USD" }
+            )
+
+            await store.refreshAutomaticCurrency()
+
+            XCTAssertFalse(didFetch)
+            XCTAssertEqual(store.currency?.unitsPerUSD, 1)
+            XCTAssertEqual(store.currency?.source, .system)
         }
     }
 
@@ -104,5 +215,14 @@ final class DisplayCurrencyStoreTests: XCTestCase {
         }
         defer { defaults.removePersistentDomain(forName: suiteName) }
         body(defaults)
+    }
+
+    private func withIsolatedDefaults(_ body: (UserDefaults) async -> Void) async {
+        let suiteName = "DisplayCurrencyStoreTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Could not create isolated defaults")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        await body(defaults)
     }
 }

--- a/MeterBarTests/DisplayCurrencyTests.swift
+++ b/MeterBarTests/DisplayCurrencyTests.swift
@@ -1,10 +1,8 @@
 import XCTest
 @testable import MeterBar
 
-/// Unit tests for `DisplayCurrency` — the presentation-only, user-supplied
-/// conversion behind issue #270. MeterBar never fetches a live exchange rate;
-/// these tests pin down the rounding rule and the disclosure text that keeps
-/// a converted figure from being mistaken for a live quote.
+/// Unit tests for the presentation-only conversion model. These pin down the
+/// rounding rule and source-aware disclosure text.
 final class DisplayCurrencyTests: XCTestCase {
     private let enteredAt = Date(timeIntervalSince1970: 1_784_000_000)
 
@@ -13,6 +11,15 @@ final class DisplayCurrencyTests: XCTestCase {
     private var enteredAtDayString: String {
         let formatter = DateFormatter()
         formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: enteredAt)
+    }
+
+    private var referenceDateDayString: String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter.string(from: enteredAt)
     }
@@ -59,6 +66,31 @@ final class DisplayCurrencyTests: XCTestCase {
         let currency = DisplayCurrency(code: "EUR", unitsPerUSD: 0.92, enteredAt: enteredAt)
 
         XCTAssertEqual(currency.disclosureText, "1 USD = 0.92 EUR, entered \(enteredAtDayString)")
+    }
+
+    func testAutomaticDisclosureNamesECBAndItsReferenceDate() {
+        let currency = DisplayCurrency(
+            code: "EUR",
+            unitsPerUSD: 0.92,
+            enteredAt: enteredAt,
+            source: .europeanCentralBank
+        )
+
+        XCTAssertEqual(
+            currency.disclosureText,
+            "1 USD = 0.92 EUR, ECB reference rate \(referenceDateDayString)"
+        )
+    }
+
+    func testSystemIdentityDisclosureNamesMacRegionSettings() {
+        let currency = DisplayCurrency(
+            code: "USD",
+            unitsPerUSD: 1,
+            enteredAt: enteredAt,
+            source: .system
+        )
+
+        XCTAssertEqual(currency.disclosureText, "1 USD = 1 USD, from Mac region settings")
     }
 
     func testConvertTreatsANonFiniteRateAsAnIdentityFallback() {

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ by itself once a limit resets.
 
 - **Local Cost Scan**: 30-day token spend computed from local session logs — nothing is uploaded
 - **Optimize Tab**: See where tokens actually go, and which provider has the most headroom right now
-- **Display Currency**: Show costs in your own currency at a rate you enter (Settings → Costs)
+- **Display Currency**: Automatically show costs in your Mac's regional currency using daily ECB reference rates, with an offline cache and manual fallback (Settings → Costs)
 
 ### Scripting
 
@@ -233,8 +233,11 @@ corpus each time. Nothing is uploaded; the numbers are derived entirely from
 files already on your disk.
 
 Set a **Display Currency** under **Settings → Costs** to show totals in a
-currency other than USD, using a conversion rate you enter yourself. MeterBar
-does not fetch exchange rates.
+currency other than USD. MeterBar detects the currency from your Mac's Region
+settings, refreshes the official ECB reference rate daily, and keeps the last
+successful quote offline. Manual rates remain available for currencies the ECB
+does not publish. The automatic refresh sends no usage or cost data; it only
+requests the ECB's public daily rate feed.
 
 ## CLI Tool
 


### PR DESCRIPTION
## Summary

- detect the display currency from macOS Region settings
- fetch keyless daily reference rates from the European Central Bank and convert them to units per USD
- cache the last successful quote for offline use and refresh at most daily
- preserve existing manual rates and keep manual entry for currencies the ECB does not publish
- disclose the automatic source and official reference date in the UI

Depends on #423. This PR is stacked on the 1.8.35 version bump and will be retargeted to master after it merges.

## Privacy

The automatic refresh requests only the ECB public XML feed. No usage, cost, account, or provider data is sent.

## Verification

- swiftlint lint --strict: 0 violations across 278 files
- swift test: 2,319 passed, 6 skipped, 0 failures
- focused automatic-currency suite: 34 passed
- native Debug app/widget Xcode build: succeeded