### PR TITLE
fix: exhaustive provider routing and additional-limit widget urgency

### DIFF
--- a/MeterBar/App/UsageNotificationCoordinator.swift
+++ b/MeterBar/App/UsageNotificationCoordinator.swift
@@ -23,6 +23,13 @@ extension AccountNotificationIdentity {
     }
 }
 
+/// One provider's live accounts for exhaustive notification routing.
+struct NotificationAccountBundle {
+    let accounts: [AccountNotificationIdentity]
+    let metrics: [UUID: UsageMetrics]
+    let defaultID: UUID
+}
+
 /// Owns quota-threshold and Session Wake banners, extracted from
 /// `MeterBarApp.swift` (C1 split).
 ///
@@ -47,6 +54,68 @@ final class UsageNotificationCoordinator {
     /// scoped providers fan out through `AccountNotificationPlanner` instead.
     static var flatNotificationServices: [ServiceType] {
         ServiceType.allCases.filter { !$0.hasAccountScopedNotifications }
+    }
+
+    /// Exhaustive account-scoped notification inputs. A new `ServiceType` with
+    /// `hasAccountScopedNotifications` is a compile error in the switch until
+    /// its account bundle is wired here.
+    static func accountScopedPlanInputs(
+        metrics: [ServiceType: UsageMetrics],
+        isEnabled: (ServiceType) -> Bool,
+        claude: NotificationAccountBundle,
+        codex: NotificationAccountBundle,
+        grok: NotificationAccountBundle
+    ) -> [AccountNotificationPlanInput] {
+        ServiceType.allCases.filter(\.hasAccountScopedNotifications).compactMap { service in
+            switch service {
+            case .claudeCode:
+                return planInput(
+                    service: .claudeCode,
+                    providerEnabled: isEnabled(.claudeCode),
+                    bundle: claude,
+                    fallbackMetrics: metrics[.claudeCode]
+                )
+            case .codexCli:
+                return planInput(
+                    service: .codexCli,
+                    providerEnabled: isEnabled(.codexCli),
+                    bundle: codex,
+                    fallbackMetrics: metrics[.codexCli]
+                )
+            case .grok:
+                return planInput(
+                    service: .grok,
+                    providerEnabled: isEnabled(.grok),
+                    bundle: grok,
+                    fallbackMetrics: metrics[.grok]
+                )
+            case .cursor, .openRouter:
+                assertionFailure(
+                    "account-scoped notifications for \(service.rawValue) have no routing"
+                )
+                return nil
+            }
+        }
+    }
+
+    private static func planInput(
+        service: ServiceType,
+        providerEnabled: Bool,
+        bundle: NotificationAccountBundle,
+        fallbackMetrics: UsageMetrics?
+    ) -> AccountNotificationPlanInput {
+        AccountNotificationPlanInput(
+            service: service,
+            providerEnabled: providerEnabled,
+            accounts: bundle.accounts,
+            accountMetrics: bundle.metrics,
+            fallbackMetrics: fallbackMetrics,
+            representativeAccountID: AccountNotificationPlanInput.representativeAccountID(
+                accounts: bundle.accounts,
+                accountMetrics: bundle.metrics,
+                defaultID: bundle.defaultID
+            )
+        )
     }
 
     func start() {
@@ -170,52 +239,32 @@ final class UsageNotificationCoordinator {
             }
         }
 
-        let claudeAccounts = ClaudeCodeAccountStore.shared.accounts.map(AccountNotificationIdentity.init(account:))
-        let claudeAccountMetrics = UsageDataManager.shared.claudeCodeAccountMetrics
-        let codexAccounts = CodexAccountStore.shared.accounts.map(AccountNotificationIdentity.init(account:))
-        let codexAccountMetrics = UsageDataManager.shared.codexAccountMetrics
-        let grokAccounts = GrokAccountStore.shared.accounts.map(AccountNotificationIdentity.init(account:))
-        let grokAccountMetrics = UsageDataManager.shared.grokAccountMetrics
-
         let accountPlan = AccountNotificationPlanner(decider: decider).plan(
-            inputs: [
-                AccountNotificationPlanInput(
-                    service: .claudeCode,
-                    providerEnabled: providerVisibilityStore.isEnabled(.claudeCode),
-                    accounts: claudeAccounts,
-                    accountMetrics: claudeAccountMetrics,
-                    fallbackMetrics: currentMetrics[.claudeCode],
-                    representativeAccountID: AccountNotificationPlanInput.representativeAccountID(
-                        accounts: claudeAccounts,
-                        accountMetrics: claudeAccountMetrics,
-                        defaultID: ClaudeCodeAccount.defaultID
-                    )
+            inputs: Self.accountScopedPlanInputs(
+                metrics: currentMetrics,
+                isEnabled: providerVisibilityStore.isEnabled,
+                claude: NotificationAccountBundle(
+                    accounts: ClaudeCodeAccountStore.shared.accounts.map(
+                        AccountNotificationIdentity.init(account:)
+                    ),
+                    metrics: UsageDataManager.shared.claudeCodeAccountMetrics,
+                    defaultID: ClaudeCodeAccount.defaultID
                 ),
-                AccountNotificationPlanInput(
-                    service: .codexCli,
-                    providerEnabled: providerVisibilityStore.isEnabled(.codexCli),
-                    accounts: codexAccounts,
-                    accountMetrics: codexAccountMetrics,
-                    fallbackMetrics: currentMetrics[.codexCli],
-                    representativeAccountID: AccountNotificationPlanInput.representativeAccountID(
-                        accounts: codexAccounts,
-                        accountMetrics: codexAccountMetrics,
-                        defaultID: CodexAccount.defaultID
-                    )
+                codex: NotificationAccountBundle(
+                    accounts: CodexAccountStore.shared.accounts.map(
+                        AccountNotificationIdentity.init(account:)
+                    ),
+                    metrics: UsageDataManager.shared.codexAccountMetrics,
+                    defaultID: CodexAccount.defaultID
                 ),
-                AccountNotificationPlanInput(
-                    service: .grok,
-                    providerEnabled: providerVisibilityStore.isEnabled(.grok),
-                    accounts: grokAccounts,
-                    accountMetrics: grokAccountMetrics,
-                    fallbackMetrics: currentMetrics[.grok],
-                    representativeAccountID: AccountNotificationPlanInput.representativeAccountID(
-                        accounts: grokAccounts,
-                        accountMetrics: grokAccountMetrics,
-                        defaultID: GrokAccount.defaultID
-                    )
+                grok: NotificationAccountBundle(
+                    accounts: GrokAccountStore.shared.accounts.map(
+                        AccountNotificationIdentity.init(account:)
+                    ),
+                    metrics: UsageDataManager.shared.grokAccountMetrics,
+                    defaultID: GrokAccount.defaultID
                 )
-            ],
+            ),
             alreadyNotified: keys,
             now: now
         )

--- a/MeterBar/Services/QuotaEventService.swift
+++ b/MeterBar/Services/QuotaEventService.swift
@@ -49,33 +49,21 @@ nonisolated enum QuotaEventSnapshotCatalog {
             )
         }
 
-        result += accountSnapshots(
-            provider: .claudeCode,
-            accounts: accounts.claudeAccounts.map {
-                AccountMetricIdentity(id: $0.id, name: $0.name, isEnabled: $0.isEnabled)
-            },
-            accountMetrics: accounts.claudeAccountMetrics,
-            fallbackMetrics: metrics[.claudeCode],
-            enabledServices: enabledServices
-        )
-        result += accountSnapshots(
-            provider: .codexCli,
-            accounts: accounts.codexAccounts.map {
-                AccountMetricIdentity(id: $0.id, name: $0.name, isEnabled: $0.isEnabled)
-            },
-            accountMetrics: accounts.codexAccountMetrics,
-            fallbackMetrics: metrics[.codexCli],
-            enabledServices: enabledServices
-        )
-        result += accountSnapshots(
-            provider: .grok,
-            accounts: accounts.grokAccounts.map {
-                AccountMetricIdentity(id: $0.id, name: $0.name, isEnabled: $0.isEnabled)
-            },
-            accountMetrics: accounts.grokAccountMetrics,
-            fallbackMetrics: metrics[.grok],
-            enabledServices: enabledServices
-        )
+        for provider in ServiceType.allCases where provider.hasAccountScopedQuotaEvents {
+            guard let source = accountSource(for: provider, from: accounts) else {
+                assertionFailure(
+                    "account-scoped quota events for \(provider.rawValue) have no routing"
+                )
+                continue
+            }
+            result += accountSnapshots(
+                provider: provider,
+                accounts: source.accounts,
+                accountMetrics: source.metrics,
+                fallbackMetrics: metrics[provider],
+                enabledServices: enabledServices
+            )
+        }
         return result.sorted {
             if $0.provider.sortOrder != $1.provider.sortOrder {
                 return $0.provider.sortOrder < $1.provider.sortOrder
@@ -89,35 +77,66 @@ nonisolated enum QuotaEventSnapshotCatalog {
         codexAccounts: [CodexAccount],
         grokAccounts: [GrokAccount]
     ) -> [QuotaEventSelectableAccount] {
+        let inputs = QuotaEventAccountInputs(
+            claudeAccounts: claudeAccounts,
+            codexAccounts: codexAccounts,
+            grokAccounts: grokAccounts
+        )
         let flat = flatProviders.map {
             QuotaEventSelectableAccount(provider: $0, accountID: "default", name: $0.displayName)
         }
-        let claude = claudeAccounts.filter(\.isEnabled).map {
-            QuotaEventSelectableAccount(
-                provider: .claudeCode,
-                accountID: $0.id.uuidString,
-                name: $0.name
-            )
+        var scoped: [QuotaEventSelectableAccount] = []
+        for provider in ServiceType.allCases where provider.hasAccountScopedQuotaEvents {
+            guard let source = accountSource(for: provider, from: inputs) else {
+                assertionFailure(
+                    "account-scoped quota events for \(provider.rawValue) have no routing"
+                )
+                continue
+            }
+            scoped += source.accounts.filter(\.isEnabled).map {
+                QuotaEventSelectableAccount(
+                    provider: provider,
+                    accountID: $0.id.uuidString,
+                    name: $0.name
+                )
+            }
         }
-        let codex = codexAccounts.filter(\.isEnabled).map {
-            QuotaEventSelectableAccount(
-                provider: .codexCli,
-                accountID: $0.id.uuidString,
-                name: $0.name
-            )
-        }
-        let grok = grokAccounts.filter(\.isEnabled).map {
-            QuotaEventSelectableAccount(
-                provider: .grok,
-                accountID: $0.id.uuidString,
-                name: $0.name
-            )
-        }
-        return (claude + codex + grok + flat).sorted {
+        return (scoped + flat).sorted {
             if $0.provider.sortOrder != $1.provider.sortOrder {
                 return $0.provider.sortOrder < $1.provider.sortOrder
             }
             return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+    }
+
+    private static func accountSource(
+        for provider: ServiceType,
+        from accounts: QuotaEventAccountInputs
+    ) -> (accounts: [AccountMetricIdentity], metrics: [UUID: UsageMetrics])? {
+        switch provider {
+        case .claudeCode:
+            return (
+                accounts.claudeAccounts.map {
+                    AccountMetricIdentity(id: $0.id, name: $0.name, isEnabled: $0.isEnabled)
+                },
+                accounts.claudeAccountMetrics
+            )
+        case .codexCli:
+            return (
+                accounts.codexAccounts.map {
+                    AccountMetricIdentity(id: $0.id, name: $0.name, isEnabled: $0.isEnabled)
+                },
+                accounts.codexAccountMetrics
+            )
+        case .grok:
+            return (
+                accounts.grokAccounts.map {
+                    AccountMetricIdentity(id: $0.id, name: $0.name, isEnabled: $0.isEnabled)
+                },
+                accounts.grokAccountMetrics
+            )
+        case .cursor, .openRouter:
+            return nil
         }
     }
 

--- a/MeterBarTests/ProviderCapabilitiesTests.swift
+++ b/MeterBarTests/ProviderCapabilitiesTests.swift
@@ -248,6 +248,56 @@ final class ProviderCapabilitiesTests: XCTestCase {
         XCTAssertEqual(serve.body, try UsageCLIJSONResponse(metrics: metrics).jsonData())
     }
 
+    func testAccountScopedNotificationAndQuotaEventRoutingIsExhaustive() {
+        let notificationInputs = UsageNotificationCoordinator.accountScopedPlanInputs(
+            metrics: MetricsFixtures.allProviders(),
+            isEnabled: { _ in true },
+            claude: NotificationAccountBundle(
+                accounts: [AccountNotificationIdentity(account: ClaudeCodeAccount.defaultAccount)],
+                metrics: [ClaudeCodeAccount.defaultID: MetricsFixtures.claudeCode()],
+                defaultID: ClaudeCodeAccount.defaultID
+            ),
+            codex: NotificationAccountBundle(
+                accounts: [AccountNotificationIdentity(account: CodexAccount.defaultAccount)],
+                metrics: [CodexAccount.defaultID: MetricsFixtures.codexCli()],
+                defaultID: CodexAccount.defaultID
+            ),
+            grok: NotificationAccountBundle(
+                accounts: [AccountNotificationIdentity(account: GrokAccount.defaultAccount)],
+                metrics: [GrokAccount.defaultID: MetricsFixtures.grok()],
+                defaultID: GrokAccount.defaultID
+            )
+        )
+        XCTAssertEqual(
+            Set(notificationInputs.map(\.service)),
+            Set(ServiceType.allCases.filter(\.hasAccountScopedNotifications))
+        )
+        for input in notificationInputs {
+            XCTAssertFalse(
+                input.accounts.isEmpty,
+                "\(input.service) account-scoped notification routing has no accounts"
+            )
+        }
+
+        let selectable = QuotaEventSnapshotCatalog.selectableAccounts(
+            claudeAccounts: [.defaultAccount],
+            codexAccounts: [.defaultAccount],
+            grokAccounts: [.defaultAccount]
+        )
+        for service in ServiceType.allCases {
+            XCTAssertTrue(
+                selectable.contains { $0.provider == service },
+                "\(service) missing from quota-event selectable accounts"
+            )
+        }
+        for service in ServiceType.allCases where service.hasAccountScopedQuotaEvents {
+            XCTAssertTrue(
+                selectable.contains { $0.provider == service && $0.accountID != "default" },
+                "\(service) account-scoped quota events still use the flat default path"
+            )
+        }
+    }
+
     func testNotificationsAndEventsCoverEveryProvider() {
         let coveredNotifications = Set(UsageNotificationCoordinator.flatNotificationServices)
             .union(ServiceType.allCases.filter(\.hasAccountScopedNotifications))

--- a/MeterBarTests/WidgetBurnDownTests.swift
+++ b/MeterBarTests/WidgetBurnDownTests.swift
@@ -53,6 +53,25 @@ final class WidgetBurnDownTests: XCTestCase {
         XCTAssertNotEqual(MeterBarWidgetKind.usage, MeterBarWidgetKind.burnDown)
     }
 
+    func testBurnDownPlaceholderCoversEveryProviderIncludingCursor() throws {
+        let metrics = WidgetPlaceholderMetrics.burnDown(now: now)
+        XCTAssertEqual(Set(metrics.keys), Set(ServiceType.allCases))
+        XCTAssertNotNil(metrics[.cursor], "Burn Down placeholder omitted Cursor")
+        for service in ServiceType.allCases {
+            let metric = try? XCTUnwrap(metrics[service], "\(service) missing from Burn Down placeholder")
+            XCTAssertEqual(metric?.service, service)
+            XCTAssertNotNil(metric?.weeklyLimit, "\(service) placeholder has no weekly window")
+            XCTAssertEqual(metric?.lastUpdated, now, "\(service)")
+        }
+
+        let cursorOnly = presentation(
+            metrics: [ .cursor: try XCTUnwrap(metrics[.cursor]) ],
+            family: .small
+        )
+        XCTAssertEqual(cursorOnly.rows.map(\.service), [.cursor])
+        XCTAssertNil(cursorOnly.emptyState)
+    }
+
     func testReservePaceCountsDownToReset() throws {
         let resetTime = now.addingTimeInterval(2.5 * 60 * 60)
         let row = try XCTUnwrap(

--- a/MeterBarTests/WidgetPresentationTests.swift
+++ b/MeterBarTests/WidgetPresentationTests.swift
@@ -104,6 +104,79 @@ final class WidgetPresentationTests: XCTestCase {
         XCTAssertEqual(result.rows.map(\.service), [.codexCli, .cursor, .claudeCode])
     }
 
+    func testUrgencyOrderingIncludesVisibleAdditionalLimits() {
+        var preferences = WidgetPreferences.defaults
+        preferences.accountOrdering = .urgency
+        preferences.visibleQuotaWindows = [.weekly]
+        let metrics: [ServiceType: UsageMetrics] = [
+            .claudeCode: makeMetrics(.claudeCode, weeklyUsed: 90),
+            .cursor: makeMetrics(
+                .cursor,
+                weeklyUsed: 10,
+                additionalLimits: [
+                    UsageLimit(used: 100, total: 100, resetTime: nil, periodKind: .weekly)
+                ]
+            )
+        ]
+
+        let result = presentation(
+            metrics: metrics,
+            preferences: preferences,
+            family: .large
+        )
+
+        XCTAssertEqual(uniqueServices(in: result), [.cursor, .claudeCode])
+    }
+
+    func testUrgencyOrderingIgnoresAdditionalLimitsOutsideVisibleWindows() {
+        var preferences = WidgetPreferences.defaults
+        preferences.accountOrdering = .urgency
+        preferences.visibleQuotaWindows = [.weekly]
+        let metrics: [ServiceType: UsageMetrics] = [
+            .claudeCode: makeMetrics(.claudeCode, weeklyUsed: 90),
+            .cursor: makeMetrics(
+                .cursor,
+                weeklyUsed: 10,
+                additionalLimits: [
+                    UsageLimit(used: 100, total: 100, resetTime: nil, periodKind: .daily)
+                ]
+            )
+        ]
+
+        let result = presentation(
+            metrics: metrics,
+            preferences: preferences,
+            family: .large
+        )
+
+        XCTAssertEqual(result.rows.map(\.service), [.claudeCode, .cursor])
+    }
+
+    func testUrgencyOrderingUsesWidgetWindowForAdditionalLimitPeriod() {
+        var preferences = WidgetPreferences.defaults
+        preferences.accountOrdering = .urgency
+        preferences.visibleQuotaWindows = [.session]
+        let metrics: [ServiceType: UsageMetrics] = [
+            .claudeCode: makeMetrics(.claudeCode, sessionUsed: 20, weeklyUsed: 90),
+            .cursor: makeMetrics(
+                .cursor,
+                sessionUsed: 5,
+                weeklyUsed: 10,
+                additionalLimits: [
+                    UsageLimit(used: 100, total: 100, resetTime: nil, periodKind: .daily)
+                ]
+            )
+        ]
+
+        let result = presentation(
+            metrics: metrics,
+            preferences: preferences,
+            family: .large
+        )
+
+        XCTAssertEqual(uniqueServices(in: result), [.cursor, .claudeCode])
+    }
+
     func testUsedAndRemainingModesProduceComplementaryValues() throws {
         let metrics: [ServiceType: UsageMetrics] = [
             .claudeCode: makeMetrics(.claudeCode, weeklyUsed: 25)
@@ -430,6 +503,14 @@ final class WidgetPresentationTests: XCTestCase {
         }
     }
 
+    private func uniqueServices(in presentation: WidgetPresentation) -> [ServiceType] {
+        var seen = Set<WidgetAccountIdentifier>()
+        return presentation.rows.compactMap { row in
+            guard seen.insert(row.accountIdentifier).inserted else { return nil }
+            return row.service
+        }
+    }
+
     /// One row per quota window for a single provider, built through the real
     /// planner rather than a hand-made row.
     private func allWindowRows(service: ServiceType, total: Double) -> [WidgetPresentationRow] {
@@ -566,7 +647,8 @@ final class WidgetPresentationTests: XCTestCase {
         total: Double = 100,
         modelLimitLabel: String? = nil,
         resetTime: Date? = nil,
-        lastUpdated: Date? = nil
+        lastUpdated: Date? = nil,
+        additionalLimits: [UsageLimit] = []
     ) -> UsageMetrics {
         UsageMetrics(
             service: service,
@@ -580,6 +662,7 @@ final class WidgetPresentationTests: XCTestCase {
                 UsageLimit(used: $0, total: total, resetTime: resetTime)
             },
             modelLimitLabel: modelLimitLabel,
+            additionalLimits: additionalLimits,
             lastUpdated: lastUpdated ?? now
         )
     }

--- a/MeterBarWidget/BurnDownWidget.swift
+++ b/MeterBarWidget/BurnDownWidget.swift
@@ -39,28 +39,7 @@ struct BurnDownWidgetProvider: TimelineProvider {
         let now = Date()
         return BurnDownWidgetEntry(
             date: now,
-            metrics: [
-                .claudeCode: placeholderMetrics(
-                    service: .claudeCode,
-                    used: 72,
-                    resetTime: now.addingTimeInterval(2.5 * 24 * 60 * 60)
-                ),
-                .codexCli: placeholderMetrics(
-                    service: .codexCli,
-                    used: 38,
-                    resetTime: now.addingTimeInterval(4 * 24 * 60 * 60)
-                ),
-                .grok: placeholderMetrics(
-                    service: .grok,
-                    used: 47,
-                    resetTime: now.addingTimeInterval(3 * 24 * 60 * 60)
-                ),
-                .openRouter: placeholderMetrics(
-                    service: .openRouter,
-                    used: 32,
-                    resetTime: now.addingTimeInterval(18 * 24 * 60 * 60)
-                )
-            ],
+            metrics: WidgetPlaceholderMetrics.burnDown(now: now),
             accountMetrics: [],
             preferences: .defaults
         )
@@ -92,23 +71,6 @@ struct BurnDownWidgetProvider: TimelineProvider {
 
     private func presentationFamily(_ family: WidgetFamily) -> WidgetPresentationFamily {
         family == .systemSmall ? .small : .medium
-    }
-
-    private func placeholderMetrics(
-        service: ServiceType,
-        used: Double,
-        resetTime: Date
-    ) -> UsageMetrics {
-        UsageMetrics(
-            service: service,
-            weeklyLimit: UsageLimit(
-                used: used,
-                total: 100,
-                resetTime: resetTime,
-                windowSeconds: 7 * 24 * 60 * 60
-            ),
-            lastUpdated: Date()
-        )
     }
 }
 

--- a/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPlaceholderMetrics.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPlaceholderMetrics.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Synthetic metrics the widget extension shows before a timeline loads.
+///
+/// Built from an exhaustive `ServiceType` switch so a new provider is a
+/// compile error here and a test failure in `WidgetBurnDownTests` until the
+/// placeholder is updated.
+public enum WidgetPlaceholderMetrics {
+    public static func burnDown(now: Date = Date()) -> [ServiceType: UsageMetrics] {
+        Dictionary(uniqueKeysWithValues: ServiceType.allCases.map { service in
+            (service, metrics(for: service, now: now))
+        })
+    }
+
+    private static func metrics(for service: ServiceType, now: Date) -> UsageMetrics {
+        let used: Double
+        let resetDelay: TimeInterval
+        switch service {
+        case .claudeCode:
+            used = 72
+            resetDelay = 2.5 * 24 * 60 * 60
+        case .codexCli:
+            used = 38
+            resetDelay = 4 * 24 * 60 * 60
+        case .cursor:
+            used = 55
+            resetDelay = 5 * 24 * 60 * 60
+        case .grok:
+            used = 47
+            resetDelay = 3 * 24 * 60 * 60
+        case .openRouter:
+            used = 32
+            resetDelay = 18 * 24 * 60 * 60
+        }
+        return UsageMetrics(
+            service: service,
+            weeklyLimit: UsageLimit(
+                used: used,
+                total: 100,
+                resetTime: now.addingTimeInterval(resetDelay),
+                windowSeconds: 7 * 24 * 60 * 60
+            ),
+            lastUpdated: now
+        )
+    }
+}

--- a/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPresentation.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/WidgetPresentation.swift
@@ -334,10 +334,15 @@ public enum WidgetPresentationPlanner {
         visibleWindows: Set<WidgetQuotaWindow>
     ) -> Double {
         guard let metrics = source.metrics else { return -Double.infinity }
-        return WidgetQuotaWindow.allCases
+        let primary = WidgetQuotaWindow.allCases
             .filter { visibleWindows.contains($0) }
             .compactMap { limit(for: $0, metrics: metrics)?.percentage }
-            .max() ?? 0
+        let additional = metrics.additionalLimits.compactMap { additionalLimit -> Double? in
+            let window = widgetWindow(for: additionalLimit.periodKind)
+            guard visibleWindows.contains(window) else { return nil }
+            return additionalLimit.percentage
+        }
+        return (primary + additional).max() ?? 0
     }
 
     private static func presentationRows(


### PR DESCRIPTION
## Summary
- Make account-scoped notification and quota-event routing exhaustive so a new provider cannot be silently omitted, and include Cursor in the Burn Down placeholder (`#475`).
- Include visible `additionalLimits` in widget urgency ordering using `widgetWindow(for:)`, so an exhausted Grok Bot bar can rank above a quieter primary quota (`#477`).
- Board hygiene already landed on the issues: `#389` is the next-providers epic, `#394` is closed.

## Related issue
Closes #475
Closes #477

## Scope
- Notification/quota-event routing now iterates `ServiceType.allCases` and switches exhaustively onto Claude/Codex/Grok account bundles.
- Burn Down placeholder metrics live in `WidgetPlaceholderMetrics` so adding a `ServiceType` is a compile/test failure.
- Widget urgency still ignores additional limits whose mapped window is hidden.
- No change to `mapSandUsage` omission rules.

## Verification
- `swiftlint lint --strict` on touched production files: 0 violations
- Focused: `ProviderCapabilitiesTests`, `QuotaEventServiceTests`, `WidgetBurnDownTests`, `WidgetPresentationTests`
- `swift test`: 2621 tests, 6 skipped, 0 failures
- App/widget/CLI builds left to CI

## Screenshots
Not applicable

## Checklist
- [x] I reviewed the final diff for unrelated changes.
- [x] I ran the relevant focused checks or documented why they were left to CI.
- [x] I updated relevant documentation or explained why no documentation change is needed.
- [x] I documented migrations, release steps, or external configuration changes, or marked them not applicable.
- [x] I did not include secrets, credentials, personal data, customer data, or generated build output.
- [ ] If CodeRabbit says "Review rate limited", I re-requested review before merge. A green CodeRabbit tick is not a review in that case.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage notifications and quota-event account selection across supported providers.
  * Fixed widget urgency ordering to account for visible additional limits and selected time windows.
  * Ensured burn-down placeholders consistently display all supported services, including Cursor.

* **Widget Improvements**
  * Standardized placeholder usage data and timestamps for more consistent widget previews.
  * Improved single-service presentations so they display correctly without an empty state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->