### PR TITLE
fix(cli): title Cursor's third quota window "On-demand"

### DIFF
--- a/MeterBar/Models/CLIUsageTextReport.swift
+++ b/MeterBar/Models/CLIUsageTextReport.swift
@@ -1,0 +1,98 @@
+import Foundation
+import MeterBarShared
+
+/// The human-readable report printed by `meterbar usage` without `--json`.
+///
+/// Lives here rather than in the executable for the same reason as
+/// `CLIProviderFilter`: quota titles are centralized on `ServiceType`, and the
+/// only copy the tests could not reach is the copy that drifted — the CLI kept
+/// spelling out the code-review label itself and so printed "Code Review" for
+/// Cursor's on-demand window.
+nonisolated public enum CLIUsageTextReport {
+    /// Every line of the report, in print order. Empty strings are blank lines.
+    public static func lines(
+        for metrics: [ServiceType: UsageMetrics],
+        filter: String? = nil
+    ) -> [String] {
+        var lines = [
+            "╭─────────────────────────────────────────╮",
+            "│             MeterBar Usage              │",
+            "╰─────────────────────────────────────────╯",
+            "",
+        ]
+
+        // A `--provider` typo used to print the header and nothing else, which
+        // reads like "this provider has no quota data". Say what happened, the
+        // way `meterbar doctor` already does — and distinguish a typo from a
+        // real provider the cache simply has not seen yet.
+        guard !metrics.isEmpty else {
+            lines.append(CLIProviderFilter.emptyReportMessage(for: filter))
+            return lines
+        }
+
+        for (service, metric) in metrics.sorted(by: { $0.key.rawValue < $1.key.rawValue }) {
+            lines.append("▸ \(service.displayName)")
+
+            if let session = metric.sessionLimit {
+                lines += limitLines(
+                    service == .openRouter ? "  Key limit" : "  Session",
+                    session,
+                    currency: service == .openRouter
+                )
+            }
+            if let weekly = metric.weeklyLimit {
+                lines += limitLines(
+                    "  \(service.weeklyQuotaTitle)",
+                    weekly,
+                    currency: service == .openRouter
+                )
+            }
+            if let codeReview = metric.codeReviewLimit {
+                let label = service.codeReviewQuotaTitle(modelLimitLabel: metric.modelLimitLabel)
+                lines += limitLines("  \(label)", codeReview)
+            }
+            lines.append("")
+        }
+
+        return lines
+    }
+
+    private static func limitLines(
+        _ label: String,
+        _ limit: UsageLimit,
+        currency: Bool = false
+    ) -> [String] {
+        let percent = limit.percentage
+        let bar = progressBar(percent: percent, width: 20)
+        let status = statusEmoji(for: limit)
+        let percentText = currency ? String(format: "%.0f%%", percent) : limit.percentageText
+
+        var lines = ["\(label): \(bar) \(percentText) \(status)"]
+        if currency {
+            lines.append("    \(UsageFormat.cost(limit.used)) spent / \(UsageFormat.cost(limit.total)) credits")
+        } else {
+            let estimateDetail = limit.isEstimated ? " (estimated limit)" : ""
+            lines.append("    \(Int(limit.used))/\(Int(limit.total)) used\(estimateDetail)")
+        }
+        if let reset = limit.resetTime {
+            lines.append("    Resets: \(UsageFormat.relative(reset))")
+        }
+        return lines
+    }
+
+    private static func progressBar(percent: Double, width: Int) -> String {
+        let filled = Int((percent / 100) * Double(width))
+        let empty = width - filled
+        return "[" + String(repeating: "█", count: filled) + String(repeating: "░", count: empty) + "]"
+    }
+
+    /// Same severity bands as the app (previously the CLI warned at 50% used
+    /// while the app warned at 75%).
+    private static func statusEmoji(for limit: UsageLimit) -> String {
+        switch QuotaBand.forLimit(limit) {
+        case .healthy: return "✓"
+        case .tight: return "⚠"
+        case .critical, .exhausted: return "✗"
+        }
+    }
+}

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -112,75 +112,8 @@ struct Usage: ParsableCommand {
     }
 
     private func printText(_ metrics: [ServiceType: UsageMetrics]) {
-        print("╭─────────────────────────────────────────╮")
-        print("│             MeterBar Usage              │")
-        print("╰─────────────────────────────────────────╯")
-        print()
-
-        // A `--provider` typo used to print the header and nothing else, which
-        // reads like "this provider has no quota data". Say what happened, the
-        // way `meterbar doctor` already does — and distinguish a typo from a
-        // real provider the cache simply has not seen yet.
-        if metrics.isEmpty {
-            print(CLIProviderFilter.emptyReportMessage(for: provider))
-            return
-        }
-
-        for (service, metric) in metrics.sorted(by: { $0.key.rawValue < $1.key.rawValue }) {
-            print("▸ \(service.displayName)")
-
-            if let session = metric.sessionLimit {
-                printLimit(
-                    service == .openRouter ? "  Key limit" : "  Session",
-                    session,
-                    currency: service == .openRouter
-                )
-            }
-            if let weekly = metric.weeklyLimit {
-                printLimit(
-                    "  \(service.weeklyQuotaTitle)",
-                    weekly,
-                    currency: service == .openRouter
-                )
-            }
-            if let codeReview = metric.codeReviewLimit {
-                let label = service == .claudeCode ? (metric.modelLimitLabel ?? "Model") : "Code Review"
-                printLimit("  \(label)", codeReview)
-            }
-            print()
-        }
-    }
-
-    private func printLimit(_ label: String, _ limit: UsageLimit, currency: Bool = false) {
-        let percent = limit.percentage
-        let bar = progressBar(percent: percent, width: 20)
-        let status = statusEmoji(for: limit)
-
-        print("\(label): \(bar) \(currency ? String(format: "%.0f%%", percent) : limit.percentageText) \(status)")
-        if currency {
-            print("    \(UsageFormat.cost(limit.used)) spent / \(UsageFormat.cost(limit.total)) credits")
-        } else {
-            let estimateDetail = limit.isEstimated ? " (estimated limit)" : ""
-            print("    \(Int(limit.used))/\(Int(limit.total)) used\(estimateDetail)")
-        }
-        if let reset = limit.resetTime {
-            print("    Resets: \(UsageFormat.relative(reset))")
-        }
-    }
-
-    private func progressBar(percent: Double, width: Int) -> String {
-        let filled = Int((percent / 100) * Double(width))
-        let empty = width - filled
-        return "[" + String(repeating: "█", count: filled) + String(repeating: "░", count: empty) + "]"
-    }
-
-    /// Same severity bands as the app (previously the CLI warned at 50% used
-    /// while the app warned at 75%).
-    private func statusEmoji(for limit: UsageLimit) -> String {
-        switch QuotaBand.forLimit(limit) {
-        case .healthy: return "✓"
-        case .tight: return "⚠"
-        case .critical, .exhausted: return "✗"
+        for line in CLIUsageTextReport.lines(for: metrics, filter: provider) {
+            print(line)
         }
     }
 }

--- a/MeterBarTests/CLIUsageTextReportTests.swift
+++ b/MeterBarTests/CLIUsageTextReportTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// `meterbar usage` text output. The quota titles must come from the same
+/// `ServiceType` helpers the popover, widget, and notifications use — the CLI
+/// spelled the code-review label out itself and printed "Code Review" over
+/// Cursor's on-demand window.
+final class CLIUsageTextReportTests: XCTestCase {
+    private let referenceDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+    func testCursorCodeReviewWindowIsTitledOnDemand() {
+        let text = render(
+            .cursor,
+            metric: UsageMetrics(
+                service: .cursor,
+                codeReviewLimit: UsageLimit(used: 12, total: 50, resetTime: nil),
+                lastUpdated: referenceDate
+            )
+        )
+
+        XCTAssertTrue(text.contains("On-demand:"), text)
+        XCTAssertFalse(text.contains("Code Review"), text)
+    }
+
+    func testClaudeCodeReviewWindowUsesTheReportedModelLabel() {
+        let text = render(
+            .claudeCode,
+            metric: UsageMetrics(
+                service: .claudeCode,
+                codeReviewLimit: UsageLimit(used: 12, total: 50, resetTime: nil),
+                modelLimitLabel: "Fable",
+                lastUpdated: referenceDate
+            )
+        )
+
+        XCTAssertTrue(text.contains("Fable:"), text)
+        XCTAssertFalse(text.contains("Code Review"), text)
+    }
+
+    /// No label parsed from the CLI payload: a neutral "Model", never a
+    /// hardcoded model name.
+    func testClaudeCodeReviewWindowFallsBackToModelWithoutALabel() {
+        let text = render(
+            .claudeCode,
+            metric: UsageMetrics(
+                service: .claudeCode,
+                codeReviewLimit: UsageLimit(used: 12, total: 50, resetTime: nil),
+                lastUpdated: referenceDate
+            )
+        )
+
+        XCTAssertTrue(text.contains("Model:"), text)
+    }
+
+    /// Providers whose third window really is code review keep that title.
+    func testCodexCodeReviewWindowKeepsTheCodeReviewTitle() {
+        let text = render(
+            .codexCli,
+            metric: UsageMetrics(
+                service: .codexCli,
+                codeReviewLimit: UsageLimit(used: 12, total: 50, resetTime: nil),
+                lastUpdated: referenceDate
+            )
+        )
+
+        XCTAssertTrue(text.contains("Code Review:"), text)
+    }
+
+    private func render(_ service: ServiceType, metric: UsageMetrics) -> String {
+        CLIUsageTextReport.lines(for: [service: metric]).joined(separator: "\n")
+    }
+}


### PR DESCRIPTION
The `meterbar usage` text report spelled the code-review label out itself:

```swift
let label = service == .claudeCode ? (metric.modelLimitLabel ?? "Model") : "Code Review"
```

So `meterbar usage` printed **"Code Review:"** over Cursor’s on-demand spend window, while the popover, widget, and notifications all printed **"On-demand"** — they call the centralized `ServiceType.codeReviewQuotaTitle(modelLimitLabel:)`. The CLI was the last caller that had not adopted it.

## Changes

- **`CLIUsageTextReport`** (`MeterBar/Models/`) — the usage text report moved out of the executable and into the library, matching `CLIProviderFilter` and `CLIJSONOutput`. It returns lines instead of printing them, so the rendering is reachable from `swift test`; the executable target has no test target of its own, which is why this copy drifted unnoticed. Output is byte-identical (same header, same ordering, same blank lines).
- **Adopted `codeReviewQuotaTitle(modelLimitLabel:)`** — the one behavior change. Cursor → "On-demand", Claude → reported model label (falling back to "Model"), everything else → "Code Review".
- **`CLIUsageTextReportTests`** — four cases: Cursor titles the window "On-demand" and never "Code Review"; Claude uses the reported label; Claude with no label falls back to "Model"; Codex keeps "Code Review".

The session-window ternary (`service == .openRouter ? "Key limit" : "Session"`) was moved verbatim and left alone — see the note below.

## Verification

- Red first: with the old ternary in place, the Cursor test failed on the literal `Code Review:` line.
- `swift test` — **2400 passed, 6 skipped (network-gated), 0 failures**.
- `cd MeterBarCLI && swift build` — clean (the pre-existing `Guard.swift` main-actor warning is untouched).
- `swiftlint` — clean on all three files.

## Noted, not fixed

`ServiceType.sessionQuotaTitle(limitTotal:)` has the same shape of drift: the CLI hardcodes `"Session"` where the helper returns **"Cursor Models"** for a Cursor percent-of-100 pool. Adopting it changes Cursor’s session line, which is outside this fix — worth a follow-up issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CLI label fix plus a refactor with tests; no auth, data, or API behavior changes.
> 
> **Overview**
> **`meterbar usage` text output** now routes third-quota labels through `ServiceType.codeReviewQuotaTitle(modelLimitLabel:)`, matching the popover, widget, and notifications. Cursor’s window shows **On-demand** instead of **Code Review**; Claude still uses the reported model label (or **Model**); other providers keep **Code Review**.
> 
> The human-readable report was **moved from the CLI executable into** `CLIUsageTextReport` in the MeterBar library (line-based API, same layout as before). `MeterBarCLI` only prints those lines, so rendering is covered by unit tests. **`CLIUsageTextReportTests`** lock in the four provider-specific title behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ace9cac0c36bee9fa6bc0d8de876df8cd6a5bab8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->