### PR TITLE
chore(release): bump version to 1.8.37

### DIFF
--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.36;
+				MARKETING_VERSION = 1.8.37;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -369,7 +369,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.36;
+				MARKETING_VERSION = 1.8.37;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -534,7 +534,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.36;
+				MARKETING_VERSION = 1.8.37;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug;
 				PRODUCT_NAME = "MeterBar Dev";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -580,7 +580,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.36;
+				MARKETING_VERSION = 1.8.37;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
Bumps `MARKETING_VERSION` to 1.8.37 across all four build configurations so the release tag, app bundle, and bundled CLI agree. `CURRENT_PROJECT_VERSION` derives from it and needs no edit; the CLI reads `CFBundleShortVersionString` from the enclosing app bundle at runtime.

Verified locally on macOS 26: Debug build succeeds, `codesign --verify --deep --strict` passes, and the installed bundle plus `dev.meterbar.app.debug.Widget` both report 1.8.37.

## What ships in 1.8.37

**Grok**
- Per-account threshold notifications and adaptive movement tracking (#464)
- Account-scoped quota hooks and webhooks (#469)
- Reported quota cadence and period identity preserved (#471)

**Cursor**
- Grok Bot weekly usage shown as a fourth bar (#476)
- Pace derived from `billingCycleStart` / `billingCycleEnd` (#474)
- "Out" read only when both included pools are spent (#449)

**CLI**
- Account-scoped usage in text, JSON, and serve (#468)
- Grok profile targeting in `meterbar guard` (#465)
- `/usage` endpoint shares the CLI provider filter (#445)
- Cursor's third quota window titled "On-demand" (#446)
- One shared cancellation flag and signal installer (#447)

**Correctness**
- Truthful stale/failed state on every usage card (#473)
- Per-account diagnostics readiness for multi-account providers (#472)
- Honest progress for deferred files (#470)
- Colliding session ids kept apart in flattened breakdowns (#450)
- Home-directory paths kept out of public log lines (#444)
- Popover quota titles routed through the shared key (#454); widget Settings preview localized from its own copy (#451)

**Internal**
- Provider capability registry and all-provider fixture matrix (#467)
- Shared scan seams across the three cost scanners (#452); unused display-currency source dropped (#448)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only Xcode marketing version constants change; no runtime logic or security-sensitive code is modified.
> 
> **Overview**
> Raises **`MARKETING_VERSION`** from **1.8.36** to **1.8.37** in `MeterBar.xcodeproj` for MeterBar Debug/Release and MeterBarWidget Debug/Release. **`CURRENT_PROJECT_VERSION`** stays tied to `$(MARKETING_VERSION)`, so build and bundle version strings move with this single edit.
> 
> No application source changes in this PR; it is a release-version alignment step ahead of tagging **1.8.37**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b780aef568702805a28428429b944c824e7c1ec7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app and widget extension version to 1.8.37.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->