### PR TITLE
fix(cursor): read Out only when both included pools are spent

### DIFF
--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -60,10 +60,16 @@ struct ProviderSnapshot: Identifiable {
         return providerLimits.min { $0.percentLeft < $1.percentLeft }
     }
 
-    /// Two or more included Cursor pools (Cursor Models / Other Models). A lone
-    /// legacy monthly bar has nothing to spill into and keeps the normal rules.
+    /// Two or more included Cursor pools (Cursor Models / Other Models). Only the
+    /// percent-of-100 pools spill into each other, so the check is the pool
+    /// denominator, not the window count: a legacy on-demand + monthly pair is
+    /// two blocking windows that do NOT share a budget and keeps the normal
+    /// tightest-window rules, as does a lone monthly bar.
     private var hasCursorSpilloverPools: Bool {
-        service == .cursor && limits.filter(\.isProviderBlocking).count >= 2
+        guard service == .cursor else { return false }
+        let providerLimits = limits.filter(\.isProviderBlocking)
+        return providerLimits.count >= 2
+            && providerLimits.allSatisfy { ServiceType.isCursorIncludedPool(total: $0.usageLimit.total) }
     }
 
     /// Severity band of the primary limit; `nil` when no limits are reported.

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -46,9 +46,24 @@ struct ProviderSnapshot: Identifiable {
     /// The provider-wide limit closest to exhaustion — what the card's status
     /// reflects. Model-scoped Sonnet/Fable and code-review windows remain
     /// visible on their own rows but do not mean the provider is unavailable.
+    ///
+    /// Cursor's included pools spill over into each other, so the card's status
+    /// follows the pool with the most room: emptying Cursor Models while Other
+    /// Models still has 73% left is not "Out". Only when every pool is gone does
+    /// the roomiest one read exhausted too, and the header agrees with
+    /// `blockingLimits`.
     var primaryLimit: SnapshotLimit? {
         let providerLimits = limits.filter(\.isProviderBlocking)
+        if hasCursorSpilloverPools {
+            return providerLimits.max { $0.percentLeft < $1.percentLeft }
+        }
         return providerLimits.min { $0.percentLeft < $1.percentLeft }
+    }
+
+    /// Two or more included Cursor pools (Cursor Models / Other Models). A lone
+    /// legacy monthly bar has nothing to spill into and keeps the normal rules.
+    private var hasCursorSpilloverPools: Bool {
+        service == .cursor && limits.filter(\.isProviderBlocking).count >= 2
     }
 
     /// Severity band of the primary limit; `nil` when no limits are reported.
@@ -59,21 +74,19 @@ struct ProviderSnapshot: Identifiable {
     /// Session/weekly windows that can block normal provider usage. Secondary
     /// model/code-review quotas remain visible but must not collapse the entire
     /// provider card or claim the provider is unavailable.
-        var blockingLimits: [SnapshotLimit] {
+    var blockingLimits: [SnapshotLimit] {
         guard extraUsage?.state != .on else { return [] }
         let exhausted = limits.filter {
             $0.isProviderBlocking
                 && !$0.usageLimit.isEstimated
                 && $0.usageLimit.isAtLimit
         }
-        if service == .cursor {
-            let pools = limits.filter(\.isProviderBlocking)
+        if hasCursorSpilloverPools {
             // Spillover: emptying Cursor Models still leaves Other Models, and
             // the reverse. Collapse the card only when every included pool is
             // gone. A lone legacy monthly bar still blocks on its own.
-            if pools.count >= 2 {
-                return exhausted.count == pools.count ? exhausted : []
-            }
+            let pools = limits.filter(\.isProviderBlocking)
+            return exhausted.count == pools.count ? exhausted : []
         }
         return exhausted
     }

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -475,11 +475,53 @@ final class ProviderSnapshotTests: XCTestCase {
             emptyDetail: ""
         )
 
-        XCTAssertEqual(snapshot.band, .exhausted)
+        // Spillover: the header must reflect the pool that still has room, not
+        // the one that ran dry — Cursor is only "Out" when both are gone.
+        XCTAssertEqual(snapshot.primaryLimit?.kind, .session)
+        XCTAssertEqual(snapshot.band, .healthy)
         XCTAssertFalse(snapshot.hasExhaustedLimit)
         XCTAssertFalse(snapshot.hasExhaustedWeeklyLimit)
         XCTAssertTrue(snapshot.blockingLimits.isEmpty)
         XCTAssertEqual(snapshot.detailLimits.map(\.id), ["session", "weekly"])
+    }
+
+    func testCursorOtherModelsExhaustedStillReadsCursorModelsHeadroom() {
+        let snapshot = ProviderSnapshotBuilder.snapshot(
+            title: "Cursor",
+            service: .cursor,
+            metrics: makeMetrics(service: .cursor, session: 27, weekly: 100),
+            emptyDetail: ""
+        )
+
+        XCTAssertEqual(snapshot.primaryLimit?.kind, .session)
+        XCTAssertEqual(snapshot.primaryLimit?.percentLeft, 73)
+        XCTAssertEqual(snapshot.band, .healthy)
+        XCTAssertFalse(snapshot.hasExhaustedLimit)
+    }
+
+    func testCursorSpilloverBandTracksTheRoomiestPool() {
+        let snapshot = ProviderSnapshotBuilder.snapshot(
+            title: "Cursor",
+            service: .cursor,
+            metrics: makeMetrics(service: .cursor, session: 100, weekly: 92),
+            emptyDetail: ""
+        )
+
+        XCTAssertEqual(snapshot.primaryLimit?.kind, .weekly)
+        XCTAssertEqual(snapshot.band, .critical)
+        XCTAssertFalse(snapshot.hasExhaustedLimit)
+    }
+
+    func testCursorLegacySinglePoolStillUsesTightestWindow() {
+        let snapshot = ProviderSnapshotBuilder.snapshot(
+            title: "Cursor",
+            service: .cursor,
+            metrics: makeMetrics(service: .cursor, weekly: 100),
+            emptyDetail: ""
+        )
+
+        XCTAssertEqual(snapshot.band, .exhausted)
+        XCTAssertTrue(snapshot.hasExhaustedLimit)
     }
 
     func testCursorBothPoolsExhaustedBlocksTheProvider() {
@@ -490,6 +532,7 @@ final class ProviderSnapshotTests: XCTestCase {
             emptyDetail: ""
         )
 
+        XCTAssertEqual(snapshot.band, .exhausted)
         XCTAssertTrue(snapshot.hasExhaustedLimit)
         XCTAssertTrue(snapshot.hasExhaustedWeeklyLimit)
         XCTAssertEqual(Set(snapshot.blockingLimits.map(\.kind)), [.session, .weekly])

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -624,6 +624,30 @@ final class ProviderSnapshotTests: XCTestCase {
         XCTAssertTrue(snapshot.hasExhaustedLimit)
     }
 
+    func testCursorLegacyTwoWindowsKeepTheTightestWindowRule() {
+        // Legacy Cursor payloads map an on-demand session limit plus a
+        // request-count monthly quota — two provider-blocking windows that do
+        // not share a budget, so neither spills into the other. Only the
+        // percent-of-100 included pools do.
+        let metrics = UsageMetrics(
+            service: .cursor,
+            sessionLimit: UsageLimit(used: 5, total: 50, resetTime: nil),
+            weeklyLimit: UsageLimit(used: 500, total: 500, resetTime: nil),
+            codeReviewLimit: nil
+        )
+        let snapshot = ProviderSnapshotBuilder.snapshot(
+            title: "Cursor",
+            service: .cursor,
+            metrics: metrics,
+            emptyDetail: ""
+        )
+
+        XCTAssertEqual(snapshot.primaryLimit?.kind, .weekly)
+        XCTAssertEqual(snapshot.band, .exhausted)
+        XCTAssertTrue(snapshot.hasExhaustedLimit)
+        XCTAssertEqual(snapshot.blockingLimits.map(\.kind), [.weekly])
+    }
+
     func testCursorBothPoolsExhaustedBlocksTheProvider() {
         let snapshot = ProviderSnapshotBuilder.snapshot(
             title: "Cursor",


### PR DESCRIPTION
## Summary
- Cursor card read **Out** as soon as one included pool (Other Models) hit 100%, even with 73% of Cursor Models left.
- `blockingLimits` already treated the two pools as spillover (collapse only when both are gone); the header `band` still used the tightest pool.
- `primaryLimit` now follows the roomiest pool for Cursor spillover setups (≥2 included pools). Both pools spent → still **Out**. Legacy single monthly bar keeps the tightest-window rule. Dashboard hero (`tightestLimit`) inherits the fix.

## Tests
- Flipped the test that locked in the bug; added spillover cases (Other Models out / Cursor Models out / roomiest pool critical / legacy single pool / both out).
- `swift test`: 2399 passed, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display logic only in ProviderSnapshot quota aggregation; behavior is narrowed to Cursor included-pool payloads with expanded unit tests.
> 
> **Overview**
> Fixes a mismatch where the Cursor card header could show **Out** / exhausted as soon as one included pool (Cursor Models / Other Models) hit 100%, even though `blockingLimits` already treated those pools as spillover and left the provider usable.
> 
> **`primaryLimit`** (and thus **`band`**, hero **`tightestLimit`**, etc.) now picks the **roomiest** blocking pool when `hasCursorSpilloverPools` is true (Cursor, ≥2 provider-blocking windows, all percent-of-100 included pools). **Out** only when every such pool is exhausted, aligning the header with **`blockingLimits`**. Legacy Cursor shapes (single monthly bar, or on-demand + request-count monthly) keep the existing **tightest-window** rule.
> 
> Tests were updated to expect healthy/critical bands when only one spillover pool is dry, plus legacy and both-pools-exhausted cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82f9009d5725639cb717acab78457a0a39869d7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved capacity handling for accounts with multiple usage limits.
  * Available capacity is now prioritized before marking usage as restricted.
  * Usage remains healthy or critical while any applicable limit still has capacity.
  * Restrictions are applied only after all relevant limits are exhausted.
  * Existing behavior for single or legacy limits remains unchanged.
  * Added coverage for multi-limit exhaustion and spillover usage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->