### PR TITLE
fix(diagnostics): report readiness per account for every multi-account provider

### DIFF
--- a/MeterBar/Services/ClaudeCodeLocalService.swift
+++ b/MeterBar/Services/ClaudeCodeLocalService.swift
@@ -46,6 +46,14 @@ class ClaudeCodeLocalService: ObservableObject {
     @Published private(set) var lastError: ServiceError?
     @Published private(set) var authState: ClaudeCodeAuthState = .unavailable
 
+    /// Last fetch failure per Claude profile, keyed by account id.
+    ///
+    /// `lastError` / `authState` describe only the default profile (they back
+    /// the provider-wide Settings overview). Custom-account failures must not
+    /// overwrite that, and a healthy default must not hide a broken custom
+    /// profile. Read account-scoped errors through `firstError(for:)`.
+    @Published private(set) var accountErrors: [UUID: ServiceError] = [:]
+
     /// The last observed auth/connection state *per account*. `authState` above
     /// describes only the default profile, because it backs the provider-wide
     /// Settings overview; a logged-out secondary profile used to compute its
@@ -202,6 +210,10 @@ class ClaudeCodeLocalService: ObservableObject {
         }
     }
 
+    func firstError(for accounts: [ClaudeCodeAccount]) -> ServiceError? {
+        accounts.lazy.compactMap { self.accountErrors[$0.id] }.first
+    }
+
     // MARK: - Usage Fetching
 
     func fetchUsageMetrics(account: ClaudeCodeAccount = .defaultAccount) async throws -> UsageMetrics {
@@ -308,6 +320,7 @@ class ClaudeCodeLocalService: ObservableObject {
                     self.hasAccess = true
                     self.authState = .connected(.oauth)
                 }
+                self.accountErrors.removeValue(forKey: account.id)
                 self.accountAuthStates[account.id] = .connected(.oauth)
             }
             return metrics
@@ -320,6 +333,7 @@ class ClaudeCodeLocalService: ObservableObject {
                 state = .error(serviceError.localizedDescription)
             }
             await MainActor.run {
+                self.accountErrors[account.id] = serviceError
                 self.accountAuthStates[account.id] = state
                 guard publishesSharedState else { return }
                 self.lastError = serviceError
@@ -336,6 +350,7 @@ class ClaudeCodeLocalService: ObservableObject {
         account: ClaudeCodeAccount,
         publishesSharedState: Bool
     ) {
+        accountErrors[account.id] = .notAuthenticated
         accountAuthStates[account.id] = .needsLogin
         guard publishesSharedState else { return }
         lastError = .notAuthenticated
@@ -466,6 +481,7 @@ class ClaudeCodeLocalService: ObservableObject {
                 }
                 // A CLI-only login is still a login, so this succeeds even when
                 // the OAuth step above found no credential.
+                self.accountErrors.removeValue(forKey: account.id)
                 self.accountAuthStates[account.id] = .connected(.cli)
             }
             // The CLI output does not expose the "extra usage" toggle. Only read
@@ -482,6 +498,7 @@ class ClaudeCodeLocalService: ObservableObject {
             // MeterBar rather than as the actionable "run claude login".
             let state = isLoggedOut ? ClaudeCodeAuthState.needsLogin : authState(from: error)
             await MainActor.run {
+                self.accountErrors[account.id] = serviceError
                 self.accountAuthStates[account.id] = state
                 if Self.publishesSharedConnectionState(for: account) {
                     self.lastError = serviceError

--- a/MeterBar/Services/DiagnosticsRunner.swift
+++ b/MeterBar/Services/DiagnosticsRunner.swift
@@ -13,6 +13,7 @@ enum DiagnosticsRunner {
         let providers: [ServiceType]
         let defaultClaudeAccountEnabled: Bool
         let enabledClaudeCustomAccountIDs: [UUID]
+        var enabledCodexAccountIDs: [UUID] = []
         var enabledGrokAccountIDs: [UUID] = []
     }
 
@@ -43,19 +44,45 @@ enum DiagnosticsRunner {
         return result
     }
 
+    static func accountRefreshErrors(
+        claudeDefaultAccountEnabled: Bool,
+        claudeError: ServiceError?,
+        claudeAccountErrors: [UUID: ServiceError] = [:],
+        codexAccountErrors: [UUID: ServiceError] = [:],
+        grokAccountErrors: [UUID: ServiceError] = [:]
+    ) -> [ServiceType: [UUID: ServiceError]] {
+        var claude = claudeAccountErrors
+        if claudeDefaultAccountEnabled, let claudeError {
+            claude[ClaudeCodeAccount.defaultID] = claude[ClaudeCodeAccount.defaultID] ?? claudeError
+        }
+        var result: [ServiceType: [UUID: ServiceError]] = [:]
+        if !claude.isEmpty { result[.claudeCode] = claude }
+        if !codexAccountErrors.isEmpty { result[.codexCli] = codexAccountErrors }
+        if !grokAccountErrors.isEmpty { result[.grok] = grokAccountErrors }
+        return result
+    }
+
     static func inspect(
         enabledProviders: Set<ServiceType>,
         refreshErrors: [ServiceType: ServiceError],
+        accountRefreshErrors: [ServiceType: [UUID: ServiceError]] = [:],
+        claudeAccounts: [ClaudeCodeAccount] = [.defaultAccount],
+        claudeAccountMetrics: [UUID: UsageMetrics] = [:],
         claudeDefaultAccountEnabled: Bool,
         claudeEnabledAccountMetrics: [UsageMetrics],
+        codexAccounts: [CodexAccount] = [.defaultAccount],
         grokAccounts: [GrokAccount] = [.defaultAccount]
     ) async -> [ProviderReadiness] {
         await Task.detached(priority: .userInitiated) {
             ProviderReadinessInspector.reports(
                 providers: enabledProviders,
                 refreshErrors: refreshErrors,
+                accountRefreshErrors: accountRefreshErrors,
+                claudeAccounts: claudeAccounts,
+                claudeAccountMetrics: claudeAccountMetrics,
                 claudeDefaultAccountEnabled: claudeDefaultAccountEnabled,
                 claudeEnabledAccountMetrics: claudeEnabledAccountMetrics,
+                codexAccounts: codexAccounts,
                 grokAccounts: grokAccounts
             )
         }.value

--- a/MeterBar/Services/DiagnosticsRunner.swift
+++ b/MeterBar/Services/DiagnosticsRunner.swift
@@ -45,18 +45,12 @@ enum DiagnosticsRunner {
     }
 
     static func accountRefreshErrors(
-        claudeDefaultAccountEnabled: Bool,
-        claudeError: ServiceError?,
         claudeAccountErrors: [UUID: ServiceError] = [:],
         codexAccountErrors: [UUID: ServiceError] = [:],
         grokAccountErrors: [UUID: ServiceError] = [:]
     ) -> [ServiceType: [UUID: ServiceError]] {
-        var claude = claudeAccountErrors
-        if claudeDefaultAccountEnabled, let claudeError {
-            claude[ClaudeCodeAccount.defaultID] = claude[ClaudeCodeAccount.defaultID] ?? claudeError
-        }
         var result: [ServiceType: [UUID: ServiceError]] = [:]
-        if !claude.isEmpty { result[.claudeCode] = claude }
+        if !claudeAccountErrors.isEmpty { result[.claudeCode] = claudeAccountErrors }
         if !codexAccountErrors.isEmpty { result[.codexCli] = codexAccountErrors }
         if !grokAccountErrors.isEmpty { result[.grok] = grokAccountErrors }
         return result

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -43,50 +43,82 @@ nonisolated public enum ProviderReadinessInspector {
     static func reports(
         providers: Set<ServiceType> = Set(ServiceType.allCases),
         refreshErrors: [ServiceType: ServiceError] = [:],
+        accountRefreshErrors: [ServiceType: [UUID: ServiceError]] = [:],
         now: Date = Date(),
+        claudeAccounts: [ClaudeCodeAccount]? = nil,
+        claudeAccountMetrics: [UUID: UsageMetrics] = [:],
         claudeDefaultAccountEnabled: Bool = true,
         claudeEnabledAccountMetrics: [UsageMetrics] = [],
-        grokAccounts: [GrokAccount]?,
+        claudeCredentialsProbe: ((ClaudeCodeAccount) -> Data?)? = nil,
+        codexAccounts: [CodexAccount]? = nil,
+        codexAuthProbe: ((CodexAccount) -> (exists: Bool, readable: Bool, json: Data?))? = nil,
+        grokAccounts: [GrokAccount]? = nil,
+        grokAuthProbe: ((GrokAccount) -> (exists: Bool, readable: Bool))? = nil,
         parseHealth: [ServiceType: ProviderParseHealthRecord]? = nil,
-        cachedMetrics: [ServiceType: UsageMetrics]? = nil
+        cachedMetrics: [ServiceType: UsageMetrics]? = nil,
+        cachedAccountMetrics: [AccountUsageSnapshot]? = nil
     ) -> [ProviderReadiness] {
         let metrics = cachedMetrics ?? SharedDataStore.shared.loadMetrics()
-        let configuredGrokAccounts = grokAccounts
-            ?? UsageRefreshConfigurationStore.load()?.grokAccounts
+        let accountSnapshots = cachedAccountMetrics ?? SharedDataStore.shared.loadAccountMetrics()
+        let snapshotsByID = Dictionary(uniqueKeysWithValues: accountSnapshots.map { ($0.id, $0.metrics) })
+        let configuration = UsageRefreshConfigurationStore.load()
+        let configuredClaudeAccounts = claudeAccounts ?? configuration?.claudeAccounts
+        let configuredCodexAccounts = codexAccounts
+            ?? configuration?.codexAccounts
             ?? [.defaultAccount]
+        let configuredGrokAccounts = grokAccounts
+            ?? configuration?.grokAccounts
+            ?? [.defaultAccount]
+        let mergedClaudeMetrics = snapshotsByID.merging(claudeAccountMetrics) { _, incoming in incoming }
+        let health = parseHealth ?? ProviderParseHealthStore.sharedRecords()
+
         let baseReports = reports(
             providers: providers,
             refreshErrors: refreshErrors,
             now: now,
-            claudeReport: {
-                claudeReport(
-                    refreshError: $0,
-                    now: $1,
+            claudeReport: { error, date in
+                claudeReports(
+                    refreshError: error,
+                    accountRefreshErrors: accountRefreshErrors[.claudeCode] ?? [:],
+                    now: date,
+                    accounts: configuredClaudeAccounts,
+                    accountMetrics: mergedClaudeMetrics,
                     cachedMetrics: metrics[.claudeCode],
                     defaultAccountEnabled: claudeDefaultAccountEnabled,
-                    enabledAccountMetrics: claudeEnabledAccountMetrics
+                    enabledAccountMetrics: claudeEnabledAccountMetrics,
+                    credentialsProbe: claudeCredentialsProbe
                 )
             },
-            codexReport: { codexReport(refreshError: $0, now: $1) },
-            cursorReport: { cursorReport(refreshError: $0, now: $1) },
-            openRouterReport: { error, _ in openRouterReport(refreshError: error) },
-            grokReport: { error, _ in
-                grokReport(accounts: configuredGrokAccounts, refreshError: error)
+            codexReport: { error, date in
+                codexReports(
+                    refreshError: error,
+                    accountRefreshErrors: accountRefreshErrors[.codexCli] ?? [:],
+                    now: date,
+                    accounts: configuredCodexAccounts,
+                    accountMetrics: snapshotsByID,
+                    authProbe: codexAuthProbe
+                )
+            },
+            cursorReport: { error, date in [cursorReport(refreshError: error, now: date)] },
+            openRouterReport: { error, _ in [openRouterReport(refreshError: error)] },
+            grokReport: { error, date in
+                grokReports(
+                    refreshError: error,
+                    accountRefreshErrors: accountRefreshErrors[.grok] ?? [:],
+                    now: date,
+                    accounts: configuredGrokAccounts,
+                    accountMetrics: snapshotsByID,
+                    authProbe: grokAuthProbe
+                )
             }
         )
-        let health = parseHealth ?? ProviderParseHealthStore.sharedRecords()
-        return baseReports.map { report in
-            let record = health[report.provider]
-            let providerMetrics = metrics[report.provider]
-            return ProviderReadiness(
-                provider: report.provider,
-                checks: reconciledRefreshChecks(
-                    report.checks,
-                    record: record,
-                    metrics: providerMetrics
-                ) + [parseHealthCheck(record, metrics: providerMetrics, now: now)]
-            )
-        }
+        return decorate(
+            baseReports,
+            health: health,
+            metrics: metrics,
+            accountMetrics: mergedClaudeMetrics.merging(snapshotsByID) { incoming, _ in incoming },
+            now: now
+        )
     }
 
     /// Injectable routing seam used to prove that disabled providers perform no
@@ -96,18 +128,18 @@ nonisolated public enum ProviderReadinessInspector {
         providers: Set<ServiceType>,
         refreshErrors: [ServiceType: ServiceError],
         now: Date,
-        claudeReport: (ServiceError?, Date) -> ProviderReadiness,
-        codexReport: (ServiceError?, Date) -> ProviderReadiness,
-        cursorReport: (ServiceError?, Date) -> ProviderReadiness,
-        openRouterReport: (ServiceError?, Date) -> ProviderReadiness = { error, _ in
-            ProviderReadinessInspector.openRouterReport(refreshError: error)
+        claudeReport: (ServiceError?, Date) -> [ProviderReadiness],
+        codexReport: (ServiceError?, Date) -> [ProviderReadiness],
+        cursorReport: (ServiceError?, Date) -> [ProviderReadiness],
+        openRouterReport: (ServiceError?, Date) -> [ProviderReadiness] = { error, _ in
+            [ProviderReadinessInspector.openRouterReport(refreshError: error)]
         },
-        grokReport: (ServiceError?, Date) -> ProviderReadiness = { error, _ in
-            ProviderReadinessInspector.grokReport(refreshError: error)
+        grokReport: (ServiceError?, Date) -> [ProviderReadiness] = { error, _ in
+            [ProviderReadinessInspector.grokReport(refreshError: error)]
         }
     ) -> [ProviderReadiness] {
-        ServiceType.allCases.compactMap { provider in
-            guard providers.contains(provider) else { return nil }
+        ServiceType.allCases.flatMap { provider -> [ProviderReadiness] in
+            guard providers.contains(provider) else { return [] }
             switch provider {
             case .claudeCode:
                 return claudeReport(refreshErrors[provider], now)
@@ -130,7 +162,63 @@ nonisolated public enum ProviderReadinessInspector {
     /// login, and a later breakage surfaces through the refresh-error check.
     static let recentUsageFetchWindow: TimeInterval = 24 * 60 * 60
 
+    // swiftlint:disable:next function_parameter_count
+    static func claudeReports(
+        refreshError: ServiceError?,
+        accountRefreshErrors: [UUID: ServiceError],
+        now: Date,
+        accounts: [ClaudeCodeAccount]?,
+        accountMetrics: [UUID: UsageMetrics],
+        cachedMetrics: UsageMetrics?,
+        defaultAccountEnabled: Bool,
+        enabledAccountMetrics: [UsageMetrics],
+        isCLIInstalled: Bool = CLIBinaryLocator.isAvailable(
+            command: "claude",
+            overrideEnvVar: "CLAUDE_CLI_PATH"
+        ),
+        isOAuthFallbackEnabled: () -> Bool = {
+            ClaudeCodeLocalService.isOAuthUsageEnabled()
+        },
+        credentialsProbe: ((ClaudeCodeAccount) -> Data?)?
+    ) -> [ProviderReadiness] {
+        if let accounts {
+            let enabled = accounts.filter(\.isEnabled)
+            let reports = enabled.map { account in
+                claudeReport(
+                    identity: .account(.claudeCode, id: account.id, name: account.name),
+                    refreshError: accountRefreshErrors[account.id] ?? (account.isDefault ? refreshError : nil),
+                    now: now,
+                    cachedMetrics: accountMetrics[account.id],
+                    defaultAccountEnabled: account.isDefault,
+                    enabledAccountMetrics: accountMetrics[account.id].map { [$0] } ?? [],
+                    isCLIInstalled: isCLIInstalled,
+                    isOAuthFallbackEnabled: isOAuthFallbackEnabled,
+                    credentialsData: {
+                        if let credentialsProbe {
+                            return credentialsProbe(account)
+                        }
+                        return ClaudeCodeLocalService.shared.credentialsData(for: account)
+                    }
+                )
+            }
+            return pack(provider: .claudeCode, accountReports: reports)
+        }
+
+        return [
+            claudeReport(
+                refreshError: refreshError,
+                now: now,
+                cachedMetrics: cachedMetrics,
+                defaultAccountEnabled: defaultAccountEnabled,
+                enabledAccountMetrics: enabledAccountMetrics,
+                isCLIInstalled: isCLIInstalled,
+                isOAuthFallbackEnabled: isOAuthFallbackEnabled
+            ),
+        ]
+    }
+
     static func claudeReport(
+        identity: ReadinessIdentity = .provider(.claudeCode),
         refreshError: ServiceError? = nil,
         now: Date = Date(),
         cachedMetrics: @autoclosure () -> UsageMetrics? = SharedDataStore.shared.loadMetrics()[.claudeCode],
@@ -168,7 +256,7 @@ nonisolated public enum ProviderReadinessInspector {
             refreshError: sanitize(refreshError),
             now: now
         )
-        return ProviderReadinessEvaluator.claudeCode(input)
+        return ProviderReadinessEvaluator.claudeCode(input).withIdentity(identity)
     }
 
     /// Whether the shared metrics cache holds a Claude Code entry fetched
@@ -185,23 +273,63 @@ nonisolated public enum ProviderReadinessInspector {
         return age >= 0 && age <= recentUsageFetchWindow
     }
 
+    static func codexReports(
+        refreshError: ServiceError?,
+        accountRefreshErrors: [UUID: ServiceError],
+        now: Date,
+        accounts: [CodexAccount],
+        accountMetrics: [UUID: UsageMetrics],
+        isCLIInstalled: Bool = CLIBinaryLocator.isAvailable(command: "codex"),
+        authProbe: ((CodexAccount) -> (exists: Bool, readable: Bool, json: Data?))?
+    ) -> [ProviderReadiness] {
+        let enabled = accounts.filter(\.isEnabled)
+        let reports = enabled.map { account in
+            codexReport(
+                account: account,
+                refreshError: accountRefreshErrors[account.id] ?? (account.isDefault ? refreshError : nil),
+                now: now,
+                isCLIInstalled: isCLIInstalled,
+                authProbe: authProbe
+            )
+        }
+        _ = accountMetrics
+        return pack(provider: .codexCli, accountReports: reports)
+    }
+
     static func codexReport(refreshError: ServiceError? = nil, now: Date = Date()) -> ProviderReadiness {
-        let fileManager = FileManager.default
-        let path = CodexHomeDirectory.authFilePath()
-        let exists = fileManager.fileExists(atPath: path)
-        let bytes = exists && fileManager.isReadableFile(atPath: path)
-            ? fileManager.contents(atPath: path)
-            : nil
+        codexReport(account: .defaultAccount, refreshError: refreshError, now: now)
+    }
+
+    static func codexReport(
+        account: CodexAccount,
+        refreshError: ServiceError? = nil,
+        now: Date = Date(),
+        isCLIInstalled: Bool = CLIBinaryLocator.isAvailable(command: "codex"),
+        authProbe: ((CodexAccount) -> (exists: Bool, readable: Bool, json: Data?))? = nil
+    ) -> ProviderReadiness {
+        let probe: (exists: Bool, readable: Bool, json: Data?)
+        if let authProbe {
+            probe = authProbe(account)
+        } else {
+            let fileManager = FileManager.default
+            let path = CodexHomeDirectory.authFilePath(for: account)
+            let exists = fileManager.fileExists(atPath: path)
+            let bytes = exists && fileManager.isReadableFile(atPath: path)
+                ? fileManager.contents(atPath: path)
+                : nil
+            probe = (exists, bytes != nil, bytes)
+        }
 
         let input = CodexReadinessInput(
-            isCLIInstalled: CLIBinaryLocator.isAvailable(command: "codex"),
-            authFileExists: exists,
-            authFileReadable: bytes != nil,
-            authJSON: bytes,
+            isCLIInstalled: isCLIInstalled,
+            authFileExists: probe.exists,
+            authFileReadable: probe.readable,
+            authJSON: probe.json,
             refreshError: sanitize(refreshError),
             now: now
         )
         return ProviderReadinessEvaluator.codexCli(input)
+            .withIdentity(.account(.codexCli, id: account.id, name: account.name))
     }
 
     static func cursorReport(refreshError: ServiceError? = nil, now: Date = Date()) -> ProviderReadiness {
@@ -227,6 +355,32 @@ nonisolated public enum ProviderReadinessInspector {
         )
     }
 
+    static func grokReports(
+        refreshError: ServiceError?,
+        accountRefreshErrors: [UUID: ServiceError],
+        now: Date,
+        accounts: [GrokAccount],
+        accountMetrics: [UUID: UsageMetrics],
+        isCLIInstalled: Bool = CLIBinaryLocator.isAvailable(
+            command: "grok",
+            overrideEnvVar: "GROK_CLI_PATH"
+        ),
+        authProbe: ((GrokAccount) -> (exists: Bool, readable: Bool))?
+    ) -> [ProviderReadiness] {
+        _ = now
+        _ = accountMetrics
+        return pack(
+            provider: .grok,
+            accountReports: grokAccountReports(
+                accounts: accounts,
+                refreshError: refreshError,
+                accountRefreshErrors: accountRefreshErrors,
+                isCLIInstalled: isCLIInstalled,
+                authProbe: authProbe
+            )
+        )
+    }
+
     static func grokReport(refreshError: ServiceError? = nil) -> ProviderReadiness {
         grokReport(accounts: [.defaultAccount], refreshError: refreshError)
     }
@@ -237,21 +391,222 @@ nonisolated public enum ProviderReadinessInspector {
         isCLIInstalled: Bool = CLIBinaryLocator.isAvailable(
             command: "grok",
             overrideEnvVar: "GROK_CLI_PATH"
-        )
+        ),
+        authProbe: ((GrokAccount) -> (exists: Bool, readable: Bool))? = nil
     ) -> ProviderReadiness {
-        let fileManager = FileManager.default
-        let enabledAccounts = accounts.filter(\.isEnabled)
-        let authPaths = enabledAccounts.map(GrokHomeDirectory.authFilePath(for:))
-        let authExists = !authPaths.isEmpty && authPaths.allSatisfy(fileManager.fileExists(atPath:))
-        let authReadable = authExists && authPaths.allSatisfy(fileManager.isReadableFile(atPath:))
-        return ProviderReadinessEvaluator.grok(
-            GrokReadinessInput(
+        let reports = pack(
+            provider: .grok,
+            accountReports: grokAccountReports(
+                accounts: accounts,
+                refreshError: refreshError,
+                accountRefreshErrors: [:],
                 isCLIInstalled: isCLIInstalled,
-                authFileExists: authExists,
-                authFileReadable: authReadable,
-                refreshError: sanitize(refreshError)
+                authProbe: authProbe
             )
         )
+        return reports.first { !$0.identity.isAccountScoped } ?? reports.first ?? ProviderReadiness(
+            identity: .provider(.grok),
+            checks: []
+        )
+    }
+
+    private static func grokAccountReports(
+        accounts: [GrokAccount],
+        refreshError: ServiceError?,
+        accountRefreshErrors: [UUID: ServiceError],
+        isCLIInstalled: Bool,
+        authProbe: ((GrokAccount) -> (exists: Bool, readable: Bool))?
+    ) -> [ProviderReadiness] {
+        accounts.filter(\.isEnabled).map { account in
+            let probe: (exists: Bool, readable: Bool)
+            if let authProbe {
+                probe = authProbe(account)
+            } else {
+                let path = GrokHomeDirectory.authFilePath(for: account)
+                let exists = FileManager.default.fileExists(atPath: path)
+                probe = (exists, exists && FileManager.default.isReadableFile(atPath: path))
+            }
+            return ProviderReadinessEvaluator.grok(
+                GrokReadinessInput(
+                    isCLIInstalled: isCLIInstalled,
+                    authFileExists: probe.exists,
+                    authFileReadable: probe.readable,
+                    refreshError: sanitize(
+                        accountRefreshErrors[account.id] ?? (account.isDefault ? refreshError : nil)
+                    )
+                )
+            )
+            .withIdentity(.account(.grok, id: account.id, name: account.name))
+        }
+    }
+
+    /// One account-scoped report when a single profile is enabled; otherwise the
+    /// independent account reports plus one provider-wide aggregate.
+    private static func pack(
+        provider: ServiceType,
+        accountReports: [ProviderReadiness]
+    ) -> [ProviderReadiness] {
+        guard !accountReports.isEmpty else {
+            return [
+                ProviderReadiness(
+                    identity: .provider(provider),
+                    checks: [
+                        ReadinessCheck(
+                            id: ReadinessCheckID.auth,
+                            title: "Signed in",
+                            level: .fail,
+                            detail: "No enabled \(provider.displayName) profiles.",
+                            recovery: "Enable a profile in MeterBar Settings."
+                        ),
+                    ]
+                ),
+            ]
+        }
+        guard accountReports.count > 1 else { return accountReports }
+        let parseHealth = ProviderReadiness.aggregatedParseHealth(
+            accountReports.compactMap { $0.check(ReadinessCheckID.parseHealth) }
+        )
+        let aggregate = ProviderReadiness.aggregate(
+            provider: provider,
+            accountReports: accountReports,
+            parseHealth: parseHealth
+        )
+        return [aggregate] + accountReports
+    }
+
+    private static func decorate(
+        _ reports: [ProviderReadiness],
+        health: [ServiceType: ProviderParseHealthRecord],
+        metrics: [ServiceType: UsageMetrics],
+        accountMetrics: [UUID: UsageMetrics],
+        now: Date
+    ) -> [ProviderReadiness] {
+        let decorated = reports.map { report in
+            decorate(
+                report,
+                health: health,
+                metrics: metrics,
+                accountMetrics: accountMetrics,
+                now: now
+            )
+        }
+        return decorated.map { report in
+            guard !report.identity.isAccountScoped else { return report }
+            let siblings = decorated.filter {
+                $0.identity.isAccountScoped && $0.provider == report.provider
+            }
+            guard !siblings.isEmpty else { return report }
+            let parseHealth = ProviderReadiness.aggregatedParseHealth(
+                siblings.compactMap { $0.check(ReadinessCheckID.parseHealth) }
+            )
+            let withoutParse = report.checks.filter { $0.id != ReadinessCheckID.parseHealth }
+            return ProviderReadiness(identity: report.identity, checks: withoutParse + [parseHealth])
+        }
+    }
+
+    private static func decorate(
+        _ report: ProviderReadiness,
+        health: [ServiceType: ProviderParseHealthRecord],
+        metrics: [ServiceType: UsageMetrics],
+        accountMetrics: [UUID: UsageMetrics],
+        now: Date
+    ) -> ProviderReadiness {
+        if let accountID = report.identity.accountID {
+            let accountMetric = accountMetrics[accountID]
+            let record = health[report.provider]
+            return ProviderReadiness(
+                identity: report.identity,
+                checks: reconciledRefreshChecks(
+                    report.checks,
+                    record: record,
+                    metrics: accountMetric ?? metrics[report.provider]
+                ) + [
+                    accountParseHealthCheck(
+                        report: report,
+                        metrics: accountMetric,
+                        record: record,
+                        providerMetrics: metrics[report.provider],
+                        now: now
+                    ),
+                ]
+            )
+        }
+
+        let record = health[report.provider]
+        let providerMetrics = metrics[report.provider]
+        return ProviderReadiness(
+            identity: report.identity,
+            checks: reconciledRefreshChecks(
+                report.checks,
+                record: record,
+                metrics: providerMetrics
+            ) + [parseHealthCheck(record, metrics: providerMetrics, now: now)]
+        )
+    }
+
+    private static func accountParseHealthCheck(
+        report: ProviderReadiness,
+        metrics: UsageMetrics?,
+        record: ProviderParseHealthRecord?,
+        providerMetrics: UsageMetrics?,
+        now: Date
+    ) -> ReadinessCheck {
+        let title = "Usage data"
+        let threshold = "Data is considered stale after 2 hours."
+        let refresh = report.check(ReadinessCheckID.refresh)
+        let refreshFailed = refresh?.level == .fail
+        if refreshFailed, isParseFailureDetail(refresh?.detail) {
+            return ReadinessCheck(
+                id: ReadinessCheckID.parseHealth,
+                title: title,
+                level: .fail,
+                detail: "MeterBar couldn't read the latest usage — the provider's "
+                    + "response format changed. \(threshold)",
+                recovery: "Refresh once more, then copy this Diagnostics report if it persists."
+            )
+        }
+
+        let hasRecentSuccess = metrics.map {
+            let age = now.timeIntervalSince($0.lastUpdated)
+            return age >= 0 && age <= ProviderParseHealthRecord.staleAfter
+        } ?? false
+        if hasRecentSuccess {
+            return ReadinessCheck(
+                id: ReadinessCheckID.parseHealth,
+                title: title,
+                level: .pass,
+                detail: "Showing usage from a recent successful refresh. \(threshold)"
+            )
+        }
+
+        if refreshFailed {
+            return ReadinessCheck(
+                id: ReadinessCheckID.parseHealth,
+                title: title,
+                level: .warn,
+                detail: "The last refresh failed and there's no recent usage to fall back on. \(threshold)",
+                recovery: "Refresh the provider and review any new error."
+            )
+        }
+        if metrics != nil {
+            return ReadinessCheck(
+                id: ReadinessCheckID.parseHealth,
+                title: title,
+                level: .warn,
+                detail: "Usage data is older than the 2-hour freshness window.",
+                recovery: "Refresh the provider and review any new error."
+            )
+        }
+        return parseHealthCheck(record, metrics: providerMetrics, now: now)
+    }
+
+    private static func isParseFailureDetail(_ detail: String?) -> Bool {
+        guard let detail else { return false }
+        let lowered = detail.lowercased()
+        return lowered.contains("could not parse")
+            || lowered.contains("format")
+            || detail.contains(GrokRefreshFailure.unparseableResponse.message)
+            || ClaudeCodeParseFailure.messages.contains(where: detail.contains)
     }
 
     // MARK: - Helpers

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -49,6 +49,7 @@ nonisolated public enum ProviderReadinessInspector {
         claudeAccountMetrics: [UUID: UsageMetrics] = [:],
         claudeDefaultAccountEnabled: Bool = true,
         claudeEnabledAccountMetrics: [UsageMetrics] = [],
+        claudeIsCLIInstalled: Bool? = nil,
         claudeCredentialsProbe: ((ClaudeCodeAccount) -> Data?)? = nil,
         codexAccounts: [CodexAccount]? = nil,
         codexAuthProbe: ((CodexAccount) -> (exists: Bool, readable: Bool, json: Data?))? = nil,
@@ -87,6 +88,10 @@ nonisolated public enum ProviderReadinessInspector {
                     cachedMetrics: metrics[.claudeCode],
                     defaultAccountEnabled: claudeDefaultAccountEnabled,
                     enabledAccountMetrics: claudeEnabledAccountMetrics,
+                    isCLIInstalled: claudeIsCLIInstalled ?? CLIBinaryLocator.isAvailable(
+                        command: "claude",
+                        overrideEnvVar: "CLAUDE_CLI_PATH"
+                    ),
                     credentialsProbe: claudeCredentialsProbe
                 )
             },

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -53,6 +53,7 @@ nonisolated public enum ProviderReadinessInspector {
         codexAccounts: [CodexAccount]? = nil,
         codexAuthProbe: ((CodexAccount) -> (exists: Bool, readable: Bool, json: Data?))? = nil,
         grokAccounts: [GrokAccount]? = nil,
+        grokIsCLIInstalled: Bool? = nil,
         grokAuthProbe: ((GrokAccount) -> (exists: Bool, readable: Bool))? = nil,
         parseHealth: [ServiceType: ProviderParseHealthRecord]? = nil,
         cachedMetrics: [ServiceType: UsageMetrics]? = nil,
@@ -108,6 +109,10 @@ nonisolated public enum ProviderReadinessInspector {
                     now: date,
                     accounts: configuredGrokAccounts,
                     accountMetrics: snapshotsByID,
+                    isCLIInstalled: grokIsCLIInstalled ?? CLIBinaryLocator.isAvailable(
+                        command: "grok",
+                        overrideEnvVar: "GROK_CLI_PATH"
+                    ),
                     authProbe: grokAuthProbe
                 )
             }
@@ -186,7 +191,7 @@ nonisolated public enum ProviderReadinessInspector {
             let reports = enabled.map { account in
                 claudeReport(
                     identity: .account(.claudeCode, id: account.id, name: account.name),
-                    refreshError: accountRefreshErrors[account.id] ?? (account.isDefault ? refreshError : nil),
+                    refreshError: accountRefreshErrors[account.id],
                     now: now,
                     cachedMetrics: accountMetrics[account.id],
                     defaultAccountEnabled: account.isDefault,
@@ -286,7 +291,7 @@ nonisolated public enum ProviderReadinessInspector {
         let reports = enabled.map { account in
             codexReport(
                 account: account,
-                refreshError: accountRefreshErrors[account.id] ?? (account.isDefault ? refreshError : nil),
+                refreshError: accountRefreshErrors[account.id],
                 now: now,
                 isCLIInstalled: isCLIInstalled,
                 authProbe: authProbe
@@ -431,9 +436,7 @@ nonisolated public enum ProviderReadinessInspector {
                     isCLIInstalled: isCLIInstalled,
                     authFileExists: probe.exists,
                     authFileReadable: probe.readable,
-                    refreshError: sanitize(
-                        accountRefreshErrors[account.id] ?? (account.isDefault ? refreshError : nil)
-                    )
+                    refreshError: sanitize(accountRefreshErrors[account.id])
                 )
             )
             .withIdentity(.account(.grok, id: account.id, name: account.name))
@@ -513,19 +516,12 @@ nonisolated public enum ProviderReadinessInspector {
     ) -> ProviderReadiness {
         if let accountID = report.identity.accountID {
             let accountMetric = accountMetrics[accountID]
-            let record = health[report.provider]
             return ProviderReadiness(
                 identity: report.identity,
-                checks: reconciledRefreshChecks(
-                    report.checks,
-                    record: record,
-                    metrics: accountMetric ?? metrics[report.provider]
-                ) + [
+                checks: report.checks + [
                     accountParseHealthCheck(
                         report: report,
                         metrics: accountMetric,
-                        record: record,
-                        providerMetrics: metrics[report.provider],
                         now: now
                     ),
                 ]
@@ -547,8 +543,6 @@ nonisolated public enum ProviderReadinessInspector {
     private static func accountParseHealthCheck(
         report: ProviderReadiness,
         metrics: UsageMetrics?,
-        record: ProviderParseHealthRecord?,
-        providerMetrics: UsageMetrics?,
         now: Date
     ) -> ReadinessCheck {
         let title = "Usage data"
@@ -597,7 +591,12 @@ nonisolated public enum ProviderReadinessInspector {
                 recovery: "Refresh the provider and review any new error."
             )
         }
-        return parseHealthCheck(record, metrics: providerMetrics, now: now)
+        return ReadinessCheck(
+            id: ReadinessCheckID.parseHealth,
+            title: title,
+            level: .warn,
+            detail: "No refresh outcome has been recorded yet. \(threshold)"
+        )
     }
 
     private static func isParseFailureDetail(_ detail: String?) -> Bool {

--- a/MeterBar/Views/Components/ReadinessComponents.swift
+++ b/MeterBar/Views/Components/ReadinessComponents.swift
@@ -103,7 +103,7 @@ struct ReadinessProviderCard: View {
             size: compact ? 15 : 18,
             foregroundColor: .primary
           )
-          Text(report.provider.displayName)
+          Text(report.identity.displayTitle)
             .font(compact ? .subheadline : .headline)
             .fontWeight(.semibold)
           Spacer(minLength: 0)
@@ -138,7 +138,7 @@ enum DiagnosticsReportText {
   static func plainText(_ reports: [ProviderReadiness]) -> String {
     var lines = ["MeterBar Diagnostics", ""]
     for report in reports {
-      lines.append("\(report.provider.displayName)  [\(report.overall.rawValue.uppercased())]")
+      lines.append("\(report.identity.displayTitle)  [\(report.overall.rawValue.uppercased())]")
       for check in report.checks {
         lines.append("  \(symbol(check.level)) \(check.title): \(check.detail)")
         if let recovery = check.recovery {

--- a/MeterBar/Views/DashboardDiagnosticsSection.swift
+++ b/MeterBar/Views/DashboardDiagnosticsSection.swift
@@ -133,9 +133,11 @@ struct DashboardDiagnosticsSection: View {
             grokError: grokService.firstError(for: grokAccountStore.enabledAccounts)
         )
         let accountErrors = DiagnosticsRunner.accountRefreshErrors(
-            claudeDefaultAccountEnabled: claudeAccountStore.defaultAccountIsEnabled,
-            claudeError: claudeCodeService.lastError,
-            claudeAccountErrors: [:],
+            claudeAccountErrors: Dictionary(
+                uniqueKeysWithValues: claudeAccountStore.enabledAccounts.compactMap { account in
+                    claudeCodeService.accountErrors[account.id].map { (account.id, $0) }
+                }
+            ),
             codexAccountErrors: Dictionary(
                 uniqueKeysWithValues: codexAccountStore.enabledAccounts.compactMap { account in
                     codexCliService.accountErrors[account.id].map { (account.id, $0) }

--- a/MeterBar/Views/DashboardDiagnosticsSection.swift
+++ b/MeterBar/Views/DashboardDiagnosticsSection.swift
@@ -95,6 +95,7 @@ struct DashboardDiagnosticsSection: View {
             enabledClaudeCustomAccountIDs: claudeAccountStore.enabledAccounts
                 .filter { !$0.isDefault }
                 .map(\.id),
+            enabledCodexAccountIDs: codexAccountStore.enabledAccounts.map(\.id),
             enabledGrokAccountIDs: grokAccountStore.enabledAccounts.map(\.id)
         )
     }
@@ -131,16 +132,37 @@ struct DashboardDiagnosticsSection: View {
             openRouterError: openRouterService.lastError,
             grokError: grokService.firstError(for: grokAccountStore.enabledAccounts)
         )
+        let accountErrors = DiagnosticsRunner.accountRefreshErrors(
+            claudeDefaultAccountEnabled: claudeAccountStore.defaultAccountIsEnabled,
+            claudeError: claudeCodeService.lastError,
+            claudeAccountErrors: [:],
+            codexAccountErrors: Dictionary(
+                uniqueKeysWithValues: codexAccountStore.enabledAccounts.compactMap { account in
+                    codexCliService.accountErrors[account.id].map { (account.id, $0) }
+                }
+            ),
+            grokAccountErrors: Dictionary(
+                uniqueKeysWithValues: grokAccountStore.enabledAccounts.compactMap { account in
+                    grokService.accountErrors[account.id].map { (account.id, $0) }
+                }
+            )
+        )
         let defaultClaudeAccountEnabled = claudeAccountStore.defaultAccountIsEnabled
         let enabledClaudeAccounts = claudeAccountStore.enabledAccounts
-        let claudeMetrics = enabledClaudeAccounts.compactMap {
-            dataManager.claudeCodeAccountMetrics[$0.id]
-        }
+        let claudeMetricsByID = Dictionary(
+            uniqueKeysWithValues: enabledClaudeAccounts.compactMap { account in
+                dataManager.claudeCodeAccountMetrics[account.id].map { (account.id, $0) }
+            }
+        )
         return await DiagnosticsRunner.inspect(
             enabledProviders: enabledProviders,
             refreshErrors: errors,
+            accountRefreshErrors: accountErrors,
+            claudeAccounts: claudeAccountStore.accounts,
+            claudeAccountMetrics: claudeMetricsByID,
             claudeDefaultAccountEnabled: defaultClaudeAccountEnabled,
-            claudeEnabledAccountMetrics: claudeMetrics,
+            claudeEnabledAccountMetrics: Array(claudeMetricsByID.values),
+            codexAccounts: codexAccountStore.accounts,
             grokAccounts: grokAccountStore.accounts
         )
     }

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -118,6 +118,9 @@ struct MenuBarView: View {
             claudeEnabledAccountMetrics: claudeAccountStore.enabledAccounts.compactMap {
               dataManager.claudeCodeAccountMetrics[$0.id]
             },
+            claudeAccounts: claudeAccountStore.accounts,
+            claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
+            codexAccounts: codexAccountStore.accounts,
             grokAccounts: grokAccountStore.accounts,
             showsRecommendationHint: menuBarDisplayPreferences.showsRecommendationHint
           )

--- a/MeterBar/Views/PopoverOverviewPanel.swift
+++ b/MeterBar/Views/PopoverOverviewPanel.swift
@@ -17,6 +17,9 @@ struct PopoverOverviewPanel: View {
     let claudeDefaultAccountEnabled: Bool
     let claudeEnabledCustomAccountIDs: [UUID]
     let claudeEnabledAccountMetrics: [UsageMetrics]
+    let claudeAccounts: [ClaudeCodeAccount]
+    let claudeAccountMetrics: [UUID: UsageMetrics]
+    let codexAccounts: [CodexAccount]
     let grokAccounts: [GrokAccount]
     /// Opt-in one-line "what to use next" hint. Defaults to off so the popover
     /// keeps its pre-feature layout; the full ranking lives in the dashboard.
@@ -39,6 +42,9 @@ struct PopoverOverviewPanel: View {
         claudeDefaultAccountEnabled: Bool = true,
         claudeEnabledCustomAccountIDs: [UUID] = [],
         claudeEnabledAccountMetrics: [UsageMetrics] = [],
+        claudeAccounts: [ClaudeCodeAccount] = [.defaultAccount],
+        claudeAccountMetrics: [UUID: UsageMetrics] = [:],
+        codexAccounts: [CodexAccount] = [.defaultAccount],
         grokAccounts: [GrokAccount] = [.defaultAccount],
         showsRecommendationHint: Bool = false
     ) {
@@ -50,6 +56,9 @@ struct PopoverOverviewPanel: View {
         self.claudeDefaultAccountEnabled = claudeDefaultAccountEnabled
         self.claudeEnabledCustomAccountIDs = claudeEnabledCustomAccountIDs
         self.claudeEnabledAccountMetrics = claudeEnabledAccountMetrics
+        self.claudeAccounts = claudeAccounts
+        self.claudeAccountMetrics = claudeAccountMetrics
+        self.codexAccounts = codexAccounts
         self.grokAccounts = grokAccounts
         self.showsRecommendationHint = showsRecommendationHint
     }
@@ -65,7 +74,8 @@ struct PopoverOverviewPanel: View {
     /// *warning* must not keep "Finish setup" pinned open forever. The section
     /// collapses (renders nothing) once no enabled provider has a real setup gap.
     private var providersNeedingSetup: [ProviderReadiness] {
-        setupReports.filter { enabledProviders.contains($0.provider) && $0.needsSetup }
+        ProviderReadiness.setupChecklistReports(from: setupReports)
+            .filter { enabledProviders.contains($0.provider) }
     }
 
     /// Captures *which* tiles the panel shows, not their values. The panel
@@ -87,6 +97,7 @@ struct PopoverOverviewPanel: View {
         let defaultClaudeAccountEnabled: Bool
         let enabledClaudeCustomAccountIDs: [UUID]
         let claudeMetricFreshness: [Bool]
+        let enabledCodexAccountIDs: [UUID]
         let enabledGrokAccountIDs: [UUID]
     }
 
@@ -109,6 +120,7 @@ struct PopoverOverviewPanel: View {
             claudeMetricFreshness: claudeEnabledAccountMetrics.map {
                 ProviderReadinessInspector.hasRecentClaudeUsageFetch(metrics: $0, now: now)
             },
+            enabledCodexAccountIDs: codexAccounts.filter(\.isEnabled).map(\.id),
             enabledGrokAccountIDs: grokAccounts.filter(\.isEnabled).map(\.id)
         )
     }
@@ -275,12 +287,18 @@ struct PopoverOverviewPanel: View {
         let requestedProviders = enabledProviders
         let defaultAccountEnabled = claudeDefaultAccountEnabled
         let accountMetrics = claudeEnabledAccountMetrics
+        let claudeProfiles = claudeAccounts
+        let claudeMetricsByID = claudeAccountMetrics
+        let codexProfiles = codexAccounts
         let grokProfiles = grokAccounts
         let reports = await Task.detached(priority: .utility) {
             ProviderReadinessInspector.reports(
                 providers: requestedProviders,
+                claudeAccounts: claudeProfiles,
+                claudeAccountMetrics: claudeMetricsByID,
                 claudeDefaultAccountEnabled: defaultAccountEnabled,
                 claudeEnabledAccountMetrics: accountMetrics,
+                codexAccounts: codexProfiles,
                 grokAccounts: grokProfiles
             )
         }.value

--- a/MeterBarCLI/Sources/MeterBarCLI.swift
+++ b/MeterBarCLI/Sources/MeterBarCLI.swift
@@ -414,7 +414,7 @@ struct Doctor: ParsableCommand {
     }
 
     private func printJSON(_ reports: [ProviderReadiness]) throws {
-        let dtos = reports.map(DoctorReportDTO.init)
+        let dtos = reports.map(ProviderReadinessExport.init)
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data: Data
@@ -443,7 +443,7 @@ struct Doctor: ParsableCommand {
         }
 
         for report in reports {
-            print("▸ \(report.provider.displayName)  [\(report.overall.rawValue.uppercased())]")
+            print("▸ \(report.identity.displayTitle)  [\(report.overall.rawValue.uppercased())]")
             for check in report.checks {
                 print("  \(symbol(for: check.level)) \(check.title): \(check.detail)")
                 if let recovery = check.recovery {
@@ -465,22 +465,5 @@ struct Doctor: ParsableCommand {
         case .warn: return "⚠"
         case .fail: return "✗"
         }
-    }
-}
-
-/// JSON shape for `meterbar doctor --json`: the report plus its rolled-up
-/// `overall`/`healthy` (which are computed, so not part of the core's own
-/// Codable form). Redacted upstream by `ProviderReadinessInspector`.
-private struct DoctorReportDTO: Encodable {
-    let provider: String
-    let overall: String
-    let healthy: Bool
-    let checks: [ReadinessCheck]
-
-    init(_ report: ProviderReadiness) {
-        provider = report.provider.rawValue
-        overall = report.overall.rawValue
-        healthy = report.isHealthy
-        checks = report.checks
     }
 }

--- a/MeterBarTests/DiagnosticsRunnerTests.swift
+++ b/MeterBarTests/DiagnosticsRunnerTests.swift
@@ -46,9 +46,7 @@ final class DiagnosticsRunnerTests: XCTestCase {
     func testAccountRefreshErrorsKeepPerAccountIdentity() {
         let work = UUID()
         let result = DiagnosticsRunner.accountRefreshErrors(
-            claudeDefaultAccountEnabled: true,
-            claudeError: .apiError("claude"),
-            claudeAccountErrors: [:],
+            claudeAccountErrors: [ClaudeCodeAccount.defaultID: .apiError("claude")],
             codexAccountErrors: [work: .notAuthenticated],
             grokAccountErrors: [:]
         )
@@ -56,6 +54,16 @@ final class DiagnosticsRunnerTests: XCTestCase {
         XCTAssertNotNil(result[.claudeCode]?[ClaudeCodeAccount.defaultID])
         XCTAssertNotNil(result[.codexCli]?[work])
         XCTAssertNil(result[.grok])
+    }
+
+    func testAccountRefreshErrorsDoNotCopyAProviderClaudeErrorOntoTheDefaultAccount() {
+        let work = UUID()
+        let result = DiagnosticsRunner.accountRefreshErrors(
+            claudeAccountErrors: [work: .notAuthenticated]
+        )
+
+        XCTAssertNil(result[.claudeCode]?[ClaudeCodeAccount.defaultID])
+        XCTAssertNotNil(result[.claudeCode]?[work])
     }
 
     func testRefreshErrorsMapsEachNonClaudeProvider() {

--- a/MeterBarTests/DiagnosticsRunnerTests.swift
+++ b/MeterBarTests/DiagnosticsRunnerTests.swift
@@ -43,6 +43,21 @@ final class DiagnosticsRunnerTests: XCTestCase {
         XCTAssertTrue(result.isEmpty)
     }
 
+    func testAccountRefreshErrorsKeepPerAccountIdentity() {
+        let work = UUID()
+        let result = DiagnosticsRunner.accountRefreshErrors(
+            claudeDefaultAccountEnabled: true,
+            claudeError: .apiError("claude"),
+            claudeAccountErrors: [:],
+            codexAccountErrors: [work: .notAuthenticated],
+            grokAccountErrors: [:]
+        )
+
+        XCTAssertNotNil(result[.claudeCode]?[ClaudeCodeAccount.defaultID])
+        XCTAssertNotNil(result[.codexCli]?[work])
+        XCTAssertNil(result[.grok])
+    }
+
     func testRefreshErrorsMapsEachNonClaudeProvider() {
         let result = DiagnosticsRunner.refreshErrors(
             claudeDefaultAccountEnabled: true,

--- a/MeterBarTests/ProviderReadinessInspectorTests.swift
+++ b/MeterBarTests/ProviderReadinessInspectorTests.swift
@@ -33,6 +33,185 @@ final class ProviderReadinessInspectorTests: XCTestCase {
         XCTAssertEqual(mixedReport.check(ReadinessCheckID.auth)?.level, .fail)
     }
 
+    func testMixedGrokProfilesIdentifyOnlyTheFailingAccount() throws {
+        let fixtures = try grokMixedFixtures()
+        defer { fixtures.tearDown() }
+
+        let reports = ProviderReadinessInspector.reports(
+            providers: [.grok],
+            grokAccounts: [fixtures.healthy, fixtures.missing],
+            parseHealth: [:],
+            cachedMetrics: [:]
+        )
+        let byID = Dictionary(uniqueKeysWithValues: reports.compactMap { report -> (UUID, ProviderReadiness)? in
+            guard let id = report.identity.accountID else { return nil }
+            return (id, report)
+        })
+
+        XCTAssertEqual(byID[fixtures.healthy.id]?.check(ReadinessCheckID.auth)?.level, .pass)
+        XCTAssertEqual(byID[fixtures.missing.id]?.check(ReadinessCheckID.auth)?.level, .fail)
+        XCTAssertNotEqual(byID[fixtures.healthy.id]?.overall, .fail)
+        XCTAssertEqual(byID[fixtures.missing.id]?.overall, .fail)
+        XCTAssertEqual(
+            reports.first { !$0.identity.isAccountScoped }?.check(ReadinessCheckID.auth)?.level,
+            .fail
+        )
+        XCTAssertEqual(byID[fixtures.missing.id]?.identity.accountName, "Missing")
+        XCTAssertFalse((byID[fixtures.healthy.id]?.identity.accountName ?? "").contains("/"))
+    }
+
+    func testDisabledDefaultAndCustomOnlyGrokConfigurationReportsTheEnabledAccount() throws {
+        let fixtures = try grokMixedFixtures()
+        defer { fixtures.tearDown() }
+
+        var disabledDefault = GrokAccount.defaultAccount
+        disabledDefault.isEnabled = false
+        let reports = ProviderReadinessInspector.reports(
+            providers: [.grok],
+            grokAccounts: [disabledDefault, fixtures.healthy],
+            parseHealth: [:],
+            cachedMetrics: [:]
+        )
+        let accountIDs = Set(reports.compactMap(\.identity.accountID))
+
+        XCTAssertFalse(accountIDs.contains(GrokAccount.defaultID))
+        XCTAssertTrue(accountIDs.contains(fixtures.healthy.id))
+        XCTAssertEqual(
+            reports.first { $0.identity.accountID == fixtures.healthy.id }?.check(ReadinessCheckID.auth)?.level,
+            .pass
+        )
+    }
+
+    func testMixedCodexProfilesIdentifyOnlyTheFailingAccount() {
+        let healthyID = UUID()
+        let failingID = UUID()
+        let healthy = CodexAccount(id: healthyID, name: "Healthy", homeDirectory: "/tmp/healthy-codex")
+        let failing = CodexAccount(id: failingID, name: "Broken", homeDirectory: "/tmp/broken-codex")
+        let token = futureCodexAuthJSON()
+
+        let reports = ProviderReadinessInspector.reports(
+            providers: [.codexCli],
+            now: Date(timeIntervalSince1970: 1_000_000),
+            codexAccounts: [healthy, failing],
+            codexAuthProbe: { account in
+                if account.id == healthyID {
+                    return (true, true, token)
+                }
+                return (false, false, nil)
+            },
+            parseHealth: [:],
+            cachedMetrics: [:]
+        )
+        let byID = Dictionary(uniqueKeysWithValues: reports.compactMap { report -> (UUID, ProviderReadiness)? in
+            guard let id = report.identity.accountID else { return nil }
+            return (id, report)
+        })
+
+        XCTAssertEqual(byID[healthyID]?.check(ReadinessCheckID.auth)?.level, .pass)
+        XCTAssertEqual(byID[failingID]?.check(ReadinessCheckID.auth)?.level, .fail)
+        XCTAssertEqual(byID[healthyID]?.identity.accountName, "Healthy")
+        XCTAssertFalse((byID[failingID]?.check(ReadinessCheckID.auth)?.detail ?? "").contains("/tmp/"))
+    }
+
+    func testDisabledDefaultClaudeUsesOnlyEnabledCustomAccount() {
+        let customID = UUID()
+        let custom = ClaudeCodeAccount(
+            id: customID,
+            name: "Work",
+            configDirectory: "/tmp/claude-work",
+            isEnabled: true
+        )
+        var disabledDefault = ClaudeCodeAccount.defaultAccount
+        disabledDefault.isEnabled = false
+        let now = Date(timeIntervalSince1970: 20_000)
+        let recent = UsageMetrics(service: .claudeCode, lastUpdated: now.addingTimeInterval(-60))
+        var probed = [UUID]()
+
+        let reports = ProviderReadinessInspector.reports(
+            providers: [.claudeCode],
+            now: now,
+            claudeAccounts: [disabledDefault, custom],
+            claudeAccountMetrics: [customID: recent],
+            claudeCredentialsProbe: { account in
+                probed.append(account.id)
+                return nil
+            },
+            parseHealth: [:],
+            cachedMetrics: [:]
+        )
+        let accountIDs = Set(reports.compactMap(\.identity.accountID))
+
+        XCTAssertFalse(accountIDs.contains(ClaudeCodeAccount.defaultID))
+        XCTAssertTrue(accountIDs.contains(customID))
+        XCTAssertFalse(probed.contains(ClaudeCodeAccount.defaultID))
+        XCTAssertEqual(
+            reports.first { $0.identity.accountID == customID }?.check(ReadinessCheckID.auth)?.level,
+            .pass
+        )
+    }
+
+    func testParseHealthAggregationStaysHonestWhenOneAccountSucceedsAndOneFails() {
+        let now = Date(timeIntervalSince1970: 80_000)
+        let healthyID = UUID()
+        let failingID = UUID()
+        let healthy = GrokAccount(id: healthyID, name: "Healthy", homeDirectory: nil)
+        let failing = GrokAccount(id: failingID, name: "Broken", homeDirectory: nil)
+        let recent = UsageMetrics(service: .grok, lastUpdated: now.addingTimeInterval(-60))
+
+        let reports = ProviderReadinessInspector.reports(
+            providers: [.grok],
+            accountRefreshErrors: [
+                .grok: [failingID: .parsingError("HTTP 500 <body>")],
+            ],
+            now: now,
+            grokAccounts: [healthy, failing],
+            grokAuthProbe: { _ in (true, true) },
+            parseHealth: [
+                .grok: .success(provider: .grok, at: now.addingTimeInterval(-60)),
+            ],
+            cachedMetrics: [.grok: recent],
+            cachedAccountMetrics: [
+                AccountUsageSnapshot(id: healthyID, name: "Healthy", metrics: recent),
+            ]
+        )
+        let byID = Dictionary(uniqueKeysWithValues: reports.compactMap { report -> (UUID, ProviderReadiness)? in
+            guard let id = report.identity.accountID else { return nil }
+            return (id, report)
+        })
+        let aggregate = reports.first { !$0.identity.isAccountScoped }
+
+        XCTAssertEqual(byID[healthyID]?.check(ReadinessCheckID.parseHealth)?.level, .pass)
+        XCTAssertEqual(byID[failingID]?.check(ReadinessCheckID.parseHealth)?.level, .fail)
+        XCTAssertEqual(aggregate?.check(ReadinessCheckID.parseHealth)?.level, .warn)
+        XCTAssertTrue(
+            (aggregate?.check(ReadinessCheckID.parseHealth)?.detail ?? "").contains("Some accounts"),
+            aggregate?.check(ReadinessCheckID.parseHealth)?.detail ?? ""
+        )
+    }
+
+    func testDoctorJSONIncludesPerAccountIdentityWithoutPaths() throws {
+        let fixtures = try grokMixedFixtures()
+        defer { fixtures.tearDown() }
+
+        let reports = ProviderReadinessInspector.reports(
+            providers: [.grok],
+            grokAccounts: [fixtures.healthy, fixtures.missing],
+            parseHealth: [:],
+            cachedMetrics: [:]
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(reports.map(ProviderReadinessExport.init))
+        let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+        let payload = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+
+        XCTAssertTrue(payload.contains { $0["accountName"] as? String == "Missing" })
+        XCTAssertTrue(payload.contains { $0["accountId"] as? String == fixtures.missing.id.uuidString })
+        XCTAssertFalse(json.contains(fixtures.missing.homeDirectory ?? "___"))
+        XCTAssertFalse(json.contains("auth.json"))
+        XCTAssertFalse(json.contains("homeDirectory"))
+    }
+
     func testReportsGatherOnlyRequestedProvidersInStableOrder() {
         var gathered: [ServiceType] = []
         let reports = ProviderReadinessInspector.reports(
@@ -41,20 +220,51 @@ final class ProviderReadinessInspectorTests: XCTestCase {
             now: Date(timeIntervalSince1970: 1_000),
             claudeReport: { _, _ in
                 gathered.append(.claudeCode)
-                return self.report(for: .claudeCode)
+                return [self.report(for: .claudeCode)]
             },
             codexReport: { _, _ in
                 gathered.append(.codexCli)
-                return self.report(for: .codexCli)
+                return [self.report(for: .codexCli)]
             },
             cursorReport: { _, _ in
                 gathered.append(.cursor)
-                return self.report(for: .cursor)
+                return [self.report(for: .cursor)]
             }
         )
 
         XCTAssertEqual(gathered, [.codexCli, .cursor])
         XCTAssertEqual(reports.map(\.provider), [.codexCli, .cursor])
+    }
+
+    func testUnrelatedProvidersAreNotProbedWhenFiltered() {
+        var probed: [ServiceType] = []
+        _ = ProviderReadinessInspector.reports(
+            providers: [.grok],
+            refreshErrors: [:],
+            now: Date(timeIntervalSince1970: 2_000),
+            claudeReport: { _, _ in
+                probed.append(.claudeCode)
+                return [self.report(for: .claudeCode)]
+            },
+            codexReport: { _, _ in
+                probed.append(.codexCli)
+                return [self.report(for: .codexCli)]
+            },
+            cursorReport: { _, _ in
+                probed.append(.cursor)
+                return [self.report(for: .cursor)]
+            },
+            openRouterReport: { _, _ in
+                probed.append(.openRouter)
+                return [self.report(for: .openRouter)]
+            },
+            grokReport: { _, _ in
+                probed.append(.grok)
+                return [self.report(for: .grok)]
+            }
+        )
+
+        XCTAssertEqual(probed, [.grok])
     }
 
     func testRecentClaudeUsageSkipsCredentialRead() {
@@ -211,15 +421,27 @@ final class ProviderReadinessInspectorTests: XCTestCase {
             lastUpdated: now.addingTimeInterval(-60)
         )
 
+        var disabledDefault = ClaudeCodeAccount.defaultAccount
+        disabledDefault.isEnabled = false
+        let custom = ClaudeCodeAccount(
+            id: UUID(),
+            name: "Work",
+            configDirectory: "/tmp/claude-work"
+        )
         let reports = ProviderReadinessInspector.reports(
             providers: [.claudeCode],
             now: now,
+            claudeAccounts: [disabledDefault, custom],
+            claudeAccountMetrics: [custom.id: recentCustomMetrics],
             claudeDefaultAccountEnabled: false,
             claudeEnabledAccountMetrics: [recentCustomMetrics],
             parseHealth: [:]
         )
 
-        XCTAssertEqual(reports.first?.check(ReadinessCheckID.auth)?.level, .pass)
+        XCTAssertEqual(
+            reports.first { $0.identity.accountID == custom.id }?.check(ReadinessCheckID.auth)?.level,
+            .pass
+        )
     }
 
     func testApiErrorDropsResponseBodyKeepsStatusCode() {
@@ -269,8 +491,10 @@ final class ProviderReadinessInspectorTests: XCTestCase {
         let reports = ProviderReadinessInspector.reports(
             providers: [.codexCli],
             now: now,
+            codexAccounts: [.defaultAccount],
             parseHealth: [.codexCli: record],
-            cachedMetrics: [:]
+            cachedMetrics: [:],
+            cachedAccountMetrics: []
         )
         let check = reports.first?.check(ReadinessCheckID.parseHealth)
 
@@ -293,8 +517,10 @@ final class ProviderReadinessInspectorTests: XCTestCase {
         let reports = ProviderReadinessInspector.reports(
             providers: [.codexCli],
             now: now,
+            codexAccounts: [.defaultAccount],
             parseHealth: [.codexCli: record],
-            cachedMetrics: [.codexCli: metrics]
+            cachedMetrics: [.codexCli: metrics],
+            cachedAccountMetrics: []
         )
 
         XCTAssertEqual(reports.first?.check(ReadinessCheckID.parseHealth)?.level, .pass)
@@ -317,8 +543,10 @@ final class ProviderReadinessInspectorTests: XCTestCase {
         let reports = ProviderReadinessInspector.reports(
             providers: [.claudeCode],
             now: now,
+            claudeAccounts: [.defaultAccount],
             parseHealth: [.claudeCode: record],
-            cachedMetrics: [.claudeCode: metrics]
+            cachedMetrics: [.claudeCode: metrics],
+            cachedAccountMetrics: []
         )
         let refresh = reports.first?.check(ReadinessCheckID.refresh)
 
@@ -335,6 +563,40 @@ final class ProviderReadinessInspectorTests: XCTestCase {
         ProviderReadiness(
             provider: provider,
             checks: [ReadinessCheck(id: "test", title: "Test", level: .pass, detail: "Ready")]
+        )
+    }
+
+    private func grokMixedFixtures() throws -> (
+        healthy: GrokAccount,
+        missing: GrokAccount,
+        tearDown: () -> Void
+    ) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ProviderReadinessInspectorTests-\(UUID().uuidString)", isDirectory: true)
+        let healthyHome = root.appendingPathComponent("healthy", isDirectory: true)
+        try FileManager.default.createDirectory(at: healthyHome, withIntermediateDirectories: true)
+        try Data().write(to: healthyHome.appendingPathComponent("auth.json"))
+        let healthy = GrokAccount(id: UUID(), name: "Healthy", homeDirectory: healthyHome.path)
+        let missing = GrokAccount(
+            id: UUID(),
+            name: "Missing",
+            homeDirectory: root.appendingPathComponent("missing").path
+        )
+        return (healthy, missing, { try? FileManager.default.removeItem(at: root) })
+    }
+
+    private func futureCodexAuthJSON() -> Data {
+        let payload = Data(#"{"exp":2000000}"#.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        let token = "header.\(payload).signature"
+        return Data(
+            """
+            {"OPENAI_API_KEY":null,"tokens":{"id_token":"id","access_token":"\(token)",\
+            "refresh_token":"refresh","account_id":"acct_test"},"last_refresh":"2026-07-03T00:00:00Z"}
+            """.utf8
         )
     }
 }

--- a/MeterBarTests/ProviderReadinessInspectorTests.swift
+++ b/MeterBarTests/ProviderReadinessInspectorTests.swift
@@ -40,14 +40,17 @@ final class ProviderReadinessInspectorTests: XCTestCase {
         let reports = ProviderReadinessInspector.reports(
             providers: [.grok],
             grokAccounts: [fixtures.healthy, fixtures.missing],
+            grokIsCLIInstalled: true,
             parseHealth: [:],
-            cachedMetrics: [:]
+            cachedMetrics: [:],
+            cachedAccountMetrics: []
         )
         let byID = Dictionary(uniqueKeysWithValues: reports.compactMap { report -> (UUID, ProviderReadiness)? in
             guard let id = report.identity.accountID else { return nil }
             return (id, report)
         })
 
+        XCTAssertEqual(byID[fixtures.healthy.id]?.check(ReadinessCheckID.installed)?.level, .pass)
         XCTAssertEqual(byID[fixtures.healthy.id]?.check(ReadinessCheckID.auth)?.level, .pass)
         XCTAssertEqual(byID[fixtures.missing.id]?.check(ReadinessCheckID.auth)?.level, .fail)
         XCTAssertNotEqual(byID[fixtures.healthy.id]?.overall, .fail)
@@ -69,8 +72,10 @@ final class ProviderReadinessInspectorTests: XCTestCase {
         let reports = ProviderReadinessInspector.reports(
             providers: [.grok],
             grokAccounts: [disabledDefault, fixtures.healthy],
+            grokIsCLIInstalled: true,
             parseHealth: [:],
-            cachedMetrics: [:]
+            cachedMetrics: [:],
+            cachedAccountMetrics: []
         )
         let accountIDs = Set(reports.compactMap(\.identity.accountID))
 
@@ -150,6 +155,77 @@ final class ProviderReadinessInspectorTests: XCTestCase {
         )
     }
 
+    func testClaudeCustomFailureDoesNotPoisonAHealthyDefault() {
+        let now = Date(timeIntervalSince1970: 70_000)
+        let customID = UUID()
+        let custom = ClaudeCodeAccount(id: customID, name: "Work", configDirectory: "/tmp/claude-work")
+        let recent = UsageMetrics(service: .claudeCode, lastUpdated: now.addingTimeInterval(-60))
+
+        let reports = ProviderReadinessInspector.reports(
+            providers: [.claudeCode],
+            refreshErrors: [.claudeCode: .apiError("HTTP 500 <body>")],
+            accountRefreshErrors: [
+                .claudeCode: [customID: .apiError("HTTP 500 <body>")],
+            ],
+            now: now,
+            claudeAccounts: [.defaultAccount, custom],
+            claudeAccountMetrics: [
+                ClaudeCodeAccount.defaultID: recent,
+            ],
+            parseHealth: [
+                .claudeCode: ProviderParseHealthRecord(
+                    provider: .claudeCode,
+                    lastSuccess: now.addingTimeInterval(-60),
+                    lastAttempt: now,
+                    consecutiveFailures: 1,
+                    lastFailureWasShapeMismatch: true
+                ),
+            ],
+            cachedMetrics: [.claudeCode: recent],
+            cachedAccountMetrics: []
+        )
+        let byID = Dictionary(uniqueKeysWithValues: reports.compactMap { report -> (UUID, ProviderReadiness)? in
+            guard let id = report.identity.accountID else { return nil }
+            return (id, report)
+        })
+
+        XCTAssertEqual(byID[ClaudeCodeAccount.defaultID]?.check(ReadinessCheckID.refresh)?.level, .pass)
+        XCTAssertEqual(byID[ClaudeCodeAccount.defaultID]?.check(ReadinessCheckID.parseHealth)?.level, .pass)
+        XCTAssertNotEqual(byID[ClaudeCodeAccount.defaultID]?.overall, .fail)
+        XCTAssertEqual(byID[customID]?.check(ReadinessCheckID.refresh)?.level, .fail)
+    }
+
+    func testClaudeCustomOnlyReportsTheCustomAccountError() {
+        let now = Date(timeIntervalSince1970: 71_000)
+        let customID = UUID()
+        var disabledDefault = ClaudeCodeAccount.defaultAccount
+        disabledDefault.isEnabled = false
+        let custom = ClaudeCodeAccount(id: customID, name: "Work", configDirectory: "/tmp/claude-work")
+        let recent = UsageMetrics(service: .claudeCode, lastUpdated: now.addingTimeInterval(-60))
+
+        let reports = ProviderReadinessInspector.reports(
+            providers: [.claudeCode],
+            refreshErrors: [.claudeCode: .notAuthenticated],
+            accountRefreshErrors: [
+                .claudeCode: [customID: .notAuthenticated],
+            ],
+            now: now,
+            claudeAccounts: [disabledDefault, custom],
+            claudeAccountMetrics: [customID: recent],
+            parseHealth: [:],
+            cachedMetrics: [:],
+            cachedAccountMetrics: []
+        )
+        let accountIDs = Set(reports.compactMap(\.identity.accountID))
+
+        XCTAssertFalse(accountIDs.contains(ClaudeCodeAccount.defaultID))
+        XCTAssertTrue(accountIDs.contains(customID))
+        XCTAssertEqual(
+            reports.first { $0.identity.accountID == customID }?.check(ReadinessCheckID.refresh)?.level,
+            .fail
+        )
+    }
+
     func testParseHealthAggregationStaysHonestWhenOneAccountSucceedsAndOneFails() {
         let now = Date(timeIntervalSince1970: 80_000)
         let healthyID = UUID()
@@ -165,6 +241,7 @@ final class ProviderReadinessInspectorTests: XCTestCase {
             ],
             now: now,
             grokAccounts: [healthy, failing],
+            grokIsCLIInstalled: true,
             grokAuthProbe: { _ in (true, true) },
             parseHealth: [
                 .grok: .success(provider: .grok, at: now.addingTimeInterval(-60)),
@@ -196,8 +273,10 @@ final class ProviderReadinessInspectorTests: XCTestCase {
         let reports = ProviderReadinessInspector.reports(
             providers: [.grok],
             grokAccounts: [fixtures.healthy, fixtures.missing],
+            grokIsCLIInstalled: true,
             parseHealth: [:],
-            cachedMetrics: [:]
+            cachedMetrics: [:],
+            cachedAccountMetrics: []
         )
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
@@ -481,7 +560,7 @@ final class ProviderReadinessInspectorTests: XCTestCase {
     func testParseHealthAddsImmediateFormatMismatchCheckWithStalenessThreshold() {
         let now = Date(timeIntervalSince1970: 40_000)
         let record = ProviderParseHealthRecord(
-            provider: .codexCli,
+            provider: .cursor,
             lastSuccess: now.addingTimeInterval(-60),
             lastAttempt: now,
             consecutiveFailures: 1,
@@ -489,10 +568,9 @@ final class ProviderReadinessInspectorTests: XCTestCase {
         )
 
         let reports = ProviderReadinessInspector.reports(
-            providers: [.codexCli],
+            providers: [.cursor],
             now: now,
-            codexAccounts: [.defaultAccount],
-            parseHealth: [.codexCli: record],
+            parseHealth: [.cursor: record],
             cachedMetrics: [:],
             cachedAccountMetrics: []
         )
@@ -506,20 +584,19 @@ final class ProviderReadinessInspectorTests: XCTestCase {
     func testFreshPayloadSupersedesOlderParseHealthTimestamp() {
         let now = Date(timeIntervalSince1970: 50_000)
         let record = ProviderParseHealthRecord.success(
-            provider: .codexCli,
+            provider: .cursor,
             at: now.addingTimeInterval(-ProviderParseHealthRecord.staleAfter - 1)
         )
         let metrics = UsageMetrics(
-            service: .codexCli,
+            service: .cursor,
             lastUpdated: now.addingTimeInterval(-60)
         )
 
         let reports = ProviderReadinessInspector.reports(
-            providers: [.codexCli],
+            providers: [.cursor],
             now: now,
-            codexAccounts: [.defaultAccount],
-            parseHealth: [.codexCli: record],
-            cachedMetrics: [.codexCli: metrics],
+            parseHealth: [.cursor: record],
+            cachedMetrics: [.cursor: metrics],
             cachedAccountMetrics: []
         )
 
@@ -529,11 +606,11 @@ final class ProviderReadinessInspectorTests: XCTestCase {
     func testPersistedFailureReplacesContradictoryNoErrorRefreshCheck() {
         let now = Date(timeIntervalSince1970: 60_000)
         let metrics = UsageMetrics(
-            service: .claudeCode,
+            service: .cursor,
             lastUpdated: now.addingTimeInterval(-ProviderParseHealthRecord.staleAfter - 60)
         )
         let record = ProviderParseHealthRecord(
-            provider: .claudeCode,
+            provider: .cursor,
             lastSuccess: metrics.lastUpdated,
             lastAttempt: now.addingTimeInterval(-60),
             consecutiveFailures: 1,
@@ -541,11 +618,10 @@ final class ProviderReadinessInspectorTests: XCTestCase {
         )
 
         let reports = ProviderReadinessInspector.reports(
-            providers: [.claudeCode],
+            providers: [.cursor],
             now: now,
-            claudeAccounts: [.defaultAccount],
-            parseHealth: [.claudeCode: record],
-            cachedMetrics: [.claudeCode: metrics],
+            parseHealth: [.cursor: record],
+            cachedMetrics: [.cursor: metrics],
             cachedAccountMetrics: []
         )
         let refresh = reports.first?.check(ReadinessCheckID.refresh)

--- a/MeterBarTests/ProviderReadinessInspectorTests.swift
+++ b/MeterBarTests/ProviderReadinessInspectorTests.swift
@@ -137,6 +137,7 @@ final class ProviderReadinessInspectorTests: XCTestCase {
             now: now,
             claudeAccounts: [disabledDefault, custom],
             claudeAccountMetrics: [customID: recent],
+            claudeIsCLIInstalled: true,
             claudeCredentialsProbe: { account in
                 probed.append(account.id)
                 return nil
@@ -172,6 +173,7 @@ final class ProviderReadinessInspectorTests: XCTestCase {
             claudeAccountMetrics: [
                 ClaudeCodeAccount.defaultID: recent,
             ],
+            claudeIsCLIInstalled: true,
             parseHealth: [
                 .claudeCode: ProviderParseHealthRecord(
                     provider: .claudeCode,
@@ -189,6 +191,7 @@ final class ProviderReadinessInspectorTests: XCTestCase {
             return (id, report)
         })
 
+        XCTAssertEqual(byID[ClaudeCodeAccount.defaultID]?.check(ReadinessCheckID.installed)?.level, .pass)
         XCTAssertEqual(byID[ClaudeCodeAccount.defaultID]?.check(ReadinessCheckID.refresh)?.level, .pass)
         XCTAssertEqual(byID[ClaudeCodeAccount.defaultID]?.check(ReadinessCheckID.parseHealth)?.level, .pass)
         XCTAssertNotEqual(byID[ClaudeCodeAccount.defaultID]?.overall, .fail)
@@ -212,6 +215,7 @@ final class ProviderReadinessInspectorTests: XCTestCase {
             now: now,
             claudeAccounts: [disabledDefault, custom],
             claudeAccountMetrics: [customID: recent],
+            claudeIsCLIInstalled: true,
             parseHealth: [:],
             cachedMetrics: [:],
             cachedAccountMetrics: []
@@ -514,6 +518,7 @@ final class ProviderReadinessInspectorTests: XCTestCase {
             claudeAccountMetrics: [custom.id: recentCustomMetrics],
             claudeDefaultAccountEnabled: false,
             claudeEnabledAccountMetrics: [recentCustomMetrics],
+            claudeIsCLIInstalled: true,
             parseHealth: [:]
         )
 

--- a/MeterBarTests/ProviderReadinessTests.swift
+++ b/MeterBarTests/ProviderReadinessTests.swift
@@ -418,6 +418,144 @@ final class ProviderReadinessTests: XCTestCase {
         XCTAssertEqual(decoded, report)
     }
 
+    func testReadinessIdentityOmitsPathsAndNamesAccountReports() {
+        let id = UUID()
+        let identity = ReadinessIdentity.account(.grok, id: id, name: "Work")
+
+        XCTAssertTrue(identity.isAccountScoped)
+        XCTAssertEqual(identity.displayTitle, "Grok · Work")
+        XCTAssertEqual(ReadinessIdentity.provider(.cursor).displayTitle, "Cursor")
+        XCTAssertFalse(identity.displayTitle.contains("/"))
+    }
+
+    func testAccountScopedReportIdIncludesAccountAndProviderStaysStable() {
+        let id = UUID()
+        let report = ProviderReadiness(
+            identity: .account(.codexCli, id: id, name: "Work"),
+            checks: [ReadinessCheck(id: "auth", title: "Signed in", level: .pass, detail: "OK")]
+        )
+
+        XCTAssertEqual(report.provider, .codexCli)
+        XCTAssertEqual(report.id, "\(ServiceType.codexCli.rawValue):\(id.uuidString)")
+        XCTAssertEqual(
+            ProviderReadiness(
+                provider: .cursor,
+                checks: [ReadinessCheck(id: "auth", title: "Signed in", level: .pass, detail: "OK")]
+            ).id,
+            ServiceType.cursor.rawValue
+        )
+    }
+
+    func testDoctorExportIncludesAccountIdentityWithoutPaths() throws {
+        let id = UUID()
+        let report = ProviderReadiness(
+            identity: .account(.grok, id: id, name: "Work"),
+            checks: [
+                ReadinessCheck(
+                    id: ReadinessCheckID.auth,
+                    title: "Signed in",
+                    level: .fail,
+                    detail: "Not signed in — no Grok Build cached login found.",
+                    recovery: "Run `grok login`."
+                ),
+            ]
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(ProviderReadinessExport(report))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        XCTAssertEqual(object["provider"] as? String, ServiceType.grok.rawValue)
+        XCTAssertEqual(object["accountId"] as? String, id.uuidString)
+        XCTAssertEqual(object["accountName"] as? String, "Work")
+        XCTAssertEqual(object["overall"] as? String, "fail")
+        XCTAssertEqual(object["healthy"] as? Bool, false)
+        XCTAssertFalse(json.contains("/Users"))
+        XCTAssertFalse(json.contains("homeDirectory"))
+        XCTAssertFalse(json.contains("auth.json"))
+        XCTAssertFalse(json.contains("GROK_HOME"))
+    }
+
+    func testDoctorExportOmitsAccountFieldsForProviderWideReports() throws {
+        let report = ProviderReadinessEvaluator.cursor(
+            CursorReadinessInput(isInstalled: true, database: .tokenPresent, now: now)
+        )
+        let data = try JSONEncoder().encode(ProviderReadinessExport(report))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(object["provider"] as? String, ServiceType.cursor.rawValue)
+        XCTAssertNil(object["accountId"])
+        XCTAssertNil(object["accountName"])
+    }
+
+    func testAggregateIdentifiesMixedAccountFailuresWithoutHidingHealthySiblings() {
+        let healthy = ProviderReadinessEvaluator.grok(
+            GrokReadinessInput(isCLIInstalled: true, authFileExists: true, authFileReadable: true)
+        ).withIdentity(.account(.grok, id: UUID(), name: "Healthy"))
+        let failing = ProviderReadinessEvaluator.grok(
+            GrokReadinessInput(isCLIInstalled: true, authFileExists: false, authFileReadable: false)
+        ).withIdentity(.account(.grok, id: UUID(), name: "Missing"))
+
+        let aggregate = ProviderReadiness.aggregate(
+            provider: .grok,
+            accountReports: [healthy, failing],
+            parseHealth: ProviderReadiness.aggregatedParseHealth([
+                ReadinessCheck(
+                    id: ReadinessCheckID.parseHealth,
+                    title: "Usage data",
+                    level: .pass,
+                    detail: "ok"
+                ),
+                ReadinessCheck(
+                    id: ReadinessCheckID.parseHealth,
+                    title: "Usage data",
+                    level: .fail,
+                    detail: "format"
+                ),
+            ])
+        )
+
+        XCTAssertFalse(aggregate.identity.isAccountScoped)
+        XCTAssertEqual(aggregate.check(ReadinessCheckID.auth)?.level, .fail)
+        XCTAssertTrue(
+            (aggregate.check(ReadinessCheckID.auth)?.detail ?? "").contains("1 of 2"),
+            aggregate.check(ReadinessCheckID.auth)?.detail ?? ""
+        )
+        XCTAssertEqual(healthy.check(ReadinessCheckID.auth)?.level, .pass)
+        XCTAssertEqual(failing.check(ReadinessCheckID.auth)?.level, .fail)
+        XCTAssertEqual(aggregate.check(ReadinessCheckID.parseHealth)?.level, .warn)
+        XCTAssertTrue(
+            (aggregate.check(ReadinessCheckID.parseHealth)?.detail ?? "").contains("Some accounts"),
+            aggregate.check(ReadinessCheckID.parseHealth)?.detail ?? ""
+        )
+    }
+
+    func testSetupChecklistPrefersAccountReportsOverTheProviderAggregate() {
+        let aggregate = ProviderReadiness(
+            provider: .grok,
+            checks: [
+                ReadinessCheck(id: ReadinessCheckID.auth, title: "Signed in", level: .fail, detail: "1 of 2"),
+            ]
+        )
+        let healthy = ProviderReadiness(
+            identity: .account(.grok, id: UUID(), name: "Healthy"),
+            checks: [
+                ReadinessCheck(id: ReadinessCheckID.auth, title: "Signed in", level: .pass, detail: "OK"),
+            ]
+        )
+        let failing = ProviderReadiness(
+            identity: .account(.grok, id: UUID(), name: "Missing"),
+            checks: [
+                ReadinessCheck(id: ReadinessCheckID.auth, title: "Signed in", level: .fail, detail: "Not signed in"),
+            ]
+        )
+
+        let setup = ProviderReadiness.setupChecklistReports(from: [aggregate, healthy, failing])
+
+        XCTAssertEqual(setup.map(\.identity.accountName), ["Missing"])
+    }
+
     func testSummaryCountsWarningsSeparatelyFromAttention() {
         let ready = ProviderReadiness(
             provider: .claudeCode,

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ProviderReadiness.swift
@@ -60,18 +60,130 @@ public struct ReadinessCheck: Codable, Sendable, Equatable, Identifiable {
     }
 }
 
-/// The full readiness report for one provider: an ordered list of checks
-/// (installed → auth → data → refresh) plus a rolled-up overall status.
-public struct ProviderReadiness: Codable, Sendable, Equatable, Identifiable {
+/// Identifies a readiness report as provider-wide or account-scoped.
+///
+/// Account identity is MeterBar's local profile id plus the user-facing display
+/// name — never a filesystem path, credential, or provider-side account id.
+/// Cursor and OpenRouter stay provider-wide (`accountID == nil`).
+public struct ReadinessIdentity: Codable, Sendable, Equatable, Hashable {
     public let provider: ServiceType
+    public let accountID: UUID?
+    public let accountName: String?
+
+    public init(provider: ServiceType, accountID: UUID? = nil, accountName: String? = nil) {
+        self.provider = provider
+        self.accountID = accountID
+        self.accountName = accountName
+    }
+
+    public static func provider(_ provider: ServiceType) -> Self {
+        Self(provider: provider)
+    }
+
+    public static func account(_ provider: ServiceType, id: UUID, name: String) -> Self {
+        Self(provider: provider, accountID: id, accountName: name)
+    }
+
+    public var isAccountScoped: Bool { accountID != nil }
+
+    /// Header used by Diagnostics, the setup checklist, and `meterbar doctor`.
+    public var displayTitle: String {
+        if let accountName {
+            let trimmed = accountName.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return "\(provider.displayName) · \(trimmed)"
+            }
+        }
+        return provider.displayName
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case provider
+        case accountId
+        case accountName
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        provider = try container.decode(ServiceType.self, forKey: .provider)
+        accountID = try container.decodeIfPresent(UUID.self, forKey: .accountId)
+        accountName = try container.decodeIfPresent(String.self, forKey: .accountName)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(provider, forKey: .provider)
+        try container.encodeIfPresent(accountID, forKey: .accountId)
+        try container.encodeIfPresent(accountName, forKey: .accountName)
+    }
+}
+
+/// Flattened, paste-safe JSON for `meterbar doctor --json`. Account fields are
+/// omitted on provider-wide reports so Cursor/OpenRouter stay path-free.
+public struct ProviderReadinessExport: Encodable, Sendable, Equatable {
+    public let provider: String
+    public let accountId: String?
+    public let accountName: String?
+    public let overall: String
+    public let healthy: Bool
     public let checks: [ReadinessCheck]
 
+    public init(_ report: ProviderReadiness) {
+        provider = report.provider.rawValue
+        accountId = report.identity.accountID?.uuidString
+        accountName = report.identity.accountName
+        overall = report.overall.rawValue
+        healthy = report.isHealthy
+        checks = report.checks
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case provider
+        case accountId
+        case accountName
+        case overall
+        case healthy
+        case checks
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(provider, forKey: .provider)
+        try container.encodeIfPresent(accountId, forKey: .accountId)
+        try container.encodeIfPresent(accountName, forKey: .accountName)
+        try container.encode(overall, forKey: .overall)
+        try container.encode(healthy, forKey: .healthy)
+        try container.encode(checks, forKey: .checks)
+    }
+}
+
+/// The full readiness report for one provider or one account: an ordered list of
+/// checks (installed → auth → data → refresh) plus a rolled-up overall status.
+public struct ProviderReadiness: Codable, Sendable, Equatable, Identifiable {
+    public let identity: ReadinessIdentity
+    public let checks: [ReadinessCheck]
+
+    public var provider: ServiceType { identity.provider }
+
     public init(provider: ServiceType, checks: [ReadinessCheck]) {
-        self.provider = provider
+        self.init(identity: .provider(provider), checks: checks)
+    }
+
+    public init(identity: ReadinessIdentity, checks: [ReadinessCheck]) {
+        self.identity = identity
         self.checks = checks
     }
 
-    public var id: String { provider.rawValue }
+    public var id: String {
+        if let accountID = identity.accountID {
+            return "\(identity.provider.rawValue):\(accountID.uuidString)"
+        }
+        return identity.provider.rawValue
+    }
+
+    public func withIdentity(_ identity: ReadinessIdentity) -> ProviderReadiness {
+        ProviderReadiness(identity: identity, checks: checks)
+    }
 
     /// The worst level across all checks (fail > warn > pass).
     public var overall: ReadinessLevel {
@@ -91,6 +203,158 @@ public struct ProviderReadiness: Codable, Sendable, Equatable, Identifiable {
 
     public func check(_ id: String) -> ReadinessCheck? {
         checks.first { $0.id == id }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case provider
+        case identity
+        case checks
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        checks = try container.decode([ReadinessCheck].self, forKey: .checks)
+        if let identity = try container.decodeIfPresent(ReadinessIdentity.self, forKey: .identity) {
+            self.identity = identity
+        } else {
+            let provider = try container.decode(ServiceType.self, forKey: .provider)
+            identity = .provider(provider)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(provider, forKey: .provider)
+        try container.encode(identity, forKey: .identity)
+        try container.encode(checks, forKey: .checks)
+    }
+
+    /// Rolls independently evaluated account reports into one provider-wide
+    /// summary. Mixed pass/fail on the same check stays visible instead of
+    /// collapsing to the last account that finished.
+    public static func aggregate(
+        provider: ServiceType,
+        accountReports: [ProviderReadiness],
+        parseHealth: ReadinessCheck
+    ) -> ProviderReadiness {
+        let checkIDs = [
+            ReadinessCheckID.installed,
+            ReadinessCheckID.auth,
+            ReadinessCheckID.data,
+            ReadinessCheckID.refresh,
+        ]
+        let rolled = checkIDs.compactMap { id -> ReadinessCheck? in
+            rollup(id: id, from: accountReports)
+        }
+        return ProviderReadiness(
+            identity: .provider(provider),
+            checks: rolled + [parseHealth]
+        )
+    }
+
+    /// Provider-level parse-health: a format success on one account must not
+    /// hide a failure on another, and a single healthy sibling must not make
+    /// the provider look fully broken.
+    public static func aggregatedParseHealth(_ accountChecks: [ReadinessCheck]) -> ReadinessCheck {
+        let title = "Usage data"
+        let threshold = "Data is considered stale after 2 hours."
+        guard !accountChecks.isEmpty else {
+            return ReadinessCheck(
+                id: ReadinessCheckID.parseHealth,
+                title: title,
+                level: .warn,
+                detail: "No refresh outcome has been recorded yet. \(threshold)"
+            )
+        }
+
+        let hasPass = accountChecks.contains { $0.level == .pass }
+        let hasFail = accountChecks.contains { $0.level == .fail }
+        let hasWarn = accountChecks.contains { $0.level == .warn }
+
+        if hasPass && hasFail {
+            return ReadinessCheck(
+                id: ReadinessCheckID.parseHealth,
+                title: title,
+                level: .warn,
+                detail: "Some accounts refreshed successfully; others failed. \(threshold)",
+                recovery: "Refresh the failing account and review its Usage data check."
+            )
+        }
+        if hasFail {
+            let worst = accountChecks.first { $0.level == .fail }
+            return ReadinessCheck(
+                id: ReadinessCheckID.parseHealth,
+                title: title,
+                level: .fail,
+                detail: worst?.detail ?? "MeterBar couldn't read the latest usage. \(threshold)",
+                recovery: worst?.recovery
+            )
+        }
+        if hasWarn {
+            return ReadinessCheck(
+                id: ReadinessCheckID.parseHealth,
+                title: title,
+                level: .warn,
+                detail: "Usage data is older than the 2-hour freshness window on at least one account.",
+                recovery: "Refresh the provider and review any new error."
+            )
+        }
+        return ReadinessCheck(
+            id: ReadinessCheckID.parseHealth,
+            title: title,
+            level: .pass,
+            detail: "Showing usage from a recent successful refresh. \(threshold)"
+        )
+    }
+
+    /// Setup checklist prefers account-scoped failures so a broken profile is
+    /// named once instead of repeating the provider aggregate.
+    public static func setupChecklistReports(from reports: [ProviderReadiness]) -> [ProviderReadiness] {
+        let needing = reports.filter(\.needsSetup)
+        let accountScoped = needing.filter(\.identity.isAccountScoped)
+        guard !accountScoped.isEmpty else { return needing }
+        let accountProviders = Set(accountScoped.map(\.provider))
+        return needing.filter { report in
+            report.identity.isAccountScoped || !accountProviders.contains(report.provider)
+        }
+    }
+
+    private static func rollup(id: String, from reports: [ProviderReadiness]) -> ReadinessCheck? {
+        let matching = reports.compactMap { $0.check(id) }
+        guard let representative = matching.max(by: { $0.level.severity < $1.level.severity }) else {
+            return nil
+        }
+        let passCount = matching.filter { $0.level == .pass }.count
+        let failCount = matching.filter { $0.level == .fail }.count
+        let total = matching.count
+        let detail: String
+        if failCount > 0, passCount > 0 {
+            detail = mixedDetail(id: id, failing: failCount, total: total)
+        } else {
+            detail = representative.detail
+        }
+        return ReadinessCheck(
+            id: id,
+            title: representative.title,
+            level: representative.level,
+            detail: detail,
+            recovery: representative.recovery
+        )
+    }
+
+    private static func mixedDetail(id: String, failing: Int, total: Int) -> String {
+        switch id {
+        case ReadinessCheckID.auth:
+            return "\(failing) of \(total) accounts are not signed in."
+        case ReadinessCheckID.data:
+            return "\(failing) of \(total) accounts cannot read usage."
+        case ReadinessCheckID.refresh:
+            return "\(failing) of \(total) accounts failed their last refresh."
+        case ReadinessCheckID.installed:
+            return "\(failing) of \(total) accounts reported an install problem."
+        default:
+            return "\(failing) of \(total) accounts need attention."
+        }
     }
 }
 

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -616,6 +616,8 @@ documents, it is a diagnostic DTO rather than a versioned cache schema:
 [
   {
     "provider": "Codex CLI",
+    "accountId": "00000000-0000-0000-0000-000000000002",
+    "accountName": "Default CLI Profile",
     "overall": "warn",
     "healthy": false,
     "checks": [
@@ -632,9 +634,12 @@ documents, it is a diagnostic DTO rather than a versioned cache schema:
 ```
 
 `overall` and `checks[].level` are `pass`, `warn`, or `fail`. `healthy` is true only when
-`overall` is `pass`. The report contains only the fields shown above; credential, token, password,
-authorization, and secret-bearing fields are never emitted. Diagnostic messages may use standard
-error, but standard output remains one JSON document.
+`overall` is `pass`. Multi-account providers (Claude, Codex, Grok) emit one object per enabled
+profile, plus a provider-wide aggregate when more than one profile is enabled. `accountId` is
+MeterBar's local profile id and `accountName` is the user-facing display name; both are omitted
+for provider-wide reports (Cursor, OpenRouter, and the aggregate). Filesystem paths, credentials,
+tokens, passwords, authorization headers, and raw response bodies are never emitted. Diagnostic
+messages may use standard error, but standard output remains one JSON document.
 
 ## Serve
 

--- a/scripts/fixtures/cli-json-smoke/fake-meterbar.sh
+++ b/scripts/fixtures/cli-json-smoke/fake-meterbar.sh
@@ -34,7 +34,7 @@ case "$scenario:$command_name" in
   data:doctor)
     echo "fixture diagnostic remains on stderr" >&2
     printf '%s\n' \
-      '[{"provider":"Codex CLI","overall":"pass","healthy":true,"checks":[{"id":"auth","title":"Signed in","level":"pass","detail":"Signed in.","recovery":null}]}]'
+      '[{"provider":"Codex CLI","accountId":"00000000-0000-0000-0000-000000000002","accountName":"Work","overall":"pass","healthy":true,"checks":[{"id":"auth","title":"Signed in","level":"pass","detail":"Signed in.","recovery":null}]}]'
     ;;
   malformed:usage)
     printf '%s\n' 'debug output that contaminates stdout'

--- a/scripts/verify-cli-json-smoke.sh
+++ b/scripts/verify-cli-json-smoke.sh
@@ -261,7 +261,9 @@ def validate_doctor(document):
     require(document, "doctor must contain at least one provider report")
     reject_secret_keys(document)
 
-    report_keys = {"provider", "overall", "healthy", "checks"}
+    required_report_keys = {"provider", "overall", "healthy", "checks"}
+    optional_report_keys = {"accountId", "accountName"}
+    allowed_report_keys = required_report_keys | optional_report_keys
     required_check_keys = {"id", "title", "level", "detail"}
     allowed_check_keys = required_check_keys | {"recovery"}
     levels = {"pass", "warn", "fail"}
@@ -269,7 +271,10 @@ def validate_doctor(document):
     for report_index, report in enumerate(document):
         path = f"doctor[{report_index}]"
         require(isinstance(report, dict), f"{path} must be an object")
-        require(set(report) == report_keys, f"{path} fields do not match the redacted DTO")
+        require(
+            required_report_keys <= set(report) <= allowed_report_keys,
+            f"{path} fields do not match the redacted DTO",
+        )
         require(
             isinstance(report["provider"], str) and report["provider"],
             f"{path}.provider must be a non-empty string",
@@ -280,6 +285,12 @@ def validate_doctor(document):
             report["healthy"] == (report["overall"] == "pass"),
             f"{path}.healthy conflicts with overall",
         )
+        for field in optional_report_keys:
+            if field in report:
+                require(
+                    isinstance(report[field], str) and report[field],
+                    f"{path}.{field} must be a non-empty string",
+                )
         require(isinstance(report["checks"], list), f"{path}.checks must be an array")
 
         for check_index, check in enumerate(report["checks"]):


### PR DESCRIPTION
Fixes #462

## Summary
- Diagnostics were provider-scoped while connection failures are account-scoped. A broken custom profile could hide behind a healthy default, or make the whole provider look failed.
- Claude, Codex, and Grok now evaluate every **enabled** profile independently. Two or more enabled profiles also get one safe provider-wide aggregate.
- Cursor and OpenRouter stay provider-wide.
- Shared `ReadinessIdentity` carries account id + display name only — no filesystem paths, credentials, or raw responses.
- Dashboard Diagnostics, the Finish setup checklist, and `meterbar doctor` text/JSON all use the same reports.

## Tests
- Mixed healthy/failing Grok and Codex fixtures identify only the affected accounts.
- Default-disabled / custom-only Claude and Grok configurations omit the disabled default.
- Parse-health aggregation warns when one account succeeds and one fails, instead of collapsing to the last write.
- Doctor JSON includes `accountId` / `accountName` and never emits paths.
- Doctor `--provider` filter still skips unrelated providers via the injectable `reports(...)` seam.
- `swift test`: 2465 passed, 5 skipped, 0 failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches diagnostics, refresh error attribution, and doctor JSON across app and CLI; behavior is well covered by tests but multi-report output is a user-visible contract change.
> 
> **Overview**
> **Multi-account readiness** replaces provider-only diagnostics for Claude, Codex, and Grok. Each **enabled** profile gets its own report (install/auth/refresh/usage checks); with two or more profiles, a provider-wide aggregate is added. Cursor and OpenRouter stay single-report.
> 
> **Per-account refresh errors** are tracked on local services (e.g. `accountErrors` on Claude) without letting a failing custom profile overwrite default `lastError`/`authState`, or vice versa. `DiagnosticsRunner` passes these maps into the inspector so refresh failures attach to the right profile.
> 
> **Shared model**: `ReadinessIdentity` and `ProviderReadinessExport` add display titles like `Grok · Work` and optional `accountId`/`accountName` in `meterbar doctor --json`—no paths or credentials. Setup checklist uses `setupChecklistReports` to surface named account failures instead of only the aggregate.
> 
> **Wiring**: Dashboard Diagnostics, popover “Finish setup,” readiness cards, and CLI doctor text/JSON all consume the same multi-report list; docs and CLI JSON smoke tests accept the new optional fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 229d69beba4be4bbe7909362b6ab1cfe55e9c692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->