### PR TITLE
feat(grok): show banked usage-limit resets

### DIFF
--- a/.agents/memory/providers.md
+++ b/.agents/memory/providers.md
@@ -13,7 +13,7 @@ MeterBar reads usage from local CLI artifacts and provider APIs. CLI-backed prov
 | Codex CLI | `.codexCli` | `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`) → `https://chatgpt.com/backend-api/wham/usage`. Exhausted accounts can spend a banked reset credit after explicit confirmation. |
 | Cursor | `.cursor` | Session JWT from Cursor `state.vscdb` → `https://cursor.com/api/usage-summary`. If the API omits totals, the UI uses an assumed 500-request default — treat as an estimate. |
 | OpenRouter | `.openRouter` | User API key in Keychain → documented `/api/v1/credits` and `/api/v1/key`. |
-| Grok | `.grok` | On by default (opt-out). Official Grok Build CLI ACP stdio; maps `_x.ai/billing`. MeterBar checks `$GROK_HOME/auth.json` exists; it never opens or logs the token. |
+| Grok | `.grok` | On by default (opt-out). Official Grok Build CLI ACP stdio maps `_x.ai/billing` for the weekly gauge. Usage-limit resets (Redeem) come from unofficial grok.com `ConsumerUiSvc/GetRemainingResets` using the cached OIDC token in `$GROK_HOME/auth.json` — same class as Codex wham. The token is not logged. |
 | Claude admin | `.claude` | User Anthropic Admin key → `/v1/organizations/usage_report/messages` (50-page cap). |
 | OpenAI admin | `.openai` | User OpenAI Admin key → `/v1/organization/usage/completions` (50-page cap). |
 

--- a/MeterBar/Services/GrokCLIUsageService.swift
+++ b/MeterBar/Services/GrokCLIUsageService.swift
@@ -4,8 +4,9 @@ import MeterBarShared
 import os
 
 /// Reads Grok Build subscription usage through the CLI's official ACP stdio
-/// extension. MeterBar asks the CLI to authenticate with its cached login and
-/// never opens, decodes, logs, or persists `$GROK_HOME/auth.json`.
+/// extension for weekly quota, then (like Codex) reads the cached OIDC token
+/// from `$GROK_HOME/auth.json` only to ask grok.com how many usage-limit resets
+/// remain. The token is used for that request and is never logged.
 final class GrokCLIUsageService: ObservableObject {
     nonisolated static let shared = GrokCLIUsageService()
 
@@ -21,6 +22,8 @@ final class GrokCLIUsageService: ObservableObject {
     nonisolated private let binaryPathProvider: @Sendable () -> String?
     nonisolated private let authAvailableProvider: @Sendable (GrokAccount) -> Bool
     nonisolated private let billingResultProvider: @Sendable (String, String) async throws -> GrokBillingResult
+    nonisolated private let authFileDataProvider: @Sendable (GrokAccount) -> Data?
+    nonisolated private let remainingResetsProvider: @Sendable (String) async -> Int?
 
     init(
         binaryPathProvider: @escaping @Sendable () -> String? = {
@@ -33,11 +36,20 @@ final class GrokCLIUsageService: ObservableObject {
         },
         billingResultProvider: @escaping @Sendable (String, String) async throws -> GrokBillingResult = {
             try await GrokBillingRPC.fetch(binaryPath: $0, grokHome: $1)
+        },
+        authFileDataProvider: @escaping @Sendable (GrokAccount) -> Data? = { account in
+            let path = GrokHomeDirectory.authFilePath(for: account)
+            return FileManager.default.contents(atPath: path)
+        },
+        remainingResetsProvider: @escaping @Sendable (String) async -> Int? = { token in
+            try? await GrokResetCreditsRPC.fetchAvailableCount(accessToken: token)
         }
     ) {
         self.binaryPathProvider = binaryPathProvider
         self.authAvailableProvider = authAvailableProvider
         self.billingResultProvider = billingResultProvider
+        self.authFileDataProvider = authFileDataProvider
+        self.remainingResetsProvider = remainingResetsProvider
         Task.detached(priority: .utility) { [weak self] in
             self?.checkAccess()
         }
@@ -74,7 +86,14 @@ final class GrokCLIUsageService: ObservableObject {
 
         do {
             let result = try await billingResultProvider(binaryPath, GrokHomeDirectory.path(for: account))
-            let metrics = try Self.map(result)
+            var metrics = try Self.map(result)
+            // Billing first: the CLI authenticate step refreshes the OIDC
+            // token on disk. Reset fetch is best-effort — a 401 or parse
+            // miss must not blank the weekly gauge.
+            if let token = GrokResetCredits.accessToken(from: authFileDataProvider(account)),
+               let resetCount = await remainingResetsProvider(token) {
+                metrics = metrics.withResetCreditsAvailable(resetCount)
+            }
             accountErrors.removeValue(forKey: account.id)
             if account.isDefault {
                 hasAccess = true

--- a/MeterBar/Services/GrokResetCredits.swift
+++ b/MeterBar/Services/GrokResetCredits.swift
@@ -1,0 +1,236 @@
+import Foundation
+import MeterBarShared
+
+/// Banked Grok usage-limit resets — the Redeem row in grok.com Settings → Usage.
+///
+/// Weekly percent still comes from official `_x.ai/billing`. This RPC is the
+/// same class of unofficial HTTP Codex uses for reset credits: grok.com
+/// `prod_mc_billing.ConsumerUiSvc/GetRemainingResets`, authenticated with the
+/// cached OIDC access token from `$GROK_HOME/auth.json`. The token is held only
+/// for the request and is never logged.
+nonisolated enum GrokResetCredits {
+    /// One still-valid (or already-expired) reset token.
+    struct Token: Equatable, Sendable {
+        let tokenID: String
+        let validFrom: Date?
+        let expiresAt: Date?
+    }
+
+    struct Snapshot: Equatable, Sendable {
+        let tokens: [Token]
+        /// Tokens whose `expiresAt` is still in the future at decode time.
+        /// Missing expiry is treated as still valid — the server accepted it.
+        let availableCount: Int
+
+        init(tokens: [Token], now: Date = Date()) {
+            self.tokens = tokens
+            availableCount = tokens.filter { token in
+                guard let expiresAt = token.expiresAt else { return true }
+                return expiresAt > now
+            }.count
+        }
+    }
+
+    /// Reads the cached Grok Build OIDC access token. The outer object is keyed
+    /// by issuer + client id; any first non-empty `key` that is not a
+    /// parseably-expired JWT is usable.
+    static func accessToken(from data: Data?, now: Date = Date()) -> String? {
+        guard let data,
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        for value in object.values {
+            guard let credential = value as? [String: Any],
+                  let key = credential["key"] as? String else {
+                continue
+            }
+            let token = key.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !token.isEmpty else { continue }
+            guard !OAuthTokenExpiry.isExpired(jwt: token, now: now) else { continue }
+            return token
+        }
+        return nil
+    }
+
+    static func decode(grpcWeb data: Data, now: Date = Date()) throws -> Snapshot {
+        guard let message = GrpcWeb.unprefixedMessage(in: data) else {
+            throw GrokResetCreditsRPC.Error.invalidResponse
+        }
+        let tokens = try Proto.resetTokens(in: message)
+        return Snapshot(tokens: tokens, now: now)
+    }
+}
+
+// MARK: - Transport
+
+nonisolated enum GrokResetCreditsRPC {
+    enum Error: Swift.Error, Equatable {
+        case invalidResponse
+        case requestFailed
+    }
+
+    static let remainingResetsURL = URL(
+        string: "https://grok.com/prod_mc_billing.ConsumerUiSvc/GetRemainingResets"
+    )!
+
+    /// Empty protobuf framed as one uncompressed grpc-web data frame.
+    static let emptyRequest = Data([0x00, 0x00, 0x00, 0x00, 0x00])
+
+    static func fetchAvailableCount(
+        accessToken: String,
+        session: URLSession = ServiceSupport.session,
+        now: Date = Date()
+    ) async throws -> Int {
+        var request = URLRequest(url: remainingResetsURL)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/grpc-web+proto", forHTTPHeaderField: "Content-Type")
+        request.setValue("1", forHTTPHeaderField: "X-Grpc-Web")
+        request.setValue("https://grok.com", forHTTPHeaderField: "Origin")
+        request.httpBody = emptyRequest
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw Error.requestFailed
+        }
+        return try GrokResetCredits.decode(grpcWeb: data, now: now).availableCount
+    }
+}
+
+// MARK: - grpc-web + proto
+
+/// grpc-web: 1 flag byte + 4-byte big-endian length + payload. The high bit on
+/// the flag marks a trailer frame (`grpc-status: 0`), which we skip.
+private enum GrpcWeb {
+    static func unprefixedMessage(in data: Data) -> Data? {
+        var offset = 0
+        var message: Data?
+        while offset + 5 <= data.count {
+            let flags = data[offset]
+            let length = Int(data[offset + 1]) << 24
+                | Int(data[offset + 2]) << 16
+                | Int(data[offset + 3]) << 8
+                | Int(data[offset + 4])
+            offset += 5
+            guard offset + length <= data.count else { return nil }
+            let payload = data.subdata(in: offset..<(offset + length))
+            offset += length
+            if flags & 0x80 == 0 {
+                message = payload
+            }
+        }
+        return message
+    }
+}
+
+/// Just enough protobuf to read `ConsumerGetRemainingResetsResp`.
+///
+///     message ConsumerGetRemainingResetsResp {
+///       repeated ConsumerResetToken tokens = 10;
+///     }
+///     message ConsumerResetToken {
+///       string token_id = 10;
+///       google.protobuf.Timestamp validity_start = 20;
+///       google.protobuf.Timestamp validity_end = 30;
+///     }
+private enum Proto {
+    static let tokensField = 10
+    static let tokenIDField = 10
+    static let validFromField = 20
+    static let expiresAtField = 30
+    static let timestampSecondsField = 1
+
+    static func resetTokens(in message: Data) throws -> [GrokResetCredits.Token] {
+        try fields(in: message).compactMap { field, value -> GrokResetCredits.Token? in
+            guard field == tokensField else { return nil }
+            return token(in: value)
+        }
+    }
+
+    private static func token(in message: Data) -> GrokResetCredits.Token? {
+        var tokenID: String?
+        var validFrom: Date?
+        var expiresAt: Date?
+        for (field, value) in (try? fields(in: message)) ?? [] {
+            switch field {
+            case tokenIDField:
+                tokenID = String(data: value, encoding: .utf8)
+            case validFromField:
+                validFrom = timestamp(in: value)
+            case expiresAtField:
+                expiresAt = timestamp(in: value)
+            default:
+                continue
+            }
+        }
+        guard let tokenID, !tokenID.isEmpty else { return nil }
+        return GrokResetCredits.Token(tokenID: tokenID, validFrom: validFrom, expiresAt: expiresAt)
+    }
+
+    private static func timestamp(in message: Data) -> Date? {
+        for (field, value) in (try? fields(in: message)) ?? [] {
+            guard field == timestampSecondsField, let seconds = varint(value) else { continue }
+            return Date(timeIntervalSince1970: TimeInterval(seconds))
+        }
+        return nil
+    }
+
+    /// Length-delimited fields only — every field this decoder cares about is a
+    /// nested message or a string. Unknown wire types are skipped when possible.
+    private static func fields(in data: Data) throws -> [(Int, Data)] {
+        var offset = 0
+        var result: [(Int, Data)] = []
+        while offset < data.count {
+            guard let (tag, tagEnd) = readVarint(data, at: offset) else {
+                throw GrokResetCreditsRPC.Error.invalidResponse
+            }
+            offset = tagEnd
+            let field = Int(tag >> 3)
+            let wire = Int(tag & 0x7)
+            switch wire {
+            case 0:
+                guard let (_, next) = readVarint(data, at: offset) else {
+                    throw GrokResetCreditsRPC.Error.invalidResponse
+                }
+                let raw = data.subdata(in: tagEnd..<next)
+                result.append((field, raw))
+                offset = next
+            case 1:
+                guard offset + 8 <= data.count else { throw GrokResetCreditsRPC.Error.invalidResponse }
+                offset += 8
+            case 2:
+                guard let (length, lenEnd) = readVarint(data, at: offset),
+                      lenEnd + Int(length) <= data.count else {
+                    throw GrokResetCreditsRPC.Error.invalidResponse
+                }
+                result.append((field, data.subdata(in: lenEnd..<(lenEnd + Int(length)))))
+                offset = lenEnd + Int(length)
+            case 5:
+                guard offset + 4 <= data.count else { throw GrokResetCreditsRPC.Error.invalidResponse }
+                offset += 4
+            default:
+                throw GrokResetCreditsRPC.Error.invalidResponse
+            }
+        }
+        return result
+    }
+
+    private static func varint(_ data: Data) -> UInt64? {
+        readVarint(data, at: 0)?.value
+    }
+
+    private static func readVarint(_ data: Data, at start: Int) -> (value: UInt64, end: Int)? {
+        var value: UInt64 = 0
+        var shift = 0
+        var index = start
+        while index < data.count {
+            let byte = data[index]
+            index += 1
+            value |= UInt64(byte & 0x7F) << shift
+            if byte < 0x80 { return (value, index) }
+            shift += 7
+            if shift > 63 { return nil }
+        }
+        return nil
+    }
+}

--- a/MeterBar/Views/Settings/ProviderSettingsFacts.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsFacts.swift
@@ -46,7 +46,7 @@ struct ProviderSettingsFacts {
         case .openRouter:
             "OpenRouter credits + key APIs"
         case .grok:
-            "Grok Build ACP billing"
+            "Grok Build ACP billing + usage reset API"
         }
     }
 

--- a/MeterBarTests/GrokCLIUsageServiceTests.swift
+++ b/MeterBarTests/GrokCLIUsageServiceTests.swift
@@ -429,7 +429,9 @@ final class GrokCLIUsageServiceTests: XCTestCase {
             authAvailableProvider: { _ in true },
             billingResultProvider: { _, grokHome in
                 grokHome == "/tmp/grok-work" ? workResult : defaultResult
-            }
+            },
+            authFileDataProvider: { _ in nil },
+            remainingResetsProvider: { _ in nil }
         )
 
         let defaultMetrics = try await service.fetchUsageMetrics(account: .defaultAccount)
@@ -450,7 +452,9 @@ final class GrokCLIUsageServiceTests: XCTestCase {
         let service = GrokCLIUsageService(
             binaryPathProvider: { "/usr/local/bin/grok" },
             authAvailableProvider: { $0.isDefault },
-            billingResultProvider: { _, _ in defaultResult }
+            billingResultProvider: { _, _ in defaultResult },
+            authFileDataProvider: { _ in nil },
+            remainingResetsProvider: { _ in nil }
         )
 
         do {

--- a/MeterBarTests/GrokResetCreditsTests.swift
+++ b/MeterBarTests/GrokResetCreditsTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// Grok usage-limit resets arrive from grok.com `ConsumerUiSvc/GetRemainingResets`
+/// as grpc-web protobuf. Weekly quota still comes from official `_x.ai/billing`.
+final class GrokResetCreditsTests: XCTestCase {
+    /// Captured 2026-08-13 from a SuperGrok Heavy account with one reset
+    /// expiring 2026-09-12T18:49:00Z (`restok_vpYDqo`).
+    private static let liveGrpcWebResponse = Data([
+        0x00, 0x00, 0x00, 0x00, 0x23,
+        0x52, 0x21, 0x52, 0x0D, 0x72, 0x65, 0x73, 0x74, 0x6F, 0x6B, 0x5F,
+        0x76, 0x70, 0x59, 0x44, 0x71, 0x6F,
+        0xA2, 0x01, 0x06, 0x08, 0x9C, 0x80, 0xF3, 0xD3, 0x06,
+        0xF2, 0x01, 0x06, 0x08, 0x9C, 0xBD, 0x96, 0xD5, 0x06,
+        0x80, 0x00, 0x00, 0x00, 0x0F,
+        0x67, 0x72, 0x70, 0x63, 0x2D, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x3A, 0x30, 0x0D, 0x0A
+    ])
+
+    func testLiveGrpcWebFixtureDecodesOneUnexpiredReset() throws {
+        let now = try XCTUnwrap(FlexibleISO8601.date(from: "2026-08-13T12:00:00Z"))
+        let resets = try GrokResetCredits.decode(grpcWeb: Self.liveGrpcWebResponse, now: now)
+
+        XCTAssertEqual(resets.tokens.map(\.tokenID), ["restok_vpYDqo"])
+        XCTAssertEqual(resets.tokens.first?.validFrom, Date(timeIntervalSince1970: 1_786_560_540))
+        XCTAssertEqual(resets.tokens.first?.expiresAt, Date(timeIntervalSince1970: 1_789_238_940))
+        XCTAssertEqual(resets.availableCount, 1)
+    }
+
+    func testExpiredTokensAreNotCountedAsAvailable() throws {
+        let afterExpiry = try XCTUnwrap(FlexibleISO8601.date(from: "2026-09-13T00:00:00Z"))
+        let resets = try GrokResetCredits.decode(grpcWeb: Self.liveGrpcWebResponse, now: afterExpiry)
+
+        XCTAssertEqual(resets.tokens.count, 1)
+        XCTAssertEqual(resets.availableCount, 0)
+    }
+
+    func testEmptyProtobufMessageMeansZeroResets() throws {
+        let empty = Data([0x00, 0x00, 0x00, 0x00, 0x00])
+        let resets = try GrokResetCredits.decode(grpcWeb: empty, now: Date())
+
+        XCTAssertTrue(resets.tokens.isEmpty)
+        XCTAssertEqual(resets.availableCount, 0)
+    }
+
+    func testAccessTokenIsReadFromTheCachedLoginWithoutRequiringAJWTShape() {
+        let data = Data(#"{"https://auth.x.ai::client":{"key":"cached-access-token","auth_mode":"oidc"}}"#.utf8)
+
+        XCTAssertEqual(GrokResetCredits.accessToken(from: data), "cached-access-token")
+    }
+
+    func testExpiredJWTAccessTokenIsIgnored() {
+        // exp = 1_000_000_000 → 2001-09-09. Malformed tokens stay usable so the
+        // server can still be the source of truth; a parseable past exp must not.
+        let payload = Data(#"{"exp":1000000000}"#.utf8).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        let jwt = "eyJhbGciOiJub25lIn0.\(payload).sig"
+        let data = Data(#"{"https://auth.x.ai::client":{"key":"\#(jwt)"}}"#.utf8)
+
+        XCTAssertNil(GrokResetCredits.accessToken(from: data, now: Date()))
+    }
+
+    func testMissingOrEmptyAuthFileYieldsNoToken() {
+        XCTAssertNil(GrokResetCredits.accessToken(from: nil))
+        XCTAssertNil(GrokResetCredits.accessToken(from: Data(#"{}"#.utf8)))
+        XCTAssertNil(GrokResetCredits.accessToken(from: Data(#"{"https://auth.x.ai::client":{}}"#.utf8)))
+    }
+
+    func testMapAttachesResetCountWhenProvided() throws {
+        let result = try JSONDecoder().decode(
+            GrokBillingResult.self,
+            from: Data(#"{"config":{"creditUsagePercent":16,"billingPeriodStart":"2026-08-12T15:05:27Z","billingPeriodEnd":"2026-08-19T15:05:27Z"}}"#.utf8)
+        )
+
+        let metrics = try GrokCLIUsageService.map(result).withResetCreditsAvailable(1)
+
+        XCTAssertEqual(metrics.weeklyLimit?.used, 16)
+        XCTAssertEqual(metrics.resetCreditsAvailable, 1)
+    }
+
+    func testFetchAttachesResetCountAndSurvivesAResetTransportFailure() async throws {
+        let billing = try JSONDecoder().decode(
+            GrokBillingResult.self,
+            from: Data(#"{"config":{"creditUsagePercent":16,"billingPeriodStart":"2026-08-12T15:05:27Z","billingPeriodEnd":"2026-08-19T15:05:27Z"}}"#.utf8)
+        )
+        let auth = Data(#"{"https://auth.x.ai::client":{"key":"cached-access-token"}}"#.utf8)
+
+        let ok = GrokCLIUsageService(
+            binaryPathProvider: { "/usr/local/bin/grok" },
+            authAvailableProvider: { _ in true },
+            billingResultProvider: { _, _ in billing },
+            authFileDataProvider: { _ in auth },
+            remainingResetsProvider: { token in
+                XCTAssertEqual(token, "cached-access-token")
+                return 1
+            }
+        )
+        let okMetrics = try await ok.fetchUsageMetrics()
+        XCTAssertEqual(okMetrics.resetCreditsAvailable, 1)
+
+        let failed = GrokCLIUsageService(
+            binaryPathProvider: { "/usr/local/bin/grok" },
+            authAvailableProvider: { _ in true },
+            billingResultProvider: { _, _ in billing },
+            authFileDataProvider: { _ in auth },
+            remainingResetsProvider: { _ in nil }
+        )
+        let failedMetrics = try await failed.fetchUsageMetrics()
+        XCTAssertEqual(failedMetrics.weeklyLimit?.used, 16)
+        XCTAssertNil(failedMetrics.resetCreditsAvailable)
+    }
+}

--- a/MeterBarTests/ProviderReadinessTests.swift
+++ b/MeterBarTests/ProviderReadinessTests.swift
@@ -45,8 +45,8 @@ final class ProviderReadinessTests: XCTestCase {
     }
 
     func testGrokUnreadableCachedLoginIsDistinctFromMissingOne() {
-        // Presence only — MeterBar must never open `~/.grok/auth.json`, so an
-        // existing-but-unreadable file still has to produce its own advice.
+        // Presence is still enough for readiness: weekly quota goes through the
+        // CLI. An existing-but-unreadable file must produce its own advice.
         let unreadable = ProviderReadinessEvaluator.grok(
             GrokReadinessInput(isCLIInstalled: true, authFileExists: true, authFileReadable: false)
         )

--- a/MeterBarTests/ProviderSettingsFactsTests.swift
+++ b/MeterBarTests/ProviderSettingsFactsTests.swift
@@ -56,7 +56,7 @@ final class ProviderSettingsFactsTests: XCTestCase {
         XCTAssertEqual(facts(service: .codexCli).sourceText, "~/.codex/auth.json + ChatGPT usage API")
         XCTAssertEqual(facts(service: .cursor).sourceText, "Cursor local state + usage API")
         XCTAssertEqual(facts(service: .openRouter).sourceText, "OpenRouter credits + key APIs")
-        XCTAssertEqual(facts(service: .grok).sourceText, "Grok Build ACP billing")
+        XCTAssertEqual(facts(service: .grok).sourceText, "Grok Build ACP billing + usage reset API")
     }
 
     // MARK: - planText

--- a/Packages/MeterBarShared/Sources/MeterBarShared/UsageMetrics.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/UsageMetrics.swift
@@ -48,7 +48,8 @@ public struct UsageMetrics: Codable, Identifiable, Sendable {
     public let modelLimitLabel: String?
     public let extraUsage: ExtraUsageStatus?
     /// Number of banked rate-limit resets the account can trigger on demand.
-    /// Codex-only (OpenAI "reset credits"); `nil` for providers/accounts without the feature.
+    /// Codex (OpenAI reset credits) and Grok (usage-limit reset tokens). `nil`
+    /// when the provider did not report the feature.
     public let resetCreditsAvailable: Int?
     public let lastUpdated: Date
 
@@ -93,6 +94,22 @@ public struct UsageMetrics: Codable, Identifiable, Sendable {
         self.extraUsage = extraUsage
         self.resetCreditsAvailable = resetCreditsAvailable
         self.lastUpdated = lastUpdated
+    }
+
+    /// Returns a copy with the given reset-credit count, preserving identity,
+    /// limits, extra usage, and timestamp.
+    public func withResetCreditsAvailable(_ count: Int?) -> UsageMetrics {
+        UsageMetrics(
+            id: id,
+            service: service,
+            sessionLimit: sessionLimit,
+            weeklyLimit: weeklyLimit,
+            codeReviewLimit: codeReviewLimit,
+            modelLimitLabel: modelLimitLabel,
+            extraUsage: extraUsage,
+            resetCreditsAvailable: count,
+            lastUpdated: lastUpdated
+        )
     }
 
     /// Returns a copy with the given extra-usage status, preserving identity, limits,

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ open MeterBar.xcodeproj
 1. Install [Grok Build](https://x.ai/cli)
 2. Log in: `grok login`
 3. Enable Grok under **Settings → General → Tracked Providers**
-4. MeterBar asks the official CLI for billing data over ACP; it does not read or store the cached token
+4. MeterBar asks the official CLI for weekly billing over ACP. Usage-limit resets are read from grok.com with the cached login token (never logged), the same way Codex reset credits work.
 
 To track more than one Grok Build account, give each CLI login a distinct
 `GROK_HOME`, then add that directory under **Settings → Providers → Grok Build**:
@@ -305,19 +305,19 @@ claude /usage            # Claude Code usage fallback (CLI output)
 ~/.claude/               # Claude Code account metadata and local sessions
 $CODEX_HOME/auth.json    # Codex CLI OAuth token (defaults to ~/.codex/auth.json)
 ~/Library/Application Support/Cursor/  # Cursor local DB
-$GROK_HOME/auth.json     # Grok CLI login presence only; defaults to ~/.grok
+$GROK_HOME/auth.json     # Grok CLI login (weekly quota via ACP; resets via grok.com)
 ```
 
 It then uses the respective local source or API to fetch current usage data:
 - Claude Code (primary): `https://api.anthropic.com/api/oauth/usage`, using the `Claude Code-credentials` Keychain OAuth token
 - Codex: `https://chatgpt.com/backend-api/wham/usage`
-- Grok: official `grok agent --no-leader stdio` ACP billing response, scoped per profile with `GROK_HOME`
+- Grok: official `grok agent` ACP `_x.ai/billing` for the weekly gauge; grok.com `ConsumerUiSvc/GetRemainingResets` for usage-limit resets
 
 Claude Code usage reads the authenticated `/api/oauth/usage` endpoint — the same data Claude Code's own `/usage` screen shows — because `claude /usage` no longer renders in a headless (non-interactive) spawn. Parsing the CLI output is kept as a fallback and can be forced by turning off "Claude Code OAuth usage" in Settings.
 - Explicitly scoped Claude accounts are tracked by running `claude /usage` with each account's configured `CLAUDE_CONFIG_DIR` (they have no profile-specific Keychain token of their own).
 - Cursor: Local SQLite queries
 
-**No provider API keys are required for CLI-backed services** - the app reuses local Claude Code, Codex, and Grok sign-ins. The unscoped default Claude Code account's Keychain OAuth token is read to fetch usage (a one-time macOS Keychain prompt on first launch); Grok authentication remains inside the official CLI process.
+**No provider API keys are required for CLI-backed services** - the app reuses local Claude Code, Codex, and Grok sign-ins. The unscoped default Claude Code account's Keychain OAuth token is read to fetch usage (a one-time macOS Keychain prompt on first launch). Grok weekly quota still goes through the official CLI; the cached login token is used only for usage-limit resets and is never logged.
 
 ## Privacy & Security
 


### PR DESCRIPTION
## Why

Grok Settings now shows **Reset Available / Redeem / Expires Sep 12**. That is a banked usage-limit reset, same idea as Codex reset credits.

## Official API?

**No.** Rechecked after Grok 4.6 (CLI **1.0.3**, latest as of today, changelog 2026-08-12):

- `_x.ai/billing` still only has weekly 16% + extra credits
- Every ACP alias for remaining resets is method-not-found
- Nothing on disk in `~/.grok`

The web UI calls unofficial `prod_mc_billing.ConsumerUiSvc/GetRemainingResets` (grpc-web). Live probe returned the Sep 12 token. Same class as Codex reading `auth.json` and calling ChatGPT wham.

## What

- After ACP billing (so the CLI can refresh the OIDC token), read `$GROK_HOME/auth.json` and fetch remaining resets
- Map onto existing `resetCreditsAvailable` so the **N reset(s) available** badge lights up
- Token used for the request only, never logged
- Reset fetch is best-effort; weekly gauge still publishes if grok.com 401s
- **No Redeem** in this PR — display only

## Test

`swift test --filter 'GrokResetCreditsTests|GrokCLIUsageServiceTests|ProviderSettingsFactsTests|ProviderReadinessTests'` — 86 passed, including a fixture captured from the live grpc-web response.