### PR TITLE
feat(cli): expose account-scoped usage in text, JSON, and serve

### DIFF
--- a/MeterBar/Models/CLIJSONOutput.swift
+++ b/MeterBar/Models/CLIJSONOutput.swift
@@ -30,11 +30,22 @@ nonisolated public struct UsageCLIJSONResponse: CLIJSONDocument {
 
     private let schemaVersion = currentSchemaVersion
     private let providers: [Provider]
+    /// Per-profile snapshots for Claude / Codex / Grok. Omitted when the
+    /// account cache is empty so version-1 `providers`-only documents stay
+    /// byte-stable.
+    private let accounts: [Account]?
 
-    public init(metrics: [ServiceType: UsageMetrics]) {
+    public init(metrics: [ServiceType: UsageMetrics], accounts: [AccountUsageSnapshot] = []) {
         providers = metrics
             .sorted { $0.key.sortOrder < $1.key.sortOrder }
             .map { Provider(service: $0.key, metrics: $0.value) }
+        self.accounts = accounts.isEmpty
+            ? nil
+            : CLIAccountFilter.apply(nil, to: accounts).map(Account.init(snapshot:))
+    }
+
+    public init(selection: UsageCLISelection) {
+        self.init(metrics: selection.metrics, accounts: selection.accounts)
     }
 
     private struct Provider: Encodable {
@@ -48,11 +59,28 @@ nonisolated public struct UsageCLIJSONResponse: CLIJSONDocument {
         init(service: ServiceType, metrics: UsageMetrics) {
             provider = service.cliIdentifier
             displayName = service.displayName
-            windows = [
-                metrics.sessionLimit.map { Window(kind: "session", limit: $0) },
-                metrics.weeklyLimit.map { Window(kind: "weekly", limit: $0) },
-                metrics.codeReviewLimit.map { Window(kind: "codeReview", limit: $0) },
-            ].compactMap { $0 }
+            windows = Window.all(from: metrics)
+            extraUsage = metrics.extraUsage.map(ExtraUsage.init(status:))
+            resetCreditsAvailable = metrics.resetCreditsAvailable
+            lastUpdated = metrics.lastUpdated
+        }
+    }
+
+    private struct Account: Encodable {
+        let provider: String
+        let accountId: String
+        let accountName: String
+        let windows: [Window]
+        let extraUsage: ExtraUsage?
+        let resetCreditsAvailable: Int?
+        let lastUpdated: Date
+
+        init(snapshot: AccountUsageSnapshot) {
+            let metrics = snapshot.metrics
+            provider = metrics.service.cliIdentifier
+            accountId = snapshot.id.uuidString
+            accountName = snapshot.name
+            windows = Window.all(from: metrics)
             extraUsage = metrics.extraUsage.map(ExtraUsage.init(status:))
             resetCreditsAvailable = metrics.resetCreditsAvailable
             lastUpdated = metrics.lastUpdated
@@ -80,6 +108,14 @@ nonisolated public struct UsageCLIJSONResponse: CLIJSONDocument {
             windowSeconds = limit.windowSeconds
             quotaBand = QuotaBand.forLimit(limit).cliIdentifier
             estimated = limit.isEstimated
+        }
+
+        static func all(from metrics: UsageMetrics) -> [Window] {
+            [
+                metrics.sessionLimit.map { Window(kind: "session", limit: $0) },
+                metrics.weeklyLimit.map { Window(kind: "weekly", limit: $0) },
+                metrics.codeReviewLimit.map { Window(kind: "codeReview", limit: $0) },
+            ].compactMap { $0 }
         }
     }
 

--- a/MeterBar/Models/CLIUsageTextReport.swift
+++ b/MeterBar/Models/CLIUsageTextReport.swift
@@ -12,8 +12,20 @@ nonisolated public enum CLIUsageTextReport {
     /// Every line of the report, in print order. Empty strings are blank lines.
     public static func lines(
         for metrics: [ServiceType: UsageMetrics],
-        filter: String? = nil
+        accounts: [AccountUsageSnapshot] = [],
+        filter: String? = nil,
+        accountFilter: String? = nil
     ) -> [String] {
+        lines(for: UsageCLISelection.resolve(
+            metrics: metrics,
+            accounts: accounts,
+            provider: filter,
+            account: accountFilter
+        ))
+    }
+
+    /// Every line of the report, in print order. Empty strings are blank lines.
+    public static func lines(for selection: UsageCLISelection) -> [String] {
         var lines = [
             "╭─────────────────────────────────────────╮",
             "│             MeterBar Usage              │",
@@ -21,39 +33,57 @@ nonisolated public enum CLIUsageTextReport {
             "",
         ]
 
-        // A `--provider` typo used to print the header and nothing else, which
-        // reads like "this provider has no quota data". Say what happened, the
-        // way `meterbar doctor` already does — and distinguish a typo from a
-        // real provider the cache simply has not seen yet.
-        guard !metrics.isEmpty else {
-            lines.append(CLIProviderFilter.emptyReportMessage(for: filter))
+        // A `--provider` / `--account` typo used to print the header and
+        // nothing else, which reads like "this provider has no quota data".
+        if let message = selection.emptyReportMessage {
+            lines.append(message)
             return lines
         }
 
-        for (service, metric) in metrics.sorted(by: { $0.key.rawValue < $1.key.rawValue }) {
-            lines.append("▸ \(service.displayName)")
+        let accountFilterActive = CLIAccountFilter.isActive(selection.accountFilter)
+        let accountsByService = Dictionary(grouping: selection.accounts, by: \.metrics.service)
 
-            if let session = metric.sessionLimit {
-                lines += limitLines(
-                    service == .openRouter ? "  Key limit" : "  Session",
-                    session,
-                    currency: service == .openRouter
-                )
+        for service in ServiceType.allCases.sorted(by: { $0.rawValue < $1.rawValue }) {
+            if let serviceAccounts = accountsByService[service], !serviceAccounts.isEmpty {
+                for snapshot in serviceAccounts {
+                    lines.append("▸ \(service.displayName) · \(snapshot.name)")
+                    lines += metricLines(service, snapshot.metrics)
+                    lines.append("")
+                }
+                continue
             }
-            if let weekly = metric.weeklyLimit {
-                lines += limitLines(
-                    "  \(service.weeklyQuotaTitle)",
-                    weekly,
-                    currency: service == .openRouter
-                )
-            }
-            if let codeReview = metric.codeReviewLimit {
-                let label = service.codeReviewQuotaTitle(modelLimitLabel: metric.modelLimitLabel)
-                lines += limitLines("  \(label)", codeReview)
-            }
+
+            // `--account` is account-scoped: do not fall back to the
+            // representative provider row when the account needle missed.
+            guard !accountFilterActive, let metric = selection.metrics[service] else { continue }
+            lines.append("▸ \(service.displayName)")
+            lines += metricLines(service, metric)
             lines.append("")
         }
 
+        return lines
+    }
+
+    private static func metricLines(_ service: ServiceType, _ metric: UsageMetrics) -> [String] {
+        var lines: [String] = []
+        if let session = metric.sessionLimit {
+            lines += limitLines(
+                service == .openRouter ? "  Key limit" : "  Session",
+                session,
+                currency: service == .openRouter
+            )
+        }
+        if let weekly = metric.weeklyLimit {
+            lines += limitLines(
+                "  \(service.weeklyQuotaTitle)",
+                weekly,
+                currency: service == .openRouter
+            )
+        }
+        if let codeReview = metric.codeReviewLimit {
+            let label = service.codeReviewQuotaTitle(modelLimitLabel: metric.modelLimitLabel)
+            lines += limitLines("  \(label)", codeReview)
+        }
         return lines
     }
 

--- a/MeterBar/Models/UsageCLISelection.swift
+++ b/MeterBar/Models/UsageCLISelection.swift
@@ -1,0 +1,103 @@
+import Foundation
+import MeterBarShared
+
+/// The `--provider` / `--account` selection shared by `meterbar usage` and
+/// `serve /usage`.
+///
+/// Provider matching stays on `CLIProviderFilter`. Account matching is
+/// exact-token — the account id (UUID string) or the exact account name —
+/// so a short name cannot silently select a longer one.
+nonisolated public struct UsageCLISelection: Sendable {
+    /// Printed when `--account` / `?account=` matches nothing.
+    public static let noMatchingAccountsMessage = "No matching accounts."
+
+    public let metrics: [ServiceType: UsageMetrics]
+    public let accounts: [AccountUsageSnapshot]
+    public let providerFilter: String?
+    public let accountFilter: String?
+
+    public init(
+        metrics: [ServiceType: UsageMetrics],
+        accounts: [AccountUsageSnapshot],
+        providerFilter: String?,
+        accountFilter: String?
+    ) {
+        self.metrics = metrics
+        self.accounts = accounts
+        self.providerFilter = providerFilter
+        self.accountFilter = accountFilter
+    }
+
+    /// Applies the same filters the CLI flags and the serve query parameters use.
+    public static func resolve(
+        metrics: [ServiceType: UsageMetrics],
+        accounts: [AccountUsageSnapshot],
+        provider: String? = nil,
+        account: String? = nil
+    ) -> UsageCLISelection {
+        let filteredMetrics = CLIProviderFilter.apply(provider, to: metrics)
+        let selectedProviders = CLIProviderFilter.select(provider)
+        let providerFilteredAccounts = accounts.filter { selectedProviders.contains($0.metrics.service) }
+        return UsageCLISelection(
+            metrics: filteredMetrics,
+            accounts: CLIAccountFilter.apply(account, to: providerFilteredAccounts),
+            providerFilter: provider,
+            accountFilter: account
+        )
+    }
+
+    /// `nil` when the selection has something to print. Distinguishes a provider
+    /// typo from an account typo from a real provider the cache has not seen.
+    public var emptyReportMessage: String? {
+        if CLIProviderFilter.select(providerFilter).isEmpty {
+            return CLIProviderFilter.noMatchesMessage
+        }
+        if CLIAccountFilter.isActive(accountFilter), accounts.isEmpty {
+            return Self.noMatchingAccountsMessage
+        }
+        if metrics.isEmpty, accounts.isEmpty {
+            return CLIProviderFilter.emptyReportMessage(for: providerFilter)
+        }
+        return nil
+    }
+}
+
+/// Exact-token account matching for `--account` / `?account=`.
+nonisolated enum CLIAccountFilter {
+    static func isActive(_ filter: String?) -> Bool {
+        needle(from: filter) != nil
+    }
+
+    static func apply(_ filter: String?, to accounts: [AccountUsageSnapshot]) -> [AccountUsageSnapshot] {
+        let filtered: [AccountUsageSnapshot]
+        if let needle = needle(from: filter) {
+            filtered = accounts.filter { matches($0, needle) }
+        } else {
+            filtered = accounts
+        }
+        return sorted(filtered)
+    }
+
+    private static func needle(from filter: String?) -> String? {
+        guard let trimmed = filter?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+
+    private static func matches(_ snapshot: AccountUsageSnapshot, _ needle: String) -> Bool {
+        snapshot.id.uuidString.compare(needle, options: .caseInsensitive) == .orderedSame
+            || snapshot.name.compare(needle, options: .caseInsensitive) == .orderedSame
+    }
+
+    private static func sorted(_ accounts: [AccountUsageSnapshot]) -> [AccountUsageSnapshot] {
+        accounts.sorted { lhs, rhs in
+            if lhs.metrics.service.sortOrder != rhs.metrics.service.sortOrder {
+                return lhs.metrics.service.sortOrder < rhs.metrics.service.sortOrder
+            }
+            if lhs.name != rhs.name {
+                return lhs.name < rhs.name
+            }
+            return lhs.id.uuidString < rhs.id.uuidString
+        }
+    }
+}

--- a/MeterBar/Serve/ServeRouter.swift
+++ b/MeterBar/Serve/ServeRouter.swift
@@ -12,18 +12,22 @@ nonisolated public enum ServeRouter {
     public struct DataSource: Sendable {
         public let loadUsageMetrics: @Sendable () -> [ServiceType: UsageMetrics]
         public let loadCostCache: @Sendable () -> CostSummaryCache?
+        public let loadAccountMetrics: @Sendable () -> [AccountUsageSnapshot]
 
         public init(
             loadUsageMetrics: @escaping @Sendable () -> [ServiceType: UsageMetrics],
-            loadCostCache: @escaping @Sendable () -> CostSummaryCache?
+            loadCostCache: @escaping @Sendable () -> CostSummaryCache?,
+            loadAccountMetrics: @escaping @Sendable () -> [AccountUsageSnapshot] = { [] }
         ) {
             self.loadUsageMetrics = loadUsageMetrics
             self.loadCostCache = loadCostCache
+            self.loadAccountMetrics = loadAccountMetrics
         }
 
         public static let liveCache = DataSource(
             loadUsageMetrics: { SharedDataStore.shared.loadMetrics() },
-            loadCostCache: { CostSummaryStore.load() }
+            loadCostCache: { CostSummaryStore.load() },
+            loadAccountMetrics: { SharedDataStore.shared.loadAccountMetrics() }
         )
     }
 
@@ -58,17 +62,24 @@ nonisolated public enum ServeRouter {
 
     private static func usageResponse(dataSource: DataSource, query: [String: String]) -> ServeHTTPResponse {
         let metrics = dataSource.loadUsageMetrics()
-        guard !metrics.isEmpty else {
+        let accounts = dataSource.loadAccountMetrics()
+        guard !metrics.isEmpty || !accounts.isEmpty else {
             return errorResponse(
                 code: "usage_cache_missing",
                 message: "No cached metrics found. Open MeterBar app to fetch data."
             )
         }
 
-        // Same selection as `meterbar usage --provider`, so a padded or blank
-        // needle can't mean one thing over HTTP and another on the CLI.
-        let filtered = CLIProviderFilter.apply(query["provider"], to: metrics)
-        return jsonResponse(UsageCLIJSONResponse(metrics: filtered))
+        // Same selection as `meterbar usage --provider` / `--account`, so a
+        // padded or blank needle can't mean one thing over HTTP and another
+        // on the CLI.
+        let selection = UsageCLISelection.resolve(
+            metrics: metrics,
+            accounts: accounts,
+            provider: query["provider"],
+            account: query["account"]
+        )
+        return jsonResponse(UsageCLIJSONResponse(selection: selection))
     }
 
     private static func costResponse(dataSource: DataSource, query: [String: String]) -> ServeHTTPResponse {

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -85,11 +85,18 @@ struct Usage: ParsableCommand {
     @Option(name: .shortAndLong, help: "Filter by provider (claude, codex, cursor, openrouter, grok)")
     var provider: String?
 
-    func run() throws {
-        // Same app-group file, codec, and models as the app and widget.
-        let metrics = SharedDataStore.shared.loadMetrics()
+    @Option(
+        name: .long,
+        help: "Filter by account id (UUID) or exact account name"
+    )
+    var account: String?
 
-        if metrics.isEmpty {
+    func run() throws {
+        // Same app-group files, codec, and models as the app and widget.
+        let metrics = SharedDataStore.shared.loadMetrics()
+        let accounts = SharedDataStore.shared.loadAccountMetrics()
+
+        if metrics.isEmpty, accounts.isEmpty {
             if json {
                 try emitJSON(CLIJSONErrorResponse(
                     code: "usage_cache_missing",
@@ -102,17 +109,22 @@ struct Usage: ParsableCommand {
             return
         }
 
-        let filtered = CLIProviderFilter.apply(provider, to: metrics)
+        let selection = UsageCLISelection.resolve(
+            metrics: metrics,
+            accounts: accounts,
+            provider: provider,
+            account: account
+        )
 
         if json {
-            try emitJSON(UsageCLIJSONResponse(metrics: filtered))
+            try emitJSON(UsageCLIJSONResponse(selection: selection))
         } else {
-            printText(filtered)
+            printText(selection)
         }
     }
 
-    private func printText(_ metrics: [ServiceType: UsageMetrics]) {
-        for line in CLIUsageTextReport.lines(for: metrics, filter: provider) {
+    private func printText(_ selection: UsageCLISelection) {
+        for line in CLIUsageTextReport.lines(for: selection) {
             print(line)
         }
     }

--- a/MeterBarTests/CLIJSONOutputTests.swift
+++ b/MeterBarTests/CLIJSONOutputTests.swift
@@ -31,6 +31,80 @@ final class CLIJSONOutputTests: XCTestCase {
         XCTAssertEqual(try response.jsonString(), usageFixture)
     }
 
+    /// Additive `accounts` must not change the version-1 `providers` document
+    /// when the account cache is empty — existing consumers only decode
+    /// `schemaVersion` + `providers`.
+    func testUsageResponseOmitsAccountsWhenTheAccountCacheIsEmpty() throws {
+        let response = UsageCLIJSONResponse(
+            metrics: [.claudeCode: claudeUsageMetrics],
+            accounts: []
+        )
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: response.jsonData()) as? [String: Any]
+        )
+
+        XCTAssertEqual(object["schemaVersion"] as? Int, 1)
+        XCTAssertNil(object["accounts"])
+        XCTAssertEqual(try response.jsonString(), usageFixture)
+    }
+
+    func testUsageResponseAccountsMatchTheSharedCacheAndNeverExposePaths() throws {
+        let accountID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x12))
+        let snapshot = AccountUsageSnapshot(
+            id: accountID,
+            name: "Work",
+            metrics: claudeUsageMetrics
+        )
+        let response = UsageCLIJSONResponse(
+            metrics: [.claudeCode: claudeUsageMetrics],
+            accounts: [snapshot]
+        )
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: response.jsonData()) as? [String: Any]
+        )
+        let accounts = try XCTUnwrap(object["accounts"] as? [[String: Any]])
+        let account = try XCTUnwrap(accounts.first)
+        let windows = try XCTUnwrap(account["windows"] as? [[String: Any]])
+
+        XCTAssertEqual(object["schemaVersion"] as? Int, 1)
+        XCTAssertEqual(account["provider"] as? String, "claude")
+        XCTAssertEqual(account["accountId"] as? String, accountID.uuidString)
+        XCTAssertEqual(account["accountName"] as? String, "Work")
+        XCTAssertEqual(account["lastUpdated"] as? String, "2023-11-14T22:13:20Z")
+        XCTAssertEqual(account["resetCreditsAvailable"] as? Int, nil)
+        XCTAssertEqual((account["extraUsage"] as? [String: Any])?["state"] as? String, "on")
+        XCTAssertEqual(windows.map { $0["kind"] as? String }, ["session", "weekly"])
+        XCTAssertEqual(windows.first?["used"] as? Double, 42.5)
+        XCTAssertEqual(windows.first?["total"] as? Double, 100)
+        XCTAssertEqual(Set(account.keys), [
+            "provider", "accountId", "accountName", "lastUpdated",
+            "windows", "extraUsage",
+        ])
+
+        let json = try response.jsonString()
+        XCTAssertFalse(json.contains("/"), json)
+        XCTAssertFalse(json.contains("GROK_HOME"), json)
+        XCTAssertFalse(json.contains("configDirectory"), json)
+        XCTAssertFalse(json.contains("homeDirectory"), json)
+    }
+
+    func testSchemaVersionOneConsumersStillDecodeProvidersWithoutReadingAccounts() throws {
+        let snapshot = AccountUsageSnapshot(
+            id: UUID(),
+            name: "Work",
+            metrics: claudeUsageMetrics
+        )
+        let data = try UsageCLIJSONResponse(
+            metrics: [.claudeCode: claudeUsageMetrics],
+            accounts: [snapshot]
+        ).jsonData()
+
+        let decoded = try JSONDecoder().decode(LegacyUsageDocument.self, from: data)
+        XCTAssertEqual(decoded.schemaVersion, 1)
+        XCTAssertEqual(decoded.providers.map(\.provider), ["claude"])
+        XCTAssertEqual(decoded.providers.first?.windows.map(\.kind), ["session", "weekly"])
+    }
+
     func testCostResponseMatchesVersionOneFixture() throws {
         let cost = TokenCost(
             provider: .codexCli,
@@ -466,6 +540,43 @@ final class CLIJSONOutputTests: XCTestCase {
           "totalTokens" : 1800
         }
         """
+    }
+
+    private var claudeUsageMetrics: UsageMetrics {
+        UsageMetrics(
+            service: .claudeCode,
+            sessionLimit: UsageLimit(
+                used: 42.5,
+                total: 100,
+                resetTime: referenceDate,
+                windowSeconds: 18_000
+            ),
+            weeklyLimit: UsageLimit(
+                used: 90,
+                total: 100,
+                resetTime: nil,
+                windowSeconds: 604_800,
+                isEstimated: true
+            ),
+            extraUsage: ExtraUsageStatus(state: .on, detail: "$0.00 used"),
+            lastUpdated: referenceDate
+        )
+    }
+
+    /// The schema-v1 surface: `providers` only. A consumer that never heard of
+    /// `accounts` must still decode a document that includes the new key.
+    private struct LegacyUsageDocument: Decodable {
+        let schemaVersion: Int
+        let providers: [Provider]
+
+        struct Provider: Decodable {
+            let provider: String
+            let windows: [Window]
+        }
+
+        struct Window: Decodable {
+            let kind: String
+        }
     }
 
     private var errorFixture: String {

--- a/MeterBarTests/CLIUsageTextReportTests.swift
+++ b/MeterBarTests/CLIUsageTextReportTests.swift
@@ -68,6 +68,69 @@ final class CLIUsageTextReportTests: XCTestCase {
         XCTAssertTrue(text.contains("Code Review:"), text)
     }
 
+    func testAccountSnapshotsListIndependentlyInsteadOfHidingBehindTheProviderRow() {
+        let work = AccountUsageSnapshot(
+            id: UUID(),
+            name: "Work",
+            metrics: UsageMetrics(
+                service: .claudeCode,
+                sessionLimit: UsageLimit(used: 80, total: 100, resetTime: nil),
+                lastUpdated: referenceDate
+            )
+        )
+        let personal = AccountUsageSnapshot(
+            id: UUID(),
+            name: "Personal",
+            metrics: UsageMetrics(
+                service: .claudeCode,
+                sessionLimit: UsageLimit(used: 20, total: 100, resetTime: nil),
+                lastUpdated: referenceDate
+            )
+        )
+        let text = CLIUsageTextReport.lines(
+            for: [
+                .claudeCode: MetricsFixtures.claudeCode(),
+                .cursor: MetricsFixtures.cursor(),
+            ],
+            accounts: [work, personal]
+        ).joined(separator: "\n")
+
+        XCTAssertTrue(text.contains("▸ Claude Code · Personal"), text)
+        XCTAssertTrue(text.contains("▸ Claude Code · Work"), text)
+        XCTAssertTrue(text.contains("▸ Cursor"), text)
+        XCTAssertFalse(text.contains("▸ Claude Code\n"), text)
+    }
+
+    func testProviderOnlyOutputIsUnchangedWhenTheAccountCacheIsMissing() {
+        let metric = UsageMetrics(
+            service: .cursor,
+            codeReviewLimit: UsageLimit(used: 12, total: 50, resetTime: nil),
+            lastUpdated: referenceDate
+        )
+        let withoutAccounts = CLIUsageTextReport.lines(for: [.cursor: metric])
+        let withEmptyAccounts = CLIUsageTextReport.lines(for: [.cursor: metric], accounts: [])
+
+        XCTAssertEqual(withoutAccounts, withEmptyAccounts)
+        XCTAssertTrue(withoutAccounts.joined(separator: "\n").contains("▸ Cursor"))
+    }
+
+    func testUnknownAccountFilterPrintsADeterministicEmptyMessage() {
+        let text = CLIUsageTextReport.lines(
+            for: [.claudeCode: MetricsFixtures.claudeCode()],
+            accounts: [
+                AccountUsageSnapshot(
+                    id: UUID(),
+                    name: "Work",
+                    metrics: MetricsFixtures.claudeCode()
+                ),
+            ],
+            accountFilter: "Missing"
+        ).joined(separator: "\n")
+
+        XCTAssertTrue(text.contains(UsageCLISelection.noMatchingAccountsMessage), text)
+        XCTAssertFalse(text.contains("▸ Claude Code"), text)
+    }
+
     private func render(_ service: ServiceType, metric: UsageMetrics) -> String {
         CLIUsageTextReport.lines(for: [service: metric]).joined(separator: "\n")
     }

--- a/MeterBarTests/ServeRouterTests.swift
+++ b/MeterBarTests/ServeRouterTests.swift
@@ -51,13 +51,15 @@ final class ServeRouterTests: XCTestCase {
 
     private func makeDataSource(
         metrics: [ServiceType: UsageMetrics]? = nil,
+        accounts: [AccountUsageSnapshot] = [],
         costCache: CostSummaryCache?? = nil
     ) -> ServeRouter.DataSource {
         let resolvedMetrics = metrics ?? self.metrics
         let resolvedCostCache = costCache ?? .some(self.costCache)
         return ServeRouter.DataSource(
             loadUsageMetrics: { resolvedMetrics },
-            loadCostCache: { resolvedCostCache }
+            loadCostCache: { resolvedCostCache },
+            loadAccountMetrics: { accounts }
         )
     }
 
@@ -248,6 +250,61 @@ final class ServeRouterTests: XCTestCase {
         try assertUsageEndpoint(provider: "clod", selects: [])
     }
 
+    // MARK: `?account=` parity with `meterbar usage --account`
+
+    func testUsageEndpointAccountQueryUsesTheSameSelectionAndDTOAsTheCLI() throws {
+        let workID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x12))
+        let personalID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x11))
+        let accounts = [
+            AccountUsageSnapshot(
+                id: workID,
+                name: "Work",
+                metrics: UsageMetrics(
+                    service: .claudeCode,
+                    sessionLimit: UsageLimit(used: 80, total: 100, resetTime: referenceDate),
+                    lastUpdated: referenceDate
+                )
+            ),
+            AccountUsageSnapshot(
+                id: personalID,
+                name: "Personal",
+                metrics: UsageMetrics(
+                    service: .claudeCode,
+                    sessionLimit: UsageLimit(used: 20, total: 100, resetTime: referenceDate),
+                    lastUpdated: referenceDate
+                )
+            ),
+            AccountUsageSnapshot(
+                id: UUID(),
+                name: "Work",
+                metrics: UsageMetrics(
+                    service: .codexCli,
+                    weeklyLimit: UsageLimit(used: 10, total: 100, resetTime: referenceDate),
+                    lastUpdated: referenceDate
+                )
+            ),
+        ]
+
+        try assertUsageEndpoint(
+            provider: nil,
+            account: "Work",
+            metrics: multiProviderMetrics,
+            accounts: accounts
+        )
+        try assertUsageEndpoint(
+            provider: "claude",
+            account: workID.uuidString,
+            metrics: multiProviderMetrics,
+            accounts: accounts
+        )
+        try assertUsageEndpoint(
+            provider: nil,
+            account: "missing",
+            metrics: multiProviderMetrics,
+            accounts: accounts
+        )
+    }
+
     /// A missing filter selects everything, and a blank one is still no
     /// filter — the router used to treat "   " as a needle matching nothing.
     func testUsageEndpointWithoutAProviderQueryReturnsEveryCachedProvider() throws {
@@ -379,21 +436,60 @@ final class ServeRouterTests: XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
+        try assertUsageEndpoint(
+            provider: provider,
+            account: nil,
+            metrics: multiProviderMetrics,
+            accounts: [],
+            selectedProviders: selected,
+            file: file,
+            line: line
+        )
+    }
+
+    private func assertUsageEndpoint(
+        provider: String?,
+        account: String?,
+        metrics: [ServiceType: UsageMetrics],
+        accounts: [AccountUsageSnapshot],
+        selectedProviders: Set<ServiceType>? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        var query: [String: String] = [:]
+        if let provider { query["provider"] = provider }
+        if let account { query["account"] = account }
+
         let response = ServeRouter.handle(
-            request(
-                path: "/usage",
-                query: provider.map { ["provider": $0] } ?? [:],
-                token: token
-            ),
+            request(path: "/usage", query: query, token: token),
             token: token,
-            dataSource: makeDataSource(metrics: multiProviderMetrics)
+            dataSource: makeDataSource(metrics: metrics, accounts: accounts)
         )
 
-        let expectedMetrics = multiProviderMetrics.filter { selected.contains($0.key) }
-        XCTAssertEqual(expectedMetrics.count, selected.count, "fixture is missing \(selected)", file: file, line: line)
+        let selection = UsageCLISelection.resolve(
+            metrics: metrics,
+            accounts: accounts,
+            provider: provider,
+            account: account
+        )
+        if let selectedProviders {
+            XCTAssertEqual(
+                Set(selection.metrics.keys),
+                selectedProviders,
+                "fixture is missing \(selectedProviders)",
+                file: file,
+                line: line
+            )
+        }
 
-        let expected = try UsageCLIJSONResponse(metrics: expectedMetrics).jsonData()
-        XCTAssertEqual(response.body, expected, "provider=\(provider.debugDescription)", file: file, line: line)
+        let expected = try UsageCLIJSONResponse(selection: selection).jsonData()
+        XCTAssertEqual(
+            response.body,
+            expected,
+            "provider=\(provider.debugDescription) account=\(account.debugDescription)",
+            file: file,
+            line: line
+        )
     }
 
     private func assertBodyContainsNoUsageData(_ response: ServeHTTPResponse, file: StaticString = #filePath, line: UInt = #line) {

--- a/MeterBarTests/UsageCLISelectionTests.swift
+++ b/MeterBarTests/UsageCLISelectionTests.swift
@@ -1,0 +1,187 @@
+import Foundation
+import MeterBarShared
+import XCTest
+@testable import MeterBar
+
+/// Shared `--provider` / `--account` selection for `meterbar usage` and
+/// `serve /usage`. Account matching is exact-token (id or name), never a
+/// substring, so "Work" cannot silently select "Workplace".
+final class UsageCLISelectionTests: XCTestCase {
+    private let claudePersonalID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x11))
+    private let claudeWorkID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x12))
+    private let claudeStagingID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x13))
+    private let codexDefaultID = CodexAccount.defaultID
+    private let codexWorkID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x22))
+    private let grokTeamID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x33))
+
+    private lazy var metrics: [ServiceType: UsageMetrics] = [
+        .claudeCode: MetricsFixtures.claudeCode(sessionUsedPercent: 10),
+        .codexCli: MetricsFixtures.codexCli(sessionUsedPercent: 20),
+        .cursor: MetricsFixtures.cursor(),
+        .openRouter: openRouterMetrics,
+        .grok: MetricsFixtures.grok(),
+    ]
+
+    private lazy var accounts: [AccountUsageSnapshot] = [
+        snapshot(id: claudeWorkID, name: "Work", metrics: MetricsFixtures.claudeCode(sessionUsedPercent: 80)),
+        snapshot(id: claudeStagingID, name: "Staging", metrics: MetricsFixtures.claudeCode(sessionUsedPercent: 15)),
+        snapshot(id: claudePersonalID, name: "Personal", metrics: MetricsFixtures.claudeCode(sessionUsedPercent: 40)),
+        snapshot(id: codexWorkID, name: "Work", metrics: MetricsFixtures.codexCli(sessionUsedPercent: 70)),
+        snapshot(id: codexDefaultID, name: CodexAccount.defaultName, metrics: MetricsFixtures.codexCli()),
+        snapshot(id: grokTeamID, name: "Team", metrics: MetricsFixtures.grok(weeklyUsedPercent: 90)),
+    ]
+
+    private var openRouterMetrics: UsageMetrics {
+        UsageMetrics(
+            service: .openRouter,
+            weeklyLimit: UsageLimit(used: 8, total: 20, resetTime: MetricsFixtures.referenceDate),
+            lastUpdated: MetricsFixtures.referenceDate
+        )
+    }
+
+    // MARK: Listing
+
+    func testThreeProfileClaudeCodexGrokFixturesListIndependently() {
+        let selection = resolve()
+
+        XCTAssertEqual(
+            selection.accounts.map { "\($0.metrics.service.cliIdentifier):\($0.name)" },
+            [
+                "claude:Personal",
+                "claude:Staging",
+                "claude:Work",
+                "codex:Default CLI Profile",
+                "codex:Work",
+                "grok:Team",
+            ]
+        )
+        XCTAssertEqual(Set(selection.metrics.keys), Set(ServiceType.allCases))
+    }
+
+    func testCursorAndOpenRouterStayProviderOnlyWithNoFakeAccounts() {
+        let selection = resolve()
+
+        XCTAssertFalse(selection.accounts.contains { $0.metrics.service == .cursor })
+        XCTAssertFalse(selection.accounts.contains { $0.metrics.service == .openRouter })
+        XCTAssertNotNil(selection.metrics[.cursor])
+        XCTAssertNotNil(selection.metrics[.openRouter])
+    }
+
+    func testLegacyProviderOnlyCacheKeepsAccountsEmpty() {
+        let selection = UsageCLISelection.resolve(metrics: metrics, accounts: [])
+
+        XCTAssertTrue(selection.accounts.isEmpty)
+        XCTAssertEqual(Set(selection.metrics.keys), Set(ServiceType.allCases))
+    }
+
+    func testMissingAccountCacheAndEmptyFiltersAreDeterministic() {
+        let noAccounts = UsageCLISelection.resolve(metrics: metrics, accounts: [], provider: nil, account: nil)
+        let blankFilters = UsageCLISelection.resolve(
+            metrics: metrics,
+            accounts: accounts,
+            provider: "   ",
+            account: "  "
+        )
+
+        XCTAssertTrue(noAccounts.accounts.isEmpty)
+        XCTAssertEqual(blankFilters.accounts.map(\.id), resolve().accounts.map(\.id))
+    }
+
+    // MARK: Selection
+
+    func testAccountIdSelectsExactlyOneProfile() {
+        let selection = resolve(account: claudeWorkID.uuidString)
+
+        XCTAssertEqual(selection.accounts.map(\.id), [claudeWorkID])
+        XCTAssertEqual(selection.accounts.first?.name, "Work")
+        XCTAssertEqual(selection.accounts.first?.metrics.service, .claudeCode)
+    }
+
+    func testAccountIdMatchIsCaseInsensitive() {
+        let selection = resolve(account: claudeWorkID.uuidString.uppercased())
+
+        XCTAssertEqual(selection.accounts.map(\.id), [claudeWorkID])
+    }
+
+    func testExactAccountNameSelectsEveryDuplicateAcrossProviders() {
+        let selection = resolve(account: "Work")
+
+        XCTAssertEqual(selection.accounts.map(\.id), [claudeWorkID, codexWorkID])
+        XCTAssertEqual(selection.accounts.map(\.metrics.service), [.claudeCode, .codexCli])
+    }
+
+    func testAccountNameMatchIsExactAndCaseInsensitiveNotSubstring() {
+        XCTAssertEqual(resolve(account: "work").accounts.map(\.id), [claudeWorkID, codexWorkID])
+        XCTAssertEqual(resolve(account: " Work ").accounts.map(\.id), [claudeWorkID, codexWorkID])
+        XCTAssertTrue(resolve(account: "Workplace").accounts.isEmpty)
+        XCTAssertTrue(resolve(account: "Pers").accounts.isEmpty)
+    }
+
+    func testProviderAndAccountFiltersIntersect() {
+        let selection = resolve(provider: "claude", account: "Work")
+
+        XCTAssertEqual(selection.accounts.map(\.id), [claudeWorkID])
+        XCTAssertEqual(Set(selection.metrics.keys), [.claudeCode])
+    }
+
+    func testProviderFilterAloneKeepsEveryAccountForThatProvider() {
+        let selection = resolve(provider: "codex")
+
+        XCTAssertEqual(selection.accounts.map(\.name), [CodexAccount.defaultName, "Work"])
+        XCTAssertEqual(Set(selection.metrics.keys), [.codexCli])
+    }
+
+    func testUnknownAccountIsDeterministicallyEmpty() {
+        let selection = resolve(account: "not-a-real-account")
+
+        XCTAssertTrue(selection.accounts.isEmpty)
+        XCTAssertEqual(selection.emptyReportMessage, UsageCLISelection.noMatchingAccountsMessage)
+        XCTAssertEqual(Set(selection.metrics.keys), Set(ServiceType.allCases))
+    }
+
+    func testUnknownProviderStillWinsOverAnAccountFilter() {
+        let selection = resolve(provider: "clod", account: "Work")
+
+        XCTAssertTrue(selection.metrics.isEmpty)
+        XCTAssertTrue(selection.accounts.isEmpty)
+        XCTAssertEqual(selection.emptyReportMessage, CLIProviderFilter.noMatchesMessage)
+    }
+
+    func testDisabledOrDeletedProfilesAreOnlyWhatTheCacheStillHolds() {
+        let liveOnly = [
+            snapshot(id: claudePersonalID, name: "Personal", metrics: MetricsFixtures.claudeCode()),
+        ]
+
+        let selection = UsageCLISelection.resolve(metrics: metrics, accounts: liveOnly)
+
+        XCTAssertEqual(selection.accounts.map(\.name), ["Personal"])
+        XCTAssertFalse(selection.accounts.contains { $0.name == "Work" })
+    }
+
+    func testAccountsAreSortedByProviderThenNameThenId() {
+        let sameNameA = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x41))
+        let sameNameB = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x40))
+        let shuffled = [
+            snapshot(id: sameNameA, name: "Twin", metrics: MetricsFixtures.claudeCode()),
+            snapshot(id: grokTeamID, name: "Team", metrics: MetricsFixtures.grok()),
+            snapshot(id: sameNameB, name: "Twin", metrics: MetricsFixtures.claudeCode()),
+        ]
+
+        let selection = UsageCLISelection.resolve(metrics: metrics, accounts: shuffled)
+
+        XCTAssertEqual(selection.accounts.map(\.id), [sameNameB, sameNameA, grokTeamID])
+    }
+
+    private func resolve(provider: String? = nil, account: String? = nil) -> UsageCLISelection {
+        UsageCLISelection.resolve(
+            metrics: metrics,
+            accounts: accounts,
+            provider: provider,
+            account: account
+        )
+    }
+
+    private func snapshot(id: UUID, name: String, metrics: UsageMetrics) -> AccountUsageSnapshot {
+        AccountUsageSnapshot(id: id, name: name, metrics: metrics)
+    }
+}

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -23,6 +23,8 @@ Provider identifiers are stable tokens: `claude`, `codex`, `cursor`, `openrouter
 ```sh
 meterbar usage --json
 meterbar usage --provider codex --json
+meterbar usage --account Work --json
+meterbar usage --provider claude --account 00000000-0000-0000-0000-000000000012 --json
 ```
 
 Version 1 shape:
@@ -64,6 +66,61 @@ use MeterBar's shared quota rules; `quotaBand` is `healthy`, `tight`, `critical`
 
 `extraUsage.state` is `on`, `off`, or `unknown`; its optional `detail` is provider-supplied display
 context. `resetCreditsAvailable` is present only when the provider reports banked reset credits.
+
+### Accounts
+
+Claude, Codex, and Grok can have more than one profile. `providers[]` stays the representative
+provider-wide snapshot (`loadMetrics()`), so schema-v1 consumers that only read `providers` keep
+working. When the app-group account cache (`loadAccountMetrics()`) has snapshots, the document
+also includes an additive `accounts` array — one entry per cached profile, never a filesystem path,
+`GROK_HOME`, or token.
+
+`accounts` is omitted when that cache is empty (legacy provider-only files, or Cursor / OpenRouter
+which stay provider-only and never get fake accounts).
+
+```json
+{
+  "schemaVersion": 1,
+  "providers": [
+    {
+      "provider": "claude",
+      "displayName": "Claude Code",
+      "lastUpdated": "2026-07-14T10:00:00Z",
+      "windows": []
+    }
+  ],
+  "accounts": [
+    {
+      "provider": "claude",
+      "accountId": "00000000-0000-0000-0000-000000000012",
+      "accountName": "Work",
+      "lastUpdated": "2026-07-14T10:00:00Z",
+      "windows": [
+        {
+          "kind": "session",
+          "used": 80,
+          "total": 100,
+          "percentUsed": 80,
+          "percentLeft": 20,
+          "quotaBand": "tight",
+          "estimated": false
+        }
+      ]
+    }
+  ]
+}
+```
+
+`--account` / `GET /usage?account=` matches an account id (UUID string) or the exact account name.
+Matching is case-insensitive and trims surrounding whitespace; it is not a substring. Duplicate
+names return every match, sorted by provider, then name, then id. An unknown account is
+deterministic and successful: `accounts` is omitted (or empty after filtering) and `providers[]`
+is unchanged except for any `--provider` / `?provider=` filter. Human text prints
+`No matching accounts.` instead of the provider rows.
+
+`--provider` / `?provider=` still filters both arrays. Combining `--provider` and `--account`
+intersects them. Disabled or deleted profiles are simply absent from the cache — usage never
+invents rows for them.
 
 ## Cost
 
@@ -617,7 +674,7 @@ trickles bytes cannot hold a handler open indefinitely. Request heads over 8 KiB
 
 | Method & path | Query parameters | Behavior |
 | --- | --- | --- |
-| `GET /usage` | `provider` (optional, same matching as `meterbar usage --provider`) | Returns `UsageCLIJSONResponse` |
+| `GET /usage` | `provider` (optional, same matching as `meterbar usage --provider`); `account` (optional, same matching as `meterbar usage --account`: exact account id or name) | Returns `UsageCLIJSONResponse` |
 | `GET /cost` | `days` (optional, same matching as `meterbar cost --days`; non-positive or non-numeric values are ignored) | Returns `CostCLIJSONResponse` |
 
 An unknown path returns `404` with the same generic error envelope. If the underlying cache is

--- a/scripts/fixtures/cli-json-smoke/fake-meterbar.sh
+++ b/scripts/fixtures/cli-json-smoke/fake-meterbar.sh
@@ -25,7 +25,7 @@ case "$scenario:$command_name" in
     ;;
   data:usage)
     printf '%s\n' \
-      '{"schemaVersion":1,"providers":[{"provider":"codex","displayName":"OpenAI Codex","lastUpdated":"2026-07-17T00:00:00Z","windows":[{"kind":"weekly","used":25,"total":100,"percentUsed":25,"percentLeft":75,"quotaBand":"healthy","estimated":false}]}]}'
+      '{"schemaVersion":1,"accounts":[{"accountId":"00000000-0000-0000-0000-000000000002","accountName":"Work","lastUpdated":"2026-07-17T00:00:00Z","provider":"codex","windows":[{"kind":"weekly","used":25,"total":100,"percentUsed":25,"percentLeft":75,"quotaBand":"healthy","estimated":false}]}],"providers":[{"provider":"codex","displayName":"OpenAI Codex","lastUpdated":"2026-07-17T00:00:00Z","windows":[{"kind":"weekly","used":25,"total":100,"percentUsed":25,"percentLeft":75,"quotaBand":"healthy","estimated":false}]}]}'
     ;;
   data:cost)
     printf '%s\n' \

--- a/scripts/verify-cli-json-smoke.sh
+++ b/scripts/verify-cli-json-smoke.sh
@@ -117,6 +117,37 @@ def validate_error_or_providers(document, label, expected_error_code):
     return providers
 
 
+def validate_usage_windows(entry, path):
+    require(isinstance(entry, dict), f"{path} must be an object")
+    require(
+        isinstance(entry.get("provider"), str) and entry["provider"],
+        f"{path}.provider must be a non-empty string",
+    )
+    require(
+        isinstance(entry.get("lastUpdated"), str) and entry["lastUpdated"],
+        f"{path}.lastUpdated must be a non-empty string",
+    )
+    windows = entry.get("windows")
+    require(isinstance(windows, list), f"{path}.windows must be an array")
+    for window_index, window in enumerate(windows):
+        window_path = f"{path}.windows[{window_index}]"
+        require(isinstance(window, dict), f"{window_path} must be an object")
+        require(
+            window.get("kind") in {"session", "weekly", "codeReview"},
+            f"{window_path}.kind is unexpected",
+        )
+        require(
+            window.get("quotaBand") in {"healthy", "tight", "critical", "exhausted"},
+            f"{window_path}.quotaBand is unexpected",
+        )
+        require(
+            isinstance(window.get("estimated"), bool),
+            f"{window_path}.estimated must be boolean",
+        )
+        for field in ("used", "total", "percentUsed", "percentLeft"):
+            require_number(window.get(field), f"{window_path}.{field}")
+
+
 def validate_usage(document):
     providers = validate_error_or_providers(
         document,
@@ -129,38 +160,34 @@ def validate_usage(document):
     require(providers, "usage.providers must contain at least one provider")
     for provider_index, provider in enumerate(providers):
         path = f"usage.providers[{provider_index}]"
-        require(isinstance(provider, dict), f"{path} must be an object")
-        require(
-            isinstance(provider.get("provider"), str) and provider["provider"],
-            f"{path}.provider must be a non-empty string",
-        )
+        validate_usage_windows(provider, path)
         require(
             isinstance(provider.get("displayName"), str) and provider["displayName"],
             f"{path}.displayName must be a non-empty string",
         )
-        require(
-            isinstance(provider.get("lastUpdated"), str) and provider["lastUpdated"],
-            f"{path}.lastUpdated must be a non-empty string",
-        )
-        windows = provider.get("windows")
-        require(isinstance(windows, list), f"{path}.windows must be an array")
-        for window_index, window in enumerate(windows):
-            window_path = f"{path}.windows[{window_index}]"
-            require(isinstance(window, dict), f"{window_path} must be an object")
+
+    if "accounts" in document:
+        accounts = document["accounts"]
+        require(isinstance(accounts, list), "usage.accounts must be an array")
+        require(accounts, "usage.accounts must be omitted when empty")
+        for account_index, account in enumerate(accounts):
+            path = f"usage.accounts[{account_index}]"
+            require(isinstance(account, dict), f"{path} must be an object")
+            validate_usage_windows(account, path)
             require(
-                window.get("kind") in {"session", "weekly", "codeReview"},
-                f"{window_path}.kind is unexpected",
+                isinstance(account.get("accountId"), str) and account["accountId"],
+                f"{path}.accountId must be a non-empty string",
             )
             require(
-                window.get("quotaBand") in {"healthy", "tight", "critical", "exhausted"},
-                f"{window_path}.quotaBand is unexpected",
+                isinstance(account.get("accountName"), str) and account["accountName"],
+                f"{path}.accountName must be a non-empty string",
             )
+            for forbidden in ("configDirectory", "homeDirectory", "path", "token"):
+                require(forbidden not in account, f"{path} must not expose {forbidden}")
             require(
-                isinstance(window.get("estimated"), bool),
-                f"{window_path}.estimated must be boolean",
+                "/" not in account["accountName"] and "/" not in account["accountId"],
+                f"{path} must not expose a filesystem path",
             )
-            for field in ("used", "total", "percentUsed", "percentLeft"):
-                require_number(window.get(field), f"{window_path}.{field}")
 
 
 def validate_cost(document):


### PR DESCRIPTION
## Summary

`meterbar usage` and `serve /usage` now read the same app-group `AccountUsageSnapshot` cache the widget already uses, so Claude / Codex / Grok custom profiles can be listed and selected independently.

- Shared `UsageCLISelection` drives both the CLI and `GET /usage` (same provider + account filters, same DTO).
- Schema v1 stays additive: `providers[]` is still the representative `loadMetrics()` snapshot. Optional `accounts[]` is omitted when the account cache is empty.
- `--account` / `?account=` matches an account id (UUID) or the exact account name. Unknown accounts are a successful empty selection (`No matching accounts.` in text).
- Cursor and OpenRouter stay provider-only. No paths, tokens, or `GROK_HOME`.

## Related issue

Fixes #461

## Scope

- Reuses `SharedDataStore.loadAccountMetrics()`. No new cache format.
- Does not change Grok period mapping or card health.
- Does not expose filesystem paths.

## Verification

- `swift test` — 2472 tests, 5 skipped, 0 failures
- `scripts/test-cli-json-smoke.sh` — passed
- Broader app/CLI builds left to CI

## Screenshots

Not applicable

## Checklist

- [x] I reviewed the final diff for unrelated changes.
- [x] I ran the relevant focused checks or documented why they were left to CI.
- [x] I updated relevant documentation or explained why no documentation change is needed.
- [x] I documented migrations, release steps, or external configuration changes, or marked them not applicable.
- [x] I did not include secrets, credentials, personal data, customer data, or generated build output.
- [x] If CodeRabbit says "Review rate limited", I re-requested review before merge. A green CodeRabbit tick is not a review in that case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive schema and read-only cache paths with broad test coverage; main risk is integrators assuming `providers[]` is the only per-profile view when `accounts[]` is present.
> 
> **Overview**
> **Adds per-profile usage** for Claude, Codex, and Grok by reading the same app-group `AccountUsageSnapshot` cache the widget uses, with **`--account`** on `meterbar usage` and **`?account=`** on `GET /usage`.
> 
> **`UsageCLISelection`** centralizes provider + account filtering for the CLI and serve so HTTP and shell stay aligned. Account matching is **exact** (UUID or full name, case-insensitive); unknown accounts yield **`No matching accounts.`** in text and do not fall back to the aggregate provider row when `--account` is active.
> 
> **Schema v1 stays backward compatible:** `providers[]` remains the representative `loadMetrics()` snapshot; optional **`accounts[]`** is omitted when the account cache is empty so existing JSON consumers stay byte-stable. Text output lists **`Provider · Account`** rows when snapshots exist; Cursor/OpenRouter stay provider-only.
> 
> Docs, CLI JSON smoke fixtures, and validators cover the new `accounts` shape and forbid paths/tokens in account objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b7f5df566b5a4310650c1951f83ade346ebe211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->