### PR TITLE
refactor(cost): share the duplicated scan seams across the three scanners

### DIFF
--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -338,7 +338,7 @@ enum ClaudeCostScanner {
                     continue
                 }
                 session.noteProcessedFile()
-                guard Self.fold(totals, into: &windows) else {
+                guard windows.fold(period: totals.period, lifetime: totals.lifetime) else {
                     // This file shares only *some* of its events with one
                     // already folded in — a stale copy holding a prefix of the
                     // live transcript. Aggregates cannot be de-overlapped after
@@ -356,30 +356,6 @@ enum ClaudeCostScanner {
         // withholds the prune when the walk itself came up short.
         session.retain(coverage: coverage, provider: .claude)
         return windows
-    }
-
-    /// Merges one transcript's aggregates in, if that can be done without
-    /// double-counting.
-    ///
-    /// - Returns: `false` when the file's events partly overlap what is already
-    ///   folded in, which is the one case aggregates cannot express — the
-    ///   caller has to fall back to ``foldByEvent(_:projectID:session:windows:)``.
-    nonisolated private static func fold(
-        _ totals: ScanWindows<ClaudeSessionTotals>,
-        into windows: inout ScanWindows<ClaudeSessionTotals>
-    ) -> Bool {
-        // Period keys are a subset of lifetime keys by construction (every
-        // in-window event is also a lifetime event), so the lifetime test
-        // answers for both windows.
-        let keys = totals.lifetime.eventKeys
-        if keys.isDisjoint(with: windows.lifetime.eventKeys) {
-            windows.period.merge(totals.period)
-            windows.lifetime.merge(totals.lifetime)
-            return true
-        }
-        // Every event is already counted: a duplicated transcript with nothing
-        // new in it.
-        return keys.isSubset(of: windows.lifetime.eventKeys)
     }
 
     /// Re-reads a partly-overlapping transcript from byte zero and folds in only
@@ -449,7 +425,12 @@ enum ClaudeCostScanner {
         projectID: String,
         session: CostScanSession
     ) -> ScanWindows<ClaudeSessionTotals>? {
-        let record = Self.resumableRecord(for: file, session: session)
+        let record = CostScanResumption.resumableRecord(
+            existing: session.record(for: file.cacheKey, provider: .claude),
+            file: file,
+            cutoff: session.cutoff,
+            hourlyCutoff: session.hourlyCutoff
+        )
 
         // Nothing appended since the last pass. This is the steady state once
         // the corpus is warm, and it is why a refresh costs almost no I/O.
@@ -543,28 +524,6 @@ enum ClaudeCostScanner {
             provider: .claude
         )
         return Self.windows(payload, cutoff: session.cutoff, hourlyCutoff: session.hourlyCutoff)
-    }
-
-    /// The cached entry to resume from, rebased onto this refresh's cutoff.
-    ///
-    /// - Returns: `nil` when the file has to be re-read from byte zero.
-    nonisolated private static func resumableRecord(
-        for file: CostScanFile,
-        session: CostScanSession
-    ) -> CostScanFileRecord<ClaudeFileTotals>? {
-        guard var record = CostScanResumption.resumableRecord(
-            existing: session.record(for: file.cacheKey, provider: .claude),
-            file: file,
-            cutoff: session.cutoff,
-            rebase: { payload, cutoff in payload.rebasePeriod(to: cutoff) }
-        ) else { return nil }
-        guard record.hourlyCutoff <= session.hourlyCutoff else { return nil }
-        if record.hourlyCutoff < session.hourlyCutoff {
-            record.payload.period.hourly = record.payload.period.hourly.filter { $0.key >= session.hourlyCutoff }
-            record.payload.lifetime.hourly = record.payload.lifetime.hourly.filter { $0.key >= session.hourlyCutoff }
-            record.hourlyCutoff = session.hourlyCutoff
-        }
-        return record
     }
 
     nonisolated private static func windows(

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -26,22 +26,6 @@ enum CodexCostScanner {
         return result
     }()
 
-    /// Seeds both windows the way the two separate scans used to seed themselves:
-    /// `earliestDate` starts at now and only decreases, `latestDate` starts at the
-    /// window floor (the cutoff for the period, `.distantPast` for lifetime) and
-    /// only increases.
-    nonisolated static func scanWindows(
-        cutoff: Date,
-        hourlyCutoff: Date = .distantPast
-    ) -> ScanWindows<CostScanWindowContext> {
-        ScanWindows(
-            period: CostScanWindowContext(earliestDate: Date(), latestDate: cutoff),
-            lifetime: CostScanWindowContext(earliestDate: Date(), latestDate: .distantPast),
-            cutoff: cutoff,
-            hourlyCutoff: hourlyCutoff
-        )
-    }
-
     /// The rate card in effect for `model` at `timestamp`. Every Codex price
     /// resolution goes through the shared table so the app, the widget, and the
     /// CLI cannot drift apart (issues #130 and #339).
@@ -330,7 +314,10 @@ enum CodexCostScanner {
         directories: [URL],
         session: CostScanSession
     ) -> ScanWindows<CostScanWindowContext> {
-        var windows = Self.scanWindows(cutoff: session.cutoff, hourlyCutoff: session.hourlyCutoff)
+        var windows = CostScanWindowContext.scanWindows(
+            cutoff: session.cutoff,
+            hourlyCutoff: session.hourlyCutoff
+        )
         let listing = Self.distinctRollouts(in: directories, modifiedSince: session.listingCutoff)
         var coverage = CostScanCorpusCoverage()
         coverage.add(listing)
@@ -340,7 +327,7 @@ enum CodexCostScanner {
             coverage.keep(file.cacheKey)
             guard let totals = Self.totals(for: file, session: session) else { continue }
             session.noteProcessedFile()
-            guard Self.fold(totals, into: &windows) else {
+            guard windows.fold(period: totals.period, lifetime: totals.lifetime) else {
                 // This rollout shares only *some* of its events with one already
                 // folded in. Aggregates cannot be de-overlapped after the fact,
                 // so the file goes back through the event-level path, where
@@ -377,7 +364,12 @@ enum CodexCostScanner {
         for file: CostScanFile,
         session: CostScanSession
     ) -> CodexFileTotals? {
-        let record = Self.resumableRecord(for: file, session: session)
+        let record = CostScanResumption.resumableRecord(
+            existing: session.record(for: file.cacheKey, provider: .codex),
+            file: file,
+            cutoff: session.cutoff,
+            hourlyCutoff: session.hourlyCutoff
+        )
 
         // Nothing appended since the last pass.
         if let record, record.isComplete, record.stamp.matches(file.stamp) {
@@ -550,54 +542,6 @@ enum CodexCostScanner {
             // letting the next slice read the file again.
             session.noteDeferred(.codex)
         }
-    }
-
-    /// Adds one rollout's tally to the shared windows.
-    ///
-    /// - Returns: `false` when the file's events partly overlap what is already
-    ///   counted, which no aggregate merge can resolve — the caller has to
-    ///   re-read that file event by event.
-    nonisolated private static func fold(
-        _ totals: CodexFileTotals,
-        into windows: inout ScanWindows<CostScanWindowContext>
-    ) -> Bool {
-        // Period keys are a subset of lifetime keys by construction (every
-        // in-window event is also a lifetime event), so the lifetime test
-        // answers for both windows.
-        let keys = totals.lifetime.eventKeys
-        if keys.isDisjoint(with: windows.lifetime.eventKeys) {
-            windows.period.merge(totals.period)
-            windows.lifetime.merge(totals.lifetime)
-            return true
-        }
-        // Every event is already counted: a duplicated rollout with nothing new.
-        return keys.isSubset(of: windows.lifetime.eventKeys)
-    }
-
-    /// The cached entry to resume from, rebased onto this refresh's cutoff.
-    ///
-    /// - Returns: `nil` when the rollout has to be re-read from byte zero.
-    nonisolated private static func resumableRecord(
-        for file: CostScanFile,
-        session: CostScanSession
-    ) -> CostScanFileRecord<CodexFileTotals>? {
-        guard var record = CostScanResumption.resumableRecord(
-            existing: session.record(for: file.cacheKey, provider: .codex),
-            file: file,
-            cutoff: session.cutoff,
-            rebase: { payload, cutoff in payload.rebasePeriod(to: cutoff) }
-        ) else { return nil }
-        guard record.hourlyCutoff <= session.hourlyCutoff else { return nil }
-        if record.hourlyCutoff < session.hourlyCutoff {
-            record.payload.period.hourlyTotals = record.payload.period.hourlyTotals.filter {
-                $0.key >= session.hourlyCutoff
-            }
-            record.payload.lifetime.hourlyTotals = record.payload.lifetime.hourlyTotals.filter {
-                $0.key >= session.hourlyCutoff
-            }
-            record.hourlyCutoff = session.hourlyCutoff
-        }
-        return record
     }
 
     /// Picks up the model/originator carried by the non-usage rollout events.
@@ -926,21 +870,14 @@ enum CodexCostScanner {
         let output = event.output
         let reasoning = event.reasoning
 
-        // Use whole-millisecond precision for the dedup key so equivalent events
-        // produce a stable, collision-resistant string (raw Double formatting can
-        // vary and risks both false matches and false misses).
-        //
-        // Model, origin, and project are deliberately absent. The deferred
-        // back-fill replays a parked event once its rollout finally names a
-        // model, and a budgeted slice that ends with events still parked rolls
-        // its offset back so the next refresh re-reads them — both hand the same
-        // charge to `apply` twice under different attribution, and only an
-        // attribution-free key sees through it. The price is that two distinct
-        // same-millisecond events with identical counts collapse into one.
-        // `CostScanCorpusTests` pins both halves; widen this key only with a
-        // proof that the deferred path still dedups.
-        let timestampMillis = Int((timestamp.timeIntervalSince1970 * 1000).rounded())
-        let key = "\(timestampMillis)-\(sessionID)-\(input)-\(cached)-\(output)-\(reasoning)"
+        // Attribution-free by design; see `CostScanValues.deduplicationKey`. A
+        // timestamp that cannot be expressed in whole milliseconds means a
+        // corrupt record, so the event is dropped rather than counted.
+        guard let key = CostScanValues.deduplicationKey(
+            timestamp: timestamp,
+            sessionID: sessionID,
+            counts: [input, cached, output, reasoning]
+        ) else { return }
         let keys = CostScanEventKeys(
             day: calendar.startOfDay(for: timestamp),
             hour: timestamp >= windows.hourlyCutoff

--- a/MeterBar/Services/CostScanFileCache.swift
+++ b/MeterBar/Services/CostScanFileCache.swift
@@ -55,11 +55,58 @@ nonisolated enum CostScanResumption {
         record.cutoff = cutoff
         return record
     }
+
+    /// The same validation, plus the trailing-seven-day hourly window every
+    /// provider scan also has to reconcile.
+    ///
+    /// The two cutoffs move independently and are handled differently on
+    /// purpose. The period cutoff slides forward daily and its tally can often
+    /// be *rebased* from lifetime; the hourly boundary only ever needs buckets
+    /// dropped, because an hour that has aged out contributes nothing and no
+    /// event can arrive for it later. A record built against a *later* hourly
+    /// boundary than this refresh wants is unusable in the other direction —
+    /// the buckets it dropped cannot be reconstructed — so it is rejected
+    /// outright rather than trimmed.
+    ///
+    /// - Returns: `nil` when the file has to be re-read from byte zero.
+    static func resumableRecord<Payload: CostScanWindowedPayload>(
+        existing: CostScanFileRecord<Payload>?,
+        file: CostScanFile,
+        cutoff: Date,
+        hourlyCutoff: Date
+    ) -> CostScanFileRecord<Payload>? {
+        guard var record = resumableRecord(
+            existing: existing,
+            file: file,
+            cutoff: cutoff,
+            rebase: { payload, cutoff in payload.rebasePeriod(to: cutoff) }
+        ) else { return nil }
+        guard record.hourlyCutoff <= hourlyCutoff else { return nil }
+        if record.hourlyCutoff < hourlyCutoff {
+            record.payload.period.hourly = record.payload.period.hourly.filter { $0.key >= hourlyCutoff }
+            record.payload.lifetime.hourly = record.payload.lifetime.hourly.filter { $0.key >= hourlyCutoff }
+            record.hourlyCutoff = hourlyCutoff
+        }
+        return record
+    }
 }
 
 /// Provider payload behavior injected into ``CostScanResumption``.
 nonisolated protocol CostScanPeriodRebasable: Codable, Sendable {
     mutating func rebasePeriod(to cutoff: Date) -> Bool
+}
+
+/// A rebasable payload whose two windows are both full breakdown sets.
+///
+/// All three providers store exactly this — a period window and a lifetime
+/// window of the same type — so the hourly trim in ``CostScanResumption`` can
+/// reach `hourly` generically instead of once per scanner. The Claude payload
+/// spells the property `hourly` and the Codex/Grok one spells it
+/// `hourlyTotals`; `CostScanBreakdowns` already forwards between them.
+nonisolated protocol CostScanWindowedPayload: CostScanPeriodRebasable {
+    associatedtype Window: CostScanBreakdowns
+    var period: Window { get set }
+    var lifetime: Window { get set }
 }
 
 /// Every transcript's record, keyed by standardized path.
@@ -358,7 +405,7 @@ nonisolated struct GrokFileTotals: Codable, Sendable {
     }
 }
 
-nonisolated extension ClaudeFileTotals: CostScanPeriodRebasable {
+nonisolated extension ClaudeFileTotals: CostScanWindowedPayload {
     mutating func rebasePeriod(to cutoff: Date) -> Bool {
         // The period window slides every day; lifetime totals never expire. So
         // the only question is whether the cached period tally can be rebased
@@ -380,10 +427,8 @@ nonisolated extension ClaudeFileTotals: CostScanPeriodRebasable {
 }
 
 /// The identical period/lifetime shape shared by Codex and Grok payloads.
-nonisolated protocol CostScanWindowPeriodRebasable: CostScanPeriodRebasable {
-    var period: CostScanWindowContext { get set }
-    var lifetime: CostScanWindowContext { get }
-}
+nonisolated protocol CostScanWindowPeriodRebasable: CostScanWindowedPayload
+    where Window == CostScanWindowContext {}
 
 nonisolated extension CostScanWindowPeriodRebasable {
     mutating func rebasePeriod(to cutoff: Date) -> Bool {

--- a/MeterBar/Services/CostScanValues.swift
+++ b/MeterBar/Services/CostScanValues.swift
@@ -1,7 +1,7 @@
 import Foundation
 import MeterBarShared
 
-/// Value coercion and display naming shared by the Claude and Codex scans.
+/// Value coercion and display naming shared by the Claude, Codex, and Grok scans.
 /// Split out of `CostTracker` (audit C1d) so each rule is directly assertable
 /// instead of reachable only through a full filesystem scan.
 enum CostScanValues {
@@ -28,6 +28,59 @@ enum CostScanValues {
         }
         if let value = value as? String { return Int(value) ?? 0 }
         return 0
+    }
+
+    /// Whole milliseconds since the epoch, or `nil` when the value cannot be
+    /// expressed as one. `Int(_:)` traps on a `Double` outside `Int`'s range and
+    /// `isFinite` does not rule that out — `1e300` is finite, and its
+    /// millisecond value (~1e303) crashed the Grok scan on the way into the
+    /// dedup key.
+    ///
+    /// Codex timestamps arrive as bounded ISO-8601 strings and Grok's as a raw
+    /// JSON number, so only Grok can carry one today. Both go through this
+    /// anyway: the bound is a property of the conversion, not of the writer, and
+    /// "this parser can never emit an absurd date" is not a claim worth a trap.
+    nonisolated static func millisecondsSinceEpoch(_ seconds: Double) -> Int? {
+        let milliseconds = (seconds * 1000).rounded()
+        guard milliseconds.isFinite,
+              milliseconds >= Double(Int.min),
+              milliseconds < Double(Int.max) else { return nil }
+        return Int(milliseconds)
+    }
+
+    /// The attribution-free dedup key the Codex and Grok scans share.
+    ///
+    /// Whole-millisecond precision so equivalent events produce a stable,
+    /// collision-resistant string; raw `Double` formatting can vary and risks
+    /// both false matches and false misses.
+    ///
+    /// Model, origin, and project are deliberately absent. Codex's deferred
+    /// back-fill replays a parked event once its rollout finally names a model,
+    /// and a budgeted slice that ends with events still parked rolls its offset
+    /// back so the next refresh re-reads them — both hand the same charge to
+    /// `apply` twice under different attribution, and only an attribution-free
+    /// key sees through it. The price is that two distinct same-millisecond
+    /// events with identical counts collapse into one. `CostScanCorpusTests`
+    /// pins both halves; widen this key only with a proof that the deferred
+    /// path still dedups.
+    ///
+    /// - Parameter counts: Token counts in a fixed provider-specific order,
+    ///   joined after the timestamp and session. Codex passes input, cached,
+    ///   output, reasoning; Grok appends its cost ticks. Order is part of the
+    ///   key — reordering it silently stops matching previously cached events.
+    /// - Returns: `nil` when the timestamp cannot be expressed in whole
+    ///   milliseconds, which means the record is corrupt and must be dropped.
+    nonisolated static func deduplicationKey(
+        timestamp: Date,
+        sessionID: String,
+        counts: [Int]
+    ) -> String? {
+        guard let milliseconds = millisecondsSinceEpoch(timestamp.timeIntervalSince1970) else { return nil }
+        var key = "\(milliseconds)-\(sessionID)"
+        for count in counts {
+            key += "-\(count)"
+        }
+        return key
     }
 
     nonisolated static func displayModelName(_ raw: String?) -> String {

--- a/MeterBar/Services/CostScanWindows.swift
+++ b/MeterBar/Services/CostScanWindows.swift
@@ -71,6 +71,14 @@ nonisolated protocol CostScanBreakdowns {
     var projectSessionModels: [String: [String: [String: TokenAccumulator]]] { get set }
     var dailyProjectSessions: [Date: [String: [String: TokenAccumulator]]] { get set }
     var dailyProjectSessionModels: [Date: [String: [String: [String: TokenAccumulator]]]] { get set }
+
+    /// Dedup keys for every event already folded in. What makes a whole-window
+    /// merge decidable: without them there is no way to tell a file that adds
+    /// new spend from one that restates spend already counted.
+    var eventKeys: Set<String> { get }
+
+    /// Folds another window of the same shape in wholesale, keys included.
+    mutating func merge(_ other: Self)
 }
 
 /// Which bucket of each breakdown one event lands in.
@@ -127,6 +135,32 @@ nonisolated extension CostScanBreakdowns {
             keys.model,
             default: TokenAccumulator()
         ].add(event)
+    }
+}
+
+nonisolated extension ScanWindows where Totals: CostScanBreakdowns {
+    /// Merges one file's cached aggregates into the shared windows, if that can
+    /// be done without double-counting.
+    ///
+    /// Shared by all three scans: the decision is the same whether the file is a
+    /// Claude transcript, a Codex rollout, or a Grok session, and only the
+    /// caller's fallback differs.
+    ///
+    /// - Returns: `false` when the file's events *partly* overlap what is
+    ///   already folded in, which is the one case aggregates cannot express —
+    ///   the caller has to re-read that file event by event.
+    mutating func fold(period incomingPeriod: Totals, lifetime incomingLifetime: Totals) -> Bool {
+        // Period keys are a subset of lifetime keys by construction (every
+        // in-window event is also a lifetime event), so the lifetime test
+        // answers for both windows.
+        let keys = incomingLifetime.eventKeys
+        if keys.isDisjoint(with: lifetime.eventKeys) {
+            period.merge(incomingPeriod)
+            lifetime.merge(incomingLifetime)
+            return true
+        }
+        // Every event is already counted: a duplicated file with nothing new.
+        return keys.isSubset(of: lifetime.eventKeys)
     }
 }
 
@@ -389,6 +423,26 @@ nonisolated struct CostScanWindowContext: Sendable, Codable {
         sessionIDs.formUnion(other.sessionIDs)
         earliestDate = min(earliestDate, other.earliestDate)
         latestDate = max(latestDate, other.latestDate)
+    }
+
+    /// Seeds both windows the way the Codex and Grok scans each used to seed
+    /// themselves: `earliestDate` starts at now and only decreases, `latestDate`
+    /// starts at the window floor (the cutoff for the period, `.distantPast` for
+    /// lifetime) and only increases.
+    ///
+    /// A static on the window type rather than on either scanner: the two copies
+    /// were byte-identical, and a scanner-owned factory is what let them drift
+    /// apart unnoticed in the first place.
+    static func scanWindows(
+        cutoff: Date,
+        hourlyCutoff: Date = .distantPast
+    ) -> ScanWindows<CostScanWindowContext> {
+        ScanWindows(
+            period: CostScanWindowContext(earliestDate: Date(), latestDate: cutoff),
+            lifetime: CostScanWindowContext(earliestDate: Date(), latestDate: .distantPast),
+            cutoff: cutoff,
+            hourlyCutoff: hourlyCutoff
+        )
     }
 }
 

--- a/MeterBar/Services/GrokCostScanner.swift
+++ b/MeterBar/Services/GrokCostScanner.swift
@@ -71,20 +71,6 @@ enum GrokCostScanner {
     /// skipping `JSONSerialization` on the rest is what keeps the scan cheap.
     nonisolated private static let turnCompletedMarker = Data("\"turn_completed\"".utf8)
 
-    /// Seeds both windows: `earliestDate` starts at now and only decreases,
-    /// `latestDate` starts at the window floor and only increases.
-    nonisolated static func scanWindows(
-        cutoff: Date,
-        hourlyCutoff: Date = .distantPast
-    ) -> ScanWindows<CostScanWindowContext> {
-        ScanWindows(
-            period: CostScanWindowContext(earliestDate: Date(), latestDate: cutoff),
-            lifetime: CostScanWindowContext(earliestDate: Date(), latestDate: .distantPast),
-            cutoff: cutoff,
-            hourlyCutoff: hourlyCutoff
-        )
-    }
-
     /// The `sessions` directories to scan, one per Grok home.
     ///
     /// Resolution goes through `GrokHomeDirectory` rather than a literal
@@ -127,7 +113,10 @@ enum GrokCostScanner {
         _ roots: [URL],
         session: CostScanSession
     ) -> ScanWindows<CostScanWindowContext> {
-        var windows = Self.scanWindows(cutoff: session.cutoff, hourlyCutoff: session.hourlyCutoff)
+        var windows = CostScanWindowContext.scanWindows(
+            cutoff: session.cutoff,
+            hourlyCutoff: session.hourlyCutoff
+        )
         var coverage = CostScanCorpusCoverage()
 
         for root in roots {
@@ -144,7 +133,7 @@ enum GrokCostScanner {
                 guard coverage.keep(file.cacheKey) else { continue }
                 guard let totals = Self.totals(for: file, session: session) else { continue }
                 session.noteProcessedFile()
-                guard Self.fold(totals, into: &windows) else {
+                guard windows.fold(period: totals.period, lifetime: totals.lifetime) else {
                     // This file shares only *some* of its events with one
                     // already folded in — a stale copy holding a prefix of the
                     // live session. Aggregates cannot be de-overlapped after
@@ -158,28 +147,6 @@ enum GrokCostScanner {
 
         session.retain(coverage: coverage, provider: .grok)
         return windows
-    }
-
-    /// Adds one file's tally to the shared windows.
-    ///
-    /// - Returns: `false` when the file's events partly overlap what is already
-    ///   counted, which no aggregate merge can resolve — the caller has to
-    ///   re-read that file event by event.
-    nonisolated private static func fold(
-        _ totals: GrokFileTotals,
-        into windows: inout ScanWindows<CostScanWindowContext>
-    ) -> Bool {
-        // Period keys are a subset of lifetime keys by construction (every
-        // in-window event is also a lifetime event), so the lifetime test
-        // answers for both windows.
-        let keys = totals.lifetime.eventKeys
-        if keys.isDisjoint(with: windows.lifetime.eventKeys) {
-            windows.period.merge(totals.period)
-            windows.lifetime.merge(totals.lifetime)
-            return true
-        }
-        // Every event is already counted: a duplicated session with nothing new.
-        return keys.isSubset(of: windows.lifetime.eventKeys)
     }
 
     /// Streams one file straight into the shared windows, under the same budget
@@ -301,7 +268,12 @@ enum GrokCostScanner {
         for file: CostScanFile,
         session: CostScanSession
     ) -> GrokFileTotals? {
-        let record = Self.resumableRecord(for: file, session: session)
+        let record = CostScanResumption.resumableRecord(
+            existing: session.record(for: file.cacheKey, provider: .grok),
+            file: file,
+            cutoff: session.cutoff,
+            hourlyCutoff: session.hourlyCutoff
+        )
 
         // Nothing appended since the last pass.
         if let record, record.isComplete, record.stamp.matches(file.stamp) {
@@ -365,32 +337,6 @@ enum GrokCostScanner {
         return payload
     }
 
-    /// The cached entry to resume from, rebased onto this refresh's cutoff.
-    ///
-    /// - Returns: `nil` when the file has to be re-read from byte zero.
-    nonisolated private static func resumableRecord(
-        for file: CostScanFile,
-        session: CostScanSession
-    ) -> CostScanFileRecord<GrokFileTotals>? {
-        guard var record = CostScanResumption.resumableRecord(
-            existing: session.record(for: file.cacheKey, provider: .grok),
-            file: file,
-            cutoff: session.cutoff,
-            rebase: { payload, cutoff in payload.rebasePeriod(to: cutoff) }
-        ) else { return nil }
-        guard record.hourlyCutoff <= session.hourlyCutoff else { return nil }
-        if record.hourlyCutoff < session.hourlyCutoff {
-            record.payload.period.hourlyTotals = record.payload.period.hourlyTotals.filter {
-                $0.key >= session.hourlyCutoff
-            }
-            record.payload.lifetime.hourlyTotals = record.payload.lifetime.hourlyTotals.filter {
-                $0.key >= session.hourlyCutoff
-            }
-            record.hourlyCutoff = session.hourlyCutoff
-        }
-        return record
-    }
-
     /// Project and fallback session identity, both derived from where the file
     /// lives: `<root>/<percent-encoded project path>/<session uuid>/updates.jsonl`.
     ///
@@ -405,20 +351,6 @@ enum GrokCostScanner {
             ),
             fallbackSessionID: sessionDirectory.lastPathComponent
         )
-    }
-
-    /// Whole milliseconds since the epoch, or `nil` when the value cannot be
-    /// expressed as one. `Int(_:)` traps on a `Double` outside `Int`'s range and
-    /// `isFinite` does not rule that out — `1e300` is finite, and its
-    /// millisecond value (~1e303) crashed the scan on the way into the dedup
-    /// key. Unlike Codex, whose timestamps arrive as bounded ISO-8601 strings,
-    /// Grok logs a raw JSON number, so any file on disk can carry one.
-    nonisolated private static func millisecondsSinceEpoch(_ seconds: Double) -> Int? {
-        let milliseconds = (seconds * 1000).rounded()
-        guard milliseconds.isFinite,
-              milliseconds >= Double(Int.min),
-              milliseconds < Double(Int.max) else { return nil }
-        return Int(milliseconds)
     }
 
     /// One `turn_completed` line's usage, or `nil` for every other line.
@@ -440,7 +372,7 @@ enum GrokCostScanner {
               let method = envelope["method"] as? String,
               method.hasSuffix("session/update"),
               let seconds = (envelope["timestamp"] as? NSNumber)?.doubleValue,
-              Self.millisecondsSinceEpoch(seconds) != nil,
+              CostScanValues.millisecondsSinceEpoch(seconds) != nil,
               let params = envelope["params"] as? [String: Any],
               let update = params["update"] as? [String: Any],
               update["sessionUpdate"] as? String == "turn_completed",
@@ -516,16 +448,15 @@ enum GrokCostScanner {
         let freshInput = max(0, event.input - event.cached)
         let cost = Double(event.ticks) * Self.usdPerCostTick
 
-        // Whole-millisecond precision, matching the Codex key, so equivalent
-        // records produce a stable string rather than a formatted Double.
-        // Parsing already rejected timestamps that cannot be expressed this way;
-        // converting through the same helper keeps the conversion trap-free
-        // rather than relying on that guarantee holding at a distance.
-        guard let timestampMillis = Self.millisecondsSinceEpoch(timestamp.timeIntervalSince1970) else { return }
-        let key = """
-            \(timestampMillis)-\(sessionID)-\(event.input)-\(event.cached)-\
-            \(event.output)-\(event.reasoning)-\(event.ticks)
-            """
+        // The shared Codex/Grok key, with the cost ticks appended. Parsing
+        // already rejected timestamps that cannot be expressed in whole
+        // milliseconds; going back through the same helper keeps the conversion
+        // trap-free rather than relying on that guarantee holding at a distance.
+        guard let key = CostScanValues.deduplicationKey(
+            timestamp: timestamp,
+            sessionID: sessionID,
+            counts: [event.input, event.cached, event.output, event.reasoning, event.ticks]
+        ) else { return }
         let keys = CostScanEventKeys(
             day: calendar.startOfDay(for: timestamp),
             hour: timestamp >= windows.hourlyCutoff

--- a/MeterBarTests/CostScanCollaboratorTests.swift
+++ b/MeterBarTests/CostScanCollaboratorTests.swift
@@ -471,7 +471,7 @@ final class CostScanCollaboratorTests: XCTestCase {
         }
 
         let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-07-01T00:00:00Z"))
-        var windows = CodexCostScanner.scanWindows(cutoff: cutoff)
+        var windows = CostScanWindowContext.scanWindows(cutoff: cutoff)
         CodexCostScanner.scanSQLiteLogs(database: database, since: cutoff, windows: &windows)
 
         XCTAssertEqual(windows.period.totals.input, 120)

--- a/MeterBarTests/CostScanCorpusTests.swift
+++ b/MeterBarTests/CostScanCorpusTests.swift
@@ -147,7 +147,7 @@ final class CostScanCorpusTests: XCTestCase {
         try writeCodexRollout(in: directory, path: "c.jsonl", lines: [old])
         try writeCodexRollout(in: directory, path: "d.jsonl", lines: [old])
 
-        var windows = CodexCostScanner.scanWindows(cutoff: cutoff)
+        var windows = CostScanWindowContext.scanWindows(cutoff: cutoff)
         CostScanFixtureScan.codexRollouts(in: directory, windows: &windows)
 
         XCTAssertEqual(windows.period.totals.input, 1_000)
@@ -179,7 +179,7 @@ final class CostScanCorpusTests: XCTestCase {
             codexTokenLine(timestamp: "2026-06-16T10:00:00Z", model: nil)
         ])
 
-        var windows = CodexCostScanner.scanWindows(cutoff: cutoff)
+        var windows = CostScanWindowContext.scanWindows(cutoff: cutoff)
         CostScanFixtureScan.codexRollouts(in: directory, windows: &windows)
 
         XCTAssertEqual(windows.lifetime.totals.input, 1_000)
@@ -209,7 +209,7 @@ final class CostScanCorpusTests: XCTestCase {
             codexTokenLine(timestamp: "2026-06-16T10:00:00Z", model: "gpt-5.5-codex")
         ])
 
-        var windows = CodexCostScanner.scanWindows(cutoff: cutoff)
+        var windows = CostScanWindowContext.scanWindows(cutoff: cutoff)
         CostScanFixtureScan.codexRollouts(in: directory, windows: &windows)
 
         XCTAssertEqual(windows.lifetime.totals.input, 1_000)
@@ -234,7 +234,7 @@ final class CostScanCorpusTests: XCTestCase {
             withIntermediateDirectories: true
         )
 
-        var windows = CodexCostScanner.scanWindows(cutoff: cutoff)
+        var windows = CostScanWindowContext.scanWindows(cutoff: cutoff)
         CostScanFixtureScan.codexRollouts(in: directory, windows: &windows)
 
         XCTAssertEqual(windows.lifetime.totals.input, 1_000)
@@ -261,7 +261,7 @@ final class CostScanCorpusTests: XCTestCase {
             codexTokenLine(timestamp: "2026-06-15T11:00:00Z", conversationID: "conv-0", input: 5, output: 5)
         ])
 
-        var windows = CodexCostScanner.scanWindows(cutoff: cutoff)
+        var windows = CostScanWindowContext.scanWindows(cutoff: cutoff)
         CostScanFixtureScan.codexRollouts(in: directory, windows: &windows)
 
         XCTAssertEqual(windows.lifetime.sessionIDs.count, 5)
@@ -278,7 +278,7 @@ final class CostScanCorpusTests: XCTestCase {
             codexTokenLine(timestamp: "2025-06-14T11:00:00Z", conversationID: "b", input: 200),
         ])
 
-        var windows = CodexCostScanner.scanWindows(cutoff: periodCutoff, hourlyCutoff: hourlyCutoff)
+        var windows = CostScanWindowContext.scanWindows(cutoff: periodCutoff, hourlyCutoff: hourlyCutoff)
         CostScanFixtureScan.codexRollouts(in: directory, windows: &windows)
         let rows = try XCTUnwrap(CodexCostScanner.makeCost(from: windows.period)?.2)
 

--- a/MeterBarTests/CostScanResumptionTests.swift
+++ b/MeterBarTests/CostScanResumptionTests.swift
@@ -5,6 +5,7 @@ import XCTest
 final class CostScanResumptionTests: XCTestCase {
     private let originalCutoff = Date(timeIntervalSince1970: 1_780_000_000)
     private let currentCutoff = Date(timeIntervalSince1970: 1_781_000_000)
+    private let hourlyCutoff = Date(timeIntervalSince1970: 1_781_100_000)
 
     func testRejectsOffsetBeyondCurrentFileSize() {
         let file = makeFile(size: 100)
@@ -149,6 +150,86 @@ final class CostScanResumptionTests: XCTestCase {
         let insideResult = try XCTUnwrap(resumableRecord(makeRecord(payload: insidePayload)))
         XCTAssertEqual(insideResult.payload.period.input, 25)
         XCTAssertEqual(insideResult.payload.period.eventKeys, ["current"])
+    }
+
+    // MARK: - Hourly window
+
+    /// The hourly boundary only ever moves buckets *out*: an hour that has aged
+    /// out can gain no further events, so the record is trimmed rather than
+    /// discarded.
+    func testHourlyRebaseDropsBucketsBelowTheNewBoundary() throws {
+        let stale = hourlyCutoff.addingTimeInterval(-3_600)
+        let live = hourlyCutoff.addingTimeInterval(3_600)
+        var payload = CodexFileTotals(cutoff: currentCutoff)
+        payload.period.hourlyTotals = [stale: TokenAccumulator(), live: TokenAccumulator()]
+        payload.lifetime.hourlyTotals = [stale: TokenAccumulator(), live: TokenAccumulator()]
+        var record = makeRecord(payload: payload)
+        record.cutoff = currentCutoff
+
+        let result = try XCTUnwrap(resumableRecord(record, hourlyCutoff: hourlyCutoff))
+
+        XCTAssertEqual(Set(result.payload.period.hourlyTotals.keys), [live])
+        XCTAssertEqual(Set(result.payload.lifetime.hourlyTotals.keys), [live])
+        XCTAssertEqual(result.hourlyCutoff, hourlyCutoff)
+    }
+
+    /// A record built against a *later* boundary already dropped buckets this
+    /// refresh still needs, and dropped buckets cannot be reconstructed — so it
+    /// is rejected outright rather than trimmed in the wrong direction.
+    func testHourlyRebaseRejectsRecordBuiltAgainstALaterBoundary() {
+        var payload = CodexFileTotals(cutoff: currentCutoff)
+        payload.lifetime.hourlyTotals = [hourlyCutoff: TokenAccumulator()]
+        var record = makeRecord(payload: payload)
+        record.cutoff = currentCutoff
+        record.hourlyCutoff = hourlyCutoff.addingTimeInterval(3_600)
+
+        XCTAssertNil(resumableRecord(record, hourlyCutoff: hourlyCutoff))
+    }
+
+    func testHourlyRebaseLeavesBucketsAloneWhenTheBoundaryIsUnchanged() throws {
+        let stale = hourlyCutoff.addingTimeInterval(-3_600)
+        var payload = CodexFileTotals(cutoff: currentCutoff)
+        payload.lifetime.hourlyTotals = [stale: TokenAccumulator()]
+        var record = makeRecord(payload: payload)
+        record.cutoff = currentCutoff
+        record.hourlyCutoff = hourlyCutoff
+
+        let result = try XCTUnwrap(resumableRecord(record, hourlyCutoff: hourlyCutoff))
+
+        XCTAssertEqual(Set(result.payload.lifetime.hourlyTotals.keys), [stale])
+    }
+
+    /// Claude spells the same window `hourly` where Codex and Grok spell it
+    /// `hourlyTotals`; both reach the trim through one generic seam.
+    func testClaudeHourlyRebaseSharesTheSameTrim() throws {
+        let stale = hourlyCutoff.addingTimeInterval(-3_600)
+        let live = hourlyCutoff.addingTimeInterval(3_600)
+        var payload = ClaudeFileTotals()
+        payload.period.hourly = [stale: TokenAccumulator(), live: TokenAccumulator()]
+        payload.lifetime.hourly = [stale: TokenAccumulator(), live: TokenAccumulator()]
+        var record = makeRecord(payload: payload)
+        record.cutoff = currentCutoff
+
+        let result = try XCTUnwrap(resumableRecord(record, hourlyCutoff: hourlyCutoff))
+
+        XCTAssertEqual(Set(result.payload.period.hourly.keys), [live])
+        XCTAssertEqual(Set(result.payload.lifetime.hourly.keys), [live])
+    }
+
+    private func resumableRecord<Payload: CostScanWindowedPayload>(
+        _ record: CostScanFileRecord<Payload>,
+        hourlyCutoff: Date
+    ) -> CostScanFileRecord<Payload>? {
+        CostScanResumption.resumableRecord(
+            existing: record,
+            file: makeFile(
+                size: record.stamp.size,
+                modified: record.stamp.modified,
+                fileID: record.stamp.fileID
+            ),
+            cutoff: currentCutoff,
+            hourlyCutoff: hourlyCutoff
+        )
     }
 
     private func resumableRecord<Payload: CostScanPeriodRebasable>(

--- a/MeterBarTests/CostScanSharedSeamTests.swift
+++ b/MeterBarTests/CostScanSharedSeamTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import XCTest
+@testable import MeterBar
+
+/// The seams the three provider scans now share instead of each carrying their
+/// own copy. Every one of these used to be duplicated two or three times, so
+/// the risk they guard against is silent drift: a change made in one scanner's
+/// copy and not the others. Asserted here directly rather than only through a
+/// full corpus scan, which would notice a divergence only as a wrong total.
+final class CostScanSharedSeamTests: XCTestCase {
+    private let cutoff = Date(timeIntervalSince1970: 1_780_000_000)
+
+    // MARK: - Window seeding
+
+    func testScanWindowsSeedsPeriodAtCutoffAndLifetimeAtDistantPast() {
+        let hourlyCutoff = cutoff.addingTimeInterval(3_600)
+        let before = Date()
+
+        let windows = CostScanWindowContext.scanWindows(cutoff: cutoff, hourlyCutoff: hourlyCutoff)
+
+        XCTAssertEqual(windows.cutoff, cutoff)
+        XCTAssertEqual(windows.hourlyCutoff, hourlyCutoff)
+        // `latestDate` starts at the window floor so the first event can only
+        // move it forward.
+        XCTAssertEqual(windows.period.latestDate, cutoff)
+        XCTAssertEqual(windows.lifetime.latestDate, .distantPast)
+        // `earliestDate` starts at now so the first event can only move it back.
+        XCTAssertGreaterThanOrEqual(windows.period.earliestDate, before)
+        XCTAssertGreaterThanOrEqual(windows.lifetime.earliestDate, before)
+    }
+
+    func testScanWindowsDefaultsHourlyCutoffToDistantPast() {
+        let windows = CostScanWindowContext.scanWindows(cutoff: cutoff)
+
+        XCTAssertEqual(windows.hourlyCutoff, .distantPast)
+    }
+
+    // MARK: - Aggregate fold
+
+    func testFoldMergesBothWindowsWhenKeysAreDisjoint() {
+        var windows = CostScanWindowContext.scanWindows(cutoff: cutoff)
+        windows.lifetime.eventKeys = ["already-counted"]
+        windows.lifetime.totals.input = 10
+        windows.period.totals.input = 4
+
+        var incomingPeriod = CostScanWindowContext(earliestDate: cutoff, latestDate: cutoff)
+        incomingPeriod.eventKeys = ["fresh"]
+        incomingPeriod.totals.input = 3
+        var incomingLifetime = CostScanWindowContext(earliestDate: cutoff, latestDate: cutoff)
+        incomingLifetime.eventKeys = ["fresh"]
+        incomingLifetime.totals.input = 7
+
+        XCTAssertTrue(windows.fold(period: incomingPeriod, lifetime: incomingLifetime))
+        XCTAssertEqual(windows.period.totals.input, 7)
+        XCTAssertEqual(windows.lifetime.totals.input, 17)
+        XCTAssertEqual(windows.lifetime.eventKeys, ["already-counted", "fresh"])
+    }
+
+    /// A duplicate file — a sync conflict copy, a restored backup — carries
+    /// nothing new, so it folds successfully while adding nothing.
+    func testFoldSucceedsWithoutMergingWhenEveryKeyIsAlreadyCounted() {
+        var windows = CostScanWindowContext.scanWindows(cutoff: cutoff)
+        windows.lifetime.eventKeys = ["a", "b"]
+        windows.lifetime.totals.input = 10
+
+        var incoming = CostScanWindowContext(earliestDate: cutoff, latestDate: cutoff)
+        incoming.eventKeys = ["a"]
+        incoming.totals.input = 5
+
+        XCTAssertTrue(windows.fold(period: incoming, lifetime: incoming))
+        XCTAssertEqual(windows.lifetime.totals.input, 10)
+        XCTAssertEqual(windows.lifetime.eventKeys, ["a", "b"])
+    }
+
+    /// The one case aggregates cannot express: a stale copy holding a prefix of
+    /// the live session. The caller has to re-read it event by event.
+    func testFoldRejectsPartialOverlapWithoutMutatingEitherWindow() {
+        var windows = CostScanWindowContext.scanWindows(cutoff: cutoff)
+        windows.lifetime.eventKeys = ["a"]
+        windows.lifetime.totals.input = 10
+        windows.period.totals.input = 10
+
+        var incoming = CostScanWindowContext(earliestDate: cutoff, latestDate: cutoff)
+        incoming.eventKeys = ["a", "b"]
+        incoming.totals.input = 5
+
+        XCTAssertFalse(windows.fold(period: incoming, lifetime: incoming))
+        XCTAssertEqual(windows.lifetime.totals.input, 10)
+        XCTAssertEqual(windows.period.totals.input, 10)
+        XCTAssertEqual(windows.lifetime.eventKeys, ["a"])
+    }
+
+    /// Claude folds the same way through the same generic seam. Covered
+    /// explicitly because its window type is a different shape entirely —
+    /// a conformance gap would compile and silently stop merging.
+    func testFoldAppliesToClaudeWindowsToo() {
+        var windows = ScanWindows(
+            period: ClaudeSessionTotals(),
+            lifetime: ClaudeSessionTotals(),
+            cutoff: cutoff,
+            hourlyCutoff: .distantPast
+        )
+        var incoming = ClaudeSessionTotals()
+        incoming.eventKeys = ["fresh"]
+        incoming.input = 6
+
+        XCTAssertTrue(windows.fold(period: incoming, lifetime: incoming))
+        XCTAssertEqual(windows.lifetime.input, 6)
+
+        var overlapping = ClaudeSessionTotals()
+        overlapping.eventKeys = ["fresh", "new"]
+        overlapping.input = 9
+
+        XCTAssertFalse(windows.fold(period: overlapping, lifetime: overlapping))
+        XCTAssertEqual(windows.lifetime.input, 6)
+    }
+
+    // MARK: - Millisecond conversion
+
+    func testMillisecondsSinceEpochRoundsToWholeMilliseconds() {
+        XCTAssertEqual(CostScanValues.millisecondsSinceEpoch(0), 0)
+        XCTAssertEqual(CostScanValues.millisecondsSinceEpoch(1.2345), 1_235)
+        XCTAssertEqual(CostScanValues.millisecondsSinceEpoch(-1.2345), -1_235)
+    }
+
+    /// `Int(_:)` traps rather than saturating, and `isFinite` does not rule the
+    /// trap out — `1e300` is finite and its millisecond value is not.
+    func testMillisecondsSinceEpochRejectsValuesOutsideIntRange() {
+        XCTAssertNil(CostScanValues.millisecondsSinceEpoch(1e300))
+        XCTAssertNil(CostScanValues.millisecondsSinceEpoch(-1e300))
+        XCTAssertNil(CostScanValues.millisecondsSinceEpoch(.infinity))
+        XCTAssertNil(CostScanValues.millisecondsSinceEpoch(-.infinity))
+        XCTAssertNil(CostScanValues.millisecondsSinceEpoch(.nan))
+    }
+
+    // MARK: - Dedup key
+
+    /// Pins the exact on-the-wire format both scans emitted before they shared a
+    /// builder. These strings are compared against keys already persisted in the
+    /// per-file cache, so a formatting change is a silent dedup failure.
+    func testDeduplicationKeyPinsTheCodexAndGrokFormats() {
+        let timestamp = Date(timeIntervalSince1970: 1_780_000_000.25)
+
+        XCTAssertEqual(
+            CostScanValues.deduplicationKey(
+                timestamp: timestamp,
+                sessionID: "session-a",
+                counts: [1, 2, 3, 4]
+            ),
+            "1780000000250-session-a-1-2-3-4"
+        )
+        XCTAssertEqual(
+            CostScanValues.deduplicationKey(
+                timestamp: timestamp,
+                sessionID: "session-a",
+                counts: [1, 2, 3, 4, 5]
+            ),
+            "1780000000250-session-a-1-2-3-4-5"
+        )
+    }
+
+    /// Order is part of the key: reordering the counts silently stops matching
+    /// previously cached events rather than failing loudly.
+    func testDeduplicationKeyIsOrderSensitive() {
+        let timestamp = Date(timeIntervalSince1970: 1_780_000_000)
+
+        XCTAssertNotEqual(
+            CostScanValues.deduplicationKey(timestamp: timestamp, sessionID: "s", counts: [1, 2]),
+            CostScanValues.deduplicationKey(timestamp: timestamp, sessionID: "s", counts: [2, 1])
+        )
+    }
+
+    func testDeduplicationKeyIsNilForATimestampOutsideMillisecondRange() {
+        XCTAssertNil(
+            CostScanValues.deduplicationKey(
+                timestamp: Date(timeIntervalSince1970: 1e300),
+                sessionID: "session-a",
+                counts: [1]
+            )
+        )
+    }
+}

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -649,7 +649,7 @@ final class CostTrackerTests: XCTestCase {
             )
         ])
         let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
-        var wholeFile = CodexCostScanner.scanWindows(cutoff: cutoff)
+        var wholeFile = CostScanWindowContext.scanWindows(cutoff: cutoff)
         CostScanFixtureScan.codexRollouts(in: directory, windows: &wholeFile)
 
         let session = CostScanSession(cutoff: cutoff, options: .unlimited)
@@ -1576,7 +1576,7 @@ final class CostTrackerTests: XCTestCase {
             codexTokenLine(timestamp: "2026-06-15T10:00:00Z", conversationID: "new", input: 100)
         ])
         let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
-        var windows = CodexCostScanner.scanWindows(cutoff: cutoff)
+        var windows = CostScanWindowContext.scanWindows(cutoff: cutoff)
 
         CostScanFixtureScan.codexRollouts(in: dir, windows: &windows)
 
@@ -1590,7 +1590,7 @@ final class CostTrackerTests: XCTestCase {
         let line = codexTokenLine(timestamp: "2026-06-15T10:00:00Z")
         let dir = try writeCodexArchive(lines: [line, line])
         let cutoff = FlexibleISO8601.date(from: "2026-01-01T00:00:00Z")!
-        var windows = CodexCostScanner.scanWindows(cutoff: cutoff)
+        var windows = CostScanWindowContext.scanWindows(cutoff: cutoff)
 
         CostScanFixtureScan.codexRollouts(in: dir, windows: &windows)
 


### PR DESCRIPTION
Behavior-preserving DRY pass over the three provider cost scanners. Each carried its own copy of the same logic; the copies were byte-identical or near enough that a fix applied to one and not the others would have surfaced only as a wrong total.

## What moved

Into the **existing** shared cost-scan types, not a new parallel abstraction:

| Was | Now |
|---|---|
| `fold(_:into:)` private in all three scanners | `ScanWindows.fold(period:lifetime:)` on `Totals: CostScanBreakdowns` |
| `scanWindows(cutoff:hourlyCutoff:)` byte-identical in Codex + Grok | `CostScanWindowContext.scanWindows(cutoff:hourlyCutoff:)` |
| `resumableRecord(for:session:)` private in all three | `CostScanResumption.resumableRecord(existing:file:cutoff:hourlyCutoff:)` |
| Grok's private `millisecondsSinceEpoch` + two hand-built key strings | `CostScanValues.millisecondsSinceEpoch` / `.deduplicationKey` |

Supporting changes:

- `CostScanBreakdowns` gains the `eventKeys` / `merge(_:)` requirements the merge decision needs.
- New `CostScanWindowedPayload` lets the hourly trim reach `hourly` generically across all three payload shapes (`ClaudeFileTotals` spells it `hourly`, Codex/Grok spell it `hourlyTotals`; `CostScanBreakdowns` already forwards). `CostScanWindowPeriodRebasable` collapses to a `where Window == CostScanWindowContext` clause.
- The seeding factory lives on the window type rather than a scanner — a scanner-owned factory is what let the two copies drift in the first place.

## One behavior change, requested

Codex built its dedup key with an unchecked `Int((...).rounded())`, which **traps** on a timestamp outside `Int`'s millisecond range. It now goes through the same bounds-checked helper Grok already used, so a corrupt record drops the event instead of crashing the scan. Nothing changes for well-formed input.

## Left alone deliberately

`totals(for:session:)` and `foldByEvent`. Codex's versions carry deferred-usage machinery — parked events, offset rollback, rollout context — the other two have no equivalent of. Consolidating would trade three readable copies for one branchy shared function, which fails the "only if it stays clean" bar.

## Compatibility

`costCacheParserVersion` stays at **5**. No on-disk format change, no dedup-key format change — the emitted strings are pinned byte-for-byte in the new tests.

## Verification

- `swift test` → **2411 passed, 6 skipped, 0 failures** (baseline at master: 2396, so +15 net-new tests)
- `xcodebuild -scheme MeterBar build` → **BUILD SUCCEEDED**
- `swiftlint` → clean

New `CostScanSharedSeamTests` covers all four seams directly — window seeding, the three fold outcomes (disjoint merge / full-subset no-op / partial-overlap rejection with neither window mutated), millisecond range rejection, and the exact key format for both the 4-count Codex and 5-count Grok shapes. `CostScanResumptionTests` gains four hourly-rebase cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core deduplication, cache resumption, and aggregate folding for all three providers; risk is mitigated by preserved key formats, unchanged parser version, and extensive new seam tests, plus one deliberate Codex hardening path.
> 
> **Overview**
> **Behavior-preserving refactor** that pulls duplicated cost-scan logic out of `ClaudeCostScanner`, `CodexCostScanner`, and `GrokCostScanner` into existing shared types so fixes cannot land in only one copy.
> 
> **Shared seams:** aggregate **fold** (disjoint merge vs full duplicate vs partial overlap) moves to `ScanWindows.fold(period:lifetime:)` on `CostScanBreakdowns`; **empty window seeding** moves to `CostScanWindowContext.scanWindows`; **resumable file records** including hourly bucket trimming move to `CostScanResumption.resumableRecord(existing:file:cutoff:hourlyCutoff:)` via new `CostScanWindowedPayload`; **Codex/Grok dedup keys** and safe millisecond conversion move to `CostScanValues.deduplicationKey` and `millisecondsSinceEpoch`.
> 
> **Intentional behavior change:** Codex dedup now uses the same bounds-checked millisecond path as Grok, so absurd timestamps **drop the event** instead of **crashing** the scan on `Int` conversion.
> 
> **Tests:** `CostScanSharedSeamTests` pins fold outcomes and key wire format; `CostScanResumptionTests` adds hourly rebase cases; call sites switch from per-scanner `scanWindows` to `CostScanWindowContext.scanWindows`. `costCacheParserVersion` stays at **5** (no on-disk format change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3668cce9cee27496f1656707cc70fc4e9a791e15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->