### PR TITLE
fix(l10n): route popover quota titles through the shared key

### DIFF
--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -154,6 +154,11 @@ struct SnapshotLimit: Identifiable {
     let id: String
     let kind: Kind
     let title: String
+    /// Which quota-window title the builder routed this limit to, or `nil` when
+    /// the copy was handed in directly (previews, layout fixtures). Localization
+    /// switches over this instead of over `title`, so renaming the English words
+    /// cannot silently drop a locale back to English.
+    let quotaTitleKey: ServiceType.QuotaTitleKey?
     let usageLimit: UsageLimit
     let valueStyle: ValueStyle
 
@@ -162,10 +167,29 @@ struct SnapshotLimit: Identifiable {
         case currency
     }
 
+    /// Routed construction: the shared key decides both the English words and
+    /// the translated ones, so the two cannot disagree.
+    init(
+        id: String,
+        kind: Kind,
+        quotaTitleKey: ServiceType.QuotaTitleKey,
+        usageLimit: UsageLimit,
+        valueStyle: ValueStyle = .quota
+    ) {
+        self.id = id
+        self.kind = kind
+        self.title = quotaTitleKey.englishTitle
+        self.quotaTitleKey = quotaTitleKey
+        self.usageLimit = usageLimit
+        self.valueStyle = valueStyle
+    }
+
+    /// Verbatim construction for copy that is not a routed quota window.
     init(id: String, kind: Kind, title: String, usageLimit: UsageLimit, valueStyle: ValueStyle = .quota) {
         self.id = id
         self.kind = kind
         self.title = title
+        self.quotaTitleKey = nil
         self.usageLimit = usageLimit
         self.valueStyle = valueStyle
     }
@@ -201,30 +225,37 @@ struct SnapshotLimit: Identifiable {
 
     /// App-target projection for standard quota-window copy. Parsed model
     /// labels are provider data and remain verbatim.
+    ///
+    /// Which title applies — the OpenRouter exceptions, Cursor's included-pool
+    /// split, Claude Code's model window — is decided once in `ServiceType`.
+    /// This switch only supplies the app bundle's words for that decision, the
+    /// same way `WidgetLocalizedContent.quotaTitle(for:)` supplies the widget
+    /// bundle's. Matching on the English `title` instead would mean a rename in
+    /// `ServiceType` quietly shipped English to every locale.
     var localizedTitle: String {
-        switch (kind, title) {
-        case (.session, "Key limit"):
+        guard let quotaTitleKey else { return title }
+        switch quotaTitleKey {
+        case .keyLimit:
             return String(localized: "quota.title.key_limit", defaultValue: "Key limit")
-        case (.session, "Session"):
-            return String(localized: "quota.title.session", defaultValue: "Session")
-        case (.session, "Cursor Models"):
-            return String(localized: "quota.title.cursor_models", defaultValue: "Cursor Models")
-        case (.weekly, "Account credits"):
-            return String(localized: "quota.title.account_credits", defaultValue: "Account credits")
-        case (.weekly, "Other Models"):
-            return String(localized: "quota.title.other_models", defaultValue: "Other Models")
-        case (.weekly, "Monthly"):
-            return String(localized: "quota.title.monthly", defaultValue: "Monthly")
-        case (.weekly, "Weekly"):
-            return String(localized: "quota.title.weekly", defaultValue: "Weekly")
-        case (.codeReview, "Code Review"):
-            return String(localized: "quota.title.code_review", defaultValue: "Code Review")
-        case (.codeReview, "On-demand"):
+        case let .model(label):
+            return label
+                ?? String(localized: "quota.title.model", defaultValue: "Model")
+        case .onDemand:
             return String(localized: "quota.title.on_demand", defaultValue: "On-demand")
-        case (.codeReview, "Model"):
-            return String(localized: "quota.title.model", defaultValue: "Model")
-        default:
-            return title
+        case .codeReview:
+            return String(localized: "quota.title.code_review", defaultValue: "Code Review")
+        case .cursorModels:
+            return String(localized: "quota.title.cursor_models", defaultValue: "Cursor Models")
+        case .session:
+            return String(localized: "quota.title.session", defaultValue: "Session")
+        case .accountCredits:
+            return String(localized: "quota.title.account_credits", defaultValue: "Account credits")
+        case .otherModels:
+            return String(localized: "quota.title.other_models", defaultValue: "Other Models")
+        case .monthly:
+            return String(localized: "quota.title.monthly", defaultValue: "Monthly")
+        case .weekly:
+            return String(localized: "quota.title.weekly", defaultValue: "Weekly")
         }
     }
 
@@ -472,7 +503,7 @@ enum ProviderSnapshotBuilder {
             result.append(SnapshotLimit(
                 id: "session",
                 kind: .session,
-                title: service.sessionQuotaTitle(limitTotal: session.total),
+                quotaTitleKey: service.sessionQuotaTitleKey(limitTotal: session.total),
                 usageLimit: session,
                 valueStyle: service == .openRouter ? .currency : .quota
             ))
@@ -481,7 +512,7 @@ enum ProviderSnapshotBuilder {
             result.append(SnapshotLimit(
                 id: "weekly",
                 kind: .weekly,
-                title: service.weeklyQuotaTitle(limitTotal: weekly.total),
+                quotaTitleKey: service.weeklyQuotaTitleKey(limitTotal: weekly.total),
                 usageLimit: weekly,
                 valueStyle: service == .openRouter ? .currency : .quota
             ))
@@ -493,7 +524,7 @@ enum ProviderSnapshotBuilder {
             result.append(SnapshotLimit(
                 id: "codeReview",
                 kind: .codeReview,
-                title: service.codeReviewQuotaTitle(modelLimitLabel: metrics.modelLimitLabel),
+                quotaTitleKey: service.codeReviewQuotaTitleKey(modelLimitLabel: metrics.modelLimitLabel),
                 usageLimit: codeReview
             ))
         }

--- a/MeterBarTests/LocalizationResourceContractTests.swift
+++ b/MeterBarTests/LocalizationResourceContractTests.swift
@@ -114,6 +114,58 @@ final class LocalizationResourceContractTests: XCTestCase {
         }
     }
 
+    /// The app-side mirror of the widget contract above. The popover switches
+    /// over the same routing key, so a case without an app key would ship
+    /// English into every locale.
+    func testAppCatalogCoversEveryQuotaTitleRoutingKey() throws {
+        let appKeys = Set(try strings(in: loadCatalog(at: appCatalogURL)).keys)
+        for key in Self.appQuotaTitleCatalogKeys.map(\.catalogKey) {
+            XCTAssertTrue(appKeys.contains(key), "\(key) missing from the app catalog")
+        }
+    }
+
+    /// Every routing key resolves a real catalog entry rather than falling back
+    /// to hardcoded English.
+    ///
+    /// The SwiftPM test target excludes `MeterBar/Resources`, so
+    /// `String(localized:)` here returns its `defaultValue`; comparing that
+    /// against the shipped catalog's English value is what proves the key is
+    /// present and still says the same words. Rename or delete a key in either
+    /// place and this fails instead of silently degrading to English at runtime.
+    func testLocalizedQuotaTitleResolvesAnAppCatalogEntryForEveryRoutingKey() throws {
+        let appStrings = try strings(in: loadCatalog(at: appCatalogURL))
+
+        for (routingKey, catalogKey) in Self.appQuotaTitleCatalogKeys {
+            // Deliberately built with one fixed kind: localization routes off
+            // the shared key alone, never off the window it happened to fill.
+            let limit = SnapshotLimit(
+                id: "quota",
+                kind: .session,
+                quotaTitleKey: routingKey,
+                usageLimit: UsageLimit(used: 4, total: 100, resetTime: nil)
+            )
+            let catalogEnglish = try englishValue(for: catalogKey, in: appStrings)
+
+            XCTAssertEqual(limit.localizedTitle, catalogEnglish, catalogKey)
+            XCTAssertEqual(routingKey.englishTitle, catalogEnglish, catalogKey)
+        }
+    }
+
+    /// One app catalog key per `ServiceType.QuotaTitleKey` case, spelled out so
+    /// a new case has to be given words before it can ship.
+    private static let appQuotaTitleCatalogKeys: [(routingKey: ServiceType.QuotaTitleKey, catalogKey: String)] = [
+        (.keyLimit, "quota.title.key_limit"),
+        (.model(label: nil), "quota.title.model"),
+        (.onDemand, "quota.title.on_demand"),
+        (.codeReview, "quota.title.code_review"),
+        (.cursorModels, "quota.title.cursor_models"),
+        (.session, "quota.title.session"),
+        (.accountCredits, "quota.title.account_credits"),
+        (.otherModels, "quota.title.other_models"),
+        (.monthly, "quota.title.monthly"),
+        (.weekly, "quota.title.weekly"),
+    ]
+
     func testCountStringsCarryEnglishOneAndOtherPluralRules() throws {
         try assertPluralRules(
             keys: ["reset.exhausted_limits", "reset.exhausted_detail"],

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -386,6 +386,106 @@ final class ProviderSnapshotTests: XCTestCase {
         )
     }
 
+    // MARK: - Quota title routing
+
+    /// The shared routing key each `(service, window, total)` triple resolves
+    /// to, spelled out independently of `ServiceType` so a routing change has to
+    /// be made deliberately in both places. Mirrors the widget-side table in
+    /// `WidgetPresentationTests`.
+    private func expectedQuotaTitleKey(
+        service: ServiceType,
+        kind: SnapshotLimit.Kind,
+        limitTotal: Double,
+        modelLimitLabel: String?
+    ) -> ServiceType.QuotaTitleKey {
+        let isIncludedPool = ServiceType.isCursorIncludedPool(total: limitTotal)
+        switch kind {
+        case .session:
+            switch service {
+            case .openRouter: return .keyLimit
+            case .cursor: return isIncludedPool ? .cursorModels : .session
+            case .claudeCode, .codexCli, .grok: return .session
+            }
+        case .weekly:
+            switch service {
+            case .openRouter: return .accountCredits
+            case .cursor: return isIncludedPool ? .otherModels : .monthly
+            case .claudeCode, .codexCli, .grok: return .weekly
+            }
+        case .codeReview:
+            switch service {
+            case .claudeCode: return .model(label: modelLimitLabel)
+            case .cursor: return .onDemand
+            case .codexCli, .openRouter, .grok: return .codeReview
+            }
+        }
+    }
+
+    /// Every built limit carries the shared routing key, and its English title
+    /// stays that key's English words. Localization switches over the key, so a
+    /// limit whose key disagreed with the routing would translate as some other
+    /// window without any English-language symptom.
+    func testBuiltLimitsCarryTheSharedQuotaTitleRoutingKey() {
+        for service in ServiceType.allCases {
+            for total in [ServiceType.cursorIncludedPoolTotal, 500] {
+                let metrics = UsageMetrics(
+                    service: service,
+                    sessionLimit: UsageLimit(used: 4, total: total, resetTime: nil),
+                    weeklyLimit: UsageLimit(used: 64, total: total, resetTime: nil),
+                    codeReviewLimit: UsageLimit(used: 12, total: total, resetTime: nil),
+                    modelLimitLabel: service == .claudeCode ? "Fable" : nil
+                )
+                let limits = ProviderSnapshotBuilder.limits(for: metrics, service: service)
+                XCTAssertEqual(limits.count, 3, "\(service) total \(total)")
+
+                for limit in limits {
+                    let expected = expectedQuotaTitleKey(
+                        service: service,
+                        kind: limit.kind,
+                        limitTotal: total,
+                        modelLimitLabel: metrics.modelLimitLabel
+                    )
+                    let context = "\(service) \(limit.id) total \(total)"
+                    XCTAssertEqual(limit.quotaTitleKey, expected, context)
+                    XCTAssertEqual(limit.title, expected.englishTitle, context)
+                }
+            }
+        }
+    }
+
+    /// The parsed Claude model label is provider data: it stays verbatim in the
+    /// English title and in the localized one, and only a missing label falls
+    /// back to translated "Model" copy.
+    func testClaudeModelWindowKeepsTheParsedLabelVerbatim() {
+        let labeled = ProviderSnapshotBuilder.limits(
+            for: makeMetrics(service: .claudeCode, codeReview: 10, modelLimitLabel: "Fable"),
+            service: .claudeCode
+        )
+        XCTAssertEqual(labeled.map(\.quotaTitleKey), [.model(label: "Fable")])
+        XCTAssertEqual(labeled.map(\.localizedTitle), ["Fable"])
+
+        let unlabeled = ProviderSnapshotBuilder.limits(
+            for: makeMetrics(service: .claudeCode, codeReview: 10),
+            service: .claudeCode
+        )
+        XCTAssertEqual(unlabeled.map(\.quotaTitleKey), [.model(label: nil)])
+    }
+
+    /// Copy handed in directly — pseudo-localized layout fixtures, previews —
+    /// is not routed, so it renders verbatim instead of being string-matched
+    /// back onto a quota window.
+    func testDirectlyTitledLimitIsNotRoutedThroughTheCatalog() {
+        let limit = SnapshotLimit(
+            id: "credits",
+            kind: .weekly,
+            title: "Credits",
+            usageLimit: UsageLimit(used: 4, total: 10, resetTime: nil)
+        )
+
+        XCTAssertNil(limit.quotaTitleKey)
+        XCTAssertEqual(limit.localizedTitle, "Credits")
+    }
+
     // MARK: - Limits
 
     func testThirdLimitUsesReportedClaudeModelLabelAndCodeReviewForCodex() {


### PR DESCRIPTION
## Problem

`SnapshotLimit.localizedTitle` was the third copy of the `(service, quotaWindow)` quota-title routing, and the only one that routed on **English words**:

```swift
switch (kind, title) {
case (.weekly, "Monthly"):
    return String(localized: "quota.title.monthly", defaultValue: "Monthly")
...
default:
    return title
}
```

`title` is produced by `ServiceType.sessionQuotaTitle` / `weeklyQuotaTitle` / `codeReviewQuotaTitle`. So the app localized by string-matching its own English. Rename any title in `ServiceType` — "Monthly" → "Billing cycle" — and every locale falls through `default:` and silently ships untranslated English. No test caught it.

## Change

Carry `ServiceType.QuotaTitleKey` (added in #451) on `SnapshotLimit` and switch over the key, exactly as `WidgetLocalizedContent.quotaTitle(for:)` already does on the widget side. The three builder sites set it from the matching `…QuotaTitleKey` helper. Which title applies is decided once in `ServiceType`; each bundle only supplies the words.

The `(kind, title)` coupling is gone too — routing no longer depends on which window a title happened to fill.

**The English `title` stays.** Non-UI callers and the CLI JSON contract read it; on routed limits it is now derived from the key. A second `init(id:kind:title:…)` keeps verbatim copy (previews, pseudo-localized layout fixtures) out of the routing path instead of string-matching it back onto a quota window; those limits carry a `nil` key and render verbatim.

**No catalog changes** — all ten `quota.title.*` keys already existed.

## Tests

- `ProviderSnapshotTests.testBuiltLimitsCarryTheSharedQuotaTitleRoutingKey` — every service × every window, at both `ServiceType.cursorIncludedPoolTotal` and a plain total: the limit's key equals the shared routing, and `title` still equals `key.englishTitle`. The expected routing table is spelled out independently, mirroring `WidgetPresentationTests.testQuotaTitleIsDerivedFromTheSharedRoutingKey`.
- `LocalizationResourceContractTests.testLocalizedQuotaTitleResolvesAnAppCatalogEntryForEveryRoutingKey` — for every `QuotaTitleKey` case, `localizedTitle` is compared against the shipped catalog's English value. The SwiftPM target excludes `MeterBar/Resources`, so `String(localized:)` returns its `defaultValue` here; comparing it to the catalog is what proves the key is present and still says the same words. Deleting or renaming a key, or drifting `ServiceType`'s English from the catalog, fails.
- `LocalizationResourceContractTests.testAppCatalogCoversEveryQuotaTitleRoutingKey` — one `quota.title.*` key per case, the app-side mirror of the widget contract.
- Plus verbatim-label coverage: the parsed Claude model label stays verbatim, a missing label falls back to translated `quota.title.model`, and directly-titled copy is not routed.

## Deliberately out of scope

Both call sites named in the brief were checked. Neither is localized here, for different reasons:

- **`ProviderRecommendation.swift:82-84`** — stays English. `MeterBarShared` ships **no resource bundle**, which is why `LocalizedUsageFormat` takes `bundle: Bundle = .main` and makes the *caller* supply strings. `ProviderRecommendationWindow.title(for:limitTotal:)` is shared/CLI-facing; localizing it inside the package would resolve against whatever bundle happened to be `.main`. If it ever needs translation, the pattern is the one used here — expose the key, let each target supply words.
- **`NotificationDecider.swift:242-248`** — out of scope, and larger than a key swap. There is currently **zero** `String(localized:)` anywhere in the notification path and **no** `notification.*` keys in the app catalog. `FiredNotification.title`/`.body` are hardcoded English sentence templates that interpolate `quotaDisplayName.lowercased()`; localizing only the quota noun would produce mixed-language banners, and `.lowercased()` on a translated noun is wrong outright in languages that capitalize nouns. `displayName(for:…)` also applies Title Case overrides ("Key Limit", "Account Credits") that diverge from the catalog's sentence-case values, so it would need *new* keys rather than the existing ones. Notification copy wants whole-sentence keys and no `.lowercased()` — a separate wave.

## Branching

#451 is still open, so this branches off `fix/widget-preview-localization-parity` and targets it. Rebase onto `master` if #451 lands first.

## Verification

- `swift test` — 2415 tests, 0 failures.
- `xcrun xcstringstool compile` on both `MeterBar/Resources/Localizable.xcstrings` and `MeterBarWidget/Resources/Localizable.xcstrings` — clean.
- `xcodebuild -project MeterBar.xcodeproj -scheme MeterBar -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" build` — **BUILD SUCCEEDED**.
- `swiftlint lint --quiet` — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI localization refactor with no catalog changes; behavior should match prior strings when keys align, with tests guarding routing and catalog parity.
> 
> **Overview**
> Popover quota labels no longer localize by matching English `title` strings; **`SnapshotLimit`** now carries **`ServiceType.QuotaTitleKey`**, and **`localizedTitle`** switches on that key (same pattern as the widget), so renaming English copy in **`ServiceType`** cannot silently fall through to untranslated text.
> 
> **`ProviderSnapshotBuilder.limits`** sets the key from **`…QuotaTitleKey`** helpers instead of string titles. Routed limits derive **`title`** from **`quotaTitleKey.englishTitle`**; previews/fixtures keep a verbatim **`init`** with **`quotaTitleKey == nil`**.
> 
> Tests lock routing per service/window, catalog coverage for every **`quota.title.*`** key, and verbatim Claude model labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c2e84ca96013562c6aec561733a03a94d03c8cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->