### PR TITLE
fix(ui): unify provider status pills

### DIFF
--- a/MeterBar/App/StatusMenuBuilder.swift
+++ b/MeterBar/App/StatusMenuBuilder.swift
@@ -226,7 +226,7 @@ struct StatusMenuBuilder {
 
         if let report = status.reports[service] {
             let summaryItem = Self.disabledMenuItem(
-                title: report.summary.description ?? report.summary.indicator.summaryLabel,
+                title: report.summary.indicator.summaryLabel,
                 image: MenuBarIconRenderer.statusDot(for: report.summary.indicator)
             )
             menu.addItem(summaryItem)
@@ -287,7 +287,7 @@ struct StatusMenuBuilder {
 
     static func providerStatusMenuTitle(for service: ServiceType, status: StatusSnapshot) -> String {
         if let report = status.reports[service] {
-            let summary = report.summary.description ?? report.summary.indicator.summaryLabel
+            let summary = report.summary.indicator.summaryLabel
             return "\(service.statusPageDisplayName) — \(summary)"
         }
         if status.errors[service] != nil {

--- a/MeterBar/Services/ProviderStatusMonitor.swift
+++ b/MeterBar/Services/ProviderStatusMonitor.swift
@@ -47,13 +47,13 @@ enum ProviderStatusIndicator: String, Codable, Equatable {
     var summaryLabel: String {
         switch self {
         case .none:
-            return "Operational"
+            return "Healthy"
         case .minor:
-            return "Partial Degradation"
+            return "Degraded"
         case .major:
-            return "Major Outage"
+            return "Outage"
         case .critical:
-            return "Critical Issue"
+            return "Down"
         case .maintenance:
             return "Maintenance"
         case .unknown:
@@ -120,13 +120,13 @@ struct ProviderStatusComponent: Identifiable, Equatable {
     static func label(forStatuspageStatus status: String) -> String {
         switch status {
         case "operational":
-            return "Operational"
+            return "Healthy"
         case "degraded_performance":
             return "Degraded"
         case "partial_outage":
-            return "Partial Outage"
+            return "Outage"
         case "major_outage", "full_outage":
-            return "Major Outage"
+            return "Down"
         case "under_maintenance":
             return "Maintenance"
         default:

--- a/MeterBar/Views/Components/ProviderBlockedUsageSummary.swift
+++ b/MeterBar/Views/Components/ProviderBlockedUsageSummary.swift
@@ -133,12 +133,7 @@ struct ProviderBlockedUsageSummary: View {
 
                     Spacer(minLength: MeterBarTheme.Spacing.sm)
 
-                    Text(content.statusText)
-                        .font(.caption2)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(ProviderCardPresentation.statusColor(for: snapshot))
-                        .lineLimit(1)
-                        .fixedSize(horizontal: true, vertical: false)
+                    ProviderCardStatusLabel(snapshot: snapshot)
                 }
 
                 if let resetText = content.resetText {

--- a/MeterBar/Views/Components/ProviderBlockedUsageSummary.swift
+++ b/MeterBar/Views/Components/ProviderBlockedUsageSummary.swift
@@ -111,41 +111,41 @@ struct ProviderBlockedUsageSummary: View {
                 hasAuthNotice: snapshot.authNotice != nil
             )
 
-            // The countdown takes its own line. Sharing the title's row made the
-            // title the only compressible element between two `fixedSize`
-            // siblings, so at popover width it collapsed to one character while
-            // the countdown kept its full ideal size.
-            VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.xs) {
-                HStack(spacing: density == .popoverCard ? MeterBarTheme.Spacing.sm : MeterBarTheme.Spacing.md) {
+            // The countdown stays below the title, while status gets its own
+            // trailing rail centered against the complete summary. Sharing all
+            // three on one line made the title collapse at popover width.
+            HStack(spacing: density == .popoverCard ? MeterBarTheme.Spacing.sm : MeterBarTheme.Spacing.md) {
+                VStack(alignment: .leading, spacing: MeterBarTheme.Spacing.xs) {
                     if showsTitle {
-                        ProviderLogoView(
-                            kind: snapshot.logoKind,
-                            size: density == .popoverCard ? 17 : 16,
-                            foregroundColor: snapshot.accentColor
-                        )
-                        Text(snapshot.title)
-                            .font(.subheadline)
-                            .fontWeight(.semibold)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                            .layoutPriority(1)
+                        HStack(spacing: density == .popoverCard ? MeterBarTheme.Spacing.sm : MeterBarTheme.Spacing.md) {
+                            ProviderLogoView(
+                                kind: snapshot.logoKind,
+                                size: density == .popoverCard ? 17 : 16,
+                                foregroundColor: snapshot.accentColor
+                            )
+                            Text(snapshot.title)
+                                .font(.subheadline)
+                                .fontWeight(.semibold)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                                .layoutPriority(1)
+                        }
                     }
 
-                    Spacer(minLength: MeterBarTheme.Spacing.sm)
-
-                    ProviderCardStatusLabel(snapshot: snapshot)
+                    if let resetText = content.resetText {
+                        Label(resetText, systemImage: "hourglass")
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(snapshot.accentColor)
+                            .monospacedDigit()
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.72)
+                            .numericRefreshTransition(value: resetText, reduceMotion: reduceMotion)
+                    }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
 
-                if let resetText = content.resetText {
-                    Label(resetText, systemImage: "hourglass")
-                        .font(.caption)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(snapshot.accentColor)
-                        .monospacedDigit()
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.72)
-                        .numericRefreshTransition(value: resetText, reduceMotion: reduceMotion)
-                }
+                ProviderCardStatusLabel(snapshot: snapshot)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityElement(children: .combine)

--- a/MeterBar/Views/Components/ProviderCardHeader.swift
+++ b/MeterBar/Views/Components/ProviderCardHeader.swift
@@ -9,8 +9,9 @@ import SwiftUI
 /// hovering a card replaced it with something that read like a different
 /// provider, and a logged-out account looked healthy the moment the pointer
 /// landed on it. One component keeps them identical; the only legitimate
-/// difference is the disclosure chevron, which belongs to the card because the
-/// panel is already the thing it discloses.
+/// difference is placement: a full provider card can move status and disclosure
+/// into a trailing rail that centers against the complete card, while the hover
+/// panel keeps them inline with its compact header.
 struct ProviderCardHeader: View {
     /// Display strings for the header, with no SwiftUI attached so each rule is
     /// directly assertable and the two surfaces can be compared value-to-value.
@@ -28,6 +29,7 @@ struct ProviderCardHeader: View {
     }
 
     let snapshot: ProviderSnapshot
+    var showsStatus: Bool = true
     var showsDisclosureChevron: Bool = false
 
     var content: Content { Content(snapshot: snapshot) }
@@ -50,7 +52,9 @@ struct ProviderCardHeader: View {
 
             Spacer(minLength: 0)
 
-            ProviderCardStatusLabel(snapshot: snapshot)
+            if showsStatus {
+                ProviderCardStatusLabel(snapshot: snapshot)
+            }
 
             if showsDisclosureChevron {
                 CardDisclosureChevron()

--- a/MeterBar/Views/Components/ProviderCardStatusLabel.swift
+++ b/MeterBar/Views/Components/ProviderCardStatusLabel.swift
@@ -3,29 +3,24 @@ import SwiftUI
 
 /// Status word on a provider card header or overview row.
 ///
-/// Amber and red bands (plus login/attention overlays) render as uppercase
-/// `MeterBarChip`s; healthy and subdued states stay plain semibold text so a
-/// wall of green pills does not compete with the quota bars below.
+/// Every state uses the same uppercase `MeterBarChip` treatment. Keeping the
+/// surface stable prevents a provider card from changing its visual grammar
+/// when it crosses a quota threshold; only the label and semantic tint change.
 struct ProviderCardStatusLabel: View {
-    let snapshot: ProviderSnapshot
+    let text: String
+    let color: Color
 
-    private var text: String {
-        ProviderCardPresentation.statusText(for: snapshot)
+    init(snapshot: ProviderSnapshot) {
+        text = ProviderCardPresentation.statusText(for: snapshot)
+        color = ProviderCardPresentation.statusColor(for: snapshot)
     }
 
-    private var color: Color {
-        ProviderCardPresentation.statusColor(for: snapshot)
+    init(band: QuotaBand) {
+        text = band.shortLabel
+        color = band.color
     }
 
     var body: some View {
-        if ProviderCardPresentation.statusUsesChip(for: snapshot) {
-            MeterBarChip(text.uppercased(), tint: color, style: .flat)
-        } else {
-            Text(text)
-                .font(.caption2)
-                .fontWeight(.semibold)
-                .foregroundColor(color)
-                .lineLimit(1)
-        }
+        MeterBarChip(text.uppercased(), tint: color, style: .flat)
     }
 }

--- a/MeterBar/Views/DashboardOverviewSection.swift
+++ b/MeterBar/Views/DashboardOverviewSection.swift
@@ -169,22 +169,19 @@ private struct OverviewProviderRow: View {
                     )
 
                     VStack(alignment: .leading, spacing: 3) {
-                        HStack(spacing: 8) {
-                            Text(snapshot.title)
-                                .font(.subheadline)
-                                .fontWeight(.semibold)
-                                .lineLimit(1)
-
-                            Spacer(minLength: 4)
-
-                            ProviderCardStatusLabel(snapshot: snapshot)
-                        }
+                        Text(snapshot.title)
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                            .lineLimit(1)
 
                         Text(DashboardOverviewSection.detailLine(for: snapshot, now: timeline.date))
                             .font(.caption)
                             .foregroundStyle(.secondary)
                             .lineLimit(2)
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    ProviderCardStatusLabel(snapshot: snapshot)
 
                     CardDisclosureChevron()
                 }

--- a/MeterBar/Views/OptimizeInsightsView.swift
+++ b/MeterBar/Views/OptimizeInsightsView.swift
@@ -454,9 +454,27 @@ struct OptimizeInsightsView: View {
 /// left, reset countdown, pace — so the ordering can be read off the row rather
 /// than taken on faith. Deliberately plain: this is arithmetic over cached
 /// quota numbers, not a prediction.
-private struct HeadroomRecommendationRow: View {
+struct HeadroomRecommendationRow: View {
+  struct Content: Equatable {
+    let statusBand: QuotaBand
+    let valueText: String
+    let detailParts: [String]
+
+    init(row: ProviderRecommendationRow) {
+      statusBand = row.band
+      valueText = row.headroomText
+      if row.isExhausted {
+        detailParts = [row.windowTitle, row.availabilityText].compactMap { $0 }
+      } else {
+        detailParts = [row.windowTitle, row.resetText, row.paceText].compactMap { $0 }
+      }
+    }
+  }
+
   let rank: Int
   let row: ProviderRecommendationRow
+
+  var content: Content { Content(row: row) }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 5) {
@@ -478,20 +496,22 @@ private struct HeadroomRecommendationRow: View {
           .lineLimit(1)
           .truncationMode(.middle)
 
-        MeterBarChip(row.windowTitle, tint: row.band.color, style: .flat)
+        ProviderCardStatusLabel(band: content.statusBand)
 
         Spacer(minLength: 8)
 
-        Text(row.isExhausted ? "Spent" : row.headroomText)
+        Text(content.valueText)
           .font(.callout)
           .monospacedDigit()
-          .foregroundColor(row.band.color)
       }
 
-      ShareBar(fraction: Double(row.percentLeft) / 100, tint: row.band.color)
+      ShareBar(
+        fraction: Double(row.percentLeft) / 100,
+        tint: MeterBarTheme.accent(for: row.service)
+      )
 
-      if !detailParts.isEmpty {
-        Text(detailParts.joined(separator: " · "))
+      if !content.detailParts.isEmpty {
+        Text(content.detailParts.joined(separator: " · "))
           .font(.caption)
           .foregroundColor(.secondary)
           .lineLimit(1)
@@ -502,14 +522,6 @@ private struct HeadroomRecommendationRow: View {
     .accessibilityValue(row.summary)
   }
 
-  /// The score inputs that don't fit the headline row, in weighting order: when
-  /// the window refills, then how the burn compares to the clock.
-  private var detailParts: [String] {
-    if row.isExhausted {
-      return [row.availabilityText].compactMap { $0 }
-    }
-    return [row.resetText, row.paceText].compactMap { $0 }
-  }
 }
 
 /// A provider left out of the ranking, with the reason in place of a rank.

--- a/MeterBar/Views/OptimizeInsightsView.swift
+++ b/MeterBar/Views/OptimizeInsightsView.swift
@@ -521,7 +521,6 @@ struct HeadroomRecommendationRow: View {
     .accessibilityLabel("Rank \(rank)")
     .accessibilityValue(row.summary)
   }
-
 }
 
 /// A provider left out of the ranking, with the reason in place of a rank.

--- a/MeterBar/Views/ProviderCardPresentation.swift
+++ b/MeterBar/Views/ProviderCardPresentation.swift
@@ -29,21 +29,6 @@ enum ProviderCardPresentation {
         return snapshot.band?.shortLabel ?? "Offline"
     }
 
-    /// Healthy and subdued auth states stay plain text; amber and red bands get
-    /// a pill so attention-grabbing status does not wallpaper every card.
-    static func statusUsesChip(for snapshot: ProviderSnapshot) -> Bool {
-        switch snapshot.authNotice {
-        case .loginRequired, .attention:
-            return true
-        case .stale, .notConnected:
-            return false
-        case .none:
-            break
-        }
-        guard let band = snapshot.band else { return false }
-        return band != .healthy
-    }
-
     /// How long a login-required card may keep showing its cached gauges before
     /// they stop being useful context and start being noise. Two hours is past
     /// any session window the cache could still be describing.

--- a/MeterBar/Views/ProviderStatusCard.swift
+++ b/MeterBar/Views/ProviderStatusCard.swift
@@ -136,10 +136,7 @@ struct ProviderStatusCard: View {
                 .fontWeight(.semibold)
                 .lineLimit(1)
             Spacer(minLength: 8)
-            Text("Offline")
-                .font(.caption2)
-                .fontWeight(.semibold)
-                .foregroundStyle(.secondary)
+            ProviderCardStatusLabel(snapshot: snapshot)
         }
     }
 
@@ -155,10 +152,7 @@ struct ProviderStatusCard: View {
                 .fontWeight(.semibold)
                 .lineLimit(1)
             Spacer(minLength: 8)
-            Text(ProviderAuthNotice.loginRequired.shortLabel)
-                .font(.caption2)
-                .fontWeight(.semibold)
-                .foregroundStyle(MeterBarTheme.warning)
+            ProviderCardStatusLabel(snapshot: snapshot)
         }
         .help("\(snapshot.updatedText) — log in to resume tracking")
     }

--- a/MeterBar/Views/ProviderStatusCard.swift
+++ b/MeterBar/Views/ProviderStatusCard.swift
@@ -198,34 +198,48 @@ struct ProviderStatusCard: View {
     }
 
     private var expandedCardBody: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            // The chevron rides along only when the card opens a detail panel,
-            // so "clickable" is visible instead of relying on the
-            // accessibilityHint alone.
-            ProviderCardHeader(snapshot: snapshot, showsDisclosureChevron: allowsDetailNavigation)
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 10) {
+                ProviderCardHeader(snapshot: snapshot, showsStatus: false)
 
-            if snapshot.hasExhaustedLimit {
-                BlockingLimitResetCounter(
-                    windows: snapshot.resetWindows,
-                    accentColor: snapshot.accentColor,
-                    format: menuBarDisplayPreferences.resetTimeFormat
-                )
-            } else {
-                VStack(alignment: .leading, spacing: 9) {
-                    ForEach(snapshot.limits) { limit in
-                        LimitRow(limit: limit, accentColor: snapshot.accentColor, density: limitDensity)
+                if snapshot.hasExhaustedLimit {
+                    BlockingLimitResetCounter(
+                        windows: snapshot.resetWindows,
+                        accentColor: snapshot.accentColor,
+                        format: menuBarDisplayPreferences.resetTimeFormat
+                    )
+                } else {
+                    VStack(alignment: .leading, spacing: 9) {
+                        ForEach(snapshot.limits) { limit in
+                            LimitRow(limit: limit, accentColor: snapshot.accentColor, density: limitDensity)
+                        }
                     }
                 }
-            }
 
-            let badges = ProviderStatusBadges(snapshot: snapshot, style: badgeStyle)
-            if badges.hasContent {
-                badges
-            }
+                let badges = ProviderStatusBadges(snapshot: snapshot, style: badgeStyle)
+                if badges.hasContent {
+                    badges
+                }
 
-            if showsResetCreditAction {
-                Divider()
-                resetCreditButton(isCompact: false)
+                if showsResetCreditAction {
+                    Divider()
+                    resetCreditButton(isCompact: false)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            // Status belongs to the whole card, not its first text line. Keeping
+            // it in a dedicated rail also reserves space so it cannot overlap a
+            // quota value or bar as the card grows.
+            HStack(spacing: 7) {
+                ProviderCardStatusLabel(snapshot: snapshot)
+
+                // The chevron rides along only when the card opens a detail
+                // panel, so "clickable" is visible without relying on the
+                // accessibility hint alone.
+                if allowsDetailNavigation {
+                    CardDisclosureChevron()
+                }
             }
         }
     }

--- a/MeterBar/Views/ProviderStatusViews.swift
+++ b/MeterBar/Views/ProviderStatusViews.swift
@@ -101,7 +101,10 @@ private struct ProviderStatusDisclosureRow: View {
     }
 
     private var headline: String {
-        report?.summary.description ?? report?.summary.indicator.summaryLabel ?? "Loading status"
+        if let report {
+            return report.summary.indicator.summaryLabel
+        }
+        return error == nil ? "Loading" : "Unavailable"
     }
 
     var body: some View {
@@ -370,7 +373,10 @@ private struct MenuBarStatusDetailProviderSection: View {
     }
 
     private var headline: String {
-        report?.summary.description ?? report?.summary.indicator.summaryLabel ?? "Loading status"
+        if let report {
+            return report.summary.indicator.summaryLabel
+        }
+        return error == nil ? "Loading" : "Unavailable"
     }
 
     private var subtitle: String? {

--- a/MeterBarTests/AppDelegateSplitTests.swift
+++ b/MeterBarTests/AppDelegateSplitTests.swift
@@ -86,14 +86,14 @@ final class AppDelegateSplitTests: XCTestCase {
         XCTAssertEqual(builder.makeMenu().items[2].state, .off)
     }
 
-    func testProviderStatusMenuTitleUsesReportSummaryDescription() {
+    func testProviderStatusMenuTitleUsesCompactIndicatorLabel() {
         let status = StatusMenuBuilder.StatusSnapshot(
             reports: [.claudeCode: Self.report(indicator: .minor, description: "Elevated errors")]
         )
 
         XCTAssertEqual(
             StatusMenuBuilder.providerStatusMenuTitle(for: .claudeCode, status: status),
-            "\(ServiceType.claudeCode.statusPageDisplayName) — Elevated errors"
+            "\(ServiceType.claudeCode.statusPageDisplayName) — Degraded"
         )
     }
 
@@ -104,7 +104,7 @@ final class AppDelegateSplitTests: XCTestCase {
 
         XCTAssertEqual(
             StatusMenuBuilder.providerStatusMenuTitle(for: .claudeCode, status: status),
-            "\(ServiceType.claudeCode.statusPageDisplayName) — Operational"
+            "\(ServiceType.claudeCode.statusPageDisplayName) — Healthy"
         )
     }
 
@@ -167,7 +167,7 @@ final class AppDelegateSplitTests: XCTestCase {
 
         // summary + separator + 2 components + separator + open item
         XCTAssertEqual(submenu.items.count, 6)
-        XCTAssertEqual(submenu.items[0].title, "Elevated errors")
+        XCTAssertEqual(submenu.items[0].title, "Degraded")
         XCTAssertFalse(submenu.items[0].isEnabled)
         XCTAssertTrue(submenu.items[1].isSeparatorItem)
         XCTAssertTrue(submenu.items[2].title.hasPrefix("API"))
@@ -213,7 +213,7 @@ final class AppDelegateSplitTests: XCTestCase {
         let item = StatusMenuBuilder.makeStatusComponentMenuItem(component)
 
         XCTAssertEqual(item.submenu?.items.count, 1)
-        XCTAssertEqual(item.submenu?.items[0].title, "API  Operational")
+        XCTAssertEqual(item.submenu?.items[0].title, "API  Healthy")
         XCTAssertTrue(item.isEnabled)
     }
 

--- a/MeterBarTests/MenuBarDetailPanelLayoutTests.swift
+++ b/MeterBarTests/MenuBarDetailPanelLayoutTests.swift
@@ -290,16 +290,22 @@ final class MenuBarProviderDetailParityTests: XCTestCase {
         XCTAssertEqual(plain.fittingSize.height, withEmptySeries.fittingSize.height)
     }
 
-    func testHeaderRendersWithAndWithoutTheDisclosureChevron() {
-        for showsChevron in [true, false] {
-            let header = ProviderCardHeader(snapshot: snapshot(), showsDisclosureChevron: showsChevron)
-            let host = NSHostingView(rootView: header.frame(width: 320))
-            host.layoutSubtreeIfNeeded()
-            XCTAssertGreaterThan(
-                host.fittingSize.height,
-                0,
-                "ProviderCardHeader(showsDisclosureChevron: \(showsChevron)) should lay out"
-            )
+    func testHeaderRendersWithInlineAndExternalStatusLayouts() {
+        for showsStatus in [true, false] {
+            for showsChevron in [true, false] {
+                let header = ProviderCardHeader(
+                    snapshot: snapshot(),
+                    showsStatus: showsStatus,
+                    showsDisclosureChevron: showsChevron
+                )
+                let host = NSHostingView(rootView: header.frame(width: 320))
+                host.layoutSubtreeIfNeeded()
+                XCTAssertGreaterThan(
+                    host.fittingSize.height,
+                    0,
+                    "ProviderCardHeader(status: \(showsStatus), chevron: \(showsChevron)) should lay out"
+                )
+            }
         }
     }
 }

--- a/MeterBarTests/MeterBarChipTests.swift
+++ b/MeterBarTests/MeterBarChipTests.swift
@@ -107,6 +107,42 @@ final class MeterBarChipTests: XCTestCase {
         assertHosts(ProviderStatusBadge(indicator: .critical, label: "Major outage"))
     }
 
+    /// PR #483 mixed plain Healthy text with an OUT pill. Both statuses now use
+    /// the same capsule grammar; the semantic label and tint are the only
+    /// differences.
+    func testProviderStatusLabelUsesPillsForHealthyAndOut() {
+        let plainHeight = fittingHeight(
+            Text("HEALTHY")
+                .font(.caption2)
+                .fontWeight(.semibold)
+        )
+        let healthyHeight = fittingHeight(
+            ProviderCardStatusLabel(snapshot: providerSnapshot(used: 10))
+        )
+        let exhaustedHeight = fittingHeight(
+            ProviderCardStatusLabel(snapshot: providerSnapshot(used: 100))
+        )
+
+        XCTAssertGreaterThan(healthyHeight, plainHeight)
+        XCTAssertEqual(exhaustedHeight, healthyHeight, accuracy: 0.5)
+    }
+
+    func testOptimizeRowUsesStatusForThePillAndWindowForSupportingText() throws {
+        let healthy = try XCTUnwrap(recommendationRow(used: 26))
+        let healthyContent = HeadroomRecommendationRow.Content(row: healthy)
+
+        XCTAssertEqual(healthyContent.statusBand, .healthy)
+        XCTAssertEqual(healthyContent.valueText, "74% left")
+        XCTAssertEqual(healthyContent.detailParts.first, "Session")
+
+        let exhausted = try XCTUnwrap(recommendationRow(used: 100))
+        let exhaustedContent = HeadroomRecommendationRow.Content(row: exhausted)
+
+        XCTAssertEqual(exhaustedContent.statusBand, .exhausted)
+        XCTAssertEqual(exhaustedContent.valueText, "0% left")
+        XCTAssertEqual(exhaustedContent.detailParts, ["Session", "Available in 1h"])
+    }
+
     // MARK: - Helpers
 
     /// Renders a view in an off-screen host and asserts it lays out to a real,
@@ -123,5 +159,55 @@ final class MeterBarChipTests: XCTestCase {
         let size = host.fittingSize
         XCTAssertGreaterThan(size.width, 0, "chip should have non-zero width", file: file, line: line)
         XCTAssertGreaterThan(size.height, 0, "chip should have non-zero height", file: file, line: line)
+    }
+
+    private func fittingHeight(_ view: some View) -> CGFloat {
+        let host = NSHostingView(rootView: view)
+        host.frame = NSRect(x: 0, y: 0, width: 300, height: 100)
+        host.layoutSubtreeIfNeeded()
+        return host.fittingSize.height
+    }
+
+    private func providerSnapshot(used: Double) -> ProviderSnapshot {
+        ProviderSnapshot(
+            id: "cursor",
+            title: "Cursor",
+            service: .cursor,
+            updatedAt: Date(),
+            limits: [
+                SnapshotLimit(
+                    id: "weekly",
+                    kind: .weekly,
+                    title: "Weekly",
+                    usageLimit: UsageLimit(
+                        used: used,
+                        total: 100,
+                        resetTime: Date().addingTimeInterval(3_600)
+                    )
+                )
+            ],
+            emptyDetail: "Waiting for refresh",
+            extraUsage: nil,
+            resetCreditsAvailable: nil,
+            accountID: nil
+        )
+    }
+
+    private func recommendationRow(used: Double) -> ProviderRecommendationRow? {
+        let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
+        let candidate = ProviderRecommendationCandidate(
+            id: "codex",
+            name: "Codex",
+            service: .codexCli,
+            displayOrder: 0,
+            sessionLimit: UsageLimit(
+                used: used,
+                total: 100,
+                resetTime: now.addingTimeInterval(3_600)
+            ),
+            weeklyLimit: nil,
+            lastUpdated: now
+        )
+        return ProviderRecommendationPlanner.rank(candidates: [candidate], now: now).top
     }
 }

--- a/MeterBarTests/MeterBarChipTests.swift
+++ b/MeterBarTests/MeterBarChipTests.swift
@@ -103,8 +103,8 @@ final class MeterBarChipTests: XCTestCase {
     }
 
     func testProviderStatusBadgeHosts() {
-        assertHosts(ProviderStatusBadge(indicator: .none, label: "All systems operational"))
-        assertHosts(ProviderStatusBadge(indicator: .critical, label: "Major outage"))
+        assertHosts(ProviderStatusBadge(indicator: .none, label: "Healthy"))
+        assertHosts(ProviderStatusBadge(indicator: .critical, label: "Down"))
     }
 
     /// PR #483 mixed plain Healthy text with an OUT pill. Both statuses now use

--- a/MeterBarTests/ProviderPresentationHealthTests.swift
+++ b/MeterBarTests/ProviderPresentationHealthTests.swift
@@ -543,62 +543,6 @@ final class ProviderPresentationHealthTests: XCTestCase {
         XCTAssertEqual(ProviderCardPresentation.statusText(for: cursor), QuotaBand.healthy.shortLabel)
     }
 
-    func testHealthyStatusStaysPlainTextWhileAttentionUsesAChip() throws {
-        let healthy = try card(
-            .codex,
-            lastUpdated: freshAt,
-            refresh: .success,
-            parseHealth: .success(provider: .codexCli, at: freshAt)
-        )
-        XCTAssertFalse(ProviderCardPresentation.statusUsesChip(for: healthy))
-
-        let critical = ProviderSnapshot(
-            id: "cursor",
-            title: "Cursor",
-            service: .cursor,
-            updatedAt: freshAt,
-            limits: [
-                SnapshotLimit(
-                    id: "weekly",
-                    kind: .weekly,
-                    title: "Weekly",
-                    usageLimit: UsageLimit(used: 95, total: 100, resetTime: nil)
-                )
-            ],
-            emptyDetail: "Waiting",
-            extraUsage: nil,
-            resetCreditsAvailable: nil,
-            accountID: nil
-        )
-        XCTAssertTrue(ProviderCardPresentation.statusUsesChip(for: critical))
-
-        var stale = healthy
-        stale.authNotice = .stale(since: freshAt)
-        XCTAssertFalse(ProviderCardPresentation.statusUsesChip(for: stale))
-
-        var staleCritical = critical
-        staleCritical.authNotice = .stale(since: freshAt)
-        XCTAssertFalse(
-            ProviderCardPresentation.statusUsesChip(for: staleCritical),
-            "stale must stay plain text even when cached quota is critical"
-        )
-
-        var notConnectedCritical = critical
-        notConnectedCritical.authNotice = .notConnected
-        XCTAssertFalse(
-            ProviderCardPresentation.statusUsesChip(for: notConnectedCritical),
-            "offline/not-connected must stay plain text even when cached quota is critical"
-        )
-
-        var login = healthy
-        login.authNotice = .loginRequired
-        XCTAssertTrue(ProviderCardPresentation.statusUsesChip(for: login))
-
-        var attention = healthy
-        attention.authNotice = .attention("Refresh failed")
-        XCTAssertTrue(ProviderCardPresentation.statusUsesChip(for: attention))
-    }
-
     // MARK: - Helpers
 
     private func card(

--- a/MeterBarTests/ProviderStatusMonitorTests.swift
+++ b/MeterBarTests/ProviderStatusMonitorTests.swift
@@ -100,7 +100,20 @@ final class ProviderStatusMonitorTests: XCTestCase {
         XCTAssertEqual(components[0].children.map(\.name), ["Responses API"])
         XCTAssertEqual(components[0].children.first?.indicator, .major)
         XCTAssertEqual(components[1].name, "ChatGPT")
-        XCTAssertEqual(components[1].statusLabel, "Operational")
+        XCTAssertEqual(components[1].statusLabel, "Healthy")
+    }
+
+    func testProviderStatusLabelsStayCompact() {
+        XCTAssertEqual(ProviderStatusIndicator.none.summaryLabel, "Healthy")
+        XCTAssertEqual(ProviderStatusIndicator.minor.summaryLabel, "Degraded")
+        XCTAssertEqual(ProviderStatusIndicator.major.summaryLabel, "Outage")
+        XCTAssertEqual(ProviderStatusIndicator.critical.summaryLabel, "Down")
+        XCTAssertEqual(ProviderStatusIndicator.maintenance.summaryLabel, "Maintenance")
+        XCTAssertEqual(ProviderStatusIndicator.unknown.summaryLabel, "Unknown")
+
+        XCTAssertEqual(ProviderStatusComponent.label(forStatuspageStatus: "operational"), "Healthy")
+        XCTAssertEqual(ProviderStatusComponent.label(forStatuspageStatus: "partial_outage"), "Outage")
+        XCTAssertEqual(ProviderStatusComponent.label(forStatuspageStatus: "major_outage"), "Down")
     }
 
     func testServiceTypeStatusPageURLs() throws {


### PR DESCRIPTION
## Summary
- render every provider state with the same uppercase status pill across dashboard, Limits, and popover paths
- fix bypass paths for blocked, offline, and login-required cards
- normalize Optimize rows so status owns the pill, quota windows move to supporting text, percentages use primary text, and bars retain provider identity

## Regression findings
- before PR #483, Healthy and Out were consistent because both were plain text
- PR #483 introduced the mixed plain/pill presentation
- Optimize window-name pills predate #483 (introduced with Optimize PR #353), but exposed the same inconsistent visual grammar

## Verification
- `swift test --filter MeterBarChipTests` (12 passed)
- `swift test --filter ProviderPresentationHealthTests` (26 passed)
- fresh `xcodebuild` Debug artifact succeeded

Visual validation is pending on the installed MeterBar Dev build before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Presentation-only, but it touches many quota and status surfaces plus user-facing copy. Layout and truncation at popover width are the main regression risk.
> 
> **Overview**
> Makes provider status a single visual grammar: every state (healthy, exhausted, offline, login-required) is an uppercase `MeterBarChip`, instead of mixing plain text with pills.
> 
> **Cards and lists** put that chip in a trailing rail so it no longer shares a line with the title. Expanded `ProviderStatusCard` hides header status and centers the chip against the whole card; blocked, offline, overview, and Optimize rows follow the same pattern. Optimize pills now show quota band, not window name; window/reset/pace move to supporting text and bars keep the provider accent.
> 
> **Status pages** drop vendor `description` copy and use short indicator labels (`Healthy`, `Degraded`, `Outage`, `Down`) in menus, dashboards, and component rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cb9dc5aa792792a40dba833868ad39d6be991a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Standardized provider status labels across cards, summaries, dashboards, menus, and optimization insights.
  * Statuses now use consistent pill-style presentation, sizing, colors, and service-based indicators.
  * Improved layouts and alignment for provider details, status labels, reset information, and disclosure controls.
  * Recommendation rows now display clearer headroom values and supporting details.
  * Clarified loading and unavailable states in status views.

* **Tests**
  * Added coverage for status label sizing, layout configurations, and recommendation content calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->