### PR TITLE
fix(logging): keep home-directory paths out of public log lines

### DIFF
--- a/MeterBar/Services/CostScanFileCache.swift
+++ b/MeterBar/Services/CostScanFileCache.swift
@@ -307,11 +307,7 @@ nonisolated enum CostScanCacheStoreError: LocalizedError {
     /// Encoder failures matter here too — the cache is keyed by transcript path,
     /// so `EncodingError`'s own description would name one.
     static func reason(for error: Error) -> String {
-        if let error = error as? SecureFileWriterError {
-            return error.logDescription
-        }
-        let error = error as NSError
-        return "\(error.domain) \(error.code)"
+        SecureFileWriterError.logDescription(for: error)
     }
 }
 

--- a/MeterBar/Services/CostTracker.swift
+++ b/MeterBar/Services/CostTracker.swift
@@ -362,7 +362,12 @@ class CostTracker: ObservableObject {
         do {
             try CostSummaryStore.save(CostSummaryCache(summary: costSummary, lastScanDate: lastScanDate))
         } catch {
-            AppLog.cost.error("Failed to save cost summary cache: \(error.localizedDescription, privacy: .public)")
+            AppLog.cost.error(
+                """
+                Failed to save cost summary cache: \
+                \(SecureFileWriterError.logDescription(for: error), privacy: .public)
+                """
+            )
         }
     }
 }

--- a/MeterBar/Services/ProviderParseHealthStore.swift
+++ b/MeterBar/Services/ProviderParseHealthStore.swift
@@ -194,7 +194,10 @@ final class ProviderParseHealthStore: ObservableObject {
                 try SecureFileWriter.write(data, to: sharedFileURL)
             } catch {
                 AppLog.storage.error(
-                    "Failed to save provider health: \(error.localizedDescription, privacy: .public)"
+                    """
+                    Failed to save provider health: \
+                    \(SecureFileWriterError.logDescription(for: error), privacy: .public)
+                    """
                 )
             }
         }

--- a/MeterBar/Services/SecureFileWriter.swift
+++ b/MeterBar/Services/SecureFileWriter.swift
@@ -207,6 +207,24 @@ enum SecureFileWriterError: LocalizedError {
         }
     }
 
+    /// Path-free rendering of *any* error raised while persisting a file.
+    ///
+    /// The single entry point for the catch blocks that log at
+    /// `privacy: .public`: they hold an opaque `Error`, so the narrowing has to
+    /// happen here rather than at each call site — reaching for
+    /// `localizedDescription` there is exactly the leak this exists to prevent.
+    /// A writer error reduces to its errno; anything else — a Cocoa write error
+    /// naming the file it could not save, an `EncodingError` naming the
+    /// transcript path a cache is keyed by — reduces to a domain and code, which
+    /// names nobody.
+    static func logDescription(for error: Error) -> String {
+        if let error = error as? SecureFileWriterError {
+            return error.logDescription
+        }
+        let error = error as NSError
+        return "\(error.domain) \(error.code)"
+    }
+
     private static func describe(_ code: Int32) -> String {
         String(cString: strerror(code))
     }

--- a/MeterBar/Services/SharedDataStore.swift
+++ b/MeterBar/Services/SharedDataStore.swift
@@ -68,7 +68,12 @@ nonisolated public final class SharedDataStore: @unchecked Sendable {
                 try SecureFileWriter.write(data, to: fileURL)
                 self?.didWrite()
             } catch {
-                AppLog.storage.error("Failed to save shared metrics: \(error.localizedDescription, privacy: .public)")
+                AppLog.storage.error(
+                    """
+                    Failed to save shared metrics: \
+                    \(SecureFileWriterError.logDescription(for: error), privacy: .public)
+                    """
+                )
             }
         }
     }
@@ -86,7 +91,10 @@ nonisolated public final class SharedDataStore: @unchecked Sendable {
                 self?.didWrite()
             } catch {
                 AppLog.storage.error(
-                    "Failed to save shared account metrics: \(error.localizedDescription, privacy: .public)"
+                    """
+                    Failed to save shared account metrics: \
+                    \(SecureFileWriterError.logDescription(for: error), privacy: .public)
+                    """
                 )
             }
         }

--- a/MeterBar/SessionWake/ReplayLedger.swift
+++ b/MeterBar/SessionWake/ReplayLedger.swift
@@ -94,7 +94,9 @@ actor ReplayLedger {
             let data = try JSONEncoder().encode(order)
             try SecureFileWriter.write(data, to: fileURL)
         } catch {
-            AppLog.wake.error("Failed to persist replay ledger: \(error.localizedDescription, privacy: .public)")
+            AppLog.wake.error(
+                "Failed to persist replay ledger: \(SecureFileWriterError.logDescription(for: error), privacy: .public)"
+            )
         }
     }
 }

--- a/MeterBar/SessionWake/WakeRunLogger.swift
+++ b/MeterBar/SessionWake/WakeRunLogger.swift
@@ -47,7 +47,9 @@ nonisolated struct WakeRunLogger: Sendable {
             appendData(line, to: fileURL)
             pruneOldLogs()
         } catch {
-            AppLog.wake.error("Failed to write wake log: \(error.localizedDescription, privacy: .public)")
+            AppLog.wake.error(
+                "Failed to write wake log: \(SecureFileWriterError.logDescription(for: error), privacy: .public)"
+            )
         }
     }
 

--- a/MeterBarTests/SecureFileWriterTests.swift
+++ b/MeterBarTests/SecureFileWriterTests.swift
@@ -217,6 +217,69 @@ final class SecureFileWriterTests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: url), existing)
     }
 
+    // MARK: - Log redaction
+
+    /// `errorDescription` names the file, which is right in front of a human
+    /// holding the URL. A `privacy: .public` log line is a different audience:
+    /// everything this writer touches lives under the user's home directory, so
+    /// a path published to the unified log publishes the account name with it.
+    func testLogDescriptionOmitsTheHomeDirectoryPath() {
+        let path = "/Users/someaccount/Library/Application Support/MeterBar/metrics.json"
+        let cases: [(error: SecureFileWriterError, code: Int32)] = [
+            (.create(code: EACCES, path: path), EACCES),
+            (.write(code: ENOSPC, path: path), ENOSPC),
+            (.replace(code: EACCES, path: path), EACCES)
+        ]
+
+        for (error, code) in cases {
+            XCTAssertTrue(
+                error.localizedDescription.contains(path),
+                "precondition: the human-facing description is the one that names the file"
+            )
+            XCTAssertFalse(error.logDescription.contains(path))
+            XCTAssertFalse(error.logDescription.contains("someaccount"))
+            XCTAssertTrue(
+                error.logDescription.contains(String(cString: strerror(code))),
+                "the errno is the part an operator acts on and must survive"
+            )
+        }
+    }
+
+    /// The catch blocks that log see an opaque `Error`, so the shared entry
+    /// point has to do the narrowing — a call site that reaches for
+    /// `localizedDescription` is exactly the mistake this guards.
+    func testLogDescriptionForRedactsAThrownWriterError() {
+        let url = tempDirectory.appendingPathComponent("occupied")
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+
+        XCTAssertThrowsError(try SecureFileWriter.write(Data("x".utf8), to: url)) { error in
+            let logged = SecureFileWriterError.logDescription(for: error)
+            XCTAssertFalse(logged.contains(self.tempDirectory.path))
+            XCTAssertFalse(logged.contains("/Users/"))
+            XCTAssertFalse(logged.contains(NSHomeDirectory()))
+            XCTAssertTrue(logged.hasPrefix("replace failed:"))
+        }
+    }
+
+    /// Non-writer errors reach the same catch blocks — a Cocoa write error names
+    /// the file and folder in its own description, and `EncodingError` names the
+    /// transcript path a cache is keyed by. Domain and code name nobody.
+    func testLogDescriptionForFallsBackToDomainAndCodeForOtherErrors() {
+        let error = NSError(
+            domain: NSCocoaErrorDomain,
+            code: NSFileWriteNoPermissionError,
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "You don’t have permission to save the file in the folder /Users/someaccount/Library."
+            ]
+        )
+
+        let logged = SecureFileWriterError.logDescription(for: error)
+
+        XCTAssertEqual(logged, "\(NSCocoaErrorDomain) \(NSFileWriteNoPermissionError)")
+        XCTAssertFalse(logged.contains("someaccount"))
+    }
+
     // MARK: - Helpers
 
     private func permissions(of url: URL) throws -> Int {


### PR DESCRIPTION
## Problem

`SecureFileWriterError.errorDescription` names the file it could not write — correct in front of a human holding the URL. But every path this writer touches sits under the user's home directory, so any catch block that logged `error.localizedDescription` at `privacy: .public` published the macOS **account name** verbatim to the unified system log.

`SecureFileWriterError.logDescription` (path-free, errno only) already existed for exactly this reason, and `CostScanFileCache` / `ProviderUsageLedgerStore` already used it via `CostScanCacheStoreError.reason(for:)`. Five other call sites did not.

## Fix

- **One shared entry point.** `SecureFileWriterError.logDescription(for: Error)` — narrows a writer error to its errno, falls back to `domain code` for anything else (a Cocoa write error names the file it could not save; `EncodingError` names the transcript path a cost cache is keyed by). Catch blocks hold an opaque `Error`, so the narrowing has to live here rather than at each call site.
- `CostScanCacheStoreError.reason(for:)` now delegates to it — one narrowing rule instead of two copies of the same body.
- **Converted call sites:** `SharedDataStore.saveMetrics` / `saveAccountMetrics`, `ProviderParseHealthStore.persistSharedData`, `WakeRunLogger.append`, `ReplayLedger.persist`, `CostTracker.saveCachedSummary`.
- **Left alone (already safe):** `CostScanSession` and `UsageDataManager` log `CostScanCacheStoreError`, whose reasons are sanitized at the throw site. `UsageNotificationCoordinator` and `GrokCLIUsageService` log non-file errors.

The errno survives — `ENOSPC` and `EACCES` call for different fixes, and neither says who the user is.

## Tests

Three new cases in `SecureFileWriterTests`:

- `testLogDescriptionOmitsTheHomeDirectoryPath` — all three error cases built over `/Users/someaccount/...`; asserts `localizedDescription` **does** carry the path (precondition proving the leak is real) while `logDescription` carries neither the path nor the account name, and still carries the errno text.
- `testLogDescriptionForRedactsAThrownWriterError` — a real `rename(2)` failure caught as an opaque `Error`; asserts the built line contains no temp path, no `/Users/`, and not `NSHomeDirectory()`.
- `testLogDescriptionForFallsBackToDomainAndCodeForOtherErrors` — a Cocoa error whose own description names a home path reduces to `NSCocoaErrorDomain 513`.

`swift test`: **2399 passed, 0 failures**, 6 skipped (network-credentialed). SwiftLint clean on the diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only privacy hardening; persistence behavior and error handling paths are unchanged aside from what gets written to the unified log.
> 
> **Overview**
> **Stops leaking macOS account names** when file-persist failures are logged at `privacy: .public`. Those paths sit under the user’s home directory, so `error.localizedDescription` on writer (and related) errors was publishing identifiable paths to the unified log.
> 
> Adds **`SecureFileWriterError.logDescription(for:)`** as the single path-free formatter: `SecureFileWriterError` → errno-only text; everything else → `NSError` domain and code (so Cocoa/`EncodingError` messages that embed transcript or file paths never reach public logs). **`CostScanCacheStoreError.reason(for:)`** now delegates to it instead of duplicating the same logic.
> 
> **Call sites** that catch opaque `Error` after `SecureFileWriter` (or similar) persistence now use that helper: shared metrics/account metrics, provider parse health, cost summary cache, replay ledger, and wake run logging.
> 
> **Tests** in `SecureFileWriterTests` cover path-free `logDescription`, thrown writer errors, and domain/code fallback for non-writer errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0c132557319c2b03d43ab83c789a71c87212ed6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for file operations across the app.
  * Error logs now omit sensitive file paths and usernames while retaining useful diagnostic details.
  * Standardized handling of storage and persistence failures for clearer, privacy-conscious logs.

* **Tests**
  * Added coverage to verify sensitive information is removed from error messages while actionable error codes remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->