### PR TITLE
test(providers): add a capability registry and all-provider fixture matrix

### DIFF
--- a/MeterBar/App/UsageNotificationCoordinator.swift
+++ b/MeterBar/App/UsageNotificationCoordinator.swift
@@ -43,11 +43,10 @@ final class UsageNotificationCoordinator {
     /// threshold. Keys are cleared when usage drops back below.
     private var notifiedLimitKeys: Set<String> = []
 
-    /// Providers whose quotas are tracked as a single flat snapshot. Claude Code,
-    /// Codex CLI, and Grok are excluded because they fan out per account and are
-    /// handled by `AccountNotificationPlanner` instead.
+    /// Providers whose quotas are tracked as a single flat snapshot. Account-
+    /// scoped providers fan out through `AccountNotificationPlanner` instead.
     static var flatNotificationServices: [ServiceType] {
-        ServiceType.allCases.filter { $0 != .claudeCode && $0 != .codexCli && $0 != .grok }
+        ServiceType.allCases.filter { !$0.hasAccountScopedNotifications }
     }
 
     func start() {

--- a/MeterBar/Guard/QuotaGuardTarget.swift
+++ b/MeterBar/Guard/QuotaGuardTarget.swift
@@ -196,14 +196,6 @@ nonisolated enum QuotaGuardPath {
     }
 }
 
-nonisolated extension ServiceType {
-    /// Only the CLI-backed providers keep per-account config directories the
-    /// app mirrors for cross-process reads.
-    var supportsGuardConfigDirectory: Bool {
-        self == .claudeCode || self == .codexCli || self == .grok
-    }
-}
-
 nonisolated private extension String {
     var trimmed: String {
         trimmingCharacters(in: .whitespacesAndNewlines)

--- a/MeterBar/Models/DemoData+Cost.swift
+++ b/MeterBar/Models/DemoData+Cost.swift
@@ -8,8 +8,8 @@ import MeterBarShared
 /// the shared `DemoData` namespace. `CostTracker` publishes this instead of
 /// scanning real CLI logs when demo mode is active.
 ///
-/// The summary is deliberately **non-alarming** — a ~$205 30-day estimate split
-/// across three providers. Model and origin breakdowns are **fully synthetic**,
+/// The summary is deliberately **non-alarming** — a ~$240 30-day estimate split
+/// across every provider. Model and origin breakdowns are **fully synthetic**,
 /// drawn from `syntheticBreakdownNames` only (public model ids and generic
 /// origin labels), so the model-spend and origin charts render in screenshots
 /// without ever surfacing the owner's real project paths or private routing.
@@ -23,6 +23,7 @@ extension DemoData {
     static let syntheticBreakdownNames: Set<String> = [
         "claude-fable-5", "claude-opus-5", "claude-haiku-4-5",
         "gpt-5.6-sol", "gpt-5.6-luna",
+        "grok-4.5-build", "grok-4.5",
         "Main chat", "Agents", "Code review",
     ]
 
@@ -44,6 +45,10 @@ extension DemoData {
             DemoSplit(name: "gpt-5.6-sol", fraction: 0.72),
             DemoSplit(name: "gpt-5.6-luna", fraction: 0.28),
         ],
+        .grok: [
+            DemoSplit(name: "grok-4.5-build", fraction: 0.74),
+            DemoSplit(name: "grok-4.5", fraction: 0.26),
+        ],
     ]
 
     private static let demoOriginSplits: [ServiceType: [DemoSplit]] = [
@@ -55,6 +60,10 @@ extension DemoData {
         .codexCli: [
             DemoSplit(name: "Main chat", fraction: 0.57),
             DemoSplit(name: "Agents", fraction: 0.43),
+        ],
+        .grok: [
+            DemoSplit(name: "Main chat", fraction: 0.61),
+            DemoSplit(name: "Agents", fraction: 0.39),
         ],
     ]
 
@@ -78,7 +87,7 @@ extension DemoData {
         }
     }
     /// Per-provider 30-day totals (USD) and token magnitudes for the demo cost
-    /// summary. Sums to $204.90 ≈ "$205".
+    /// summary. Sums to $240.10 ≈ "$240".
     private struct DemoProviderCost {
         let provider: ServiceType
         let inputTokens: Int
@@ -117,6 +126,25 @@ extension DemoData {
             cacheReadTokens: 0,
             costUSD: 41.30,
             sessionCount: 54
+        ),
+        DemoProviderCost(
+            provider: .grok,
+            inputTokens: 1_850_000,
+            outputTokens: 610_000,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 0,
+            costUSD: 22.40,
+            sessionCount: 41
+        ),
+        // OpenRouter is billed in dollars, not tokens, so it contributes cost only.
+        DemoProviderCost(
+            provider: .openRouter,
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 0,
+            costUSD: 12.80,
+            sessionCount: 18
         )
     ]
 

--- a/MeterBar/Services/QuotaEventService.swift
+++ b/MeterBar/Services/QuotaEventService.swift
@@ -29,8 +29,8 @@ nonisolated struct QuotaEventAccountInputs: Sendable {
 /// Builds the app-wide provider/account input without ever projecting
 /// credential or filesystem configuration into the event model.
 nonisolated enum QuotaEventSnapshotCatalog {
-    static let flatProviders = ServiceType.allCases.filter {
-        $0 != .claudeCode && $0 != .codexCli && $0 != .grok
+    static var flatProviders: [ServiceType] {
+        ServiceType.allCases.filter { !$0.hasAccountScopedQuotaEvents }
     }
 
     static func snapshots(

--- a/MeterBar/Views/DashboardShareSection.swift
+++ b/MeterBar/Views/DashboardShareSection.swift
@@ -40,20 +40,27 @@ struct DashboardShareSection: View {
         self._shareStatus = shareStatus
     }
 
-    /// The card's provenance line. Only the three log-backed providers contribute
-    /// a local source; the API-only ones have nothing on disk to cite.
+    /// The card's provenance line. Only providers that write local token logs
+    /// contribute a source; API-only ones have nothing on disk to cite.
     static func enabledSourceLabels(for enabledServices: Set<ServiceType>) -> [String] {
-        var labels: [String] = []
-        if enabledServices.contains(.codexCli) {
-            labels.append("Codex logs")
+        ServiceType.allCases.compactMap { service in
+            guard enabledServices.contains(service), service.hasLocalHistorySource else {
+                return nil
+            }
+            return sourceLabel(for: service)
         }
-        if enabledServices.contains(.claudeCode) {
-            labels.append("Claude JSONL")
+    }
+
+    /// Share-card wording for one local-history source. Internal so the parity
+    /// suite can pin the labels without duplicating them.
+    static func sourceLabel(for service: ServiceType) -> String {
+        switch service {
+        case .claudeCode: return "Claude JSONL"
+        case .codexCli: return "Codex logs"
+        case .grok: return "Grok JSONL"
+        case .cursor: return "Cursor local state"
+        case .openRouter: return "OpenRouter logs"
         }
-        if enabledServices.contains(.cursor) {
-            labels.append("Cursor local state")
-        }
-        return labels
     }
 
     /// Shared with the Costs cards so the preview and the spend cards announce

--- a/MeterBarTests/AppDelegateSplitTests.swift
+++ b/MeterBarTests/AppDelegateSplitTests.swift
@@ -594,11 +594,18 @@ final class AppDelegateSplitTests: XCTestCase {
     func testFlatNotificationServicesExcludeTheAccountAwareProviders() {
         let services = UsageNotificationCoordinator.flatNotificationServices
 
+        XCTAssertEqual(
+            services,
+            ServiceType.allCases.filter { !$0.hasAccountScopedNotifications }
+        )
         XCTAssertFalse(services.contains(.claudeCode))
         XCTAssertFalse(services.contains(.codexCli))
         XCTAssertFalse(services.contains(.grok))
         XCTAssertEqual(services, [.cursor, .openRouter])
-        XCTAssertEqual(services.count, ServiceType.allCases.count - 3)
+        XCTAssertEqual(
+            services.count,
+            ServiceType.allCases.filter { !$0.hasAccountScopedNotifications }.count
+        )
     }
 
     func testAccountNotificationIdentityMapsClaudeCodexAndGrokAccounts() {

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -13,7 +13,7 @@ final class CostTrackerTests: XCTestCase {
 
         let summary = tracker.costSummary
         XCTAssertNotNil(summary, "demo mode should publish a summary at construction")
-        XCTAssertEqual(summary?.totalCostUSD ?? 0, 204.90, accuracy: 0.001)
+        XCTAssertEqual(summary?.totalCostUSD ?? 0, 240.10, accuracy: 0.001)
         XCTAssertEqual(summary?.periodDays, 30)
         XCTAssertNil(summary?.lifetime)
         XCTAssertNotNil(tracker.lastScanDate)

--- a/MeterBarTests/DashboardSectionSplitTests.swift
+++ b/MeterBarTests/DashboardSectionSplitTests.swift
@@ -483,14 +483,18 @@ final class DashboardSectionSplitTests: XCTestCase {
     func testEnabledSourceLabelsCoverOnlyTheLogBackedProviders() {
         XCTAssertEqual(
             DashboardShareSection.enabledSourceLabels(for: Set(ServiceType.allCases)),
-            ["Codex logs", "Claude JSONL", "Cursor local state"]
+            ["Claude JSONL", "Codex logs", "Grok JSONL"]
         )
         XCTAssertEqual(
             DashboardShareSection.enabledSourceLabels(for: [.claudeCode]),
             ["Claude JSONL"]
         )
+        XCTAssertEqual(
+            DashboardShareSection.enabledSourceLabels(for: [.openRouter, .grok]),
+            ["Grok JSONL"]
+        )
         XCTAssertTrue(
-            DashboardShareSection.enabledSourceLabels(for: [.openRouter, .grok]).isEmpty,
+            DashboardShareSection.enabledSourceLabels(for: [.openRouter, .cursor]).isEmpty,
             "API-only providers contribute no local log source"
         )
     }

--- a/MeterBarTests/DemoDataTests.swift
+++ b/MeterBarTests/DemoDataTests.swift
@@ -14,15 +14,15 @@ final class DemoDataTests: XCTestCase {
 
     // MARK: - Coverage & generic labels
 
-    func testCoversThreeProvidersKeyedByGenericServiceType() {
+    func testCoversEveryServiceTypeKeyedByGenericLabels() {
         let metrics = DemoData.metrics(now: now)
 
-        XCTAssertEqual(Set(metrics.keys), [.claudeCode, .codexCli, .cursor])
+        XCTAssertEqual(Set(metrics.keys), Set(ServiceType.allCases))
         // Labels come from the service enum's product display names, never the
         // owner's custom account/profile names.
-        XCTAssertEqual(metrics[.claudeCode]?.service.displayName, "Claude Code")
-        XCTAssertEqual(metrics[.codexCli]?.service.displayName, "OpenAI Codex")
-        XCTAssertEqual(metrics[.cursor]?.service.displayName, "Cursor")
+        for service in ServiceType.allCases {
+            XCTAssertEqual(metrics[service]?.service.displayName, service.displayName)
+        }
         // The one free-text label the fixture sets is a model window name, not a
         // project name.
         XCTAssertEqual(metrics[.claudeCode]?.modelLimitLabel, "Fable")
@@ -30,7 +30,7 @@ final class DemoDataTests: XCTestCase {
 
     func testEveryProviderHasData() {
         let metrics = DemoData.metrics(now: now)
-        for service in [ServiceType.claudeCode, .codexCli, .cursor] {
+        for service in ServiceType.allCases {
             XCTAssertEqual(metrics[service]?.hasData, true, "\(service) should have data")
         }
     }
@@ -89,6 +89,10 @@ final class DemoDataTests: XCTestCase {
         let metrics = DemoData.metrics(now: now)
 
         XCTAssertEqual(metrics[.codexCli]?.resetCreditsAvailable, 2)
+        XCTAssertEqual(metrics[.grok]?.resetCreditsAvailable, 1)
+        XCTAssertNotNil(metrics[.claudeCode]?.extraUsage)
+        XCTAssertNotNil(metrics[.grok]?.extraUsage)
+        XCTAssertNil(metrics[.grok]?.sessionLimit)
         // Cursor mirrors the real percent-pool mapping: no window seconds,
         // so no pace label is ever produced.
         XCTAssertNil(metrics[.cursor]?.sessionLimit?.pace(now: now))
@@ -100,11 +104,11 @@ final class DemoDataTests: XCTestCase {
     func testCostSummaryIsNonAlarmingAndCarriesOnlySyntheticBreakdowns() {
         let summary = DemoData.costSummary(now: now)
 
-        XCTAssertEqual(summary.totalCostUSD, 204.90, accuracy: 0.001, "~$205, deliberately modest")
+        XCTAssertEqual(summary.totalCostUSD, 240.10, accuracy: 0.001, "~$240, deliberately modest")
         XCTAssertEqual(summary.periodDays, 30)
         XCTAssertNil(summary.lifetime)
-        XCTAssertEqual(summary.costs.count, 3)
-        XCTAssertEqual(Set(summary.costs.map(\.provider)), [.claudeCode, .codexCli, .cursor])
+        XCTAssertEqual(summary.costs.count, ServiceType.allCases.count)
+        XCTAssertEqual(Set(summary.costs.map(\.provider)), Set(ServiceType.allCases))
         XCTAssertEqual(
             summary.totalTokens,
             summary.costs.reduce(0) { $0 + $1.totalTokens },
@@ -115,7 +119,7 @@ final class DemoDataTests: XCTestCase {
         // Breakdowns exist so demo screenshots show the model/origin charts —
         // but only from the fixture's fixed synthetic vocabulary. Nothing here
         // may ever look like a real project path or leak private routing.
-        for cost in summary.costs where cost.provider != .cursor {
+        for cost in summary.costs where cost.provider.writesLocalTokenLogs {
             XCTAssertFalse(cost.modelBreakdowns.isEmpty, "\(cost.provider) demo needs model rows")
             XCTAssertFalse(cost.originBreakdowns.isEmpty, "\(cost.provider) demo needs origin rows")
 
@@ -136,9 +140,11 @@ final class DemoDataTests: XCTestCase {
             }
         }
 
-        // Cursor is dollar-billed with no token telemetry; it stays plain.
-        let cursor = summary.costs.first { $0.provider == .cursor }
-        XCTAssertEqual(cursor?.modelBreakdowns.isEmpty, true)
+        // Dollar-billed providers have no token telemetry; they stay plain.
+        for provider in ServiceType.allCases where !provider.writesLocalTokenLogs {
+            let cost = summary.costs.first { $0.provider == provider }
+            XCTAssertEqual(cost?.modelBreakdowns.isEmpty, true, "\(provider)")
+        }
     }
 
     /// Daily rows carry per-model attribution so the 7-day window's model chart
@@ -165,12 +171,13 @@ final class DemoDataTests: XCTestCase {
         let summary = DemoData.costSummary(now: now)
 
         XCTAssertFalse(summary.dailyUsage.isEmpty)
-        // Cursor is billed in dollars (0 tokens) so it contributes cost only and
-        // never appears as a token row.
-        XCTAssertFalse(summary.dailyUsage.contains { $0.provider == .cursor })
-        XCTAssertTrue(summary.dailyUsage.allSatisfy { [.claudeCode, .codexCli].contains($0.provider) })
+        // Dollar-billed providers contribute cost only and never appear as a
+        // token row. Local-log providers fill the daily chart.
+        let tokenProviders = Set(ServiceType.allCases.filter(\.writesLocalTokenLogs))
+        XCTAssertFalse(summary.dailyUsage.contains { !$0.provider.writesLocalTokenLogs })
+        XCTAssertEqual(Set(summary.dailyUsage.map(\.provider)), tokenProviders)
         // One row per token-billed provider per day across the 30-day window.
-        XCTAssertEqual(summary.dailyUsage.count, 30 * 2)
+        XCTAssertEqual(summary.dailyUsage.count, 30 * tokenProviders.count)
     }
 
     func testFixtureIsDeterministicForAGivenClock() {

--- a/MeterBarTests/MetricsFixtures.swift
+++ b/MeterBarTests/MetricsFixtures.swift
@@ -2,13 +2,26 @@ import Foundation
 import MeterBarShared
 @testable import MeterBar
 
-/// Deterministic `UsageMetrics` fixtures for the three providers, shared across
+/// Deterministic `UsageMetrics` fixtures for every `ServiceType`, shared across
 /// the service-layer tests (SharedDataStore round-trip, UsageDataManager
 /// orchestration) and the widget-rendering checks. All timestamps are fixed so
-/// nothing depends on wall-clock time.
+/// nothing depends on wall-clock time. Adding a provider is a compile error in
+/// `metrics(for:)` until a fixture is declared.
 enum MetricsFixtures {
     /// A stable reference instant used for every reset/last-updated field.
     static let referenceDate = Date(timeIntervalSinceReferenceDate: 700_000_000)
+
+    /// One populated metric for `service`. Exhaustive so a new `ServiceType`
+    /// cannot join the matrix without a fixture.
+    static func metrics(for service: ServiceType) -> UsageMetrics {
+        switch service {
+        case .claudeCode: return claudeCode()
+        case .codexCli: return codexCli()
+        case .cursor: return cursor()
+        case .openRouter: return openRouter()
+        case .grok: return grok()
+        }
+    }
 
     static func claudeCode(
         sessionUsedPercent: Double = 42.5,
@@ -97,16 +110,41 @@ enum MetricsFixtures {
                 windowSeconds: 7 * 24 * 3_600
             ),
             extraUsage: ExtraUsageStatus(state: .on, detail: "$10.00 credits"),
+            resetCreditsAvailable: 1,
             lastUpdated: referenceDate
         )
     }
 
-    /// One populated metric per provider, keyed by `ServiceType`.
+    /// OpenRouter: key-limit + account-credits, matching production mapping.
+    static func openRouter(
+        keyUsed: Double = 12.8,
+        keyTotal: Double = 40,
+        creditsUsed: Double = 42,
+        creditsTotal: Double = 100
+    ) -> UsageMetrics {
+        UsageMetrics(
+            service: .openRouter,
+            sessionLimit: UsageLimit(
+                used: keyUsed,
+                total: keyTotal,
+                resetTime: referenceDate.addingTimeInterval(18 * 24 * 3_600),
+                windowSeconds: 30 * 24 * 3_600
+            ),
+            weeklyLimit: UsageLimit(
+                used: creditsUsed,
+                total: creditsTotal,
+                resetTime: nil
+            ),
+            lastUpdated: referenceDate
+        )
+    }
+
+    /// One populated metric per `ServiceType`. Adding a case without a
+    /// `metrics(for:)` fixture is a compile error; omitting it from this map
+    /// is a parity-test failure.
     static func allProviders() -> [ServiceType: UsageMetrics] {
-        [
-            .claudeCode: claudeCode(),
-            .codexCli: codexCli(),
-            .cursor: cursor()
-        ]
+        Dictionary(uniqueKeysWithValues: ServiceType.allCases.map { service in
+            (service, metrics(for: service))
+        })
     }
 }

--- a/MeterBarTests/ProviderCapabilitiesTests.swift
+++ b/MeterBarTests/ProviderCapabilitiesTests.swift
@@ -1,0 +1,188 @@
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// Focused parity suite for the provider capability registry and the all-provider
+/// demo/share fixtures. Adding a `ServiceType` case is a compile error in the
+/// exhaustive capability switch, and these tests fail if capabilities or
+/// fixtures are left undeclared.
+final class ProviderCapabilitiesTests: XCTestCase {
+    private let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
+
+    // MARK: - Registry
+
+    func testEveryServiceTypeDeclaresCapabilities() {
+        for service in ServiceType.allCases {
+            _ = service.capabilities
+            XCTAssertEqual(service.capabilities, ProviderCapabilities.of(service), "\(service)")
+            XCTAssertEqual(service.hasLocalHistorySource, service.writesLocalTokenLogs, "\(service)")
+        }
+    }
+
+    func testCurrentCapabilityTruth() {
+        XCTAssertEqual(
+            ServiceType.claudeCode.capabilities,
+            ProviderCapabilities(
+                isMultiAccount: true,
+                supportsExtraUsage: true,
+                supportsResetRedemption: false,
+                supportsGuardConfigDirectory: true,
+                supportsSessionWake: true,
+                hasAccountScopedNotifications: true,
+                hasAccountScopedQuotaEvents: true
+            )
+        )
+        XCTAssertEqual(
+            ServiceType.codexCli.capabilities,
+            ProviderCapabilities(
+                isMultiAccount: true,
+                supportsExtraUsage: false,
+                supportsResetRedemption: true,
+                supportsGuardConfigDirectory: true,
+                supportsSessionWake: true,
+                hasAccountScopedNotifications: true,
+                hasAccountScopedQuotaEvents: true
+            )
+        )
+        XCTAssertEqual(
+            ServiceType.grok.capabilities,
+            ProviderCapabilities(
+                isMultiAccount: true,
+                supportsExtraUsage: true,
+                supportsResetRedemption: true,
+                supportsGuardConfigDirectory: true,
+                supportsSessionWake: false,
+                hasAccountScopedNotifications: true,
+                hasAccountScopedQuotaEvents: true
+            )
+        )
+        for service in [ServiceType.cursor, .openRouter] {
+            XCTAssertEqual(
+                service.capabilities,
+                ProviderCapabilities(
+                    isMultiAccount: false,
+                    supportsExtraUsage: false,
+                    supportsResetRedemption: false,
+                    supportsGuardConfigDirectory: false,
+                    supportsSessionWake: false,
+                    hasAccountScopedNotifications: false,
+                    hasAccountScopedQuotaEvents: false
+                ),
+                "\(service)"
+            )
+        }
+    }
+
+    func testSessionWakeIsAnExplicitExceptionForGrok() {
+        XCTAssertTrue(ServiceType.grok.isMultiAccount)
+        XCTAssertTrue(ServiceType.grok.writesLocalTokenLogs)
+        XCTAssertTrue(ServiceType.grok.supportsGuardConfigDirectory)
+        XCTAssertTrue(ServiceType.grok.hasAccountScopedNotifications)
+        XCTAssertTrue(ServiceType.grok.hasAccountScopedQuotaEvents)
+        XCTAssertFalse(ServiceType.grok.supportsSessionWake)
+    }
+
+    // MARK: - Generic list helpers
+
+    func testFlatNotificationServicesAreExactlyThoseWithoutAccountScopedNotifications() {
+        XCTAssertEqual(
+            UsageNotificationCoordinator.flatNotificationServices,
+            ServiceType.allCases.filter { !$0.hasAccountScopedNotifications }
+        )
+        XCTAssertFalse(UsageNotificationCoordinator.flatNotificationServices.contains(.claudeCode))
+        XCTAssertFalse(UsageNotificationCoordinator.flatNotificationServices.contains(.codexCli))
+        XCTAssertFalse(UsageNotificationCoordinator.flatNotificationServices.contains(.grok))
+        XCTAssertTrue(UsageNotificationCoordinator.flatNotificationServices.contains(.cursor))
+        XCTAssertTrue(UsageNotificationCoordinator.flatNotificationServices.contains(.openRouter))
+    }
+
+    func testFlatQuotaEventProvidersAreExactlyThoseWithoutAccountScopedQuotaEvents() {
+        XCTAssertEqual(
+            QuotaEventSnapshotCatalog.flatProviders,
+            ServiceType.allCases.filter { !$0.hasAccountScopedQuotaEvents }
+        )
+        XCTAssertFalse(QuotaEventSnapshotCatalog.flatProviders.contains(.claudeCode))
+        XCTAssertFalse(QuotaEventSnapshotCatalog.flatProviders.contains(.codexCli))
+        XCTAssertFalse(QuotaEventSnapshotCatalog.flatProviders.contains(.grok))
+    }
+
+    func testGuardConfigDirectoryFollowsTheCapabilityFlag() {
+        for service in ServiceType.allCases {
+            XCTAssertEqual(
+                service.supportsGuardConfigDirectory,
+                service.capabilities.supportsGuardConfigDirectory,
+                "\(service)"
+            )
+        }
+        XCTAssertTrue(ServiceType.claudeCode.supportsGuardConfigDirectory)
+        XCTAssertTrue(ServiceType.codexCli.supportsGuardConfigDirectory)
+        XCTAssertTrue(ServiceType.grok.supportsGuardConfigDirectory)
+        XCTAssertFalse(ServiceType.cursor.supportsGuardConfigDirectory)
+        XCTAssertFalse(ServiceType.openRouter.supportsGuardConfigDirectory)
+    }
+
+    // MARK: - Demo fixtures
+
+    func testDemoDataCoversEveryServiceType() {
+        let metrics = DemoData.metrics(now: now)
+        XCTAssertEqual(Set(metrics.keys), Set(ServiceType.allCases))
+        for service in ServiceType.allCases {
+            let metric = try? XCTUnwrap(metrics[service], "\(service) missing from DemoData")
+            XCTAssertEqual(metric?.hasData, true, "\(service) demo must render a supported state")
+            XCTAssertEqual(metric?.lastUpdated, now, "\(service)")
+        }
+    }
+
+    func testDemoFixturesFollowDeclaredCapabilities() {
+        let metrics = DemoData.metrics(now: now)
+        for service in ServiceType.allCases {
+            let metric = try? XCTUnwrap(metrics[service])
+            if service.supportsExtraUsage {
+                XCTAssertNotNil(metric?.extraUsage, "\(service) supports extra usage")
+            }
+            if service.supportsResetRedemption {
+                XCTAssertNotNil(metric?.resetCreditsAvailable, "\(service) supports reset redemption")
+            }
+        }
+        XCTAssertNil(metrics[.grok]?.sessionLimit, "do not invent a Grok session bar")
+        XCTAssertNotNil(metrics[.grok]?.weeklyLimit)
+        XCTAssertEqual(
+            ServiceType.openRouter.sessionQuotaTitleKey(limitTotal: metrics[.openRouter]?.sessionLimit?.total),
+            .keyLimit
+        )
+        XCTAssertEqual(
+            ServiceType.openRouter.weeklyQuotaTitleKey(limitTotal: metrics[.openRouter]?.weeklyLimit?.total),
+            .accountCredits
+        )
+    }
+
+    func testDemoCostDataCoversEveryServiceType() {
+        let summary = DemoData.costSummary(now: now)
+        XCTAssertEqual(Set(summary.costs.map(\.provider)), Set(ServiceType.allCases))
+        for cost in summary.costs where cost.provider.writesLocalTokenLogs {
+            XCTAssertFalse(cost.modelBreakdowns.isEmpty, "\(cost.provider)")
+            XCTAssertFalse(cost.originBreakdowns.isEmpty, "\(cost.provider)")
+        }
+    }
+
+    // MARK: - Share provenance
+
+    func testShareSourceLabelsIncludeEveryLocalLogProvider() {
+        let labels = DashboardShareSection.enabledSourceLabels(for: Set(ServiceType.allCases))
+        let expected = ServiceType.allCases.compactMap { service -> String? in
+            guard service.writesLocalTokenLogs else { return nil }
+            return DashboardShareSection.sourceLabel(for: service)
+        }
+        XCTAssertEqual(labels, expected)
+        XCTAssertTrue(labels.contains("Grok JSONL"))
+        XCTAssertFalse(labels.contains(where: { $0.localizedCaseInsensitiveContains("OpenRouter") }))
+        XCTAssertEqual(
+            DashboardShareSection.enabledSourceLabels(for: [.openRouter]),
+            []
+        )
+        XCTAssertEqual(
+            DashboardShareSection.enabledSourceLabels(for: [.grok]),
+            ["Grok JSONL"]
+        )
+    }
+}

--- a/MeterBarTests/ProviderCapabilitiesTests.swift
+++ b/MeterBarTests/ProviderCapabilitiesTests.swift
@@ -167,6 +167,157 @@ final class ProviderCapabilitiesTests: XCTestCase {
 
     // MARK: - Share provenance
 
+    func testCanonicalFixtureCoversEveryServiceType() {
+        let metrics = MetricsFixtures.allProviders()
+        XCTAssertEqual(Set(metrics.keys), Set(ServiceType.allCases))
+        for service in ServiceType.allCases {
+            let metric = try? XCTUnwrap(metrics[service], "\(service) missing from MetricsFixtures")
+            XCTAssertEqual(metric?.service, service)
+            XCTAssertEqual(metric?.hasData, true, "\(service) fixture must render a supported state")
+        }
+    }
+
+    func testPopoverAndDashboardRowsCoverEveryProvider() {
+        let metrics = MetricsFixtures.allProviders()
+        let snapshots = ProviderSnapshotBuilder.snapshots(
+            ProviderSnapshotBuilder.Input(
+                metrics: metrics,
+                claudeAccounts: [.defaultAccount],
+                claudeAccountMetrics: [:],
+                enabledServices: Set(ServiceType.allCases)
+            )
+        )
+        XCTAssertEqual(Set(snapshots.map(\.service)), Set(ServiceType.allCases))
+        for snapshot in snapshots {
+            XCTAssertTrue(snapshot.hasMetrics, "\(snapshot.service) popover/dashboard row has no metrics")
+            XCTAssertFalse(snapshot.limits.isEmpty, "\(snapshot.service) popover/dashboard row is empty")
+        }
+    }
+
+    func testEveryWidgetFamilyRendersEveryProvider() {
+        let metrics = MetricsFixtures.allProviders()
+        for service in ServiceType.allCases {
+            let providerMetrics = try? XCTUnwrap(metrics[service])
+            for family in WidgetPresentationFamily.allCases {
+                let presentation = WidgetPresentationPlanner.makePresentation(
+                    metrics: providerMetrics.map { [service: $0] } ?? [:],
+                    accountMetrics: [],
+                    preferences: .defaults,
+                    family: family,
+                    now: MetricsFixtures.referenceDate
+                )
+                XCTAssertEqual(
+                    presentation.rows.map(\.service),
+                    [service],
+                    "\(family) dropped \(service)"
+                )
+                XCTAssertNil(presentation.emptyState, "\(family) \(service)")
+                XCTAssertFalse(
+                    presentation.rows.first?.accessibilityValueText.isEmpty ?? true,
+                    "\(family) \(service) has no spoken value"
+                )
+            }
+        }
+    }
+
+    func testCLIAndServeEmitEveryProvider() throws {
+        let metrics = MetricsFixtures.allProviders()
+        let cli = try UsageCLIJSONResponse(metrics: metrics).jsonString()
+        for service in ServiceType.allCases {
+            XCTAssertTrue(
+                cli.contains("\"provider\" : \"\(service.cliIdentifier)\""),
+                "CLI JSON omitted \(service.cliIdentifier)"
+            )
+            XCTAssertTrue(cli.contains(service.displayName), "CLI JSON omitted \(service.displayName)")
+        }
+
+        let serve = ServeRouter.handle(
+            ServeHTTPRequest(
+                method: "GET",
+                path: "/usage",
+                query: [:],
+                authorizationHeader: "Bearer fixture-token"
+            ),
+            token: "fixture-token",
+            dataSource: ServeRouter.DataSource(
+                loadUsageMetrics: { metrics },
+                loadCostCache: { nil }
+            )
+        )
+        XCTAssertEqual(serve.status, 200)
+        XCTAssertEqual(serve.body, try UsageCLIJSONResponse(metrics: metrics).jsonData())
+    }
+
+    func testNotificationsAndEventsCoverEveryProvider() {
+        let coveredNotifications = Set(UsageNotificationCoordinator.flatNotificationServices)
+            .union(ServiceType.allCases.filter(\.hasAccountScopedNotifications))
+        XCTAssertEqual(coveredNotifications, Set(ServiceType.allCases))
+
+        let decider = NotificationDecider(preferences: .default)
+        for service in ServiceType.allCases {
+            let evaluation = decider.evaluate(
+                metrics: UsageMetrics(
+                    service: service,
+                    weeklyLimit: UsageLimit(used: 95, total: 100, resetTime: nil),
+                    lastUpdated: MetricsFixtures.referenceDate
+                ),
+                providerEnabled: true,
+                alreadyNotified: [],
+                now: MetricsFixtures.referenceDate
+            )
+            XCTAssertFalse(
+                evaluation.notifications.isEmpty,
+                "\(service) produced no notification from a critical weekly window"
+            )
+        }
+
+        let events = QuotaEventSnapshotCatalog.snapshots(
+            metrics: MetricsFixtures.allProviders(),
+            accounts: QuotaEventAccountInputs(
+                claudeAccounts: [.defaultAccount],
+                claudeAccountMetrics: [ClaudeCodeAccount.defaultID: MetricsFixtures.claudeCode()],
+                codexAccounts: [.defaultAccount],
+                codexAccountMetrics: [CodexAccount.defaultID: MetricsFixtures.codexCli()],
+                grokAccounts: [.defaultAccount],
+                grokAccountMetrics: [GrokAccount.defaultID: MetricsFixtures.grok()]
+            ),
+            enabledServices: Set(ServiceType.allCases)
+        )
+        XCTAssertEqual(Set(events.map(\.provider)), Set(ServiceType.allCases))
+    }
+
+    func testDiagnosticsCoverEveryProvider() {
+        let errors = DiagnosticsRunner.refreshErrors(
+            claudeDefaultAccountEnabled: true,
+            claudeError: .apiError("claude"),
+            codexError: .apiError("codex"),
+            cursorError: .apiError("cursor"),
+            openRouterError: .apiError("openrouter"),
+            grokError: .apiError("grok")
+        )
+        XCTAssertEqual(Set(errors.keys), Set(ServiceType.allCases))
+    }
+
+    func testAccessibilityCoversEveryProvider() {
+        let snapshots = ProviderSnapshotBuilder.snapshots(
+            ProviderSnapshotBuilder.Input(
+                metrics: MetricsFixtures.allProviders(),
+                claudeAccounts: [.defaultAccount],
+                claudeAccountMetrics: [:],
+                enabledServices: Set(ServiceType.allCases)
+            )
+        )
+        XCTAssertEqual(Set(snapshots.map(\.service)), Set(ServiceType.allCases))
+        for snapshot in snapshots {
+            XCTAssertFalse(snapshot.accessibilityLabel.isEmpty, "\(snapshot.service) label")
+            XCTAssertFalse(snapshot.accessibilityValue.isEmpty, "\(snapshot.service) value")
+            for limit in snapshot.limits {
+                XCTAssertFalse(limit.accessibilityLabel.isEmpty, "\(snapshot.service) \(limit.id) label")
+                XCTAssertFalse(limit.accessibilityValue.isEmpty, "\(snapshot.service) \(limit.id) value")
+            }
+        }
+    }
+
     func testShareSourceLabelsIncludeEveryLocalLogProvider() {
         let labels = DashboardShareSection.enabledSourceLabels(for: Set(ServiceType.allCases))
         let expected = ServiceType.allCases.compactMap { service -> String? in

--- a/MeterBarTests/SharedDataStoreTests.swift
+++ b/MeterBarTests/SharedDataStoreTests.swift
@@ -41,6 +41,8 @@ final class SharedDataStoreTests: XCTestCase {
         XCTAssertEqual(loaded[.claudeCode]?.sessionLimit, metrics[.claudeCode]?.sessionLimit)
         XCTAssertEqual(loaded[.codexCli]?.resetCreditsAvailable, 2)
         XCTAssertEqual(loaded[.cursor]?.weeklyLimit?.total, 500)
+        XCTAssertEqual(loaded[.grok]?.resetCreditsAvailable, 1)
+        XCTAssertEqual(loaded[.openRouter]?.sessionLimit?.total, 40)
     }
 
     func testFileWrittenAtExpectedPath() throws {

--- a/MeterBarTests/WidgetPresentationTests.swift
+++ b/MeterBarTests/WidgetPresentationTests.swift
@@ -375,7 +375,7 @@ final class WidgetPresentationTests: XCTestCase {
         XCTAssertEqual(statuses.filter { $0 == .warning }.count, 1)
         XCTAssertFalse(statuses.contains(.critical))
         // Only generic product providers, never owner project names.
-        XCTAssertTrue(result.rows.allSatisfy { [.claudeCode, .codexCli, .cursor].contains($0.service) })
+        XCTAssertTrue(result.rows.allSatisfy { Set(ServiceType.allCases).contains($0.service) })
     }
 
     // MARK: - Quota title routing

--- a/MeterBarTests/WidgetRenderingTests.swift
+++ b/MeterBarTests/WidgetRenderingTests.swift
@@ -81,33 +81,42 @@ final class WidgetRenderingTests: XCTestCase {
 
     func testAllFamiliesRenderNonEmptyForEveryProvider() {
         let metrics = MetricsFixtures.allProviders()
+        XCTAssertEqual(
+            Set(metrics.keys),
+            Set(ServiceType.allCases),
+            "the canonical fixture must cover every ServiceType"
+        )
 
-        for family in WidgetFamily.allCases {
-            let services = renderedServices(metrics, family: family)
-            XCTAssertEqual(
-                Set(services),
-                Set(metrics.keys),
-                "family \(family) dropped a provider (cap too low for the fixture set)"
-            )
-            for service in services {
-                guard let providerMetrics = metrics[service] else {
-                    XCTFail("no fixture metrics for rendered service \(service)")
-                    continue
-                }
-                assertRowRendersNonEmpty(service, metrics: providerMetrics)
+        for service in ServiceType.allCases {
+            guard let providerMetrics = metrics[service] else {
+                XCTFail("no fixture metrics for \(service)")
+                continue
             }
+            for family in WidgetFamily.allCases {
+                let rendered = renderedServices([service: providerMetrics], family: family)
+                XCTAssertEqual(rendered, [service], "family \(family) failed to render \(service)")
+            }
+            assertRowRendersNonEmpty(service, metrics: providerMetrics)
+        }
+
+        for family in WidgetPresentationFamily.allCases {
+            let presentation = WidgetPresentationPlanner.makePresentation(
+                metrics: metrics,
+                accountMetrics: [],
+                preferences: .defaults,
+                family: family,
+                now: MetricsFixtures.referenceDate
+            )
+            XCTAssertFalse(presentation.rows.isEmpty, "\(family) planned no rows from the all-provider fixture")
+            XCTAssertTrue(
+                Set(presentation.rows.map(\.service)).isSubset(of: Set(ServiceType.allCases)),
+                "\(family) invented an unknown provider"
+            )
         }
     }
 
     func testEachProviderRendersIndividually() {
-        // Every CLI-backed provider renders a populated row on its own.
-        let cases: [(ServiceType, UsageMetrics)] = [
-            (.claudeCode, MetricsFixtures.claudeCode()),
-            (.codexCli, MetricsFixtures.codexCli()),
-            (.cursor, MetricsFixtures.cursor()),
-            (.grok, MetricsFixtures.grok())
-        ]
-        for (service, metrics) in cases {
+        for (service, metrics) in MetricsFixtures.allProviders() {
             for family in WidgetFamily.allCases {
                 let rendered = renderedServices([service: metrics], family: family)
                 XCTAssertEqual(rendered, [service], "family \(family) failed to render \(service)")
@@ -119,11 +128,12 @@ final class WidgetRenderingTests: XCTestCase {
     // MARK: - Sort + cap behavior
 
     func testProvidersRenderInStableSortOrder() {
-        // Regardless of insertion order, rows render Claude → Codex → Cursor.
         let metrics = MetricsFixtures.allProviders()
+        let expected = ServiceType.allCases.sorted { $0.sortOrder < $1.sortOrder }
+        XCTAssertEqual(renderedServices(metrics, family: .large), expected)
         XCTAssertEqual(
             renderedServices(metrics, family: .medium),
-            [.claudeCode, .codexCli, .cursor]
+            Array(expected.prefix(WidgetFamily.medium.visibleRowCount(totalRowCount: expected.count)))
         )
     }
 

--- a/MeterBarWidget/BurnDownWidget.swift
+++ b/MeterBarWidget/BurnDownWidget.swift
@@ -49,6 +49,16 @@ struct BurnDownWidgetProvider: TimelineProvider {
                     service: .codexCli,
                     used: 38,
                     resetTime: now.addingTimeInterval(4 * 24 * 60 * 60)
+                ),
+                .grok: placeholderMetrics(
+                    service: .grok,
+                    used: 47,
+                    resetTime: now.addingTimeInterval(3 * 24 * 60 * 60)
+                ),
+                .openRouter: placeholderMetrics(
+                    service: .openRouter,
+                    used: 32,
+                    resetTime: now.addingTimeInterval(18 * 24 * 60 * 60)
                 )
             ],
             accountMetrics: [],

--- a/MeterBarWidget/UsageWidget.swift
+++ b/MeterBarWidget/UsageWidget.swift
@@ -62,6 +62,14 @@ struct UsageWidgetProvider: TimelineProvider {
                 .claudeCode: UsageMetrics(
                     service: .claudeCode,
                     weeklyLimit: UsageLimit(used: 90, total: 100, resetTime: nil)
+                ),
+                .grok: UsageMetrics(
+                    service: .grok,
+                    weeklyLimit: UsageLimit(used: 47, total: 100, resetTime: nil)
+                ),
+                .openRouter: UsageMetrics(
+                    service: .openRouter,
+                    weeklyLimit: UsageLimit(used: 42, total: 100, resetTime: nil)
                 )
             ],
             accountMetrics: [],

--- a/Packages/MeterBarShared/Sources/MeterBarShared/DemoData.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/DemoData.swift
@@ -10,10 +10,11 @@ import Foundation
 ///
 /// Design rules the fixture upholds (each is asserted by `DemoDataTests`):
 ///  - **Generic labels only.** The map is keyed by `ServiceType`, whose display
-///    names ("Claude Code", "OpenAI Codex", "Cursor") are product names, never
-///    the owner's custom account/profile names. The app's demo wiring pairs this
-///    with default-only account stores so provider cards title as "Claude" /
-///    "Codex" / "Cursor" regardless of the real accounts on the machine.
+///    names ("Claude Code", "OpenAI Codex", "Cursor", "OpenRouter", "Grok")
+///    are product names, never the owner's custom account/profile names. The
+///    app's demo wiring pairs this with default-only account stores so
+///    provider cards title as "Claude" / "Codex" / "Cursor" / "OpenRouter" /
+///    "Grok" regardless of the real accounts on the machine.
 ///  - **Mostly comfortable green.** Every quota window sits at ≤75% used
 ///    (`QuotaBand.healthy`) except exactly one.
 ///  - **Exactly one "tight" amber band.** Codex's weekly window sits at 82%
@@ -36,20 +37,23 @@ public enum DemoData {
 
     /// Synthetic provider metrics for demo mode, keyed by service.
     ///
-    /// Covers three providers — Claude Code, Codex CLI, Cursor — which is enough
-    /// to populate the Overview window, the menu-bar panel, and the medium
-    /// widget while staying visually uncluttered.
+    /// Covers every `ServiceType` so demo / regression surfaces can exercise
+    /// Grok and OpenRouter without credentials. Adding a provider is a fixture
+    /// gap the capability parity tests fail on.
     public static func metrics(now: Date = Date()) -> [ServiceType: UsageMetrics] {
         [
             .claudeCode: claudeCode(now: now),
             .codexCli: codexCli(now: now),
-            .cursor: cursor(now: now)
+            .cursor: cursor(now: now),
+            .openRouter: openRouter(now: now),
+            .grok: grok(now: now)
         ]
     }
 
     // MARK: - Providers
 
-    /// Claude Code: all three windows comfortably green.
+    /// Claude Code: all three windows comfortably green. Extra usage is on
+    /// with nothing spent, matching the production extra-usage surface.
     private static func claudeCode(now: Date) -> UsageMetrics {
         UsageMetrics(
             service: .claudeCode,
@@ -57,6 +61,7 @@ public enum DemoData {
             weeklyLimit: weeklyLimit(usedPercent: 58, now: now),
             codeReviewLimit: modelLimit(usedPercent: 34, now: now),
             modelLimitLabel: "Fable",
+            extraUsage: ExtraUsageStatus(state: .on, detail: "$0.00 used"),
             lastUpdated: now
         )
     }
@@ -90,6 +95,39 @@ public enum DemoData {
                 total: ServiceType.cursorIncludedPoolTotal,
                 resetTime: reset
             ),
+            lastUpdated: now
+        )
+    }
+
+    /// OpenRouter: key-limit + account-credits windows matching production
+    /// mapping (`sessionLimit` = key spend cap, `weeklyLimit` = credit
+    /// balance). Dollar amounts stay comfortably green.
+    private static func openRouter(now: Date) -> UsageMetrics {
+        UsageMetrics(
+            service: .openRouter,
+            sessionLimit: UsageLimit(
+                used: 12.80,
+                total: 40,
+                resetTime: now.addingTimeInterval(18 * 24 * 3_600),
+                windowSeconds: 30 * 24 * 3_600
+            ),
+            weeklyLimit: UsageLimit(
+                used: 42,
+                total: 100,
+                resetTime: nil
+            ),
+            lastUpdated: now
+        )
+    }
+
+    /// Grok: a weekly-style window plus extra usage and a banked reset.
+    /// Production often has no session period — do not invent one.
+    private static func grok(now: Date) -> UsageMetrics {
+        UsageMetrics(
+            service: .grok,
+            weeklyLimit: weeklyLimit(usedPercent: 47, now: now),
+            extraUsage: ExtraUsageStatus(state: .on, detail: "$10.00 credits"),
+            resetCreditsAvailable: 1,
             lastUpdated: now
         )
     }

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ProviderCapabilities.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ProviderCapabilities.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Explicit per-provider feature flags consumed via `ServiceType`.
+///
+/// Provider additions used to rely on scattered hand-written lists. This
+/// registry is the single place those lists must be declared; the factory
+/// switch is exhaustive so a new `ServiceType` case is a compile error.
+///
+/// Values here are the current production truth, not the desired end-state
+/// of sibling issues. Grok is multi-account, writes local logs, and has
+/// account-scoped notifications (#464), guard config directories (#465),
+/// and quota events (#469). Session Wake stays false — it needs a dedicated
+/// runtime, not a flag flip.
+public struct ProviderCapabilities: Equatable, Sendable {
+    public let isMultiAccount: Bool
+    public let supportsExtraUsage: Bool
+    public let supportsResetRedemption: Bool
+    public let supportsGuardConfigDirectory: Bool
+    /// Session Wake is Claude + Codex only. Grok is multi-account and writes
+    /// local logs, but wake is an explicit capability-gated exception — it
+    /// needs a dedicated runtime, not a flag flip.
+    public let supportsSessionWake: Bool
+    public let hasAccountScopedNotifications: Bool
+    public let hasAccountScopedQuotaEvents: Bool
+
+    public init(
+        isMultiAccount: Bool,
+        supportsExtraUsage: Bool,
+        supportsResetRedemption: Bool,
+        supportsGuardConfigDirectory: Bool,
+        supportsSessionWake: Bool,
+        hasAccountScopedNotifications: Bool,
+        hasAccountScopedQuotaEvents: Bool
+    ) {
+        self.isMultiAccount = isMultiAccount
+        self.supportsExtraUsage = supportsExtraUsage
+        self.supportsResetRedemption = supportsResetRedemption
+        self.supportsGuardConfigDirectory = supportsGuardConfigDirectory
+        self.supportsSessionWake = supportsSessionWake
+        self.hasAccountScopedNotifications = hasAccountScopedNotifications
+        self.hasAccountScopedQuotaEvents = hasAccountScopedQuotaEvents
+    }
+
+    public static func of(_ service: ServiceType) -> ProviderCapabilities {
+        switch service {
+        case .claudeCode:
+            return ProviderCapabilities(
+                isMultiAccount: true,
+                supportsExtraUsage: true,
+                supportsResetRedemption: false,
+                supportsGuardConfigDirectory: true,
+                supportsSessionWake: true,
+                hasAccountScopedNotifications: true,
+                hasAccountScopedQuotaEvents: true
+            )
+        case .codexCli:
+            return ProviderCapabilities(
+                isMultiAccount: true,
+                supportsExtraUsage: false,
+                supportsResetRedemption: true,
+                supportsGuardConfigDirectory: true,
+                supportsSessionWake: true,
+                hasAccountScopedNotifications: true,
+                hasAccountScopedQuotaEvents: true
+            )
+        case .grok:
+            return ProviderCapabilities(
+                isMultiAccount: true,
+                supportsExtraUsage: true,
+                supportsResetRedemption: true,
+                supportsGuardConfigDirectory: true,
+                supportsSessionWake: false,
+                hasAccountScopedNotifications: true,
+                hasAccountScopedQuotaEvents: true
+            )
+        case .cursor, .openRouter:
+            return ProviderCapabilities(
+                isMultiAccount: false,
+                supportsExtraUsage: false,
+                supportsResetRedemption: false,
+                supportsGuardConfigDirectory: false,
+                supportsSessionWake: false,
+                hasAccountScopedNotifications: false,
+                hasAccountScopedQuotaEvents: false
+            )
+        }
+    }
+}
+
+extension ServiceType {
+    public var capabilities: ProviderCapabilities { .of(self) }
+
+    public var isMultiAccount: Bool { capabilities.isMultiAccount }
+    public var supportsExtraUsage: Bool { capabilities.supportsExtraUsage }
+    public var supportsResetRedemption: Bool { capabilities.supportsResetRedemption }
+    public var supportsGuardConfigDirectory: Bool { capabilities.supportsGuardConfigDirectory }
+    public var supportsSessionWake: Bool { capabilities.supportsSessionWake }
+    public var hasAccountScopedNotifications: Bool { capabilities.hasAccountScopedNotifications }
+    public var hasAccountScopedQuotaEvents: Bool { capabilities.hasAccountScopedQuotaEvents }
+
+    /// Share-card / history provenance. Same split as `writesLocalTokenLogs` —
+    /// do not fork a second list.
+    public var hasLocalHistorySource: Bool { writesLocalTokenLogs }
+}


### PR DESCRIPTION
Fixes #463

Adds a single explicit provider capability registry and an all-provider demo/share fixture matrix so adding a `ServiceType` is a compile/test failure instead of a silent list drift.

## What changed
- New `ProviderCapabilities` in `Packages/MeterBarShared`, consumed via `ServiceType`. Exhaustive switch. Current production truth only (Grok still false for account-scoped notifications/events/guard and Session Wake).
- Generic surfaces now iterate `ServiceType.allCases` and gate on the declared flag:
  - notifications → `!hasAccountScopedNotifications`
  - quota events → `!hasAccountScopedQuotaEvents`
  - guard `--config-dir` → `supportsGuardConfigDirectory`
  - share provenance → `writesLocalTokenLogs` / `hasLocalHistorySource` (Grok is a local-log source)
- DemoData covers all five providers. Grok is weekly + extra usage + reset credits (no invented session bar). OpenRouter is key-limit + account-credits. Cost fixtures and widget placeholders include Grok and OpenRouter.
- Session Wake is documented as an explicit capability-gated exception on the flag.

## Tests
- New `ProviderCapabilitiesTests` fail if a provider is added without capabilities, demo fixtures, or share-source labels.
- Updated DemoData / share / notification / cost tests for the five-provider matrix.
- Focused tests + `swift test`: 2461 tests, 5 skipped, 0 failures.

## Out of scope
- Grok account-scoped notifications/hooks/guard (#458/#459/#460)
- UsageMetrics cache slots (#456)
- Inventing quota windows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly declarative capability wiring, demo/test fixtures, and refactors off hard-coded lists; production behavior is intended to match current truth and is heavily regression-tested.
> 
> **Overview**
> Introduces **`ProviderCapabilities`** in MeterBarShared with an exhaustive per-`ServiceType` registry and convenience flags on `ServiceType`, replacing scattered hard-coded provider lists.
> 
> **Notifications**, **quota events**, and **guard `--config-dir`** now filter `ServiceType.allCases` via `hasAccountScopedNotifications`, `hasAccountScopedQuotaEvents`, and `supportsGuardConfigDirectory` (the local `supportsGuardConfigDirectory` extension on `ServiceType` in QuotaGuard is removed). **Share-card provenance** iterates all services and uses `hasLocalHistorySource` / `writesLocalTokenLogs`, with centralized `sourceLabel(for:)` (including Grok JSONL).
> 
> **Demo and test fixtures** expand to all five providers: shared `DemoData` adds OpenRouter and Grok usage shapes; app `DemoData+Cost` bumps the demo total to ~$240 and adds Grok/OpenRouter cost rows; `MetricsFixtures` becomes exhaustive via `metrics(for:)`. Widget placeholders gain Grok and OpenRouter.
> 
> A new **`ProviderCapabilitiesTests`** suite pins capability truth, demo/share parity, widgets, CLI/serve, notifications, events, and diagnostics so a new `ServiceType` without fixtures or flags fails tests instead of drifting silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91b92e0625283ba073b1c9d53924fc394b9145b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader support for Grok and OpenRouter across usage metrics, cost tracking, quota events, notifications, dashboard sharing, and widgets.
  * Added provider-specific capability handling so supported features and data sources are identified automatically.
  * Expanded demo data to include Grok and OpenRouter metrics, costs, credits, and usage limits.
* **Bug Fixes**
  * Improved provider coverage and consistency across dashboards, widgets, sharing, and account-related displays.
* **Tests**
  * Added comprehensive coverage for all supported providers and their feature combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->