### PR TITLE
feat(grok): add per-account threshold notifications and adaptive movement tracking

### DIFF
--- a/MeterBar/App/UsageNotificationCoordinator.swift
+++ b/MeterBar/App/UsageNotificationCoordinator.swift
@@ -5,8 +5,8 @@ import os
 import UserNotifications
 
 /// The shape `AccountNotificationPlanner` needs from a provider account.
-/// `ClaudeCodeAccount` and `CodexAccount` were mapped by two byte-identical
-/// closures in `checkAndNotify()`; this collapses them to one.
+/// `ClaudeCodeAccount`, `CodexAccount`, and `GrokAccount` were mapped by
+/// byte-identical closures in `checkAndNotify()`; this collapses them to one.
 nonisolated protocol NotificationAccountIdentity {
     var id: UUID { get }
     var name: String { get }
@@ -15,6 +15,7 @@ nonisolated protocol NotificationAccountIdentity {
 
 extension ClaudeCodeAccount: NotificationAccountIdentity {}
 extension CodexAccount: NotificationAccountIdentity {}
+extension GrokAccount: NotificationAccountIdentity {}
 
 extension AccountNotificationIdentity {
     nonisolated init(account: some NotificationAccountIdentity) {
@@ -42,11 +43,11 @@ final class UsageNotificationCoordinator {
     /// threshold. Keys are cleared when usage drops back below.
     private var notifiedLimitKeys: Set<String> = []
 
-    /// Providers whose quotas are tracked as a single flat snapshot. Claude Code
-    /// and Codex CLI are excluded because they fan out per account and are
+    /// Providers whose quotas are tracked as a single flat snapshot. Claude Code,
+    /// Codex CLI, and Grok are excluded because they fan out per account and are
     /// handled by `AccountNotificationPlanner` instead.
     static var flatNotificationServices: [ServiceType] {
-        ServiceType.allCases.filter { $0 != .claudeCode && $0 != .codexCli }
+        ServiceType.allCases.filter { $0 != .claudeCode && $0 != .codexCli && $0 != .grok }
     }
 
     func start() {
@@ -108,6 +109,11 @@ final class UsageNotificationCoordinator {
             CodexAccountStore.shared.$defaultAccountHomeDirectory.map { _ in () }.eraseToAnyPublisher(),
             CodexAccountStore.shared.$defaultAccountIsEnabled.map { _ in () }.eraseToAnyPublisher(),
         ])
+        let grokAccountChanges = Publishers.Merge3(
+            GrokAccountStore.shared.$customAccounts.map { _ in () },
+            GrokAccountStore.shared.$defaultAccountName.map { _ in () },
+            GrokAccountStore.shared.$defaultAccountIsEnabled.map { _ in () }
+        )
         let thresholdChanges = Publishers.Merge3(
             notificationPreferences.$isEnabled.map { _ in () },
             notificationPreferences.$warningThreshold.map { _ in () },
@@ -120,6 +126,7 @@ final class UsageNotificationCoordinator {
             refreshChanges.eraseToAnyPublisher(),
             claudeAccountChanges.eraseToAnyPublisher(),
             codexAccountChanges.eraseToAnyPublisher(),
+            grokAccountChanges.eraseToAnyPublisher(),
             visibilityChanges.eraseToAnyPublisher(),
             thresholdChanges.eraseToAnyPublisher()
         ]
@@ -179,6 +186,13 @@ final class UsageNotificationCoordinator {
                     accounts: CodexAccountStore.shared.accounts.map(AccountNotificationIdentity.init(account:)),
                     accountMetrics: UsageDataManager.shared.codexAccountMetrics,
                     fallbackMetrics: currentMetrics[.codexCli]
+                ),
+                AccountNotificationPlanInput(
+                    service: .grok,
+                    providerEnabled: providerVisibilityStore.isEnabled(.grok),
+                    accounts: GrokAccountStore.shared.accounts.map(AccountNotificationIdentity.init(account:)),
+                    accountMetrics: UsageDataManager.shared.grokAccountMetrics,
+                    fallbackMetrics: currentMetrics[.grok]
                 )
             ],
             alreadyNotified: keys,

--- a/MeterBar/App/UsageNotificationCoordinator.swift
+++ b/MeterBar/App/UsageNotificationCoordinator.swift
@@ -171,28 +171,50 @@ final class UsageNotificationCoordinator {
             }
         }
 
+        let claudeAccounts = ClaudeCodeAccountStore.shared.accounts.map(AccountNotificationIdentity.init(account:))
+        let claudeAccountMetrics = UsageDataManager.shared.claudeCodeAccountMetrics
+        let codexAccounts = CodexAccountStore.shared.accounts.map(AccountNotificationIdentity.init(account:))
+        let codexAccountMetrics = UsageDataManager.shared.codexAccountMetrics
+        let grokAccounts = GrokAccountStore.shared.accounts.map(AccountNotificationIdentity.init(account:))
+        let grokAccountMetrics = UsageDataManager.shared.grokAccountMetrics
+
         let accountPlan = AccountNotificationPlanner(decider: decider).plan(
             inputs: [
                 AccountNotificationPlanInput(
                     service: .claudeCode,
                     providerEnabled: providerVisibilityStore.isEnabled(.claudeCode),
-                    accounts: ClaudeCodeAccountStore.shared.accounts.map(AccountNotificationIdentity.init(account:)),
-                    accountMetrics: UsageDataManager.shared.claudeCodeAccountMetrics,
-                    fallbackMetrics: currentMetrics[.claudeCode]
+                    accounts: claudeAccounts,
+                    accountMetrics: claudeAccountMetrics,
+                    fallbackMetrics: currentMetrics[.claudeCode],
+                    representativeAccountID: AccountNotificationPlanInput.representativeAccountID(
+                        accounts: claudeAccounts,
+                        accountMetrics: claudeAccountMetrics,
+                        defaultID: ClaudeCodeAccount.defaultID
+                    )
                 ),
                 AccountNotificationPlanInput(
                     service: .codexCli,
                     providerEnabled: providerVisibilityStore.isEnabled(.codexCli),
-                    accounts: CodexAccountStore.shared.accounts.map(AccountNotificationIdentity.init(account:)),
-                    accountMetrics: UsageDataManager.shared.codexAccountMetrics,
-                    fallbackMetrics: currentMetrics[.codexCli]
+                    accounts: codexAccounts,
+                    accountMetrics: codexAccountMetrics,
+                    fallbackMetrics: currentMetrics[.codexCli],
+                    representativeAccountID: AccountNotificationPlanInput.representativeAccountID(
+                        accounts: codexAccounts,
+                        accountMetrics: codexAccountMetrics,
+                        defaultID: CodexAccount.defaultID
+                    )
                 ),
                 AccountNotificationPlanInput(
                     service: .grok,
                     providerEnabled: providerVisibilityStore.isEnabled(.grok),
-                    accounts: GrokAccountStore.shared.accounts.map(AccountNotificationIdentity.init(account:)),
-                    accountMetrics: UsageDataManager.shared.grokAccountMetrics,
-                    fallbackMetrics: currentMetrics[.grok]
+                    accounts: grokAccounts,
+                    accountMetrics: grokAccountMetrics,
+                    fallbackMetrics: currentMetrics[.grok],
+                    representativeAccountID: AccountNotificationPlanInput.representativeAccountID(
+                        accounts: grokAccounts,
+                        accountMetrics: grokAccountMetrics,
+                        defaultID: GrokAccount.defaultID
+                    )
                 )
             ],
             alreadyNotified: keys,

--- a/MeterBar/Services/AccountNotificationPlanner.swift
+++ b/MeterBar/Services/AccountNotificationPlanner.swift
@@ -23,7 +23,7 @@ struct AccountNotificationPlan: Equatable, Sendable {
     let notifiedKeys: Set<String>
 }
 
-/// Pure account/fallback orchestration shared by Claude Code and Codex.
+/// Pure account/fallback orchestration shared by Claude Code, Codex, and Grok.
 ///
 /// Account metrics take precedence whenever at least one enabled account has
 /// data. Provider fallback is used only when every enabled account is

--- a/MeterBar/Services/AccountNotificationPlanner.swift
+++ b/MeterBar/Services/AccountNotificationPlanner.swift
@@ -15,6 +15,26 @@ struct AccountNotificationPlanInput {
     let accounts: [AccountNotificationIdentity]
     let accountMetrics: [UUID: UsageMetrics]
     let fallbackMetrics: UsageMetrics?
+    /// Account whose metrics the provider-wide fallback snapshot represents.
+    /// Legacy fallback keys migrate only into this namespace so a secondary
+    /// profile cannot inherit another home's already-notified band.
+    let representativeAccountID: UUID?
+
+    /// Same selection `UsageDataManager` uses when publishing the provider-wide
+    /// snapshot: the enabled default when it has data, otherwise the first
+    /// enabled account with metrics.
+    static func representativeAccountID(
+        accounts: [AccountNotificationIdentity],
+        accountMetrics: [UUID: UsageMetrics],
+        defaultID: UUID
+    ) -> UUID? {
+        let enabled = accounts.filter(\.isEnabled)
+        if enabled.contains(where: { $0.id == defaultID }),
+           accountMetrics[defaultID] != nil {
+            return defaultID
+        }
+        return enabled.first { accountMetrics[$0.id] != nil }?.id
+    }
 }
 
 /// Fired notifications and the dedup state to thread into the next planning pass.
@@ -27,9 +47,9 @@ struct AccountNotificationPlan: Equatable, Sendable {
 ///
 /// Account metrics take precedence whenever at least one enabled account has
 /// data. Provider fallback is used only when every enabled account is
-/// unavailable. Switching between those namespaces primes the new namespace
-/// without delivering, so the same quota state does not produce a duplicate
-/// banner merely because account data appeared or disappeared.
+/// unavailable. Switching from fallback primes only the representative
+/// account's namespace, so a secondary profile cannot inherit another home's
+/// already-notified band.
 struct AccountNotificationPlanner {
     private typealias AvailableAccount = (
         identity: AccountNotificationIdentity,
@@ -144,8 +164,14 @@ struct AccountNotificationPlanner {
         }
 
         let fallbackState = clearFallbackState(service: input.service, keys: &keys)
+        let migrationAccountIDs = Self.fallbackMigrationAccountIDs(
+            representativeAccountID: input.representativeAccountID,
+            availableAccounts: availableAccounts
+        )
         for available in availableAccounts {
-            let accountKey = available.identity.id.uuidString
+            let accountID = available.identity.id
+            let accountKey = accountID.uuidString
+            guard migrationAccountIDs.contains(accountID) else { continue }
             guard !hasObservedAccountState(
                 service: input.service,
                 accountKey: accountKey,
@@ -178,6 +204,16 @@ struct AccountNotificationPlanner {
             )
             notifications.append(contentsOf: evaluation.notifications)
         }
+    }
+
+    private static func fallbackMigrationAccountIDs(
+        representativeAccountID: UUID?,
+        availableAccounts: [AvailableAccount]
+    ) -> Set<UUID> {
+        if let representativeAccountID {
+            return [representativeAccountID]
+        }
+        return Set(availableAccounts.map(\.identity.id))
     }
 
     @discardableResult

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -1019,6 +1019,9 @@ class UsageDataManager: ObservableObject {
         for (accountID, accountMetrics) in codexAccountMetrics {
             collect(accountMetrics, prefix: "codex.\(accountID.uuidString)")
         }
+        for (accountID, accountMetrics) in grokAccountMetrics {
+            collect(accountMetrics, prefix: "grok.\(accountID.uuidString)")
+        }
         return AdaptiveQuotaSnapshot(values: values)
     }
 

--- a/MeterBarTests/AccountNotificationPlannerTests.swift
+++ b/MeterBarTests/AccountNotificationPlannerTests.swift
@@ -41,14 +41,16 @@ final class AccountNotificationPlannerTests: XCTestCase {
         providerEnabled: Bool = true,
         accounts: [AccountNotificationIdentity],
         accountMetrics: [UUID: UsageMetrics] = [:],
-        fallbackMetrics: UsageMetrics? = nil
+        fallbackMetrics: UsageMetrics? = nil,
+        representativeAccountID: UUID? = nil
     ) -> AccountNotificationPlanInput {
         AccountNotificationPlanInput(
             service: service,
             providerEnabled: providerEnabled,
             accounts: accounts,
             accountMetrics: accountMetrics,
-            fallbackMetrics: fallbackMetrics
+            fallbackMetrics: fallbackMetrics,
+            representativeAccountID: representativeAccountID
         )
     }
 
@@ -784,7 +786,8 @@ final class AccountNotificationPlannerTests: XCTestCase {
                         grokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100),
                         secondGrokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 10)
                     ],
-                    fallbackMetrics: metrics(service: .grok, used: 0, weeklyUsed: 100)
+                    fallbackMetrics: metrics(service: .grok, used: 0, weeklyUsed: 100),
+                    representativeAccountID: grokAccountID
                 )
             ],
             alreadyNotified: legacyKeys,
@@ -821,5 +824,103 @@ final class AccountNotificationPlannerTests: XCTestCase {
         XCTAssertEqual(workCrosses.notifications.map(\.key), [
             "Grok-\(secondGrokAccountID.uuidString)-weekly-critical"
         ])
+    }
+
+    func testLegacyGrokMigrationDoesNotSuppressNonRepresentativeAlert() {
+        let defaultAccount = account(id: grokAccountID, name: GrokAccount.defaultName)
+        let work = account(id: secondGrokAccountID, name: "Work")
+        let legacyKeys: Set<String> = [
+            "Grok-weekly-warn",
+            "Grok-weekly-critical"
+        ]
+
+        let migrated = planner.plan(
+            inputs: [
+                input(
+                    service: .grok,
+                    accounts: [defaultAccount, work],
+                    accountMetrics: [
+                        grokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100),
+                        secondGrokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 95)
+                    ],
+                    fallbackMetrics: metrics(service: .grok, used: 0, weeklyUsed: 100),
+                    representativeAccountID: grokAccountID
+                )
+            ],
+            alreadyNotified: legacyKeys,
+            now: now
+        )
+
+        XCTAssertEqual(
+            migrated.notifications.map(\.key),
+            ["Grok-\(secondGrokAccountID.uuidString)-weekly-warn"],
+            "A non-representative profile already in-band must still fire; fallback only represented the default home."
+        )
+        XCTAssertTrue(migrated.notifications.allSatisfy { $0.serviceDisplayName == "Work (Grok)" })
+        XCTAssertFalse(
+            migrated.notifications.contains { $0.key.contains(grokAccountID.uuidString) },
+            "The representative profile must inherit the legacy band without a duplicate banner."
+        )
+        XCTAssertTrue(migrated.notifiedKeys.contains(
+            "Grok-\(grokAccountID.uuidString)-weekly-critical"
+        ))
+        XCTAssertTrue(migrated.notifiedKeys.contains(
+            "Grok-\(secondGrokAccountID.uuidString)-weekly-warn"
+        ))
+        XCTAssertFalse(migrated.notifiedKeys.contains("Grok-weekly-critical"))
+
+        let workExhausts = planner.plan(
+            inputs: [
+                input(
+                    service: .grok,
+                    accounts: [defaultAccount, work],
+                    accountMetrics: [
+                        grokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100),
+                        secondGrokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100)
+                    ],
+                    representativeAccountID: grokAccountID
+                )
+            ],
+            alreadyNotified: migrated.notifiedKeys,
+            now: now
+        )
+        XCTAssertEqual(workExhausts.notifications.map(\.key), [
+            "Grok-\(secondGrokAccountID.uuidString)-weekly-critical"
+        ])
+        XCTAssertTrue(workExhausts.notifications.allSatisfy { $0.level == .critical })
+    }
+
+    func testRepresentativeAccountIDPrefersEnabledDefaultWithMetrics() {
+        XCTAssertEqual(
+            AccountNotificationPlanInput.representativeAccountID(
+                accounts: [
+                    account(id: grokAccountID, name: GrokAccount.defaultName),
+                    account(id: secondGrokAccountID, name: "Work")
+                ],
+                accountMetrics: [
+                    grokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 18),
+                    secondGrokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 88)
+                ],
+                defaultID: grokAccountID
+            ),
+            grokAccountID
+        )
+    }
+
+    func testRepresentativeAccountIDFallsBackToFirstEnabledAccountWithMetrics() {
+        XCTAssertEqual(
+            AccountNotificationPlanInput.representativeAccountID(
+                accounts: [
+                    account(id: grokAccountID, name: GrokAccount.defaultName, isEnabled: false),
+                    account(id: secondGrokAccountID, name: "Work")
+                ],
+                accountMetrics: [
+                    grokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100),
+                    secondGrokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 40)
+                ],
+                defaultID: grokAccountID
+            ),
+            secondGrokAccountID
+        )
     }
 }

--- a/MeterBarTests/AccountNotificationPlannerTests.swift
+++ b/MeterBarTests/AccountNotificationPlannerTests.swift
@@ -7,6 +7,8 @@ final class AccountNotificationPlannerTests: XCTestCase {
     private let claudeAccountID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10))
     private let secondClaudeAccountID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11))
     private let codexAccountID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12))
+    private let grokAccountID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13))
+    private let secondGrokAccountID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 14))
 
     private var planner: AccountNotificationPlanner {
         AccountNotificationPlanner(preferences: .default)
@@ -534,5 +536,290 @@ final class AccountNotificationPlannerTests: XCTestCase {
             )
         )
         XCTAssertFalse(result.notifiedKeys.contains("Claude Code-session-critical"))
+    }
+
+    // MARK: - Grok per-account
+
+    func testTwoGrokProfilesCrossWarningCriticalExhaustedAndRecoverIndependently() {
+        let personal = account(id: grokAccountID, name: "Personal")
+        let work = account(id: secondGrokAccountID, name: "Work")
+        let accounts = [personal, work]
+
+        let personalWarns = planner.plan(
+            inputs: [
+                input(
+                    service: .grok,
+                    accounts: accounts,
+                    accountMetrics: [
+                        grokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 95),
+                        secondGrokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 10)
+                    ]
+                )
+            ],
+            alreadyNotified: [],
+            now: now
+        )
+        XCTAssertEqual(personalWarns.notifications.map(\.key), [
+            "Grok-\(grokAccountID.uuidString)-weekly-warn"
+        ])
+        XCTAssertEqual(personalWarns.notifications.map(\.serviceDisplayName), [
+            "Personal (Grok)"
+        ])
+        XCTAssertFalse(personalWarns.notifiedKeys.contains {
+            $0.hasPrefix("Grok-\(secondGrokAccountID.uuidString)-weekly")
+        })
+
+        let workExhausts = planner.plan(
+            inputs: [
+                input(
+                    service: .grok,
+                    accounts: accounts,
+                    accountMetrics: [
+                        grokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 95),
+                        secondGrokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100)
+                    ]
+                )
+            ],
+            alreadyNotified: personalWarns.notifiedKeys,
+            now: now
+        )
+        XCTAssertEqual(workExhausts.notifications.map(\.key), [
+            "Grok-\(secondGrokAccountID.uuidString)-weekly-critical"
+        ])
+        XCTAssertEqual(workExhausts.notifications.map(\.level), [.critical])
+        XCTAssertTrue(workExhausts.notifiedKeys.contains(
+            "Grok-\(grokAccountID.uuidString)-weekly-warn"
+        ))
+
+        let personalExhausts = planner.plan(
+            inputs: [
+                input(
+                    service: .grok,
+                    accounts: accounts,
+                    accountMetrics: [
+                        grokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100),
+                        secondGrokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100)
+                    ]
+                )
+            ],
+            alreadyNotified: workExhausts.notifiedKeys,
+            now: now
+        )
+        XCTAssertEqual(personalExhausts.notifications.map(\.key), [
+            "Grok-\(grokAccountID.uuidString)-weekly-critical"
+        ])
+
+        let personalRecovers = planner.plan(
+            inputs: [
+                input(
+                    service: .grok,
+                    accounts: accounts,
+                    accountMetrics: [
+                        grokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 10),
+                        secondGrokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100)
+                    ]
+                )
+            ],
+            alreadyNotified: personalExhausts.notifiedKeys,
+            now: now
+        )
+        XCTAssertTrue(personalRecovers.notifications.isEmpty)
+        XCTAssertFalse(personalRecovers.notifiedKeys.contains {
+            $0.hasPrefix("Grok-\(grokAccountID.uuidString)-weekly")
+        })
+        XCTAssertTrue(personalRecovers.notifiedKeys.contains(
+            "Grok-\(secondGrokAccountID.uuidString)-weekly-critical"
+        ))
+
+        let workRecovers = planner.plan(
+            inputs: [
+                input(
+                    service: .grok,
+                    accounts: accounts,
+                    accountMetrics: [
+                        grokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 10),
+                        secondGrokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 10)
+                    ]
+                )
+            ],
+            alreadyNotified: personalRecovers.notifiedKeys,
+            now: now
+        )
+        XCTAssertTrue(workRecovers.notifications.isEmpty)
+        XCTAssertFalse(workRecovers.notifiedKeys.contains {
+            $0.hasPrefix("Grok-\(secondGrokAccountID.uuidString)-weekly")
+        })
+    }
+
+    func testGrokEnableDisableDeleteAndRenameReconcilesNotificationState() {
+        let enabledInput = input(
+            service: .grok,
+            accounts: [
+                account(id: grokAccountID, name: "Personal"),
+                account(id: secondGrokAccountID, name: "Work")
+            ],
+            accountMetrics: [
+                grokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100),
+                secondGrokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100)
+            ]
+        )
+        let first = planner.plan(inputs: [enabledInput], alreadyNotified: [], now: now)
+        XCTAssertEqual(first.notifications.count, 2)
+
+        let disabled = planner.plan(
+            inputs: [
+                input(
+                    service: .grok,
+                    accounts: [
+                        account(id: grokAccountID, name: "Personal", isEnabled: false),
+                        account(id: secondGrokAccountID, name: "Work")
+                    ],
+                    accountMetrics: [
+                        grokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100),
+                        secondGrokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100)
+                    ]
+                )
+            ],
+            alreadyNotified: first.notifiedKeys,
+            now: now
+        )
+        XCTAssertTrue(disabled.notifications.isEmpty)
+        XCTAssertFalse(disabled.notifiedKeys.contains {
+            $0.hasPrefix("Grok-\(grokAccountID.uuidString)")
+        })
+        XCTAssertTrue(disabled.notifiedKeys.contains {
+            $0.hasPrefix("Grok-\(secondGrokAccountID.uuidString)")
+        })
+
+        let reenabled = planner.plan(
+            inputs: [enabledInput],
+            alreadyNotified: disabled.notifiedKeys,
+            now: now
+        )
+        XCTAssertEqual(reenabled.notifications.map(\.key), [
+            "Grok-\(grokAccountID.uuidString)-weekly-critical"
+        ])
+
+        let deleted = planner.plan(
+            inputs: [
+                input(
+                    service: .grok,
+                    accounts: [account(id: secondGrokAccountID, name: "Work")],
+                    accountMetrics: [
+                        secondGrokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100)
+                    ]
+                )
+            ],
+            alreadyNotified: reenabled.notifiedKeys,
+            now: now
+        )
+        XCTAssertTrue(deleted.notifications.isEmpty)
+        XCTAssertTrue(deleted.notifiedKeys.contains(
+            "Grok-\(secondGrokAccountID.uuidString)-weekly-critical"
+        ))
+
+        let renamed = planner.plan(
+            inputs: [
+                input(
+                    service: .grok,
+                    accounts: [account(id: secondGrokAccountID, name: "Studio")],
+                    accountMetrics: [
+                        secondGrokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100)
+                    ]
+                )
+            ],
+            alreadyNotified: deleted.notifiedKeys,
+            now: now
+        )
+        XCTAssertTrue(renamed.notifications.isEmpty)
+
+        let recoveredThenCrossed = planner.plan(
+            inputs: [
+                input(
+                    service: .grok,
+                    accounts: [account(id: secondGrokAccountID, name: "Studio")],
+                    accountMetrics: [
+                        secondGrokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 10)
+                    ]
+                )
+            ],
+            alreadyNotified: renamed.notifiedKeys,
+            now: now
+        )
+        let renamedCrossing = planner.plan(
+            inputs: [
+                input(
+                    service: .grok,
+                    accounts: [account(id: secondGrokAccountID, name: "Studio")],
+                    accountMetrics: [
+                        secondGrokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100)
+                    ]
+                )
+            ],
+            alreadyNotified: recoveredThenCrossed.notifiedKeys,
+            now: now
+        )
+        XCTAssertEqual(renamedCrossing.notifications.map(\.serviceDisplayName), [
+            "Studio (Grok)"
+        ])
+        XCTAssertEqual(renamedCrossing.notifications.map(\.key), [
+            "Grok-\(secondGrokAccountID.uuidString)-weekly-critical"
+        ])
+    }
+
+    func testLegacyGrokProviderWideStateDoesNotRefireUnchangedAlert() {
+        let defaultAccount = account(id: grokAccountID, name: GrokAccount.defaultName)
+        let work = account(id: secondGrokAccountID, name: "Work")
+        let legacyKeys: Set<String> = [
+            "Grok-weekly-warn",
+            "Grok-weekly-critical"
+        ]
+
+        let migrated = planner.plan(
+            inputs: [
+                input(
+                    service: .grok,
+                    accounts: [defaultAccount, work],
+                    accountMetrics: [
+                        grokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100),
+                        secondGrokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 10)
+                    ],
+                    fallbackMetrics: metrics(service: .grok, used: 0, weeklyUsed: 100)
+                )
+            ],
+            alreadyNotified: legacyKeys,
+            now: now
+        )
+
+        XCTAssertTrue(
+            migrated.notifications.isEmpty,
+            "The representative profile must inherit the legacy Grok band without a duplicate banner."
+        )
+        XCTAssertFalse(migrated.notifiedKeys.contains("Grok-weekly-warn"))
+        XCTAssertFalse(migrated.notifiedKeys.contains("Grok-weekly-critical"))
+        XCTAssertTrue(migrated.notifiedKeys.contains(
+            "Grok-\(grokAccountID.uuidString)-weekly-critical"
+        ))
+        XCTAssertFalse(migrated.notifiedKeys.contains {
+            $0.hasPrefix("Grok-\(secondGrokAccountID.uuidString)-weekly")
+        })
+
+        let workCrosses = planner.plan(
+            inputs: [
+                input(
+                    service: .grok,
+                    accounts: [defaultAccount, work],
+                    accountMetrics: [
+                        grokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100),
+                        secondGrokAccountID: metrics(service: .grok, used: 0, weeklyUsed: 100)
+                    ]
+                )
+            ],
+            alreadyNotified: migrated.notifiedKeys,
+            now: now
+        )
+        XCTAssertEqual(workCrosses.notifications.map(\.key), [
+            "Grok-\(secondGrokAccountID.uuidString)-weekly-critical"
+        ])
     }
 }

--- a/MeterBarTests/AppDelegateSplitTests.swift
+++ b/MeterBarTests/AppDelegateSplitTests.swift
@@ -596,10 +596,12 @@ final class AppDelegateSplitTests: XCTestCase {
 
         XCTAssertFalse(services.contains(.claudeCode))
         XCTAssertFalse(services.contains(.codexCli))
-        XCTAssertEqual(services.count, ServiceType.allCases.count - 2)
+        XCTAssertFalse(services.contains(.grok))
+        XCTAssertEqual(services, [.cursor, .openRouter])
+        XCTAssertEqual(services.count, ServiceType.allCases.count - 3)
     }
 
-    func testAccountNotificationIdentityMapsBothAccountTypes() {
+    func testAccountNotificationIdentityMapsClaudeCodexAndGrokAccounts() {
         let claudeID = UUID()
         let claude = ClaudeCodeAccount(
             id: claudeID,
@@ -617,6 +619,18 @@ final class AppDelegateSplitTests: XCTestCase {
         XCTAssertEqual(
             AccountNotificationIdentity(account: codex),
             AccountNotificationIdentity(id: codexID, name: "Codex Work", isEnabled: true)
+        )
+
+        let grokID = UUID()
+        let grok = GrokAccount(
+            id: grokID,
+            name: "Grok Work",
+            homeDirectory: "/tmp/grok",
+            isEnabled: false
+        )
+        XCTAssertEqual(
+            AccountNotificationIdentity(account: grok),
+            AccountNotificationIdentity(id: grokID, name: "Grok Work", isEnabled: false)
         )
     }
 

--- a/MeterBarTests/UsageDataManagerTests.swift
+++ b/MeterBarTests/UsageDataManagerTests.swift
@@ -977,6 +977,47 @@ final class UsageDataManagerTests: XCTestCase {
     }
 
     /// Reset-credit publish skips refresh methods; movement must still reschedule Adaptive.
+    func testAdaptiveSchedulerReschedulesWhenNonRepresentativeGrokQuotaMoves() async throws {
+        let now = Date(timeIntervalSinceReferenceDate: 800_000_000)
+        let accountSuite = "UsageDataManagerTests-grok-adaptive-\(UUID().uuidString)"
+        createdSuiteNames.append(accountSuite)
+        let accountDefaults = try XCTUnwrap(UserDefaults(suiteName: accountSuite))
+        let accountStore = GrokAccountStore(userDefaults: accountDefaults)
+        accountStore.addAccount(name: "Work", homeDirectory: "/tmp/grok-work")
+        let work = try XCTUnwrap(accountStore.customAccounts.first)
+        let cachedDefault = MetricsFixtures.grok(weeklyUsedPercent: 18)
+        let cachedWork = MetricsFixtures.grok(weeklyUsedPercent: 67)
+        let provider = MultiAccountGrokProvider(metricsByAccount: [
+            GrokAccount.defaultID: cachedDefault,
+            work.id: MetricsFixtures.grok(weeklyUsedPercent: 88)
+        ])
+        let codex = StubProvider(hasAccess: false, result: .success(MetricsFixtures.codexCli()))
+        let cursor = StubProvider(hasAccess: false, result: .success(MetricsFixtures.cursor()))
+        let (manager, _) = makeManager(
+            codex: codex,
+            cursor: cursor,
+            grok: provider,
+            grokAccountStore: accountStore,
+            hidden: [.codexCli, .cursor, .openRouter],
+            preloadGrokAccountMetrics: [
+                GrokAccount.defaultID: cachedDefault,
+                work.id: cachedWork
+            ],
+            savedRefreshInterval: .adaptive,
+            schedulesAutoRefresh: true,
+            adaptiveNow: { now }
+        )
+
+        XCTAssertEqual(try XCTUnwrap(manager.scheduledRefreshInterval), 1_800, accuracy: 0.01)
+
+        await manager.refreshAll()
+
+        XCTAssertEqual(manager.metrics[.grok]?.weeklyLimit?.used, 18)
+        XCTAssertEqual(manager.grokAccountMetrics[work.id]?.weeklyLimit?.used, 88)
+        XCTAssertEqual(try XCTUnwrap(manager.scheduledRefreshInterval), 60, accuracy: 0.01)
+        XCTAssertEqual(manager.effectiveRefreshReason, AdaptiveRefreshReason.recentQuotaMovement.displayText)
+    }
+
     func testAdaptiveSchedulerReschedulesWhenResetCreditPublishMovesQuota() {
         let now = Date(timeIntervalSinceReferenceDate: 800_000_000)
         let cached = MetricsFixtures.codexCli(sessionUsedPercent: 40)


### PR DESCRIPTION
## Summary
- Grok was already multi-account in refresh, cards, menu, widgets, and cache, but notifications and adaptive refresh still treated it as one provider-wide snapshot.
- `GrokAccount` now conforms to `NotificationAccountIdentity`. Grok is removed from `flatNotificationServices` and planned beside Claude/Codex.
- Account add/rename/enable/disable on `GrokAccountStore` re-runs the threshold sweep.
- Every Grok profile is tracked in `makeAdaptiveQuotaSnapshot` under `grok.<uuid>`, so a non-representative home can escalate Adaptive.
- `AccountNotificationPlanInput` now carries `representativeAccountID`. Legacy `Grok-weekly-*` keys migrate only into that account's namespace, so a secondary profile already in-band still fires independently.

## Tests
- Two Grok profiles independently cross warning / critical / exhausted / recovered.
- Enable, disable, delete, and rename reconcile notification state.
- Legacy provider-wide Grok keys do not re-fire an unchanged representative alert.
- A non-representative profile already warning during migration still fires; a later critical crossing on that profile still fires.
- Adaptive cadence goes to the fast bound when only a non-representative Grok weekly window moves.
- `swift test`: 2461 passed, 5 skipped, 0 failures.

Fixes #458

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes notification dedup and migration behavior for all account-aware providers (representative account), with broad test coverage; user-facing alert timing could shift for multi-account setups.
> 
> **Overview**
> **Grok** now uses the same per-account quota notification path as Claude Code and Codex instead of a single provider-wide snapshot.
> 
> `GrokAccount` joins the shared notification identity protocol; Grok is removed from flat notification services and planned via `AccountNotificationPlanner`, with `GrokAccountStore` changes re-triggering threshold checks. Claude and Codex inputs now pass a **`representativeAccountID`** (aligned with the provider-wide metrics snapshot) so legacy provider-wide dedup keys migrate **only** into that account’s namespace—secondary profiles no longer inherit another home’s “already notified” state.
> 
> **Adaptive refresh** includes each Grok profile in the quota movement snapshot (`grok.<uuid>`), so weekly usage changes on a non-default account can still tighten the refresh cadence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3ce8e1f4a5baefd3145ca37d9a90a6d09fac3c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->