### PR TITLE
fix(grok): preserve reported quota cadence and period identity

### DIFF
--- a/MeterBar/Guard/GuardCLIResponse.swift
+++ b/MeterBar/Guard/GuardCLIResponse.swift
@@ -17,6 +17,7 @@ nonisolated struct GuardCLIResponse: CLIJSONDocument {
     private let provider: String?
     private let displayName: String?
     private let window: String?
+    private let periodKind: String?
     private let account: Account?
     private let used: Double?
     private let total: Double?
@@ -37,6 +38,7 @@ nonisolated struct GuardCLIResponse: CLIJSONDocument {
         provider = evaluation.service?.cliIdentifier
         displayName = evaluation.service?.displayName
         window = evaluation.window?.cliIdentifier
+        periodKind = evaluation.periodKind?.rawValue
         account = evaluation.account.map(Account.init(account:))
         used = evaluation.quota?.used
         total = evaluation.quota?.total

--- a/MeterBar/Guard/QuotaGuardEvaluator.swift
+++ b/MeterBar/Guard/QuotaGuardEvaluator.swift
@@ -43,6 +43,7 @@ nonisolated struct QuotaGuardEvaluation: Sendable {
     let checkedAt: Date
     let service: ServiceType?
     let window: QuotaGuardWindow?
+    let periodKind: UsageLimit.PeriodKind?
     let account: QuotaGuardAccount?
     let minRemainingPercent: Double?
     let quota: QuotaGuardQuota?
@@ -60,7 +61,8 @@ nonisolated struct QuotaGuardEvaluation: Sendable {
     var summaryLine: String {
         var parts = ["Guard: \(outcome.rawValue)"]
         if let service {
-            parts.append([service.displayName, window?.displayName].compactMap { $0 }.joined(separator: " "))
+            let cadence = periodKind?.guardDisplayName ?? window?.displayName
+            parts.append([service.displayName, cadence].compactMap { $0 }.joined(separator: " "))
         }
         if let quota {
             parts.append("\(quota.percentLeft)% left")
@@ -84,6 +86,7 @@ nonisolated struct QuotaGuardEvaluation: Sendable {
             checkedAt: checkedAt,
             service: nil,
             window: nil,
+            periodKind: nil,
             account: nil,
             minRemainingPercent: nil,
             quota: nil,
@@ -181,7 +184,7 @@ nonisolated enum QuotaGuardEvaluator {
             resetCountdown: countdown,
             estimated: limit.isEstimated
         )
-        let window = target.window.displayName
+        let window = target.window.displayName(for: limit)
         let resetSentence = countdown.map { "Resets in \($0)." } ?? "Reset time unknown."
 
         // Exhaustion outranks the caller's threshold: the quota is blocking
@@ -192,6 +195,7 @@ nonisolated enum QuotaGuardEvaluator {
                 checkedAt: now,
                 service: target.service,
                 window: target.window,
+                periodKind: limit.periodKind,
                 account: account,
                 minRemainingPercent: target.minRemainingPercent,
                 quota: quota,
@@ -207,6 +211,7 @@ nonisolated enum QuotaGuardEvaluator {
                 checkedAt: now,
                 service: target.service,
                 window: target.window,
+                periodKind: limit.periodKind,
                 account: account,
                 minRemainingPercent: minimum,
                 quota: quota,
@@ -224,6 +229,7 @@ nonisolated enum QuotaGuardEvaluator {
             checkedAt: now,
             service: target.service,
             window: target.window,
+            periodKind: limit.periodKind,
             account: account,
             minRemainingPercent: target.minRemainingPercent,
             quota: quota,
@@ -246,6 +252,7 @@ nonisolated enum QuotaGuardEvaluator {
             checkedAt: now,
             service: target.service,
             window: target.window,
+            periodKind: nil,
             account: account,
             minRemainingPercent: target.minRemainingPercent,
             quota: nil,

--- a/MeterBar/Guard/QuotaGuardTarget.swift
+++ b/MeterBar/Guard/QuotaGuardTarget.swift
@@ -7,6 +7,10 @@ nonisolated enum QuotaGuardWindow: String, CaseIterable, Equatable, Sendable {
     case session
     case weekly
     case codeReview
+    case daily
+    case monthly
+    case billing
+    case unknown
 
     /// Accepts the documented spellings plus the hyphen/underscore and casing
     /// variants a shell script is likely to pass.
@@ -20,19 +24,43 @@ nonisolated enum QuotaGuardWindow: String, CaseIterable, Equatable, Sendable {
         case "session": return .session
         case "weekly": return .weekly
         case "codereview": return .codeReview
+        case "daily": return .daily
+        case "monthly": return .monthly
+        case "billing": return .billing
+        case "billingcycle": return .billing
+        case "unknown": return .unknown
         default: return nil
         }
     }
 
-    static let acceptedValues = "session, weekly, code-review"
+    static let acceptedValues = "session, weekly, code-review, daily, monthly, billing, unknown"
 
-    var cliIdentifier: String { rawValue }
+    /// Version 1 JSON `window` token. Cadence selectors collapse onto the
+    /// compatible slot so exhaustive v1 consumers keep working.
+    var cliIdentifier: String {
+        switch self {
+        case .session, .daily: return "session"
+        case .weekly, .monthly, .billing, .unknown: return "weekly"
+        case .codeReview: return "codeReview"
+        }
+    }
 
     var displayName: String {
+        displayName(for: nil)
+    }
+
+    func displayName(for limit: UsageLimit?) -> String {
+        if let periodKind = limit?.periodKind {
+            return periodKind.guardDisplayName
+        }
         switch self {
         case .session: return "session"
         case .weekly: return "weekly"
         case .codeReview: return "code review"
+        case .daily: return "daily"
+        case .monthly: return "monthly"
+        case .billing: return "billing cycle"
+        case .unknown: return "quota"
         }
     }
 
@@ -41,6 +69,36 @@ nonisolated enum QuotaGuardWindow: String, CaseIterable, Equatable, Sendable {
         case .session: return metrics.sessionLimit
         case .weekly: return metrics.weeklyLimit
         case .codeReview: return metrics.codeReviewLimit
+        case .daily: return Self.firstLimit(in: metrics, periodKind: .daily)
+        case .monthly: return Self.firstLimit(in: metrics, periodKind: .monthly)
+        case .billing: return Self.firstLimit(in: metrics, periodKind: .billing)
+        case .unknown: return Self.firstLimit(in: metrics, periodKind: .unknown)
+        }
+    }
+
+    /// Slot first, then overflow: a monthly allowance stored in `weeklyLimit`
+    /// is addressable as `--limit monthly` without inventing a fourth slot.
+    private static func firstLimit(
+        in metrics: UsageMetrics,
+        periodKind: UsageLimit.PeriodKind
+    ) -> UsageLimit? {
+        let slots = [metrics.sessionLimit, metrics.weeklyLimit, metrics.codeReviewLimit]
+        if let match = slots.compactMap({ $0 }).first(where: { $0.periodKind == periodKind }) {
+            return match
+        }
+        return metrics.additionalLimits.first { $0.periodKind == periodKind }
+    }
+}
+
+nonisolated extension UsageLimit.PeriodKind {
+    var guardDisplayName: String {
+        switch self {
+        case .session: return "session"
+        case .daily: return "daily"
+        case .weekly: return "weekly"
+        case .monthly: return "monthly"
+        case .billing: return "billing cycle"
+        case .unknown: return "quota"
         }
     }
 }

--- a/MeterBar/Models/CLIJSONOutput.swift
+++ b/MeterBar/Models/CLIJSONOutput.swift
@@ -483,10 +483,10 @@ nonisolated extension ServiceType {
 }
 
 nonisolated private extension UsageLimit {
-    /// Extra windows use the reported cadence as `windows[].kind`. The three
-    /// legacy slots keep `session` / `weekly` / `codeReview`.
+    /// Extra windows keep a v1 `kind` token (`session` / `weekly`). Cadence
+    /// lives in `periodKind` so exhaustive v1 consumers are not broken.
     var cliWindowKind: String {
-        periodKind?.rawValue ?? "unknown"
+        periodKind?.legacyWindowKind ?? "weekly"
     }
 }
 

--- a/MeterBar/Models/CLIJSONOutput.swift
+++ b/MeterBar/Models/CLIJSONOutput.swift
@@ -89,6 +89,7 @@ nonisolated public struct UsageCLIJSONResponse: CLIJSONDocument {
 
     private struct Window: Encodable {
         let kind: String
+        let periodKind: String?
         let used: Double
         let total: Double
         let percentUsed: Double
@@ -100,6 +101,7 @@ nonisolated public struct UsageCLIJSONResponse: CLIJSONDocument {
 
         init(kind: String, limit: UsageLimit) {
             self.kind = kind
+            periodKind = limit.periodKind?.rawValue
             used = limit.used
             total = limit.total
             percentUsed = limit.percentage
@@ -115,7 +117,9 @@ nonisolated public struct UsageCLIJSONResponse: CLIJSONDocument {
                 metrics.sessionLimit.map { Window(kind: "session", limit: $0) },
                 metrics.weeklyLimit.map { Window(kind: "weekly", limit: $0) },
                 metrics.codeReviewLimit.map { Window(kind: "codeReview", limit: $0) },
-            ].compactMap { $0 }
+            ].compactMap { $0 } + metrics.additionalLimits.map {
+                Window(kind: $0.cliWindowKind, limit: $0)
+            }
         }
     }
 
@@ -475,6 +479,14 @@ nonisolated extension ServiceType {
     static func fromCLIIdentifier(_ raw: String) -> ServiceType? {
         let needle = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return allCases.first { $0.cliIdentifier == needle }
+    }
+}
+
+nonisolated private extension UsageLimit {
+    /// Extra windows use the reported cadence as `windows[].kind`. The three
+    /// legacy slots keep `session` / `weekly` / `codeReview`.
+    var cliWindowKind: String {
+        periodKind?.rawValue ?? "unknown"
     }
 }
 

--- a/MeterBar/Models/CLIUsageTextReport.swift
+++ b/MeterBar/Models/CLIUsageTextReport.swift
@@ -68,14 +68,14 @@ nonisolated public enum CLIUsageTextReport {
         var lines: [String] = []
         if let session = metric.sessionLimit {
             lines += limitLines(
-                service == .openRouter ? "  Key limit" : "  Session",
+                "  \(service.sessionQuotaTitle(limitTotal: session.total, periodKind: session.periodKind))",
                 session,
                 currency: service == .openRouter
             )
         }
         if let weekly = metric.weeklyLimit {
             lines += limitLines(
-                "  \(service.weeklyQuotaTitle)",
+                "  \(service.weeklyQuotaTitle(limitTotal: weekly.total, periodKind: weekly.periodKind))",
                 weekly,
                 currency: service == .openRouter
             )
@@ -83,6 +83,12 @@ nonisolated public enum CLIUsageTextReport {
         if let codeReview = metric.codeReviewLimit {
             let label = service.codeReviewQuotaTitle(modelLimitLabel: metric.modelLimitLabel)
             lines += limitLines("  \(label)", codeReview)
+        }
+        for additional in metric.additionalLimits {
+            lines += limitLines(
+                "  \(service.additionalQuotaTitleKey(for: additional).englishTitle)",
+                additional
+            )
         }
         return lines
     }

--- a/MeterBar/Resources/Localizable.xcstrings
+++ b/MeterBar/Resources/Localizable.xcstrings
@@ -198,6 +198,17 @@
         }
       }
     },
+    "quota.title.billing_cycle": {
+      "comment": "Quota window that resets with the provider billing cycle.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Billing cycle"
+          }
+        }
+      }
+    },
     "quota.title.code_review": {
       "localizations": {
         "en": {
@@ -215,6 +226,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cursor Models"
+          }
+        }
+      }
+    },
+    "quota.title.daily": {
+      "comment": "Quota window that resets each day.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Daily"
           }
         }
       }
@@ -267,6 +289,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "Other Models"
+          }
+        }
+      }
+    },
+    "quota.title.quota": {
+      "comment": "Neutral title for a reported quota whose cadence is unknown.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quota"
           }
         }
       }
@@ -524,6 +557,17 @@
         }
       }
     },
+    "widget.quota.billing_cycle": {
+      "comment": "Quota title for a provider billing-cycle window.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Billing cycle"
+          }
+        }
+      }
+    },
     "widget.quota.code_review": {
       "comment": "Quota title for a code-review window.",
       "localizations": {
@@ -542,6 +586,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cursor Models"
+          }
+        }
+      }
+    },
+    "widget.quota.daily": {
+      "comment": "Quota title for a daily window.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Daily"
           }
         }
       }
@@ -597,6 +652,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "Other Models"
+          }
+        }
+      }
+    },
+    "widget.quota.quota": {
+      "comment": "Neutral title for a reported quota whose cadence is unknown.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quota"
           }
         }
       }

--- a/MeterBar/Services/AccountNotificationPlanner.swift
+++ b/MeterBar/Services/AccountNotificationPlanner.swift
@@ -115,7 +115,8 @@ struct AccountNotificationPlanner {
             keys.subtract(
                 NotificationDecider.notificationKeys(
                     service: input.service,
-                    accountKey: account.id.uuidString
+                    accountKey: account.id.uuidString,
+                    includingExisting: keys
                 )
             )
             keys.remove(
@@ -221,7 +222,10 @@ struct AccountNotificationPlanner {
         service: ServiceType,
         keys: inout Set<String>
     ) -> Set<String> {
-        let fallbackKeys = NotificationDecider.notificationKeys(service: service)
+        let fallbackKeys = NotificationDecider.notificationKeys(
+            service: service,
+            includingExisting: keys
+        )
         let removedState = keys.intersection(fallbackKeys)
         keys.subtract(fallbackKeys)
         keys.remove(observedFallbackKey(service: service))
@@ -233,7 +237,10 @@ struct AccountNotificationPlanner {
         service: ServiceType,
         keys: inout Set<String>
     ) -> Set<String> {
-        let fallbackKeys = NotificationDecider.notificationKeys(service: service)
+        let fallbackKeys = NotificationDecider.notificationKeys(
+            service: service,
+            includingExisting: keys
+        )
         let fallbackStateKeys = fallbackKeys.union([observedFallbackKey(service: service)])
         let servicePrefix = "\(service.rawValue)-"
         let accountKeys = Set(keys.filter {
@@ -251,7 +258,8 @@ struct AccountNotificationPlanner {
         keys.intersection(
             NotificationDecider.notificationKeys(
                 service: service,
-                accountKey: accountKey
+                accountKey: accountKey,
+                includingExisting: keys
             )
         )
     }
@@ -287,7 +295,10 @@ struct AccountNotificationPlanner {
         keys: Set<String>
     ) -> Bool {
         keys.contains(observedFallbackKey(service: service))
-            || !keys.isDisjoint(with: NotificationDecider.notificationKeys(service: service))
+            || !keys.isDisjoint(with: NotificationDecider.notificationKeys(
+                service: service,
+                includingExisting: keys
+            ))
     }
 
     private func recordObservedFallbackState(
@@ -295,7 +306,10 @@ struct AccountNotificationPlanner {
         keys: inout Set<String>
     ) {
         let observedKey = observedFallbackKey(service: service)
-        if keys.isDisjoint(with: NotificationDecider.notificationKeys(service: service)) {
+        if keys.isDisjoint(with: NotificationDecider.notificationKeys(
+            service: service,
+            includingExisting: keys
+        )) {
             keys.insert(observedKey)
         } else {
             keys.remove(observedKey)

--- a/MeterBar/Services/GrokCLIUsageService.swift
+++ b/MeterBar/Services/GrokCLIUsageService.swift
@@ -174,8 +174,6 @@ final class GrokCLIUsageService: ObservableObject {
     static func map(_ result: GrokBillingResult, now: Date = Date()) throws -> UsageMetrics {
         let config = result.config
         let periods = config.usagePeriods ?? []
-        let sessionPeriod = periods.first { $0.kind == .session }
-        let weeklyPeriod = periods.first { $0.kind == .weekly }
 
         // The account-wide billing-cycle percent, in descending order of trust:
         // the number the provider reports, the one its credits pair implies, and
@@ -186,11 +184,53 @@ final class GrokCLIUsageService: ObservableObject {
         let accountPercent = config.creditUsagePercent
             ?? config.derivedCreditPercent
             ?? impliedZeroPercent(for: result)
-        let weeklyPercent = weeklyPeriod?.usagePercent ?? accountPercent
-        let sessionLimit = limit(percent: sessionPeriod?.usagePercent, window: sessionPeriod)
-        let weeklyLimit = limit(percent: weeklyPercent, window: weeklyPeriod ?? config.fallbackPeriod)
 
-        guard sessionLimit != nil || weeklyLimit != nil else {
+        var sessionLimit: UsageLimit?
+        var weeklyLimit: UsageLimit?
+        var additionalLimits: [UsageLimit] = []
+
+        for period in periods {
+            guard let mapped = limit(
+                percent: period.usagePercent,
+                window: period,
+                periodKind: period.kind
+            ) else {
+                continue
+            }
+            switch period.kind {
+            case .session:
+                if sessionLimit == nil {
+                    sessionLimit = mapped
+                } else {
+                    additionalLimits.append(mapped)
+                }
+            case .weekly:
+                if weeklyLimit == nil {
+                    weeklyLimit = mapped
+                } else {
+                    additionalLimits.append(mapped)
+                }
+            case .monthly, .billing:
+                if weeklyLimit == nil {
+                    weeklyLimit = mapped
+                } else {
+                    additionalLimits.append(mapped)
+                }
+            case .daily, .unknown:
+                additionalLimits.append(mapped)
+            }
+        }
+
+        if weeklyLimit == nil {
+            let fallback = config.fallbackPeriod
+            weeklyLimit = limit(
+                percent: accountPercent,
+                window: fallback,
+                periodKind: fallback?.kind
+            )
+        }
+
+        guard sessionLimit != nil || weeklyLimit != nil || !additionalLimits.isEmpty else {
             throw GrokBillingRPC.Error.invalidResponse
         }
 
@@ -199,6 +239,7 @@ final class GrokCLIUsageService: ObservableObject {
             sessionLimit: sessionLimit,
             weeklyLimit: weeklyLimit,
             extraUsage: config.extraUsageStatus,
+            additionalLimits: additionalLimits,
             lastUpdated: now
         )
     }
@@ -224,13 +265,18 @@ final class GrokCLIUsageService: ObservableObject {
         return 0
     }
 
-    private static func limit(percent: Double?, window: GrokBillingConfig.Period?) -> UsageLimit? {
+    private static func limit(
+        percent: Double?,
+        window: GrokBillingConfig.Period?,
+        periodKind: UsageLimit.PeriodKind?
+    ) -> UsageLimit? {
         guard let percent else { return nil }
         return UsageLimit(
             used: min(100, max(0, percent)),
             total: 100,
             resetTime: window?.endDate,
-            windowSeconds: window?.windowSeconds
+            windowSeconds: window?.windowSeconds,
+            periodKind: periodKind
         )
     }
 
@@ -432,11 +478,9 @@ nonisolated struct GrokBillingResult: Decodable, Sendable {
 
 nonisolated struct GrokBillingConfig: Decodable, Sendable {
     struct Period: Decodable, Sendable {
-        /// Which shared quota window a provider period belongs to.
-        enum Kind: Sendable {
-            case session
-            case weekly
-        }
+        /// Provider-reported cadence. Classified by the token first and the
+        /// dated window second so a monthly allowance is never called weekly.
+        typealias Kind = UsageLimit.PeriodKind
 
         let type: String?
         let start: String?
@@ -472,18 +516,38 @@ nonisolated struct GrokBillingConfig: Decodable, Sendable {
 
         /// Classified by the provider's own token where possible, and by window
         /// length otherwise — a new token spelling should re-bucket the period,
-        /// not drop it.
-        var kind: Kind? {
+        /// not drop it. An unrecognized token with no dated window stays
+        /// `.unknown` rather than being discarded or invented as weekly.
+        var kind: Kind {
             if let token = type?.uppercased() {
-                if ["WEEK", "MONTH", "BILLING", "CYCLE"].contains(where: token.contains) {
-                    return .weekly
-                }
-                if ["HOUR", "DAILY", "DAY", "SESSION"].contains(where: token.contains) {
+                if token.contains("HOUR") || token.contains("SESSION") {
                     return .session
                 }
+                if token.contains("DAY") || token.contains("DAILY") {
+                    return .daily
+                }
+                if token.contains("WEEK") {
+                    return .weekly
+                }
+                if token.contains("MONTH") {
+                    return .monthly
+                }
+                if token.contains("BILLING") || token.contains("CYCLE") {
+                    return .billing
+                }
+                return kindFromWindow ?? .unknown
             }
+            return kindFromWindow ?? .unknown
+        }
+
+        /// Duration buckets used only when the provider omitted a usable token.
+        /// Keeps the historical 5-hour → session and 7-day → weekly readings.
+        private var kindFromWindow: Kind? {
             guard let windowSeconds else { return nil }
-            return windowSeconds <= 24 * 60 * 60 ? .session : .weekly
+            if windowSeconds <= 24 * 60 * 60 { return .session }
+            if windowSeconds <= 8 * 24 * 60 * 60 { return .weekly }
+            if windowSeconds <= 45 * 24 * 60 * 60 { return .monthly }
+            return .billing
         }
     }
 

--- a/MeterBar/Services/NotificationDecider.swift
+++ b/MeterBar/Services/NotificationDecider.swift
@@ -144,7 +144,8 @@ struct NotificationDecider {
             let quotaDisplayName = quotaKind.displayName(
                 for: metrics.service,
                 modelLimitLabel: metrics.modelLimitLabel,
-                limitTotal: limit.total
+                limitTotal: limit.total,
+                periodKind: limit.periodKind
             )
             let blocksProvider = Self.blocksProvider(
                 service: metrics.service,
@@ -232,18 +233,19 @@ struct NotificationDecider {
         func displayName(
             for service: ServiceType,
             modelLimitLabel: String?,
-            limitTotal: Double? = nil
+            limitTotal: Double? = nil,
+            periodKind: UsageLimit.PeriodKind? = nil
         ) -> String {
             switch self {
             case .session:
                 // Notification copy is Title Case for OpenRouter's key cap.
                 return service == .openRouter
                     ? "Key Limit"
-                    : service.sessionQuotaTitle(limitTotal: limitTotal)
+                    : service.sessionQuotaTitle(limitTotal: limitTotal, periodKind: periodKind)
             case .weekly:
                 return service == .openRouter
                     ? "Account Credits"
-                    : service.weeklyQuotaTitle(limitTotal: limitTotal)
+                    : service.weeklyQuotaTitle(limitTotal: limitTotal, periodKind: periodKind)
             case .codeReview:
                 return service.codeReviewQuotaTitle(modelLimitLabel: modelLimitLabel)
             }

--- a/MeterBar/Services/NotificationDecider.swift
+++ b/MeterBar/Services/NotificationDecider.swift
@@ -103,11 +103,51 @@ struct NotificationDecider {
             && providerEnabled
             && now.timeIntervalSince(metrics.lastUpdated) <= stalenessThreshold
 
-        let limits: [(limit: UsageLimit?, kind: QuotaKind)] = [
-            (metrics.sessionLimit, .session),
-            (metrics.weeklyLimit, .weekly),
-            (metrics.codeReviewLimit, .codeReview)
+        var evaluated: [(limit: UsageLimit?, token: String, displayName: String, blocksProvider: Bool)] = [
+            (
+                metrics.sessionLimit,
+                QuotaKind.session.rawValue,
+                QuotaKind.session.displayName(
+                    for: metrics.service,
+                    modelLimitLabel: metrics.modelLimitLabel,
+                    limitTotal: metrics.sessionLimit?.total,
+                    periodKind: metrics.sessionLimit?.periodKind
+                ),
+                Self.blocksProvider(service: metrics.service, quotaKind: .session, metrics: metrics)
+            ),
+            (
+                metrics.weeklyLimit,
+                QuotaKind.weekly.rawValue,
+                QuotaKind.weekly.displayName(
+                    for: metrics.service,
+                    modelLimitLabel: metrics.modelLimitLabel,
+                    limitTotal: metrics.weeklyLimit?.total,
+                    periodKind: metrics.weeklyLimit?.periodKind
+                ),
+                Self.blocksProvider(service: metrics.service, quotaKind: .weekly, metrics: metrics)
+            ),
+            (
+                metrics.codeReviewLimit,
+                QuotaKind.codeReview.rawValue,
+                QuotaKind.codeReview.displayName(
+                    for: metrics.service,
+                    modelLimitLabel: metrics.modelLimitLabel,
+                    limitTotal: metrics.codeReviewLimit?.total,
+                    periodKind: metrics.codeReviewLimit?.periodKind
+                ),
+                Self.blocksProvider(service: metrics.service, quotaKind: .codeReview, metrics: metrics)
+            ),
         ]
+        for (index, additional) in metrics.additionalLimits.enumerated() {
+            evaluated.append((
+                additional,
+                "additional-\(index)",
+                metrics.service.additionalQuotaTitleKey(for: additional).englishTitle,
+                false
+            ))
+        }
+
+        let limits = evaluated
 
         var keys = alreadyNotified
         var fired: [FiredNotification] = []
@@ -115,11 +155,11 @@ struct NotificationDecider {
         let warningRank = preferences.warningThreshold.band.severityRank
         let criticalRank = preferences.criticalThreshold.band.severityRank
 
-        for (limit, quotaKind) in limits {
+        for (limit, token, quotaDisplayName, blocksProvider) in limits {
             let baseKey = Self.notificationBaseKey(
                 service: metrics.service,
                 accountKey: accountKey,
-                quotaKind: quotaKind
+                token: token
             )
             let warnKey = "\(baseKey)-warn"
             let criticalKey = "\(baseKey)-critical"
@@ -141,17 +181,6 @@ struct NotificationDecider {
 
             let band = QuotaBand.forLimit(limit)
             let bandRank = band.severityRank
-            let quotaDisplayName = quotaKind.displayName(
-                for: metrics.service,
-                modelLimitLabel: metrics.modelLimitLabel,
-                limitTotal: limit.total,
-                periodKind: limit.periodKind
-            )
-            let blocksProvider = Self.blocksProvider(
-                service: metrics.service,
-                quotaKind: quotaKind,
-                metrics: metrics
-            )
 
             if bandRank >= criticalRank {
                 // Preserve the warning key while critical. Otherwise falling
@@ -201,26 +230,53 @@ struct NotificationDecider {
     /// inactive account and fallback state without duplicating key construction.
     static func notificationKeys(
         service: ServiceType,
-        accountKey: String? = nil
+        accountKey: String? = nil,
+        additionalLimitCount: Int = 0,
+        includingExisting existing: Set<String> = []
     ) -> Set<String> {
-        Set(QuotaKind.allCases.flatMap { quotaKind in
+        var tokens = QuotaKind.allCases.map(\.rawValue)
+        tokens += (0..<max(0, additionalLimitCount)).map { "additional-\($0)" }
+        var result = Set(tokens.flatMap { token -> [String] in
             let baseKey = notificationBaseKey(
                 service: service,
                 accountKey: accountKey,
-                quotaKind: quotaKind
+                token: token
             )
             return ["\(baseKey)-warn", "\(baseKey)-critical"]
         })
+        for key in existing where isOwnedNotificationKey(key, service: service, accountKey: accountKey) {
+            result.insert(key)
+        }
+        return result
     }
 
     private static func notificationBaseKey(
         service: ServiceType,
         accountKey: String?,
-        quotaKind: QuotaKind
+        token: String
     ) -> String {
-        [service.rawValue, accountKey, quotaKind.rawValue]
+        [service.rawValue, accountKey, token]
             .compactMap { $0 }
             .joined(separator: "-")
+    }
+
+    /// Fallback keys must not swallow account-scoped keys that share the
+    /// `"Grok-"` prefix. Account keys include a UUID between the service and
+    /// the window token.
+    private static func isOwnedNotificationKey(
+        _ key: String,
+        service: ServiceType,
+        accountKey: String?
+    ) -> Bool {
+        guard key.hasSuffix("-warn") || key.hasSuffix("-critical") else { return false }
+        if let accountKey {
+            return key.hasPrefix("\(service.rawValue)-\(accountKey)-")
+        }
+        let prefix = "\(service.rawValue)-"
+        guard key.hasPrefix(prefix) else { return false }
+        let levelLength = key.hasSuffix("-warn") ? 5 : 9
+        let token = String(key.dropFirst(prefix.count).dropLast(levelLength))
+        return QuotaKind(rawValue: token) != nil || token.hasPrefix("additional-")
     }
 
     /// Stable quota key plus provider-specific display copy. `codeReviewLimit`

--- a/MeterBar/Services/QuotaEventPlanner.swift
+++ b/MeterBar/Services/QuotaEventPlanner.swift
@@ -25,10 +25,32 @@ nonisolated enum QuotaEventWindow: String, Codable, CaseIterable, Sendable {
     case codeReview = "code_review"
 
     var displayName: String {
-        switch self {
+        displayName(periodKind: nil)
+    }
+
+    func displayName(periodKind: UsageLimit.PeriodKind?) -> String {
+        switch periodKind {
         case .session: return "Session"
+        case .daily: return "Daily"
         case .weekly: return "Weekly"
-        case .codeReview: return "Model / code review"
+        case .monthly: return "Monthly"
+        case .billing: return "Billing cycle"
+        case .unknown: return "Quota"
+        case nil:
+            switch self {
+            case .session: return "Session"
+            case .weekly: return "Weekly"
+            case .codeReview: return "Model / code review"
+            }
+        }
+    }
+
+    static func compatible(for periodKind: UsageLimit.PeriodKind?) -> QuotaEventWindow {
+        switch periodKind {
+        case .session, .daily:
+            return .session
+        case .weekly, .monthly, .billing, .unknown, nil:
+            return .weekly
         }
     }
 }
@@ -83,6 +105,7 @@ nonisolated struct QuotaEventPayload: Codable, Equatable, Sendable {
     let account: QuotaEventAccount
     let event: QuotaEventKind
     let window: QuotaEventWindow
+    let periodKind: UsageLimit.PeriodKind?
     let percentage: Double
     let band: QuotaEventBand
     let timestamp: Date
@@ -92,6 +115,7 @@ nonisolated struct QuotaEventPayload: Codable, Equatable, Sendable {
         account: QuotaEventAccount,
         event: QuotaEventKind,
         window: QuotaEventWindow,
+        periodKind: UsageLimit.PeriodKind? = nil,
         percentage: Double,
         band: QuotaEventBand,
         timestamp: Date
@@ -101,6 +125,7 @@ nonisolated struct QuotaEventPayload: Codable, Equatable, Sendable {
         self.account = account
         self.event = event
         self.window = window
+        self.periodKind = periodKind
         self.percentage = percentage
         self.band = band
         self.timestamp = timestamp
@@ -112,9 +137,23 @@ nonisolated struct QuotaEventPayload: Codable, Equatable, Sendable {
         case account
         case event
         case window
+        case periodKind = "period_kind"
         case percentage
         case band
         case timestamp
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
+        try container.encode(provider, forKey: .provider)
+        try container.encode(account, forKey: .account)
+        try container.encode(event, forKey: .event)
+        try container.encode(window, forKey: .window)
+        try container.encodeIfPresent(periodKind, forKey: .periodKind)
+        try container.encode(percentage, forKey: .percentage)
+        try container.encode(band, forKey: .band)
+        try container.encode(timestamp, forKey: .timestamp)
     }
 }
 
@@ -129,6 +168,7 @@ nonisolated struct QuotaEventPlanner: Sendable {
         let provider: ServiceType
         let accountID: String
         let window: QuotaEventWindow
+        let overflowIndex: Int?
     }
 
     private struct DeliveryKey: Hashable, Sendable {
@@ -152,17 +192,20 @@ nonisolated struct QuotaEventPlanner: Sendable {
         var activeNamespaces = Set<Namespace>()
 
         for snapshot in snapshots {
-            let limits: [(QuotaEventWindow, UsageLimit?)] = [
-                (.session, snapshot.metrics.sessionLimit),
-                (.weekly, snapshot.metrics.weeklyLimit),
-                (.codeReview, snapshot.metrics.codeReviewLimit),
-            ]
+            let limits: [(QuotaEventWindow, UsageLimit?, Int?)] = [
+                (.session, snapshot.metrics.sessionLimit, nil),
+                (.weekly, snapshot.metrics.weeklyLimit, nil),
+                (.codeReview, snapshot.metrics.codeReviewLimit, nil),
+            ] + snapshot.metrics.additionalLimits.enumerated().map { index, limit in
+                (QuotaEventWindow.compatible(for: limit.periodKind), limit, index)
+            }
 
-            for (window, limit) in limits {
+            for (window, limit, overflowIndex) in limits {
                 let namespace = Namespace(
                     provider: snapshot.provider,
                     accountID: snapshot.account.id,
-                    window: window
+                    window: window,
+                    overflowIndex: overflowIndex
                 )
                 guard let limit, !limit.isEstimated else {
                     bands.removeValue(forKey: namespace)
@@ -190,6 +233,7 @@ nonisolated struct QuotaEventPlanner: Sendable {
                     account: snapshot.account,
                     event: event,
                     window: window,
+                    periodKind: limit.periodKind,
                     percentage: limit.percentage,
                     band: band,
                     timestamp: now

--- a/MeterBar/SessionWake/WakeEventHook.swift
+++ b/MeterBar/SessionWake/WakeEventHook.swift
@@ -73,19 +73,23 @@ nonisolated struct WakeEventHookContext: Equatable, Sendable {
         let percentage = payload.percentage.rounded() == payload.percentage
             ? String(Int(payload.percentage))
             : String(format: "%.2f", payload.percentage)
+        var environment = [
+            "METERBAR_EVENT": payload.event.rawValue,
+            "METERBAR_PROVIDER": payload.provider.rawValue,
+            "METERBAR_ACCOUNT_ID": payload.account.id,
+            "METERBAR_ACCOUNT_NAME": payload.account.name,
+            "METERBAR_WINDOW": payload.window.rawValue,
+            "METERBAR_PERCENTAGE": percentage,
+            "METERBAR_BAND": payload.band.rawValue,
+            "METERBAR_TIMESTAMP": ISO8601DateFormatter().string(from: payload.timestamp),
+        ]
+        if let periodKind = payload.periodKind {
+            environment["METERBAR_PERIOD_KIND"] = periodKind.rawValue
+        }
         return Self(
             eventName: payload.event.rawValue,
             provider: nil,
-            environment: [
-                "METERBAR_EVENT": payload.event.rawValue,
-                "METERBAR_PROVIDER": payload.provider.rawValue,
-                "METERBAR_ACCOUNT_ID": payload.account.id,
-                "METERBAR_ACCOUNT_NAME": payload.account.name,
-                "METERBAR_WINDOW": payload.window.rawValue,
-                "METERBAR_PERCENTAGE": percentage,
-                "METERBAR_BAND": payload.band.rawValue,
-                "METERBAR_TIMESTAMP": ISO8601DateFormatter().string(from: payload.timestamp),
-            ],
+            environment: environment,
             diagnosticProvider: payload.provider.rawValue
         )
     }

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -168,6 +168,7 @@ struct SnapshotLimit: Identifiable {
         case session
         case weekly
         case codeReview
+        case additional
     }
 
     let id: String
@@ -228,7 +229,19 @@ struct SnapshotLimit: Identifiable {
     /// Pace copy differs for rolling session windows vs weekly/billing windows.
     /// Derived from the limit's kind, not by string-matching the display title.
     var paceContext: PaceLabelContext {
-        kind == .weekly ? .weekly : .session
+        switch kind {
+        case .weekly:
+            return .weekly
+        case .additional:
+            switch usageLimit.periodKind {
+            case .weekly, .monthly, .billing:
+                return .weekly
+            case .session, .daily, .unknown, nil:
+                return .session
+            }
+        case .session, .codeReview:
+            return .session
+        }
     }
 
     // MARK: - Accessibility
@@ -275,6 +288,12 @@ struct SnapshotLimit: Identifiable {
             return String(localized: "quota.title.monthly", defaultValue: "Monthly")
         case .weekly:
             return String(localized: "quota.title.weekly", defaultValue: "Weekly")
+        case .daily:
+            return String(localized: "quota.title.daily", defaultValue: "Daily")
+        case .billingCycle:
+            return String(localized: "quota.title.billing_cycle", defaultValue: "Billing cycle")
+        case .quota:
+            return String(localized: "quota.title.quota", defaultValue: "Quota")
         }
     }
 
@@ -669,7 +688,10 @@ enum ProviderSnapshotBuilder {
             result.append(SnapshotLimit(
                 id: "session",
                 kind: .session,
-                quotaTitleKey: service.sessionQuotaTitleKey(limitTotal: session.total),
+                quotaTitleKey: service.sessionQuotaTitleKey(
+                    limitTotal: session.total,
+                    periodKind: session.periodKind
+                ),
                 usageLimit: session,
                 valueStyle: service == .openRouter ? .currency : .quota
             ))
@@ -678,7 +700,10 @@ enum ProviderSnapshotBuilder {
             result.append(SnapshotLimit(
                 id: "weekly",
                 kind: .weekly,
-                quotaTitleKey: service.weeklyQuotaTitleKey(limitTotal: weekly.total),
+                quotaTitleKey: service.weeklyQuotaTitleKey(
+                    limitTotal: weekly.total,
+                    periodKind: weekly.periodKind
+                ),
                 usageLimit: weekly,
                 valueStyle: service == .openRouter ? .currency : .quota
             ))
@@ -692,6 +717,14 @@ enum ProviderSnapshotBuilder {
                 kind: .codeReview,
                 quotaTitleKey: service.codeReviewQuotaTitleKey(modelLimitLabel: metrics.modelLimitLabel),
                 usageLimit: codeReview
+            ))
+        }
+        for (index, additional) in metrics.additionalLimits.enumerated() {
+            result.append(SnapshotLimit(
+                id: "additional-\(index)",
+                kind: .additional,
+                quotaTitleKey: service.additionalQuotaTitleKey(for: additional),
+                usageLimit: additional
             ))
         }
         return result

--- a/MeterBarTests/CLIJSONOutputTests.swift
+++ b/MeterBarTests/CLIJSONOutputTests.swift
@@ -462,6 +462,43 @@ final class CLIJSONOutputTests: XCTestCase {
         XCTAssertEqual(displayCurrency["source"] as? String, "manual")
     }
 
+    func testPeriodKindIsEmittedAdditivelyAndAdditionalWindowsUseCadenceKind() throws {
+        let metrics = UsageMetrics(
+            service: .grok,
+            sessionLimit: UsageLimit(
+                used: 10,
+                total: 100,
+                resetTime: referenceDate,
+                windowSeconds: 18_000,
+                periodKind: .session
+            ),
+            weeklyLimit: UsageLimit(
+                used: 41,
+                total: 100,
+                resetTime: nil,
+                windowSeconds: 2_678_400,
+                periodKind: .monthly
+            ),
+            additionalLimits: [
+                UsageLimit(used: 12, total: 100, resetTime: nil, periodKind: .daily),
+                UsageLimit(used: 8, total: 100, resetTime: nil, periodKind: .unknown)
+            ],
+            lastUpdated: referenceDate
+        )
+
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: UsageCLIJSONResponse(metrics: [.grok: metrics]).jsonData()
+            ) as? [String: Any]
+        )
+        let providers = try XCTUnwrap(object["providers"] as? [[String: Any]])
+        let windows = try XCTUnwrap(providers.first?["windows"] as? [[String: Any]])
+
+        XCTAssertEqual(windows.map { $0["kind"] as? String }, ["session", "weekly", "daily", "unknown"])
+        XCTAssertEqual(windows.map { $0["periodKind"] as? String }, ["session", "monthly", "daily", "unknown"])
+        XCTAssertEqual(windows[1]["used"] as? Double, 41)
+    }
+
     func testErrorResponseIsVersionedAndMachineStable() throws {
         let response = CLIJSONErrorResponse(
             code: "usage_cache_missing",

--- a/MeterBarTests/CLIJSONOutputTests.swift
+++ b/MeterBarTests/CLIJSONOutputTests.swift
@@ -494,9 +494,14 @@ final class CLIJSONOutputTests: XCTestCase {
         let providers = try XCTUnwrap(object["providers"] as? [[String: Any]])
         let windows = try XCTUnwrap(providers.first?["windows"] as? [[String: Any]])
 
-        XCTAssertEqual(windows.map { $0["kind"] as? String }, ["session", "weekly", "daily", "unknown"])
+        XCTAssertEqual(windows.map { $0["kind"] as? String }, ["session", "weekly", "session", "weekly"])
         XCTAssertEqual(windows.map { $0["periodKind"] as? String }, ["session", "monthly", "daily", "unknown"])
         XCTAssertEqual(windows[1]["used"] as? Double, 41)
+        XCTAssertTrue(
+            windows.allSatisfy { window in
+                ["session", "weekly", "codeReview"].contains(window["kind"] as? String)
+            }
+        )
     }
 
     func testErrorResponseIsVersionedAndMachineStable() throws {

--- a/MeterBarTests/CLIUsageTextReportTests.swift
+++ b/MeterBarTests/CLIUsageTextReportTests.swift
@@ -131,6 +131,37 @@ final class CLIUsageTextReportTests: XCTestCase {
         XCTAssertFalse(text.contains("▸ Claude Code"), text)
     }
 
+    func testGrokMonthlyWeeklySlotIsTitledMonthlyNeverWeekly() {
+        let text = render(
+            .grok,
+            metric: UsageMetrics(
+                service: .grok,
+                weeklyLimit: UsageLimit(used: 41, total: 100, resetTime: nil, periodKind: .monthly),
+                lastUpdated: referenceDate
+            )
+        )
+
+        XCTAssertTrue(text.contains("Monthly:"), text)
+        XCTAssertFalse(text.contains("Weekly"), text)
+    }
+
+    func testAdditionalLimitsAppearInTheTextReport() {
+        let text = render(
+            .grok,
+            metric: UsageMetrics(
+                service: .grok,
+                weeklyLimit: UsageLimit(used: 20, total: 100, resetTime: nil, periodKind: .weekly),
+                additionalLimits: [
+                    UsageLimit(used: 12, total: 100, resetTime: nil, periodKind: .daily)
+                ],
+                lastUpdated: referenceDate
+            )
+        )
+
+        XCTAssertTrue(text.contains("Weekly:"), text)
+        XCTAssertTrue(text.contains("Daily:"), text)
+    }
+
     private func render(_ service: ServiceType, metric: UsageMetrics) -> String {
         CLIUsageTextReport.lines(for: [service: metric]).joined(separator: "\n")
     }

--- a/MeterBarTests/CachedMetricsContractTests.swift
+++ b/MeterBarTests/CachedMetricsContractTests.swift
@@ -19,13 +19,17 @@ final class CachedMetricsContractTests: XCTestCase {
                 total: 100,
                 resetTime: Date(timeIntervalSinceReferenceDate: 700_000_000),
                 windowSeconds: 5 * 3_600,
-                isEstimated: true
+                isEstimated: true,
+                periodKind: .session
             ),
-            weeklyLimit: UsageLimit(used: 12, total: 100, resetTime: nil),
+            weeklyLimit: UsageLimit(used: 12, total: 100, resetTime: nil, periodKind: .weekly),
             codeReviewLimit: UsageLimit(used: 32, total: 100, resetTime: nil),
             modelLimitLabel: "Fable",
             extraUsage: ExtraUsageStatus(state: .on, detail: "$0.00 used"),
             resetCreditsAvailable: 2,
+            additionalLimits: [
+                UsageLimit(used: 8, total: 100, resetTime: nil, periodKind: .daily)
+            ],
             lastUpdated: Date(timeIntervalSinceReferenceDate: 699_999_000)
         )
     }
@@ -49,6 +53,8 @@ final class CachedMetricsContractTests: XCTestCase {
         XCTAssertEqual(metrics.modelLimitLabel, "Fable")
         XCTAssertEqual(metrics.extraUsage, ExtraUsageStatus(state: .on, detail: "$0.00 used"))
         XCTAssertEqual(metrics.resetCreditsAvailable, 2)
+        XCTAssertEqual(metrics.additionalLimits, original["Claude Code"]?.additionalLimits)
+        XCTAssertEqual(metrics.sessionLimit?.periodKind, .session)
         XCTAssertEqual(metrics.lastUpdated, original["Claude Code"]?.lastUpdated)
     }
 
@@ -62,18 +68,23 @@ final class CachedMetricsContractTests: XCTestCase {
 
         let topLevelKeys = [
             "id", "service", "sessionLimit", "weeklyLimit", "codeReviewLimit", "modelLimitLabel",
-            "extraUsage", "resetCreditsAvailable", "lastUpdated",
+            "extraUsage", "resetCreditsAvailable", "additionalLimits", "lastUpdated",
         ]
         for key in topLevelKeys {
             XCTAssertNotNil(object[key], "missing top-level key '\(key)'")
         }
 
         let session = try XCTUnwrap(object["sessionLimit"] as? [String: Any])
-        for key in ["used", "total", "resetTime", "windowSeconds", "isEstimated"] {
+        for key in ["used", "total", "resetTime", "windowSeconds", "isEstimated", "periodKind"] {
             XCTAssertNotNil(session[key], "missing sessionLimit key '\(key)'")
         }
         XCTAssertEqual(session["used"] as? Double, 42.5)
         XCTAssertEqual(session["isEstimated"] as? Bool, true)
+        XCTAssertEqual(session["periodKind"] as? String, "session")
+
+        let additional = try XCTUnwrap(object["additionalLimits"] as? [[String: Any]])
+        XCTAssertEqual(additional.count, 1)
+        XCTAssertEqual(additional[0]["periodKind"] as? String, "daily")
 
         let extra = try XCTUnwrap(object["extraUsage"] as? [String: Any])
         XCTAssertEqual(extra["state"] as? String, "on")
@@ -111,6 +122,8 @@ final class CachedMetricsContractTests: XCTestCase {
         XCTAssertNil(metrics.extraUsage)
         XCTAssertNil(metrics.resetCreditsAvailable)
         XCTAssertNil(metrics.modelLimitLabel)
+        XCTAssertNil(metrics.weeklyLimit?.periodKind)
+        XCTAssertTrue(metrics.additionalLimits.isEmpty)
     }
 
     // MARK: - Shared App Group location (issue #13 — a rename must break CI)

--- a/MeterBarTests/GrokCLIUsageServiceTests.swift
+++ b/MeterBarTests/GrokCLIUsageServiceTests.swift
@@ -36,7 +36,9 @@ final class GrokCLIUsageServiceTests: XCTestCase {
         XCTAssertNil(metrics.sessionLimit)
         XCTAssertEqual(metrics.weeklyLimit?.used, 73.5)
         XCTAssertEqual(metrics.weeklyLimit?.total, 100)
+        XCTAssertEqual(metrics.weeklyLimit?.periodKind, .weekly)
         XCTAssertEqual(metrics.weeklyLimit?.windowSeconds, 7 * 24 * 60 * 60)
+        XCTAssertTrue(metrics.additionalLimits.isEmpty)
         XCTAssertEqual(
             metrics.weeklyLimit?.resetTime,
             FlexibleISO8601.date(from: "2026-07-15T15:05:27.877598+00:00")
@@ -79,15 +81,18 @@ final class GrokCLIUsageServiceTests: XCTestCase {
         let session = try XCTUnwrap(metrics.sessionLimit)
         XCTAssertEqual(session.used, 40)
         XCTAssertEqual(session.total, 100)
+        XCTAssertEqual(session.periodKind, .session)
         XCTAssertEqual(session.windowSeconds, 5 * 60 * 60)
         XCTAssertEqual(session.resetTime, FlexibleISO8601.date(from: "2026-07-15T17:00:00Z"))
         XCTAssertNotNil(session.pace(now: now), "A real session window must resolve pace")
 
         let weekly = try XCTUnwrap(metrics.weeklyLimit)
         XCTAssertEqual(weekly.used, 73.5)
+        XCTAssertEqual(weekly.periodKind, .weekly)
         XCTAssertEqual(weekly.windowSeconds, 7 * 24 * 60 * 60)
         XCTAssertEqual(weekly.resetTime, FlexibleISO8601.date(from: "2026-07-15T15:05:27Z"))
         XCTAssertNotNil(weekly.pace(now: now), "A real weekly window must resolve pace")
+        XCTAssertTrue(metrics.additionalLimits.isEmpty)
     }
 
     func testUnknownFieldShapeStillMapsTheUsageItCanRead() throws {
@@ -154,7 +159,9 @@ final class GrokCLIUsageServiceTests: XCTestCase {
         let metrics = try GrokCLIUsageService.map(result, now: Date(timeIntervalSince1970: 1_000))
 
         XCTAssertEqual(metrics.sessionLimit?.used, 12)
+        XCTAssertEqual(metrics.sessionLimit?.periodKind, .session)
         XCTAssertEqual(metrics.weeklyLimit?.used, 44)
+        XCTAssertEqual(metrics.weeklyLimit?.periodKind, .weekly)
     }
 
     func testUsageWithoutAnyReadablePercentIsUnknownRatherThanZero() throws {
@@ -292,6 +299,7 @@ final class GrokCLIUsageServiceTests: XCTestCase {
         let metrics = try GrokCLIUsageService.map(result)
 
         XCTAssertEqual(metrics.weeklyLimit?.used, 25, "50 of a 200 allowance is 25%")
+        XCTAssertEqual(metrics.weeklyLimit?.periodKind, .monthly)
         XCTAssertEqual(metrics.weeklyLimit?.resetTime, FlexibleISO8601.date(from: "2026-08-01T00:00:00Z"))
     }
 
@@ -391,6 +399,167 @@ final class GrokCLIUsageServiceTests: XCTestCase {
         XCTAssertEqual(metrics.weeklyLimit?.used, 10)
         XCTAssertNotNil(metrics.weeklyLimit?.resetTime)
         XCTAssertEqual(metrics.extraUsage?.state, .unknown)
+    }
+
+    func testMonthlyPeriodOccupiesTheWeeklySlotWithHonestPeriodKind() throws {
+        let result = try decodeResult(
+            """
+            {
+              "config": {
+                "usagePeriods": [
+                  {
+                    "type": "USAGE_PERIOD_TYPE_MONTHLY",
+                    "start": "2026-07-01T00:00:00Z",
+                    "end": "2026-08-01T00:00:00Z",
+                    "usagePercent": 41
+                  }
+                ]
+              }
+            }
+            """
+        )
+
+        let metrics = try GrokCLIUsageService.map(result)
+
+        let weekly = try XCTUnwrap(metrics.weeklyLimit)
+        XCTAssertEqual(weekly.used, 41)
+        XCTAssertEqual(weekly.periodKind, .monthly)
+        XCTAssertEqual(weekly.windowSeconds, 31 * 24 * 60 * 60)
+        XCTAssertEqual(weekly.resetTime, FlexibleISO8601.date(from: "2026-08-01T00:00:00Z"))
+        XCTAssertNil(metrics.sessionLimit)
+        XCTAssertTrue(metrics.additionalLimits.isEmpty)
+    }
+
+    func testBillingPeriodOccupiesTheWeeklySlotWhenWeeklyIsEmpty() throws {
+        let result = try decodeResult(
+            """
+            {
+              "config": {
+                "usagePeriods": [
+                  {
+                    "type": "USAGE_PERIOD_TYPE_BILLING_CYCLE",
+                    "start": "2026-07-01T00:00:00Z",
+                    "end": "2026-08-01T00:00:00Z",
+                    "usagePercent": 18
+                  }
+                ]
+              }
+            }
+            """
+        )
+
+        let weekly = try XCTUnwrap(try GrokCLIUsageService.map(result).weeklyLimit)
+        XCTAssertEqual(weekly.used, 18)
+        XCTAssertEqual(weekly.periodKind, .billing)
+    }
+
+    func testMultipleACPPeriodsAreKeptRatherThanDiscarded() throws {
+        let result = try decodeResult(
+            """
+            {
+              "config": {
+                "usagePeriods": [
+                  {
+                    "type": "USAGE_PERIOD_TYPE_SESSION",
+                    "start": "2026-07-15T12:00:00Z",
+                    "end": "2026-07-15T17:00:00Z",
+                    "usagePercent": 22
+                  },
+                  {
+                    "type": "USAGE_PERIOD_TYPE_DAILY",
+                    "start": "2026-07-15T00:00:00Z",
+                    "end": "2026-07-16T00:00:00Z",
+                    "usagePercent": 33
+                  },
+                  {
+                    "type": "USAGE_PERIOD_TYPE_WEEKLY",
+                    "start": "2026-07-08T15:05:27Z",
+                    "end": "2026-07-15T15:05:27Z",
+                    "usagePercent": 44
+                  },
+                  {
+                    "type": "USAGE_PERIOD_TYPE_MONTHLY",
+                    "start": "2026-07-01T00:00:00Z",
+                    "end": "2026-08-01T00:00:00Z",
+                    "usagePercent": 55
+                  },
+                  {
+                    "type": "USAGE_PERIOD_TYPE_BILLING_CYCLE",
+                    "start": "2026-06-01T00:00:00Z",
+                    "end": "2026-07-01T00:00:00Z",
+                    "usagePercent": 66
+                  }
+                ]
+              }
+            }
+            """
+        )
+
+        let metrics = try GrokCLIUsageService.map(result)
+
+        XCTAssertEqual(metrics.sessionLimit?.used, 22)
+        XCTAssertEqual(metrics.sessionLimit?.periodKind, .session)
+        XCTAssertEqual(metrics.weeklyLimit?.used, 44)
+        XCTAssertEqual(metrics.weeklyLimit?.periodKind, .weekly)
+        XCTAssertEqual(metrics.additionalLimits.map(\.used), [33, 55, 66])
+        XCTAssertEqual(
+            metrics.additionalLimits.map(\.periodKind),
+            [.daily, .monthly, .billing]
+        )
+    }
+
+    func testUnknownPeriodTypeWithPercentIsKeptAndWithoutPercentIsSkipped() throws {
+        let result = try decodeResult(
+            """
+            {
+              "config": {
+                "usagePeriods": [
+                  {
+                    "type": "USAGE_PERIOD_TYPE_EXPERIMENTAL_BUCKET",
+                    "usagePercent": 17
+                  },
+                  {
+                    "type": "USAGE_PERIOD_TYPE_EXPERIMENTAL_BUCKET"
+                  },
+                  {
+                    "type": "USAGE_PERIOD_TYPE_WEEKLY",
+                    "start": "2026-07-08T15:05:27Z",
+                    "end": "2026-07-15T15:05:27Z",
+                    "usagePercent": 40
+                  }
+                ]
+              }
+            }
+            """
+        )
+
+        let metrics = try GrokCLIUsageService.map(result)
+
+        XCTAssertEqual(metrics.weeklyLimit?.used, 40)
+        XCTAssertEqual(metrics.weeklyLimit?.periodKind, .weekly)
+        XCTAssertEqual(metrics.additionalLimits.count, 1)
+        XCTAssertEqual(metrics.additionalLimits.first?.used, 17)
+        XCTAssertEqual(metrics.additionalLimits.first?.periodKind, .unknown)
+        XCTAssertNil(metrics.additionalLimits.first?.resetTime)
+        XCTAssertNil(metrics.additionalLimits.first?.windowSeconds)
+    }
+
+    func testUnknownPeriodWithoutPercentAndNoOtherReadingIsUnknownRatherThanZero() throws {
+        let result = try decodeResult(
+            """
+            {
+              "config": {
+                "usagePeriods": [
+                  { "type": "USAGE_PERIOD_TYPE_EXPERIMENTAL_BUCKET" }
+                ]
+              }
+            }
+            """
+        )
+
+        XCTAssertThrowsError(try GrokCLIUsageService.map(result)) { error in
+            XCTAssertEqual(error as? GrokBillingRPC.Error, .invalidResponse)
+        }
     }
 
     // MARK: - Transport

--- a/MeterBarTests/LocalizationResourceContractTests.swift
+++ b/MeterBarTests/LocalizationResourceContractTests.swift
@@ -112,6 +112,9 @@ final class LocalizationResourceContractTests: XCTestCase {
             "widget.quota.other_models",
             "widget.quota.monthly",
             "widget.quota.weekly",
+            "widget.quota.daily",
+            "widget.quota.billing_cycle",
+            "widget.quota.quota",
         ] {
             let appValue = try englishValue(for: key, in: appStrings)
             let widgetValue = try englishValue(for: key, in: widgetStrings)
@@ -135,6 +138,9 @@ final class LocalizationResourceContractTests: XCTestCase {
             "widget.quota.other_models",
             "widget.quota.monthly",
             "widget.quota.weekly",
+            "widget.quota.daily",
+            "widget.quota.billing_cycle",
+            "widget.quota.quota",
         ] {
             XCTAssertTrue(widgetKeys.contains(key), "\(key) missing from the widget catalog")
         }
@@ -190,6 +196,9 @@ final class LocalizationResourceContractTests: XCTestCase {
         (.otherModels, "quota.title.other_models"),
         (.monthly, "quota.title.monthly"),
         (.weekly, "quota.title.weekly"),
+        (.daily, "quota.title.daily"),
+        (.billingCycle, "quota.title.billing_cycle"),
+        (.quota, "quota.title.quota"),
     ]
 
     func testCountStringsCarryEnglishOneAndOtherPluralRules() throws {

--- a/MeterBarTests/NotificationDeciderTests.swift
+++ b/MeterBarTests/NotificationDeciderTests.swift
@@ -23,6 +23,7 @@ final class NotificationDeciderTests: XCTestCase {
         session: UsageLimit? = nil,
         weekly: UsageLimit? = nil,
         codeReview: UsageLimit? = nil,
+        additional: [UsageLimit] = [],
         modelLimitLabel: String? = nil,
         extraUsage: ExtraUsageStatus? = nil,
         lastUpdated: Date? = nil
@@ -35,6 +36,7 @@ final class NotificationDeciderTests: XCTestCase {
             modelLimitLabel: modelLimitLabel
                 ?? (service == .claudeCode && codeReview != nil ? "Sonnet" : nil),
             extraUsage: extraUsage,
+            additionalLimits: additional,
             lastUpdated: lastUpdated ?? now
         )
     }
@@ -448,5 +450,36 @@ final class NotificationDeciderTests: XCTestCase {
         XCTAssertEqual(result.notifications.first?.quotaDisplayName, "Monthly")
         XCTAssertEqual(result.notifications.first?.title, "Grok Monthly Limit Reached")
         XCTAssertFalse(result.notifications.contains { $0.quotaDisplayName == "Weekly" })
+    }
+
+    func testAdditionalLimitsFireIndependentThresholdNotifications() {
+        let result = decider().evaluate(
+            metrics: metrics(
+                service: .grok,
+                weekly: UsageLimit(used: 10, total: 100, resetTime: nil, periodKind: .weekly),
+                additional: [
+                    UsageLimit(used: 100, total: 100, resetTime: nil, periodKind: .daily),
+                    UsageLimit(used: 95, total: 100, resetTime: nil, periodKind: .billing),
+                    UsageLimit(used: 95, total: 100, resetTime: nil, periodKind: .unknown)
+                ]
+            ),
+            providerEnabled: true,
+            alreadyNotified: [],
+            now: now
+        )
+
+        XCTAssertEqual(
+            Set(result.notifications.map(\.quotaDisplayName)),
+            ["Daily", "Billing cycle", "Quota"]
+        )
+        XCTAssertEqual(
+            Set(result.notifications.map(\.key)),
+            [
+                "Grok-additional-0-critical",
+                "Grok-additional-1-warn",
+                "Grok-additional-2-warn",
+            ]
+        )
+        XCTAssertTrue(result.notifications.allSatisfy { !$0.blocksProvider })
     }
 }

--- a/MeterBarTests/NotificationDeciderTests.swift
+++ b/MeterBarTests/NotificationDeciderTests.swift
@@ -433,4 +433,20 @@ final class NotificationDeciderTests: XCTestCase {
         XCTAssertEqual(result.notifications.first?.key, "Codex CLI-work-account-session-critical")
         XCTAssertEqual(result.notifications.first?.title, "Work (OpenAI Codex) Session Limit Reached")
     }
+
+    func testGrokMonthlyWeeklySlotNotificationIsTitledMonthly() {
+        let result = decider().evaluate(
+            metrics: metrics(
+                service: .grok,
+                weekly: UsageLimit(used: 100, total: 100, resetTime: nil, periodKind: .monthly)
+            ),
+            providerEnabled: true,
+            alreadyNotified: [],
+            now: now
+        )
+
+        XCTAssertEqual(result.notifications.first?.quotaDisplayName, "Monthly")
+        XCTAssertEqual(result.notifications.first?.title, "Grok Monthly Limit Reached")
+        XCTAssertFalse(result.notifications.contains { $0.quotaDisplayName == "Weekly" })
+    }
 }

--- a/MeterBarTests/ProviderRecommendationTests.swift
+++ b/MeterBarTests/ProviderRecommendationTests.swift
@@ -50,6 +50,18 @@ final class ProviderRecommendationTests: XCTestCase {
         )
     }
 
+    func testGrokMonthlyWeeklySlotRecommendationIsTitledMonthly() {
+        let recommendation = rank([
+            makeCandidate(
+                id: "grok-monthly",
+                service: .grok,
+                weekly: UsageLimit(used: 40, total: 100, resetTime: nil, periodKind: .monthly)
+            )
+        ])
+
+        XCTAssertEqual(recommendation.rows.map(\.windowTitle), ["Monthly"])
+    }
+
     func testEqualScoresFallBackToStableProviderOrder() {
         let recommendation = rank([
             makeCandidate(id: "grok", service: .grok, session: limit(used: 40)),

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -418,6 +418,8 @@ final class ProviderSnapshotTests: XCTestCase {
             case .cursor: return .onDemand
             case .codexCli, .openRouter, .grok: return .codeReview
             }
+        case .additional:
+            return .quota
         }
     }
 
@@ -896,5 +898,38 @@ final class ProviderSnapshotTests: XCTestCase {
         )
 
         XCTAssertEqual(snapshot.detailLimits.map(\.id), ["session", "weekly"])
+    }
+
+    func testGrokMonthlyWeeklySlotIsTitledMonthlyNeverWeekly() {
+        let metrics = UsageMetrics(
+            service: .grok,
+            weeklyLimit: UsageLimit(used: 41, total: 100, resetTime: nil, periodKind: .monthly)
+        )
+        let limits = ProviderSnapshotBuilder.limits(for: metrics, service: .grok)
+        let weekly = try? XCTUnwrap(limits.first { $0.id == "weekly" })
+
+        XCTAssertEqual(weekly?.quotaTitleKey, .monthly)
+        XCTAssertEqual(weekly?.title, "Monthly")
+        XCTAssertEqual(weekly?.localizedTitle, "Monthly")
+        XCTAssertFalse(weekly?.title.contains("Weekly") == true)
+    }
+
+    func testAdditionalLimitsBecomeExtraSnapshotRows() {
+        let metrics = UsageMetrics(
+            service: .grok,
+            sessionLimit: UsageLimit(used: 10, total: 100, resetTime: nil, periodKind: .session),
+            weeklyLimit: UsageLimit(used: 20, total: 100, resetTime: nil, periodKind: .weekly),
+            additionalLimits: [
+                UsageLimit(used: 30, total: 100, resetTime: nil, periodKind: .daily),
+                UsageLimit(used: 40, total: 100, resetTime: nil, periodKind: .billing),
+                UsageLimit(used: 50, total: 100, resetTime: nil, periodKind: .unknown)
+            ]
+        )
+        let limits = ProviderSnapshotBuilder.limits(for: metrics, service: .grok)
+
+        XCTAssertEqual(limits.map(\.id), ["session", "weekly", "additional-0", "additional-1", "additional-2"])
+        XCTAssertEqual(limits.map(\.quotaTitleKey), [.session, .weekly, .daily, .billingCycle, .quota])
+        XCTAssertEqual(limits.map(\.title), ["Session", "Weekly", "Daily", "Billing cycle", "Quota"])
+        XCTAssertEqual(limits.last?.localizedTitle, "Quota")
     }
 }

--- a/MeterBarTests/QuotaEventDeliveryTests.swift
+++ b/MeterBarTests/QuotaEventDeliveryTests.swift
@@ -30,6 +30,7 @@ final class QuotaEventDeliveryTests: XCTestCase {
         XCTAssertTrue(output.contains("METERBAR_ACCOUNT_ID=account-id"))
         XCTAssertTrue(output.contains("METERBAR_ACCOUNT_NAME=Work"))
         XCTAssertTrue(output.contains("METERBAR_WINDOW=session"))
+        XCTAssertFalse(output.contains("METERBAR_PERIOD_KIND="))
         XCTAssertTrue(output.contains("METERBAR_PERCENTAGE=91"))
         XCTAssertTrue(output.contains("METERBAR_BAND=critical"))
         XCTAssertFalse(output.contains("CLAUDE_CONFIG_DIR"))
@@ -76,11 +77,49 @@ final class QuotaEventDeliveryTests: XCTestCase {
         XCTAssertTrue(output.contains("METERBAR_PROVIDER=Grok"))
         XCTAssertTrue(output.contains("METERBAR_ACCOUNT_ID=\(GrokAccount.defaultID.uuidString)"))
         XCTAssertTrue(output.contains("METERBAR_ACCOUNT_NAME=Work"))
+        XCTAssertFalse(output.contains("METERBAR_PERIOD_KIND="))
         XCTAssertFalse(output.contains("GROK_HOME"))
         XCTAssertFalse(output.contains("homeDirectory"))
         XCTAssertFalse(output.contains("/secret/"))
         XCTAssertFalse(output.localizedCaseInsensitiveContains("token="))
         XCTAssertFalse(output.contains("auth.json"))
+    }
+
+    func testLocalHookIncludesPeriodKindWhenReported() async throws {
+        let tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("QuotaEventDeliveryTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let runner = QuotaEventLocalHookRunner(
+            runner: WakeEventHookRunner(
+                logger: WakeRunLogger(directory: tempDirectory.appendingPathComponent("logs", isDirectory: true))
+            )
+        )
+        let grokAccountID = GrokAccount.defaultID.uuidString
+        let result = await runner.run(
+            configuration: configuration(
+                executable: "/usr/bin/env",
+                arguments: [],
+                webhookURL: "",
+                provider: .grok,
+                accountID: grokAccountID
+            ),
+            payload: QuotaEventPayload(
+                provider: .grok,
+                account: QuotaEventAccount(id: grokAccountID, name: "Work"),
+                event: .exhausted,
+                window: .weekly,
+                periodKind: .monthly,
+                percentage: 100,
+                band: .exhausted,
+                timestamp: Date(timeIntervalSince1970: 1_800_000_000)
+            )
+        )
+        let output = try XCTUnwrap(String(bytes: result.stdoutCapture, encoding: .utf8))
+
+        XCTAssertTrue(output.contains("METERBAR_WINDOW=weekly"))
+        XCTAssertTrue(output.contains("METERBAR_PERIOD_KIND=monthly"))
     }
 
     func testOneDeliveryFailureDoesNotBlockOtherChannelsOrLaterEvents() async {

--- a/MeterBarTests/QuotaEventPlannerTests.swift
+++ b/MeterBarTests/QuotaEventPlannerTests.swift
@@ -204,6 +204,84 @@ final class QuotaEventPlannerTests: XCTestCase {
         XCTAssertEqual(exhausted.map(\.event), [.exhausted])
     }
 
+    func testMonthlyWeeklySlotKeepsWeeklyWindowAndAddsPeriodKind() throws {
+        var planner = QuotaEventPlanner(debounceInterval: 60)
+        let primed = QuotaEventSnapshot(
+            provider: .grok,
+            account: account,
+            metrics: UsageMetrics(
+                service: .grok,
+                weeklyLimit: UsageLimit(used: 50, total: 100, resetTime: nil, periodKind: .monthly),
+                lastUpdated: start
+            )
+        )
+        XCTAssertTrue(planner.evaluate(snapshots: [primed], now: start).isEmpty)
+
+        let events = planner.evaluate(
+            snapshots: [
+                QuotaEventSnapshot(
+                    provider: .grok,
+                    account: account,
+                    metrics: UsageMetrics(
+                        service: .grok,
+                        weeklyLimit: UsageLimit(used: 100, total: 100, resetTime: nil, periodKind: .monthly),
+                        lastUpdated: start
+                    )
+                )
+            ],
+            now: start.addingTimeInterval(1)
+        )
+
+        XCTAssertEqual(events.map(\.window), [.weekly])
+        XCTAssertEqual(events.map(\.periodKind), [.monthly])
+        XCTAssertEqual(events.first?.window.displayName(periodKind: events.first?.periodKind), "Monthly")
+        XCTAssertEqual(QuotaEventWindow.allCases.map(\.rawValue), ["session", "weekly", "code_review"])
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoder.encode(try XCTUnwrap(events.first))) as? [String: Any]
+        )
+        XCTAssertEqual(object["window"] as? String, "weekly")
+        XCTAssertEqual(object["period_kind"] as? String, "monthly")
+    }
+
+    func testAdditionalLimitsEmitIndependentOverflowEvents() {
+        var planner = QuotaEventPlanner(debounceInterval: 60)
+        func snapshot(daily: Double, billing: Double, unknown: Double) -> QuotaEventSnapshot {
+            QuotaEventSnapshot(
+                provider: .grok,
+                account: account,
+                metrics: UsageMetrics(
+                    service: .grok,
+                    weeklyLimit: UsageLimit(used: 10, total: 100, resetTime: nil, periodKind: .weekly),
+                    additionalLimits: [
+                        UsageLimit(used: daily, total: 100, resetTime: nil, periodKind: .daily),
+                        UsageLimit(used: billing, total: 100, resetTime: nil, periodKind: .billing),
+                        UsageLimit(used: unknown, total: 100, resetTime: nil, periodKind: .unknown)
+                    ],
+                    lastUpdated: start
+                )
+            )
+        }
+
+        XCTAssertTrue(planner.evaluate(snapshots: [snapshot(daily: 10, billing: 10, unknown: 10)], now: start).isEmpty)
+
+        let events = planner.evaluate(
+            snapshots: [snapshot(daily: 80, billing: 100, unknown: 91)],
+            now: start.addingTimeInterval(1)
+        )
+
+        XCTAssertEqual(Set(events.map(\.window)), [.session, .weekly])
+        XCTAssertEqual(
+            Set(events.compactMap(\.periodKind)),
+            [.daily, .billing, .unknown]
+        )
+        XCTAssertTrue(events.contains { $0.window == .session && $0.periodKind == .daily })
+        XCTAssertTrue(events.contains { $0.window == .weekly && $0.periodKind == .billing })
+        XCTAssertTrue(events.contains { $0.window == .weekly && $0.periodKind == .unknown })
+    }
+
     private func snapshot(
         account: QuotaEventAccount,
         used: Double

--- a/MeterBarTests/QuotaGuardTests.swift
+++ b/MeterBarTests/QuotaGuardTests.swift
@@ -29,6 +29,62 @@ final class QuotaGuardTests: XCTestCase {
         XCTAssertEqual(try target(window: "code-review").window, .codeReview)
         XCTAssertEqual(try target(window: "codeReview").window, .codeReview)
         XCTAssertEqual(try target(window: " CODE_REVIEW ").window, .codeReview)
+        XCTAssertEqual(try target(window: "monthly").window, .monthly)
+        XCTAssertEqual(try target(window: "daily").window, .daily)
+        XCTAssertEqual(try target(window: "billing-cycle").window, .billing)
+        XCTAssertEqual(try target(window: "unknown").window, .unknown)
+    }
+
+    func testGrokMonthlyWeeklySlotIsGuardedAsMonthlyNeverWeekly() throws {
+        let evaluation = QuotaGuardEvaluator.evaluate(
+            target: try target(provider: "grok", window: "weekly"),
+            account: .providerWide,
+            metrics: metrics(
+                service: .grok,
+                weekly: UsageLimit(used: 100, total: 100, resetTime: now.addingTimeInterval(3_600), periodKind: .monthly)
+            ),
+            now: now
+        )
+
+        XCTAssertEqual(evaluation.window, .weekly)
+        XCTAssertEqual(evaluation.window?.cliIdentifier, "weekly")
+        XCTAssertEqual(evaluation.periodKind, .monthly)
+        XCTAssertTrue(evaluation.message.contains("monthly"), evaluation.message)
+        XCTAssertFalse(evaluation.message.contains("weekly"), evaluation.message)
+        XCTAssertEqual(try json(evaluation)["window"] as? String, "weekly")
+        XCTAssertEqual(try json(evaluation)["periodKind"] as? String, "monthly")
+    }
+
+    func testCadenceSelectorFindsMonthlyInTheWeeklySlotAndDailyOverflow() throws {
+        let metrics = metrics(
+            service: .grok,
+            weekly: UsageLimit(used: 40, total: 100, resetTime: nil, periodKind: .monthly),
+            additional: [
+                UsageLimit(used: 80, total: 100, resetTime: nil, periodKind: .daily)
+            ]
+        )
+
+        let monthly = QuotaGuardEvaluator.evaluate(
+            target: try target(provider: "grok", window: "monthly"),
+            account: .providerWide,
+            metrics: metrics,
+            now: now
+        )
+        XCTAssertEqual(monthly.outcome, .available)
+        XCTAssertEqual(monthly.periodKind, .monthly)
+        XCTAssertEqual(monthly.window?.cliIdentifier, "weekly")
+        XCTAssertTrue(monthly.message.contains("monthly"), monthly.message)
+
+        let daily = QuotaGuardEvaluator.evaluate(
+            target: try target(provider: "grok", window: "daily"),
+            account: .providerWide,
+            metrics: metrics,
+            now: now
+        )
+        XCTAssertEqual(daily.percentLeft, 20)
+        XCTAssertEqual(daily.periodKind, .daily)
+        XCTAssertEqual(daily.window?.cliIdentifier, "session")
+        XCTAssertTrue(daily.message.contains("daily"), daily.message)
     }
 
     func testResolveAcceptsStableProviderTokens() throws {
@@ -694,6 +750,7 @@ final class QuotaGuardTests: XCTestCase {
         session: UsageLimit? = nil,
         weekly: UsageLimit? = nil,
         codeReview: UsageLimit? = nil,
+        additional: [UsageLimit] = [],
         ageSeconds: TimeInterval = 60
     ) -> UsageMetrics {
         UsageMetrics(
@@ -701,6 +758,7 @@ final class QuotaGuardTests: XCTestCase {
             sessionLimit: session,
             weeklyLimit: weekly,
             codeReviewLimit: codeReview,
+            additionalLimits: additional,
             lastUpdated: now.addingTimeInterval(-ageSeconds)
         )
     }

--- a/MeterBarTests/QuotaWebhookClientTests.swift
+++ b/MeterBarTests/QuotaWebhookClientTests.swift
@@ -121,6 +121,7 @@ final class QuotaWebhookClientTests: XCTestCase {
             XCTAssertEqual(object["provider"] as? String, ServiceType.codexCli.rawValue)
             XCTAssertEqual(object["event"] as? String, "exhausted")
             XCTAssertEqual(object["window"] as? String, "weekly")
+            XCTAssertNil(object["period_kind"])
             XCTAssertEqual(object["band"] as? String, "exhausted")
             let account = try XCTUnwrap(object["account"] as? [String: Any])
             XCTAssertEqual(Set(account.keys), ["id", "name"])

--- a/MeterBarTests/ServiceTypeTests.swift
+++ b/MeterBarTests/ServiceTypeTests.swift
@@ -129,4 +129,35 @@ final class ServiceTypeTests: XCTestCase {
         )
         XCTAssertEqual(ServiceType.claudeCode.sessionQuotaTitle(limitTotal: 100), "Session")
     }
+
+    /// A Grok monthly (or billing) allowance occupies the legacy weekly slot
+    /// but must never be titled Weekly.
+    func testGrokWeeklySlotHonorsReportedPeriodKind() {
+        XCTAssertEqual(
+            ServiceType.grok.weeklyQuotaTitle(limitTotal: 100, periodKind: .monthly),
+            "Monthly"
+        )
+        XCTAssertEqual(
+            ServiceType.grok.weeklyQuotaTitle(limitTotal: 100, periodKind: .billing),
+            "Billing cycle"
+        )
+        XCTAssertEqual(
+            ServiceType.grok.weeklyQuotaTitle(limitTotal: 100, periodKind: .weekly),
+            "Weekly"
+        )
+        XCTAssertEqual(
+            ServiceType.grok.weeklyQuotaTitle(limitTotal: 100, periodKind: .unknown),
+            "Quota"
+        )
+        XCTAssertEqual(
+            ServiceType.grok.sessionQuotaTitle(limitTotal: 100, periodKind: .session),
+            "Session"
+        )
+        XCTAssertEqual(
+            ServiceType.grok.additionalQuotaTitleKey(
+                for: UsageLimit(used: 10, total: 100, resetTime: nil, periodKind: .daily)
+            ),
+            .daily
+        )
+    }
 }

--- a/MeterBarTests/UsageLimitTests.swift
+++ b/MeterBarTests/UsageLimitTests.swift
@@ -23,6 +23,26 @@ final class UsageLimitTests: XCTestCase {
         let limit = try JSONDecoder().decode(UsageLimit.self, from: data)
 
         XCTAssertFalse(limit.isEstimated)
+        XCTAssertNil(limit.periodKind)
+    }
+
+    func testPeriodKindRoundTripsAndIsOmittedWhenAbsent() throws {
+        let withKind = UsageLimit(
+            used: 25,
+            total: 100,
+            resetTime: nil,
+            periodKind: .monthly
+        )
+        let encoded = try JSONEncoder().encode(withKind)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        XCTAssertEqual(object["periodKind"] as? String, "monthly")
+
+        let decoded = try JSONDecoder().decode(UsageLimit.self, from: encoded)
+        XCTAssertEqual(decoded.periodKind, .monthly)
+
+        let withoutKind = try JSONEncoder().encode(UsageLimit(used: 1, total: 100, resetTime: nil))
+        let omitted = try XCTUnwrap(JSONSerialization.jsonObject(with: withoutKind) as? [String: Any])
+        XCTAssertNil(omitted["periodKind"])
     }
 
     func testPercentageValues() {

--- a/MeterBarTests/UsageMetricsTests.swift
+++ b/MeterBarTests/UsageMetricsTests.swift
@@ -30,6 +30,19 @@ final class UsageMetricsTests: XCTestCase {
         XCTAssertNil(metrics.sessionLimit)
         XCTAssertNil(metrics.weeklyLimit)
         XCTAssertNil(metrics.codeReviewLimit)
+        XCTAssertTrue(metrics.additionalLimits.isEmpty)
+        XCTAssertFalse(metrics.hasData)
+    }
+
+    func testHasDataIsTrueWhenOnlyAdditionalLimitsExist() {
+        let metrics = UsageMetrics(
+            service: .grok,
+            additionalLimits: [
+                UsageLimit(used: 12, total: 100, resetTime: nil, periodKind: .daily)
+            ]
+        )
+
+        XCTAssertTrue(metrics.hasData)
     }
 
     func testIdIsUnique() {
@@ -76,6 +89,25 @@ final class UsageMetricsTests: XCTestCase {
 
         XCTAssertEqual(decoded.service, .claudeCode)
         XCTAssertNil(decoded.modelLimitLabel)
+        XCTAssertTrue(decoded.additionalLimits.isEmpty)
+    }
+
+    func testAdditionalLimitsRoundTripAndPreserveCopies() throws {
+        let original = UsageMetrics(
+            service: .grok,
+            weeklyLimit: UsageLimit(used: 40, total: 100, resetTime: nil, periodKind: .weekly),
+            additionalLimits: [
+                UsageLimit(used: 12, total: 100, resetTime: nil, periodKind: .daily)
+            ]
+        )
+
+        let decoded = try JSONDecoder().decode(UsageMetrics.self, from: JSONEncoder().encode(original))
+        XCTAssertEqual(decoded.additionalLimits, original.additionalLimits)
+        XCTAssertEqual(decoded.weeklyLimit?.periodKind, .weekly)
+
+        let copied = decoded.withResetCreditsAvailable(1).withExtraUsage(.unknown)
+        XCTAssertEqual(copied.additionalLimits, original.additionalLimits)
+        XCTAssertEqual(copied.resetCreditsAvailable, 1)
     }
 
     func testOverallStatusIgnoresModelScopedExhaustion() {

--- a/MeterBarTests/WidgetPresentationTests.swift
+++ b/MeterBarTests/WidgetPresentationTests.swift
@@ -474,6 +474,50 @@ final class WidgetPresentationTests: XCTestCase {
         )
     }
 
+    func testGrokMonthlyWeeklySlotIsTitledMonthlyNeverWeekly() {
+        var preferences = WidgetPreferences.defaults
+        preferences.visibleQuotaWindows = [.weekly]
+        let presentation = presentation(
+            metrics: [
+                .grok: UsageMetrics(
+                    service: .grok,
+                    weeklyLimit: UsageLimit(used: 41, total: 100, resetTime: nil, periodKind: .monthly),
+                    lastUpdated: now
+                )
+            ],
+            preferences: preferences
+        )
+        let row = presentation.rows.first { $0.service == .grok && $0.quotaWindow == .weekly }
+
+        XCTAssertEqual(row?.quotaTitleKey, .monthly)
+        XCTAssertEqual(row?.quotaTitle, "Monthly")
+        XCTAssertNotEqual(row?.quotaTitle, "Weekly")
+    }
+
+    func testAdditionalLimitsAppearAsExtraWidgetRows() {
+        var preferences = WidgetPreferences.defaults
+        preferences.visibleQuotaWindows = Set(WidgetQuotaWindow.allCases)
+        let presentation = presentation(
+            metrics: [
+                .grok: UsageMetrics(
+                    service: .grok,
+                    sessionLimit: UsageLimit(used: 10, total: 100, resetTime: nil, periodKind: .session),
+                    weeklyLimit: UsageLimit(used: 20, total: 100, resetTime: nil, periodKind: .weekly),
+                    additionalLimits: [
+                        UsageLimit(used: 30, total: 100, resetTime: nil, periodKind: .daily)
+                    ],
+                    lastUpdated: now
+                )
+            ],
+            preferences: preferences
+        )
+        let titles = presentation.rows.filter { $0.service == .grok }.map(\.quotaTitle)
+
+        XCTAssertTrue(titles.contains("Session"))
+        XCTAssertTrue(titles.contains("Weekly"))
+        XCTAssertTrue(titles.contains("Daily"), titles.joined(separator: ", "))
+    }
+
     private func makeMetrics(
         _ service: ServiceType,
         sessionUsed: Double? = nil,

--- a/MeterBarWidget/Resources/Localizable.xcstrings
+++ b/MeterBarWidget/Resources/Localizable.xcstrings
@@ -286,6 +286,17 @@
         }
       }
     },
+    "widget.quota.billing_cycle": {
+      "comment": "Quota window that resets with the provider billing cycle.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Billing cycle"
+          }
+        }
+      }
+    },
     "widget.quota.code_review": {
       "localizations": {
         "en": {
@@ -303,6 +314,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cursor Models"
+          }
+        }
+      }
+    },
+    "widget.quota.daily": {
+      "comment": "Quota window that resets each day.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Daily"
           }
         }
       }
@@ -355,6 +377,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "Other Models"
+          }
+        }
+      }
+    },
+    "widget.quota.quota": {
+      "comment": "Neutral title for a reported quota whose cadence is unknown.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quota"
           }
         }
       }

--- a/Packages/MeterBarShared/Sources/MeterBarShared/LocalizedUsageFormatting.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/LocalizedUsageFormatting.swift
@@ -379,6 +379,30 @@ public enum LocalizedUsageFormat {
                 locale: locale,
                 comment: "Quota title for a weekly window."
             )
+        case .daily:
+            return String(
+                localized: "widget.quota.daily",
+                defaultValue: "Daily",
+                bundle: bundle,
+                locale: locale,
+                comment: "Quota title for a daily window."
+            )
+        case .billingCycle:
+            return String(
+                localized: "widget.quota.billing_cycle",
+                defaultValue: "Billing cycle",
+                bundle: bundle,
+                locale: locale,
+                comment: "Quota title for a provider billing-cycle window."
+            )
+        case .quota:
+            return String(
+                localized: "widget.quota.quota",
+                defaultValue: "Quota",
+                bundle: bundle,
+                locale: locale,
+                comment: "Neutral title for a reported quota whose cadence is unknown."
+            )
         }
     }
 

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ProviderRecommendation.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ProviderRecommendation.swift
@@ -76,12 +76,16 @@ public enum ProviderRecommendationWindow: String, Equatable, Sendable {
     case session
     case weekly
 
-    public func title(for service: ServiceType, limitTotal: Double? = nil) -> String {
+    public func title(
+        for service: ServiceType,
+        limitTotal: Double? = nil,
+        periodKind: UsageLimit.PeriodKind? = nil
+    ) -> String {
         switch self {
         case .session:
-            return service.sessionQuotaTitle(limitTotal: limitTotal)
+            return service.sessionQuotaTitle(limitTotal: limitTotal, periodKind: periodKind)
         case .weekly:
-            return service.weeklyQuotaTitle(limitTotal: limitTotal)
+            return service.weeklyQuotaTitle(limitTotal: limitTotal, periodKind: periodKind)
         }
     }
 }
@@ -134,7 +138,7 @@ public struct ProviderRecommendationRow: Identifiable, Equatable, Sendable {
     }
 
     public var windowTitle: String {
-        window.title(for: service, limitTotal: limit.total)
+        window.title(for: service, limitTotal: limit.total, periodKind: limit.periodKind)
     }
 
     public var headroomText: String {

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ServiceType.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ServiceType.swift
@@ -118,6 +118,11 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
         case otherModels
         case monthly
         case weekly
+        case daily
+        case billingCycle
+        /// Neutral title when the provider reported a window MeterBar cannot
+        /// name honestly. Never a guessed cadence such as "Weekly".
+        case quota
         case codeReview
         case onDemand
         /// Claude Code's model-scoped window. The parsed label is provider data
@@ -136,6 +141,9 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
             case .otherModels: return "Other Models"
             case .monthly: return "Monthly"
             case .weekly: return "Weekly"
+            case .daily: return "Daily"
+            case .billingCycle: return "Billing cycle"
+            case .quota: return "Quota"
             case .codeReview: return "Code Review"
             case .onDemand: return "On-demand"
             case let .model(label): return label ?? "Model"
@@ -178,11 +186,20 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
     /// key spend cap. Cursor's is the **Cursor Models** pool when the payload
     /// used the percent-of-100 shape, and "Session" for the legacy on-demand
     /// mapping.
-    public func sessionQuotaTitle(limitTotal: Double?) -> String {
-        sessionQuotaTitleKey(limitTotal: limitTotal).englishTitle
+    public func sessionQuotaTitle(
+        limitTotal: Double?,
+        periodKind: UsageLimit.PeriodKind? = nil
+    ) -> String {
+        sessionQuotaTitleKey(limitTotal: limitTotal, periodKind: periodKind).englishTitle
     }
 
-    public func sessionQuotaTitleKey(limitTotal: Double?) -> QuotaTitleKey {
+    public func sessionQuotaTitleKey(
+        limitTotal: Double?,
+        periodKind: UsageLimit.PeriodKind? = nil
+    ) -> QuotaTitleKey {
+        if let periodKind, let titled = quotaTitleKey(overridingWith: periodKind) {
+            return titled
+        }
         switch self {
         case .openRouter: return .keyLimit
         case .cursor:
@@ -204,11 +221,20 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
     /// Pass `limitTotal` when the concrete window is known: Cursor's percent
     /// pools title as **Other Models**, matching the dashboard; a request-count
     /// billing-cycle quota stays **Monthly**.
-    public func weeklyQuotaTitle(limitTotal: Double?) -> String {
-        weeklyQuotaTitleKey(limitTotal: limitTotal).englishTitle
+    public func weeklyQuotaTitle(
+        limitTotal: Double?,
+        periodKind: UsageLimit.PeriodKind? = nil
+    ) -> String {
+        weeklyQuotaTitleKey(limitTotal: limitTotal, periodKind: periodKind).englishTitle
     }
 
-    public func weeklyQuotaTitleKey(limitTotal: Double?) -> QuotaTitleKey {
+    public func weeklyQuotaTitleKey(
+        limitTotal: Double?,
+        periodKind: UsageLimit.PeriodKind? = nil
+    ) -> QuotaTitleKey {
+        if let periodKind, let titled = quotaTitleKey(overridingWith: periodKind) {
+            return titled
+        }
         switch self {
         case .openRouter: return .accountCredits
         case .cursor:
@@ -221,4 +247,43 @@ public enum ServiceType: String, Codable, CaseIterable, Identifiable, Sendable {
     }
 
     public var weeklyQuotaTitle: String { weeklyQuotaTitle(limitTotal: nil) }
+
+    /// Title for a reported period that did not land in a named slot.
+    public func additionalQuotaTitleKey(for limit: UsageLimit) -> QuotaTitleKey {
+        quotaTitleKey(for: limit.periodKind, limitTotal: limit.total, unspecified: .quota)
+    }
+
+    /// Shared cadence → title mapping. `session` / `weekly` keep each
+    /// provider's existing slot exceptions; every other kind is named honestly
+    /// so a monthly Grok allowance cannot render as "Weekly".
+    public func quotaTitleKey(
+        for periodKind: UsageLimit.PeriodKind?,
+        limitTotal: Double? = nil,
+        unspecified: QuotaTitleKey = .quota
+    ) -> QuotaTitleKey {
+        guard let periodKind else { return unspecified }
+        if let titled = quotaTitleKey(overridingWith: periodKind) {
+            return titled
+        }
+        switch periodKind {
+        case .session:
+            return sessionQuotaTitleKey(limitTotal: limitTotal)
+        case .weekly:
+            return weeklyQuotaTitleKey(limitTotal: limitTotal)
+        case .daily, .monthly, .billing, .unknown:
+            return unspecified
+        }
+    }
+
+    /// Cadences that replace the slot's default title. `session` and `weekly`
+    /// return `nil` so OpenRouter / Cursor exceptions still apply.
+    private func quotaTitleKey(overridingWith periodKind: UsageLimit.PeriodKind) -> QuotaTitleKey? {
+        switch periodKind {
+        case .daily: return .daily
+        case .monthly: return .monthly
+        case .billing: return .billingCycle
+        case .unknown: return .quota
+        case .session, .weekly: return nil
+        }
+    }
 }

--- a/Packages/MeterBarShared/Sources/MeterBarShared/UsageLimit.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/UsageLimit.swift
@@ -14,6 +14,17 @@ public struct UsageLimit: Codable, Equatable, Sendable {
         case monthly
         case billing
         case unknown
+
+        /// Compatible v1 slot token for CLI / webhook `kind` / `window` fields.
+        /// Cadence itself is carried separately in `periodKind`.
+        public var legacyWindowKind: String {
+            switch self {
+            case .session, .daily:
+                return "session"
+            case .weekly, .monthly, .billing, .unknown:
+                return "weekly"
+            }
+        }
     }
 
     public let used: Double

--- a/Packages/MeterBarShared/Sources/MeterBarShared/UsageLimit.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/UsageLimit.swift
@@ -1,6 +1,21 @@
 import Foundation
 
 public struct UsageLimit: Codable, Equatable, Sendable {
+    /// The provider-reported cadence of this window, when known.
+    ///
+    /// Distinct from the legacy `sessionLimit` / `weeklyLimit` slot the value
+    /// occupies: a monthly Grok allowance still lives in `weeklyLimit` so older
+    /// readers keep working, but `periodKind` is what titles and CLI identity
+    /// must honor. Missing on payloads written before this field existed.
+    public enum PeriodKind: String, Codable, Equatable, Sendable {
+        case session
+        case daily
+        case weekly
+        case monthly
+        case billing
+        case unknown
+    }
+
     public let used: Double
     public let total: Double
     public let resetTime: Date?
@@ -8,19 +23,22 @@ public struct UsageLimit: Codable, Equatable, Sendable {
     /// True when MeterBar substituted or derived the quota total instead of
     /// receiving it from the provider.
     public let isEstimated: Bool
+    public let periodKind: PeriodKind?
 
     public init(
         used: Double,
         total: Double,
         resetTime: Date?,
         windowSeconds: TimeInterval? = nil,
-        isEstimated: Bool = false
+        isEstimated: Bool = false,
+        periodKind: PeriodKind? = nil
     ) {
         self.used = used
         self.total = total
         self.resetTime = resetTime
         self.windowSeconds = windowSeconds
         self.isEstimated = isEstimated
+        self.periodKind = periodKind
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -29,6 +47,7 @@ public struct UsageLimit: Codable, Equatable, Sendable {
         case resetTime
         case windowSeconds
         case isEstimated
+        case periodKind
     }
 
     public init(from decoder: Decoder) throws {
@@ -38,6 +57,17 @@ public struct UsageLimit: Codable, Equatable, Sendable {
         resetTime = try container.decodeIfPresent(Date.self, forKey: .resetTime)
         windowSeconds = try container.decodeIfPresent(TimeInterval.self, forKey: .windowSeconds)
         isEstimated = try container.decodeIfPresent(Bool.self, forKey: .isEstimated) ?? false
+        periodKind = try container.decodeIfPresent(PeriodKind.self, forKey: .periodKind)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(used, forKey: .used)
+        try container.encode(total, forKey: .total)
+        try container.encodeIfPresent(resetTime, forKey: .resetTime)
+        try container.encodeIfPresent(windowSeconds, forKey: .windowSeconds)
+        try container.encode(isEstimated, forKey: .isEstimated)
+        try container.encodeIfPresent(periodKind, forKey: .periodKind)
     }
 
     public var rawPercentage: Double {

--- a/Packages/MeterBarShared/Sources/MeterBarShared/UsageMetrics.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/UsageMetrics.swift
@@ -51,6 +51,12 @@ public struct UsageMetrics: Codable, Identifiable, Sendable {
     /// Codex (OpenAI reset credits) and Grok (usage-limit reset tokens). `nil`
     /// when the provider did not report the feature.
     public let resetCreditsAvailable: Int?
+    /// Extra readable periods that did not fit the three legacy slots.
+    ///
+    /// A second weekly window, a daily allowance next to session/weekly, or a
+    /// monthly period that arrived after `weeklyLimit` was already filled.
+    /// Missing on older cached payloads; decodes as empty.
+    public let additionalLimits: [UsageLimit]
     public let lastUpdated: Date
 
     public init(
@@ -61,6 +67,7 @@ public struct UsageMetrics: Codable, Identifiable, Sendable {
         modelLimitLabel: String? = nil,
         extraUsage: ExtraUsageStatus? = nil,
         resetCreditsAvailable: Int? = nil,
+        additionalLimits: [UsageLimit] = [],
         lastUpdated: Date = Date()
     ) {
         self.id = UUID()
@@ -71,6 +78,7 @@ public struct UsageMetrics: Codable, Identifiable, Sendable {
         self.modelLimitLabel = modelLimitLabel
         self.extraUsage = extraUsage
         self.resetCreditsAvailable = resetCreditsAvailable
+        self.additionalLimits = additionalLimits
         self.lastUpdated = lastUpdated
     }
 
@@ -83,6 +91,7 @@ public struct UsageMetrics: Codable, Identifiable, Sendable {
         modelLimitLabel: String?,
         extraUsage: ExtraUsageStatus?,
         resetCreditsAvailable: Int?,
+        additionalLimits: [UsageLimit],
         lastUpdated: Date
     ) {
         self.id = id
@@ -93,7 +102,51 @@ public struct UsageMetrics: Codable, Identifiable, Sendable {
         self.modelLimitLabel = modelLimitLabel
         self.extraUsage = extraUsage
         self.resetCreditsAvailable = resetCreditsAvailable
+        self.additionalLimits = additionalLimits
         self.lastUpdated = lastUpdated
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case service
+        case sessionLimit
+        case weeklyLimit
+        case codeReviewLimit
+        case modelLimitLabel
+        case extraUsage
+        case resetCreditsAvailable
+        case additionalLimits
+        case lastUpdated
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        service = try container.decode(ServiceType.self, forKey: .service)
+        sessionLimit = try container.decodeIfPresent(UsageLimit.self, forKey: .sessionLimit)
+        weeklyLimit = try container.decodeIfPresent(UsageLimit.self, forKey: .weeklyLimit)
+        codeReviewLimit = try container.decodeIfPresent(UsageLimit.self, forKey: .codeReviewLimit)
+        modelLimitLabel = try container.decodeIfPresent(String.self, forKey: .modelLimitLabel)
+        extraUsage = try container.decodeIfPresent(ExtraUsageStatus.self, forKey: .extraUsage)
+        resetCreditsAvailable = try container.decodeIfPresent(Int.self, forKey: .resetCreditsAvailable)
+        additionalLimits = try container.decodeIfPresent([UsageLimit].self, forKey: .additionalLimits) ?? []
+        lastUpdated = try container.decode(Date.self, forKey: .lastUpdated)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(service, forKey: .service)
+        try container.encodeIfPresent(sessionLimit, forKey: .sessionLimit)
+        try container.encodeIfPresent(weeklyLimit, forKey: .weeklyLimit)
+        try container.encodeIfPresent(codeReviewLimit, forKey: .codeReviewLimit)
+        try container.encodeIfPresent(modelLimitLabel, forKey: .modelLimitLabel)
+        try container.encodeIfPresent(extraUsage, forKey: .extraUsage)
+        try container.encodeIfPresent(resetCreditsAvailable, forKey: .resetCreditsAvailable)
+        if !additionalLimits.isEmpty {
+            try container.encode(additionalLimits, forKey: .additionalLimits)
+        }
+        try container.encode(lastUpdated, forKey: .lastUpdated)
     }
 
     /// Returns a copy with the given reset-credit count, preserving identity,
@@ -108,6 +161,7 @@ public struct UsageMetrics: Codable, Identifiable, Sendable {
             modelLimitLabel: modelLimitLabel,
             extraUsage: extraUsage,
             resetCreditsAvailable: count,
+            additionalLimits: additionalLimits,
             lastUpdated: lastUpdated
         )
     }
@@ -124,6 +178,7 @@ public struct UsageMetrics: Codable, Identifiable, Sendable {
             modelLimitLabel: modelLimitLabel,
             extraUsage: status,
             resetCreditsAvailable: resetCreditsAvailable,
+            additionalLimits: additionalLimits,
             lastUpdated: lastUpdated
         )
     }
@@ -147,6 +202,9 @@ public struct UsageMetrics: Codable, Identifiable, Sendable {
     }
 
     public var hasData: Bool {
-        sessionLimit != nil || weeklyLimit != nil || codeReviewLimit != nil
+        sessionLimit != nil
+            || weeklyLimit != nil
+            || codeReviewLimit != nil
+            || !additionalLimits.isEmpty
     }
 }

--- a/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPresentation.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPresentation.swift
@@ -67,6 +67,22 @@ public struct WidgetPresentationRow: Identifiable, Equatable, Sendable {
     /// change here reaches the localized widget instead of silently diverging
     /// from it.
     public var quotaTitleKey: ServiceType.QuotaTitleKey {
+        if let periodKind = limit?.periodKind {
+            switch periodKind {
+            case .daily:
+                return .daily
+            case .monthly:
+                return .monthly
+            case .billing:
+                return .billingCycle
+            case .unknown:
+                return .quota
+            case .session:
+                return service.sessionQuotaTitleKey(limitTotal: limit?.total)
+            case .weekly:
+                return service.weeklyQuotaTitleKey(limitTotal: limit?.total)
+            }
+        }
         switch quotaWindow {
         case .codeReview:
             return service.codeReviewQuotaTitleKey(modelLimitLabel: modelLimitLabel)
@@ -344,15 +360,60 @@ public enum WidgetPresentationPlanner {
         let health: WidgetDataHealth = now.timeIntervalSince(metrics.lastUpdated) > stalenessThreshold
             ? .stale
             : .healthy
-        return windows.compactMap { window in
-            guard let limit = limit(for: window, metrics: metrics) else { return nil }
+        let selectedRows: [WidgetPresentationRow] = windows.compactMap { window in
+            guard let windowLimit = limit(for: window, metrics: metrics) else { return nil }
             return row(
                 source: source,
                 window: window,
-                limit: limit,
+                limit: windowLimit,
                 health: health,
                 preferences: preferences
             )
+        }
+        let additionalRows = additionalRows(
+            source: source,
+            metrics: metrics,
+            health: health,
+            preferences: preferences
+        )
+        return selectedRows + additionalRows
+    }
+
+    private static func additionalRows(
+        source: Source,
+        metrics: UsageMetrics,
+        health: WidgetDataHealth,
+        preferences: WidgetPreferences
+    ) -> [WidgetPresentationRow] {
+        metrics.additionalLimits.enumerated().compactMap { index, limit in
+            let window = widgetWindow(for: limit.periodKind)
+            guard preferences.visibleQuotaWindows.contains(window) else { return nil }
+            return WidgetPresentationRow(
+                id: "\(source.identifier.rawValue):additional-\(index)",
+                accountIdentifier: source.identifier,
+                service: source.service,
+                accountName: source.name,
+                quotaWindow: window,
+                modelLimitLabel: metrics.modelLimitLabel,
+                limit: limit,
+                health: health,
+                displayMode: preferences.displayMode,
+                preservesLegacyOpenRouterBalance: source.service == .openRouter
+                    && preferences.preservesLegacyOpenRouterBalance,
+                resetTime: preferences.showsResetTime ? limit.resetTime : nil,
+                freshnessDate: preferences.showsFreshness ? metrics.lastUpdated : nil
+            )
+        }
+    }
+
+    /// Additional periods reuse the existing session/weekly preference toggles
+    /// rather than inventing a fourth widget slot.
+    private static func widgetWindow(for periodKind: UsageLimit.PeriodKind?) -> WidgetQuotaWindow {
+        switch periodKind {
+        case .session, .daily:
+            return .session
+        case .weekly, .monthly, .billing, .unknown, nil:
+            return .weekly
         }
     }
 

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -59,18 +59,21 @@ Version 1 shape:
 }
 ```
 
-`windows[].kind` is `session`, `weekly`, or `codeReview` for the three legacy slots. Additional
-reported periods appear as extra windows whose `kind` is the cadence itself: `daily`, `monthly`,
-`billing`, or `unknown`. `percentUsed` is clamped to `0...100` for display, while `used` and
-`total` preserve the source values. `percentLeft` and `quotaBand` use MeterBar's shared quota
-rules; `quotaBand` is `healthy`, `tight`, `critical`, or `exhausted`. `estimated` identifies
-totals MeterBar inferred instead of receiving from the provider.
+`windows[].kind` is only `session`, `weekly`, or `codeReview`. That enum is closed in version 1:
+consumers may switch on it exhaustively. Extra reported periods are appended as additional
+`windows[]` entries that still use one of those three tokens — short cadences (`session`,
+`daily`) reuse `session`, longer cadences (`weekly`, `monthly`, `billing`, `unknown`) reuse
+`weekly`. Multiple entries may therefore share a `kind`. `percentUsed` is clamped to `0...100`
+for display, while `used` and `total` preserve the source values. `percentLeft` and `quotaBand`
+use MeterBar's shared quota rules; `quotaBand` is `healthy`, `tight`, `critical`, or `exhausted`.
+`estimated` identifies totals MeterBar inferred instead of receiving from the provider.
 
-`windows[].periodKind` is an additive optional field. It names the provider-reported cadence
-(`session`, `daily`, `weekly`, `monthly`, `billing`, `unknown`) even when the row still occupies
-a legacy `kind` such as `weekly`. A monthly Grok allowance therefore stays `kind: "weekly"` for
-existing consumers and adds `"periodKind": "monthly"` so identity is honest. The key is omitted
-when the cache did not record a cadence.
+`windows[].periodKind` is the additive identity field. It names the provider-reported cadence
+(`session`, `daily`, `weekly`, `monthly`, `billing`, `unknown`) even when `kind` stays a legacy
+slot token. A monthly Grok allowance therefore stays `kind: "weekly"` and adds
+`"periodKind": "monthly"`. An extra daily period is `kind: "session"` plus
+`"periodKind": "daily"`. The key is omitted when the cache did not record a cadence. Do not
+treat `kind` as the human title or as unique within a provider.
 
 `extraUsage.state` is `on`, `off`, or `unknown`; its optional `detail` is provider-supplied display
 context. `resetCreditsAvailable` is present only when the provider reports banked reset credits.
@@ -523,11 +526,17 @@ quota to reset and never consumes a reset credit — that is `meterbar wake`.
 Severity comes from the shared quota band model the menu bar and `meterbar usage` already use, so
 a band threshold change moves guard's behavior with it.
 
-`--limit` accepts `session`, `weekly`, and `code-review`. `--min-remaining` is a percentage of
-quota that must remain; without it, only exhaustion blocks. `--config-dir` narrows the check to one
-configured Claude Code, OpenAI Codex, or Grok account by its configuration directory (Claude/Codex
-config dir, or Grok `GROK_HOME`). Cursor and OpenRouter have no per-account directories and are
-rejected.
+`--limit` accepts the version 1 window tokens `session`, `weekly`, and `code-review`. Additive
+cadence selectors `daily`, `monthly`, `billing`, and `unknown` resolve a reported period by
+`periodKind` — including a monthly allowance stored in the weekly slot, or an extra daily
+period in `additionalLimits`. `--min-remaining` is a percentage of quota that must remain;
+without it, only exhaustion blocks. `--config-dir` narrows the check to one configured Claude
+Code, OpenAI Codex, or Grok account by its configuration directory (Claude/Codex config dir, or
+Grok `GROK_HOME`). Cursor and OpenRouter have no per-account directories and are rejected.
+
+The JSON `window` field stays `session`, `weekly`, or `codeReview`. Additive `periodKind` names
+the reported cadence. Human `message` text uses that cadence ("monthly", never "weekly" for a
+monthly Grok allowance).
 
 Version 1 shape:
 
@@ -578,10 +587,10 @@ caller-supplied input was at fault:
   "outcome": "usageError",
   "exitCode": 13,
   "checkedAt": "2026-07-20T17:00:00Z",
-  "message": "Unknown quota window 'hourly' for --limit. Expected one of: session, weekly, code-review.",
+  "message": "Unknown quota window 'hourly' for --limit. Expected one of: session, weekly, code-review, daily, monthly, billing, unknown.",
   "error": {
     "code": "invalid_window",
-    "message": "Unknown quota window 'hourly' for --limit. Expected one of: session, weekly, code-review.",
+    "message": "Unknown quota window 'hourly' for --limit. Expected one of: session, weekly, code-review, daily, monthly, billing, unknown.",
     "flag": "--limit",
     "value": "hourly"
   }
@@ -740,6 +749,7 @@ rather than printed by the CLI:
   },
   "event": "exhausted",
   "window": "weekly",
+  "period_kind": "monthly",
   "percentage": 100,
   "band": "exhausted",
   "timestamp": "2027-01-15T08:00:00Z"

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -59,10 +59,18 @@ Version 1 shape:
 }
 ```
 
-`windows[].kind` is `session`, `weekly`, or `codeReview`. `percentUsed` is clamped to `0...100`
-for display, while `used` and `total` preserve the source values. `percentLeft` and `quotaBand`
-use MeterBar's shared quota rules; `quotaBand` is `healthy`, `tight`, `critical`, or `exhausted`.
-`estimated` identifies totals MeterBar inferred instead of receiving from the provider.
+`windows[].kind` is `session`, `weekly`, or `codeReview` for the three legacy slots. Additional
+reported periods appear as extra windows whose `kind` is the cadence itself: `daily`, `monthly`,
+`billing`, or `unknown`. `percentUsed` is clamped to `0...100` for display, while `used` and
+`total` preserve the source values. `percentLeft` and `quotaBand` use MeterBar's shared quota
+rules; `quotaBand` is `healthy`, `tight`, `critical`, or `exhausted`. `estimated` identifies
+totals MeterBar inferred instead of receiving from the provider.
+
+`windows[].periodKind` is an additive optional field. It names the provider-reported cadence
+(`session`, `daily`, `weekly`, `monthly`, `billing`, `unknown`) even when the row still occupies
+a legacy `kind` such as `weekly`. A monthly Grok allowance therefore stays `kind: "weekly"` for
+existing consumers and adds `"periodKind": "monthly"` so identity is honest. The key is omitted
+when the cache did not record a cadence.
 
 `extraUsage.state` is `on`, `off`, or `unknown`; its optional `detail` is provider-supplied display
 context. `resetCreditsAvailable` is present only when the provider reports banked reset credits.

--- a/docs/quota-event-webhooks.md
+++ b/docs/quota-event-webhooks.md
@@ -35,7 +35,8 @@ Fields:
 | `account.id` | string | Account UUID for Claude Code, Codex CLI, and Grok profiles, or `default` for a single-account provider |
 | `account.name` | string | The user-visible account or provider name |
 | `event` | string | `warning`, `critical`, `exhausted`, or `recovered` |
-| `window` | string | `session`, `weekly`, or `code_review` |
+| `window` | string | `session`, `weekly`, or `code_review`. Version 1 enum is closed; extra periods reuse a compatible token. |
+| `period_kind` | string, optional | Reported cadence: `session`, `daily`, `weekly`, `monthly`, `billing`, or `unknown`. Omitted when unknown. A monthly Grok allowance stays `window: "weekly"` and adds `"period_kind": "monthly"`. |
 | `percentage` | number | Provider usage percentage clamped to `0...100` |
 | `band` | string | `healthy`, `tight`, `critical`, or `exhausted` |
 | `timestamp` | string | Time the transition was observed |
@@ -91,10 +92,14 @@ METERBAR_PROVIDER
 METERBAR_ACCOUNT_ID
 METERBAR_ACCOUNT_NAME
 METERBAR_WINDOW
+METERBAR_PERIOD_KIND
 METERBAR_PERCENTAGE
 METERBAR_BAND
 METERBAR_TIMESTAMP
 ```
+
+`METERBAR_WINDOW` stays `session`, `weekly`, or `code_review`. `METERBAR_PERIOD_KIND` is
+omitted when the cache did not record a cadence.
 
 Existing Session Wake hooks migrated into Event Integrations keep their
 unchanged `METERBAR_WAKE_EVENT` and `METERBAR_WAKE_PROVIDER` contract.


### PR DESCRIPTION
Fixes #456.

Grok's ACP mapper was collapsing MONTH / BILLING / CYCLE into the weekly slot and dropping every other reported period. A monthly allowance then rendered as Weekly on every surface.

## What changed

- `UsageLimit.periodKind` is an optional Codable cadence (`session`, `daily`, `weekly`, `monthly`, `billing`, `unknown`). Old cache payloads still decode.
- `UsageMetrics.additionalLimits` is additive. Missing decodes as `[]`. The three legacy slots are unchanged.
- Grok period classification is token-first, window-length second. Unknown tokens without a window stay `unknown`; percents are never fabricated.
- First session-like period stays in `sessionLimit`. First weekly-like stays in `weeklyLimit`. First monthly/billing occupies the weekly slot only when it is empty, with an honest `periodKind`. Daily and overflow periods are kept in `additionalLimits`.
- Titles honor `periodKind`: Monthly, Daily, Billing cycle, or a neutral Quota. Never Weekly for a monthly allowance.
- Widget, popover, notifications, and CLI text/JSON agree. Schema v1 `windows[].kind` stays `session`/`weekly`/`codeReview` for the three slots; `periodKind` is an additive optional field. Extra windows use the cadence as `kind`.
- Cache date strategy is unchanged (default JSONEncoder / seconds since reference date).

## Tests

- Monthly Grok fixtures title Monthly, never Weekly, on snapshot, widget, notification, recommendation, and CLI text/JSON.
- Weekly and session fixtures keep their titles, reset times, and pace.
- Multiple ACP periods are retained; unknown types without a percent are skipped.
- Old cached JSON without `periodKind` / `additionalLimits` still decodes.

Focused tests plus `swift test` were run. The only full-suite failure is pre-existing `UsageDataManagerTests.testRefreshGenerationDoesNotAdvanceForASkippedOverlappingCycle` (also fails on current master).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared cache wire format, Grok quota mapping, guard/CLI/webhook contracts, and notification state across many surfaces; changes are mostly additive with backward-compatible decoding but incorrect mapping could misreport limits or alerts.
> 
> **Overview**
> Introduces **`UsageLimit.periodKind`** and **`UsageMetrics.additionalLimits`** so provider-reported cadences (daily, monthly, billing, unknown) are stored and surfaced without mislabeling a monthly allowance as "Weekly."
> 
> **Grok ACP mapping** now classifies periods token-first, keeps overflow in `additionalLimits`, and maps monthly/billing into the legacy weekly slot only when empty—still with an honest `periodKind`.
> 
> **Titles and UI** (popover, widget, CLI text, notifications, recommendations) route through `periodKind` and new localization keys (Daily, Billing cycle, Quota).
> 
> **CLI / guard / webhooks** stay schema v1: `windows[].kind` and `window` remain `session`/`weekly`/`codeReview`; additive **`periodKind`** / **`period_kind`** and **`METERBAR_PERIOD_KIND`** carry cadence. Guard adds `--limit` selectors (`daily`, `monthly`, `billing`, `unknown`) that resolve by `periodKind`.
> 
> **Notifications and quota events** evaluate `additionalLimits` with distinct keys; notification key cleanup accounts for existing `additional-*` state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab6aedda923ce7239156a286dcdff3fff8009b38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->