### PR TITLE
feat(widget): add burn-down countdown family

### DIFF
--- a/.agents/SYSTEM/ARCHITECTURE.md
+++ b/.agents/SYSTEM/ARCHITECTURE.md
@@ -54,7 +54,7 @@ meterbar/
 │   ├── Views/                # MenuBarView, SettingsView, UsageDashboardView,
 │   │                         # MeterBarTheme, RefreshingIcon
 │   └── Resources/, Assets.xcassets, Info.plist, MeterBar.entitlements
-├── MeterBarWidget/           # Widget extension (UsageWidget kind "UsageWidget")
+├── MeterBarWidget/           # Widget extension (Usage + Burn Down kinds)
 ├── MeterBarCLI/              # `meterbar` CLI package
 ├── MeterBarTests/            # XCTest suite (runs via `swift test`)
 ├── scripts/                  # Bun/Playwright asset generators, check-coverage.sh
@@ -100,6 +100,8 @@ On the first launch, `FirstRunOnboardingStore` auto-opens the menu panel and sho
 ## Widget & CLI data contract
 
 The app, widget, and CLI consume the canonical `ServiceType`, `UsageLimit`, and `UsageMetrics` definitions from `Packages/MeterBarShared`. The app-group JSON contract is locked by `CachedMetricsContractTests` and `CachedMetricsReplicaContractTests` so fields and date encoding cannot silently drift across targets.
+
+The widget bundle preserves the original `UsageWidget` (small, medium, large) and also registers the distinct `BurnDownWidget` (small, medium). Both read the same `WidgetPreferences` provider/account/window selection. The shared `WidgetBurnDownPlanner` uses `UsageLimit.pace()` to choose projected exhaustion versus reset, suppresses projections for stale or estimated data, and provides a bounded one-to-fifteen-minute WidgetKit reload policy around meaningful countdown boundaries.
 
 Dates in the shared JSON use `JSONEncoder`/`JSONDecoder` **default** strategies (seconds since 2001-01-01 reference date). Changing either side's date strategy breaks widget + CLI decode.
 

--- a/.agents/docs/TESTING.md
+++ b/.agents/docs/TESTING.md
@@ -232,3 +232,11 @@ each state:
       the remaining providers rather than going fully empty.
 - [ ] **Reload** — change the refresh interval or force a refresh in the app and
       confirm the widget updates (via `WidgetCenter.reloadTimelines`).
+- [ ] **Burn Down** — add the small and medium Burn Down widgets; confirm reserve,
+      on-pace, deficit, projected-empty, and reset countdown states use the same
+      account/window selections as Usage.
+- [ ] **Burn Down health** — verify stale cached data keeps the reset countdown but
+      does not claim a projected exhaustion, and unavailable selections remain
+      visibly unavailable.
+- [ ] **Appearances** — verify Usage and Burn Down in light and dark appearances;
+      labels, provider marks, pace color, and VoiceOver values remain legible.

--- a/MeterBar/Services/SharedDataStore.swift
+++ b/MeterBar/Services/SharedDataStore.swift
@@ -122,7 +122,9 @@ nonisolated public final class SharedDataStore: @unchecked Sendable {
     private static func reloadWidgetTimelines() {
         #if canImport(WidgetKit)
         if #available(macOS 11.0, *) {
-            WidgetCenter.shared.reloadTimelines(ofKind: "UsageWidget")
+            for kind in MeterBarWidgetKind.all {
+                WidgetCenter.shared.reloadTimelines(ofKind: kind)
+            }
         }
         #endif
     }

--- a/MeterBar/Views/Settings/WidgetSettingsView.swift
+++ b/MeterBar/Views/Settings/WidgetSettingsView.swift
@@ -179,18 +179,21 @@ struct WidgetSettingsPreviewData {
             sessionLimit: UsageLimit(
                 used: max(10, used - 12),
                 total: 100,
-                resetTime: now.addingTimeInterval(90 * 60)
+                resetTime: now.addingTimeInterval(90 * 60),
+                windowSeconds: 5 * 60 * 60
             ),
             weeklyLimit: UsageLimit(
                 used: used,
                 total: 100,
-                resetTime: now.addingTimeInterval(3 * 24 * 60 * 60)
+                resetTime: now.addingTimeInterval(3 * 24 * 60 * 60),
+                windowSeconds: 7 * 24 * 60 * 60
             ),
             codeReviewLimit: service == .claudeCode
                 ? UsageLimit(
                     used: min(92, used + 8),
                     total: 100,
-                    resetTime: now.addingTimeInterval(5 * 24 * 60 * 60)
+                    resetTime: now.addingTimeInterval(5 * 24 * 60 * 60),
+                    windowSeconds: 7 * 24 * 60 * 60
                 )
                 : nil,
             lastUpdated: now
@@ -393,8 +396,12 @@ struct WidgetSettingsView: View {
                 color: .primary
             )
             SettingsNotice(
-                text: "2. Search for MeterBar, choose Small, Medium, or Large, then drag it into place.",
+                text: "2. Search for MeterBar, choose Usage or Burn Down, then drag a supported size into place.",
                 color: .primary
+            )
+            SettingsNotice(
+                text: "Usage supports Small, Medium, and Large. Burn Down supports Small and Medium.",
+                color: .secondary
             )
             SettingsNotice(
                 text: "macOS owns widget placement; MeterBar cannot add or move widgets for you.",
@@ -545,11 +552,24 @@ struct WidgetSettingsPreviewGallery: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
+            Text("Usage")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
             HStack(alignment: .top, spacing: 12) {
                 preview(for: .small)
                 preview(for: .medium)
             }
             preview(for: .large)
+
+            Text("Burn Down")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+            HStack(alignment: .top, spacing: 12) {
+                burnDownPreview(for: .small)
+                burnDownPreview(for: .medium)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -572,6 +592,141 @@ struct WidgetSettingsPreviewGallery: View {
                 appearance: appearance
             )
         }
+    }
+
+    private func burnDownPreview(for family: WidgetPresentationFamily) -> some View {
+        let presentation = WidgetBurnDownPlanner.makePresentation(
+            metrics: data.metrics,
+            accountMetrics: data.accountMetrics,
+            preferences: preferences,
+            family: family,
+            now: Date()
+        )
+        return VStack(alignment: .leading, spacing: 5) {
+            Text(family.settingsTitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            WidgetSettingsBurnDownPreviewSurface(
+                family: family,
+                presentation: presentation,
+                appearance: appearance
+            )
+        }
+    }
+}
+
+struct WidgetSettingsBurnDownPreviewSurface: View {
+    let family: WidgetPresentationFamily
+    let presentation: WidgetBurnDownPresentation
+    let appearance: WidgetSettingsPreviewAppearance
+
+    private var metrics: WidgetGlanceMetrics { WidgetGlance.metrics(for: family) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: metrics.stackSpacing) {
+            if let emptyState = presentation.emptyState {
+                Spacer()
+                Image(systemName: emptyState == .noSelection ? "slider.horizontal.3" : "exclamationmark.triangle")
+                Text(emptyState.title)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                Text(emptyState.detail)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            } else if family == .small {
+                if let row = presentation.rows.first {
+                    WidgetSettingsBurnDownPreviewRow(row: row, family: family)
+                }
+                overflow
+            } else {
+                HStack(alignment: .top, spacing: metrics.stackSpacing) {
+                    ForEach(presentation.rows) { row in
+                        WidgetSettingsBurnDownPreviewRow(row: row, family: family)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        if row.id != presentation.rows.last?.id {
+                            Divider()
+                        }
+                    }
+                }
+                overflow
+            }
+        }
+        .padding(metrics.contentPadding)
+        .frame(
+            width: family.previewSize.width,
+            height: family.previewSize.height,
+            alignment: .topLeading
+        )
+        .background(appearance.background)
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(.primary.opacity(0.10), lineWidth: 1)
+        }
+        .environment(\.colorScheme, appearance.colorScheme)
+        .saturation(appearance == .grayscale ? 0 : 1)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(family.settingsTitle) burn down widget preview")
+    }
+
+    @ViewBuilder private var overflow: some View {
+        if presentation.hiddenRowCount > 0 {
+            Label(
+                "+\(presentation.hiddenRowCount) more",
+                systemImage: "ellipsis.circle"
+            )
+            .font(.system(size: metrics.captionSize))
+            .foregroundStyle(.secondary)
+        }
+    }
+}
+
+struct WidgetSettingsBurnDownPreviewRow: View {
+    let row: WidgetBurnDownRow
+    let family: WidgetPresentationFamily
+
+    private var metrics: WidgetGlanceMetrics { WidgetGlance.metrics(for: family) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: metrics.rowSpacing + 2) {
+            HStack(spacing: metrics.rowSpacing * 2) {
+                ProviderLogoView(
+                    kind: .forService(row.service),
+                    size: metrics.iconSize,
+                    foregroundColor: .primary
+                )
+                Text(row.accountName)
+                    .font(.system(size: metrics.titleSize, weight: .medium))
+                    .lineLimit(1)
+                Spacer(minLength: metrics.rowSpacing)
+            }
+            Text(row.countdownTitle)
+                .font(.system(size: metrics.captionSize, weight: .medium))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Text(row.countdownText)
+                .font(.system(size: metrics.headlineSize, weight: .semibold, design: .rounded))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.55)
+            Label(row.stageText, systemImage: row.stage.previewSymbolName)
+                .font(.system(size: metrics.captionSize, weight: .semibold))
+                .foregroundStyle(stageColor)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+            Text("\(row.quotaTitle) · \(row.row.limit?.percentLeftText ?? "Unavailable")")
+                .font(.system(size: metrics.captionSize))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(row.accountName)
+        .accessibilityValue(row.accessibilityValueText)
+    }
+
+    private var stageColor: Color {
+        row.isExhausted ? MeterBarTheme.danger : row.stage.previewColor
     }
 }
 
@@ -831,6 +986,32 @@ private extension WidgetAccountOrdering {
         switch self {
         case .provider: return "Provider"
         case .urgency: return "Urgency"
+        }
+    }
+}
+
+private extension WidgetBurnDownStage {
+    var previewColor: Color {
+        switch self {
+        case .onPace, .unavailable:
+            return .secondary
+        case .reserve:
+            return MeterBarTheme.success
+        case .deficit:
+            return MeterBarTheme.warning
+        }
+    }
+
+    var previewSymbolName: String {
+        switch self {
+        case .onPace:
+            return "equal.circle.fill"
+        case .reserve:
+            return "arrow.down.right.circle.fill"
+        case .deficit:
+            return "arrow.up.right.circle.fill"
+        case .unavailable:
+            return "questionmark.circle"
         }
     }
 }

--- a/MeterBarTests/WidgetBurnDownTests.swift
+++ b/MeterBarTests/WidgetBurnDownTests.swift
@@ -1,0 +1,265 @@
+import MeterBarShared
+import XCTest
+
+final class WidgetBurnDownTests: XCTestCase {
+    private let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
+    private let windowSeconds: TimeInterval = 5 * 60 * 60
+
+    func testBurnDownUsesADistinctStableWidgetKind() {
+        XCTAssertEqual(MeterBarWidgetKind.usage, "UsageWidget")
+        XCTAssertEqual(MeterBarWidgetKind.burnDown, "BurnDownWidget")
+        XCTAssertNotEqual(MeterBarWidgetKind.usage, MeterBarWidgetKind.burnDown)
+    }
+
+    func testReservePaceCountsDownToReset() throws {
+        let resetTime = now.addingTimeInterval(2.5 * 60 * 60)
+        let row = try XCTUnwrap(
+            presentation(metrics: [.claudeCode: metrics(.claudeCode, used: 40, resetTime: resetTime)])
+                .rows.first
+        )
+
+        XCTAssertEqual(row.stage, .reserve)
+        XCTAssertEqual(row.stageText, "10% in reserve")
+        XCTAssertEqual(row.countdownKind, .reset)
+        XCTAssertEqual(row.countdownTitle, "Resets in")
+        XCTAssertEqual(row.countdownTarget, resetTime)
+        XCTAssertEqual(row.countdownText, "2h 30m")
+    }
+
+    func testDeficitPaceCountsDownToProjectedExhaustion() throws {
+        let resetTime = now.addingTimeInterval(2.5 * 60 * 60)
+        let row = try XCTUnwrap(
+            presentation(metrics: [.claudeCode: metrics(.claudeCode, used: 75, resetTime: resetTime)])
+                .rows.first
+        )
+
+        XCTAssertEqual(row.stage, .deficit)
+        XCTAssertEqual(row.stageText, "25% in deficit")
+        XCTAssertEqual(row.countdownKind, .projectedExhaustion)
+        XCTAssertEqual(row.countdownTitle, "Projected empty in")
+        XCTAssertEqual(try XCTUnwrap(row.countdownTarget).timeIntervalSince(now), 50 * 60, accuracy: 0.01)
+        XCTAssertEqual(row.countdownText, "50m")
+    }
+
+    func testExhaustedWindowCountsDownToReset() throws {
+        let resetTime = now.addingTimeInterval(2.5 * 60 * 60)
+        let row = try XCTUnwrap(
+            presentation(metrics: [.codexCli: metrics(.codexCli, used: 100, resetTime: resetTime)])
+                .rows.first
+        )
+
+        XCTAssertEqual(row.stage, .deficit)
+        XCTAssertEqual(row.stageText, "Out of quota")
+        XCTAssertTrue(row.isExhausted)
+        XCTAssertEqual(row.countdownKind, .reset)
+        XCTAssertEqual(row.countdownTarget, resetTime)
+        XCTAssertEqual(row.countdownText, "2h 30m")
+    }
+
+    func testStaleDataKeepsResetCountdownButSuppressesProjection() throws {
+        let resetTime = now.addingTimeInterval(2.5 * 60 * 60)
+        let staleMetrics = metrics(
+            .claudeCode,
+            used: 75,
+            resetTime: resetTime,
+            lastUpdated: now.addingTimeInterval(-3 * 60 * 60)
+        )
+        let row = try XCTUnwrap(presentation(metrics: [.claudeCode: staleMetrics]).rows.first)
+
+        XCTAssertEqual(row.health, .stale)
+        XCTAssertEqual(row.stage, .unavailable)
+        XCTAssertEqual(row.stageText, "Stale data")
+        XCTAssertEqual(row.countdownKind, .reset)
+        XCTAssertEqual(row.countdownTarget, resetTime)
+        XCTAssertTrue(row.accessibilityValueText.contains("Stale usage data"))
+    }
+
+    func testEstimatedOrIncompleteLimitNeverClaimsAPaceProjection() throws {
+        let resetTime = now.addingTimeInterval(2.5 * 60 * 60)
+        let estimated = metrics(
+            .claudeCode,
+            used: 75,
+            resetTime: resetTime,
+            isEstimated: true
+        )
+        let incomplete = UsageMetrics(
+            service: .codexCli,
+            weeklyLimit: UsageLimit(used: 75, total: 100, resetTime: resetTime),
+            lastUpdated: now
+        )
+
+        for metric in [estimated, incomplete] {
+            let row = try XCTUnwrap(presentation(metrics: [metric.service: metric]).rows.first)
+            XCTAssertEqual(row.stage, .unavailable)
+            XCTAssertEqual(row.stageText, "Pace unavailable")
+            XCTAssertEqual(row.countdownKind, .reset)
+            XCTAssertEqual(row.countdownTarget, resetTime)
+        }
+    }
+
+    func testMissingExplicitSelectionRendersUnavailableRatherThanDisappearing() throws {
+        let missing = WidgetAccountIdentifier.account(service: .codexCli, id: UUID())
+        var preferences = WidgetPreferences.defaults
+        preferences.accountSelection = .explicit([missing])
+
+        let row = try XCTUnwrap(presentation(metrics: [:], preferences: preferences).rows.first)
+
+        XCTAssertEqual(row.accountIdentifier, missing)
+        XCTAssertEqual(row.health, .unavailable)
+        XCTAssertEqual(row.stage, .unavailable)
+        XCTAssertEqual(row.countdownKind, .unavailable)
+        XCTAssertEqual(row.countdownText, "Unavailable")
+        XCTAssertTrue(row.accessibilityValueText.contains("Usage unavailable"))
+    }
+
+    func testNoSelectionAndEmptyCacheRemainDistinctEmptyStates() {
+        var noSelectionPreferences = WidgetPreferences.defaults
+        noSelectionPreferences.accountSelection = .explicit([])
+
+        let noSelection = presentation(metrics: [:], preferences: noSelectionPreferences)
+        let unavailable = presentation(metrics: [:])
+
+        XCTAssertEqual(noSelection.emptyState, .noSelection)
+        XCTAssertEqual(unavailable.emptyState, .unavailable)
+    }
+
+    func testAccountSelectionWindowSelectionAndOrderingComeFromWidgetPreferences() throws {
+        let selectedID = UUID()
+        let unselectedID = UUID()
+        let resetTime = now.addingTimeInterval(2.5 * 60 * 60)
+        var preferences = WidgetPreferences.defaults
+        preferences.accountSelection = .explicit([
+            .account(service: .claudeCode, id: selectedID)
+        ])
+        preferences.visibleQuotaWindows = [.session]
+        let accounts = [
+            AccountUsageSnapshot(
+                id: unselectedID,
+                name: "Personal",
+                metrics: metrics(.claudeCode, used: 40, resetTime: resetTime)
+            ),
+            AccountUsageSnapshot(
+                id: selectedID,
+                name: "Work",
+                metrics: metrics(
+                    .claudeCode,
+                    used: 75,
+                    resetTime: resetTime,
+                    window: .session
+                )
+            )
+        ]
+
+        let row = try XCTUnwrap(
+            presentation(metrics: [:], accountMetrics: accounts, preferences: preferences).rows.first
+        )
+
+        XCTAssertEqual(row.accountName, "Work")
+        XCTAssertEqual(row.accountIdentifier, .account(service: .claudeCode, id: selectedID))
+        XCTAssertEqual(row.quotaWindow, .session)
+    }
+
+    func testSmallAndMediumUsePurposeBuiltRowBudgetsWithAccurateOverflow() {
+        let resetTime = now.addingTimeInterval(2.5 * 60 * 60)
+        let metricsByService: [ServiceType: UsageMetrics] = [
+            .claudeCode: metrics(.claudeCode, used: 10, resetTime: resetTime),
+            .codexCli: metrics(.codexCli, used: 20, resetTime: resetTime),
+            .cursor: metrics(.cursor, used: 30, resetTime: resetTime)
+        ]
+
+        let small = presentation(metrics: metricsByService, family: .small)
+        let medium = presentation(metrics: metricsByService, family: .medium)
+
+        XCTAssertEqual(small.rows.count, 1)
+        XCTAssertEqual(small.hiddenRowCount, 2)
+        XCTAssertEqual(medium.rows.count, 2)
+        XCTAssertEqual(medium.hiddenRowCount, 1)
+    }
+
+    func testTimelineRefreshesAtNearestMeaningfulBoundaryWithinFifteenMinutes() throws {
+        let resetTime = now.addingTimeInterval(2.5 * 60 * 60)
+        let nearExhaustion = try XCTUnwrap(
+            presentation(metrics: [.claudeCode: metrics(.claudeCode, used: 98, resetTime: resetTime)])
+                .rows.first?.countdownTarget
+        )
+        let presentation = presentation(
+            metrics: [.claudeCode: metrics(.claudeCode, used: 98, resetTime: resetTime)]
+        )
+
+        XCTAssertEqual(
+            WidgetBurnDownTimeline.nextUpdateDate(after: now, presentation: presentation),
+            nearExhaustion
+        )
+
+        let longReset = presentationForReset(in: 60 * 60)
+        XCTAssertEqual(
+            WidgetBurnDownTimeline.nextUpdateDate(after: now, presentation: longReset),
+            now.addingTimeInterval(15 * 60)
+        )
+    }
+
+    func testTimelineDoesNotRequestReloadsMoreOftenThanOncePerMinute() {
+        let resetTime = now.addingTimeInterval(10)
+        let presentation = presentation(
+            metrics: [.claudeCode: metrics(.claudeCode, used: 100, resetTime: resetTime)]
+        )
+
+        XCTAssertEqual(
+            WidgetBurnDownTimeline.nextUpdateDate(after: now, presentation: presentation),
+            now.addingTimeInterval(60)
+        )
+    }
+
+    private func presentationForReset(in interval: TimeInterval) -> WidgetBurnDownPresentation {
+        presentation(
+            metrics: [
+                .claudeCode: metrics(
+                    .claudeCode,
+                    used: 10,
+                    resetTime: now.addingTimeInterval(interval),
+                    windowSeconds: max(windowSeconds, interval * 2)
+                )
+            ]
+        )
+    }
+
+    private func presentation(
+        metrics: [ServiceType: UsageMetrics],
+        accountMetrics: [AccountUsageSnapshot] = [],
+        preferences: WidgetPreferences = .defaults,
+        family: WidgetPresentationFamily = .medium
+    ) -> WidgetBurnDownPresentation {
+        WidgetBurnDownPlanner.makePresentation(
+            metrics: metrics,
+            accountMetrics: accountMetrics,
+            preferences: preferences,
+            family: family,
+            now: now
+        )
+    }
+
+    private func metrics(
+        _ service: ServiceType,
+        used: Double,
+        resetTime: Date,
+        lastUpdated: Date? = nil,
+        isEstimated: Bool = false,
+        window: WidgetQuotaWindow = .weekly,
+        windowSeconds: TimeInterval? = nil
+    ) -> UsageMetrics {
+        let limit = UsageLimit(
+            used: used,
+            total: 100,
+            resetTime: resetTime,
+            windowSeconds: windowSeconds ?? self.windowSeconds,
+            isEstimated: isEstimated
+        )
+        return UsageMetrics(
+            service: service,
+            sessionLimit: window == .session ? limit : nil,
+            weeklyLimit: window == .weekly ? limit : nil,
+            codeReviewLimit: window == .codeReview ? limit : nil,
+            lastUpdated: lastUpdated ?? now
+        )
+    }
+}

--- a/MeterBarTests/WidgetSettingsPreviewParityTests.swift
+++ b/MeterBarTests/WidgetSettingsPreviewParityTests.swift
@@ -111,6 +111,40 @@ final class WidgetSettingsPreviewParityTests: XCTestCase {
         }
     }
 
+    func testBurnDownPreviewRendersSupportedFamiliesInLightAndDark() {
+        for family in [WidgetPresentationFamily.small, .medium] {
+            let burnDown = WidgetBurnDownPlanner.makePresentation(
+                metrics: [
+                    .claudeCode: UsageMetrics(
+                        service: .claudeCode,
+                        weeklyLimit: UsageLimit(
+                            used: 72,
+                            total: 100,
+                            resetTime: now.addingTimeInterval(2.5 * 24 * 60 * 60),
+                            windowSeconds: 7 * 24 * 60 * 60
+                        ),
+                        lastUpdated: now
+                    )
+                ],
+                accountMetrics: [],
+                preferences: .defaults,
+                family: family,
+                now: now
+            )
+            for appearance in [WidgetSettingsPreviewAppearance.light, .dark] {
+                let host = NSHostingView(
+                    rootView: WidgetSettingsBurnDownPreviewSurface(
+                        family: family,
+                        presentation: burnDown,
+                        appearance: appearance
+                    )
+                )
+                host.layoutSubtreeIfNeeded()
+                XCTAssertGreaterThan(host.fittingSize.height, 0, "\(family) \(appearance)")
+            }
+        }
+    }
+
     // MARK: - Fixtures
 
     private func presentation(family: WidgetPresentationFamily) -> WidgetPresentation {

--- a/MeterBarTests/WidgetSettingsTests.swift
+++ b/MeterBarTests/WidgetSettingsTests.swift
@@ -115,6 +115,18 @@ final class WidgetSettingsTests: XCTestCase {
             XCTAssertNil(presentation.emptyState, "\(family)")
             XCTAssertEqual(presentation.rows.first?.displayMode, .remaining, "\(family)")
         }
+
+        for family in [WidgetPresentationFamily.small, .medium] {
+            let presentation = WidgetBurnDownPlanner.makePresentation(
+                metrics: data.metrics,
+                accountMetrics: data.accountMetrics,
+                preferences: preferences,
+                family: family,
+                now: Date(timeIntervalSinceReferenceDate: 1_000_000)
+            )
+            XCTAssertFalse(presentation.rows.isEmpty, "\(family)")
+            XCTAssertTrue(presentation.rows.allSatisfy { $0.stage != .unavailable }, "\(family)")
+        }
     }
 
     func testWidgetSettingsAndAllPreviewAppearancesRender() {

--- a/MeterBarWidget/BurnDownWidget.swift
+++ b/MeterBarWidget/BurnDownWidget.swift
@@ -1,0 +1,253 @@
+import MeterBarShared
+import SwiftUI
+import WidgetKit
+
+struct BurnDownWidget: Widget {
+    let kind: String = MeterBarWidgetKind.burnDown
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: BurnDownWidgetProvider()) { entry in
+            BurnDownWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("MeterBar Burn Down")
+        .description("See whether quota will last and count down to exhaustion or reset")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+struct BurnDownWidgetEntry: TimelineEntry {
+    let date: Date
+    let metrics: [ServiceType: UsageMetrics]
+    let accountMetrics: [AccountUsageSnapshot]
+    let preferences: WidgetPreferences
+
+    func presentation(for family: WidgetPresentationFamily) -> WidgetBurnDownPresentation {
+        WidgetBurnDownPlanner.makePresentation(
+            metrics: metrics,
+            accountMetrics: accountMetrics,
+            preferences: preferences,
+            family: family,
+            now: date
+        )
+    }
+}
+
+struct BurnDownWidgetProvider: TimelineProvider {
+    func placeholder(in context: Context) -> BurnDownWidgetEntry {
+        let now = Date()
+        return BurnDownWidgetEntry(
+            date: now,
+            metrics: [
+                .claudeCode: placeholderMetrics(
+                    service: .claudeCode,
+                    used: 72,
+                    resetTime: now.addingTimeInterval(2.5 * 24 * 60 * 60)
+                ),
+                .codexCli: placeholderMetrics(
+                    service: .codexCli,
+                    used: 38,
+                    resetTime: now.addingTimeInterval(4 * 24 * 60 * 60)
+                )
+            ],
+            accountMetrics: [],
+            preferences: .defaults
+        )
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (BurnDownWidgetEntry) -> Void) {
+        completion(currentEntry(at: Date()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<BurnDownWidgetEntry>) -> Void) {
+        let now = Date()
+        let entry = currentEntry(at: now)
+        let presentation = entry.presentation(for: presentationFamily(context.family))
+        let nextUpdate = WidgetBurnDownTimeline.nextUpdateDate(
+            after: now,
+            presentation: presentation
+        )
+        completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
+    }
+
+    private func currentEntry(at date: Date) -> BurnDownWidgetEntry {
+        BurnDownWidgetEntry(
+            date: date,
+            metrics: SharedMetricsStore.loadMetrics(),
+            accountMetrics: SharedMetricsStore.loadAccountMetrics(),
+            preferences: WidgetPreferencesStore().preferences
+        )
+    }
+
+    private func presentationFamily(_ family: WidgetFamily) -> WidgetPresentationFamily {
+        family == .systemSmall ? .small : .medium
+    }
+
+    private func placeholderMetrics(
+        service: ServiceType,
+        used: Double,
+        resetTime: Date
+    ) -> UsageMetrics {
+        UsageMetrics(
+            service: service,
+            weeklyLimit: UsageLimit(
+                used: used,
+                total: 100,
+                resetTime: resetTime,
+                windowSeconds: 7 * 24 * 60 * 60
+            ),
+            lastUpdated: Date()
+        )
+    }
+}
+
+struct BurnDownWidgetEntryView: View {
+    let entry: BurnDownWidgetEntry
+
+    @Environment(\.widgetFamily)
+    private var family
+
+    var body: some View {
+        switch family {
+        case .systemMedium:
+            BurnDownWidgetSurface(entry: entry, family: .medium)
+        default:
+            BurnDownWidgetSurface(entry: entry, family: .small)
+        }
+    }
+}
+
+struct BurnDownWidgetSurface: View {
+    let entry: BurnDownWidgetEntry
+    let family: WidgetPresentationFamily
+
+    private var presentation: WidgetBurnDownPresentation {
+        entry.presentation(for: family)
+    }
+
+    private var metrics: WidgetGlanceMetrics {
+        WidgetGlance.metrics(for: family)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: metrics.stackSpacing) {
+            if let emptyState = presentation.emptyState {
+                WidgetEmptyStateView(state: emptyState, compact: family == .small)
+            } else if family == .small {
+                if let row = presentation.rows.first {
+                    BurnDownWidgetRowView(row: row, entryDate: entry.date, isCompact: false)
+                }
+                WidgetOverflowView(hiddenRowCount: presentation.hiddenRowCount, metrics: metrics)
+            } else {
+                HStack(alignment: .top, spacing: metrics.stackSpacing) {
+                    ForEach(presentation.rows) { row in
+                        BurnDownWidgetRowView(row: row, entryDate: entry.date, isCompact: true)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        if row.id != presentation.rows.last?.id {
+                            Divider()
+                        }
+                    }
+                }
+                WidgetOverflowView(hiddenRowCount: presentation.hiddenRowCount, metrics: metrics)
+            }
+        }
+        .padding(metrics.contentPadding)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+struct BurnDownWidgetRowView: View {
+    let row: WidgetBurnDownRow
+    let entryDate: Date
+    let isCompact: Bool
+
+    private var metrics: WidgetGlanceMetrics {
+        WidgetGlance.metrics(for: isCompact ? .medium : .small)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: metrics.rowSpacing + 2) {
+            HStack(spacing: metrics.rowSpacing * 2) {
+                WidgetProviderIcon(service: row.service, size: metrics.iconSize)
+                Text(row.accountName)
+                    .font(.system(size: metrics.titleSize, weight: .medium))
+                    .lineLimit(1)
+                Spacer(minLength: metrics.rowSpacing)
+                WidgetHealthIndicator(health: row.health, size: metrics.captionSize)
+            }
+
+            Text(row.countdownTitle)
+                .font(.system(size: metrics.captionSize, weight: .medium))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+
+            countdown
+
+            Label(row.stageText, systemImage: row.stage.symbolName)
+                .font(.system(size: metrics.captionSize, weight: .semibold))
+                .foregroundStyle(stageColor)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+
+            HStack(spacing: metrics.rowSpacing) {
+                Text(row.quotaTitle)
+                if let limit = row.row.limit {
+                    Text("·")
+                    Text(limit.percentLeftText)
+                }
+            }
+            .font(.system(size: metrics.captionSize))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(row.accountName)
+        .accessibilityValue(row.accessibilityValueText)
+    }
+
+    private var stageColor: Color {
+        row.isExhausted ? .red : row.stage.color
+    }
+
+    @ViewBuilder private var countdown: some View {
+        if let target = row.countdownTarget, target > entryDate {
+            Text(target, style: .timer)
+                .font(.system(size: metrics.headlineSize, weight: .semibold, design: .rounded))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.55)
+        } else {
+            Text(row.countdownText)
+                .font(.system(size: metrics.headlineSize, weight: .semibold, design: .rounded))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.55)
+        }
+    }
+}
+
+private extension WidgetBurnDownStage {
+    var color: Color {
+        switch self {
+        case .onPace, .unavailable:
+            return .secondary
+        case .reserve:
+            return .green
+        case .deficit:
+            return .orange
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .onPace:
+            return "equal.circle.fill"
+        case .reserve:
+            return "arrow.down.right.circle.fill"
+        case .deficit:
+            return "arrow.up.right.circle.fill"
+        case .unavailable:
+            return "questionmark.circle"
+        }
+    }
+}

--- a/MeterBarWidget/MeterBarWidgetBundle.swift
+++ b/MeterBarWidget/MeterBarWidgetBundle.swift
@@ -12,5 +12,6 @@ import SwiftUI
 struct MeterBarWidgetBundle: WidgetBundle {
     var body: some Widget {
         UsageWidget()
+        BurnDownWidget()
     }
 }

--- a/MeterBarWidget/UsageWidget.swift
+++ b/MeterBarWidget/UsageWidget.swift
@@ -17,7 +17,7 @@ extension UsageStatus {
 // MARK: - Widget
 
 struct UsageWidget: Widget {
-    let kind: String = "UsageWidget"
+    let kind: String = MeterBarWidgetKind.usage
 
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: kind, provider: UsageWidgetProvider()) { entry in

--- a/Packages/MeterBarShared/Sources/MeterBarShared/MeterBarWidgetKind.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/MeterBarWidgetKind.swift
@@ -1,0 +1,8 @@
+/// Stable WidgetKit identifiers shared by registration and every reload path.
+/// Changing one removes an installed widget from the user's desktop, so these
+/// values are intentionally pinned by tests.
+public enum MeterBarWidgetKind {
+    public static let usage = "UsageWidget"
+    public static let burnDown = "BurnDownWidget"
+    public static let all = [usage, burnDown]
+}

--- a/Packages/MeterBarShared/Sources/MeterBarShared/WidgetBurnDown.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/WidgetBurnDown.swift
@@ -1,0 +1,215 @@
+import Foundation
+
+public enum WidgetBurnDownStage: Equatable, Sendable {
+    case onPace
+    case reserve
+    case deficit
+    case unavailable
+}
+
+public enum WidgetBurnDownCountdownKind: Equatable, Sendable {
+    case projectedExhaustion
+    case reset
+    case unavailable
+}
+
+/// One selected quota window reduced to the information a countdown surface
+/// needs. The underlying glance row remains the source of provider/account
+/// identity, selection, quota-window naming, and data health.
+public struct WidgetBurnDownRow: Identifiable, Equatable, Sendable {
+    public let row: WidgetPresentationRow
+    public let stage: WidgetBurnDownStage
+    public let stageText: String
+    public let countdownKind: WidgetBurnDownCountdownKind
+    public let countdownTitle: String
+    public let countdownTarget: Date?
+    public let countdownText: String
+
+    public var id: String { row.id }
+    public var accountIdentifier: WidgetAccountIdentifier { row.accountIdentifier }
+    public var service: ServiceType { row.service }
+    public var accountName: String { row.accountName }
+    public var quotaWindow: WidgetQuotaWindow { row.quotaWindow }
+    public var quotaTitle: String { row.quotaTitle }
+    public var health: WidgetDataHealth { row.health }
+    public var isExhausted: Bool { row.limit?.isAtLimit == true }
+
+    public var accessibilityValueText: String {
+        var phrases = [quotaTitle, stageText, "\(countdownTitle) \(countdownText)"]
+        if let health = health.accessibilityDescription,
+           !phrases.contains(health) {
+            phrases.append(health)
+        }
+        return phrases.joined(separator: ", ")
+    }
+
+    public init(
+        row: WidgetPresentationRow,
+        stage: WidgetBurnDownStage,
+        stageText: String,
+        countdownKind: WidgetBurnDownCountdownKind,
+        countdownTitle: String,
+        countdownTarget: Date?,
+        countdownText: String
+    ) {
+        self.row = row
+        self.stage = stage
+        self.stageText = stageText
+        self.countdownKind = countdownKind
+        self.countdownTitle = countdownTitle
+        self.countdownTarget = countdownTarget
+        self.countdownText = countdownText
+    }
+}
+
+public struct WidgetBurnDownPresentation: Equatable, Sendable {
+    public let rows: [WidgetBurnDownRow]
+    public let hiddenRowCount: Int
+    public let emptyState: WidgetPresentationEmptyState?
+
+    public init(
+        rows: [WidgetBurnDownRow],
+        hiddenRowCount: Int,
+        emptyState: WidgetPresentationEmptyState?
+    ) {
+        self.rows = rows
+        self.hiddenRowCount = hiddenRowCount
+        self.emptyState = emptyState
+    }
+}
+
+/// Pure burn-down policy layered on the existing widget selection planner.
+///
+/// Estimated and stale snapshots can still provide a provider-authored reset,
+/// but never a fresh-looking projected exhaustion derived from an unreliable
+/// burn rate.
+public enum WidgetBurnDownPlanner {
+    public static func makePresentation(
+        metrics: [ServiceType: UsageMetrics],
+        accountMetrics: [AccountUsageSnapshot],
+        preferences: WidgetPreferences,
+        family: WidgetPresentationFamily,
+        now: Date,
+        stalenessThreshold: TimeInterval = WidgetPresentationPlanner.defaultStalenessThreshold
+    ) -> WidgetBurnDownPresentation {
+        var selectionPreferences = preferences
+        selectionPreferences.showsResetTime = true
+        selectionPreferences.showsFreshness = false
+
+        let base = WidgetPresentationPlanner.makePresentation(
+            metrics: metrics,
+            accountMetrics: accountMetrics,
+            preferences: selectionPreferences,
+            family: family,
+            now: now,
+            stalenessThreshold: stalenessThreshold
+        )
+        let capacity = family == .small ? 1 : 2
+        let visibleRows = Array(base.rows.prefix(capacity))
+
+        return WidgetBurnDownPresentation(
+            rows: visibleRows.map { makeRow(from: $0, now: now) },
+            hiddenRowCount: base.hiddenRowCount + max(0, base.rows.count - visibleRows.count),
+            emptyState: base.emptyState
+        )
+    }
+
+    private static func makeRow(from row: WidgetPresentationRow, now: Date) -> WidgetBurnDownRow {
+        guard row.health != .unavailable, let limit = row.limit else {
+            return WidgetBurnDownRow(
+                row: row,
+                stage: .unavailable,
+                stageText: "Usage unavailable",
+                countdownKind: .unavailable,
+                countdownTitle: "Countdown",
+                countdownTarget: nil,
+                countdownText: "Unavailable"
+            )
+        }
+
+        let pace = row.health == .healthy && !limit.isEstimated
+            ? limit.pace(now: now)
+            : nil
+        let stage = burnDownStage(pace: pace)
+        let stageText: String
+        if row.health == .stale {
+            stageText = "Stale data"
+        } else {
+            stageText = pace?.leftLabel ?? "Pace unavailable"
+        }
+
+        let countdown = countdown(limit: limit, pace: pace, now: now)
+        return WidgetBurnDownRow(
+            row: row,
+            stage: row.health == .healthy ? stage : .unavailable,
+            stageText: stageText,
+            countdownKind: countdown.kind,
+            countdownTitle: countdown.title,
+            countdownTarget: countdown.target,
+            countdownText: countdown.text
+        )
+    }
+
+    private static func burnDownStage(pace: UsagePace?) -> WidgetBurnDownStage {
+        guard let pace else { return .unavailable }
+        switch pace.stage {
+        case .onPace:
+            return .onPace
+        case .reserve:
+            return .reserve
+        case .deficit:
+            return .deficit
+        }
+    }
+
+    private static func countdown(
+        limit: UsageLimit,
+        pace: UsagePace?,
+        now: Date
+    ) -> (kind: WidgetBurnDownCountdownKind, title: String, target: Date?, text: String) {
+        if let pace,
+           !pace.isExhausted,
+           !pace.willLastToReset,
+           let etaSeconds = pace.etaSeconds {
+            let target = now.addingTimeInterval(max(0, etaSeconds))
+            return (
+                .projectedExhaustion,
+                "Projected empty in",
+                target,
+                UsageDurationText.short(seconds: etaSeconds)
+            )
+        }
+
+        if let resetTime = limit.resetTime {
+            return (
+                .reset,
+                "Resets in",
+                resetTime,
+                limit.resetCountdownText(now: now) ?? "Unavailable"
+            )
+        }
+
+        return (.unavailable, "Countdown", nil, "Unavailable")
+    }
+}
+
+/// WidgetKit reload policy for countdowns. The text can animate between entries,
+/// while the shared pace calculation is recomputed at least every 15 minutes
+/// and at an earlier reset/exhaustion boundary when one is close.
+public enum WidgetBurnDownTimeline {
+    public static let minimumRefreshInterval: TimeInterval = 60
+    public static let maximumRefreshInterval: TimeInterval = 15 * 60
+
+    public static func nextUpdateDate(
+        after now: Date,
+        presentation: WidgetBurnDownPresentation
+    ) -> Date {
+        let maximumRefresh = now.addingTimeInterval(maximumRefreshInterval)
+        let nearestBoundary = presentation.rows
+            .compactMap(\.countdownTarget)
+            .filter { $0 > now }
+            .min() ?? maximumRefresh
+        let requested = min(maximumRefresh, nearestBoundary)
+        return max(now.addingTimeInterval(minimumRefreshInterval), requested)
+    }
+}

--- a/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPreferences.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPreferences.swift
@@ -373,7 +373,9 @@ public final class WidgetPreferencesStore: ObservableObject {
 
     private static func reloadWidgetTimelines() {
         #if canImport(WidgetKit)
-        WidgetCenter.shared.reloadTimelines(ofKind: "UsageWidget")
+        for kind in MeterBarWidgetKind.all {
+            WidgetCenter.shared.reloadTimelines(ofKind: kind)
+        }
         #endif
     }
 }


### PR DESCRIPTION
## Summary
- register a distinct BurnDownWidget alongside the preserved UsageWidget for small and medium families
- derive pace stage and projected exhaustion versus reset countdowns from UsageLimit.pace(), while suppressing unreliable projections for stale or estimated data
- reuse WidgetPreferences provider, account, quota-window, and ordering selection plus WidgetGlance sizing and existing health/empty-state presentation
- add accessible live countdown surfaces, light/dark settings previews, bounded WidgetKit timeline reloads, and reload both stable widget kinds on data or preference changes

## Scope
Implements the burn-down/countdown-first slice of #390. The existing UsageWidget remains unchanged in behavior. The compact single-metric family sketched in #390 is intentionally left as a separate follow-up.

## Verification
- TDD: new burn-down tests failed before planner/widget-kind implementation, then passed
- focused widget suites: 76 tests, 0 failures
- final focused burn-down suite: 12 tests, 0 failures
- full coverage gate: 2,329 tests, 6 opt-in live-integration skips, 0 failures; 78.2% coverage against 19% threshold
- SwiftLint strict: 281 files, 0 violations
- universal Release app plus embedded widget build: BUILD SUCCEEDED; app and widget binaries each contain arm64 and x86_64
- staged diff check: clean

The Xcode build continues to report pre-existing Swift concurrency and SDK deprecation warnings outside this issue scope.