### PR TITLE
fix(ui): keep provider cards in a stable subscription-then-label order

### DIFF
--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -287,10 +287,12 @@ enum ProviderSnapshotBuilder {
         var grokHasAccess: Bool = false
     }
 
-    /// Builds the provider cards in display order (Codex, Claude accounts,
-    /// Cursor, OpenRouter, Grok). Providers without metrics are included with an empty-state
-    /// detail so the popover can render a "waiting / log in" card; the
-    /// dashboard filters those out via `hasMetrics`.
+    /// Builds the provider cards. Emission order follows each store; the
+    /// returned array is then sorted for display: same subscription stays
+    /// together, groups sit at their earliest label, labels inside a group
+    /// are alphabetical. Providers without metrics are included with an
+    /// empty-state detail so the popover can render a "waiting / log in"
+    /// card; the dashboard filters those out via `hasMetrics`.
     static func snapshots(_ input: Input) -> [ProviderSnapshot] {
         var result: [ProviderSnapshot] = []
 
@@ -397,7 +399,44 @@ enum ProviderSnapshotBuilder {
             }
         }
 
-        return result
+        return orderedForDisplay(result)
+    }
+
+    /// Stable card order for the popover, Overview, and Limits.
+    ///
+    /// Group by subscription so two Claude (or Codex, or Grok) accounts stay
+    /// adjacent. Place each group where its alphabetically-earliest label
+    /// belongs, then sort labels inside the group. Focus/selection must not
+    /// call this with a different ranking — clicking a card scrolls to it.
+    static func orderedForDisplay(_ snapshots: [ProviderSnapshot]) -> [ProviderSnapshot] {
+        let groupKeyByService: [ServiceType: String] = Dictionary(
+            grouping: snapshots,
+            by: \.service
+        ).mapValues { group in
+            group.map(\.title).min { lhs, rhs in
+                lhs.localizedStandardCompare(rhs) == .orderedAscending
+            } ?? ""
+        }
+
+        return snapshots.sorted { lhs, rhs in
+            let lhsGroup = groupKeyByService[lhs.service] ?? lhs.title
+            let rhsGroup = groupKeyByService[rhs.service] ?? rhs.title
+            let groupOrder = lhsGroup.localizedStandardCompare(rhsGroup)
+            if groupOrder != .orderedSame {
+                return groupOrder == .orderedAscending
+            }
+            if lhs.service != rhs.service {
+                let typeOrder = lhs.service.shortName.localizedStandardCompare(rhs.service.shortName)
+                if typeOrder != .orderedSame {
+                    return typeOrder == .orderedAscending
+                }
+            }
+            let titleOrder = lhs.title.localizedStandardCompare(rhs.title)
+            if titleOrder != .orderedSame {
+                return titleOrder == .orderedAscending
+            }
+            return lhs.id < rhs.id
+        }
     }
 
     static func snapshot(

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -5,6 +5,18 @@ import SwiftUI
 // pages are fed. Each page lives in its own `Dashboard*Section` file (C1 split);
 // the navigation types live in `DashboardNavigation.swift`.
 
+/// Limits card order. Focus is for scrolling, not ranking — pinning the
+/// selected provider reshuffled Overview vs Limits every time a card was
+/// clicked.
+enum DashboardLimitsLayout {
+    static func orderedSnapshots(
+        _ snapshots: [ProviderSnapshot],
+        focusedProviderID _: ProviderSnapshot.ID?
+    ) -> [ProviderSnapshot] {
+        snapshots
+    }
+}
+
 struct UsageDashboardView: View {
     private static let detailHorizontalPadding = MeterBarTheme.Spacing.xxl
 
@@ -233,35 +245,43 @@ struct UsageDashboardView: View {
 
     private var detailContent: some View {
         GeometryReader { viewport in
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    if navigation.isShowingSettings {
-                        settingsSectionContent
-                    } else {
-                        monitoringSectionContent(viewportWidth: viewport.size.width)
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        if navigation.isShowingSettings {
+                            settingsSectionContent
+                        } else {
+                            monitoringSectionContent(
+                                viewportWidth: viewport.size.width,
+                                scrollProxy: proxy
+                            )
+                        }
                     }
+                    .padding(.horizontal, Self.detailHorizontalPadding)
+                    .padding(.top, MeterBarTheme.Spacing.md)
+                    .padding(.bottom, MeterBarTheme.Spacing.xxl)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .padding(.horizontal, Self.detailHorizontalPadding)
-                .padding(.top, MeterBarTheme.Spacing.md)
-                .padding(.bottom, MeterBarTheme.Spacing.xxl)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .scrollContentBackground(.hidden)
+                .scrollEdgeEffectHidden(for: .top)
+                .background {
+                    // This is one continuous surface through the titlebar. The toolbar
+                    // still owns the refresh/settings controls, but paints no separate
+                    // background band and adds no scroll-edge fade.
+                    MeterBarDetailBackground()
+                }
+                .navigationTitle("")
+                .navigationSubtitle("")
             }
-            .scrollContentBackground(.hidden)
-            .scrollEdgeEffectHidden(for: .top)
-            .background {
-                // This is one continuous surface through the titlebar. The toolbar
-                // still owns the refresh/settings controls, but paints no separate
-                // background band and adds no scroll-edge fade.
-                MeterBarDetailBackground()
-            }
-            .navigationTitle("")
-            .navigationSubtitle("")
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
     @ViewBuilder
-    private func monitoringSectionContent(viewportWidth: CGFloat) -> some View {
+    private func monitoringSectionContent(
+        viewportWidth: CGFloat,
+        scrollProxy: ScrollViewProxy
+    ) -> some View {
         switch activeSection {
         case .overview:
             DashboardOverviewSection(
@@ -273,7 +293,7 @@ struct UsageDashboardView: View {
                 }
             )
         case .limits:
-            limitsContent
+            limitsContent(scrollProxy: scrollProxy)
         case .status:
             DashboardStatusSection()
         case .costs:
@@ -333,7 +353,7 @@ struct UsageDashboardView: View {
         }
     }
 
-    private var limitsContent: some View {
+    private func limitsContent(scrollProxy: ScrollViewProxy) -> some View {
         VStack(alignment: .leading, spacing: 14) {
             if providerSnapshots.isEmpty {
                 DashboardCard(title: "No Quota Windows") {
@@ -342,21 +362,35 @@ struct UsageDashboardView: View {
                         .foregroundColor(.secondary)
                 }
             } else {
-                // Same two-column masonry as Overview: the shared provider card
-                // was designed at popover width, and stretching its gauges
-                // across the whole detail pane read as one washed-out column.
-                // The focused provider is first in the list, so it lands top-left.
+                // Same two-column masonry as Overview. Clicking a card from
+                // Overview still focuses it (scroll), but the grid order stays
+                // subscription-then-label so cards do not jump around.
                 ProviderMasonryLayout(columnCount: 2, spacing: MeterBarTheme.Spacing.sm) {
-                    ForEach(orderedProviderSnapshotsForLimits) { snapshot in
+                    ForEach(DashboardLimitsLayout.orderedSnapshots(
+                        providerSnapshots,
+                        focusedProviderID: navigation.focusedProviderID
+                    )) { snapshot in
                         // The one provider card, shared with the popover, so
                         // the two surfaces cannot drift.
                         ProviderStatusCard(snapshot: snapshot)
+                            .id(snapshot.id)
                     }
                 }
                 .frame(maxWidth: .infinity)
+                .onAppear {
+                    scrollToFocusedProvider(using: scrollProxy)
+                }
+                .onChange(of: navigation.focusedProviderID) { _, _ in
+                    scrollToFocusedProvider(using: scrollProxy)
+                }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func scrollToFocusedProvider(using proxy: ScrollViewProxy) {
+        guard let focusedProviderID = navigation.focusedProviderID else { return }
+        proxy.scrollTo(focusedProviderID, anchor: .top)
     }
 
     private var providerSnapshots: [ProviderSnapshot] {
@@ -386,15 +420,6 @@ struct UsageDashboardView: View {
             openRouterHasAccess: openRouterService.hasAccess,
             grokHasAccess: grokService.hasAccess
         ))
-    }
-
-    private var orderedProviderSnapshotsForLimits: [ProviderSnapshot] {
-        guard let focusedProviderID = navigation.focusedProviderID else {
-            return providerSnapshots
-        }
-        let focused = providerSnapshots.filter { $0.id == focusedProviderID }
-        guard !focused.isEmpty else { return providerSnapshots }
-        return focused + providerSnapshots.filter { $0.id != focusedProviderID }
     }
 
     /// The snapshot for a provider in the Costs panel — prefers an exhausted

--- a/MeterBarTests/DashboardSectionSplitTests.swift
+++ b/MeterBarTests/DashboardSectionSplitTests.swift
@@ -112,6 +112,24 @@ final class DashboardSectionSplitTests: XCTestCase {
         XCTAssertEqual(navigation.selectedSection, .costs, "settings mode must not lose the page underneath")
     }
 
+    func testLimitsKeepsDisplayOrderWhenAProviderIsFocused() {
+        let snapshots = [
+            snapshot(id: "claude", title: "Claude", service: .claudeCode),
+            snapshot(id: "codex", title: "Codex", service: .codexCli),
+            snapshot(id: "cursor", title: "Cursor", service: .cursor)
+        ]
+
+        XCTAssertEqual(
+            DashboardLimitsLayout.orderedSnapshots(snapshots, focusedProviderID: "cursor").map(\.id),
+            snapshots.map(\.id)
+        )
+        XCTAssertNotEqual(
+            DashboardLimitsLayout.orderedSnapshots(snapshots, focusedProviderID: "cursor").first?.id,
+            "cursor",
+            "clicking an Overview card must not pin that provider to the top-left of Limits"
+        )
+    }
+
     // MARK: - Trailing status strings
 
     func testCostRefreshStatusPrefersScanningOverTheMissingDayTopUp() {
@@ -603,7 +621,11 @@ final class DashboardSectionSplitTests: XCTestCase {
         XCTAssertGreaterThan(hostingView.fittingSize.height, 0, file: file, line: line)
     }
 
-    private func snapshot() -> ProviderSnapshot {
+    private func snapshot(
+        id: String = "codex",
+        title: String = "Codex",
+        service: ServiceType = .codexCli
+    ) -> ProviderSnapshot {
         let weekly = UsageLimit(
             used: 40,
             total: 100,
@@ -611,9 +633,9 @@ final class DashboardSectionSplitTests: XCTestCase {
             windowSeconds: 604_800
         )
         return ProviderSnapshot(
-            id: "codex",
-            title: "Codex",
-            service: .codexCli,
+            id: id,
+            title: title,
+            service: service,
             updatedAt: Date(),
             limits: [
                 SnapshotLimit(id: "weekly", kind: .weekly, title: "Weekly", usageLimit: weekly)

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -77,7 +77,7 @@ final class ProviderSnapshotTests: XCTestCase {
 
     // MARK: - Ordering and inclusion
 
-    func testDisplayOrderIsCodexClaudeCursorOpenRouterGrok() {
+    func testDisplayOrderIsAlphabeticalByVisibleLabels() {
         let snapshots = ProviderSnapshotBuilder.snapshots(makeInput(
             metrics: [
                 .codexCli: makeMetrics(service: .codexCli, weekly: 10),
@@ -88,8 +88,51 @@ final class ProviderSnapshotTests: XCTestCase {
             ]
         ))
 
-        XCTAssertEqual(snapshots.map(\.service), [.codexCli, .claudeCode, .cursor, .openRouter, .grok])
-        XCTAssertEqual(snapshots.map(\.title), ["Codex", "Claude", "Cursor", "OpenRouter", "Grok"])
+        XCTAssertEqual(
+            snapshots.map(\.service),
+            [.claudeCode, .codexCli, .cursor, .grok, .openRouter]
+        )
+        XCTAssertEqual(snapshots.map(\.title), ["Claude", "Codex", "Cursor", "Grok", "OpenRouter"])
+    }
+
+    /// Two accounts on one subscription stay adjacent even when their labels
+    /// would otherwise split around another provider. The group sits where its
+    /// earliest label belongs, then labels inside the group are alphabetical.
+    func testDisplayOrderGroupsSubscriptionTypeThenSortsLabelsAlphabetically() {
+        let personal = ClaudeCodeAccount(id: UUID(), name: "Personal", configDirectory: "/tmp/personal")
+        let work = ClaudeCodeAccount(id: UUID(), name: "Work", configDirectory: "/tmp/work")
+        let snapshots = ProviderSnapshotBuilder.snapshots(makeInput(
+            metrics: [
+                .codexCli: makeMetrics(service: .codexCli, weekly: 10),
+                .cursor: makeMetrics(service: .cursor, weekly: 30)
+            ],
+            claudeAccounts: [work, personal],
+            claudeAccountMetrics: [
+                work.id: makeMetrics(service: .claudeCode, weekly: 20),
+                personal.id: makeMetrics(service: .claudeCode, weekly: 40)
+            ],
+            enabledServices: [.codexCli, .claudeCode, .cursor]
+        ))
+
+        XCTAssertEqual(snapshots.map(\.title), ["Codex", "Cursor", "Personal", "Work"])
+        XCTAssertEqual(snapshots.map(\.service), [.codexCli, .cursor, .claudeCode, .claudeCode])
+    }
+
+    func testDisplayOrderKeepsSameProviderAccountsTogetherWhenLabelsWouldOtherwiseSplit() {
+        let alpha = ClaudeCodeAccount(id: UUID(), name: "alpha", configDirectory: "/tmp/alpha")
+        let zLab = ClaudeCodeAccount(id: UUID(), name: "z-lab", configDirectory: "/tmp/z")
+        let snapshots = ProviderSnapshotBuilder.snapshots(makeInput(
+            metrics: [.codexCli: makeMetrics(service: .codexCli, weekly: 10)],
+            claudeAccounts: [zLab, alpha],
+            claudeAccountMetrics: [
+                zLab.id: makeMetrics(service: .claudeCode, weekly: 20),
+                alpha.id: makeMetrics(service: .claudeCode, weekly: 40)
+            ],
+            enabledServices: [.codexCli, .claudeCode]
+        ))
+
+        XCTAssertEqual(snapshots.map(\.title), ["alpha", "z-lab", "Codex"])
+        XCTAssertEqual(snapshots.map(\.service), [.claudeCode, .claudeCode, .codexCli])
     }
 
     func testDisabledProvidersAreExcluded() {
@@ -149,7 +192,7 @@ final class ProviderSnapshotTests: XCTestCase {
             enabledServices: [.codexCli, .claudeCode, .grok]
         ))
 
-        XCTAssertEqual(snapshots.map(\.title), ["Codex Work", "Claude Personal", "Grok Studio"])
+        XCTAssertEqual(snapshots.map(\.title), ["Claude Personal", "Codex Work", "Grok Studio"])
     }
 
     func testMultipleClaudeAccountsUseAccountNames() {


### PR DESCRIPTION
## Summary

- Stop pinning the focused provider to the top-left of Limits when an Overview card is clicked, so the grid no longer reshuffles.
- Rank popover, Overview, and Limits cards the same way: same subscription stays together, each group sits at its earliest label, labels inside a group are alphabetical.
- Clicking a card still opens Limits and scrolls to that provider.

## Related issue

No-Issue — live dashboard bug found while testing the Cursor two-pool and cost work already on master, not a tracked GitHub issue.

## Scope

- Display order only. Account stores keep their own reorder lists for Settings.
- Focus is still used for scrolling, not ranking.

## Verification

- `swift test --filter 'ProviderSnapshotTests|DashboardSectionSplitTests'`
- Manual: MeterBar Dev, Overview → Limits clicks no longer move cards. Expected order for the live set is Codex, Cursor, genfeedai, Grok.

Broader tests, lint, and the universal build are left to CI.

## Screenshots

Not attached — the change is card order, not chrome. Verified locally in MeterBar Dev.

## Checklist

- [x] I reviewed the final diff for unrelated changes.
- [x] I ran the relevant focused checks or documented why they were left to CI.
- [x] I updated relevant documentation or explained why no documentation change is needed.
- [x] I documented migrations, release steps, or external configuration changes, or marked them not applicable.
- [x] I did not include secrets, credentials, personal data, customer data, or generated build output.
- [ ] If CodeRabbit says "Review rate limited", I re-requested review before merge. A green CodeRabbit tick is not a review in that case.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Provider cards are now grouped by service and displayed in a consistent alphabetical order.
  * Accounts within each service group are sorted alphabetically for easier scanning.
  * The Limits dashboard keeps its stable ordering when a provider is focused.
  * Focusing or selecting a provider now automatically scrolls it into view.
* **Bug Fixes**
  * Resolved unexpected provider reordering when navigating or focusing dashboard content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->