### PR TITLE
fix(cursor): derive pace from billingCycleStart and billingCycleEnd

### DIFF
--- a/MeterBar/Services/CursorLocalService.swift
+++ b/MeterBar/Services/CursorLocalService.swift
@@ -340,10 +340,7 @@ class CursorLocalService: ObservableObject {
     /// only when the selected shape carries none of those is the assumed quota
     /// substituted and flagged `isEstimated`.
     static func mapSummary(_ summaryData: CursorUsageSummaryResponse) -> UsageMetrics {
-        var resetTime: Date?
-        if let billingEnd = summaryData.billingCycleEnd {
-            resetTime = FlexibleISO8601.date(from: billingEnd)
-        }
+        let cycle = billingCycle(from: summaryData)
 
         let usage = selectedUsage(from: summaryData)
         let plan = usage.plan
@@ -351,9 +348,21 @@ class CursorLocalService: ObservableObject {
         if let autoPercent = plan?.autoPercentUsed, let apiPercent = plan?.apiPercentUsed {
             return UsageMetrics(
                 service: .cursor,
-                sessionLimit: percentPoolLimit(autoPercent, resetTime: resetTime),
-                weeklyLimit: percentPoolLimit(apiPercent, resetTime: resetTime),
-                codeReviewLimit: onDemandLimit(from: usage.onDemand, resetTime: resetTime)
+                sessionLimit: percentPoolLimit(
+                    autoPercent,
+                    resetTime: cycle.resetTime,
+                    windowSeconds: cycle.windowSeconds
+                ),
+                weeklyLimit: percentPoolLimit(
+                    apiPercent,
+                    resetTime: cycle.resetTime,
+                    windowSeconds: cycle.windowSeconds
+                ),
+                codeReviewLimit: onDemandLimit(
+                    from: usage.onDemand,
+                    resetTime: cycle.resetTime,
+                    windowSeconds: cycle.windowSeconds
+                )
             )
         }
 
@@ -367,31 +376,59 @@ class CursorLocalService: ObservableObject {
         // the legacy title for this window is "Monthly".
         return UsageMetrics(
             service: .cursor,
-            sessionLimit: onDemandLimit(from: usage.onDemand, resetTime: resetTime),
+            sessionLimit: onDemandLimit(
+                from: usage.onDemand,
+                resetTime: cycle.resetTime,
+                windowSeconds: cycle.windowSeconds
+            ),
             weeklyLimit: UsageLimit(
                 used: planUsed,
                 total: planTotal,
-                resetTime: resetTime,
+                resetTime: cycle.resetTime,
+                windowSeconds: cycle.windowSeconds,
                 isEstimated: planTotalIsEstimated
             ),
             codeReviewLimit: nil
         )
     }
 
+    /// `billingCycleEnd` is the reset. `end − start` is the real cycle length
+    /// when both parse and the duration is positive — no assumed 30-day month.
+    private static func billingCycle(
+        from summary: CursorUsageSummaryResponse
+    ) -> (resetTime: Date?, windowSeconds: TimeInterval?) {
+        let start = summary.billingCycleStart.flatMap(FlexibleISO8601.date(from:))
+        let end = summary.billingCycleEnd.flatMap(FlexibleISO8601.date(from:))
+        let windowSeconds: TimeInterval?
+        if let start, let end {
+            let duration = end.timeIntervalSince(start)
+            windowSeconds = duration > 0 ? duration : nil
+        } else {
+            windowSeconds = nil
+        }
+        return (end, windowSeconds)
+    }
+
     /// One included pool as the dashboard draws it: `used` is already a
     /// 0…100 percent, so the denominator is 100 rather than a request grant.
-    private static func percentPoolLimit(_ percentUsed: Double, resetTime: Date?) -> UsageLimit {
+    private static func percentPoolLimit(
+        _ percentUsed: Double,
+        resetTime: Date?,
+        windowSeconds: TimeInterval?
+    ) -> UsageLimit {
         UsageLimit(
             used: max(0, percentUsed),
             total: ServiceType.cursorIncludedPoolTotal,
             resetTime: resetTime,
+            windowSeconds: windowSeconds,
             isEstimated: false
         )
     }
 
     private static func onDemandLimit(
         from onDemand: CursorOnDemandUsage?,
-        resetTime: Date?
+        resetTime: Date?,
+        windowSeconds: TimeInterval?
     ) -> UsageLimit? {
         guard let onDemand, onDemand.enabled == true else { return nil }
         let onDemandUsed = Double(onDemand.used ?? 0)
@@ -401,6 +438,7 @@ class CursorLocalService: ObservableObject {
             used: onDemandUsed,
             total: onDemandLimit > 0 ? onDemandLimit : onDemandUsed * onDemandHeadroomMultiplier,
             resetTime: resetTime,
+            windowSeconds: windowSeconds,
             isEstimated: onDemandLimit <= 0
         )
     }

--- a/MeterBarTests/CursorLocalServiceTests.swift
+++ b/MeterBarTests/CursorLocalServiceTests.swift
@@ -53,9 +53,12 @@ final class CursorLocalServiceTests: XCTestCase {
         XCTAssertEqual(metrics.weeklyLimit?.total, 750)
         XCTAssertEqual(metrics.weeklyLimit?.isEstimated, false)
         XCTAssertEqual(metrics.weeklyLimit?.resetTime, FlexibleISO8601.date(from: "2026-08-01T00:00:00Z"))
+        XCTAssertEqual(metrics.weeklyLimit?.windowSeconds, 31 * 24 * 3_600)
         XCTAssertEqual(metrics.sessionLimit?.used, 4)
         XCTAssertEqual(metrics.sessionLimit?.total, 20)
         XCTAssertEqual(metrics.sessionLimit?.isEstimated, false)
+        XCTAssertEqual(metrics.sessionLimit?.windowSeconds, 31 * 24 * 3_600)
+        XCTAssertNotNil(metrics.weeklyLimit?.pace(now: Date(timeIntervalSince1970: 1_783_036_800)))
     }
 
     func testMapSummaryFallsBackToBreakdownTotalWhenPlanLimitAbsent() throws {
@@ -293,8 +296,59 @@ final class CursorLocalServiceTests: XCTestCase {
         XCTAssertEqual(metrics.weeklyLimit?.used, 64)
         XCTAssertEqual(metrics.weeklyLimit?.total, 100)
         XCTAssertEqual(metrics.weeklyLimit?.resetTime, FlexibleISO8601.date(from: "2026-09-10T00:00:00Z"))
+        XCTAssertNil(metrics.weeklyLimit?.windowSeconds, "End without start cannot invent a cycle length")
+        XCTAssertNil(metrics.sessionLimit?.windowSeconds)
         XCTAssertNil(metrics.codeReviewLimit)
         XCTAssertNotEqual(metrics.overallStatus, .critical)
+    }
+
+    func testMapSummaryUsesBillingCycleStartAndEndForPace() throws {
+        let json = """
+        {
+          "billingCycleStart": "2026-08-10T00:00:00Z",
+          "billingCycleEnd": "2026-09-10T00:00:00Z",
+          "individualUsage": {
+            "plan": {
+              "autoPercentUsed": 30,
+              "apiPercentUsed": 100
+            },
+            "onDemand": { "used": 2, "limit": 10, "enabled": true }
+          }
+        }
+        """
+        let metrics = CursorLocalService.mapSummary(try decodeSummary(json))
+        let expectedWindow = 31 * 24 * 3_600.0
+        let reset = FlexibleISO8601.date(from: "2026-09-10T00:00:00Z")
+
+        XCTAssertEqual(metrics.sessionLimit?.resetTime, reset)
+        XCTAssertEqual(metrics.weeklyLimit?.resetTime, reset)
+        XCTAssertEqual(metrics.codeReviewLimit?.resetTime, reset)
+        XCTAssertEqual(metrics.sessionLimit?.windowSeconds, expectedWindow)
+        XCTAssertEqual(metrics.weeklyLimit?.windowSeconds, expectedWindow)
+        XCTAssertEqual(metrics.codeReviewLimit?.windowSeconds, expectedWindow)
+
+        let start = try XCTUnwrap(FlexibleISO8601.date(from: "2026-08-10T00:00:00Z"))
+        let now = start.addingTimeInterval(15 * 24 * 3_600)
+        XCTAssertNotNil(metrics.sessionLimit?.pace(now: now))
+        XCTAssertNotNil(metrics.weeklyLimit?.pace(now: now))
+    }
+
+    func testMapSummaryIgnoresNonPositiveBillingCycleDuration() throws {
+        let json = """
+        {
+          "billingCycleStart": "2026-09-10T00:00:00Z",
+          "billingCycleEnd": "2026-09-10T00:00:00Z",
+          "individualUsage": {
+            "plan": { "autoPercentUsed": 4, "apiPercentUsed": 64 }
+          }
+        }
+        """
+        let metrics = CursorLocalService.mapSummary(try decodeSummary(json))
+
+        XCTAssertEqual(metrics.weeklyLimit?.resetTime, FlexibleISO8601.date(from: "2026-09-10T00:00:00Z"))
+        XCTAssertNil(metrics.weeklyLimit?.windowSeconds)
+        XCTAssertNil(metrics.sessionLimit?.windowSeconds)
+        XCTAssertNil(metrics.weeklyLimit?.pace())
     }
 
     func testMapSummaryIgnoresTotalPercentUsedInFavorOfTheTwoPools() throws {


### PR DESCRIPTION
## Why

Cursor `/api/usage-summary` already sends `billingCycleStart` and `billingCycleEnd`. We decoded both and only used the end date as `resetTime`, so Cursor cards showed “resets in 25d” but never pace (no green reserve / red deficit overlay).

That was not an API gap. The mapper dropped the cycle length.

## Change

`windowSeconds = billingCycleEnd − billingCycleStart` when both parse and the duration is positive. Same window is applied to Cursor Models, Other Models, on-demand, and the legacy monthly request slot.

- End without start → reset countdown only (unchanged)
- Zero or inverted duration → no invented window
- No assumed 30-day month

## Tests

- Start+end on percent pools and on-demand produce the same 31-day window and a non-nil `pace()`
- End-only payload still has no `windowSeconds`
- Equal start/end does not invent a window

`swift test --filter CursorLocalServiceTests` — 32 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure mapping and display logic in `CursorLocalService.mapSummary` with no auth, network, or persistence changes; behavior is guarded by unit tests.
> 
> **Overview**
> Cursor usage cards could show a reset countdown but **no pace overlay** (ahead/behind vs. expected usage) because the mapper only used `billingCycleEnd` as `resetTime` and never set **`windowSeconds`**.
> 
> **`mapSummary`** now derives the billing window via a new **`billingCycle(from:)`** helper: **`windowSeconds = billingCycleEnd − billingCycleStart`** when both ISO dates parse and the duration is positive. That value is passed into every Cursor **`UsageLimit`** (percent pools, on-demand, and the legacy monthly slot) alongside the existing reset time. There is **no assumed 30-day month**; end-only payloads still get reset countdown only; zero or inverted start/end leave **`windowSeconds`** nil so pace is not invented.
> 
> Tests lock in a 31-day window and non-nil **`pace()`** when start+end are present, and nil window/pace when start is missing or start equals end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1923752d5c3f01ad824ba714e1fdf3cc02f68e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage tracking to account for the full billing-cycle duration.
  * Updated usage limits, percentage pools, legacy quotas, and on-demand usage to reset and pace correctly throughout the billing cycle.
  * Added handling for invalid or non-positive billing-cycle durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->