### PR TITLE
chore(release): bump version to 1.8.39

### DIFF
--- a/MeterBar.xcodeproj/project.pbxproj
+++ b/MeterBar.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.38;
+				MARKETING_VERSION = 1.8.39;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -369,7 +369,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.38;
+				MARKETING_VERSION = 1.8.39;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -534,7 +534,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.38;
+				MARKETING_VERSION = 1.8.39;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app.debug;
 				PRODUCT_NAME = "MeterBar Dev";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -580,7 +580,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.38;
+				MARKETING_VERSION = 1.8.39;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.meterbar.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary
- bump MARKETING_VERSION from 1.8.38 to 1.8.39 in all four app/widget build configurations
- prepare the signed release for merged PRs #483 and #484

## Verification
- diff limited to the four standard version fields
- Swift build parity fixtures pass
- release tag validation passes
- release ancestry validation passes
- signed-release workflow contract passes

## Release
- merge only after required CI is green
- then tag v1.8.39 from the merged master commit
- release workflow publishes the signed/notarized app, Sparkle appcast, and Homebrew cask update

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-number-only change in Xcode project settings; no code, auth, or data-handling changes.
> 
> **Overview**
> Bumps `MARKETING_VERSION` from **1.8.38** to **1.8.39** for the app and widget Debug/Release configs in `project.pbxproj`, preparing the next signed release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e30aba7ed678fef6fb08f16f2803e87f0a27cee8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->