### PR TITLE
feat(grok): make quota hooks and webhooks account-scoped

### DIFF
--- a/MeterBar/App/QuotaEventCoordinator.swift
+++ b/MeterBar/App/QuotaEventCoordinator.swift
@@ -14,6 +14,7 @@ final class QuotaEventCoordinator {
     private let dataManager: UsageDataManager
     private let claudeAccounts: ClaudeCodeAccountStore
     private let codexAccounts: CodexAccountStore
+    private let grokAccounts: GrokAccountStore
     private let providerVisibility: ProviderVisibilityStore
     private let settings: QuotaEventSettingsStore
     private let diagnostics: QuotaEventDiagnosticStore
@@ -26,6 +27,7 @@ final class QuotaEventCoordinator {
         dataManager: UsageDataManager? = nil,
         claudeAccounts: ClaudeCodeAccountStore? = nil,
         codexAccounts: CodexAccountStore? = nil,
+        grokAccounts: GrokAccountStore? = nil,
         providerVisibility: ProviderVisibilityStore? = nil,
         settings: QuotaEventSettingsStore? = nil,
         diagnostics: QuotaEventDiagnosticStore? = nil,
@@ -34,6 +36,7 @@ final class QuotaEventCoordinator {
         self.dataManager = dataManager ?? .shared
         self.claudeAccounts = claudeAccounts ?? .shared
         self.codexAccounts = codexAccounts ?? .shared
+        self.grokAccounts = grokAccounts ?? .shared
         self.providerVisibility = providerVisibility ?? .shared
         self.settings = settings ?? .shared
         self.diagnostics = diagnostics ?? .shared
@@ -54,6 +57,9 @@ final class QuotaEventCoordinator {
             codexAccounts.$customAccounts.map { _ in () }.eraseToAnyPublisher(),
             codexAccounts.$defaultAccountName.map { _ in () }.eraseToAnyPublisher(),
             codexAccounts.$defaultAccountIsEnabled.map { _ in () }.eraseToAnyPublisher(),
+            grokAccounts.$customAccounts.map { _ in () }.eraseToAnyPublisher(),
+            grokAccounts.$defaultAccountName.map { _ in () }.eraseToAnyPublisher(),
+            grokAccounts.$defaultAccountIsEnabled.map { _ in () }.eraseToAnyPublisher(),
         ]
 
         Publishers.MergeMany(triggers)
@@ -68,10 +74,14 @@ final class QuotaEventCoordinator {
     private func evaluateCurrentSnapshot() {
         let snapshots = QuotaEventSnapshotCatalog.snapshots(
             metrics: dataManager.metrics,
-            claudeAccounts: claudeAccounts.accounts,
-            claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
-            codexAccounts: codexAccounts.accounts,
-            codexAccountMetrics: dataManager.codexAccountMetrics,
+            accounts: QuotaEventAccountInputs(
+                claudeAccounts: claudeAccounts.accounts,
+                claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
+                codexAccounts: codexAccounts.accounts,
+                codexAccountMetrics: dataManager.codexAccountMetrics,
+                grokAccounts: grokAccounts.accounts,
+                grokAccountMetrics: dataManager.grokAccountMetrics
+            ),
             enabledServices: providerVisibility.enabledServices
         )
         let configuration = settings.configuration

--- a/MeterBar/Services/QuotaEventService.swift
+++ b/MeterBar/Services/QuotaEventService.swift
@@ -1,19 +1,41 @@
 import Foundation
 import MeterBarShared
 
+/// One provider/account row the Event Integrations settings can opt into.
+/// Identity is the same UUID-or-`default` contract the webhook payload uses.
+nonisolated struct QuotaEventSelectableAccount: Identifiable, Equatable, Sendable {
+    let provider: ServiceType
+    let accountID: String
+    let name: String
+
+    var id: String { "\(provider.rawValue):\(accountID)" }
+
+    var selection: QuotaEventAccountSelection {
+        QuotaEventAccountSelection(provider: provider, accountID: accountID)
+    }
+}
+
+/// Account-aware inputs for Claude, Codex, and Grok. Flat providers still
+/// arrive through the provider-wide metrics map.
+nonisolated struct QuotaEventAccountInputs: Sendable {
+    var claudeAccounts: [ClaudeCodeAccount] = []
+    var claudeAccountMetrics: [UUID: UsageMetrics] = [:]
+    var codexAccounts: [CodexAccount] = []
+    var codexAccountMetrics: [UUID: UsageMetrics] = [:]
+    var grokAccounts: [GrokAccount] = []
+    var grokAccountMetrics: [UUID: UsageMetrics] = [:]
+}
+
 /// Builds the app-wide provider/account input without ever projecting
 /// credential or filesystem configuration into the event model.
 nonisolated enum QuotaEventSnapshotCatalog {
     static let flatProviders = ServiceType.allCases.filter {
-        $0 != .claudeCode && $0 != .codexCli
+        $0 != .claudeCode && $0 != .codexCli && $0 != .grok
     }
 
     static func snapshots(
         metrics: [ServiceType: UsageMetrics],
-        claudeAccounts: [ClaudeCodeAccount],
-        claudeAccountMetrics: [UUID: UsageMetrics],
-        codexAccounts: [CodexAccount],
-        codexAccountMetrics: [UUID: UsageMetrics],
+        accounts: QuotaEventAccountInputs,
         enabledServices: Set<ServiceType>
     ) -> [QuotaEventSnapshot] {
         var result = flatProviders.compactMap { provider -> QuotaEventSnapshot? in
@@ -29,20 +51,29 @@ nonisolated enum QuotaEventSnapshotCatalog {
 
         result += accountSnapshots(
             provider: .claudeCode,
-            accounts: claudeAccounts.map {
+            accounts: accounts.claudeAccounts.map {
                 AccountMetricIdentity(id: $0.id, name: $0.name, isEnabled: $0.isEnabled)
             },
-            accountMetrics: claudeAccountMetrics,
+            accountMetrics: accounts.claudeAccountMetrics,
             fallbackMetrics: metrics[.claudeCode],
             enabledServices: enabledServices
         )
         result += accountSnapshots(
             provider: .codexCli,
-            accounts: codexAccounts.map {
+            accounts: accounts.codexAccounts.map {
                 AccountMetricIdentity(id: $0.id, name: $0.name, isEnabled: $0.isEnabled)
             },
-            accountMetrics: codexAccountMetrics,
+            accountMetrics: accounts.codexAccountMetrics,
             fallbackMetrics: metrics[.codexCli],
+            enabledServices: enabledServices
+        )
+        result += accountSnapshots(
+            provider: .grok,
+            accounts: accounts.grokAccounts.map {
+                AccountMetricIdentity(id: $0.id, name: $0.name, isEnabled: $0.isEnabled)
+            },
+            accountMetrics: accounts.grokAccountMetrics,
+            fallbackMetrics: metrics[.grok],
             enabledServices: enabledServices
         )
         return result.sorted {
@@ -50,6 +81,43 @@ nonisolated enum QuotaEventSnapshotCatalog {
                 return $0.provider.sortOrder < $1.provider.sortOrder
             }
             return $0.account.name.localizedCaseInsensitiveCompare($1.account.name) == .orderedAscending
+        }
+    }
+
+    static func selectableAccounts(
+        claudeAccounts: [ClaudeCodeAccount],
+        codexAccounts: [CodexAccount],
+        grokAccounts: [GrokAccount]
+    ) -> [QuotaEventSelectableAccount] {
+        let flat = flatProviders.map {
+            QuotaEventSelectableAccount(provider: $0, accountID: "default", name: $0.displayName)
+        }
+        let claude = claudeAccounts.filter(\.isEnabled).map {
+            QuotaEventSelectableAccount(
+                provider: .claudeCode,
+                accountID: $0.id.uuidString,
+                name: $0.name
+            )
+        }
+        let codex = codexAccounts.filter(\.isEnabled).map {
+            QuotaEventSelectableAccount(
+                provider: .codexCli,
+                accountID: $0.id.uuidString,
+                name: $0.name
+            )
+        }
+        let grok = grokAccounts.filter(\.isEnabled).map {
+            QuotaEventSelectableAccount(
+                provider: .grok,
+                accountID: $0.id.uuidString,
+                name: $0.name
+            )
+        }
+        return (claude + codex + grok + flat).sorted {
+            if $0.provider.sortOrder != $1.provider.sortOrder {
+                return $0.provider.sortOrder < $1.provider.sortOrder
+            }
+            return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
         }
     }
 

--- a/MeterBar/Services/QuotaEventSettingsStore.swift
+++ b/MeterBar/Services/QuotaEventSettingsStore.swift
@@ -17,6 +17,21 @@ nonisolated struct QuotaEventAccountSelection: Codable, Equatable, Hashable, Sen
     init(payload: QuotaEventPayload) {
         self.init(provider: payload.provider, accountID: payload.account.id)
     }
+
+    /// Existing provider-wide Grok opt-ins used `default`. The default Grok
+    /// profile now has a stable UUID, so rewrite that one identifier in place.
+    var normalizedForPersistence: QuotaEventAccountSelection {
+        guard provider == .grok, accountID == "default" else { return self }
+        return QuotaEventAccountSelection(provider: .grok, accountID: GrokAccount.defaultID.uuidString)
+    }
+
+    func matches(_ payload: QuotaEventPayload) -> Bool {
+        guard provider == payload.provider else { return false }
+        if accountID == payload.account.id { return true }
+        return provider == .grok
+            && accountID == "default"
+            && payload.account.id == GrokAccount.defaultID.uuidString
+    }
 }
 
 /// Versioned app-wide outbound integration preferences.
@@ -75,7 +90,13 @@ nonisolated struct QuotaEventIntegrationConfiguration: Codable, Equatable, Senda
     func includes(_ payload: QuotaEventPayload) -> Bool {
         enabledQuotaEvents.contains(payload.event)
             && enabledProviders.contains(payload.provider)
-            && enabledAccounts.contains(QuotaEventAccountSelection(payload: payload))
+            && enabledAccounts.contains { $0.matches(payload) }
+    }
+
+    func migratingLegacyGrokDefaultSelection() -> QuotaEventIntegrationConfiguration {
+        var updated = self
+        updated.enabledAccounts = Set(enabledAccounts.map(\.normalizedForPersistence))
+        return updated
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -151,7 +172,11 @@ final class QuotaEventSettingsStore: ObservableObject {
         self.userDefaults = userDefaults
         if let data = userDefaults.data(forKey: StorageKeys.quotaEventIntegrations),
            let decoded = try? JSONDecoder().decode(QuotaEventIntegrationConfiguration.self, from: data) {
-            configuration = decoded
+            let migrated = decoded.migratingLegacyGrokDefaultSelection()
+            configuration = migrated
+            if migrated != decoded {
+                persist()
+            }
         } else {
             configuration = Self.migratedConfiguration(from: userDefaults)
             persist()
@@ -226,7 +251,9 @@ final class QuotaEventSettingsStore: ObservableObject {
     }
 
     func setAccountEnabled(_ enabled: Bool, for account: QuotaEventAccountSelection) {
-        guard let updated = updatedSet(configuration.enabledAccounts, value: account, enabled: enabled) else {
+        let normalized = account.normalizedForPersistence
+        let current = Set(configuration.enabledAccounts.map(\.normalizedForPersistence))
+        guard let updated = updatedSet(current, value: normalized, enabled: enabled) else {
             return
         }
         configuration.enabledAccounts = updated

--- a/MeterBar/Views/Settings/QuotaEventSettingsView.swift
+++ b/MeterBar/Views/Settings/QuotaEventSettingsView.swift
@@ -8,6 +8,7 @@ struct QuotaEventSettingsView: View {
     @StateObject private var diagnostics = QuotaEventDiagnosticStore.shared
     @StateObject private var claudeAccounts = ClaudeCodeAccountStore.shared
     @StateObject private var codexAccounts = CodexAccountStore.shared
+    @StateObject private var grokAccounts = GrokAccountStore.shared
 
     @State private var isTestingLocalHook = false
     @State private var testMessage: String?
@@ -227,22 +228,12 @@ struct QuotaEventSettingsView: View {
         }
     }
 
-    private var integrationAccounts: [IntegrationAccount] {
-        let flat = QuotaEventSnapshotCatalog.flatProviders.map {
-            IntegrationAccount(provider: $0, accountID: "default", name: $0.displayName)
-        }
-        let claude = claudeAccounts.accounts.filter(\.isEnabled).map {
-            IntegrationAccount(provider: .claudeCode, accountID: $0.id.uuidString, name: $0.name)
-        }
-        let codex = codexAccounts.accounts.filter(\.isEnabled).map {
-            IntegrationAccount(provider: .codexCli, accountID: $0.id.uuidString, name: $0.name)
-        }
-        return (claude + codex + flat).sorted {
-            if $0.provider.sortOrder != $1.provider.sortOrder {
-                return $0.provider.sortOrder < $1.provider.sortOrder
-            }
-            return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
-        }
+    private var integrationAccounts: [QuotaEventSelectableAccount] {
+        QuotaEventSnapshotCatalog.selectableAccounts(
+            claudeAccounts: claudeAccounts.accounts,
+            codexAccounts: codexAccounts.accounts,
+            grokAccounts: grokAccounts.accounts
+        )
     }
 
     private func eventDetail(_ event: QuotaEventKind) -> String {
@@ -270,17 +261,5 @@ struct QuotaEventSettingsView: View {
             testMessage = result.userMessage
             isTestingLocalHook = false
         }
-    }
-}
-
-private struct IntegrationAccount: Identifiable {
-    let provider: ServiceType
-    let accountID: String
-    let name: String
-
-    var id: String { "\(provider.rawValue):\(accountID)" }
-
-    var selection: QuotaEventAccountSelection {
-        QuotaEventAccountSelection(provider: provider, accountID: accountID)
     }
 }

--- a/MeterBarTests/QuotaEventDeliveryTests.swift
+++ b/MeterBarTests/QuotaEventDeliveryTests.swift
@@ -34,8 +34,53 @@ final class QuotaEventDeliveryTests: XCTestCase {
         XCTAssertTrue(output.contains("METERBAR_BAND=critical"))
         XCTAssertFalse(output.contains("CLAUDE_CONFIG_DIR"))
         XCTAssertFalse(output.contains("CODEX_HOME"))
+        XCTAssertFalse(output.contains("GROK_HOME"))
         XCTAssertFalse(output.localizedCaseInsensitiveContains("api_key"))
         XCTAssertFalse(output.localizedCaseInsensitiveContains("token="))
+    }
+
+    func testGrokLocalHookEnvironmentContainsOnlyTheDocumentedSecretFreeFields() async throws {
+        let tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("QuotaEventDeliveryTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let runner = QuotaEventLocalHookRunner(
+            runner: WakeEventHookRunner(
+                logger: WakeRunLogger(directory: tempDirectory.appendingPathComponent("logs", isDirectory: true))
+            )
+        )
+        let grokPayload = QuotaEventPayload(
+            provider: .grok,
+            account: QuotaEventAccount(id: GrokAccount.defaultID.uuidString, name: "Work"),
+            event: .exhausted,
+            window: .weekly,
+            percentage: 100,
+            band: .exhausted,
+            timestamp: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+        let result = await runner.run(
+            configuration: configuration(
+                executable: "/usr/bin/env",
+                arguments: [],
+                webhookURL: "",
+                provider: .grok,
+                accountID: grokPayload.account.id
+            ),
+            payload: grokPayload
+        )
+        let output = try XCTUnwrap(String(bytes: result.stdoutCapture, encoding: .utf8))
+
+        XCTAssertTrue(result.succeeded)
+        XCTAssertTrue(output.contains("METERBAR_EVENT=exhausted"))
+        XCTAssertTrue(output.contains("METERBAR_PROVIDER=Grok"))
+        XCTAssertTrue(output.contains("METERBAR_ACCOUNT_ID=\(GrokAccount.defaultID.uuidString)"))
+        XCTAssertTrue(output.contains("METERBAR_ACCOUNT_NAME=Work"))
+        XCTAssertFalse(output.contains("GROK_HOME"))
+        XCTAssertFalse(output.contains("homeDirectory"))
+        XCTAssertFalse(output.contains("/secret/"))
+        XCTAssertFalse(output.localizedCaseInsensitiveContains("token="))
+        XCTAssertFalse(output.contains("auth.json"))
     }
 
     func testOneDeliveryFailureDoesNotBlockOtherChannelsOrLaterEvents() async {
@@ -90,7 +135,9 @@ final class QuotaEventDeliveryTests: XCTestCase {
     private func configuration(
         executable: String,
         arguments: [String],
-        webhookURL: String = ""
+        webhookURL: String = "",
+        provider: ServiceType = .cursor,
+        accountID: String = "account-id"
     ) -> QuotaEventIntegrationConfiguration {
         QuotaEventIntegrationConfiguration(
             localDeliveryEnabled: true,
@@ -99,9 +146,9 @@ final class QuotaEventDeliveryTests: XCTestCase {
             webhookDeliveryEnabled: !webhookURL.isEmpty,
             webhookURLString: webhookURL,
             enabledQuotaEvents: [.critical, .exhausted],
-            enabledProviders: [.cursor],
+            enabledProviders: [provider],
             enabledAccounts: [
-                QuotaEventAccountSelection(provider: .cursor, accountID: "account-id"),
+                QuotaEventAccountSelection(provider: provider, accountID: accountID),
             ],
             enabledWakeEvents: []
         )

--- a/MeterBarTests/QuotaEventPlannerTests.swift
+++ b/MeterBarTests/QuotaEventPlannerTests.swift
@@ -102,6 +102,87 @@ final class QuotaEventPlannerTests: XCTestCase {
         XCTAssertEqual(events.first?.event, .warning)
     }
 
+    func testGrokProfilesEmitWarningCriticalExhaustedAndRecoveredIndependentlyPerWindow() {
+        var planner = QuotaEventPlanner(debounceInterval: 60)
+        let personal = QuotaEventAccount(id: GrokAccount.defaultID.uuidString, name: "Personal")
+        let work = QuotaEventAccount(
+            id: "C3D4E5F6-A7B8-4901-8234-567890ABCDEF",
+            name: "Work"
+        )
+        _ = planner.evaluate(
+            snapshots: [
+                grokSnapshot(account: personal, sessionUsed: 50, weeklyUsed: 50),
+                grokSnapshot(account: work, sessionUsed: 50, weeklyUsed: 50),
+            ],
+            now: start
+        )
+
+        let warning = planner.evaluate(
+            snapshots: [
+                grokSnapshot(account: personal, sessionUsed: 76, weeklyUsed: 50),
+                grokSnapshot(account: work, sessionUsed: 50, weeklyUsed: 50),
+            ],
+            now: start.addingTimeInterval(1)
+        )
+        let critical = planner.evaluate(
+            snapshots: [
+                grokSnapshot(account: personal, sessionUsed: 76, weeklyUsed: 50),
+                grokSnapshot(account: work, sessionUsed: 50, weeklyUsed: 91),
+            ],
+            now: start.addingTimeInterval(2)
+        )
+        let exhausted = planner.evaluate(
+            snapshots: [
+                grokSnapshot(account: personal, sessionUsed: 100, weeklyUsed: 50),
+                grokSnapshot(account: work, sessionUsed: 50, weeklyUsed: 91),
+            ],
+            now: start.addingTimeInterval(3)
+        )
+        let recovered = planner.evaluate(
+            snapshots: [
+                grokSnapshot(account: personal, sessionUsed: 0, weeklyUsed: 50),
+                grokSnapshot(account: work, sessionUsed: 50, weeklyUsed: 91),
+            ],
+            now: start.addingTimeInterval(4)
+        )
+
+        XCTAssertEqual(warning.map(\.account), [personal])
+        XCTAssertEqual(warning.map(\.event), [.warning])
+        XCTAssertEqual(warning.map(\.window), [.session])
+        XCTAssertEqual(critical.map(\.account), [work])
+        XCTAssertEqual(critical.map(\.event), [.critical])
+        XCTAssertEqual(critical.map(\.window), [.weekly])
+        XCTAssertEqual(exhausted.map(\.account), [personal])
+        XCTAssertEqual(exhausted.map(\.event), [.exhausted])
+        XCTAssertEqual(exhausted.map(\.window), [.session])
+        XCTAssertEqual(recovered.map(\.account), [personal])
+        XCTAssertEqual(recovered.map(\.event), [.recovered])
+        XCTAssertEqual(recovered.map(\.window), [.session])
+    }
+
+    func testLegacyGrokDefaultNamespaceReprimesToTheAccountIdWithoutReplaying() {
+        var planner = QuotaEventPlanner(debounceInterval: 60)
+        let legacy = QuotaEventAccount(id: "default", name: "Grok")
+        let migrated = QuotaEventAccount(id: GrokAccount.defaultID.uuidString, name: GrokAccount.defaultName)
+        _ = planner.evaluate(
+            snapshots: [grokSnapshot(account: legacy, sessionUsed: 91, weeklyUsed: 50)],
+            now: start
+        )
+
+        let afterMigration = planner.evaluate(
+            snapshots: [grokSnapshot(account: migrated, sessionUsed: 91, weeklyUsed: 50)],
+            now: start.addingTimeInterval(1)
+        )
+        let exhausted = planner.evaluate(
+            snapshots: [grokSnapshot(account: migrated, sessionUsed: 100, weeklyUsed: 50)],
+            now: start.addingTimeInterval(2)
+        )
+
+        XCTAssertTrue(afterMigration.isEmpty)
+        XCTAssertEqual(exhausted.map(\.event), [.exhausted])
+        XCTAssertEqual(exhausted.first?.account, migrated)
+    }
+
     func testRemovedAccountNamespaceReprimesInsteadOfReplayingAStaleCrossing() {
         var planner = QuotaEventPlanner(debounceInterval: 60)
         _ = planner.evaluate(
@@ -136,6 +217,31 @@ final class QuotaEventPlannerTests: XCTestCase {
                     used: used,
                     total: 100,
                     resetTime: start.addingTimeInterval(3_600)
+                ),
+                lastUpdated: start
+            )
+        )
+    }
+
+    private func grokSnapshot(
+        account: QuotaEventAccount,
+        sessionUsed: Double,
+        weeklyUsed: Double
+    ) -> QuotaEventSnapshot {
+        QuotaEventSnapshot(
+            provider: .grok,
+            account: account,
+            metrics: UsageMetrics(
+                service: .grok,
+                sessionLimit: UsageLimit(
+                    used: sessionUsed,
+                    total: 100,
+                    resetTime: start.addingTimeInterval(3_600)
+                ),
+                weeklyLimit: UsageLimit(
+                    used: weeklyUsed,
+                    total: 100,
+                    resetTime: start.addingTimeInterval(86_400)
                 ),
                 lastUpdated: start
             )

--- a/MeterBarTests/QuotaEventServiceTests.swift
+++ b/MeterBarTests/QuotaEventServiceTests.swift
@@ -17,19 +17,29 @@ final class QuotaEventServiceTests: XCTestCase {
             name: "Codex Work",
             homeDirectory: "/secret/codex-home"
         )
+        let grok = GrokAccount(
+            id: UUID(uuidString: "C3D4E5F6-A7B8-4901-8234-567890ABCDEF")!,
+            name: "Grok Work",
+            homeDirectory: "/secret/grok-home"
+        )
         let metrics = Dictionary(uniqueKeysWithValues: QuotaEventSnapshotCatalog.flatProviders.map {
             ($0, usage(service: $0, used: 50))
         })
 
         let snapshots = QuotaEventSnapshotCatalog.snapshots(
             metrics: metrics,
-            claudeAccounts: [claude],
-            claudeAccountMetrics: [claude.id: usage(service: .claudeCode, used: 50)],
-            codexAccounts: [codex],
-            codexAccountMetrics: [codex.id: usage(service: .codexCli, used: 50)],
+            accounts: QuotaEventAccountInputs(
+                claudeAccounts: [claude],
+                claudeAccountMetrics: [claude.id: usage(service: .claudeCode, used: 50)],
+                codexAccounts: [codex],
+                codexAccountMetrics: [codex.id: usage(service: .codexCli, used: 50)],
+                grokAccounts: [grok],
+                grokAccountMetrics: [grok.id: usage(service: .grok, used: 50)]
+            ),
             enabledServices: Set(ServiceType.allCases)
         )
 
+        XCTAssertFalse(QuotaEventSnapshotCatalog.flatProviders.contains(.grok))
         XCTAssertEqual(snapshots.count, ServiceType.allCases.count)
         XCTAssertEqual(Set(snapshots.map(\.provider)), Set(ServiceType.allCases))
         XCTAssertEqual(
@@ -40,11 +50,112 @@ final class QuotaEventServiceTests: XCTestCase {
             snapshots.first { $0.provider == .codexCli }?.account,
             QuotaEventAccount(id: codex.id.uuidString, name: codex.name)
         )
+        XCTAssertEqual(
+            snapshots.first { $0.provider == .grok }?.account,
+            QuotaEventAccount(id: grok.id.uuidString, name: grok.name)
+        )
         let encoded = try? JSONEncoder().encode(snapshots.map(\.account))
         let text = encoded.map { String(decoding: $0, as: UTF8.self) } ?? ""
         XCTAssertFalse(text.contains("secret"))
         XCTAssertFalse(text.contains("configDirectory"))
         XCTAssertFalse(text.contains("homeDirectory"))
+        XCTAssertFalse(text.contains("GROK_HOME"))
+        XCTAssertFalse(text.localizedCaseInsensitiveContains("token"))
+    }
+
+    func testCatalogExposesEachEnabledGrokProfileAsAStableSelectableAccount() {
+        let work = GrokAccount(
+            id: UUID(uuidString: "C3D4E5F6-A7B8-4901-8234-567890ABCDEF")!,
+            name: "Work",
+            homeDirectory: "/secret/grok-work"
+        )
+        var personal = GrokAccount.defaultAccount
+        personal.name = "Personal"
+        var disabled = GrokAccount(
+            id: UUID(uuidString: "D4E5F6A7-B8C9-4012-9345-67890ABCDEF0")!,
+            name: "Disabled",
+            homeDirectory: "/secret/grok-disabled"
+        )
+        disabled.isEnabled = false
+
+        let selectable = QuotaEventSnapshotCatalog.selectableAccounts(
+            claudeAccounts: [],
+            codexAccounts: [],
+            grokAccounts: [personal, work, disabled]
+        )
+        let grok = selectable.filter { $0.provider == .grok }
+
+        XCTAssertEqual(grok.map(\.accountID), [personal.id.uuidString, work.id.uuidString])
+        XCTAssertEqual(Set(grok.map(\.name)), ["Personal", "Work"])
+        XCTAssertEqual(
+            grok.map(\.selection),
+            [
+                QuotaEventAccountSelection(provider: .grok, accountID: personal.id.uuidString),
+                QuotaEventAccountSelection(provider: .grok, accountID: work.id.uuidString),
+            ]
+        )
+        XCTAssertFalse(grok.contains { $0.accountID == disabled.id.uuidString })
+        XCTAssertFalse(grok.contains { $0.accountID == "default" })
+        XCTAssertFalse(selectable.contains { $0.provider == .grok && $0.name == ServiceType.grok.displayName })
+        XCTAssertFalse(QuotaEventSnapshotCatalog.flatProviders.contains(.grok))
+    }
+
+    func testCatalogEvaluatesEnabledGrokProfilesIndependentlyAndOmitsDisabledOnes() {
+        let work = GrokAccount(
+            id: UUID(uuidString: "C3D4E5F6-A7B8-4901-8234-567890ABCDEF")!,
+            name: "Work",
+            homeDirectory: "/secret/grok-work"
+        )
+        var disabled = GrokAccount(
+            id: UUID(uuidString: "D4E5F6A7-B8C9-4012-9345-67890ABCDEF0")!,
+            name: "Disabled",
+            homeDirectory: "/secret/grok-disabled"
+        )
+        disabled.isEnabled = false
+        let snapshots = QuotaEventSnapshotCatalog.snapshots(
+            metrics: [.grok: usage(service: .grok, used: 10)],
+            accounts: QuotaEventAccountInputs(
+                grokAccounts: [.defaultAccount, work, disabled],
+                grokAccountMetrics: [
+                    GrokAccount.defaultID: usage(service: .grok, used: 50),
+                    work.id: usage(service: .grok, used: 91),
+                    disabled.id: usage(service: .grok, used: 100),
+                ]
+            ),
+            enabledServices: [.grok]
+        )
+
+        XCTAssertEqual(snapshots.map(\.provider), [.grok, .grok])
+        XCTAssertEqual(
+            Set(snapshots.map(\.account)),
+            [
+                QuotaEventAccount(id: GrokAccount.defaultID.uuidString, name: GrokAccount.defaultName),
+                QuotaEventAccount(id: work.id.uuidString, name: work.name),
+            ]
+        )
+        XCTAssertEqual(
+            snapshots.first { $0.account.id == work.id.uuidString }?.metrics.sessionLimit?.used,
+            91
+        )
+        XCTAssertFalse(snapshots.contains { $0.account.id == "default" })
+        XCTAssertFalse(snapshots.contains { $0.account.id == disabled.id.uuidString })
+    }
+
+    func testLegacyProviderWideGrokSnapshotDoesNotCoexistWithAccountSnapshots() {
+        let snapshots = QuotaEventSnapshotCatalog.snapshots(
+            metrics: [.grok: usage(service: .grok, used: 76)],
+            accounts: QuotaEventAccountInputs(
+                grokAccounts: [.defaultAccount],
+                grokAccountMetrics: [GrokAccount.defaultID: usage(service: .grok, used: 76)]
+            ),
+            enabledServices: [.grok]
+        )
+
+        XCTAssertEqual(snapshots.count, 1)
+        XCTAssertEqual(snapshots.first?.provider, .grok)
+        XCTAssertEqual(snapshots.first?.account.id, GrokAccount.defaultID.uuidString)
+        XCTAssertEqual(snapshots.first?.account.name, GrokAccount.defaultName)
+        XCTAssertFalse(QuotaEventSnapshotCatalog.flatProviders.contains(.grok))
     }
 
     func testCatalogUsesAggregateFallbackOnlyWhenOneEnabledAccountOwnsIt() {
@@ -58,18 +169,12 @@ final class QuotaEventServiceTests: XCTestCase {
 
         let single = QuotaEventSnapshotCatalog.snapshots(
             metrics: [.claudeCode: fallback],
-            claudeAccounts: [one],
-            claudeAccountMetrics: [:],
-            codexAccounts: [],
-            codexAccountMetrics: [:],
+            accounts: QuotaEventAccountInputs(claudeAccounts: [one]),
             enabledServices: [.claudeCode]
         )
         let ambiguous = QuotaEventSnapshotCatalog.snapshots(
             metrics: [.claudeCode: fallback],
-            claudeAccounts: [one, second],
-            claudeAccountMetrics: [:],
-            codexAccounts: [],
-            codexAccountMetrics: [:],
+            accounts: QuotaEventAccountInputs(claudeAccounts: [one, second]),
             enabledServices: [.claudeCode]
         )
 
@@ -114,6 +219,90 @@ final class QuotaEventServiceTests: XCTestCase {
         XCTAssertEqual(crossed.events.map(\.event), [.critical])
         XCTAssertEqual(crossed.diagnostics.count, 2)
         XCTAssertEqual(crossed.diagnostics.filter(\.succeeded).count, 1)
+    }
+
+    func testServiceEvaluatesGrokProfilesIndependentlyAndMigratesLegacyDefaultWithoutDuplicateDelivery() async {
+        var delivered: [QuotaEventPayload] = []
+        let engine = QuotaEventDeliveryEngine(handlers: QuotaEventDeliveryHandlers(
+            local: { payload, _ in
+                delivered.append(payload)
+                return .succeeded
+            },
+            webhook: { _, _ in .succeeded }
+        ))
+        let service = QuotaEventService(
+            planner: QuotaEventPlanner(debounceInterval: 0),
+            deliveryEngine: engine
+        )
+        let work = GrokAccount(
+            id: UUID(uuidString: "C3D4E5F6-A7B8-4901-8234-567890ABCDEF")!,
+            name: "Work",
+            homeDirectory: "/secret/grok-work"
+        )
+        let defaultAccount = QuotaEventAccount(
+            id: GrokAccount.defaultID.uuidString,
+            name: GrokAccount.defaultName
+        )
+        let workAccount = QuotaEventAccount(id: work.id.uuidString, name: work.name)
+        let configuration = QuotaEventIntegrationConfiguration(
+            localDeliveryEnabled: true,
+            localExecutablePath: "/usr/bin/true",
+            localArguments: [],
+            webhookDeliveryEnabled: false,
+            webhookURLString: "",
+            enabledQuotaEvents: [.warning, .critical, .exhausted, .recovered],
+            enabledProviders: [.grok],
+            enabledAccounts: [
+                QuotaEventAccountSelection(provider: .grok, accountID: "default"),
+                QuotaEventAccountSelection(provider: .grok, accountID: defaultAccount.id),
+                QuotaEventAccountSelection(provider: .grok, accountID: workAccount.id),
+            ],
+            enabledWakeEvents: []
+        )
+
+        let primed = await service.observe(
+            snapshots: [
+                QuotaEventSnapshot(
+                    provider: .grok,
+                    account: QuotaEventAccount(id: "default", name: "Grok"),
+                    metrics: usage(service: .grok, used: 50)
+                ),
+            ],
+            configuration: configuration,
+            now: now
+        )
+        delivered.removeAll()
+        let migratedSameBand = await service.observe(
+            snapshots: [
+                QuotaEventSnapshot(provider: .grok, account: defaultAccount, metrics: usage(service: .grok, used: 50)),
+                QuotaEventSnapshot(provider: .grok, account: workAccount, metrics: usage(service: .grok, used: 50)),
+            ],
+            configuration: configuration,
+            now: now.addingTimeInterval(1)
+        )
+        let crossed = await service.observe(
+            snapshots: [
+                QuotaEventSnapshot(provider: .grok, account: defaultAccount, metrics: usage(service: .grok, used: 91)),
+                QuotaEventSnapshot(provider: .grok, account: workAccount, metrics: usage(service: .grok, used: 76)),
+            ],
+            configuration: configuration,
+            now: now.addingTimeInterval(2)
+        )
+
+        XCTAssertTrue(primed.events.isEmpty)
+        XCTAssertTrue(migratedSameBand.events.isEmpty)
+        XCTAssertEqual(Set(crossed.events.map(\.account)), [defaultAccount, workAccount])
+        XCTAssertEqual(
+            crossed.events.first { $0.account == defaultAccount }?.event,
+            .critical
+        )
+        XCTAssertEqual(
+            crossed.events.first { $0.account == workAccount }?.event,
+            .warning
+        )
+        XCTAssertEqual(delivered.count, 2)
+        XCTAssertEqual(Set(delivered.map(\.account.id)), [defaultAccount.id, workAccount.id])
+        XCTAssertFalse(delivered.contains { $0.account.id == "default" })
     }
 
     private func snapshot(account: QuotaEventAccount, used: Double) -> QuotaEventSnapshot {

--- a/MeterBarTests/QuotaEventSettingsStoreTests.swift
+++ b/MeterBarTests/QuotaEventSettingsStoreTests.swift
@@ -103,6 +103,118 @@ final class QuotaEventSettingsStoreTests: XCTestCase {
         XCTAssertFalse(store.configuration.includes(wrongAccount))
     }
 
+    func testMigratesLegacyGrokDefaultSelectionWithoutDuplicatingTheDefaultProfile() throws {
+        let legacy = QuotaEventAccountSelection(provider: .grok, accountID: "default")
+        let defaultProfile = QuotaEventAccountSelection(
+            provider: .grok,
+            accountID: GrokAccount.defaultID.uuidString
+        )
+        let work = QuotaEventAccountSelection(
+            provider: .grok,
+            accountID: "C3D4E5F6-A7B8-4901-8234-567890ABCDEF"
+        )
+        let stored = QuotaEventIntegrationConfiguration(
+            localDeliveryEnabled: false,
+            localExecutablePath: "",
+            localArguments: [],
+            webhookDeliveryEnabled: true,
+            webhookURLString: "https://hooks.example.com/meterbar",
+            enabledQuotaEvents: [.warning, .critical],
+            enabledProviders: [.grok],
+            enabledAccounts: [legacy, defaultProfile, work],
+            enabledWakeEvents: []
+        )
+        defaults.set(try JSONEncoder().encode(stored), forKey: StorageKeys.quotaEventIntegrations)
+
+        let store = QuotaEventSettingsStore(userDefaults: defaults)
+        let reloaded = try JSONDecoder().decode(
+            QuotaEventIntegrationConfiguration.self,
+            from: try XCTUnwrap(defaults.data(forKey: StorageKeys.quotaEventIntegrations))
+        )
+
+        XCTAssertEqual(store.configuration.enabledAccounts, [defaultProfile, work])
+        XCTAssertEqual(reloaded.enabledAccounts, [defaultProfile, work])
+        XCTAssertTrue(store.configuration.includes(
+            payload(provider: .grok, accountID: GrokAccount.defaultID.uuidString, event: .critical)
+        ))
+        XCTAssertFalse(store.configuration.includes(
+            payload(provider: .grok, accountID: "default", event: .critical)
+        ))
+        XCTAssertTrue(store.configuration.includes(
+            payload(provider: .grok, accountID: work.accountID, event: .warning)
+        ))
+    }
+
+    func testLegacyGrokDefaultSelectionStillMatchesTheDefaultProfilePayload() {
+        let store = QuotaEventSettingsStore(userDefaults: defaults)
+        store.setQuotaEventEnabled(true, for: .exhausted)
+        store.setProviderEnabled(true, for: .grok)
+        store.setAccountEnabled(true, for: QuotaEventAccountSelection(provider: .grok, accountID: "default"))
+
+        XCTAssertTrue(store.configuration.includes(
+            payload(provider: .grok, accountID: GrokAccount.defaultID.uuidString, event: .exhausted)
+        ))
+        XCTAssertFalse(store.configuration.includes(
+            payload(
+                provider: .grok,
+                accountID: "C3D4E5F6-A7B8-4901-8234-567890ABCDEF",
+                event: .exhausted
+            )
+        ))
+    }
+
+    func testStaleGrokAccountSelectionIsIgnoredAfterTheProfileLeavesTheCatalog() {
+        let removed = GrokAccount(
+            id: UUID(uuidString: "C3D4E5F6-A7B8-4901-8234-567890ABCDEF")!,
+            name: "Work",
+            homeDirectory: "/secret/grok-work"
+        )
+        let store = QuotaEventSettingsStore(userDefaults: defaults)
+        store.setQuotaEventEnabled(true, for: .critical)
+        store.setProviderEnabled(true, for: .grok)
+        store.setAccountEnabled(
+            true,
+            for: QuotaEventAccountSelection(provider: .grok, accountID: removed.id.uuidString)
+        )
+
+        let remaining = QuotaEventSnapshotCatalog.snapshots(
+            metrics: [:],
+            accounts: QuotaEventAccountInputs(
+                grokAccounts: [.defaultAccount],
+                grokAccountMetrics: [GrokAccount.defaultID: payloadMetrics()]
+            ),
+            enabledServices: [.grok]
+        )
+        let selectable = QuotaEventSnapshotCatalog.selectableAccounts(
+            claudeAccounts: [],
+            codexAccounts: [],
+            grokAccounts: [.defaultAccount]
+        )
+
+        XCTAssertFalse(remaining.contains { $0.account.id == removed.id.uuidString })
+        XCTAssertFalse(selectable.contains { $0.accountID == removed.id.uuidString })
+        XCTAssertTrue(store.configuration.enabledAccounts.contains {
+            $0.accountID == removed.id.uuidString
+        })
+        XCTAssertFalse(remaining.contains { snapshot in
+            store.configuration.includes(
+                payload(provider: snapshot.provider, accountID: snapshot.account.id, event: .critical)
+            )
+        })
+    }
+
+    private func payloadMetrics() -> UsageMetrics {
+        UsageMetrics(
+            service: .grok,
+            sessionLimit: UsageLimit(
+                used: 50,
+                total: 100,
+                resetTime: Date(timeIntervalSince1970: 1_800_003_600)
+            ),
+            lastUpdated: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+    }
+
     private func payload(
         provider: ServiceType,
         accountID: String,

--- a/MeterBarTests/QuotaWebhookClientTests.swift
+++ b/MeterBarTests/QuotaWebhookClientTests.swift
@@ -138,6 +138,49 @@ final class QuotaWebhookClientTests: XCTestCase {
         XCTAssertEqual(result, .succeeded)
     }
 
+    func testGrokAccountPayloadOmitsHomeTokenAndRawProviderOutput() async throws {
+        let client = makeClient()
+        let url = try XCTUnwrap(QuotaWebhookURLPolicy.validatedURL("https://hooks.example.com/meterbar"))
+        let payload = QuotaEventPayload(
+            provider: .grok,
+            account: QuotaEventAccount(id: GrokAccount.defaultID.uuidString, name: "Work"),
+            event: .warning,
+            window: .weekly,
+            percentage: 76,
+            band: .tight,
+            timestamp: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        StubURLProtocol.handler = { request in
+            let body = try XCTUnwrap(Self.bodyData(from: request))
+            let text = String(decoding: body, as: UTF8.self)
+            let object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            XCTAssertEqual(
+                Set(object.keys),
+                ["schema_version", "provider", "account", "event", "window", "percentage", "band", "timestamp"]
+            )
+            XCTAssertEqual(object["provider"] as? String, ServiceType.grok.rawValue)
+            let account = try XCTUnwrap(object["account"] as? [String: Any])
+            XCTAssertEqual(Set(account.keys), ["id", "name"])
+            XCTAssertEqual(account["id"] as? String, GrokAccount.defaultID.uuidString)
+            XCTAssertFalse(text.contains("GROK_HOME"))
+            XCTAssertFalse(text.contains("homeDirectory"))
+            XCTAssertFalse(text.contains("/secret/"))
+            XCTAssertFalse(text.localizedCaseInsensitiveContains("token"))
+            XCTAssertFalse(text.contains("auth.json"))
+            XCTAssertFalse(text.contains("_x.ai/billing"))
+            XCTAssertFalse(text.contains("GetRemainingResets"))
+
+            return (
+                try XCTUnwrap(HTTPURLResponse(url: url, statusCode: 204, httpVersion: nil, headerFields: nil)),
+                Data()
+            )
+        }
+
+        let result = await client.post(payload: payload, to: url)
+        XCTAssertEqual(result, .succeeded)
+    }
+
     func testTransportAndHTTPFailuresReturnSafeNonfatalResultsWithoutResponseBodies() async throws {
         let client = makeClient()
         let url = try XCTUnwrap(QuotaWebhookURLPolicy.validatedURL("https://hooks.example.com/meterbar"))

--- a/docs/quota-event-webhooks.md
+++ b/docs/quota-event-webhooks.md
@@ -32,7 +32,7 @@ Fields:
 |---|---|---|
 | `schema_version` | integer | Current major version: `1` |
 | `provider` | string | `Claude Code`, `Codex CLI`, `Cursor`, `OpenRouter`, or `Grok` |
-| `account.id` | string | Account UUID, or `default` for a single-account provider |
+| `account.id` | string | Account UUID for Claude Code, Codex CLI, and Grok profiles, or `default` for a single-account provider |
 | `account.name` | string | The user-visible account or provider name |
 | `event` | string | `warning`, `critical`, `exhausted`, or `recovered` |
 | `window` | string | `session`, `weekly`, or `code_review` |
@@ -53,16 +53,21 @@ MeterBar derives events from its shared quota bands:
 - `exhausted`: reaches 0% remaining.
 - `recovered`: returns to Healthy (more than 25% remaining).
 
-Each provider/account/window is tracked independently. The first observation
+Each provider/account/window is tracked independently. Claude Code, Codex CLI,
+and Grok evaluate every enabled profile on its own. A provider-wide `Grok` /
+`default` selection from earlier releases maps to the default Grok profile UUID
+and does not also emit a second provider-wide event. The first observation
 primes state; it does not replay cached status as a new event. Repeated states
 are deduplicated, rapid same-event flapping is debounced, and dropping out of a
-band re-arms the next genuine crossing.
+band re-arms the next genuine crossing. Disabled or removed profiles leave the
+catalog so their planner namespace is dropped; a later re-enable primes again
+instead of replaying a stale crossing.
 
 ## Privacy and network boundary
 
 The payload never contains provider credentials, API keys, tokens,
-`CLAUDE_CONFIG_DIR`, `CODEX_HOME`, or other configuration paths. MeterBar sends
-only the fields documented above.
+`CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `GROK_HOME`, or other configuration paths.
+MeterBar sends only the fields documented above.
 
 Webhook URLs must use HTTPS on port 443 with no embedded credentials or
 fragment. Literal loopback, link-local, private, multicast, single-label LAN,


### PR DESCRIPTION
## Summary

Quota hooks and webhooks now treat Grok like Claude and Codex: every enabled profile is its own selectable account, with independent warning/critical/exhausted/recovered evaluation per profile and window.

- Remove Grok from `QuotaEventSnapshotCatalog.flatProviders` and route it through `accountSnapshots` with `GrokAccountStore` + `grokAccountMetrics`.
- Event Integrations lists each enabled Grok profile by stable UUID and name.
- The coordinator observes Grok add/rename/enable/disable so planner namespaces re-prime instead of replaying stale crossings.
- Existing `Grok/default` selections migrate to the default Grok profile UUID and do not double-deliver.
- Public webhook schema, secret/path sanitization, and period mapping are unchanged.

## Related issue

Fixes #459

## Scope

- Shared catalog/identity only. Native threshold notifications remain #458.
- Period mapping is unchanged.
- Payload still contains only the documented version-1 fields. No `GROK_HOME`, token, or raw provider output.

## Verification

- `swift test --filter 'QuotaEvent|QuotaWebhook'` — 31 passed
- `swift test` at worktree root — 2462 passed, 5 skipped
- `swiftlint lint --strict` on the four production files — 0 violations

Broader CI (app/widget/CLI builds, coverage, CodeRabbit) left to GitHub.

## Screenshots

Not applicable. Settings account rows reuse the existing Event Integrations toggles; no visual chrome change.

## Checklist

- [x] I reviewed the final diff for unrelated changes.
- [x] I ran the relevant focused checks or documented why they were left to CI.
- [x] I updated relevant documentation or explained why no documentation change is needed.
- [x] I documented migrations, release steps, or external configuration changes, or marked them not applicable.
- [x] I did not include secrets, credentials, personal data, customer data, or generated build output.
- [x] If CodeRabbit says "Review rate limited", I re-requested review before merge. A green CodeRabbit tick is not a review in that case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbound quota event identity, persistence migration, and delivery scoping for Grok; incorrect migration or matching could miss or duplicate notifications, though behavior is heavily tested and the webhook schema stays version 1.
> 
> **Overview**
> **Grok quota events are now per-profile**, aligned with Claude Code and Codex CLI: hooks, webhooks, and Event Integrations treat each enabled Grok profile as its own account with independent band transitions per window.
> 
> Grok is removed from the flat provider catalog and built through shared `QuotaEventAccountInputs` / `accountSnapshots`, fed by `GrokAccountStore` and `grokAccountMetrics`. The coordinator also watches Grok account changes so planner namespaces re-prime when profiles are added, renamed, enabled, or removed.
> 
> Event Integrations account rows come from `QuotaEventSelectableAccount` / `selectableAccounts`, listing enabled Grok profiles by stable UUID and display name. **Legacy `Grok` / `default` opt-ins** are normalized to the default profile UUID on load and when toggling accounts; `matches` keeps delivery working without duplicate events when the planner namespace moves from `default` to that UUID.
> 
> Docs note per-profile Grok semantics and that payloads still exclude `GROK_HOME` and other secrets. Tests cover catalog behavior, planner migration, settings persistence, and secret-free local/webhook delivery for Grok.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44babd9848b2de06da25e20f17c7b94a9b6ed6d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->