### PR TITLE
chore(release): bump version to 1.8.38

### DIFF
--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.37;
+				MARKETING_VERSION = 1.8.38;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -369,7 +369,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.37;
+				MARKETING_VERSION = 1.8.38;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -534,7 +534,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.37;
+				MARKETING_VERSION = 1.8.38;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug;
 				PRODUCT_NAME = "MeterBar Dev";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -580,7 +580,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.37;
+				MARKETING_VERSION = 1.8.38;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary
- Version bump `MARKETING_VERSION` 1.8.37 → 1.8.38 (4 build configurations), matching the #478 bump shape
- Ships today's merged work: #479 (provider routing + widget urgency fixes), #480 (OpenRouter key-save crash), #481 (OpenRouter multi-key management)

## Test plan
- [x] Diff limited to `project.pbxproj` version strings (4 lines, same as previous bump)
- [ ] CI green on the bump commit
- [ ] Tag `v1.8.38` pushed after merge; `Release` workflow publishes signed build + appcast + Homebrew tap update

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to 1.8.38 across all build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->