### PR TITLE
fix(openrouter): stop the key-save crash and uncrush the API-key row

### DIFF
--- a/MeterBar/Services/OpenRouterService.swift
+++ b/MeterBar/Services/OpenRouterService.swift
@@ -22,11 +22,11 @@ final class OpenRouterService: ObservableObject {
     private(set) var latestUsageObservation: ProviderUsageObservation?
 
     private let keychain: KeychainManager
-    private let fetchData: (URLRequest) async throws -> Data
+    private let fetchData: @Sendable (URLRequest) async throws -> Data
 
     init(
         keychain: KeychainManager = .shared,
-        fetchData: ((URLRequest) async throws -> Data)? = nil
+        fetchData: (@Sendable (URLRequest) async throws -> Data)? = nil
     ) {
         self.keychain = keychain
         self.fetchData = fetchData ?? Self.fetch
@@ -63,16 +63,11 @@ final class OpenRouterService: ObservableObject {
         }
 
         do {
-            async let creditsData = fetchData(try Self.request(path: "credits", apiKey: apiKey))
-            async let keyData = fetchData(try Self.request(path: "key", apiKey: apiKey))
-            let decoder = JSONDecoder()
-            let credits = try decoder.decode(OpenRouterCreditsResponse.self, from: await creditsData)
-            let key = try decoder.decode(OpenRouterKeyResponse.self, from: await keyData)
-            let metrics = Self.map(credits: credits.data, key: key.data)
-            latestUsageObservation = Self.observation(key: key.data, at: metrics.lastUpdated)
+            let fetched = try await Self.fetchRemotely(apiKey: apiKey, fetchData: fetchData)
+            latestUsageObservation = fetched.observation
             hasAccess = true
             lastError = nil
-            return metrics
+            return fetched.metrics
         } catch {
             let serviceError = ServiceSupport.serviceError(from: error)
             lastError = serviceError
@@ -83,7 +78,45 @@ final class OpenRouterService: ObservableObject {
         }
     }
 
-    static func map(
+    /// The outcome of one off-main poll, shipped back to the caller as one
+    /// `Sendable` value so the main-actor side only ever touches its own
+    /// `@Published` state after the network work has fully settled.
+    private struct FetchedUsage: Sendable {
+        let metrics: UsageMetrics
+        let observation: ProviderUsageObservation
+    }
+
+    /// Runs both network legs and the decode off the main actor.
+    ///
+    /// The app target compiles with `SWIFT_DEFAULT_ACTOR_ISOLATION =
+    /// MainActor`, so an unannotated fetch path here would execute as
+    /// main-actor jobs — and the two `async let` legs through the *stored*
+    /// `fetchData` closure cross a reabstraction-thunk actor hop whose
+    /// caller-owned argument buffer does not reliably survive. That is the
+    /// exact hazard that crashed Settings → Codex (#328, 4a38ab6) and that
+    /// crashed 1.8.37 entering `NSURLSession.data(for:delegate:)` with a dead
+    /// receiver the moment a key was saved and validated. Nothing in the
+    /// detached scope touches main-actor state: only `Sendable` values go in,
+    /// only a `Sendable` result comes out.
+    nonisolated private static func fetchRemotely(
+        apiKey: String,
+        fetchData: @escaping @Sendable (URLRequest) async throws -> Data
+    ) async throws -> FetchedUsage {
+        try await Task.detached(priority: .userInitiated) {
+            async let creditsData = fetchData(try request(path: "credits", apiKey: apiKey))
+            async let keyData = fetchData(try request(path: "key", apiKey: apiKey))
+            let decoder = JSONDecoder()
+            let credits = try decoder.decode(OpenRouterCreditsResponse.self, from: await creditsData)
+            let key = try decoder.decode(OpenRouterKeyResponse.self, from: await keyData)
+            let metrics = map(credits: credits.data, key: key.data)
+            return FetchedUsage(
+                metrics: metrics,
+                observation: observation(key: key.data, at: metrics.lastUpdated)
+            )
+        }.value
+    }
+
+    nonisolated static func map(
         credits: OpenRouterCredits,
         key: OpenRouterKey,
         now: Date = Date(),
@@ -127,7 +160,7 @@ final class OpenRouterService: ObservableObject {
     /// the whole account. Mixing the two would have the delta path and the
     /// authoritative-today path measuring different things and contradicting
     /// each other on alternating polls.
-    static func observation(key: OpenRouterKey, at observedAt: Date) -> ProviderUsageObservation {
+    nonisolated static func observation(key: OpenRouterKey, at observedAt: Date) -> ProviderUsageObservation {
         ProviderUsageObservation(
             provider: .openRouter,
             unit: .usd,
@@ -144,7 +177,7 @@ final class OpenRouterService: ObservableObject {
         )
     }
 
-    private static func request(path: String, apiKey: String) throws -> URLRequest {
+    nonisolated private static func request(path: String, apiKey: String) throws -> URLRequest {
         guard let url = URL(string: "https://openrouter.ai/api/v1/\(path)") else {
             throw ServiceError.invalidURL
         }
@@ -155,13 +188,13 @@ final class OpenRouterService: ObservableObject {
         return request
     }
 
-    private static func fetch(_ request: URLRequest) async throws -> Data {
+    nonisolated private static func fetch(_ request: URLRequest) async throws -> Data {
         let (data, response) = try await ServiceSupport.session.data(for: request)
         try ServiceSupport.validate(response, data: data)
         return data
     }
 
-    private static func resetWindow(
+    nonisolated private static func resetWindow(
         _ rawValue: String?,
         now: Date,
         calendar: Calendar
@@ -186,11 +219,14 @@ final class OpenRouterService: ObservableObject {
     }
 }
 
-struct OpenRouterCreditsResponse: Codable {
+// `nonisolated` keeps the Codable conformances usable from the detached fetch
+// scope — under default MainActor isolation they would otherwise be
+// main-actor-isolated and unusable off the main actor.
+nonisolated struct OpenRouterCreditsResponse: Codable {
     let data: OpenRouterCredits
 }
 
-struct OpenRouterCredits: Codable {
+nonisolated struct OpenRouterCredits: Codable {
     let totalCredits: Double
     let totalUsage: Double
 
@@ -200,11 +236,11 @@ struct OpenRouterCredits: Codable {
     }
 }
 
-struct OpenRouterKeyResponse: Codable {
+nonisolated struct OpenRouterKeyResponse: Codable {
     let data: OpenRouterKey
 }
 
-struct OpenRouterKey: Codable {
+nonisolated struct OpenRouterKey: Codable {
     let label: String?
     let limit: Double?
     let limitReset: String?

--- a/MeterBar/Views/Settings/ProviderSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsView.swift
@@ -698,6 +698,13 @@ struct ProviderSettingsView: View {
                             Task { await dataManager.refresh(service: .openRouter) }
                         }
                         .buttonStyle(.bordered)
+
+                        Button("Get Key") {
+                            if let url = URL(string: "https://openrouter.ai/settings/keys") {
+                                NSWorkspace.shared.open(url)
+                            }
+                        }
+                        .buttonStyle(.bordered)
                     }
                 } else {
                     // The control column clamps at `controlMaxWidth` (300pt) with

--- a/MeterBar/Views/Settings/ProviderSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsView.swift
@@ -690,35 +690,43 @@ struct ProviderSettingsView: View {
                     ? "Configured. Refresh validates access and updates credits."
                     : "Create a key at openrouter.ai/settings/keys."
             ) {
-                HStack(spacing: 8) {
-                    if openRouterService.hasAccess {
+                if openRouterService.hasAccess {
+                    HStack(spacing: 8) {
                         StatusPill(title: "Configured", isConnected: true)
                         Button("Remove", role: .destructive) {
                             openRouterService.removeAPIKey()
                             Task { await dataManager.refresh(service: .openRouter) }
                         }
                         .buttonStyle(.bordered)
-                    } else {
+                    }
+                } else {
+                    // The control column clamps at `controlMaxWidth` (300pt) with
+                    // `.fixedSize`, so the field and both buttons cannot share
+                    // one row — they crush into circles. The field leads and the
+                    // actions sit under it, mirroring the other provider rows.
+                    VStack(alignment: .trailing, spacing: 8) {
                         SecureField("sk-or-v1-...", text: $openRouterKeyDraft)
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 260)
 
-                        Button("Save & Validate") {
-                            guard openRouterService.saveAPIKey(openRouterKeyDraft) else { return }
-                            openRouterKeyDraft = ""
-                            providerVisibility.set(.openRouter, isEnabled: true)
-                            Task { await dataManager.refresh(service: .openRouter) }
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .disabled(openRouterKeyDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                    }
+                        HStack(spacing: 8) {
+                            Button("Save & Validate") {
+                                guard openRouterService.saveAPIKey(openRouterKeyDraft) else { return }
+                                openRouterKeyDraft = ""
+                                providerVisibility.set(.openRouter, isEnabled: true)
+                                Task { await dataManager.refresh(service: .openRouter) }
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .disabled(openRouterKeyDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
 
-                    Button("Get Key") {
-                        if let url = URL(string: "https://openrouter.ai/settings/keys") {
-                            NSWorkspace.shared.open(url)
+                            Button("Get Key") {
+                                if let url = URL(string: "https://openrouter.ai/settings/keys") {
+                                    NSWorkspace.shared.open(url)
+                                }
+                            }
+                            .buttonStyle(.bordered)
                         }
                     }
-                    .buttonStyle(.bordered)
                 }
             }
 

--- a/MeterBarTests/OpenRouterServiceTests.swift
+++ b/MeterBarTests/OpenRouterServiceTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MeterBarShared
+import Security
 import XCTest
 @testable import MeterBar
 
@@ -145,6 +146,49 @@ final class OpenRouterServiceTests: XCTestCase {
         XCTAssertNotEqual(observation.runningTotal, credits.data.totalUsage)
     }
 
+    // MARK: - Off-main fetch regression
+
+    /// Regression for the 1.8.37 crash entering `NSURLSession.data` the moment
+    /// a saved key was first validated: with `SWIFT_DEFAULT_ACTOR_ISOLATION =
+    /// MainActor` the fetch legs ran as main-actor jobs through the *stored*
+    /// `fetchData` closure's reabstraction thunk, the same actor-hop hazard as
+    /// the Settings → Codex crash (#328). The network legs now run detached, so
+    /// probing through the stored closure from off the main actor — the exact
+    /// shape production uses after "Save & Validate" — must still record
+    /// success and publish `hasAccess`.
+    func testFetchUsageMetricsProbedThroughStoredClosureFromDetachedTask() async throws {
+        let metrics = try await Task.detached(priority: .userInitiated) {
+            let keychain = KeychainManager(
+                backend: SeededKeychainBackend(),
+                currentService: "test.openrouter.regression"
+            )
+            XCTAssertTrue(keychain.save(key: OpenRouterService.keychainKey, value: "sk-or-v1-test"))
+
+            let service = OpenRouterService(keychain: keychain) { request in
+                switch request.url?.path {
+                case "/api/v1/credits":
+                    return Data(#"{"data":{"total_credits":100,"total_usage":25}}"#.utf8)
+                case "/api/v1/key":
+                    return Data(
+                        #"{"data":{"limit":null,"limit_reset":null,"usage":27.5,"usage_daily":1.25}}"#.utf8
+                    )
+                default:
+                    throw ServiceError.invalidURL
+                }
+            }
+
+            let fetched = try await service.fetchUsageMetrics()
+            return (fetched, service.hasAccess)
+        }.value
+
+        XCTAssertEqual(metrics.0.service, .openRouter)
+        XCTAssertEqual(metrics.0.weeklyLimit?.used, 25)
+        XCTAssertEqual(metrics.0.weeklyLimit?.total, 100)
+        // The fixture key carries `limit: null`, so no session window maps.
+        XCTAssertNil(metrics.0.sessionLimit)
+        XCTAssertTrue(metrics.1)
+    }
+
     private func decodeCredits(_ json: String) throws -> OpenRouterCreditsResponse {
         try JSONDecoder().decode(OpenRouterCreditsResponse.self, from: Data(json.utf8))
     }
@@ -157,5 +201,58 @@ final class OpenRouterServiceTests: XCTestCase {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
         return calendar.date(from: DateComponents(year: year, month: month, day: day, hour: hour)) ?? .distantPast
+    }
+}
+
+/// In-memory `KeychainBackend` seeded purely by writes, keyed by service and
+/// account like the real item space. Only what the regression test needs:
+/// update-then-add save, data-returning read.
+nonisolated private final class SeededKeychainBackend: KeychainBackend {
+    private struct ItemKey: Hashable {
+        let service: String
+        let account: String
+    }
+
+    private var storage: [ItemKey: Data] = [:]
+
+    private func itemKey(in query: [String: Any]) -> ItemKey? {
+        guard let service = query[kSecAttrService as String] as? String,
+              let account = query[kSecAttrAccount as String] as? String else {
+            return nil
+        }
+        return ItemKey(service: service, account: account)
+    }
+
+    func update(query: [String: Any], attributes: [String: Any]) -> OSStatus {
+        guard let itemKey = itemKey(in: query), storage[itemKey] != nil,
+              let data = attributes[kSecValueData as String] as? Data else {
+            return errSecItemNotFound
+        }
+        storage[itemKey] = data
+        return errSecSuccess
+    }
+
+    func add(query: [String: Any]) -> OSStatus {
+        guard let itemKey = itemKey(in: query),
+              let data = query[kSecValueData as String] as? Data else {
+            return errSecParam
+        }
+        storage[itemKey] = data
+        return errSecSuccess
+    }
+
+    func copyMatching(query: [String: Any], result: inout AnyObject?) -> OSStatus {
+        guard let itemKey = itemKey(in: query), let data = storage[itemKey] else {
+            return errSecItemNotFound
+        }
+        if (query[kSecReturnData as String] as? Bool) == true {
+            result = data as AnyObject
+        }
+        return errSecSuccess
+    }
+
+    func delete(query: [String: Any]) -> OSStatus {
+        guard let itemKey = itemKey(in: query) else { return errSecParam }
+        return storage.removeValue(forKey: itemKey) == nil ? errSecItemNotFound : errSecSuccess
     }
 }


### PR DESCRIPTION
## Crash (1.8.37, SIGSEGV on key save)

Saving and validating an OpenRouter key crashed with `EXC_BAD_ACCESS` entering `NSURLSession.data(for:delegate:)` on the main thread — null receiver at function entry, dispatched as a Swift Concurrency job on the main queue.

**Root cause:** the app target compiles with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so both `async let` network legs in `fetchUsageMetrics` executed as main-actor jobs routed through the *stored* `fetchData` closure's reabstraction thunk. That is the same stored-closure actor-entry-hop hazard as the Settings → Codex crash (#328, commit `4a38ab6`): the caller-owned argument buffer does not reliably survive the hop.

**Fix:** the network legs and decode now run in `Task.detached` via `fetchRemotely`. Only `Sendable` values cross; `@Published` state is applied back on the main actor. Detached-scope helpers are `nonisolated`; response models are `nonisolated` so their `Codable` conformances work off-main; the stored closure is `@Sendable`.

## UI

The API-key row's control column clamps at 300pt with `.fixedSize`, so the unconfigured state (260pt field + "Save & Validate" + "Get Key" ≈ 480pt) crushed both buttons into circles. The field now leads and the actions sit beneath it; the configured state is unchanged.

## Tests

- New regression test probes `fetchUsageMetrics` through the stored closure from a detached task — the exact production shape after "Save & Validate".
- Full suite: **2617 tests, 0 failures, 6 skipped** (pre-existing skips).
- `xcodebuild -scheme MeterBar build` succeeds; SwiftLint clean on touched files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OpenRouter fetch concurrency and key-validation after save — a crash-prone actor-isolation path — but does not change auth semantics or what is sent to the API.
> 
> **Overview**
> Fixes the 1.8.37 SIGSEGV when saving and validating an OpenRouter key. With default MainActor isolation, `fetchUsageMetrics` ran both `async let` network legs as main-actor jobs through the stored `fetchData` closure — the same reabstraction-thunk hop that crashed Settings → Codex (#328).
> 
> Network work and decode now run in `Task.detached` via `fetchRemotely`. Only `Sendable` values cross back; helpers and Codable models are `nonisolated`, and the stored closure is `@Sendable`. A regression test probes that path from a detached task.
> 
> The unconfigured API-key row no longer crushes buttons: the field leads and Save/Get Key sit underneath the 300pt control column.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e35b67806d1cdb7c0ed3c577afdaf54faf0d60a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * OpenRouter data fetching now runs more efficiently, helping keep the app responsive during network requests.
  * Updated the OpenRouter API key settings layout for clearer configuration management.
  * The “Get Key” option now appears only when no API key is configured.
  * Configured keys display a dedicated status and removal action, while unconfigured keys show the entry and validation controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->