### PR TITLE
docs/l10n: finish PR #435 review follow-ups

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -1,5 +1,5 @@
 ---
-last_verified: 2026-08-12
+last_verified: 2026-08-16
 status: active
 ---
 
@@ -23,7 +23,7 @@ User contracts (not agent memory): `README.md`, `docs/cli-json-schema.md`, `docs
 
 - Repo: `VincentShipsIt/meterbar.dev`. Public. Default branch `master`.
 - Product: native **macOS 26** menu bar app + WidgetKit widgets + bundled `meterbar` CLI. No backend. No database server.
-- Version at last verify: **1.8.35** (`ea7a382`). Releases after **v1.6.1** are Developer ID signed and notarized. Sparkle 2 from **v1.7.1**.
+- Version at last verify: **1.8.36** (`2d67144`). Releases after **v1.6.1** are Developer ID signed and notarized. Sparkle 2 from **v1.7.1**.
 - Providers: Claude Code, Codex CLI, Cursor, OpenRouter, Grok, plus optional Anthropic/OpenAI admin keys.
 - Shared models live in `Packages/MeterBarShared`. App group `group.dev.meterbar.app`.
 - Release bundle ids `dev.meterbar.app` / `dev.meterbar.app.Widget`. Debug uses `dev.meterbar.app.debug` so local builds cannot shadow the installed app.

--- a/.agents/memory/architecture.md
+++ b/.agents/memory/architecture.md
@@ -1,5 +1,5 @@
 ---
-last_verified: 2026-08-12
+last_verified: 2026-08-16
 status: active
 ---
 
@@ -19,7 +19,7 @@ First launch: `FirstRunOnboardingStore` offers launch-at-login once via `SMAppSe
 
 ## Layout
 
-```
+```text
 MeterBar/                 app (App, Models, Services, SessionWake, Views, Resources)
 MeterBarWidget/           Usage + Burn Down widgets
 MeterBarCLI/              meterbar SwiftPM package

--- a/.agents/memory/conventions.md
+++ b/.agents/memory/conventions.md
@@ -1,5 +1,5 @@
 ---
-last_verified: 2026-08-12
+last_verified: 2026-08-16
 status: active
 ---
 
@@ -48,7 +48,7 @@ CLI human output may stay English. `--json` keys, enum tokens, and exit codes ar
 
 ## Git
 
-```
+```text
 type(scope): description
 ```
 

--- a/.agents/memory/deferred.md
+++ b/.agents/memory/deferred.md
@@ -1,5 +1,5 @@
 ---
-last_verified: 2026-08-12
+last_verified: 2026-08-16
 status: active
 ---
 
@@ -9,10 +9,7 @@ Only items that are still open. Shipped audit findings belong on GitHub, not her
 
 ## Still open on the board
 
-- **#387** — Costs dashboard month-to-date picker, provider-independent model rollup, `cost --json` top-level rollup, serve `/cost` MTD.
 - **#389** / **#427** / **#428** / **#429** — next providers (Kimi, Z.ai/GLM, Copilot).
-- **#433** — burn-down widget strings into the widget catalog (this branch).
-- **#434** — CodeRabbit rate-limit must not report pass.
 
 ## Structural debt (no issue required to remember)
 
@@ -23,4 +20,4 @@ Only items that are still open. Shipped audit findings belong on GitHub, not her
 
 ## Done — do not re-open as debt
 
-MeterBarShared extraction. CI test/lint hard gates. View-file split of the old dashboard monolith. Signing/notarization. Aug 8 correctness batch (#374–#386, #422). Localization groundwork (#431). Burn-down widget family (#432).
+MeterBarShared extraction. CI test/lint hard gates. View-file split of the old dashboard monolith. Signing/notarization. Aug 8 correctness batch (#374–#386, #422). Localization groundwork (#431). Burn-down widget family (#432). Burn-down widget catalog (#433). Costs dashboard MTD/rollup (#387). CodeRabbit rate-limit reporting (#434).

--- a/MeterBar/Resources/Localizable.xcstrings
+++ b/MeterBar/Resources/Localizable.xcstrings
@@ -513,6 +513,116 @@
       },
       "comment": "Widget placeholder heading when no provider usage could be read."
     },
+    "widget.quota.account_credits": {
+      "comment": "Quota title for an account credit balance.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Account credits"
+          }
+        }
+      }
+    },
+    "widget.quota.code_review": {
+      "comment": "Quota title for a code-review window.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Code Review"
+          }
+        }
+      }
+    },
+    "widget.quota.cursor_models": {
+      "comment": "Cursor included-usage pool for Cursor Grok and Composer.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cursor Models"
+          }
+        }
+      }
+    },
+    "widget.quota.key_limit": {
+      "comment": "Quota title for an API-key spend cap.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Key limit"
+          }
+        }
+      }
+    },
+    "widget.quota.model": {
+      "comment": "Fallback quota title for a model-scoped window when the provider omitted a label.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model"
+          }
+        }
+      }
+    },
+    "widget.quota.monthly": {
+      "comment": "Quota title for a monthly billing-cycle window.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monthly"
+          }
+        }
+      }
+    },
+    "widget.quota.on_demand": {
+      "comment": "Cursor on-demand spend beyond included pools.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "On-demand"
+          }
+        }
+      }
+    },
+    "widget.quota.other_models": {
+      "comment": "Cursor included-usage pool for third-party API models.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Other Models"
+          }
+        }
+      }
+    },
+    "widget.quota.session": {
+      "comment": "Quota title for a short session window.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Session"
+          }
+        }
+      }
+    },
+    "widget.quota.weekly": {
+      "comment": "Quota title for a weekly window.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weekly"
+          }
+        }
+      }
+    },
     "widget.unavailable": {
       "localizations": {
         "en": {

--- a/MeterBar/Views/Settings/WidgetSettingsView.swift
+++ b/MeterBar/Views/Settings/WidgetSettingsView.swift
@@ -729,7 +729,7 @@ struct WidgetSettingsBurnDownPreviewRow: View {
                 .foregroundStyle(stageColor)
                 .lineLimit(1)
                 .minimumScaleFactor(0.75)
-            Text("\(row.quotaTitle) · \(quotaLeftText)")
+            Text("\(quotaTitleText) · \(quotaLeftText)")
                 .font(.system(size: metrics.captionSize))
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
@@ -737,6 +737,13 @@ struct WidgetSettingsBurnDownPreviewRow: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(row.accountName)
         .accessibilityValue(row.accessibilityValueText)
+    }
+
+    /// The same localized quota title the widget draws — not the shared
+    /// model's English `quotaTitle`, which would leave this preview speaking
+    /// English beside a translated widget.
+    var quotaTitleText: String {
+        LocalizedUsageFormat.quotaTitle(for: row.row.quotaTitleKey)
     }
 
     /// The same countdown value the widget draws, fallback and all — the
@@ -861,6 +868,13 @@ struct WidgetSettingsPreviewRow: View {
 
     var metrics: WidgetGlanceMetrics { WidgetGlance.metrics(for: family) }
 
+    /// The same localized quota title the widget draws — not the shared
+    /// model's English `quotaTitle`, which would leave this preview speaking
+    /// English beside a translated widget.
+    var quotaTitleText: String {
+        LocalizedUsageFormat.quotaTitle(for: row.quotaTitleKey)
+    }
+
     private var isHero: Bool { family == .small }
 
     var body: some View {
@@ -890,7 +904,7 @@ struct WidgetSettingsPreviewRow: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(row.accountName)
-        .accessibilityValue("\(row.quotaTitle), \(row.summaryText)")
+        .accessibilityValue("\(quotaTitleText), \(row.summaryText)")
     }
 
     private var summary: some View {
@@ -943,7 +957,7 @@ struct WidgetSettingsPreviewRow: View {
 
     private var caption: some View {
         HStack(spacing: metrics.captionSize / 2) {
-            Text(row.quotaTitle)
+            Text(quotaTitleText)
             if let resetTime = row.resetTime {
                 Label {
                     Text(resetTime, style: .relative)

--- a/MeterBarTests/LocalizationResourceContractTests.swift
+++ b/MeterBarTests/LocalizationResourceContractTests.swift
@@ -93,6 +93,32 @@ final class LocalizationResourceContractTests: XCTestCase {
         }
     }
 
+    /// The Settings preview draws widget quota titles from the app bundle, so
+    /// both catalogs have to carry the same `widget.quota.*` keys with the
+    /// same English words. Translated only on one side, the preview would
+    /// contradict the widget it is previewing.
+    func testWidgetQuotaTitleCopyIsCarriedByBothCatalogsWithMatchingEnglish() throws {
+        let appStrings = try strings(in: loadCatalog(at: appCatalogURL))
+        let widgetStrings = try strings(in: loadCatalog(at: widgetCatalogURL))
+
+        for key in [
+            "widget.quota.key_limit",
+            "widget.quota.model",
+            "widget.quota.on_demand",
+            "widget.quota.code_review",
+            "widget.quota.cursor_models",
+            "widget.quota.session",
+            "widget.quota.account_credits",
+            "widget.quota.other_models",
+            "widget.quota.monthly",
+            "widget.quota.weekly",
+        ] {
+            let appValue = try englishValue(for: key, in: appStrings)
+            let widgetValue = try englishValue(for: key, in: widgetStrings)
+            XCTAssertEqual(appValue, widgetValue, "\(key) must read identically in both bundles")
+        }
+    }
+
     /// One key per `ServiceType.QuotaTitleKey` case. The shared routing decides
     /// which case applies; the widget catalog only supplies its words, so a new
     /// case without a key would silently ship English.

--- a/MeterBarTests/LocalizedUsageFormattingTests.swift
+++ b/MeterBarTests/LocalizedUsageFormattingTests.swift
@@ -62,6 +62,34 @@ final class LocalizedUsageFormattingTests: XCTestCase {
         )
     }
 
+    /// English source copy has to stay word-for-word what `QuotaTitleKey`
+    /// already says, or the Settings preview would change wording the moment
+    /// it started routing through the localized helper. Parsed model labels
+    /// stay verbatim.
+    func testQuotaTitleMatchesSharedEnglishSourceAndPreservesModelLabels() {
+        let english = Locale(identifier: "en")
+        let keys: [ServiceType.QuotaTitleKey] = [
+            .keyLimit,
+            .session,
+            .cursorModels,
+            .accountCredits,
+            .otherModels,
+            .monthly,
+            .weekly,
+            .codeReview,
+            .onDemand,
+            .model(label: nil),
+            .model(label: "Fable"),
+        ]
+        for key in keys {
+            XCTAssertEqual(
+                LocalizedUsageFormat.quotaTitle(for: key, locale: english),
+                key.englishTitle,
+                String(describing: key)
+            )
+        }
+    }
+
     /// The English source copy has to stay word-for-word what the locale-neutral
     /// shared model says, or the Settings preview would change wording the
     /// moment it started routing through the localized helper.

--- a/MeterBarTests/WidgetSettingsPreviewParityTests.swift
+++ b/MeterBarTests/WidgetSettingsPreviewParityTests.swift
@@ -175,6 +175,50 @@ final class WidgetSettingsPreviewParityTests: XCTestCase {
         }
     }
 
+    /// The preview used to print the shared model's English `quotaTitle` while
+    /// the widget localized `quotaTitleKey`. Both preview surfaces now ask
+    /// the same formatter the widget uses, including verbatim model labels.
+    func testPreviewQuotaTitlesUseTheSharedRoutingKey() {
+        let cases: [(ServiceType, WidgetQuotaWindow, Double, String?)] = [
+            (.claudeCode, .weekly, 100, nil),
+            (.claudeCode, .codeReview, 100, "Fable"),
+            (.claudeCode, .codeReview, 100, nil),
+            (.cursor, .session, ServiceType.cursorIncludedPoolTotal, nil),
+            (.cursor, .weekly, ServiceType.cursorIncludedPoolTotal, nil),
+            (.cursor, .codeReview, 40, nil),
+            (.openRouter, .session, 10, nil),
+            (.openRouter, .weekly, 10, nil),
+            (.codexCli, .session, 100, nil),
+            (.grok, .weekly, 100, nil),
+        ]
+        for (service, window, total, modelLabel) in cases {
+            let row = plannedQuotaRow(
+                service: service,
+                window: window,
+                total: total,
+                modelLabel: modelLabel
+            )
+            let expected = LocalizedUsageFormat.quotaTitle(for: row.quotaTitleKey)
+            let preview = WidgetSettingsPreviewRow(row: row, family: .medium)
+            XCTAssertEqual(preview.quotaTitleText, expected, "\(service) \(window)")
+
+            let burnDown = WidgetSettingsBurnDownPreviewRow(
+                row: WidgetBurnDownRow(
+                    row: row,
+                    stage: .onPace,
+                    stageText: "On pace",
+                    countdownKind: .reset,
+                    countdownTitle: LocalizedUsageFormat.burnDownCountdownTitle(.reset),
+                    countdownTarget: nil,
+                    countdownText: "2h 5m"
+                ),
+                family: .medium
+            )
+            XCTAssertEqual(burnDown.quotaTitleText, expected, "burn-down \(service) \(window)")
+            XCTAssertEqual(expected, row.quotaTitleKey.englishTitle, "\(service) \(window) English")
+        }
+    }
+
     /// The preview inlined the widget's `"Unavailable"` sentinel check instead
     /// of asking the shared formatter, which is two copies of one rule.
     func testBurnDownPreviewCountdownMatchesTheSharedFallback() {
@@ -257,6 +301,36 @@ final class WidgetSettingsPreviewParityTests: XCTestCase {
             family: family,
             now: now
         )
+    }
+
+    private func plannedQuotaRow(
+        service: ServiceType,
+        window: WidgetQuotaWindow,
+        total: Double,
+        modelLabel: String?
+    ) -> WidgetPresentationRow {
+        var preferences = WidgetPreferences.defaults
+        preferences.visibleQuotaWindows = [window]
+        let limit = UsageLimit(used: 40, total: total, resetTime: nil)
+        let metrics = UsageMetrics(
+            service: service,
+            sessionLimit: window == .session ? limit : nil,
+            weeklyLimit: window == .weekly ? limit : nil,
+            codeReviewLimit: window == .codeReview ? limit : nil,
+            modelLimitLabel: modelLabel,
+            lastUpdated: now
+        )
+        let presentation = WidgetPresentationPlanner.makePresentation(
+            metrics: [service: metrics],
+            accountMetrics: [],
+            preferences: preferences,
+            family: .medium,
+            now: now
+        )
+        guard let row = presentation.rows.first else {
+            preconditionFailure("fixture must plan a \(service) \(window) row")
+        }
+        return row
     }
 
     private func firstRow(family: WidgetPresentationFamily) -> WidgetPresentationRow {

--- a/MeterBarWidget/WidgetLocalization.swift
+++ b/MeterBarWidget/WidgetLocalization.swift
@@ -9,37 +9,10 @@ enum WidgetLocalizedContent {
         quotaTitle(for: row.quotaTitleKey)
     }
 
-    /// Translates the shared row's already-decided quota title.
-    ///
-    /// Which title applies — the OpenRouter exceptions, Cursor's included-pool
-    /// split, Claude Code's model window — is decided once in
-    /// `WidgetPresentationRow.quotaTitleKey`. This switch only supplies the
-    /// widget bundle's words for it, so the widget cannot answer a routing
-    /// question differently from the app.
+    /// Same formatter the Settings preview uses, so the two surfaces cannot
+    /// pick different words for the same routing key.
     static func quotaTitle(for key: ServiceType.QuotaTitleKey) -> String {
-        switch key {
-        case .keyLimit:
-            return String(localized: "widget.quota.key_limit", defaultValue: "Key limit")
-        case let .model(label):
-            return label
-                ?? String(localized: "widget.quota.model", defaultValue: "Model")
-        case .onDemand:
-            return String(localized: "widget.quota.on_demand", defaultValue: "On-demand")
-        case .codeReview:
-            return String(localized: "widget.quota.code_review", defaultValue: "Code Review")
-        case .cursorModels:
-            return String(localized: "widget.quota.cursor_models", defaultValue: "Cursor Models")
-        case .session:
-            return String(localized: "widget.quota.session", defaultValue: "Session")
-        case .accountCredits:
-            return String(localized: "widget.quota.account_credits", defaultValue: "Account credits")
-        case .otherModels:
-            return String(localized: "widget.quota.other_models", defaultValue: "Other Models")
-        case .monthly:
-            return String(localized: "widget.quota.monthly", defaultValue: "Monthly")
-        case .weekly:
-            return String(localized: "widget.quota.weekly", defaultValue: "Weekly")
-        }
+        LocalizedUsageFormat.quotaTitle(for: key)
     }
 
     static func summaryText(for row: WidgetPresentationRow) -> String {

--- a/Packages/MeterBarShared/Sources/MeterBarShared/LocalizedUsageFormatting.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/LocalizedUsageFormatting.swift
@@ -284,6 +284,104 @@ public enum LocalizedUsageFormat {
         )
     }
 
+    /// Translates the shared row's already-decided quota title.
+    ///
+    /// Which title applies — the OpenRouter exceptions, Cursor's included-pool
+    /// split, Claude Code's model window — is decided once in
+    /// `WidgetPresentationRow.quotaTitleKey`. This switch only supplies the
+    /// caller's bundle's words for it, so the Settings preview and the widget
+    /// cannot answer a routing question differently.
+    ///
+    /// Parsed model labels are provider data and stay verbatim in every locale.
+    public static func quotaTitle(
+        for key: ServiceType.QuotaTitleKey,
+        bundle: Bundle = .main,
+        locale: Locale = .current
+    ) -> String {
+        switch key {
+        case .keyLimit:
+            return String(
+                localized: "widget.quota.key_limit",
+                defaultValue: "Key limit",
+                bundle: bundle,
+                locale: locale,
+                comment: "Quota title for an API-key spend cap."
+            )
+        case let .model(label):
+            return label ?? String(
+                localized: "widget.quota.model",
+                defaultValue: "Model",
+                bundle: bundle,
+                locale: locale,
+                comment: "Fallback quota title for a model-scoped window when the provider omitted a label."
+            )
+        case .onDemand:
+            return String(
+                localized: "widget.quota.on_demand",
+                defaultValue: "On-demand",
+                bundle: bundle,
+                locale: locale,
+                comment: "Cursor on-demand spend beyond included pools."
+            )
+        case .codeReview:
+            return String(
+                localized: "widget.quota.code_review",
+                defaultValue: "Code Review",
+                bundle: bundle,
+                locale: locale,
+                comment: "Quota title for a code-review window."
+            )
+        case .cursorModels:
+            return String(
+                localized: "widget.quota.cursor_models",
+                defaultValue: "Cursor Models",
+                bundle: bundle,
+                locale: locale,
+                comment: "Cursor included-usage pool for Cursor Grok and Composer."
+            )
+        case .session:
+            return String(
+                localized: "widget.quota.session",
+                defaultValue: "Session",
+                bundle: bundle,
+                locale: locale,
+                comment: "Quota title for a short session window."
+            )
+        case .accountCredits:
+            return String(
+                localized: "widget.quota.account_credits",
+                defaultValue: "Account credits",
+                bundle: bundle,
+                locale: locale,
+                comment: "Quota title for an account credit balance."
+            )
+        case .otherModels:
+            return String(
+                localized: "widget.quota.other_models",
+                defaultValue: "Other Models",
+                bundle: bundle,
+                locale: locale,
+                comment: "Cursor included-usage pool for third-party API models."
+            )
+        case .monthly:
+            return String(
+                localized: "widget.quota.monthly",
+                defaultValue: "Monthly",
+                bundle: bundle,
+                locale: locale,
+                comment: "Quota title for a monthly billing-cycle window."
+            )
+        case .weekly:
+            return String(
+                localized: "widget.quota.weekly",
+                defaultValue: "Weekly",
+                bundle: bundle,
+                locale: locale,
+                comment: "Quota title for a weekly window."
+            )
+        }
+    }
+
     public static func widgetEmptyTitle(
         _ state: WidgetPresentationEmptyState,
         bundle: Bundle = .main,

--- a/docs/audits/00-repo-map.md
+++ b/docs/audits/00-repo-map.md
@@ -1,7 +1,7 @@
 # 00 — Repo Map: MeterBar
 
 > **Superseded 2026-08-12.** Historical snapshot only. Do not treat this file as current architecture.
-> Live map: `.agents/memory/MEMORY.md` and `architecture.md`.
+> Live map: `.agents/memory/MEMORY.md` and `.agents/memory/architecture.md`.
 > Since this audit: `MeterBarShared` shipped, CI tests/lint are hard gates, views were split, releases are notarized, and the 2026-08-08 bug batch (#374–#386, #422) landed.
 
 **Audit date:** 2026-07-02


### PR DESCRIPTION
Fixes #439

Leftover review items from merged PR #435. #451/#454 already localized Settings empty states and routed the popover through `QuotaTitleKey`; Settings preview quota titles were still English.

## Review-thread evidence

**[MD040 fences](https://github.com/VincentShipsIt/meterbar.dev/pull/435#discussion_r3770308099)**
- `.agents/memory/architecture.md` layout tree is now ` ```text `
- `.agents/memory/conventions.md` git type fence is now ` ```text `

**[deferred.md #433](https://github.com/VincentShipsIt/meterbar.dev/pull/435#discussion_r3770308107)**
- `gh issue view` on 2026-08-16: #387, #433, and #434 are all closed
- Moved those three to Done; left #389 / #427 / #428 / #429 as the open provider set

**[Historical repo map](https://github.com/VincentShipsIt/meterbar.dev/pull/435#discussion_r3770308119)**
- `docs/audits/00-repo-map.md` now points at `.agents/memory/architecture.md` (file still exists; not resurrected)

**[Settings preview quota titles](https://github.com/VincentShipsIt/meterbar.dev/pull/435#discussion_r3770308156)**
- Added `LocalizedUsageFormat.quotaTitle(for:)` over `ServiceType.QuotaTitleKey`
- Widget `WidgetLocalizedContent` and both Settings preview surfaces (`WidgetSettingsPreviewRow`, `WidgetSettingsBurnDownPreviewRow`) use that helper
- Model labels stay verbatim
- App catalog now carries matching `widget.quota.*` English source copy, same pattern as the empty-state keys from #451

## Other MEMORY refresh

- Version at last verify is **1.8.36** (`2d67144` / tag `v1.8.36`)
- `last_verified: 2026-08-16` on the touched memory files
- Did not invent a newer unreleased version

## Verification

- `swift test --filter 'LocalizedUsageFormattingTests|LocalizationResourceContractTests|WidgetSettingsPreviewParityTests|WidgetPresentationTests'` — 43 tests, 0 failures
- `swiftlint lint --strict` on the six changed Swift files — 0 violations
- App `Localizable.xcstrings` parses as JSON
- Opening fences in the two cited memory files now have language identifiers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localization and preview parity only; behavior is covered by contract and parity tests with no auth, data, or API contract changes.
> 
> **Overview**
> Finishes **PR #435 review follow-ups** (#439): agent memory is refreshed (version **1.8.36**, `last_verified` 2026-08-16), closed issues **#387**, **#433**, and **#434** move to Done in `deferred.md`, and markdown code fences get `text` language tags.
> 
> The functional change is **widget quota title localization parity**. `LocalizedUsageFormat.quotaTitle(for:)` in **MeterBarShared** centralizes lookup of `widget.quota.*` strings from `ServiceType.QuotaTitleKey`. The widget’s `WidgetLocalizedContent` and both Settings preview surfaces (`WidgetSettingsPreviewRow`, burn-down preview) call that helper instead of English `quotaTitle` or a duplicate switch. The app catalog gains matching `widget.quota.*` English entries so the Settings preview resolves the same keys as the widget extension.
> 
> **Tests** lock catalog parity between app and widget bundles and assert preview quota titles match the shared routing key (including verbatim model labels).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21f8821a5579470f77fbf4c4f02de121452f7a25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->