### PR TITLE
feat(cli): support Grok profile targeting in meterbar guard

### DIFF
--- a/MeterBar/Guard/QuotaGuardEvaluator.swift
+++ b/MeterBar/Guard/QuotaGuardEvaluator.swift
@@ -306,7 +306,7 @@ nonisolated enum QuotaGuardAccountResolver {
                     )
                 )
             }
-        default:
+        case .codexCli:
             candidates = configuration.codexAccounts.map {
                 (
                     id: $0.id,
@@ -317,6 +317,26 @@ nonisolated enum QuotaGuardAccountResolver {
                     )
                 )
             }
+        case .grok:
+            candidates = configuration.grokAccounts.map {
+                (
+                    id: $0.id,
+                    name: $0.name,
+                    directory: QuotaGuardPath.normalize(
+                        $0.homeDirectory ?? defaultDirectories.grok,
+                        home: home
+                    )
+                )
+            }
+        default:
+            return .failure(QuotaGuardFailure(
+                outcome: .usageError,
+                code: "unsupported_config_dir",
+                message: "--config-dir is not supported for \(target.service.displayName). "
+                    + "Only Claude Code, OpenAI Codex, and Grok have per-account config directories.",
+                flag: "--config-dir",
+                value: requestedDirectory
+            ))
         }
 
         guard let match = candidates.first(where: { $0.directory == needle }) else {

--- a/MeterBar/Guard/QuotaGuardTarget.swift
+++ b/MeterBar/Guard/QuotaGuardTarget.swift
@@ -129,7 +129,7 @@ nonisolated struct QuotaGuardTarget: Equatable, Sendable {
                     outcome: .usageError,
                     code: "unsupported_config_dir",
                     message: "--config-dir is not supported for \(service.displayName). "
-                        + "Only Claude Code and OpenAI Codex have per-account config directories.",
+                        + "Only Claude Code, OpenAI Codex, and Grok have per-account config directories.",
                     flag: "--config-dir",
                     value: trimmedConfigDirectory
                 ))
@@ -151,6 +151,7 @@ nonisolated struct QuotaGuardTarget: Equatable, Sendable {
 nonisolated struct QuotaGuardDefaultDirectories: Equatable, Sendable {
     let claude: String
     let codex: String
+    let grok: String
 
     static func current(
         environment: [String: String] = ProcessInfo.processInfo.environment,
@@ -168,7 +169,11 @@ nonisolated struct QuotaGuardDefaultDirectories: Equatable, Sendable {
                 environment: environment,
                 realHomeDirectory: realHomeDirectory
             ),
-            codex: codex
+            codex: codex,
+            grok: GrokHomeDirectory.path(
+                environment: environment,
+                realHomeDirectory: realHomeDirectory
+            )
         )
     }
 }
@@ -195,7 +200,7 @@ nonisolated extension ServiceType {
     /// Only the CLI-backed providers keep per-account config directories the
     /// app mirrors for cross-process reads.
     var supportsGuardConfigDirectory: Bool {
-        self == .claudeCode || self == .codexCli
+        self == .claudeCode || self == .codexCli || self == .grok
     }
 }
 

--- a/MeterBarCLI/Sources/Guard.swift
+++ b/MeterBarCLI/Sources/Guard.swift
@@ -35,7 +35,10 @@ struct Guard: AsyncParsableCommand {
     )
     var minRemaining: String?
 
-    @Option(name: .long, help: "Check one configured account by its config directory.")
+    @Option(
+        name: .long,
+        help: "Check one configured Claude, Codex, or Grok account by its config directory."
+    )
     var configDir: String?
 
     @Flag(name: .long, help: "Refresh usage before deciding instead of reading the cached snapshot.")

--- a/MeterBarTests/QuotaGuardTests.swift
+++ b/MeterBarTests/QuotaGuardTests.swift
@@ -35,6 +35,7 @@ final class QuotaGuardTests: XCTestCase {
         XCTAssertEqual(try target(provider: "claude").service, .claudeCode)
         XCTAssertEqual(try target(provider: "codex").service, .codexCli)
         XCTAssertEqual(try target(provider: " Cursor ").service, .cursor)
+        XCTAssertEqual(try target(provider: "grok").service, .grok)
     }
 
     func testUnknownProviderIsAUsageErrorNamingTheInput() {
@@ -87,10 +88,21 @@ final class QuotaGuardTests: XCTestCase {
     }
 
     func testConfigDirIsRejectedForProvidersWithoutAccounts() {
-        let failure = expectFailure(provider: "cursor", configDirectory: "/tmp/x")
-        XCTAssertEqual(failure.outcome, .usageError)
-        XCTAssertEqual(failure.code, "unsupported_config_dir")
-        XCTAssertTrue(failure.message.contains("Cursor"), failure.message)
+        let cursor = expectFailure(provider: "cursor", configDirectory: "/tmp/x")
+        XCTAssertEqual(cursor.outcome, .usageError)
+        XCTAssertEqual(cursor.code, "unsupported_config_dir")
+        XCTAssertTrue(cursor.message.contains("Cursor"), cursor.message)
+
+        let openRouter = expectFailure(provider: "openrouter", configDirectory: "/tmp/x")
+        XCTAssertEqual(openRouter.outcome, .usageError)
+        XCTAssertEqual(openRouter.code, "unsupported_config_dir")
+        XCTAssertTrue(openRouter.message.contains("OpenRouter"), openRouter.message)
+    }
+
+    func testConfigDirIsAcceptedForGrok() throws {
+        let resolved = try target(provider: "grok", configDirectory: "/tmp/grok-work")
+        XCTAssertEqual(resolved.service, .grok)
+        XCTAssertEqual(resolved.configDirectory, "/tmp/grok-work")
     }
 
     // MARK: - Available
@@ -336,6 +348,248 @@ final class QuotaGuardTests: XCTestCase {
         XCTAssertEqual(selection.metrics?.sessionLimit?.used, 5)
     }
 
+    func testCodexConfigDirStillSelectsTheMatchingAccountSnapshot() throws {
+        let account = CodexAccount(id: UUID(), name: "Lab", homeDirectory: "/tmp/work-codex")
+        let snapshot = AccountUsageSnapshot(
+            id: account.id,
+            name: account.name,
+            metrics: metrics(service: .codexCli, weekly: limit(used: 33))
+        )
+
+        let selection = try QuotaGuardAccountResolver.resolve(
+            target: try target(provider: "codex", configDirectory: "/tmp/work-codex/"),
+            configuration: configuration(codexAccounts: [account]),
+            accountSnapshots: [snapshot],
+            providerMetrics: [.codexCli: metrics(service: .codexCli, weekly: limit(used: 90))],
+            defaultDirectories: defaultDirectories
+        ).get()
+
+        XCTAssertEqual(selection.account.scope, .account)
+        XCTAssertEqual(selection.account.name, "Lab")
+        XCTAssertEqual(selection.metrics?.weeklyLimit?.used, 33)
+    }
+
+    func testGrokConfigDirSelectsTheMatchingCustomProfile() throws {
+        let account = GrokAccount(id: UUID(), name: "Work", homeDirectory: "/tmp/grok-work")
+        let snapshot = AccountUsageSnapshot(
+            id: account.id,
+            name: account.name,
+            metrics: metrics(service: .grok, weekly: limit(used: 12))
+        )
+
+        let selection = try QuotaGuardAccountResolver.resolve(
+            target: try target(provider: "grok", configDirectory: "/tmp/grok-work/"),
+            configuration: configuration(grokAccounts: [account]),
+            accountSnapshots: [snapshot],
+            providerMetrics: [.grok: metrics(service: .grok, weekly: limit(used: 90))],
+            defaultDirectories: defaultDirectories
+        ).get()
+
+        XCTAssertEqual(selection.account.scope, .account)
+        XCTAssertEqual(selection.account.id, account.id)
+        XCTAssertEqual(selection.account.name, "Work")
+        XCTAssertEqual(selection.metrics?.weeklyLimit?.used, 12)
+    }
+
+    func testGrokDefaultHomeSelectsTheDefaultProfile() throws {
+        let snapshot = AccountUsageSnapshot(
+            id: GrokAccount.defaultID,
+            name: GrokAccount.defaultName,
+            metrics: metrics(service: .grok, weekly: limit(used: 8))
+        )
+
+        let selection = try QuotaGuardAccountResolver.resolve(
+            target: try target(provider: "grok", configDirectory: "/Users/test/.grok"),
+            configuration: configuration(grokAccounts: [.defaultAccount]),
+            accountSnapshots: [snapshot],
+            providerMetrics: [:],
+            defaultDirectories: defaultDirectories
+        ).get()
+
+        XCTAssertEqual(selection.account.id, GrokAccount.defaultID)
+        XCTAssertEqual(selection.account.name, GrokAccount.defaultName)
+        XCTAssertEqual(selection.metrics?.weeklyLimit?.used, 8)
+    }
+
+    func testGrokDisabledProfileIsStillSelectableByHomeDirectory() throws {
+        let account = GrokAccount(
+            id: UUID(),
+            name: "Paused",
+            homeDirectory: "/tmp/grok-paused",
+            isEnabled: false
+        )
+        let snapshot = AccountUsageSnapshot(
+            id: account.id,
+            name: account.name,
+            metrics: metrics(service: .grok, weekly: limit(used: 40))
+        )
+
+        let selection = try QuotaGuardAccountResolver.resolve(
+            target: try target(provider: "grok", configDirectory: "/tmp/grok-paused"),
+            configuration: configuration(grokAccounts: [account]),
+            accountSnapshots: [snapshot],
+            providerMetrics: [:],
+            defaultDirectories: defaultDirectories
+        ).get()
+
+        XCTAssertEqual(selection.account.id, account.id)
+        XCTAssertEqual(selection.metrics?.weeklyLimit?.used, 40)
+    }
+
+    func testDeletedGrokProfileIsUnknownRatherThanFallingBack() throws {
+        let leftover = AccountUsageSnapshot(
+            id: UUID(),
+            name: "Gone",
+            metrics: metrics(service: .grok, weekly: limit(used: 1))
+        )
+
+        let failure = QuotaGuardAccountResolver.resolve(
+            target: try target(provider: "grok", configDirectory: "/tmp/grok-gone"),
+            configuration: configuration(grokAccounts: [.defaultAccount]),
+            accountSnapshots: [leftover],
+            providerMetrics: [.grok: metrics(service: .grok, weekly: limit(used: 70))],
+            defaultDirectories: defaultDirectories
+        ).failureValue
+
+        XCTAssertEqual(failure?.outcome, .usageError)
+        XCTAssertEqual(failure?.code, "unknown_account")
+        XCTAssertEqual(failure?.flag, "--config-dir")
+        XCTAssertEqual(failure?.value, "/tmp/grok-gone")
+        XCTAssertTrue(failure?.message.contains("/tmp/grok-gone") == true, failure?.message ?? "")
+        XCTAssertFalse(failure?.message.contains("/Users/test/.grok") == true, failure?.message ?? "")
+    }
+
+    func testGrokDuplicateNormalizedHomesSelectTheFirstConfiguredProfile() throws {
+        let first = GrokAccount(id: UUID(), name: "First", homeDirectory: "/tmp/grok-dup")
+        let second = GrokAccount(id: UUID(), name: "Second", homeDirectory: "/tmp/grok-dup/")
+        let firstSnapshot = AccountUsageSnapshot(
+            id: first.id,
+            name: first.name,
+            metrics: metrics(service: .grok, weekly: limit(used: 15))
+        )
+        let secondSnapshot = AccountUsageSnapshot(
+            id: second.id,
+            name: second.name,
+            metrics: metrics(service: .grok, weekly: limit(used: 85))
+        )
+
+        let selection = try QuotaGuardAccountResolver.resolve(
+            target: try target(provider: "grok", configDirectory: "/tmp/grok-dup/"),
+            configuration: configuration(grokAccounts: [first, second]),
+            accountSnapshots: [firstSnapshot, secondSnapshot],
+            providerMetrics: [:],
+            defaultDirectories: defaultDirectories
+        ).get()
+
+        XCTAssertEqual(selection.account.id, first.id)
+        XCTAssertEqual(selection.account.name, "First")
+        XCTAssertEqual(selection.metrics?.weeklyLimit?.used, 15)
+    }
+
+    func testGrokTildeAndTrailingSlashSelectTheSameProfile() throws {
+        let home = ServiceSupport.realHomeDirectory()
+        let workHome = (home as NSString).appendingPathComponent(".grok-work")
+        let account = GrokAccount(id: UUID(), name: "Work", homeDirectory: workHome)
+        let snapshot = AccountUsageSnapshot(
+            id: account.id,
+            name: account.name,
+            metrics: metrics(service: .grok, weekly: limit(used: 21))
+        )
+        let configuration = configuration(grokAccounts: [account])
+
+        for requested in ["~/.grok-work", "~/.grok-work/", workHome + "/"] {
+            let selection = try QuotaGuardAccountResolver.resolve(
+                target: try target(provider: "grok", configDirectory: requested),
+                configuration: configuration,
+                accountSnapshots: [snapshot],
+                providerMetrics: [:],
+                defaultDirectories: defaultDirectories
+            ).get()
+
+            XCTAssertEqual(selection.account.id, account.id, requested)
+            XCTAssertEqual(selection.metrics?.weeklyLimit?.used, 21, requested)
+        }
+    }
+
+    func testUnknownGrokHomeEchoesTheCallerSuppliedDirectoryNotTheResolvedPath() throws {
+        let failure = QuotaGuardAccountResolver.resolve(
+            target: try target(provider: "grok", configDirectory: "~/.grok-unknown"),
+            configuration: configuration(grokAccounts: [.defaultAccount]),
+            accountSnapshots: [],
+            providerMetrics: [:],
+            defaultDirectories: defaultDirectories
+        ).failureValue
+
+        XCTAssertEqual(failure?.code, "unknown_account")
+        XCTAssertEqual(failure?.value, "~/.grok-unknown")
+        XCTAssertTrue(failure?.message.contains("~/.grok-unknown") == true, failure?.message ?? "")
+        XCTAssertFalse(
+            failure?.message.contains(ServiceSupport.realHomeDirectory()) == true,
+            failure?.message ?? ""
+        )
+    }
+
+    func testGrokRefreshAndCachePathsSelectTheSameProfile() throws {
+        let account = GrokAccount(id: UUID(), name: "Work", homeDirectory: "/tmp/grok-work")
+        let cached = AccountUsageSnapshot(
+            id: account.id,
+            name: account.name,
+            metrics: metrics(service: .grok, weekly: limit(used: 18), ageSeconds: 3_600)
+        )
+        let refreshed = AccountUsageSnapshot(
+            id: account.id,
+            name: account.name,
+            metrics: metrics(service: .grok, weekly: limit(used: 27), ageSeconds: 5)
+        )
+        let configuration = configuration(grokAccounts: [account])
+        let resolvedTarget = try target(provider: "grok", configDirectory: "/tmp/grok-work")
+
+        let cachedSelection = try QuotaGuardAccountResolver.resolve(
+            target: resolvedTarget,
+            configuration: configuration,
+            accountSnapshots: [cached],
+            providerMetrics: [.grok: metrics(service: .grok, weekly: limit(used: 99))],
+            defaultDirectories: defaultDirectories
+        ).get()
+        let refreshedSelection = try QuotaGuardAccountResolver.resolve(
+            target: resolvedTarget,
+            configuration: configuration,
+            accountSnapshots: [refreshed],
+            providerMetrics: [.grok: metrics(service: .grok, weekly: limit(used: 99))],
+            defaultDirectories: defaultDirectories
+        ).get()
+
+        XCTAssertEqual(cachedSelection.account, refreshedSelection.account)
+        XCTAssertEqual(cachedSelection.account.id, account.id)
+        XCTAssertEqual(cachedSelection.metrics?.weeklyLimit?.used, 18)
+        XCTAssertEqual(refreshedSelection.metrics?.weeklyLimit?.used, 27)
+    }
+
+    func testDefaultDirectoriesResolveGrokHomeThroughGrokHomeDirectory() {
+        let withEnv = QuotaGuardDefaultDirectories.current(
+            environment: ["GROK_HOME": "~/.grok-work"],
+            realHomeDirectory: "/Users/tester"
+        )
+        XCTAssertEqual(
+            withEnv.grok,
+            GrokHomeDirectory.path(
+                environment: ["GROK_HOME": "~/.grok-work"],
+                realHomeDirectory: "/Users/tester"
+            )
+        )
+        XCTAssertEqual(withEnv.grok, "/Users/tester/.grok-work")
+
+        let fallback = QuotaGuardDefaultDirectories.current(
+            environment: [:],
+            realHomeDirectory: "/Users/tester"
+        )
+        XCTAssertEqual(
+            fallback.grok,
+            GrokHomeDirectory.path(environment: [:], realHomeDirectory: "/Users/tester")
+        )
+        XCTAssertEqual(fallback.grok, "/Users/tester/.grok")
+    }
+
     // MARK: - JSON contract
 
     func testAvailableResponseMatchesVersionOneFixture() throws {
@@ -402,17 +656,23 @@ final class QuotaGuardTests: XCTestCase {
     // MARK: - Helpers
 
     private var defaultDirectories: QuotaGuardDefaultDirectories {
-        QuotaGuardDefaultDirectories(claude: "/Users/test/.claude", codex: "/Users/test/.codex")
+        QuotaGuardDefaultDirectories(
+            claude: "/Users/test/.claude",
+            codex: "/Users/test/.codex",
+            grok: "/Users/test/.grok"
+        )
     }
 
     private func configuration(
         claudeAccounts: [ClaudeCodeAccount] = [],
-        codexAccounts: [CodexAccount] = []
+        codexAccounts: [CodexAccount] = [],
+        grokAccounts: [GrokAccount] = []
     ) -> UsageRefreshConfigurationStore.Snapshot {
         UsageRefreshConfigurationStore.Snapshot(
             hiddenServices: [],
             claudeAccounts: claudeAccounts,
-            codexAccounts: codexAccounts
+            codexAccounts: codexAccounts,
+            grokAccounts: grokAccounts
         )
     }
 

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -502,6 +502,7 @@ refresh` is not answered `alreadyRunning` by an abandoned holder.
 ```sh
 meterbar guard --provider claude --limit session --min-remaining 25
 meterbar guard --provider codex --limit weekly --json
+meterbar guard --provider grok --config-dir ~/.grok-work --json
 meterbar guard --config-dir ~/.claude-work --refresh --json
 ```
 
@@ -516,7 +517,9 @@ a band threshold change moves guard's behavior with it.
 
 `--limit` accepts `session`, `weekly`, and `code-review`. `--min-remaining` is a percentage of
 quota that must remain; without it, only exhaustion blocks. `--config-dir` narrows the check to one
-configured Claude Code or OpenAI Codex account by its configuration directory.
+configured Claude Code, OpenAI Codex, or Grok account by its configuration directory (Claude/Codex
+config dir, or Grok `GROK_HOME`). Cursor and OpenRouter have no per-account directories and are
+rejected.
 
 Version 1 shape:
 


### PR DESCRIPTION
## Summary

`meterbar guard --provider grok --config-dir <home>` now selects the matching Grok profile from the app-group account snapshot, the same way Claude and Codex already match configured homes.

Grok was the only multi-account CLI provider that `supportsGuardConfigDirectory` still rejected, even though refresh configuration already stores Grok accounts and `GROK_HOME` is a first-class profile root.

## Related issue

Fixes #460

## Scope

- Accept Grok for account-targeted guard evaluation.
- Resolve the default Grok home through `GrokHomeDirectory` (`GROK_HOME` or `~/.grok`). Do not invent a third expansion helper.
- Match `--config-dir` against configured Grok accounts with the same normalized path compare Claude/Codex use.
- Keep Cursor/OpenRouter rejection explicit.
- Echo only the caller-supplied `--config-dir` value in errors; do not leak resolved local paths.
- Update CLI help and `docs/cli-json-schema.md` so they no longer claim only Claude/Codex are account-targetable.
- No CLI usage account listing (#461). No period-identity or card-health changes.

## Verification

- `swift test --filter QuotaGuardTests` — 40 tests, 0 failures
- `swift test` at worktree root — 2462 tests, 5 skipped, 0 failures

Covers default, custom, disabled, deleted, duplicate-normalized, and unknown Grok homes; refresh vs cache selection of the same profile; Claude/Codex unchanged; Cursor/OpenRouter still rejected.

## Screenshots

Not applicable

## Checklist

- [x] I reviewed the final diff for unrelated changes.
- [x] I ran the relevant focused checks or documented why they were left to CI.
- [x] I updated relevant documentation or explained why no documentation change is needed.
- [x] I documented migrations, release steps, or external configuration changes, or marked them not applicable.
- [x] I did not include secrets, credentials, personal data, customer data, or generated build output.
- [x] If CodeRabbit says "Review rate limited", I re-requested review before merge. A green CodeRabbit tick is not a review in that case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI guard and account-selection behavior only; no auth or payment paths, with broad QuotaGuard test coverage for edge cases.
> 
> **Overview**
> **`meterbar guard --config-dir`** now works for **Grok** the same way it does for Claude Code and Codex: it matches configured Grok profiles by normalized home (`GROK_HOME` / `~/.grok`) against the app-group account snapshot.
> 
> Guard account resolution is split so **Codex** and **Grok** each have explicit branches; other providers get a clear **`unsupported_config_dir`** usage error instead of incorrect fallback behavior. Default Grok home resolution goes through **`GrokHomeDirectory`**, and **`--config-dir`** errors still echo only the caller-supplied path.
> 
> CLI help and **`docs/cli-json-schema.md`** are updated to list Grok alongside Claude/Codex; **Cursor** and **OpenRouter** remain rejected for `--config-dir`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3aec15e9736b08509d4d12524fb177d5fd0e505. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-account quota configuration support for Grok.
  * Added Grok default-directory resolution and profile selection.
  * Improved account handling for Codex configuration directories.

* **Bug Fixes**
  * Unsupported providers now return a clear configuration error instead of using an incorrect fallback.

* **Documentation**
  * Updated CLI guidance and examples for Grok configuration.
  * Clarified which providers support `--config-dir`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->