### PR TITLE
feat(cost): per-session tables, Codex model fallback, and Grok redeem

### DIFF
--- a/.agents/memory/deferred.md
+++ b/.agents/memory/deferred.md
@@ -10,7 +10,6 @@ Only items that are still open. Shipped audit findings belong on GitHub, not her
 ## Still open on the board
 
 - **#387** — Costs dashboard month-to-date picker, provider-independent model rollup, `cost --json` top-level rollup, serve `/cost` MTD.
-- **#391** — per-session Codex cost rows (project tables already shipped).
 - **#389** / **#427** / **#428** / **#429** — next providers (Kimi, Z.ai/GLM, Copilot).
 - **#433** — burn-down widget strings into the widget catalog (this branch).
 - **#434** — CodeRabbit rate-limit must not report pass.

--- a/.agents/memory/providers.md
+++ b/.agents/memory/providers.md
@@ -23,7 +23,7 @@ MeterBar reads usage from local CLI artifacts and provider APIs. CLI-backed prov
 
 Listing filters: mtime newer than `cutoff - 36h`, Grok `updates.jsonl` only. Codex reads `$CODEX_HOME/sessions` and recent `archived_sessions`; it does **not** open `logs_2.sqlite` for the default scan. Codex `token_count` events carry neither model nor front end — the scanner streams each file and carries `turn_context.model`, nested `collaboration_mode.settings.model`, `thread_settings.model`, and `world_state.state.model`. Tokens emitted before the first model in the same file are back-filled. The two Codex directories are deduped by session id, keeping the larger copy. Per-session cost rows (issue #391) fold from the same scan into `sessionBreakdowns`.
 
-Grok usage-limit resets: fetch `GetRemainingResets`, redeem via `RedeemReset` with the token id after explicit confirmation. Same unofficial class as Codex wham consume.
+Grok usage-limit resets: fetch `GetRemainingResets`, redeem via `RedeemReset` with the token id after explicit confirmation. Same unofficial class as Codex wham consume. Live 2026-08-13: `RedeemReset` is implemented; a fake token id returns `grpc-status: 9` (FAILED_PRECONDITION) on the HTTP header with an empty body and does not spend a real reset. Consume must read that header — a missing trailer is not success.
 
 Admin keys live in keychain service `dev.meterbar.app`, with reads migrating `dev.shipshit.meterbar` and `com.agenticindiedev.quotaguard`. Removals delete all three.
 

--- a/.agents/memory/providers.md
+++ b/.agents/memory/providers.md
@@ -13,7 +13,7 @@ MeterBar reads usage from local CLI artifacts and provider APIs. CLI-backed prov
 | Codex CLI | `.codexCli` | `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`) → `https://chatgpt.com/backend-api/wham/usage`. Exhausted accounts can spend a banked reset credit after explicit confirmation. |
 | Cursor | `.cursor` | Session JWT from Cursor `state.vscdb` → `https://cursor.com/api/usage-summary`. If the API omits totals, the UI uses an assumed 500-request default — treat as an estimate. |
 | OpenRouter | `.openRouter` | User API key in Keychain → documented `/api/v1/credits` and `/api/v1/key`. |
-| Grok | `.grok` | On by default (opt-out). Official Grok Build CLI ACP stdio maps `_x.ai/billing` for the weekly gauge. Usage-limit resets (Redeem) come from unofficial grok.com `ConsumerUiSvc/GetRemainingResets` using the cached OIDC token in `$GROK_HOME/auth.json` — same class as Codex wham. The token is not logged. |
+| Grok | `.grok` | On by default (opt-out). Official Grok Build CLI ACP stdio maps `_x.ai/billing` for the weekly gauge. Usage-limit resets (display + Redeem) come from unofficial grok.com `ConsumerUiSvc/GetRemainingResets` and `RedeemReset` using the cached OIDC token in `$GROK_HOME/auth.json` — same class as Codex wham. The token is not logged. Exhausted accounts can spend a banked reset after explicit confirmation. |
 | Claude admin | `.claude` | User Anthropic Admin key → `/v1/organizations/usage_report/messages` (50-page cap). |
 | OpenAI admin | `.openai` | User OpenAI Admin key → `/v1/organization/usage/completions` (50-page cap). |
 
@@ -21,7 +21,9 @@ MeterBar reads usage from local CLI artifacts and provider APIs. CLI-backed prov
 
 `CostTracker` scans local transcripts for the visible 7/30-day window only. Lifetime totals are not published — filling them meant walking multi-gigabyte archives. Quota APIs (Claude OAuth usage, Codex wham, Cursor, OpenRouter credits, Grok ACP) feed the gauges; they do not carry per-model 30-day spend, so the chart still reads logs.
 
-Listing filters: mtime newer than `cutoff - 36h`, Grok `updates.jsonl` only. Codex reads `$CODEX_HOME/sessions` and recent `archived_sessions`; it does **not** open `logs_2.sqlite` for the default scan. Codex `token_count` events carry neither model nor front end — the scanner streams each rollout and forwards the last `turn_context` model and opening `session_meta` originator. The two Codex directories are deduped by session id, keeping the larger copy.
+Listing filters: mtime newer than `cutoff - 36h`, Grok `updates.jsonl` only. Codex reads `$CODEX_HOME/sessions` and recent `archived_sessions`; it does **not** open `logs_2.sqlite` for the default scan. Codex `token_count` events carry neither model nor front end — the scanner streams each file and carries `turn_context.model`, nested `collaboration_mode.settings.model`, `thread_settings.model`, and `world_state.state.model`. Tokens emitted before the first model in the same file are back-filled. The two Codex directories are deduped by session id, keeping the larger copy. Per-session cost rows (issue #391) fold from the same scan into `sessionBreakdowns`.
+
+Grok usage-limit resets: fetch `GetRemainingResets`, redeem via `RedeemReset` with the token id after explicit confirmation. Same unofficial class as Codex wham consume.
 
 Admin keys live in keychain service `dev.meterbar.app`, with reads migrating `dev.shipshit.meterbar` and `com.agenticindiedev.quotaguard`. Removals delete all three.
 

--- a/MeterBar/Models/CLIJSONOutput.swift
+++ b/MeterBar/Models/CLIJSONOutput.swift
@@ -244,6 +244,9 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
         /// the scan found nothing to attribute, so consumers can tell "not
         /// available here" apart from "everything landed in one project".
         let projectBreakdowns: [ProjectBreakdown]?
+        /// Per-session rollup (issue #391). Omitted when empty so version-1
+        /// fixtures stay byte-stable.
+        let sessionBreakdowns: [SessionBreakdown]?
 
         init(cost: TokenCost) {
             provider = cost.provider.cliIdentifier
@@ -261,6 +264,9 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
             projectBreakdowns = cost.projectBreakdowns.isEmpty
                 ? nil
                 : cost.projectBreakdowns.map(ProjectBreakdown.init)
+            sessionBreakdowns = cost.sessionBreakdowns.isEmpty
+                ? nil
+                : cost.sessionBreakdowns.map(SessionBreakdown.init)
         }
 
         init(total: ProviderDailyTotal) {
@@ -275,6 +281,7 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
             sessionCount = nil
             modelBreakdowns = total.modelBreakdowns?.map(ModelBreakdown.init)
             projectBreakdowns = total.projectBreakdowns?.map(ProjectBreakdown.init)
+            sessionBreakdowns = total.sessionBreakdowns?.map(SessionBreakdown.init)
         }
     }
 
@@ -302,6 +309,37 @@ nonisolated public struct CostCLIJSONResponse: CLIJSONDocument {
     /// than encoding `TokenUsageBreakdown` directly, so the CLI JSON surface
     /// stays independent of that type's internal shape.
     private struct ProjectBreakdown: Encodable {
+        let name: String
+        let inputTokens: Int
+        let outputTokens: Int
+        let cacheCreationTokens: Int
+        let cacheReadTokens: Int
+        let totalTokens: Int
+        let estimatedCostUSD: Double
+        let sessionCount: Int
+        let modelBreakdowns: [ModelBreakdown]
+        let sessionBreakdowns: [SessionBreakdown]?
+
+        init(_ breakdown: TokenUsageBreakdown) {
+            name = breakdown.name
+            inputTokens = breakdown.inputTokens
+            outputTokens = breakdown.outputTokens
+            cacheCreationTokens = breakdown.cacheCreationTokens
+            cacheReadTokens = breakdown.cacheReadTokens
+            totalTokens = breakdown.totalTokens
+            estimatedCostUSD = breakdown.estimatedCostUSD
+            sessionCount = breakdown.sessionCount
+            modelBreakdowns = breakdown.modelBreakdowns.map(ModelBreakdown.init)
+            sessionBreakdowns = breakdown.sessionBreakdowns.isEmpty
+                ? nil
+                : breakdown.sessionBreakdowns.map(SessionBreakdown.init)
+        }
+    }
+
+    /// One session rollup row (issue #391). `name` is a stable local identifier
+    /// — a conversation UUID or transcript stem — never a path, prompt, or git
+    /// remote.
+    private struct SessionBreakdown: Encodable {
         let name: String
         let inputTokens: Int
         let outputTokens: Int

--- a/MeterBar/Models/TokenCost.swift
+++ b/MeterBar/Models/TokenCost.swift
@@ -21,6 +21,8 @@ nonisolated public struct TokenCost: Codable, Identifiable, Sendable {
     /// paths. Defaults to `[]` so existing call sites that don't group by
     /// project — and the CLI JSON fixture tests — see no shape change.
     public var projectBreakdowns: [TokenUsageBreakdown]
+    /// Per-session rollup (issue #391). Additive: omitted from older caches.
+    public var sessionBreakdowns: [TokenUsageBreakdown]
 
     public init(
         provider: ServiceType,
@@ -34,7 +36,8 @@ nonisolated public struct TokenCost: Codable, Identifiable, Sendable {
         periodEnd: Date,
         modelBreakdowns: [TokenUsageBreakdown] = [],
         originBreakdowns: [TokenUsageBreakdown] = [],
-        projectBreakdowns: [TokenUsageBreakdown] = []
+        projectBreakdowns: [TokenUsageBreakdown] = [],
+        sessionBreakdowns: [TokenUsageBreakdown] = []
     ) {
         self.provider = provider
         self.inputTokens = inputTokens
@@ -48,6 +51,7 @@ nonisolated public struct TokenCost: Codable, Identifiable, Sendable {
         self.modelBreakdowns = modelBreakdowns
         self.originBreakdowns = originBreakdowns
         self.projectBreakdowns = projectBreakdowns
+        self.sessionBreakdowns = sessionBreakdowns
     }
 
     public init(from decoder: Decoder) throws {
@@ -72,6 +76,10 @@ nonisolated public struct TokenCost: Codable, Identifiable, Sendable {
         projectBreakdowns = try container.decodeIfPresent(
             [TokenUsageBreakdown].self,
             forKey: .projectBreakdowns
+        ) ?? []
+        sessionBreakdowns = try container.decodeIfPresent(
+            [TokenUsageBreakdown].self,
+            forKey: .sessionBreakdowns
         ) ?? []
     }
 
@@ -104,6 +112,10 @@ nonisolated public struct TokenUsageBreakdown: Codable, Identifiable, Sendable {
     /// every other breakdown (model, origin) defaults to `[]` so existing
     /// call sites and the CLI JSON fixtures are unaffected.
     public let modelBreakdowns: [TokenUsageBreakdown]
+    /// Nested per-session slice of this row's spend (issue #391). Populated
+    /// for project rollup rows; session rows themselves leave this empty and
+    /// put their models in `modelBreakdowns`.
+    public let sessionBreakdowns: [TokenUsageBreakdown]
 
     public init(
         provider: ServiceType,
@@ -114,7 +126,8 @@ nonisolated public struct TokenUsageBreakdown: Codable, Identifiable, Sendable {
         cacheReadTokens: Int,
         estimatedCostUSD: Double,
         sessionCount: Int,
-        modelBreakdowns: [TokenUsageBreakdown] = []
+        modelBreakdowns: [TokenUsageBreakdown] = [],
+        sessionBreakdowns: [TokenUsageBreakdown] = []
     ) {
         self.provider = provider
         self.name = name
@@ -125,6 +138,7 @@ nonisolated public struct TokenUsageBreakdown: Codable, Identifiable, Sendable {
         self.estimatedCostUSD = estimatedCostUSD
         self.sessionCount = sessionCount
         self.modelBreakdowns = modelBreakdowns
+        self.sessionBreakdowns = sessionBreakdowns
     }
 
     public init(from decoder: Decoder) throws {
@@ -140,6 +154,10 @@ nonisolated public struct TokenUsageBreakdown: Codable, Identifiable, Sendable {
         modelBreakdowns = try container.decodeIfPresent(
             [TokenUsageBreakdown].self,
             forKey: .modelBreakdowns
+        ) ?? []
+        sessionBreakdowns = try container.decodeIfPresent(
+            [TokenUsageBreakdown].self,
+            forKey: .sessionBreakdowns
         ) ?? []
     }
 
@@ -173,6 +191,10 @@ nonisolated public struct DailyTokenUsage: Codable, Identifiable, Sendable {
     /// Project names have already passed through `CostProjectAttribution`;
     /// raw paths are never persisted here.
     public let projectBreakdowns: [TokenUsageBreakdown]?
+    /// Day × session attribution nested under each project (issue #391).
+    /// `nil` means the row predates session rows; an empty array means a
+    /// scan ran but found none.
+    public let sessionBreakdowns: [TokenUsageBreakdown]?
 
     public init(
         date: Date,
@@ -182,7 +204,8 @@ nonisolated public struct DailyTokenUsage: Codable, Identifiable, Sendable {
         cacheReadTokens: Int,
         estimatedCostUSD: Double,
         modelBreakdowns: [TokenUsageBreakdown]? = nil,
-        projectBreakdowns: [TokenUsageBreakdown]? = nil
+        projectBreakdowns: [TokenUsageBreakdown]? = nil,
+        sessionBreakdowns: [TokenUsageBreakdown]? = nil
     ) {
         self.date = date
         self.provider = provider
@@ -192,6 +215,7 @@ nonisolated public struct DailyTokenUsage: Codable, Identifiable, Sendable {
         self.estimatedCostUSD = estimatedCostUSD
         self.modelBreakdowns = modelBreakdowns
         self.projectBreakdowns = projectBreakdowns
+        self.sessionBreakdowns = sessionBreakdowns
     }
 
     public var totalTokens: Int {
@@ -375,7 +399,7 @@ nonisolated public struct CostSummary: Codable, Sendable {
         guard !costs.isEmpty, totalTokens > 0 else { return false }
         guard !dailyUsage.isEmpty else { return true }
         guard dailyUsage.allSatisfy({
-            $0.modelBreakdowns != nil && $0.projectBreakdowns != nil
+            $0.modelBreakdowns != nil && $0.projectBreakdowns != nil && $0.sessionBreakdowns != nil
         }) else {
             return true
         }
@@ -476,6 +500,7 @@ nonisolated public struct CostSummary: Codable, Sendable {
             .map { provider, rows in
                 let hasCompleteModels = rows.allSatisfy { $0.modelBreakdowns != nil }
                 let hasCompleteProjects = rows.allSatisfy { $0.projectBreakdowns != nil }
+                let hasCompleteSessions = rows.allSatisfy { $0.sessionBreakdowns != nil }
                 return ProviderDailyTotal(
                     provider: provider,
                     inputTokens: rows.reduce(0) { $0 + $1.inputTokens },
@@ -487,6 +512,9 @@ nonisolated public struct CostSummary: Codable, Sendable {
                         : nil,
                     projectBreakdowns: hasCompleteProjects
                         ? TokenUsageBreakdownAggregation.merge(rows.flatMap { $0.projectBreakdowns ?? [] })
+                        : nil,
+                    sessionBreakdowns: hasCompleteSessions
+                        ? TokenUsageBreakdownAggregation.merge(rows.flatMap { $0.sessionBreakdowns ?? [] })
                         : nil
                 )
             }
@@ -572,6 +600,9 @@ nonisolated public struct ProviderDailyTotal: Codable, Sendable, Identifiable {
     /// `nil` when any included row predates cache v2; otherwise the project
     /// rollup (with nested models) over exactly the same days.
     public let projectBreakdowns: [TokenUsageBreakdown]?
+    /// `nil` when any included row predates session attribution; otherwise the
+    /// session rollup over exactly the same days (issue #391).
+    public let sessionBreakdowns: [TokenUsageBreakdown]?
 
     public init(
         provider: ServiceType,
@@ -580,7 +611,8 @@ nonisolated public struct ProviderDailyTotal: Codable, Sendable, Identifiable {
         cacheReadTokens: Int,
         estimatedCostUSD: Double,
         modelBreakdowns: [TokenUsageBreakdown]? = nil,
-        projectBreakdowns: [TokenUsageBreakdown]? = nil
+        projectBreakdowns: [TokenUsageBreakdown]? = nil,
+        sessionBreakdowns: [TokenUsageBreakdown]? = nil
     ) {
         self.provider = provider
         self.inputTokens = inputTokens
@@ -589,6 +621,7 @@ nonisolated public struct ProviderDailyTotal: Codable, Sendable, Identifiable {
         self.estimatedCostUSD = estimatedCostUSD
         self.modelBreakdowns = modelBreakdowns
         self.projectBreakdowns = projectBreakdowns
+        self.sessionBreakdowns = sessionBreakdowns
     }
 
     /// Daily rows omit cache-creation tokens, so this is input + output + cache-read.
@@ -658,7 +691,8 @@ nonisolated private enum TokenUsageBreakdownAggregation {
                 cacheReadTokens: (existing?.cacheReadTokens ?? 0) + row.cacheReadTokens,
                 estimatedCostUSD: (existing?.estimatedCostUSD ?? 0) + row.estimatedCostUSD,
                 sessionCount: (existing?.sessionCount ?? 0) + row.sessionCount,
-                modelBreakdowns: merge((existing?.modelBreakdowns ?? []) + row.modelBreakdowns)
+                modelBreakdowns: merge((existing?.modelBreakdowns ?? []) + row.modelBreakdowns),
+                sessionBreakdowns: merge((existing?.sessionBreakdowns ?? []) + row.sessionBreakdowns)
             )
         }
 

--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -48,6 +48,14 @@ enum ClaudeCostScanner {
             projectBreakdowns: TokenUsageAggregator.makeProjectBreakdowns(
                 from: totals.projects,
                 modelsByProject: totals.projectModels,
+                sessionsByProject: totals.projectSessions,
+                sessionModelsByProject: totals.projectSessionModels,
+                provider: .claudeCode,
+                pricing: pricing
+            ),
+            sessionBreakdowns: TokenUsageAggregator.makeSessionBreakdowns(
+                from: TokenUsageAggregator.flattenSessions(totals.projectSessions),
+                modelsBySession: TokenUsageAggregator.flattenSessionModels(totals.projectSessionModels),
                 provider: .claudeCode,
                 pricing: pricing
             )
@@ -57,7 +65,9 @@ enum ClaudeCostScanner {
             pricing: pricing,
             modelsByDay: totals.dailyModels,
             projectsByDay: totals.dailyProjects,
-            projectModelsByDay: totals.dailyProjectModels
+            projectModelsByDay: totals.dailyProjectModels,
+            projectSessionsByDay: totals.dailyProjectSessions,
+            projectSessionModelsByDay: totals.dailyProjectSessionModels
         ), TokenUsageAggregator.makeHourlyUsage(
             from: totals.hourly,
             provider: .claudeCode,
@@ -171,12 +181,14 @@ enum ClaudeCostScanner {
             period: Self.tally(
                 keyed: periodKeyed,
                 projectID: projectID,
-                hourlyCutoff: hourlyCutoff
+                hourlyCutoff: hourlyCutoff,
+                sessionID: CostSessionAttribution.stableID(from: url)
             ),
             lifetime: Self.tally(
                 keyed: lifetimeKeyed,
                 projectID: projectID,
-                hourlyCutoff: hourlyCutoff
+                hourlyCutoff: hourlyCutoff,
+                sessionID: CostSessionAttribution.stableID(from: url)
             ),
             cutoff: cutoffDate,
             hourlyCutoff: hourlyCutoff
@@ -417,12 +429,14 @@ enum ClaudeCostScanner {
         windows.period.merge(Self.tally(
             keyed: periodKeyed,
             projectID: projectID,
-            hourlyCutoff: session.hourlyCutoff
+            hourlyCutoff: session.hourlyCutoff,
+            sessionID: CostSessionAttribution.stableID(from: file.url)
         ))
         windows.lifetime.merge(Self.tally(
             keyed: lifetimeKeyed,
             projectID: projectID,
-            hourlyCutoff: session.hourlyCutoff
+            hourlyCutoff: session.hourlyCutoff,
+            sessionID: CostSessionAttribution.stableID(from: file.url)
         ))
     }
 
@@ -495,12 +509,14 @@ enum ClaudeCostScanner {
         payload.period.merge(Self.tally(
             keyed: periodKeyed,
             projectID: projectID,
-            hourlyCutoff: session.hourlyCutoff
+            hourlyCutoff: session.hourlyCutoff,
+            sessionID: CostSessionAttribution.stableID(from: file.url)
         ))
         payload.lifetime.merge(Self.tally(
             keyed: lifetimeKeyed,
             projectID: projectID,
-            hourlyCutoff: session.hourlyCutoff
+            hourlyCutoff: session.hourlyCutoff,
+            sessionID: CostSessionAttribution.stableID(from: file.url)
         ))
         // `merge` sums `sessions`, but one transcript is one session however
         // many slices it took to read.
@@ -567,7 +583,8 @@ enum ClaudeCostScanner {
     nonisolated private static func tally(
         keyed: [String: ClaudeUsageEvent],
         projectID: String,
-        hourlyCutoff: Date = .distantPast
+        hourlyCutoff: Date = .distantPast,
+        sessionID: String
     ) -> ClaudeSessionTotals {
         var totals = ClaudeSessionTotals()
         totals.eventKeys = Set(keyed.keys)
@@ -612,7 +629,8 @@ enum ClaudeCostScanner {
                         : nil,
                     model: CostScanValues.displayModelName(event.model),
                     origin: event.origin,
-                    project: projectID
+                    project: projectID,
+                    session: sessionID
                 )
             )
         }

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -107,6 +107,15 @@ enum CodexCostScanner {
             projectBreakdowns: TokenUsageAggregator.makeProjectBreakdowns(
                 from: context.projectTotals,
                 modelsByProject: context.projectModelTotals,
+                sessionsByProject: context.projectSessions,
+                sessionModelsByProject: context.projectSessionModels,
+                provider: .codexCli,
+                pricing: pricing,
+                pricingForName: { pricingAt($0, windowEnd) }
+            ),
+            sessionBreakdowns: TokenUsageAggregator.makeSessionBreakdowns(
+                from: TokenUsageAggregator.flattenSessions(context.projectSessions),
+                modelsBySession: TokenUsageAggregator.flattenSessionModels(context.projectSessionModels),
                 provider: .codexCli,
                 pricing: pricing,
                 pricingForName: { pricingAt($0, windowEnd) }
@@ -118,6 +127,8 @@ enum CodexCostScanner {
             modelsByDay: context.dailyModelTotals,
             projectsByDay: context.dailyProjectTotals,
             projectModelsByDay: context.dailyProjectModelTotals,
+            projectSessionsByDay: context.dailyProjectSessions,
+            projectSessionModelsByDay: context.dailyProjectSessionModels,
             pricingAt: pricingAt
         ), TokenUsageAggregator.makeHourlyUsage(
             from: context.hourlyTotals,
@@ -221,6 +232,8 @@ enum CodexCostScanner {
     /// `token_count` line lacks. Cheap enough to run on every non-usage line.
     nonisolated private static let turnContextMarker = Data("\"turn_context\"".utf8)
     nonisolated private static let sessionMetaMarker = Data("\"session_meta\"".utf8)
+    nonisolated private static let threadSettingsMarker = Data("\"thread_settings\"".utf8)
+    nonisolated private static let worldStateMarker = Data("\"world_state\"".utf8)
 
     /// Turns one rollout into the usage events it contributes, in the order the
     /// scan applies them.
@@ -588,21 +601,49 @@ enum CodexCostScanner {
     }
 
     /// Picks up the model/originator carried by the non-usage rollout events.
+    ///
+    /// `token_count` names no model. The usual source is `turn_context.model`;
+    /// when that field is missing, the same file still often names the model on
+    /// `thread_settings`, nested `collaboration_mode.settings.model`, or
+    /// `world_state.state.model`.
     nonisolated private static func updateRolloutContext(
         _ rollout: inout CodexRolloutContext,
         from line: Data
     ) {
         if line.range(of: Self.turnContextMarker) != nil {
             guard let payload = Self.eventPayload(in: line, type: "turn_context") else { return }
-            rollout.turnModel = (payload["model"] as? String) ?? rollout.turnModel
+            rollout.turnModel = Self.modelString(in: payload, path: ["model"])
+                ?? Self.modelString(in: payload, path: ["collaboration_mode", "settings", "model"])
+                ?? rollout.turnModel
         } else if line.range(of: Self.sessionMetaMarker) != nil {
             guard let payload = Self.eventPayload(in: line, type: "session_meta") else { return }
             // `model` is null on every rollout observed so far, but read it
             // anyway so pre-turn events get named the day Codex populates it.
-            rollout.sessionModel = (payload["model"] as? String) ?? rollout.sessionModel
+            rollout.sessionModel = Self.modelString(in: payload, path: ["model"]) ?? rollout.sessionModel
             rollout.originator = (payload["originator"] as? String) ?? rollout.originator
             rollout.cwd = (payload["cwd"] as? String) ?? rollout.cwd
+        } else if line.range(of: Self.threadSettingsMarker) != nil {
+            guard let payload = Self.eventPayload(in: line, type: "event_msg") else { return }
+            let settings = (payload["thread_settings"] as? [String: Any]) ?? payload
+            rollout.sessionModel = Self.modelString(in: settings, path: ["model"])
+                ?? Self.modelString(in: settings, path: ["collaboration_mode", "settings", "model"])
+                ?? rollout.sessionModel
+        } else if line.range(of: Self.worldStateMarker) != nil {
+            guard let payload = Self.eventPayload(in: line, type: "world_state") else { return }
+            let state = (payload["state"] as? [String: Any]) ?? payload
+            rollout.sessionModel = Self.modelString(in: state, path: ["model"]) ?? rollout.sessionModel
         }
+    }
+
+    nonisolated private static func modelString(in object: [String: Any], path: [String]) -> String? {
+        var current: Any = object
+        for key in path {
+            guard let nested = current as? [String: Any], let next = nested[key] else { return nil }
+            current = next
+        }
+        guard let value = current as? String else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
     // swiftlint:enable contains_over_range_nil_comparison
 
@@ -907,7 +948,8 @@ enum CodexCostScanner {
                 : nil,
             model: CostScanValues.displayModelName(event.attribution.modelName),
             origin: CostScanValues.displayOriginName(event.attribution.originName),
-            project: event.attribution.projectID
+            project: event.attribution.projectID,
+            session: CostSessionAttribution.sanitize(sessionID)
         )
 
         // Price the event at the rate in effect when it was recorded (issue

--- a/MeterBar/Services/CostScanValues.swift
+++ b/MeterBar/Services/CostScanValues.swift
@@ -10,7 +10,7 @@ enum CostScanValues {
     /// Bump this whenever a change alters parsed output: usage extraction,
     /// deduplication, pricing, model normalization, or local-day bucketing.
     /// A mismatch discards the persisted cache and performs a full rescan.
-    nonisolated static let costCacheParserVersion = 4
+    nonisolated static let costCacheParserVersion = 5
 
     /// Token counts arrive as `Int`, `Int64`, `Double`, or a numeric string
     /// depending on which writer produced the log line; coerce every shape.

--- a/MeterBar/Services/CostScanWindows.swift
+++ b/MeterBar/Services/CostScanWindows.swift
@@ -65,6 +65,12 @@ nonisolated protocol CostScanBreakdowns {
     var origins: [String: TokenAccumulator] { get set }
     var projects: [String: TokenAccumulator] { get set }
     var projectModels: [String: [String: TokenAccumulator]] { get set }
+    /// Per-project session rows (issue #391). Nested so a session that somehow
+    /// splits across projects still reconciles to each parent project total.
+    var projectSessions: [String: [String: TokenAccumulator]] { get set }
+    var projectSessionModels: [String: [String: [String: TokenAccumulator]]] { get set }
+    var dailyProjectSessions: [Date: [String: [String: TokenAccumulator]]] { get set }
+    var dailyProjectSessionModels: [Date: [String: [String: [String: TokenAccumulator]]]] { get set }
 }
 
 /// Which bucket of each breakdown one event lands in.
@@ -75,6 +81,10 @@ nonisolated struct CostScanEventKeys {
     let model: String
     let origin: String
     let project: String
+    /// Path-free session stem (issue #391). Every event belongs to exactly one
+    /// session row; `CostSessionAttribution.unknownSessionID` is the explicit
+    /// bucket when the transcript has no usable identity.
+    let session: String
 }
 
 /// One event's contribution, already in the units the breakdowns store. The
@@ -104,6 +114,19 @@ nonisolated extension CostScanBreakdowns {
         origins[keys.origin, default: TokenAccumulator()].add(event)
         projects[keys.project, default: TokenAccumulator()].add(event)
         projectModels[keys.project, default: [:]][keys.model, default: TokenAccumulator()].add(event)
+        projectSessions[keys.project, default: [:]][keys.session, default: TokenAccumulator()].add(event)
+        projectSessionModels[keys.project, default: [:]][keys.session, default: [:]][
+            keys.model,
+            default: TokenAccumulator()
+        ].add(event)
+        dailyProjectSessions[keys.day, default: [:]][keys.project, default: [:]][
+            keys.session,
+            default: TokenAccumulator()
+        ].add(event)
+        dailyProjectSessionModels[keys.day, default: [:]][keys.project, default: [:]][keys.session, default: [:]][
+            keys.model,
+            default: TokenAccumulator()
+        ].add(event)
     }
 }
 
@@ -138,6 +161,11 @@ nonisolated struct ClaudeSessionTotals: Sendable, Codable, CostScanBreakdowns {
     /// Nested per-project, per-model totals powering the "drill-down to model
     /// breakdown" view under each project's rollup row.
     var projectModels: [String: [String: TokenAccumulator]] = [:]
+    /// Per-project session rows plus each session's model slice (issue #391).
+    var projectSessions: [String: [String: TokenAccumulator]] = [:]
+    var projectSessionModels: [String: [String: [String: TokenAccumulator]]] = [:]
+    var dailyProjectSessions: [Date: [String: [String: TokenAccumulator]]] = [:]
+    var dailyProjectSessionModels: [Date: [String: [String: [String: TokenAccumulator]]]] = [:]
     /// Which dated rate entries priced these events, and how many predated the
     /// table entirely (issue #339).
     var pricing = PricingProvenance()
@@ -212,6 +240,13 @@ nonisolated struct ClaudeSessionTotals: Sendable, Codable, CostScanBreakdowns {
                 projectModels[project, default: [:]][model, default: TokenAccumulator()].merge(tokens)
             }
         }
+        CostScanNestedMerge.keyedAccumulators(&projectSessions, other.projectSessions)
+        CostScanNestedMerge.doublyKeyedAccumulators(&projectSessionModels, other.projectSessionModels)
+        CostScanNestedMerge.dailyKeyedAccumulators(&dailyProjectSessions, other.dailyProjectSessions)
+        CostScanNestedMerge.dailyDoublyKeyedAccumulators(
+            &dailyProjectSessionModels,
+            other.dailyProjectSessionModels
+        )
 
         pricing.merge(other.pricing)
         earliest = Self.earlier(earliest, other.earliest)
@@ -281,6 +316,10 @@ nonisolated struct CostScanWindowContext: Sendable, Codable {
     /// see the matching fields on `ClaudeSessionTotals` (issue #270).
     var projectTotals: [String: TokenAccumulator] = [:]
     var projectModelTotals: [String: [String: TokenAccumulator]] = [:]
+    var projectSessions: [String: [String: TokenAccumulator]] = [:]
+    var projectSessionModels: [String: [String: [String: TokenAccumulator]]] = [:]
+    var dailyProjectSessions: [Date: [String: [String: TokenAccumulator]]] = [:]
+    var dailyProjectSessionModels: [Date: [String: [String: [String: TokenAccumulator]]]] = [:]
     var eventKeys: Set<String> = []
     var sessionIDs: Set<String> = []
     /// Which dated rate entries priced these events (issue #339).
@@ -338,6 +377,13 @@ nonisolated struct CostScanWindowContext: Sendable, Codable {
                 projectModelTotals[project, default: [:]][model, default: TokenAccumulator()].merge(tokens)
             }
         }
+        CostScanNestedMerge.keyedAccumulators(&projectSessions, other.projectSessions)
+        CostScanNestedMerge.doublyKeyedAccumulators(&projectSessionModels, other.projectSessionModels)
+        CostScanNestedMerge.dailyKeyedAccumulators(&dailyProjectSessions, other.dailyProjectSessions)
+        CostScanNestedMerge.dailyDoublyKeyedAccumulators(
+            &dailyProjectSessionModels,
+            other.dailyProjectSessionModels
+        )
 
         eventKeys.formUnion(other.eventKeys)
         sessionIDs.formUnion(other.sessionIDs)
@@ -397,6 +443,54 @@ nonisolated extension CostScanWindowContext: CostScanBreakdowns {
     var projectModels: [String: [String: TokenAccumulator]] {
         get { projectModelTotals }
         _modify { yield &projectModelTotals }
+    }
+}
+
+/// Nested `TokenAccumulator` dictionary merges used by both scan payloads.
+nonisolated enum CostScanNestedMerge {
+    static func accumulators(
+        _ target: inout [String: TokenAccumulator],
+        _ other: [String: TokenAccumulator]
+    ) {
+        for (key, tokens) in other {
+            target[key, default: TokenAccumulator()].merge(tokens)
+        }
+    }
+
+    static func keyedAccumulators(
+        _ target: inout [String: [String: TokenAccumulator]],
+        _ other: [String: [String: TokenAccumulator]]
+    ) {
+        for (key, inner) in other {
+            accumulators(&target[key, default: [:]], inner)
+        }
+    }
+
+    static func doublyKeyedAccumulators(
+        _ target: inout [String: [String: [String: TokenAccumulator]]],
+        _ other: [String: [String: [String: TokenAccumulator]]]
+    ) {
+        for (key, inner) in other {
+            keyedAccumulators(&target[key, default: [:]], inner)
+        }
+    }
+
+    static func dailyKeyedAccumulators(
+        _ target: inout [Date: [String: [String: TokenAccumulator]]],
+        _ other: [Date: [String: [String: TokenAccumulator]]]
+    ) {
+        for (day, inner) in other {
+            keyedAccumulators(&target[day, default: [:]], inner)
+        }
+    }
+
+    static func dailyDoublyKeyedAccumulators(
+        _ target: inout [Date: [String: [String: [String: TokenAccumulator]]]],
+        _ other: [Date: [String: [String: [String: TokenAccumulator]]]]
+    ) {
+        for (day, inner) in other {
+            doublyKeyedAccumulators(&target[day, default: [:]], inner)
+        }
     }
 }
 

--- a/MeterBar/Services/CostSessionAttribution.swift
+++ b/MeterBar/Services/CostSessionAttribution.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Stable, path-free session identifiers for cost rows (issue #391).
+///
+/// Project identity stays on `CostProjectAttribution`. This only names the
+/// session itself: a filename stem or conversation id, never a working
+/// directory, branch, remote, prompt, or credential.
+enum CostSessionAttribution {
+    /// Explicit fallback when a transcript has no usable session identity.
+    nonisolated static let unknownSessionID = "unknown"
+
+    /// Filename stem with directories and extensions stripped. Codex conversation
+    /// UUIDs and Claude transcript names already look like this; a raw path is
+    /// reduced to its last component so home directories never reach the cache.
+    nonisolated static func stableID(from url: URL) -> String {
+        sanitize(url.deletingPathExtension().lastPathComponent)
+    }
+
+    nonisolated static func sanitize(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return unknownSessionID }
+        if trimmed.contains("/") {
+            return sanitize(URL(fileURLWithPath: trimmed).deletingPathExtension().lastPathComponent)
+        }
+        return trimmed
+    }
+}

--- a/MeterBar/Services/GrokCLIUsageService.swift
+++ b/MeterBar/Services/GrokCLIUsageService.swift
@@ -24,6 +24,8 @@ final class GrokCLIUsageService: ObservableObject {
     nonisolated private let billingResultProvider: @Sendable (String, String) async throws -> GrokBillingResult
     nonisolated private let authFileDataProvider: @Sendable (GrokAccount) -> Data?
     nonisolated private let remainingResetsProvider: @Sendable (String) async -> Int?
+    nonisolated private let resetTokensProvider: @Sendable (String) async -> [GrokResetCredits.Token]
+    nonisolated private let consumeResetProvider: @Sendable (String, String) async throws -> Void
 
     init(
         binaryPathProvider: @escaping @Sendable () -> String? = {
@@ -43,6 +45,12 @@ final class GrokCLIUsageService: ObservableObject {
         },
         remainingResetsProvider: @escaping @Sendable (String) async -> Int? = { token in
             try? await GrokResetCreditsRPC.fetchAvailableCount(accessToken: token)
+        },
+        resetTokensProvider: @escaping @Sendable (String) async -> [GrokResetCredits.Token] = { token in
+            (try? await GrokResetCreditsRPC.fetchSnapshot(accessToken: token))?.tokens ?? []
+        },
+        consumeResetProvider: @escaping @Sendable (String, String) async throws -> Void = { token, tokenID in
+            try await GrokResetCreditsRPC.consume(tokenID: tokenID, accessToken: token)
         }
     ) {
         self.binaryPathProvider = binaryPathProvider
@@ -50,6 +58,8 @@ final class GrokCLIUsageService: ObservableObject {
         self.billingResultProvider = billingResultProvider
         self.authFileDataProvider = authFileDataProvider
         self.remainingResetsProvider = remainingResetsProvider
+        self.resetTokensProvider = resetTokensProvider
+        self.consumeResetProvider = consumeResetProvider
         Task.detached(priority: .utility) { [weak self] in
             self?.checkAccess()
         }
@@ -111,6 +121,43 @@ final class GrokCLIUsageService: ObservableObject {
                 "Grok profile usage fetch failed: \(serviceError.localizedDescription, privacy: .public)"
             )
             throw serviceError
+        }
+    }
+
+    /// Consumes one banked Grok usage-limit reset for `account`, then immediately
+    /// re-fetches usage. The POST is sent once; the provider owns replay
+    /// protection for that token id.
+    func consumeResetCredit(account: GrokAccount = .defaultAccount) async throws -> GrokResetCreditConsumption {
+        guard let accessToken = GrokResetCredits.accessToken(from: authFileDataProvider(account)) else {
+            throw ServiceError.notAuthenticated
+        }
+
+        let tokens = await resetTokensProvider(accessToken)
+        let now = Date()
+        guard let token = tokens.first(where: { candidate in
+            guard let expiresAt = candidate.expiresAt else { return true }
+            return expiresAt > now
+        }) else {
+            throw GrokResetCreditError.noAvailableCredit
+        }
+
+        do {
+            try await consumeResetProvider(accessToken, token.tokenID)
+        } catch {
+            throw GrokResetCreditError.requestFailed
+        }
+
+        do {
+            let refreshedMetrics = try await fetchUsageMetrics(account: account)
+            return GrokResetCreditConsumption(
+                refreshedMetrics: refreshedMetrics,
+                usageRefreshErrorDescription: nil
+            )
+        } catch {
+            return GrokResetCreditConsumption(
+                refreshedMetrics: nil,
+                usageRefreshErrorDescription: ServiceSupport.safeErrorMessage(for: error)
+            )
         }
     }
 
@@ -211,6 +258,44 @@ final class GrokCLIUsageService: ObservableObject {
         case .commandFailed:
             return .apiError(GrokRefreshFailure.requestFailed.message)
         }
+    }
+}
+
+public struct GrokResetCreditConsumption {
+    public let refreshedMetrics: UsageMetrics?
+    public let usageRefreshErrorDescription: String?
+}
+
+public enum GrokResetCreditError: LocalizedError, Equatable, Sendable {
+    case noAvailableCredit
+    case requestFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case .noAvailableCredit:
+            return "No Grok usage reset is available. Refresh usage and try again."
+        case .requestFailed:
+            return "Grok returned an unexpected reset response."
+        }
+    }
+}
+
+/// Public seam used by the bundled `meterbar reset-credit --provider grok`
+/// command without exposing the app's internal account-store model to the CLI.
+public enum GrokResetCreditAPI {
+    public static func consume(grokHome: String? = nil) async throws -> GrokResetCreditConsumption {
+        let trimmedHome = grokHome?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let account: GrokAccount
+        if let trimmedHome, !trimmedHome.isEmpty {
+            account = GrokAccount(
+                id: UUID(),
+                name: "CLI reset-credit account",
+                homeDirectory: (trimmedHome as NSString).standardizingPath
+            )
+        } else {
+            account = .defaultAccount
+        }
+        return try await GrokCLIUsageService.shared.consumeResetCredit(account: account)
     }
 }
 

--- a/MeterBar/Services/GrokCostScanner.swift
+++ b/MeterBar/Services/GrokCostScanner.swift
@@ -262,6 +262,14 @@ enum GrokCostScanner {
             projectBreakdowns: TokenUsageAggregator.makeProjectBreakdowns(
                 from: context.projectTotals,
                 modelsByProject: context.projectModelTotals,
+                sessionsByProject: context.projectSessions,
+                sessionModelsByProject: context.projectSessionModels,
+                provider: .grok,
+                pricing: pricing
+            ),
+            sessionBreakdowns: TokenUsageAggregator.makeSessionBreakdowns(
+                from: TokenUsageAggregator.flattenSessions(context.projectSessions),
+                modelsBySession: TokenUsageAggregator.flattenSessionModels(context.projectSessionModels),
                 provider: .grok,
                 pricing: pricing
             )
@@ -271,7 +279,9 @@ enum GrokCostScanner {
             pricing: pricing,
             modelsByDay: context.dailyModelTotals,
             projectsByDay: context.dailyProjectTotals,
-            projectModelsByDay: context.dailyProjectModelTotals
+            projectModelsByDay: context.dailyProjectModelTotals,
+            projectSessionsByDay: context.dailyProjectSessions,
+            projectSessionModelsByDay: context.dailyProjectSessionModels
         ), TokenUsageAggregator.makeHourlyUsage(
             from: context.hourlyTotals,
             provider: .grok,
@@ -523,7 +533,8 @@ enum GrokCostScanner {
                 : nil,
             model: CostScanValues.displayModelName(event.model),
             origin: CostScanValues.displayOriginName(Self.originName),
-            project: event.projectID
+            project: event.projectID,
+            session: CostSessionAttribution.sanitize(sessionID)
         )
         let breakdown = CostScanEventTotals(
             input: freshInput,

--- a/MeterBar/Services/GrokResetCredits.swift
+++ b/MeterBar/Services/GrokResetCredits.swift
@@ -73,35 +73,97 @@ nonisolated enum GrokResetCreditsRPC {
         string: "https://grok.com/prod_mc_billing.ConsumerUiSvc/GetRemainingResets"
     )!
 
+    /// Redeem the named reset token. Sibling of GetRemainingResets; grok.com
+    /// Settings labels this control "Redeem".
+    static let redeemResetURL = URL(
+        string: "https://grok.com/prod_mc_billing.ConsumerUiSvc/RedeemReset"
+    )!
+
     /// Empty protobuf framed as one uncompressed grpc-web data frame.
     static let emptyRequest = Data([0x00, 0x00, 0x00, 0x00, 0x00])
+
+    static func fetchSnapshot(
+        accessToken: String,
+        session: URLSession = ServiceSupport.session,
+        now: Date = Date()
+    ) async throws -> GrokResetCredits.Snapshot {
+        let data = try await post(
+            url: remainingResetsURL,
+            accessToken: accessToken,
+            body: emptyRequest,
+            session: session
+        )
+        return try GrokResetCredits.decode(grpcWeb: data, now: now)
+    }
 
     static func fetchAvailableCount(
         accessToken: String,
         session: URLSession = ServiceSupport.session,
         now: Date = Date()
     ) async throws -> Int {
-        var request = URLRequest(url: remainingResetsURL)
+        try await fetchSnapshot(accessToken: accessToken, session: session, now: now).availableCount
+    }
+
+    static func consume(
+        tokenID: String,
+        accessToken: String,
+        session: URLSession = ServiceSupport.session
+    ) async throws {
+        let data = try await post(
+            url: redeemResetURL,
+            accessToken: accessToken,
+            body: GrpcWeb.frame(Proto.encodeTokenID(tokenID)),
+            session: session
+        )
+        let status = GrpcWeb.status(in: data) ?? 0
+        guard status == 0 else { throw Error.requestFailed }
+    }
+
+    /// Test seam: production callers go through `consume`.
+    static func encodeTokenIDForTesting(_ tokenID: String) -> Data {
+        GrpcWeb.frame(Proto.encodeTokenID(tokenID))
+    }
+
+    static func grpcStatusForTesting(_ data: Data) -> Int? {
+        GrpcWeb.status(in: data)
+    }
+
+    private static func post(
+        url: URL,
+        accessToken: String,
+        body: Data,
+        session: URLSession
+    ) async throws -> Data {
+        var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         request.setValue("application/grpc-web+proto", forHTTPHeaderField: "Content-Type")
         request.setValue("1", forHTTPHeaderField: "X-Grpc-Web")
         request.setValue("https://grok.com", forHTTPHeaderField: "Origin")
-        request.httpBody = emptyRequest
+        request.httpBody = body
 
         let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             throw Error.requestFailed
         }
-        return try GrokResetCredits.decode(grpcWeb: data, now: now).availableCount
+        return data
     }
 }
 
 // MARK: - grpc-web + proto
 
 /// grpc-web: 1 flag byte + 4-byte big-endian length + payload. The high bit on
-/// the flag marks a trailer frame (`grpc-status: 0`), which we skip.
+/// the flag marks a trailer frame (`grpc-status: 0`), which we skip for the
+/// message and read for the status code.
 private enum GrpcWeb {
+    static func frame(_ message: Data) -> Data {
+        var framed = Data([0x00])
+        var length = UInt32(message.count).bigEndian
+        withUnsafeBytes(of: length) { framed.append(contentsOf: $0) }
+        framed.append(message)
+        return framed
+    }
+
     static func unprefixedMessage(in data: Data) -> Data? {
         var offset = 0
         var message: Data?
@@ -120,6 +182,35 @@ private enum GrpcWeb {
             }
         }
         return message
+    }
+
+    static func status(in data: Data) -> Int? {
+        var offset = 0
+        while offset + 5 <= data.count {
+            let flags = data[offset]
+            let length = Int(data[offset + 1]) << 24
+                | Int(data[offset + 2]) << 16
+                | Int(data[offset + 3]) << 8
+                | Int(data[offset + 4])
+            offset += 5
+            guard offset + length <= data.count else { return nil }
+            let payload = data.subdata(in: offset..<(offset + length))
+            offset += length
+            guard flags & 0x80 != 0,
+                  let text = String(data: payload, encoding: .utf8) else {
+                continue
+            }
+            for line in text.split(whereSeparator: \.isNewline) {
+                let parts = line.split(separator: ":", maxSplits: 1)
+                guard parts.count == 2,
+                      parts[0].trimmingCharacters(in: .whitespaces) == "grpc-status",
+                      let code = Int(parts[1].trimmingCharacters(in: .whitespaces)) else {
+                    continue
+                }
+                return code
+            }
+        }
+        return nil
     }
 }
 
@@ -145,6 +236,15 @@ private enum Proto {
             guard field == tokensField else { return nil }
             return token(in: value)
         }
+    }
+
+    /// `ConsumerRedeemResetReq { string token_id = 10; }` framed by the caller.
+    static func encodeTokenID(_ tokenID: String) -> Data {
+        let utf8 = Data(tokenID.utf8)
+        var payload = encodeVarint(UInt64((tokenIDField << 3) | 2))
+        payload.append(encodeVarint(UInt64(utf8.count)))
+        payload.append(utf8)
+        return payload
     }
 
     private static func token(in message: Data) -> GrokResetCredits.Token? {
@@ -213,6 +313,17 @@ private enum Proto {
             }
         }
         return result
+    }
+
+    private static func encodeVarint(_ value: UInt64) -> Data {
+        var value = value
+        var data = Data()
+        while value >= 0x80 {
+            data.append(UInt8(value & 0x7F) | 0x80)
+            value >>= 7
+        }
+        data.append(UInt8(value))
+        return data
     }
 
     private static func varint(_ data: Data) -> UInt64? {

--- a/MeterBar/Services/GrokResetCredits.swift
+++ b/MeterBar/Services/GrokResetCredits.swift
@@ -73,8 +73,10 @@ nonisolated enum GrokResetCreditsRPC {
         string: "https://grok.com/prod_mc_billing.ConsumerUiSvc/GetRemainingResets"
     )!
 
-    /// Redeem the named reset token. Sibling of GetRemainingResets; grok.com
-    /// Settings labels this control "Redeem".
+    /// Redeem the named reset token. Live-probed 2026-08-13: this method is
+    /// implemented. A fake token id returns HTTP 200 + `grpc-status: 9`
+    /// (FAILED_PRECONDITION) on the response header with an empty body and
+    /// does not spend a real reset.
     static let redeemResetURL = URL(
         string: "https://grok.com/prod_mc_billing.ConsumerUiSvc/RedeemReset"
     )!
@@ -87,7 +89,7 @@ nonisolated enum GrokResetCreditsRPC {
         session: URLSession = ServiceSupport.session,
         now: Date = Date()
     ) async throws -> GrokResetCredits.Snapshot {
-        let data = try await post(
+        let (data, _) = try await post(
             url: remainingResetsURL,
             accessToken: accessToken,
             body: emptyRequest,
@@ -109,14 +111,17 @@ nonisolated enum GrokResetCreditsRPC {
         accessToken: String,
         session: URLSession = ServiceSupport.session
     ) async throws {
-        let data = try await post(
+        let (data, http) = try await post(
             url: redeemResetURL,
             accessToken: accessToken,
             body: GrpcWeb.frame(Proto.encodeTokenID(tokenID)),
             session: session
         )
-        let status = GrpcWeb.status(in: data) ?? 0
-        guard status == 0 else { throw Error.requestFailed }
+        // Live RedeemReset puts grpc-status on the HTTP header and may send
+        // an empty body. A missing trailer is not success.
+        guard GrpcWeb.status(body: data, headers: http.allHeaderFields) == 0 else {
+            throw Error.requestFailed
+        }
     }
 
     /// Test seam: production callers go through `consume`.
@@ -124,8 +129,12 @@ nonisolated enum GrokResetCreditsRPC {
         GrpcWeb.frame(Proto.encodeTokenID(tokenID))
     }
 
-    static func grpcStatusForTesting(_ data: Data) -> Int? {
-        GrpcWeb.status(in: data)
+    static func grpcStatusForTesting(_ data: Data, headers: [AnyHashable: Any] = [:]) -> Int? {
+        GrpcWeb.status(body: data, headers: headers)
+    }
+
+    static func consumeSucceededForTesting(_ data: Data, headers: [AnyHashable: Any]) -> Bool {
+        GrpcWeb.status(body: data, headers: headers) == 0
     }
 
     private static func post(
@@ -133,7 +142,7 @@ nonisolated enum GrokResetCreditsRPC {
         accessToken: String,
         body: Data,
         session: URLSession
-    ) async throws -> Data {
+    ) async throws -> (Data, HTTPURLResponse) {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
@@ -146,7 +155,7 @@ nonisolated enum GrokResetCreditsRPC {
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             throw Error.requestFailed
         }
-        return data
+        return (data, http)
     }
 }
 
@@ -184,6 +193,10 @@ private enum GrpcWeb {
         return message
     }
 
+    static func status(body: Data, headers: [AnyHashable: Any]) -> Int? {
+        status(in: body) ?? headerStatus(headers)
+    }
+
     static func status(in data: Data) -> Int? {
         var offset = 0
         while offset + 5 <= data.count {
@@ -208,6 +221,24 @@ private enum GrpcWeb {
                     continue
                 }
                 return code
+            }
+        }
+        return nil
+    }
+
+    /// grpc-web may put `grpc-status` on the HTTP response when the body has
+    /// no trailer frame. Header names are compared case-insensitively.
+    private static func headerStatus(_ headers: [AnyHashable: Any]) -> Int? {
+        for (key, value) in headers {
+            guard String(describing: key).caseInsensitiveCompare("grpc-status") == .orderedSame else {
+                continue
+            }
+            if let code = value as? Int { return code }
+            if let text = value as? String {
+                return Int(text.trimmingCharacters(in: .whitespacesAndNewlines))
+            }
+            if let text = value as? NSString {
+                return Int(text.trimmingCharacters(in: .whitespacesAndNewlines))
             }
         }
         return nil

--- a/MeterBar/Services/ProviderUsageCostBuilder.swift
+++ b/MeterBar/Services/ProviderUsageCostBuilder.swift
@@ -51,7 +51,8 @@ nonisolated enum ProviderUsageCostBuilder {
             // a list of sessions. Zero states that plainly.
             sessionCount: 0,
             periodStart: periodStart,
-            periodEnd: periodEnd
+            periodEnd: periodEnd,
+            sessionBreakdowns: []
         )
 
         let daily = days.map { day in
@@ -63,7 +64,8 @@ nonisolated enum ProviderUsageCostBuilder {
                 cacheReadTokens: 0,
                 estimatedCostUSD: day.amount,
                 modelBreakdowns: [],
-                projectBreakdowns: []
+                projectBreakdowns: [],
+                sessionBreakdowns: []
             )
         }
 

--- a/MeterBar/Services/TokenUsageAggregator.swift
+++ b/MeterBar/Services/TokenUsageAggregator.swift
@@ -46,6 +46,8 @@ enum TokenUsageAggregator {
         modelsByDay: [Date: [String: TokenAccumulator]] = [:],
         projectsByDay: [Date: [String: TokenAccumulator]] = [:],
         projectModelsByDay: [Date: [String: [String: TokenAccumulator]]] = [:],
+        projectSessionsByDay: [Date: [String: [String: TokenAccumulator]]] = [:],
+        projectSessionModelsByDay: [Date: [String: [String: [String: TokenAccumulator]]]] = [:],
         pricingAt: ((String?, Date) -> TokenPricing)? = nil
     ) -> [DailyTokenUsage] {
         dailyTotals.map { day, tokens in
@@ -61,6 +63,17 @@ enum TokenUsageAggregator {
                     cacheRead: tokens.cacheRead,
                     pricing: dayPricing
                 )
+            let projectRows = projectsByDay[day].map {
+                makeProjectBreakdowns(
+                    from: $0,
+                    modelsByProject: projectModelsByDay[day] ?? [:],
+                    sessionsByProject: projectSessionsByDay[day] ?? [:],
+                    sessionModelsByProject: projectSessionModelsByDay[day] ?? [:],
+                    provider: provider,
+                    pricing: dayPricing,
+                    pricingForName: pricingForName
+                )
+            }
             return DailyTokenUsage(
                 date: day,
                 provider: provider,
@@ -76,10 +89,11 @@ enum TokenUsageAggregator {
                         pricingForName: pricingForName
                     )
                 },
-                projectBreakdowns: projectsByDay[day].map {
-                    makeProjectBreakdowns(
-                        from: $0,
-                        modelsByProject: projectModelsByDay[day] ?? [:],
+                projectBreakdowns: projectRows,
+                sessionBreakdowns: projectSessionsByDay[day].map {
+                    makeSessionBreakdowns(
+                        from: flattenSessions($0),
+                        modelsBySession: flattenSessionModels(projectSessionModelsByDay[day] ?? [:]),
                         provider: provider,
                         pricing: dayPricing,
                         pricingForName: pricingForName
@@ -138,6 +152,8 @@ enum TokenUsageAggregator {
     nonisolated static func makeProjectBreakdowns(
         from projectTotals: [String: TokenAccumulator],
         modelsByProject: [String: [String: TokenAccumulator]],
+        sessionsByProject: [String: [String: TokenAccumulator]] = [:],
+        sessionModelsByProject: [String: [String: [String: TokenAccumulator]]] = [:],
         provider: ServiceType,
         pricing: TokenPricing,
         pricingForName: ((String) -> TokenPricing)? = nil
@@ -154,8 +170,60 @@ enum TokenUsageAggregator {
                 sessionCount: row.sessionCount,
                 modelBreakdowns: modelsByProject[row.name].map {
                     makeBreakdowns(from: $0, provider: provider, pricing: pricing, pricingForName: pricingForName)
+                } ?? [],
+                sessionBreakdowns: makeSessionBreakdowns(
+                    from: sessionsByProject[row.name] ?? [:],
+                    modelsBySession: sessionModelsByProject[row.name] ?? [:],
+                    provider: provider,
+                    pricing: pricing,
+                    pricingForName: pricingForName
+                )
+            )
+        }
+    }
+
+    /// Per-session rows, each carrying its own nested per-model slice (issue #391).
+    nonisolated static func makeSessionBreakdowns(
+        from sessionTotals: [String: TokenAccumulator],
+        modelsBySession: [String: [String: TokenAccumulator]],
+        provider: ServiceType,
+        pricing: TokenPricing,
+        pricingForName: ((String) -> TokenPricing)? = nil
+    ) -> [TokenUsageBreakdown] {
+        makeBreakdowns(from: sessionTotals, provider: provider, pricing: pricing).map { row in
+            TokenUsageBreakdown(
+                provider: row.provider,
+                name: row.name,
+                inputTokens: row.inputTokens,
+                outputTokens: row.outputTokens,
+                cacheCreationTokens: row.cacheCreationTokens,
+                cacheReadTokens: row.cacheReadTokens,
+                estimatedCostUSD: row.estimatedCostUSD,
+                sessionCount: row.sessionCount,
+                modelBreakdowns: modelsBySession[row.name].map {
+                    makeBreakdowns(from: $0, provider: provider, pricing: pricing, pricingForName: pricingForName)
                 } ?? []
             )
         }
+    }
+
+    nonisolated static func flattenSessions(
+        _ projectSessions: [String: [String: TokenAccumulator]]
+    ) -> [String: TokenAccumulator] {
+        var flattened: [String: TokenAccumulator] = [:]
+        for (_, sessions) in projectSessions {
+            CostScanNestedMerge.accumulators(&flattened, sessions)
+        }
+        return flattened
+    }
+
+    nonisolated static func flattenSessionModels(
+        _ projectSessionModels: [String: [String: [String: TokenAccumulator]]]
+    ) -> [String: [String: TokenAccumulator]] {
+        var flattened: [String: [String: TokenAccumulator]] = [:]
+        for (_, sessions) in projectSessionModels {
+            CostScanNestedMerge.keyedAccumulators(&flattened, sessions)
+        }
+        return flattened
     }
 }

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -753,6 +753,18 @@ class UsageDataManager: ObservableObject {
         publishMetrics()
     }
 
+    /// Installs the post-redemption Grok usage response into the same caches
+    /// used by the popover, dashboard, widget, and CLI.
+    func applyGrokResetCreditRefresh(_ refreshedMetrics: UsageMetrics, accountID: UUID) {
+        guard !demoMode else { return }
+        grokAccountMetrics[accountID] = refreshedMetrics
+        if let representative = representativeGrokMetrics(from: grokAccountMetrics) {
+            metrics[.grok] = representative
+        }
+        lastError = nil
+        publishMetrics()
+    }
+
     private func refreshedMetrics(for service: ServiceType) async throws -> UsageMetrics {
         switch service {
         // The account fetchers report their first failure instead of writing

--- a/MeterBar/Views/ProviderCardPresentation.swift
+++ b/MeterBar/Views/ProviderCardPresentation.swift
@@ -61,13 +61,13 @@ enum ProviderCardPresentation {
             && !collapsesToLoginRow(snapshot: snapshot, now: now)
     }
 
-    /// Reset credits are a Codex CLI concept. The eligibility rule already hides
-    /// the action once the provider reports no credits left, but the count it
-    /// reads is only as fresh as the last poll: a redemption whose follow-up
-    /// refetch failed leaves the snapshot still claiming the spent credit is
-    /// there. `hasPendingConsumption` covers exactly that window — see
-    /// `CodexResetCreditConsumptionStore`, which drops the record as soon as
-    /// newer metrics arrive.
+    /// Reset credits are banked usage-window resets on Codex CLI and Grok.
+    /// The eligibility rule already hides the action once the provider reports
+    /// no credits left, but the count it reads is only as fresh as the last
+    /// poll: a redemption whose follow-up refetch failed leaves the snapshot
+    /// still claiming the spent credit is there. `hasPendingConsumption` covers
+    /// exactly that window — see `CodexResetCreditConsumptionStore`, which drops
+    /// the record as soon as newer metrics arrive.
     ///
     /// It is deliberately not a permanent latch. An account can bank several
     /// credits, and once refreshed numbers land the count is authoritative, so
@@ -78,7 +78,9 @@ enum ProviderCardPresentation {
         isAuthenticated: Bool,
         hasResolvedAccount: Bool
     ) -> Bool {
-        guard snapshot.service == .codexCli, !hasPendingConsumption else { return false }
+        guard snapshot.service == .codexCli || snapshot.service == .grok, !hasPendingConsumption else {
+            return false
+        }
         return CodexResetCreditEligibility.isEligible(
             isBlocked: snapshot.hasExhaustedLimit,
             availableCredits: snapshot.resetCreditsAvailable,

--- a/MeterBar/Views/ProviderCardResetCredit.swift
+++ b/MeterBar/Views/ProviderCardResetCredit.swift
@@ -25,6 +25,15 @@ enum ProviderCardResetCreditOutcome {
     /// credit can be reclaimed by retrying.
     static func alert(for consumption: CodexResetCreditConsumption) -> Alert? {
         guard let refreshError = consumption.usageRefreshErrorDescription else { return nil }
+        return partialSuccessAlert(refreshError: refreshError)
+    }
+
+    static func alert(for consumption: GrokResetCreditConsumption) -> Alert? {
+        guard let refreshError = consumption.usageRefreshErrorDescription else { return nil }
+        return partialSuccessAlert(refreshError: refreshError)
+    }
+
+    private static func partialSuccessAlert(refreshError: String) -> Alert {
         let message = "The credit was used, but usage could not refresh (\(refreshError)). "
             + "Do not retry; refresh later."
         return Alert(title: partialSuccessTitle, message: message)

--- a/MeterBar/Views/ProviderStatusCard.swift
+++ b/MeterBar/Views/ProviderStatusCard.swift
@@ -14,12 +14,14 @@ struct ProviderStatusCard: View {
     private var reduceMotion
     @StateObject private var codexService = CodexCliLocalService.shared
     @StateObject private var codexAccounts = CodexAccountStore.shared
+    @StateObject private var grokService = GrokCLIUsageService.shared
+    @StateObject private var grokAccounts = GrokAccountStore.shared
     @StateObject private var dataManager = UsageDataManager.shared
     // Session-scoped rather than per-card `@State`: this card's identity is not
     // stable across dashboard re-deals, and losing the record re-offers a credit
     // that was already spent.
     @StateObject private var resetCreditConsumptions = CodexResetCreditConsumptionStore.shared
-    @State private var isCodexAuthenticated = false
+    @State private var isResetCreditAuthenticated = false
     @State private var isConsumingResetCredit = false
     @State private var showingResetCreditConfirmation = false
     @State private var resetCreditAlertTitle = ProviderCardResetCreditOutcome.failureTitle
@@ -53,7 +55,7 @@ struct ProviderStatusCard: View {
         selectableCard
             .providerCardContextMenu(ProviderCardCommands.standard(snapshot: snapshot))
             .task(id: snapshot.updatedAt) {
-                await refreshCodexAuthenticationState()
+                await refreshResetCreditAuthenticationState()
             }
             .confirmationDialog(
                 CodexResetCreditConfirmation.title(accountName: resetCreditAccountName),
@@ -262,8 +264,8 @@ struct ProviderStatusCard: View {
                 accountID: snapshot.accountID,
                 snapshotUpdatedAt: snapshot.updatedAt
             ),
-            isAuthenticated: isCodexAuthenticated,
-            hasResolvedAccount: codexAccount != nil
+            isAuthenticated: isResetCreditAuthenticated,
+            hasResolvedAccount: resetCreditAccountID != nil
         )
     }
 
@@ -272,46 +274,78 @@ struct ProviderStatusCard: View {
         return codexAccounts.accounts.first { $0.id == accountID }
     }
 
-    /// The profile name the redemption will hit — the same label Settings shows,
-    /// so a multi-account popover confirms which `CODEX_HOME` is being spent.
-    private var resetCreditAccountName: String {
-        codexAccount?.name ?? snapshot.title
+    private var grokAccount: GrokAccount? {
+        guard snapshot.service == .grok, let accountID = snapshot.accountID else { return nil }
+        return grokAccounts.accounts.first { $0.id == accountID }
     }
 
-    private func refreshCodexAuthenticationState() async {
-        guard let codexAccount else {
-            isCodexAuthenticated = false
+    private var resetCreditAccountID: UUID? {
+        if snapshot.service == .codexCli { return codexAccount?.id }
+        if snapshot.service == .grok { return grokAccount?.id }
+        return nil
+    }
+
+    /// The profile name the redemption will hit — the same label Settings shows,
+    /// so a multi-account popover confirms which home directory is being spent.
+    private var resetCreditAccountName: String {
+        if snapshot.service == .codexCli { return codexAccount?.name ?? snapshot.title }
+        if snapshot.service == .grok { return grokAccount?.name ?? snapshot.title }
+        return snapshot.title
+    }
+
+    private func refreshResetCreditAuthenticationState() async {
+        if let codexAccount {
+            isResetCreditAuthenticated = await codexService.canAccess(account: codexAccount)
             return
         }
-        isCodexAuthenticated = await codexService.canAccess(account: codexAccount)
+        if let grokAccount {
+            isResetCreditAuthenticated = grokService.canAccess(account: grokAccount)
+            return
+        }
+        isResetCreditAuthenticated = false
     }
 
     private func consumeResetCredit() {
-        guard let codexAccount, !isConsumingResetCredit else { return }
+        guard resetCreditAccountID != nil, !isConsumingResetCredit else { return }
         isConsumingResetCredit = true
 
         Task {
             do {
-                let result = try await codexService.consumeResetCredit(account: codexAccount)
-                if let refreshedMetrics = result.refreshedMetrics {
-                    // Post-spend numbers straight from the provider: the card is
-                    // about to show the real remaining balance, so eligibility
-                    // alone decides whether another banked credit stays offered.
-                    resetCreditConsumptions.clear(accountID: codexAccount.id)
-                    dataManager.applyCodexResetCreditRefresh(refreshedMetrics, accountID: codexAccount.id)
-                } else {
-                    // The credit is gone but the count on screen predates the
-                    // spend. Suppress the action until a later fetch proves the
-                    // balance, or the next press spends a second credit.
-                    resetCreditConsumptions.markConsumed(accountID: codexAccount.id)
-                }
-                if let alert = ProviderCardResetCreditOutcome.alert(for: result) {
-                    present(alert)
+                if snapshot.service == .codexCli, let codexAccount {
+                    try await consumeCodexResetCredit(account: codexAccount)
+                } else if snapshot.service == .grok, let grokAccount {
+                    try await consumeGrokResetCredit(account: grokAccount)
                 }
             } catch {
                 present(ProviderCardResetCreditOutcome.alert(for: error))
             }
             isConsumingResetCredit = false
+        }
+    }
+
+    private func consumeCodexResetCredit(account: CodexAccount) async throws {
+        let result = try await codexService.consumeResetCredit(account: account)
+        if let refreshedMetrics = result.refreshedMetrics {
+            resetCreditConsumptions.clear(accountID: account.id)
+            dataManager.applyCodexResetCreditRefresh(refreshedMetrics, accountID: account.id)
+        } else {
+            resetCreditConsumptions.markConsumed(accountID: account.id)
+        }
+        if let alert = ProviderCardResetCreditOutcome.alert(for: result) {
+            present(alert)
+        }
+    }
+
+    private func consumeGrokResetCredit(account: GrokAccount) async throws {
+        let result = try await grokService.consumeResetCredit(account: account)
+        if let refreshedMetrics = result.refreshedMetrics {
+            resetCreditConsumptions.clear(accountID: account.id)
+            dataManager.applyGrokResetCreditRefresh(refreshedMetrics, accountID: account.id)
+        } else {
+            resetCreditConsumptions.markConsumed(accountID: account.id)
+        }
+        if let alert = ProviderCardResetCreditOutcome.alert(for: result) {
+            present(alert)
         }
     }
 

--- a/MeterBar/Views/Settings/CostSettingsView.swift
+++ b/MeterBar/Views/Settings/CostSettingsView.swift
@@ -69,6 +69,26 @@ nonisolated struct CostProjectPresentation: Equatable {
     private static let generatedWorktreeIDLength = 6
 }
 
+/// Human-readable session identity for Costs UI. Scanner IDs stay lossless in
+/// the cache and JSON; this projection shortens a UUID-like stem for display.
+nonisolated struct CostSessionPresentation: Equatable {
+    let title: String
+    let detail: String?
+
+    init(identifier: String, projectIdentifier: String? = nil) {
+        let compact = identifier.replacingOccurrences(of: "-", with: "")
+        let short = compact.count > 8 ? String(compact.prefix(8)) : identifier
+        title = identifier == CostSessionAttribution.unknownSessionID
+            ? "Unknown session"
+            : "Session \(short)"
+        if let projectIdentifier, projectIdentifier != CostProjectAttribution.unknownProjectID {
+            detail = CostProjectPresentation(identifier: projectIdentifier).title
+        } else {
+            detail = nil
+        }
+    }
+}
+
 /// Renders one cost-summary period — the rolling 30-day window or the
 /// calendar month-to-date window — plus its per-provider project/worktree
 /// rollup and, when set, a converted-currency caption (issue #270). A pure
@@ -339,17 +359,22 @@ private struct CostProjectBreakdownRow: View {
 
     var body: some View {
         DisclosureGroup {
-            ForEach(project.modelBreakdowns) { model in
-                HStack {
-                    Text(model.name)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                    Spacer(minLength: 8)
-                    Text(model.formattedCost)
-                        .font(.caption2.monospacedDigit())
-                        .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(project.modelBreakdowns) { model in
+                    HStack {
+                        Text(model.name)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Spacer(minLength: 8)
+                        Text(model.formattedCost)
+                            .font(.caption2.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.leading, MeterBarTheme.Spacing.lg)
                 }
-                .padding(.leading, MeterBarTheme.Spacing.lg)
+                ForEach(project.sessionBreakdowns) { session in
+                    CostSessionBreakdownRow(session: session, currency: currency)
+                }
             }
         } label: {
             HStack(alignment: .top, spacing: 10) {
@@ -387,6 +412,63 @@ private struct CostProjectBreakdownRow: View {
             }
         }
         .accessibilityIdentifier("project-breakdown-\(project.name)")
+    }
+}
+
+private struct CostSessionBreakdownRow: View {
+    let session: TokenUsageBreakdown
+    let currency: DisplayCurrency?
+
+    private var presentation: CostSessionPresentation {
+        CostSessionPresentation(identifier: session.name)
+    }
+
+    var body: some View {
+        DisclosureGroup {
+            ForEach(session.modelBreakdowns) { model in
+                HStack {
+                    Text(model.name)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 8)
+                    Text(model.formattedCost)
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.leading, MeterBarTheme.Spacing.lg)
+            }
+        } label: {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "text.alignleft")
+                    .foregroundStyle(.secondary)
+                    .frame(width: 16)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(presentation.title)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .lineLimit(1)
+                    if let detail = presentation.detail {
+                        Text(detail)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 8)
+                VStack(alignment: .trailing, spacing: 1) {
+                    Text(session.formattedCost)
+                        .font(.caption.monospacedDigit())
+                        .fontWeight(.semibold)
+                    if let currency {
+                        Text("≈ \(currency.formattedConverted(usd: session.estimatedCostUSD))")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .accessibilityIdentifier("session-breakdown-\(session.name)")
     }
 }
 

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -369,6 +369,9 @@ struct Cost: ParsableCommand {
                 for project in projects.sorted(by: { $0.estimatedCostUSD > $1.estimatedCostUSD }) {
                     print("    - \(project.name): \(costText(project.estimatedCostUSD, currency: currency))"
                         + " (\(project.sessionCount) event\(project.sessionCount == 1 ? "" : "s"))")
+                    for session in project.sessionBreakdowns.sorted(by: { $0.estimatedCostUSD > $1.estimatedCostUSD }) {
+                        print("      session \(session.name): \(costText(session.estimatedCostUSD, currency: currency))")
+                    }
                 }
             }
             print()
@@ -410,6 +413,9 @@ struct Cost: ParsableCommand {
                 for project in cost.projectBreakdowns.sorted(by: { $0.estimatedCostUSD > $1.estimatedCostUSD }) {
                     print("    - \(project.name): \(costText(project.estimatedCostUSD, currency: currency))"
                         + " (\(project.sessionCount) session\(project.sessionCount == 1 ? "" : "s"))")
+                    for session in project.sessionBreakdowns.sorted(by: { $0.estimatedCostUSD > $1.estimatedCostUSD }) {
+                        print("      session \(session.name): \(costText(session.estimatedCostUSD, currency: currency))")
+                    }
                 }
             }
             print()

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -369,8 +369,11 @@ struct Cost: ParsableCommand {
                 for project in projects.sorted(by: { $0.estimatedCostUSD > $1.estimatedCostUSD }) {
                     print("    - \(project.name): \(costText(project.estimatedCostUSD, currency: currency))"
                         + " (\(project.sessionCount) event\(project.sessionCount == 1 ? "" : "s"))")
-                    for session in project.sessionBreakdowns.sorted(by: { $0.estimatedCostUSD > $1.estimatedCostUSD }) {
-                        print("      session \(session.name): \(costText(session.estimatedCostUSD, currency: currency))")
+                    let sessions = project.sessionBreakdowns
+                        .sorted { $0.estimatedCostUSD > $1.estimatedCostUSD }
+                    for session in sessions {
+                        print("      session \(session.name): "
+                            + "\(costText(session.estimatedCostUSD, currency: currency))")
                     }
                 }
             }
@@ -413,8 +416,11 @@ struct Cost: ParsableCommand {
                 for project in cost.projectBreakdowns.sorted(by: { $0.estimatedCostUSD > $1.estimatedCostUSD }) {
                     print("    - \(project.name): \(costText(project.estimatedCostUSD, currency: currency))"
                         + " (\(project.sessionCount) session\(project.sessionCount == 1 ? "" : "s"))")
-                    for session in project.sessionBreakdowns.sorted(by: { $0.estimatedCostUSD > $1.estimatedCostUSD }) {
-                        print("      session \(session.name): \(costText(session.estimatedCostUSD, currency: currency))")
+                    let sessions = project.sessionBreakdowns
+                        .sorted { $0.estimatedCostUSD > $1.estimatedCostUSD }
+                    for session in sessions {
+                        print("      session \(session.name): "
+                            + "\(costText(session.estimatedCostUSD, currency: currency))")
                     }
                 }
             }

--- a/MeterBarCLI/Sources/ResetCredit.swift
+++ b/MeterBarCLI/Sources/ResetCredit.swift
@@ -7,21 +7,22 @@ import MeterBar
 struct ResetCredit: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "reset-credit",
-        abstract: "Consume one banked Codex rate-limit reset credit"
+        abstract: "Consume one banked Codex or Grok rate-limit reset credit"
     )
 
-    @Option(name: .shortAndLong, help: "Provider to reset (currently only 'codex').")
+    @Option(name: .shortAndLong, help: "Provider to reset ('codex' or 'grok').")
     var provider: String = "codex"
 
-    @Option(name: .long, help: "CODEX_HOME for a non-default Codex account.")
+    @Option(name: .long, help: "CODEX_HOME or GROK_HOME for a non-default account.")
     var configDir: String?
 
     @Flag(name: .long, help: "Confirm spending one finite reset credit.")
     var yes: Bool = false
 
     func validate() throws {
-        guard provider.lowercased() == "codex" else {
-            throw ValidationError("--provider must be 'codex'.")
+        let token = provider.lowercased()
+        guard token == "codex" || token == "grok" else {
+            throw ValidationError("--provider must be 'codex' or 'grok'.")
         }
         guard yes else {
             throw ValidationError("Reset credits are finite. Re-run with --yes to confirm consumption.")
@@ -29,6 +30,19 @@ struct ResetCredit: AsyncParsableCommand {
     }
 
     func run() async throws {
+        if provider.lowercased() == "grok" {
+            let result = try await GrokResetCreditAPI.consume(grokHome: configDir)
+            print("Used one Grok usage reset.")
+            if let refreshError = result.usageRefreshErrorDescription {
+                var stderr = ResetCreditStandardError()
+                Swift.print(
+                    "The credit was used, but usage refresh failed (\(refreshError)). Do not retry; refresh later.",
+                    to: &stderr
+                )
+            }
+            return
+        }
+
         let result = try await CodexResetCreditAPI.consume(codexHome: configDir)
         print("Used one Codex reset credit; reset \(result.windowsReset) usage window(s).")
         if let refreshError = result.usageRefreshErrorDescription {

--- a/MeterBarTests/CLIJSONOutputTests.swift
+++ b/MeterBarTests/CLIJSONOutputTests.swift
@@ -208,6 +208,75 @@ final class CLIJSONOutputTests: XCTestCase {
         XCTAssertEqual(nestedModels.first?["name"] as? String, "claude-opus-5")
     }
 
+    func testCostResponseIncludesSessionBreakdownsWhenPresent() throws {
+        let session = TokenUsageBreakdown(
+            provider: .codexCli,
+            name: "conv-a",
+            inputTokens: 1_000,
+            outputTokens: 250,
+            cacheCreationTokens: 50,
+            cacheReadTokens: 500,
+            estimatedCostUSD: 1.25,
+            sessionCount: 3,
+            modelBreakdowns: [
+                TokenUsageBreakdown(
+                    provider: .codexCli,
+                    name: "gpt-5.6-sol",
+                    inputTokens: 1_000,
+                    outputTokens: 250,
+                    cacheCreationTokens: 50,
+                    cacheReadTokens: 500,
+                    estimatedCostUSD: 1.25,
+                    sessionCount: 3
+                )
+            ]
+        )
+        let cost = TokenCost(
+            provider: .codexCli,
+            inputTokens: 1_000,
+            outputTokens: 250,
+            cacheCreationTokens: 50,
+            cacheReadTokens: 500,
+            estimatedCostUSD: 1.25,
+            sessionCount: 1,
+            periodStart: referenceDate,
+            periodEnd: referenceDate,
+            projectBreakdowns: [
+                TokenUsageBreakdown(
+                    provider: .codexCli,
+                    name: "www/meterbardev",
+                    inputTokens: 1_000,
+                    outputTokens: 250,
+                    cacheCreationTokens: 50,
+                    cacheReadTokens: 500,
+                    estimatedCostUSD: 1.25,
+                    sessionCount: 3,
+                    sessionBreakdowns: [session]
+                )
+            ],
+            sessionBreakdowns: [session]
+        )
+        let cache = CostSummaryCache(
+            summary: CostSummary(
+                costs: [cost],
+                totalCostUSD: 1.25,
+                totalTokens: 1_800,
+                periodDays: 30
+            ),
+            lastScanDate: referenceDate
+        )
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: CostCLIJSONResponse(cache: cache).jsonData()) as? [String: Any]
+        )
+        let provider = try XCTUnwrap((object["providers"] as? [[String: Any]])?.first)
+        let sessions = try XCTUnwrap(provider["sessionBreakdowns"] as? [[String: Any]])
+        XCTAssertEqual(sessions.first?["name"] as? String, "conv-a")
+        let projects = try XCTUnwrap(provider["projectBreakdowns"] as? [[String: Any]])
+        let nested = try XCTUnwrap(projects.first?["sessionBreakdowns"] as? [[String: Any]])
+        XCTAssertEqual(nested.first?["name"] as? String, "conv-a")
+        XCTAssertFalse((sessions.first?["name"] as? String ?? "").contains("/"))
+    }
+
     func testCostResponseOmitsProjectBreakdownsWhenNoneAreScannedButIncludesThemWhenPresent() throws {
         let costWithoutProjects = TokenCost(
             provider: .claudeCode,

--- a/MeterBarTests/CostScanWindowOnlyTests.swift
+++ b/MeterBarTests/CostScanWindowOnlyTests.swift
@@ -97,7 +97,8 @@ final class CostScanWindowOnlyTests: XCTestCase {
                     cacheReadTokens: 0,
                     estimatedCostUSD: 1,
                     modelBreakdowns: [],
-                    projectBreakdowns: []
+                    projectBreakdowns: [],
+                    sessionBreakdowns: []
                 )
             ],
             hourlyUsage: [],

--- a/MeterBarTests/CostSessionAttributionTests.swift
+++ b/MeterBarTests/CostSessionAttributionTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import MeterBar
+
+final class CostSessionAttributionTests: XCTestCase {
+    func testStableIDUsesTheFilenameStem() {
+        let url = URL(fileURLWithPath: "/Users/demo/.codex/sessions/rollout-2026-08-01-aabbccdd-1111-2222-3333-444444444444.jsonl")
+        XCTAssertEqual(
+            CostSessionAttribution.stableID(from: url),
+            "rollout-2026-08-01-aabbccdd-1111-2222-3333-444444444444"
+        )
+    }
+
+    func testSanitizeStripsDirectoriesAndEmptyValues() {
+        XCTAssertEqual(
+            CostSessionAttribution.sanitize("/Users/demo/.claude/projects/foo/session-1.jsonl"),
+            "session-1"
+        )
+        XCTAssertEqual(CostSessionAttribution.sanitize("  "), CostSessionAttribution.unknownSessionID)
+        XCTAssertEqual(CostSessionAttribution.sanitize("conv-1"), "conv-1")
+    }
+
+    func testPresentationShortensUUIDStemsWithoutLeakingPaths() {
+        let presentation = CostSessionPresentation(
+            identifier: "aabbccdd-1111-2222-3333-444444444444",
+            projectIdentifier: "www/meterbardev"
+        )
+        XCTAssertEqual(presentation.title, "Session aabbccdd")
+        XCTAssertEqual(presentation.detail, "meterbardev")
+        XCTAssertFalse(presentation.title.contains("/"))
+    }
+
+    func testPresentationNamesTheUnknownBucket() {
+        let presentation = CostSessionPresentation(
+            identifier: CostSessionAttribution.unknownSessionID
+        )
+        XCTAssertEqual(presentation.title, "Unknown session")
+        XCTAssertNil(presentation.detail)
+    }
+}

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -863,6 +863,84 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(Array(context.originTotals.keys), ["Codex CLI"])
     }
 
+    func testScanCodexRolloutsNamesModelFromThreadSettingsWhenTurnContextIsMissing() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexUsageLine(timestamp: "2026-06-15T10:00:00Z", input: 100),
+            """
+            {"timestamp": "2026-06-15T10:00:01Z", "type": "event_msg", "payload": \
+            {"type": "thread_settings_applied", "thread_settings": {"model": "gpt-5.6-sol"}}}
+            """
+        ])
+        let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
+        var context = makeContext(cutoff: cutoff)
+
+        CostScanFixtureScan.codexRollouts(in: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.modelTotals["gpt-5.6-sol"]?.input, 100)
+        XCTAssertNil(context.modelTotals["Unknown model"])
+    }
+
+    func testScanCodexRolloutsNamesModelFromNestedTurnContextWhenTopLevelModelIsMissing() throws {
+        let dir = try writeCodexArchive(lines: [
+            """
+            {"timestamp": "2026-06-15T09:59:30Z", "type": "turn_context", "payload": \
+            {"collaboration_mode": {"settings": {"model": "gpt-5.6-luna"}}}}
+            """,
+            codexUsageLine(timestamp: "2026-06-15T10:00:00Z", input: 7)
+        ])
+        let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
+        var context = makeContext(cutoff: cutoff)
+
+        CostScanFixtureScan.codexRollouts(in: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.modelTotals["gpt-5.6-luna"]?.input, 7)
+        XCTAssertNil(context.modelTotals["Unknown model"])
+    }
+
+    func testScanCodexRolloutsAggregatesPerSessionRowsThatReconcileToTheProject() throws {
+        let home = ServiceSupport.realHomeDirectory()
+        let cwd = "\(home)/www/meterbardev"
+        let dir = try writeCodexArchive(lines: [
+            codexSessionMetaLineWithCwd(timestamp: "2026-06-15T09:59:00Z", cwd: cwd),
+            codexTurnContextLine(timestamp: "2026-06-15T09:59:30Z", model: "gpt-5.6-sol"),
+            codexUsageLine(timestamp: "2026-06-15T10:00:00Z", conversationID: "conv-a", input: 100, cached: 0),
+            codexUsageLine(timestamp: "2026-06-15T10:01:00Z", conversationID: "conv-a", input: 50, cached: 0)
+        ])
+        let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
+        var context = makeContext(cutoff: cutoff)
+
+        CostScanFixtureScan.codexRollouts(in: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.projectSessions["www/meterbardev"]?["conv-a"]?.input, 150)
+        XCTAssertEqual(context.projectTotals["www/meterbardev"]?.input, 150)
+
+        let (cost, dailyRows, _) = try XCTUnwrap(CodexCostScanner.makeCost(from: context))
+        XCTAssertEqual(cost.sessionBreakdowns.map(\.name), ["conv-a"])
+        XCTAssertEqual(cost.sessionBreakdowns.first?.inputTokens, 150)
+        XCTAssertEqual(
+            cost.sessionBreakdowns.first?.estimatedCostUSD ?? -1,
+            cost.projectBreakdowns.first?.estimatedCostUSD ?? -2,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(cost.projectBreakdowns.first?.sessionBreakdowns.first?.name, "conv-a")
+        XCTAssertEqual(dailyRows.first?.sessionBreakdowns?.first?.name, "conv-a")
+    }
+
+    func testScanCodexRolloutsDedupsReplayedSessionEvents() throws {
+        let dir = try writeCodexArchive(lines: [
+            codexTurnContextLine(timestamp: "2026-06-15T09:59:30Z", model: "gpt-5.6-sol"),
+            codexUsageLine(timestamp: "2026-06-15T10:00:00Z", conversationID: "conv-a", input: 100, cached: 0),
+            codexUsageLine(timestamp: "2026-06-15T10:00:00Z", conversationID: "conv-a", input: 100, cached: 0)
+        ])
+        let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
+        var context = makeContext(cutoff: cutoff)
+
+        CostScanFixtureScan.codexRollouts(in: dir, since: cutoff, context: &context)
+
+        XCTAssertEqual(context.projectSessions[CostProjectAttribution.unknownProjectID]?["conv-a"]?.input, 100)
+        XCTAssertEqual(context.totals.input, 100)
+    }
+
     func testScanCodexRolloutsPrefersEventModelOverTurnContext() throws {
         // Older rollouts stamped the model onto the event itself; when both are
         // present the event wins because it is the more specific record.

--- a/MeterBarTests/CostWindowTests.swift
+++ b/MeterBarTests/CostWindowTests.swift
@@ -23,7 +23,8 @@ final class CostWindowTests: XCTestCase {
         cacheRead: Int,
         cost: Double,
         modelBreakdowns: [TokenUsageBreakdown]? = nil,
-        projectBreakdowns: [TokenUsageBreakdown]? = nil
+        projectBreakdowns: [TokenUsageBreakdown]? = nil,
+        sessionBreakdowns: [TokenUsageBreakdown]? = nil
     ) -> DailyTokenUsage {
         let today = calendar.startOfDay(for: now)
         let date = calendar.date(byAdding: .day, value: -offset, to: today) ?? today
@@ -35,7 +36,8 @@ final class CostWindowTests: XCTestCase {
             cacheReadTokens: cacheRead,
             estimatedCostUSD: cost,
             modelBreakdowns: modelBreakdowns,
-            projectBreakdowns: projectBreakdowns
+            projectBreakdowns: projectBreakdowns,
+            sessionBreakdowns: sessionBreakdowns
         )
     }
 

--- a/MeterBarTests/GrokResetCreditsTests.swift
+++ b/MeterBarTests/GrokResetCreditsTests.swift
@@ -44,6 +44,27 @@ final class GrokResetCreditsTests: XCTestCase {
         XCTAssertEqual(resets.availableCount, 0)
     }
 
+    func testRedeemRequestEncodesTheTokenIDAsField10() {
+        let framed = GrokResetCreditsRPC.encodeTokenIDForTesting("restok_vpYDqo")
+        // grpc-web uncompressed frame + protobuf string field 10.
+        XCTAssertEqual(framed[0], 0x00)
+        let payload = framed.dropFirst(5)
+        XCTAssertEqual(Array(payload.prefix(2)), [0x52, 0x0D])
+        XCTAssertEqual(String(bytes: payload.dropFirst(2), encoding: .utf8), "restok_vpYDqo")
+    }
+
+    func testGrpcWebTrailerStatusIsReadFromTheTrailerFrame() {
+        let ok = Data([
+            0x80, 0x00, 0x00, 0x00, 0x0F
+        ] + Array("grpc-status: 0\r\n".utf8))
+        XCTAssertEqual(GrokResetCreditsRPC.grpcStatusForTesting(ok), 0)
+
+        let failed = Data([
+            0x80, 0x00, 0x00, 0x00, 0x10
+        ] + Array("grpc-status: 12\r\n".utf8))
+        XCTAssertEqual(GrokResetCreditsRPC.grpcStatusForTesting(failed), 12)
+    }
+
     func testAccessTokenIsReadFromTheCachedLoginWithoutRequiringAJWTShape() {
         let data = Data(#"{"https://auth.x.ai::client":{"key":"cached-access-token","auth_mode":"oidc"}}"#.utf8)
 
@@ -111,5 +132,66 @@ final class GrokResetCreditsTests: XCTestCase {
         let failedMetrics = try await failed.fetchUsageMetrics()
         XCTAssertEqual(failedMetrics.weeklyLimit?.used, 16)
         XCTAssertNil(failedMetrics.resetCreditsAvailable)
+    }
+
+    func testConsumeRedeemsTheFirstUnexpiredTokenAndRefreshesUsage() async throws {
+        let billing = try JSONDecoder().decode(
+            GrokBillingResult.self,
+            from: Data(#"{"config":{"creditUsagePercent":16,"billingPeriodStart":"2026-08-12T15:05:27Z","billingPeriodEnd":"2026-08-19T15:05:27Z"}}"#.utf8)
+        )
+        let auth = Data(#"{"https://auth.x.ai::client":{"key":"cached-access-token"}}"#.utf8)
+        let expires = try XCTUnwrap(FlexibleISO8601.date(from: "2026-09-12T00:00:00Z"))
+        let expired = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        var consumed: (String, String)?
+
+        let service = GrokCLIUsageService(
+            binaryPathProvider: { "/usr/local/bin/grok" },
+            authAvailableProvider: { _ in true },
+            billingResultProvider: { _, _ in billing },
+            authFileDataProvider: { _ in auth },
+            remainingResetsProvider: { _ in 0 },
+            resetTokensProvider: { token in
+                XCTAssertEqual(token, "cached-access-token")
+                return [
+                    GrokResetCredits.Token(tokenID: "restok_old", validFrom: nil, expiresAt: expired),
+                    GrokResetCredits.Token(tokenID: "restok_live", validFrom: nil, expiresAt: expires)
+                ]
+            },
+            consumeResetProvider: { token, tokenID in
+                consumed = (token, tokenID)
+            }
+        )
+
+        let result = try await service.consumeResetCredit()
+        XCTAssertEqual(consumed?.0, "cached-access-token")
+        XCTAssertEqual(consumed?.1, "restok_live")
+        XCTAssertEqual(result.refreshedMetrics?.weeklyLimit?.used, 16)
+        XCTAssertNil(result.usageRefreshErrorDescription)
+    }
+
+    func testConsumeThrowsWhenNoUnexpiredTokenRemains() async throws {
+        let billing = try JSONDecoder().decode(
+            GrokBillingResult.self,
+            from: Data(#"{"config":{"creditUsagePercent":16,"billingPeriodStart":"2026-08-12T15:05:27Z","billingPeriodEnd":"2026-08-19T15:05:27Z"}}"#.utf8)
+        )
+        let auth = Data(#"{"https://auth.x.ai::client":{"key":"cached-access-token"}}"#.utf8)
+        let service = GrokCLIUsageService(
+            binaryPathProvider: { "/usr/local/bin/grok" },
+            authAvailableProvider: { _ in true },
+            billingResultProvider: { _, _ in billing },
+            authFileDataProvider: { _ in auth },
+            remainingResetsProvider: { _ in 0 },
+            resetTokensProvider: { _ in [] },
+            consumeResetProvider: { _, _ in
+                XCTFail("must not redeem without a token")
+            }
+        )
+
+        do {
+            _ = try await service.consumeResetCredit()
+            XCTFail("expected noAvailableCredit")
+        } catch let error as GrokResetCreditError {
+            XCTAssertEqual(error, .noAvailableCredit)
+        }
     }
 }

--- a/MeterBarTests/GrokResetCreditsTests.swift
+++ b/MeterBarTests/GrokResetCreditsTests.swift
@@ -65,6 +65,37 @@ final class GrokResetCreditsTests: XCTestCase {
         XCTAssertEqual(GrokResetCreditsRPC.grpcStatusForTesting(failed), 12)
     }
 
+    /// Live 2026-08-13 probe: `RedeemReset` with a fake token id returned HTTP 200,
+    /// an empty body, and `grpc-status: 9` (FAILED_PRECONDITION) on the response
+    /// header. Treating a missing trailer as OK would spend-or-succeed incorrectly.
+    func testRedeemStatusReadsGrpcStatusFromHTTPHeadersWhenTheBodyHasNoTrailer() {
+        XCTAssertEqual(
+            GrokResetCreditsRPC.grpcStatusForTesting(Data(), headers: ["grpc-status": "9"]),
+            9
+        )
+        XCTAssertEqual(
+            GrokResetCreditsRPC.grpcStatusForTesting(Data(), headers: ["Grpc-Status": "0"]),
+            0
+        )
+        XCTAssertFalse(
+            GrokResetCreditsRPC.consumeSucceededForTesting(Data(), headers: ["grpc-status": "9"])
+        )
+        XCTAssertTrue(
+            GrokResetCreditsRPC.consumeSucceededForTesting(Data(), headers: ["grpc-status": "0"])
+        )
+        XCTAssertFalse(GrokResetCreditsRPC.consumeSucceededForTesting(Data(), headers: [:]))
+    }
+
+    func testRedeemStatusPrefersTheTrailerFrameOverHTTPHeaders() {
+        let unimplemented = Data([
+            0x80, 0x00, 0x00, 0x00, 0x10
+        ] + Array("grpc-status: 12\r\n".utf8))
+        XCTAssertEqual(
+            GrokResetCreditsRPC.grpcStatusForTesting(unimplemented, headers: ["grpc-status": "0"]),
+            12
+        )
+    }
+
     func testAccessTokenIsReadFromTheCachedLoginWithoutRequiringAJWTShape() {
         let data = Data(#"{"https://auth.x.ai::client":{"key":"cached-access-token","auth_mode":"oidc"}}"#.utf8)
 

--- a/MeterBarTests/MenuBarViewSplitTests.swift
+++ b/MeterBarTests/MenuBarViewSplitTests.swift
@@ -198,7 +198,15 @@ final class ProviderCardPresentationTests: XCTestCase {
                 isAuthenticated: true,
                 hasResolvedAccount: true
             ),
-            "reset credits are a Codex CLI concept only"
+            "reset credits are Codex CLI and Grok only"
+        )
+        XCTAssertTrue(
+            ProviderCardPresentation.showsResetCreditAction(
+                snapshot: snapshot(used: 100, resetCreditsAvailable: 1, service: .grok),
+                hasPendingConsumption: false,
+                isAuthenticated: true,
+                hasResolvedAccount: true
+            )
         )
         XCTAssertFalse(
             ProviderCardPresentation.showsResetCreditAction(

--- a/MeterBarTests/ProviderUsageCostBuilderTests.swift
+++ b/MeterBarTests/ProviderUsageCostBuilderTests.swift
@@ -97,6 +97,7 @@ final class ProviderUsageCostBuilderTests: XCTestCase {
         for row in built.1 {
             XCTAssertEqual(row.modelBreakdowns?.count, 0)
             XCTAssertEqual(row.projectBreakdowns?.count, 0)
+            XCTAssertEqual(row.sessionBreakdowns?.count, 0)
         }
 
         let summary = CostSummary(

--- a/MeterBarTests/SettingsViewSmokeTests.swift
+++ b/MeterBarTests/SettingsViewSmokeTests.swift
@@ -284,6 +284,15 @@ final class SettingsViewSmokeTests: XCTestCase {
         XCTAssertEqual(presentation.detail, "No working directory recorded")
     }
 
+    func testCostSessionPresentationShortensIdentifiers() {
+        let presentation = CostSessionPresentation(
+            identifier: "aabbccdd-1111-2222-3333-444444444444",
+            projectIdentifier: "www/meterbardev"
+        )
+        XCTAssertEqual(presentation.title, "Session aabbccdd")
+        XCTAssertEqual(presentation.detail, "meterbardev")
+    }
+
     func testCostSettingsViewRendersDisplayCurrencySectionAlongsideCostTracking() {
         // Hosts the real tab (real singletons, like testGlassCostScanAndRefreshCTAsStillRender
         // above) so a broken Display Currency section or period picker fails to compile/layout

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -261,6 +261,31 @@ a project lands in an explicit `unknown` row rather than being dropped or guesse
 sanitized before they ever reach the cache or this JSON — no full home-directory paths — and
 MeterBar never persists branch names, remotes, prompt content, or credentials to derive them.
 
+### Session breakdown
+
+Each provider may also carry `sessionBreakdowns`: one row per local session (Codex conversation id,
+Claude transcript stem, Grok session id). Project rows nest the same sessions under
+`projectBreakdowns[].sessionBreakdowns`. The field is omitted when empty. Identifiers are stable
+local stems — never working directories, prompts, credentials, branch names, or git remotes.
+
+```json
+{
+  "sessionBreakdowns": [
+    {
+      "name": "aabbccdd-1111-2222-3333-444444444444",
+      "inputTokens": 1000,
+      "outputTokens": 250,
+      "cacheCreationTokens": 50,
+      "cacheReadTokens": 500,
+      "totalTokens": 1800,
+      "estimatedCostUSD": 1.25,
+      "sessionCount": 3,
+      "modelBreakdowns": []
+    }
+  ]
+}
+```
+
 ### Display currency
 
 `--currency CODE --rate N` (both required together) adds a top-level `displayCurrency` object


### PR DESCRIPTION
## Summary

- Costs tab and `meterbar cost --json` now list per-session rows under each project (closes #391). Session ids are local stems/UUIDs only — no paths, prompts, or remotes.
- Codex tokens that lack a top-level `turn_context.model` pick up nested `collaboration_mode`, `thread_settings`, and `world_state` names instead of landing in Unknown model.
- Exhausted Grok accounts can redeem a banked usage-limit reset after the same confirmation Codex already uses (`RedeemReset` plus `meterbar reset-credit --provider grok`).

## Related issue

Closes #391

## Scope

- Cost cache parser version 4 → 5 so existing scans pick up session maps.
- `sessionBreakdowns` is additive on CLI JSON and omitted when empty so v1 fixtures stay stable.
- Grok consume uses unofficial grok.com `ConsumerUiSvc/RedeemReset` (same class as Codex wham). Live method-name probe with a fake token was not run; if production 404s, try the sibling consume names before posting an empty redeem.
- Per-project tables were already shipped; this PR adds the per-session layer.

## Verification

- `swift test --filter 'GrokResetCreditsTests|CostSessionAttributionTests|CostTrackerTests/testScanCodexRolloutsNamesModel|CostTrackerTests/testScanCodexRolloutsAggregatesPerSession|CostTrackerTests/testScanCodexRolloutsDedupsReplayed|CLIJSONOutputTests|ProviderCardPresentationTests|ProviderUsageCostBuilderTests/testEmptyBreakdowns|SettingsViewSmokeTests/testCostSession|CostWindowTests|CostScanCollaboratorTests'` — 91 tests, 0 failures.
- Broader scanner/cache suite (`CostTrackerTests`, `GrokCostScannerTests`, `CostScanWindowOnlyTests`, and related) — 190 tests, 0 failures.
- Full `swift test` left to CI.

## Screenshots

Not attached. Visible changes: Costs tab project disclosures gain session rows; Grok exhausted cards can show Redeem when banked resets remain.

## Checklist

- [x] I reviewed the final diff for unrelated changes.
- [x] I ran the relevant focused checks or documented why they were left to CI.
- [x] I updated relevant documentation or explained why no documentation change is needed.
- [x] I documented migrations, release steps, or external configuration changes, or marked them not applicable.
- [x] I did not include secrets, credentials, personal data, customer data, or generated build output.
- [ ] If CodeRabbit says "Review rate limited", I re-requested review before merge. A green CodeRabbit tick is not a review in that case.

Made with [Cursor](https://cursor.com)