### PR TITLE
refactor(cost): drop the unused system display-currency source

### DIFF
--- a/MeterBar/Models/DisplayCurrency.swift
+++ b/MeterBar/Models/DisplayCurrency.swift
@@ -17,7 +17,6 @@ nonisolated enum DisplayCurrencySelection: String, CaseIterable, Identifiable, S
 nonisolated public enum DisplayCurrencySource: String, Equatable, Sendable {
     case manual
     case europeanCentralBank = "ecb"
-    case system
 }
 
 /// A presentation-only currency conversion for cost views and the CLI.
@@ -88,8 +87,6 @@ nonisolated public struct DisplayCurrency: Equatable, Sendable {
         case .europeanCentralBank:
             let day = Self.referenceDateFormatter.string(from: enteredAt)
             return "1 USD = \(formattedRate) \(code), ECB reference rate \(day)"
-        case .system:
-            return "1 USD = \(formattedRate) \(code), from Mac region settings"
         }
     }
 

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -170,7 +170,8 @@ nonisolated enum StorageKeys {
     static let displayCurrencyRate = "DisplayCurrencyRate"
     /// Manual entry time or official reference date for the saved rate.
     static let displayCurrencyEnteredAt = "DisplayCurrencyEnteredAt"
-    /// `DisplayCurrencySource` raw value. Missing migrates to `.manual`.
+    /// `DisplayCurrencySource` raw value. Missing or unrecognized (a retired
+    /// case from an older build) migrates to `.manual`.
     static let displayCurrencySource = "DisplayCurrencySource"
     /// Legacy automatic-mode flag retained for migration from 1.8.35.
     static let displayCurrencyAutomatic = "DisplayCurrencyAutomatic"

--- a/MeterBarTests/DisplayCurrencyStoreTests.swift
+++ b/MeterBarTests/DisplayCurrencyStoreTests.swift
@@ -205,6 +205,25 @@ final class DisplayCurrencyStoreTests: XCTestCase {
         }
     }
 
+    /// The short-lived `system` source never reached a tagged release, but a
+    /// build run between #425 and #426 could have persisted its raw value, so
+    /// an unrecognized source must load as `.manual` rather than drop the rate.
+    func testLoadMapsAnUnrecognizedPersistedSourceToManual() {
+        withIsolatedDefaults { defaults in
+            defaults.set("EUR", forKey: StorageKeys.displayCurrencySelection)
+            defaults.set("EUR", forKey: StorageKeys.displayCurrencyCode)
+            defaults.set(0.92, forKey: StorageKeys.displayCurrencyRate)
+            defaults.set(Date(timeIntervalSince1970: 1_784_000_000), forKey: StorageKeys.displayCurrencyEnteredAt)
+            defaults.set("system", forKey: StorageKeys.displayCurrencySource)
+
+            let store = DisplayCurrencyStore(userDefaults: defaults)
+
+            XCTAssertEqual(store.selection, .eur)
+            XCTAssertEqual(store.currency?.code, "EUR")
+            XCTAssertEqual(store.currency?.source, .manual)
+        }
+    }
+
     private func withIsolatedDefaults(_ body: (UserDefaults) -> Void) {
         let suiteName = "DisplayCurrencyStoreTests-\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {

--- a/MeterBarTests/DisplayCurrencyTests.swift
+++ b/MeterBarTests/DisplayCurrencyTests.swift
@@ -82,17 +82,6 @@ final class DisplayCurrencyTests: XCTestCase {
         )
     }
 
-    func testSystemIdentityDisclosureNamesMacRegionSettings() {
-        let currency = DisplayCurrency(
-            code: "USD",
-            unitsPerUSD: 1,
-            enteredAt: enteredAt,
-            source: .system
-        )
-
-        XCTAssertEqual(currency.disclosureText, "1 USD = 1 USD, from Mac region settings")
-    }
-
     func testConvertTreatsANonFiniteRateAsAnIdentityFallback() {
         // `Double.infinity` and `.nan` both slip past a bare `rate > 0` check
         // (NaN fails it, infinity passes it), so a corrupted defaults value


### PR DESCRIPTION
## What

Removes `DisplayCurrencySource.system` and its `disclosureText` arm.

## Why it's dead

`.system` arrived in #425 for the Mac-region-derived identity rate (`1 USD = 1 USD`). #426 replaced automatic region detection with the USD/EUR picker and dropped the only construction site. Since then the only reference in the tree was a test asserting the disclosure string for a value nothing produces.

Verified with a full-tree grep across `MeterBar`, `MeterBarWidget`, `MeterBarCLI`, `Packages`, and `MeterBarTests`.

## Persistence

`DisplayCurrencySource` is `RawRepresentable`, not `Codable`. Its only persisted form is the `DisplayCurrencySource` defaults key, read through `DisplayCurrencySource.init(rawValue:) ?? .manual` — an unknown raw value already falls back rather than failing.

No tagged release ever wrote `"system"`: #425 and #426 both land between `v1.8.34` and `v1.8.35`. A build run from master between the two PRs could still hold it, so the fallback stays and is now pinned by a test instead of being implicit.

## Changes

- `DisplayCurrency.swift` — remove the case and its switch arm.
- `StorageKeys.swift` — note that an unrecognized source migrates to `.manual`.
- `DisplayCurrencyStoreTests` — new `testLoadMapsAnUnrecognizedPersistedSourceToManual`: a persisted `"system"` loads as `.manual` with the rate intact.
- `DisplayCurrencyTests` — drop the disclosure test for the removed case.

## Verification

`swift test` — 2396 tests, 6 skipped, 0 failures (three consecutive runs). `cd MeterBarCLI && swift build` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer enum cleanup with unchanged load fallback; behavior for edge-case persisted `"system"` is now explicitly tested as manual.
> 
> **Overview**
> Removes **`DisplayCurrencySource.system`** and its **Mac region settings** disclosure branch from `DisplayCurrency`, leaving only manual and ECB sources for presentation-only cost conversion.
> 
> **`StorageKeys`** now documents that an unrecognized persisted source (including retired **`"system"`** from unreleased builds) maps to **`.manual`** via existing `init(rawValue:) ?? .manual` loading in `DisplayCurrencyStore`.
> 
> Tests drop the system disclosure assertion and add **`testLoadMapsAnUnrecognizedPersistedSourceToManual`** so a saved **`"system"`** raw value still restores EUR with **`.manual`** source instead of dropping the rate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79306045276cc819701328719bee9f38121cd8ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->