### PR TITLE
fix(cost): keep colliding session ids apart in flattened breakdowns

### DIFF
--- a/MeterBar/Services/TokenUsageAggregator.swift
+++ b/MeterBar/Services/TokenUsageAggregator.swift
@@ -207,23 +207,68 @@ enum TokenUsageAggregator {
         }
     }
 
+    /// Session ids are only unique inside their own project, so flattening the
+    /// nested map by raw id merged two unrelated conversations into one row —
+    /// and always merged every project's `unknown` fallback bucket. Ids that
+    /// stay unambiguous keep the bare conversation id consumers index on; the
+    /// rest are qualified as `"<project>/<session>"`.
     nonisolated static func flattenSessions(
         _ projectSessions: [String: [String: TokenAccumulator]]
     ) -> [String: TokenAccumulator] {
         var flattened: [String: TokenAccumulator] = [:]
-        for (_, sessions) in projectSessions {
-            CostScanNestedMerge.accumulators(&flattened, sessions)
+        let ambiguous = ambiguousSessionIDs(in: projectSessions)
+        for (project, sessions) in projectSessions {
+            CostScanNestedMerge.accumulators(
+                &flattened,
+                qualifyKeys(sessions, project: project, ambiguous: ambiguous)
+            )
         }
         return flattened
     }
 
+    /// Qualified in lockstep with `flattenSessions`: `makeSessionBreakdowns`
+    /// looks each row's model slice up by the session row's own name.
     nonisolated static func flattenSessionModels(
         _ projectSessionModels: [String: [String: [String: TokenAccumulator]]]
     ) -> [String: [String: TokenAccumulator]] {
         var flattened: [String: [String: TokenAccumulator]] = [:]
-        for (_, sessions) in projectSessionModels {
-            CostScanNestedMerge.keyedAccumulators(&flattened, sessions)
+        let ambiguous = ambiguousSessionIDs(in: projectSessionModels)
+        for (project, sessions) in projectSessionModels {
+            CostScanNestedMerge.keyedAccumulators(
+                &flattened,
+                qualifyKeys(sessions, project: project, ambiguous: ambiguous)
+            )
         }
         return flattened
+    }
+
+    /// Ids that cannot stand alone in a flattened map: the `unknown` fallback
+    /// (never an identity, and qualifying it unconditionally keeps the key
+    /// stable across days rather than only on days two projects both fall back)
+    /// plus any id recorded under more than one project.
+    private nonisolated static func ambiguousSessionIDs<Value>(
+        in projectSessions: [String: [String: Value]]
+    ) -> Set<String> {
+        var seen: Set<String> = []
+        var ambiguous: Set<String> = [CostSessionAttribution.unknownSessionID]
+        for (_, sessions) in projectSessions {
+            for id in sessions.keys where !seen.insert(id).inserted {
+                ambiguous.insert(id)
+            }
+        }
+        return ambiguous
+    }
+
+    private nonisolated static func qualifyKeys<Value>(
+        _ sessions: [String: Value],
+        project: String,
+        ambiguous: Set<String>
+    ) -> [String: Value] {
+        guard sessions.keys.contains(where: ambiguous.contains) else { return sessions }
+        return Dictionary(
+            uniqueKeysWithValues: sessions.map { id, value in
+                (ambiguous.contains(id) ? "\(project)/\(id)" : id, value)
+            }
+        )
     }
 }

--- a/MeterBar/Services/TokenUsageAggregator.swift
+++ b/MeterBar/Services/TokenUsageAggregator.swift
@@ -246,7 +246,7 @@ enum TokenUsageAggregator {
     /// (never an identity, and qualifying it unconditionally keeps the key
     /// stable across days rather than only on days two projects both fall back)
     /// plus any id recorded under more than one project.
-    private nonisolated static func ambiguousSessionIDs<Value>(
+    nonisolated private static func ambiguousSessionIDs<Value>(
         in projectSessions: [String: [String: Value]]
     ) -> Set<String> {
         var seen: Set<String> = []
@@ -259,7 +259,7 @@ enum TokenUsageAggregator {
         return ambiguous
     }
 
-    private nonisolated static func qualifyKeys<Value>(
+    nonisolated private static func qualifyKeys<Value>(
         _ sessions: [String: Value],
         project: String,
         ambiguous: Set<String>

--- a/MeterBarTests/CostScanCollaboratorTests.swift
+++ b/MeterBarTests/CostScanCollaboratorTests.swift
@@ -330,6 +330,96 @@ final class CostScanCollaboratorTests: XCTestCase {
         XCTAssertTrue(appB.modelBreakdowns.isEmpty)
     }
 
+    func testFlattenSessionsKeepsUnambiguousIdsBare() {
+        let flattened = TokenUsageAggregator.flattenSessions([
+            "app-a": ["conv-a": totals(input: 10, output: 0, cacheRead: 0, cost: 1)],
+            "app-b": ["conv-b": totals(input: 20, output: 0, cacheRead: 0, cost: 2)]
+        ])
+
+        // A session id that belongs to exactly one project stays addressable by
+        // the raw conversation id consumers already index on.
+        XCTAssertEqual(Set(flattened.keys), ["conv-a", "conv-b"])
+        XCTAssertEqual(flattened["conv-a"]?.input, 10)
+        XCTAssertEqual(flattened["conv-b"]?.input, 20)
+    }
+
+    func testFlattenSessionsQualifiesIdsSharedByMoreThanOneProject() {
+        let flattened = TokenUsageAggregator.flattenSessions([
+            "app-a": [
+                "shared": totals(input: 10, output: 0, cacheRead: 0, cost: 1),
+                "solo-a": totals(input: 1, output: 0, cacheRead: 0)
+            ],
+            "app-b": ["shared": totals(input: 200, output: 0, cacheRead: 0, cost: 2)]
+        ])
+
+        // Same id under two projects is two different conversations; merging
+        // them would report one row with nobody's totals.
+        XCTAssertEqual(Set(flattened.keys), ["app-a/shared", "app-b/shared", "solo-a"])
+        XCTAssertEqual(flattened["app-a/shared"]?.input, 10)
+        XCTAssertEqual(flattened["app-b/shared"]?.input, 200)
+        XCTAssertEqual(flattened["app-a/shared"]?.estimatedCostUSD ?? -1, 1, accuracy: 0.0001)
+        XCTAssertEqual(flattened["app-b/shared"]?.estimatedCostUSD ?? -1, 2, accuracy: 0.0001)
+    }
+
+    func testFlattenSessionsQualifiesTheUnknownFallbackEvenForASingleProject() {
+        let unknown = CostSessionAttribution.unknownSessionID
+        let flattened = TokenUsageAggregator.flattenSessions([
+            "app-a": [unknown: totals(input: 10, output: 0, cacheRead: 0)]
+        ])
+
+        // "unknown" is a fallback bucket, not an identity: qualify it always so
+        // the key stays stable on the day a second project also falls back.
+        XCTAssertEqual(Set(flattened.keys), ["app-a/\(unknown)"])
+        XCTAssertEqual(flattened["app-a/\(unknown)"]?.input, 10)
+    }
+
+    func testFlattenSessionModelsQualifiesInLockstepWithFlattenSessions() {
+        let projectSessionModels: [String: [String: [String: TokenAccumulator]]] = [
+            "app-a": ["shared": ["opus": totals(input: 10, output: 0, cacheRead: 0)]],
+            "app-b": ["shared": ["haiku": totals(input: 200, output: 0, cacheRead: 0)]]
+        ]
+
+        let flattened = TokenUsageAggregator.flattenSessionModels(projectSessionModels)
+
+        // `makeSessionBreakdowns` looks the model slice up by the session row's
+        // name, so both maps have to agree on when a key is qualified.
+        XCTAssertEqual(Set(flattened.keys), ["app-a/shared", "app-b/shared"])
+        XCTAssertEqual(flattened["app-a/shared"]?["opus"]?.input, 10)
+        XCTAssertEqual(flattened["app-b/shared"]?["haiku"]?.input, 200)
+    }
+
+    func testDailyUsageSplitsCollidingSessionIdsIntoDistinctFlattenedRows() throws {
+        let day = try XCTUnwrap(FlexibleISO8601.date(from: "2026-07-01T00:00:00Z"))
+        let rows = TokenUsageAggregator.makeDailyUsage(
+            from: [day: totals(input: 210, output: 0, cacheRead: 0, cost: 3)],
+            provider: .claudeCode,
+            pricing: ModelPricing.claude(for: nil),
+            projectsByDay: [day: [
+                "app-a": totals(input: 10, output: 0, cacheRead: 0, cost: 1),
+                "app-b": totals(input: 200, output: 0, cacheRead: 0, cost: 2)
+            ]],
+            projectSessionsByDay: [day: [
+                "app-a": ["shared": totals(input: 10, output: 0, cacheRead: 0, cost: 1)],
+                "app-b": ["shared": totals(input: 200, output: 0, cacheRead: 0, cost: 2)]
+            ]],
+            projectSessionModelsByDay: [day: [
+                "app-a": ["shared": ["opus": totals(input: 10, output: 0, cacheRead: 0, cost: 1)]],
+                "app-b": ["shared": ["haiku": totals(input: 200, output: 0, cacheRead: 0, cost: 2)]]
+            ]]
+        )
+
+        let sessions = try XCTUnwrap(rows.first?.sessionBreakdowns)
+        XCTAssertEqual(sessions.map(\.name), ["app-b/shared", "app-a/shared"])
+        XCTAssertEqual(sessions.reduce(0) { $0 + $1.inputTokens }, 210)
+        XCTAssertEqual(sessions.first { $0.name == "app-a/shared" }?.modelBreakdowns.map(\.name), ["opus"])
+        XCTAssertEqual(sessions.first { $0.name == "app-b/shared" }?.modelBreakdowns.map(\.name), ["haiku"])
+
+        // The per-project nested rows keep the bare id — they are already
+        // namespaced by their parent project row.
+        let projects = try XCTUnwrap(rows.first?.projectBreakdowns)
+        XCTAssertEqual(projects.first { $0.name == "app-a" }?.sessionBreakdowns.map(\.name), ["shared"])
+    }
+
     // MARK: - ClaudeCostScanner
 
     func testProjectsURLAppendsProjectsUnlessAlreadyPresent() {

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -268,6 +268,12 @@ Claude transcript stem, Grok session id). Project rows nest the same sessions un
 `projectBreakdowns[].sessionBreakdowns`. The field is omitted when empty. Identifiers are stable
 local stems — never working directories, prompts, credentials, branch names, or git remotes.
 
+Session ids are only unique within their own project, so the provider-level list qualifies any name
+that would otherwise be ambiguous as `"<project>/<session>"`: the `unknown` fallback bucket always,
+and any id recorded under more than one project. Every other row keeps the bare session id. Rows
+nested under `projectBreakdowns[]` are already scoped by their parent project and always use the bare
+id. Match on the trailing path component if you want to pair a provider-level row with its project.
+
 ```json
 {
   "sessionBreakdowns": [


### PR DESCRIPTION
## Problem

`TokenUsageAggregator.flattenSessions` merged every project's session map by raw id:

```swift
for (_, sessions) in projectSessions {
    CostScanNestedMerge.accumulators(&flattened, sessions)
}
```

Session ids are only unique **within** a project. Two projects sharing an id — guaranteed for the `CostSessionAttribution.unknownSessionID` fallback bucket, possible for any real id — collapsed into a single provider-level `sessionBreakdowns` row whose totals belonged to neither conversation. That row is user-visible through `meterbar cost --json` and the `--days` / `--month-to-date` window merge in `TokenCost.dailyCostWindow`.

The nested `projectBreakdowns[].sessionBreakdowns` rows (what the UI and human CLI output render) are already scoped by their parent project and were never affected. The flattened path had no test.

## Fix

Qualify only the ambiguous keys as `<project>/<session>`:

- **the `unknown` fallback always** — it is a bucket, not an identity, and qualifying it unconditionally keeps the key stable day to day. Collision-only qualification would rename it on days two projects both fall back, fragmenting rows in the windowed merge.
- **any id recorded under more than one project**.

Everything else keeps the bare conversation id, which is what consumers index on. Cross-project merging of a genuinely shared id was deliberate (see the design note at `MeterBar/Services/CostScanWindows.swift:68`) — it stays, it just isn't silent any more when the id is ambiguous.

`flattenSessionModels` qualifies in lockstep, since `makeSessionBreakdowns` looks each row's model slice up by the session row's name. Both public signatures are unchanged, so the three scanner call sites (Claude/Codex/Grok) need no edits.

## Schema

`docs/cli-json-schema.md` documents the qualification rule. **No `schemaVersion` bump** — no field is removed, renamed, or retyped; only previously ambiguous key values change, and the merged value was wrong.

## Tests

New coverage in `MeterBarTests/CostScanCollaboratorTests.swift` (written first, confirmed failing against the old implementation):

- shared id under two projects → two rows with correct per-project totals
- `unknown` qualified even for a single project
- unambiguous ids stay bare
- `flattenSessionModels` keys match `flattenSessions`
- end-to-end through `makeDailyUsage`: distinct flattened rows summing to the day total, each with its own model slice, while the nested project rows keep the bare id

`swift test`: 2401 tests, 0 failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible cost JSON session row names and fixes previously wrong merged totals; logic is localized to aggregation with strong test coverage and no scanner API changes.
> 
> **Overview**
> Fixes **incorrect provider-level `sessionBreakdowns`** when flattening per-project session maps: merging by raw session id combined different conversations (including every project’s `unknown` fallback) into a single row with wrong totals, visible via `meterbar cost --json` and windowed cost merges.
> 
> **`TokenUsageAggregator.flattenSessions` and `flattenSessionModels`** now detect ambiguous ids—the `unknown` bucket always, plus any id appearing under more than one project—and rewrite only those keys to `"<project>/<session>"` before merge. Unambiguous ids stay bare so existing consumers can keep indexing on the raw conversation id. Nested `projectBreakdowns[].sessionBreakdowns` are unchanged (already scoped by parent project).
> 
> Adds contract tests for bare vs qualified keys, model map parity, and end-to-end `makeDailyUsage` behavior. **`docs/cli-json-schema.md`** documents the qualification rule without a `schemaVersion` bump (same fields; only previously wrong `name` values change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f862895b130e5cffb20d1046f3a5015805c1619. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->