### PR TITLE
fix(providers): show truthful stale and failed state on every usage card

### DIFF
--- a/MeterBar/Services/ProviderParseHealthStore.swift
+++ b/MeterBar/Services/ProviderParseHealthStore.swift
@@ -59,11 +59,15 @@ nonisolated public struct ProviderParseHealthRecord: Codable, Equatable, Sendabl
         )
     }
 
+    /// Sustained transport failures or consecutive shape mismatches. Does not
+    /// include an aged `lastSuccess` — that is staleness, not attention.
+    var isSustainedOrParseFailure: Bool {
+        consecutiveShapeMismatches >= Self.sustainedShapeMismatchCount
+            || consecutiveFailures >= Self.sustainedFailureCount
+    }
+
     func needsAttention(now: Date = Date()) -> Bool {
-        if consecutiveShapeMismatches >= Self.sustainedShapeMismatchCount
-            || consecutiveFailures >= Self.sustainedFailureCount {
-            return true
-        }
+        if isSustainedOrParseFailure { return true }
         guard let lastSuccess else { return false }
         return now.timeIntervalSince(lastSuccess) > Self.staleAfter
     }

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -81,16 +81,18 @@ struct MenuBarView: View {
   private var snapshots: [ProviderSnapshot] {
     ProviderSnapshotBuilder.snapshots(
       .live(
-        dataManager: dataManager,
-        claudeAccounts: claudeAccountStore.accounts,
-        codexAccounts: codexAccountStore.accounts,
-        grokAccounts: grokAccountStore.accounts,
-        enabledServices: providerVisibility.enabledServices,
-        claudeCodeService: claudeCodeService,
-        codexCliService: codexCliService,
-        cursorService: cursorService,
-        openRouterService: openRouterService,
-        grokService: grokService,
+        stores: .init(
+          dataManager: dataManager,
+          claudeAccounts: claudeAccountStore.accounts,
+          codexAccounts: codexAccountStore.accounts,
+          grokAccounts: grokAccountStore.accounts,
+          enabledServices: providerVisibility.enabledServices,
+          claudeCodeService: claudeCodeService,
+          codexCliService: codexCliService,
+          cursorService: cursorService,
+          openRouterService: openRouterService,
+          grokService: grokService
+        ),
         parseHealth: parseHealthStore.records
       ))
   }

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -25,6 +25,7 @@ struct MenuBarView: View {
   // tracker's initializer just rehydrates the cached summary and ledger from
   // disk — observing it never starts a scan.
   @StateObject private var costTracker = CostTracker.shared
+  @StateObject private var parseHealthStore = ProviderParseHealthStore.shared
 
   @State private var contentHeight: CGFloat = 320
   @State private var expandedDetailID: String?
@@ -79,22 +80,18 @@ struct MenuBarView: View {
   /// every account at once.
   private var snapshots: [ProviderSnapshot] {
     ProviderSnapshotBuilder.snapshots(
-      ProviderSnapshotBuilder.Input(
-        metrics: dataManager.metrics,
-        codexAccounts: codexAccountStore.accounts,
-        codexAccountMetrics: dataManager.codexAccountMetrics,
-        codexAccountAccess: codexCliService.accountAccess,
-        grokAccounts: grokAccountStore.accounts,
-        grokAccountMetrics: dataManager.grokAccountMetrics,
+      .live(
+        dataManager: dataManager,
         claudeAccounts: claudeAccountStore.accounts,
-        claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
+        codexAccounts: codexAccountStore.accounts,
+        grokAccounts: grokAccountStore.accounts,
         enabledServices: providerVisibility.enabledServices,
-        claudeAccountStates: dataManager.claudeCodeAccountStates,
-        claudeCodeHasAccess: claudeCodeService.hasAccess,
-        codexCliHasAccess: codexCliService.hasAccess,
-        cursorHasAccess: cursorService.hasAccess,
-        openRouterHasAccess: openRouterService.hasAccess,
-        grokHasAccess: grokService.hasAccess
+        claudeCodeService: claudeCodeService,
+        codexCliService: codexCliService,
+        cursorService: cursorService,
+        openRouterService: openRouterService,
+        grokService: grokService,
+        parseHealth: parseHealthStore.records
       ))
   }
 

--- a/MeterBar/Views/ProviderPresentationHealth.swift
+++ b/MeterBar/Views/ProviderPresentationHealth.swift
@@ -69,18 +69,35 @@ enum ProviderPresentationHealth {
         return nil
     }
 
+    /// Live `lastError` wins when the process still has it. After relaunch that
+    /// field is empty, so a persisted parse-health attempt newer than this
+    /// card's cache is the failure. A cache as new as the attempt is evidence
+    /// this account succeeded and must not inherit a sibling's failure.
     static func refreshOutcome(
         lastError: ServiceError?,
         parseHealth: ProviderParseHealthRecord?,
-        hasCache: Bool
+        lastUpdated: Date?
     ) -> RefreshOutcome {
-        guard lastError != nil else {
-            return hasCache ? .success : .unprobed
+        if lastError != nil {
+            return parseHealth?.isSustainedOrParseFailure == true
+                ? .sustainedOrParseFailure
+                : .transientFailure
         }
-        if parseHealth?.isSustainedOrParseFailure == true {
-            return .sustainedOrParseFailure
+
+        guard let lastUpdated else { return .unprobed }
+        guard let parseHealth else { return .success }
+
+        if lastUpdated >= parseHealth.lastAttempt {
+            return .success
         }
-        return .transientFailure
+
+        let attemptFailed = parseHealth.lastSuccess.map { parseHealth.lastAttempt > $0 }
+            ?? (parseHealth.consecutiveFailures > 0)
+        guard attemptFailed else { return .success }
+
+        return parseHealth.isSustainedOrParseFailure
+            ? .sustainedOrParseFailure
+            : .transientFailure
     }
 
     static func access(

--- a/MeterBar/Views/ProviderPresentationHealth.swift
+++ b/MeterBar/Views/ProviderPresentationHealth.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// One provider/account card's connection health, separate from `QuotaBand`.
+///
+/// Quota severity stays a pure function of the cached percentages. This
+/// projection answers whether those numbers are current, stale, or from a
+/// failed refresh, so a 70%-left cache cannot be labelled Healthy.
+enum ProviderPresentationHealth {
+    /// Signed-in / access. `unprobed` is not a failure.
+    enum Access: Equatable {
+        case unprobed
+        case signedIn
+        case loginRequired
+        case notConnected
+    }
+
+    /// Latest refresh for this card. `unprobed` is not a failure.
+    enum RefreshOutcome: Equatable {
+        case unprobed
+        case success
+        case transientFailure
+        case sustainedOrParseFailure
+    }
+
+    /// Last observed fetch errors. Missing entries are unprobed, not failures.
+    struct LastErrors {
+        var cursor: ServiceError?
+        var openRouter: ServiceError?
+        var codexAccounts: [UUID: ServiceError] = [:]
+        var grokAccounts: [UUID: ServiceError] = [:]
+    }
+
+    static var staleAfter: TimeInterval { ProviderParseHealthRecord.staleAfter }
+
+    /// Maps access, refresh outcome, parse health, and cache freshness onto the
+    /// card overlay. `nil` means the band may speak. No cache never fabricates
+    /// stale or attention — empty/offline stays empty/offline.
+    static func notice(
+        access: Access,
+        refresh: RefreshOutcome,
+        lastUpdated: Date?,
+        parseHealth: ProviderParseHealthRecord?,
+        now: Date
+    ) -> ProviderAuthNotice? {
+        guard let lastUpdated else { return nil }
+
+        switch access {
+        case .loginRequired:
+            return .loginRequired
+        case .notConnected:
+            return .notConnected
+        case .unprobed, .signedIn:
+            break
+        }
+
+        if refresh == .sustainedOrParseFailure
+            || (refresh != .success && parseHealth?.isSustainedOrParseFailure == true) {
+            return .attention("Refresh failed")
+        }
+
+        if refresh == .transientFailure {
+            return .stale(since: lastUpdated)
+        }
+
+        if now.timeIntervalSince(lastUpdated) > staleAfter {
+            return .stale(since: lastUpdated)
+        }
+
+        return nil
+    }
+
+    static func refreshOutcome(
+        lastError: ServiceError?,
+        parseHealth: ProviderParseHealthRecord?,
+        hasCache: Bool
+    ) -> RefreshOutcome {
+        guard lastError != nil else {
+            return hasCache ? .success : .unprobed
+        }
+        if parseHealth?.isSustainedOrParseFailure == true {
+            return .sustainedOrParseFailure
+        }
+        return .transientFailure
+    }
+
+    static func access(
+        probed: Bool?,
+        lastError: ServiceError?,
+        usesAPIKey: Bool
+    ) -> Access {
+        if probed == true { return .signedIn }
+        if probed == false {
+            return usesAPIKey ? .notConnected : .loginRequired
+        }
+        if case .notAuthenticated = lastError {
+            return usesAPIKey ? .notConnected : .loginRequired
+        }
+        return .unprobed
+    }
+}

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -316,6 +316,12 @@ struct SnapshotLimit: Identifiable {
 enum ProviderSnapshotBuilder {
     struct Input {
         var metrics: [ServiceType: UsageMetrics]
+        /// Clock for cache-freshness. Injectable so stale-cache fixtures do not
+        /// depend on wall time.
+        var now: Date = Date()
+        /// Provider-level parse health. Applied only to a card whose own
+        /// refresh failed, so one broken custom profile cannot mark siblings.
+        var parseHealth: [ServiceType: ProviderParseHealthRecord] = [:]
         var codexAccounts: [CodexAccount] = [.defaultAccount]
         var codexAccountMetrics: [UUID: UsageMetrics] = [:]
         /// Last observed Codex auth result per account id. Empty means "nothing
@@ -323,6 +329,8 @@ enum ProviderSnapshotBuilder {
         var codexAccountAccess: [UUID: Bool] = [:]
         var grokAccounts: [GrokAccount] = [.defaultAccount]
         var grokAccountMetrics: [UUID: UsageMetrics] = [:]
+        /// Last observed Grok auth result per account id. Empty means unprobed.
+        var grokAccountAccess: [UUID: Bool] = [:]
         var claudeAccounts: [ClaudeCodeAccount]
         var claudeAccountMetrics: [UUID: UsageMetrics]
         var enabledServices: Set<ServiceType>
@@ -335,6 +343,55 @@ enum ProviderSnapshotBuilder {
         var cursorHasAccess: Bool = false
         var openRouterHasAccess: Bool = false
         var grokHasAccess: Bool = false
+        var lastErrors: ProviderPresentationHealth.LastErrors = .init()
+
+        /// The popover, dashboard, and settings cards all read the same live
+        /// stores. Building Input here keeps lastError / parse health / Grok
+        /// access from drifting apart across those surfaces.
+        @MainActor
+        static func live(
+            dataManager: UsageDataManager,
+            claudeAccounts: [ClaudeCodeAccount],
+            codexAccounts: [CodexAccount],
+            grokAccounts: [GrokAccount],
+            enabledServices: Set<ServiceType>,
+            claudeCodeService: ClaudeCodeLocalService,
+            codexCliService: CodexCliLocalService,
+            cursorService: CursorLocalService,
+            openRouterService: OpenRouterService,
+            grokService: GrokCLIUsageService,
+            parseHealth: [ServiceType: ProviderParseHealthRecord],
+            now: Date = Date()
+        ) -> Input {
+            Input(
+                metrics: dataManager.metrics,
+                now: now,
+                parseHealth: parseHealth,
+                codexAccounts: codexAccounts,
+                codexAccountMetrics: dataManager.codexAccountMetrics,
+                codexAccountAccess: codexCliService.accountAccess,
+                grokAccounts: grokAccounts,
+                grokAccountMetrics: dataManager.grokAccountMetrics,
+                grokAccountAccess: Dictionary(uniqueKeysWithValues: grokAccounts.map {
+                    ($0.id, grokService.canAccess(account: $0))
+                }),
+                claudeAccounts: claudeAccounts,
+                claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
+                enabledServices: enabledServices,
+                claudeAccountStates: dataManager.claudeCodeAccountStates,
+                claudeCodeHasAccess: claudeCodeService.hasAccess,
+                codexCliHasAccess: codexCliService.hasAccess,
+                cursorHasAccess: cursorService.hasAccess,
+                openRouterHasAccess: openRouterService.hasAccess,
+                grokHasAccess: grokService.hasAccess,
+                lastErrors: ProviderPresentationHealth.LastErrors(
+                    cursor: cursorService.lastError,
+                    openRouter: openRouterService.lastError,
+                    codexAccounts: codexCliService.accountErrors,
+                    grokAccounts: grokService.accountErrors
+                )
+            )
+        }
     }
 
     /// Builds the provider cards. Emission order follows each store; the
@@ -370,12 +427,19 @@ enum ProviderSnapshotBuilder {
                         && input.codexAccountMetrics.isEmpty
                         ? input.metrics[.codexCli]
                         : nil
+                    let metrics = input.codexAccountMetrics[account.id] ?? fallbackMetrics
                     result.append(snapshot(
                         title: title,
                         service: .codexCli,
-                        metrics: input.codexAccountMetrics[account.id] ?? fallbackMetrics,
+                        metrics: metrics,
                         emptyDetail: emptyDetail,
-                        accountID: account.id
+                        accountID: account.id,
+                        authNotice: notice(
+                            for: .codexCli,
+                            accountID: account.id,
+                            metrics: metrics,
+                            input: input
+                        )
                     ))
                 }
             }
@@ -394,33 +458,43 @@ enum ProviderSnapshotBuilder {
                     let emptyDetail = account.isDefault && input.claudeCodeHasAccess
                         ? "Waiting for refresh"
                         : "Run claude login"
+                    let metrics = accountMetrics[account.id] ?? (account.isDefault ? input.metrics[.claudeCode] : nil)
                     result.append(snapshot(
                         title: title,
                         service: .claudeCode,
-                        metrics: accountMetrics[account.id] ?? (account.isDefault ? input.metrics[.claudeCode] : nil),
+                        metrics: metrics,
                         emptyDetail: emptyDetail,
                         accountID: account.id,
-                        authNotice: ProviderAuthNotice.forState(input.claudeAccountStates[account.id])
+                        authNotice: notice(
+                            for: .claudeCode,
+                            accountID: account.id,
+                            metrics: metrics,
+                            input: input
+                        )
                     ))
                 }
             }
         }
 
         if input.enabledServices.contains(.cursor) {
+            let metrics = input.metrics[.cursor]
             result.append(snapshot(
                 title: ServiceType.cursor.shortName,
                 service: .cursor,
-                metrics: input.metrics[.cursor],
-                emptyDetail: input.cursorHasAccess ? "Waiting for refresh" : "Log in to Cursor"
+                metrics: metrics,
+                emptyDetail: input.cursorHasAccess ? "Waiting for refresh" : "Log in to Cursor",
+                authNotice: notice(for: .cursor, accountID: nil, metrics: metrics, input: input)
             ))
         }
 
         if input.enabledServices.contains(.openRouter) {
+            let metrics = input.metrics[.openRouter]
             result.append(snapshot(
                 title: ServiceType.openRouter.shortName,
                 service: .openRouter,
-                metrics: input.metrics[.openRouter],
-                emptyDetail: input.openRouterHasAccess ? "Waiting for refresh" : "Add an OpenRouter API key"
+                metrics: metrics,
+                emptyDetail: input.openRouterHasAccess ? "Waiting for refresh" : "Add an OpenRouter API key",
+                authNotice: notice(for: .openRouter, accountID: nil, metrics: metrics, input: input)
             ))
         }
 
@@ -437,19 +511,91 @@ enum ProviderSnapshotBuilder {
                     && input.grokAccountMetrics.isEmpty
                     ? input.metrics[.grok]
                     : nil
+                let metrics = input.grokAccountMetrics[account.id] ?? fallbackMetrics
                 result.append(snapshot(
                     title: title,
                     service: .grok,
-                    metrics: input.grokAccountMetrics[account.id] ?? fallbackMetrics,
+                    metrics: metrics,
                     emptyDetail: account.isDefault && input.grokHasAccess
                         ? "Waiting for refresh"
                         : "Run grok login",
-                    accountID: account.id
+                    accountID: account.id,
+                    authNotice: notice(for: .grok, accountID: account.id, metrics: metrics, input: input)
                 ))
             }
         }
 
         return orderedForDisplay(result)
+    }
+
+    /// Connection-health overlay for one card. Claude states still win for
+    /// login/unavailable/error; lastUpdated and parse health then apply so a
+    /// connected-but-aged cache is Stale, not Healthy. Non-Claude cards use
+    /// lastError + access + parse health. Provider-level parse health only
+    /// upgrades a card whose own refresh failed.
+    private static func notice(
+        for service: ServiceType,
+        accountID: UUID?,
+        metrics: UsageMetrics?,
+        input: Input
+    ) -> ProviderAuthNotice? {
+        if service == .claudeCode {
+            if let state = accountID.flatMap({ input.claudeAccountStates[$0] }),
+               let claudeNotice = ProviderAuthNotice.forState(state) {
+                return claudeNotice
+            }
+            return ProviderPresentationHealth.notice(
+                access: .signedIn,
+                refresh: metrics == nil ? .unprobed : .success,
+                lastUpdated: metrics?.lastUpdated,
+                parseHealth: nil,
+                now: input.now
+            )
+        }
+
+        let lastError: ServiceError?
+        let probed: Bool?
+        let usesAPIKey: Bool
+        switch service {
+        case .codexCli:
+            lastError = accountID.flatMap { input.lastErrors.codexAccounts[$0] }
+            probed = accountID.flatMap { input.codexAccountAccess[$0] }
+            usesAPIKey = false
+        case .grok:
+            lastError = accountID.flatMap { input.lastErrors.grokAccounts[$0] }
+            probed = accountID.flatMap { input.grokAccountAccess[$0] }
+            usesAPIKey = false
+        case .cursor:
+            lastError = input.lastErrors.cursor
+            probed = input.cursorHasAccess ? true : nil
+            usesAPIKey = false
+        case .openRouter:
+            lastError = input.lastErrors.openRouter
+            probed = input.openRouterHasAccess ? true : nil
+            usesAPIKey = true
+        case .claudeCode:
+            lastError = nil
+            probed = nil
+            usesAPIKey = false
+        }
+
+        let parseHealth = input.parseHealth[service]
+        let refresh = ProviderPresentationHealth.refreshOutcome(
+            lastError: lastError,
+            parseHealth: parseHealth,
+            hasCache: metrics != nil
+        )
+        return ProviderPresentationHealth.notice(
+            access: ProviderPresentationHealth.access(
+                probed: probed,
+                lastError: lastError,
+                usesAPIKey: usesAPIKey
+            ),
+            refresh: refresh,
+            lastUpdated: metrics?.lastUpdated,
+            parseHealth: parseHealth,
+            now: input.now
+        )
     }
 
     /// Stable card order for the popover, Overview, and Limits.

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -318,7 +318,7 @@ enum ProviderSnapshotBuilder {
         var metrics: [ServiceType: UsageMetrics]
         /// Clock for cache-freshness. Injectable so stale-cache fixtures do not
         /// depend on wall time.
-        var now: Date = Date()
+        var now = Date()
         /// Provider-level parse health. Applied only to a card whose own
         /// refresh failed, so one broken custom profile cannot mark siblings.
         var parseHealth: [ServiceType: ProviderParseHealthRecord] = [:]
@@ -345,50 +345,55 @@ enum ProviderSnapshotBuilder {
         var grokHasAccess: Bool = false
         var lastErrors: ProviderPresentationHealth.LastErrors = .init()
 
-        /// The popover, dashboard, and settings cards all read the same live
-        /// stores. Building Input here keeps lastError / parse health / Grok
-        /// access from drifting apart across those surfaces.
+        /// Live stores the popover, dashboard, and settings cards share.
+        /// Grouped so `live(stores:parseHealth:)` stays under the parameter cap.
+        struct LiveStores {
+            var dataManager: UsageDataManager
+            var claudeAccounts: [ClaudeCodeAccount]
+            var codexAccounts: [CodexAccount]
+            var grokAccounts: [GrokAccount]
+            var enabledServices: Set<ServiceType>
+            var claudeCodeService: ClaudeCodeLocalService
+            var codexCliService: CodexCliLocalService
+            var cursorService: CursorLocalService
+            var openRouterService: OpenRouterService
+            var grokService: GrokCLIUsageService
+        }
+
+        /// Builds Input here so lastError / parse health / Grok access cannot
+        /// drift apart across those surfaces.
         @MainActor
         static func live(
-            dataManager: UsageDataManager,
-            claudeAccounts: [ClaudeCodeAccount],
-            codexAccounts: [CodexAccount],
-            grokAccounts: [GrokAccount],
-            enabledServices: Set<ServiceType>,
-            claudeCodeService: ClaudeCodeLocalService,
-            codexCliService: CodexCliLocalService,
-            cursorService: CursorLocalService,
-            openRouterService: OpenRouterService,
-            grokService: GrokCLIUsageService,
+            stores: LiveStores,
             parseHealth: [ServiceType: ProviderParseHealthRecord],
             now: Date = Date()
         ) -> Input {
             Input(
-                metrics: dataManager.metrics,
+                metrics: stores.dataManager.metrics,
                 now: now,
                 parseHealth: parseHealth,
-                codexAccounts: codexAccounts,
-                codexAccountMetrics: dataManager.codexAccountMetrics,
-                codexAccountAccess: codexCliService.accountAccess,
-                grokAccounts: grokAccounts,
-                grokAccountMetrics: dataManager.grokAccountMetrics,
-                grokAccountAccess: Dictionary(uniqueKeysWithValues: grokAccounts.map {
-                    ($0.id, grokService.canAccess(account: $0))
+                codexAccounts: stores.codexAccounts,
+                codexAccountMetrics: stores.dataManager.codexAccountMetrics,
+                codexAccountAccess: stores.codexCliService.accountAccess,
+                grokAccounts: stores.grokAccounts,
+                grokAccountMetrics: stores.dataManager.grokAccountMetrics,
+                grokAccountAccess: Dictionary(uniqueKeysWithValues: stores.grokAccounts.map {
+                    ($0.id, stores.grokService.canAccess(account: $0))
                 }),
-                claudeAccounts: claudeAccounts,
-                claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
-                enabledServices: enabledServices,
-                claudeAccountStates: dataManager.claudeCodeAccountStates,
-                claudeCodeHasAccess: claudeCodeService.hasAccess,
-                codexCliHasAccess: codexCliService.hasAccess,
-                cursorHasAccess: cursorService.hasAccess,
-                openRouterHasAccess: openRouterService.hasAccess,
-                grokHasAccess: grokService.hasAccess,
+                claudeAccounts: stores.claudeAccounts,
+                claudeAccountMetrics: stores.dataManager.claudeCodeAccountMetrics,
+                enabledServices: stores.enabledServices,
+                claudeAccountStates: stores.dataManager.claudeCodeAccountStates,
+                claudeCodeHasAccess: stores.claudeCodeService.hasAccess,
+                codexCliHasAccess: stores.codexCliService.hasAccess,
+                cursorHasAccess: stores.cursorService.hasAccess,
+                openRouterHasAccess: stores.openRouterService.hasAccess,
+                grokHasAccess: stores.grokService.hasAccess,
                 lastErrors: ProviderPresentationHealth.LastErrors(
-                    cursor: cursorService.lastError,
-                    openRouter: openRouterService.lastError,
-                    codexAccounts: codexCliService.accountErrors,
-                    grokAccounts: grokService.accountErrors
+                    cursor: stores.cursorService.lastError,
+                    openRouter: stores.openRouterService.lastError,
+                    codexAccounts: stores.codexCliService.accountErrors,
+                    grokAccounts: stores.grokService.accountErrors
                 )
             )
         }
@@ -539,18 +544,10 @@ enum ProviderSnapshotBuilder {
         metrics: UsageMetrics?,
         input: Input
     ) -> ProviderAuthNotice? {
-        if service == .claudeCode {
-            if let state = accountID.flatMap({ input.claudeAccountStates[$0] }),
-               let claudeNotice = ProviderAuthNotice.forState(state) {
-                return claudeNotice
-            }
-            return ProviderPresentationHealth.notice(
-                access: .signedIn,
-                refresh: metrics == nil ? .unprobed : .success,
-                lastUpdated: metrics?.lastUpdated,
-                parseHealth: nil,
-                now: input.now
-            )
+        if service == .claudeCode,
+           let state = accountID.flatMap({ input.claudeAccountStates[$0] }),
+           let claudeNotice = ProviderAuthNotice.forState(state) {
+            return claudeNotice
         }
 
         let lastError: ServiceError?
@@ -575,7 +572,7 @@ enum ProviderSnapshotBuilder {
             usesAPIKey = true
         case .claudeCode:
             lastError = nil
-            probed = nil
+            probed = input.claudeCodeHasAccess ? true : nil
             usesAPIKey = false
         }
 
@@ -583,7 +580,7 @@ enum ProviderSnapshotBuilder {
         let refresh = ProviderPresentationHealth.refreshOutcome(
             lastError: lastError,
             parseHealth: parseHealth,
-            hasCache: metrics != nil
+            lastUpdated: metrics?.lastUpdated
         )
         return ProviderPresentationHealth.notice(
             access: ProviderPresentationHealth.access(

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -340,8 +340,10 @@ enum ProviderSnapshotBuilder {
         var claudeAccountStates: [UUID: ClaudeCodeAuthState] = [:]
         var claudeCodeHasAccess: Bool = false
         var codexCliHasAccess: Bool = false
-        var cursorHasAccess: Bool = false
-        var openRouterHasAccess: Bool = false
+        /// Last Cursor probe. `nil` is unprobed; `false` is confirmed signed-out.
+        var cursorHasAccess: Bool?
+        /// Last OpenRouter probe. `nil` is unprobed; `false` is confirmed no key.
+        var openRouterHasAccess: Bool?
         var grokHasAccess: Bool = false
         var lastErrors: ProviderPresentationHealth.LastErrors = .init()
 
@@ -487,7 +489,7 @@ enum ProviderSnapshotBuilder {
                 title: ServiceType.cursor.shortName,
                 service: .cursor,
                 metrics: metrics,
-                emptyDetail: input.cursorHasAccess ? "Waiting for refresh" : "Log in to Cursor",
+                emptyDetail: input.cursorHasAccess == true ? "Waiting for refresh" : "Log in to Cursor",
                 authNotice: notice(for: .cursor, accountID: nil, metrics: metrics, input: input)
             ))
         }
@@ -498,7 +500,9 @@ enum ProviderSnapshotBuilder {
                 title: ServiceType.openRouter.shortName,
                 service: .openRouter,
                 metrics: metrics,
-                emptyDetail: input.openRouterHasAccess ? "Waiting for refresh" : "Add an OpenRouter API key",
+                emptyDetail: input.openRouterHasAccess == true
+                    ? "Waiting for refresh"
+                    : "Add an OpenRouter API key",
                 authNotice: notice(for: .openRouter, accountID: nil, metrics: metrics, input: input)
             ))
         }
@@ -564,11 +568,11 @@ enum ProviderSnapshotBuilder {
             usesAPIKey = false
         case .cursor:
             lastError = input.lastErrors.cursor
-            probed = input.cursorHasAccess ? true : nil
+            probed = input.cursorHasAccess
             usesAPIKey = false
         case .openRouter:
             lastError = input.lastErrors.openRouter
-            probed = input.openRouterHasAccess ? true : nil
+            probed = input.openRouterHasAccess
             usesAPIKey = true
         case .claudeCode:
             lastError = nil

--- a/MeterBar/Views/Settings/GeneralSettingsView.swift
+++ b/MeterBar/Views/Settings/GeneralSettingsView.swift
@@ -58,16 +58,18 @@ struct GeneralSettingsView: View {
     private var providerSnapshots: [ProviderSnapshot] {
         ProviderSnapshotBuilder.snapshots(
             .live(
-                dataManager: dataManager,
-                claudeAccounts: claudeAccountStore.accounts,
-                codexAccounts: codexAccountStore.accounts,
-                grokAccounts: grokAccountStore.accounts,
-                enabledServices: providerVisibility.enabledServices,
-                claudeCodeService: claudeCodeService,
-                codexCliService: codexCliService,
-                cursorService: cursorService,
-                openRouterService: openRouterService,
-                grokService: grokService,
+                stores: .init(
+                    dataManager: dataManager,
+                    claudeAccounts: claudeAccountStore.accounts,
+                    codexAccounts: codexAccountStore.accounts,
+                    grokAccounts: grokAccountStore.accounts,
+                    enabledServices: providerVisibility.enabledServices,
+                    claudeCodeService: claudeCodeService,
+                    codexCliService: codexCliService,
+                    cursorService: cursorService,
+                    openRouterService: openRouterService,
+                    grokService: grokService
+                ),
                 parseHealth: parseHealthStore.records
             )
         )

--- a/MeterBar/Views/Settings/GeneralSettingsView.swift
+++ b/MeterBar/Views/Settings/GeneralSettingsView.swift
@@ -37,6 +37,7 @@ struct GeneralSettingsView: View {
     @StateObject private var notificationPreferences = NotificationPreferencesStore.shared
     @StateObject private var launchAtLogin = LaunchAtLoginStore.shared
     @StateObject private var softwareUpdates = SoftwareUpdateController.shared
+    @StateObject private var parseHealthStore = ProviderParseHealthStore.shared
 
     /// Explains a rejected menu-bar account selection; nil while under the cap.
     @State private var capNotice: String?
@@ -56,22 +57,18 @@ struct GeneralSettingsView: View {
     // tab does.
     private var providerSnapshots: [ProviderSnapshot] {
         ProviderSnapshotBuilder.snapshots(
-            ProviderSnapshotBuilder.Input(
-                metrics: dataManager.metrics,
-                codexAccounts: codexAccountStore.accounts,
-                codexAccountMetrics: dataManager.codexAccountMetrics,
-                codexAccountAccess: codexCliService.accountAccess,
-                grokAccounts: grokAccountStore.accounts,
-                grokAccountMetrics: dataManager.grokAccountMetrics,
+            .live(
+                dataManager: dataManager,
                 claudeAccounts: claudeAccountStore.accounts,
-                claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
+                codexAccounts: codexAccountStore.accounts,
+                grokAccounts: grokAccountStore.accounts,
                 enabledServices: providerVisibility.enabledServices,
-                claudeAccountStates: dataManager.claudeCodeAccountStates,
-                claudeCodeHasAccess: claudeCodeService.hasAccess,
-                codexCliHasAccess: codexCliService.hasAccess,
-                cursorHasAccess: cursorService.hasAccess,
-                openRouterHasAccess: openRouterService.hasAccess,
-                grokHasAccess: grokService.hasAccess
+                claudeCodeService: claudeCodeService,
+                codexCliService: codexCliService,
+                cursorService: cursorService,
+                openRouterService: openRouterService,
+                grokService: grokService,
+                parseHealth: parseHealthStore.records
             )
         )
     }

--- a/MeterBar/Views/Settings/ProviderCatalogSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderCatalogSettingsView.swift
@@ -45,25 +45,22 @@ struct ProviderCatalogSettingsView: View {
     @StateObject private var openRouterService = OpenRouterService.shared
     @StateObject private var grokService = GrokCLIUsageService.shared
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
+    @StateObject private var parseHealthStore = ProviderParseHealthStore.shared
 
     private var providerSnapshots: [ProviderSnapshot] {
         ProviderSnapshotBuilder.snapshots(
-            ProviderSnapshotBuilder.Input(
-                metrics: dataManager.metrics,
-                codexAccounts: codexAccountStore.accounts,
-                codexAccountMetrics: dataManager.codexAccountMetrics,
-                codexAccountAccess: codexCliService.accountAccess,
-                grokAccounts: grokAccountStore.accounts,
-                grokAccountMetrics: dataManager.grokAccountMetrics,
+            .live(
+                dataManager: dataManager,
                 claudeAccounts: claudeAccountStore.accounts,
-                claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
+                codexAccounts: codexAccountStore.accounts,
+                grokAccounts: grokAccountStore.accounts,
                 enabledServices: providerVisibility.enabledServices,
-                claudeAccountStates: dataManager.claudeCodeAccountStates,
-                claudeCodeHasAccess: claudeCodeService.hasAccess,
-                codexCliHasAccess: codexCliService.hasAccess,
-                cursorHasAccess: cursorService.hasAccess,
-                openRouterHasAccess: openRouterService.hasAccess,
-                grokHasAccess: grokService.hasAccess
+                claudeCodeService: claudeCodeService,
+                codexCliService: codexCliService,
+                cursorService: cursorService,
+                openRouterService: openRouterService,
+                grokService: grokService,
+                parseHealth: parseHealthStore.records
             )
         )
     }

--- a/MeterBar/Views/Settings/ProviderCatalogSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderCatalogSettingsView.swift
@@ -50,16 +50,18 @@ struct ProviderCatalogSettingsView: View {
     private var providerSnapshots: [ProviderSnapshot] {
         ProviderSnapshotBuilder.snapshots(
             .live(
-                dataManager: dataManager,
-                claudeAccounts: claudeAccountStore.accounts,
-                codexAccounts: codexAccountStore.accounts,
-                grokAccounts: grokAccountStore.accounts,
-                enabledServices: providerVisibility.enabledServices,
-                claudeCodeService: claudeCodeService,
-                codexCliService: codexCliService,
-                cursorService: cursorService,
-                openRouterService: openRouterService,
-                grokService: grokService,
+                stores: .init(
+                    dataManager: dataManager,
+                    claudeAccounts: claudeAccountStore.accounts,
+                    codexAccounts: codexAccountStore.accounts,
+                    grokAccounts: grokAccountStore.accounts,
+                    enabledServices: providerVisibility.enabledServices,
+                    claudeCodeService: claudeCodeService,
+                    codexCliService: codexCliService,
+                    cursorService: cursorService,
+                    openRouterService: openRouterService,
+                    grokService: grokService
+                ),
                 parseHealth: parseHealthStore.records
             )
         )

--- a/MeterBar/Views/Settings/ProviderSettingsFacts+Live.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsFacts+Live.swift
@@ -44,17 +44,6 @@ extension ProviderSettingsFacts {
                 grokLiveState()
             }
 
-        let metered = matching.filter(\.hasMetrics)
-        let notices = metered.compactMap(\.authNotice)
-        let sharedNotice: ProviderAuthNotice?
-        if metered.count <= 1 {
-            sharedNotice = notices.first
-        } else if !metered.isEmpty, metered.allSatisfy({ $0.authNotice != nil }) {
-            sharedNotice = notices.first
-        } else {
-            sharedNotice = nil
-        }
-
         return ProviderSettingsFacts(
             service: service,
             isEnabled: ProviderVisibilityStore.shared.isEnabled(service),
@@ -64,7 +53,7 @@ extension ProviderSettingsFacts {
             errorText: live.error,
             updatedText: matching.filter(\.hasMetrics).map(\.updatedText).first ?? "No data",
             worstBand: matching.compactMap(\.band).max(by: { $0.severity < $1.severity }),
-            authNotice: sharedNotice,
+            authNotice: sharedNotice(in: matching),
             codexAuthFileDisplayPath: CodexHomeDirectory.authFileDisplayPath(
                 for: CodexAccountStore.shared.accounts.first(where: \.isDefault) ?? .defaultAccount
             )

--- a/MeterBar/Views/Settings/ProviderSettingsFacts+Live.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsFacts+Live.swift
@@ -44,6 +44,17 @@ extension ProviderSettingsFacts {
                 grokLiveState()
             }
 
+        let metered = matching.filter(\.hasMetrics)
+        let notices = metered.compactMap(\.authNotice)
+        let sharedNotice: ProviderAuthNotice?
+        if metered.count <= 1 {
+            sharedNotice = notices.first
+        } else if !metered.isEmpty, metered.allSatisfy({ $0.authNotice != nil }) {
+            sharedNotice = notices.first
+        } else {
+            sharedNotice = nil
+        }
+
         return ProviderSettingsFacts(
             service: service,
             isEnabled: ProviderVisibilityStore.shared.isEnabled(service),
@@ -53,6 +64,7 @@ extension ProviderSettingsFacts {
             errorText: live.error,
             updatedText: matching.filter(\.hasMetrics).map(\.updatedText).first ?? "No data",
             worstBand: matching.compactMap(\.band).max(by: { $0.severity < $1.severity }),
+            authNotice: sharedNotice,
             codexAuthFileDisplayPath: CodexHomeDirectory.authFileDisplayPath(
                 for: CodexAccountStore.shared.accounts.first(where: \.isDefault) ?? .defaultAccount
             )

--- a/MeterBar/Views/Settings/ProviderSettingsFacts.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsFacts.swift
@@ -35,6 +35,19 @@ struct ProviderSettingsFacts {
     /// labelled Healthy. `nil` when cards disagree (one failed custom must not
     /// paint a healthy sibling) or when nothing is overlayed.
     var authNotice: ProviderAuthNotice?
+
+    /// Overlay shown on the Settings row only when every metered card carries
+    /// the same notice. Distinct overlays (stale vs attention) must not collapse
+    /// to whichever card happens to come first.
+    static func sharedNotice(in snapshots: [ProviderSnapshot]) -> ProviderAuthNotice? {
+        let metered = snapshots.filter(\.hasMetrics)
+        let notices = metered.compactMap(\.authNotice)
+        guard !metered.isEmpty, notices.count == metered.count else { return nil }
+        let labels = Set(notices.map(\.shortLabel))
+        guard labels.count == 1 else { return nil }
+        return notices.first
+    }
+
     /// Display path of the Codex auth file (only used by the Codex source line).
     let codexAuthFileDisplayPath: String
 

--- a/MeterBar/Views/Settings/ProviderSettingsFacts.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsFacts.swift
@@ -30,6 +30,11 @@ struct ProviderSettingsFacts {
     let updatedText: String
     /// The single most-severe quota band across this provider's windows.
     let worstBand: QuotaBand?
+    /// Card-level connection overlay when every visible card for this provider
+    /// agrees. Kept separate from `worstBand` so a stale 70%-left cache is not
+    /// labelled Healthy. `nil` when cards disagree (one failed custom must not
+    /// paint a healthy sibling) or when nothing is overlayed.
+    var authNotice: ProviderAuthNotice? = nil
     /// Display path of the Codex auth file (only used by the Codex source line).
     let codexAuthFileDisplayPath: String
 
@@ -91,6 +96,9 @@ struct ProviderSettingsFacts {
         guard hasAccess else {
             return "Not connected"
         }
+        if let authNotice {
+            return authNotice.shortLabel
+        }
         if errorText != nil {
             return "Refresh failed"
         }
@@ -105,6 +113,14 @@ struct ProviderSettingsFacts {
     var statusColor: Color {
         guard isEnabled, hasAccess else {
             return .secondary
+        }
+        if let authNotice {
+            switch authNotice {
+            case .loginRequired, .attention:
+                return MeterBarTheme.warning
+            case .stale, .notConnected:
+                return .secondary
+            }
         }
         if errorText != nil {
             return MeterBarTheme.warning

--- a/MeterBar/Views/Settings/ProviderSettingsFacts.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsFacts.swift
@@ -34,7 +34,7 @@ struct ProviderSettingsFacts {
     /// agrees. Kept separate from `worstBand` so a stale 70%-left cache is not
     /// labelled Healthy. `nil` when cards disagree (one failed custom must not
     /// paint a healthy sibling) or when nothing is overlayed.
-    var authNotice: ProviderAuthNotice? = nil
+    var authNotice: ProviderAuthNotice?
     /// Display path of the Codex auth file (only used by the Codex source line).
     let codexAuthFileDisplayPath: String
 

--- a/MeterBar/Views/Settings/ProviderSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsView.swift
@@ -123,16 +123,18 @@ struct ProviderSettingsView: View {
     private var providerSnapshots: [ProviderSnapshot] {
         ProviderSnapshotBuilder.snapshots(
             .live(
-                dataManager: dataManager,
-                claudeAccounts: claudeAccountStore.accounts,
-                codexAccounts: codexAccountStore.accounts,
-                grokAccounts: grokAccountStore.accounts,
-                enabledServices: providerVisibility.enabledServices,
-                claudeCodeService: claudeCodeService,
-                codexCliService: codexCliService,
-                cursorService: cursorService,
-                openRouterService: openRouterService,
-                grokService: grokService,
+                stores: .init(
+                    dataManager: dataManager,
+                    claudeAccounts: claudeAccountStore.accounts,
+                    codexAccounts: codexAccountStore.accounts,
+                    grokAccounts: grokAccountStore.accounts,
+                    enabledServices: providerVisibility.enabledServices,
+                    claudeCodeService: claudeCodeService,
+                    codexCliService: codexCliService,
+                    cursorService: cursorService,
+                    openRouterService: openRouterService,
+                    grokService: grokService
+                ),
                 parseHealth: parseHealthStore.records
             )
         )

--- a/MeterBar/Views/Settings/ProviderSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsView.swift
@@ -105,6 +105,7 @@ struct ProviderSettingsView: View {
     @StateObject private var menuBarAccountSelection = MenuBarAccountSelectionStore.shared
     @StateObject private var widgetPreferences = WidgetPreferencesStore.shared
     @StateObject private var sessionWakeSettings = SessionWakeSettingsStore.shared
+    @StateObject private var parseHealthStore = ProviderParseHealthStore.shared
 
     @State private var isAddingClaudeAccount = false
     @State private var isAddingCodexAccount = false
@@ -121,22 +122,18 @@ struct ProviderSettingsView: View {
 
     private var providerSnapshots: [ProviderSnapshot] {
         ProviderSnapshotBuilder.snapshots(
-            ProviderSnapshotBuilder.Input(
-                metrics: dataManager.metrics,
-                codexAccounts: codexAccountStore.accounts,
-                codexAccountMetrics: dataManager.codexAccountMetrics,
-                codexAccountAccess: codexCliService.accountAccess,
-                grokAccounts: grokAccountStore.accounts,
-                grokAccountMetrics: dataManager.grokAccountMetrics,
+            .live(
+                dataManager: dataManager,
                 claudeAccounts: claudeAccountStore.accounts,
-                claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
+                codexAccounts: codexAccountStore.accounts,
+                grokAccounts: grokAccountStore.accounts,
                 enabledServices: providerVisibility.enabledServices,
-                claudeAccountStates: dataManager.claudeCodeAccountStates,
-                claudeCodeHasAccess: claudeCodeService.hasAccess,
-                codexCliHasAccess: codexCliService.hasAccess,
-                cursorHasAccess: cursorService.hasAccess,
-                openRouterHasAccess: openRouterService.hasAccess,
-                grokHasAccess: grokService.hasAccess
+                claudeCodeService: claudeCodeService,
+                codexCliService: codexCliService,
+                cursorService: cursorService,
+                openRouterService: openRouterService,
+                grokService: grokService,
+                parseHealth: parseHealthStore.records
             )
         )
     }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -405,16 +405,18 @@ struct UsageDashboardView: View {
     /// recommendation card — read this instead of the filtered list.
     private var allProviderSnapshots: [ProviderSnapshot] {
         ProviderSnapshotBuilder.snapshots(.live(
-            dataManager: dataManager,
-            claudeAccounts: claudeAccountStore.accounts,
-            codexAccounts: codexAccountStore.accounts,
-            grokAccounts: grokAccountStore.accounts,
-            enabledServices: providerVisibility.enabledServices,
-            claudeCodeService: claudeCodeService,
-            codexCliService: codexCliService,
-            cursorService: cursorService,
-            openRouterService: openRouterService,
-            grokService: grokService,
+            stores: .init(
+                dataManager: dataManager,
+                claudeAccounts: claudeAccountStore.accounts,
+                codexAccounts: codexAccountStore.accounts,
+                grokAccounts: grokAccountStore.accounts,
+                enabledServices: providerVisibility.enabledServices,
+                claudeCodeService: claudeCodeService,
+                codexCliService: codexCliService,
+                cursorService: cursorService,
+                openRouterService: openRouterService,
+                grokService: grokService
+            ),
             parseHealth: parseHealthStore.records
         ))
     }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -35,6 +35,7 @@ struct UsageDashboardView: View {
     @StateObject private var providerStatusMonitor = ProviderStatusMonitor.shared
     @StateObject private var navigation = DashboardNavigationStore.shared
     @StateObject private var sessionWakeStore = SessionWakeSettingsStore.shared
+    @StateObject private var parseHealthStore = ProviderParseHealthStore.shared
 
     /// Owned by the shell rather than the Share page because the toolbar's
     /// Refresh also re-stamps the card.
@@ -403,22 +404,18 @@ struct UsageDashboardView: View {
     /// Sections that must *name* a silent provider — the Optimize page's
     /// recommendation card — read this instead of the filtered list.
     private var allProviderSnapshots: [ProviderSnapshot] {
-        ProviderSnapshotBuilder.snapshots(ProviderSnapshotBuilder.Input(
-            metrics: dataManager.metrics,
-            codexAccounts: codexAccountStore.accounts,
-            codexAccountMetrics: dataManager.codexAccountMetrics,
-            codexAccountAccess: codexCliService.accountAccess,
-            grokAccounts: grokAccountStore.accounts,
-            grokAccountMetrics: dataManager.grokAccountMetrics,
+        ProviderSnapshotBuilder.snapshots(.live(
+            dataManager: dataManager,
             claudeAccounts: claudeAccountStore.accounts,
-            claudeAccountMetrics: dataManager.claudeCodeAccountMetrics,
+            codexAccounts: codexAccountStore.accounts,
+            grokAccounts: grokAccountStore.accounts,
             enabledServices: providerVisibility.enabledServices,
-            claudeAccountStates: dataManager.claudeCodeAccountStates,
-            claudeCodeHasAccess: claudeCodeService.hasAccess,
-            codexCliHasAccess: codexCliService.hasAccess,
-            cursorHasAccess: cursorService.hasAccess,
-            openRouterHasAccess: openRouterService.hasAccess,
-            grokHasAccess: grokService.hasAccess
+            claudeCodeService: claudeCodeService,
+            codexCliService: codexCliService,
+            cursorService: cursorService,
+            openRouterService: openRouterService,
+            grokService: grokService,
+            parseHealth: parseHealthStore.records
         ))
     }
 

--- a/MeterBarTests/ClaudeAccountAuthStateTests.swift
+++ b/MeterBarTests/ClaudeAccountAuthStateTests.swift
@@ -200,7 +200,7 @@ final class ClaudeAccountAuthStateTests: XCTestCase {
         XCTAssertNil(defaultCard.authNotice, "A connected profile must not inherit its neighbour's notice")
     }
 
-    func testNonClaudeCardsNeverCarryANotice() throws {
+    func testClaudeLoginStateDoesNotLeakOntoAFreshCursorCard() throws {
         let snapshots = ProviderSnapshotBuilder.snapshots(ProviderSnapshotBuilder.Input(
             metrics: [.cursor: UsageMetrics(
                 service: .cursor,

--- a/MeterBarTests/ProviderPresentationHealthTests.swift
+++ b/MeterBarTests/ProviderPresentationHealthTests.swift
@@ -1,0 +1,521 @@
+import XCTest
+@testable import MeterBar
+import MeterBarShared
+
+/// Issue #457: every usage card must show connection health separately from
+/// quota severity. A stale or failed refresh with a 70%-left cache stays
+/// numerically 70% left and must not be labelled Healthy.
+final class ProviderPresentationHealthTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_750_000_000)
+    private let freshAt = Date(timeIntervalSince1970: 1_750_000_000)
+    private lazy var staleAt = now.addingTimeInterval(-(ProviderParseHealthRecord.staleAfter + 60))
+
+    private enum FixtureKind: String, CaseIterable {
+        case claude
+        case codex
+        case grok
+        case cursor
+        case openRouter
+
+        var service: ServiceType {
+            switch self {
+            case .claude: return .claudeCode
+            case .codex: return .codexCli
+            case .grok: return .grok
+            case .cursor: return .cursor
+            case .openRouter: return .openRouter
+            }
+        }
+
+        var isFlat: Bool {
+            self == .cursor || self == .openRouter
+        }
+    }
+
+    // MARK: - Projection
+
+    func testFreshSuccessCarriesNoNotice() {
+        XCTAssertNil(
+            ProviderPresentationHealth.notice(
+                access: .signedIn,
+                refresh: .success,
+                lastUpdated: freshAt,
+                parseHealth: .success(provider: .cursor, at: freshAt),
+                now: now
+            )
+        )
+    }
+
+    func testUnprobedStateIsNotAFailure() {
+        XCTAssertNil(
+            ProviderPresentationHealth.notice(
+                access: .unprobed,
+                refresh: .unprobed,
+                lastUpdated: nil,
+                parseHealth: nil,
+                now: now
+            )
+        )
+    }
+
+    func testTransientFailureWithCacheIsStaleAndKeepsTheTimestamp() {
+        XCTAssertEqual(
+            ProviderPresentationHealth.notice(
+                access: .signedIn,
+                refresh: .transientFailure,
+                lastUpdated: freshAt,
+                parseHealth: transientFailureRecord(provider: .codexCli, at: freshAt),
+                now: now
+            ),
+            .stale(since: freshAt)
+        )
+    }
+
+    func testSustainedFailureWithCacheIsAttention() {
+        XCTAssertEqual(
+            ProviderPresentationHealth.notice(
+                access: .signedIn,
+                refresh: .sustainedOrParseFailure,
+                lastUpdated: freshAt,
+                parseHealth: sustainedFailureRecord(provider: .openRouter, at: freshAt),
+                now: now
+            ),
+            .attention("Refresh failed")
+        )
+    }
+
+    func testParseFailureWithCacheIsAttention() {
+        XCTAssertEqual(
+            ProviderPresentationHealth.notice(
+                access: .signedIn,
+                refresh: .sustainedOrParseFailure,
+                lastUpdated: freshAt,
+                parseHealth: parseFailureRecord(provider: .grok, at: freshAt),
+                now: now
+            ),
+            .attention("Refresh failed")
+        )
+    }
+
+    func testStaleCacheAfterSuccessIsStaleNotHealthy() {
+        XCTAssertEqual(
+            ProviderPresentationHealth.notice(
+                access: .signedIn,
+                refresh: .success,
+                lastUpdated: staleAt,
+                parseHealth: .success(provider: .claudeCode, at: staleAt),
+                now: now
+            ),
+            .stale(since: staleAt)
+        )
+    }
+
+    func testNoDataIsNotAFabricatedFailure() {
+        XCTAssertNil(
+            ProviderPresentationHealth.notice(
+                access: .unprobed,
+                refresh: .unprobed,
+                lastUpdated: nil,
+                parseHealth: nil,
+                now: now
+            )
+        )
+        XCTAssertNil(
+            ProviderPresentationHealth.notice(
+                access: .signedIn,
+                refresh: .unprobed,
+                lastUpdated: nil,
+                parseHealth: nil,
+                now: now
+            )
+        )
+    }
+
+    func testLoginRequiredBeatsAHealthyCache() {
+        XCTAssertEqual(
+            ProviderPresentationHealth.notice(
+                access: .loginRequired,
+                refresh: .success,
+                lastUpdated: freshAt,
+                parseHealth: .success(provider: .claudeCode, at: freshAt),
+                now: now
+            ),
+            .loginRequired
+        )
+    }
+
+    func testNotConnectedBeatsAHealthyCache() {
+        XCTAssertEqual(
+            ProviderPresentationHealth.notice(
+                access: .notConnected,
+                refresh: .transientFailure,
+                lastUpdated: freshAt,
+                parseHealth: nil,
+                now: now
+            ),
+            .notConnected
+        )
+    }
+
+    func testTransientFailureWithoutCacheIsNotAFabricatedStaleNotice() {
+        XCTAssertNil(
+            ProviderPresentationHealth.notice(
+                access: .signedIn,
+                refresh: .transientFailure,
+                lastUpdated: nil,
+                parseHealth: transientFailureRecord(provider: .cursor, at: freshAt),
+                now: now
+            )
+        )
+    }
+
+    func testSustainedFailureWithoutCacheIsNotAFabricatedAttentionNotice() {
+        XCTAssertNil(
+            ProviderPresentationHealth.notice(
+                access: .unprobed,
+                refresh: .sustainedOrParseFailure,
+                lastUpdated: nil,
+                parseHealth: sustainedFailureRecord(provider: .cursor, at: freshAt),
+                now: now
+            )
+        )
+    }
+
+    // MARK: - Builder fixtures: all five providers
+
+    func testFreshSuccessHasNoOverlayAndKeepsTheBand() throws {
+        for kind in FixtureKind.allCases {
+            let card = try card(
+                kind,
+                lastUpdated: freshAt,
+                refresh: .success,
+                parseHealth: .success(provider: kind.service, at: freshAt)
+            )
+
+            XCTAssertNil(card.authNotice, "\(kind.rawValue) fresh success must not overlay the band")
+            XCTAssertEqual(card.band, .healthy, "\(kind.rawValue) must keep the cached 30%-used band")
+            XCTAssertEqual(ProviderCardPresentation.statusText(for: card), QuotaBand.healthy.shortLabel)
+            XCTAssertEqual(ProviderCardPresentation.statusColor(for: card), QuotaBand.healthy.color)
+            XCTAssertTrue(card.accessibilityLabel.contains(QuotaBand.healthy.shortLabel))
+            XCTAssertFalse(recommendationUnavailable(card))
+        }
+    }
+
+    func testTransientFailureWithCacheShowsStaleKeepsNumbers() throws {
+        for kind in FixtureKind.allCases {
+            let card = try card(
+                kind,
+                lastUpdated: freshAt,
+                refresh: .transientFailure,
+                parseHealth: transientFailureRecord(provider: kind.service, at: freshAt)
+            )
+
+            XCTAssertEqual(card.authNotice, .stale(since: freshAt), kind.rawValue)
+            XCTAssertEqual(card.band, .healthy, "\(kind.rawValue) numbers stay 70% left")
+            XCTAssertEqual(card.primaryLimit?.percentLeft, 70)
+            XCTAssertEqual(ProviderCardPresentation.statusText(for: card), "Stale")
+            XCTAssertEqual(ProviderCardPresentation.statusColor(for: card), .secondary)
+            XCTAssertTrue(card.accessibilityLabel.contains("Stale"), card.accessibilityLabel)
+            XCTAssertFalse(
+                card.accessibilityLabel.contains(QuotaBand.healthy.shortLabel),
+                "VoiceOver must not read a stale \(kind.rawValue) cache as Healthy"
+            )
+            XCTAssertTrue(recommendationUnavailable(card), "\(kind.rawValue) stale cache is not live")
+        }
+    }
+
+    func testSustainedOrParseFailureWithCacheShowsAttentionNotHealthy() throws {
+        for kind in FixtureKind.allCases {
+            let card = try card(
+                kind,
+                lastUpdated: freshAt,
+                refresh: .sustainedOrParseFailure,
+                parseHealth: parseFailureRecord(provider: kind.service, at: freshAt)
+            )
+
+            XCTAssertEqual(card.authNotice, .attention("Refresh failed"), kind.rawValue)
+            XCTAssertEqual(card.band, .healthy, "\(kind.rawValue) band stays a function of the cached percentages")
+            XCTAssertEqual(ProviderCardPresentation.statusText(for: card), "Needs attention")
+            XCTAssertEqual(ProviderCardPresentation.statusColor(for: card), MeterBarTheme.warning)
+            XCTAssertTrue(card.accessibilityLabel.contains("Needs attention"), card.accessibilityLabel)
+            XCTAssertFalse(card.accessibilityLabel.contains(QuotaBand.healthy.shortLabel))
+            XCTAssertTrue(recommendationUnavailable(card))
+        }
+    }
+
+    func testStaleCacheAfterLastSuccessShowsStaleNotHealthy() throws {
+        for kind in FixtureKind.allCases {
+            let card = try card(
+                kind,
+                lastUpdated: staleAt,
+                refresh: .success,
+                parseHealth: .success(provider: kind.service, at: staleAt)
+            )
+
+            XCTAssertEqual(card.authNotice, .stale(since: staleAt), kind.rawValue)
+            XCTAssertEqual(card.band, .healthy)
+            XCTAssertEqual(ProviderCardPresentation.statusText(for: card), "Stale")
+            XCTAssertNotEqual(ProviderCardPresentation.statusText(for: card), QuotaBand.healthy.shortLabel)
+            XCTAssertTrue(recommendationUnavailable(card))
+        }
+    }
+
+    func testNoDataStaysEmptyOfflineNotAFabricatedFailure() throws {
+        for kind in FixtureKind.allCases {
+            let card = try emptyCard(kind)
+
+            XCTAssertNil(card.authNotice, "\(kind.rawValue) unprobed empty must not invent a failure")
+            XCTAssertFalse(card.hasMetrics)
+            XCTAssertNil(card.band)
+            XCTAssertEqual(ProviderCardPresentation.statusText(for: card), "Offline")
+            XCTAssertTrue(card.accessibilityLabel.contains("No data"), card.accessibilityLabel)
+            XCTAssertFalse(card.accessibilityLabel.contains("Needs attention"))
+            XCTAssertFalse(card.accessibilityLabel.contains("Stale"))
+        }
+    }
+
+    // MARK: - Mixed profiles
+
+    func testOneFailedCustomProfileDoesNotMarkHealthySiblings() throws {
+        let claudeWork = ClaudeCodeAccount(id: UUID(), name: "Claude Work", configDirectory: "/tmp/claude-work")
+        let codexWork = CodexAccount(id: UUID(), name: "Codex Work", homeDirectory: "/tmp/codex-work")
+        let grokWork = GrokAccount(id: UUID(), name: "Grok Work", homeDirectory: "/tmp/grok-work")
+
+        let snapshots = ProviderSnapshotBuilder.snapshots(
+            ProviderSnapshotBuilder.Input(
+                metrics: [:],
+                now: now,
+                parseHealth: [
+                    .claudeCode: .success(provider: .claudeCode, at: freshAt),
+                    .codexCli: .success(provider: .codexCli, at: freshAt),
+                    .grok: .success(provider: .grok, at: freshAt)
+                ],
+                codexAccounts: [.defaultAccount, codexWork],
+                codexAccountMetrics: [
+                    CodexAccount.defaultID: healthyMetrics(.codexCli, lastUpdated: freshAt),
+                    codexWork.id: healthyMetrics(.codexCli, lastUpdated: freshAt)
+                ],
+                codexAccountAccess: [CodexAccount.defaultID: true, codexWork.id: true],
+                grokAccounts: [.defaultAccount, grokWork],
+                grokAccountMetrics: [
+                    GrokAccount.defaultID: healthyMetrics(.grok, lastUpdated: freshAt),
+                    grokWork.id: healthyMetrics(.grok, lastUpdated: freshAt)
+                ],
+                grokAccountAccess: [GrokAccount.defaultID: true, grokWork.id: true],
+                claudeAccounts: [.defaultAccount, claudeWork],
+                claudeAccountMetrics: [
+                    ClaudeCodeAccount.defaultID: healthyMetrics(.claudeCode, lastUpdated: freshAt),
+                    claudeWork.id: healthyMetrics(.claudeCode, lastUpdated: freshAt)
+                ],
+                enabledServices: [.claudeCode, .codexCli, .grok],
+                claudeAccountStates: [
+                    ClaudeCodeAccount.defaultID: .connected(.oauth),
+                    claudeWork.id: .error("Work refresh failed")
+                ],
+                claudeCodeHasAccess: true,
+                codexCliHasAccess: true,
+                grokHasAccess: true,
+                lastErrors: ProviderPresentationHealth.LastErrors(
+                    codexAccounts: [codexWork.id: .apiError("Codex work failed")],
+                    grokAccounts: [grokWork.id: .parsingError("Grok work failed")]
+                )
+            )
+        )
+
+        let claudeDefault = try XCTUnwrap(snapshots.first { $0.accountID == ClaudeCodeAccount.defaultID })
+        let claudeFailed = try XCTUnwrap(snapshots.first { $0.accountID == claudeWork.id })
+        let codexDefault = try XCTUnwrap(snapshots.first { $0.accountID == CodexAccount.defaultID })
+        let codexFailed = try XCTUnwrap(snapshots.first { $0.accountID == codexWork.id })
+        let grokDefault = try XCTUnwrap(snapshots.first { $0.accountID == GrokAccount.defaultID })
+        let grokFailed = try XCTUnwrap(snapshots.first { $0.accountID == grokWork.id })
+
+        XCTAssertNil(claudeDefault.authNotice)
+        XCTAssertEqual(ProviderCardPresentation.statusText(for: claudeDefault), QuotaBand.healthy.shortLabel)
+        XCTAssertEqual(claudeFailed.authNotice, .attention("Work refresh failed"))
+        XCTAssertEqual(claudeFailed.band, .healthy)
+
+        XCTAssertNil(codexDefault.authNotice)
+        XCTAssertEqual(ProviderCardPresentation.statusText(for: codexDefault), QuotaBand.healthy.shortLabel)
+        XCTAssertEqual(codexFailed.authNotice, .stale(since: freshAt))
+        XCTAssertEqual(codexFailed.band, .healthy)
+
+        XCTAssertNil(grokDefault.authNotice)
+        XCTAssertEqual(ProviderCardPresentation.statusText(for: grokDefault), QuotaBand.healthy.shortLabel)
+        XCTAssertEqual(grokFailed.authNotice, .stale(since: freshAt))
+        XCTAssertEqual(grokFailed.band, .healthy)
+
+        let recommendation = snapshots.headroomRecommendation(now: now)
+        let unavailableIDs = Set(recommendation.unavailable.map(\.id))
+        XCTAssertFalse(unavailableIDs.contains(claudeDefault.id))
+        XCTAssertFalse(unavailableIDs.contains(codexDefault.id))
+        XCTAssertFalse(unavailableIDs.contains(grokDefault.id))
+        XCTAssertTrue(unavailableIDs.contains(claudeFailed.id))
+        XCTAssertTrue(unavailableIDs.contains(codexFailed.id))
+        XCTAssertTrue(unavailableIDs.contains(grokFailed.id))
+    }
+
+    func testClaudeConnectedButAgedCacheIsStaleNotHealthy() throws {
+        let card = try card(
+            .claude,
+            lastUpdated: staleAt,
+            refresh: .success,
+            parseHealth: .success(provider: .claudeCode, at: staleAt),
+            claudeState: .connected(.oauth)
+        )
+
+        XCTAssertEqual(card.authNotice, .stale(since: staleAt))
+        XCTAssertEqual(card.band, .healthy)
+        XCTAssertEqual(ProviderCardPresentation.statusText(for: card), "Stale")
+    }
+
+    func testCursorClaudeLoginStateDoesNotLeakOntoAFreshCursorCard() throws {
+        let snapshots = ProviderSnapshotBuilder.snapshots(
+            ProviderSnapshotBuilder.Input(
+                metrics: [.cursor: healthyMetrics(.cursor, lastUpdated: freshAt)],
+                now: now,
+                parseHealth: [.cursor: .success(provider: .cursor, at: freshAt)],
+                claudeAccounts: [.defaultAccount],
+                claudeAccountMetrics: [:],
+                enabledServices: [.cursor],
+                claudeAccountStates: [ClaudeCodeAccount.defaultID: .needsLogin],
+                cursorHasAccess: true
+            )
+        )
+
+        let cursor = try XCTUnwrap(snapshots.first { $0.service == .cursor })
+        XCTAssertNil(cursor.authNotice)
+        XCTAssertEqual(ProviderCardPresentation.statusText(for: cursor), QuotaBand.healthy.shortLabel)
+    }
+
+    // MARK: - Helpers
+
+    private func card(
+        _ kind: FixtureKind,
+        lastUpdated: Date,
+        refresh: ProviderPresentationHealth.RefreshOutcome,
+        parseHealth: ProviderParseHealthRecord,
+        claudeState: ClaudeCodeAuthState? = nil
+    ) throws -> ProviderSnapshot {
+        let metrics = healthyMetrics(kind.service, lastUpdated: lastUpdated)
+        let snapshots = ProviderSnapshotBuilder.snapshots(input(
+            kind,
+            metrics: metrics,
+            refresh: refresh,
+            parseHealth: parseHealth,
+            claudeState: claudeState
+        ))
+        return try XCTUnwrap(snapshots.first { $0.service == kind.service }, kind.rawValue)
+    }
+
+    private func emptyCard(_ kind: FixtureKind) throws -> ProviderSnapshot {
+        let snapshots = ProviderSnapshotBuilder.snapshots(input(
+            kind,
+            metrics: nil,
+            refresh: .unprobed,
+            parseHealth: nil,
+            claudeState: nil
+        ))
+        return try XCTUnwrap(snapshots.first { $0.service == kind.service }, kind.rawValue)
+    }
+
+    private func input(
+        _ kind: FixtureKind,
+        metrics: UsageMetrics?,
+        refresh: ProviderPresentationHealth.RefreshOutcome,
+        parseHealth: ProviderParseHealthRecord?,
+        claudeState: ClaudeCodeAuthState?
+    ) -> ProviderSnapshotBuilder.Input {
+        var lastErrors = ProviderPresentationHealth.LastErrors()
+        switch (kind, refresh) {
+        case (.cursor, .transientFailure), (.cursor, .sustainedOrParseFailure):
+            lastErrors.cursor = .apiError("Cursor refresh failed")
+        case (.openRouter, .transientFailure), (.openRouter, .sustainedOrParseFailure):
+            lastErrors.openRouter = .apiError("OpenRouter refresh failed")
+        case (.codex, .transientFailure), (.codex, .sustainedOrParseFailure):
+            lastErrors.codexAccounts = [CodexAccount.defaultID: .apiError("Codex refresh failed")]
+        case (.grok, .transientFailure), (.grok, .sustainedOrParseFailure):
+            lastErrors.grokAccounts = [GrokAccount.defaultID: .apiError("Grok refresh failed")]
+        default:
+            break
+        }
+
+        var claudeStates: [UUID: ClaudeCodeAuthState] = [:]
+        if kind == .claude {
+            switch refresh {
+            case .unprobed:
+                break
+            case .success:
+                claudeStates[ClaudeCodeAccount.defaultID] = claudeState ?? .connected(.oauth)
+            case .transientFailure:
+                claudeStates[ClaudeCodeAccount.defaultID] = .stale(since: metrics?.lastUpdated ?? freshAt)
+            case .sustainedOrParseFailure:
+                claudeStates[ClaudeCodeAccount.defaultID] = .error("Refresh failed")
+            }
+        }
+
+        return ProviderSnapshotBuilder.Input(
+            metrics: kind.isFlat ? metrics.map { [kind.service: $0] } ?? [:] : [:],
+            now: now,
+            parseHealth: parseHealth.map { [kind.service: $0] } ?? [:],
+            codexAccounts: kind == .codex ? [.defaultAccount] : [],
+            codexAccountMetrics: kind == .codex ? metrics.map { [CodexAccount.defaultID: $0] } ?? [:] : [:],
+            codexAccountAccess: kind == .codex && refresh != .unprobed ? [CodexAccount.defaultID: true] : [:],
+            grokAccounts: kind == .grok ? [.defaultAccount] : [],
+            grokAccountMetrics: kind == .grok ? metrics.map { [GrokAccount.defaultID: $0] } ?? [:] : [:],
+            grokAccountAccess: kind == .grok && refresh != .unprobed ? [GrokAccount.defaultID: true] : [:],
+            claudeAccounts: kind == .claude ? [.defaultAccount] : [],
+            claudeAccountMetrics: kind == .claude ? metrics.map { [ClaudeCodeAccount.defaultID: $0] } ?? [:] : [:],
+            enabledServices: [kind.service],
+            claudeAccountStates: claudeStates,
+            claudeCodeHasAccess: kind == .claude && refresh != .unprobed,
+            codexCliHasAccess: kind == .codex && refresh != .unprobed,
+            cursorHasAccess: kind == .cursor && refresh != .unprobed,
+            openRouterHasAccess: kind == .openRouter && refresh != .unprobed,
+            grokHasAccess: kind == .grok && refresh != .unprobed,
+            lastErrors: lastErrors
+        )
+    }
+
+    private func healthyMetrics(_ service: ServiceType, lastUpdated: Date) -> UsageMetrics {
+        UsageMetrics(
+            service: service,
+            sessionLimit: UsageLimit(used: 30, total: 100, resetTime: nil),
+            lastUpdated: lastUpdated
+        )
+    }
+
+    private func recommendationUnavailable(_ snapshot: ProviderSnapshot) -> Bool {
+        [snapshot].headroomRecommendation(now: now).unavailable.contains { $0.id == snapshot.id }
+    }
+
+    private func transientFailureRecord(provider: ServiceType, at date: Date) -> ProviderParseHealthRecord {
+        ProviderParseHealthRecord(
+            provider: provider,
+            lastSuccess: date,
+            lastAttempt: date,
+            consecutiveFailures: 1,
+            lastFailureWasShapeMismatch: false
+        )
+    }
+
+    private func sustainedFailureRecord(provider: ServiceType, at date: Date) -> ProviderParseHealthRecord {
+        ProviderParseHealthRecord(
+            provider: provider,
+            lastSuccess: date,
+            lastAttempt: date,
+            consecutiveFailures: ProviderParseHealthRecord.sustainedFailureCount,
+            lastFailureWasShapeMismatch: false
+        )
+    }
+
+    private func parseFailureRecord(provider: ServiceType, at date: Date) -> ProviderParseHealthRecord {
+        ProviderParseHealthRecord(
+            provider: provider,
+            lastSuccess: date,
+            lastAttempt: date,
+            consecutiveFailures: ProviderParseHealthRecord.sustainedShapeMismatchCount,
+            lastFailureWasShapeMismatch: true,
+            consecutiveShapeMismatches: ProviderParseHealthRecord.sustainedShapeMismatchCount
+        )
+    }
+}

--- a/MeterBarTests/ProviderPresentationHealthTests.swift
+++ b/MeterBarTests/ProviderPresentationHealthTests.swift
@@ -469,6 +469,60 @@ final class ProviderPresentationHealthTests: XCTestCase {
         XCTAssertEqual(ProviderCardPresentation.statusText(for: newer), QuotaBand.healthy.shortLabel)
     }
 
+    func testSignedOutCursorWithFreshCacheIsNotHealthy() throws {
+        let snapshots = ProviderSnapshotBuilder.snapshots(
+            ProviderSnapshotBuilder.Input(
+                metrics: [.cursor: healthyMetrics(.cursor, lastUpdated: freshAt)],
+                now: now,
+                claudeAccounts: [],
+                claudeAccountMetrics: [:],
+                enabledServices: [.cursor],
+                cursorHasAccess: false
+            )
+        )
+
+        let card = try XCTUnwrap(snapshots.first { $0.service == .cursor })
+        XCTAssertEqual(card.authNotice, .loginRequired)
+        XCTAssertEqual(card.band, .healthy, "The cached percentages stay healthy")
+        XCTAssertEqual(ProviderCardPresentation.statusText(for: card), "Login required")
+        XCTAssertNotEqual(ProviderCardPresentation.statusText(for: card), QuotaBand.healthy.shortLabel)
+    }
+
+    func testSignedOutOpenRouterWithFreshCacheIsNotHealthy() throws {
+        let snapshots = ProviderSnapshotBuilder.snapshots(
+            ProviderSnapshotBuilder.Input(
+                metrics: [.openRouter: healthyMetrics(.openRouter, lastUpdated: freshAt)],
+                now: now,
+                claudeAccounts: [],
+                claudeAccountMetrics: [:],
+                enabledServices: [.openRouter],
+                openRouterHasAccess: false
+            )
+        )
+
+        let card = try XCTUnwrap(snapshots.first { $0.service == .openRouter })
+        XCTAssertEqual(card.authNotice, .notConnected)
+        XCTAssertEqual(card.band, .healthy)
+        XCTAssertEqual(ProviderCardPresentation.statusText(for: card), "Not connected")
+        XCTAssertNotEqual(ProviderCardPresentation.statusText(for: card), QuotaBand.healthy.shortLabel)
+    }
+
+    func testUnprobedCursorWithFreshCacheIsNotTreatedAsSignedOut() throws {
+        let snapshots = ProviderSnapshotBuilder.snapshots(
+            ProviderSnapshotBuilder.Input(
+                metrics: [.cursor: healthyMetrics(.cursor, lastUpdated: freshAt)],
+                now: now,
+                claudeAccounts: [],
+                claudeAccountMetrics: [:],
+                enabledServices: [.cursor]
+            )
+        )
+
+        let card = try XCTUnwrap(snapshots.first { $0.service == .cursor })
+        XCTAssertNil(card.authNotice, "Unknown/unprobed is not a fabricated login failure")
+        XCTAssertEqual(ProviderCardPresentation.statusText(for: card), QuotaBand.healthy.shortLabel)
+    }
+
     func testCursorClaudeLoginStateDoesNotLeakOntoAFreshCursorCard() throws {
         let snapshots = ProviderSnapshotBuilder.snapshots(
             ProviderSnapshotBuilder.Input(
@@ -526,8 +580,8 @@ final class ProviderPresentationHealthTests: XCTestCase {
                 claudeAccounts: kind == .claude ? [.defaultAccount] : [],
                 claudeAccountMetrics: kind == .claude ? [ClaudeCodeAccount.defaultID: metrics] : [:],
                 enabledServices: [kind.service],
-                cursorHasAccess: kind == .cursor,
-                openRouterHasAccess: kind == .openRouter
+                cursorHasAccess: kind == .cursor ? true : nil,
+                openRouterHasAccess: kind == .openRouter ? true : nil
             )
         )
         return try XCTUnwrap(snapshots.first { $0.service == kind.service }, kind.rawValue)
@@ -595,8 +649,8 @@ final class ProviderPresentationHealthTests: XCTestCase {
             claudeAccountStates: claudeStates,
             claudeCodeHasAccess: kind == .claude && refresh != .unprobed,
             codexCliHasAccess: kind == .codex && refresh != .unprobed,
-            cursorHasAccess: kind == .cursor && refresh != .unprobed,
-            openRouterHasAccess: kind == .openRouter && refresh != .unprobed,
+            cursorHasAccess: kind == .cursor && refresh != .unprobed ? true : nil,
+            openRouterHasAccess: kind == .openRouter && refresh != .unprobed ? true : nil,
             grokHasAccess: kind == .grok && refresh != .unprobed,
             lastErrors: lastErrors
         )

--- a/MeterBarTests/ProviderPresentationHealthTests.swift
+++ b/MeterBarTests/ProviderPresentationHealthTests.swift
@@ -181,6 +181,52 @@ final class ProviderPresentationHealthTests: XCTestCase {
         )
     }
 
+    func testPersistedParseFailureWithEmptyLastErrorIsNotSuccess() {
+        let lastSuccess = now.addingTimeInterval(-30)
+        let lastAttempt = now
+        let health = relaunchParseFailureRecord(
+            provider: .cursor,
+            lastSuccess: lastSuccess,
+            lastAttempt: lastAttempt
+        )
+
+        XCTAssertEqual(
+            ProviderPresentationHealth.refreshOutcome(
+                lastError: nil,
+                parseHealth: health,
+                lastUpdated: lastSuccess
+            ),
+            .sustainedOrParseFailure
+        )
+        XCTAssertEqual(
+            ProviderPresentationHealth.notice(
+                access: .signedIn,
+                refresh: .sustainedOrParseFailure,
+                lastUpdated: lastSuccess,
+                parseHealth: health,
+                now: now
+            ),
+            .attention("Refresh failed")
+        )
+    }
+
+    func testCardCacheAsNewAsTheFailedAttemptIsStillSuccess() {
+        let lastSuccess = now.addingTimeInterval(-30)
+        let lastAttempt = now
+        XCTAssertEqual(
+            ProviderPresentationHealth.refreshOutcome(
+                lastError: nil,
+                parseHealth: relaunchParseFailureRecord(
+                    provider: .codexCli,
+                    lastSuccess: lastSuccess,
+                    lastAttempt: lastAttempt
+                ),
+                lastUpdated: lastAttempt
+            ),
+            .success
+        )
+    }
+
     // MARK: - Builder fixtures: all five providers
 
     func testFreshSuccessHasNoOverlayAndKeepsTheBand() throws {
@@ -368,6 +414,61 @@ final class ProviderPresentationHealthTests: XCTestCase {
         XCTAssertEqual(ProviderCardPresentation.statusText(for: card), "Stale")
     }
 
+    func testRelaunchWithPersistedParseFailureAndFreshCacheIsNotHealthy() throws {
+        let lastSuccess = now.addingTimeInterval(-30)
+        for kind in FixtureKind.allCases {
+            let health = relaunchParseFailureRecord(
+                provider: kind.service,
+                lastSuccess: lastSuccess,
+                lastAttempt: now
+            )
+            let card = try relaunchCard(kind, lastUpdated: lastSuccess, parseHealth: health)
+
+            XCTAssertEqual(card.authNotice, .attention("Refresh failed"), kind.rawValue)
+            XCTAssertEqual(card.band, .healthy, "\(kind.rawValue) keeps the cached percentages")
+            XCTAssertNotEqual(
+                ProviderCardPresentation.statusText(for: card),
+                QuotaBand.healthy.shortLabel,
+                "\(kind.rawValue) must not look live after a persisted parse failure"
+            )
+            XCTAssertTrue(card.accessibilityLabel.contains("Needs attention"), card.accessibilityLabel)
+            XCTAssertTrue(recommendationUnavailable(card))
+        }
+    }
+
+    func testPersistedProviderFailureDoesNotMarkSiblingWithNewerCache() throws {
+        let lastSuccess = now.addingTimeInterval(-30)
+        let work = CodexAccount(id: UUID(), name: "Work", homeDirectory: "/tmp/codex-work")
+        let snapshots = ProviderSnapshotBuilder.snapshots(
+            ProviderSnapshotBuilder.Input(
+                metrics: [:],
+                now: now,
+                parseHealth: [
+                    .codexCli: relaunchParseFailureRecord(
+                        provider: .codexCli,
+                        lastSuccess: lastSuccess,
+                        lastAttempt: now
+                    )
+                ],
+                codexAccounts: [.defaultAccount, work],
+                codexAccountMetrics: [
+                    CodexAccount.defaultID: healthyMetrics(.codexCli, lastUpdated: lastSuccess),
+                    work.id: healthyMetrics(.codexCli, lastUpdated: now)
+                ],
+                codexAccountAccess: [CodexAccount.defaultID: true, work.id: true],
+                claudeAccounts: [],
+                claudeAccountMetrics: [:],
+                enabledServices: [.codexCli]
+            )
+        )
+
+        let failed = try XCTUnwrap(snapshots.first { $0.accountID == CodexAccount.defaultID })
+        let newer = try XCTUnwrap(snapshots.first { $0.accountID == work.id })
+        XCTAssertEqual(failed.authNotice, .attention("Refresh failed"))
+        XCTAssertNil(newer.authNotice, "A sibling whose cache is as new as the attempt is not failed")
+        XCTAssertEqual(ProviderCardPresentation.statusText(for: newer), QuotaBand.healthy.shortLabel)
+    }
+
     func testCursorClaudeLoginStateDoesNotLeakOntoAFreshCursorCard() throws {
         let snapshots = ProviderSnapshotBuilder.snapshots(
             ProviderSnapshotBuilder.Input(
@@ -404,6 +505,31 @@ final class ProviderPresentationHealthTests: XCTestCase {
             parseHealth: parseHealth,
             claudeState: claudeState
         ))
+        return try XCTUnwrap(snapshots.first { $0.service == kind.service }, kind.rawValue)
+    }
+
+    private func relaunchCard(
+        _ kind: FixtureKind,
+        lastUpdated: Date,
+        parseHealth: ProviderParseHealthRecord
+    ) throws -> ProviderSnapshot {
+        let metrics = healthyMetrics(kind.service, lastUpdated: lastUpdated)
+        let snapshots = ProviderSnapshotBuilder.snapshots(
+            ProviderSnapshotBuilder.Input(
+                metrics: kind.isFlat ? [kind.service: metrics] : [:],
+                now: now,
+                parseHealth: [kind.service: parseHealth],
+                codexAccounts: kind == .codex ? [.defaultAccount] : [],
+                codexAccountMetrics: kind == .codex ? [CodexAccount.defaultID: metrics] : [:],
+                grokAccounts: kind == .grok ? [.defaultAccount] : [],
+                grokAccountMetrics: kind == .grok ? [GrokAccount.defaultID: metrics] : [:],
+                claudeAccounts: kind == .claude ? [.defaultAccount] : [],
+                claudeAccountMetrics: kind == .claude ? [ClaudeCodeAccount.defaultID: metrics] : [:],
+                enabledServices: [kind.service],
+                cursorHasAccess: kind == .cursor,
+                openRouterHasAccess: kind == .openRouter
+            )
+        )
         return try XCTUnwrap(snapshots.first { $0.service == kind.service }, kind.rawValue)
     }
 
@@ -505,6 +631,23 @@ final class ProviderPresentationHealthTests: XCTestCase {
             lastAttempt: date,
             consecutiveFailures: ProviderParseHealthRecord.sustainedFailureCount,
             lastFailureWasShapeMismatch: false
+        )
+    }
+
+    /// After relaunch, parse health still has the failed attempt and
+    /// `lastError` is empty. `lastSuccess` is older than `lastAttempt`.
+    private func relaunchParseFailureRecord(
+        provider: ServiceType,
+        lastSuccess: Date,
+        lastAttempt: Date
+    ) -> ProviderParseHealthRecord {
+        ProviderParseHealthRecord(
+            provider: provider,
+            lastSuccess: lastSuccess,
+            lastAttempt: lastAttempt,
+            consecutiveFailures: ProviderParseHealthRecord.sustainedShapeMismatchCount,
+            lastFailureWasShapeMismatch: true,
+            consecutiveShapeMismatches: ProviderParseHealthRecord.sustainedShapeMismatchCount
         )
     }
 

--- a/MeterBarTests/ProviderSettingsFactsTests.swift
+++ b/MeterBarTests/ProviderSettingsFactsTests.swift
@@ -33,6 +33,28 @@ final class ProviderSettingsFactsTests: XCTestCase {
         )
     }
 
+    private func snapshot(notice: ProviderAuthNotice?) -> ProviderSnapshot {
+        ProviderSnapshot(
+            id: "claude-\(UUID().uuidString)",
+            title: "Claude",
+            service: .claudeCode,
+            updatedAt: Date(),
+            limits: [
+                SnapshotLimit(
+                    id: "session",
+                    kind: .session,
+                    title: "Session",
+                    usageLimit: UsageLimit(used: 30, total: 100, resetTime: nil)
+                )
+            ],
+            emptyDetail: "Waiting for refresh",
+            extraUsage: nil,
+            resetCreditsAvailable: nil,
+            accountID: nil,
+            authNotice: notice
+        )
+    }
+
     // MARK: - noticeText
 
     /// An authored parse failure knows the single step that fixes it, and the
@@ -115,6 +137,28 @@ final class ProviderSettingsFactsTests: XCTestCase {
         derived.authNotice = .stale(since: Date())
         XCTAssertEqual(derived.statusText, "Stale")
         XCTAssertEqual(derived.statusColor, .secondary)
+    }
+
+    func testSharedNoticeRequiresEveryMeteredCardToAgree() {
+        let stale = snapshot(notice: .stale(since: Date(timeIntervalSince1970: 1)))
+        let attention = snapshot(notice: .attention("Work refresh failed"))
+        XCTAssertNil(
+            ProviderSettingsFacts.sharedNotice(in: [stale, attention]),
+            "Distinct overlays must not collapse to whichever card comes first"
+        )
+    }
+
+    func testSharedNoticeKeepsAnAgreedOverlay() {
+        let first = snapshot(notice: .stale(since: Date(timeIntervalSince1970: 1)))
+        let second = snapshot(notice: .stale(since: Date(timeIntervalSince1970: 2)))
+        XCTAssertEqual(ProviderSettingsFacts.sharedNotice(in: [first, second])?.shortLabel, "Stale")
+        XCTAssertEqual(ProviderSettingsFacts.sharedNotice(in: [first])?.shortLabel, "Stale")
+    }
+
+    func testSharedNoticeIsNilWhenASiblingHasNoOverlay() {
+        let stale = snapshot(notice: .stale(since: Date()))
+        let healthy = snapshot(notice: nil)
+        XCTAssertNil(ProviderSettingsFacts.sharedNotice(in: [stale, healthy]))
     }
 
     func testStatusTextWaitingWhenConnectedButNoBand() {

--- a/MeterBarTests/ProviderSettingsFactsTests.swift
+++ b/MeterBarTests/ProviderSettingsFactsTests.swift
@@ -28,6 +28,7 @@ final class ProviderSettingsFactsTests: XCTestCase {
             errorText: errorText,
             updatedText: "Updated just now",
             worstBand: worstBand,
+            authNotice: nil,
             codexAuthFileDisplayPath: "~/.codex/auth.json"
         )
     }

--- a/MeterBarTests/ProviderSettingsFactsTests.swift
+++ b/MeterBarTests/ProviderSettingsFactsTests.swift
@@ -109,6 +109,13 @@ final class ProviderSettingsFactsTests: XCTestCase {
         XCTAssertEqual(facts(service: .claudeCode, worstBand: .exhausted).statusText, "Out")
     }
 
+    func testStatusTextAuthNoticeBeatsAHealthyBand() {
+        var derived = facts(service: .cursor, worstBand: .healthy)
+        derived.authNotice = .stale(since: Date())
+        XCTAssertEqual(derived.statusText, "Stale")
+        XCTAssertEqual(derived.statusColor, .secondary)
+    }
+
     func testStatusTextWaitingWhenConnectedButNoBand() {
         XCTAssertEqual(facts(service: .claudeCode).statusText, "Waiting for refresh")
     }


### PR DESCRIPTION
## Summary

Cards were labeling a cached 70%-left band **Healthy** after a failed refresh because `authNotice` only came from Claude account state. Codex, Grok, Cursor, and OpenRouter kept last-good numbers (availability-biased cache) with no overlay.

This adds one `ProviderPresentationHealth` projection — access, last refresh outcome, parse health, and `lastUpdated` — and feeds it to every `ProviderSnapshot`.

- Fresh success → no overlay; band stays a function of the percentages
- One transient failure with cache → **Stale**; numbers kept
- Sustained / parse failure with cache → **Needs attention**, not Healthy
- Aged cache after last success → **Stale**, not Healthy
- No data / unprobed → existing empty / Offline, not a fabricated failure
- One failed custom Claude / Codex / Grok profile does not mark a healthy sibling

Quota severity and connection health stay separate. The same notice drives card status, VoiceOver, recommendation eligibility, and settings status when every visible card agrees.

## Test plan

- [x] `swift test` at worktree root (2471 tests, 5 skipped, 0 failures)
- [x] All five providers have fixtures for success, transient failure, sustained/parse failure, stale cache, and no data
- [x] Mixed Claude / Codex / Grok: one failed custom, sibling stays Healthy

Fixes #457

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared snapshot building and user-visible health across popover, dashboard, settings, and recommendations; logic is well-tested but misclassification would mislead users about quota freshness.
> 
> **Overview**
> Provider cards no longer treat cached quota percentages as **Healthy** when the underlying refresh failed, aged out, or the account is signed out. A new **`ProviderPresentationHealth`** layer maps access, `lastError`, persisted parse health, and `lastUpdated` into **`authNotice`** overlays (**Stale**, **Needs attention**, login/not connected) while **`QuotaBand`** stays tied only to the cached numbers.
> 
> **`ProviderSnapshotBuilder`** now computes that notice for every provider (not just Claude account state), scopes provider-level parse failures to cards whose own cache is older than the failed attempt, and centralizes live wiring via **`Input.live(stores:parseHealth:)`** so popover, dashboard, and settings share the same inputs. **`ProviderParseHealthRecord`** adds **`isSustainedOrParseFailure`** separate from time-based staleness.
> 
> Settings **`ProviderSettingsFacts`** surfaces a shared **`authNotice`** when all metered cards agree, so status rows can show **Stale** instead of a healthy band. Extensive tests cover all five providers and multi-account isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f183034c41dfa094e85e2961695813a8981e9e84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->