### PR TITLE
feat(cost): add USD/EUR currency picker

### DIFF
--- a/MeterBar/Models/DisplayCurrency.swift
+++ b/MeterBar/Models/DisplayCurrency.swift
@@ -1,5 +1,19 @@
 import Foundation
 
+nonisolated enum DisplayCurrencySelection: String, CaseIterable, Identifiable, Sendable {
+    case usd = "USD"
+    case eur = "EUR"
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .usd: "USD — US Dollar"
+        case .eur: "EUR — Euro"
+        }
+    }
+}
+
 nonisolated public enum DisplayCurrencySource: String, Equatable, Sendable {
     case manual
     case europeanCentralBank = "ecb"

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -161,6 +161,8 @@ nonisolated enum StorageKeys {
 
     // MARK: - Display Currency (#270)
 
+    /// `DisplayCurrencySelection` raw value. Missing or unknown means USD.
+    static let displayCurrencySelection = "DisplayCurrencySelection"
     /// Display currency code/label. Presentation only — stored and exported
     /// cost data always stays USD.
     static let displayCurrencyCode = "DisplayCurrencyCode"
@@ -170,7 +172,7 @@ nonisolated enum StorageKeys {
     static let displayCurrencyEnteredAt = "DisplayCurrencyEnteredAt"
     /// `DisplayCurrencySource` raw value. Missing migrates to `.manual`.
     static let displayCurrencySource = "DisplayCurrencySource"
-    /// Whether the app should detect the Mac's currency and refresh its rate.
+    /// Legacy automatic-mode flag retained for migration from 1.8.35.
     static let displayCurrencyAutomatic = "DisplayCurrencyAutomatic"
     /// Last successful automatic refresh, used to cap fetches at once per day.
     static let displayCurrencyLastRefreshAt = "DisplayCurrencyLastRefreshAt"

--- a/MeterBar/Services/DisplayCurrencyStore.swift
+++ b/MeterBar/Services/DisplayCurrencyStore.swift
@@ -93,11 +93,14 @@ final class DisplayCurrencyStore: ObservableObject {
         do {
             let quote = try await fetchAutomaticRate(code)
             guard selection == .eur else { return }
-            guard quote.unitsPerUSD > 0, quote.unitsPerUSD.isFinite else {
+            let normalizedCode = quote.code.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+            guard normalizedCode == code,
+                  quote.unitsPerUSD > 0,
+                  quote.unitsPerUSD.isFinite else {
                 throw DisplayCurrencyRateError.invalidPayload
             }
             let next = DisplayCurrency(
-                code: quote.code,
+                code: normalizedCode,
                 unitsPerUSD: quote.unitsPerUSD,
                 enteredAt: quote.referenceDate,
                 source: .europeanCentralBank

--- a/MeterBar/Services/DisplayCurrencyStore.swift
+++ b/MeterBar/Services/DisplayCurrencyStore.swift
@@ -1,56 +1,52 @@
 import Combine
 import Foundation
 
-/// Persists the optional presentation-only currency conversion.
+/// Persists the presentation-only USD/EUR choice.
 ///
-/// Automatic mode detects the currency configured in macOS Region settings,
-/// refreshes it from the ECB at most once per day, and keeps the last
-/// successful quote for offline use. Manual mode remains available for a
-/// currency the ECB does not publish. Stored and exported cost data stays USD.
+/// USD is the default and needs no conversion. EUR refreshes from the ECB at
+/// most once per day and keeps the last successful quote for offline use.
+/// Stored and exported cost data always stays USD.
 final class DisplayCurrencyStore: ObservableObject {
     static let shared = DisplayCurrencyStore()
 
     @Published private(set) var currency: DisplayCurrency?
-    @Published private(set) var isAutomatic: Bool
+    @Published private(set) var selection: DisplayCurrencySelection
     @Published private(set) var isRefreshingAutomaticRate = false
     @Published private(set) var automaticRateError: String?
-
-    var detectedCurrencyCode: String? {
-        Self.normalizedCode(localeCurrencyCode())
-    }
 
     private static let automaticRefreshInterval: TimeInterval = 24 * 60 * 60
 
     private let userDefaults: UserDefaults
     private let fetchAutomaticRate: (String) async throws -> DisplayCurrencyRateQuote
-    private let localeCurrencyCode: () -> String?
     private let now: () -> Date
 
-    /// Internal seams keep locale, time, networking, and persistence fully
+    /// Internal seams keep time, networking, and persistence fully
     /// deterministic in tests. Production uses the official ECB client.
     init(
         userDefaults: UserDefaults = .standard,
         fetchAutomaticRate: ((String) async throws -> DisplayCurrencyRateQuote)? = nil,
-        localeCurrencyCode: @escaping () -> String? = { Locale.autoupdatingCurrent.currency?.identifier },
         now: @escaping () -> Date = Date.init
     ) {
         self.userDefaults = userDefaults
         self.fetchAutomaticRate = fetchAutomaticRate ?? { code in
             try await DisplayCurrencyRateClient().fetchRate(for: code)
         }
-        self.localeCurrencyCode = localeCurrencyCode
         self.now = now
         currency = nil
-        isAutomatic = false
+        selection = .usd
         load()
 
-        if userDefaults.object(forKey: StorageKeys.displayCurrencyAutomatic) != nil {
-            isAutomatic = userDefaults.bool(forKey: StorageKeys.displayCurrencyAutomatic)
-        } else {
-            // Preserve an existing manual conversion during migration. Fresh
-            // installs have no conversion and opt into the useful default.
-            isAutomatic = currency == nil
+        if let saved = userDefaults.string(forKey: StorageKeys.displayCurrencySelection)
+            .flatMap(DisplayCurrencySelection.init(rawValue:)) {
+            selection = saved
         }
+
+        if selection == .usd {
+            clearSavedRate()
+        } else if currency?.code != DisplayCurrencySelection.eur.rawValue {
+            currency = nil
+        }
+        userDefaults.set(selection.rawValue, forKey: StorageKeys.displayCurrencySelection)
     }
 
     /// Read-only projection used by CLI-oriented call sites and tests.
@@ -59,51 +55,30 @@ final class DisplayCurrencyStore: ObservableObject {
         fetchAutomaticRate = { code in
             throw DisplayCurrencyRateError.unsupportedCurrency(code)
         }
-        localeCurrencyCode = { nil }
         now = Date.init
         self.currency = currency
-        isAutomatic = false
+        selection = currency?.code == DisplayCurrencySelection.eur.rawValue ? .eur : .usd
     }
 
-    /// Saves an explicit manual rate and disables background replacement.
-    func set(code: String, rate: Double) {
-        let trimmedCode = Self.normalizedCode(code) ?? ""
-        guard !trimmedCode.isEmpty, rate > 0, rate.isFinite else {
-            clear()
-            return
+    func setSelection(_ nextSelection: DisplayCurrencySelection) {
+        selection = nextSelection
+        automaticRateError = nil
+        userDefaults.set(nextSelection.rawValue, forKey: StorageKeys.displayCurrencySelection)
+
+        if nextSelection == .usd {
+            clearSavedRate()
         }
-        let next = DisplayCurrency(
-            code: trimmedCode,
-            unitsPerUSD: rate,
-            enteredAt: now(),
-            source: .manual
-        )
-        isAutomatic = false
-        automaticRateError = nil
-        userDefaults.set(false, forKey: StorageKeys.displayCurrencyAutomatic)
-        userDefaults.removeObject(forKey: StorageKeys.displayCurrencyLastRefreshAt)
-        currency = next
-        persist(next)
     }
 
-    func setAutomaticEnabled(_ enabled: Bool) {
-        isAutomatic = enabled
-        automaticRateError = nil
-        userDefaults.set(enabled, forKey: StorageKeys.displayCurrencyAutomatic)
-    }
-
-    /// Refreshes only when automatic mode is enabled and the cached fetch is
-    /// stale, unless the user explicitly requested `force` from Settings.
+    /// Refreshes EUR only when its cached quote is stale, unless the user
+    /// explicitly requested `force` from Settings.
     /// Failures never discard the last-known-good quote.
     func refreshAutomaticCurrency(force: Bool = false) async {
-        guard isAutomatic, !isRefreshingAutomaticRate else { return }
-        guard let code = detectedCurrencyCode else {
-            automaticRateError = "Choose a currency in macOS Region settings or enter a manual rate."
-            return
-        }
+        guard selection == .eur, !isRefreshingAutomaticRate else { return }
+        let code = DisplayCurrencySelection.eur.rawValue
 
         let refreshDate = userDefaults.object(forKey: StorageKeys.displayCurrencyLastRefreshAt) as? Date
-        let cacheMatches = currency?.code == code && currency?.source != .manual
+        let cacheMatches = currency?.code == code
         if !force,
            cacheMatches,
            let refreshDate,
@@ -116,30 +91,20 @@ final class DisplayCurrencyStore: ObservableObject {
         defer { isRefreshingAutomaticRate = false }
 
         do {
-            let next: DisplayCurrency
-            if code == "USD" {
-                next = DisplayCurrency(
-                    code: "USD",
-                    unitsPerUSD: 1,
-                    enteredAt: now(),
-                    source: .system
-                )
-            } else {
-                let quote = try await fetchAutomaticRate(code)
-                guard quote.unitsPerUSD > 0, quote.unitsPerUSD.isFinite else {
-                    throw DisplayCurrencyRateError.invalidPayload
-                }
-                next = DisplayCurrency(
-                    code: quote.code,
-                    unitsPerUSD: quote.unitsPerUSD,
-                    enteredAt: quote.referenceDate,
-                    source: .europeanCentralBank
-                )
+            let quote = try await fetchAutomaticRate(code)
+            guard selection == .eur else { return }
+            guard quote.unitsPerUSD > 0, quote.unitsPerUSD.isFinite else {
+                throw DisplayCurrencyRateError.invalidPayload
             }
+            let next = DisplayCurrency(
+                code: quote.code,
+                unitsPerUSD: quote.unitsPerUSD,
+                enteredAt: quote.referenceDate,
+                source: .europeanCentralBank
+            )
 
             currency = next
             persist(next)
-            userDefaults.set(true, forKey: StorageKeys.displayCurrencyAutomatic)
             userDefaults.set(now(), forKey: StorageKeys.displayCurrencyLastRefreshAt)
         } catch let error as DisplayCurrencyRateError {
             automaticRateError = error.localizedDescription + offlineFallbackSuffix
@@ -148,13 +113,9 @@ final class DisplayCurrencyStore: ObservableObject {
         }
     }
 
-    /// Removes the saved conversion and disables automatic mode so choosing
-    /// "Show USD" remains stable across view appearances.
-    func clear() {
+    private func clearSavedRate() {
         currency = nil
-        isAutomatic = false
         automaticRateError = nil
-        userDefaults.set(false, forKey: StorageKeys.displayCurrencyAutomatic)
         userDefaults.removeObject(forKey: StorageKeys.displayCurrencyCode)
         userDefaults.removeObject(forKey: StorageKeys.displayCurrencyRate)
         userDefaults.removeObject(forKey: StorageKeys.displayCurrencyEnteredAt)
@@ -163,13 +124,10 @@ final class DisplayCurrencyStore: ObservableObject {
     }
 
     private var offlineFallbackSuffix: String {
-        currency == nil ? " Enter a manual rate instead." : " The last saved rate is still in use."
-    }
-
-    private static func normalizedCode(_ code: String?) -> String? {
-        guard let code else { return nil }
-        let normalized = code.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
-        return normalized.isEmpty ? nil : normalized
+        if currency == nil {
+            return " Totals remain in USD until a EUR rate is available."
+        }
+        return " The last saved rate is still in use."
     }
 
     private func persist(_ currency: DisplayCurrency) {
@@ -181,7 +139,7 @@ final class DisplayCurrencyStore: ObservableObject {
 
     private func load() {
         guard
-            let code = Self.normalizedCode(userDefaults.string(forKey: StorageKeys.displayCurrencyCode)),
+            let code = userDefaults.string(forKey: StorageKeys.displayCurrencyCode)?.uppercased(),
             userDefaults.object(forKey: StorageKeys.displayCurrencyRate) != nil
         else {
             currency = nil

--- a/MeterBar/Views/Settings/CostSettingsView.swift
+++ b/MeterBar/Views/Settings/CostSettingsView.swift
@@ -410,8 +410,6 @@ struct CostSettingsView: View {
     @StateObject private var displayCurrencyStore = DisplayCurrencyStore.shared
 
     @State private var periodMode: CostPeriodMode = .last30Days
-    @State private var currencyCodeInput: String = ""
-    @State private var currencyRateInput: String = ""
 
     private var visibleCostSummary: CostSummary? {
         costTracker.costSummary?.filtered(to: providerVisibility.enabledServices)
@@ -510,36 +508,37 @@ struct CostSettingsView: View {
         .accessibilityIdentifier("cost-period-picker")
     }
 
-    /// Presentation-only currency preference. Automatic mode uses the Mac's
-    /// region currency and the ECB's daily reference feed; manual entry remains
-    /// available for unsupported currencies. Stored/exported data stays USD.
+    /// Presentation-only currency preference. USD is the default; EUR uses
+    /// the ECB's daily reference feed. Stored/exported data stays USD.
     private var displayCurrencySection: some View {
         SettingsPanelSection(title: "Display Currency", systemImage: "banknote", color: MeterBarTheme.warning) {
             Text("Converts totals for display only. Stored and exported cost data always stays USD.")
                 .font(.caption)
                 .foregroundColor(.secondary)
 
-            SettingsRowView(title: "Automatic rate") {
-                HStack(spacing: 8) {
-                    if displayCurrencyStore.isRefreshingAutomaticRate {
-                        ProgressView()
-                            .controlSize(.small)
+            SettingsRowView(title: "Currency") {
+                Picker("Display currency", selection: displayCurrencyBinding) {
+                    ForEach(DisplayCurrencySelection.allCases) { selection in
+                        Text(selection.title).tag(selection)
                     }
-                    Toggle("Automatic rate", isOn: automaticCurrencyBinding)
-                        .labelsHidden()
-                        .accessibilityIdentifier("display-currency-automatic-toggle")
                 }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .fixedSize()
+                .accessibilityIdentifier("display-currency-picker")
             }
 
-            if displayCurrencyStore.isAutomatic {
-                Text("Uses the currency in macOS Region settings and ECB reference rates, refreshed daily.")
+            if displayCurrencyStore.selection == .eur {
+                Text("EUR totals use the ECB reference rate, refreshed daily. The last successful rate works offline.")
                     .font(.caption)
                     .foregroundColor(.secondary)
 
-                SettingsRowView(title: "Currency") {
+                SettingsRowView(title: "EUR rate") {
                     HStack(spacing: 10) {
-                        Text(displayCurrencyStore.detectedCurrencyCode ?? "Not configured")
-                            .foregroundStyle(.secondary)
+                        if displayCurrencyStore.isRefreshingAutomaticRate {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
 
                         Button("Refresh Now") {
                             refreshAutomaticCurrency(force: true)
@@ -553,50 +552,6 @@ struct CostSettingsView: View {
                 if let error = displayCurrencyStore.automaticRateError {
                     SettingsNotice(text: error, color: MeterBarTheme.warning)
                 }
-            } else {
-                Text("Enter a manual rate only if you do not want to use the currency from your Mac's region.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-
-                SettingsRowView(title: "Currency code") {
-                    TextField("e.g. EUR", text: $currencyCodeInput)
-                        .textFieldStyle(.roundedBorder)
-                        .accessibilityIdentifier("display-currency-code-field")
-                }
-
-                SettingsRowView(title: "Units per 1 USD") {
-                    TextField("e.g. 0.92", text: $currencyRateInput)
-                        .textFieldStyle(.roundedBorder)
-                        .accessibilityIdentifier("display-currency-rate-field")
-                }
-
-                HStack(spacing: 8) {
-                    Spacer(minLength: 0)
-
-                    Button("Save Manual Rate") {
-                        guard let rate = parsedCurrencyRate else { return }
-                        displayCurrencyStore.set(code: currencyCodeInput, rate: rate)
-                    }
-                    .buttonStyle(.bordered)
-                    .disabled(
-                        currencyCodeInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                            || parsedCurrencyRate == nil
-                    )
-                    .accessibilityIdentifier("display-currency-save-button")
-                }
-            }
-
-            if displayCurrencyStore.currency != nil {
-                HStack {
-                    Spacer(minLength: 0)
-                    Button("Show USD", role: .destructive) {
-                        displayCurrencyStore.clear()
-                        currencyCodeInput = ""
-                        currencyRateInput = ""
-                    }
-                    .buttonStyle(.bordered)
-                    .accessibilityIdentifier("display-currency-clear-button")
-                }
             }
 
             if let currency = displayCurrencyStore.currency {
@@ -604,43 +559,25 @@ struct CostSettingsView: View {
             }
         }
         .onAppear {
-            syncCurrencyInputsFromStore()
             refreshAutomaticCurrency()
         }
     }
 
-    private var automaticCurrencyBinding: Binding<Bool> {
+    private var displayCurrencyBinding: Binding<DisplayCurrencySelection> {
         Binding(
-            get: { displayCurrencyStore.isAutomatic },
-            set: { enabled in
-                displayCurrencyStore.setAutomaticEnabled(enabled)
-                if enabled {
+            get: { displayCurrencyStore.selection },
+            set: { selection in
+                displayCurrencyStore.setSelection(selection)
+                if selection == .eur {
                     refreshAutomaticCurrency(force: true)
-                } else {
-                    syncCurrencyInputsFromStore()
                 }
             }
         )
     }
 
-    /// `Double("inf")` and `Double("nan")` both parse, so plain
-    /// `Double(_:) != nil` would enable Save for a rate that can only render
-    /// as "inf". The store rejects those too; this keeps the button honest.
-    private var parsedCurrencyRate: Double? {
-        guard let rate = Double(currencyRateInput), rate > 0, rate.isFinite else { return nil }
-        return rate
-    }
-
-    private func syncCurrencyInputsFromStore() {
-        guard let currency = displayCurrencyStore.currency else { return }
-        currencyCodeInput = currency.code
-        currencyRateInput = String(currency.unitsPerUSD)
-    }
-
     private func refreshAutomaticCurrency(force: Bool = false) {
         Task {
             await displayCurrencyStore.refreshAutomaticCurrency(force: force)
-            syncCurrencyInputsFromStore()
         }
     }
 

--- a/MeterBarTests/DisplayCurrencyStoreTests.swift
+++ b/MeterBarTests/DisplayCurrencyStoreTests.swift
@@ -1,121 +1,20 @@
 import XCTest
 @testable import MeterBar
 
-/// Unit tests for the UserDefaults-backed manual and automatic conversion
-/// modes, with locale, clock, and networking injected.
+/// Unit tests for the UserDefaults-backed USD/EUR choice, with clock and
+/// networking injected so no test depends on the live ECB feed.
 final class DisplayCurrencyStoreTests: XCTestCase {
-    func testDefaultsToNoConversionWhenNothingHasBeenSaved() {
+    func testDefaultsToUSDWithNoConversion() {
         withIsolatedDefaults { defaults in
             let store = DisplayCurrencyStore(userDefaults: defaults)
 
+            XCTAssertEqual(store.selection, .usd)
             XCTAssertNil(store.currency)
-            XCTAssertTrue(store.isAutomatic)
+            XCTAssertEqual(defaults.string(forKey: StorageKeys.displayCurrencySelection), "USD")
         }
     }
 
-    func testSetPersistsCodeRateAndAnEnteredAtTimestamp() {
-        withIsolatedDefaults { defaults in
-            let store = DisplayCurrencyStore(userDefaults: defaults)
-
-            store.set(code: "eur", rate: 0.92)
-
-            guard let currency = store.currency else {
-                return XCTFail("Expected the manual currency to be saved")
-            }
-            XCTAssertEqual(currency.code, "EUR")
-            XCTAssertEqual(currency.unitsPerUSD, 0.92, accuracy: 0.0001)
-            XCTAssertEqual(currency.source, .manual)
-            XCTAssertFalse(store.isAutomatic)
-            XCTAssertLessThan(abs(currency.enteredAt.timeIntervalSinceNow), 5)
-
-            let reloaded = DisplayCurrencyStore(userDefaults: defaults)
-            XCTAssertEqual(reloaded.currency, currency)
-        }
-    }
-
-    func testSetTrimsAndUppercasesTheCode() {
-        withIsolatedDefaults { defaults in
-            let store = DisplayCurrencyStore(userDefaults: defaults)
-
-            store.set(code: "  jpy  ", rate: 150)
-
-            XCTAssertEqual(store.currency?.code, "JPY")
-        }
-    }
-
-    func testSetRejectsANonPositiveRateAndClearsAnyExistingConversion() {
-        withIsolatedDefaults { defaults in
-            let store = DisplayCurrencyStore(userDefaults: defaults)
-            store.set(code: "EUR", rate: 0.92)
-
-            store.set(code: "EUR", rate: 0)
-
-            XCTAssertNil(store.currency)
-            XCTAssertNil(DisplayCurrencyStore(userDefaults: defaults).currency)
-        }
-    }
-
-    func testSetRejectsANonFiniteRateAndClearsAnyExistingConversion() {
-        withIsolatedDefaults { defaults in
-            let store = DisplayCurrencyStore(userDefaults: defaults)
-            store.set(code: "EUR", rate: 0.92)
-
-            // Infinity satisfies `rate > 0`, so without an explicit finite
-            // check it would persist and turn every converted total into "inf".
-            store.set(code: "EUR", rate: .infinity)
-
-            XCTAssertNil(store.currency)
-            XCTAssertNil(DisplayCurrencyStore(userDefaults: defaults).currency)
-        }
-    }
-
-    func testLoadIgnoresAPersistedNonFiniteRate() {
-        withIsolatedDefaults { defaults in
-            defaults.set("EUR", forKey: StorageKeys.displayCurrencyCode)
-            defaults.set(Double.infinity, forKey: StorageKeys.displayCurrencyRate)
-            defaults.set(Date(), forKey: StorageKeys.displayCurrencyEnteredAt)
-
-            XCTAssertNil(DisplayCurrencyStore(userDefaults: defaults).currency)
-        }
-    }
-
-    func testSetRejectsAnEmptyOrBlankCode() {
-        withIsolatedDefaults { defaults in
-            let store = DisplayCurrencyStore(userDefaults: defaults)
-
-            store.set(code: "   ", rate: 0.92)
-
-            XCTAssertNil(store.currency)
-        }
-    }
-
-    func testClearRemovesAPersistedConversion() {
-        withIsolatedDefaults { defaults in
-            let store = DisplayCurrencyStore(userDefaults: defaults)
-            store.set(code: "EUR", rate: 0.92)
-
-            store.clear()
-
-            XCTAssertNil(store.currency)
-            XCTAssertFalse(store.isAutomatic)
-            XCTAssertNil(DisplayCurrencyStore(userDefaults: defaults).currency)
-        }
-    }
-
-    func testExistingSavedRateMigratesAsManualWithoutAutomaticReplacement() {
-        withIsolatedDefaults { defaults in
-            defaults.set("EUR", forKey: StorageKeys.displayCurrencyCode)
-            defaults.set(0.92, forKey: StorageKeys.displayCurrencyRate)
-            defaults.set(Date(timeIntervalSince1970: 1_784_000_000), forKey: StorageKeys.displayCurrencyEnteredAt)
-
-            let store = DisplayCurrencyStore(userDefaults: defaults)
-
-            XCTAssertEqual(store.currency?.source, .manual)
-            XCTAssertFalse(store.isAutomatic)
-        }
-    }
-
-    func testAutomaticRefreshDetectsLocaleFetchesAndPersistsOfficialRate() async {
+    func testSelectingEURFetchesAndPersistsOfficialRate() async {
         await withIsolatedDefaults { defaults in
             let now = Date(timeIntervalSince1970: 1_786_000_000)
             let referenceDate = Date(timeIntervalSince1970: 1_785_888_000)
@@ -130,26 +29,77 @@ final class DisplayCurrencyStoreTests: XCTestCase {
                         referenceDate: referenceDate
                     )
                 },
-                localeCurrencyCode: { "eur" },
                 now: { now }
             )
 
+            store.setSelection(.eur)
             await store.refreshAutomaticCurrency()
 
             XCTAssertEqual(requestedCodes, ["EUR"])
+            XCTAssertEqual(store.selection, .eur)
             XCTAssertEqual(store.currency?.code, "EUR")
             XCTAssertEqual(store.currency?.unitsPerUSD ?? 0, 0.8645, accuracy: 0.000_001)
             XCTAssertEqual(store.currency?.enteredAt, referenceDate)
             XCTAssertEqual(store.currency?.source, .europeanCentralBank)
-            XCTAssertTrue(defaults.bool(forKey: StorageKeys.displayCurrencyAutomatic))
+            XCTAssertEqual(defaults.string(forKey: StorageKeys.displayCurrencySelection), "EUR")
 
             let reloaded = DisplayCurrencyStore(userDefaults: defaults)
+            XCTAssertEqual(reloaded.selection, .eur)
             XCTAssertEqual(reloaded.currency, store.currency)
-            XCTAssertTrue(reloaded.isAutomatic)
         }
     }
 
-    func testFreshAutomaticCacheDoesNotFetchAgain() async {
+    func testSelectingUSDClearsConversionAndDoesNotFetch() async {
+        await withIsolatedDefaults { defaults in
+            var fetchCount = 0
+            let store = DisplayCurrencyStore(
+                userDefaults: defaults,
+                fetchAutomaticRate: { code in
+                    fetchCount += 1
+                    return DisplayCurrencyRateQuote(code: code, unitsPerUSD: 0.86, referenceDate: Date())
+                }
+            )
+            store.setSelection(.eur)
+            await store.refreshAutomaticCurrency()
+            XCTAssertNotNil(store.currency)
+
+            store.setSelection(.usd)
+            await store.refreshAutomaticCurrency(force: true)
+
+            XCTAssertEqual(fetchCount, 1)
+            XCTAssertEqual(store.selection, .usd)
+            XCTAssertNil(store.currency)
+            XCTAssertNil(defaults.string(forKey: StorageKeys.displayCurrencyCode))
+        }
+    }
+
+    func testLegacyEURRateMigratesToUSDDefault() {
+        withIsolatedDefaults { defaults in
+            defaults.set("EUR", forKey: StorageKeys.displayCurrencyCode)
+            defaults.set(0.92, forKey: StorageKeys.displayCurrencyRate)
+            defaults.set(Date(timeIntervalSince1970: 1_784_000_000), forKey: StorageKeys.displayCurrencyEnteredAt)
+
+            let store = DisplayCurrencyStore(userDefaults: defaults)
+
+            XCTAssertEqual(store.selection, .usd)
+            XCTAssertNil(store.currency)
+        }
+    }
+
+    func testLegacyNonEURRateMigratesToUSDWithoutConversion() {
+        withIsolatedDefaults { defaults in
+            defaults.set("GBP", forKey: StorageKeys.displayCurrencyCode)
+            defaults.set(0.78, forKey: StorageKeys.displayCurrencyRate)
+            defaults.set(Date(timeIntervalSince1970: 1_784_000_000), forKey: StorageKeys.displayCurrencyEnteredAt)
+
+            let store = DisplayCurrencyStore(userDefaults: defaults)
+
+            XCTAssertEqual(store.selection, .usd)
+            XCTAssertNil(store.currency)
+        }
+    }
+
+    func testFreshEURCacheDoesNotFetchAgain() async {
         await withIsolatedDefaults { defaults in
             let now = Date(timeIntervalSince1970: 1_786_000_000)
             var fetchCount = 0
@@ -159,10 +109,10 @@ final class DisplayCurrencyStoreTests: XCTestCase {
                     fetchCount += 1
                     return DisplayCurrencyRateQuote(code: code, unitsPerUSD: 0.86, referenceDate: now)
                 },
-                localeCurrencyCode: { "EUR" },
                 now: { now }
             )
 
+            store.setSelection(.eur)
             await store.refreshAutomaticCurrency()
             await store.refreshAutomaticCurrency()
 
@@ -170,16 +120,22 @@ final class DisplayCurrencyStoreTests: XCTestCase {
         }
     }
 
-    func testAutomaticFailureKeepsLastSavedRate() async {
+    func testEURRefreshFailureKeepsLastSavedRate() async {
         await withIsolatedDefaults { defaults in
+            let now = Date(timeIntervalSince1970: 1_786_000_000)
+            var shouldFail = false
             let store = DisplayCurrencyStore(
                 userDefaults: defaults,
-                fetchAutomaticRate: { _ in throw URLError(.notConnectedToInternet) },
-                localeCurrencyCode: { "EUR" }
+                fetchAutomaticRate: { code in
+                    if shouldFail { throw URLError(.notConnectedToInternet) }
+                    return DisplayCurrencyRateQuote(code: code, unitsPerUSD: 0.91, referenceDate: now)
+                },
+                now: { now }
             )
-            store.set(code: "EUR", rate: 0.91)
+            store.setSelection(.eur)
+            await store.refreshAutomaticCurrency()
             let saved = store.currency
-            store.setAutomaticEnabled(true)
+            shouldFail = true
 
             await store.refreshAutomaticCurrency(force: true)
 
@@ -188,23 +144,40 @@ final class DisplayCurrencyStoreTests: XCTestCase {
         }
     }
 
-    func testUSDAutomaticModeUsesIdentityWithoutNetwork() async {
+    func testSwitchingToUSDDuringFetchDoesNotRestoreEUR() async {
         await withIsolatedDefaults { defaults in
-            var didFetch = false
+            let fetchStarted = expectation(description: "EUR fetch started")
             let store = DisplayCurrencyStore(
                 userDefaults: defaults,
                 fetchAutomaticRate: { code in
-                    didFetch = true
-                    throw DisplayCurrencyRateError.unsupportedCurrency(code)
-                },
-                localeCurrencyCode: { "USD" }
+                    fetchStarted.fulfill()
+                    try await Task.sleep(for: .milliseconds(50))
+                    return DisplayCurrencyRateQuote(code: code, unitsPerUSD: 0.9, referenceDate: Date())
+                }
             )
+            store.setSelection(.eur)
 
-            await store.refreshAutomaticCurrency()
+            let refresh = Task { await store.refreshAutomaticCurrency() }
+            await fulfillment(of: [fetchStarted], timeout: 1)
+            store.setSelection(.usd)
+            await refresh.value
 
-            XCTAssertFalse(didFetch)
-            XCTAssertEqual(store.currency?.unitsPerUSD, 1)
-            XCTAssertEqual(store.currency?.source, .system)
+            XCTAssertEqual(store.selection, .usd)
+            XCTAssertNil(store.currency)
+        }
+    }
+
+    func testLoadIgnoresPersistedNonFiniteEURRate() {
+        withIsolatedDefaults { defaults in
+            defaults.set("EUR", forKey: StorageKeys.displayCurrencySelection)
+            defaults.set("EUR", forKey: StorageKeys.displayCurrencyCode)
+            defaults.set(Double.infinity, forKey: StorageKeys.displayCurrencyRate)
+            defaults.set(Date(), forKey: StorageKeys.displayCurrencyEnteredAt)
+
+            let store = DisplayCurrencyStore(userDefaults: defaults)
+
+            XCTAssertEqual(store.selection, .eur)
+            XCTAssertNil(store.currency)
         }
     }
 

--- a/MeterBarTests/DisplayCurrencyStoreTests.swift
+++ b/MeterBarTests/DisplayCurrencyStoreTests.swift
@@ -49,6 +49,30 @@ final class DisplayCurrencyStoreTests: XCTestCase {
         }
     }
 
+    func testEURSelectionRejectsQuoteForAnotherCurrency() async {
+        await withIsolatedDefaults { defaults in
+            let store = DisplayCurrencyStore(
+                userDefaults: defaults,
+                fetchAutomaticRate: { _ in
+                    DisplayCurrencyRateQuote(
+                        code: "GBP",
+                        unitsPerUSD: 0.78,
+                        referenceDate: Date(timeIntervalSince1970: 1_785_888_000)
+                    )
+                }
+            )
+
+            store.setSelection(.eur)
+            await store.refreshAutomaticCurrency()
+
+            XCTAssertEqual(store.selection, .eur)
+            XCTAssertNil(store.currency)
+            XCTAssertNotNil(store.automaticRateError)
+            XCTAssertNil(defaults.string(forKey: StorageKeys.displayCurrencyCode))
+            XCTAssertNil(defaults.object(forKey: StorageKeys.displayCurrencyLastRefreshAt))
+        }
+    }
+
     func testSelectingUSDClearsConversionAndDoesNotFetch() async {
         await withIsolatedDefaults { defaults in
             var fetchCount = 0

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ by itself once a limit resets.
 
 - **Local Cost Scan**: 30-day token spend computed from local session logs — nothing is uploaded
 - **Optimize Tab**: See where tokens actually go, and which provider has the most headroom right now
-- **Display Currency**: Automatically show costs in your Mac's regional currency using daily ECB reference rates, with an offline cache and manual fallback (Settings → Costs)
+- **Display Currency**: Keep USD as the default or choose EUR with daily ECB reference rates and an offline cache (Settings → Costs)
 
 ### Scripting
 
@@ -232,12 +232,10 @@ per-file results and picks up where it left off rather than re-reading the whole
 corpus each time. Nothing is uploaded; the numbers are derived entirely from
 files already on your disk.
 
-Set a **Display Currency** under **Settings → Costs** to show totals in a
-currency other than USD. MeterBar detects the currency from your Mac's Region
-settings, refreshes the official ECB reference rate daily, and keeps the last
-successful quote offline. Manual rates remain available for currencies the ECB
-does not publish. The automatic refresh sends no usage or cost data; it only
-requests the ECB's public daily rate feed.
+Choose **USD** or **EUR** under **Settings → Costs**. USD is the default and
+needs no conversion. When EUR is selected, MeterBar refreshes the official ECB
+reference rate daily and keeps the last successful quote offline. The refresh
+sends no usage or cost data; it only requests the ECB's public daily rate feed.
 
 ## CLI Tool
 


### PR DESCRIPTION
## Summary

- Replace automatic/manual currency controls with a USD/EUR dropdown.
- Make USD the default for fresh and upgraded installations.
- Fetch and cache the daily ECB conversion only when EUR is selected.
- Prevent an in-flight EUR refresh from restoring conversion after switching to USD.
- Keep stored and exported costs in USD.

## Verification

- Focused display-currency/settings tests: 30 passed.
- Full Swift test suite: 2,315 passed, 6 expected live-integration skips, 0 failures.
- Strict SwiftLint: 0 violations across 278 files.
- Native Xcode Debug app and widget build: succeeded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Choose between USD and EUR for displayed costs.
  * EUR conversions use daily ECB reference rates with offline caching.
  * Currency selection is saved and restored automatically.

* **Bug Fixes**
  * Improved handling of failed or unavailable EUR rate updates while retaining the last valid rate.
  * Prevented outdated conversion results from appearing after switching to USD.

* **Documentation**
  * Updated currency guidance to reflect explicit USD/EUR selection and offline rate caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->