### PR TITLE
Dashboard overview/limits split, quota UI polish, and URLSession crash fix

### DIFF
--- a/MeterBar/Models/ProviderDailyUsageSeries.swift
+++ b/MeterBar/Models/ProviderDailyUsageSeries.swift
@@ -227,6 +227,14 @@ struct ProviderDailyUsageSeries: Equatable {
     /// seven flat bars, which would read as a genuinely quiet week.
     var hasHistory: Bool { days.contains { $0.isMeasured && $0.value > 0 } }
 
+    /// Whether the hover detail panel should render the history section.
+    ///
+    /// Log-scanning providers always get a block (empty, loading, or chart).
+    /// Polled providers (Cursor, OpenRouter) only when the ledger has data —
+    /// Cursor's documented Admin API daily history requires Enterprise API keys
+    /// MeterBar does not use, and `/api/usage-summary` publishes no dated series.
+    var showsInOverview: Bool { hasHistory || service.writesLocalTokenLogs }
+
     /// True when the source could speak for part of the window but not all of
     /// it, which is worth a one-line caption rather than an empty state.
     var hasPartialCoverage: Bool { days.contains { !$0.isMeasured } }

--- a/MeterBar/Services/CodexCliLocalService.swift
+++ b/MeterBar/Services/CodexCliLocalService.swift
@@ -235,27 +235,30 @@ class CodexCliLocalService: ObservableObject {
         )
 
         do {
-            let (data, response) = try await urlSession.data(for: request)
-            try ServiceSupport.validate(response, data: data)
-
-            let decoder = JSONDecoder()
-            // Note: Codex CLI API uses Unix timestamps (Int64), not ISO8601 dates
-
-            // Decode the actual Codex CLI usage response
-            let usageResponse = try decoder.decode(CodexCliUsageResponse.self, from: data)
+            // Network + decode must not run as main-actor jobs: same
+            // `NSURLSession.data(for:)` null-receiver hazard as Cursor /
+            // OpenRouter (#480) when default actor isolation is MainActor.
+            let session = urlSession
+            let (metrics, planType) = try await Task.detached(priority: .userInitiated) {
+                let (data, response) = try await session.data(for: request)
+                try ServiceSupport.validate(response, data: data)
+                // Codex CLI API uses Unix timestamps (Int64), not ISO8601 dates.
+                let usageResponse = try JSONDecoder().decode(CodexCliUsageResponse.self, from: data)
+                return (usageResponse.toUsageMetrics(), usageResponse.planType)
+            }.value
 
             await MainActor.run {
                 self.accountErrors.removeValue(forKey: account.id)
                 self.record(true, for: account)
                 if account.isDefault {
-                    self.subscriptionType = usageResponse.planType
+                    self.subscriptionType = planType
                 }
             }
 
             // Pure response→UsageMetrics mapping (window math, code-review limit,
             // extra-usage + reset-credit derivation) lives on the response type
             // so it's unit-testable with fixture JSON, no network.
-            return usageResponse.toUsageMetrics()
+            return metrics
         } catch {
             let serviceError = ServiceSupport.serviceError(from: error)
             AppLog.usage.error("Codex usage fetch failed: \(serviceError.localizedDescription)")
@@ -310,9 +313,12 @@ class CodexCliLocalService: ObservableObject {
 
         let response: ConsumeResetCreditResponse
         do {
-            let (data, urlResponse) = try await urlSession.data(for: request)
-            try ServiceSupport.validate(urlResponse, data: data)
-            response = try JSONDecoder().decode(ConsumeResetCreditResponse.self, from: data)
+            let session = urlSession
+            response = try await Task.detached(priority: .userInitiated) {
+                let (data, urlResponse) = try await session.data(for: request)
+                try ServiceSupport.validate(urlResponse, data: data)
+                return try JSONDecoder().decode(ConsumeResetCreditResponse.self, from: data)
+            }.value
         } catch {
             throw ServiceSupport.serviceError(from: error)
         }
@@ -355,9 +361,12 @@ class CodexCliLocalService: ObservableObject {
         )
 
         do {
-            let (data, response) = try await urlSession.data(for: request)
-            try ServiceSupport.validate(response, data: data)
-            return try JSONDecoder().decode(ResetCreditsResponse.self, from: data)
+            let session = urlSession
+            return try await Task.detached(priority: .userInitiated) {
+                let (data, response) = try await session.data(for: request)
+                try ServiceSupport.validate(response, data: data)
+                return try JSONDecoder().decode(ResetCreditsResponse.self, from: data)
+            }.value
         } catch {
             throw ServiceSupport.serviceError(from: error)
         }
@@ -395,7 +404,7 @@ class CodexCliLocalService: ObservableObject {
     /// Thin alias over `CodexCliUsageResponse.toUsageMetrics()` — the single
     /// implementation of the window/limit derivation — kept so both fixture
     /// test suites exercise the same code path.
-    static func mapUsageResponse(_ usageResponse: CodexCliUsageResponse) -> UsageMetrics {
+    nonisolated static func mapUsageResponse(_ usageResponse: CodexCliUsageResponse) -> UsageMetrics {
         usageResponse.toUsageMetrics()
     }
 }
@@ -629,7 +638,7 @@ extension CodexCliUsageResponse {
     /// limit and moves the only remaining weekly window into `primary_window`.
     /// Free accounts (null `rate_limit`) carry no windows, only the
     /// extra-usage/reset-credit signals.
-    func toUsageMetrics() -> UsageMetrics {
+    nonisolated func toUsageMetrics() -> UsageMetrics {
         guard let rateLimit else {
             // Free accounts have a null rate_limit — no quota windows to report.
             return UsageMetrics(

--- a/MeterBar/Services/CursorLocalService.swift
+++ b/MeterBar/Services/CursorLocalService.swift
@@ -15,23 +15,26 @@ class CursorLocalService: ObservableObject {
     nonisolated static let shared = CursorLocalService()
 
     // API endpoint (from Vibeviewer: https://github.com/MarveleE/Vibeviewer)
-    private let usageSummaryEndpoint = "https://cursor.com/api/usage-summary"
+    nonisolated private static let usageSummaryEndpoint = "https://cursor.com/api/usage-summary"
 
     /// Cursor Ultra weekly Grok Bot entitlement. Not MeterBar's Grok
     /// provider and not present on `/api/usage-summary`.
-    private let sandUsageEndpoint =
+    nonisolated private static let sandUsageEndpoint =
         "https://api2.cursor.sh/aiserver.v1.DashboardService/GetSandUsageStatus"
 
-    // Shared URLSession with the standard usage-request timeouts
-    private let urlSession = ServiceSupport.session
+    /// Production and tests share this seam so the off-main regression can
+    /// probe through a *stored* `@Sendable` closure — the exact shape that
+    /// crashed 1.8.38 entering `NSURLSession.data(for:)` (OpenRouter #480,
+    /// Codex #328).
+    private let fetchData: @Sendable (URLRequest) async throws -> Data
 
     // Last-resort monthly request quota, used only when the API returns no
     // usable plan quota at all; the resulting limit is marked `isEstimated`.
     // Static so the pure `mapSummary` mapping can share the same constant.
-    private static let defaultPlanTotal: Double = 500
+    nonisolated private static let defaultPlanTotal: Double = 500
 
     // Display headroom estimate when no explicit on-demand limit is returned by the API
-    private static let onDemandHeadroomMultiplier: Double = 1.5
+    nonisolated private static let onDemandHeadroomMultiplier: Double = 1.5
 
     @Published private(set) var hasAccess: Bool = false
     @Published private(set) var subscriptionType: String?
@@ -45,7 +48,8 @@ class CursorLocalService: ObservableObject {
     /// only way Cursor can appear in a dated series. See `ProviderUsageLedger`.
     private(set) var latestUsageObservation: ProviderUsageObservation?
 
-    private init() {
+    init(fetchData: (@Sendable (URLRequest) async throws -> Data)? = nil) {
+        self.fetchData = fetchData ?? Self.fetch
         // Defer I/O off main thread; only @Published mutations land on main actor
         Task.detached(priority: .utility) { [weak self] in self?.checkAccess(forceRescan: false) }
     }
@@ -218,7 +222,7 @@ class CursorLocalService: ObservableObject {
     }
 
     /// Format authentication cookie for Cursor API
-    private static func formatAuthCookie(userId: String, token: String) -> String {
+    nonisolated private static func formatAuthCookie(userId: String, token: String) -> String {
         // Format: userId::token (URL encoded)
         "\(userId)%3A%3A\(token)"
     }
@@ -261,22 +265,75 @@ class CursorLocalService: ObservableObject {
             self.hasAccess = true
         }
 
-        // Fetch usage summary data (uses /api/usage-summary endpoint)
-        let summaryData = try await fetchUsageSummary(userId: userId, token: token)
-        // Grok Bot weekly pool is a separate optional Connect RPC. Failure
-        // must not drop the three usage-summary bars.
-        let sandStatus = await fetchSandUsageStatus(token: token)
-
-        let metrics = CursorLocalService.mapSummary(summaryData, sandStatus: sandStatus)
-
-        // Clear any previous errors on success
-        await MainActor.run {
-            self.lastError = nil
-            self.subscriptionType = summaryData.membershipType
-            self.latestUsageObservation = CursorLocalService.observation(summaryData, at: metrics.lastUpdated)
+        do {
+            let fetched = try await Self.fetchRemotely(
+                userId: userId,
+                token: token,
+                fetchData: fetchData
+            )
+            await MainActor.run {
+                self.lastError = nil
+                self.subscriptionType = fetched.membershipType
+                self.latestUsageObservation = fetched.observation
+            }
+            return fetched.metrics
+        } catch {
+            let serviceError = ServiceSupport.serviceError(from: error)
+            AppLog.usage.error("Cursor usage-summary fetch failed: \(serviceError.localizedDescription)")
+            await MainActor.run {
+                self.lastError = serviceError
+                if case .notAuthenticated = serviceError {
+                    self.hasAccess = false
+                }
+            }
+            throw serviceError
         }
+    }
 
-        return metrics
+    /// Outcome of one off-main poll — only `Sendable` values cross back so the
+    /// main-actor side never touches network state.
+    nonisolated struct FetchedUsage: Sendable {
+        let metrics: UsageMetrics
+        let observation: ProviderUsageObservation?
+        let membershipType: String?
+    }
+
+    /// Runs both network legs and the decode off the main actor.
+    ///
+    /// The app target compiles with `SWIFT_DEFAULT_ACTOR_ISOLATION =
+    /// MainActor`, so an unannotated fetch path here would execute as
+    /// main-actor jobs — and hops through a *stored* `fetchData` closure's
+    /// reabstraction thunk leave a dead receiver entering
+    /// `NSURLSession.data(for:delegate:)`. That is the 1.8.38 Cursor refresh
+    /// crash (same class as OpenRouter #480 / Codex #328). Nothing in the
+    /// detached scope touches main-actor state.
+    nonisolated static func fetchRemotely(
+        userId: String,
+        token: String,
+        fetchData: @escaping @Sendable (URLRequest) async throws -> Data
+    ) async throws -> FetchedUsage {
+        try await Task.detached(priority: .userInitiated) {
+            let summaryData = try await fetchUsageSummary(
+                userId: userId,
+                token: token,
+                fetchData: fetchData
+            )
+            // Grok Bot weekly pool is a separate optional Connect RPC. Failure
+            // must not drop the three usage-summary bars.
+            let sandStatus = await fetchSandUsageStatus(token: token, fetchData: fetchData)
+            let metrics = mapSummary(summaryData, sandStatus: sandStatus)
+            return FetchedUsage(
+                metrics: metrics,
+                observation: observation(summaryData, at: metrics.lastUpdated),
+                membershipType: summaryData.membershipType
+            )
+        }.value
+    }
+
+    nonisolated private static func fetch(_ request: URLRequest) async throws -> Data {
+        let (data, response) = try await ServiceSupport.session.data(for: request)
+        try ServiceSupport.validate(response, data: data)
+        return data
     }
 
     /// One poll's reading of the plan counter, in requests.
@@ -307,7 +364,7 @@ class CursorLocalService: ObservableObject {
     /// the ledger, which reads a drop as a new billing cycle and re-baselines to
     /// zero — so the next complete poll would charge the entire cycle-to-date
     /// count to a single day as a phantom spike.
-    static func observation(
+    nonisolated static func observation(
         _ summaryData: CursorUsageSummaryResponse,
         at observedAt: Date
     ) -> ProviderUsageObservation? {
@@ -351,7 +408,7 @@ class CursorLocalService: ObservableObject {
     /// Optional `sandStatus` is Cursor Ultra's weekly Grok Bot pool. It is
     /// attached as `additionalLimits` when the payload maps; omitted status
     /// leaves the three usage-summary bars unchanged.
-    static func mapSummary(
+    nonisolated static func mapSummary(
         _ summaryData: CursorUsageSummaryResponse,
         sandStatus: CursorSandUsageStatusResponse? = nil
     ) -> UsageMetrics {
@@ -412,7 +469,7 @@ class CursorLocalService: ObservableObject {
 
     /// Cursor Ultra weekly Grok Bot pool. Matches Grok Bot.app's omit rules
     /// plus MeterBar's "no phantom 0% bar without a grant" rule.
-    static func mapSandUsage(_ status: CursorSandUsageStatusResponse?) -> UsageLimit? {
+    nonisolated static func mapSandUsage(_ status: CursorSandUsageStatusResponse?) -> UsageLimit? {
         guard let status else { return nil }
         guard let usagePercent = status.usagePercent, usagePercent.isFinite else {
             return nil
@@ -447,7 +504,7 @@ class CursorLocalService: ObservableObject {
 
     /// `billingCycleEnd` is the reset. `end − start` is the real cycle length
     /// when both parse and the duration is positive — no assumed 30-day month.
-    private static func billingCycle(
+    nonisolated private static func billingCycle(
         from summary: CursorUsageSummaryResponse
     ) -> (resetTime: Date?, windowSeconds: TimeInterval?) {
         let start = summary.billingCycleStart.flatMap(FlexibleISO8601.date(from:))
@@ -464,7 +521,7 @@ class CursorLocalService: ObservableObject {
 
     /// One included pool as the dashboard draws it: `used` is already a
     /// 0…100 percent, so the denominator is 100 rather than a request grant.
-    private static func percentPoolLimit(
+    nonisolated private static func percentPoolLimit(
         _ percentUsed: Double,
         resetTime: Date?,
         windowSeconds: TimeInterval?
@@ -478,7 +535,7 @@ class CursorLocalService: ObservableObject {
         )
     }
 
-    private static func onDemandLimit(
+    nonisolated private static func onDemandLimit(
         from onDemand: CursorOnDemandUsage?,
         resetTime: Date?,
         windowSeconds: TimeInterval?
@@ -502,7 +559,7 @@ class CursorLocalService: ObservableObject {
     /// counter. If neither has a counter, retain a server-backed quota or the
     /// first available shape for the summary mapper, while `observation` still
     /// rejects the missing counter instead of inventing a reset.
-    private static func selectedUsage(
+    nonisolated private static func selectedUsage(
         from summaryData: CursorUsageSummaryResponse
     ) -> (plan: CursorPlanUsage?, onDemand: CursorOnDemandUsage?) {
         let individual = summaryData.individualUsage
@@ -530,7 +587,7 @@ class CursorLocalService: ObservableObject {
 
     /// Cursor's session cookie layered on top of the shared browser identity.
     /// Static so the header contract can be asserted without a live service.
-    static func dashboardHeaders(userId: String, token: String) -> [String: String] {
+    nonisolated static func dashboardHeaders(userId: String, token: String) -> [String: String] {
         var headers = ServiceSupport.browserHeaders(for: .cursorDashboard, accept: "*/*")
         headers["Content-Type"] = "application/json"
         headers["Cookie"] = "WorkosCursorSessionToken=\(formatAuthCookie(userId: userId, token: token))"
@@ -540,7 +597,7 @@ class CursorLocalService: ObservableObject {
     /// Connect-RPC headers for DashboardService/GetSandUsageStatus.
     /// Auth is the same Cursor JWT already read from `state.vscdb`.
     /// Static so the header contract can be asserted without a live token.
-    static func aiserverHeaders(token: String) -> [String: String] {
+    nonisolated static func aiserverHeaders(token: String) -> [String: String] {
         [
             "Content-Type": "application/json",
             "Authorization": "Bearer \(token)",
@@ -552,7 +609,11 @@ class CursorLocalService: ObservableObject {
         ]
     }
 
-    private func fetchUsageSummary(userId: String, token: String) async throws -> CursorUsageSummaryResponse {
+    nonisolated private static func fetchUsageSummary(
+        userId: String,
+        token: String,
+        fetchData: @Sendable (URLRequest) async throws -> Data
+    ) async throws -> CursorUsageSummaryResponse {
         guard let url = URL(string: usageSummaryEndpoint) else {
             throw ServiceError.invalidURL
         }
@@ -561,30 +622,20 @@ class CursorLocalService: ObservableObject {
         request.httpMethod = "GET"
         request.timeoutInterval = ServiceSupport.usageRequestTimeout
 
-        for (key, value) in Self.dashboardHeaders(userId: userId, token: token) {
+        for (key, value) in dashboardHeaders(userId: userId, token: token) {
             request.setValue(value, forHTTPHeaderField: key)
         }
 
-        do {
-            let (data, response) = try await urlSession.data(for: request)
-            try ServiceSupport.validate(response, data: data)
-            return try JSONDecoder().decode(CursorUsageSummaryResponse.self, from: data)
-        } catch {
-            let serviceError = ServiceSupport.serviceError(from: error)
-            AppLog.usage.error("Cursor usage-summary fetch failed: \(serviceError.localizedDescription)")
-            await MainActor.run {
-                self.lastError = serviceError
-                if case .notAuthenticated = serviceError {
-                    self.hasAccess = false
-                }
-            }
-            throw serviceError
-        }
+        let data = try await fetchData(request)
+        return try JSONDecoder().decode(CursorUsageSummaryResponse.self, from: data)
     }
 
     /// Optional Grok Bot weekly status. Network, 401, and decode failures
     /// return nil so the required usage-summary path still succeeds.
-    private func fetchSandUsageStatus(token: String) async -> CursorSandUsageStatusResponse? {
+    nonisolated private static func fetchSandUsageStatus(
+        token: String,
+        fetchData: @Sendable (URLRequest) async throws -> Data
+    ) async -> CursorSandUsageStatusResponse? {
         guard let url = URL(string: sandUsageEndpoint) else {
             return nil
         }
@@ -594,13 +645,12 @@ class CursorLocalService: ObservableObject {
         request.httpBody = Data("{}".utf8)
         request.timeoutInterval = ServiceSupport.usageRequestTimeout
 
-        for (key, value) in Self.aiserverHeaders(token: token) {
+        for (key, value) in aiserverHeaders(token: token) {
             request.setValue(value, forHTTPHeaderField: key)
         }
 
         do {
-            let (data, response) = try await urlSession.data(for: request)
-            try ServiceSupport.validate(response, data: data)
+            let data = try await fetchData(request)
             return try JSONDecoder().decode(CursorSandUsageStatusResponse.self, from: data)
         } catch {
             let serviceError = ServiceSupport.serviceError(from: error)

--- a/MeterBar/Views/Components/LimitRow.swift
+++ b/MeterBar/Views/Components/LimitRow.swift
@@ -44,13 +44,17 @@ struct LimitRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: density.rowSpacing) {
             header
-            UsageBar(
-                usedPercentage: limit.usedPercent,
-                accentColor: accentColor,
-                pace: content.pace,
-                paceContext: limit.paceContext
-            )
-            footer
+            if content.showsUsageBar {
+                UsageBar(
+                    usedPercentage: limit.usedPercent,
+                    accentColor: accentColor,
+                    pace: content.pace,
+                    paceContext: limit.paceContext
+                )
+            }
+            if content.showsFooter {
+                footer
+            }
         }
         // One combined VoiceOver element per limit row across all three
         // surfaces, via the shared SnapshotLimit accessibility helpers.
@@ -63,8 +67,8 @@ struct LimitRow: View {
         HStack(spacing: density.headerSpacing) {
             Text(limit.localizedTitle)
                 .font(density.titleFont)
-                .fontWeight(density.titleWeight)
-                .foregroundColor(density.titleColor)
+                .fontWeight(content.emphasizesCompactOutHeader ? .semibold : density.titleWeight)
+                .foregroundColor(content.emphasizesCompactOutHeader ? MeterBarTheme.danger : density.titleColor)
                 .lineLimit(1)
 
             if content.showsEstimatedTag {
@@ -73,12 +77,20 @@ struct LimitRow: View {
 
             Spacer(minLength: 4)
 
-            Text(content.trailingText)
-                .font(density.trailingFont)
-                .fontWeight(density.trailingWeight)
-                .foregroundColor(content.isTrailingDanger ? MeterBarTheme.danger : .primary)
-                .lineLimit(1)
-                .numericRefreshTransition(value: content.trailingText, reduceMotion: reduceMotion)
+            if content.emphasizesCompactOutHeader {
+                MeterBarChip(
+                    content.trailingText.uppercased(),
+                    tint: MeterBarTheme.danger,
+                    style: .flat
+                )
+            } else {
+                Text(content.trailingText)
+                    .font(density.trailingFont)
+                    .fontWeight(density.trailingWeight)
+                    .foregroundColor(content.isTrailingDanger ? MeterBarTheme.danger : .primary)
+                    .lineLimit(1)
+                    .numericRefreshTransition(value: content.trailingText, reduceMotion: reduceMotion)
+            }
         }
     }
 
@@ -164,6 +176,16 @@ extension LimitRow {
         private var isEstimated: Bool { limit.usageLimit.isEstimated }
         private var isOut: Bool { limit.percentLeft <= 0 }
 
+        /// A real exhaustion on a non-blocking pool (e.g. Cursor's Other Models
+        /// while Cursor Models still has room). The header keeps the same "Out"
+        /// status as other surfaces; the bar and reset footer are dropped so the
+        /// row matches the compact blocked-card treatment.
+        var compactsWhenOut: Bool { isOut && !isEstimated }
+
+        var showsUsageBar: Bool { !compactsWhenOut }
+
+        var showsFooter: Bool { !compactsWhenOut && showsReset }
+
         var showsEstimatedTag: Bool { isEstimated }
 
         /// Suppressed for estimated limits so a derived total can't drive the
@@ -192,6 +214,10 @@ extension LimitRow {
         /// The trailing value turns red once the window is exhausted, matching
         /// the pre-unification per-surface behavior.
         var isTrailingDanger: Bool { isOut }
+
+        /// Compact-out rows tint the whole header line danger so a one-line row
+        /// still scans as exhausted without bringing the bar back.
+        var emphasizesCompactOutHeader: Bool { compactsWhenOut }
 
         /// Footer "used" value. Currency limits show money spent; quota limits
         /// show percent-used.

--- a/MeterBar/Views/Components/LimitRow.swift
+++ b/MeterBar/Views/Components/LimitRow.swift
@@ -184,7 +184,11 @@ extension LimitRow {
 
         var showsUsageBar: Bool { !compactsWhenOut }
 
-        var showsFooter: Bool { !compactsWhenOut && showsReset }
+        /// Active full-density rows keep their used/pace footer even when the
+        /// provider does not publish a reset timestamp. Compact density still
+        /// renders no footer in that case because its reset-only footer body is
+        /// empty.
+        var showsFooter: Bool { !compactsWhenOut }
 
         var showsEstimatedTag: Bool { isEstimated }
 

--- a/MeterBar/Views/Components/MeterBarChip.swift
+++ b/MeterBar/Views/Components/MeterBarChip.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// A single, unified capsule chip for MeterBar's small status/tier/role badges.
 ///
 /// Before this existed, five near-identical recipes had drifted apart
-/// (`ExtraUsageStatusPill`, `ReadinessBadge`, `ProviderStatusBadge`, the
+/// (`ExtraUsageStatusToggle`, `ReadinessBadge`, `ProviderStatusBadge`, the
 /// Optimize tier badge, and the Settings role capsule) — each with its own
 /// padding, fill opacity, and stroke. `MeterBarChip` collapses them onto one
 /// padding scale and one stroke treatment so the badges read as one system.

--- a/MeterBar/Views/Components/ProviderCardHeader.swift
+++ b/MeterBar/Views/Components/ProviderCardHeader.swift
@@ -50,11 +50,7 @@ struct ProviderCardHeader: View {
 
             Spacer(minLength: 0)
 
-            Text(content.statusText)
-                .font(.caption2)
-                .fontWeight(.semibold)
-                .foregroundColor(ProviderCardPresentation.statusColor(for: snapshot))
-                .lineLimit(1)
+            ProviderCardStatusLabel(snapshot: snapshot)
 
             if showsDisclosureChevron {
                 CardDisclosureChevron()

--- a/MeterBar/Views/Components/ProviderCardStatusLabel.swift
+++ b/MeterBar/Views/Components/ProviderCardStatusLabel.swift
@@ -1,0 +1,31 @@
+import MeterBarShared
+import SwiftUI
+
+/// Status word on a provider card header or overview row.
+///
+/// Amber and red bands (plus login/attention overlays) render as uppercase
+/// `MeterBarChip`s; healthy and subdued states stay plain semibold text so a
+/// wall of green pills does not compete with the quota bars below.
+struct ProviderCardStatusLabel: View {
+    let snapshot: ProviderSnapshot
+
+    private var text: String {
+        ProviderCardPresentation.statusText(for: snapshot)
+    }
+
+    private var color: Color {
+        ProviderCardPresentation.statusColor(for: snapshot)
+    }
+
+    var body: some View {
+        if ProviderCardPresentation.statusUsesChip(for: snapshot) {
+            MeterBarChip(text.uppercased(), tint: color, style: .flat)
+        } else {
+            Text(text)
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .foregroundColor(color)
+                .lineLimit(1)
+        }
+    }
+}

--- a/MeterBar/Views/Components/ProviderComponents.swift
+++ b/MeterBar/Views/Components/ProviderComponents.swift
@@ -127,25 +127,22 @@ enum ProviderLogoImageCache {
     }
 }
 
-/// Colored On/Off chip showing whether paid "extra usage" / overage is enabled for a service.
-struct ExtraUsageStatusPill: View {
+/// Read-only switch showing whether paid "extra usage" / overage is enabled.
+///
+/// MeterBar reads this from provider APIs — it is not togglable in-app. A native
+/// `Toggle` matches settings and reads more clearly than a status pill for a
+/// binary on/off fact.
+struct ExtraUsageStatusToggle: View {
     let status: ExtraUsageStatus
 
-    // `label`/`color` are the chip's text + tint; kept internal (not private)
-    // so the migration test can assert the On/Off/Unknown mapping is preserved.
+    /// VoiceOver / test hook for the reflected state.
+    var isOn: Bool { status.state == .on }
+
     var label: String {
         switch status.state {
         case .on: return "On"
         case .off: return "Off"
         case .unknown: return "Unknown"
-        }
-    }
-
-    var color: Color {
-        switch status.state {
-        case .on: return MeterBarTheme.warning
-        case .off: return MeterBarTheme.success
-        case .unknown: return .secondary
         }
     }
 
@@ -162,11 +159,16 @@ struct ExtraUsageStatusPill: View {
     }
 
     var body: some View {
-        // Migrated to the shared `MeterBarChip`. The status color now tints the
-        // whole chip (leading dot + label) rather than only the dot, matching
-        // the other status badges; the On/Off/Unknown semantics are unchanged.
-        MeterBarChip(label, systemImage: "circle.fill", tint: color, style: .flat)
+        Toggle("", isOn: .constant(isOn))
+            .labelsHidden()
+            .toggleStyle(.switch)
+            .controlSize(.mini)
+            .disabled(true)
+            .opacity(status.state == .unknown ? 0.45 : 1)
+            .tint(status.state == .on ? MeterBarTheme.warning : nil)
             .help(tooltip)
+            .accessibilityLabel("Extra usage")
+            .accessibilityValue(label)
     }
 }
 

--- a/MeterBar/Views/Components/ProviderStatusBadges.swift
+++ b/MeterBar/Views/Components/ProviderStatusBadges.swift
@@ -3,7 +3,7 @@ import MeterBarShared
 
 /// Trailing status badges shown beneath a provider's limits:
 /// - "N reset(s) available" — banked rate-limit resets (`resetCreditsAvailable`)
-/// - "Extra usage" + On/Off pill — paid overage state (`extraUsage`)
+/// - "Extra usage" + read-only toggle — paid overage state (`extraUsage`)
 ///
 /// Shared by the single provider card (`ProviderStatusCard`) that renders on the
 /// popover, the dashboard Overview, and the Limits page — one component, so the
@@ -79,7 +79,7 @@ struct ProviderStatusBadges: View {
                         .font(textFont)
                         .foregroundColor(.secondary)
                     Spacer(minLength: 4)
-                    ExtraUsageStatusPill(status: extraUsage)
+                    ExtraUsageStatusToggle(status: extraUsage)
                 }
             }
         }

--- a/MeterBar/Views/Components/SettingsComponents.swift
+++ b/MeterBar/Views/Components/SettingsComponents.swift
@@ -325,7 +325,7 @@ struct ExtraUsageRow: View {
     var body: some View {
         SettingsRowView(title: title, detail: Self.detailText(status)) {
             HStack(spacing: 8) {
-                ExtraUsageStatusPill(status: status ?? .unknown)
+                ExtraUsageStatusToggle(status: status ?? .unknown)
 
                 Button("Manage") {
                     if let url = URL(string: manageURL) {

--- a/MeterBar/Views/DashboardLimitsSection.swift
+++ b/MeterBar/Views/DashboardLimitsSection.swift
@@ -1,0 +1,61 @@
+import MeterBarShared
+import SwiftUI
+
+/// Limits card order. Focus is for scrolling, not ranking — pinning the
+/// selected provider reshuffled Overview vs Limits every time a card was
+/// clicked.
+enum DashboardLimitsLayout {
+    static func orderedSnapshots(
+        _ snapshots: [ProviderSnapshot],
+        focusedProviderID _: ProviderSnapshot.ID?
+    ) -> [ProviderSnapshot] {
+        snapshots
+    }
+}
+
+/// Full-width stacked quota cards — the deep inspection surface. Overview stays
+/// a glanceable summary; Limits gives every window room to breathe.
+struct DashboardLimitsSection: View {
+    let snapshots: [ProviderSnapshot]
+    let focusedProviderID: ProviderSnapshot.ID?
+    let scrollProxy: ScrollViewProxy
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.md) {
+            if snapshots.isEmpty {
+                DashboardCard(title: "No Quota Windows") {
+                    Text("Enable providers in Settings to show quota windows.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+            } else {
+                VStack(spacing: MeterBarTheme.Spacing.md) {
+                    ForEach(DashboardLimitsLayout.orderedSnapshots(
+                        snapshots,
+                        focusedProviderID: focusedProviderID
+                    )) { snapshot in
+                        ProviderStatusCard(
+                            snapshot: snapshot,
+                            limitDensity: .regular,
+                            badgeStyle: .regular,
+                            tilePadding: .standard
+                        )
+                        .id(snapshot.id)
+                    }
+                }
+                .onAppear {
+                    scrollToFocusedProvider()
+                }
+                .onChange(of: focusedProviderID) { _, _ in
+                    scrollToFocusedProvider()
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func scrollToFocusedProvider() {
+        guard let focusedProviderID else { return }
+        scrollProxy.scrollTo(focusedProviderID, anchor: .top)
+    }
+}

--- a/MeterBar/Views/DashboardOverviewSection.swift
+++ b/MeterBar/Views/DashboardOverviewSection.swift
@@ -60,7 +60,7 @@ struct DashboardOverviewSection: View {
         guard let limit = snapshot.primaryLimit else {
             return snapshot.emptyDetail
         }
-        var parts = ["\(limit.localizedTitle) · \(limit.usageLimit.percentLeftText)"]
+        var parts = ["\(limit.localizedTitle) · \(LocalizedUsageFormat.percentLeft(limit.usageLimit))"]
         if needsAttention(snapshot),
            let countdown = limit.usageLimit.resetCountdownText(now: now),
            countdown != "now" {

--- a/MeterBar/Views/DashboardOverviewSection.swift
+++ b/MeterBar/Views/DashboardOverviewSection.swift
@@ -11,8 +11,6 @@ struct DashboardOverviewSection: View {
     let costSummary: CostSummary?
     let onSelectProvider: (ProviderSnapshot.ID) -> Void
 
-    private static let masonryColumnCount = 2
-
     /// Copy for the "Use next" tile — the Optimize ranking's top pick, boiled
     /// down to one glance. Replaces the old "Tracked sources" tile, which was a
     /// Settings fact that almost always read "all reporting".
@@ -37,8 +35,50 @@ struct DashboardOverviewSection: View {
         return ("No data", "Waiting for provider refresh", nil)
     }
 
+    /// Providers that need a decision or are running low, sorted ahead of the
+    /// healthy ones. Auth overlays beat quota bands.
+    static func sortedForOverview(_ snapshots: [ProviderSnapshot]) -> [ProviderSnapshot] {
+        snapshots.sorted { lhs, rhs in
+            let left = attentionRank(for: lhs)
+            let right = attentionRank(for: rhs)
+            if left != right { return left > right }
+            return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+        }
+    }
+
+    static func needsAttention(_ snapshot: ProviderSnapshot) -> Bool {
+        snapshot.authNotice != nil
+            || (snapshot.band?.severityRank ?? 0) >= QuotaBand.tight.severityRank
+    }
+
+    /// One-line summary under each overview row — enough to decide whether to
+    /// open Limits, without replaying every quota bar.
+    static func detailLine(for snapshot: ProviderSnapshot, now: Date) -> String {
+        if let authNotice = snapshot.authNotice {
+            return authNotice.shortLabel
+        }
+        guard let limit = snapshot.primaryLimit else {
+            return snapshot.emptyDetail
+        }
+        var parts = ["\(limit.localizedTitle) · \(limit.usageLimit.percentLeftText)"]
+        if needsAttention(snapshot),
+           let countdown = limit.usageLimit.resetCountdownText(now: now),
+           countdown != "now" {
+            parts.append("Resets in \(countdown)")
+        } else if needsAttention(snapshot),
+                  limit.usageLimit.resetCountdownText(now: now) == "now" {
+            parts.append("Reset due")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private static func attentionRank(for snapshot: ProviderSnapshot) -> Int {
+        if snapshot.authNotice != nil { return 1_000 }
+        return (snapshot.band?.severityRank ?? -1) * 100
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.lg) {
             OverviewSummaryStrip(
                 snapshots: snapshots,
                 tightestLimit: tightestLimit,
@@ -46,23 +86,109 @@ struct DashboardOverviewSection: View {
                 formattedTokens: UsageFormat.tokens(costSummary?.totalTokens ?? 0)
             )
 
-            // One container, one ForEach: the layout decides which column each
-            // card lands in, so a card keeps its identity — and any in-flight
-            // state — when the snapshot list changes underneath it.
-            ProviderMasonryLayout(
-                columnCount: Self.masonryColumnCount,
-                spacing: MeterBarTheme.Spacing.sm
-            ) {
+            if snapshots.isEmpty {
+                DashboardCard(title: "Providers") {
+                    Text("Enable providers in Settings to start tracking quotas.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+            } else {
+                overviewProviderList
+            }
+        }
+    }
+
+    private var overviewProviderList: some View {
+        let sorted = Self.sortedForOverview(snapshots)
+        let attention = sorted.filter(Self.needsAttention)
+        let healthy = sorted.filter { !Self.needsAttention($0) }
+
+        return VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.md) {
+            if !attention.isEmpty {
+                OverviewProviderGroup(
+                    title: "Needs attention",
+                    snapshots: attention,
+                    onSelectProvider: onSelectProvider
+                )
+            }
+
+            if !healthy.isEmpty {
+                OverviewProviderGroup(
+                    title: attention.isEmpty ? "Providers" : "Healthy",
+                    snapshots: healthy,
+                    onSelectProvider: onSelectProvider
+                )
+            }
+        }
+    }
+}
+
+private struct OverviewProviderGroup: View {
+    let title: String
+    let snapshots: [ProviderSnapshot]
+    let onSelectProvider: (ProviderSnapshot.ID) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.sm) {
+            Text(title.uppercased())
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+
+            VStack(spacing: MeterBarTheme.Spacing.sm) {
                 ForEach(snapshots) { snapshot in
-                    // Same shared provider card as the popover and the Limits
-                    // page; tapping it jumps to that provider in Limits.
-                    ProviderStatusCard(
-                        snapshot: snapshot,
-                        onSelect: { onSelectProvider(snapshot.id) }
-                    )
+                    Button {
+                        onSelectProvider(snapshot.id)
+                    } label: {
+                        OverviewProviderRow(snapshot: snapshot)
+                    }
+                    .buttonStyle(ProviderCardButtonStyle())
+                    .accessibilityHint("Open \(snapshot.title) quota details")
                 }
             }
-            .frame(maxWidth: .infinity)
+        }
+    }
+}
+
+private struct OverviewProviderRow: View {
+    let snapshot: ProviderSnapshot
+
+    var body: some View {
+        TimelineView(
+            .periodic(
+                from: ResetCountdownSchedule.anchor,
+                by: ResetCountdownSchedule.interval
+            )
+        ) { timeline in
+            DashboardTile(padding: .popover) {
+                HStack(spacing: 10) {
+                    ProviderLogoView(
+                        kind: snapshot.logoKind,
+                        size: 18,
+                        foregroundColor: snapshot.accentColor
+                    )
+
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack(spacing: 8) {
+                            Text(snapshot.title)
+                                .font(.subheadline)
+                                .fontWeight(.semibold)
+                                .lineLimit(1)
+
+                            Spacer(minLength: 4)
+
+                            ProviderCardStatusLabel(snapshot: snapshot)
+                        }
+
+                        Text(DashboardOverviewSection.detailLine(for: snapshot, now: timeline.date))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+
+                    CardDisclosureChevron()
+                }
+            }
         }
     }
 }
@@ -73,8 +199,6 @@ private struct OverviewSummaryStrip: View {
     let estimatedCost: String?
     let formattedTokens: String
 
-    // Same gutter as the provider masonry below it, so the page reads as one
-    // grid rather than two with different spacing.
     private let columns = Array(
         repeating: GridItem(.flexible(minimum: 180), spacing: MeterBarTheme.Spacing.sm),
         count: 3
@@ -106,8 +230,6 @@ private struct OverviewSummaryStrip: View {
                 style: .compact
             )
 
-            // The Optimize ranking's top pick, on the same countdown clock as
-            // the tightest-window tile so its reset caption stays current.
             TimelineView(
                 .periodic(
                     from: ResetCountdownSchedule.anchor,

--- a/MeterBar/Views/MenuBarDetailPanel.swift
+++ b/MeterBar/Views/MenuBarDetailPanel.swift
@@ -321,7 +321,7 @@ struct MenuBarProviderDetailContent: View {
         badges
       }
 
-      if let dailyUsage {
+      if let dailyUsage, dailyUsage.showsInOverview {
         // Last, and separated by a little extra space rather than a rule: the
         // rows above are the window the card already summarised, and this is the
         // week behind it. Reading top-to-bottom is now → recent past.

--- a/MeterBar/Views/ProviderCardPresentation.swift
+++ b/MeterBar/Views/ProviderCardPresentation.swift
@@ -29,6 +29,19 @@ enum ProviderCardPresentation {
         return snapshot.band?.shortLabel ?? "Offline"
     }
 
+    /// Healthy and subdued auth states stay plain text; amber and red bands get
+    /// a pill so attention-grabbing status does not wallpaper every card.
+    static func statusUsesChip(for snapshot: ProviderSnapshot) -> Bool {
+        switch snapshot.authNotice {
+        case .loginRequired, .attention:
+            return true
+        case .stale, .notConnected, .none:
+            break
+        }
+        guard let band = snapshot.band else { return false }
+        return band != .healthy
+    }
+
     /// How long a login-required card may keep showing its cached gauges before
     /// they stop being useful context and start being noise. Two hours is past
     /// any session window the cache could still be describing.

--- a/MeterBar/Views/ProviderCardPresentation.swift
+++ b/MeterBar/Views/ProviderCardPresentation.swift
@@ -35,7 +35,9 @@ enum ProviderCardPresentation {
         switch snapshot.authNotice {
         case .loginRequired, .attention:
             return true
-        case .stale, .notConnected, .none:
+        case .stale, .notConnected:
+            return false
+        case .none:
             break
         }
         guard let band = snapshot.band else { return false }

--- a/MeterBar/Views/ProviderStatusCard.swift
+++ b/MeterBar/Views/ProviderStatusCard.swift
@@ -8,6 +8,9 @@ struct ProviderStatusCard: View {
     let snapshot: ProviderSnapshot
     var onSelect: (() -> Void)?
     var onHoverChange: ((Bool) -> Void)?
+    var limitDensity: LimitRow.Density = .compact
+    var badgeStyle: ProviderStatusBadges.Style = .compact
+    var tilePadding: MeterBarTheme.CardPadding = .popover
 
     @ObservedObject private var menuBarDisplayPreferences = MenuBarDisplayPreferencesStore.shared
     @Environment(\.accessibilityReduceMotion)
@@ -31,10 +34,16 @@ struct ProviderStatusCard: View {
     init(
         snapshot: ProviderSnapshot,
         onHoverChange: ((Bool) -> Void)? = nil,
+        limitDensity: LimitRow.Density = .compact,
+        badgeStyle: ProviderStatusBadges.Style = .compact,
+        tilePadding: MeterBarTheme.CardPadding = .popover,
         onSelect: (() -> Void)? = nil
     ) {
         self.snapshot = snapshot
         self.onHoverChange = onHoverChange
+        self.limitDensity = limitDensity
+        self.badgeStyle = badgeStyle
+        self.tilePadding = tilePadding
         self.onSelect = onSelect
     }
 
@@ -99,7 +108,7 @@ struct ProviderStatusCard: View {
     }
 
     private var cardContent: some View {
-        DashboardTile(padding: .popover) {
+        DashboardTile(padding: tilePadding) {
             cardBody
         }
         .contentShape(RoundedRectangle(cornerRadius: MeterBarTheme.Radius.card, style: .continuous))
@@ -210,12 +219,12 @@ struct ProviderStatusCard: View {
             } else {
                 VStack(alignment: .leading, spacing: 9) {
                     ForEach(snapshot.limits) { limit in
-                        LimitRow(limit: limit, accentColor: snapshot.accentColor, density: .compact)
+                        LimitRow(limit: limit, accentColor: snapshot.accentColor, density: limitDensity)
                     }
                 }
             }
 
-            let badges = ProviderStatusBadges(snapshot: snapshot, style: .compact)
+            let badges = ProviderStatusBadges(snapshot: snapshot, style: badgeStyle)
             if badges.hasContent {
                 badges
             }

--- a/MeterBar/Views/UsageDashboardView.swift
+++ b/MeterBar/Views/UsageDashboardView.swift
@@ -5,18 +5,6 @@ import SwiftUI
 // pages are fed. Each page lives in its own `Dashboard*Section` file (C1 split);
 // the navigation types live in `DashboardNavigation.swift`.
 
-/// Limits card order. Focus is for scrolling, not ranking — pinning the
-/// selected provider reshuffled Overview vs Limits every time a card was
-/// clicked.
-enum DashboardLimitsLayout {
-    static func orderedSnapshots(
-        _ snapshots: [ProviderSnapshot],
-        focusedProviderID _: ProviderSnapshot.ID?
-    ) -> [ProviderSnapshot] {
-        snapshots
-    }
-}
-
 struct UsageDashboardView: View {
     private static let detailHorizontalPadding = MeterBarTheme.Spacing.xxl
 
@@ -295,7 +283,11 @@ struct UsageDashboardView: View {
                 }
             )
         case .limits:
-            limitsContent(scrollProxy: scrollProxy)
+            DashboardLimitsSection(
+                snapshots: providerSnapshots,
+                focusedProviderID: navigation.focusedProviderID,
+                scrollProxy: scrollProxy
+            )
         case .status:
             DashboardStatusSection()
         case .costs:
@@ -353,46 +345,6 @@ struct UsageDashboardView: View {
         case .about:
             AboutSettingsView()
         }
-    }
-
-    private func limitsContent(scrollProxy: ScrollViewProxy) -> some View {
-        VStack(alignment: .leading, spacing: 14) {
-            if providerSnapshots.isEmpty {
-                DashboardCard(title: "No Quota Windows") {
-                    Text("Enable providers in Settings to show quota windows.")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                }
-            } else {
-                // Same two-column masonry as Overview. Clicking a card from
-                // Overview still focuses it (scroll), but the grid order stays
-                // subscription-then-label so cards do not jump around.
-                ProviderMasonryLayout(columnCount: 2, spacing: MeterBarTheme.Spacing.sm) {
-                    ForEach(DashboardLimitsLayout.orderedSnapshots(
-                        providerSnapshots,
-                        focusedProviderID: navigation.focusedProviderID
-                    )) { snapshot in
-                        // The one provider card, shared with the popover, so
-                        // the two surfaces cannot drift.
-                        ProviderStatusCard(snapshot: snapshot)
-                            .id(snapshot.id)
-                    }
-                }
-                .frame(maxWidth: .infinity)
-                .onAppear {
-                    scrollToFocusedProvider(using: scrollProxy)
-                }
-                .onChange(of: navigation.focusedProviderID) { _, _ in
-                    scrollToFocusedProvider(using: scrollProxy)
-                }
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private func scrollToFocusedProvider(using proxy: ScrollViewProxy) {
-        guard let focusedProviderID = navigation.focusedProviderID else { return }
-        proxy.scrollTo(focusedProviderID, anchor: .top)
     }
 
     private var providerSnapshots: [ProviderSnapshot] {

--- a/MeterBarTests/CardStateTransitionTests.swift
+++ b/MeterBarTests/CardStateTransitionTests.swift
@@ -132,13 +132,11 @@ final class CardStateTransitionTests: XCTestCase {
         )
     }
 
-    // MARK: - Overview masonry build smoke
+    // MARK: - Overview provider list
 
-    /// The overview's provider grid moved from nested per-column `VStack`s to a
-    /// single `ProviderMasonryLayout` container so a card keeps its identity —
-    /// and its in-flight redemption state — when the snapshot list changes
-    /// underneath it. An odd count exercises the uneven-columns path.
-    func testOverviewSectionRendersTheProviderMasonry() {
+    /// Overview is a summary + tappable rows now, not a duplicate of the Limits
+    /// masonry grid.
+    func testOverviewSectionRendersTheProviderList() {
         let snapshots = ProviderSnapshotBuilder.snapshots(
             ProviderSnapshotBuilder.Input(
                 metrics: [
@@ -151,7 +149,6 @@ final class CardStateTransitionTests: XCTestCase {
                 enabledServices: [.codexCli, .cursor, .grok]
             )
         )
-        XCTAssertEqual(snapshots.count % 2, 1, "fixture must be odd to leave one column short")
 
         assertRenders(
             DashboardOverviewSection(
@@ -162,7 +159,7 @@ final class CardStateTransitionTests: XCTestCase {
             )
         )
 
-        // Empty is the other structural state: no cards, no columns to place.
+        // Empty is the other structural state: no rows to list.
         assertRenders(
             DashboardOverviewSection(
                 snapshots: [],

--- a/MeterBarTests/CursorLocalServiceTests.swift
+++ b/MeterBarTests/CursorLocalServiceTests.swift
@@ -737,4 +737,60 @@ final class CursorLocalServiceTests: XCTestCase {
     func testExtractUserIdReturnsNilForMalformedToken() {
         XCTAssertNil(CursorLocalService.extractUserIdFromJWT("not-a-jwt"))
     }
+
+    // MARK: - Off-main fetch regression
+
+    /// Regression for the 1.8.38 SIGSEGV entering `NSURLSession.data` during
+    /// Cursor refresh: with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` the
+    /// usage-summary / sand legs ran as main-actor jobs through a *stored*
+    /// fetch closure's reabstraction thunk (OpenRouter #480, Codex #328).
+    /// Network + decode now run detached; probing that path from off the main
+    /// actor through a stored `@Sendable` closure must still succeed.
+    func testFetchRemotelyProbedThroughStoredClosureFromDetachedTask() async throws {
+        let summaryJSON = """
+        {
+          "billingCycleStart": "2026-07-01T00:00:00Z",
+          "billingCycleEnd": "2026-08-01T00:00:00Z",
+          "membershipType": "pro",
+          "individualUsage": {
+            "plan": { "used": 10, "limit": 100 },
+            "onDemand": { "used": 0, "limit": 20, "enabled": true }
+          }
+        }
+        """
+        let sandJSON = """
+        {
+          "currentPeriodStart": "2026-07-01T00:00:00Z",
+          "nextResetTimestampUtc": "2026-07-08T00:00:00Z",
+          "usagePercent": 12,
+          "hasAvailableUsage": true,
+          "hasNonZeroIncludedLimit": true
+        }
+        """
+
+        let fetched = try await Task.detached(priority: .userInitiated) {
+            let fetchData: @Sendable (URLRequest) async throws -> Data = { request in
+                let path = request.url?.path ?? ""
+                if path.contains("usage-summary") {
+                    return Data(summaryJSON.utf8)
+                }
+                if path.contains("GetSandUsageStatus") {
+                    return Data(sandJSON.utf8)
+                }
+                throw ServiceError.invalidURL
+            }
+            return try await CursorLocalService.fetchRemotely(
+                userId: "user-test",
+                token: "tok-test",
+                fetchData: fetchData
+            )
+        }.value
+
+        XCTAssertEqual(fetched.metrics.service, .cursor)
+        XCTAssertEqual(fetched.membershipType, "pro")
+        XCTAssertEqual(fetched.metrics.weeklyLimit?.used, 10)
+        XCTAssertEqual(fetched.metrics.weeklyLimit?.total, 100)
+        XCTAssertEqual(fetched.observation?.runningTotal, 10)
+        XCTAssertEqual(fetched.metrics.additionalLimits.first?.used, 12)
+    }
 }

--- a/MeterBarTests/DashboardSectionSplitTests.swift
+++ b/MeterBarTests/DashboardSectionSplitTests.swift
@@ -414,6 +414,43 @@ final class DashboardSectionSplitTests: XCTestCase {
         XCTAssertNil(tile.band)
     }
 
+    func testOverviewSortsAttentionAheadOfHealthyProviders() {
+        let snapshots = [
+            snapshot(id: "codex", title: "Codex", service: .codexCli),
+            snapshot(id: "cursor", title: "Cursor", service: .cursor, used: 95),
+        ]
+
+        XCTAssertEqual(
+            DashboardOverviewSection.sortedForOverview(snapshots).map(\.id),
+            ["cursor", "codex"]
+        )
+        XCTAssertTrue(DashboardOverviewSection.needsAttention(snapshots[1]))
+        XCTAssertFalse(DashboardOverviewSection.needsAttention(snapshots[0]))
+    }
+
+    func testOverviewDetailLineNamesAuthBeforeQuota() {
+        let since = Date(timeIntervalSince1970: 1_750_000_000)
+        var stale = snapshot()
+        stale.authNotice = .stale(since: since)
+
+        XCTAssertEqual(
+            DashboardOverviewSection.detailLine(for: stale, now: since),
+            ProviderAuthNotice.stale(since: since).shortLabel
+        )
+    }
+
+    func testLimitsCardsUseRegularDensityAtFullWidth() {
+        let card = ProviderStatusCard(
+            snapshot: snapshot(),
+            limitDensity: .regular,
+            badgeStyle: .regular,
+            tilePadding: .standard
+        )
+        .frame(maxWidth: .infinity)
+
+        assertRenders(card, width: 900, height: 260)
+    }
+
     // MARK: - Optimize KPI tiles
 
     /// The four KPI tiles are one glanceable band of headline numbers, not a
@@ -628,10 +665,11 @@ final class DashboardSectionSplitTests: XCTestCase {
     private func snapshot(
         id: String = "codex",
         title: String = "Codex",
-        service: ServiceType = .codexCli
+        service: ServiceType = .codexCli,
+        used: Double = 40
     ) -> ProviderSnapshot {
         let weekly = UsageLimit(
-            used: 40,
+            used: used,
             total: 100,
             resetTime: Date().addingTimeInterval(3600),
             windowSeconds: 604_800

--- a/MeterBarTests/DashboardSectionSplitTests.swift
+++ b/MeterBarTests/DashboardSectionSplitTests.swift
@@ -439,6 +439,16 @@ final class DashboardSectionSplitTests: XCTestCase {
         )
     }
 
+    func testOverviewDetailLineUsesLocalizedPercentLeftCopy() throws {
+        let provider = snapshot()
+        let limit = try XCTUnwrap(provider.primaryLimit)
+
+        XCTAssertEqual(
+            DashboardOverviewSection.detailLine(for: provider, now: Date()),
+            "\(limit.localizedTitle) · \(LocalizedUsageFormat.percentLeft(limit.usageLimit))"
+        )
+    }
+
     func testLimitsCardsUseRegularDensityAtFullWidth() {
         let card = ProviderStatusCard(
             snapshot: snapshot(),

--- a/MeterBarTests/LimitRowTests.swift
+++ b/MeterBarTests/LimitRowTests.swift
@@ -59,6 +59,21 @@ final class LimitRowTests: XCTestCase {
         XCTAssertTrue(content.isTrailingDanger)
     }
 
+    func testOutRowCompactsToHeaderOnly() {
+        let content = LimitRow.RowContent(limit: quotaLimit(used: 100, resetTime: future))
+        XCTAssertTrue(content.compactsWhenOut)
+        XCTAssertTrue(content.emphasizesCompactOutHeader)
+        XCTAssertFalse(content.showsUsageBar)
+        XCTAssertFalse(content.showsFooter)
+    }
+
+    func testNonOutRowStillShowsBarAndReset() {
+        let content = LimitRow.RowContent(limit: quotaLimit(used: 40, resetTime: future))
+        XCTAssertFalse(content.compactsWhenOut)
+        XCTAssertTrue(content.showsUsageBar)
+        XCTAssertTrue(content.showsFooter)
+    }
+
     func testEstimatedExhaustedShowsPercentInsteadOfOut() {
         // An estimated total must never claim a hard "Out" — the total is a
         // guess, so it falls back to the (approximate) percent-left label.
@@ -155,6 +170,24 @@ final class LimitRowTests: XCTestCase {
         let host = NSHostingView(rootView: row.frame(width: 320))
         host.layoutSubtreeIfNeeded()
         XCTAssertGreaterThan(host.fittingSize.height, 0)
+    }
+
+    func testCompactOutRowIsShorterThanActiveRow() {
+        let active = LimitRow(
+            limit: quotaLimit(used: 40, resetTime: future),
+            accentColor: .blue,
+            density: .compact
+        )
+        let out = LimitRow(
+            limit: quotaLimit(used: 100, resetTime: future),
+            accentColor: .blue,
+            density: .compact
+        )
+        let activeHost = NSHostingView(rootView: active.frame(width: 320))
+        let outHost = NSHostingView(rootView: out.frame(width: 320))
+        activeHost.layoutSubtreeIfNeeded()
+        outHost.layoutSubtreeIfNeeded()
+        XCTAssertTrue(outHost.fittingSize.height < activeHost.fittingSize.height)
     }
 }
 

--- a/MeterBarTests/LimitRowTests.swift
+++ b/MeterBarTests/LimitRowTests.swift
@@ -74,6 +74,17 @@ final class LimitRowTests: XCTestCase {
         XCTAssertTrue(content.showsFooter)
     }
 
+    func testNonOutRowWithoutResetKeepsFullDensityFooterContent() {
+        let content = LimitRow.RowContent(limit: quotaLimit(used: 40))
+        XCTAssertFalse(content.compactsWhenOut)
+        XCTAssertTrue(content.showsUsageBar)
+        XCTAssertTrue(
+            content.showsFooter,
+            "detail and regular rows must keep used/pace text without a reset timestamp"
+        )
+        XCTAssertFalse(content.showsReset)
+    }
+
     func testEstimatedExhaustedShowsPercentInsteadOfOut() {
         // An estimated total must never claim a hard "Out" — the total is a
         // guess, so it falls back to the (approximate) percent-left label.

--- a/MeterBarTests/MenuBarDetailPanelLayoutTests.swift
+++ b/MeterBarTests/MenuBarDetailPanelLayoutTests.swift
@@ -140,6 +140,28 @@ final class MenuBarProviderDetailParityTests: XCTestCase {
         )
     }
 
+    private func cursorSnapshot() -> ProviderSnapshot {
+        let weekly = UsageLimit(
+            used: 40,
+            total: 100,
+            resetTime: Date().addingTimeInterval(3600),
+            windowSeconds: 604_800
+        )
+        return ProviderSnapshot(
+            id: "cursor",
+            title: "Cursor",
+            service: .cursor,
+            updatedAt: Date(),
+            limits: [
+                SnapshotLimit(id: "weekly", kind: .weekly, title: "Weekly", usageLimit: weekly)
+            ],
+            emptyDetail: "Waiting for refresh",
+            extraUsage: nil,
+            resetCreditsAvailable: nil,
+            accountID: nil
+        )
+    }
+
     /// The parity that matters: both surfaces derive their identity row from the
     /// same component, so neither can quietly start showing a different field.
     func testDetailPanelHeaderMatchesTheCardHeader() {
@@ -243,6 +265,29 @@ final class MenuBarProviderDetailParityTests: XCTestCase {
         charted.layoutSubtreeIfNeeded()
 
         XCTAssertGreaterThan(charted.fittingSize.height, plain.fittingSize.height)
+    }
+
+    func testCursorWithoutLedgerHistoryOmitsTheStripEntirely() {
+        let plain = NSHostingView(
+            rootView: MenuBarProviderDetailContent(snapshot: cursorSnapshot())
+                .frame(width: MeterBarMenuDetailPanelLayout.detailWidth)
+        )
+        let withEmptySeries = NSHostingView(
+            rootView: MenuBarProviderDetailContent(
+                snapshot: cursorSnapshot(),
+                dailyUsage: ProviderDailyUsageSeries.make(
+                    service: .cursor,
+                    dailyUsage: [],
+                    ledger: ProviderUsageLedger(),
+                    accountCount: 1
+                )
+            )
+            .frame(width: MeterBarMenuDetailPanelLayout.detailWidth)
+        )
+        plain.layoutSubtreeIfNeeded()
+        withEmptySeries.layoutSubtreeIfNeeded()
+
+        XCTAssertEqual(plain.fittingSize.height, withEmptySeries.fittingSize.height)
     }
 
     func testHeaderRendersWithAndWithoutTheDisclosureChevron() {

--- a/MeterBarTests/MeterBarChipTests.swift
+++ b/MeterBarTests/MeterBarChipTests.swift
@@ -56,25 +56,22 @@ final class MeterBarChipTests: XCTestCase {
         assertHosts(MeterBarChip("Scan", systemImage: "bolt.fill", tint: .blue, style: .glass))
     }
 
-    // MARK: - ExtraUsageStatusPill migration
+    // MARK: - ExtraUsageStatusToggle
 
-    func testExtraUsagePillPreservesLabelAndTint() {
-        let on = ExtraUsageStatusPill(status: ExtraUsageStatus(state: .on))
-        XCTAssertEqual(on.label, "On")
-        XCTAssertEqual(on.color, MeterBarTheme.warning)
+    func testExtraUsageToggleReflectsProviderState() {
+        XCTAssertTrue(ExtraUsageStatusToggle(status: ExtraUsageStatus(state: .on)).isOn)
+        XCTAssertEqual(ExtraUsageStatusToggle(status: ExtraUsageStatus(state: .on)).label, "On")
 
-        let off = ExtraUsageStatusPill(status: ExtraUsageStatus(state: .off))
-        XCTAssertEqual(off.label, "Off")
-        XCTAssertEqual(off.color, MeterBarTheme.success)
+        XCTAssertFalse(ExtraUsageStatusToggle(status: ExtraUsageStatus(state: .off)).isOn)
+        XCTAssertEqual(ExtraUsageStatusToggle(status: ExtraUsageStatus(state: .off)).label, "Off")
 
-        let unknown = ExtraUsageStatusPill(status: .unknown)
-        XCTAssertEqual(unknown.label, "Unknown")
-        XCTAssertEqual(unknown.color, .secondary)
+        XCTAssertFalse(ExtraUsageStatusToggle(status: .unknown).isOn)
+        XCTAssertEqual(ExtraUsageStatusToggle(status: .unknown).label, "Unknown")
     }
 
-    func testExtraUsagePillHosts() {
+    func testExtraUsageToggleHosts() {
         for state in [ExtraUsageStatus.State.on, .off, .unknown] {
-            assertHosts(ExtraUsageStatusPill(status: ExtraUsageStatus(state: state)))
+            assertHosts(ExtraUsageStatusToggle(status: ExtraUsageStatus(state: state)))
         }
     }
 

--- a/MeterBarTests/ProviderDailyUsageSeriesTests.swift
+++ b/MeterBarTests/ProviderDailyUsageSeriesTests.swift
@@ -351,6 +351,57 @@ final class ProviderDailyUsageSeriesTests: XCTestCase {
         XCTAssertFalse(ServiceType.openRouter.writesLocalTokenLogs)
     }
 
+    func testPolledProvidersHideOverviewUntilLedgerHasHistory() {
+        let emptyCursor = ProviderDailyUsageSeries.make(
+            service: .cursor,
+            dailyUsage: [],
+            ledger: ProviderUsageLedger(),
+            accountCount: 1,
+            now: now,
+            calendar: calendar
+        )
+        XCTAssertFalse(emptyCursor.showsInOverview)
+
+        var ledger = ProviderUsageLedger()
+        ledger.record(
+            ProviderUsageObservation(
+                provider: .cursor,
+                unit: .requests,
+                runningTotal: 0,
+                observedAt: day(-4)
+            ),
+            calendar: calendar
+        )
+        ledger.record(
+            ProviderUsageObservation(
+                provider: .cursor,
+                unit: .requests,
+                runningTotal: 12,
+                observedAt: day(-2)
+            ),
+            calendar: calendar
+        )
+        let cursorWithHistory = ProviderDailyUsageSeries.make(
+            service: .cursor,
+            dailyUsage: [],
+            ledger: ledger,
+            accountCount: 1,
+            now: now,
+            calendar: calendar
+        )
+        XCTAssertTrue(cursorWithHistory.showsInOverview)
+
+        let emptyCodex = ProviderDailyUsageSeries.make(
+            service: .codexCli,
+            dailyUsage: [],
+            ledger: ledger,
+            accountCount: 1,
+            now: now,
+            calendar: calendar
+        )
+        XCTAssertTrue(emptyCodex.showsInOverview, "log providers still prompt for a scan")
+    }
+
     func testRequestHeaderTotalDoesNotRepeatTheUnitNoun() {
         var ledger = ProviderUsageLedger()
         ledger.record(

--- a/MeterBarTests/ProviderPresentationHealthTests.swift
+++ b/MeterBarTests/ProviderPresentationHealthTests.swift
@@ -593,6 +593,10 @@ final class ProviderPresentationHealthTests: XCTestCase {
         var login = healthy
         login.authNotice = .loginRequired
         XCTAssertTrue(ProviderCardPresentation.statusUsesChip(for: login))
+
+        var attention = healthy
+        attention.authNotice = .attention("Refresh failed")
+        XCTAssertTrue(ProviderCardPresentation.statusUsesChip(for: attention))
     }
 
     // MARK: - Helpers

--- a/MeterBarTests/ProviderPresentationHealthTests.swift
+++ b/MeterBarTests/ProviderPresentationHealthTests.swift
@@ -543,6 +543,39 @@ final class ProviderPresentationHealthTests: XCTestCase {
         XCTAssertEqual(ProviderCardPresentation.statusText(for: cursor), QuotaBand.healthy.shortLabel)
     }
 
+    func testHealthyStatusStaysPlainTextWhileAttentionUsesAChip() throws {
+        let healthy = try card(.codex, lastUpdated: freshAt, refresh: .success, parseHealth: .success(provider: .codexCli, at: freshAt))
+        XCTAssertFalse(ProviderCardPresentation.statusUsesChip(for: healthy))
+
+        let critical = ProviderSnapshot(
+            id: "cursor",
+            title: "Cursor",
+            service: .cursor,
+            updatedAt: freshAt,
+            limits: [
+                SnapshotLimit(
+                    id: "weekly",
+                    kind: .weekly,
+                    title: "Weekly",
+                    usageLimit: UsageLimit(used: 95, total: 100, resetTime: nil)
+                )
+            ],
+            emptyDetail: "Waiting",
+            extraUsage: nil,
+            resetCreditsAvailable: nil,
+            accountID: nil
+        )
+        XCTAssertTrue(ProviderCardPresentation.statusUsesChip(for: critical))
+
+        var stale = healthy
+        stale.authNotice = .stale(since: freshAt)
+        XCTAssertFalse(ProviderCardPresentation.statusUsesChip(for: stale))
+
+        var login = healthy
+        login.authNotice = .loginRequired
+        XCTAssertTrue(ProviderCardPresentation.statusUsesChip(for: login))
+    }
+
     // MARK: - Helpers
 
     private func card(

--- a/MeterBarTests/ProviderPresentationHealthTests.swift
+++ b/MeterBarTests/ProviderPresentationHealthTests.swift
@@ -544,7 +544,12 @@ final class ProviderPresentationHealthTests: XCTestCase {
     }
 
     func testHealthyStatusStaysPlainTextWhileAttentionUsesAChip() throws {
-        let healthy = try card(.codex, lastUpdated: freshAt, refresh: .success, parseHealth: .success(provider: .codexCli, at: freshAt))
+        let healthy = try card(
+            .codex,
+            lastUpdated: freshAt,
+            refresh: .success,
+            parseHealth: .success(provider: .codexCli, at: freshAt)
+        )
         XCTAssertFalse(ProviderCardPresentation.statusUsesChip(for: healthy))
 
         let critical = ProviderSnapshot(
@@ -570,6 +575,20 @@ final class ProviderPresentationHealthTests: XCTestCase {
         var stale = healthy
         stale.authNotice = .stale(since: freshAt)
         XCTAssertFalse(ProviderCardPresentation.statusUsesChip(for: stale))
+
+        var staleCritical = critical
+        staleCritical.authNotice = .stale(since: freshAt)
+        XCTAssertFalse(
+            ProviderCardPresentation.statusUsesChip(for: staleCritical),
+            "stale must stay plain text even when cached quota is critical"
+        )
+
+        var notConnectedCritical = critical
+        notConnectedCritical.authNotice = .notConnected
+        XCTAssertFalse(
+            ProviderCardPresentation.statusUsesChip(for: notConnectedCritical),
+            "offline/not-connected must stay plain text even when cached quota is critical"
+        )
 
         var login = healthy
         login.authNotice = .loginRequired


### PR DESCRIPTION
## Summary

- Fix Cursor/Codex `NSURLSession` crashes under Swift default MainActor isolation by detaching network fetches (same class of bug as OpenRouter #480).
- Split the dashboard companion into two distinct surfaces: **Overview** (KPI strip + attention-ranked provider rows) vs **Limits** (stacked full-width cards with regular-density quota rows).
- Polish quota presentation: compact exhausted rows with red **OUT** chip, status pills only for amber/red (healthy stays plain green text), extra usage as a read-only toggle, and hide Cursor/OpenRouter history when the ledger has nothing to show.

## Related issue

No-Issue — session work spanning crash fix and dashboard/quota UX polish.

## Scope

- Popover and menu-bar detail panel keep compact card density; only the dashboard Limits page uses `.regular` limit rows and `.standard` tile padding.
- Enterprise Cursor Admin API daily history is out of scope (different auth model).

## Verification

- `swift test --filter 'LimitRowTests|DashboardSectionSplitTests|ProviderPresentationHealthTests.testHealthyStatusStaysPlainTextWhileAttentionUsesAChip|CursorLocalServiceTests'`
- Manual smoke on **MeterBar Dev** (`/tmp/MeterBarDerived/Build/Products/Debug/MeterBar Dev.app`): Overview ↔ Limits navigation, compact **Out** rows, healthy plain status vs **CRITICAL** pill.

## Screenshots

Not applicable (captured locally during session; UI changes visible in Dev build).

## Checklist

- [x] I reviewed the final diff for unrelated changes.
- [x] I ran the relevant focused checks or documented why they were left to CI.
- [x] I updated relevant documentation or explained why no documentation change is needed.
- [x] I documented migrations, release steps, or external configuration changes, or marked them not applicable.
- [x] I did not include secrets, credentials, personal data, customer data, or generated build output.
- [ ] If CodeRabbit says "Review rate limited", I re-requested review before merge. A green CodeRabbit tick is not a review in that case.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Overview now groups providers into healthy and attention-needed sections with clearer status and reset details.
  - Limits are presented in dedicated cards with improved scrolling and empty states.
  - Extra usage status now appears as an accessible read-only toggle.
  - Local-log providers can remain visible while awaiting a scan.

- **Bug Fixes**
  - Empty usage histories no longer display unnecessary daily usage charts.
  - Exhausted limits use a more compact, prominent warning presentation.
  - Provider status labels and attention styling are now more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->