### PR TITLE
feat(l10n): add app and widget localization groundwork

### DIFF
--- a/MeterBar/Resources/Localizable.xcstrings
+++ b/MeterBar/Resources/Localizable.xcstrings
@@ -1,0 +1,375 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "duration.less_than_one_minute" : {
+      "comment" : "Compact duration shorter than one minute.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "<1m"
+          }
+        }
+      }
+    },
+    "quota.amount_left" : {
+      "comment" : "Formatted currency amount remaining.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ left"
+          }
+        }
+      }
+    },
+    "quota.amount_spent" : {
+      "comment" : "Formatted currency amount already spent.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ spent"
+          }
+        }
+      }
+    },
+    "quota.estimated" : {
+      "comment" : "Badge on a quota total derived by MeterBar rather than reported by a provider.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estimated"
+          }
+        }
+      }
+    },
+    "quota.estimated_label" : {
+      "comment" : "VoiceOver quota title. The variable is the quota window name.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@, estimated"
+          }
+        }
+      }
+    },
+    "quota.out" : {
+      "comment" : "Quota is exhausted.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Out"
+          }
+        }
+      }
+    },
+    "quota.paired_value" : {
+      "comment" : "VoiceOver quota summary. The first variable is remaining or out; the second is used or spent.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@, %2$@"
+          }
+        }
+      }
+    },
+    "quota.percent_left" : {
+      "comment" : "Quota percentage remaining. The variable is a whole-number percentage.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld%% left"
+          }
+        }
+      }
+    },
+    "quota.percent_left.estimated" : {
+      "comment" : "Approximate quota percentage remaining. The variable is a whole-number percentage.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "~%lld%% left"
+          }
+        }
+      }
+    },
+    "quota.percent_used" : {
+      "comment" : "Quota percentage used. The variable is a whole-number percentage.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld%% used"
+          }
+        }
+      }
+    },
+    "quota.percent_used.estimated" : {
+      "comment" : "Approximate quota percentage used. The variable is a whole-number percentage.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "~%lld%% used"
+          }
+        }
+      }
+    },
+    "quota.title.account_credits" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account credits"
+          }
+        }
+      }
+    },
+    "quota.title.code_review" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Code Review"
+          }
+        }
+      }
+    },
+    "quota.title.key_limit" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Key limit"
+          }
+        }
+      }
+    },
+    "quota.title.model" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Model"
+          }
+        }
+      }
+    },
+    "quota.title.monthly" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monthly"
+          }
+        }
+      }
+    },
+    "quota.title.session" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session"
+          }
+        }
+      }
+    },
+    "quota.title.weekly" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weekly"
+          }
+        }
+      }
+    },
+    "reset.at" : {
+      "comment" : "Reset clock time. The variable is a localized time.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resets at %@"
+          }
+        }
+      }
+    },
+    "reset.counter_at" : {
+      "comment" : "Condensed reset time. The variable is a localized clock time.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "at %@"
+          }
+        }
+      }
+    },
+    "reset.counter_in" : {
+      "comment" : "Condensed reset countdown. The variable is a localized duration.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "in %@"
+          }
+        }
+      }
+    },
+    "reset.due" : {
+      "comment" : "Reset is due now.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset due"
+          }
+        }
+      }
+    },
+    "reset.due_now" : {
+      "comment" : "Reset is due now.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "due now"
+          }
+        }
+      }
+    },
+    "reset.exhausted_detail" : {
+      "comment" : "Blocking quota detail. The variable is the number of exhausted limits.",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Usage is unavailable until this limit resets."
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Usage resumes after %lld exhausted limits reset."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "reset.exhausted_limits" : {
+      "comment" : "Blocking quota title. The variable is the number of exhausted limits.",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Limit exhausted"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld limits exhausted"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "reset.in" : {
+      "comment" : "Reset countdown. The variable is a localized duration.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resets in %@"
+          }
+        }
+      }
+    },
+    "reset.time_unavailable" : {
+      "comment" : "Shown when a provider has not reported a reset time.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset time unavailable"
+          }
+        }
+      }
+    },
+    "reset.titled_at" : {
+      "comment" : "Reset clock time. The first variable is the quota title; the second is a localized time.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ resets at %2$@"
+          }
+        }
+      }
+    },
+    "reset.titled_due" : {
+      "comment" : "Reset countdown that is due. The variable is the quota window title.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ reset due"
+          }
+        }
+      }
+    },
+    "reset.titled_in" : {
+      "comment" : "Reset countdown. The first variable is the quota title; the second is a duration.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ reset in %2$@"
+          }
+        }
+      }
+    },
+    "reset.unavailable_until_reported" : {
+      "comment" : "Detail shown when an exhausted quota has no known reset time.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usage is unavailable until the reset is reported."
+          }
+        }
+      }
+    },
+    "reset.window_reset" : {
+      "comment" : "Blocking quota title. The variable is the localized quota-window title.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ reset"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/MeterBar/Views/Components/LimitRow.swift
+++ b/MeterBar/Views/Components/LimitRow.swift
@@ -35,8 +35,8 @@ struct LimitRow: View {
     /// deliberately density-independent — the popover, detail panel, and
     /// dashboard must all speak an identical reading. Exposed so tests can assert
     /// the wiring per density without a rendered-view accessibility harness.
-    var accessibilityLabelText: String { limit.accessibilityLabel }
-    var accessibilityValueText: String { limit.accessibilityValue }
+    var accessibilityLabelText: String { limit.localizedAccessibilityLabel }
+    var accessibilityValueText: String { limit.localizedAccessibilityValue }
 
     // Every surface that draws a `LimitRow` already sits inside a card, so the
     // row never draws one of its own. The detail panel used to, which is exactly
@@ -61,7 +61,7 @@ struct LimitRow: View {
 
     private var header: some View {
         HStack(spacing: density.headerSpacing) {
-            Text(limit.title)
+            Text(limit.localizedTitle)
                 .font(density.titleFont)
                 .fontWeight(density.titleWeight)
                 .foregroundColor(density.titleColor)
@@ -87,7 +87,10 @@ struct LimitRow: View {
     /// user's text-size setting. Kept behind the density so all three surfaces
     /// render it through one code path.
     private var estimatedTag: some View {
-        Text("Estimated")
+        Text(
+            "quota.estimated",
+            comment: "Badge on a quota total derived by MeterBar rather than reported by a provider."
+        )
             .font(density.estimatedFont)
             .fontWeight(.semibold)
             .foregroundColor(.secondary)
@@ -98,7 +101,7 @@ struct LimitRow: View {
         case .resetOnly:
             if content.showsReset {
                 ResetCountdownLabel(
-                    title: limit.title,
+                    title: limit.localizedTitle,
                     limit: limit.usageLimit,
                     font: density.resetFont,
                     foregroundColor: .secondary,
@@ -178,9 +181,11 @@ extension LimitRow {
             switch limit.valueStyle {
             case .currency:
                 let remaining = max(0, limit.usageLimit.total - limit.usageLimit.used)
-                return "\(UsageFormat.cost(remaining)) left"
+                return LocalizedUsageFormat.amountLeft(UsageFormat.cost(remaining))
             case .quota:
-                return (isOut && !isEstimated) ? "Out" : limit.usageLimit.percentLeftText
+                return (isOut && !isEstimated)
+                    ? LocalizedUsageFormat.out()
+                    : LocalizedUsageFormat.percentLeft(limit.usageLimit)
             }
         }
 
@@ -193,9 +198,9 @@ extension LimitRow {
         var usedText: String {
             switch limit.valueStyle {
             case .currency:
-                return "\(UsageFormat.cost(limit.usageLimit.used)) spent"
+                return LocalizedUsageFormat.amountSpent(UsageFormat.cost(limit.usageLimit.used))
             case .quota:
-                return limit.usageLimit.usedPercentageText
+                return LocalizedUsageFormat.percentUsed(limit.usageLimit)
             }
         }
     }

--- a/MeterBar/Views/Components/ResetCountdowns.swift
+++ b/MeterBar/Views/Components/ResetCountdowns.swift
@@ -83,17 +83,51 @@ struct ResetCountdownLabel: View {
         timeZone: TimeZone = .current
     ) -> String? {
         guard let resetTime = limit.resetTime,
-              let countdown = limit.resetCountdownText(now: now) else { return nil }
-        if countdown == "now" {
-            return title.map { "\($0) reset due" } ?? "Reset due"
+              let seconds = limit.secondsUntilReset(now: now) else { return nil }
+        if seconds <= 0 {
+            if let title {
+                return String(
+                    localized: "reset.titled_due",
+                    defaultValue: "\(title) reset due",
+                    comment: "Reset countdown that is due. The variable is the quota window title."
+                )
+            }
+            return String(localized: "reset.due", defaultValue: "Reset due", comment: "Reset is due now.")
         }
 
         switch format {
         case .countdown:
-            return title.map { "\($0) reset in \(countdown)" } ?? "Resets in \(countdown)"
+            let countdown = LocalizedUsageFormat.countdown(seconds: seconds, locale: locale)
+            if let title {
+                return String(
+                    localized: "reset.titled_in",
+                    defaultValue: "\(title) reset in \(countdown)",
+                    locale: locale,
+                    comment: "Reset countdown. The first variable is the quota title; the second is a duration."
+                )
+            }
+            return String(
+                localized: "reset.in",
+                defaultValue: "Resets in \(countdown)",
+                locale: locale,
+                comment: "Reset countdown. The variable is a localized duration."
+            )
         case .clock:
             let clock = formattedClockTime(resetTime, locale: locale, timeZone: timeZone)
-            return title.map { "\($0) resets at \(clock)" } ?? "Resets at \(clock)"
+            if let title {
+                return String(
+                    localized: "reset.titled_at",
+                    defaultValue: "\(title) resets at \(clock)",
+                    locale: locale,
+                    comment: "Reset clock time. The first variable is the quota title; the second is a localized time."
+                )
+            }
+            return String(
+                localized: "reset.at",
+                defaultValue: "Resets at \(clock)",
+                locale: locale,
+                comment: "Reset clock time. The variable is a localized time."
+            )
         }
     }
 
@@ -257,17 +291,31 @@ struct BlockingLimitResetCounter: View {
 
     static func titleText(for window: ResetCountdownWindow?, in windows: [ResetCountdownWindow]) -> String {
         if let window {
-            return "\(window.title) reset"
+            return String(
+                localized: "reset.window_reset",
+                defaultValue: "\(window.title) reset",
+                comment: "Blocking quota title. The variable is the localized quota-window title."
+            )
         }
 
         let exhaustedCount = windows.filter { $0.limit.isAtLimit }.count
-        return exhaustedCount > 1 ? "Limits exhausted" : "Limit exhausted"
+        return String(
+            localized: "reset.exhausted_limits",
+            defaultValue: "\(exhaustedCount) limits exhausted",
+            comment: "Blocking quota title. The variable is the number of exhausted limits."
+        )
     }
 
     /// Returned whenever no reset instant is known. Callers that can omit the
     /// countdown entirely compare against this rather than re-deriving the
     /// "is there anything to count down to?" test from the window.
-    static let unavailableCounterText = "Reset time unavailable"
+    static var unavailableCounterText: String {
+        String(
+            localized: "reset.time_unavailable",
+            defaultValue: "Reset time unavailable",
+            comment: "Shown when a provider has not reported a reset time."
+        )
+    }
 
     static func counterText(
         for window: ResetCountdownWindow?,
@@ -277,32 +325,50 @@ struct BlockingLimitResetCounter: View {
         timeZone: TimeZone = .current
     ) -> String {
         guard let window,
-              let countdown = window.limit.resetCountdownText(now: now) else {
+              let seconds = window.limit.secondsUntilReset(now: now) else {
             return unavailableCounterText
         }
 
-        if countdown == "now" {
-            return "due now"
+        if seconds <= 0 {
+            return String(localized: "reset.due_now", defaultValue: "due now", comment: "Reset is due now.")
         }
 
         switch format {
         case .countdown:
-            return "in \(countdown)"
+            let countdown = LocalizedUsageFormat.countdown(seconds: seconds, locale: locale)
+            return String(
+                localized: "reset.counter_in",
+                defaultValue: "in \(countdown)",
+                locale: locale,
+                comment: "Condensed reset countdown. The variable is a localized duration."
+            )
         case .clock:
             guard let resetTime = window.limit.resetTime else { return unavailableCounterText }
-            return "at \(ResetCountdownLabel.formattedClockTime(resetTime, locale: locale, timeZone: timeZone))"
+            let clock = ResetCountdownLabel.formattedClockTime(resetTime, locale: locale, timeZone: timeZone)
+            return String(
+                localized: "reset.counter_at",
+                defaultValue: "at \(clock)",
+                locale: locale,
+                comment: "Condensed reset time. The variable is a localized clock time."
+            )
         }
     }
 
     static func detailText(for window: ResetCountdownWindow?, in windows: [ResetCountdownWindow]) -> String {
         guard window != nil else {
-            return "Usage is unavailable until the reset is reported."
+            return String(
+                localized: "reset.unavailable_until_reported",
+                defaultValue: "Usage is unavailable until the reset is reported.",
+                comment: "Detail shown when an exhausted quota has no known reset time."
+            )
         }
 
         let exhaustedCount = windows.filter { $0.limit.isAtLimit }.count
-        return exhaustedCount > 1
-            ? "Usage resumes after exhausted limits reset."
-            : "Usage is unavailable until this limit resets."
+        return String(
+            localized: "reset.exhausted_detail",
+            defaultValue: "Usage resumes after \(exhaustedCount) exhausted limits reset.",
+            comment: "Blocking quota detail. The variable is the number of exhausted limits."
+        )
     }
 }
 

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -75,7 +75,7 @@ struct ProviderSnapshot: Identifiable {
         blockingLimits.map {
             ResetCountdownWindow(
                 id: "\(id)-\($0.title)",
-                title: $0.title,
+                title: $0.localizedTitle,
                 limit: $0.usageLimit
             )
         }
@@ -189,6 +189,35 @@ struct SnapshotLimit: Identifiable {
         usageLimit.isEstimated ? "\(title), estimated" : title
     }
 
+    /// App-target projection for standard quota-window copy. Parsed model
+    /// labels are provider data and remain verbatim.
+    var localizedTitle: String {
+        switch (kind, title) {
+        case (.session, "Key limit"):
+            return String(localized: "quota.title.key_limit", defaultValue: "Key limit")
+        case (.session, "Session"):
+            return String(localized: "quota.title.session", defaultValue: "Session")
+        case (.weekly, "Account credits"):
+            return String(localized: "quota.title.account_credits", defaultValue: "Account credits")
+        case (.weekly, "Monthly"):
+            return String(localized: "quota.title.monthly", defaultValue: "Monthly")
+        case (.weekly, "Weekly"):
+            return String(localized: "quota.title.weekly", defaultValue: "Weekly")
+        case (.codeReview, "Code Review"):
+            return String(localized: "quota.title.code_review", defaultValue: "Code Review")
+        case (.codeReview, "Model"):
+            return String(localized: "quota.title.model", defaultValue: "Model")
+        default:
+            return title
+        }
+    }
+
+    /// Localized equivalent used by UI surfaces. The English property above is
+    /// retained for existing non-UI callers and compatibility tests.
+    var localizedAccessibilityLabel: String {
+        usageLimit.isEstimated ? LocalizedUsageFormat.estimatedLabel(localizedTitle) : localizedTitle
+    }
+
     /// VoiceOver value for a quota window: how much is left and how much is
     /// used/spent, mirroring the trailing value + used-value copy the rows
     /// render. Currency-style limits (OpenRouter key/credit balances) speak
@@ -200,6 +229,21 @@ struct SnapshotLimit: Identifiable {
         }
         let trailing = (isOut && !usageLimit.isEstimated) ? "Out" : usageLimit.percentLeftText
         return "\(trailing), \(usageLimit.usedPercentageText)"
+    }
+
+    /// Localized equivalent used by app views and VoiceOver.
+    var localizedAccessibilityValue: String {
+        if valueStyle == .currency {
+            let left = LocalizedUsageFormat.amountLeft(
+                UsageFormat.cost(max(0, usageLimit.total - usageLimit.used))
+            )
+            let spent = LocalizedUsageFormat.amountSpent(UsageFormat.cost(usageLimit.used))
+            return LocalizedUsageFormat.pairedValue(left, spent)
+        }
+        let trailing = (isOut && !usageLimit.isEstimated)
+            ? LocalizedUsageFormat.out()
+            : LocalizedUsageFormat.percentLeft(usageLimit)
+        return LocalizedUsageFormat.pairedValue(trailing, LocalizedUsageFormat.percentUsed(usageLimit))
     }
 }
 

--- a/MeterBarTests/LocalizationLayoutTests.swift
+++ b/MeterBarTests/LocalizationLayoutTests.swift
@@ -1,0 +1,83 @@
+import AppKit
+import MeterBarShared
+import SwiftUI
+import XCTest
+@testable import MeterBar
+
+/// Double-length and RTL smoke coverage for the first localized surfaces.
+/// Xcode's pseudolanguages remain the visual QA gate; these tests make the
+/// narrow app geometry and the flexible settings-row behavior regressible.
+@MainActor
+final class LocalizationLayoutTests: XCTestCase {
+    func testPseudoLocalizedQuotaRowRendersAtPopoverWidthInBothDirections() {
+        let limit = SnapshotLimit(
+            id: "weekly",
+            kind: .weekly,
+            title: pseudo("Weekly usage limit"),
+            usageLimit: UsageLimit(
+                used: 72,
+                total: 100,
+                resetTime: Date().addingTimeInterval(3_660),
+                windowSeconds: 604_800,
+                isEstimated: true
+            )
+        )
+
+        for direction in [LayoutDirection.leftToRight, .rightToLeft] {
+            let view = LimitRow(limit: limit, accentColor: .blue, density: .compact)
+                .environment(\.locale, Locale(identifier: direction == .leftToRight ? "en_XA" : "ar_XB"))
+                .environment(\.layoutDirection, direction)
+                .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+                .frame(width: 240)
+            let host = NSHostingView(rootView: view)
+            host.layoutSubtreeIfNeeded()
+            XCTAssertGreaterThan(host.fittingSize.height, 0)
+            XCTAssertLessThan(host.fittingSize.height, 180, "quota row expanded beyond the popover budget")
+        }
+    }
+
+    func testPseudoLocalizedSettingsRowStillUsesAvailableWidth() {
+        for direction in [LayoutDirection.leftToRight, .rightToLeft] {
+            let narrow = settingsRowHeight(width: 560, direction: direction)
+            let wide = settingsRowHeight(width: 900, direction: direction)
+            XCTAssertLessThan(wide, narrow, "pseudo-localized settings copy did not reflow for \(direction)")
+        }
+    }
+
+    private func settingsRowHeight(width: CGFloat, direction: LayoutDirection) -> CGFloat {
+        let view = SettingsRowView(
+            title: pseudo("Follow focused application"),
+            detail: pseudo(
+                "MeterBar matches the frontmost application's bundle identifier locally and never reads window text."
+            )
+        ) {
+            Toggle("", isOn: .constant(false)).labelsHidden()
+        }
+        .environment(\.locale, Locale(identifier: direction == .leftToRight ? "en_XA" : "ar_XB"))
+        .environment(\.layoutDirection, direction)
+        .frame(width: width)
+
+        let host = NSHostingView(rootView: view)
+        host.layoutSubtreeIfNeeded()
+        return host.fittingSize.height
+    }
+
+    private func pseudo(_ source: String) -> String {
+        let expanded = source.map { character -> String in
+            switch character {
+            case "a": return "àà"
+            case "e": return "ëë"
+            case "i": return "ïï"
+            case "o": return "ôô"
+            case "u": return "üü"
+            case "A": return "ÀÀ"
+            case "E": return "ËË"
+            case "I": return "ÏÏ"
+            case "O": return "ÔÔ"
+            case "U": return "ÜÜ"
+            default: return String(character)
+            }
+        }.joined()
+        return "[!! \(expanded) !!]"
+    }
+}

--- a/MeterBarTests/LocalizationResourceContractTests.swift
+++ b/MeterBarTests/LocalizationResourceContractTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+final class LocalizationResourceContractTests: XCTestCase {
+    private var repositoryRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private var appCatalogURL: URL {
+        repositoryRoot.appendingPathComponent("MeterBar/Resources/Localizable.xcstrings")
+    }
+
+    private var widgetCatalogURL: URL {
+        repositoryRoot.appendingPathComponent("MeterBarWidget/Resources/Localizable.xcstrings")
+    }
+
+    func testAppAndWidgetOwnIndependentEnglishSourceCatalogs() throws {
+        for url in [appCatalogURL, widgetCatalogURL] {
+            let catalog = try loadCatalog(at: url)
+            XCTAssertEqual(catalog["sourceLanguage"] as? String, "en", url.path)
+            XCTAssertEqual(catalog["version"] as? String, "1.0", url.path)
+            XCTAssertFalse(try strings(in: catalog).isEmpty, url.path)
+        }
+    }
+
+    func testHighTrafficVerticalSliceKeysStayInTheExpectedTargetCatalog() throws {
+        let appKeys = Set(try strings(in: loadCatalog(at: appCatalogURL)).keys)
+        XCTAssertTrue([
+            "quota.percent_left",
+            "quota.percent_used",
+            "quota.amount_left",
+            "quota.amount_spent",
+            "quota.title.session",
+            "quota.title.weekly",
+            "reset.titled_in",
+            "reset.window_reset",
+            "reset.exhausted_limits",
+            "reset.exhausted_detail",
+        ].allSatisfy(appKeys.contains))
+
+        let widgetKeys = Set(try strings(in: loadCatalog(at: widgetCatalogURL)).keys)
+        XCTAssertTrue([
+            "widget.description",
+            "widget.empty.choose_title",
+            "widget.health.stale",
+            "widget.quota.session",
+            "count.more_rows",
+            "count.more_usage_rows",
+        ].allSatisfy(widgetKeys.contains))
+    }
+
+    func testCountStringsCarryEnglishOneAndOtherPluralRules() throws {
+        try assertPluralRules(
+            keys: ["reset.exhausted_limits", "reset.exhausted_detail"],
+            catalogURL: appCatalogURL
+        )
+        try assertPluralRules(
+            keys: ["count.more_rows", "count.more_usage_rows"],
+            catalogURL: widgetCatalogURL
+        )
+    }
+
+    /// Localization must never redefine these as display copy. They are CLI
+    /// protocol tokens consumed by shell scripts and JSON clients.
+    func testCLIMachineTokensRemainStableAndOutsideTheCatalogs() throws {
+        XCTAssertEqual(
+            ServiceType.allCases.sorted { $0.sortOrder < $1.sortOrder }.map(\.cliIdentifier),
+            ["claude", "codex", "cursor", "openrouter", "grok"]
+        )
+
+        let reservedTokens: Set<String> = [
+            "usage",
+            "cost",
+            "doctor",
+            "guard",
+            "session",
+            "weekly",
+            "codeReview",
+            "schemaVersion",
+        ]
+        let catalogKeys = Set(try strings(in: loadCatalog(at: appCatalogURL)).keys)
+            .union(try strings(in: loadCatalog(at: widgetCatalogURL)).keys)
+        XCTAssertTrue(reservedTokens.isDisjoint(with: catalogKeys))
+    }
+
+    private func loadCatalog(at url: URL) throws -> [String: Any] {
+        let data = try Data(contentsOf: url)
+        return try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any],
+            "Invalid String Catalog JSON at \(url.path)"
+        )
+    }
+
+    private func strings(in catalog: [String: Any]) throws -> [String: Any] {
+        try XCTUnwrap(catalog["strings"] as? [String: Any])
+    }
+
+    private func assertPluralRules(keys: [String], catalogURL: URL) throws {
+        let catalogStrings = try strings(in: loadCatalog(at: catalogURL))
+        for key in keys {
+            let entry = try XCTUnwrap(catalogStrings[key] as? [String: Any], key)
+            let localizations = try XCTUnwrap(entry["localizations"] as? [String: Any], key)
+            let english = try XCTUnwrap(localizations["en"] as? [String: Any], key)
+            let variations = try XCTUnwrap(english["variations"] as? [String: Any], key)
+            let plural = try XCTUnwrap(variations["plural"] as? [String: Any], key)
+            XCTAssertNotNil(plural["one"], "\(key) needs an English one rule")
+            XCTAssertNotNil(plural["other"], "\(key) needs an English other rule")
+        }
+    }
+}

--- a/MeterBarTests/LocalizedUsageFormattingTests.swift
+++ b/MeterBarTests/LocalizedUsageFormattingTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import MeterBarShared
+import XCTest
+
+final class LocalizedUsageFormattingTests: XCTestCase {
+    private func limit(used: Double, isEstimated: Bool = false) -> UsageLimit {
+        UsageLimit(
+            used: used,
+            total: 100,
+            resetTime: nil,
+            isEstimated: isEstimated
+        )
+    }
+
+    func testQuotaPercentFormattingKeepsUsedAndRemainingSemantics() {
+        XCTAssertEqual(
+            LocalizedUsageFormat.percentLeft(limit(used: 40), locale: Locale(identifier: "en")),
+            "60% left"
+        )
+        XCTAssertEqual(
+            LocalizedUsageFormat.percentUsed(limit(used: 40), locale: Locale(identifier: "en")),
+            "40% used"
+        )
+    }
+
+    func testEstimatedPercentFormattingKeepsApproximationMark() {
+        XCTAssertEqual(
+            LocalizedUsageFormat.percentLeft(
+                limit(used: 100, isEstimated: true),
+                locale: Locale(identifier: "en")
+            ),
+            "~0% left"
+        )
+        XCTAssertEqual(
+            LocalizedUsageFormat.percentUsed(
+                limit(used: 40, isEstimated: true),
+                locale: Locale(identifier: "en")
+            ),
+            "~40% used"
+        )
+    }
+
+    func testCountdownUsesLocaleAwareUnitFormatting() {
+        let english = LocalizedUsageFormat.countdown(
+            seconds: 3_660,
+            locale: Locale(identifier: "en")
+        )
+        let japanese = LocalizedUsageFormat.countdown(
+            seconds: 3_660,
+            locale: Locale(identifier: "ja")
+        )
+
+        XCTAssertEqual(english, "1h 1m")
+        XCTAssertNotEqual(japanese, english)
+        XCTAssertFalse(japanese.isEmpty)
+    }
+
+    func testCountdownKeepsCompactSubMinuteFallback() {
+        XCTAssertEqual(
+            LocalizedUsageFormat.countdown(seconds: 59, locale: Locale(identifier: "en")),
+            "<1m"
+        )
+    }
+}

--- a/MeterBarWidget/Resources/Localizable.xcstrings
+++ b/MeterBarWidget/Resources/Localizable.xcstrings
@@ -1,0 +1,269 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "count.more_rows" : {
+      "comment" : "Widget overflow label. The variable is the hidden row count.",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "+%lld more"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "+%lld more"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "count.more_usage_rows" : {
+      "comment" : "VoiceOver widget overflow label. The variable is the hidden usage-row count.",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld more usage row"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld more usage rows"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "quota.amount_left" : {
+      "comment" : "Formatted currency amount remaining.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ left"
+          }
+        }
+      }
+    },
+    "quota.amount_spent" : {
+      "comment" : "Formatted currency amount already spent.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ spent"
+          }
+        }
+      }
+    },
+    "quota.percent_left" : {
+      "comment" : "Quota percentage remaining. The variable is a whole-number percentage.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld%% left"
+          }
+        }
+      }
+    },
+    "quota.percent_left.estimated" : {
+      "comment" : "Approximate quota percentage remaining. The variable is a whole-number percentage.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "~%lld%% left"
+          }
+        }
+      }
+    },
+    "quota.percent_used" : {
+      "comment" : "Quota percentage used. The variable is a whole-number percentage.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld%% used"
+          }
+        }
+      }
+    },
+    "quota.percent_used.estimated" : {
+      "comment" : "Approximate quota percentage used. The variable is a whole-number percentage.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "~%lld%% used"
+          }
+        }
+      }
+    },
+    "widget.description" : {
+      "comment" : "Widget Gallery description.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Track your AI coding assistant usage limits"
+          }
+        }
+      }
+    },
+    "widget.empty.choose_detail" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select accounts and quota windows in MeterBar Settings."
+          }
+        }
+      }
+    },
+    "widget.empty.choose_title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose usage to show"
+          }
+        }
+      }
+    },
+    "widget.empty.unavailable_detail" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open MeterBar to refresh provider usage."
+          }
+        }
+      }
+    },
+    "widget.empty.unavailable_title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usage unavailable"
+          }
+        }
+      }
+    },
+    "widget.health.stale" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stale usage data"
+          }
+        }
+      }
+    },
+    "widget.health.unavailable" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usage unavailable"
+          }
+        }
+      }
+    },
+    "widget.quota.account_credits" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account credits"
+          }
+        }
+      }
+    },
+    "widget.quota.code_review" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Code Review"
+          }
+        }
+      }
+    },
+    "widget.quota.key_limit" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Key limit"
+          }
+        }
+      }
+    },
+    "widget.quota.model" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Model"
+          }
+        }
+      }
+    },
+    "widget.quota.monthly" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monthly"
+          }
+        }
+      }
+    },
+    "widget.quota.session" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session"
+          }
+        }
+      }
+    },
+    "widget.quota.weekly" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weekly"
+          }
+        }
+      }
+    },
+    "widget.unavailable" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unavailable"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/MeterBarWidget/UsageWidget.swift
+++ b/MeterBarWidget/UsageWidget.swift
@@ -24,7 +24,7 @@ struct UsageWidget: Widget {
             UsageWidgetEntryView(entry: entry)
         }
         .configurationDisplayName("MeterBar")
-        .description("Track your AI coding assistant usage limits")
+        .description("widget.description")
         .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
     }
 }
@@ -203,7 +203,7 @@ struct WidgetGlanceRow: View {
                     .lineLimit(1)
                 Spacer(minLength: metrics.rowSpacing)
                 WidgetHealthIndicator(health: row.health, size: metrics.captionSize)
-                Text(row.summaryText)
+                Text(WidgetLocalizedContent.summaryText(for: row))
                     .font(.system(size: metrics.headlineSize, weight: .semibold, design: .rounded))
                     .monospacedDigit()
                     .lineLimit(1)
@@ -215,7 +215,7 @@ struct WidgetGlanceRow: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(row.accountName)
-        .accessibilityValue(row.accessibilityValueText)
+        .accessibilityValue(WidgetLocalizedContent.accessibilityValue(for: row))
     }
 }
 
@@ -236,7 +236,7 @@ struct WidgetGlanceHero: View {
                 WidgetHealthIndicator(health: row.health, size: metrics.captionSize)
             }
 
-            Text(row.summaryText)
+            Text(WidgetLocalizedContent.summaryText(for: row))
                 .font(.system(size: metrics.headlineSize, weight: .semibold, design: .rounded))
                 .monospacedDigit()
                 .lineLimit(1)
@@ -247,7 +247,7 @@ struct WidgetGlanceHero: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(row.accountName)
-        .accessibilityValue(row.accessibilityValueText)
+        .accessibilityValue(WidgetLocalizedContent.accessibilityValue(for: row))
     }
 }
 
@@ -268,14 +268,14 @@ struct WidgetGlanceRail: View {
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                         Spacer(minLength: metrics.rowSpacing)
-                        Text(row.compactSummaryText)
+                        Text(WidgetLocalizedContent.compactSummaryText(for: row))
                             .font(.system(size: metrics.captionSize, weight: .medium))
                             .monospacedDigit()
                             .foregroundStyle(row.usageStatus?.color ?? .secondary)
                     }
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel(row.accountName)
-                    .accessibilityValue(row.compactAccessibilityValueText)
+                    .accessibilityValue(WidgetLocalizedContent.accessibilityValue(for: row, compact: true))
                 }
             }
         }
@@ -320,7 +320,7 @@ struct WidgetGlanceCaption: View {
 
     var body: some View {
         HStack(spacing: size / 2) {
-            Text(row.quotaTitle)
+            Text(WidgetLocalizedContent.quotaTitle(for: row))
             if let resetTime = row.resetTime {
                 Label {
                     Text(resetTime, style: .relative)
@@ -369,7 +369,7 @@ struct WidgetHealthIndicator: View {
     /// `WidgetDataHealth`, so they cannot end up describing one state two ways.
     /// A healthy row draws no glyph, so it never reaches this.
     private var label: String {
-        health.accessibilityDescription ?? ""
+        WidgetLocalizedContent.healthDescription(health) ?? ""
     }
 }
 
@@ -379,10 +379,10 @@ struct WidgetOverflowView: View {
 
     var body: some View {
         if hiddenRowCount > 0 {
-            Label("+\(hiddenRowCount) more", systemImage: "ellipsis.circle")
+            Label(LocalizedUsageFormat.moreRows(hiddenRowCount), systemImage: "ellipsis.circle")
                 .font(.system(size: metrics.captionSize))
                 .foregroundStyle(.secondary)
-                .accessibilityLabel("\(hiddenRowCount) more usage rows")
+                .accessibilityLabel(LocalizedUsageFormat.moreUsageRows(hiddenRowCount))
         }
     }
 }
@@ -398,10 +398,10 @@ struct WidgetEmptyStateView: View {
                     .font(.title2)
                     .foregroundStyle(state == .noSelection ? Color.secondary : Color.orange)
             }
-            Text(state.title)
+            Text(WidgetLocalizedContent.emptyTitle(state))
                 .font(.caption)
                 .bold()
-            Text(state.detail)
+            Text(WidgetLocalizedContent.emptyDetail(state))
                 .font(.caption2)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(compact ? .leading : .center)

--- a/MeterBarWidget/WidgetLocalization.swift
+++ b/MeterBarWidget/WidgetLocalization.swift
@@ -1,0 +1,103 @@
+import Foundation
+import MeterBarShared
+
+/// Target-localized copy derived from the shared widget presentation model.
+/// The shared model stays locale-neutral so the app preview and CLI contracts
+/// do not accidentally resolve against the widget extension's bundle.
+enum WidgetLocalizedContent {
+    static func quotaTitle(for row: WidgetPresentationRow) -> String {
+        switch (row.service, row.quotaWindow) {
+        case (.openRouter, .session):
+            return String(localized: "widget.quota.key_limit", defaultValue: "Key limit")
+        case (.claudeCode, .codeReview):
+            return row.modelLimitLabel
+                ?? String(localized: "widget.quota.model", defaultValue: "Model")
+        case (_, .codeReview):
+            return String(localized: "widget.quota.code_review", defaultValue: "Code Review")
+        case (_, .session):
+            return String(localized: "widget.quota.session", defaultValue: "Session")
+        case (.openRouter, .weekly):
+            return String(localized: "widget.quota.account_credits", defaultValue: "Account credits")
+        case (.cursor, .weekly):
+            return String(localized: "widget.quota.monthly", defaultValue: "Monthly")
+        case (_, .weekly):
+            return String(localized: "widget.quota.weekly", defaultValue: "Weekly")
+        }
+    }
+
+    static func summaryText(for row: WidgetPresentationRow) -> String {
+        guard let limit = row.limit else {
+            return String(localized: "widget.unavailable", defaultValue: "Unavailable")
+        }
+        if row.service == .openRouter {
+            let amount: Double
+            switch row.preservesLegacyOpenRouterBalance ? .remaining : row.displayMode {
+            case .used:
+                amount = max(0, limit.used)
+                return LocalizedUsageFormat.amountSpent(ExtraUsageStatus.formatAmount(amount))
+            case .remaining:
+                amount = max(0, limit.total - limit.used)
+                return LocalizedUsageFormat.amountLeft(ExtraUsageStatus.formatAmount(amount))
+            }
+        }
+
+        switch row.displayMode {
+        case .used:
+            return LocalizedUsageFormat.percentUsed(limit)
+        case .remaining:
+            return LocalizedUsageFormat.percentLeft(limit)
+        }
+    }
+
+    static func compactSummaryText(for row: WidgetPresentationRow) -> String {
+        guard row.service == .openRouter,
+              row.preservesLegacyOpenRouterBalance,
+              let limit = row.limit else {
+            return summaryText(for: row)
+        }
+        return ExtraUsageStatus.formatAmount(max(0, limit.total - limit.used))
+    }
+
+    static func accessibilityValue(for row: WidgetPresentationRow, compact: Bool = false) -> String {
+        let leading = compact
+            ? [compactSummaryText(for: row)]
+            : [quotaTitle(for: row), summaryText(for: row)]
+        return (leading + [healthDescription(row.health)].compactMap { $0 })
+            .formatted(.list(type: .and, width: .short))
+    }
+
+    static func healthDescription(_ health: WidgetDataHealth) -> String? {
+        switch health {
+        case .healthy:
+            return nil
+        case .stale:
+            return String(localized: "widget.health.stale", defaultValue: "Stale usage data")
+        case .unavailable:
+            return String(localized: "widget.health.unavailable", defaultValue: "Usage unavailable")
+        }
+    }
+
+    static func emptyTitle(_ state: WidgetPresentationEmptyState) -> String {
+        switch state {
+        case .noSelection:
+            return String(localized: "widget.empty.choose_title", defaultValue: "Choose usage to show")
+        case .unavailable:
+            return String(localized: "widget.empty.unavailable_title", defaultValue: "Usage unavailable")
+        }
+    }
+
+    static func emptyDetail(_ state: WidgetPresentationEmptyState) -> String {
+        switch state {
+        case .noSelection:
+            return String(
+                localized: "widget.empty.choose_detail",
+                defaultValue: "Select accounts and quota windows in MeterBar Settings."
+            )
+        case .unavailable:
+            return String(
+                localized: "widget.empty.unavailable_detail",
+                defaultValue: "Open MeterBar to refresh provider usage."
+            )
+        }
+    }
+}

--- a/Packages/MeterBarShared/Sources/MeterBarShared/LocalizedUsageFormatting.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/LocalizedUsageFormatting.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+/// Bundle-aware, locale-safe formatting for quota UI.
+///
+/// The existing English `UsageLimit` display properties remain unchanged
+/// because the bundled CLI uses them for stable terminal output. App and
+/// widget callers opt into this formatter and pass their own resource bundle,
+/// allowing both UI targets to own an independent String Catalog without
+/// coupling machine-readable CLI contracts to a display locale.
+public enum LocalizedUsageFormat {
+    public static func percentLeft(
+        _ limit: UsageLimit,
+        bundle: Bundle = .main,
+        locale: Locale = .current
+    ) -> String {
+        let percent = QuotaMath.percentLeft(for: limit)
+        if limit.isEstimated {
+            return String(
+                localized: "quota.percent_left.estimated",
+                defaultValue: "~\(percent)% left",
+                bundle: bundle,
+                locale: locale,
+                comment: "Approximate quota percentage remaining. The variable is a whole-number percentage."
+            )
+        }
+        return String(
+            localized: "quota.percent_left",
+            defaultValue: "\(percent)% left",
+            bundle: bundle,
+            locale: locale,
+            comment: "Quota percentage remaining. The variable is a whole-number percentage."
+        )
+    }
+
+    public static func percentUsed(
+        _ limit: UsageLimit,
+        bundle: Bundle = .main,
+        locale: Locale = .current
+    ) -> String {
+        let percent = Int(limit.percentage.rounded())
+        if limit.isEstimated {
+            return String(
+                localized: "quota.percent_used.estimated",
+                defaultValue: "~\(percent)% used",
+                bundle: bundle,
+                locale: locale,
+                comment: "Approximate quota percentage used. The variable is a whole-number percentage."
+            )
+        }
+        return String(
+            localized: "quota.percent_used",
+            defaultValue: "\(percent)% used",
+            bundle: bundle,
+            locale: locale,
+            comment: "Quota percentage used. The variable is a whole-number percentage."
+        )
+    }
+
+    public static func amountLeft(
+        _ amount: String,
+        bundle: Bundle = .main,
+        locale: Locale = .current
+    ) -> String {
+        String(
+            localized: "quota.amount_left",
+            defaultValue: "\(amount) left",
+            bundle: bundle,
+            locale: locale,
+            comment: "Formatted currency amount remaining."
+        )
+    }
+
+    public static func amountSpent(
+        _ amount: String,
+        bundle: Bundle = .main,
+        locale: Locale = .current
+    ) -> String {
+        String(
+            localized: "quota.amount_spent",
+            defaultValue: "\(amount) spent",
+            bundle: bundle,
+            locale: locale,
+            comment: "Formatted currency amount already spent."
+        )
+    }
+
+    public static func pairedValue(
+        _ primary: String,
+        _ secondary: String,
+        bundle: Bundle = .main,
+        locale: Locale = .current
+    ) -> String {
+        String(
+            localized: "quota.paired_value",
+            defaultValue: "\(primary), \(secondary)",
+            bundle: bundle,
+            locale: locale,
+            comment: "VoiceOver quota summary. The first variable is remaining or out; the second is used or spent."
+        )
+    }
+
+    public static func estimatedLabel(
+        _ title: String,
+        bundle: Bundle = .main,
+        locale: Locale = .current
+    ) -> String {
+        String(
+            localized: "quota.estimated_label",
+            defaultValue: "\(title), estimated",
+            bundle: bundle,
+            locale: locale,
+            comment: "VoiceOver quota title. The variable is the quota window name."
+        )
+    }
+
+    public static func out(bundle: Bundle = .main, locale: Locale = .current) -> String {
+        String(
+            localized: "quota.out",
+            defaultValue: "Out",
+            bundle: bundle,
+            locale: locale,
+            comment: "Quota is exhausted."
+        )
+    }
+
+    /// Compact, locale-aware countdown with at most two non-zero units.
+    /// `DateComponentsFormatter` owns unit grammar/plurals for every locale.
+    public static func countdown(
+        seconds: TimeInterval,
+        bundle: Bundle = .main,
+        locale: Locale = .current
+    ) -> String {
+        let wholeSeconds = max(0, Int(seconds.rounded()))
+        guard wholeSeconds >= 60 else {
+            return String(
+                localized: "duration.less_than_one_minute",
+                defaultValue: "<1m",
+                bundle: bundle,
+                locale: locale,
+                comment: "Compact duration shorter than one minute."
+            )
+        }
+
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .abbreviated
+        formatter.allowedUnits = [.day, .hour, .minute]
+        formatter.maximumUnitCount = 2
+        formatter.zeroFormattingBehavior = .dropAll
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = locale
+        formatter.calendar = calendar
+        return formatter.string(from: TimeInterval(wholeSeconds)) ?? "<1m"
+    }
+
+    public static func moreRows(
+        _ count: Int,
+        bundle: Bundle = .main,
+        locale: Locale = .current
+    ) -> String {
+        String(
+            localized: "count.more_rows",
+            defaultValue: "+\(count) more",
+            bundle: bundle,
+            locale: locale,
+            comment: "Widget overflow label. The variable is the hidden row count."
+        )
+    }
+
+    public static func moreUsageRows(
+        _ count: Int,
+        bundle: Bundle = .main,
+        locale: Locale = .current
+    ) -> String {
+        String(
+            localized: "count.more_usage_rows",
+            defaultValue: "\(count) more usage rows",
+            bundle: bundle,
+            locale: locale,
+            comment: "VoiceOver widget overflow label. The variable is the hidden usage-row count."
+        )
+    }
+}

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -1,0 +1,62 @@
+# Localization groundwork
+
+Issue #392 is intentionally shipping in reviewable waves. The first phase adds
+String Catalog infrastructure and localizes the quota/reset vertical slice; it
+does not claim complete language support.
+
+## Catalog ownership
+
+- `MeterBar/Resources/Localizable.xcstrings` belongs to the app bundle.
+- `MeterBarWidget/Resources/Localizable.xcstrings` belongs to the widget
+  extension bundle. Widget copy must resolve here, not through the app bundle.
+- `LocalizedUsageFormat` centralizes percentage, money-label, compact-duration,
+  and count formatting shared by the two UI targets. Compact countdown units
+  use Foundation's locale-aware `DateComponentsFormatter`; count labels use
+  String Catalog plural variations.
+- Provider/account/model names are runtime values and remain verbatim unless a
+  future product decision explicitly defines a translated display name.
+
+The English source catalog is the current shipping locale. Every new opaque key
+must have an English value, a translator comment for ambiguous/interpolated
+copy, and a resource-contract test when it is part of a critical flow.
+
+## CLI compatibility boundary
+
+Phase one does not localize CLI output. The existing English `UsageLimit`
+properties remain available to the CLI while app/widget code opts into
+`LocalizedUsageFormat`.
+
+The following are protocol, not display copy, and must never be localized:
+
+- command, subcommand, flag, provider, and quota-window tokens;
+- JSON keys, enum values, error codes, and schema versions;
+- exit codes and stdout-only JSON behavior.
+
+If human-readable CLI output is localized later, locale selection must be
+explicit and must not affect any `--json` document or stable command token.
+`docs/cli-json-schema.md` remains the compatibility contract.
+
+## Translation waves still open
+
+1. Complete extraction and linguistic QA for Simplified Chinese (`zh-Hans`)
+   and Japanese (`ja`) across the remaining app/settings/dashboard surfaces,
+   then translate both app and widget catalogs together.
+2. Repeat the same reviewed pass for German (`de`), French (`fr`), and Spanish
+   (`es`). Do not copy machine translations into the catalogs as a bulk dump.
+3. Before each language ships, verify screenshots at popover, dashboard,
+   settings, and all widget-family widths; audit VoiceOver, dates, currencies,
+   percentages, plural categories, truncation, and provider terminology.
+
+## Verification
+
+Compile each catalog before review:
+
+```sh
+xcrun xcstringstool compile MeterBar/Resources/Localizable.xcstrings --output-directory /tmp/meterbar-app-l10n
+xcrun xcstringstool compile MeterBarWidget/Resources/Localizable.xcstrings --output-directory /tmp/meterbar-widget-l10n
+```
+
+Use Xcode's Double-Length and Right-to-Left pseudolanguages for the visual
+layout pass. Automated tests cover catalog/resource contracts, plural-rule
+presence, locale-aware countdown formatting, narrow quota rows, RTL direction,
+and the flexible settings-row geometry.


### PR DESCRIPTION
## Summary

- add target-owned English source String Catalogs for the app and widget extension
- centralize locale-aware quota percentages, currency labels, countdowns, accessibility composition, and plural-safe counts
- localize the high-traffic quota/reset/widget slice while preserving dynamic provider, account, and model names
- add resource-contract, plural-rule, double-length, RTL, narrow-layout, and formatter tests
- document the CLI compatibility boundary and remaining translation waves

## Compatibility boundary

CLI output remains English in this phase. Stable commands, flags, provider/window tokens, JSON keys and enum values, error codes, schema versions, exit codes, and stdout-only JSON behavior are unchanged and remain outside the catalogs.

## Remaining work

Issue #392 intentionally remains open. The next reviewed wave completes extraction and linguistic QA for zh-Hans and ja across remaining app, settings, and dashboard surfaces, followed later by de, fr, and es. This PR does not bulk-import unreviewed machine translations.

## Verification

- strict SwiftLint: 0 violations across 280 files
- focused localization/reset/layout suite: 40 tests passed
- full Swift suite: 2,326 tests passed, 6 intentional live/credential skips, 0 failures
- app Xcode build: passed
- independent widget extension Xcode build: passed
- standalone CLI Swift build: passed
- both String Catalogs compiled with xcstringstool
- CLI JSON smoke validator fixtures: passed
- git diff --check: passed

Refs #392