### PR TITLE
fix(ui): keep active provider status in card headers

### DIFF
--- a/MeterBar/Models/OptimizationInsights.swift
+++ b/MeterBar/Models/OptimizationInsights.swift
@@ -34,12 +34,24 @@ nonisolated enum ModelTier: String, Sendable, Equatable {
 
     var isPremium: Bool { self == .premium }
 
-    var label: String {
+    /// Compact relative-price marker used by the Optimize breakdown. The tier
+    /// is intentionally typography-only: status colors stay reserved for
+    /// health and attention states elsewhere in the app.
+    var costIndicator: String {
         switch self {
-        case .premium: return "Premium"
-        case .standard: return "Standard"
-        case .economy: return "Economy"
-        case .unknown: return "Other"
+        case .premium: return "$$$"
+        case .standard: return "$$"
+        case .economy: return "$"
+        case .unknown: return "—"
+        }
+    }
+
+    var costAccessibilityLabel: String {
+        switch self {
+        case .premium: return "High-cost model"
+        case .standard: return "Mid-cost model"
+        case .economy: return "Low-cost model"
+        case .unknown: return "Unknown cost tier"
         }
     }
 }
@@ -297,13 +309,13 @@ nonisolated struct OptimizationInsights: Equatable, Sendable {
 
         var recommendations: [OptimizationRecommendation] = []
 
-        // Premium-model routing.
+        // High-cost model routing.
         if premiumShare >= Threshold.premiumWarning {
             recommendations.append(OptimizationRecommendation(
                 id: "premium-share",
-                title: "Premium models are doing most of the work",
-                detail: "Premium models handled \(percentString(premiumShare)) of your tokens. "
-                    + "Routing routine edits, summaries, and lookups to a mid-tier or economy model "
+                title: "High-cost models are doing most of the work",
+                detail: "$$$ models handled \(percentString(premiumShare)) of your tokens. "
+                    + "Routing routine edits, summaries, and lookups to $$ or $ models "
                     + "can cut token spend without much quality loss.",
                 severity: .warning,
                 systemImage: "bolt.badge.automatic"
@@ -311,9 +323,9 @@ nonisolated struct OptimizationInsights: Equatable, Sendable {
         } else if premiumShare >= Threshold.premiumSuggestion {
             recommendations.append(OptimizationRecommendation(
                 id: "premium-share",
-                title: "Consider tiering your model choice",
-                detail: "Premium models handled \(percentString(premiumShare)) of your tokens. "
-                    + "Reserve them for the hardest reasoning and let cheaper models handle the rest.",
+                title: "Use lower-cost models more often",
+                detail: "$$$ models handled \(percentString(premiumShare)) of your tokens. "
+                    + "Reserve them for the hardest reasoning and route routine work to $$ or $ models.",
                 severity: .suggestion,
                 systemImage: "bolt.badge.automatic"
             ))
@@ -390,7 +402,7 @@ nonisolated struct OptimizationInsights: Equatable, Sendable {
                 id: "lean",
                 title: "Usage looks lean",
                 detail: "No major optimization flags right now — your model mix, cache reuse, and context "
-                    + "size are in a healthy range. Keep an eye on premium share as usage grows.",
+                    + "size are in a healthy range. Keep an eye on $$$ model share as usage grows.",
                 severity: .positive,
                 systemImage: "leaf"
             ))

--- a/MeterBar/Views/Components/ProviderCardHeader.swift
+++ b/MeterBar/Views/Components/ProviderCardHeader.swift
@@ -9,9 +9,9 @@ import SwiftUI
 /// hovering a card replaced it with something that read like a different
 /// provider, and a logged-out account looked healthy the moment the pointer
 /// landed on it. One component keeps them identical; the only legitimate
-/// difference is placement: a full provider card can move status and disclosure
-/// into a trailing rail that centers against the complete card, while the hover
-/// panel keeps them inline with its compact header.
+/// difference is the disclosure chevron, which belongs to the card because the
+/// panel is already the thing it discloses. Status always stays beside the
+/// provider identity; only compact terminal summaries center it against a card.
 struct ProviderCardHeader: View {
     /// Display strings for the header, with no SwiftUI attached so each rule is
     /// directly assertable and the two surfaces can be compared value-to-value.
@@ -29,7 +29,6 @@ struct ProviderCardHeader: View {
     }
 
     let snapshot: ProviderSnapshot
-    var showsStatus: Bool = true
     var showsDisclosureChevron: Bool = false
 
     var content: Content { Content(snapshot: snapshot) }
@@ -52,9 +51,7 @@ struct ProviderCardHeader: View {
 
             Spacer(minLength: 0)
 
-            if showsStatus {
-                ProviderCardStatusLabel(snapshot: snapshot)
-            }
+            ProviderCardStatusLabel(snapshot: snapshot)
 
             if showsDisclosureChevron {
                 CardDisclosureChevron()

--- a/MeterBar/Views/Components/ProviderCardHeader.swift
+++ b/MeterBar/Views/Components/ProviderCardHeader.swift
@@ -36,14 +36,12 @@ struct ProviderCardHeader: View {
     var body: some View {
         HStack(spacing: 7) {
             ProviderLogoView(kind: snapshot.logoKind, size: 17, foregroundColor: snapshot.accentColor)
-                .accessibilityIdentifier("provider-card-header-logo")
 
             VStack(alignment: .leading, spacing: 1) {
                 Text(content.title)
                     .font(.subheadline)
                     .fontWeight(.semibold)
                     .lineLimit(1)
-                    .accessibilityIdentifier("provider-card-header-title")
                 Text(content.subtitle)
                     .font(.caption2)
                     .foregroundColor(.secondary)
@@ -54,7 +52,6 @@ struct ProviderCardHeader: View {
             Spacer(minLength: 0)
 
             ProviderCardStatusLabel(snapshot: snapshot)
-                .accessibilityIdentifier("provider-card-header-status")
 
             if showsDisclosureChevron {
                 CardDisclosureChevron()

--- a/MeterBar/Views/Components/ProviderCardHeader.swift
+++ b/MeterBar/Views/Components/ProviderCardHeader.swift
@@ -36,12 +36,14 @@ struct ProviderCardHeader: View {
     var body: some View {
         HStack(spacing: 7) {
             ProviderLogoView(kind: snapshot.logoKind, size: 17, foregroundColor: snapshot.accentColor)
+                .accessibilityIdentifier("provider-card-header-logo")
 
             VStack(alignment: .leading, spacing: 1) {
                 Text(content.title)
                     .font(.subheadline)
                     .fontWeight(.semibold)
                     .lineLimit(1)
+                    .accessibilityIdentifier("provider-card-header-title")
                 Text(content.subtitle)
                     .font(.caption2)
                     .foregroundColor(.secondary)
@@ -52,6 +54,7 @@ struct ProviderCardHeader: View {
             Spacer(minLength: 0)
 
             ProviderCardStatusLabel(snapshot: snapshot)
+                .accessibilityIdentifier("provider-card-header-status")
 
             if showsDisclosureChevron {
                 CardDisclosureChevron()

--- a/MeterBar/Views/OptimizeInsightsView.swift
+++ b/MeterBar/Views/OptimizeInsightsView.swift
@@ -196,7 +196,7 @@ struct OptimizeInsightsView: View {
     DashboardStatusHero(
       title: "Optimization score \(insights.optimizationScore)/100 · \(insights.scoreGrade)",
       detail:
-        "\(insights.scoreHeadline) — based on premium-model share, context size, cache reuse, "
+        "\(insights.scoreHeadline) — based on high-cost model share, context size, cache reuse, "
         + "and how concentrated your usage is.",
       iconName: "leaf.fill",
       color: Self.gradeColor(insights.optimizationScore)
@@ -254,9 +254,9 @@ struct OptimizeInsightsView: View {
   private func kpiGrid(for insights: OptimizationInsights) -> some View {
     LazyVGrid(columns: Self.kpiColumns, alignment: .leading, spacing: 12) {
       DashboardMetricTile(
-        title: "Premium model share",
+        title: "$$$ model share",
         value: insights.formattedPremiumShare,
-        caption: "of tokens on premium models",
+        caption: "tokens routed to high-cost models",
         systemImage: "bolt.fill",
         indicatorTint: Self.shareTint(insights.premiumTokenShare)
       )
@@ -306,36 +306,29 @@ struct OptimizeInsightsView: View {
   }
 
   private func modelBreakdownCard(for insights: OptimizationInsights) -> some View {
-    DashboardCard(title: "Token Burn by Model") {
-      if insights.topModels.isEmpty {
-        Text("No per-model breakdown available in the current scan.")
-          .font(.caption)
-          .foregroundColor(.secondary)
-      } else {
-        VStack(spacing: 10) {
-          ForEach(insights.topModels.prefix(6)) { entry in
-            RankedBreakdownRow(entry: entry, showsTier: true)
-          }
-        }
-      }
-    }
+    breakdownCard(kind: .model, entries: insights.topModels)
   }
 
   private func originBreakdownCard(for insights: OptimizationInsights) -> some View {
-    DashboardCard(title: "Top Usage Origins") {
-      VStack(alignment: .leading, spacing: 10) {
-        Text("Where tokens are spent — agents, tool use, skills, and main chat.")
-          .font(.caption)
-          .foregroundColor(.secondary)
+    breakdownCard(kind: .origin, entries: insights.topOrigins)
+  }
 
-        if insights.topOrigins.isEmpty {
-          Text("No origin breakdown available in the current scan.")
+  private func breakdownCard(
+    kind: RankedBreakdownKind,
+    entries: [RankedTokenEntry]
+  ) -> some View {
+    DashboardCard(title: kind.title) {
+      VStack(alignment: .leading, spacing: 10) {
+        Text(kind.subtitle)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+
+        if entries.isEmpty {
+          Text(kind.emptyText)
             .font(.caption)
-            .foregroundColor(.secondary)
+            .foregroundStyle(.secondary)
         } else {
-          ForEach(insights.topOrigins.prefix(6)) { entry in
-            RankedBreakdownRow(entry: entry, showsTier: false)
-          }
+          RankedBreakdownTable(entries: Array(entries.prefix(6)), kind: kind)
         }
       }
     }
@@ -573,54 +566,129 @@ private struct HeadroomUnavailableRow: View {
   }
 }
 
-// MARK: - Ranked breakdown row
+// MARK: - Ranked breakdown table
 
-private struct RankedBreakdownRow: View {
-  let entry: RankedTokenEntry
-  let showsTier: Bool
+private enum RankedBreakdownKind: Equatable {
+  case model
+  case origin
 
-  var body: some View {
-    VStack(alignment: .leading, spacing: 5) {
-      HStack(spacing: 8) {
-        Circle()
-          .fill(MeterBarTheme.accent(for: entry.provider))
-          .frame(width: 8, height: 8)
-
-        Text(entry.name)
-          .font(.callout)
-          .fontWeight(.medium)
-          .lineLimit(1)
-          .truncationMode(.middle)
-
-        if showsTier, entry.tier != .unknown {
-          // Migrated to the shared `MeterBarChip`; fill normalizes 0.18 -> 0.14
-          // and it picks up the standard hairline stroke. Tier color unchanged.
-          MeterBarChip(entry.tier.label, tint: tierColor, style: .flat)
-        }
-
-        Spacer(minLength: 8)
-
-        Text(entry.formattedTokens)
-          .font(.callout)
-          .monospacedDigit()
-        Text(entry.formattedShare)
-          .font(.caption)
-          .foregroundColor(.secondary)
-          .monospacedDigit()
-          .frame(width: 42, alignment: .trailing)
-      }
-
-      ShareBar(fraction: entry.tokenShare, tint: MeterBarTheme.accent(for: entry.provider))
+  var title: String {
+    switch self {
+    case .model: return "Token Burn by Model"
+    case .origin: return "Top Usage Origins"
     }
   }
 
-  private var tierColor: Color {
-    switch entry.tier {
-    case .premium: return MeterBarTheme.danger
-    case .standard: return MeterBarTheme.warning
-    case .economy: return MeterBarTheme.success
-    case .unknown: return .secondary
+  var subtitle: String {
+    switch self {
+    case .model: return "Model mix by token share. $ is lower-cost; $$$ is higher-cost."
+    case .origin: return "Where tokens are spent across apps, agents, tools, skills, and chat."
     }
+  }
+
+  var emptyText: String {
+    switch self {
+    case .model: return "No per-model breakdown available in the current scan."
+    case .origin: return "No origin breakdown available in the current scan."
+    }
+  }
+
+  var primaryColumnTitle: String {
+    switch self {
+    case .model: return "Model"
+    case .origin: return "Origin"
+    }
+  }
+
+  var showsCostTier: Bool { self == .model }
+  var columnCount: Int { showsCostTier ? 4 : 3 }
+}
+
+private struct RankedBreakdownTable: View {
+  let entries: [RankedTokenEntry]
+  let kind: RankedBreakdownKind
+
+  var body: some View {
+    Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 6) {
+      GridRow {
+        Text(kind.primaryColumnTitle)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .gridColumnAlignment(.leading)
+
+        if kind.showsCostTier {
+          Text("Cost tier")
+            .gridColumnAlignment(.center)
+        }
+
+        Text("Tokens")
+          .gridColumnAlignment(.trailing)
+        Text("Share")
+          .gridColumnAlignment(.trailing)
+      }
+      .font(.caption2)
+      .fontWeight(.semibold)
+      .foregroundStyle(.secondary)
+      .textCase(.uppercase)
+
+      ForEach(entries) { entry in
+        RankedBreakdownRow(entry: entry, kind: kind)
+      }
+    }
+    .frame(maxWidth: .infinity)
+  }
+}
+
+private struct RankedBreakdownRow: View {
+  let entry: RankedTokenEntry
+  let kind: RankedBreakdownKind
+
+  @ViewBuilder var body: some View {
+    GridRow {
+      Text(entry.name)
+        .font(.callout)
+        .fontWeight(.medium)
+        .lineLimit(1)
+        .truncationMode(.middle)
+        .frame(maxWidth: .infinity, alignment: .leading)
+
+      if kind.showsCostTier {
+        Text(entry.tier.costIndicator)
+          .font(.caption)
+          .fontWeight(.semibold)
+          .foregroundStyle(.secondary)
+          .monospaced()
+          .accessibilityLabel(entry.tier.costAccessibilityLabel)
+      }
+
+      Text(entry.formattedTokens)
+        .font(.callout)
+        .fontWeight(.semibold)
+        .monospacedDigit()
+
+      Text(entry.formattedShare)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .monospacedDigit()
+    }
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(entry.name)
+    .accessibilityValue(accessibilityValue)
+
+    GridRow {
+      ShareBar(fraction: entry.tokenShare, tint: MeterBarTheme.accent(for: entry.provider))
+        .gridCellColumns(kind.columnCount)
+        .accessibilityHidden(true)
+    }
+  }
+
+  private var accessibilityValue: String {
+    var parts: [String] = []
+    if kind.showsCostTier {
+      parts.append(entry.tier.costAccessibilityLabel)
+    }
+    parts.append("\(entry.formattedTokens) tokens")
+    parts.append(entry.formattedShare)
+    return parts.joined(separator: ", ")
   }
 }
 

--- a/MeterBar/Views/OptimizeInsightsView.swift
+++ b/MeterBar/Views/OptimizeInsightsView.swift
@@ -457,18 +457,23 @@ struct OptimizeInsightsView: View {
 struct HeadroomRecommendationRow: View {
   struct Content: Equatable {
     let statusBand: QuotaBand
-    let valueText: String
-    let detailParts: [String]
+    let windowText: String
+    let valueText: String?
+    let footerParts: [String]
 
     init(row: ProviderRecommendationRow) {
       statusBand = row.band
-      valueText = row.headroomText
+      windowText = row.windowTitle
       if row.isExhausted {
-        detailParts = [row.windowTitle, row.availabilityText].compactMap { $0 }
+        valueText = nil
+        footerParts = [row.availabilityText].compactMap { $0 }
       } else {
-        detailParts = [row.windowTitle, row.resetText, row.paceText].compactMap { $0 }
+        valueText = row.headroomText
+        footerParts = [row.resetText, row.paceText].compactMap { $0 }
       }
     }
+
+    var showsUsage: Bool { valueText != nil }
   }
 
   let rank: Int
@@ -496,22 +501,39 @@ struct HeadroomRecommendationRow: View {
           .lineLimit(1)
           .truncationMode(.middle)
 
-        ProviderCardStatusLabel(band: content.statusBand)
-
         Spacer(minLength: 8)
 
-        Text(content.valueText)
-          .font(.callout)
-          .monospacedDigit()
+        ProviderCardStatusLabel(band: content.statusBand)
       }
 
-      ShareBar(
-        fraction: Double(row.percentLeft) / 100,
-        tint: MeterBarTheme.accent(for: row.service)
-      )
+      if content.showsUsage {
+        HStack(spacing: 8) {
+          Text(content.windowText)
+            .font(.caption)
+            .fontWeight(.semibold)
+            .foregroundColor(.secondary)
 
-      if !content.detailParts.isEmpty {
-        Text(content.detailParts.joined(separator: " · "))
+          Spacer(minLength: 8)
+
+          if let valueText = content.valueText {
+            Text(valueText)
+              .font(.callout)
+              .fontWeight(.semibold)
+              .monospacedDigit()
+          }
+        }
+
+        ShareBar(
+          fraction: Double(row.percentLeft) / 100,
+          tint: MeterBarTheme.accent(for: row.service)
+        )
+      }
+
+      let supportingParts = content.showsUsage
+        ? content.footerParts
+        : [content.windowText] + content.footerParts
+      if !supportingParts.isEmpty {
+        Text(supportingParts.joined(separator: " · "))
           .font(.caption)
           .foregroundColor(.secondary)
           .lineLimit(1)

--- a/MeterBar/Views/ProviderStatusCard.swift
+++ b/MeterBar/Views/ProviderStatusCard.swift
@@ -198,48 +198,34 @@ struct ProviderStatusCard: View {
     }
 
     private var expandedCardBody: some View {
-        HStack(spacing: 10) {
-            VStack(alignment: .leading, spacing: 10) {
-                ProviderCardHeader(snapshot: snapshot, showsStatus: false)
+        VStack(alignment: .leading, spacing: 10) {
+            // Active providers keep status beside their identity. Terminal
+            // summaries (Out, Offline, login required) use the compact card
+            // branches above, where centering against the whole row is useful.
+            ProviderCardHeader(snapshot: snapshot, showsDisclosureChevron: allowsDetailNavigation)
 
-                if snapshot.hasExhaustedLimit {
-                    BlockingLimitResetCounter(
-                        windows: snapshot.resetWindows,
-                        accentColor: snapshot.accentColor,
-                        format: menuBarDisplayPreferences.resetTimeFormat
-                    )
-                } else {
-                    VStack(alignment: .leading, spacing: 9) {
-                        ForEach(snapshot.limits) { limit in
-                            LimitRow(limit: limit, accentColor: snapshot.accentColor, density: limitDensity)
-                        }
+            if snapshot.hasExhaustedLimit {
+                BlockingLimitResetCounter(
+                    windows: snapshot.resetWindows,
+                    accentColor: snapshot.accentColor,
+                    format: menuBarDisplayPreferences.resetTimeFormat
+                )
+            } else {
+                VStack(alignment: .leading, spacing: 9) {
+                    ForEach(snapshot.limits) { limit in
+                        LimitRow(limit: limit, accentColor: snapshot.accentColor, density: limitDensity)
                     }
                 }
-
-                let badges = ProviderStatusBadges(snapshot: snapshot, style: badgeStyle)
-                if badges.hasContent {
-                    badges
-                }
-
-                if showsResetCreditAction {
-                    Divider()
-                    resetCreditButton(isCompact: false)
-                }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
 
-            // Status belongs to the whole card, not its first text line. Keeping
-            // it in a dedicated rail also reserves space so it cannot overlap a
-            // quota value or bar as the card grows.
-            HStack(spacing: 7) {
-                ProviderCardStatusLabel(snapshot: snapshot)
+            let badges = ProviderStatusBadges(snapshot: snapshot, style: badgeStyle)
+            if badges.hasContent {
+                badges
+            }
 
-                // The chevron rides along only when the card opens a detail
-                // panel, so "clickable" is visible without relying on the
-                // accessibility hint alone.
-                if allowsDetailNavigation {
-                    CardDisclosureChevron()
-                }
+            if showsResetCreditAction {
+                Divider()
+                resetCreditButton(isCompact: false)
             }
         }
     }

--- a/MeterBarTests/MenuBarDetailPanelLayoutTests.swift
+++ b/MeterBarTests/MenuBarDetailPanelLayoutTests.swift
@@ -290,80 +290,61 @@ final class MenuBarProviderDetailParityTests: XCTestCase {
         XCTAssertEqual(plain.fittingSize.height, withEmptySeries.fittingSize.height)
     }
 
-    func testHeaderAlwaysRendersInlineStatusWithOrWithoutDisclosureChevron() throws {
+    func testHeaderAlwaysRendersInlineStatusWithOrWithoutDisclosureChevron() {
         for showsChevron in [true, false] {
             let currentSnapshot = snapshot()
             let expectedStatus = ProviderCardPresentation.statusText(for: currentSnapshot)
-            let header = ProviderCardHeader(
-                snapshot: currentSnapshot,
-                showsDisclosureChevron: showsChevron
+            let headerHost = NSHostingView(
+                rootView: ProviderCardHeader(
+                    snapshot: currentSnapshot,
+                    showsDisclosureChevron: showsChevron
+                )
             )
-            let host = NSHostingView(rootView: header.frame(width: 320))
-            host.frame = NSRect(origin: .zero, size: host.fittingSize)
-            host.layoutSubtreeIfNeeded()
-
-            let logo = try XCTUnwrap(
-                accessibilityElement(identifier: "provider-card-header-logo", in: host),
-                "Provider logo should render when chevron is \(showsChevron)"
+            let identityHost = NSHostingView(
+                rootView: HStack(spacing: 7) {
+                    ProviderLogoView(
+                        kind: currentSnapshot.logoKind,
+                        size: 17,
+                        foregroundColor: currentSnapshot.accentColor
+                    )
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(currentSnapshot.title)
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                            .lineLimit(1)
+                        Text(currentSnapshot.updatedText)
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                    }
+                    if showsChevron {
+                        CardDisclosureChevron()
+                    }
+                }
             )
-            let title = try XCTUnwrap(
-                accessibilityElement(identifier: "provider-card-header-title", in: host),
-                "Provider title should render when chevron is \(showsChevron)"
-            )
-            let status = try XCTUnwrap(
-                accessibilityElement(identifier: "provider-card-header-status", in: host),
-                "Provider status should render when chevron is \(showsChevron)"
-            )
+            let statusHost = NSHostingView(rootView: ProviderCardStatusLabel(snapshot: currentSnapshot))
 
             XCTAssertEqual(
-                status.accessibilityLabel(),
+                ProviderCardHeader.Content(snapshot: currentSnapshot).statusText,
                 expectedStatus,
                 "Provider status should render when chevron is \(showsChevron)"
             )
-            XCTAssertEqual(
-                logo.accessibilityFrame().midY,
-                title.accessibilityFrame().midY,
-                accuracy: 1,
-                "Provider logo and title should stay on one row when chevron is \(showsChevron)"
+            XCTAssertGreaterThanOrEqual(
+                headerHost.fittingSize.width,
+                identityHost.fittingSize.width + statusHost.fittingSize.width,
+                "Provider header should include identity and status when chevron is \(showsChevron)"
             )
             XCTAssertEqual(
-                title.accessibilityFrame().midY,
-                status.accessibilityFrame().midY,
+                headerHost.fittingSize.height,
+                max(identityHost.fittingSize.height, statusHost.fittingSize.height),
                 accuracy: 1,
-                "Provider title and status should stay on one row when chevron is \(showsChevron)"
+                "Provider identity and status should stay on one row when chevron is \(showsChevron)"
             )
             XCTAssertGreaterThan(
-                host.fittingSize.height,
+                headerHost.fittingSize.height,
                 0,
                 "ProviderCardHeader(chevron: \(showsChevron)) should keep status inline"
             )
         }
-    }
-
-    private func accessibilityElement(
-        identifier: String,
-        in element: Any
-    ) -> NSAccessibilityElement? {
-        if let accessibleElement = element as? NSAccessibilityElement,
-           accessibleElement.accessibilityIdentifier() == identifier {
-            return accessibleElement
-        }
-
-        for child in accessibilityChildren(of: element) {
-            if let match = accessibilityElement(identifier: identifier, in: child) {
-                return match
-            }
-        }
-        return nil
-    }
-
-    private func accessibilityChildren(of element: Any) -> [Any] {
-        if let view = element as? NSView {
-            return view.accessibilityChildren() ?? []
-        }
-        if let accessibleElement = element as? NSAccessibilityElement {
-            return accessibleElement.accessibilityChildren() ?? []
-        }
-        return []
     }
 }

--- a/MeterBarTests/MenuBarDetailPanelLayoutTests.swift
+++ b/MeterBarTests/MenuBarDetailPanelLayoutTests.swift
@@ -290,22 +290,19 @@ final class MenuBarProviderDetailParityTests: XCTestCase {
         XCTAssertEqual(plain.fittingSize.height, withEmptySeries.fittingSize.height)
     }
 
-    func testHeaderRendersWithInlineAndExternalStatusLayouts() {
-        for showsStatus in [true, false] {
-            for showsChevron in [true, false] {
-                let header = ProviderCardHeader(
-                    snapshot: snapshot(),
-                    showsStatus: showsStatus,
-                    showsDisclosureChevron: showsChevron
-                )
-                let host = NSHostingView(rootView: header.frame(width: 320))
-                host.layoutSubtreeIfNeeded()
-                XCTAssertGreaterThan(
-                    host.fittingSize.height,
-                    0,
-                    "ProviderCardHeader(status: \(showsStatus), chevron: \(showsChevron)) should lay out"
-                )
-            }
+    func testHeaderAlwaysRendersInlineStatusWithOrWithoutDisclosureChevron() {
+        for showsChevron in [true, false] {
+            let header = ProviderCardHeader(
+                snapshot: snapshot(),
+                showsDisclosureChevron: showsChevron
+            )
+            let host = NSHostingView(rootView: header.frame(width: 320))
+            host.layoutSubtreeIfNeeded()
+            XCTAssertGreaterThan(
+                host.fittingSize.height,
+                0,
+                "ProviderCardHeader(chevron: \(showsChevron)) should keep status inline"
+            )
         }
     }
 }

--- a/MeterBarTests/MenuBarDetailPanelLayoutTests.swift
+++ b/MeterBarTests/MenuBarDetailPanelLayoutTests.swift
@@ -290,19 +290,80 @@ final class MenuBarProviderDetailParityTests: XCTestCase {
         XCTAssertEqual(plain.fittingSize.height, withEmptySeries.fittingSize.height)
     }
 
-    func testHeaderAlwaysRendersInlineStatusWithOrWithoutDisclosureChevron() {
+    func testHeaderAlwaysRendersInlineStatusWithOrWithoutDisclosureChevron() throws {
         for showsChevron in [true, false] {
+            let currentSnapshot = snapshot()
+            let expectedStatus = ProviderCardPresentation.statusText(for: currentSnapshot)
             let header = ProviderCardHeader(
-                snapshot: snapshot(),
+                snapshot: currentSnapshot,
                 showsDisclosureChevron: showsChevron
             )
             let host = NSHostingView(rootView: header.frame(width: 320))
+            host.frame = NSRect(origin: .zero, size: host.fittingSize)
             host.layoutSubtreeIfNeeded()
+
+            let logo = try XCTUnwrap(
+                accessibilityElement(identifier: "provider-card-header-logo", in: host),
+                "Provider logo should render when chevron is \(showsChevron)"
+            )
+            let title = try XCTUnwrap(
+                accessibilityElement(identifier: "provider-card-header-title", in: host),
+                "Provider title should render when chevron is \(showsChevron)"
+            )
+            let status = try XCTUnwrap(
+                accessibilityElement(identifier: "provider-card-header-status", in: host),
+                "Provider status should render when chevron is \(showsChevron)"
+            )
+
+            XCTAssertEqual(
+                status.accessibilityLabel(),
+                expectedStatus,
+                "Provider status should render when chevron is \(showsChevron)"
+            )
+            XCTAssertEqual(
+                logo.accessibilityFrame().midY,
+                title.accessibilityFrame().midY,
+                accuracy: 1,
+                "Provider logo and title should stay on one row when chevron is \(showsChevron)"
+            )
+            XCTAssertEqual(
+                title.accessibilityFrame().midY,
+                status.accessibilityFrame().midY,
+                accuracy: 1,
+                "Provider title and status should stay on one row when chevron is \(showsChevron)"
+            )
             XCTAssertGreaterThan(
                 host.fittingSize.height,
                 0,
                 "ProviderCardHeader(chevron: \(showsChevron)) should keep status inline"
             )
         }
+    }
+
+    private func accessibilityElement(
+        identifier: String,
+        in element: Any
+    ) -> NSAccessibilityElement? {
+        if let accessibleElement = element as? NSAccessibilityElement,
+           accessibleElement.accessibilityIdentifier() == identifier {
+            return accessibleElement
+        }
+
+        for child in accessibilityChildren(of: element) {
+            if let match = accessibilityElement(identifier: identifier, in: child) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    private func accessibilityChildren(of element: Any) -> [Any] {
+        if let view = element as? NSView {
+            return view.accessibilityChildren() ?? []
+        }
+        if let accessibleElement = element as? NSAccessibilityElement {
+            return accessibleElement.accessibilityChildren() ?? []
+        }
+        return []
     }
 }

--- a/MeterBarTests/MeterBarChipTests.swift
+++ b/MeterBarTests/MeterBarChipTests.swift
@@ -133,14 +133,18 @@ final class MeterBarChipTests: XCTestCase {
 
         XCTAssertEqual(healthyContent.statusBand, .healthy)
         XCTAssertEqual(healthyContent.valueText, "74% left")
-        XCTAssertEqual(healthyContent.detailParts.first, "Session")
+        XCTAssertEqual(healthyContent.windowText, "Session")
+        XCTAssertTrue(healthyContent.showsUsage)
+        XCTAssertEqual(healthyContent.footerParts.first, "Resets in 1h")
 
         let exhausted = try XCTUnwrap(recommendationRow(used: 100))
         let exhaustedContent = HeadroomRecommendationRow.Content(row: exhausted)
 
         XCTAssertEqual(exhaustedContent.statusBand, .exhausted)
-        XCTAssertEqual(exhaustedContent.valueText, "0% left")
-        XCTAssertEqual(exhaustedContent.detailParts, ["Session", "Available in 1h"])
+        XCTAssertEqual(exhaustedContent.windowText, "Session")
+        XCTAssertNil(exhaustedContent.valueText)
+        XCTAssertFalse(exhaustedContent.showsUsage)
+        XCTAssertEqual(exhaustedContent.footerParts, ["Available in 1h"])
     }
 
     // MARK: - Helpers

--- a/MeterBarTests/OptimizationInsightsTests.swift
+++ b/MeterBarTests/OptimizationInsightsTests.swift
@@ -48,6 +48,18 @@ final class OptimizationInsightsTests: XCTestCase {
         XCTAssertFalse(ModelTier.unknown.isPremium)
     }
 
+    func testModelCostTierIndicatorsUseNeutralRelativePriceScale() {
+        XCTAssertEqual(ModelTier.economy.costIndicator, "$")
+        XCTAssertEqual(ModelTier.standard.costIndicator, "$$")
+        XCTAssertEqual(ModelTier.premium.costIndicator, "$$$")
+        XCTAssertEqual(ModelTier.unknown.costIndicator, "—")
+
+        XCTAssertEqual(ModelTier.economy.costAccessibilityLabel, "Low-cost model")
+        XCTAssertEqual(ModelTier.standard.costAccessibilityLabel, "Mid-cost model")
+        XCTAssertEqual(ModelTier.premium.costAccessibilityLabel, "High-cost model")
+        XCTAssertEqual(ModelTier.unknown.costAccessibilityLabel, "Unknown cost tier")
+    }
+
     // MARK: - Optimization score
 
     func testScoreBestCaseIsHundred() {
@@ -164,9 +176,11 @@ final class OptimizationInsightsTests: XCTestCase {
         ])
         let insights = OptimizationInsights(summary: summary, now: Self.referenceNow)
 
-        let premiumRec = insights.recommendations.first { $0.title.localizedCaseInsensitiveContains("premium") }
+        let premiumRec = insights.recommendations.first { $0.id == "premium-share" }
         XCTAssertNotNil(premiumRec)
         XCTAssertEqual(premiumRec?.severity, .warning)
+        XCTAssertEqual(premiumRec?.title, "High-cost models are doing most of the work")
+        XCTAssertTrue(premiumRec?.detail.contains("$$$ models") == true)
     }
 
     func testLowCacheReuseProducesWarning() {


### PR DESCRIPTION
## Summary
- restore HEALTHY, STALE, TIGHT, and other active status pills beside the provider identity
- retain vertically centered status only for compact terminal summaries such as OUT
- remove the header status-hiding escape hatch that caused popover and Limits to regress together

## Root cause
PR #484 wrapped every expanded ProviderStatusCard in a full-height trailing status rail. Popover and Limits share that card, while Overview does not, which explains the inconsistent result.

## Verification
- swift test --filter MenuBarProviderDetailParityTests (8 passed)
- swift test --filter MeterBarChipTests|ProviderPresentationHealthTests|DashboardLayoutTests (49 passed)
- universal Release app/widget build succeeded
- nested app, widget, Sparkle, CLI signatures and entitlements verified
- launch smoke passed
- corrected 1.8.39 bundle installed and running locally for visual validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy and layout only. Status placement and Optimize tables change, with no auth, data, or scoring-logic changes.
> 
> **Overview**
> Puts **active provider status back inline** with the identity row on expanded cards and hover headers. The `showsStatus` escape hatch is gone, so HEALTHY/STALE/TIGHT no longer hide when popover and Limits share `ProviderStatusCard`. Compact terminal rows (Out, Offline, login) still center status against the whole card.
> 
> Optimize copy and breakdowns now use a **neutral relative-price scale** (`$` / `$$` / `$$$`) instead of colored Premium/Standard chips. Model and origin lists share a columned table; “What to use next” rows keep the status pill on the name line and move window/headroom under it, hiding the usage bar when a window is exhausted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f9d60daeb8a69581fd3863cdf6a6a353e33c6ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Provider status labels now appear consistently within card and hover-panel headers.
  * Expanded provider cards use a simpler, unified vertical layout with independently controlled disclosure chevrons.
  * Optimization insights now show cost indicators, clearer model-routing details, and streamlined comparison tables.
  * Recommendation rows provide clearer usage, availability, and reset information based on provider status.
  * Improved accessibility labels and identifiers for provider headers and model cost indicators.

* **Bug Fixes**
  * Improved consistency of status placement and alignment across provider views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->