### PR TITLE
fix(l10n): route popover quota titles through the shared key

### DIFF
--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -154,6 +154,11 @@ struct SnapshotLimit: Identifiable {
     let id: String
     let kind: Kind
     let title: String
+    /// Which quota-window title the builder routed this limit to, or `nil` when
+    /// the copy was handed in directly (previews, layout fixtures). Localization
+    /// switches over this instead of over `title`, so renaming the English words
+    /// cannot silently drop a locale back to English.
+    let quotaTitleKey: ServiceType.QuotaTitleKey?
     let usageLimit: UsageLimit
     let valueStyle: ValueStyle
 
@@ -162,10 +167,29 @@ struct SnapshotLimit: Identifiable {
         case currency
     }
 
+    /// Routed construction: the shared key decides both the English words and
+    /// the translated ones, so the two cannot disagree.
+    init(
+        id: String,
+        kind: Kind,
+        quotaTitleKey: ServiceType.QuotaTitleKey,
+        usageLimit: UsageLimit,
+        valueStyle: ValueStyle = .quota
+    ) {
+        self.id = id
+        self.kind = kind
+        self.title = quotaTitleKey.englishTitle
+        self.quotaTitleKey = quotaTitleKey
+        self.usageLimit = usageLimit
+        self.valueStyle = valueStyle
+    }
+
+    /// Verbatim construction for copy that is not a routed quota window.
     init(id: String, kind: Kind, title: String, usageLimit: UsageLimit, valueStyle: ValueStyle = .quota) {
         self.id = id
         self.kind = kind
         self.title = title
+        self.quotaTitleKey = nil
         self.usageLimit = usageLimit
         self.valueStyle = valueStyle
     }
@@ -201,30 +225,37 @@ struct SnapshotLimit: Identifiable {
 
     /// App-target projection for standard quota-window copy. Parsed model
     /// labels are provider data and remain verbatim.
+    ///
+    /// Which title applies — the OpenRouter exceptions, Cursor's included-pool
+    /// split, Claude Code's model window — is decided once in `ServiceType`.
+    /// This switch only supplies the app bundle's words for that decision, the
+    /// same way `WidgetLocalizedContent.quotaTitle(for:)` supplies the widget
+    /// bundle's. Matching on the English `title` instead would mean a rename in
+    /// `ServiceType` quietly shipped English to every locale.
     var localizedTitle: String {
-        switch (kind, title) {
-        case (.session, "Key limit"):
+        guard let quotaTitleKey else { return title }
+        switch quotaTitleKey {
+        case .keyLimit:
             return String(localized: "quota.title.key_limit", defaultValue: "Key limit")
-        case (.session, "Session"):
-            return String(localized: "quota.title.session", defaultValue: "Session")
-        case (.session, "Cursor Models"):
-            return String(localized: "quota.title.cursor_models", defaultValue: "Cursor Models")
-        case (.weekly, "Account credits"):
-            return String(localized: "quota.title.account_credits", defaultValue: "Account credits")
-        case (.weekly, "Other Models"):
-            return String(localized: "quota.title.other_models", defaultValue: "Other Models")
-        case (.weekly, "Monthly"):
-            return String(localized: "quota.title.monthly", defaultValue: "Monthly")
-        case (.weekly, "Weekly"):
-            return String(localized: "quota.title.weekly", defaultValue: "Weekly")
-        case (.codeReview, "Code Review"):
-            return String(localized: "quota.title.code_review", defaultValue: "Code Review")
-        case (.codeReview, "On-demand"):
+        case let .model(label):
+            return label
+                ?? String(localized: "quota.title.model", defaultValue: "Model")
+        case .onDemand:
             return String(localized: "quota.title.on_demand", defaultValue: "On-demand")
-        case (.codeReview, "Model"):
-            return String(localized: "quota.title.model", defaultValue: "Model")
-        default:
-            return title
+        case .codeReview:
+            return String(localized: "quota.title.code_review", defaultValue: "Code Review")
+        case .cursorModels:
+            return String(localized: "quota.title.cursor_models", defaultValue: "Cursor Models")
+        case .session:
+            return String(localized: "quota.title.session", defaultValue: "Session")
+        case .accountCredits:
+            return String(localized: "quota.title.account_credits", defaultValue: "Account credits")
+        case .otherModels:
+            return String(localized: "quota.title.other_models", defaultValue: "Other Models")
+        case .monthly:
+            return String(localized: "quota.title.monthly", defaultValue: "Monthly")
+        case .weekly:
+            return String(localized: "quota.title.weekly", defaultValue: "Weekly")
         }
     }
 
@@ -472,7 +503,7 @@ enum ProviderSnapshotBuilder {
             result.append(SnapshotLimit(
                 id: "session",
                 kind: .session,
-                title: service.sessionQuotaTitle(limitTotal: session.total),
+                quotaTitleKey: service.sessionQuotaTitleKey(limitTotal: session.total),
                 usageLimit: session,
                 valueStyle: service == .openRouter ? .currency : .quota
             ))
@@ -481,7 +512,7 @@ enum ProviderSnapshotBuilder {
             result.append(SnapshotLimit(
                 id: "weekly",
                 kind: .weekly,
-                title: service.weeklyQuotaTitle(limitTotal: weekly.total),
+                quotaTitleKey: service.weeklyQuotaTitleKey(limitTotal: weekly.total),
                 usageLimit: weekly,
                 valueStyle: service == .openRouter ? .currency : .quota
             ))
@@ -493,7 +524,7 @@ enum ProviderSnapshotBuilder {
             result.append(SnapshotLimit(
                 id: "codeReview",
                 kind: .codeReview,
-                title: service.codeReviewQuotaTitle(modelLimitLabel: metrics.modelLimitLabel),
+                quotaTitleKey: service.codeReviewQuotaTitleKey(modelLimitLabel: metrics.modelLimitLabel),
                 usageLimit: codeReview
             ))
         }

--- a/MeterBarTests/LocalizationResourceContractTests.swift
+++ b/MeterBarTests/LocalizationResourceContractTests.swift
@@ -114,6 +114,58 @@ final class LocalizationResourceContractTests: XCTestCase {
         }
     }
 
+    /// The app-side mirror of the widget contract above. The popover switches
+    /// over the same routing key, so a case without an app key would ship
+    /// English into every locale.
+    func testAppCatalogCoversEveryQuotaTitleRoutingKey() throws {
+        let appKeys = Set(try strings(in: loadCatalog(at: appCatalogURL)).keys)
+        for key in Self.appQuotaTitleCatalogKeys.map(\.catalogKey) {
+            XCTAssertTrue(appKeys.contains(key), "\(key) missing from the app catalog")
+        }
+    }
+
+    /// Every routing key resolves a real catalog entry rather than falling back
+    /// to hardcoded English.
+    ///
+    /// The SwiftPM test target excludes `MeterBar/Resources`, so
+    /// `String(localized:)` here returns its `defaultValue`; comparing that
+    /// against the shipped catalog's English value is what proves the key is
+    /// present and still says the same words. Rename or delete a key in either
+    /// place and this fails instead of silently degrading to English at runtime.
+    func testLocalizedQuotaTitleResolvesAnAppCatalogEntryForEveryRoutingKey() throws {
+        let appStrings = try strings(in: loadCatalog(at: appCatalogURL))
+
+        for (routingKey, catalogKey) in Self.appQuotaTitleCatalogKeys {
+            // Deliberately built with one fixed kind: localization routes off
+            // the shared key alone, never off the window it happened to fill.
+            let limit = SnapshotLimit(
+                id: "quota",
+                kind: .session,
+                quotaTitleKey: routingKey,
+                usageLimit: UsageLimit(used: 4, total: 100, resetTime: nil)
+            )
+            let catalogEnglish = try englishValue(for: catalogKey, in: appStrings)
+
+            XCTAssertEqual(limit.localizedTitle, catalogEnglish, catalogKey)
+            XCTAssertEqual(routingKey.englishTitle, catalogEnglish, catalogKey)
+        }
+    }
+
+    /// One app catalog key per `ServiceType.QuotaTitleKey` case, spelled out so
+    /// a new case has to be given words before it can ship.
+    private static let appQuotaTitleCatalogKeys: [(routingKey: ServiceType.QuotaTitleKey, catalogKey: String)] = [
+        (.keyLimit, "quota.title.key_limit"),
+        (.model(label: nil), "quota.title.model"),
+        (.onDemand, "quota.title.on_demand"),
+        (.codeReview, "quota.title.code_review"),
+        (.cursorModels, "quota.title.cursor_models"),
+        (.session, "quota.title.session"),
+        (.accountCredits, "quota.title.account_credits"),
+        (.otherModels, "quota.title.other_models"),
+        (.monthly, "quota.title.monthly"),
+        (.weekly, "quota.title.weekly"),
+    ]
+
     func testCountStringsCarryEnglishOneAndOtherPluralRules() throws {
         try assertPluralRules(
             keys: ["reset.exhausted_limits", "reset.exhausted_detail"],

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -386,6 +386,106 @@ final class ProviderSnapshotTests: XCTestCase {
         )
     }
 
+    // MARK: - Quota title routing
+
+    /// The shared routing key each `(service, window, total)` triple resolves
+    /// to, spelled out independently of `ServiceType` so a routing change has to
+    /// be made deliberately in both places. Mirrors the widget-side table in
+    /// `WidgetPresentationTests`.
+    private func expectedQuotaTitleKey(
+        service: ServiceType,
+        kind: SnapshotLimit.Kind,
+        limitTotal: Double,
+        modelLimitLabel: String?
+    ) -> ServiceType.QuotaTitleKey {
+        let isIncludedPool = ServiceType.isCursorIncludedPool(total: limitTotal)
+        switch kind {
+        case .session:
+            switch service {
+            case .openRouter: return .keyLimit
+            case .cursor: return isIncludedPool ? .cursorModels : .session
+            case .claudeCode, .codexCli, .grok: return .session
+            }
+        case .weekly:
+            switch service {
+            case .openRouter: return .accountCredits
+            case .cursor: return isIncludedPool ? .otherModels : .monthly
+            case .claudeCode, .codexCli, .grok: return .weekly
+            }
+        case .codeReview:
+            switch service {
+            case .claudeCode: return .model(label: modelLimitLabel)
+            case .cursor: return .onDemand
+            case .codexCli, .openRouter, .grok: return .codeReview
+            }
+        }
+    }
+
+    /// Every built limit carries the shared routing key, and its English title
+    /// stays that key's English words. Localization switches over the key, so a
+    /// limit whose key disagreed with the routing would translate as some other
+    /// window without any English-language symptom.
+    func testBuiltLimitsCarryTheSharedQuotaTitleRoutingKey() {
+        for service in ServiceType.allCases {
+            for total in [ServiceType.cursorIncludedPoolTotal, 500] {
+                let metrics = UsageMetrics(
+                    service: service,
+                    sessionLimit: UsageLimit(used: 4, total: total, resetTime: nil),
+                    weeklyLimit: UsageLimit(used: 64, total: total, resetTime: nil),
+                    codeReviewLimit: UsageLimit(used: 12, total: total, resetTime: nil),
+                    modelLimitLabel: service == .claudeCode ? "Fable" : nil
+                )
+                let limits = ProviderSnapshotBuilder.limits(for: metrics, service: service)
+                XCTAssertEqual(limits.count, 3, "\(service) total \(total)")
+
+                for limit in limits {
+                    let expected = expectedQuotaTitleKey(
+                        service: service,
+                        kind: limit.kind,
+                        limitTotal: total,
+                        modelLimitLabel: metrics.modelLimitLabel
+                    )
+                    let context = "\(service) \(limit.id) total \(total)"
+                    XCTAssertEqual(limit.quotaTitleKey, expected, context)
+                    XCTAssertEqual(limit.title, expected.englishTitle, context)
+                }
+            }
+        }
+    }
+
+    /// The parsed Claude model label is provider data: it stays verbatim in the
+    /// English title and in the localized one, and only a missing label falls
+    /// back to translated "Model" copy.
+    func testClaudeModelWindowKeepsTheParsedLabelVerbatim() {
+        let labeled = ProviderSnapshotBuilder.limits(
+            for: makeMetrics(service: .claudeCode, codeReview: 10, modelLimitLabel: "Fable"),
+            service: .claudeCode
+        )
+        XCTAssertEqual(labeled.map(\.quotaTitleKey), [.model(label: "Fable")])
+        XCTAssertEqual(labeled.map(\.localizedTitle), ["Fable"])
+
+        let unlabeled = ProviderSnapshotBuilder.limits(
+            for: makeMetrics(service: .claudeCode, codeReview: 10),
+            service: .claudeCode
+        )
+        XCTAssertEqual(unlabeled.map(\.quotaTitleKey), [.model(label: nil)])
+    }
+
+    /// Copy handed in directly — pseudo-localized layout fixtures, previews —
+    /// is not routed, so it renders verbatim instead of being string-matched
+    /// back onto a quota window.
+    func testDirectlyTitledLimitIsNotRoutedThroughTheCatalog() {
+        let limit = SnapshotLimit(
+            id: "credits",
+            kind: .weekly,
+            title: "Credits",
+            usageLimit: UsageLimit(used: 4, total: 10, resetTime: nil)
+        )
+
+        XCTAssertNil(limit.quotaTitleKey)
+        XCTAssertEqual(limit.localizedTitle, "Credits")
+    }
+
     // MARK: - Limits
 
     func testThirdLimitUsesReportedClaudeModelLabelAndCodeReviewForCodex() {


### PR DESCRIPTION
Replaces #453, which GitHub auto-closed when its base branch (`fix/widget-preview-localization-parity`, PR #451) was deleted on merge. Same change, rebased onto master.

`SnapshotLimit.localizedTitle` matched on the English `title` string `ServiceType` had already produced, with a `default:` returning it unchanged — so renaming any English quota title dropped every locale through that default and shipped untranslated English with no failing test.

Carries `ServiceType.QuotaTitleKey` on the limit and switches over it instead, matching what `WidgetLocalizedContent.quotaTitle(for:)` already does widget-side. The English `title` stays for the CLI JSON contract, derived from the key on routed limits; a second initializer keeps verbatim copy (previews, pseudo-localized fixtures) out of the routing path.

No catalog changes — all ten `quota.title.*` keys already exist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI localization routing only; existing `quota.title.*` keys unchanged and behavior is covered by new contract and routing tests.
> 
> **Overview**
> Fixes a localization bug where popover quota labels could silently show English after `ServiceType` renamed its English titles.
> 
> **`SnapshotLimit`** now carries an optional `ServiceType.QuotaTitleKey` on built limits. `localizedTitle` switches on that key (aligned with the widget’s `WidgetLocalizedContent.quotaTitle(for:)`) instead of matching hardcoded English `title` strings. Routed limits get a dedicated initializer that sets `title` from `quotaTitleKey.englishTitle`; previews and fixtures keep a verbatim `title` initializer with `quotaTitleKey == nil`.
> 
> **`ProviderSnapshotBuilder.limits`** wires session/weekly/code-review rows through `sessionQuotaTitleKey`, `weeklyQuotaTitleKey`, and `codeReviewQuotaTitleKey` rather than string title helpers.
> 
> Tests assert per-service routing keys, Claude model labels stay verbatim, non-routed titles pass through, and every routing key has a matching `quota.title.*` app catalog entry. No string catalog edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 489e4d505a8f6c9bdff6c6e810b0ccd3c147a9e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quota title handling across session, weekly, and code-review limits.
  * Added more reliable localization for service quotas and Claude model labels.
  * Preserved directly supplied titles exactly when no localization route is available.

* **Tests**
  * Added coverage for quota-title routing, English title resolution, and localization catalog consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->