### PR TITLE
test(session-wake): make lock holder fixture deterministic

### DIFF
--- a/MeterBarTests/SessionWakeControllerTests.swift
+++ b/MeterBarTests/SessionWakeControllerTests.swift
@@ -395,14 +395,15 @@ final class SessionWakeControllerTests: XCTestCase {
     }
 
     func testDifferentPIDLifetimeLockHolderStillReportsContention() throws {
-        let lockURL = testLockURL()
+        let lockDirectory = testLockURL().deletingLastPathComponent()
+            .appendingPathComponent("spawned-holder-\(UUID().uuidString)", isDirectory: true)
+        let lockURL = lockDirectory.appendingPathComponent("watcher.lock")
+        defer { try? FileManager.default.removeItem(at: lockDirectory) }
         let holder = try SpawnedWakeLockHolder(lockURL: lockURL)
         defer { holder.release() }
-        poll {
-            guard let data = try? Data(contentsOf: lockURL),
-                  let record = try? JSONDecoder().decode(WakeLockHolder.self, from: data) else { return false }
-            return record.pid == holder.pid
-        }
+        let data = try Data(contentsOf: lockURL)
+        let record = try JSONDecoder().decode(WakeLockHolder.self, from: data)
+        XCTAssertEqual(record.pid, holder.pid)
         XCTAssertNotEqual(holder.pid, getpid())
 
         let store = armedStore()
@@ -414,7 +415,7 @@ final class SessionWakeControllerTests: XCTestCase {
             accounts: ClaudeCodeAccountStore(userDefaults: defaults),
             rescanInterval: 3_600,
             makeWatcher: { _, _, onState in FakeWatcher(recorder: recorder, onState: onState) },
-            makeLifetimeLock: lifetimeLockFactory()
+            makeLifetimeLock: { WakeLock(lockURL: lockURL, legacyLockURLs: [], holderKind: .app) }
         )
 
         controller.activate()
@@ -763,8 +764,14 @@ nonisolated private final class SpawnedWakeLockHolder {
     private var isReleased = false
 
     init(lockURL: URL) throws {
+        try FileManager.default.createDirectory(
+            at: lockURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
         let process = Process()
         let input = Pipe()
+        let output = Pipe()
+        let error = Pipe()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
         process.arguments = [
             "-c",
@@ -775,14 +782,25 @@ nonisolated private final class SpawnedWakeLockHolder {
                 json.dump({"kind": "agent", "pid": os.getpid(), "host": socket.gethostname(), \
                     "startedAtEpoch": time.time()}, lock_file)
                 lock_file.flush()
+                sys.stdout.buffer.write(bytes([1]))
+                sys.stdout.buffer.flush()
                 sys.stdin.buffer.read(1)
             """,
             lockURL.path,
         ]
         process.standardInput = input
-        process.standardOutput = Pipe()
-        process.standardError = Pipe()
+        process.standardOutput = output
+        process.standardError = error
         try process.run()
+        let ready = output.fileHandleForReading.readData(ofLength: 1)
+        guard ready == Data([1]) else {
+            process.waitUntilExit()
+            let stderr = error.fileHandleForReading.readDataToEndOfFile()
+            throw SpawnedWakeLockHolderError.failed(
+                status: process.terminationStatus,
+                stderr: String(data: stderr, encoding: .utf8) ?? "unreadable stderr"
+            )
+        }
 
         self.process = process
         self.input = input
@@ -792,13 +810,26 @@ nonisolated private final class SpawnedWakeLockHolder {
     func release() {
         guard !isReleased else { return }
         isReleased = true
-        try? input.fileHandleForWriting.write(contentsOf: Data([1]))
+        if process.isRunning {
+            try? input.fileHandleForWriting.write(contentsOf: Data([1]))
+        }
         try? input.fileHandleForWriting.close()
         process.waitUntilExit()
     }
 
     deinit {
         release()
+    }
+}
+
+nonisolated private enum SpawnedWakeLockHolderError: LocalizedError {
+    case failed(status: Int32, stderr: String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .failed(status, stderr):
+            "spawned wake-lock holder exited with status \(status): \(stderr)"
+        }
     }
 }
 

--- a/MeterBarTests/WakeRunnerTests.swift
+++ b/MeterBarTests/WakeRunnerTests.swift
@@ -405,6 +405,26 @@ final class WakeRunnerTests: XCTestCase {
         XCTAssertTrue(data.isEmpty, "released lock left a stale holder descriptor")
     }
 
+    func testUnlockedStaleDescriptorWithReusedPIDIsRecoverable() throws {
+        let url = tempDir.appendingPathComponent("stale-reused-pid.lock")
+        let stale = WakeLockHolder(
+            kind: .agent,
+            pid: getpid(),
+            host: "previous-holder",
+            startedAtEpoch: 1
+        )
+        try JSONEncoder().encode(stale).write(to: url)
+
+        let lock = WakeLock(lockURL: url, legacyLockURLs: [])
+        XCTAssertEqual(lock.acquire(), .acquired)
+        defer { lock.release() }
+
+        let current = try JSONDecoder().decode(WakeLockHolder.self, from: Data(contentsOf: url))
+        XCTAssertEqual(current.kind, .app)
+        XCTAssertEqual(current.pid, getpid())
+        XCTAssertGreaterThan(current.startedAtEpoch, stale.startedAtEpoch)
+    }
+
     func testLockDirectoryCreationFailureIsUnavailableNotContended() {
         // The lock's parent path runs through a regular file, so the private
         // directory cannot be created. That is an environment failure, not


### PR DESCRIPTION
## Summary

- create the unique cross-process lock directory before launching the spawned holder
- wait for an explicit holder-ready handshake and surface child startup errors
- cover stale unlocked descriptors that name a currently live, reused PID

## Root cause

The fixture launched Python against a lock path whose parent directory did not exist on a clean GitHub runner. The child exited with `FileNotFoundError`, while the test silently timed out its readiness poll. Controller activation then created the directory and acquired an uncontended lock, producing the three assertions reported by CI. Production `WakeLock` flock validation is unchanged: an actively held lock contends, an unlocked stale descriptor is recoverable even when its PID is live, and an uncontended lock acquires normally.

## Verification

- reproduced the pre-fix focused failure on a clean SwiftPM path, including child exit status 1
- focused contention test: 30 consecutive direct XCTest passes
- neighboring Session Wake suites: 72 tests, 0 failures
- CI-equivalent coverage run: 2,317 tests, 6 live-integration skips, 0 failures; 78.1% coverage against the CI 19% threshold
- SwiftLint strict: 0 violations in 278 files
- unsigned Debug macOS app build: succeeded

Closes #422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for session wake-lock behavior across processes.
  * Added validation for recovering stale lock information when process identifiers are reused.
  * Strengthened checks for lock-holder startup, readiness, metadata, and shutdown handling.
  * Added clearer diagnostics for failures during cross-process wake-lock coordination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->