### PR TITLE
fix(cost): Grok popover history, month-to-date, CodeRabbit gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,3 +25,4 @@
 - [ ] I updated relevant documentation or explained why no documentation change is needed.
 - [ ] I documented migrations, release steps, or external configuration changes, or marked them not applicable.
 - [ ] I did not include secrets, credentials, personal data, customer data, or generated build output.
+- [ ] If CodeRabbit says "Review rate limited", I re-requested review before merge. A green CodeRabbit tick is not a review in that case.

--- a/.github/workflows/coderabbit-gate.yml
+++ b/.github/workflows/coderabbit-gate.yml
@@ -1,0 +1,83 @@
+name: CodeRabbit gate
+
+# CodeRabbit's own check reports `pass` when the run was rate-limited and no
+# review happened. That is the dangerous direction. This job re-reads the
+# CodeRabbit check-run output and fails if the review did not actually occur.
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  checks: read
+  pull-requests: read
+
+jobs:
+  coderabbit-gate:
+    name: coderabbit-gate
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Fail when CodeRabbit did not review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # CodeRabbit posts after CI starts. Poll briefly; if it never
+          # appears, skip rather than fail closed on every PR.
+          for _ in 1 2 3 4 5 6; do
+            payload="$(gh api "repos/${REPO}/commits/${SHA}/check-runs" --paginate)"
+            count="$(printf '%s' "$payload" | python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("check_runs",[])))')"
+            if [ "$count" != "0" ]; then
+              break
+            fi
+            sleep 20
+          done
+
+          python3 - <<'PY'
+          import json, os, sys, urllib.request
+
+          repo = os.environ["REPO"]
+          sha = os.environ["SHA"]
+          token = os.environ["GH_TOKEN"]
+          req = urllib.request.Request(
+              f"https://api.github.com/repos/{repo}/commits/{sha}/check-runs?per_page=100",
+              headers={
+                  "Authorization": f"Bearer {token}",
+                  "Accept": "application/vnd.github+json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urllib.request.urlopen(req) as response:
+              data = json.load(response)
+
+          runs = [
+              run for run in data.get("check_runs", [])
+              if "coderabbit" in (run.get("name") or "").lower()
+              or "coderabbit" in ((run.get("app") or {}).get("slug") or "").lower()
+          ]
+          if not runs:
+              print("No CodeRabbit check-run on this SHA — skipping gate.")
+              sys.exit(0)
+
+          blocked = False
+          for run in runs:
+              name = run.get("name")
+              conclusion = run.get("conclusion")
+              output = run.get("output") or {}
+              text = " ".join(
+                  part for part in [output.get("title"), output.get("summary"), output.get("text")]
+                  if part
+              ).lower()
+              print(f"CodeRabbit check {name!r} conclusion={conclusion} title={output.get('title')!r}")
+              if "rate limited" in text or "review rate limited" in text:
+                  print(f"::error::CodeRabbit reported a rate-limited review as {conclusion}. That is not a review.")
+                  blocked = True
+              if "no review" in text and conclusion == "success":
+                  print("::error::CodeRabbit succeeded without reviewing.")
+                  blocked = True
+          sys.exit(1 if blocked else 0)
+          PY

--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.35;
+				MARKETING_VERSION = 1.8.36;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -369,7 +369,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.35;
+				MARKETING_VERSION = 1.8.36;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -534,7 +534,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.35;
+				MARKETING_VERSION = 1.8.36;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug;
 				PRODUCT_NAME = "MeterBar Dev";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -580,7 +580,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.35;
+				MARKETING_VERSION = 1.8.36;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MeterBar/Models/CLIJSONOutput.swift
+++ b/MeterBar/Models/CLIJSONOutput.swift
@@ -102,6 +102,9 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
     private let lastScannedAt: Date
     private let period: Period
     private let providers: [Provider]
+    /// Provider-independent model rollup. `nil` when no selected provider has
+    /// complete model attribution. Additive for version 1.
+    private let models: [ModelBreakdown]?
     private let totalCostUSD: Double
     private let totalTokens: Int
     /// Presentation-only conversion of `totalCostUSD` (issue #270). `nil`
@@ -165,12 +168,33 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
             totalTokens = cache.summary.totalTokens
         }
 
+        models = Self.rolledUpModels(from: providers)
+
         // Captured into a local first: referencing `self.totalCostUSD` directly
         // inside the closure below would require `self` before every stored
         // property (including `self.displayCurrency` itself) is initialized.
         let finalTotalCostUSD = totalCostUSD
         self.displayCurrency = displayCurrency.map { DisplayCurrencyJSON($0, totalCostUSD: finalTotalCostUSD) }
         pricing = cache.summary.pricing.flatMap(PricingJSON.init(provenance:))
+    }
+
+    private static func rolledUpModels(from providers: [Provider]) -> [ModelBreakdown]? {
+        let slices = providers.compactMap(\.modelBreakdowns)
+        guard slices.count == providers.count, !slices.isEmpty else { return nil }
+        var totals: [String: ModelBreakdown] = [:]
+        for slice in slices.flatMap({ $0 }) {
+            if var existing = totals[slice.name] {
+                existing.merge(slice)
+                totals[slice.name] = existing
+            } else {
+                totals[slice.name] = slice
+            }
+        }
+        let rolled = totals.values.sorted {
+            if $0.estimatedCostUSD == $1.estimatedCostUSD { return $0.name < $1.name }
+            return $0.estimatedCostUSD > $1.estimatedCostUSD
+        }
+        return rolled.isEmpty ? nil : rolled
     }
 
     private struct PricingJSON: Encodable {
@@ -303,13 +327,13 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
 
     private struct ModelBreakdown: Encodable {
         let name: String
-        let inputTokens: Int
-        let outputTokens: Int
-        let cacheCreationTokens: Int
-        let cacheReadTokens: Int
-        let totalTokens: Int
-        let estimatedCostUSD: Double
-        let sessionCount: Int
+        var inputTokens: Int
+        var outputTokens: Int
+        var cacheCreationTokens: Int
+        var cacheReadTokens: Int
+        var totalTokens: Int
+        var estimatedCostUSD: Double
+        var sessionCount: Int
 
         init(_ breakdown: TokenUsageBreakdown) {
             name = breakdown.name
@@ -320,6 +344,16 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
             totalTokens = breakdown.totalTokens
             estimatedCostUSD = breakdown.estimatedCostUSD
             sessionCount = breakdown.sessionCount
+        }
+
+        mutating func merge(_ other: ModelBreakdown) {
+            inputTokens += other.inputTokens
+            outputTokens += other.outputTokens
+            cacheCreationTokens += other.cacheCreationTokens
+            cacheReadTokens += other.cacheReadTokens
+            totalTokens += other.totalTokens
+            estimatedCostUSD += other.estimatedCostUSD
+            sessionCount += other.sessionCount
         }
     }
 }

--- a/MeterBar/Models/CostChartPresentation.swift
+++ b/MeterBar/Models/CostChartPresentation.swift
@@ -30,16 +30,23 @@ nonisolated struct CostChartPresentation: Sendable {
     init(
         summary: CostSummary,
         requestedDays: Int = CostChartPresentation.defaultRequestedDays,
+        windowStart: Date? = nil,
         now: Date = Date(),
         calendar: Calendar = .current
     ) {
-        let normalizedDays = max(1, requestedDays)
         let today = calendar.startOfDay(for: now)
-        let startDate = CostWindow.start(
-            days: normalizedDays,
-            now: now,
-            calendar: calendar
+        let startDate = calendar.startOfDay(
+            for: windowStart ?? CostWindow.start(
+                days: max(1, requestedDays),
+                now: now,
+                calendar: calendar
+            )
         )
+        let spannedDays = max(
+            1,
+            (calendar.dateComponents([.day], from: startDate, to: today).day ?? 0) + 1
+        )
+        let normalizedDays = windowStart == nil ? max(1, requestedDays) : spannedDays
         let windowRows = summary.dailyUsage.filter { row in
             let day = calendar.startOfDay(for: row.date)
             return day >= startDate && day <= today
@@ -145,6 +152,28 @@ nonisolated struct CostChartPresentation: Sendable {
 
     var modelWindowMatchesRequested: Bool {
         modelWindowDays == requestedDays
+    }
+
+    /// Same models as `modelPoints`, folded across providers so one name is
+    /// one bar. Provider-disambiguated labels stay on `modelPoints` for
+    /// drill-down; the chart uses this rollup.
+    var crossProviderModelPoints: [CostModelSpendPoint] {
+        Dictionary(grouping: modelPoints, by: \.model)
+            .compactMap { name, points -> CostModelSpendPoint? in
+                let total = points.reduce(0) { $0 + $1.costUSD }
+                guard total > 0 else { return nil }
+                let owner = points.sorted { $0.provider.rawValue < $1.provider.rawValue }[0]
+                return CostModelSpendPoint(
+                    provider: owner.provider,
+                    model: name,
+                    chartLabel: name,
+                    costUSD: total
+                )
+            }
+            .sorted {
+                if $0.costUSD == $1.costUSD { return $0.model < $1.model }
+                return $0.costUSD > $1.costUSD
+            }
     }
 
     /// Model points for a window narrower than the scan, cut from the daily

--- a/MeterBar/Models/CostWindowSelection.swift
+++ b/MeterBar/Models/CostWindowSelection.swift
@@ -30,7 +30,9 @@ nonisolated enum CostWindowSelection: Int, CaseIterable, Identifiable {
             return rawValue
         case .monthToDate:
             let start = Self.monthStart(now: now, calendar: calendar)
-            return max(1, (calendar.dateComponents([.day], from: start, to: calendar.startOfDay(for: now)).day ?? 0) + 1)
+            let today = calendar.startOfDay(for: now)
+            let elapsed = calendar.dateComponents([.day], from: start, to: today).day ?? 0
+            return max(1, elapsed + 1)
         }
     }
 

--- a/MeterBar/Models/CostWindowSelection.swift
+++ b/MeterBar/Models/CostWindowSelection.swift
@@ -1,38 +1,98 @@
 import Foundation
 
-/// The Costs page's reporting-window toggle: the same cards over the last 7 or
-/// the last 30 days.
+/// The Costs page's reporting-window toggle: last 7 days, last 30 days, or
+/// calendar month-to-date.
 ///
-/// Presentation-only — both windows are cut from the one cached 30-day scan
-/// (`CostSummary.dailyCostWindow` / `CostChartPresentation.requestedDays`), so
-/// switching never triggers a rescan; the 7-day view just renders a quarter of
-/// the marks. The raw value *is* the day count, which is what
-/// `UserDefaults` persists — an unknown stored count falls back to the month.
+/// Presentation-only — every window is cut from the one cached 30-day scan
+/// (`CostSummary.dailyCostWindow` / `monthToDateCostWindow`), so switching
+/// never triggers a rescan. Stored `7` and `30` keep working; `-1` is the
+/// calendar month. An unknown stored count falls back to the rolling month.
 nonisolated enum CostWindowSelection: Int, CaseIterable, Identifiable {
     case week = 7
     case month = 30
+    case monthToDate = -1
 
     var id: Int { rawValue }
 
-    var days: Int { rawValue }
+    /// Rolling-window day count. Month-to-date uses the live calendar span
+    /// instead; call `dayCount(now:calendar:)` when the start of the month
+    /// matters.
+    var days: Int {
+        switch self {
+        case .week, .month: return rawValue
+        case .monthToDate: return 0
+        }
+    }
+
+    func dayCount(now: Date = Date(), calendar: Calendar = .current) -> Int {
+        switch self {
+        case .week, .month:
+            return rawValue
+        case .monthToDate:
+            let start = Self.monthStart(now: now, calendar: calendar)
+            return max(1, (calendar.dateComponents([.day], from: start, to: calendar.startOfDay(for: now)).day ?? 0) + 1)
+        }
+    }
+
+    func startDate(now: Date = Date(), calendar: Calendar = .current) -> Date {
+        switch self {
+        case .week, .month:
+            return CostWindow.start(days: rawValue, now: now, calendar: calendar)
+        case .monthToDate:
+            return Self.monthStart(now: now, calendar: calendar)
+        }
+    }
 
     /// Segment title in the window picker.
-    var pickerLabel: String { "\(days) days" }
+    var pickerLabel: String {
+        switch self {
+        case .week, .month: return "\(rawValue) days"
+        case .monthToDate: return "This month"
+        }
+    }
 
-    /// Card subtitle naming the window ("Last 30 days"), shared by the estimate
-    /// card and the Daily Details trailing caption so they cannot drift.
-    var subtitle: String { "Last \(days) days" }
+    /// Card subtitle naming the window, shared by the estimate card and the
+    /// Daily Details trailing caption so they cannot drift.
+    var subtitle: String {
+        switch self {
+        case .week, .month: return "Last \(rawValue) days"
+        case .monthToDate: return "Month to date"
+        }
+    }
 
-    /// Title of the spend-chart card ("30 Day Spend").
-    var spendCardTitle: String { "\(days) Day Spend" }
+    /// Title of the spend-chart card.
+    var spendCardTitle: String {
+        switch self {
+        case .week, .month: return "\(rawValue) Day Spend"
+        case .monthToDate: return "Month-to-Date Spend"
+        }
+    }
 
     /// Calendar width used when hourly rows are unavailable. Old seven-day
-    /// caches keep their existing two-week fallback; the month always keeps
-    /// the existing six-week calendar.
+    /// caches keep their existing two-week fallback; month windows keep the
+    /// existing six-week calendar.
     var fallbackActivityWeeks: Int {
         switch self {
         case .week: return 2
-        case .month: return TokenActivityCalendar.defaultWeeks
+        case .month, .monthToDate: return TokenActivityCalendar.defaultWeeks
         }
+    }
+
+    func costWindow(
+        from summary: CostSummary,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> DailyCostWindow {
+        switch self {
+        case .week, .month:
+            return summary.dailyCostWindow(lastDays: rawValue, now: now, calendar: calendar)
+        case .monthToDate:
+            return summary.monthToDateCostWindow(now: now, calendar: calendar)
+        }
+    }
+
+    private static func monthStart(now: Date, calendar: Calendar) -> Date {
+        calendar.date(from: calendar.dateComponents([.year, .month], from: now))
+            ?? calendar.startOfDay(for: now)
     }
 }

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -155,7 +155,7 @@ nonisolated enum StorageKeys {
     /// reads `sessionWakeEventHooks` once, then this key becomes authoritative.
     static let quotaEventIntegrations = "QuotaEventIntegrationsV1"
 
-    /// `CostWindowSelection` raw value (7 or 30): the Costs page reporting
+    /// `CostWindowSelection` raw value (7, 30, or -1 for month-to-date): the Costs page reporting
     /// window. Missing or unknown means the 30-day view.
     static let costsWindowDays = "CostsWindowDays"
 

--- a/MeterBar/Models/TokenCost.swift
+++ b/MeterBar/Models/TokenCost.swift
@@ -417,6 +417,36 @@ nonisolated public struct CostSummary: Codable, Sendable {
         return hourlyUsage?.isEmpty != false
     }
 
+    /// True when an enabled local-log provider has no row in this cache.
+    ///
+    /// Adding Grok (or any later log scanner) must not wait for the user to
+    /// open Costs and hit Scan. A Claude/Codex-only cache can look complete
+    /// to `needsMissingDailyUsageRefresh` while the popover sparkline for the
+    /// new provider stays empty. A completed scan today stays authoritative so
+    /// a provider with genuinely no logs does not rescan on every hover.
+    func needsMissingEnabledProviderRefresh(
+        enabledServices: Set<ServiceType>,
+        lastScanDate: Date?,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> Bool {
+        let enabledScanServices = Set(
+            CostScanProvider.allCases
+                .map(\.service)
+                .filter(enabledServices.contains)
+        )
+        guard !enabledScanServices.isEmpty else { return false }
+
+        let today = calendar.startOfDay(for: now)
+        if let lastScanDate,
+           calendar.startOfDay(for: lastScanDate) >= today {
+            return false
+        }
+
+        let present = Set(costs.map(\.provider))
+        return enabledScanServices.contains { !present.contains($0) }
+    }
+
     /// Aggregates the cached daily rows into per-provider totals over the last
     /// `days` calendar days (inclusive of today). Pure and rescan-free: it reads
     /// only `dailyUsage`, so it can report input/output/cache-read tokens and

--- a/MeterBar/Serve/ServeRouter.swift
+++ b/MeterBar/Serve/ServeRouter.swift
@@ -86,10 +86,14 @@ nonisolated public enum ServeRouter {
             )
         }
 
-        // Mirrors `meterbar cost --days`: an invalid or non-positive value is
-        // ignored rather than rejected, falling back to the full cached summary.
-        let days = query["days"].flatMap(Int.init).flatMap { $0 >= 1 ? $0 : nil }
-        return jsonResponse(CostCLIJSONResponse(cache: cache, days: days))
+        // Mirrors `meterbar cost --days` / `--month-to-date`. An invalid or
+        // non-positive `days` is ignored. `monthToDate` wins when both appear,
+        // matching the DTO; the CLI rejects the combination at parse time.
+        let monthToDate = ["1", "true", "yes"].contains(query["monthToDate"]?.lowercased())
+        let days = monthToDate
+            ? nil
+            : query["days"].flatMap(Int.init).flatMap { $0 >= 1 ? $0 : nil }
+        return jsonResponse(CostCLIJSONResponse(cache: cache, days: days, monthToDate: monthToDate))
     }
 
     // MARK: Response construction

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -111,12 +111,21 @@ class CostTracker: ObservableObject {
             let hasEnabledCostScanProvider = Self.hasEnabledCostScanProvider(
                 in: providerVisibilityStore.enabledServices
             )
-            guard !isRefreshInProgress,
-                  let visibleSummary = costSummary?.filtered(to: providerVisibilityStore.enabledServices),
+            guard !isRefreshInProgress else { return false }
+            if costSummary == nil {
+                guard hasEnabledCostScanProvider else { return false }
+                isRefreshingMissingDays = true
+                return true
+            }
+            guard let visibleSummary = costSummary?.filtered(to: providerVisibilityStore.enabledServices),
                   visibleSummary.lifetime == nil
                     || visibleSummary.needsMissingDailyUsageRefresh(days: days, lastScanDate: lastScanDate)
                     || (hasEnabledCostScanProvider
-                        && visibleSummary.needsMissingHourlyUsageRefresh(lastScanDate: lastScanDate)) else {
+                        && visibleSummary.needsMissingHourlyUsageRefresh(lastScanDate: lastScanDate))
+                    || visibleSummary.needsMissingEnabledProviderRefresh(
+                        enabledServices: providerVisibilityStore.enabledServices,
+                        lastScanDate: lastScanDate
+                    ) else {
                 return false
             }
             isRefreshingMissingDays = true

--- a/MeterBar/Views/Components/ProviderDailyUsageSparkline.swift
+++ b/MeterBar/Views/Components/ProviderDailyUsageSparkline.swift
@@ -20,6 +20,7 @@ import SwiftUI
 struct ProviderDailyUsageSparkline: View {
     let series: ProviderDailyUsageSeries
     let accentColor: Color
+    var isRefreshing: Bool = false
 
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
@@ -130,11 +131,15 @@ struct ProviderDailyUsageSparkline: View {
     /// waiting, because there is no history to fetch — see
     /// ``ProviderUsageLedger``.
     private var emptyTitle: String {
-        series.service.writesLocalTokenLogs ? "No token history yet" : "No usage recorded yet"
+        if isRefreshing { return "Loading history" }
+        return series.service.writesLocalTokenLogs ? "No token history yet" : "No usage recorded yet"
     }
 
     private var emptyMessage: String {
-        series.service.writesLocalTokenLogs
+        if isRefreshing {
+            return "Reading \(series.service.shortName)'s local session logs."
+        }
+        return series.service.writesLocalTokenLogs
             ? "Run a cost scan to load \(series.service.shortName)'s daily usage."
             : "\(series.service.shortName) publishes no history, so MeterBar builds this from its own refreshes."
     }

--- a/MeterBar/Views/CostSpendCharts.swift
+++ b/MeterBar/Views/CostSpendCharts.swift
@@ -191,9 +191,10 @@ struct CostSpendCharts: View {
     /// `modelPoints` is already sorted by descending spend, so a prefix *is*
     /// the top of the list. The heading total always reports every model.
     private var displayedModelPoints: [CostModelSpendPoint] {
-        showsAllModels
-            ? presentation.modelPoints
-            : Array(presentation.modelPoints.prefix(Self.compactModelLimit))
+        let points = presentation.crossProviderModelPoints
+        return showsAllModels
+            ? points
+            : Array(points.prefix(Self.compactModelLimit))
     }
 
     /// Legend/scale providers come from the rows actually drawn, so the

--- a/MeterBar/Views/DashboardCostCards.swift
+++ b/MeterBar/Views/DashboardCostCards.swift
@@ -50,7 +50,7 @@ struct CostOverviewStatusCard: View {
     guard windowSelection != .month else {
       return (summary.formattedTotalCost, formattedTokens, summary.costs.count)
     }
-    let window = summary.dailyCostWindow(lastDays: windowSelection.days)
+    let window = windowSelection.costWindow(from: summary)
     return (
       UsageFormat.cost(window.totalCostUSD),
       UsageFormat.tokens(window.totalTokens),

--- a/MeterBar/Views/DashboardCostsSection.swift
+++ b/MeterBar/Views/DashboardCostsSection.swift
@@ -84,14 +84,14 @@ struct DashboardCostsSection: View {
             // would read as "measured nothing".
             let polledUsage = PolledRequestSeriesPresentation(
                 ledger: costTracker.usageLedger,
-                requestedDays: windowSelection.days
+                requestedDays: windowSelection.dayCount()
             )
             if !polledUsage.isEmpty {
                 PolledUsageCard(presentation: polledUsage)
             }
 
             if let summary, !summary.dailyUsage.isEmpty {
-                let windowStart = CostWindow.start(days: windowSelection.days)
+                let windowStart = windowSelection.startDate()
                 let windowRows = summary.dailyUsage.filter { $0.date >= windowStart }
                 if !windowRows.isEmpty {
                     DashboardCard(title: "Daily Details", trailing: windowSelection.subtitle) {
@@ -101,16 +101,15 @@ struct DashboardCostsSection: View {
             }
 
             if let summary, !summary.costs.isEmpty {
-                // In the 7-day window the per-provider cards re-cut to the same
-                // days as every chart above; a provider with no spend inside
-                // the window drops out instead of showing 30-day numbers under
-                // a 7-day heading.
-                let weekWindow = windowSelection == .week
-                    ? summary.dailyCostWindow(lastDays: windowSelection.days)
-                    : nil
+                // Narrower windows re-cut provider cards to the same days as
+                // the charts. A provider with no spend inside the window drops
+                // out instead of showing 30-day numbers under a 7-day heading.
+                let narrowedWindow = windowSelection == .month
+                    ? nil
+                    : windowSelection.costWindow(from: summary)
                 ForEach(summary.costs) { cost in
-                    let providerWindow = weekWindow?.providers.first { $0.provider == cost.provider }
-                    if weekWindow == nil || providerWindow != nil {
+                    let providerWindow = narrowedWindow?.providers.first { $0.provider == cost.provider }
+                    if narrowedWindow == nil || providerWindow != nil {
                         ProviderCostBreakdown(
                             cost: cost,
                             quotaSnapshot: quotaSnapshot(cost.provider),
@@ -181,7 +180,8 @@ struct DashboardCostsSection: View {
                 if let summary {
                     let presentation = CostChartPresentation(
                         summary: summary,
-                        requestedDays: windowSelection.days
+                        requestedDays: windowSelection.dayCount(),
+                        windowStart: windowSelection.startDate()
                     )
                     ZStack {
                         if presentation.hasSpend {

--- a/MeterBar/Views/MenuBarDetailPanel.swift
+++ b/MeterBar/Views/MenuBarDetailPanel.swift
@@ -237,12 +237,18 @@ struct MenuBarProviderDetailContent: View {
   /// series to offer, and the panel simply omits the strip — which is what the
   /// layout tests exercise.
   let dailyUsage: ProviderDailyUsageSeries?
+  let isRefreshingUsage: Bool
 
   @ObservedObject private var menuBarDisplayPreferences = MenuBarDisplayPreferencesStore.shared
 
-  init(snapshot: ProviderSnapshot, dailyUsage: ProviderDailyUsageSeries? = nil) {
+  init(
+    snapshot: ProviderSnapshot,
+    dailyUsage: ProviderDailyUsageSeries? = nil,
+    isRefreshingUsage: Bool = false
+  ) {
     self.snapshot = snapshot
     self.dailyUsage = dailyUsage
+    self.isRefreshingUsage = isRefreshingUsage
   }
 
   private var detailLimits: [SnapshotLimit] {
@@ -319,7 +325,11 @@ struct MenuBarProviderDetailContent: View {
         // Last, and separated by a little extra space rather than a rule: the
         // rows above are the window the card already summarised, and this is the
         // week behind it. Reading top-to-bottom is now → recent past.
-        ProviderDailyUsageSparkline(series: dailyUsage, accentColor: snapshot.accentColor)
+        ProviderDailyUsageSparkline(
+          series: dailyUsage,
+          accentColor: snapshot.accentColor,
+          isRefreshing: isRefreshingUsage
+        )
           .padding(.top, MeterBarTheme.Spacing.xxs)
       }
     }

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -49,6 +49,13 @@ struct MenuBarView: View {
     .onAppear {
       notifyContentSize()
     }
+    .task {
+      // The hover strip reads the cached scan. A Claude/Codex-only cache
+      // looks complete, so Costs-page backfill never runs and Grok stays
+      // empty until the user hits Scan. Kick that backfill when the menu
+      // opens instead of making them find the Costs page.
+      await costTracker.refreshMissingDaysInBackground()
+    }
     .onDisappear {
       expandedDetailID = nil
       MeterBarMenuDetailPanel.shared.dismiss()
@@ -248,7 +255,8 @@ struct MenuBarView: View {
             dailyUsage: costTracker.costSummary?.dailyUsage ?? [],
             ledger: costTracker.usageLedger,
             accountCount: accountCardCount(for: snapshot.service)
-          )
+          ),
+          isRefreshingUsage: costTracker.isRefreshingMissingDays || costTracker.isScanning
         )
       )
     )

--- a/MeterBar/Views/OptimizeInsightsView.swift
+++ b/MeterBar/Views/OptimizeInsightsView.swift
@@ -243,6 +243,11 @@ struct OptimizeInsightsView: View {
         return (selection.subtitle, "None", "no tokens recorded in the last 30 days")
       }
       return (selection.subtitle, UsageFormat.tokens(tokens30Day), "tokens in the last 30 days")
+    case .monthToDate:
+      guard tokens30Day > 0 else {
+        return (selection.subtitle, "None", "no tokens recorded this month")
+      }
+      return (selection.subtitle, UsageFormat.tokens(tokens30Day), "tokens in the cached month-to-date window")
     }
   }
 
@@ -288,7 +293,7 @@ struct OptimizeInsightsView: View {
     // (and the window tile), matching the Costs page's pattern.
     DashboardCard(title: "Token Burn", trailing: windowSelection.subtitle) {
       if let summary = visibleSummary, !summary.dailyUsage.isEmpty {
-        DailyUsageChart(dailyUsage: summary.dailyUsage, daysToShow: windowSelection.days)
+        DailyUsageChart(dailyUsage: summary.dailyUsage, daysToShow: max(1, windowSelection.dayCount()))
           .frame(height: 200)
       } else {
         Text("No daily token history yet.")

--- a/MeterBarTests/CostChartPresentationTests.swift
+++ b/MeterBarTests/CostChartPresentationTests.swift
@@ -159,6 +159,10 @@ final class CostChartPresentationTests: XCTestCase {
 
         XCTAssertEqual(Set(presentation.modelPoints.map(\.chartLabel)).count, 2)
         XCTAssertTrue(presentation.modelPoints.allSatisfy { $0.chartLabel.contains($0.provider.displayName) })
+        XCTAssertEqual(presentation.crossProviderModelPoints.count, 1)
+        XCTAssertEqual(presentation.crossProviderModelPoints.first?.model, "shared-model")
+        XCTAssertEqual(presentation.crossProviderModelPoints.first?.chartLabel, "shared-model")
+        XCTAssertEqual(presentation.crossProviderModelPoints.first?.costUSD ?? 0, 3, accuracy: 0.001)
     }
 
     func testSevenDayWindowDerivesModelSpendFromAttributedDailyRows() {

--- a/MeterBarTests/CostWindowSelectionTests.swift
+++ b/MeterBarTests/CostWindowSelectionTests.swift
@@ -7,22 +7,38 @@ final class CostWindowSelectionTests: XCTestCase {
     func testRawValuesAreTheDayCounts() {
         XCTAssertEqual(CostWindowSelection.week.days, 7)
         XCTAssertEqual(CostWindowSelection.month.days, 30)
+        XCTAssertEqual(CostWindowSelection.monthToDate.days, 0)
         XCTAssertEqual(CostWindowSelection(rawValue: 7), .week)
         XCTAssertEqual(CostWindowSelection(rawValue: 30), .month)
+        XCTAssertEqual(CostWindowSelection(rawValue: -1), .monthToDate)
         XCTAssertNil(CostWindowSelection(rawValue: 14), "unknown persisted day counts must fall back, not crash")
     }
 
-    func testPickerRunsShortWindowFirst() {
-        XCTAssertEqual(CostWindowSelection.allCases, [.week, .month])
+    func testPickerRunsShortWindowFirstThenCalendarMonth() {
+        XCTAssertEqual(CostWindowSelection.allCases, [.week, .month, .monthToDate])
     }
 
     func testDisplayStringsNameTheWindow() {
         XCTAssertEqual(CostWindowSelection.week.pickerLabel, "7 days")
         XCTAssertEqual(CostWindowSelection.month.pickerLabel, "30 days")
+        XCTAssertEqual(CostWindowSelection.monthToDate.pickerLabel, "This month")
         XCTAssertEqual(CostWindowSelection.week.subtitle, "Last 7 days")
         XCTAssertEqual(CostWindowSelection.month.subtitle, "Last 30 days")
+        XCTAssertEqual(CostWindowSelection.monthToDate.subtitle, "Month to date")
         XCTAssertEqual(CostWindowSelection.week.spendCardTitle, "7 Day Spend")
         XCTAssertEqual(CostWindowSelection.month.spendCardTitle, "30 Day Spend")
+        XCTAssertEqual(CostWindowSelection.monthToDate.spendCardTitle, "Month-to-Date Spend")
+    }
+
+    func testMonthToDateDayCountIsInclusiveOfTheFirst() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .gmt
+        let now = calendar.date(from: DateComponents(year: 2026, month: 8, day: 12))!
+        XCTAssertEqual(CostWindowSelection.monthToDate.dayCount(now: now, calendar: calendar), 12)
+        XCTAssertEqual(
+            calendar.startOfDay(for: CostWindowSelection.monthToDate.startDate(now: now, calendar: calendar)),
+            calendar.date(from: DateComponents(year: 2026, month: 8, day: 1))
+        )
     }
 
     func testFallbackActivityWeeksCoverTheSelectedWindow() {
@@ -30,5 +46,6 @@ final class CostWindowSelectionTests: XCTestCase {
         // the month keeps the unchanged six-week calendar.
         XCTAssertEqual(CostWindowSelection.week.fallbackActivityWeeks, 2)
         XCTAssertEqual(CostWindowSelection.month.fallbackActivityWeeks, TokenActivityCalendar.defaultWeeks)
+        XCTAssertEqual(CostWindowSelection.monthToDate.fallbackActivityWeeks, TokenActivityCalendar.defaultWeeks)
     }
 }

--- a/MeterBarTests/HourlyTokenUsageTests.swift
+++ b/MeterBarTests/HourlyTokenUsageTests.swift
@@ -154,6 +154,37 @@ final class HourlyTokenUsageTests: XCTestCase {
         XCTAssertEqual(filtered.hourlyUsage?.map(\.provider), [.codexCli])
     }
 
+    func testMissingEnabledLogProviderTriggersAQuietRescan() {
+        let claudeOnly = makeSummary(hourlyUsage: [
+            hourlyUsage(at: now, provider: .claudeCode),
+        ])
+        XCTAssertTrue(
+            claudeOnly.needsMissingEnabledProviderRefresh(
+                enabledServices: [.claudeCode, .grok],
+                lastScanDate: now.addingTimeInterval(-86_400),
+                now: now,
+                calendar: calendar
+            )
+        )
+        XCTAssertFalse(
+            claudeOnly.needsMissingEnabledProviderRefresh(
+                enabledServices: [.claudeCode],
+                lastScanDate: now.addingTimeInterval(-86_400),
+                now: now,
+                calendar: calendar
+            )
+        )
+        XCTAssertFalse(
+            claudeOnly.needsMissingEnabledProviderRefresh(
+                enabledServices: [.claudeCode, .grok],
+                lastScanDate: now,
+                now: now,
+                calendar: calendar
+            ),
+            "A completed scan today is authoritative even when Grok contributed no rows"
+        )
+    }
+
     func testHourlyBackfillOnlyRunsForEnabledLogScanners() {
         XCTAssertFalse(CostTracker.hasEnabledCostScanProvider(in: [.cursor, .openRouter]))
         XCTAssertTrue(CostTracker.hasEnabledCostScanProvider(in: [.claudeCode]))

--- a/MeterBarTests/ServeRouterTests.swift
+++ b/MeterBarTests/ServeRouterTests.swift
@@ -235,6 +235,17 @@ final class ServeRouterTests: XCTestCase {
         XCTAssertEqual(response.body, expected)
     }
 
+    func testCostEndpointHonorsMonthToDateQueryLikeTheCLI() throws {
+        let response = ServeRouter.handle(
+            request(path: "/cost", query: ["monthToDate": "true"], token: token),
+            token: token,
+            dataSource: makeDataSource()
+        )
+
+        let expected = try CostCLIJSONResponse(cache: costCache, monthToDate: true).jsonData()
+        XCTAssertEqual(response.body, expected)
+    }
+
     func testCostEndpointIgnoresNonPositiveDaysQuery() throws {
         let response = ServeRouter.handle(
             request(path: "/cost", query: ["days": "0"], token: token),

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -116,6 +116,12 @@ family (no rescan, and mutually exclusive with `--days`). `period.kind` distingu
 period shapes: `"days"`, `"monthToDate"`, or omitted entirely for the full, unwindowed summary (the
 version 1 fixture above never sets it, so that response is byte-for-byte unchanged).
 
+`models` is a provider-independent rollup of the same model name across providers.
+It is omitted when any selected provider lacks complete model attribution.
+
+`meterbar serve` `GET /cost` accepts the same windows as query parameters:
+`?days=7` and `?monthToDate=true`. Combining them prefers month-to-date.
+
 ```json
 {
   "schemaVersion": 1,


### PR DESCRIPTION
## Why

Grok's hover panel said **No token history yet** even though session logs exist and `GrokCostScanner` can read them. The last cache scan (Claude/Codex only) looked complete, so the quiet Costs backfill never ran. Opening the menu bar never asked either.

Also remaining audit leftovers except new providers.

## What

- Detect an enabled log provider missing from the cost cache and start the quiet backfill when the popover opens. The empty sparkline says **Loading history** while that runs.
- Costs picker: **7 days / 30 days / This month**. Charts, hero totals, and provider cards cut calendar month-to-date from the existing cache.
- Spend-by-model rolls identical names across providers. `cost --json` and `GET /cost?monthToDate=true` grow an additive top-level `models` array.
- CodeRabbit gate: fail the PR when CodeRabbit's own check is a rate-limited pass.

Closes #387. Closes #434.

## Not in this PR

- **#391** Codex per-session tables — real feature, not a leftover hole. Separate PR.
- **#389 / #427 / #428 / #429** next providers — asked to skip.
- **#433 / #435** burn-down catalog + memory migration — already on the other PR.

## Verify

- `swift test --filter 'HourlyTokenUsageTests|CostWindowSelectionTests|CostChartPresentationTests|ServeRouterTests|CLIJSONOutputTests'`
- Open the menu, hover Grok: first open may show Loading history, then the 7-day strip after the backfill (your cache was last scanned 2026-08-03).