### PR TITLE
refactor(cli): share one cancellation flag and signal installer

### DIFF
--- a/MeterBar/Models/CLICancellationFlag.swift
+++ b/MeterBar/Models/CLICancellationFlag.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// The cooperative cancellation flag shared by every long-running `meterbar`
+/// command.
+///
+/// The shape is always the same: a signal handler running off the command's
+/// task flips the flag, and the command hands the engine a
+/// `@Sendable () -> Bool` that reads it. `Task.isCancelled` cannot serve —
+/// a `DispatchSource` event handler is not running inside the command's task,
+/// so the task's own cancellation state never changes.
+///
+/// `serve`, `guard`, `refresh`, `wake`, and `wake-agent` each carried a private
+/// copy of this class, and the copies had already drifted (one used
+/// `withLock`, the rest hand-rolled `lock()`/`unlock()`).
+nonisolated public final class CLICancellationFlag: @unchecked Sendable {
+    /// Guards `cancelled`: the flag is written from a signal-source handler on
+    /// a global queue and read from the command's async engine.
+    private let lock = NSLock()
+    private var cancelled = false
+
+    public init() {}
+
+    public var isCancelled: Bool {
+        lock.withLock { cancelled }
+    }
+
+    public func cancel() {
+        lock.withLock { cancelled = true }
+    }
+}

--- a/MeterBar/Models/CLISignalHandlers.swift
+++ b/MeterBar/Models/CLISignalHandlers.swift
@@ -1,0 +1,41 @@
+import Darwin
+import Dispatch
+import Foundation
+
+/// Installs the interrupt handlers a long-running `meterbar` command needs to
+/// end on its own terms — emitting its documented output and exit code —
+/// instead of dying wherever the signal found it.
+///
+/// Five commands installed these by hand with byte-for-byte identical code.
+nonisolated public enum CLISignalHandlers {
+    /// SIGTERM as well as SIGINT: a command started by a script or a
+    /// `timeout(1)` wrapper is far more likely to be terminated than
+    /// interrupted, and both must still produce the documented JSON and exit
+    /// code. `wake` is the exception — it takes SIGINT only, per its #99
+    /// contract — and passes its own list.
+    public static let interruptAndTerminate: [Int32] = [SIGINT, SIGTERM]
+
+    /// Routes each signal to `flag.cancel()` and returns the live sources.
+    ///
+    /// The caller owns the returned sources and must cancel them (a `defer` at
+    /// the top of `run()`); a released `DispatchSourceSignal` stops observing.
+    ///
+    /// - Parameters:
+    ///   - signals: Signals to observe. Defaults to SIGINT and SIGTERM.
+    ///   - flag: The flag every handler sets.
+    public static func install(
+        _ signals: [Int32] = interruptAndTerminate,
+        cancelling flag: CLICancellationFlag
+    ) -> [DispatchSourceSignal] {
+        signals.map { signalNumber in
+            // A signal source observes the signal, it does not consume it, so
+            // without SIG_IGN the default disposition still kills the process
+            // before the handler can run.
+            signal(signalNumber, SIG_IGN)
+            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global())
+            source.setEventHandler { flag.cancel() }
+            source.resume()
+            return source
+        }
+    }
+}

--- a/MeterBarCLI/Sources/Guard.swift
+++ b/MeterBarCLI/Sources/Guard.swift
@@ -1,6 +1,4 @@
 import ArgumentParser
-import Darwin
-import Dispatch
 import Foundation
 import MeterBar
 
@@ -50,8 +48,13 @@ struct Guard: AsyncParsableCommand {
     var refreshTimeout: String?
 
     func run() async throws {
-        let cancellation = GuardCancellation()
-        let signalSources = installSignalHandlers(cancellation)
+        // `--refresh` can hold the process for up to ten minutes. Without these,
+        // Ctrl-C or a `timeout(1)` wrapper killed guard mid-window with no JSON
+        // and an exit code outside the documented set. Cancelling ends the
+        // refresh early; guard still evaluates the cached snapshot and exits
+        // 0/10/11/12/13 — consistent with a refresh that simply failed.
+        let cancellation = CLICancellationFlag()
+        let signalSources = CLISignalHandlers.install(cancelling: cancellation)
         defer { signalSources.forEach { $0.cancel() } }
 
         let result = await QuotaGuardCLI.run(
@@ -69,21 +72,6 @@ struct Guard: AsyncParsableCommand {
         throw ExitCode(result.exitCode)
     }
 
-    /// `--refresh` can hold the process for up to ten minutes. Without these,
-    /// Ctrl-C or a `timeout(1)` wrapper killed guard mid-window with no JSON
-    /// and an exit code outside the documented set. Cancelling ends the refresh
-    /// early; guard still evaluates the cached snapshot and exits 0/10/11/12/13
-    /// — consistent with a refresh that simply failed.
-    private func installSignalHandlers(_ cancellation: GuardCancellation) -> [DispatchSourceSignal] {
-        [SIGINT, SIGTERM].map { signalNumber in
-            signal(signalNumber, SIG_IGN)
-            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global())
-            source.setEventHandler { cancellation.cancel() }
-            source.resume()
-            return source
-        }
-    }
-
     private func emit(_ result: QuotaGuardCLI.Result) {
         if json {
             print(result.jsonOutput)
@@ -94,23 +82,6 @@ struct Guard: AsyncParsableCommand {
             var stderr = GuardStandardError()
             Swift.print(message, to: &stderr)
         }
-    }
-}
-
-private final class GuardCancellation: @unchecked Sendable {
-    private let lock = NSLock()
-    private var cancelled = false
-
-    var isCancelled: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return cancelled
-    }
-
-    func cancel() {
-        lock.lock()
-        cancelled = true
-        lock.unlock()
     }
 }
 

--- a/MeterBarCLI/Sources/Refresh.swift
+++ b/MeterBarCLI/Sources/Refresh.swift
@@ -1,6 +1,4 @@
 import ArgumentParser
-import Darwin
-import Dispatch
 import Foundation
 import MeterBar
 
@@ -22,8 +20,11 @@ struct Refresh: AsyncParsableCommand {
     var timeout: String?
 
     func run() async throws {
-        let cancelBox = RefreshCancelBox()
-        let signalSources = installSignalHandlers(cancelBox)
+        // SIGTERM as well as SIGINT: a refresh started by a script or a timeout
+        // wrapper is far more likely to be terminated than interrupted, and
+        // both must still produce the documented JSON and exit code.
+        let cancelBox = CLICancellationFlag()
+        let signalSources = CLISignalHandlers.install(cancelling: cancelBox)
         defer { signalSources.forEach { $0.cancel() } }
 
         let result = await UsageRefreshCLI.run(
@@ -47,32 +48,6 @@ struct Refresh: AsyncParsableCommand {
             var stderr = RefreshStandardError()
             Swift.print(message, to: &stderr)
         }
-    }
-
-    /// SIGTERM as well as SIGINT: a refresh started by a script or a timeout
-    /// wrapper is far more likely to be terminated than interrupted, and both
-    /// must still produce the documented JSON and exit code.
-    private func installSignalHandlers(_ box: RefreshCancelBox) -> [DispatchSourceSignal] {
-        [SIGINT, SIGTERM].map { signalNumber in
-            signal(signalNumber, SIG_IGN)
-            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global())
-            source.setEventHandler { box.cancel() }
-            source.resume()
-            return source
-        }
-    }
-}
-
-private final class RefreshCancelBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var cancelled = false
-
-    var isCancelled: Bool {
-        lock.withLock { cancelled }
-    }
-
-    func cancel() {
-        lock.withLock { cancelled = true }
     }
 }
 

--- a/MeterBarCLI/Sources/Serve.swift
+++ b/MeterBarCLI/Sources/Serve.swift
@@ -1,6 +1,4 @@
 import ArgumentParser
-import Darwin
-import Dispatch
 import Foundation
 import MeterBar
 
@@ -84,8 +82,8 @@ struct Serve: AsyncParsableCommand {
             )
         }
 
-        let cancellation = ServeCancellation()
-        let signalSources = installSignalHandlers(cancellation)
+        let cancellation = CLICancellationFlag()
+        let signalSources = CLISignalHandlers.install(cancelling: cancellation)
         defer { signalSources.forEach { $0.cancel() } }
 
         let request = ServeCLI.Request(
@@ -142,32 +140,5 @@ struct Serve: AsyncParsableCommand {
         case .blankEnvironment:
             return "METERBAR_SERVE_TOKEN must not be blank. Unset it to have a token generated."
         }
-    }
-
-    private func installSignalHandlers(_ cancellation: ServeCancellation) -> [DispatchSourceSignal] {
-        [SIGINT, SIGTERM].map { signalNumber in
-            signal(signalNumber, SIG_IGN)
-            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global())
-            source.setEventHandler { cancellation.cancel() }
-            source.resume()
-            return source
-        }
-    }
-}
-
-private final class ServeCancellation: @unchecked Sendable {
-    private let lock = NSLock()
-    private var cancelled = false
-
-    var isCancelled: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return cancelled
-    }
-
-    func cancel() {
-        lock.lock()
-        cancelled = true
-        lock.unlock()
     }
 }

--- a/MeterBarCLI/Sources/Wake.swift
+++ b/MeterBarCLI/Sources/Wake.swift
@@ -1,6 +1,5 @@
 import ArgumentParser
 import Darwin
-import Dispatch
 import Foundation
 import MeterBar
 
@@ -53,9 +52,12 @@ struct Wake: AsyncParsableCommand {
     var yesBypass: Bool = false
 
     func run() async throws {
-        let cancelBox = CancelBox()
-        let signalSource = installSignalHandler(cancelBox)
-        defer { signalSource.cancel() }
+        // SIGINT only: the #99 contract is that Ctrl-C releases the shared lock
+        // and leaves no child process behind. SIGTERM keeps its default
+        // disposition here.
+        let cancelBox = CLICancellationFlag()
+        let signalSources = CLISignalHandlers.install([SIGINT], cancelling: cancelBox)
+        defer { signalSources.forEach { $0.cancel() } }
 
         let request = SessionWakeCLI.Request(
             provider: provider,
@@ -86,22 +88,6 @@ struct Wake: AsyncParsableCommand {
             Swift.print(message, to: &stderr)
         }
     }
-
-    private func installSignalHandler(_ box: CancelBox) -> DispatchSourceSignal {
-        signal(SIGINT, SIG_IGN)
-        let source = DispatchSource.makeSignalSource(signal: SIGINT, queue: .global())
-        source.setEventHandler { box.cancel() }
-        source.resume()
-        return source
-    }
-}
-
-/// Thread-safe cancellation flag toggled by the SIGINT handler.
-private final class CancelBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var cancelled = false
-    var isCancelled: Bool { lock.lock(); defer { lock.unlock() }; return cancelled }
-    func cancel() { lock.lock(); cancelled = true; lock.unlock() }
 }
 
 /// Minimal stderr text stream so diagnostics never contaminate JSON stdout.

--- a/MeterBarCLI/Sources/WakeAgent.swift
+++ b/MeterBarCLI/Sources/WakeAgent.swift
@@ -1,6 +1,4 @@
 import ArgumentParser
-import Darwin
-import Dispatch
 import Foundation
 import MeterBar
 
@@ -14,40 +12,13 @@ struct WakeAgent: AsyncParsableCommand {
     )
 
     func run() async throws {
-        let cancellation = AgentCancellation()
-        let signalSources = installSignalHandlers(cancellation)
+        let cancellation = CLICancellationFlag()
+        let signalSources = CLISignalHandlers.install(cancelling: cancellation)
         defer { signalSources.forEach { $0.cancel() } }
 
         let exitCode = await SessionWakeAgent.run(shouldCancel: { cancellation.isCancelled })
         if exitCode != 0 {
             throw ExitCode(exitCode)
         }
-    }
-
-    private func installSignalHandlers(_ cancellation: AgentCancellation) -> [DispatchSourceSignal] {
-        [SIGINT, SIGTERM].map { signalNumber in
-            signal(signalNumber, SIG_IGN)
-            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global())
-            source.setEventHandler { cancellation.cancel() }
-            source.resume()
-            return source
-        }
-    }
-}
-
-private final class AgentCancellation: @unchecked Sendable {
-    private let lock = NSLock()
-    private var cancelled = false
-
-    var isCancelled: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return cancelled
-    }
-
-    func cancel() {
-        lock.lock()
-        cancelled = true
-        lock.unlock()
     }
 }

--- a/MeterBarTests/CLICancellationTests.swift
+++ b/MeterBarTests/CLICancellationTests.swift
@@ -1,0 +1,97 @@
+import Darwin
+import Dispatch
+import Foundation
+import XCTest
+@testable import MeterBar
+
+/// The cancellation flag and signal wiring shared by `serve`, `guard`,
+/// `refresh`, `wake`, and `wake-agent`. Each command used to carry its own
+/// copy; the copies drifted, and none of them was ever covered by a test.
+final class CLICancellationTests: XCTestCase {
+    func testTheFlagStartsClear() {
+        XCTAssertFalse(CLICancellationFlag().isCancelled)
+    }
+
+    func testCancelIsVisibleToASubsequentRead() {
+        let flag = CLICancellationFlag()
+        flag.cancel()
+        XCTAssertTrue(flag.isCancelled)
+    }
+
+    func testCancelIsIdempotent() {
+        let flag = CLICancellationFlag()
+        flag.cancel()
+        flag.cancel()
+        XCTAssertTrue(flag.isCancelled)
+    }
+
+    /// The real access pattern: a signal handler on a global queue writes while
+    /// the command's engine polls from somewhere else. Concurrent readers must
+    /// see a consistent value and the writes must not race.
+    func testConcurrentCancelsAndReadsAreSafe() {
+        let flag = CLICancellationFlag()
+
+        DispatchQueue.concurrentPerform(iterations: 256) { iteration in
+            if iteration.isMultiple(of: 4) {
+                flag.cancel()
+            } else {
+                _ = flag.isCancelled
+            }
+        }
+
+        XCTAssertTrue(flag.isCancelled)
+    }
+
+    /// Every reader observes the cancel once it has happened — the point of the
+    /// lock, since `shouldCancel` closures are called from threads that never
+    /// touched the flag before.
+    func testACancelOnOneThreadIsObservedOnAnother() {
+        let flag = CLICancellationFlag()
+        let observed = expectation(description: "cancel observed off-thread")
+
+        DispatchQueue.global().async {
+            flag.cancel()
+            DispatchQueue.global().async {
+                if flag.isCancelled { observed.fulfill() }
+            }
+        }
+
+        wait(for: [observed], timeout: 5)
+    }
+
+    func testInstallReturnsOneLiveSourcePerSignal() {
+        let flag = CLICancellationFlag()
+        let sources = CLISignalHandlers.install([SIGUSR1, SIGUSR2], cancelling: flag)
+        defer { sources.forEach { $0.cancel() } }
+
+        XCTAssertEqual(sources.count, 2)
+        XCTAssertFalse(sources.contains { $0.isCancelled })
+        XCTAssertFalse(flag.isCancelled, "Installing a handler must not cancel anything by itself.")
+    }
+
+    func testTheDefaultSignalListIsInterruptAndTerminate() {
+        XCTAssertEqual(CLISignalHandlers.interruptAndTerminate, [SIGINT, SIGTERM])
+    }
+
+    /// The wiring itself: delivering the signal must flip the flag rather than
+    /// kill the process, which is what `signal(_:SIG_IGN)` inside `install` buys.
+    ///
+    /// Sent to SIGUSR2, not SIGINT/SIGTERM — those would change this test
+    /// process's own disposition for every later test.
+    func testADeliveredSignalCancelsTheFlag() throws {
+        let flag = CLICancellationFlag()
+        let sources = CLISignalHandlers.install([SIGUSR2], cancelling: flag)
+        defer { sources.forEach { $0.cancel() } }
+
+        // Process-directed, not `raise()`: the signal source watches the
+        // process, and a thread-directed signal need not wake it.
+        XCTAssertEqual(kill(getpid(), SIGUSR2), 0)
+
+        let deadline = Date().addingTimeInterval(5)
+        while !flag.isCancelled, Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        }
+
+        XCTAssertTrue(flag.isCancelled, "The signal source should have cancelled the flag.")
+    }
+}


### PR DESCRIPTION
## What

`serve`, `guard`, `refresh`, `wake`, and `wake-agent` each defined a private NSLock-guarded cancellation class **and** a byte-for-byte identical `installSignalHandlers(_:)`. Five copies, already drifted: `refresh` used `lock.withLock`, the other four hand-rolled `lock()`/`unlock()`.

Replaced with two shared types in the MeterBar library:

- `CLICancellationFlag` — the `@unchecked Sendable` flag, `withLock` throughout.
- `CLISignalHandlers.install(_:cancelling:)` — installs the sources, defaults to `[SIGINT, SIGTERM]`.

## Where they live and why

`MeterBar/Models/`, beside `CLIProviderFilter` and `CLIJSONOutput` — the same place the previous shared-CLI-helper extraction landed, `nonisolated public` like the other CLI facades. The CLI package has no test target, so this is also the only home where the code is reachable from `swift test`. Not `MeterBarShared`: nothing in the app or widget needs it.

## Behavior preserved

Per-command differences kept, not flattened:

- `wake` still installs **SIGINT only** (its #99 contract: Ctrl-C releases the shared lock and leaves no child process). It passes `[SIGINT]` explicitly; the other four take the default.
- Each command's rationale comment moved to its call site rather than being dropped.
- Callers still own the returned sources and cancel them in `defer`.

## Tests

New `MeterBarTests/CLICancellationTests.swift` (8 cases): clear-on-init, cancel visibility, idempotence, 256-iteration concurrent cancel/read, cross-thread observation, one live source per signal, the default signal list, and the wiring itself — `kill(getpid(), SIGUSR2)` flips the flag instead of killing the process. `SIGUSR2` rather than SIGINT/SIGTERM so the test does not change the test process's own signal disposition.

## Verification

- `cd MeterBarCLI && swift build` — clean (remaining warnings are pre-existing Swift 6 isolation ones, also present in untouched `ResetCredit.swift`).
- `swift test` — **2404 passed, 0 failures**, 6 skipped (the usual credential-gated network tests).
- `swiftlint` clean on every touched file.
- Smoke test: `meterbar serve` + `SIGTERM` → exits 0 after printing its startup lines, i.e. the shared handler still stops a running command cleanly.

Net: **-146 / +22** lines across the five commands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with behavior explicitly preserved and new unit tests; signal handling is sensitive but unchanged except unified locking via `withLock`.
> 
> **Overview**
> **Consolidates duplicated cooperative cancellation** across `serve`, `guard`, `refresh`, `wake`, and `wake-agent` into two shared MeterBar types: `CLICancellationFlag` (thread-safe flag using `NSLock.withLock`) and `CLISignalHandlers.install` (SIG_IGN + `DispatchSourceSignal` wiring).
> 
> Each command drops its private cancellation class and copy-pasted `installSignalHandlers`; they now create a shared flag, install handlers in `defer`-cleaned `run()`, and pass `shouldCancel: { flag.isCancelled }` unchanged. **`wake` still registers SIGINT only** via `CLISignalHandlers.install([SIGINT], …)`; the other four use the default `[SIGINT, SIGTERM]`.
> 
> Adds **`MeterBarTests/CLICancellationTests`** covering flag semantics, concurrency, installer defaults, and end-to-end signal delivery (SIGUSR2) without touching process-wide SIGINT/SIGTERM disposition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71548013ba4b865e0ed138fd984cc8d38a382cf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->