### PR TITLE
feat(openrouter): manage multiple API keys with full multi-account parity

### DIFF
--- a/MeterBar/App/QuotaEventCoordinator.swift
+++ b/MeterBar/App/QuotaEventCoordinator.swift
@@ -15,6 +15,7 @@ final class QuotaEventCoordinator {
     private let claudeAccounts: ClaudeCodeAccountStore
     private let codexAccounts: CodexAccountStore
     private let grokAccounts: GrokAccountStore
+    private let openRouterKeys: OpenRouterAccountStore
     private let providerVisibility: ProviderVisibilityStore
     private let settings: QuotaEventSettingsStore
     private let diagnostics: QuotaEventDiagnosticStore
@@ -28,6 +29,7 @@ final class QuotaEventCoordinator {
         claudeAccounts: ClaudeCodeAccountStore? = nil,
         codexAccounts: CodexAccountStore? = nil,
         grokAccounts: GrokAccountStore? = nil,
+        openRouterKeys: OpenRouterAccountStore? = nil,
         providerVisibility: ProviderVisibilityStore? = nil,
         settings: QuotaEventSettingsStore? = nil,
         diagnostics: QuotaEventDiagnosticStore? = nil,
@@ -37,6 +39,7 @@ final class QuotaEventCoordinator {
         self.claudeAccounts = claudeAccounts ?? .shared
         self.codexAccounts = codexAccounts ?? .shared
         self.grokAccounts = grokAccounts ?? .shared
+        self.openRouterKeys = openRouterKeys ?? .shared
         self.providerVisibility = providerVisibility ?? .shared
         self.settings = settings ?? .shared
         self.diagnostics = diagnostics ?? .shared
@@ -60,6 +63,9 @@ final class QuotaEventCoordinator {
             grokAccounts.$customAccounts.map { _ in () }.eraseToAnyPublisher(),
             grokAccounts.$defaultAccountName.map { _ in () }.eraseToAnyPublisher(),
             grokAccounts.$defaultAccountIsEnabled.map { _ in () }.eraseToAnyPublisher(),
+            openRouterKeys.$customAccounts.map { _ in () }.eraseToAnyPublisher(),
+            openRouterKeys.$defaultAccountName.map { _ in () }.eraseToAnyPublisher(),
+            openRouterKeys.$defaultAccountIsEnabled.map { _ in () }.eraseToAnyPublisher(),
         ]
 
         Publishers.MergeMany(triggers)
@@ -80,7 +86,9 @@ final class QuotaEventCoordinator {
                 codexAccounts: codexAccounts.accounts,
                 codexAccountMetrics: dataManager.codexAccountMetrics,
                 grokAccounts: grokAccounts.accounts,
-                grokAccountMetrics: dataManager.grokAccountMetrics
+                grokAccountMetrics: dataManager.grokAccountMetrics,
+                openRouterAccounts: openRouterKeys.accounts,
+                openRouterAccountMetrics: dataManager.openRouterAccountMetrics
             ),
             enabledServices: providerVisibility.enabledServices
         )

--- a/MeterBar/App/UsageNotificationCoordinator.swift
+++ b/MeterBar/App/UsageNotificationCoordinator.swift
@@ -16,6 +16,7 @@ nonisolated protocol NotificationAccountIdentity {
 extension ClaudeCodeAccount: NotificationAccountIdentity {}
 extension CodexAccount: NotificationAccountIdentity {}
 extension GrokAccount: NotificationAccountIdentity {}
+extension OpenRouterAccount: NotificationAccountIdentity {}
 
 extension AccountNotificationIdentity {
     nonisolated init(account: some NotificationAccountIdentity) {
@@ -64,7 +65,8 @@ final class UsageNotificationCoordinator {
         isEnabled: (ServiceType) -> Bool,
         claude: NotificationAccountBundle,
         codex: NotificationAccountBundle,
-        grok: NotificationAccountBundle
+        grok: NotificationAccountBundle,
+        openRouter: NotificationAccountBundle
     ) -> [AccountNotificationPlanInput] {
         ServiceType.allCases.filter(\.hasAccountScopedNotifications).compactMap { service in
             switch service {
@@ -89,7 +91,14 @@ final class UsageNotificationCoordinator {
                     bundle: grok,
                     fallbackMetrics: metrics[.grok]
                 )
-            case .cursor, .openRouter:
+            case .openRouter:
+                return planInput(
+                    service: .openRouter,
+                    providerEnabled: isEnabled(.openRouter),
+                    bundle: openRouter,
+                    fallbackMetrics: metrics[.openRouter]
+                )
+            case .cursor:
                 assertionFailure(
                     "account-scoped notifications for \(service.rawValue) have no routing"
                 )
@@ -182,6 +191,11 @@ final class UsageNotificationCoordinator {
             GrokAccountStore.shared.$defaultAccountName.map { _ in () },
             GrokAccountStore.shared.$defaultAccountIsEnabled.map { _ in () }
         )
+        let openRouterKeyChanges = Publishers.Merge3(
+            OpenRouterAccountStore.shared.$customAccounts.map { _ in () },
+            OpenRouterAccountStore.shared.$defaultAccountName.map { _ in () },
+            OpenRouterAccountStore.shared.$defaultAccountIsEnabled.map { _ in () }
+        )
         let thresholdChanges = Publishers.Merge3(
             notificationPreferences.$isEnabled.map { _ in () },
             notificationPreferences.$warningThreshold.map { _ in () },
@@ -195,6 +209,7 @@ final class UsageNotificationCoordinator {
             claudeAccountChanges.eraseToAnyPublisher(),
             codexAccountChanges.eraseToAnyPublisher(),
             grokAccountChanges.eraseToAnyPublisher(),
+            openRouterKeyChanges.eraseToAnyPublisher(),
             visibilityChanges.eraseToAnyPublisher(),
             thresholdChanges.eraseToAnyPublisher()
         ]
@@ -263,6 +278,13 @@ final class UsageNotificationCoordinator {
                     ),
                     metrics: UsageDataManager.shared.grokAccountMetrics,
                     defaultID: GrokAccount.defaultID
+                ),
+                openRouter: NotificationAccountBundle(
+                    accounts: OpenRouterAccountStore.shared.accounts.map(
+                        AccountNotificationIdentity.init(account:)
+                    ),
+                    metrics: UsageDataManager.shared.openRouterAccountMetrics,
+                    defaultID: OpenRouterAccount.defaultID
                 )
             ),
             alreadyNotified: keys,

--- a/MeterBar/Models/MenuBarAccountSelection.swift
+++ b/MeterBar/Models/MenuBarAccountSelection.swift
@@ -102,6 +102,7 @@ nonisolated enum MenuBarAccountCatalog {
         claudeAccounts: [ClaudeCodeAccount],
         codexAccounts: [CodexAccount],
         grokAccounts: [GrokAccount] = [],
+        openRouterAccounts: [OpenRouterAccount] = [],
         enabledServices: Set<ServiceType>
     ) -> [MenuBarAccountIdentity] {
         let claude = claudeAccounts.map { account in
@@ -128,7 +129,15 @@ nonisolated enum MenuBarAccountCatalog {
                 isEnabled: account.isEnabled && enabledServices.contains(.grok)
             )
         }
-        return claude + codex + grok
+        let openRouter = openRouterAccounts.map { account in
+            identity(
+                service: .openRouter,
+                accountID: account.id,
+                rawName: account.name,
+                isEnabled: account.isEnabled && enabledServices.contains(.openRouter)
+            )
+        }
+        return claude + codex + grok + openRouter
     }
 
     // MARK: Private

--- a/MeterBar/Models/OpenRouterAccount.swift
+++ b/MeterBar/Models/OpenRouterAccount.swift
@@ -1,0 +1,288 @@
+import Combine
+import Foundation
+import MeterBarShared
+
+/// One OpenRouter API key under management.
+///
+/// The key material itself never lives here — it is a Keychain item keyed by
+/// `id` (see `OpenRouterService.keychainKey(for:)`). Only non-secret metadata
+/// (display name, enablement, order) persists to UserDefaults, and only that
+/// metadata mirrors to the CLI's refresh-configuration file.
+nonisolated struct OpenRouterAccount: Codable, Equatable, Identifiable, Sendable {
+    static let defaultName = "Default Key"
+    static let defaultID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4))
+
+    static let defaultAccount = OpenRouterAccount(
+        id: Self.defaultID,
+        name: Self.defaultName
+    )
+
+    let id: UUID
+    var name: String
+    var isEnabled: Bool
+
+    init(id: UUID, name: String, isEnabled: Bool = true) {
+        self.id = id
+        self.name = name
+        self.isEnabled = isEnabled
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        // Backward-compat: keys persisted before the enable/disable flag
+        // existed decode as enabled.
+        isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
+    }
+
+    var isDefault: Bool { id == Self.defaultID }
+}
+
+nonisolated enum OpenRouterAccountMutationOutcome: Equatable, Sendable {
+    case updated
+    case unchanged
+    case rejectedLastEnabledAccount
+}
+
+final class OpenRouterAccountStore: ObservableObject {
+    /// In demo mode the store is projected from the default account only, so
+    /// provider cards title generically ("OpenRouter") and never surface real
+    /// key names. The `init(accounts:)` projection reads and writes no real
+    /// `.standard` data.
+    static let shared = DemoMode.isActive
+        ? OpenRouterAccountStore(accounts: [.defaultAccount])
+        : OpenRouterAccountStore()
+
+    @Published private(set) var customAccounts: [OpenRouterAccount] = []
+    @Published private(set) var defaultAccountName = OpenRouterAccount.defaultName
+    @Published private(set) var defaultAccountIsEnabled = true
+    @Published private(set) var accountOrder: [UUID] = []
+
+    private let userDefaults: UserDefaults
+    private let refreshConfigurationDirectory: URL?
+
+    var accounts: [OpenRouterAccount] {
+        orderedAccounts(from: [
+            OpenRouterAccount(
+                id: OpenRouterAccount.defaultID,
+                name: defaultAccountName,
+                isEnabled: defaultAccountIsEnabled
+            )
+        ] + customAccounts)
+    }
+
+    var enabledAccounts: [OpenRouterAccount] {
+        accounts.filter(\.isEnabled)
+    }
+
+    init(userDefaults: UserDefaults = .standard, refreshConfigurationDirectory: URL? = nil) {
+        self.userDefaults = userDefaults
+        self.refreshConfigurationDirectory = refreshConfigurationDirectory
+            ?? (userDefaults === UserDefaults.standard ? SharedMetricsStore.containerURL : nil)
+        load()
+        persistRefreshConfiguration()
+    }
+
+    /// Read-only projection used by the bundled CLI.
+    init(accounts: [OpenRouterAccount]) {
+        userDefaults = .standard
+        refreshConfigurationDirectory = nil
+        let defaultAccount = accounts.first(where: \.isDefault) ?? .defaultAccount
+        defaultAccountName = defaultAccount.name
+        defaultAccountIsEnabled = defaultAccount.isEnabled
+        customAccounts = accounts.filter { !$0.isDefault }
+        accountOrder = accounts.map(\.id)
+    }
+
+    /// Returns the created account so the caller can store its key material in
+    /// the Keychain under the returned id — the store deliberately owns no
+    /// secrets.
+    @discardableResult
+    func addAccount(name: String) -> OpenRouterAccount? {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { return nil }
+
+        let account = OpenRouterAccount(id: UUID(), name: trimmedName)
+        customAccounts.append(account)
+        if !accountOrder.isEmpty {
+            accountOrder.append(account.id)
+            saveAccountOrder()
+        }
+        saveCustomAccounts()
+        return account
+    }
+
+    func updateAccount(id: UUID, name: String) {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { return }
+
+        if id == OpenRouterAccount.defaultID {
+            guard trimmedName != defaultAccountName else { return }
+            defaultAccountName = trimmedName
+            saveDefaultAccountName()
+            return
+        }
+
+        guard let index = customAccounts.firstIndex(where: { $0.id == id }) else { return }
+        guard customAccounts[index].name != trimmedName else { return }
+        var updatedAccounts = customAccounts
+        updatedAccounts[index].name = trimmedName
+        customAccounts = updatedAccounts
+        saveCustomAccounts()
+    }
+
+    func canDisableAccount(id: UUID) -> Bool {
+        guard let account = accounts.first(where: { $0.id == id }) else { return false }
+        return !account.isEnabled || enabledAccounts.count > 1
+    }
+
+    func canRemoveAccount(id: UUID) -> Bool {
+        guard id != OpenRouterAccount.defaultID,
+              let account = customAccounts.first(where: { $0.id == id }) else {
+            return false
+        }
+        return !account.isEnabled || enabledAccounts.count > 1
+    }
+
+    @discardableResult
+    func removeAccount(id: UUID) -> OpenRouterAccountMutationOutcome {
+        guard id != OpenRouterAccount.defaultID,
+              let account = customAccounts.first(where: { $0.id == id }) else {
+            return .unchanged
+        }
+        guard !account.isEnabled || enabledAccounts.count > 1 else {
+            return .rejectedLastEnabledAccount
+        }
+        customAccounts.removeAll { $0.id == id }
+        accountOrder.removeAll { $0 == id }
+        saveAccountOrder()
+        saveCustomAccounts()
+        return .updated
+    }
+
+    @discardableResult
+    func setEnabled(_ enabled: Bool, for id: UUID) -> OpenRouterAccountMutationOutcome {
+        if id == OpenRouterAccount.defaultID {
+            guard enabled != defaultAccountIsEnabled else { return .unchanged }
+            guard enabled || enabledAccounts.count > 1 else {
+                return .rejectedLastEnabledAccount
+            }
+            defaultAccountIsEnabled = enabled
+            saveDefaultAccountEnabled()
+            return .updated
+        }
+
+        guard let index = customAccounts.firstIndex(where: { $0.id == id }),
+              customAccounts[index].isEnabled != enabled else {
+            return .unchanged
+        }
+        guard enabled || enabledAccounts.count > 1 else {
+            return .rejectedLastEnabledAccount
+        }
+        var updatedAccounts = customAccounts
+        updatedAccounts[index].isEnabled = enabled
+        customAccounts = updatedAccounts
+        saveCustomAccounts()
+        return .updated
+    }
+
+    func moveAccounts(fromOffsets source: IndexSet, toOffset destination: Int) {
+        var ordered = accounts
+        let movingIndexes = source.sorted()
+        guard movingIndexes.allSatisfy({ ordered.indices.contains($0) }) else { return }
+
+        let movingAccounts = movingIndexes.map { ordered[$0] }
+        for index in movingIndexes.reversed() { ordered.remove(at: index) }
+        let removedBeforeDestination = movingIndexes.filter { $0 < destination }.count
+        let adjustedDestination = max(0, min(destination - removedBeforeDestination, ordered.count))
+        ordered.insert(contentsOf: movingAccounts, at: adjustedDestination)
+        accountOrder = ordered.map(\.id)
+        saveAccountOrder()
+    }
+
+    private func load() {
+        if let name = userDefaults.string(forKey: StorageKeys.openRouterDefaultAccountName)?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
+            defaultAccountName = name
+        }
+        if userDefaults.object(forKey: StorageKeys.openRouterDefaultAccountEnabled) != nil {
+            defaultAccountIsEnabled = userDefaults.bool(forKey: StorageKeys.openRouterDefaultAccountEnabled)
+        }
+        accountOrder = userDefaults.stringArray(forKey: StorageKeys.openRouterAccountOrder)?
+            .compactMap(UUID.init(uuidString:)) ?? []
+        if let data = userDefaults.data(forKey: StorageKeys.openRouterCustomAccounts),
+           let decoded = try? JSONDecoder().decode([OpenRouterAccount].self, from: data) {
+            customAccounts = decoded.filter { !$0.isDefault }
+        }
+        restoreDefaultAccountIfNeeded()
+        pruneAccountOrder()
+    }
+
+    private func saveCustomAccounts() {
+        guard let data = try? JSONEncoder().encode(customAccounts) else { return }
+        userDefaults.set(data, forKey: StorageKeys.openRouterCustomAccounts)
+        persistRefreshConfiguration()
+    }
+
+    private func saveDefaultAccountName() {
+        if defaultAccountName == OpenRouterAccount.defaultName {
+            userDefaults.removeObject(forKey: StorageKeys.openRouterDefaultAccountName)
+        } else {
+            userDefaults.set(defaultAccountName, forKey: StorageKeys.openRouterDefaultAccountName)
+        }
+        persistRefreshConfiguration()
+    }
+
+    private func saveDefaultAccountEnabled() {
+        if defaultAccountIsEnabled {
+            userDefaults.removeObject(forKey: StorageKeys.openRouterDefaultAccountEnabled)
+        } else {
+            userDefaults.set(false, forKey: StorageKeys.openRouterDefaultAccountEnabled)
+        }
+        persistRefreshConfiguration()
+    }
+
+    private func saveAccountOrder() {
+        if accountOrder.isEmpty {
+            userDefaults.removeObject(forKey: StorageKeys.openRouterAccountOrder)
+        } else {
+            userDefaults.set(accountOrder.map(\.uuidString), forKey: StorageKeys.openRouterAccountOrder)
+        }
+        persistRefreshConfiguration()
+    }
+
+    private func persistRefreshConfiguration() {
+        guard let refreshConfigurationDirectory else { return }
+        UsageRefreshConfigurationStore.saveOpenRouterAccounts(
+            accounts,
+            directory: refreshConfigurationDirectory
+        )
+    }
+
+    private func orderedAccounts(from unordered: [OpenRouterAccount]) -> [OpenRouterAccount] {
+        guard !accountOrder.isEmpty else { return unordered }
+        let byID = Dictionary(uniqueKeysWithValues: unordered.map { ($0.id, $0) })
+        let ordered = accountOrder.compactMap { byID[$0] }
+        let orderedIDs = Set(ordered.map(\.id))
+        return ordered + unordered.filter { !orderedIDs.contains($0.id) }
+    }
+
+    private func pruneAccountOrder() {
+        guard !accountOrder.isEmpty else { return }
+        let validIDs = Set([OpenRouterAccount.defaultID] + customAccounts.map(\.id))
+        let pruned = accountOrder.filter { validIDs.contains($0) }
+        guard pruned != accountOrder else { return }
+        accountOrder = pruned
+        saveAccountOrder()
+    }
+
+    /// Keys persisted by older builds could leave every key disabled. Keep the
+    /// sentinel internally and restore only that zero-config key so refresh,
+    /// widgets, and automation never wake up with an ambiguous empty set.
+    private func restoreDefaultAccountIfNeeded() {
+        guard !defaultAccountIsEnabled, !customAccounts.contains(where: \.isEnabled) else { return }
+        defaultAccountIsEnabled = true
+        saveDefaultAccountEnabled()
+    }
+}

--- a/MeterBar/Models/StorageKeys.swift
+++ b/MeterBar/Models/StorageKeys.swift
@@ -115,6 +115,17 @@ nonisolated enum StorageKeys {
     static let grokAccountOrder = "GrokAccountOrder"
     /// Cached per-account Grok metrics (JSON-encoded [UUID: UsageMetrics]).
     static let cachedGrokAccountMetrics = "CachedGrokAccountMetrics"
+    /// Extra OpenRouter API keys (JSON-encoded [OpenRouterAccount]). Key
+    /// material lives in the Keychain, never here.
+    static let openRouterCustomAccounts = "OpenRouterCustomAccounts"
+    /// User-chosen display name for the default OpenRouter key.
+    static let openRouterDefaultAccountName = "OpenRouterDefaultAccountName"
+    /// Whether the synthesized default OpenRouter key participates in tracking.
+    static let openRouterDefaultAccountEnabled = "OpenRouterDefaultAccountEnabled"
+    /// Persisted OpenRouter key display order (array of UUID strings).
+    static let openRouterAccountOrder = "OpenRouterAccountOrder"
+    /// Cached per-key OpenRouter metrics (JSON-encoded [UUID: UsageMetrics]).
+    static let cachedOpenRouterAccountMetrics = "CachedOpenRouterAccountMetrics"
     /// Global on/off switch for usage notifications.
     static let notificationsEnabled = "NotificationsEnabled"
     /// Raw value of the `NotificationThreshold` at which a warning notifies.

--- a/MeterBar/Services/DiagnosticsRunner.swift
+++ b/MeterBar/Services/DiagnosticsRunner.swift
@@ -47,12 +47,14 @@ enum DiagnosticsRunner {
     static func accountRefreshErrors(
         claudeAccountErrors: [UUID: ServiceError] = [:],
         codexAccountErrors: [UUID: ServiceError] = [:],
-        grokAccountErrors: [UUID: ServiceError] = [:]
+        grokAccountErrors: [UUID: ServiceError] = [:],
+        openRouterKeyErrors: [UUID: ServiceError] = [:]
     ) -> [ServiceType: [UUID: ServiceError]] {
         var result: [ServiceType: [UUID: ServiceError]] = [:]
         if !claudeAccountErrors.isEmpty { result[.claudeCode] = claudeAccountErrors }
         if !codexAccountErrors.isEmpty { result[.codexCli] = codexAccountErrors }
         if !grokAccountErrors.isEmpty { result[.grok] = grokAccountErrors }
+        if !openRouterKeyErrors.isEmpty { result[.openRouter] = openRouterKeyErrors }
         return result
     }
 
@@ -65,7 +67,8 @@ enum DiagnosticsRunner {
         claudeDefaultAccountEnabled: Bool,
         claudeEnabledAccountMetrics: [UsageMetrics],
         codexAccounts: [CodexAccount] = [.defaultAccount],
-        grokAccounts: [GrokAccount] = [.defaultAccount]
+        grokAccounts: [GrokAccount] = [.defaultAccount],
+        openRouterAccounts: [OpenRouterAccount] = [.defaultAccount]
     ) async -> [ProviderReadiness] {
         await Task.detached(priority: .userInitiated) {
             ProviderReadinessInspector.reports(
@@ -77,7 +80,8 @@ enum DiagnosticsRunner {
                 claudeDefaultAccountEnabled: claudeDefaultAccountEnabled,
                 claudeEnabledAccountMetrics: claudeEnabledAccountMetrics,
                 codexAccounts: codexAccounts,
-                grokAccounts: grokAccounts
+                grokAccounts: grokAccounts,
+                openRouterAccounts: openRouterAccounts
             )
         }.value
     }

--- a/MeterBar/Services/DiagnosticsRunner.swift
+++ b/MeterBar/Services/DiagnosticsRunner.swift
@@ -15,6 +15,9 @@ enum DiagnosticsRunner {
         let enabledClaudeCustomAccountIDs: [UUID]
         var enabledCodexAccountIDs: [UUID] = []
         var enabledGrokAccountIDs: [UUID] = []
+        /// Keys participate in the diagnostics re-run trigger like every other
+        /// provider's accounts.
+        var enabledOpenRouterKeyIDs: [UUID] = []
     }
 
     static func refreshErrors(

--- a/MeterBar/Services/OpenRouterService.swift
+++ b/MeterBar/Services/OpenRouterService.swift
@@ -71,6 +71,9 @@ final class OpenRouterService: ObservableObject {
         let deleted = keychain.delete(key: Self.keychainKey(for: accountID))
         accountLastErrors[accountID] = nil
         latestAccountObservations[accountID] = nil
+        if accountLastErrors.values.allSatisfy({ $0 == nil }) {
+            lastError = nil
+        }
         return deleted
     }
 
@@ -85,6 +88,11 @@ final class OpenRouterService: ObservableObject {
             let fetched = try await Self.fetchRemotely(apiKey: apiKey, fetchData: fetchData)
             accountLastErrors[account.id] = nil
             latestAccountObservations[account.id] = fetched.observation
+            // The aggregate clears only when every managed key is healthy;
+            // otherwise another key's failure remains the provider-wide state.
+            if accountLastErrors.values.allSatisfy({ $0 == nil }) {
+                lastError = nil
+            }
             return fetched.metrics
         } catch {
             let serviceError = ServiceSupport.serviceError(from: error)
@@ -198,15 +206,17 @@ final class OpenRouterService: ObservableObject {
     ///
     /// Running totals simply sum — each key reports its own spend. The
     /// authoritative daily total sums only when *every* polled key published
-    /// `usage_daily`; a partial sum would understate the day while looking
-    /// authoritative, so a missing report falls back to the delta path instead.
+    /// `usage_daily` (`allowsAuthoritativeDaily` additionally requires the
+    /// poll itself to be complete — a key that failed this poll would make any
+    /// daily sum understate the day); otherwise the delta path takes over.
     nonisolated static func aggregatedObservation(
         _ observations: [ProviderUsageObservation],
-        observedAt: Date
+        observedAt: Date,
+        allowsAuthoritativeDaily: Bool = true
     ) -> ProviderUsageObservation? {
         guard !observations.isEmpty else { return nil }
         let dailies = observations.map(\.authoritativeDailyTotal)
-        let authoritativeDaily: Double? = dailies.allSatisfy(\.isNotNil)
+        let authoritativeDaily: Double? = allowsAuthoritativeDaily && dailies.allSatisfy(\.isNotNil)
             ? dailies.compactMap { $0 }.reduce(0, +)
             : nil
         return ProviderUsageObservation(

--- a/MeterBar/Services/OpenRouterService.swift
+++ b/MeterBar/Services/OpenRouterService.swift
@@ -2,24 +2,29 @@ import Combine
 import Foundation
 import MeterBarShared
 
-/// Fetches OpenRouter account credits and optional per-key spending limits.
-/// The API key is stored in MeterBar's Keychain service and is only sent to
-/// OpenRouter's documented `/api/v1/credits` and `/api/v1/key` endpoints.
+/// Fetches OpenRouter account credits and optional per-key spending limits for
+/// every managed API key.
+///
+/// Each `OpenRouterAccount` owns one Keychain item keyed by its id; the key is
+/// sent only to OpenRouter's documented `/api/v1/credits` and `/api/v1/key`
+/// endpoints. The legacy single-key item (`keychainKey`) doubles as the
+/// default account's item, so pre-multi-key installs migrate without copying
+/// or rewriting anything.
 final class OpenRouterService: ObservableObject {
     nonisolated static let shared = OpenRouterService()
+    /// Legacy single-key item name — now the default account's Keychain key.
     nonisolated static let keychainKey = "openRouterAPIKey"
 
-    @Published private(set) var hasAccess: Bool
+    /// Most recent failure across all keys, cleared on any successful poll.
+    /// Aggregate surface for diagnostics views; per-key detail lives in
+    /// `accountLastErrors`.
     @Published private(set) var lastError: ServiceError?
+    /// Per-key refresh outcome, keyed by account id. Drives the Settings rows.
+    @Published private(set) var accountLastErrors: [UUID: ServiceError] = [:]
 
-    /// The running spend counter from the last successful poll.
-    ///
-    /// OpenRouter writes no session log and serves no dated history, so
-    /// differencing this scalar across polls is the only way its spend can reach
-    /// the chart at all — see `ProviderUsageLedger`. Held here rather than
-    /// returned inside `UsageMetrics`, which is serialized into the app-group
-    /// cache the widget and the CLI decode.
-    private(set) var latestUsageObservation: ProviderUsageObservation?
+    /// Latest per-key running-spend observations from the most recent polls.
+    /// `UsageDataManager` folds these into one provider-wide ledger entry.
+    private(set) var latestAccountObservations: [UUID: ProviderUsageObservation] = [:]
 
     private let keychain: KeychainManager
     private let fetchData: @Sendable (URLRequest) async throws -> Data
@@ -30,50 +35,61 @@ final class OpenRouterService: ObservableObject {
     ) {
         self.keychain = keychain
         self.fetchData = fetchData ?? Self.fetch
-        hasAccess = keychain.hasKey(key: Self.keychainKey)
+    }
+
+    /// The Keychain item name for one managed key. The default account keeps
+    /// the legacy single-key name so existing installs keep working unchanged.
+    nonisolated static func keychainKey(for accountID: UUID) -> String {
+        accountID == OpenRouterAccount.defaultID
+            ? keychainKey
+            : "\(keychainKey).\(accountID.uuidString)"
+    }
+
+    func hasKey(for accountID: UUID) -> Bool {
+        keychain.hasKey(key: Self.keychainKey(for: accountID))
+    }
+
+    /// Whether this key participates in refreshes. Sync and prompt-free: like
+    /// `KeychainManager.hasKey`, it probes attributes only and never decrypts.
+    func canAccess(account: OpenRouterAccount) -> Bool {
+        hasKey(for: account.id)
     }
 
     @discardableResult
-    func saveAPIKey(_ value: String) -> Bool {
+    func saveAPIKey(_ value: String, for accountID: UUID) -> Bool {
         let key = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !key.isEmpty, keychain.save(key: Self.keychainKey, value: key) else {
+        guard !key.isEmpty, keychain.save(key: Self.keychainKey(for: accountID), value: key) else {
             return false
         }
-        hasAccess = true
+        accountLastErrors[accountID] = nil
         lastError = nil
         return true
     }
 
     @discardableResult
-    func removeAPIKey() -> Bool {
-        let deleted = keychain.delete(key: Self.keychainKey)
-        hasAccess = keychain.hasKey(key: Self.keychainKey)
-        if !hasAccess {
-            lastError = nil
-        }
+    func removeAPIKey(for accountID: UUID) -> Bool {
+        let deleted = keychain.delete(key: Self.keychainKey(for: accountID))
+        accountLastErrors[accountID] = nil
+        latestAccountObservations[accountID] = nil
         return deleted
     }
 
-    func fetchUsageMetrics() async throws -> UsageMetrics {
-        guard let apiKey = keychain.get(key: Self.keychainKey) else {
+    func fetchUsageMetrics(account: OpenRouterAccount) async throws -> UsageMetrics {
+        guard let apiKey = keychain.get(key: Self.keychainKey(for: account.id)) else {
             let error = ServiceError.notAuthenticated
-            lastError = error
-            hasAccess = false
+            accountLastErrors[account.id] = error
             throw error
         }
 
         do {
             let fetched = try await Self.fetchRemotely(apiKey: apiKey, fetchData: fetchData)
-            latestUsageObservation = fetched.observation
-            hasAccess = true
-            lastError = nil
+            accountLastErrors[account.id] = nil
+            latestAccountObservations[account.id] = fetched.observation
             return fetched.metrics
         } catch {
             let serviceError = ServiceSupport.serviceError(from: error)
+            accountLastErrors[account.id] = serviceError
             lastError = serviceError
-            if case .notAuthenticated = serviceError {
-                hasAccess = false
-            }
             throw serviceError
         }
     }
@@ -177,6 +193,32 @@ final class OpenRouterService: ObservableObject {
         )
     }
 
+    /// Folds one poll's per-key readings into the single provider-wide ledger
+    /// observation.
+    ///
+    /// Running totals simply sum — each key reports its own spend. The
+    /// authoritative daily total sums only when *every* polled key published
+    /// `usage_daily`; a partial sum would understate the day while looking
+    /// authoritative, so a missing report falls back to the delta path instead.
+    nonisolated static func aggregatedObservation(
+        _ observations: [ProviderUsageObservation],
+        observedAt: Date
+    ) -> ProviderUsageObservation? {
+        guard !observations.isEmpty else { return nil }
+        let dailies = observations.map(\.authoritativeDailyTotal)
+        let authoritativeDaily: Double? = dailies.allSatisfy(\.isNotNil)
+            ? dailies.compactMap { $0 }.reduce(0, +)
+            : nil
+        return ProviderUsageObservation(
+            provider: .openRouter,
+            unit: .usd,
+            runningTotal: observations.reduce(0) { $0 + $1.runningTotal },
+            authoritativeDailyTotal: authoritativeDaily,
+            dayBoundary: .utc,
+            observedAt: observedAt
+        )
+    }
+
     nonisolated private static func request(path: String, apiKey: String) throws -> URLRequest {
         guard let url = URL(string: "https://openrouter.ai/api/v1/\(path)") else {
             throw ServiceError.invalidURL
@@ -217,6 +259,10 @@ final class OpenRouterService: ObservableObject {
             return (nil, nil)
         }
     }
+}
+
+private extension Optional where Wrapped == Double {
+    var isNotNil: Bool { self != nil }
 }
 
 // `nonisolated` keeps the Codable conformances usable from the detached fetch

--- a/MeterBar/Services/ProviderReadinessInspector.swift
+++ b/MeterBar/Services/ProviderReadinessInspector.swift
@@ -56,6 +56,7 @@ nonisolated public enum ProviderReadinessInspector {
         grokAccounts: [GrokAccount]? = nil,
         grokIsCLIInstalled: Bool? = nil,
         grokAuthProbe: ((GrokAccount) -> (exists: Bool, readable: Bool))? = nil,
+        openRouterAccounts: [OpenRouterAccount]? = nil,
         parseHealth: [ServiceType: ProviderParseHealthRecord]? = nil,
         cachedMetrics: [ServiceType: UsageMetrics]? = nil,
         cachedAccountMetrics: [AccountUsageSnapshot]? = nil
@@ -70,6 +71,9 @@ nonisolated public enum ProviderReadinessInspector {
             ?? [.defaultAccount]
         let configuredGrokAccounts = grokAccounts
             ?? configuration?.grokAccounts
+            ?? [.defaultAccount]
+        let configuredOpenRouterAccounts = openRouterAccounts
+            ?? configuration?.openRouterAccounts
             ?? [.defaultAccount]
         let mergedClaudeMetrics = snapshotsByID.merging(claudeAccountMetrics) { _, incoming in incoming }
         let health = parseHealth ?? ProviderParseHealthStore.sharedRecords()
@@ -106,7 +110,13 @@ nonisolated public enum ProviderReadinessInspector {
                 )
             },
             cursorReport: { error, date in [cursorReport(refreshError: error, now: date)] },
-            openRouterReport: { error, _ in [openRouterReport(refreshError: error)] },
+            openRouterReport: { error, _ in
+                openRouterReports(
+                    refreshError: error,
+                    accountRefreshErrors: accountRefreshErrors[.openRouter] ?? [:],
+                    accounts: configuredOpenRouterAccounts
+                )
+            },
             grokReport: { error, date in
                 grokReports(
                     refreshError: error,
@@ -363,6 +373,28 @@ nonisolated public enum ProviderReadinessInspector {
                 refreshError: sanitize(refreshError)
             )
         )
+    }
+
+    /// One report per enabled key plus a provider-wide aggregate when several
+    /// keys are tracked — same shape as Codex and Grok.
+    static func openRouterReports(
+        refreshError: ServiceError?,
+        accountRefreshErrors: [UUID: ServiceError],
+        accounts: [OpenRouterAccount],
+        keyProbe: ((OpenRouterAccount) -> Bool)? = nil
+    ) -> [ProviderReadiness] {
+        let reports = accounts.filter(\.isEnabled).map { account -> ProviderReadiness in
+            let hasKey = keyProbe.map { $0(account) }
+                ?? { KeychainManager.shared.hasKey(key: OpenRouterService.keychainKey(for: account.id)) }()
+            return ProviderReadinessEvaluator.openRouter(
+                OpenRouterReadinessInput(
+                    hasAPIKey: hasKey,
+                    refreshError: sanitize(accountRefreshErrors[account.id] ?? refreshError)
+                )
+            )
+            .withIdentity(.account(.openRouter, id: account.id, name: account.name))
+        }
+        return pack(provider: .openRouter, accountReports: reports)
     }
 
     static func grokReports(

--- a/MeterBar/Services/QuotaEventService.swift
+++ b/MeterBar/Services/QuotaEventService.swift
@@ -15,8 +15,8 @@ nonisolated struct QuotaEventSelectableAccount: Identifiable, Equatable, Sendabl
     }
 }
 
-/// Account-aware inputs for Claude, Codex, and Grok. Flat providers still
-/// arrive through the provider-wide metrics map.
+/// Account-aware inputs for Claude, Codex, Grok, and OpenRouter. Flat providers
+/// still arrive through the provider-wide metrics map.
 nonisolated struct QuotaEventAccountInputs: Sendable {
     var claudeAccounts: [ClaudeCodeAccount] = []
     var claudeAccountMetrics: [UUID: UsageMetrics] = [:]
@@ -24,6 +24,8 @@ nonisolated struct QuotaEventAccountInputs: Sendable {
     var codexAccountMetrics: [UUID: UsageMetrics] = [:]
     var grokAccounts: [GrokAccount] = []
     var grokAccountMetrics: [UUID: UsageMetrics] = [:]
+    var openRouterAccounts: [OpenRouterAccount] = []
+    var openRouterAccountMetrics: [UUID: UsageMetrics] = [:]
 }
 
 /// Builds the app-wide provider/account input without ever projecting
@@ -75,12 +77,14 @@ nonisolated enum QuotaEventSnapshotCatalog {
     static func selectableAccounts(
         claudeAccounts: [ClaudeCodeAccount],
         codexAccounts: [CodexAccount],
-        grokAccounts: [GrokAccount]
+        grokAccounts: [GrokAccount],
+        openRouterAccounts: [OpenRouterAccount] = []
     ) -> [QuotaEventSelectableAccount] {
         let inputs = QuotaEventAccountInputs(
             claudeAccounts: claudeAccounts,
             codexAccounts: codexAccounts,
-            grokAccounts: grokAccounts
+            grokAccounts: grokAccounts,
+            openRouterAccounts: openRouterAccounts
         )
         let flat = flatProviders.map {
             QuotaEventSelectableAccount(provider: $0, accountID: "default", name: $0.displayName)
@@ -135,7 +139,14 @@ nonisolated enum QuotaEventSnapshotCatalog {
                 },
                 accounts.grokAccountMetrics
             )
-        case .cursor, .openRouter:
+        case .openRouter:
+            return (
+                accounts.openRouterAccounts.map {
+                    AccountMetricIdentity(id: $0.id, name: $0.name, isEnabled: $0.isEnabled)
+                },
+                accounts.openRouterAccountMetrics
+            )
+        case .cursor:
             return nil
         }
     }

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -344,7 +344,8 @@ class UsageDataManager: ObservableObject {
             ?? openRouterResult?.firstFailure
             ?? simpleResults.firstFailure
 
-        // Claude Code metrics (local files)
+        // Claude Code metrics (local files). Its auth states and skip reason
+        // differ; Codex, Grok, and OpenRouter share `foldUniformAccountPhase`.
         if let claudeResult {
             claudeCodeAccountMetrics = claudeResult.metrics
             claudeCodeAccountStates = claudeResult.accountStates
@@ -361,49 +362,32 @@ class UsageDataManager: ObservableObject {
             states[.claudeCode] = (.skipped, claudeCodeSkipReason(hasEnabledAccount: hasEnabledClaudeAccount))
         }
 
-        if let codexResult {
-            codexAccountMetrics = codexResult.metrics
-            if let representative = representativeCodexMetrics(from: codexResult.metrics) {
-                newMetrics[.codexCli] = representative
-            }
-            states[.codexCli] = accountFetchState(codexResult)
-        } else {
-            codexAccountMetrics = [:]
-            states[.codexCli] = (
-                .skipped,
-                providerVisibilityStore.isEnabled(.codexCli) ? Self.noEnabledAccountsReason : Self.disabledReason
-            )
-        }
+        foldUniformAccountPhase(
+            .codexCli,
+            result: codexResult,
+            representative: { representativeCodexMetrics(from: $0.metrics) },
+            storeAccountMetrics: { codexAccountMetrics = $0?.metrics ?? [:] },
+            newMetrics: &newMetrics,
+            states: &states
+        )
 
-        if let grokResult {
-            grokAccountMetrics = grokResult.metrics
-            if let representative = representativeGrokMetrics(from: grokResult.metrics) {
-                newMetrics[.grok] = representative
-            }
-            states[.grok] = accountFetchState(grokResult)
-        } else {
-            grokAccountMetrics = [:]
-            states[.grok] = (
-                .skipped,
-                providerVisibilityStore.isEnabled(.grok) ? Self.noEnabledAccountsReason : Self.disabledReason
-            )
-        }
+        foldUniformAccountPhase(
+            .grok,
+            result: grokResult,
+            representative: { representativeGrokMetrics(from: $0.metrics) },
+            storeAccountMetrics: { grokAccountMetrics = $0?.metrics ?? [:] },
+            newMetrics: &newMetrics,
+            states: &states
+        )
 
-        if let openRouterResult {
-            openRouterAccountMetrics = openRouterResult.metrics
-            if let representative = representativeOpenRouterMetrics(from: openRouterResult.metrics) {
-                newMetrics[.openRouter] = representative
-            }
-            states[.openRouter] = accountFetchState(openRouterResult)
-        } else {
-            openRouterAccountMetrics = [:]
-            states[.openRouter] = (
-                .skipped,
-                providerVisibilityStore.isEnabled(.openRouter)
-                    ? Self.noEnabledAccountsReason
-                    : Self.disabledReason
-            )
-        }
+        foldUniformAccountPhase(
+            .openRouter,
+            result: openRouterResult,
+            representative: { representativeOpenRouterMetrics(from: $0.metrics) },
+            storeAccountMetrics: { openRouterAccountMetrics = $0?.metrics ?? [:] },
+            newMetrics: &newMetrics,
+            states: &states
+        )
 
         // Simple (single-account) providers. On failure the final merge loop
         // below preserves any cached metrics (graceful degradation).
@@ -444,6 +428,33 @@ class UsageDataManager: ObservableObject {
     private static let noEnabledAccountsReason = "No enabled accounts for this provider."
     private static let refreshContendedReason = "Another MeterBar refresh is already running."
     private static let refreshLockUnavailableReason = "The shared MeterBar refresh lock is unavailable."
+
+    /// Folds one Codex/Grok/OpenRouter-shaped account phase into the committed
+    /// snapshot: publish the fetch result and its representative, or clear the
+    /// phase's caches and mark it skipped when it never ran (disabled or no
+    /// enabled accounts). Claude has its own block above.
+    private func foldUniformAccountPhase(
+        _ service: ServiceType,
+        result: AccountFetchResult?,
+        representative: (AccountFetchResult) -> UsageMetrics?,
+        storeAccountMetrics: (AccountFetchResult?) -> Void,
+        newMetrics: inout [ServiceType: UsageMetrics],
+        states: inout [ServiceType: (state: ProviderRefreshState, reason: String?)]
+    ) {
+        if let result {
+            storeAccountMetrics(result)
+            if let representative = representative(result) {
+                newMetrics[service] = representative
+            }
+            states[service] = accountFetchState(result)
+        } else {
+            storeAccountMetrics(nil)
+            states[service] = (
+                .skipped,
+                providerVisibilityStore.isEnabled(service) ? Self.noEnabledAccountsReason : Self.disabledReason
+            )
+        }
+    }
 
     private enum RefreshLockLease {
         case acquired(WakeLock?)
@@ -648,6 +659,41 @@ class UsageDataManager: ObservableObject {
         }
     }
 
+    /// Clears one provider's per-account caches (used on disable and when its
+    /// enabled-account set becomes empty). Cursor has no account caches.
+    private func clearAccountState(for service: ServiceType) {
+        switch service {
+        case .claudeCode:
+            claudeCodeAccountMetrics = [:]
+            claudeCodeAccountStates = [:]
+        case .codexCli:
+            codexAccountMetrics = [:]
+        case .grok:
+            grokAccountMetrics = [:]
+        case .openRouter:
+            openRouterAccountMetrics = [:]
+        case .cursor:
+            break
+        }
+    }
+
+    /// How many enabled accounts back `service`'s fetch. `nil` for the
+    /// single-account providers, which have no empty-set early-out.
+    private func enabledAccountCount(for service: ServiceType) -> Int? {
+        switch service {
+        case .claudeCode:
+            return claudeCodeAccountStore.enabledAccounts.count
+        case .codexCli:
+            return codexAccountStore.enabledAccounts.count
+        case .grok:
+            return grokAccountStore.enabledAccounts.count
+        case .openRouter:
+            return openRouterAccountStore.enabledAccounts.count
+        case .cursor:
+            return nil
+        }
+    }
+
     func refresh(service: ServiceType) async {
         guard !demoMode else { return }
         lastMeterBarInteractionAt = adaptiveNow()
@@ -661,44 +707,15 @@ class UsageDataManager: ObservableObject {
 
         guard providerVisibilityStore.isEnabled(service) else {
             metrics.removeValue(forKey: service)
-            if service == .claudeCode {
-                claudeCodeAccountMetrics = [:]
-                claudeCodeAccountStates = [:]
-            } else if service == .codexCli {
-                codexAccountMetrics = [:]
-            } else if service == .grok {
-                grokAccountMetrics = [:]
-            } else if service == .openRouter {
-                openRouterAccountMetrics = [:]
-            }
+            clearAccountState(for: service)
             publishMetrics()
             return
         }
 
-        if service == .claudeCode, claudeCodeAccountStore.enabledAccounts.isEmpty {
-            claudeCodeAccountMetrics = [:]
-            claudeCodeAccountStates = [:]
-            metrics.removeValue(forKey: service)
-            publishMetrics()
-            return
-        }
-
-        if service == .codexCli, codexAccountStore.enabledAccounts.isEmpty {
-            codexAccountMetrics = [:]
-            metrics.removeValue(forKey: service)
-            publishMetrics()
-            return
-        }
-
-        if service == .grok, grokAccountStore.enabledAccounts.isEmpty {
-            grokAccountMetrics = [:]
-            metrics.removeValue(forKey: service)
-            publishMetrics()
-            return
-        }
-
-        if service == .openRouter, openRouterAccountStore.enabledAccounts.isEmpty {
-            openRouterAccountMetrics = [:]
+        // Every account-aware provider with zero enabled accounts has nothing
+        // to fetch; Cursor (single-account) never takes this early-out.
+        if enabledAccountCount(for: service) == 0 {
+            clearAccountState(for: service)
             metrics.removeValue(forKey: service)
             publishMetrics()
             return
@@ -813,8 +830,32 @@ class UsageDataManager: ObservableObject {
 
     private func refreshedMetrics(for service: ServiceType) async throws -> UsageMetrics {
         switch service {
-        // The account fetchers report their first failure instead of writing
-        // `lastError` themselves (see `refreshAll`), so this path surfaces it.
+        case .cursor:
+            return try await refreshedCursorMetrics()
+        case .claudeCode, .codexCli, .grok, .openRouter:
+            return try await refreshedAccountAwareMetrics(for: service)
+        }
+    }
+
+    /// Cursor's single-account refresh with cache-preserving degradation.
+    private func refreshedCursorMetrics() async throws -> UsageMetrics {
+        guard hasProviderAccess(.cursor) else { throw ServiceError.notAuthenticated }
+        do {
+            return try await fetchSimpleProviderMetrics(.cursor)
+        } catch {
+            if let cachedMetric = metrics[.cursor] {
+                lastError = error
+                return cachedMetric
+            }
+            throw error
+        }
+    }
+
+    /// The account-aware providers' per-service refresh. Each account fetcher
+    /// reports its first failure instead of writing `lastError` itself (see
+    /// `refreshAll`), so this path surfaces it.
+    private func refreshedAccountAwareMetrics(for service: ServiceType) async throws -> UsageMetrics {
+        switch service {
         case .claudeCode:
             let fetch = await fetchClaudeCodeAccountMetrics(trigger: .userInitiated)
             claudeCodeAccountMetrics = fetch.metrics
@@ -840,16 +881,7 @@ class UsageDataManager: ObservableObject {
             if let representative = representativeOpenRouterMetrics(from: fetch.metrics) { return representative }
             throw ServiceError.notAuthenticated
         case .cursor:
-            guard hasProviderAccess(service) else { throw ServiceError.notAuthenticated }
-            do {
-                return try await fetchSimpleProviderMetrics(service)
-            } catch {
-                if let cachedMetric = metrics[service] {
-                    lastError = error
-                    return cachedMetric
-                }
-                throw error
-            }
+            preconditionFailure("Cursor uses refreshedCursorMetrics")
         }
 
         if let cachedMetric = metrics[service] { return cachedMetric }
@@ -903,22 +935,18 @@ class UsageDataManager: ObservableObject {
     }
 
     private func loadCachedAccountMetrics() {
-        if let data = cacheDefaults.data(forKey: StorageKeys.cachedClaudeCodeAccountMetrics),
-           let decoded = try? JSONDecoder().decode([UUID: UsageMetrics].self, from: data) {
-            claudeCodeAccountMetrics = decoded
-        }
-        if let data = cacheDefaults.data(forKey: StorageKeys.cachedCodexAccountMetrics),
-           let decoded = try? JSONDecoder().decode([UUID: UsageMetrics].self, from: data) {
-            codexAccountMetrics = decoded
-        }
-        if let data = cacheDefaults.data(forKey: StorageKeys.cachedGrokAccountMetrics),
-           let decoded = try? JSONDecoder().decode([UUID: UsageMetrics].self, from: data) {
-            grokAccountMetrics = decoded
-        }
-        if let data = cacheDefaults.data(forKey: StorageKeys.cachedOpenRouterAccountMetrics),
-           let decoded = try? JSONDecoder().decode([UUID: UsageMetrics].self, from: data) {
-            openRouterAccountMetrics = decoded
-        }
+        claudeCodeAccountMetrics = Self.decodedAccountCache(
+            StorageKeys.cachedClaudeCodeAccountMetrics, in: cacheDefaults
+        ) ?? claudeCodeAccountMetrics
+        codexAccountMetrics = Self.decodedAccountCache(
+            StorageKeys.cachedCodexAccountMetrics, in: cacheDefaults
+        ) ?? codexAccountMetrics
+        grokAccountMetrics = Self.decodedAccountCache(
+            StorageKeys.cachedGrokAccountMetrics, in: cacheDefaults
+        ) ?? grokAccountMetrics
+        openRouterAccountMetrics = Self.decodedAccountCache(
+            StorageKeys.cachedOpenRouterAccountMetrics, in: cacheDefaults
+        ) ?? openRouterAccountMetrics
 
         guard claudeCodeAccountMetrics.isEmpty
             || codexAccountMetrics.isEmpty
@@ -928,33 +956,36 @@ class UsageDataManager: ObservableObject {
         }
         let sharedSnapshots = sharedStore.loadAccountMetrics()
         if claudeCodeAccountMetrics.isEmpty {
-            claudeCodeAccountMetrics = Dictionary(
-                uniqueKeysWithValues: sharedSnapshots
-                    .filter { $0.metrics.service == .claudeCode }
-                    .map { ($0.id, $0.metrics) }
-            )
+            claudeCodeAccountMetrics = Self.sharedFallback(.claudeCode, from: sharedSnapshots)
         }
         if codexAccountMetrics.isEmpty {
-            codexAccountMetrics = Dictionary(
-                uniqueKeysWithValues: sharedSnapshots
-                    .filter { $0.metrics.service == .codexCli }
-                    .map { ($0.id, $0.metrics) }
-            )
+            codexAccountMetrics = Self.sharedFallback(.codexCli, from: sharedSnapshots)
         }
         if grokAccountMetrics.isEmpty {
-            grokAccountMetrics = Dictionary(
-                uniqueKeysWithValues: sharedSnapshots
-                    .filter { $0.metrics.service == .grok }
-                    .map { ($0.id, $0.metrics) }
-            )
+            grokAccountMetrics = Self.sharedFallback(.grok, from: sharedSnapshots)
         }
         if openRouterAccountMetrics.isEmpty {
-            openRouterAccountMetrics = Dictionary(
-                uniqueKeysWithValues: sharedSnapshots
-                    .filter { $0.metrics.service == .openRouter }
-                    .map { ($0.id, $0.metrics) }
-            )
+            openRouterAccountMetrics = Self.sharedFallback(.openRouter, from: sharedSnapshots)
         }
+    }
+
+    private static func decodedAccountCache(
+        _ key: String,
+        in defaults: UserDefaults
+    ) -> [UUID: UsageMetrics]? {
+        guard let data = defaults.data(forKey: key) else { return nil }
+        return try? JSONDecoder().decode([UUID: UsageMetrics].self, from: data)
+    }
+
+    private static func sharedFallback(
+        _ service: ServiceType,
+        from snapshots: [AccountUsageSnapshot]
+    ) -> [UUID: UsageMetrics] {
+        Dictionary(
+            uniqueKeysWithValues: snapshots
+                .filter { $0.metrics.service == service }
+                .map { ($0.id, $0.metrics) }
+        )
     }
 
     private func saveCachedAccountMetrics() {
@@ -986,7 +1017,7 @@ class UsageDataManager: ObservableObject {
             guard let metrics = grokAccountMetrics[account.id] else { return nil }
             return AccountUsageSnapshot(id: account.id, name: account.name, metrics: metrics)
         }
-        let openRouterSnapshots = openRouterAccountStore.enabledAccounts.compactMap { account -> AccountUsageSnapshot? in
+        let openRouterSnapshots: [AccountUsageSnapshot] = openRouterAccountStore.enabledAccounts.compactMap { account in
             guard let metrics = openRouterAccountMetrics[account.id] else { return nil }
             return AccountUsageSnapshot(id: account.id, name: account.name, metrics: metrics)
         }

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -1414,6 +1414,10 @@ class UsageDataManager: ObservableObject {
         var refreshedMetrics: [UUID: UsageMetrics] = [:]
         var firstFailure: Error?
         var successCount = 0
+        // Keys that succeeded *this poll*. Only their observations fold into
+        // the ledger — a key that failed keeps a stale counter from an earlier
+        // poll, and summing it in would look like spend moved when it didn't.
+        var polledObservations: [ProviderUsageObservation] = []
 
         let legs = await fanOut(count: enabledAccounts.count) { [enabledAccounts] index in
             let account = enabledAccounts[index]
@@ -1427,6 +1431,9 @@ class UsageDataManager: ObservableObject {
             if let metrics = leg.metrics {
                 refreshedMetrics[account.id] = metrics
                 successCount += 1
+                if let observation = openRouterService.latestAccountObservations[account.id] {
+                    polledObservations.append(observation)
+                }
             } else if let error = leg.error {
                 // A keyless account is a skip, not a failure, and must not
                 // resurrect a stale cache — same semantics as Codex/Grok.
@@ -1444,7 +1451,10 @@ class UsageDataManager: ObservableObject {
             parseHealthStore.recordFailure(.openRouter, error: firstFailure)
         }
 
-        recordOpenRouterLedgerObservation(successCount: successCount)
+        recordOpenRouterLedgerObservation(
+            polledObservations,
+            allowsAuthoritativeDaily: successCount == enabledAccounts.count
+        )
 
         return AccountFetchResult(
             metrics: refreshedMetrics,
@@ -1454,15 +1464,18 @@ class UsageDataManager: ObservableObject {
     }
 
     /// Folds this poll's per-key spend readings into the single provider-wide
-    /// ledger entry. Keys that failed keep their previous contribution out of
-    /// the sum — a partial poll must not look like spend went backwards.
-    private func recordOpenRouterLedgerObservation(successCount: Int) {
-        guard !demoMode, let store = usageLedgerStore, successCount > 0 else { return }
-        let polledKeys = openRouterAccountStore.enabledAccounts.filter {
-            openRouterService.latestAccountObservations[$0.id] != nil
-        }
-        let observations = polledKeys.compactMap { openRouterService.latestAccountObservations[$0.id] }
-        guard let aggregated = OpenRouterService.aggregatedObservation(observations, observedAt: Date()) else {
+    /// ledger entry. Only keys that succeeded this poll contribute; the sum of
+    /// a partial poll is still honest because each key's counter is its own.
+    private func recordOpenRouterLedgerObservation(
+        _ observations: [ProviderUsageObservation],
+        allowsAuthoritativeDaily: Bool
+    ) {
+        guard !demoMode, let store = usageLedgerStore, !observations.isEmpty else { return }
+        guard let aggregated = OpenRouterService.aggregatedObservation(
+            observations,
+            observedAt: Date(),
+            allowsAuthoritativeDaily: allowsAuthoritativeDaily
+        ) else {
             return
         }
 

--- a/MeterBar/Services/UsageDataManager.swift
+++ b/MeterBar/Services/UsageDataManager.swift
@@ -31,7 +31,6 @@ extension SimpleUsageProviding {
 }
 
 extension CursorLocalService: SimpleUsageProviding {}
-extension OpenRouterService: SimpleUsageProviding {}
 
 protocol ClaudeCodeUsageProviding: AnyObject {
     var hasAccess: Bool { get }
@@ -77,6 +76,19 @@ protocol GrokUsageProviding: AnyObject {
 
 extension GrokCLIUsageService: GrokUsageProviding {}
 
+/// Account-aware seam for the OpenRouter API keys. `canAccess` is a sync,
+/// prompt-free Keychain attribute probe (never a decrypt), so — unlike Codex's
+/// async probe — it can gate the leg directly.
+protocol OpenRouterUsageProviding: AnyObject {
+    func canAccess(account: OpenRouterAccount) -> Bool
+    func fetchUsageMetrics(account: OpenRouterAccount) async throws -> UsageMetrics
+    /// Per-key running-spend observations from the most recent polls, keyed by
+    /// account id. Read after the fan-out folds to build the ledger entry.
+    var latestAccountObservations: [UUID: ProviderUsageObservation] { get }
+}
+
+extension OpenRouterService: OpenRouterUsageProviding {}
+
 @MainActor
 class UsageDataManager: ObservableObject {
     static let shared = UsageDataManager(demoMode: DemoMode.isActive)
@@ -89,6 +101,7 @@ class UsageDataManager: ObservableObject {
     @Published private(set) var claudeCodeAccountStates: [UUID: ClaudeCodeAuthState] = [:]
     @Published var codexAccountMetrics: [UUID: UsageMetrics] = [:]
     @Published var grokAccountMetrics: [UUID: UsageMetrics] = [:]
+    @Published var openRouterAccountMetrics: [UUID: UsageMetrics] = [:]
     @Published var isLoading: Bool = false
     @Published var lastError: Error?
     /// Human-readable explanation for the interval currently installed. The
@@ -117,11 +130,12 @@ class UsageDataManager: ObservableObject {
     private let claudeCodeService: ClaudeCodeUsageProviding
     private let cursorService: SimpleUsageProviding
     private let codexCliService: CodexUsageProviding
-    private let openRouterService: SimpleUsageProviding
+    private let openRouterService: OpenRouterUsageProviding
     private let grokService: GrokUsageProviding
     private let claudeCodeAccountStore: ClaudeCodeAccountStore
     private let codexAccountStore: CodexAccountStore
     private let grokAccountStore: GrokAccountStore
+    private let openRouterAccountStore: OpenRouterAccountStore
     private let providerVisibilityStore: ProviderVisibilityStore
     private let parseHealthStore: ProviderParseHealthStore
     private let refreshLockMode: UsageRefreshLockMode
@@ -164,12 +178,13 @@ class UsageDataManager: ObservableObject {
     init(
         codexCliService: CodexUsageProviding? = nil,
         cursorService: SimpleUsageProviding = CursorLocalService.shared,
-        openRouterService: SimpleUsageProviding = OpenRouterService.shared,
+        openRouterService: OpenRouterUsageProviding = OpenRouterService.shared,
         grokService: GrokUsageProviding = GrokCLIUsageService.shared,
         claudeCodeService: ClaudeCodeUsageProviding = ClaudeCodeLocalService.shared,
         claudeCodeAccountStore: ClaudeCodeAccountStore? = nil,
         codexAccountStore: CodexAccountStore? = nil,
         grokAccountStore: GrokAccountStore? = nil,
+        openRouterAccountStore: OpenRouterAccountStore? = nil,
         providerVisibilityStore: ProviderVisibilityStore? = nil,
         sharedStore: SharedDataStore = .shared,
         preferences: UserDefaults = .standard,
@@ -195,6 +210,7 @@ class UsageDataManager: ObservableObject {
         self.claudeCodeAccountStore = claudeCodeAccountStore ?? .shared
         self.codexAccountStore = codexAccountStore ?? .shared
         self.grokAccountStore = grokAccountStore ?? .shared
+        self.openRouterAccountStore = openRouterAccountStore ?? .shared
         self.providerVisibilityStore = providerVisibilityStore ?? .shared
         self.sharedStore = sharedStore
         self.preferences = preferences
@@ -291,6 +307,7 @@ class UsageDataManager: ObservableObject {
         let hasEnabledClaudeAccount = !claudeCodeAccountStore.enabledAccounts.isEmpty
         let hasEnabledCodexAccount = !codexAccountStore.enabledAccounts.isEmpty
         let hasEnabledGrokAccount = !grokAccountStore.enabledAccounts.isEmpty
+        let hasEnabledOpenRouterKey = !openRouterAccountStore.enabledAccounts.isEmpty
 
         // The four phases own disjoint state, so they run concurrently: a cycle
         // now costs the slowest phase instead of their sum. Every published
@@ -307,11 +324,15 @@ class UsageDataManager: ObservableObject {
         async let grokFetch = grokAccountFetch(
             isEnabled: providerVisibilityStore.isEnabled(.grok) && hasEnabledGrokAccount
         )
+        async let openRouterFetch = openRouterAccountFetch(
+            isEnabled: providerVisibilityStore.isEnabled(.openRouter) && hasEnabledOpenRouterKey
+        )
         async let simpleFetch = refreshSimpleProviders()
 
         let claudeResult = await claudeFetch
         let codexResult = await codexFetch
         let grokResult = await grokFetch
+        let openRouterResult = await openRouterFetch
         let simpleResults = await simpleFetch
 
         // Rank the phases here, in a fixed order, rather than letting each one
@@ -320,6 +341,7 @@ class UsageDataManager: ObservableObject {
         lastError = claudeResult?.firstFailure
             ?? codexResult?.firstFailure
             ?? grokResult?.firstFailure
+            ?? openRouterResult?.firstFailure
             ?? simpleResults.firstFailure
 
         // Claude Code metrics (local files)
@@ -367,6 +389,22 @@ class UsageDataManager: ObservableObject {
             )
         }
 
+        if let openRouterResult {
+            openRouterAccountMetrics = openRouterResult.metrics
+            if let representative = representativeOpenRouterMetrics(from: openRouterResult.metrics) {
+                newMetrics[.openRouter] = representative
+            }
+            states[.openRouter] = accountFetchState(openRouterResult)
+        } else {
+            openRouterAccountMetrics = [:]
+            states[.openRouter] = (
+                .skipped,
+                providerVisibilityStore.isEnabled(.openRouter)
+                    ? Self.noEnabledAccountsReason
+                    : Self.disabledReason
+            )
+        }
+
         // Simple (single-account) providers. On failure the final merge loop
         // below preserves any cached metrics (graceful degradation).
         newMetrics.merge(simpleResults.metrics) { _, refreshed in refreshed }
@@ -376,7 +414,7 @@ class UsageDataManager: ObservableObject {
         for service in ServiceType.allCases where providerVisibilityStore.isEnabled(service) {
             if service == .claudeCode, !hasEnabledClaudeAccount { continue }
             // Account caches are merged during their provider-specific refresh.
-            if service == .codexCli || service == .grok { continue }
+            if service == .codexCli || service == .grok || service == .openRouter { continue }
             if newMetrics[service] == nil, let cachedMetric = self.metrics[service] {
                 newMetrics[service] = cachedMetric
             }
@@ -532,7 +570,8 @@ class UsageDataManager: ObservableObject {
 
         // Visibility and access are synchronous, so resolve them up front and
         // fan out only the legs that will actually reach a provider.
-        for service in [ServiceType.cursor, .openRouter] {
+        // OpenRouter left this path for the account-aware fetcher.
+        for service in [ServiceType.cursor] {
             guard providerVisibilityStore.isEnabled(service) else {
                 states[service] = (.skipped, Self.disabledReason)
                 continue
@@ -604,9 +643,7 @@ class UsageDataManager: ObservableObject {
         switch service {
         case .cursor:
             return cursorService
-        case .openRouter:
-            return openRouterService
-        case .claudeCode, .codexCli, .grok:
+        case .claudeCode, .codexCli, .grok, .openRouter:
             return nil
         }
     }
@@ -631,6 +668,8 @@ class UsageDataManager: ObservableObject {
                 codexAccountMetrics = [:]
             } else if service == .grok {
                 grokAccountMetrics = [:]
+            } else if service == .openRouter {
+                openRouterAccountMetrics = [:]
             }
             publishMetrics()
             return
@@ -658,6 +697,13 @@ class UsageDataManager: ObservableObject {
             return
         }
 
+        if service == .openRouter, openRouterAccountStore.enabledAccounts.isEmpty {
+            openRouterAccountMetrics = [:]
+            metrics.removeValue(forKey: service)
+            publishMetrics()
+            return
+        }
+
         do {
             let newMetrics = try await refreshedMetrics(for: service)
 
@@ -667,7 +713,7 @@ class UsageDataManager: ObservableObject {
             if lastError == nil {
                 lastError = error
             }
-            if service == .codexCli || service == .grok {
+            if service == .codexCli || service == .grok || service == .openRouter {
                 // Account-aware aggregate metrics carry no account identity. Scoped
                 // per-account caches are restored inside the provider fetcher;
                 // if none exist, showing no data is safer than relabeling a
@@ -787,7 +833,13 @@ class UsageDataManager: ObservableObject {
             if let failure = fetch.firstFailure { lastError = failure }
             if let representative = representativeGrokMetrics(from: fetch.metrics) { return representative }
             throw ServiceError.notAuthenticated
-        case .cursor, .openRouter:
+        case .openRouter:
+            let fetch = await fetchOpenRouterAccountMetrics()
+            openRouterAccountMetrics = fetch.metrics
+            if let failure = fetch.firstFailure { lastError = failure }
+            if let representative = representativeOpenRouterMetrics(from: fetch.metrics) { return representative }
+            throw ServiceError.notAuthenticated
+        case .cursor:
             guard hasProviderAccess(service) else { throw ServiceError.notAuthenticated }
             do {
                 return try await fetchSimpleProviderMetrics(service)
@@ -863,10 +915,15 @@ class UsageDataManager: ObservableObject {
            let decoded = try? JSONDecoder().decode([UUID: UsageMetrics].self, from: data) {
             grokAccountMetrics = decoded
         }
+        if let data = cacheDefaults.data(forKey: StorageKeys.cachedOpenRouterAccountMetrics),
+           let decoded = try? JSONDecoder().decode([UUID: UsageMetrics].self, from: data) {
+            openRouterAccountMetrics = decoded
+        }
 
         guard claudeCodeAccountMetrics.isEmpty
             || codexAccountMetrics.isEmpty
-            || grokAccountMetrics.isEmpty else {
+            || grokAccountMetrics.isEmpty
+            || openRouterAccountMetrics.isEmpty else {
             return
         }
         let sharedSnapshots = sharedStore.loadAccountMetrics()
@@ -891,6 +948,13 @@ class UsageDataManager: ObservableObject {
                     .map { ($0.id, $0.metrics) }
             )
         }
+        if openRouterAccountMetrics.isEmpty {
+            openRouterAccountMetrics = Dictionary(
+                uniqueKeysWithValues: sharedSnapshots
+                    .filter { $0.metrics.service == .openRouter }
+                    .map { ($0.id, $0.metrics) }
+            )
+        }
     }
 
     private func saveCachedAccountMetrics() {
@@ -902,6 +966,9 @@ class UsageDataManager: ObservableObject {
         }
         if let data = try? JSONEncoder().encode(grokAccountMetrics) {
             cacheDefaults.set(data, forKey: StorageKeys.cachedGrokAccountMetrics)
+        }
+        if let data = try? JSONEncoder().encode(openRouterAccountMetrics) {
+            cacheDefaults.set(data, forKey: StorageKeys.cachedOpenRouterAccountMetrics)
         }
     }
 
@@ -919,7 +986,11 @@ class UsageDataManager: ObservableObject {
             guard let metrics = grokAccountMetrics[account.id] else { return nil }
             return AccountUsageSnapshot(id: account.id, name: account.name, metrics: metrics)
         }
-        let accountSnapshots = claudeSnapshots + codexSnapshots + grokSnapshots
+        let openRouterSnapshots = openRouterAccountStore.enabledAccounts.compactMap { account -> AccountUsageSnapshot? in
+            guard let metrics = openRouterAccountMetrics[account.id] else { return nil }
+            return AccountUsageSnapshot(id: account.id, name: account.name, metrics: metrics)
+        }
+        let accountSnapshots = claudeSnapshots + codexSnapshots + grokSnapshots + openRouterSnapshots
         sharedStore.saveAccountMetrics(accountSnapshots)
     }
 
@@ -1022,6 +1093,9 @@ class UsageDataManager: ObservableObject {
         for (accountID, accountMetrics) in grokAccountMetrics {
             collect(accountMetrics, prefix: "grok.\(accountID.uuidString)")
         }
+        for (accountID, accountMetrics) in openRouterAccountMetrics {
+            collect(accountMetrics, prefix: "openrouter.\(accountID.uuidString)")
+        }
         return AdaptiveQuotaSnapshot(values: values)
     }
 
@@ -1069,7 +1143,15 @@ class UsageDataManager: ObservableObject {
             }
         }
 
-        for service in [ServiceType.cursor, .openRouter]
+        if providerVisibilityStore.isEnabled(.openRouter),
+           !openRouterAccountStore.enabledAccounts.isEmpty {
+            for account in openRouterAccountStore.enabledAccounts
+            where openRouterService.canAccess(account: account) {
+                collect(openRouterAccountMetrics[account.id])
+            }
+        }
+
+        for service in [ServiceType.cursor]
         where providerVisibilityStore.isEnabled(service) && hasProviderAccess(service) {
             collect(metrics[service])
         }
@@ -1096,6 +1178,9 @@ class UsageDataManager: ObservableObject {
     /// account contributes no metrics, no cached fallback, and no failure.
     private struct CodexAccountUnreachable: Error {}
     private struct GrokAccountUnreachable: Error {}
+    /// A key with no Keychain item: a skip, not a failure — the account exists
+    /// but its credential was never entered (or was removed).
+    private struct OpenRouterKeyUnreachable: Error {}
 
     private func claudeAccountFetch(
         isEnabled: Bool,
@@ -1113,6 +1198,11 @@ class UsageDataManager: ObservableObject {
     private func grokAccountFetch(isEnabled: Bool) async -> AccountFetchResult? {
         guard isEnabled else { return nil }
         return await fetchGrokAccountMetrics()
+    }
+
+    private func openRouterAccountFetch(isEnabled: Bool) async -> AccountFetchResult? {
+        guard isEnabled else { return nil }
+        return await fetchOpenRouterAccountMetrics()
     }
 
     private func fetchClaudeCodeAccountMetrics(
@@ -1288,6 +1378,82 @@ class UsageDataManager: ObservableObject {
         return grokAccountStore.enabledAccounts.lazy.compactMap { accountMetrics[$0.id] }.first
     }
 
+    private func fetchOpenRouterAccountMetrics() async -> AccountFetchResult {
+        let enabledAccounts = openRouterAccountStore.enabledAccounts
+        var refreshedMetrics: [UUID: UsageMetrics] = [:]
+        var firstFailure: Error?
+        var successCount = 0
+
+        let legs = await fanOut(count: enabledAccounts.count) { [enabledAccounts] index in
+            let account = enabledAccounts[index]
+            guard self.openRouterService.canAccess(account: account) else {
+                throw OpenRouterKeyUnreachable()
+            }
+            return try await self.openRouterService.fetchUsageMetrics(account: account)
+        }
+
+        for (account, leg) in zip(enabledAccounts, legs) {
+            if let metrics = leg.metrics {
+                refreshedMetrics[account.id] = metrics
+                successCount += 1
+            } else if let error = leg.error {
+                // A keyless account is a skip, not a failure, and must not
+                // resurrect a stale cache — same semantics as Codex/Grok.
+                if error is OpenRouterKeyUnreachable { continue }
+                if firstFailure == nil { firstFailure = error }
+                if let cachedMetrics = openRouterAccountMetrics[account.id] {
+                    refreshedMetrics[account.id] = cachedMetrics
+                }
+            }
+        }
+
+        if successCount > 0 {
+            parseHealthStore.recordSuccess(.openRouter)
+        } else if let firstFailure {
+            parseHealthStore.recordFailure(.openRouter, error: firstFailure)
+        }
+
+        recordOpenRouterLedgerObservation(successCount: successCount)
+
+        return AccountFetchResult(
+            metrics: refreshedMetrics,
+            successCount: successCount,
+            firstFailure: firstFailure
+        )
+    }
+
+    /// Folds this poll's per-key spend readings into the single provider-wide
+    /// ledger entry. Keys that failed keep their previous contribution out of
+    /// the sum — a partial poll must not look like spend went backwards.
+    private func recordOpenRouterLedgerObservation(successCount: Int) {
+        guard !demoMode, let store = usageLedgerStore, successCount > 0 else { return }
+        let polledKeys = openRouterAccountStore.enabledAccounts.filter {
+            openRouterService.latestAccountObservations[$0.id] != nil
+        }
+        let observations = polledKeys.compactMap { openRouterService.latestAccountObservations[$0.id] }
+        guard let aggregated = OpenRouterService.aggregatedObservation(observations, observedAt: Date()) else {
+            return
+        }
+
+        var ledger = store.load()
+        ledger.record(aggregated)
+        do {
+            try store.save(ledger)
+        } catch {
+            AppLog.usage.error(
+                "Failed to persist provider usage observations: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    private func representativeOpenRouterMetrics(from accountMetrics: [UUID: UsageMetrics]) -> UsageMetrics? {
+        if openRouterAccountStore.defaultAccountIsEnabled,
+           let defaultMetrics = accountMetrics[OpenRouterAccount.defaultID] {
+            return defaultMetrics
+        }
+        return openRouterAccountStore.enabledAccounts.lazy.compactMap { accountMetrics[$0.id] }.first
+    }
+
     // MARK: - Provider strategy
 
     private func hasProviderAccess(_ service: ServiceType) -> Bool {
@@ -1299,23 +1465,24 @@ class UsageDataManager: ObservableObject {
         case .cursor:
             return cursorService.hasAccess
         case .openRouter:
-            return openRouterService.hasAccess
+            // Access means at least one enabled key has its Keychain item.
+            return openRouterAccountStore.enabledAccounts.contains {
+                openRouterService.canAccess(account: $0)
+            }
         case .grok:
             return false
         }
     }
 
-    /// Fetch for the providers without multi-account handling (Claude Code has
-    /// its own account-aware path).
+    /// Fetch for the providers without multi-account handling (Claude Code,
+    /// Codex, Grok, and OpenRouter have their own account-aware paths).
     private func fetchSimpleProviderMetrics(_ service: ServiceType) async throws -> UsageMetrics {
         do {
             let result: UsageMetrics
             switch service {
             case .cursor:
                 result = try await cursorService.fetchUsageMetrics()
-            case .openRouter:
-                result = try await openRouterService.fetchUsageMetrics()
-            case .claudeCode, .codexCli, .grok:
+            case .claudeCode, .codexCli, .grok, .openRouter:
                 preconditionFailure("Account-aware providers use dedicated fetch paths")
             }
             parseHealthStore.recordSuccess(service)

--- a/MeterBar/UsageRefresh/UsageRefreshConfigurationStore.swift
+++ b/MeterBar/UsageRefresh/UsageRefreshConfigurationStore.swift
@@ -13,17 +13,20 @@ nonisolated enum UsageRefreshConfigurationStore {
         let claudeAccounts: [ClaudeCodeAccount]
         let codexAccounts: [CodexAccount]
         let grokAccounts: [GrokAccount]
+        let openRouterAccounts: [OpenRouterAccount]
 
         init(
             hiddenServices: Set<ServiceType>,
             claudeAccounts: [ClaudeCodeAccount],
             codexAccounts: [CodexAccount],
-            grokAccounts: [GrokAccount] = [.defaultAccount]
+            grokAccounts: [GrokAccount] = [.defaultAccount],
+            openRouterAccounts: [OpenRouterAccount] = [.defaultAccount]
         ) {
             self.hiddenServices = hiddenServices
             self.claudeAccounts = claudeAccounts
             self.codexAccounts = codexAccounts
             self.grokAccounts = grokAccounts
+            self.openRouterAccounts = openRouterAccounts
         }
     }
 
@@ -31,6 +34,7 @@ nonisolated enum UsageRefreshConfigurationStore {
     private static let claudeAccountsFileName = "refresh-claude-accounts-v1.json"
     private static let codexAccountsFileName = "refresh-codex-accounts-v1.json"
     private static let grokAccountsFileName = "refresh-grok-accounts-v1.json"
+    private static let openRouterAccountsFileName = "refresh-openrouter-accounts-v1.json"
 
     static func saveVisibility(
         _ hiddenServices: Set<ServiceType>,
@@ -60,6 +64,13 @@ nonisolated enum UsageRefreshConfigurationStore {
         write(accounts, fileName: grokAccountsFileName, directory: directory)
     }
 
+    static func saveOpenRouterAccounts(
+        _ accounts: [OpenRouterAccount],
+        directory: URL? = SharedMetricsStore.containerURL
+    ) {
+        write(accounts, fileName: openRouterAccountsFileName, directory: directory)
+    }
+
     /// Fail closed unless the original three projections exist and decode.
     /// Grok's account projection is additive and optional so a CLI bundled with
     /// this version can still refresh after an older app wrote the v1 files.
@@ -83,6 +94,8 @@ nonisolated enum UsageRefreshConfigurationStore {
             claudeAccounts: claudeAccounts,
             codexAccounts: codexAccounts,
             grokAccounts: read(fileName: grokAccountsFileName, directory: directory)
+                ?? [.defaultAccount],
+            openRouterAccounts: read(fileName: openRouterAccountsFileName, directory: directory)
                 ?? [.defaultAccount]
         )
     }

--- a/MeterBar/Views/DashboardDiagnosticsSection.swift
+++ b/MeterBar/Views/DashboardDiagnosticsSection.swift
@@ -97,7 +97,8 @@ struct DashboardDiagnosticsSection: View {
                 .filter { !$0.isDefault }
                 .map(\.id),
             enabledCodexAccountIDs: codexAccountStore.enabledAccounts.map(\.id),
-            enabledGrokAccountIDs: grokAccountStore.enabledAccounts.map(\.id)
+            enabledGrokAccountIDs: grokAccountStore.enabledAccounts.map(\.id),
+            enabledOpenRouterKeyIDs: openRouterAccountStore.enabledAccounts.map(\.id)
         )
     }
 

--- a/MeterBar/Views/DashboardDiagnosticsSection.swift
+++ b/MeterBar/Views/DashboardDiagnosticsSection.swift
@@ -35,6 +35,7 @@ struct DashboardDiagnosticsSection: View {
     @StateObject private var openRouterService = OpenRouterService.shared
     @StateObject private var grokService = GrokCLIUsageService.shared
     @StateObject private var grokAccountStore = GrokAccountStore.shared
+    @StateObject private var openRouterAccountStore = OpenRouterAccountStore.shared
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -147,6 +148,11 @@ struct DashboardDiagnosticsSection: View {
                 uniqueKeysWithValues: grokAccountStore.enabledAccounts.compactMap { account in
                     grokService.accountErrors[account.id].map { (account.id, $0) }
                 }
+            ),
+            openRouterKeyErrors: Dictionary(
+                uniqueKeysWithValues: openRouterAccountStore.enabledAccounts.compactMap { account in
+                    openRouterService.accountLastErrors[account.id].map { (account.id, $0) }
+                }
             )
         )
         let defaultClaudeAccountEnabled = claudeAccountStore.defaultAccountIsEnabled
@@ -165,7 +171,8 @@ struct DashboardDiagnosticsSection: View {
             claudeDefaultAccountEnabled: defaultClaudeAccountEnabled,
             claudeEnabledAccountMetrics: Array(claudeMetricsByID.values),
             codexAccounts: codexAccountStore.accounts,
-            grokAccounts: grokAccountStore.accounts
+            grokAccounts: grokAccountStore.accounts,
+            openRouterAccounts: openRouterAccountStore.accounts
         )
     }
 

--- a/MeterBar/Views/MenuBarView.swift
+++ b/MeterBar/Views/MenuBarView.swift
@@ -14,6 +14,7 @@ struct MenuBarView: View {
   @StateObject private var codexCliService = CodexCliLocalService.shared
   @StateObject private var codexAccountStore = CodexAccountStore.shared
   @StateObject private var grokAccountStore = GrokAccountStore.shared
+  @StateObject private var openRouterAccountStore = OpenRouterAccountStore.shared
   @StateObject private var cursorService = CursorLocalService.shared
   @StateObject private var openRouterService = OpenRouterService.shared
   @StateObject private var grokService = GrokCLIUsageService.shared
@@ -86,6 +87,7 @@ struct MenuBarView: View {
           claudeAccounts: claudeAccountStore.accounts,
           codexAccounts: codexAccountStore.accounts,
           grokAccounts: grokAccountStore.accounts,
+          openRouterAccounts: openRouterAccountStore.accounts,
           enabledServices: providerVisibility.enabledServices,
           claudeCodeService: claudeCodeService,
           codexCliService: codexCliService,

--- a/MeterBar/Views/ProviderPresentationHealth.swift
+++ b/MeterBar/Views/ProviderPresentationHealth.swift
@@ -28,6 +28,7 @@ enum ProviderPresentationHealth {
         var openRouter: ServiceError?
         var codexAccounts: [UUID: ServiceError] = [:]
         var grokAccounts: [UUID: ServiceError] = [:]
+        var openRouterAccounts: [UUID: ServiceError] = [:]
     }
 
     static var staleAfter: TimeInterval { ProviderParseHealthRecord.staleAfter }

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -363,8 +363,10 @@ enum ProviderSnapshotBuilder {
         var codexCliHasAccess: Bool = false
         /// Last Cursor probe. `nil` is unprobed; `false` is confirmed signed-out.
         var cursorHasAccess: Bool?
-        /// Last OpenRouter probe. `nil` is unprobed; `false` is confirmed no key.
-        var openRouterHasAccess: Bool?
+        /// Per-key Keychain probes and refresh errors for the OpenRouter cards.
+        var openRouterAccounts: [OpenRouterAccount] = []
+        var openRouterAccountMetrics: [UUID: UsageMetrics] = [:]
+        var openRouterAccountAccess: [UUID: Bool] = [:]
         var grokHasAccess: Bool = false
         var lastErrors: ProviderPresentationHealth.LastErrors = .init()
 
@@ -375,6 +377,7 @@ enum ProviderSnapshotBuilder {
             var claudeAccounts: [ClaudeCodeAccount]
             var codexAccounts: [CodexAccount]
             var grokAccounts: [GrokAccount]
+            var openRouterAccounts: [OpenRouterAccount]
             var enabledServices: Set<ServiceType>
             var claudeCodeService: ClaudeCodeLocalService
             var codexCliService: CodexCliLocalService
@@ -410,13 +413,18 @@ enum ProviderSnapshotBuilder {
                 claudeCodeHasAccess: stores.claudeCodeService.hasAccess,
                 codexCliHasAccess: stores.codexCliService.hasAccess,
                 cursorHasAccess: stores.cursorService.hasAccess,
-                openRouterHasAccess: stores.openRouterService.hasAccess,
+                openRouterAccounts: stores.openRouterAccounts,
+                openRouterAccountMetrics: stores.dataManager.openRouterAccountMetrics,
+                openRouterAccountAccess: Dictionary(uniqueKeysWithValues: stores.openRouterAccounts.map {
+                    ($0.id, stores.openRouterService.canAccess(account: $0))
+                }),
                 grokHasAccess: stores.grokService.hasAccess,
                 lastErrors: ProviderPresentationHealth.LastErrors(
                     cursor: stores.cursorService.lastError,
                     openRouter: stores.openRouterService.lastError,
                     codexAccounts: stores.codexCliService.accountErrors,
-                    grokAccounts: stores.grokService.accountErrors
+                    grokAccounts: stores.grokService.accountErrors,
+                    openRouterAccounts: stores.openRouterService.accountLastErrors
                 )
             )
         }
@@ -516,16 +524,34 @@ enum ProviderSnapshotBuilder {
         }
 
         if input.enabledServices.contains(.openRouter) {
-            let metrics = input.metrics[.openRouter]
-            result.append(snapshot(
-                title: ServiceType.openRouter.shortName,
-                service: .openRouter,
-                metrics: metrics,
-                emptyDetail: input.openRouterHasAccess == true
-                    ? "Waiting for refresh"
-                    : "Add an OpenRouter API key",
-                authNotice: notice(for: .openRouter, accountID: nil, metrics: metrics, input: input)
-            ))
+            let enabledAccounts = input.openRouterAccounts.filter(\.isEnabled)
+            for account in enabledAccounts {
+                let title = account.isDefault
+                    && account.name == OpenRouterAccount.defaultName
+                    && enabledAccounts.count == 1
+                    ? ServiceType.openRouter.shortName
+                    : account.name
+                let fallbackMetrics = account.isDefault
+                    && enabledAccounts.count == 1
+                    && input.openRouterAccountMetrics.isEmpty
+                    ? input.metrics[.openRouter]
+                    : nil
+                let metrics = input.openRouterAccountMetrics[account.id] ?? fallbackMetrics
+                let hasKey = input.openRouterAccountAccess[account.id] == true
+                result.append(snapshot(
+                    title: title,
+                    service: .openRouter,
+                    metrics: metrics,
+                    emptyDetail: hasKey ? "Waiting for refresh" : "Add an OpenRouter API key",
+                    accountID: account.id,
+                    authNotice: notice(
+                        for: .openRouter,
+                        accountID: account.id,
+                        metrics: metrics,
+                        input: input
+                    )
+                ))
+            }
         }
 
         if input.enabledServices.contains(.grok) {
@@ -592,8 +618,12 @@ enum ProviderSnapshotBuilder {
             probed = input.cursorHasAccess
             usesAPIKey = false
         case .openRouter:
-            lastError = input.lastErrors.openRouter
-            probed = input.openRouterHasAccess
+            // Per-key health when the card is key-scoped; the provider-wide
+            // aggregate falls back to the service-level probe and error.
+            lastError = accountID.flatMap { input.lastErrors.openRouterAccounts[$0] }
+                ?? input.lastErrors.openRouter
+            probed = accountID.flatMap { input.openRouterAccountAccess[$0] }
+                ?? input.openRouterAccountAccess.values.first { $0 }
             usesAPIKey = true
         case .claudeCode:
             lastError = nil

--- a/MeterBar/Views/ProviderSnapshot.swift
+++ b/MeterBar/Views/ProviderSnapshot.swift
@@ -618,12 +618,15 @@ enum ProviderSnapshotBuilder {
             probed = input.cursorHasAccess
             usesAPIKey = false
         case .openRouter:
-            // Per-key health when the card is key-scoped; the provider-wide
-            // aggregate falls back to the service-level probe and error.
-            lastError = accountID.flatMap { input.lastErrors.openRouterAccounts[$0] }
-                ?? input.lastErrors.openRouter
-            probed = accountID.flatMap { input.openRouterAccountAccess[$0] }
-                ?? input.openRouterAccountAccess.values.first { $0 }
+            // A key-scoped card speaks only about its own key: another key's
+            // failure or missing credential must never dim this card.
+            if let accountID {
+                lastError = input.lastErrors.openRouterAccounts[accountID]
+                probed = input.openRouterAccountAccess[accountID]
+            } else {
+                lastError = input.lastErrors.openRouter
+                probed = input.openRouterAccountAccess.values.first { $0 }
+            }
             usesAPIKey = true
         case .claudeCode:
             lastError = nil

--- a/MeterBar/Views/Settings/AddProviderAPIKeySheet.swift
+++ b/MeterBar/Views/Settings/AddProviderAPIKeySheet.swift
@@ -1,0 +1,79 @@
+import MeterBarShared
+import SwiftUI
+
+/// Modal sheet for adding one OpenRouter API key. The key goes straight into
+/// the Keychain via `onAdd`; the sheet never stores or logs it.
+struct AddProviderAPIKeySheet: View {
+    let providerName: String
+    let logoKind: ProviderLogoKind
+    let accent: Color
+    let subtitle: String
+    let keyPlaceholder: String
+    let onAdd: (String, String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(spacing: 10) {
+                ProviderLogoView(kind: logoKind, size: 18, foregroundColor: accent)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Add \(providerName) Key")
+                        .font(.headline)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Key name")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextField("Work", text: $accountName)
+                        .settingsInput()
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("API key")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    SecureField(keyPlaceholder, text: $apiKey)
+                        .settingsInput()
+                }
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Add Key") {
+                    onAdd(trimmedName, trimmedKey)
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(!canAdd)
+            }
+        }
+        .padding(MeterBarTheme.Spacing.xxl)
+        .frame(width: 520)
+    }
+
+    @Environment(\.dismiss)
+    private var dismiss
+    @State private var accountName = ""
+    @State private var apiKey = ""
+
+    private var trimmedName: String {
+        accountName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedKey: String {
+        apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var canAdd: Bool {
+        !trimmedName.isEmpty && !trimmedKey.isEmpty
+    }
+}

--- a/MeterBar/Views/Settings/GeneralSettingsView.swift
+++ b/MeterBar/Views/Settings/GeneralSettingsView.swift
@@ -26,6 +26,7 @@ struct GeneralSettingsView: View {
     @StateObject private var codexCliService = CodexCliLocalService.shared
     @StateObject private var codexAccountStore = CodexAccountStore.shared
     @StateObject private var grokAccountStore = GrokAccountStore.shared
+    @StateObject private var openRouterAccountStore = OpenRouterAccountStore.shared
     @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
     @StateObject private var cursorService = CursorLocalService.shared
     @StateObject private var openRouterService = OpenRouterService.shared
@@ -63,6 +64,7 @@ struct GeneralSettingsView: View {
                     claudeAccounts: claudeAccountStore.accounts,
                     codexAccounts: codexAccountStore.accounts,
                     grokAccounts: grokAccountStore.accounts,
+                    openRouterAccounts: openRouterAccountStore.accounts,
                     enabledServices: providerVisibility.enabledServices,
                     claudeCodeService: claudeCodeService,
                     codexCliService: codexCliService,

--- a/MeterBar/Views/Settings/GeneralSettingsView.swift
+++ b/MeterBar/Views/Settings/GeneralSettingsView.swift
@@ -43,12 +43,13 @@ struct GeneralSettingsView: View {
     /// Explains a rejected menu-bar account selection; nil while under the cap.
     @State private var capNotice: String?
 
-    /// Every tracked Claude/Codex account, already sanitized for display.
+    /// Every tracked account-aware provider profile, already sanitized for display.
     private var menuBarAccounts: [MenuBarAccountIdentity] {
         MenuBarAccountCatalog.identities(
             claudeAccounts: claudeAccountStore.accounts,
             codexAccounts: codexAccountStore.accounts,
             grokAccounts: grokAccountStore.accounts,
+            openRouterAccounts: openRouterAccountStore.accounts,
             enabledServices: providerVisibility.enabledServices
         )
     }

--- a/MeterBar/Views/Settings/ProviderAccountProfileRow.swift
+++ b/MeterBar/Views/Settings/ProviderAccountProfileRow.swift
@@ -28,6 +28,7 @@ struct ProviderAccountProfileRow: View {
         canMoveUp: Bool = false,
         canMoveDown: Bool = false,
         isRefreshing: Bool = false,
+        showsPathField: Bool = true,
         showsRefresh: Bool = false,
         showsReconnect: Bool = false,
         reconnectProviderName: String = "",
@@ -48,6 +49,7 @@ struct ProviderAccountProfileRow: View {
         self.pathPlaceholder = pathPlaceholder
         self.resolvedPath = resolvedPath
         self.defaultPathHelp = defaultPathHelp
+        self.showsPathField = showsPathField
         self.statusPresentation = statusPresentation
         self.statusAccessibilityValue = statusAccessibilityValue
         self.canDisable = canDisable
@@ -98,26 +100,28 @@ struct ProviderAccountProfileRow: View {
                         .onSubmit(saveChanges)
                 }
 
-                fieldRow(label: pathLabel) {
-                    HStack(spacing: 8) {
-                        TextField(pathPlaceholder, text: $draft.path)
-                            .textFieldStyle(.plain)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 6)
-                            .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 6))
-                            .accessibilityLabel("\(pathLabel) for \(accountName)")
-                            .onSubmit(saveChanges)
+                if showsPathField {
+                    fieldRow(label: pathLabel) {
+                        HStack(spacing: 8) {
+                            TextField(pathPlaceholder, text: $draft.path)
+                                .textFieldStyle(.plain)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 6)
+                                .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 6))
+                                .accessibilityLabel("\(pathLabel) for \(accountName)")
+                                .onSubmit(saveChanges)
 
-                        Button {
-                            chooseDirectory()
-                        } label: {
-                            Image(systemName: "folder")
+                            Button {
+                                chooseDirectory()
+                            } label: {
+                                Image(systemName: "folder")
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .fixedSize()
+                            .accessibilityLabel("Choose \(pathLabel) for \(accountName)")
+                            .help("Choose \(pathLabel)")
                         }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                        .fixedSize()
-                        .accessibilityLabel("Choose \(pathLabel) for \(accountName)")
-                        .help("Choose \(pathLabel)")
                     }
                 }
 
@@ -208,6 +212,9 @@ struct ProviderAccountProfileRow: View {
     private let pathPlaceholder: String
     private let resolvedPath: String
     private let defaultPathHelp: String?
+    /// Credential-less providers (OpenRouter keys live in the Keychain) hide
+    /// the path field entirely; their row is name + status + controls.
+    private let showsPathField: Bool
     private let statusPresentation: SettingsStatusPresentation
     /// Richer VoiceOver sentence for the status pill; `nil` falls back to the
     /// pill's own text.

--- a/MeterBar/Views/Settings/ProviderAccountSelectionReconciler.swift
+++ b/MeterBar/Views/Settings/ProviderAccountSelectionReconciler.swift
@@ -18,6 +18,7 @@ struct ProviderAccountSelectionAvailability {
         claudeAccounts: [ClaudeCodeAccount],
         codexAccounts: [CodexAccount],
         grokAccounts: [GrokAccount],
+        openRouterAccounts: [OpenRouterAccount] = [],
         enabledServices: Set<ServiceType>
     ) {
         menuBarKeys = Set(
@@ -25,6 +26,7 @@ struct ProviderAccountSelectionAvailability {
                 claudeAccounts: claudeAccounts,
                 codexAccounts: codexAccounts,
                 grokAccounts: grokAccounts,
+                openRouterAccounts: openRouterAccounts,
                 enabledServices: enabledServices
             )
             .filter(\.isEnabled)
@@ -36,7 +38,8 @@ struct ProviderAccountSelectionAvailability {
                 enabledServices: enabledServices,
                 claudeAccounts: claudeAccounts,
                 codexAccounts: codexAccounts,
-                grokAccounts: grokAccounts
+                grokAccounts: grokAccounts,
+                openRouterAccounts: openRouterAccounts
             )
             .map(\.id)
         )

--- a/MeterBar/Views/Settings/ProviderCatalogSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderCatalogSettingsView.swift
@@ -40,6 +40,7 @@ struct ProviderCatalogSettingsView: View {
     @StateObject private var codexCliService = CodexCliLocalService.shared
     @StateObject private var codexAccountStore = CodexAccountStore.shared
     @StateObject private var grokAccountStore = GrokAccountStore.shared
+    @StateObject private var openRouterAccountStore = OpenRouterAccountStore.shared
     @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
     @StateObject private var cursorService = CursorLocalService.shared
     @StateObject private var openRouterService = OpenRouterService.shared
@@ -55,6 +56,7 @@ struct ProviderCatalogSettingsView: View {
                     claudeAccounts: claudeAccountStore.accounts,
                     codexAccounts: codexAccountStore.accounts,
                     grokAccounts: grokAccountStore.accounts,
+                    openRouterAccounts: openRouterAccountStore.accounts,
                     enabledServices: providerVisibility.enabledServices,
                     claudeCodeService: claudeCodeService,
                     codexCliService: codexCliService,

--- a/MeterBar/Views/Settings/ProviderSettingsFacts+Live.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsFacts+Live.swift
@@ -34,12 +34,7 @@ extension ProviderSettingsFacts {
                     CursorLocalService.shared.lastError?.localizedDescription
                 )
             case .openRouter:
-                (
-                    OpenRouterService.shared.hasAccess,
-                    nil,
-                    nil,
-                    OpenRouterService.shared.lastError?.localizedDescription
-                )
+                openRouterLiveState()
             case .grok:
                 grokLiveState()
             }
@@ -95,6 +90,25 @@ extension ProviderSettingsFacts {
             service.subscriptionType,
             nil,
             service.firstError(for: accounts)?.localizedDescription
+        )
+    }
+
+    /// OpenRouter is connected when any enabled key has its Keychain item —
+    /// same any-enabled-profile semantics as Codex and Grok.
+    @MainActor
+    private static func openRouterLiveState() -> (
+        hasAccess: Bool,
+        subscription: String?,
+        tier: String?,
+        error: String?
+    ) {
+        let service = OpenRouterService.shared
+        let accounts = OpenRouterAccountStore.shared.enabledAccounts
+        return (
+            accounts.contains(where: service.canAccess(account:)),
+            nil,
+            nil,
+            service.lastError?.localizedDescription
         )
     }
 }

--- a/MeterBar/Views/Settings/ProviderSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsView.swift
@@ -784,6 +784,10 @@ struct ProviderSettingsView: View {
                                 Task { await dataManager.refreshAll() }
                             },
                             onRemove: {
+                                // Eligibility first: a rejected last-enabled
+                                // removal must not have already deleted the
+                                // credential.
+                                guard openRouterAccountStore.canRemoveAccount(id: account.id) else { return }
                                 openRouterService.removeAPIKey(for: account.id)
                                 openRouterAccountStore.removeAccount(id: account.id)
                                 reconcileProviderAccountSelections()
@@ -1067,6 +1071,7 @@ struct ProviderSettingsView: View {
                 claudeAccounts: claudeAccountStore.accounts,
                 codexAccounts: codexAccountStore.accounts,
                 grokAccounts: grokAccountStore.accounts,
+                openRouterAccounts: openRouterAccountStore.accounts,
                 enabledServices: providerVisibility.enabledServices
             ),
             menuBarSelection: menuBarAccountSelection,

--- a/MeterBar/Views/Settings/ProviderSettingsView.swift
+++ b/MeterBar/Views/Settings/ProviderSettingsView.swift
@@ -80,6 +80,18 @@ struct ProviderSettingsView: View {
                 Task { await dataManager.refreshAll() }
             }
         }
+        .sheet(isPresented: $isAddingOpenRouterKey) {
+            AddProviderAPIKeySheet(
+                providerName: ServiceType.openRouter.shortName,
+                logoKind: .openRouter,
+                accent: MeterBarTheme.openRouterAccent,
+                subtitle: "The key is stored in macOS Keychain and sent only to OpenRouter's credits and key APIs.",
+                keyPlaceholder: "sk-or-v1-..."
+            ) { name, apiKey in
+                addOpenRouterKey(name: name, apiKey: apiKey)
+                isAddingOpenRouterKey = false
+            }
+        }
         .task(id: codexDefaultAccount) {
             guard service == .codexCli, codexDefaultAccount.isEnabled else { return }
             let codexCliService = codexCliService
@@ -97,6 +109,7 @@ struct ProviderSettingsView: View {
     @StateObject private var codexCliService = CodexCliLocalService.shared
     @StateObject private var codexAccountStore = CodexAccountStore.shared
     @StateObject private var grokAccountStore = GrokAccountStore.shared
+    @StateObject private var openRouterAccountStore = OpenRouterAccountStore.shared
     @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
     @StateObject private var cursorService = CursorLocalService.shared
     @StateObject private var openRouterService = OpenRouterService.shared
@@ -110,9 +123,9 @@ struct ProviderSettingsView: View {
     @State private var isAddingClaudeAccount = false
     @State private var isAddingCodexAccount = false
     @State private var isAddingGrokAccount = false
+    @State private var isAddingOpenRouterKey = false
     @State private var refreshingClaudeAccountIDs: Set<UUID> = []
     @State private var claudeReconnectError: String?
-    @State private var openRouterKeyDraft = ""
 
     /// Same key ClaudeCodeLocalService reads. OAuth (`/api/oauth/usage`) is the
     /// primary Claude Code usage source and is on by default; turning this off
@@ -128,6 +141,7 @@ struct ProviderSettingsView: View {
                     claudeAccounts: claudeAccountStore.accounts,
                     codexAccounts: codexAccountStore.accounts,
                     grokAccounts: grokAccountStore.accounts,
+                    openRouterAccounts: openRouterAccountStore.accounts,
                     enabledServices: providerVisibility.enabledServices,
                     claudeCodeService: claudeCodeService,
                     codexCliService: codexCliService,
@@ -674,73 +688,40 @@ struct ProviderSettingsView: View {
     }
 
     private var openRouterSection: some View {
-        SettingsPanelSection(
+        let hasAccess = openRouterAccountStore.enabledAccounts.contains {
+            openRouterService.canAccess(account: $0)
+        }
+        return SettingsPanelSection(
             title: ServiceType.openRouter.displayName,
             logoKind: .openRouter,
             color: MeterBarTheme.openRouterAccent
         ) {
             SettingsNotice(
-                text: "The key is stored in macOS Keychain and sent only to OpenRouter's credits and key APIs.",
+                text: "Each key is stored in macOS Keychain and sent only to OpenRouter's credits and key APIs. "
+                    + "Create keys at openrouter.ai/settings/keys.",
                 color: .secondary
             )
 
-            SettingsRowView(
-                title: "API key",
-                detail: openRouterService.hasAccess
-                    ? "Configured. Refresh validates access and updates credits."
-                    : "Create a key at openrouter.ai/settings/keys."
-            ) {
-                if openRouterService.hasAccess {
-                    HStack(spacing: 8) {
-                        StatusPill(title: "Configured", isConnected: true)
-                        Button("Remove", role: .destructive) {
-                            openRouterService.removeAPIKey()
-                            Task { await dataManager.refresh(service: .openRouter) }
-                        }
-                        .buttonStyle(.bordered)
+            SettingsRowView(title: "Connection") {
+                HStack(spacing: 8) {
+                    StatusPill(
+                        title: hasAccess ? "Connected" : "Not Connected",
+                        isConnected: hasAccess
+                    )
 
-                        Button("Get Key") {
-                            if let url = URL(string: "https://openrouter.ai/settings/keys") {
-                                NSWorkspace.shared.open(url)
-                            }
-                        }
-                        .buttonStyle(.bordered)
-                    }
-                } else {
-                    // The control column clamps at `controlMaxWidth` (300pt) with
-                    // `.fixedSize`, so the field and both buttons cannot share
-                    // one row — they crush into circles. The field leads and the
-                    // actions sit under it, mirroring the other provider rows.
-                    VStack(alignment: .trailing, spacing: 8) {
-                        SecureField("sk-or-v1-...", text: $openRouterKeyDraft)
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: 260)
-
-                        HStack(spacing: 8) {
-                            Button("Save & Validate") {
-                                guard openRouterService.saveAPIKey(openRouterKeyDraft) else { return }
-                                openRouterKeyDraft = ""
-                                providerVisibility.set(.openRouter, isEnabled: true)
-                                Task { await dataManager.refresh(service: .openRouter) }
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .disabled(openRouterKeyDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-
-                            Button("Get Key") {
-                                if let url = URL(string: "https://openrouter.ai/settings/keys") {
-                                    NSWorkspace.shared.open(url)
-                                }
-                            }
-                            .buttonStyle(.bordered)
+                    Button("Get Key") {
+                        if let url = URL(string: "https://openrouter.ai/settings/keys") {
+                            NSWorkspace.shared.open(url)
                         }
                     }
+                    .buttonStyle(.bordered)
                 }
             }
 
             if let error = openRouterService.lastError {
                 let detail = switch error {
                 case .notAuthenticated:
-                    "OpenRouter rejected this key. Remove it and add a valid API key."
+                    "OpenRouter rejected a key. Remove it and add a valid API key."
                 default:
                     error.localizedDescription
                 }
@@ -750,6 +731,69 @@ struct ProviderSettingsView: View {
                     message: detail,
                     tone: .warning
                 )
+            }
+
+            SettingsDivider()
+
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Text("API Keys")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                    Spacer()
+                    Button {
+                        isAddingOpenRouterKey = true
+                    } label: {
+                        Label("Add Key", systemImage: "plus")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                }
+
+                VStack(spacing: 0) {
+                    ForEach(Array(openRouterAccountStore.accounts.enumerated()), id: \.element.id) { index, account in
+                        if index > 0 { SettingsDivider() }
+                        ProviderAccountProfileRow(
+                            accountName: account.name,
+                            isDefault: account.isDefault,
+                            isEnabled: account.isEnabled,
+                            accent: MeterBarTheme.openRouterAccent,
+                            pathLabel: "API key",
+                            pathPlaceholder: "sk-or-v1-...",
+                            resolvedPath: "",
+                            defaultPathHelp: nil,
+                            statusPresentation: ProviderAccountConnectionState
+                                .from(
+                                    isEnabled: account.isEnabled,
+                                    isConnected: openRouterService.canAccess(account: account)
+                                )
+                                .statusPresentation,
+                            canMoveUp: index > 0,
+                            canMoveDown: index < openRouterAccountStore.accounts.count - 1,
+                            showsPathField: false,
+                            deleteMessage:
+                                "MeterBar will stop tracking this key and delete it from the Keychain. "
+                                + "The key keeps working on OpenRouter until you revoke it there.",
+                            onEnabledChange: { isEnabled in
+                                openRouterAccountStore.setEnabled(isEnabled, for: account.id)
+                                reconcileProviderAccountSelections()
+                                Task { await dataManager.refreshAll() }
+                            },
+                            onSave: { name, _ in
+                                openRouterAccountStore.updateAccount(id: account.id, name: name)
+                                Task { await dataManager.refreshAll() }
+                            },
+                            onRemove: {
+                                openRouterService.removeAPIKey(for: account.id)
+                                openRouterAccountStore.removeAccount(id: account.id)
+                                reconcileProviderAccountSelections()
+                                Task { await dataManager.refreshAll() }
+                            },
+                            onMoveUp: { moveOpenRouterKey(at: index, down: false) },
+                            onMoveDown: { moveOpenRouterKey(at: index, down: true) }
+                        )
+                    }
+                }
             }
         }
     }
@@ -967,6 +1011,26 @@ struct ProviderSettingsView: View {
         moveAccount(at: index, down: down, count: grokAccountStore.accounts.count) {
             grokAccountStore.moveAccounts(fromOffsets: $0, toOffset: $1)
         }
+    }
+
+    private func moveOpenRouterKey(at index: Int, down: Bool) {
+        moveAccount(at: index, down: down, count: openRouterAccountStore.accounts.count) {
+            openRouterAccountStore.moveAccounts(fromOffsets: $0, toOffset: $1)
+        }
+    }
+
+    /// Stores the key material first; only a successful Keychain write creates
+    /// the account, so an account can never exist without its credential.
+    private func addOpenRouterKey(name: String, apiKey: String) {
+        guard let account = openRouterAccountStore.addAccount(name: name) else { return }
+        guard openRouterService.saveAPIKey(apiKey, for: account.id) else {
+            openRouterAccountStore.removeAccount(id: account.id)
+            return
+        }
+        // First key ever: OpenRouter is opt-in, so adding one un-hides it.
+        providerVisibility.set(.openRouter, isEnabled: true)
+        reconcileProviderAccountSelections()
+        Task { await dataManager.refreshAll() }
     }
 
     private func moveAccount(

--- a/MeterBar/Views/Settings/WidgetSettingsView.swift
+++ b/MeterBar/Views/Settings/WidgetSettingsView.swift
@@ -14,7 +14,8 @@ enum WidgetSettingsAccountProjection {
         enabledServices: Set<ServiceType>,
         claudeAccounts: [ClaudeCodeAccount],
         codexAccounts: [CodexAccount],
-        grokAccounts: [GrokAccount] = []
+        grokAccounts: [GrokAccount] = [],
+        openRouterAccounts: [OpenRouterAccount] = []
     ) -> [WidgetSettingsAccountOption] {
         ServiceType.allCases.flatMap { service -> [WidgetSettingsAccountOption] in
             guard enabledServices.contains(service) else { return [] }
@@ -44,7 +45,17 @@ enum WidgetSettingsAccountProjection {
                         name: $0.name
                     )
                 }
-            case .cursor, .openRouter:
+            case .openRouter:
+                // One widget row per managed key, like every other
+                // account-aware provider.
+                return openRouterAccounts.filter(\.isEnabled).map {
+                    WidgetSettingsAccountOption(
+                        id: .account(service: service, id: $0.id),
+                        service: service,
+                        name: $0.name
+                    )
+                }
+            case .cursor:
                 return [
                     WidgetSettingsAccountOption(
                         id: .provider(service),
@@ -209,6 +220,7 @@ struct WidgetSettingsView: View {
     @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
     @StateObject private var codexAccountStore = CodexAccountStore.shared
     @StateObject private var grokAccountStore = GrokAccountStore.shared
+    @StateObject private var openRouterAccountStore = OpenRouterAccountStore.shared
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
     @State private var previewAppearance: WidgetSettingsPreviewAppearance = .light
 
@@ -230,7 +242,8 @@ struct WidgetSettingsView: View {
             enabledServices: providerVisibility.enabledServices,
             claudeAccounts: claudeAccountStore.accounts,
             codexAccounts: codexAccountStore.accounts,
-            grokAccounts: grokAccountStore.accounts
+            grokAccounts: grokAccountStore.accounts,
+            openRouterAccounts: openRouterAccountStore.accounts
         )
     }
 

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -25,6 +25,7 @@ struct UsageDashboardView: View {
     @StateObject private var claudeAccountStore = ClaudeCodeAccountStore.shared
     @StateObject private var codexAccountStore = CodexAccountStore.shared
     @StateObject private var grokAccountStore = GrokAccountStore.shared
+    @StateObject private var openRouterAccountStore = OpenRouterAccountStore.shared
     @StateObject private var providerVisibility = ProviderVisibilityStore.shared
     @StateObject private var claudeCodeService = ClaudeCodeLocalService.shared
     @StateObject private var codexCliService = CodexCliLocalService.shared
@@ -410,6 +411,7 @@ struct UsageDashboardView: View {
                 claudeAccounts: claudeAccountStore.accounts,
                 codexAccounts: codexAccountStore.accounts,
                 grokAccounts: grokAccountStore.accounts,
+                openRouterAccounts: openRouterAccountStore.accounts,
                 enabledServices: providerVisibility.enabledServices,
                 claudeCodeService: claudeCodeService,
                 codexCliService: codexCliService,

--- a/MeterBarTests/AppDelegateSplitTests.swift
+++ b/MeterBarTests/AppDelegateSplitTests.swift
@@ -601,7 +601,8 @@ final class AppDelegateSplitTests: XCTestCase {
         XCTAssertFalse(services.contains(.claudeCode))
         XCTAssertFalse(services.contains(.codexCli))
         XCTAssertFalse(services.contains(.grok))
-        XCTAssertEqual(services, [.cursor, .openRouter])
+        XCTAssertFalse(services.contains(.openRouter))
+        XCTAssertEqual(services, [.cursor])
         XCTAssertEqual(
             services.count,
             ServiceType.allCases.filter { !$0.hasAccountScopedNotifications }.count

--- a/MeterBarTests/OpenRouterMultiKeyTests.swift
+++ b/MeterBarTests/OpenRouterMultiKeyTests.swift
@@ -1,0 +1,194 @@
+import Foundation
+import MeterBarShared
+import Security
+import XCTest
+@testable import MeterBar
+
+// MARK: - Keychain layout
+
+final class OpenRouterKeychainLayoutTests: XCTestCase {
+    /// The default account keeps the legacy single-key item name so pre-multi-key
+    /// installs migrate without copying or rewriting anything.
+    func testDefaultAccountUsesTheLegacySingleKeyName() {
+        XCTAssertEqual(
+            OpenRouterService.keychainKey(for: OpenRouterAccount.defaultID),
+            OpenRouterService.keychainKey
+        )
+    }
+
+    func testCustomAccountsGetPerAccountItemNames() {
+        let id = UUID()
+        XCTAssertNotEqual(OpenRouterService.keychainKey(for: id), OpenRouterService.keychainKey)
+        XCTAssertTrue(OpenRouterService.keychainKey(for: id).hasPrefix(OpenRouterService.keychainKey))
+        XCTAssertEqual(
+            OpenRouterService.keychainKey(for: id),
+            OpenRouterService.keychainKey(for: id),
+            "item names must be stable across launches"
+        )
+    }
+
+    func testSaveHasAndRemoveRoundTripPerAccount() {
+        let keychain = KeychainManager(
+            backend: SeededKeychainBackend(),
+            currentService: "test.openrouter.layout"
+        )
+        let service = OpenRouterService(keychain: keychain)
+        let first = UUID()
+        let second = UUID()
+
+        XCTAssertFalse(service.hasKey(for: first))
+        XCTAssertTrue(service.saveAPIKey("sk-or-v1-a", for: first))
+        XCTAssertTrue(service.saveAPIKey("sk-or-v1-b", for: second))
+
+        XCTAssertTrue(service.hasKey(for: first))
+        XCTAssertTrue(service.hasKey(for: second))
+        XCTAssertEqual(keychain.get(key: OpenRouterService.keychainKey(for: first)), "sk-or-v1-a")
+        XCTAssertEqual(keychain.get(key: OpenRouterService.keychainKey(for: second)), "sk-or-v1-b")
+
+        XCTAssertTrue(service.removeAPIKey(for: first))
+        XCTAssertFalse(service.hasKey(for: first))
+        XCTAssertTrue(service.hasKey(for: second), "removing one key must not touch its peers")
+    }
+
+    /// An existing 1.8.x single key is the default account's key with no
+    /// migration step: the legacy item simply *is* the default account's item.
+    func testLegacySingleKeyIsReadableThroughTheDefaultAccount() {
+        let keychain = KeychainManager(
+            backend: SeededKeychainBackend(),
+            currentService: "test.openrouter.legacy"
+        )
+        XCTAssertTrue(keychain.save(key: OpenRouterService.keychainKey, value: "sk-or-v1-legacy"))
+
+        let service = OpenRouterService(keychain: keychain)
+        XCTAssertTrue(service.canAccess(account: OpenRouterAccount.defaultAccount))
+    }
+}
+
+// MARK: - Ledger aggregation
+
+final class OpenRouterAggregatedObservationTests: XCTestCase {
+    private func observation(running: Double, daily: Double?) -> ProviderUsageObservation {
+        ProviderUsageObservation(
+            provider: .openRouter,
+            unit: .usd,
+            runningTotal: running,
+            authoritativeDailyTotal: daily,
+            dayBoundary: .utc,
+            observedAt: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    func testSumsRunningTotalsAcrossKeys() throws {
+        let aggregated = try XCTUnwrap(OpenRouterService.aggregatedObservation(
+            [observation(running: 10, daily: 1), observation(running: 2.5, daily: 0.5)],
+            observedAt: Date(timeIntervalSince1970: 100)
+        ))
+        XCTAssertEqual(aggregated.runningTotal, 12.5, accuracy: 0.0001)
+        XCTAssertEqual(try XCTUnwrap(aggregated.authoritativeDailyTotal), 1.5, accuracy: 0.0001)
+        XCTAssertEqual(aggregated.provider, .openRouter)
+        XCTAssertEqual(aggregated.unit, .usd)
+        XCTAssertEqual(aggregated.dayBoundary, .utc)
+    }
+
+    /// A partial `usage_daily` sum would understate the day while looking
+    /// authoritative — a missing report falls back to the delta path instead.
+    func testMissingDailyOnAnyKeyDropsTheAuthoritativeTotal() throws {
+        let aggregated = try XCTUnwrap(OpenRouterService.aggregatedObservation(
+            [observation(running: 10, daily: 1), observation(running: 2.5, daily: nil)],
+            observedAt: Date(timeIntervalSince1970: 100)
+        ))
+        XCTAssertEqual(aggregated.runningTotal, 12.5, accuracy: 0.0001)
+        XCTAssertNil(aggregated.authoritativeDailyTotal)
+    }
+
+    func testEmptyPollProducesNoObservation() {
+        XCTAssertNil(OpenRouterService.aggregatedObservation([], observedAt: Date()))
+    }
+}
+
+// MARK: - Account store
+
+final class OpenRouterAccountStoreTests: XCTestCase {
+    private func makeStore() -> (OpenRouterAccountStore, UserDefaults) {
+        let suiteName = "OpenRouterAccountStoreTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return (OpenRouterAccountStore(accounts: [.defaultAccount]), .standard)
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return (OpenRouterAccountStore(userDefaults: defaults, refreshConfigurationDirectory: nil), defaults)
+    }
+
+    private func addKey(_ store: OpenRouterAccountStore, _ name: String) -> OpenRouterAccount {
+        guard let account = store.addAccount(name: name) else {
+            return OpenRouterAccount(id: OpenRouterAccount.defaultID, name: name)
+        }
+        return account
+    }
+
+    func testAddAccountReturnsAnIdentifiedAccountAndPersistsIt() {
+        let (store, defaults) = makeStore()
+        let account = store.addAccount(name: "Work")
+
+        let created = try? XCTUnwrap(account)
+        guard let created else { return }
+        XCTAssertEqual(created.name, "Work")
+        XCTAssertFalse(created.isDefault)
+        XCTAssertEqual(store.accounts.count, 2)
+
+        // Persists across a fresh store over the same defaults.
+        let reloaded = OpenRouterAccountStore(userDefaults: defaults, refreshConfigurationDirectory: nil)
+        XCTAssertEqual(reloaded.customAccounts.map(\.id), [created.id])
+    }
+
+    func testAddAccountRejectsBlankNames() {
+        let (store, _) = makeStore()
+        XCTAssertNil(store.addAccount(name: "   "))
+        XCTAssertEqual(store.accounts.count, 1)
+    }
+
+    func testLastEnabledKeyCannotBeDisabledOrRemoved() {
+        let (store, _) = makeStore()
+        let account = addKey(store, "Only")
+
+        // With both enabled, either can be disabled; the guard bites only when
+        // one would leave zero enabled keys.
+        XCTAssertEqual(store.setEnabled(false, for: OpenRouterAccount.defaultID), .updated)
+        XCTAssertEqual(store.setEnabled(false, for: account.id), .rejectedLastEnabledAccount)
+        XCTAssertEqual(store.removeAccount(id: account.id), .rejectedLastEnabledAccount)
+        XCTAssertEqual(store.enabledAccounts.map(\.id), [account.id])
+    }
+
+    func testRemoveDeletesCustomButNeverTheDefaultSentinel() {
+        let (store, _) = makeStore()
+        let account = addKey(store, "Temp")
+        XCTAssertTrue(store.removeAccount(id: account.id).isUpdated)
+        XCTAssertNil(store.accounts.first { $0.id == account.id })
+
+        XCTAssertEqual(store.removeAccount(id: OpenRouterAccount.defaultID), .unchanged)
+        XCTAssertTrue(store.accounts.contains(where: \.isDefault))
+    }
+
+    func testOrderSurvivesReloadAndPrunesDeletedIDs() {
+        let (store, defaults) = makeStore()
+        let first = addKey(store, "First")
+        let second = addKey(store, "Second")
+
+        var reloaded = OpenRouterAccountStore(userDefaults: defaults, refreshConfigurationDirectory: nil)
+        reloaded.moveAccounts(fromOffsets: IndexSet(integer: 2), toOffset: 0)
+
+        let reordered = OpenRouterAccountStore(userDefaults: defaults, refreshConfigurationDirectory: nil)
+        XCTAssertEqual(
+            reordered.accounts.map(\.id),
+            [second.id, OpenRouterAccount.defaultID, first.id],
+            "moving the last row to the front reorders the whole list"
+        )
+
+        reordered.removeAccount(id: second.id)
+        let pruned = OpenRouterAccountStore(userDefaults: defaults, refreshConfigurationDirectory: nil)
+        XCTAssertNil(pruned.accountOrder.first { $0 == second.id })
+    }
+}
+
+private extension OpenRouterAccountMutationOutcome {
+    var isUpdated: Bool { self == .updated }
+}

--- a/MeterBarTests/OpenRouterServiceTests.swift
+++ b/MeterBarTests/OpenRouterServiceTests.swift
@@ -177,8 +177,9 @@ final class OpenRouterServiceTests: XCTestCase {
                 }
             }
 
-            let fetched = try await service.fetchUsageMetrics()
-            return (fetched, service.hasAccess)
+            let account = OpenRouterAccount.defaultAccount
+            let fetched = try await service.fetchUsageMetrics(account: account)
+            return (fetched, service.canAccess(account: account))
         }.value
 
         XCTAssertEqual(metrics.0.service, .openRouter)
@@ -205,9 +206,10 @@ final class OpenRouterServiceTests: XCTestCase {
 }
 
 /// In-memory `KeychainBackend` seeded purely by writes, keyed by service and
+/// (shared with `OpenRouterMultiKeyTests`)
 /// account like the real item space. Only what the regression test needs:
 /// update-then-add save, data-returning read.
-nonisolated private final class SeededKeychainBackend: KeychainBackend {
+nonisolated final class SeededKeychainBackend: KeychainBackend {
     private struct ItemKey: Hashable {
         let service: String
         let account: String

--- a/MeterBarTests/ProviderCapabilitiesTests.swift
+++ b/MeterBarTests/ProviderCapabilitiesTests.swift
@@ -56,21 +56,32 @@ final class ProviderCapabilitiesTests: XCTestCase {
                 hasAccountScopedQuotaEvents: true
             )
         )
-        for service in [ServiceType.cursor, .openRouter] {
-            XCTAssertEqual(
-                service.capabilities,
-                ProviderCapabilities(
-                    isMultiAccount: false,
-                    supportsExtraUsage: false,
-                    supportsResetRedemption: false,
-                    supportsGuardConfigDirectory: false,
-                    supportsSessionWake: false,
-                    hasAccountScopedNotifications: false,
-                    hasAccountScopedQuotaEvents: false
-                ),
-                "\(service)"
-            )
-        }
+        XCTAssertEqual(
+            ServiceType.openRouter.capabilities,
+            ProviderCapabilities(
+                isMultiAccount: true,
+                supportsExtraUsage: false,
+                supportsResetRedemption: false,
+                supportsGuardConfigDirectory: false,
+                supportsSessionWake: false,
+                hasAccountScopedNotifications: true,
+                hasAccountScopedQuotaEvents: true
+            ),
+            "openRouter"
+        )
+        XCTAssertEqual(
+            ServiceType.cursor.capabilities,
+            ProviderCapabilities(
+                isMultiAccount: false,
+                supportsExtraUsage: false,
+                supportsResetRedemption: false,
+                supportsGuardConfigDirectory: false,
+                supportsSessionWake: false,
+                hasAccountScopedNotifications: false,
+                hasAccountScopedQuotaEvents: false
+            ),
+            "cursor"
+        )
     }
 
     func testSessionWakeIsAnExplicitExceptionForGrok() {
@@ -92,8 +103,8 @@ final class ProviderCapabilitiesTests: XCTestCase {
         XCTAssertFalse(UsageNotificationCoordinator.flatNotificationServices.contains(.claudeCode))
         XCTAssertFalse(UsageNotificationCoordinator.flatNotificationServices.contains(.codexCli))
         XCTAssertFalse(UsageNotificationCoordinator.flatNotificationServices.contains(.grok))
+        XCTAssertFalse(UsageNotificationCoordinator.flatNotificationServices.contains(.openRouter))
         XCTAssertTrue(UsageNotificationCoordinator.flatNotificationServices.contains(.cursor))
-        XCTAssertTrue(UsageNotificationCoordinator.flatNotificationServices.contains(.openRouter))
     }
 
     func testFlatQuotaEventProvidersAreExactlyThoseWithoutAccountScopedQuotaEvents() {
@@ -184,7 +195,8 @@ final class ProviderCapabilitiesTests: XCTestCase {
                 metrics: metrics,
                 claudeAccounts: [.defaultAccount],
                 claudeAccountMetrics: [:],
-                enabledServices: Set(ServiceType.allCases)
+                enabledServices: Set(ServiceType.allCases),
+                openRouterAccounts: [.defaultAccount]
             )
         )
         XCTAssertEqual(Set(snapshots.map(\.service)), Set(ServiceType.allCases))
@@ -266,6 +278,11 @@ final class ProviderCapabilitiesTests: XCTestCase {
                 accounts: [AccountNotificationIdentity(account: GrokAccount.defaultAccount)],
                 metrics: [GrokAccount.defaultID: MetricsFixtures.grok()],
                 defaultID: GrokAccount.defaultID
+            ),
+            openRouter: NotificationAccountBundle(
+                accounts: [AccountNotificationIdentity(account: OpenRouterAccount.defaultAccount)],
+                metrics: [OpenRouterAccount.defaultID: MetricsFixtures.openRouter()],
+                defaultID: OpenRouterAccount.defaultID
             )
         )
         XCTAssertEqual(
@@ -282,7 +299,8 @@ final class ProviderCapabilitiesTests: XCTestCase {
         let selectable = QuotaEventSnapshotCatalog.selectableAccounts(
             claudeAccounts: [.defaultAccount],
             codexAccounts: [.defaultAccount],
-            grokAccounts: [.defaultAccount]
+            grokAccounts: [.defaultAccount],
+            openRouterAccounts: [.defaultAccount]
         )
         for service in ServiceType.allCases {
             XCTAssertTrue(
@@ -329,7 +347,9 @@ final class ProviderCapabilitiesTests: XCTestCase {
                 codexAccounts: [.defaultAccount],
                 codexAccountMetrics: [CodexAccount.defaultID: MetricsFixtures.codexCli()],
                 grokAccounts: [.defaultAccount],
-                grokAccountMetrics: [GrokAccount.defaultID: MetricsFixtures.grok()]
+                grokAccountMetrics: [GrokAccount.defaultID: MetricsFixtures.grok()],
+                openRouterAccounts: [.defaultAccount],
+                openRouterAccountMetrics: [OpenRouterAccount.defaultID: MetricsFixtures.openRouter()]
             ),
             enabledServices: Set(ServiceType.allCases)
         )
@@ -354,7 +374,8 @@ final class ProviderCapabilitiesTests: XCTestCase {
                 metrics: MetricsFixtures.allProviders(),
                 claudeAccounts: [.defaultAccount],
                 claudeAccountMetrics: [:],
-                enabledServices: Set(ServiceType.allCases)
+                enabledServices: Set(ServiceType.allCases),
+                openRouterAccounts: [.defaultAccount]
             )
         )
         XCTAssertEqual(Set(snapshots.map(\.service)), Set(ServiceType.allCases))

--- a/MeterBarTests/ProviderPresentationHealthTests.swift
+++ b/MeterBarTests/ProviderPresentationHealthTests.swift
@@ -617,7 +617,10 @@ final class ProviderPresentationHealthTests: XCTestCase {
         case (.cursor, .transientFailure), (.cursor, .sustainedOrParseFailure):
             lastErrors.cursor = .apiError("Cursor refresh failed")
         case (.openRouter, .transientFailure), (.openRouter, .sustainedOrParseFailure):
-            lastErrors.openRouter = .apiError("OpenRouter refresh failed")
+            // Key-scoped cards read only their own key's error.
+            lastErrors.openRouterAccounts = [
+                OpenRouterAccount.defaultID: .apiError("OpenRouter refresh failed")
+            ]
         case (.codex, .transientFailure), (.codex, .sustainedOrParseFailure):
             lastErrors.codexAccounts = [CodexAccount.defaultID: .apiError("Codex refresh failed")]
         case (.grok, .transientFailure), (.grok, .sustainedOrParseFailure):

--- a/MeterBarTests/ProviderPresentationHealthTests.swift
+++ b/MeterBarTests/ProviderPresentationHealthTests.swift
@@ -496,7 +496,8 @@ final class ProviderPresentationHealthTests: XCTestCase {
                 claudeAccounts: [],
                 claudeAccountMetrics: [:],
                 enabledServices: [.openRouter],
-                openRouterHasAccess: false
+                openRouterAccounts: [.defaultAccount],
+                openRouterAccountAccess: [OpenRouterAccount.defaultID: false]
             )
         )
 
@@ -581,7 +582,13 @@ final class ProviderPresentationHealthTests: XCTestCase {
                 claudeAccountMetrics: kind == .claude ? [ClaudeCodeAccount.defaultID: metrics] : [:],
                 enabledServices: [kind.service],
                 cursorHasAccess: kind == .cursor ? true : nil,
-                openRouterHasAccess: kind == .openRouter ? true : nil
+                openRouterAccounts: kind == .openRouter ? [.defaultAccount] : [],
+                openRouterAccountMetrics: kind == .openRouter
+                    ? [OpenRouterAccount.defaultID: metrics]
+                    : [:],
+                openRouterAccountAccess: kind == .openRouter
+                    ? [OpenRouterAccount.defaultID: true]
+                    : [:]
             )
         )
         return try XCTUnwrap(snapshots.first { $0.service == kind.service }, kind.rawValue)
@@ -650,7 +657,13 @@ final class ProviderPresentationHealthTests: XCTestCase {
             claudeCodeHasAccess: kind == .claude && refresh != .unprobed,
             codexCliHasAccess: kind == .codex && refresh != .unprobed,
             cursorHasAccess: kind == .cursor && refresh != .unprobed ? true : nil,
-            openRouterHasAccess: kind == .openRouter && refresh != .unprobed ? true : nil,
+            openRouterAccounts: kind == .openRouter ? [.defaultAccount] : [],
+            openRouterAccountMetrics: kind == .openRouter
+                ? metrics.map { [OpenRouterAccount.defaultID: $0] } ?? [:]
+                : [:],
+            openRouterAccountAccess: kind == .openRouter && refresh != .unprobed
+                ? [OpenRouterAccount.defaultID: true]
+                : [:],
             grokHasAccess: kind == .grok && refresh != .unprobed,
             lastErrors: lastErrors
         )

--- a/MeterBarTests/ProviderSnapshotTests.swift
+++ b/MeterBarTests/ProviderSnapshotTests.swift
@@ -29,6 +29,8 @@ final class ProviderSnapshotTests: XCTestCase {
         grokAccountMetrics: [UUID: UsageMetrics] = [:],
         claudeAccounts: [ClaudeCodeAccount] = [.defaultAccount],
         claudeAccountMetrics: [UUID: UsageMetrics] = [:],
+        openRouterAccounts: [OpenRouterAccount] = [.defaultAccount],
+        openRouterAccountMetrics: [UUID: UsageMetrics] = [:],
         enabledServices: Set<ServiceType> = Set(ServiceType.allCases),
         codexAccountAccess: [UUID: Bool] = [:],
         codexCliHasAccess: Bool = false
@@ -43,7 +45,12 @@ final class ProviderSnapshotTests: XCTestCase {
             claudeAccounts: claudeAccounts,
             claudeAccountMetrics: claudeAccountMetrics,
             enabledServices: enabledServices,
-            codexCliHasAccess: codexCliHasAccess
+            codexCliHasAccess: codexCliHasAccess,
+            openRouterAccounts: openRouterAccounts,
+            openRouterAccountMetrics: openRouterAccountMetrics,
+            openRouterAccountAccess: openRouterAccounts.reduce(into: [:]) {
+                $0[$1.id] = true
+            }
         )
     }
 

--- a/MeterBarTests/QuotaEventServiceTests.swift
+++ b/MeterBarTests/QuotaEventServiceTests.swift
@@ -34,7 +34,11 @@ final class QuotaEventServiceTests: XCTestCase {
                 codexAccounts: [codex],
                 codexAccountMetrics: [codex.id: usage(service: .codexCli, used: 50)],
                 grokAccounts: [grok],
-                grokAccountMetrics: [grok.id: usage(service: .grok, used: 50)]
+                grokAccountMetrics: [grok.id: usage(service: .grok, used: 50)],
+                openRouterAccounts: [.defaultAccount],
+                openRouterAccountMetrics: [
+                    OpenRouterAccount.defaultID: usage(service: .openRouter, used: 50)
+                ]
             ),
             enabledServices: Set(ServiceType.allCases)
         )

--- a/Packages/MeterBarShared/Sources/MeterBarShared/ProviderCapabilities.swift
+++ b/Packages/MeterBarShared/Sources/MeterBarShared/ProviderCapabilities.swift
@@ -73,7 +73,7 @@ public struct ProviderCapabilities: Equatable, Sendable {
                 hasAccountScopedNotifications: true,
                 hasAccountScopedQuotaEvents: true
             )
-        case .cursor, .openRouter:
+        case .cursor:
             return ProviderCapabilities(
                 isMultiAccount: false,
                 supportsExtraUsage: false,
@@ -82,6 +82,19 @@ public struct ProviderCapabilities: Equatable, Sendable {
                 supportsSessionWake: false,
                 hasAccountScopedNotifications: false,
                 hasAccountScopedQuotaEvents: false
+            )
+        case .openRouter:
+            // Multi-key: each managed API key is an account. Extra usage, reset
+            // redemption, guard config directories, and Session Wake have no
+            // OpenRouter analog.
+            return ProviderCapabilities(
+                isMultiAccount: true,
+                supportsExtraUsage: false,
+                supportsResetRedemption: false,
+                supportsGuardConfigDirectory: false,
+                supportsSessionWake: false,
+                hasAccountScopedNotifications: true,
+                hasAccountScopedQuotaEvents: true
             )
         }
     }

--- a/docs/cli-json-schema.md
+++ b/docs/cli-json-schema.md
@@ -86,8 +86,8 @@ working. When the app-group account cache (`loadAccountMetrics()`) has snapshots
 also includes an additive `accounts` array — one entry per cached profile, never a filesystem path,
 `GROK_HOME`, or token.
 
-`accounts` is omitted when that cache is empty (legacy provider-only files, or Cursor / OpenRouter
-which stay provider-only and never get fake accounts).
+`accounts` is omitted when that cache is empty (legacy provider-only files, or Cursor which stays
+provider-only and never gets fake accounts). OpenRouter entries are one per managed API key.
 
 ```json
 {
@@ -533,7 +533,6 @@ period in `additionalLimits`. `--min-remaining` is a percentage of quota that mu
 without it, only exhaustion blocks. `--config-dir` narrows the check to one configured Claude
 Code, OpenAI Codex, or Grok account by its configuration directory (Claude/Codex config dir, or
 Grok `GROK_HOME`). Cursor and OpenRouter have no per-account directories and are rejected.
-
 The JSON `window` field stays `session`, `weekly`, or `codeReview`. Additive `periodKind` names
 the reported cadence. Human `message` text uses that cadence ("monthly", never "weekly" for a
 monthly Grok allowance).


### PR DESCRIPTION
## What

OpenRouter now supports **multiple API keys**, matching the multi-account feature parity of Claude Code, Codex, and Grok. Each key is an `OpenRouterAccount` with its own Keychain item, per-key usage card, notifications, and quota events.

**Zero-migration upgrade:** the default account maps onto the legacy `openRouterAPIKey` Keychain item, so every existing install's single key becomes "Default Key" with no copying, rewriting, or re-entry.

## Storage

- `OpenRouterAccount` + `OpenRouterAccountStore`: Codex-store pattern including the last-enabled-key guard; non-secret metadata only (UserDefaults + `refresh-openrouter-accounts-v1.json` CLI mirror). Key material never leaves the Keychain.
- Per-key items: `openRouterAPIKey` (default) / `openRouterAPIKey.<uuid>` (custom).

## Refresh

- Account-aware `OpenRouterUsageProviding` seam; fan-out mirrors Grok (keyless accounts skip without failing the provider; failed keys fall back to their own cache).
- Provider-wide slot carries the representative key's metrics. Ledger folds all polled keys' spend into one summed observation — authoritative daily total drops to nil unless *every* key published `usage_daily`, so a partial sum can't masquerade as the day's truth.
- Widget + CLI get per-key rows through the existing `AccountUsageSnapshot` cache — no schema change.

## Surfaces

- **Settings**: API Keys list — add (name + SecureField sheet), rename, enable/disable, reorder, remove (deletes the Keychain item); Get Key always reachable; first key un-hides the opt-in provider.
- **Popover/dashboard**: one card per enabled key.
- Per-key threshold notifications, quota events, aggregated readiness reports, diagnostics.
- `ProviderCapabilities` flips `isMultiAccount`, `hasAccountScopedNotifications`, `hasAccountScopedQuotaEvents`.

## Tests

- New: keychain layout + legacy migration, per-key save/remove round-trip, ledger aggregation (sum / partial-daily drop / empty poll), store persistence + ordering + last-enabled guard.
- Updated: capability-truth and coverage fixtures for the flipped flags.
- **Full suite: 2634 tests, 0 failures.** App target builds. SwiftLint clean on touched files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Keychain-backed API keys and account-scoped refresh, notifications, and metrics. Risk is moderated by reusing the existing multi-account pattern and keeping the legacy default Keychain item unchanged.
> 
> **Overview**
> OpenRouter is no longer a single-key provider. Users can add, rename, enable, reorder, and remove named API keys, each with its own Keychain item, usage card, notifications, quota events, widgets, and diagnostics.
> 
> The default account **reuses the legacy `openRouterAPIKey` item**, so existing installs keep working with no migration. Custom keys live at `openRouterAPIKey.<uuid>`; only non-secret metadata is persisted to UserDefaults and the CLI refresh config.
> 
> Refresh fans out per enabled key (keyless accounts skip; failures keep that key’s cache). Spend is summed into one ledger observation, and the authoritative daily total is dropped unless every polled key reported `usage_daily`. Settings uses a Keychain-only add sheet; popover/dashboard show one card per enabled key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8b8081ba88ad94bb949a72e252b13e7d69871fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage multiple OpenRouter API keys with named accounts.
  * Add, edit, remove, enable, disable, and reorder OpenRouter accounts in Settings.
  * View per-account usage, access status, errors, and metrics across dashboards.
  * OpenRouter usage, quota events, notifications, and diagnostics now support account-level tracking.
  * Existing default-account configurations remain supported.

* **Documentation**
  * Updated CLI account documentation to describe OpenRouter’s per-key account entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->