### PR TITLE
fix(cost): scan the 30-day window only and show progress

### DIFF
--- a/.agents/memory/decisions.md
+++ b/.agents/memory/decisions.md
@@ -1,5 +1,5 @@
 ---
-last_verified: 2026-08-12
+last_verified: 2026-08-13
 status: active
 ---
 
@@ -34,3 +34,7 @@ Live ADRs only.
 ## Availability-biased cache
 
 **Accepted.** Fetch failures keep the last good metrics. Blanking the UI on a transport error is worse than showing slightly stale numbers with health dimming.
+
+## Cost scan is the visible window only
+
+**Accepted 2026-08-13.** Quota APIs do not replace 30-day per-model spend. The local scan lists files by mtime (`cutoff - 36h`) and publishes period totals only. Lifetime is kept on `CostSummary` for cache decode and is no longer filled or shown. Codex `logs_2.sqlite` is not opened for the default scan. The Costs page shows listed file count and bytes while a refresh runs.

--- a/.agents/memory/providers.md
+++ b/.agents/memory/providers.md
@@ -1,5 +1,5 @@
 ---
-last_verified: 2026-08-12
+last_verified: 2026-08-13
 status: active
 ---
 
@@ -19,7 +19,9 @@ MeterBar reads usage from local CLI artifacts and provider APIs. CLI-backed prov
 
 ## Cost scan
 
-`CostTracker` scans `~/.claude*/projects/**/*.jsonl` and Codex `$CODEX_HOME/archived_sessions` **and** `$CODEX_HOME/sessions`, plus `$CODEX_HOME/logs_2.sqlite`. Codex `token_count` events carry neither model nor front end — the scanner streams each rollout and forwards the last `turn_context` model and opening `session_meta` originator. The two Codex directories are deduped by event content, not filename.
+`CostTracker` scans local transcripts for the visible 7/30-day window only. Lifetime totals are not published — filling them meant walking multi-gigabyte archives. Quota APIs (Claude OAuth usage, Codex wham, Cursor, OpenRouter credits, Grok ACP) feed the gauges; they do not carry per-model 30-day spend, so the chart still reads logs.
+
+Listing filters: mtime newer than `cutoff - 36h`, Grok `updates.jsonl` only. Codex reads `$CODEX_HOME/sessions` and recent `archived_sessions`; it does **not** open `logs_2.sqlite` for the default scan. Codex `token_count` events carry neither model nor front end — the scanner streams each rollout and forwards the last `turn_context` model and opening `session_meta` originator. The two Codex directories are deduped by session id, keeping the larger copy.
 
 Admin keys live in keychain service `dev.meterbar.app`, with reads migrating `dev.shipshit.meterbar` and `com.agenticindiedev.quotaguard`. Removals delete all three.
 

--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -307,8 +307,9 @@ enum ClaudeCostScanner {
         for root in roots {
             guard CostScanFileSystem.isLocalDirectory(root) else { continue }
 
-            let listing = CostScanCorpus.listing(in: root)
+            let listing = CostScanCorpus.listing(in: root, modifiedSince: session.listingCutoff)
             coverage.add(listing)
+            session.noteListing(listing)
 
             for file in listing.files {
                 // `projectRoots` can name the same directory twice (an account's
@@ -316,6 +317,7 @@ enum ClaudeCostScanner {
                 // keyed by standardized path — counting a file once per root
                 // would double its spend.
                 guard coverage.keep(file.cacheKey) else { continue }
+                session.noteProcessedFile()
 
                 let projectID = CostProjectAttribution.claudeProjectID(
                     forTranscriptURL: file.url,

--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -317,7 +317,6 @@ enum ClaudeCostScanner {
                 // keyed by standardized path — counting a file once per root
                 // would double its spend.
                 guard coverage.keep(file.cacheKey) else { continue }
-                session.noteProcessedFile()
 
                 let projectID = CostProjectAttribution.claudeProjectID(
                     forTranscriptURL: file.url,
@@ -326,6 +325,7 @@ enum ClaudeCostScanner {
                 guard let totals = Self.totals(for: file, projectID: projectID, session: session) else {
                     continue
                 }
+                session.noteProcessedFile()
                 guard Self.fold(totals, into: &windows) else {
                     // This file shares only *some* of its events with one
                     // already folded in — a stale copy holding a prefix of the

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -175,7 +175,10 @@ enum CodexCostScanner {
     /// A directory that is missing or non-local is a complete answer, not a
     /// failed walk: `archived_sessions/` routinely does not exist, and treating
     /// that as incomplete would disable pruning forever.
-    nonisolated static func distinctRollouts(in directories: [URL]) -> CostScanCorpusListing {
+    nonisolated static func distinctRollouts(
+        in directories: [URL],
+        modifiedSince: Date? = nil
+    ) -> CostScanCorpusListing {
         var chosen: [String: CostScanFile] = [:]
         var seen: Set<String> = []
         var unreadableKeys: Set<String> = []
@@ -184,7 +187,7 @@ enum CodexCostScanner {
         for directory in directories {
             guard CostScanFileSystem.isLocalDirectory(directory) else { continue }
 
-            let listing = CostScanCorpus.listing(in: directory)
+            let listing = CostScanCorpus.listing(in: directory, modifiedSince: modifiedSince)
             unreadableKeys.formUnion(listing.unreadableKeys)
             isComplete = isComplete && listing.isComplete
 
@@ -297,26 +300,15 @@ enum CodexCostScanner {
 
     // MARK: - Budgeted, resumable scan
 
-    /// Rollouts and the flat SQLite log, read under `session`'s budget.
+    /// Rollouts under `session`'s budget. The multi-gigabyte `logs_2.sqlite`
+    /// store is a recent-session fallback the windowed scan does not need —
+    /// live `sessions/` rollouts already carry the last 30 days.
     nonisolated static func scanSessions(session: CostScanSession) -> ScanWindows<CostScanWindowContext> {
         let codexDir = URL(fileURLWithPath: CodexHomeDirectory.path(), isDirectory: true)
-        var windows = Self.scanRollouts(
+        return Self.scanRollouts(
             directories: Self.rolloutDirectories(in: codexDir),
             session: session
         )
-        // Rollouts are the authoritative lifetime corpus. The SQLite store is
-        // only a recent-session fallback, and it must not escape the slice
-        // budget: a modern Codex database can be multiple gigabytes even when
-        // it contains no usage telemetry at all. Read it once, after the
-        // resumable rollout pass has completed, instead of once per slice.
-        if session.isComplete {
-            Self.scanSQLiteLogs(
-                database: codexDir.appendingPathComponent("logs_2.sqlite"),
-                since: session.cutoff,
-                windows: &windows
-            )
-        }
-        return windows
     }
 
     /// Walks `directories` newest rollout first, reading only bytes appended
@@ -326,12 +318,14 @@ enum CodexCostScanner {
         session: CostScanSession
     ) -> ScanWindows<CostScanWindowContext> {
         var windows = Self.scanWindows(cutoff: session.cutoff, hourlyCutoff: session.hourlyCutoff)
-        let listing = Self.distinctRollouts(in: directories)
+        let listing = Self.distinctRollouts(in: directories, modifiedSince: session.listingCutoff)
         var coverage = CostScanCorpusCoverage()
         coverage.add(listing)
+        session.noteListing(listing)
 
         for file in listing.files {
             coverage.keep(file.cacheKey)
+            session.noteProcessedFile()
             guard let totals = Self.totals(for: file, session: session) else { continue }
             guard Self.fold(totals, into: &windows) else {
                 // This rollout shares only *some* of its events with one already

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -325,8 +325,8 @@ enum CodexCostScanner {
 
         for file in listing.files {
             coverage.keep(file.cacheKey)
-            session.noteProcessedFile()
             guard let totals = Self.totals(for: file, session: session) else { continue }
+            session.noteProcessedFile()
             guard Self.fold(totals, into: &windows) else {
                 // This rollout shares only *some* of its events with one already
                 // folded in. Aggregates cannot be de-overlapped after the fact,

--- a/MeterBar/Services/CostScanBudget.swift
+++ b/MeterBar/Services/CostScanBudget.swift
@@ -2,10 +2,9 @@ import Foundation
 
 /// How much a single refresh is allowed to read.
 ///
-/// A cold corpus is ~10 GB; reading all of it in one pass is the 70-second
-/// freeze this budget exists to prevent. A refresh instead takes a bounded bite
-/// of whatever is still unread, persists its byte offsets, and leaves the rest
-/// for the next pass.
+/// The listing is already windowed (mtime + 36h slack), so a typical refresh
+/// is hundreds of megabytes, not the multi-gigabyte archive. The budget still
+/// exists so one pathological transcript cannot freeze the popover.
 nonisolated struct CostScanBudgetOptions: Sendable {
     /// 256 MiB. Caps the damage one pathological transcript can do: without it a
     /// single multi-gigabyte `.jsonl` would consume an entire refresh and starve
@@ -15,9 +14,8 @@ nonisolated struct CostScanBudgetOptions: Sendable {
 
     /// 512 MiB. The whole-refresh ceiling, and the knob that actually sets the
     /// slice length — roughly a second of warm sequential reads on an internal
-    /// SSD, and ~20 slices to walk a 10 GB corpus from cold. Raising it makes a
-    /// cold start converge in fewer passes at the cost of a longer stretch with
-    /// the scan queue busy.
+    /// SSD. Raising it makes a cold start converge in fewer passes at the cost
+    /// of a longer stretch with the scan queue busy.
     var maxNewBytesPerRefresh: Int
 
     /// Wall-clock ceiling, in seconds. Bytes are a poor proxy for time on a

--- a/MeterBar/Services/CostScanCorpus.swift
+++ b/MeterBar/Services/CostScanCorpus.swift
@@ -109,15 +109,21 @@ nonisolated enum CostScanCorpus {
     /// Ordering is what makes a budgeted refresh useful rather than arbitrary.
     /// The visible summary is a 30-day window, and the transcripts that fall in
     /// it are exactly the recently-written ones — so spending the budget newest
-    /// first makes the number on screen correct after the first pass, while the
-    /// older archive (which only moves the lifetime total) catches up over
-    /// subsequent refreshes.
+    /// first makes the number on screen correct after the first pass.
     ///
+    /// - Parameter modifiedSince: when set, files whose last write is older than
+    ///   this date are not opened. A file that has not been touched cannot hold
+    ///   a new in-window event, so walking a multi-gigabyte archive for lifetime
+    ///   totals is skipped at the listing layer.
+    /// - Parameter fileNames: when set, only transcripts whose last path
+    ///   component is in the set are kept (`updates.jsonl` for Grok).
     /// - Parameter stamp: injectable so tests can fail one lookup inside an
     ///   otherwise healthy tree. A stat race cannot be staged on a real file
     ///   system. Production callers use the default.
     static func listing(
         in root: URL,
+        modifiedSince: Date? = nil,
+        fileNames: Set<String>? = nil,
         stamp: (URL) -> CostScanFileStamp? = { CostScanFileStamp.read(at: $0) }
     ) -> CostScanCorpusListing {
         let keys: [URLResourceKey] = [.isRegularFileKey]
@@ -140,6 +146,9 @@ nonisolated enum CostScanCorpus {
         var files: [CostScanFile] = []
         var unreadableKeys: Set<String> = []
         for case let url as URL in enumerator where url.pathExtension == "jsonl" {
+            if let fileNames, !fileNames.contains(url.lastPathComponent) {
+                continue
+            }
             // A directory or dangling symlink named `*.jsonl` is a definite
             // answer, not a failed lookup: it is not a transcript and never was,
             // so it must stay prunable rather than pin a phantom cache key.
@@ -150,6 +159,9 @@ nonisolated enum CostScanCorpus {
             guard values.isRegularFile == true else { continue }
             guard let stamp = stamp(url) else {
                 unreadableKeys.insert(cacheKey(for: url))
+                continue
+            }
+            if let modifiedSince, stamp.modified < modifiedSince.timeIntervalSince1970 {
                 continue
             }
             files.append(

--- a/MeterBar/Services/CostScanProgress.swift
+++ b/MeterBar/Services/CostScanProgress.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// What a refresh is about to read — or is already reading — so the Costs page
+/// can say "42 files, 180 MB, last 30 days" instead of a silent hang.
+///
+/// Listed counts come from the mtime-filtered walk, not the whole home
+/// directory. A 10 GB archive that has not been touched inside the window does
+/// not appear here.
+nonisolated struct CostScanProgress: Equatable, Sendable {
+    var windowDays: Int
+    var listedFiles: Int
+    var listedBytes: Int64
+    var processedFiles: Int
+    var bytesRead: Int
+    var isComplete: Bool
+
+    /// 1 GiB. Above this the banner warns that even the windowed corpus is huge.
+    static let largeCorpusBytes: Int64 = 1_073_741_824
+
+    init(
+        windowDays: Int,
+        listedFiles: Int = 0,
+        listedBytes: Int64 = 0,
+        processedFiles: Int = 0,
+        bytesRead: Int = 0,
+        isComplete: Bool = false
+    ) {
+        self.windowDays = windowDays
+        self.listedFiles = listedFiles
+        self.listedBytes = listedBytes
+        self.processedFiles = processedFiles
+        self.bytesRead = bytesRead
+        self.isComplete = isComplete
+    }
+
+    var isLargeCorpus: Bool { listedBytes >= Self.largeCorpusBytes }
+
+    var fraction: Double? {
+        guard listedFiles > 0 else { return nil }
+        return min(1, Double(processedFiles) / Double(listedFiles))
+    }
+
+    var formattedListedSize: String { Self.formatBytes(listedBytes) }
+
+    var statusText: String {
+        if listedFiles == 0 && !isComplete {
+            return "Listing session files…"
+        }
+        if isComplete {
+            return "Scanned \(listedFiles) files (\(formattedListedSize))"
+        }
+        if processedFiles > 0 {
+            return "Scanning \(processedFiles) of \(listedFiles) files · \(formattedListedSize)"
+        }
+        return "Scanning \(listedFiles) files (\(formattedListedSize))"
+    }
+
+    var detailText: String {
+        if isLargeCorpus {
+            return "This \(windowDays)-day window is still \(formattedListedSize). Older archives are not scanned."
+        }
+        return "Only files touched in the last \(windowDays) days. Quota APIs do not include this history."
+    }
+
+    static func formatBytes(_ bytes: Int64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useKB, .useMB, .useGB]
+        formatter.countStyle = .file
+        formatter.includesUnit = true
+        return formatter.string(fromByteCount: max(0, bytes))
+    }
+}

--- a/MeterBar/Services/CostScanSession.swift
+++ b/MeterBar/Services/CostScanSession.swift
@@ -24,6 +24,14 @@ nonisolated final class CostScanSession: @unchecked Sendable {
     /// Start of the seven-calendar-day hour buckets retained by this refresh.
     let hourlyCutoff: Date
 
+    /// Slack before `cutoff` so a file whose last write is just outside the
+    /// visible window is still opened. Clock skew, timezone edges, and Codex
+    /// archive copies that land a few hours late all fit inside a day and a half.
+    static let listingSlack: TimeInterval = 36 * 60 * 60
+
+    /// Files last written before this date cannot hold an in-window event.
+    var listingCutoff: Date { cutoff.addingTimeInterval(-Self.listingSlack) }
+
     let budget: CostScanBudget
 
     private let store: CostScanCacheStore?
@@ -33,6 +41,9 @@ nonisolated final class CostScanSession: @unchecked Sendable {
     fileprivate var grokCache: CostScanFileCache<GrokFileTotals>
     private var dirtyProviders: Set<CostScanProvider> = []
     private var deferred: Set<CostScanProvider> = []
+    private var listedFiles = 0
+    private var listedBytes: Int64 = 0
+    private var processedFiles = 0
 
     init(
         cutoff: Date,
@@ -98,6 +109,34 @@ nonisolated final class CostScanSession: @unchecked Sendable {
         lock.lock()
         deferred.insert(provider)
         lock.unlock()
+    }
+
+    /// Records the files this refresh actually intends to open — the
+    /// mtime-filtered listing, not the whole provider home.
+    func noteListing(_ listing: CostScanCorpusListing) {
+        lock.lock()
+        listedFiles += listing.files.count
+        listedBytes += listing.files.reduce(0) { $0 + Int64($1.size) }
+        lock.unlock()
+    }
+
+    func noteProcessedFile() {
+        lock.lock()
+        processedFiles += 1
+        lock.unlock()
+    }
+
+    func progress(windowDays: Int) -> CostScanProgress {
+        lock.lock()
+        defer { lock.unlock() }
+        return CostScanProgress(
+            windowDays: windowDays,
+            listedFiles: listedFiles,
+            listedBytes: listedBytes,
+            processedFiles: processedFiles,
+            bytesRead: budget.bytesRead,
+            isComplete: deferred.isEmpty
+        )
     }
 
     func record<Payload>(

--- a/MeterBar/Services/CostScanSession.swift
+++ b/MeterBar/Services/CostScanSession.swift
@@ -44,6 +44,9 @@ nonisolated final class CostScanSession: @unchecked Sendable {
     private var listedFiles = 0
     private var listedBytes: Int64 = 0
     private var processedFiles = 0
+    private var lastEmittedProcessed = 0
+    private var progressWindowDays = 30
+    private var onProgress: (@Sendable (CostScanProgress) -> Void)?
 
     init(
         cutoff: Date,
@@ -111,31 +114,60 @@ nonisolated final class CostScanSession: @unchecked Sendable {
         lock.unlock()
     }
 
+    /// Publishes listing and read milestones while the slice is still running,
+    /// so a one-slice refresh can show file count and bytes instead of a blank
+    /// "Listing…" banner that disappears when the scan ends.
+    func observeProgress(
+        windowDays: Int,
+        _ handler: @escaping @Sendable (CostScanProgress) -> Void
+    ) {
+        lock.lock()
+        progressWindowDays = windowDays
+        onProgress = handler
+        lock.unlock()
+    }
+
     /// Records the files this refresh actually intends to open — the
     /// mtime-filtered listing, not the whole provider home.
     func noteListing(_ listing: CostScanCorpusListing) {
         lock.lock()
         listedFiles += listing.files.count
         listedBytes += listing.files.reduce(0) { $0 + Int64($1.size) }
+        let snapshot = snapshotLocked()
+        let handler = onProgress
         lock.unlock()
+        handler?(snapshot)
     }
 
+    /// Count only files this slice actually finished — a cache hit or a read.
+    /// Files skipped because the budget ran out stay uncounted so the banner
+    /// cannot report 100% on an incomplete refresh.
     func noteProcessedFile() {
         lock.lock()
         processedFiles += 1
+        let shouldEmit = processedFiles == listedFiles
+            || processedFiles - lastEmittedProcessed >= 8
+        if shouldEmit { lastEmittedProcessed = processedFiles }
+        let snapshot = shouldEmit ? snapshotLocked() : nil
+        let handler = onProgress
         lock.unlock()
+        if let snapshot { handler?(snapshot) }
     }
 
     func progress(windowDays: Int) -> CostScanProgress {
         lock.lock()
         defer { lock.unlock() }
-        return CostScanProgress(
-            windowDays: windowDays,
+        return snapshotLocked(windowDays: windowDays)
+    }
+
+    private func snapshotLocked(windowDays: Int? = nil) -> CostScanProgress {
+        CostScanProgress(
+            windowDays: windowDays ?? progressWindowDays,
             listedFiles: listedFiles,
             listedBytes: listedBytes,
             processedFiles: processedFiles,
             bytesRead: budget.bytesRead,
-            isComplete: deferred.isEmpty
+            isComplete: deferred.isEmpty && processedFiles == listedFiles
         )
     }
 

--- a/MeterBar/Services/CostSummaryBuilder.swift
+++ b/MeterBar/Services/CostSummaryBuilder.swift
@@ -36,9 +36,8 @@ enum CostSummaryBuilder {
     /// complete-as-of-what-has-been-read from the very first slice rather than
     /// only after the last one.
     ///
-    /// One traversal fills both windows. The lifetime scan reads a strict
-    /// superset of the period scan, so running it separately would mean reading
-    /// every transcript twice for the same numbers.
+    /// The published summary is the visible period only. Lifetime totals used
+    /// to force a walk of every archived transcript; they are no longer filled.
     ///
     /// `enabledProviders` replaces what used to be one `Bool` per provider: with
     /// three corpora that shape had grown to three flags whose order at the call
@@ -71,17 +70,13 @@ enum CostSummaryBuilder {
             let roots = claudeProjectRoots ?? ClaudeCostScanner.projectRoots(accounts: claudeAccounts)
             let claude = ClaudeCostScanner.scanRoots(roots, session: session)
             scan.period.append(ClaudeCostScanner.makeCost(from: claude.period, windowStart: session.cutoff))
-            scan.lifetime.append(ClaudeCostScanner.makeCost(from: claude.lifetime, windowStart: .distantPast))
             scan.period.record(claude.period.pricing)
-            scan.lifetime.record(claude.lifetime.pricing)
         }
 
         if enabledProviders.contains(.codex) {
             let codex = CodexCostScanner.scanSessions(session: session)
             scan.period.append(CodexCostScanner.makeCost(from: codex.period))
-            scan.lifetime.append(CodexCostScanner.makeCost(from: codex.lifetime))
             scan.period.record(codex.period.pricing)
-            scan.lifetime.record(codex.lifetime.pricing)
         }
 
         // No `record(...)` pass: Grok bills each turn itself, so its rows are
@@ -90,7 +85,6 @@ enum CostSummaryBuilder {
             let roots = GrokCostScanner.sessionRoots(accounts: grokAccounts)
             let grok = GrokCostScanner.scanRoots(roots, session: session)
             scan.period.append(GrokCostScanner.makeCost(from: grok.period))
-            scan.lifetime.append(GrokCostScanner.makeCost(from: grok.lifetime))
         }
 
         // No pricing pass either: these totals arrive already denominated in
@@ -106,19 +100,12 @@ enum CostSummaryBuilder {
                     windowStart: session.cutoff
                 )
             )
-            scan.lifetime.append(
-                ProviderUsageCostBuilder.makeCost(
-                    from: usageLedger,
-                    provider: provider,
-                    windowStart: .distantPast
-                )
-            )
         }
 
         // Events older than every entry in the table were priced at the oldest
         // known rate — a documented guess, so say so rather than let it pass as
         // a verified figure (issue #339).
-        if let note = scan.lifetime.pricing.diagnosticNote {
+        if let note = scan.period.pricing.diagnosticNote {
             AppLog.cost.warning("Pricing table gap: \(note, privacy: .public)")
         }
 
@@ -134,7 +121,7 @@ enum CostSummaryBuilder {
                     if lhs.date != rhs.date { return lhs.date < rhs.date }
                     return lhs.provider.rawValue < rhs.provider.rawValue
                 },
-                lifetime: LifetimeCostSummary(costs: scan.lifetime.costs),
+                lifetime: nil,
                 pricing: scan.period.pricing.isEmpty ? nil : scan.period.pricing
             ),
             deferredProviders: session.deferredProviders

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -245,6 +245,7 @@ class CostTracker: ObservableObject {
         await MainActor.run {
             scanProgress = CostScanProgress(windowDays: days)
         }
+        let progressBridge = CostScanProgressBridge(tracker: self)
 
         for _ in 0..<Self.maxScanSlices {
             let slice = try? await CostScanExecutor.run { token in
@@ -255,6 +256,7 @@ class CostTracker: ObservableObject {
                     store: store,
                     token: token
                 )
+                session.observeProgress(windowDays: days, progressBridge.publish)
                 let scan = CostSummaryBuilder.makeScan(
                     days: days,
                     enabledProviders: enabledProviders,
@@ -361,6 +363,22 @@ class CostTracker: ObservableObject {
             try CostSummaryStore.save(CostSummaryCache(summary: costSummary, lastScanDate: lastScanDate))
         } catch {
             AppLog.cost.error("Failed to save cost summary cache: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}
+
+/// Hops listing/read milestones off the scan queue onto the main actor so the
+/// Costs banner updates during a single-slice refresh.
+nonisolated final class CostScanProgressBridge: @unchecked Sendable {
+    private weak var tracker: CostTracker?
+
+    init(tracker: CostTracker) {
+        self.tracker = tracker
+    }
+
+    func publish(_ progress: CostScanProgress) {
+        DispatchQueue.main.async { [weak tracker] in
+            tracker?.scanProgress = progress
         }
     }
 }

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -16,6 +16,8 @@ class CostTracker: ObservableObject {
     @Published var isScanning: Bool = false
     @Published var isRefreshingMissingDays: Bool = false
     @Published var lastScanDate: Date?
+    /// What this refresh listed and how far it has got. `nil` when idle.
+    @Published var scanProgress: CostScanProgress?
 
     /// Polled running counters, accumulated into a dated series.
     ///
@@ -98,34 +100,27 @@ class CostTracker: ObservableObject {
         return await MainActor.run {
             apply(scan)
             isScanning = false
+            scanProgress = nil
             return scan?.isComplete == true ? .completed : .partial
         }
     }
 
-    /// Quietly backfills a legacy cache's missing lifetime snapshot, daily
-    /// rows, or hourly rows when Overview/Costs opens, without the visible
-    /// "Scanning" UI a manual scan shows.
+    /// Quietly backfills missing daily or hourly rows when Overview/Costs
+    /// opens, without the visible "Scanning" UI a manual scan shows.
+    ///
+    /// A missing lifetime snapshot is not a reason to rescan. Lifetime is no
+    /// longer published; treating `lifetime == nil` as incomplete was what
+    /// walked multi-gigabyte archives on every Costs open.
     func refreshMissingDaysInBackground(days: Int = 30) async {
         guard !demoMode else { return }
         let shouldStart = await MainActor.run {
-            let hasEnabledCostScanProvider = Self.hasEnabledCostScanProvider(
-                in: providerVisibilityStore.enabledServices
-            )
             guard !isRefreshInProgress else { return false }
-            if costSummary == nil {
-                guard hasEnabledCostScanProvider else { return false }
-                isRefreshingMissingDays = true
-                return true
-            }
-            guard let visibleSummary = costSummary?.filtered(to: providerVisibilityStore.enabledServices),
-                  visibleSummary.lifetime == nil
-                    || visibleSummary.needsMissingDailyUsageRefresh(days: days, lastScanDate: lastScanDate)
-                    || (hasEnabledCostScanProvider
-                        && visibleSummary.needsMissingHourlyUsageRefresh(lastScanDate: lastScanDate))
-                    || visibleSummary.needsMissingEnabledProviderRefresh(
-                        enabledServices: providerVisibilityStore.enabledServices,
-                        lastScanDate: lastScanDate
-                    ) else {
+            guard Self.needsBackgroundRefresh(
+                summary: costSummary,
+                lastScanDate: lastScanDate,
+                enabledServices: providerVisibilityStore.enabledServices,
+                days: days
+            ) else {
                 return false
             }
             isRefreshingMissingDays = true
@@ -138,7 +133,37 @@ class CostTracker: ObservableObject {
         await MainActor.run {
             apply(scan)
             isRefreshingMissingDays = false
+            scanProgress = nil
         }
+    }
+
+    /// Whether opening Costs should start a windowed backfill.
+    ///
+    /// Extracted so the "lifetime is gone on purpose" rule is unit-testable
+    /// without constructing a full tracker.
+    static func needsBackgroundRefresh(
+        summary: CostSummary?,
+        lastScanDate: Date?,
+        enabledServices: Set<ServiceType>,
+        days: Int,
+        now: Date = Date()
+    ) -> Bool {
+        let hasEnabled = hasEnabledCostScanProvider(in: enabledServices)
+        guard let summary else { return hasEnabled }
+
+        let visibleSummary = summary.filtered(to: enabledServices)
+        return visibleSummary.needsMissingDailyUsageRefresh(
+            days: days,
+            lastScanDate: lastScanDate,
+            now: now
+        )
+            || (hasEnabled
+                && visibleSummary.needsMissingHourlyUsageRefresh(lastScanDate: lastScanDate, now: now))
+            || visibleSummary.needsMissingEnabledProviderRefresh(
+                enabledServices: enabledServices,
+                lastScanDate: lastScanDate,
+                now: now
+            )
     }
 
     /// Hourly rows come from local log scanners, not from providers whose
@@ -174,8 +199,8 @@ class CostTracker: ObservableObject {
     /// Backstop against a refresh that never reports completion.
     ///
     /// Every slice that defers work has, by construction, spent budget reading
-    /// bytes — so the loop terminates on its own after ~20 slices on a cold
-    /// 10 GB corpus. This bound only exists so a corrupted cache or a
+    /// bytes — so the loop terminates on its own after a few slices of a
+    /// windowed corpus. This bound only exists so a corrupted cache or a
     /// pathological transcript cannot pin the scan queue indefinitely; hitting
     /// it costs nothing but a later refresh finishing the remainder.
     private static let maxScanSlices = 64
@@ -217,6 +242,9 @@ class CostTracker: ObservableObject {
         refreshUsageLedger()
         let usageLedger = usageLedger
         var latest: CostSummaryBuilder.CostSummaryScan?
+        await MainActor.run {
+            scanProgress = CostScanProgress(windowDays: days)
+        }
 
         for _ in 0..<Self.maxScanSlices {
             let slice = try? await CostScanExecutor.run { token in
@@ -238,17 +266,26 @@ class CostTracker: ObservableObject {
                 // Persist even when the slice was cut short: offsets commit on
                 // line boundaries, so partial progress is exactly what the next
                 // slice needs to resume from.
-                return ScanSlice(scan: scan, persistence: session.persist())
+                return ScanSlice(
+                    scan: scan,
+                    persistence: session.persist(),
+                    progress: session.progress(windowDays: days)
+                )
             }
             // Cancelled. Whatever earlier slices published stands, and the
             // offsets they committed are already on disk.
             guard let slice else { break }
 
             latest = slice.scan
+            await MainActor.run {
+                scanProgress = slice.progress
+                // Publish the partial total so the number on screen improves with
+                // every slice instead of only when the last one lands.
+                if !slice.scan.isComplete {
+                    costSummary = slice.scan.summary
+                }
+            }
             if slice.scan.isComplete { break }
-            // Publish the partial total so the number on screen improves with
-            // every slice instead of only when the last one lands.
-            await MainActor.run { costSummary = slice.scan.summary }
 
             guard Self.shouldRunAnotherSlice(after: slice.scan, persistence: slice.persistence) else {
                 Self.logStoppedScan(slice)
@@ -264,6 +301,7 @@ class CostTracker: ObservableObject {
     private struct ScanSlice: Sendable {
         let scan: CostSummaryBuilder.CostSummaryScan
         let persistence: CostScanPersistReport
+        let progress: CostScanProgress
     }
 
     /// Whether another slice can improve on the one that just finished.

--- a/MeterBar/Services/GrokCostScanner.swift
+++ b/MeterBar/Services/GrokCostScanner.swift
@@ -21,11 +21,12 @@ import MeterBarShared
 ///   is attributable the moment it is read.
 ///
 /// It does keep Codex's overlap fallback. Grok writes each session exactly
-/// once, but nothing keeps a *copy* of that file off disk: sync clients leave
-/// conflict copies, backups get restored into the tree, and `CostScanCorpus`
-/// matches every `.jsonl` under the root. Because the dedup key carries the
-/// session ID from the payload rather than from the path, a copy produces
-/// identical keys — so a blind `merge` would bill it twice.
+/// once, but nothing keeps a *copy* of `updates.jsonl` off disk: sync clients
+/// leave conflict copies and backups get restored into the tree. The listing
+/// only opens `updates.jsonl` (the rest of the session log has no usage).
+/// Because the dedup key carries the session ID from the payload rather than
+/// from the path, a copy produces identical keys — so a blind `merge` would
+/// bill it twice.
 enum GrokCostScanner {
     /// USD per unit of `costUsdTicks`.
     ///
@@ -131,11 +132,17 @@ enum GrokCostScanner {
 
         for root in roots {
             guard CostScanFileSystem.isLocalDirectory(root) else { continue }
-            let listing = CostScanCorpus.listing(in: root)
+            let listing = CostScanCorpus.listing(
+                in: root,
+                modifiedSince: session.listingCutoff,
+                fileNames: ["updates.jsonl"]
+            )
             coverage.add(listing)
+            session.noteListing(listing)
 
             for file in listing.files {
                 guard coverage.keep(file.cacheKey) else { continue }
+                session.noteProcessedFile()
                 guard let totals = Self.totals(for: file, session: session) else { continue }
                 guard Self.fold(totals, into: &windows) else {
                     // This file shares only *some* of its events with one

--- a/MeterBar/Services/GrokCostScanner.swift
+++ b/MeterBar/Services/GrokCostScanner.swift
@@ -142,8 +142,8 @@ enum GrokCostScanner {
 
             for file in listing.files {
                 guard coverage.keep(file.cacheKey) else { continue }
-                session.noteProcessedFile()
                 guard let totals = Self.totals(for: file, session: session) else { continue }
+                session.noteProcessedFile()
                 guard Self.fold(totals, into: &windows) else {
                     // This file shares only *some* of its events with one
                     // already folded in — a stale copy holding a prefix of the

--- a/MeterBar/Views/DashboardCostCards.swift
+++ b/MeterBar/Views/DashboardCostCards.swift
@@ -66,11 +66,7 @@ struct CostOverviewStatusCard: View {
   }
 
   var body: some View {
-    // `maxHeight: .infinity` lets the card *surface* stretch to the paired
-    // Lifetime card's height — the section already offers the row height, but
-    // without this the tile kept its intrinsic size and the shorter card ended
-    // mid-air beside the taller one.
-    DashboardTile(minHeight: CostHeadlineCardMetrics.minimumHeight, maxHeight: .infinity) {
+    DashboardTile(minHeight: CostHeadlineCardMetrics.minimumHeight) {
       VStack(alignment: .leading, spacing: 12) {
         HStack(alignment: .center, spacing: 9) {
           Image(systemName: "dollarsign.circle.fill")
@@ -168,96 +164,11 @@ struct CostOverviewStatusCard: View {
   }
 }
 
-struct LifetimeCostSummaryCard: View {
-  let summary: LifetimeCostSummary?
-  let isScanning: Bool
-
-  var body: some View {
-    // Same stretch as the estimate card — both surfaces must end on the same
-    // baseline whichever one is intrinsically taller.
-    DashboardTile(minHeight: CostHeadlineCardMetrics.minimumHeight, maxHeight: .infinity) {
-      VStack(alignment: .leading, spacing: 12) {
-        HStack(alignment: .center, spacing: 9) {
-          Image(systemName: "clock.arrow.circlepath")
-            .font(.system(size: 20, weight: .semibold))
-            .foregroundStyle(MeterBarTheme.appAccent)
-            .accessibilityHidden(true)
-          VStack(alignment: .leading, spacing: 2) {
-            Text("Lifetime Local Cost")
-              .font(.headline)
-              .fontWeight(.semibold)
-            Text("All available history")
-              .font(.caption)
-              .foregroundStyle(.secondary)
-          }
-          Spacer()
-          DashboardCardCaption(text: trackedDateRange)
-        }
-
-        if let summary, summary.hasBillableHistory {
-          CostHeadlineAmount(summary.formattedTotalCost)
-
-          ForEach(summary.providers) { provider in
-            HStack(spacing: 10) {
-              ProviderTitle(
-                title: provider.provider.displayName,
-                logoKind: .forService(provider.provider),
-                color: MeterBarTheme.accent(for: provider.provider),
-                font: .subheadline
-              )
-              Spacer()
-              Text(provider.formattedCost)
-                .font(.subheadline)
-                .fontWeight(.semibold)
-            }
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel(provider.provider.displayName)
-            .accessibilityValue(provider.formattedCost)
-          }
-        } else if isScanning {
-          HStack(spacing: 10) {
-            ProgressView()
-              .controlSize(.small)
-            Text("Scanning all available local history…")
-              .font(.subheadline)
-              .foregroundStyle(.secondary)
-          }
-        } else if summary == nil {
-          EmptyStateCard(
-            systemImage: "magnifyingglass",
-            title: "Lifetime scan needed",
-            message: "Run a local scan to calculate lifetime cost from available history."
-          )
-        } else {
-          EmptyStateCard(
-            systemImage: "clock.arrow.circlepath",
-            title: "No lifetime cost",
-            message: "No billable history was found for any enabled provider."
-          )
-        }
-      }
-    }
-  }
-
-  private var trackedDateRange: String? {
-    guard let firstDate = summary?.firstTrackedDate,
-          let lastDate = summary?.lastTrackedDate else {
-      return nil
-    }
-
-    let first = firstDate.formatted(date: .abbreviated, time: .omitted)
-    let last = lastDate.formatted(date: .abbreviated, time: .omitted)
-    return first == last ? first : "\(first) – \(last)"
-  }
-}
-
 private enum CostHeadlineCardMetrics {
   static let minimumHeight: CGFloat = 180
 }
 
-/// One typography contract for the two headline cost cards. Keeping the font,
-/// scaling, and digit treatment in one view prevents the 30-day and lifetime
-/// amounts from drifting apart again.
+/// One typography contract for the headline cost amount.
 private struct CostHeadlineAmount: View {
   let value: String
 
@@ -282,8 +193,49 @@ private struct CostHeadlineAmount: View {
 /// the empty slot reads as "working on it" rather than "nothing here." Contrast
 /// with `CostScanProgressBadge`, which is a small overlay used when a scan
 /// refreshes data that is *already* on screen.
+struct CostScanScopeBanner: View {
+  let progress: CostScanProgress
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(spacing: 8) {
+        ProgressView()
+          .controlSize(.small)
+        Text(progress.statusText)
+          .font(.subheadline)
+          .fontWeight(.semibold)
+          .lineLimit(2)
+        Spacer(minLength: 8)
+        Text("Last \(progress.windowDays) days")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+
+      if let fraction = progress.fraction {
+        ProgressView(value: fraction)
+          .progressViewStyle(.linear)
+      }
+
+      Label(progress.detailText, systemImage: progress.isLargeCorpus ? "exclamationmark.triangle.fill" : "info.circle")
+        .font(.caption)
+        .foregroundStyle(progress.isLargeCorpus ? Color.orange : Color.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+    .padding(12)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(
+      RoundedRectangle(cornerRadius: MeterBarTheme.Radius.medium, style: .continuous)
+        .fill(progress.isLargeCorpus ? Color.orange.opacity(0.12) : Color.primary.opacity(0.05))
+    )
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(progress.statusText)
+    .accessibilityValue(progress.detailText)
+  }
+}
+
 struct CostScanLoadingChart: View {
   let compact: Bool
+  var progress: CostScanProgress?
 
   @Environment(\.accessibilityReduceMotion)
   private var reduceMotion
@@ -307,11 +259,12 @@ struct CostScanLoadingChart: View {
           HStack(spacing: 8) {
             ProgressView()
               .controlSize(.small)
-            Text("Scanning local logs")
+            Text(progress?.statusText ?? "Scanning local logs")
               .font(compact ? .caption : .subheadline)
               .fontWeight(.semibold)
+              .lineLimit(2)
             Spacer()
-            Text("30 days")
+            Text(progress.map { "\($0.windowDays) days" } ?? "30 days")
               .font(.caption)
               .foregroundColor(.secondary)
           }
@@ -355,9 +308,10 @@ struct CostScanLoadingChart: View {
           .clipShape(RoundedRectangle(cornerRadius: MeterBarTheme.Radius.medium))
 
           if !compact {
-            Text("Parsing Claude and Codex sessions")
+            Text(progress?.detailText ?? "Parsing session files from the last 30 days")
               .font(.caption)
               .foregroundColor(.secondary)
+              .fixedSize(horizontal: false, vertical: true)
           }
         }
         .frame(width: proxy.size.width, height: proxy.size.height, alignment: .topLeading)
@@ -372,6 +326,7 @@ struct CostScanLoadingChart: View {
 /// which takes over the whole area when there is nothing to show yet.
 struct CostScanProgressBadge: View {
   let compact: Bool
+  var progress: CostScanProgress?
 
   var body: some View {
     VStack {
@@ -379,9 +334,10 @@ struct CostScanProgressBadge: View {
         HStack(spacing: 8) {
           ProgressView()
             .controlSize(.small)
-          Text(compact ? "Scanning..." : "Updating local scan")
+          Text(progress?.statusText ?? (compact ? "Scanning..." : "Updating local scan"))
             .font(.caption)
             .fontWeight(.semibold)
+            .lineLimit(2)
         }
         .padding(.horizontal, compact ? 9 : 11)
         .padding(.vertical, compact ? 6 : 8)

--- a/MeterBar/Views/DashboardCostsSection.swift
+++ b/MeterBar/Views/DashboardCostsSection.swift
@@ -46,27 +46,17 @@ struct DashboardCostsSection: View {
         VStack(alignment: .leading, spacing: 14) {
             windowPicker
 
-            // The two headline figures answer the same question over different
-            // windows, so they read as a pair. `maxHeight: .infinity` on both,
-            // with the row fixed to its intrinsic height, stretches the shorter
-            // card to the taller one instead of leaving it ending mid-air.
-            HStack(alignment: .top, spacing: MeterBarTheme.Spacing.sm) {
-                CostOverviewStatusCard(
-                    summary: summary,
-                    isScanning: costTracker.isScanning,
-                    isRefreshingMissingDays: costTracker.isRefreshingMissingDays,
-                    formattedTokens: UsageFormat.tokens(summary?.totalTokens ?? 0),
-                    windowSelection: windowSelection
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-
-                LifetimeCostSummaryCard(
-                    summary: summary?.lifetime,
-                    isScanning: costTracker.isRefreshInProgress
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            if costTracker.isRefreshInProgress, let progress = costTracker.scanProgress {
+                CostScanScopeBanner(progress: progress)
             }
-            .fixedSize(horizontal: false, vertical: true)
+
+            CostOverviewStatusCard(
+                summary: summary,
+                isScanning: costTracker.isScanning,
+                isRefreshingMissingDays: costTracker.isRefreshingMissingDays,
+                formattedTokens: UsageFormat.tokens(summary?.totalTokens ?? 0),
+                windowSelection: windowSelection
+            )
 
             costTrendCard
 
@@ -196,11 +186,14 @@ struct DashboardCostsSection: View {
                         }
 
                         if costTracker.isScanning {
-                            CostScanProgressBadge(compact: false)
+                            CostScanProgressBadge(
+                                compact: false,
+                                progress: costTracker.scanProgress
+                            )
                         }
                     }
                 } else if costTracker.isScanning {
-                    CostScanLoadingChart(compact: false)
+                    CostScanLoadingChart(compact: false, progress: costTracker.scanProgress)
                         .frame(height: 220)
                 } else {
                     VStack(alignment: .leading, spacing: 8) {

--- a/MeterBarTests/CostScanWindowOnlyTests.swift
+++ b/MeterBarTests/CostScanWindowOnlyTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+@testable import MeterBar
+import MeterBarShared
+
+/// Window-only cost scan: list by mtime / filename, never publish lifetime,
+/// and never kick a refresh just because lifetime is missing.
+final class CostScanWindowOnlyTests: XCTestCase {
+    func testListingSkipsFilesOlderThanModifiedSince() throws {
+        let root = try makeCorpusDirectory()
+        let now = Date(timeIntervalSince1970: 1_780_000_000)
+        try writeCorpusFile(in: root, name: "fresh.jsonl", bytes: 20, modified: now)
+        try writeCorpusFile(
+            in: root,
+            name: "stale.jsonl",
+            bytes: 9_999,
+            modified: now.addingTimeInterval(-CostScanSession.listingSlack - 60)
+        )
+
+        let listing = CostScanCorpus.listing(in: root, modifiedSince: now.addingTimeInterval(-60))
+
+        XCTAssertEqual(listing.files.map(\.url.lastPathComponent), ["fresh.jsonl"])
+        XCTAssertTrue(listing.isComplete)
+        XCTAssertEqual(listing.files.first?.size, 20)
+    }
+
+    func testListingKeepsTheWalkCompleteWhenItFiltersByAge() throws {
+        let root = try makeCorpusDirectory()
+        let now = Date(timeIntervalSince1970: 1_780_000_000)
+        try writeCorpusFile(in: root, name: "old.jsonl", bytes: 10, modified: now.addingTimeInterval(-10_000))
+
+        let listing = CostScanCorpus.listing(in: root, modifiedSince: now)
+
+        XCTAssertTrue(listing.files.isEmpty)
+        XCTAssertTrue(listing.isComplete)
+    }
+
+    func testListingFiltersToNamedTranscripts() throws {
+        let root = try makeCorpusDirectory()
+        let now = Date(timeIntervalSince1970: 1_780_000_000)
+        try writeCorpusFile(in: root, name: "updates.jsonl", bytes: 40, modified: now)
+        try writeCorpusFile(in: root, name: "messages.jsonl", bytes: 80, modified: now)
+
+        let listing = CostScanCorpus.listing(in: root, fileNames: ["updates.jsonl"])
+
+        XCTAssertEqual(listing.files.map(\.url.lastPathComponent), ["updates.jsonl"])
+        XCTAssertEqual(listing.files.first?.size, 40)
+    }
+
+    func testListingCutoffIsCutoffMinusSlack() {
+        let cutoff = Date(timeIntervalSince1970: 1_780_000_000)
+        let session = CostScanSession(cutoff: cutoff, options: .unlimited)
+
+        XCTAssertEqual(
+            session.listingCutoff,
+            cutoff.addingTimeInterval(-CostScanSession.listingSlack)
+        )
+        XCTAssertEqual(CostScanSession.listingSlack, 36 * 60 * 60)
+    }
+
+    func testMakeScanDoesNotPublishLifetime() {
+        let scan = CostSummaryBuilder.makeScan(
+            days: 30,
+            enabledProviders: [],
+            claudeAccounts: [],
+            grokAccounts: [],
+            session: CostScanSession(cutoff: Date(), options: .unlimited)
+        )
+
+        XCTAssertNil(scan.summary.lifetime)
+    }
+
+    func testMissingLifetimeDoesNotTriggerABackgroundRefresh() {
+        let today = Date()
+        let summary = CostSummary(
+            costs: [
+                TokenCost(
+                    provider: .claudeCode,
+                    inputTokens: 100,
+                    outputTokens: 10,
+                    cacheCreationTokens: 0,
+                    cacheReadTokens: 0,
+                    estimatedCostUSD: 1,
+                    sessionCount: 1,
+                    periodStart: today,
+                    periodEnd: today
+                )
+            ],
+            totalCostUSD: 1,
+            totalTokens: 110,
+            periodDays: 30,
+            dailyUsage: [
+                DailyTokenUsage(
+                    date: Calendar.current.startOfDay(for: today),
+                    provider: .claudeCode,
+                    inputTokens: 100,
+                    outputTokens: 10,
+                    cacheReadTokens: 0,
+                    estimatedCostUSD: 1,
+                    modelBreakdowns: [],
+                    projectBreakdowns: []
+                )
+            ],
+            hourlyUsage: [],
+            lifetime: nil
+        )
+
+        XCTAssertFalse(
+            CostTracker.needsBackgroundRefresh(
+                summary: summary,
+                lastScanDate: today,
+                enabledServices: [.claudeCode],
+                days: 30,
+                now: today
+            )
+        )
+    }
+
+    func testNilSummaryStillRefreshesWhenALogProviderIsEnabled() {
+        XCTAssertTrue(
+            CostTracker.needsBackgroundRefresh(
+                summary: nil,
+                lastScanDate: nil,
+                enabledServices: [.claudeCode],
+                days: 30
+            )
+        )
+        XCTAssertFalse(
+            CostTracker.needsBackgroundRefresh(
+                summary: nil,
+                lastScanDate: nil,
+                enabledServices: [.cursor],
+                days: 30
+            )
+        )
+    }
+
+    func testProgressWarnsOnceTheWindowedCorpusIsAGigabyte() {
+        var progress = CostScanProgress(windowDays: 30)
+        XCTAssertEqual(progress.statusText, "Listing session files…")
+        XCTAssertFalse(progress.isLargeCorpus)
+
+        progress.listedFiles = 12
+        progress.listedBytes = 180 * 1_000_000
+        progress.processedFiles = 4
+        XCTAssertTrue(progress.statusText.hasPrefix("Scanning 4 of 12 files · "))
+        XCTAssertTrue(progress.statusText.contains(CostScanProgress.formatBytes(180 * 1_000_000)))
+        XCTAssertFalse(progress.isLargeCorpus)
+        XCTAssertEqual(try XCTUnwrap(progress.fraction), 4.0 / 12.0, accuracy: 0.000_001)
+
+        progress.listedBytes = CostScanProgress.largeCorpusBytes
+        XCTAssertTrue(progress.isLargeCorpus)
+        XCTAssertTrue(progress.detailText.contains("Older archives are not scanned"))
+    }
+
+    // MARK: - Fixtures
+
+    private func makeCorpusDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CostScanWindowOnly-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+
+    private func writeCorpusFile(in root: URL, name: String, bytes: Int, modified: Date) throws {
+        let url = root.appendingPathComponent(name)
+        try Data(repeating: UInt8(ascii: "x"), count: bytes).write(to: url)
+        try FileManager.default.setAttributes([.modificationDate: modified], ofItemAtPath: url.path)
+    }
+}

--- a/MeterBarTests/CostScanWindowOnlyTests.swift
+++ b/MeterBarTests/CostScanWindowOnlyTests.swift
@@ -152,6 +152,60 @@ final class CostScanWindowOnlyTests: XCTestCase {
         XCTAssertTrue(progress.detailText.contains("Older archives are not scanned"))
     }
 
+    func testUnreadFilesAreNotCountedAsProcessed() throws {
+        let root = try makeCorpusDirectory()
+        let newest = try writeClaudeTranscript(
+            in: root,
+            name: "newest.jsonl",
+            messageID: "new",
+            modifiedAgo: 0
+        )
+        try writeClaudeTranscript(
+            in: root,
+            name: "oldest.jsonl",
+            messageID: "old",
+            modifiedAgo: 60
+        )
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let budget = CostScanBudgetOptions(
+            maxBytesPerFile: .max,
+            maxNewBytesPerRefresh: try fileSize(newest),
+            wallClock: nil
+        )
+        let session = CostScanSession(cutoff: cutoff, options: budget)
+
+        _ = ClaudeCostScanner.scanRoots([root], session: session)
+        let progress = session.progress(windowDays: 30)
+
+        XCTAssertFalse(session.isComplete)
+        XCTAssertEqual(progress.listedFiles, 2)
+        XCTAssertEqual(progress.processedFiles, 1)
+        XCTAssertEqual(try XCTUnwrap(progress.fraction), 0.5, accuracy: 0.000_001)
+        XCTAssertFalse(progress.isComplete)
+    }
+
+    func testListingEmitsProgressBeforeAnyFileIsProcessed() throws {
+        let root = try makeCorpusDirectory()
+        try writeClaudeTranscript(in: root, name: "a.jsonl", messageID: "a", modifiedAgo: 0)
+        try writeClaudeTranscript(in: root, name: "b.jsonl", messageID: "b", modifiedAgo: 1)
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let seen = CostScanProgressLog()
+        let session = CostScanSession(cutoff: cutoff, options: .unlimited)
+        session.observeProgress(windowDays: 30, seen.append)
+
+        _ = ClaudeCostScanner.scanRoots([root], session: session)
+
+        let first = try XCTUnwrap(seen.snapshots.first)
+        XCTAssertEqual(first.listedFiles, 2)
+        XCTAssertEqual(first.processedFiles, 0)
+        XCTAssertGreaterThan(first.listedBytes, 0)
+        XCTAssertFalse(first.isComplete)
+
+        let last = try XCTUnwrap(seen.snapshots.last)
+        XCTAssertEqual(last.processedFiles, 2)
+        XCTAssertTrue(last.isComplete)
+    }
+
     // MARK: - Fixtures
 
     private func makeCorpusDirectory() throws -> URL {
@@ -166,5 +220,50 @@ final class CostScanWindowOnlyTests: XCTestCase {
         let url = root.appendingPathComponent(name)
         try Data(repeating: UInt8(ascii: "x"), count: bytes).write(to: url)
         try FileManager.default.setAttributes([.modificationDate: modified], ofItemAtPath: url.path)
+    }
+
+    @discardableResult
+    private func writeClaudeTranscript(
+        in root: URL,
+        name: String,
+        messageID: String,
+        modifiedAgo: TimeInterval
+    ) throws -> URL {
+        let line = """
+        {"timestamp": "2026-07-01T10:00:00.000Z", "requestId": "req_\(messageID)", \
+        "message": {"id": "msg_\(messageID)", "model": "claude-sonnet-4-5", \
+        "usage": {"input_tokens": 100, "output_tokens": 10, \
+        "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}}
+        """
+        let url = root.appendingPathComponent(name)
+        try (line + "\n").write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(-modifiedAgo)],
+            ofItemAtPath: url.path
+        )
+        return url
+    }
+
+    private func fileSize(_ url: URL) throws -> Int {
+        try url.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
+    }
+}
+
+/// Lock-guarded so a progress handler running on the scan queue can record
+/// snapshots without tripping Sendable checking.
+private final class CostScanProgressLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [CostScanProgress] = []
+
+    var snapshots: [CostScanProgress] {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
+    }
+
+    func append(_ progress: CostScanProgress) {
+        lock.lock()
+        values.append(progress)
+        lock.unlock()
     }
 }

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -408,9 +408,7 @@ final class CostTrackerTests: XCTestCase {
     // MARK: - Codex rollout scan
 
     /// Writes a `.jsonl` into an `archived_sessions` directory and returns that
-    /// directory (the argument `CostScanFixtureScan.codexRollouts` expects). Every file is
-    /// read regardless of its modification date, so the lifetime window sees
-    /// pre-cutoff lines too.
+    /// directory (the argument `CostScanFixtureScan.codexRollouts` expects).
     private func writeCodexArchive(lines: [String]) throws -> URL {
         let root = try makeCodexHome()
         let dir = root.appendingPathComponent("archived_sessions", isDirectory: true)
@@ -448,7 +446,7 @@ final class CostTrackerTests: XCTestCase {
         try (lines.joined(separator: "\n") + "\n").write(to: url, atomically: true, encoding: .utf8)
         if let modifiedAgo {
             try FileManager.default.setAttributes(
-                [.modificationDate: Date(timeIntervalSince1970: 1_780_000_000 - modifiedAgo)],
+                [.modificationDate: Date().addingTimeInterval(-modifiedAgo)],
                 ofItemAtPath: url.path
             )
         }
@@ -2370,7 +2368,7 @@ final class CostTrackerTests: XCTestCase {
         let url = root.appendingPathComponent(name)
         try (lines.joined(separator: "\n") + "\n").write(to: url, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes(
-            [.modificationDate: Date(timeIntervalSince1970: 1_780_000_000 - modifiedAgo)],
+            [.modificationDate: Date().addingTimeInterval(-modifiedAgo)],
             ofItemAtPath: url.path
         )
         return url

--- a/MeterBarTests/CostsPageSnapshotRenderTests.swift
+++ b/MeterBarTests/CostsPageSnapshotRenderTests.swift
@@ -27,19 +27,12 @@ final class CostsPageSnapshotRenderTests: XCTestCase {
         }
 
         try render(width: 1000, name: "1-headline-row", into: outputDir) {
-            HStack(alignment: .top, spacing: MeterBarTheme.Spacing.sm) {
-                CostOverviewStatusCard(
-                    summary: summary,
-                    isScanning: false,
-                    isRefreshingMissingDays: false,
-                    formattedTokens: UsageFormat.tokens(summary.totalTokens)
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-
-                LifetimeCostSummaryCard(summary: summary.lifetime, isScanning: false)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            }
-            .fixedSize(horizontal: false, vertical: true)
+            CostOverviewStatusCard(
+                summary: summary,
+                isScanning: false,
+                isRefreshingMissingDays: false,
+                formattedTokens: UsageFormat.tokens(summary.totalTokens)
+            )
         }
 
         try render(width: 1000, name: "2-spend-charts", into: outputDir) {

--- a/MeterBarTests/DashboardLayoutTests.swift
+++ b/MeterBarTests/DashboardLayoutTests.swift
@@ -66,7 +66,7 @@ final class DashboardLayoutTests: XCTestCase {
 
     // MARK: - Cost headline cards
 
-    func testLoadedCostHeadlineCardsUseTheSameCompactHeight() {
+    func testLoadedCostOverviewCardStaysCompact() {
         let start = Date(timeIntervalSince1970: 1_765_324_800)
         let end = Date(timeIntervalSince1970: 1_786_003_200)
         let cost = TokenCost(
@@ -84,8 +84,7 @@ final class DashboardLayoutTests: XCTestCase {
             costs: [cost],
             totalCostUSD: cost.estimatedCostUSD,
             totalTokens: cost.totalTokens,
-            periodDays: 30,
-            lifetime: LifetimeCostSummary(costs: [cost])
+            periodDays: 30
         )
         let overview = CostOverviewStatusCard(
             summary: summary,
@@ -93,20 +92,25 @@ final class DashboardLayoutTests: XCTestCase {
             isRefreshingMissingDays: false,
             formattedTokens: UsageFormat.tokens(summary.totalTokens)
         )
-        let lifetime = LifetimeCostSummaryCard(summary: summary.lifetime, isScanning: false)
 
         let overviewHost = NSHostingView(rootView: overview.frame(width: 380))
-        let lifetimeHost = NSHostingView(rootView: lifetime.frame(width: 380))
         overviewHost.layoutSubtreeIfNeeded()
-        lifetimeHost.layoutSubtreeIfNeeded()
 
-        XCTAssertEqual(
-            overviewHost.fittingSize.height,
-            lifetimeHost.fittingSize.height,
-            accuracy: 0.5,
-            "30-day and lifetime surfaces must end on the same baseline"
-        )
         XCTAssertLessThan(overviewHost.fittingSize.height, 220)
+    }
+
+    func testScanScopeBannerBuildsWithALargeCorpusWarning() {
+        var progress = CostScanProgress(windowDays: 30)
+        progress.listedFiles = 80
+        progress.listedBytes = CostScanProgress.largeCorpusBytes
+        progress.processedFiles = 10
+
+        let banner = CostScanScopeBanner(progress: progress)
+        let host = NSHostingView(rootView: banner.frame(width: 760))
+        host.layoutSubtreeIfNeeded()
+
+        XCTAssertGreaterThan(host.fittingSize.height, 0)
+        XCTAssertTrue(progress.isLargeCorpus)
     }
 
     // MARK: - Provider card context-menu commands

--- a/MeterBarTests/DashboardSectionSplitTests.swift
+++ b/MeterBarTests/DashboardSectionSplitTests.swift
@@ -129,9 +129,9 @@ final class DashboardSectionSplitTests: XCTestCase {
     }
 
     /// The estimate card's subtitle names the window and nothing else: refresh
-    /// state belongs on the trailing edge, matching "Lifetime Local Cost" and
-    /// the spend card rather than replacing the card's own caption. The window
-    /// now follows the page's 7/30-day toggle.
+    /// state belongs on the trailing edge, matching the spend card rather than
+    /// replacing the card's own caption. The window follows the page's 7/30-day
+    /// toggle.
     func testCostOverviewSubtitleIsWindowOnlyAndStatusMatchesTheOtherCards() {
         XCTAssertEqual(CostWindowSelection.month.subtitle, "Last 30 days")
         XCTAssertEqual(CostWindowSelection.week.subtitle, "Last 7 days")

--- a/MeterBarTests/GrokCostScannerTests.swift
+++ b/MeterBarTests/GrokCostScannerTests.swift
@@ -252,10 +252,9 @@ final class GrokCostScannerTests: XCTestCase {
 
     /// A session directory copied by a sync client — Dropbox/iCloud conflict
     /// copies, a restored backup, a `cp -r` of `sessions/` — puts the same
-    /// events in two `.jsonl` files. `CostScanCorpus` matches every `.jsonl`
-    /// under the root, so both are read; the dedup key carries the session ID
-    /// from the *payload*, so both files produce identical keys and the second
-    /// must add nothing.
+    /// events in two `updates.jsonl` files. Both are read; the dedup key carries
+    /// the session ID from the *payload*, so both files produce identical keys
+    /// and the second must add nothing.
     func testDuplicatedSessionDirectoryIsCountedOnce() throws {
         let root = try makeSessionsRoot()
         let line = turnCompleted(at: Date(), input: 100, cachedRead: 0, output: 10, reasoning: 0, ticks: 1_000_000)
@@ -548,7 +547,7 @@ final class GrokCostScannerTests: XCTestCase {
 
         XCTAssertEqual(enabled.summary.costs.map(\.provider), [.grok])
         XCTAssertEqual(enabled.summary.dailyUsage.map(\.provider), [.grok])
-        XCTAssertEqual(enabled.summary.lifetime?.providers.map(\.provider), [.grok])
+        XCTAssertNil(enabled.summary.lifetime)
         XCTAssertTrue(disabled.summary.costs.isEmpty)
     }
 

--- a/MeterBarTests/ProviderUsageCostBuilderTests.swift
+++ b/MeterBarTests/ProviderUsageCostBuilderTests.swift
@@ -197,7 +197,7 @@ final class ProviderUsageCostBuilderTests: XCTestCase {
         XCTAssertEqual(scan.summary.totalCostUSD, 4, accuracy: 0.000_001)
         XCTAssertEqual(scan.summary.totalTokens, 0)
         XCTAssertEqual(scan.summary.dailyUsage.map(\.provider), [.openRouter])
-        XCTAssertEqual(scan.summary.lifetime?.providers.map(\.provider), [.openRouter])
+        XCTAssertNil(scan.summary.lifetime)
     }
 
     /// The default keeps every existing call site — and the scanners' own


### PR DESCRIPTION
## Why

Costs sat on **Updating…** because a missing lifetime snapshot (or a missing Grok row) kicked a walk of the whole local corpus — Claude JSONL, Codex `sessions/` + `archived_sessions/` + `logs_2.sqlite`. On this machine that was ~11 GB.

Quota APIs already power the gauges. They do **not** have per-model 30-day spend, so the chart still has to read local transcripts. They cannot replace the scan. They also cannot justify reading archives from March.

## What

- **Window only.** Listing skips files whose mtime is older than `cutoff − 36h`. Grok opens `updates.jsonl` only.
- **No lifetime card.** `CostSummary.lifetime` stays optional for cache decode and is no longer filled. `lifetime == nil` no longer starts a backfill.
- **No SQLite on the default scan.** `logs_2.sqlite` (~1.8 GB here) is a recent-session fallback the 30-day rollouts already cover.
- **Progress banner.** Costs shows listed file count and bytes while a refresh runs, and warns if the *windowed* corpus is still ≥ 1 GiB.

## Local cleanup (this machine, not the PR)

Deleted 1881 Codex `archived_sessions` rollouts dated before 2026-08-01 (**7.71 GB**). 41 August files remain (~72 MB). Live `sessions/` (1.0 GB) and `logs_2.sqlite` (1.8 GB) were left alone.

## Test

`swift test --filter 'CostScan|CostTracker|CostSummary|DashboardLayout|DashboardSectionSplit|GrokCost|ProviderUsageCost|LifetimeCost|CardState|TokenActivityCard'` — 311 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scan progress indicators showing status, date range, files, and data size.
  * Added warnings and details for large cost-data scans.
* **Changes**
  * Cost charts now focus on the selected 7- or 30-day period.
  * Removed lifetime cost summaries from the dashboard.
  * Improved refresh behavior by scanning only relevant, recently modified data.
  * Refined provider scanning to use supported cost records and avoid duplicate sessions.
* **Bug Fixes**
  * Improved progress reporting and background refresh completion for large datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->