### PR TITLE
fix(serve): share the CLI provider filter with the /usage endpoint

### DIFF
--- a/MeterBar/Serve/ServeRouter.swift
+++ b/MeterBar/Serve/ServeRouter.swift
@@ -65,16 +65,9 @@ nonisolated public enum ServeRouter {
             )
         }
 
-        let filtered: [ServiceType: UsageMetrics]
-        if let provider = query["provider"]?.lowercased(), !provider.isEmpty {
-            filtered = metrics.filter {
-                $0.key.rawValue.lowercased().contains(provider)
-                    || $0.key.displayName.lowercased().contains(provider)
-            }
-        } else {
-            filtered = metrics
-        }
-
+        // Same selection as `meterbar usage --provider`, so a padded or blank
+        // needle can't mean one thing over HTTP and another on the CLI.
+        let filtered = CLIProviderFilter.apply(query["provider"], to: metrics)
         return jsonResponse(UsageCLIJSONResponse(metrics: filtered))
     }
 

--- a/MeterBarTests/ServeRouterTests.swift
+++ b/MeterBarTests/ServeRouterTests.swift
@@ -17,6 +17,16 @@ final class ServeRouterTests: XCTestCase {
         ),
     ]
 
+    /// Two providers whose identifiers and display names diverge, so a
+    /// `?provider=` test can tell an identifier match from a display-name one.
+    private lazy var multiProviderMetrics: [ServiceType: UsageMetrics] = metrics.merging([
+        .codexCli: UsageMetrics(
+            service: .codexCli,
+            weeklyLimit: UsageLimit(used: 10, total: 100, resetTime: referenceDate),
+            lastUpdated: referenceDate
+        ),
+    ]) { current, _ in current }
+
     private lazy var costCache = CostSummaryCache(
         summary: CostSummary(
             costs: [
@@ -213,15 +223,37 @@ final class ServeRouterTests: XCTestCase {
         XCTAssertEqual(response.body, expected)
     }
 
-    func testUsageEndpointHonorsProviderQueryFilterLikeTheCLI() throws {
-        let response = ServeRouter.handle(
-            request(path: "/usage", query: ["provider": "codex"], token: token),
-            token: token,
-            dataSource: makeDataSource()
-        )
+    // MARK: `?provider=` parity with `meterbar usage --provider`
 
-        let expected = try UsageCLIJSONResponse(metrics: [:]).jsonData()
-        XCTAssertEqual(response.body, expected, "no codex entry in the fixture, so filtering should yield an empty set")
+    func testUsageEndpointProviderQueryMatchesTheProviderIdentifier() throws {
+        try assertUsageEndpoint(provider: "codex", selects: [.codexCli])
+        try assertUsageEndpoint(provider: "CODEX", selects: [.codexCli])
+    }
+
+    /// Codex's identifier is "Codex CLI" but it is displayed as "OpenAI
+    /// Codex", so "openai" can only match through the display name.
+    func testUsageEndpointProviderQueryMatchesTheDisplayName() throws {
+        try assertUsageEndpoint(provider: "openai", selects: [.codexCli])
+    }
+
+    /// `?provider=%20codex%20` decodes to a padded needle. The CLI trims it,
+    /// so the endpoint has to as well — it used to return an empty set while
+    /// `meterbar usage --provider " codex "` matched Codex.
+    func testUsageEndpointTrimsAPaddedProviderQueryLikeTheCLI() throws {
+        try assertUsageEndpoint(provider: " codex ", selects: [.codexCli])
+        try assertUsageEndpoint(provider: "\tcodex\n", selects: [.codexCli])
+    }
+
+    func testUsageEndpointReturnsAnEmptySetWhenTheProviderQueryMatchesNothing() throws {
+        try assertUsageEndpoint(provider: "clod", selects: [])
+    }
+
+    /// A missing filter selects everything, and a blank one is still no
+    /// filter — the router used to treat "   " as a needle matching nothing.
+    func testUsageEndpointWithoutAProviderQueryReturnsEveryCachedProvider() throws {
+        try assertUsageEndpoint(provider: nil, selects: [.claudeCode, .codexCli])
+        try assertUsageEndpoint(provider: "", selects: [.claudeCode, .codexCli])
+        try assertUsageEndpoint(provider: "   ", selects: [.claudeCode, .codexCli])
     }
 
     func testCostEndpointHonorsDaysQueryLikeTheCLI() throws {
@@ -338,6 +370,31 @@ final class ServeRouterTests: XCTestCase {
     }
 
     // MARK: Helpers
+
+    /// Drives `/usage` against the two-provider fixture and asserts the body
+    /// is byte-identical to the DTO the CLI would emit for `selects`.
+    private func assertUsageEndpoint(
+        provider: String?,
+        selects selected: Set<ServiceType>,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let response = ServeRouter.handle(
+            request(
+                path: "/usage",
+                query: provider.map { ["provider": $0] } ?? [:],
+                token: token
+            ),
+            token: token,
+            dataSource: makeDataSource(metrics: multiProviderMetrics)
+        )
+
+        let expectedMetrics = multiProviderMetrics.filter { selected.contains($0.key) }
+        XCTAssertEqual(expectedMetrics.count, selected.count, "fixture is missing \(selected)", file: file, line: line)
+
+        let expected = try UsageCLIJSONResponse(metrics: expectedMetrics).jsonData()
+        XCTAssertEqual(response.body, expected, "provider=\(provider.debugDescription)", file: file, line: line)
+    }
 
     private func assertBodyContainsNoUsageData(_ response: ServeHTTPResponse, file: StaticString = #filePath, line: UInt = #line) {
         guard let body = String(data: response.body, encoding: .utf8) else {


### PR DESCRIPTION
## Problem

`ServeRouter.usageResponse` hand-rolled the `?provider=` substring match instead of using `CLIProviderFilter`, so the HTTP endpoint and the CLI disagreed on two inputs:

| input | `meterbar usage --provider` | `GET /usage?provider=` (before) |
|---|---|---|
| `" codex "` | matches Codex | **empty set** |
| `"   "` | matches everything | **empty set** |

`CLIProviderFilter.needle(from:)` trims whitespace and treats a blank needle as no filter. The router lowercased but never trimmed, and `!provider.isEmpty` is true for `"   "`. The server percent-decodes query values, so `?provider=%20codex%20` really does arrive padded.

## Fix

Route the query value through `CLIProviderFilter.apply(_:to:)` — the same call `MeterBarCLI.swift:105` already makes. One implementation now backs both paths.

## Tests

`testUsageEndpointHonorsProviderQueryFilterLikeTheCLI` was hollow: the fixture had no Codex entry, so it only asserted empty in, empty out — it would have passed against any filter, including one that dropped everything.

Replaced with a two-provider fixture whose identifier and display name diverge (`Codex CLI` / `OpenAI Codex`), mirroring the cases in `CLIProviderFilterTests`:

- identifier match, case-insensitive (`codex`, `CODEX`)
- display-name-only match (`openai` — not in the identifier)
- padded needle (`" codex "`, `"\tcodex\n"`) — red before the fix
- unmatched needle returns an empty set
- missing / empty / blank needle returns every cached provider — `"   "` was red before the fix

Each asserts the body is byte-identical to the DTO the CLI would emit, matching the existing schema-stability style in this file.

## Verification

`swift test` locally: **2400 tests, 0 failures**, on two consecutive full runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral fix on a read-only cached endpoint with no auth or data-model changes; risk is limited to clients that relied on the old incorrect filtering.
> 
> **Overview**
> **`GET /usage?provider=`** now uses **`CLIProviderFilter.apply`**, the same helper as **`meterbar usage --provider`**, instead of a local substring match.
> 
> That fixes HTTP/CLI mismatches: **trimmed** needles (e.g. `" codex "`) match correctly, and **blank/whitespace-only** values return **all** cached providers instead of an empty set.
> 
> **`ServeRouterTests`** gains a two-provider fixture and parity cases (identifier vs display name, padding, no match, missing/empty filter), asserting responses are **byte-identical** to **`UsageCLIJSONResponse`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf0b9ddf01112ebe97df3505290e1d9ed12bd571. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->