### PR TITLE
fix(widget): localize the Settings preview from the widget's own copy

### DIFF
--- a/MeterBar/Resources/Localizable.xcstrings
+++ b/MeterBar/Resources/Localizable.xcstrings
@@ -469,6 +469,50 @@
         }
       }
     },
+    "widget.empty.choose_detail": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select accounts and quota windows in MeterBar Settings."
+          }
+        }
+      },
+      "comment": "Widget placeholder body telling the reader where to choose what the widget shows."
+    },
+    "widget.empty.choose_title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose usage to show"
+          }
+        }
+      },
+      "comment": "Widget placeholder heading when nothing has been selected to display."
+    },
+    "widget.empty.unavailable_detail": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open MeterBar to refresh provider usage."
+          }
+        }
+      },
+      "comment": "Widget placeholder body telling the reader how to refresh unavailable usage."
+    },
+    "widget.empty.unavailable_title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usage unavailable"
+          }
+        }
+      },
+      "comment": "Widget placeholder heading when no provider usage could be read."
+    },
     "widget.unavailable": {
       "localizations": {
         "en": {

--- a/MeterBar/Views/Settings/WidgetSettingsView.swift
+++ b/MeterBar/Views/Settings/WidgetSettingsView.swift
@@ -622,15 +622,22 @@ struct WidgetSettingsBurnDownPreviewSurface: View {
 
     private var metrics: WidgetGlanceMetrics { WidgetGlance.metrics(for: family) }
 
+    /// The placeholder copy the widget shows for this state, in the reader's
+    /// language — not the shared model's English `title`/`detail`, which would
+    /// leave this preview speaking English beside a translated widget.
+    var emptyStateText: WidgetSettingsPreviewEmptyStateText? {
+        presentation.emptyState.map(WidgetSettingsPreviewEmptyStateText.init)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: metrics.stackSpacing) {
-            if let emptyState = presentation.emptyState {
+            if let emptyState = presentation.emptyState, let emptyStateText {
                 Spacer()
                 Image(systemName: emptyState == .noSelection ? "slider.horizontal.3" : "exclamationmark.triangle")
-                Text(emptyState.title)
+                Text(emptyStateText.title)
                     .font(.caption)
                     .fontWeight(.semibold)
-                Text(emptyState.detail)
+                Text(emptyStateText.detail)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                 Spacer()
@@ -705,9 +712,7 @@ struct WidgetSettingsBurnDownPreviewRow: View {
                 .font(.system(size: metrics.captionSize, weight: .medium))
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
-            Text(row.countdownKind == .unavailable || row.countdownText == "Unavailable"
-                 ? LocalizedUsageFormat.unavailable()
-                 : row.countdownText)
+            Text(countdownText)
                 .font(.system(size: metrics.headlineSize, weight: .semibold, design: .rounded))
                 .monospacedDigit()
                 .lineLimit(1)
@@ -734,6 +739,16 @@ struct WidgetSettingsBurnDownPreviewRow: View {
         .accessibilityValue(row.accessibilityValueText)
     }
 
+    /// The same countdown value the widget draws, fallback and all — the
+    /// `"Unavailable"` sentinel check lives in `LocalizedUsageFormat` rather
+    /// than being spelled out again here.
+    var countdownText: String {
+        LocalizedUsageFormat.burnDownCountdownText(
+            kind: row.countdownKind,
+            fallback: row.countdownText
+        )
+    }
+
     private var quotaLeftText: String {
         row.row.limit.map { LocalizedUsageFormat.percentLeft($0) }
             ?? LocalizedUsageFormat.unavailable()
@@ -741,6 +756,22 @@ struct WidgetSettingsBurnDownPreviewRow: View {
 
     private var stageColor: Color {
         row.isExhausted ? MeterBarTheme.danger : row.stage.previewColor
+    }
+}
+
+/// The localized placeholder copy both Settings preview surfaces draw.
+///
+/// The widget extension renders its empty state through
+/// `WidgetLocalizedContent`, which resolves against the widget bundle; the app
+/// cannot link that type, so both targets read the same keys through the shared
+/// `LocalizedUsageFormat` helpers instead.
+struct WidgetSettingsPreviewEmptyStateText: Equatable {
+    let title: String
+    let detail: String
+
+    init(_ state: WidgetPresentationEmptyState) {
+        title = LocalizedUsageFormat.widgetEmptyTitle(state)
+        detail = LocalizedUsageFormat.widgetEmptyDetail(state)
     }
 }
 
@@ -763,15 +794,20 @@ struct WidgetSettingsPreviewSurface: View {
     /// rows everywhere else.
     var layout: WidgetGlanceLayout { WidgetGlance.layout(for: presentation, family: family) }
 
+    /// See `WidgetSettingsBurnDownPreviewSurface.emptyStateText`.
+    var emptyStateText: WidgetSettingsPreviewEmptyStateText? {
+        presentation.emptyState.map(WidgetSettingsPreviewEmptyStateText.init)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: metrics.stackSpacing) {
-            if let emptyState = presentation.emptyState {
+            if let emptyState = presentation.emptyState, let emptyStateText {
                 Spacer()
                 Image(systemName: emptyState == .noSelection ? "slider.horizontal.3" : "exclamationmark.triangle")
-                Text(emptyState.title)
+                Text(emptyStateText.title)
                     .font(.caption)
                     .fontWeight(.semibold)
-                Text(emptyState.detail)
+                Text(emptyStateText.detail)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                 Spacer()

--- a/MeterBarTests/LocalizationResourceContractTests.swift
+++ b/MeterBarTests/LocalizationResourceContractTests.swift
@@ -73,6 +73,47 @@ final class LocalizationResourceContractTests: XCTestCase {
         ].allSatisfy(appKeysAfterBurnDown.contains))
     }
 
+    /// The Settings preview draws the widget's empty states from the app bundle,
+    /// so both catalogs have to carry the same four keys with the same English
+    /// words. Translated only on one side, the preview would contradict the
+    /// widget it is previewing.
+    func testWidgetEmptyStateCopyIsCarriedByBothCatalogsWithMatchingEnglish() throws {
+        let appStrings = try strings(in: loadCatalog(at: appCatalogURL))
+        let widgetStrings = try strings(in: loadCatalog(at: widgetCatalogURL))
+
+        for key in [
+            "widget.empty.choose_title",
+            "widget.empty.choose_detail",
+            "widget.empty.unavailable_title",
+            "widget.empty.unavailable_detail",
+        ] {
+            let appValue = try englishValue(for: key, in: appStrings)
+            let widgetValue = try englishValue(for: key, in: widgetStrings)
+            XCTAssertEqual(appValue, widgetValue, "\(key) must read identically in both bundles")
+        }
+    }
+
+    /// One key per `ServiceType.QuotaTitleKey` case. The shared routing decides
+    /// which case applies; the widget catalog only supplies its words, so a new
+    /// case without a key would silently ship English.
+    func testWidgetCatalogCoversEveryQuotaTitleRoutingKey() throws {
+        let widgetKeys = Set(try strings(in: loadCatalog(at: widgetCatalogURL)).keys)
+        for key in [
+            "widget.quota.key_limit",
+            "widget.quota.model",
+            "widget.quota.on_demand",
+            "widget.quota.code_review",
+            "widget.quota.cursor_models",
+            "widget.quota.session",
+            "widget.quota.account_credits",
+            "widget.quota.other_models",
+            "widget.quota.monthly",
+            "widget.quota.weekly",
+        ] {
+            XCTAssertTrue(widgetKeys.contains(key), "\(key) missing from the widget catalog")
+        }
+    }
+
     func testCountStringsCarryEnglishOneAndOtherPluralRules() throws {
         try assertPluralRules(
             keys: ["reset.exhausted_limits", "reset.exhausted_detail"],
@@ -117,6 +158,14 @@ final class LocalizationResourceContractTests: XCTestCase {
 
     private func strings(in catalog: [String: Any]) throws -> [String: Any] {
         try XCTUnwrap(catalog["strings"] as? [String: Any])
+    }
+
+    private func englishValue(for key: String, in catalogStrings: [String: Any]) throws -> String {
+        let entry = try XCTUnwrap(catalogStrings[key] as? [String: Any], key)
+        let localizations = try XCTUnwrap(entry["localizations"] as? [String: Any], key)
+        let english = try XCTUnwrap(localizations["en"] as? [String: Any], key)
+        let unit = try XCTUnwrap(english["stringUnit"] as? [String: Any], key)
+        return try XCTUnwrap(unit["value"] as? String, key)
     }
 
     private func assertPluralRules(keys: [String], catalogURL: URL) throws {

--- a/MeterBarTests/LocalizedUsageFormattingTests.swift
+++ b/MeterBarTests/LocalizedUsageFormattingTests.swift
@@ -61,4 +61,54 @@ final class LocalizedUsageFormattingTests: XCTestCase {
             "<1m"
         )
     }
+
+    /// The English source copy has to stay word-for-word what the locale-neutral
+    /// shared model says, or the Settings preview would change wording the
+    /// moment it started routing through the localized helper.
+    func testWidgetEmptyStateCopyMatchesTheSharedEnglishSource() {
+        for state in [WidgetPresentationEmptyState.noSelection, .unavailable] {
+            XCTAssertEqual(
+                LocalizedUsageFormat.widgetEmptyTitle(state, locale: Locale(identifier: "en")),
+                state.title,
+                "\(state) title"
+            )
+            XCTAssertEqual(
+                LocalizedUsageFormat.widgetEmptyDetail(state, locale: Locale(identifier: "en")),
+                state.detail,
+                "\(state) detail"
+            )
+        }
+    }
+
+    /// `countdownText` arrives from the locale-neutral planner, so an
+    /// unavailable countdown reads as the English sentinel. Recognizing it is
+    /// the formatter's job — every renderer that spelled the check out itself is
+    /// a place the fallback could go missing.
+    func testBurnDownCountdownTextTranslatesTheUnavailableSentinel() {
+        let english = Locale(identifier: "en")
+        XCTAssertEqual(
+            LocalizedUsageFormat.burnDownCountdownText(
+                kind: .unavailable,
+                fallback: "2h 5m",
+                locale: english
+            ),
+            LocalizedUsageFormat.unavailable(locale: english)
+        )
+        XCTAssertEqual(
+            LocalizedUsageFormat.burnDownCountdownText(
+                kind: .reset,
+                fallback: "Unavailable",
+                locale: english
+            ),
+            LocalizedUsageFormat.unavailable(locale: english)
+        )
+        XCTAssertEqual(
+            LocalizedUsageFormat.burnDownCountdownText(
+                kind: .reset,
+                fallback: "2h 5m",
+                locale: english
+            ),
+            "2h 5m"
+        )
+    }
 }

--- a/MeterBarTests/WidgetPresentationTests.swift
+++ b/MeterBarTests/WidgetPresentationTests.swift
@@ -378,6 +378,85 @@ final class WidgetPresentationTests: XCTestCase {
         XCTAssertTrue(result.rows.allSatisfy { [.claudeCode, .codexCli, .cursor].contains($0.service) })
     }
 
+    // MARK: - Quota title routing
+
+    /// Which quota title a row shows is one decision with two readers: the app
+    /// and CLI take `quotaTitle`, the widget extension localizes
+    /// `quotaTitleKey`. The extension used to re-derive the routing from
+    /// `(service, quotaWindow)` on its own side, so this pins the two to the
+    /// same answer for every provider, window, and Cursor pool shape.
+    func testQuotaTitleIsDerivedFromTheSharedRoutingKey() {
+        for service in ServiceType.allCases {
+            for total in [ServiceType.cursorIncludedPoolTotal, 500] {
+                for row in allWindowRows(service: service, total: total) {
+                    XCTAssertEqual(
+                        row.quotaTitle,
+                        row.quotaTitleKey.englishTitle,
+                        "\(service) \(row.quotaWindow) total \(total)"
+                    )
+                    XCTAssertEqual(
+                        row.quotaTitleKey,
+                        expectedQuotaTitleKey(
+                            service: service,
+                            window: row.quotaWindow,
+                            total: total
+                        ),
+                        "\(service) \(row.quotaWindow) total \(total)"
+                    )
+                }
+            }
+        }
+    }
+
+    /// The routing table itself, spelled out once so a change to it has to be
+    /// deliberate. Cursor's included pools are the percent-of-100 shape;
+    /// anything else is the legacy request quota.
+    private func expectedQuotaTitleKey(
+        service: ServiceType,
+        window: WidgetQuotaWindow,
+        total: Double
+    ) -> ServiceType.QuotaTitleKey {
+        let isIncludedPool = ServiceType.isCursorIncludedPool(total: total)
+        switch (service, window) {
+        case (.claudeCode, .codeReview): return .model(label: "Fable")
+        case (.cursor, .codeReview): return .onDemand
+        case (_, .codeReview): return .codeReview
+        case (.openRouter, .session): return .keyLimit
+        case (.cursor, .session): return isIncludedPool ? .cursorModels : .session
+        case (_, .session): return .session
+        case (.openRouter, .weekly): return .accountCredits
+        case (.cursor, .weekly): return isIncludedPool ? .otherModels : .monthly
+        case (_, .weekly): return .weekly
+        }
+    }
+
+    /// One row per quota window for a single provider, built through the real
+    /// planner rather than a hand-made row.
+    private func allWindowRows(service: ServiceType, total: Double) -> [WidgetPresentationRow] {
+        var preferences = WidgetPreferences.defaults
+        preferences.visibleQuotaWindows = Set(WidgetQuotaWindow.allCases)
+        let rows = presentation(
+            metrics: [
+                service: makeMetrics(
+                    service,
+                    sessionUsed: 10,
+                    weeklyUsed: 10,
+                    codeReviewUsed: 10,
+                    total: total,
+                    modelLimitLabel: "Fable"
+                )
+            ],
+            preferences: preferences,
+            family: .large
+        ).rows
+        XCTAssertEqual(
+            Set(rows.map(\.quotaWindow)),
+            Set(WidgetQuotaWindow.allCases),
+            "\(service): every quota window must be represented"
+        )
+        return rows
+    }
+
     private func presentation(
         metrics: [ServiceType: UsageMetrics],
         accountMetrics: [AccountUsageSnapshot] = [],
@@ -400,6 +479,7 @@ final class WidgetPresentationTests: XCTestCase {
         sessionUsed: Double? = nil,
         weeklyUsed: Double? = nil,
         codeReviewUsed: Double? = nil,
+        total: Double = 100,
         modelLimitLabel: String? = nil,
         resetTime: Date? = nil,
         lastUpdated: Date? = nil
@@ -407,13 +487,13 @@ final class WidgetPresentationTests: XCTestCase {
         UsageMetrics(
             service: service,
             sessionLimit: sessionUsed.map {
-                UsageLimit(used: $0, total: 100, resetTime: resetTime)
+                UsageLimit(used: $0, total: total, resetTime: resetTime)
             },
             weeklyLimit: weeklyUsed.map {
-                UsageLimit(used: $0, total: 100, resetTime: resetTime)
+                UsageLimit(used: $0, total: total, resetTime: resetTime)
             },
             codeReviewLimit: codeReviewUsed.map {
-                UsageLimit(used: $0, total: 100, resetTime: resetTime)
+                UsageLimit(used: $0, total: total, resetTime: resetTime)
             },
             modelLimitLabel: modelLimitLabel,
             lastUpdated: lastUpdated ?? now

--- a/MeterBarTests/WidgetSettingsPreviewParityTests.swift
+++ b/MeterBarTests/WidgetSettingsPreviewParityTests.swift
@@ -145,7 +145,106 @@ final class WidgetSettingsPreviewParityTests: XCTestCase {
         }
     }
 
+    // MARK: - One language
+
+    /// The preview used to print the shared model's hardcoded English `title`
+    /// and `detail` while the widget beside it drew localized copy — so on a
+    /// non-English Mac, Settings advertised a widget in the wrong language.
+    /// Both preview surfaces now read the same keys the extension does.
+    func testPreviewEmptyStatesUseTheLocalizedWidgetCopy() {
+        for state in [WidgetPresentationEmptyState.noSelection, .unavailable] {
+            let expected = WidgetSettingsPreviewEmptyStateText(state)
+            XCTAssertEqual(expected.title, LocalizedUsageFormat.widgetEmptyTitle(state))
+            XCTAssertEqual(expected.detail, LocalizedUsageFormat.widgetEmptyDetail(state))
+
+            let glance = WidgetSettingsPreviewSurface(
+                family: .medium,
+                presentation: emptyPresentation(state),
+                appearance: .light
+            )
+            XCTAssertEqual(glance.presentation.emptyState, state, "\(state) glance fixture")
+            XCTAssertEqual(glance.emptyStateText, expected, "\(state) glance preview")
+
+            let burnDown = WidgetSettingsBurnDownPreviewSurface(
+                family: .medium,
+                presentation: emptyBurnDownPresentation(state),
+                appearance: .light
+            )
+            XCTAssertEqual(burnDown.presentation.emptyState, state, "\(state) burn-down fixture")
+            XCTAssertEqual(burnDown.emptyStateText, expected, "\(state) burn-down preview")
+        }
+    }
+
+    /// The preview inlined the widget's `"Unavailable"` sentinel check instead
+    /// of asking the shared formatter, which is two copies of one rule.
+    func testBurnDownPreviewCountdownMatchesTheSharedFallback() {
+        let cases: [(WidgetBurnDownCountdownKind, String)] = [
+            (.unavailable, "2h 5m"),
+            (.reset, "Unavailable"),
+            (.reset, "2h 5m"),
+            (.projectedExhaustion, "45m")
+        ]
+        for (kind, countdownText) in cases {
+            let preview = WidgetSettingsBurnDownPreviewRow(
+                row: burnDownRow(kind: kind, countdownText: countdownText),
+                family: .medium
+            )
+            XCTAssertEqual(
+                preview.countdownText,
+                LocalizedUsageFormat.burnDownCountdownText(kind: kind, fallback: countdownText),
+                "\(kind) / \(countdownText)"
+            )
+        }
+    }
+
     // MARK: - Fixtures
+
+    /// `.noSelection` comes from an empty quota-window selection, `.unavailable`
+    /// from a selection nothing can fill — the two ways the planner gives up.
+    private func emptyPreferences(_ state: WidgetPresentationEmptyState) -> WidgetPreferences {
+        var preferences = WidgetPreferences.defaults
+        if state == .noSelection {
+            preferences.visibleQuotaWindows = []
+        }
+        return preferences
+    }
+
+    private func emptyPresentation(_ state: WidgetPresentationEmptyState) -> WidgetPresentation {
+        WidgetPresentationPlanner.makePresentation(
+            metrics: [:],
+            accountMetrics: [],
+            preferences: emptyPreferences(state),
+            family: .medium,
+            now: now
+        )
+    }
+
+    private func emptyBurnDownPresentation(
+        _ state: WidgetPresentationEmptyState
+    ) -> WidgetBurnDownPresentation {
+        WidgetBurnDownPlanner.makePresentation(
+            metrics: [:],
+            accountMetrics: [],
+            preferences: emptyPreferences(state),
+            family: .medium,
+            now: now
+        )
+    }
+
+    private func burnDownRow(
+        kind: WidgetBurnDownCountdownKind,
+        countdownText: String
+    ) -> WidgetBurnDownRow {
+        WidgetBurnDownRow(
+            row: firstRow(family: .medium),
+            stage: .onPace,
+            stageText: "On pace",
+            countdownKind: kind,
+            countdownTitle: LocalizedUsageFormat.burnDownCountdownTitle(kind),
+            countdownTarget: nil,
+            countdownText: countdownText
+        )
+    }
 
     private func presentation(family: WidgetPresentationFamily) -> WidgetPresentation {
         WidgetPresentationPlanner.makePresentation(

--- a/MeterBarWidget/Resources/Localizable.xcstrings
+++ b/MeterBarWidget/Resources/Localizable.xcstrings
@@ -220,7 +220,8 @@
             "value": "Select accounts and quota windows in MeterBar Settings."
           }
         }
-      }
+      },
+      "comment": "Widget placeholder body telling the reader where to choose what the widget shows."
     },
     "widget.empty.choose_title": {
       "localizations": {
@@ -230,7 +231,8 @@
             "value": "Choose usage to show"
           }
         }
-      }
+      },
+      "comment": "Widget placeholder heading when nothing has been selected to display."
     },
     "widget.empty.unavailable_detail": {
       "localizations": {
@@ -240,7 +242,8 @@
             "value": "Open MeterBar to refresh provider usage."
           }
         }
-      }
+      },
+      "comment": "Widget placeholder body telling the reader how to refresh unavailable usage."
     },
     "widget.empty.unavailable_title": {
       "localizations": {
@@ -250,7 +253,8 @@
             "value": "Usage unavailable"
           }
         }
-      }
+      },
+      "comment": "Widget placeholder heading when no provider usage could be read."
     },
     "widget.health.stale": {
       "localizations": {

--- a/MeterBarWidget/WidgetLocalization.swift
+++ b/MeterBarWidget/WidgetLocalization.swift
@@ -6,27 +6,38 @@ import MeterBarShared
 /// do not accidentally resolve against the widget extension's bundle.
 enum WidgetLocalizedContent {
     static func quotaTitle(for row: WidgetPresentationRow) -> String {
-        switch (row.service, row.quotaWindow) {
-        case (.openRouter, .session):
+        quotaTitle(for: row.quotaTitleKey)
+    }
+
+    /// Translates the shared row's already-decided quota title.
+    ///
+    /// Which title applies — the OpenRouter exceptions, Cursor's included-pool
+    /// split, Claude Code's model window — is decided once in
+    /// `WidgetPresentationRow.quotaTitleKey`. This switch only supplies the
+    /// widget bundle's words for it, so the widget cannot answer a routing
+    /// question differently from the app.
+    static func quotaTitle(for key: ServiceType.QuotaTitleKey) -> String {
+        switch key {
+        case .keyLimit:
             return String(localized: "widget.quota.key_limit", defaultValue: "Key limit")
-        case (.claudeCode, .codeReview):
-            return row.modelLimitLabel
+        case let .model(label):
+            return label
                 ?? String(localized: "widget.quota.model", defaultValue: "Model")
-        case (.cursor, .codeReview):
+        case .onDemand:
             return String(localized: "widget.quota.on_demand", defaultValue: "On-demand")
-        case (_, .codeReview):
+        case .codeReview:
             return String(localized: "widget.quota.code_review", defaultValue: "Code Review")
-        case (.cursor, .session) where row.limit.map({ ServiceType.isCursorIncludedPool(total: $0.total) }) == true:
+        case .cursorModels:
             return String(localized: "widget.quota.cursor_models", defaultValue: "Cursor Models")
-        case (_, .session):
+        case .session:
             return String(localized: "widget.quota.session", defaultValue: "Session")
-        case (.openRouter, .weekly):
+        case .accountCredits:
             return String(localized: "widget.quota.account_credits", defaultValue: "Account credits")
-        case (.cursor, .weekly) where row.limit.map({ ServiceType.isCursorIncludedPool(total: $0.total) }) == true:
+        case .otherModels:
             return String(localized: "widget.quota.other_models", defaultValue: "Other Models")
-        case (.cursor, .weekly):
+        case .monthly:
             return String(localized: "widget.quota.monthly", defaultValue: "Monthly")
-        case (_, .weekly):
+        case .weekly:
             return String(localized: "widget.quota.weekly", defaultValue: "Weekly")
         }
     }
@@ -84,27 +95,11 @@ enum WidgetLocalizedContent {
     }
 
     static func emptyTitle(_ state: WidgetPresentationEmptyState) -> String {
-        switch state {
-        case .noSelection:
-            return String(localized: "widget.empty.choose_title", defaultValue: "Choose usage to show")
-        case .unavailable:
-            return String(localized: "widget.empty.unavailable_title", defaultValue: "Usage unavailable")
-        }
+        LocalizedUsageFormat.widgetEmptyTitle(state)
     }
 
     static func emptyDetail(_ state: WidgetPresentationEmptyState) -> String {
-        switch state {
-        case .noSelection:
-            return String(
-                localized: "widget.empty.choose_detail",
-                defaultValue: "Select accounts and quota windows in MeterBar Settings."
-            )
-        case .unavailable:
-            return String(
-                localized: "widget.empty.unavailable_detail",
-                defaultValue: "Open MeterBar to refresh provider usage."
-            )
-        }
+        LocalizedUsageFormat.widgetEmptyDetail(state)
     }
 
     static func burnDownCountdownTitle(for row: WidgetBurnDownRow) -> String {
@@ -120,10 +115,10 @@ enum WidgetLocalizedContent {
     }
 
     static func burnDownCountdownText(for row: WidgetBurnDownRow) -> String {
-        if row.countdownKind == .unavailable || row.countdownText == "Unavailable" {
-            return LocalizedUsageFormat.unavailable()
-        }
-        return row.countdownText
+        LocalizedUsageFormat.burnDownCountdownText(
+            kind: row.countdownKind,
+            fallback: row.countdownText
+        )
     }
 
     static func burnDownAccessibilityValue(for row: WidgetBurnDownRow) -> String {

--- a/Packages/MeterBarShared/Sources/MeterBarShared/LocalizedUsageFormatting.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/LocalizedUsageFormatting.swift
@@ -251,6 +251,26 @@ public enum LocalizedUsageFormat {
         }
     }
 
+    /// The countdown value a burn-down row shows, with the "no target" fallback
+    /// applied.
+    ///
+    /// `WidgetBurnDownRow.countdownText` is locale-neutral shared data, so an
+    /// unavailable countdown arrives as the English sentinel `"Unavailable"` —
+    /// which every renderer then has to recognize before it can translate it.
+    /// Owning that check here is what keeps the widget and the Settings preview
+    /// from disagreeing about when the fallback applies.
+    public static func burnDownCountdownText(
+        kind: WidgetBurnDownCountdownKind,
+        fallback: String,
+        bundle: Bundle = .main,
+        locale: Locale = .current
+    ) -> String {
+        if kind == .unavailable || fallback == "Unavailable" {
+            return unavailable(bundle: bundle, locale: locale)
+        }
+        return fallback
+    }
+
     public static func unavailable(
         bundle: Bundle = .main,
         locale: Locale = .current
@@ -262,5 +282,55 @@ public enum LocalizedUsageFormat {
             locale: locale,
             comment: "Generic unavailable placeholder."
         )
+    }
+
+    public static func widgetEmptyTitle(
+        _ state: WidgetPresentationEmptyState,
+        bundle: Bundle = .main,
+        locale: Locale = .current
+    ) -> String {
+        switch state {
+        case .noSelection:
+            return String(
+                localized: "widget.empty.choose_title",
+                defaultValue: "Choose usage to show",
+                bundle: bundle,
+                locale: locale,
+                comment: "Widget placeholder heading when nothing has been selected to display."
+            )
+        case .unavailable:
+            return String(
+                localized: "widget.empty.unavailable_title",
+                defaultValue: "Usage unavailable",
+                bundle: bundle,
+                locale: locale,
+                comment: "Widget placeholder heading when no provider usage could be read."
+            )
+        }
+    }
+
+    public static func widgetEmptyDetail(
+        _ state: WidgetPresentationEmptyState,
+        bundle: Bundle = .main,
+        locale: Locale = .current
+    ) -> String {
+        switch state {
+        case .noSelection:
+            return String(
+                localized: "widget.empty.choose_detail",
+                defaultValue: "Select accounts and quota windows in MeterBar Settings.",
+                bundle: bundle,
+                locale: locale,
+                comment: "Widget placeholder body telling the reader where to choose what the widget shows."
+            )
+        case .unavailable:
+            return String(
+                localized: "widget.empty.unavailable_detail",
+                defaultValue: "Open MeterBar to refresh provider usage.",
+                bundle: bundle,
+                locale: locale,
+                comment: "Widget placeholder body telling the reader how to refresh unavailable usage."
+            )
+        }
     }
 }

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ServiceType.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ServiceType.swift
@@ -100,6 +100,49 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
         }
     }
 
+    /// Which quota-window title a `(service, window, limit)` triple resolves to,
+    /// separated from the English words it resolves *into*.
+    ///
+    /// The routing below is the single decision — the OpenRouter exceptions, the
+    /// Cursor included-pool split, Claude Code's model-scoped third window. The
+    /// widget extension has to say the same thing in the user's language, and
+    /// re-deriving "which title applies" from `(service, quotaWindow)` on its own
+    /// side is how the two answers drift apart. It switches over this key
+    /// instead, so a routing change lands in one place and the localized title
+    /// follows.
+    public enum QuotaTitleKey: Equatable, Sendable {
+        case keyLimit
+        case session
+        case cursorModels
+        case accountCredits
+        case otherModels
+        case monthly
+        case weekly
+        case codeReview
+        case onDemand
+        /// Claude Code's model-scoped window. The parsed label is provider data
+        /// and stays verbatim in every locale; `nil` falls back to translated
+        /// "Model" copy.
+        case model(label: String?)
+
+        /// The English source copy. The bundled CLI and every non-UI caller read
+        /// their titles from here, so this stays the definition of the words.
+        public var englishTitle: String {
+            switch self {
+            case .keyLimit: return "Key limit"
+            case .session: return "Session"
+            case .cursorModels: return "Cursor Models"
+            case .accountCredits: return "Account credits"
+            case .otherModels: return "Other Models"
+            case .monthly: return "Monthly"
+            case .weekly: return "Weekly"
+            case .codeReview: return "Code Review"
+            case .onDemand: return "On-demand"
+            case let .model(label): return label ?? "Model"
+            }
+        }
+    }
+
     /// Display title for the third ("code review") quota window. For Claude
     /// Code this window is model-scoped: it echoes the parsed model label
     /// (e.g. "Fable", "Sonnet"), falling back to a neutral "Model" when no
@@ -110,10 +153,14 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
     /// notification copy previously each spelled out this rule — and
     /// historically did so with inverted defaults.
     public func codeReviewQuotaTitle(modelLimitLabel: String?) -> String {
+        codeReviewQuotaTitleKey(modelLimitLabel: modelLimitLabel).englishTitle
+    }
+
+    public func codeReviewQuotaTitleKey(modelLimitLabel: String?) -> QuotaTitleKey {
         switch self {
-        case .claudeCode: return modelLimitLabel ?? "Model"
-        case .cursor: return "On-demand"
-        case .codexCli, .openRouter, .grok: return "Code Review"
+        case .claudeCode: return .model(label: modelLimitLabel)
+        case .cursor: return .onDemand
+        case .codexCli, .openRouter, .grok: return .codeReview
         }
     }
 
@@ -132,14 +179,18 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
     /// used the percent-of-100 shape, and "Session" for the legacy on-demand
     /// mapping.
     public func sessionQuotaTitle(limitTotal: Double?) -> String {
+        sessionQuotaTitleKey(limitTotal: limitTotal).englishTitle
+    }
+
+    public func sessionQuotaTitleKey(limitTotal: Double?) -> QuotaTitleKey {
         switch self {
-        case .openRouter: return "Key limit"
+        case .openRouter: return .keyLimit
         case .cursor:
             if let limitTotal, Self.isCursorIncludedPool(total: limitTotal) {
-                return "Cursor Models"
+                return .cursorModels
             }
-            return "Session"
-        case .claudeCode, .codexCli, .grok: return "Session"
+            return .session
+        case .claudeCode, .codexCli, .grok: return .session
         }
     }
 
@@ -154,14 +205,18 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
     /// pools title as **Other Models**, matching the dashboard; a request-count
     /// billing-cycle quota stays **Monthly**.
     public func weeklyQuotaTitle(limitTotal: Double?) -> String {
+        weeklyQuotaTitleKey(limitTotal: limitTotal).englishTitle
+    }
+
+    public func weeklyQuotaTitleKey(limitTotal: Double?) -> QuotaTitleKey {
         switch self {
-        case .openRouter: return "Account credits"
+        case .openRouter: return .accountCredits
         case .cursor:
             if let limitTotal, Self.isCursorIncludedPool(total: limitTotal) {
-                return "Other Models"
+                return .otherModels
             }
-            return "Monthly"
-        case .claudeCode, .codexCli, .grok: return "Weekly"
+            return .monthly
+        case .claudeCode, .codexCli, .grok: return .weekly
         }
     }
 

--- a/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPresentation.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPresentation.swift
@@ -60,15 +60,25 @@ public struct WidgetPresentationRow: Identifiable, Equatable, Sendable {
     public let resetTime: Date?
     public let freshnessDate: Date?
 
-    public var quotaTitle: String {
+    /// Which quota title this row resolves to, before any language is chosen.
+    ///
+    /// The widget extension localizes *this*, rather than re-deriving the same
+    /// `(service, quotaWindow, limit)` routing against its own catalog — so a
+    /// change here reaches the localized widget instead of silently diverging
+    /// from it.
+    public var quotaTitleKey: ServiceType.QuotaTitleKey {
         switch quotaWindow {
         case .codeReview:
-            return service.codeReviewQuotaTitle(modelLimitLabel: modelLimitLabel)
+            return service.codeReviewQuotaTitleKey(modelLimitLabel: modelLimitLabel)
         case .session:
-            return service.sessionQuotaTitle(limitTotal: limit?.total)
+            return service.sessionQuotaTitleKey(limitTotal: limit?.total)
         case .weekly:
-            return service.weeklyQuotaTitle(limitTotal: limit?.total)
+            return service.weeklyQuotaTitleKey(limitTotal: limit?.total)
         }
+    }
+
+    public var quotaTitle: String {
+        quotaTitleKey.englishTitle
     }
 
     public var progressValue: Double? {


### PR DESCRIPTION
## Why

The Settings **Previews** gallery rendered `WidgetPresentationEmptyState.title` / `.detail` straight from the shared model. Those are hardcoded English by design — `MeterBarShared` stays locale-neutral so the CLI contract and app preview never resolve against the widget bundle. The widget extension, meanwhile, drew localized copy through `WidgetLocalizedContent`. On a non-English Mac the preview and the thing it previewed spoke different languages.

Two duplicated rules sat next to it and are collapsed in the same pass.

## What changed

**Empty-state copy** — new bundle-aware `LocalizedUsageFormat.widgetEmptyTitle(_:)` / `widgetEmptyDetail(_:)` follow the existing `bundle:locale:` pattern used by every other shared formatter. The widget's `emptyTitle`/`emptyDetail` now delegate to them, and both Settings preview surfaces read them via `WidgetSettingsPreviewEmptyStateText`. The app catalog gains the four `widget.empty.*` keys with the same English values as the widget catalog (the app catalog already duplicates `burndown.*` and `widget.unavailable` this way).

**Burn-down countdown fallback** — `WidgetSettingsBurnDownPreviewRow` spelled out `row.countdownKind == .unavailable || row.countdownText == "Unavailable"`, the same sentinel check the widget owned. `LocalizedUsageFormat.burnDownCountdownText(kind:fallback:)` now owns *when* the fallback applies; both renderers ask it.

**Quota title routing** — `WidgetLocalizedContent.quotaTitle(for:)` re-implemented the entire `(service, quotaWindow)` switch, Cursor included-pool `where` clause and all, instead of consuming the shared row's decision. New `ServiceType.QuotaTitleKey` names the decision; `codeReview`/`session`/`weekly` title helpers each get a `…QuotaTitleKey` sibling and the English helpers derive from it, so `WidgetPresentationRow.quotaTitle` is now `quotaTitleKey.englishTitle`. The widget switches over the key and only supplies the widget bundle's words. A future routing change can no longer land in one target and not the other.

`quotaTitle` still returns the same English strings, so the CLI JSON contract and `ProviderSnapshot` are untouched.

## Tests

- `WidgetPresentationTests.testQuotaTitleIsDerivedFromTheSharedRoutingKey` — every `(service, window)` pair at both the Cursor included-pool total and a plain total, asserted against an explicit routing table *and* against `englishTitle`.
- `WidgetSettingsPreviewParityTests.testPreviewEmptyStatesUseTheLocalizedWidgetCopy` — both preview surfaces resolve the same localized text, for both empty states, driven through the planners.
- `WidgetSettingsPreviewParityTests.testBurnDownPreviewCountdownMatchesTheSharedFallback` — preview countdown equals the shared formatter across all four kind/text combinations.
- `LocalizedUsageFormattingTests` — the localized English source is word-for-word the shared model's copy, and the sentinel translation covers kind-driven and text-driven fallbacks.
- `LocalizationResourceContractTests` — both catalogs carry the four `widget.empty.*` keys with identical English, and the widget catalog has one key per `QuotaTitleKey` case.

## Verification

- `swift test` — **2403 tests, 0 failures**, 6 skipped.
- `xcrun xcstringstool compile` on both catalogs — OK (the check `docs/localization.md` describes).
- `xcodebuild -scheme MeterBar build` — **BUILD SUCCEEDED** (the widget target is in no SPM target, so this is what compiles `WidgetLocalization.swift`).
- `swiftlint lint` — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localization and presentation parity only; English quota titles and CLI contracts are preserved, with broad test coverage.
> 
> **Overview**
> Fixes **Settings widget previews** showing hardcoded English from `WidgetPresentationEmptyState` while the real widget used localized strings.
> 
> **Empty states** — Adds `LocalizedUsageFormat.widgetEmptyTitle` / `widgetEmptyDetail` (bundle/locale aware), duplicates the four `widget.empty.*` keys in the app catalog, and routes both Usage and Burn Down preview surfaces through `WidgetSettingsPreviewEmptyStateText`. The widget extension delegates empty copy to the same helpers.
> 
> **Burn-down countdown** — Centralizes the `"Unavailable"` sentinel in `LocalizedUsageFormat.burnDownCountdownText`; Settings preview and widget both call it instead of duplicating checks.
> 
> **Quota titles** — Introduces `ServiceType.QuotaTitleKey` and `quotaTitleKey` on presentation rows so routing lives once in shared code; `WidgetLocalizedContent` only maps keys to widget catalog strings (replacing a duplicated `(service, window)` switch). English `quotaTitle` behavior is unchanged for CLI/contracts.
> 
> **Tests** — Catalog parity, routing coverage, preview parity, and formatter contract tests lock the above in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e5f441034217abde51155cd6122013d7d53a01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->