### PR TITLE
fix(cost): publish honest progress for deferred files

### DIFF
--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -337,7 +337,6 @@ enum ClaudeCostScanner {
                 guard let totals = Self.totals(for: file, projectID: projectID, session: session) else {
                     continue
                 }
-                session.noteProcessedFile()
                 guard windows.fold(period: totals.period, lifetime: totals.lifetime) else {
                     // This file shares only *some* of its events with one
                     // already folded in — a stale copy holding a prefix of the
@@ -435,6 +434,7 @@ enum ClaudeCostScanner {
         // Nothing appended since the last pass. This is the steady state once
         // the corpus is warm, and it is why a refresh costs almost no I/O.
         if let record, record.isComplete, record.stamp.matches(file.stamp) {
+            session.noteProcessedFile()
             return Self.windows(
                 record.payload,
                 cutoff: session.cutoff,
@@ -523,6 +523,7 @@ enum ClaudeCostScanner {
             for: file.cacheKey,
             provider: .claude
         )
+        session.noteProcessedFile()
         return Self.windows(payload, cutoff: session.cutoff, hourlyCutoff: session.hourlyCutoff)
     }
 

--- a/MeterBar/Services/ClaudeCostScanner.swift
+++ b/MeterBar/Services/ClaudeCostScanner.swift
@@ -523,7 +523,11 @@ enum ClaudeCostScanner {
             for: file.cacheKey,
             provider: .claude
         )
-        session.noteProcessedFile()
+        session.noteProcessedFile(
+            consumed: read.reachedEndOfFile,
+            committedOffset: read.committedOffset,
+            fileSize: file.size
+        )
         return Self.windows(payload, cutoff: session.cutoff, hourlyCutoff: session.hourlyCutoff)
     }
 

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -472,7 +472,11 @@ enum CodexCostScanner {
             for: file.cacheKey,
             provider: .codex
         )
-        session.noteProcessedFile()
+        session.noteProcessedFile(
+            consumed: read.reachedEndOfFile,
+            committedOffset: committed,
+            fileSize: file.size
+        )
         return payload
     }
 

--- a/MeterBar/Services/CodexCostScanner.swift
+++ b/MeterBar/Services/CodexCostScanner.swift
@@ -326,7 +326,6 @@ enum CodexCostScanner {
         for file in listing.files {
             coverage.keep(file.cacheKey)
             guard let totals = Self.totals(for: file, session: session) else { continue }
-            session.noteProcessedFile()
             guard windows.fold(period: totals.period, lifetime: totals.lifetime) else {
                 // This rollout shares only *some* of its events with one already
                 // folded in. Aggregates cannot be de-overlapped after the fact,
@@ -373,6 +372,7 @@ enum CodexCostScanner {
 
         // Nothing appended since the last pass.
         if let record, record.isComplete, record.stamp.matches(file.stamp) {
+            session.noteProcessedFile()
             return record.payload
         }
 
@@ -472,6 +472,7 @@ enum CodexCostScanner {
             for: file.cacheKey,
             provider: .codex
         )
+        session.noteProcessedFile()
         return payload
     }
 

--- a/MeterBar/Services/CostScanProgress.swift
+++ b/MeterBar/Services/CostScanProgress.swift
@@ -37,7 +37,13 @@ nonisolated struct CostScanProgress: Equatable, Sendable {
 
     var fraction: Double? {
         guard listedFiles > 0 else { return nil }
-        return min(1, Double(processedFiles) / Double(listedFiles))
+        if isComplete { return 1 }
+        // Deferred or still-open files can make processedFiles catch listedFiles
+        // before the refresh is done. Never report 100% in that state.
+        return min(
+            Double(processedFiles) / Double(listedFiles),
+            Double(listedFiles - 1) / Double(listedFiles)
+        )
     }
 
     var formattedListedSize: String { Self.formatBytes(listedBytes) }

--- a/MeterBar/Services/CostScanSession.swift
+++ b/MeterBar/Services/CostScanSession.swift
@@ -139,9 +139,9 @@ nonisolated final class CostScanSession: @unchecked Sendable {
         handler?(snapshot)
     }
 
-    /// Count only files this slice actually finished — a cache hit or a read.
-    /// Files skipped because the budget ran out stay uncounted so the banner
-    /// cannot report 100% on an incomplete refresh.
+    /// Count a file this slice actually handled — a warm cache hit or a read.
+    /// Files skipped because the budget ran out stay uncounted, even when a
+    /// cached partial payload is reused so the summary does not drop them.
     func noteProcessedFile() {
         lock.lock()
         processedFiles += 1

--- a/MeterBar/Services/CostScanSession.swift
+++ b/MeterBar/Services/CostScanSession.swift
@@ -139,9 +139,15 @@ nonisolated final class CostScanSession: @unchecked Sendable {
         handler?(snapshot)
     }
 
-    /// Count a file this slice actually handled — a warm cache hit or a read.
-    /// Files skipped because the budget ran out stay uncounted, even when a
-    /// cached partial payload is reused so the summary does not drop them.
+    /// Count a file only when this slice finished it — a warm complete cache
+    /// hit, or a read that consumed the whole file. Mid-file and skipped files
+    /// still fold their totals into the summary, but stay off `processedFiles`
+    /// so the banner cannot say "1 of 1" for an unfinished file.
+    func noteProcessedFile(consumed reachedEndOfFile: Bool, committedOffset: UInt64, fileSize: Int) {
+        guard reachedEndOfFile || committedOffset >= UInt64(max(0, fileSize)) else { return }
+        noteProcessedFile()
+    }
+
     func noteProcessedFile() {
         lock.lock()
         processedFiles += 1

--- a/MeterBar/Services/GrokCostScanner.swift
+++ b/MeterBar/Services/GrokCostScanner.swift
@@ -132,7 +132,6 @@ enum GrokCostScanner {
             for file in listing.files {
                 guard coverage.keep(file.cacheKey) else { continue }
                 guard let totals = Self.totals(for: file, session: session) else { continue }
-                session.noteProcessedFile()
                 guard windows.fold(period: totals.period, lifetime: totals.lifetime) else {
                     // This file shares only *some* of its events with one
                     // already folded in — a stale copy holding a prefix of the
@@ -277,6 +276,7 @@ enum GrokCostScanner {
 
         // Nothing appended since the last pass.
         if let record, record.isComplete, record.stamp.matches(file.stamp) {
+            session.noteProcessedFile()
             return record.payload
         }
 
@@ -334,6 +334,7 @@ enum GrokCostScanner {
             for: file.cacheKey,
             provider: .grok
         )
+        session.noteProcessedFile()
         return payload
     }
 

--- a/MeterBar/Services/GrokCostScanner.swift
+++ b/MeterBar/Services/GrokCostScanner.swift
@@ -334,7 +334,11 @@ enum GrokCostScanner {
             for: file.cacheKey,
             provider: .grok
         )
-        session.noteProcessedFile()
+        session.noteProcessedFile(
+            consumed: read.reachedEndOfFile,
+            committedOffset: read.committedOffset,
+            fileSize: file.size
+        )
         return payload
     }
 

--- a/MeterBarTests/CostScanWindowOnlyTests.swift
+++ b/MeterBarTests/CostScanWindowOnlyTests.swift
@@ -205,6 +205,147 @@ final class CostScanWindowOnlyTests: XCTestCase {
         let last = try XCTUnwrap(seen.snapshots.last)
         XCTAssertEqual(last.processedFiles, 2)
         XCTAssertTrue(last.isComplete)
+        XCTAssertEqual(try XCTUnwrap(last.fraction), 1.0, accuracy: 0.000_001)
+    }
+
+    func testFractionNeverReachesOneWhileTheScanIsIncomplete() {
+        var progress = CostScanProgress(windowDays: 30)
+        progress.listedFiles = 1
+        progress.processedFiles = 1
+        progress.isComplete = false
+
+        XCTAssertLessThan(try XCTUnwrap(progress.fraction), 1)
+
+        progress.listedFiles = 4
+        progress.processedFiles = 4
+        XCTAssertLessThan(try XCTUnwrap(progress.fraction), 1)
+
+        progress.isComplete = true
+        XCTAssertEqual(try XCTUnwrap(progress.fraction), 1)
+    }
+
+    /// A single file the byte budget cannot finish is still a read, so it
+    /// counts as processed — but that must not push `fraction` to 1.0 while
+    /// `isComplete` is false.
+    func testPartialReadDoesNotReportCompleteProgress() throws {
+        let root = try makeCorpusDirectory()
+        let first = claudeEventLine(messageID: "a")
+        let second = claudeEventLine(messageID: "b")
+        try writeClaudeLines(in: root, name: "partial.jsonl", lines: [first, second], modifiedAgo: 0)
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let budget = CostScanBudgetOptions(
+            maxBytesPerFile: .max,
+            maxNewBytesPerRefresh: first.utf8.count + 1,
+            wallClock: nil
+        )
+        let session = CostScanSession(cutoff: cutoff, options: budget)
+
+        let windows = ClaudeCostScanner.scanRoots([root], session: session)
+        let progress = session.progress(windowDays: 30)
+
+        XCTAssertFalse(session.isComplete)
+        XCTAssertEqual(progress.listedFiles, 1)
+        XCTAssertEqual(progress.processedFiles, 1)
+        XCTAssertFalse(progress.isComplete)
+        XCTAssertLessThan(try XCTUnwrap(progress.fraction), 1)
+        XCTAssertEqual(windows.period.input, 100)
+    }
+
+    /// Cached incomplete records still return a payload when the next slice
+    /// has no budget left. Counting those as processed reports 100% on a
+    /// refresh that read nothing new.
+    func testDeferredCachedFileDoesNotCountAsProcessed() throws {
+        let root = try makeCorpusDirectory()
+        let first = claudeEventLine(messageID: "a")
+        let second = claudeEventLine(messageID: "b")
+        try writeClaudeLines(in: root, name: "partial.jsonl", lines: [first, second], modifiedAgo: 0)
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let store = try makeScanCacheStore()
+        let firstBudget = CostScanBudgetOptions(
+            maxBytesPerFile: .max,
+            maxNewBytesPerRefresh: first.utf8.count + 1,
+            wallClock: nil
+        )
+
+        let firstSlice = CostScanSession(cutoff: cutoff, options: firstBudget, store: store)
+        _ = ClaudeCostScanner.scanRoots([root], session: firstSlice)
+        XCTAssertEqual(firstSlice.persist(), .persisted)
+        XCTAssertFalse(firstSlice.isComplete)
+
+        let emptyBudget = CostScanBudgetOptions(
+            maxBytesPerFile: .max,
+            maxNewBytesPerRefresh: 0,
+            wallClock: nil
+        )
+        let secondSlice = CostScanSession(cutoff: cutoff, options: emptyBudget, store: store)
+        _ = ClaudeCostScanner.scanRoots([root], session: secondSlice)
+        let progress = secondSlice.progress(windowDays: 30)
+
+        XCTAssertFalse(secondSlice.isComplete)
+        XCTAssertEqual(progress.listedFiles, 1)
+        XCTAssertEqual(progress.processedFiles, 0)
+        XCTAssertFalse(progress.isComplete)
+        XCTAssertLessThan(try XCTUnwrap(progress.fraction), 1)
+    }
+
+    func testWarmCacheHitsCountAsProcessedOnACompletedSlice() throws {
+        let root = try makeCorpusDirectory()
+        try writeClaudeTranscript(in: root, name: "a.jsonl", messageID: "a", modifiedAgo: 0)
+        try writeClaudeTranscript(in: root, name: "b.jsonl", messageID: "b", modifiedAgo: 1)
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let store = try makeScanCacheStore()
+
+        let first = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        _ = ClaudeCostScanner.scanRoots([root], session: first)
+        XCTAssertEqual(first.persist(), .persisted)
+        XCTAssertTrue(first.isComplete)
+
+        let second = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
+        _ = ClaudeCostScanner.scanRoots([root], session: second)
+        let progress = second.progress(windowDays: 30)
+
+        XCTAssertTrue(second.isComplete)
+        XCTAssertEqual(progress.listedFiles, 2)
+        XCTAssertEqual(progress.processedFiles, 2)
+        XCTAssertTrue(progress.isComplete)
+        XCTAssertEqual(try XCTUnwrap(progress.fraction), 1.0, accuracy: 0.000_001)
+    }
+
+    /// `CostTracker.makeCostSummary` drives one slice through `makeScan` plus
+    /// `observeProgress`. A completed single-slice refresh must publish the
+    /// listing (files + bytes, processed == 0) before the finished snapshot.
+    func testSingleSliceRefreshPublishesListingBeforeCompletion() throws {
+        let root = try makeCorpusDirectory()
+        try writeClaudeTranscript(in: root, name: "a.jsonl", messageID: "a", modifiedAgo: 0)
+        try writeClaudeTranscript(in: root, name: "b.jsonl", messageID: "b", modifiedAgo: 1)
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-06-01T00:00:00Z"))
+        let seen = CostScanProgressLog()
+        let session = CostScanSession(cutoff: cutoff, options: .unlimited)
+        session.observeProgress(windowDays: 30, seen.append)
+
+        let scan = CostSummaryBuilder.makeScan(
+            days: 30,
+            enabledProviders: [.claude],
+            claudeAccounts: [],
+            grokAccounts: [],
+            session: session,
+            claudeProjectRoots: [root]
+        )
+
+        XCTAssertTrue(scan.isComplete)
+        XCTAssertNil(scan.summary.lifetime)
+
+        let first = try XCTUnwrap(seen.snapshots.first)
+        XCTAssertEqual(first.listedFiles, 2)
+        XCTAssertEqual(first.processedFiles, 0)
+        XCTAssertGreaterThan(first.listedBytes, 0)
+        XCTAssertFalse(first.isComplete)
+        XCTAssertEqual(try XCTUnwrap(first.fraction), 0, accuracy: 0.000_001)
+
+        let last = try XCTUnwrap(seen.snapshots.last)
+        XCTAssertEqual(last.processedFiles, 2)
+        XCTAssertTrue(last.isComplete)
+        XCTAssertEqual(try XCTUnwrap(last.fraction), 1.0, accuracy: 0.000_001)
     }
 
     // MARK: - Fixtures
@@ -230,19 +371,45 @@ final class CostScanWindowOnlyTests: XCTestCase {
         messageID: String,
         modifiedAgo: TimeInterval
     ) throws -> URL {
-        let line = """
-        {"timestamp": "2026-07-01T10:00:00.000Z", "requestId": "req_\(messageID)", \
-        "message": {"id": "msg_\(messageID)", "model": "claude-sonnet-4-5", \
-        "usage": {"input_tokens": 100, "output_tokens": 10, \
-        "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}}
-        """
+        try writeClaudeLines(
+            in: root,
+            name: name,
+            lines: [claudeEventLine(messageID: messageID)],
+            modifiedAgo: modifiedAgo
+        )
+    }
+
+    @discardableResult
+    private func writeClaudeLines(
+        in root: URL,
+        name: String,
+        lines: [String],
+        modifiedAgo: TimeInterval
+    ) throws -> URL {
         let url = root.appendingPathComponent(name)
-        try (line + "\n").write(to: url, atomically: true, encoding: .utf8)
+        try (lines.joined(separator: "\n") + "\n").write(to: url, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes(
             [.modificationDate: Date().addingTimeInterval(-modifiedAgo)],
             ofItemAtPath: url.path
         )
         return url
+    }
+
+    private func claudeEventLine(messageID: String) -> String {
+        """
+        {"timestamp": "2026-07-01T10:00:00.000Z", "requestId": "req_\(messageID)", \
+        "message": {"id": "msg_\(messageID)", "model": "claude-sonnet-4-5", \
+        "usage": {"input_tokens": 100, "output_tokens": 10, \
+        "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}}
+        """
+    }
+
+    private func makeScanCacheStore() throws -> CostScanCacheStore {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CostScanWindowCache-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        return CostScanCacheStore(directory: directory)
     }
 
     private func fileSize(_ url: URL) throws -> Int {

--- a/MeterBarTests/CostScanWindowOnlyTests.swift
+++ b/MeterBarTests/CostScanWindowOnlyTests.swift
@@ -224,10 +224,10 @@ final class CostScanWindowOnlyTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(progress.fraction), 1)
     }
 
-    /// A single file the byte budget cannot finish is still a read, so it
-    /// counts as processed — but that must not push `fraction` to 1.0 while
-    /// `isComplete` is false.
-    func testPartialReadDoesNotReportCompleteProgress() throws {
+    /// A single file the byte budget cannot finish is not processed. Counting
+    /// it would make the banner say "Scanning 1 of 1 files" while the only
+    /// file is still open, and force the bar back to 0% via the incomplete cap.
+    func testPartialReadDoesNotReportOneOfOneAsProcessed() throws {
         let root = try makeCorpusDirectory()
         let first = claudeEventLine(messageID: "a")
         let second = claudeEventLine(messageID: "b")
@@ -245,8 +245,10 @@ final class CostScanWindowOnlyTests: XCTestCase {
 
         XCTAssertFalse(session.isComplete)
         XCTAssertEqual(progress.listedFiles, 1)
-        XCTAssertEqual(progress.processedFiles, 1)
+        XCTAssertEqual(progress.processedFiles, 0)
         XCTAssertFalse(progress.isComplete)
+        XCTAssertFalse(progress.statusText.contains("1 of 1"))
+        XCTAssertTrue(progress.statusText.hasPrefix("Scanning 1 files"))
         XCTAssertLessThan(try XCTUnwrap(progress.fraction), 1)
         XCTAssertEqual(windows.period.input, 100)
     }

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -1227,12 +1227,64 @@ final class CostTrackerTests: XCTestCase {
 
         XCTAssertFalse(first.isComplete)
         XCTAssertEqual(firstWindows.period.totals.input, 100)
+        let firstProgress = first.progress(windowDays: 30)
+        XCTAssertEqual(firstProgress.listedFiles, 1)
+        XCTAssertEqual(firstProgress.processedFiles, 1)
+        XCTAssertFalse(firstProgress.isComplete)
+        XCTAssertLessThan(try XCTUnwrap(firstProgress.fraction), 1)
 
         let second = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)
         let resumed = CodexCostScanner.scanRollouts(directories: [directory], session: second)
 
         XCTAssertTrue(second.isComplete)
         XCTAssertEqual(resumed.period.totals.input, 150)
+        let completed = second.progress(windowDays: 30)
+        XCTAssertEqual(completed.processedFiles, 1)
+        XCTAssertTrue(completed.isComplete)
+        XCTAssertEqual(try XCTUnwrap(completed.fraction), 1.0, accuracy: 0.000_001)
+    }
+
+    func testUnreadCodexFilesAreNotCountedAsProcessed() throws {
+        let root = try makeCodexHome()
+        let newestLines = [
+            codexTurnContextLine(timestamp: "2026-06-15T09:01:00Z", model: "gpt-5.6-sol"),
+            codexUsageLine(timestamp: "2026-06-15T09:02:00Z", conversationID: "conv-new", input: 100)
+        ]
+        let oldestLines = [
+            codexTurnContextLine(timestamp: "2026-06-15T08:01:00Z", model: "gpt-5.6-sol"),
+            codexUsageLine(timestamp: "2026-06-15T08:02:00Z", conversationID: "conv-old", input: 25)
+        ]
+        let newest = try writeCodexRollout(
+            in: root,
+            path: "sessions/\(codexRolloutName(sessionID: UUID()))",
+            modifiedAgo: 0,
+            lines: newestLines
+        )
+        try writeCodexRollout(
+            in: root,
+            path: "archived_sessions/\(codexRolloutName(sessionID: UUID()))",
+            modifiedAgo: 60,
+            lines: oldestLines
+        )
+        let cutoff = try XCTUnwrap(FlexibleISO8601.date(from: "2026-01-01T00:00:00Z"))
+        let budget = CostScanBudgetOptions(
+            maxBytesPerFile: .max,
+            maxNewBytesPerRefresh: try fileSize(newest),
+            wallClock: nil
+        )
+        let session = CostScanSession(cutoff: cutoff, options: budget)
+
+        _ = CodexCostScanner.scanRollouts(
+            directories: CodexCostScanner.rolloutDirectories(in: root),
+            session: session
+        )
+        let progress = session.progress(windowDays: 30)
+
+        XCTAssertFalse(session.isComplete)
+        XCTAssertEqual(progress.listedFiles, 2)
+        XCTAssertEqual(progress.processedFiles, 1)
+        XCTAssertEqual(try XCTUnwrap(progress.fraction), 0.5, accuracy: 0.000_001)
+        XCTAssertFalse(progress.isComplete)
     }
 
     func testBudgetedCodexScanRollsBackCumulativeBaselineWithDeferredUsage() throws {
@@ -1976,6 +2028,35 @@ final class CostTrackerTests: XCTestCase {
         let tracker = CostTracker(demoMode: true)
         tracker.lastScanDate = lastScan
         return tracker
+    }
+
+    /// Listing milestones hop off the scan queue onto the main actor so a
+    /// one-slice refresh can show file count and bytes while work is still
+    /// running — the CostTracker wiring for issue #438.
+    func testProgressBridgePublishesListingOnTheMainActor() {
+        let tracker = CostTracker(demoMode: true)
+        let bridge = CostScanProgressBridge(tracker: tracker)
+        let listed = CostScanProgress(
+            windowDays: 30,
+            listedFiles: 4,
+            listedBytes: 2_048,
+            processedFiles: 0,
+            isComplete: false
+        )
+        let published = expectation(description: "listing progress reaches the tracker")
+
+        bridge.publish(listed)
+
+        DispatchQueue.main.async {
+            XCTAssertEqual(tracker.scanProgress?.listedFiles, 4)
+            XCTAssertEqual(tracker.scanProgress?.listedBytes, 2_048)
+            XCTAssertEqual(tracker.scanProgress?.processedFiles, 0)
+            XCTAssertFalse(tracker.scanProgress?.isComplete ?? true)
+            XCTAssertEqual(tracker.scanProgress?.fraction ?? -1, 0, accuracy: 0.000_001)
+            published.fulfill()
+        }
+
+        wait(for: [published], timeout: 1)
     }
 
     @MainActor

--- a/MeterBarTests/CostTrackerTests.swift
+++ b/MeterBarTests/CostTrackerTests.swift
@@ -1229,8 +1229,9 @@ final class CostTrackerTests: XCTestCase {
         XCTAssertEqual(firstWindows.period.totals.input, 100)
         let firstProgress = first.progress(windowDays: 30)
         XCTAssertEqual(firstProgress.listedFiles, 1)
-        XCTAssertEqual(firstProgress.processedFiles, 1)
+        XCTAssertEqual(firstProgress.processedFiles, 0)
         XCTAssertFalse(firstProgress.isComplete)
+        XCTAssertFalse(firstProgress.statusText.contains("1 of 1"))
         XCTAssertLessThan(try XCTUnwrap(firstProgress.fraction), 1)
 
         let second = CostScanSession(cutoff: cutoff, options: .unlimited, store: store)


### PR DESCRIPTION
## Summary

Deferred files no longer make the Costs banner report 100% on an unfinished refresh.

PR #437 listed files and published progress, but two review findings remained:

1. A file skipped because the byte budget was already spent still returned its cached partial payload, and that return was counted as processed. One remaining file then made `CostScanProgress.fraction` hit **1.0** while `isComplete` was false.
2. A single-slice refresh needed listing (file count + bytes) on the main actor before the slice finished. The `CostScanProgressBridge` hop already existed; it had no test.

## Related issue

Fixes #438

## Scope

- Count a file toward `processedFiles` only on a warm cache hit or an actual read. Skipped files still contribute cached totals to the summary, but they stay off the banner.
- `CostScanProgress.fraction` never returns 1.0 unless `isComplete` is true.
- Claude, Codex, and Grok share the same progress seam. Scan window, cancellation, and persist semantics are unchanged.

## Verification

- `swift test --filter 'CostScan|CostTracker|GrokCost|CostSummary|LifetimeCost'` — 263 passed
- `swift test` at worktree root — 2458 tests, 5 skipped, 0 failures

## Screenshots

Not applicable — progress accounting only. Banner copy is unchanged except that it can no longer claim 100% on an incomplete refresh.

## Checklist

- [x] I reviewed the final diff for unrelated changes.
- [x] I ran the relevant focused checks or documented why they were left to CI.
- [x] I updated relevant documentation or explained why no documentation change is needed.
- [x] I documented migrations, release steps, or external configuration changes, or marked them not applicable.
- [x] I did not include secrets, credentials, personal data, customer data, or generated build output.
- [x] If CodeRabbit says "Review rate limited", I re-requested review before merge. A green CodeRabbit tick is not a review in that case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/progress accounting only; scan totals and persist behavior are unchanged aside from when files increment processedFiles.
> 
> **Overview**
> Fixes the Costs scan banner reporting **100%** or **“1 of 1”** while a refresh is still incomplete.
> 
> **Processed-file counting** moves from “returned totals from `totals(for:)`” to **only** incrementing `processedFiles` on a warm complete cache hit or after a read that **fully consumed** the file (`noteProcessedFile(consumed:committedOffset:fileSize:)`). Budget-deferred files, partial reads, and zero-budget slices that only replay cached partial payloads still contribute to cost totals but no longer bump the processed count. Claude, Codex, and Grok scanners share the same call sites.
> 
> **`CostScanProgress.fraction`** returns **1** only when `isComplete` is true; otherwise it caps below 100% so `processedFiles == listedFiles` cannot show a full bar on an unfinished slice.
> 
> Tests cover partial/deferred/cached paths, warm-cache completion, listing-before-finish via `makeScan`, and **`CostScanProgressBridge`** publishing listing snapshots on the main actor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f6c4ca4f058deb1377a6a529c796f9c10df0145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->